### PR TITLE
Fix 404 link to License file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [![Bevy](assets/branding/bevy_logo_light_small.svg)](https://bevyengine.org)
 [![Crates.io](https://img.shields.io/crates/v/bevy.svg)](https://crates.io/crates/bevy)
-[![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/bevyengine/bevy/LICENSE)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/bevyengine/bevy/blob/master/LICENSE)
 [![Crates.io](https://img.shields.io/crates/d/bevy.svg)](https://crates.io/crates/bevy)
 
 ## What is Bevy?


### PR DESCRIPTION
The License link on the README and Crates.io links to a 404 page