### PR TITLE
Flying 3D Camera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Cargo.lock
 .cargo/config
 /.idea
+/.vscode

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -21,6 +21,7 @@ bevy_property = { path = "../bevy_property", version = "0.1" }
 bevy_transform = { path = "../bevy_transform", version = "0.1" }
 bevy_type_registry = { path = "../bevy_type_registry", version = "0.1" }
 bevy_window = { path = "../bevy_window", version = "0.1" }
+bevy_input = { path = "../bevy_input", version = "0.1" }
 
 # rendering
 spirv-reflect = "0.2.3"

--- a/crates/bevy_render/src/fly_camera.rs
+++ b/crates/bevy_render/src/fly_camera.rs
@@ -1,0 +1,185 @@
+use crate::{
+    camera::{Camera, PerspectiveProjection, VisibleEntities},
+    render_graph::base,
+};
+use bevy_app::{AppBuilder, EventReader, Events, Plugin};
+use bevy_core::Time;
+use bevy_ecs::*;
+use bevy_ecs::{Bundle, Query, Res, ResMut};
+use bevy_input::{keyboard::KeyCode, mouse::MouseMotion, Input};
+use bevy_math::{Quat, Vec2, Vec3};
+use bevy_transform::components::{Rotation, Scale, Transform, Translation};
+
+/**
+Used in [CameraFlyingComponents](struct.CameraFlyingComponents.html)
+**/
+pub struct CameraFlyingOptions {
+    /// The camera's flying speed
+    pub speed: f32,
+    /// The camera's mouse sensitivity
+    pub sensitivity: f32,
+    /// The vertical pitch of the camera, constrained between `89.9f32` and `-89.9f32`. This value is kept up-to-date by the [CameraFlyingPlugin](struct.CameraFlyingPlugin.html) plugin, and can be mutated to adjust the camera's angle
+    pub pitch: f32,
+    /// The horizontal yaw of the camera. This value is kept up-to-date by the [CameraFlyingPlugin](struct.CameraFlyingPlugin.html) plugin, and can be mutated to adjust the camera's angle
+    pub yaw: f32,
+}
+impl Default for CameraFlyingOptions {
+    fn default() -> Self {
+        Self {
+            speed: 10.0,
+            sensitivity: 10.0,
+            pitch: 0.0,
+            yaw: 0.0,
+        }
+    }
+}
+
+/**
+A basic flying camera for 3D scenes.
+
+| Keybind         | Action                          |
+|-----------------|---------------------------------|
+| `W / A / S / D` | Move along the horizontal plane |
+| `Space`         | Move upward                     |
+| `Shift`         | Move downward                   |
+
+```rust
+use bevy::prelude::*;
+
+fn setup(mut commands: Commands) {
+    commands.spawn(CameraFlyingComponents::default());
+}
+
+fn main () {
+    App::build()
+        .add_default_plugins()
+        .add_startup_system(setup.system())
+        .run();
+}
+
+```
+
+**/
+#[derive(Bundle)]
+pub struct CameraFlyingComponents {
+    pub options: CameraFlyingOptions,
+    pub camera: Camera,
+    pub perspective_projection: PerspectiveProjection,
+    pub visible_entities: VisibleEntities,
+    pub transform: Transform,
+    pub translation: Translation,
+    pub rotation: Rotation,
+    pub scale: Scale,
+}
+
+impl Default for CameraFlyingComponents {
+    fn default() -> Self {
+        Self {
+            options: CameraFlyingOptions::default(),
+            camera: Camera {
+                name: Some(base::camera::CAMERA3D.to_string()),
+                ..Default::default()
+            },
+            perspective_projection: Default::default(),
+            visible_entities: Default::default(),
+            transform: Default::default(),
+            translation: Default::default(),
+            rotation: Default::default(),
+            scale: Default::default(),
+        }
+    }
+}
+
+fn forward_vector(rotation: &Rotation) -> Vec3 {
+    rotation.mul_vec3(Vec3::unit_z()).normalize()
+}
+
+fn forward_walk_vector(rotation: &Rotation) -> Vec3 {
+    let f = forward_vector(rotation);
+    let f_flattened = Vec3::new(f.x(), 0.0, f.z()).normalize();
+    f_flattened
+}
+
+fn strafe_vector(rotation: &Rotation) -> Vec3 {
+    // Rotate it 90 degrees to get the strafe direction
+    Rotation::from_rotation_y(90.0f32.to_radians())
+        .mul_vec3(forward_walk_vector(rotation))
+        .normalize()
+}
+
+fn movement_axis(input: &Res<Input<KeyCode>>, plus: KeyCode, minus: KeyCode) -> f32 {
+    let mut axis = 0.0;
+    if input.pressed(plus) {
+        axis += 1.0;
+    }
+    if input.pressed(minus) {
+        axis -= 1.0;
+    }
+    axis
+}
+
+fn camera_movement_system(
+    time: Res<Time>,
+    keyboard_input: Res<Input<KeyCode>>,
+    mut query: Query<(&CameraFlyingOptions, &mut Translation, &Rotation)>,
+) {
+    let axis_h = movement_axis(&keyboard_input, KeyCode::D, KeyCode::A);
+    let axis_v = movement_axis(&keyboard_input, KeyCode::S, KeyCode::W);
+
+    let axis_float = movement_axis(&keyboard_input, KeyCode::Space, KeyCode::LShift);
+
+    for (options, mut translation, rotation) in &mut query.iter() {
+        let delta_f = forward_walk_vector(rotation) * axis_v * options.speed * time.delta_seconds;
+
+        let delta_strafe = strafe_vector(rotation) * axis_h * options.speed * time.delta_seconds;
+
+        let delta_float = Vec3::unit_y() * axis_float * options.speed * time.delta_seconds;
+
+        translation.0 += delta_f + delta_strafe + delta_float;
+    }
+}
+
+#[derive(Default)]
+struct State {
+    mouse_motion_event_reader: EventReader<MouseMotion>,
+}
+
+fn mouse_motion_system(
+    time: Res<Time>,
+    mut state: ResMut<State>,
+    mouse_motion_events: Res<Events<MouseMotion>>,
+    mut query: Query<(&mut CameraFlyingOptions, &mut Rotation)>,
+) {
+    let mut delta: Vec2 = Vec2::zero();
+    for event in state.mouse_motion_event_reader.iter(&mouse_motion_events) {
+        delta += event.delta;
+    }
+
+    for (mut options, mut rotation) in &mut query.iter() {
+        options.yaw -= delta.x() * options.sensitivity * time.delta_seconds;
+        options.pitch += delta.y() * options.sensitivity * time.delta_seconds;
+
+        if options.pitch > 89.9 {
+            options.pitch = 89.9;
+        }
+        if options.pitch < -89.9 {
+            options.pitch = -89.9;
+        }
+
+        let yaw_radians = options.yaw.to_radians();
+        let pitch_radians = options.pitch.to_radians();
+
+        rotation.0 = Quat::from_axis_angle(Vec3::unit_y(), yaw_radians)
+            * Quat::from_axis_angle(-Vec3::unit_x(), pitch_radians);
+    }
+}
+
+pub struct CameraFlyingPlugin;
+
+impl Plugin for CameraFlyingPlugin {
+    fn build(&self, app: &mut AppBuilder) {
+        app.init_resource::<State>()
+            .add_system(camera_movement_system.system())
+            .add_system(mouse_motion_system.system());
+    }
+}

--- a/crates/bevy_render/src/fly_camera.rs
+++ b/crates/bevy_render/src/fly_camera.rs
@@ -11,31 +11,9 @@ use bevy_math::{Quat, Vec2, Vec3};
 use bevy_transform::components::{Rotation, Scale, Transform, Translation};
 
 /**
-Used in [CameraFlyingComponents](struct.CameraFlyingComponents.html)
-**/
-pub struct CameraFlyingOptions {
-    /// The camera's flying speed
-    pub speed: f32,
-    /// The camera's mouse sensitivity
-    pub sensitivity: f32,
-    /// The vertical pitch of the camera, constrained between `89.9f32` and `-89.9f32`. This value is kept up-to-date by the [CameraFlyingPlugin](struct.CameraFlyingPlugin.html) plugin, and can be mutated to adjust the camera's angle
-    pub pitch: f32,
-    /// The horizontal yaw of the camera. This value is kept up-to-date by the [CameraFlyingPlugin](struct.CameraFlyingPlugin.html) plugin, and can be mutated to adjust the camera's angle
-    pub yaw: f32,
-}
-impl Default for CameraFlyingOptions {
-    fn default() -> Self {
-        Self {
-            speed: 10.0,
-            sensitivity: 10.0,
-            pitch: 0.0,
-            yaw: 0.0,
-        }
-    }
-}
+A component to enable a (Camera3dComponents)(struct.Camera3dComponents.html) to be controlled by keyboard and mouse.
 
-/**
-A basic flying camera for 3D scenes.
+This is useful for development and testing in 3d scenes, before you create your own movement system.
 
 | Keybind         | Action                          |
 |-----------------|---------------------------------|
@@ -46,7 +24,9 @@ A basic flying camera for 3D scenes.
 ```ignore
 
 fn setup(mut commands: Commands) {
-    commands.spawn(CameraFlyingComponents::default());
+    commands
+        .spawn(Camera3dComponents::default())
+        .with(CameraFlying::default());
 }
 
 fn main () {
@@ -59,32 +39,23 @@ fn main () {
 ```
 
 **/
-#[derive(Bundle)]
-pub struct CameraFlyingComponents {
-    pub options: CameraFlyingOptions,
-    pub camera: Camera,
-    pub perspective_projection: PerspectiveProjection,
-    pub visible_entities: VisibleEntities,
-    pub transform: Transform,
-    pub translation: Translation,
-    pub rotation: Rotation,
-    pub scale: Scale,
+pub struct CameraFlying {
+    /// The camera's flying speed
+    pub speed: f32,
+    /// The camera's mouse sensitivity
+    pub sensitivity: f32,
+    /// The vertical pitch of the camera, constrained between `89.9f32` and `-89.9f32`. This value is kept up-to-date by the [CameraFlyingPlugin](struct.CameraFlyingPlugin.html) plugin, and can be mutated to adjust the camera's angle
+    pub pitch: f32,
+    /// The horizontal yaw of the camera. This value is kept up-to-date by the [CameraFlyingPlugin](struct.CameraFlyingPlugin.html) plugin, and can be mutated to adjust the camera's angle
+    pub yaw: f32,
 }
-
-impl Default for CameraFlyingComponents {
+impl Default for CameraFlying {
     fn default() -> Self {
         Self {
-            options: CameraFlyingOptions::default(),
-            camera: Camera {
-                name: Some(base::camera::CAMERA3D.to_string()),
-                ..Default::default()
-            },
-            perspective_projection: Default::default(),
-            visible_entities: Default::default(),
-            transform: Default::default(),
-            translation: Default::default(),
-            rotation: Default::default(),
-            scale: Default::default(),
+            speed: 10.0,
+            sensitivity: 10.0,
+            pitch: 0.0,
+            yaw: 0.0,
         }
     }
 }
@@ -120,7 +91,7 @@ fn movement_axis(input: &Res<Input<KeyCode>>, plus: KeyCode, minus: KeyCode) -> 
 fn camera_movement_system(
     time: Res<Time>,
     keyboard_input: Res<Input<KeyCode>>,
-    mut query: Query<(&CameraFlyingOptions, &mut Translation, &Rotation)>,
+    mut query: Query<(&CameraFlying, &mut Translation, &Rotation)>,
 ) {
     let axis_h = movement_axis(&keyboard_input, KeyCode::D, KeyCode::A);
     let axis_v = movement_axis(&keyboard_input, KeyCode::S, KeyCode::W);
@@ -147,7 +118,7 @@ fn mouse_motion_system(
     time: Res<Time>,
     mut state: ResMut<State>,
     mouse_motion_events: Res<Events<MouseMotion>>,
-    mut query: Query<(&mut CameraFlyingOptions, &mut Rotation)>,
+    mut query: Query<(&mut CameraFlying, &mut Rotation)>,
 ) {
     let mut delta: Vec2 = Vec2::zero();
     for event in state.mouse_motion_event_reader.iter(&mouse_motion_events) {

--- a/crates/bevy_render/src/fly_camera.rs
+++ b/crates/bevy_render/src/fly_camera.rs
@@ -43,8 +43,7 @@ A basic flying camera for 3D scenes.
 | `Space`         | Move upward                     |
 | `Shift`         | Move downward                   |
 
-```rust
-use bevy::prelude::*;
+```ignore
 
 fn setup(mut commands: Commands) {
     commands.spawn(CameraFlyingComponents::default());

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -20,7 +20,7 @@ pub mod prelude {
         color::Color,
         draw::Draw,
         entity::*,
-        fly_camera::{CameraFlyingComponents, CameraFlyingOptions},
+        fly_camera::CameraFlying,
         mesh::{shape, Mesh},
         pipeline::RenderPipelines,
         shader::Shader,

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -2,6 +2,7 @@ pub mod batch;
 pub mod camera;
 pub mod color;
 pub mod draw;
+pub mod fly_camera;
 pub mod mesh;
 pub mod pass;
 pub mod pipeline;
@@ -19,6 +20,7 @@ pub mod prelude {
         color::Color,
         draw::Draw,
         entity::*,
+        fly_camera::{CameraFlyingComponents, CameraFlyingOptions},
         mesh::{shape, Mesh},
         pipeline::RenderPipelines,
         shader::Shader,

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -45,12 +45,12 @@ fn setup(
             ..Default::default()
         })
         // camera
-        .spawn(CameraFlyingComponents {
-            options: CameraFlyingOptions {
-                pitch: 25.0,
-                ..Default::default()
-            },
+        .spawn(Camera3dComponents {
             translation: Translation::new(0.0, 4.0, 8.0),
+            ..Default::default()
+        })
+        .with(CameraFlying {
+            pitch: 25.0,
             ..Default::default()
         });
 }

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -31,7 +31,10 @@ fn setup(
         })
         // sphere
         .spawn(PbrComponents {
-            mesh: meshes.add(Mesh::from(shape::Icosphere { subdivisions: 4, radius: 0.5 })),
+            mesh: meshes.add(Mesh::from(shape::Icosphere {
+                subdivisions: 4,
+                radius: 0.5,
+            })),
             material: materials.add(Color::rgb(0.1, 0.4, 0.8).into()),
             translation: Translation::new(1.5, 1.5, 1.5),
             ..Default::default()
@@ -42,12 +45,12 @@ fn setup(
             ..Default::default()
         })
         // camera
-        .spawn(Camera3dComponents {
-            transform: Transform::new_sync_disabled(Mat4::face_toward(
-                Vec3::new(-3.0, 5.0, 8.0),
-                Vec3::new(0.0, 0.0, 0.0),
-                Vec3::new(0.0, 1.0, 0.0),
-            )),
+        .spawn(CameraFlyingComponents {
+            options: CameraFlyingOptions {
+                pitch: 25.0,
+                ..Default::default()
+            },
+            translation: Translation::new(0.0, 4.0, 8.0),
             ..Default::default()
         });
 }

--- a/src/add_default_plugins.rs
+++ b/src/add_default_plugins.rs
@@ -19,6 +19,7 @@ impl AddDefaultPlugins for AppBuilder {
         self.add_plugin(bevy_pbr::PbrPlugin::default());
         self.add_plugin(bevy_ui::UiPlugin::default());
         self.add_plugin(bevy_text::TextPlugin::default());
+        self.add_plugin(bevy_render::fly_camera::CameraFlyingPlugin);
 
         #[cfg(feature = "bevy_audio")]
         self.add_plugin(bevy_audio::AudioPlugin::default());


### PR DESCRIPTION
A basic flying camera seems like a good built-in feature to have for viewing 3D scenes during development, without devs having to write their own.

- Made `CameraFlyingComponents` bundle, which mirrors `Camera3dComponents`, with the addition of a `CameraFlyingOptions` component.
- Made `CameraFlyingPlugin`, and added it to the default plugins.
- Changed `examples/3d/3d_scene.rs` to use the flying camera instead of a static one.

Keybinds are:
| Keybind         | Action                          |
|-----------------|---------------------------------|
| `W / A / S / D` | Move along the horizontal plane |
| `Space`         | Move upward                     |
| `Shift`         | Move downward                   |

Some future features I'd work in later are:
- a minor amount of acceleration
- a variant enum to change whether it uses the 'Minecraft style' movement I've implemented, versus flying directly in the direction the camera is looking.

(Also, added `.vscode` to `.gitignore`)