### PR TITLE
WIP config crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ bevy_transform = { path = "crates/bevy_transform", version = "0.1" }
 bevy_text = { path = "crates/bevy_text", version = "0.1" }
 bevy_ui = { path = "crates/bevy_ui", version = "0.1" }
 bevy_window = { path = "crates/bevy_window", version = "0.1" }
+bevy_config = { path = "crates/bevy_config", version = "0.1" }
 
 # bevy (optional)
 bevy_audio = { path = "crates/bevy_audio", optional = true, version = "0.1" }

--- a/crates/bevy_config/Cargo.toml
+++ b/crates/bevy_config/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bevy_config"
+version = "0.1.0"
+edition = "2018"
+authors = ["Bevy Contributors <bevyengine@gmail.com>", "Carter Anderson <mcanders1@gmail.com>"]
+homepage = "https://bevyengine.org"
+repository = "https://github.com/bevyengine/bevy"
+license = "MIT"
+keywords = ["bevy"]
+
+[dependencies]
+# bevy
+bevy_app = { path = "../bevy_app", version = "0.1" }
+bevy_asset = { path = "../bevy_asset", version = "0.1" }
+
+# other
+serde = { version = "1", features = ["derive"] }
+toml = "0.5.6"
+anyhow = "1.0"

--- a/crates/bevy_config/src/lib.rs
+++ b/crates/bevy_config/src/lib.rs
@@ -1,0 +1,61 @@
+use anyhow::Result;
+use bevy_app::{AppBuilder, Plugin};
+use bevy_asset::{AddAsset, AssetLoader};
+use serde::{de::DeserializeOwned, Serialize};
+use std::{
+    marker::{PhantomData, Send, Sync},
+    path::Path,
+};
+use toml::de::from_slice;
+
+/// a struct wrapping a user defined configuration file
+pub struct Config<T>(T)
+where
+    T: DeserializeOwned + Serialize;
+
+impl<T> Config<T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    /// return a reference to the configuration data
+    pub fn get_config(&self) -> &T
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        &self.0
+    }
+}
+
+/// bevy asset loader for configuration files
+#[derive(Default)]
+pub struct ConfigLoader;
+
+impl<T> AssetLoader<Config<T>> for ConfigLoader
+where
+    T: DeserializeOwned + Serialize,
+{
+    fn from_bytes(&self, _asset_path: &Path, bytes: Vec<u8>) -> Result<Config<T>, anyhow::Error> {
+        let config: T = from_slice(&bytes)?;
+        Ok(Config(config))
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["toml"]
+    }
+}
+
+/// bevy configuration plugin
+#[derive(Default)]
+pub struct ConfigPlugin<T>(PhantomData<T>)
+where
+    T: Serialize + DeserializeOwned;
+
+impl<T: 'static> Plugin for ConfigPlugin<T>
+where
+    T: DeserializeOwned + Serialize + Send + Sync,
+{
+    fn build(&self, app: &mut AppBuilder) {
+        app.add_asset::<Config<T>>()
+            .add_asset_loader::<Config<T>, ConfigLoader>();
+    }
+}


### PR DESCRIPTION
Hi there!

Been tinkering around with bevy since it was released and thought it needed a built in config file plugin. This is super WIP but I think it's something that could be built upon. at the moment it loads TOML files and the config is described using a Rust type. That's why the loader has a generic type and needs to be added for each config type (unless there is a better way?)