### PR TITLE
Creates linux_dependencies.md

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -1,0 +1,8 @@
+# Installing Linux dependencies
+
+This page lists the required dependencies to build a Bevy project on your Linux machine.
+
+If you don't see your distro present in the list, feel free to add the instructions in this document.
+
+## Ubuntu 20.04
+`sudo apt-get install libx11-dev libasound2-dev`


### PR DESCRIPTION
This document will be linked in the new "Install OS dependencies" section on the "Setup" page of the book.

See related issue at [this page](https://github.com/bevyengine/bevy-website/issues/6)