### PR TITLE
Add a .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
I noticed some of the files had weird quirks:

 - white spaces at the end of lines
 - missing newline at the end of files

[editorconfig](https://editorconfig.org/) is a unified config format for editors to stop fighting over tiny details like that. This configuration is pretty conservative:

 - 4 spaces because that's mostly the default for rust
 - spaces instead of tabs because editors still can't agree on how wide a tab is
 - insert a final newline because some editors will do it anyway
 - remove trailing white spaces because these serve no purpose anyway

It applies to all text files in the repository, which should bring a bit more consistency overall (these settings also don't conflict with rustfmt)