### PR TITLE
Ignore CLion/intellij project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 .cargo/config
+/.idea


### PR DESCRIPTION
This change prevents the .idea folder created in the root of a project opened with clion as showing up as "untracked" in git