### PR TITLE
Make audio/image dependencies optional through feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,18 @@ readme = "README.md"
 exclude = ["assets/**/*", "tools/**/*", ".github/**/*", "crates/**/*"]
 
 [features]
-default = ["bevy_audio", "bevy_gltf", "bevy_wgpu", "bevy_winit"]
+default = ["bevy_audio", "bevy_gltf", "bevy_wgpu", "bevy_winit", "png", "hdr", "mp3"]
 profiler = ["bevy_ecs/profiler", "bevy_diagnostic/profiler"]
+
+# Image format support for texture loading (PNG and HDR are enabled by default)
+png = ["bevy_render/png"]
+hdr = ["bevy_render/hdr"]
+
+# Audio format support (MP3 is enabled by default)
+mp3 = ["bevy_audio/mp3"]
+flac = ["bevy_audio/flac"]
+wav = ["bevy_audio/wav"]
+vorbis = ["bevy_audio/vorbis"]
 
 [workspace]
 members = [

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -17,4 +17,10 @@ bevy_ecs = {path = "../bevy_ecs", version = "0.1"}
 
 # other
 anyhow = "1.0"
-rodio = {version = "0.11", default-features = false, features = ["mp3"]}
+rodio = {version = "0.11", default-features = false}
+
+[features]
+mp3 = ["rodio/mp3"]
+flac = ["rodio/flac"]
+wav = ["rodio/wav"]
+vorbis = ["rodio/vorbis"]

--- a/crates/bevy_audio/src/audio_source.rs
+++ b/crates/bevy_audio/src/audio_source.rs
@@ -26,7 +26,7 @@ impl AssetLoader<AudioSource> for Mp3Loader {
     }
 
     fn extensions(&self) -> &[&str] {
-        static EXTENSIONS: &[&str] = &["mp3"];
+        static EXTENSIONS: &[&str] = &["mp3", "flac", "wav", "ogg"];
         EXTENSIONS
     }
 }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -25,7 +25,7 @@ bevy_window = { path = "../bevy_window", version = "0.1" }
 # rendering
 spirv-reflect = "0.2.3"
 bevy-glsl-to-spirv = "0.1.7"
-image = { version = "0.23", default-features = false, features = ["png", "hdr"] }
+image = { version = "0.23", default-features = false }
 
 # misc
 log = { version = "0.4", features = ["release_max_level_info"] }
@@ -38,3 +38,7 @@ once_cell = "1.4.0"
 downcast-rs = "1.1.1"
 thiserror = "1.0"
 anyhow = "1.0"
+
+[features]
+png = ["image/png"]
+hdr = ["image/hdr"]

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -45,7 +45,11 @@ use render_graph::{
 };
 use renderer::{AssetRenderResourceBindings, RenderResourceBindings};
 use std::ops::Range;
-use texture::{HdrTextureLoader, ImageTextureLoader, TextureResourceSystemState};
+#[cfg(feature = "hdr")]
+use texture::HdrTextureLoader;
+#[cfg(feature = "png")]
+use texture::ImageTextureLoader;
+use texture::TextureResourceSystemState;
 
 /// The names of "render" App stages
 pub mod stage {
@@ -75,6 +79,15 @@ impl Default for RenderPlugin {
 
 impl Plugin for RenderPlugin {
     fn build(&self, app: &mut AppBuilder) {
+        #[cfg(feature = "png")]
+        {
+            app.add_asset_loader::<Texture, ImageTextureLoader>();
+        }
+        #[cfg(feature = "hdr")]
+        {
+            app.add_asset_loader::<Texture, HdrTextureLoader>();
+        }
+
         app.add_stage_after(bevy_asset::stage::ASSET_EVENTS, stage::RENDER_RESOURCE)
             .add_stage_after(stage::RENDER_RESOURCE, stage::RENDER_GRAPH_SYSTEMS)
             .add_stage_after(stage::RENDER_GRAPH_SYSTEMS, stage::DRAW)
@@ -84,8 +97,6 @@ impl Plugin for RenderPlugin {
             .add_asset::<Texture>()
             .add_asset::<Shader>()
             .add_asset::<PipelineDescriptor>()
-            .add_asset_loader::<Texture, HdrTextureLoader>()
-            .add_asset_loader::<Texture, ImageTextureLoader>()
             .register_component::<Camera>()
             .register_component::<Draw>()
             .register_component::<RenderPipelines>()

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -1,11 +1,15 @@
+#[cfg(feature = "hdr")]
 mod hdr_texture_loader;
+#[cfg(feature = "png")]
 mod image_texture_loader;
 mod sampler_descriptor;
 mod texture;
 mod texture_descriptor;
 mod texture_dimension;
 
+#[cfg(feature = "hdr")]
 pub use hdr_texture_loader::*;
+#[cfg(feature = "png")]
 pub use image_texture_loader::*;
 pub use sampler_descriptor::*;
 pub use texture::*;


### PR DESCRIPTION
This makes the dependencies for `png`, `hdr`, and `mp3` optional through feature flags, enabled by default.

I also added support for the `flac`, `wav`, and `vorbis` formats, since those are supported by `rodio`. These formats are not enabled by default.