### PR TITLE
Change Power Preference to High Performance

### DIFF
--- a/crates/bevy_wgpu/src/wgpu_renderer.rs
+++ b/crates/bevy_wgpu/src/wgpu_renderer.rs
@@ -21,7 +21,7 @@ impl WgpuRenderer {
         let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
-                power_preference: wgpu::PowerPreference::Default,
+                power_preference: wgpu::PowerPreference::HighPerformance,
                 compatible_surface: None,
             })
             .await


### PR DESCRIPTION
 Being specifically a game engine, I believe it makes sense to have preference towards a discete GPU by default. For many linux users, it can also select integrated graphics that don't support vulkan and crash, even though they have a discrete GPU that could handle it. Obviously open to discussion :)