### PR TITLE
Add Draw command to RenderCommand

### DIFF
--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -43,6 +43,10 @@ pub enum RenderCommand {
         base_vertex: i32,
         instances: Range<u32>,
     },
+    Draw {
+        vertices: Range<u32>,
+        instances: Range<u32>,
+    },
 }
 
 /// A component that indicates how to draw an entity.

--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -319,9 +319,7 @@ impl DrawState {
     }
 
     pub fn can_draw_indexed(&self) -> bool {
-        self.bind_groups.iter().all(|b| b.is_some())
-            && self.vertex_buffers.iter().all(|v| v.is_some())
-            && self.index_buffer.is_some()
+        self.can_draw() && self.index_buffer.is_some()
     }
 
     pub fn set_pipeline(

--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -245,6 +245,13 @@ impl<Q: HecsQuery + Send + Sync + 'static> Node for PassNode<Q> {
                                         log::info!("Could not draw indexed because the pipeline layout wasn't fully set for pipeline: {:?}", draw_state.pipeline);
                                     }
                                 }
+                                RenderCommand::Draw { vertices, instances } => {
+                                    if draw_state.can_draw() {
+                                        render_pass.draw(vertices.clone(), instances.clone());
+                                    } else {
+                                        log::info!("Could not draw because the pipeline layout wasn't fully set for pipeline: {:?}", draw_state.pipeline);
+                                    }
+                                }
                                 RenderCommand::SetVertexBuffer {
                                     buffer,
                                     offset,
@@ -304,6 +311,11 @@ impl DrawState {
 
     pub fn set_index_buffer(&mut self, buffer: BufferId) {
         self.index_buffer = Some(buffer);
+    }
+
+    pub fn can_draw(&self) -> bool {
+        self.bind_groups.iter().all(|b| b.is_some())
+            && self.vertex_buffers.iter().all(|v| v.is_some())
     }
 
     pub fn can_draw_indexed(&self) -> bool {


### PR DESCRIPTION
This adds a `Draw` to the `RenderCommands` enum. Pretty much the same as `DrawIndexed`, just a little different.

Apologies for all the PRs today. This is the end of my backlog 😁