### PR TITLE
Replace vector of UniformProperty with a single UniformProperty

### DIFF
--- a/crates/bevy_render/src/pipeline/binding.rs
+++ b/crates/bevy_render/src/pipeline/binding.rs
@@ -21,7 +21,7 @@ pub struct BindingDescriptor {
 pub enum BindType {
     Uniform {
         dynamic: bool,
-        properties: Vec<UniformProperty>,
+        property: UniformProperty,
     },
     StorageBuffer {
         dynamic: bool,
@@ -45,11 +45,7 @@ pub enum BindType {
 impl BindType {
     pub fn get_uniform_size(&self) -> Option<u64> {
         match self {
-            BindType::Uniform { properties, .. } => Some(
-                properties
-                    .iter()
-                    .fold(0, |total, property| total + property.get_size()),
-            ),
+            BindType::Uniform { property, .. } => Some(property.get_size()),
             _ => None,
         }
     }

--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -77,7 +77,7 @@ impl<Q: HecsQuery> PassNode<Q> {
                 index: 0,
                 bind_type: BindType::Uniform {
                     dynamic: false,
-                    properties: vec![UniformProperty::Struct(vec![UniformProperty::Mat4])],
+                    property: UniformProperty::Struct(vec![UniformProperty::Mat4]),
                 },
                 shader_stage: BindingShaderStage::VERTEX | BindingShaderStage::FRAGMENT,
             }],

--- a/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
+++ b/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
@@ -273,7 +273,7 @@ mod tests {
                     name: "a".to_string(),
                     bind_type: BindType::Uniform {
                         dynamic: false,
-                        properties: vec![UniformProperty::Struct(vec![UniformProperty::Mat4])],
+                        property: UniformProperty::Struct(vec![UniformProperty::Mat4]),
                     },
                     shader_stage: BindingShaderStage::VERTEX | BindingShaderStage::FRAGMENT,
                 },
@@ -282,7 +282,7 @@ mod tests {
                     name: "b".to_string(),
                     bind_type: BindType::Uniform {
                         dynamic: false,
-                        properties: vec![UniformProperty::Float],
+                        property: UniformProperty::Float,
                     },
                     shader_stage: BindingShaderStage::VERTEX | BindingShaderStage::FRAGMENT,
                 },

--- a/crates/bevy_render/src/shader/shader_reflect.rs
+++ b/crates/bevy_render/src/shader/shader_reflect.rs
@@ -177,7 +177,7 @@ fn reflect_binding(binding: &ReflectDescriptorBinding) -> BindingDescriptor {
             &type_description.type_name,
             BindType::Uniform {
                 dynamic: false,
-                properties: vec![reflect_uniform(type_description)],
+                property: reflect_uniform(type_description),
             },
         ),
         ReflectDescriptorType::SampledImage => (
@@ -412,9 +412,9 @@ mod tests {
                             name: "Camera".into(),
                             bind_type: BindType::Uniform {
                                 dynamic: false,
-                                properties: vec![UniformProperty::Struct(vec![
+                                property: UniformProperty::Struct(vec![
                                     UniformProperty::Mat4
-                                ])],
+                                ]),
                             },
                             shader_stage: BindingShaderStage::VERTEX | BindingShaderStage::FRAGMENT,
                         }]

--- a/crates/bevy_wgpu/src/wgpu_type_converter.rs
+++ b/crates/bevy_wgpu/src/wgpu_type_converter.rs
@@ -182,7 +182,7 @@ impl WgpuFrom<&BindType> for wgpu::BindingType {
         match bind_type {
             BindType::Uniform {
                 dynamic,
-                properties: _properties,
+                ..
             } => wgpu::BindingType::UniformBuffer {
                 dynamic: *dynamic,
                 min_binding_size: bind_type


### PR DESCRIPTION
`bevy_render::BindGroup::Uniform` originally looked like this:

```rust
pub enum BindType {
    Uniform {
        dynamic: bool,
        properties: Vec<UniformProperty>,
    },
    ...
}
```

It turns out that `properties` doesn't need to be a vector, a struct is already a valid variant of `UniformProperty`.

So, this pr renames it to `property` and makes it a single item.