### PR TITLE
Fix #134 . Missing current_item reset during reset_changed_item_counts.

### DIFF
--- a/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
@@ -90,6 +90,7 @@ where
         for buffer_status in self.uniform_arrays.iter_mut() {
             if let Some((_name, buffer_status)) = buffer_status {
                 buffer_status.changed_item_count = 0;
+                buffer_status.current_index = 0;
                 buffer_status.current_offset = 0;
                 buffer_status.changed_size = 0;
             }


### PR DESCRIPTION
Reset of the buffer was missing an attribute reset.

Locally unit tested with addition of a  despawn/spawn system in 2d/sprite.rs
Tested against my local code using bevy that was failing before.