### PR TITLE
Add support for 'or' in ECS querying

### DIFF
--- a/crates/bevy_ecs/hecs/src/lib.rs
+++ b/crates/bevy_ecs/hecs/src/lib.rs
@@ -81,7 +81,7 @@ pub use bundle::{Bundle, DynamicBundle, MissingComponent};
 pub use entities::{Entity, Location, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, EntityBuilder};
 pub use query::{
-    Access, Added, BatchedIter, Changed, Either, Mut, Mutated, Query, QueryBorrow, QueryIter, With,
+    Access, Added, BatchedIter, Changed, Mut, Mutated, Or, Query, QueryBorrow, QueryIter, With,
     Without,
 };
 pub use query_one::QueryOne;

--- a/crates/bevy_ecs/hecs/src/lib.rs
+++ b/crates/bevy_ecs/hecs/src/lib.rs
@@ -81,7 +81,8 @@ pub use bundle::{Bundle, DynamicBundle, MissingComponent};
 pub use entities::{Entity, Location, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, EntityBuilder};
 pub use query::{
-    Access, Added, BatchedIter, Changed, Mut, Mutated, Query, QueryBorrow, QueryIter, With, Without,
+    Access, Added, BatchedIter, Changed, Either, Mut, Mutated, Query, QueryBorrow, QueryIter, With,
+    Without,
 };
 pub use query_one::QueryOne;
 pub use world::{ArchetypesGeneration, Component, ComponentError, Iter, SpawnBatchIter, World};

--- a/crates/bevy_ecs/hecs/src/query.rs
+++ b/crates/bevy_ecs/hecs/src/query.rs
@@ -254,22 +254,22 @@ impl<'a, T: Component> Fetch<'a> for FetchMut<T> {
 ///     *b += 1;
 /// }
 /// let components = world
-///     .query::<Either<Mutated<bool>, Mutated<i32>>>()
+///     .query::<Or<Mutated<bool>, Mutated<i32>>>()
 ///     .iter()
 ///     .map(|(b, i)| (*b, *i))
 ///     .collect::<Vec<_>>();
 /// assert_eq!(components, &[(false, 457)]);
 /// ```
-pub struct Either<Q1, Q2>(PhantomData<(Q1, Q2)>);
+pub struct Or<Q1, Q2>(PhantomData<(Q1, Q2)>);
 
-impl<Q1: Query, Q2: Query> Query for Either<Q1, Q2> {
-    type Fetch = FetchEither<Q1::Fetch, Q2::Fetch>;
+impl<Q1: Query, Q2: Query> Query for Or<Q1, Q2> {
+    type Fetch = FetchOr<Q1::Fetch, Q2::Fetch>;
 }
 
 #[doc(hidden)]
-pub struct FetchEither<F1, F2>(F1, F2);
+pub struct FetchOr<F1, F2>(F1, F2);
 
-impl<'a, F1: Fetch<'a>, F2: Fetch<'a>> Fetch<'a> for FetchEither<F1, F2> {
+impl<'a, F1: Fetch<'a>, F2: Fetch<'a>> Fetch<'a> for FetchOr<F1, F2> {
     type Item = (F1::Item, F2::Item);
 
     fn access(archetype: &Archetype) -> Option<Access> {
@@ -1128,7 +1128,7 @@ mod tests {
     }
 
     #[test]
-    fn either_mutated_query() {
+    fn or_mutated_query() {
         let mut world = World::default();
         world.spawn((A(0), B(0)));
         let e2 = world.spawn((A(0), B(0)));
@@ -1139,7 +1139,7 @@ mod tests {
         }
 
         let a_b_changed = world
-            .query::<(Either<Mutated<A>, Mutated<B>>, Entity)>()
+            .query::<(Or<Mutated<A>, Mutated<B>>, Entity)>()
             .iter()
             .map(|((_a, _b), e)| e)
             .collect::<Vec<Entity>>();

--- a/crates/bevy_ecs/hecs/src/query.rs
+++ b/crates/bevy_ecs/hecs/src/query.rs
@@ -1130,11 +1130,17 @@ mod tests {
     #[test]
     fn or_mutated_query() {
         let mut world = World::default();
-        world.spawn((A(0), B(0)));
+        let e1 = world.spawn((A(0), B(0)));
         let e2 = world.spawn((A(0), B(0)));
-        world.spawn((A(0), B(0)));
+        let e3 = world.spawn((A(0), B(0)));
+        let _e4 = world.spawn((A(0), B(0)));
 
-        for mut b in world.query::<Mut<B>>().iter().skip(1).take(1) {
+        // Mutate A in entities e1 and e2
+        for mut a in world.query::<Mut<A>>().iter().take(2) {
+            a.0 += 1;
+        }
+        // Mutate B in entities e2 and e3
+        for mut b in world.query::<Mut<B>>().iter().skip(1).take(2) {
             b.0 += 1;
         }
 
@@ -1143,7 +1149,8 @@ mod tests {
             .iter()
             .map(|((_a, _b), e)| e)
             .collect::<Vec<Entity>>();
-        assert_eq!(a_b_changed, vec![e2]);
+        // e1 has mutated A, e3 has mutated B, e2 has mutated A and B, _e4 has no mutated component
+        assert_eq!(a_b_changed, vec![e1, e2, e3]);
     }
 
     #[test]

--- a/crates/bevy_ecs/hecs/src/query.rs
+++ b/crates/bevy_ecs/hecs/src/query.rs
@@ -1154,6 +1154,43 @@ mod tests {
     }
 
     #[test]
+    fn or_nested_query() {
+        let mut world = World::default();
+        let _e1 = world.spawn((A(0), B(0), C));
+        let e2 = world.spawn((A(0), B(0), C));
+        let _e3 = world.spawn((A(0), B(0), C));
+
+        for mut b in world.query::<Mut<B>>().iter().skip(1).take(1) {
+            b.0 += 1;
+        }
+
+        let a_b_changed = world
+            .query::<(Or<Or<Mutated<A>, Mutated<B>>, Mutated<C>>, Entity)>()
+            .iter()
+            .map(|(((_a, _b), _c), e)| e)
+            .collect::<Vec<Entity>>();
+        assert_eq!(a_b_changed, vec![e2]);
+        let a_b_changed = world
+            .query::<(Or<Mutated<C>, Or<Mutated<A>, Mutated<B>>>, Entity)>()
+            .iter()
+            .map(|((_c, (_a, _b)), e)| e)
+            .collect::<Vec<Entity>>();
+        assert_eq!(a_b_changed, vec![e2]);
+        let a_b_changed = world
+            .query::<(Or<Mutated<B>, Or<Mutated<A>, Mutated<C>>>, Entity)>()
+            .iter()
+            .map(|((_c, (_a, _b)), e)| e)
+            .collect::<Vec<Entity>>();
+        assert_eq!(a_b_changed, vec![e2]);
+        let a_b_changed = world
+            .query::<(Or<Or<Mutated<A>, Mutated<C>>, Mutated<B>>, Entity)>()
+            .iter()
+            .map(|(((_a, _b), _c), e)| e)
+            .collect::<Vec<Entity>>();
+        assert_eq!(a_b_changed, vec![e2]);
+    }
+
+    #[test]
     fn changed_query() {
         let mut world = World::default();
         let e1 = world.spawn((A(0), B(0)));

--- a/crates/bevy_ecs/hecs/src/query.rs
+++ b/crates/bevy_ecs/hecs/src/query.rs
@@ -240,6 +240,26 @@ impl<'a, T: Component> Fetch<'a> for FetchMut<T> {
     }
 }
 
+/// Query transformer performing a logical or on a pair of queries
+///
+/// Intended to be used on Mutated or Changed queries.
+///
+/// # Example
+/// ```
+/// # use bevy_hecs::*;
+/// let mut world = World::new();
+/// world.spawn((123, true));
+/// world.spawn((456, false));
+/// for mut b in world.query::<Mut<i32>>().iter().skip(1).take(1) {
+///     *b += 1;
+/// }
+/// let components = world
+///     .query::<Either<Mutated<bool>, Mutated<i32>>>()
+///     .iter()
+///     .map(|(b, i)| (*b, *i))
+///     .collect::<Vec<_>>();
+/// assert_eq!(components, &[(false, 457)]);
+/// ```
 pub struct Either<Q1, Q2>(PhantomData<(Q1, Q2)>);
 
 impl<Q1: Query, Q2: Query> Query for Either<Q1, Q2> {


### PR DESCRIPTION
Add Either query for a to do a logical or on a pair of Mutated or Changed queries (using should_skip method).

https://github.com/bevyengine/bevy/issues/162

One problem with this solution is that Query<Either<Mutated<A>, Mutated<B>>, C> yields a hierarchical tuple ((a,b), c) and not (a, b, c)