### PR TITLE
Use Rust bundled lld for msvc target

### DIFF
--- a/.cargo/config_fast_builds
+++ b/.cargo/config_fast_builds
@@ -10,8 +10,6 @@ rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]
 [target.x86_64-apple-darwin]
 rustflags = ["-Zshare-generics=y"]
 
-# NOTE: you must manually install lld on windows. you can easily do this with the "scoop" package manager:
-# `scoop install llvm`
 [target.x86_64-pc-windows-msvc]
-linker = "lld-link.exe"
-rustflags = ["-Clinker=lld", "-Zshare-generics=y"]
+linker = "rust-lld.exe"
+rustflags = ["-Zshare-generics=y"]


### PR DESCRIPTION
-Clinker=lld was overwriting linker="lld-link.exe"; having both is unnecessary.
Using the bundled lld (rust-lld) for Windows.

As outlined [here](https://github.com/rust-lang/rust/issues/39915#issuecomment-618726211), there are concerns for defaulting to lld on Linux/Unix that don't apply to Windows. On Windows it's expected that the linker is called directly, which is why linker can be assigned to lld for Windows but must be assigned to clang/gcc on Linux.

Blocking issues related to defaulting to lld on Windows can be found [here](https://github.com/rust-lang/rust/issues/71520). I don't think any of those issues apply especially to the bundled rust-lld aside from it may get patches later (or sooner) than llvm packages elsewhere.