### PR TITLE
Support multiline Texts

### DIFF
--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -83,6 +83,11 @@ impl<'a> Drawable for DrawableText<'a> {
         // set local per-character bindings
         for character in self.text.chars() {
             if character.is_control() {
+                if character == '\n' {
+                    caret.set_x(self.position.x());
+                    // TODO: Necessary to also calculate scaled_font.line_gap() in here?
+                    caret.set_y(caret.y() - scaled_font.height());
+                }
                 continue;
             }
 


### PR DESCRIPTION
See #182 . Since @karroffel assigned the `Bug` tag to it I tried to find the cause for it and develop a fix. 

Some open questions:
- Do we also need to add `scaled_font.line_gap()` to the calculation?
- Are there other (unicode) symbols which are equivalent to `\n` (or have a similar function)?
- Are there any other control characters which we might need to support? (`LTR`, `RTL`, etc. ?)