### PR TITLE
Add support for embedded buffers in GLTF loader

### DIFF
--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -19,3 +19,4 @@ bevy_render = { path = "../bevy_render", version = "0.1" }
 gltf = { version = "0.15.2", default-features = false, features = ["utils"] }
 thiserror = "1.0"
 anyhow = "1.0"
+base64 = "0.12.3"


### PR DESCRIPTION
Hello!
I was trying to load a GLTF file exported from Blender with the GLTF embedded variant and it failed with the following error:

```
thread '<unnamed>' panicked at 'index out of bounds: the len is 0 but the index is 0', /home/milan/Projects/bevy/crates/bevy_gltf/src/loader.rs:71:58
```

I decided to look at the loader and fill in a suspiciously empty part :wink: 
I've tested it by loading a different file in the `load_model` example, it appears to work fine.