### PR TITLE
Fix instance rate vertex buffers

### DIFF
--- a/crates/bevy_derive/src/as_vertex_buffer_descriptor.rs
+++ b/crates/bevy_derive/src/as_vertex_buffer_descriptor.rs
@@ -41,12 +41,12 @@ pub fn derive_as_vertex_buffer_descriptor(input: TokenStream) -> TokenStream {
                         || VertexAttributes::default(),
                         |a| {
                             syn::custom_keyword!(ignore);
+                            syn::custom_keyword!(instance_rate);
+
                             let mut vertex_attributes = VertexAttributes::default();
                             a.parse_args_with(|input: ParseStream| {
-                                if let Some(_) = input.parse::<Option<ignore>>()? {
-                                    vertex_attributes.ignore = true;
-                                    return Ok(());
-                                }
+                                vertex_attributes.ignore = input.parse::<Option<ignore>>()?.is_some();
+                                vertex_attributes.instance = input.parse::<Option<instance_rate>>()?.is_some();
                                 Ok(())
                             })
                             .expect("invalid 'vertex' attribute format");

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -351,7 +351,7 @@ impl<'a> DrawContext<'a> {
                         if let Some(buffer_info) =
                             self.render_resource_context.get_buffer_info(index_buffer)
                         {
-                            // Index buffer is u16 so divide by 2 to get bytes
+                            // Index buffer is u16 so divide by 2 to get indice count
                             indices = Some(0..(buffer_info.size / 2) as u32);
                         } else {
                             panic!("expected buffer type");

--- a/crates/bevy_render/src/pipeline/render_pipelines.rs
+++ b/crates/bevy_render/src/pipeline/render_pipelines.rs
@@ -99,11 +99,11 @@ pub fn draw_render_pipelines_system(
                     ],
                 )
                 .unwrap();
-            let indices = draw_context
+            let (indices, instances) = draw_context
                 .set_vertex_buffers_from_bindings(&mut draw, &[&render_pipelines.bindings])
                 .unwrap();
             if let Some(indices) = indices {
-                draw.draw_indexed(indices, 0, 0..1);
+                draw.draw_indexed(indices, 0, instances);
             }
         }
     }

--- a/crates/bevy_render/src/pipeline/vertex_buffer_descriptor.rs
+++ b/crates/bevy_render/src/pipeline/vertex_buffer_descriptor.rs
@@ -45,7 +45,7 @@ pub struct VertexAttributeDescriptor {
     pub shader_location: u32,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct VertexBufferDescriptors {
     pub descriptors: HashMap<String, VertexBufferDescriptor>,
 }


### PR DESCRIPTION
Implemented missing parts to support instance rate vertex buffers.

Instance count is calculated from instance rate buffer size and stride. This is not ideal if you want to render less instances than allocated buffer, but I think this is a good solution for the time being.

I also improved debug output in render, but can revert the last commit if it's too verbose.