### PR TITLE
Added actual type to Property::set panic message & reduced impl_property_std size to 300 lines

### DIFF
--- a/crates/bevy_property/bevy_property_derive/src/lib.rs
+++ b/crates/bevy_property/bevy_property_derive/src/lib.rs
@@ -268,12 +268,12 @@ pub fn derive_property(input: TokenStream) -> TokenStream {
             }
 
             #[inline]
-            fn set(&mut self, value: &dyn #bevy_property_path::Property) {
-                let value = value.any();
+            fn set(&mut self, property: &dyn #bevy_property_path::Property) {
+                let value = property.any();
                 if let Some(prop) = value.downcast_ref::<Self>() {
                     *self = prop.clone();
                 } else {
-                    panic!("prop value is not {}", std::any::type_name::<Self>());
+                    panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
                 }
             }
 
@@ -400,12 +400,12 @@ pub fn impl_property(input: TokenStream) -> TokenStream {
             }
 
             #[inline]
-            fn set(&mut self, value: &dyn #bevy_property_path::Property) {
-                let value = value.any();
+            fn set(&mut self, property: &dyn #bevy_property_path::Property) {
+                let value = property.any();
                 if let Some(prop) = value.downcast_ref::<Self>() {
                     *self = prop.clone();
                 } else {
-                    panic!("prop value is not {}", std::any::type_name::<Self>());
+                    panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
                 }
             }
 

--- a/crates/bevy_property/src/impl_property/impl_property_std.rs
+++ b/crates/bevy_property/src/impl_property/impl_property_std.rs
@@ -139,12 +139,12 @@ impl Property for String {
         self.set(value);
     }
 
-    fn set(&mut self, value: &dyn Property) {
-        let value = value.any();
+    fn set(&mut self, property: &dyn Property) {
+        let value = property.any();
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = prop.clone();
         } else {
-            panic!("prop value is not {}", std::any::type_name::<Self>());
+            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
         }
     }
 
@@ -179,12 +179,12 @@ impl Property for bool {
         self.set(value);
     }
 
-    fn set(&mut self, value: &dyn Property) {
-        let value = value.any();
+    fn set(&mut self, property: &dyn Property) {
+        let value = property.any();
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = *prop;
         } else {
-            panic!("prop value is not {}", std::any::type_name::<Self>());
+            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
         }
     }
 
@@ -219,8 +219,8 @@ impl Property for usize {
         self.set(value);
     }
 
-    fn set(&mut self, value: &dyn Property) {
-        let value = value.any();
+    fn set(&mut self, property: &dyn Property) {
+        let value = property.any();
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = *prop;
         } else if let Some(prop) = value.downcast_ref::<u64>() {
@@ -242,7 +242,7 @@ impl Property for usize {
         } else if let Some(prop) = value.downcast_ref::<i8>() {
             *self = *prop as Self;
         } else {
-            panic!("prop value is not {}", std::any::type_name::<Self>());
+            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
         }
     }
 
@@ -277,8 +277,8 @@ impl Property for u64 {
         self.set(value);
     }
 
-    fn set(&mut self, value: &dyn Property) {
-        let value = value.any();
+    fn set(&mut self, property: &dyn Property) {
+        let value = property.any();
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = *prop;
         } else if let Some(prop) = value.downcast_ref::<usize>() {
@@ -300,7 +300,7 @@ impl Property for u64 {
         } else if let Some(prop) = value.downcast_ref::<i8>() {
             *self = *prop as Self;
         } else {
-            panic!("prop value is not {}", std::any::type_name::<Self>());
+            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
         }
     }
 
@@ -335,8 +335,8 @@ impl Property for u32 {
         self.set(value);
     }
 
-    fn set(&mut self, value: &dyn Property) {
-        let value = value.any();
+    fn set(&mut self, property: &dyn Property) {
+        let value = property.any();
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = *prop;
         } else if let Some(prop) = value.downcast_ref::<u64>() {
@@ -358,7 +358,7 @@ impl Property for u32 {
         } else if let Some(prop) = value.downcast_ref::<i8>() {
             *self = *prop as Self;
         } else {
-            panic!("prop value is not {}", std::any::type_name::<Self>());
+            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
         }
     }
 
@@ -393,8 +393,8 @@ impl Property for u16 {
         self.set(value);
     }
 
-    fn set(&mut self, value: &dyn Property) {
-        let value = value.any();
+    fn set(&mut self, property: &dyn Property) {
+        let value = property.any();
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = *prop;
         } else if let Some(prop) = value.downcast_ref::<u64>() {
@@ -416,7 +416,7 @@ impl Property for u16 {
         } else if let Some(prop) = value.downcast_ref::<i8>() {
             *self = *prop as Self;
         } else {
-            panic!("prop value is not {}", std::any::type_name::<Self>());
+            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
         }
     }
 
@@ -451,8 +451,8 @@ impl Property for u8 {
         self.set(value);
     }
 
-    fn set(&mut self, value: &dyn Property) {
-        let value = value.any();
+    fn set(&mut self, property: &dyn Property) {
+        let value = property.any();
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = *prop;
         } else if let Some(prop) = value.downcast_ref::<u64>() {
@@ -474,7 +474,7 @@ impl Property for u8 {
         } else if let Some(prop) = value.downcast_ref::<i8>() {
             *self = *prop as Self;
         } else {
-            panic!("prop value is not {}", std::any::type_name::<Self>());
+            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
         }
     }
 
@@ -509,8 +509,8 @@ impl Property for isize {
         self.set(value);
     }
 
-    fn set(&mut self, value: &dyn Property) {
-        let value = value.any();
+    fn set(&mut self, property: &dyn Property) {
+        let value = property.any();
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = *prop;
         } else if let Some(prop) = value.downcast_ref::<i64>() {
@@ -532,7 +532,7 @@ impl Property for isize {
         } else if let Some(prop) = value.downcast_ref::<u8>() {
             *self = *prop as Self;
         } else {
-            panic!("prop value is not {}", std::any::type_name::<Self>());
+            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
         }
     }
 
@@ -567,8 +567,8 @@ impl Property for i64 {
         self.set(value);
     }
 
-    fn set(&mut self, value: &dyn Property) {
-        let value = value.any();
+    fn set(&mut self, property: &dyn Property) {
+        let value = property.any();
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = *prop;
         } else if let Some(prop) = value.downcast_ref::<isize>() {
@@ -590,7 +590,7 @@ impl Property for i64 {
         } else if let Some(prop) = value.downcast_ref::<u8>() {
             *self = *prop as Self;
         } else {
-            panic!("prop value is not {}", std::any::type_name::<Self>());
+            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
         }
     }
 
@@ -625,8 +625,8 @@ impl Property for i32 {
         self.set(value);
     }
 
-    fn set(&mut self, value: &dyn Property) {
-        let value = value.any();
+    fn set(&mut self, property: &dyn Property) {
+        let value = property.any();
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = *prop;
         } else if let Some(prop) = value.downcast_ref::<i64>() {
@@ -648,7 +648,7 @@ impl Property for i32 {
         } else if let Some(prop) = value.downcast_ref::<u8>() {
             *self = *prop as Self;
         } else {
-            panic!("prop value is not {}", std::any::type_name::<Self>());
+            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
         }
     }
 
@@ -683,8 +683,8 @@ impl Property for i16 {
         self.set(value);
     }
 
-    fn set(&mut self, value: &dyn Property) {
-        let value = value.any();
+    fn set(&mut self, property: &dyn Property) {
+        let value = property.any();
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = *prop;
         } else if let Some(prop) = value.downcast_ref::<i64>() {
@@ -706,7 +706,7 @@ impl Property for i16 {
         } else if let Some(prop) = value.downcast_ref::<u8>() {
             *self = *prop as Self;
         } else {
-            panic!("prop value is not {}", std::any::type_name::<Self>());
+            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
         }
     }
 
@@ -741,8 +741,8 @@ impl Property for i8 {
         self.set(value);
     }
 
-    fn set(&mut self, value: &dyn Property) {
-        let value = value.any();
+    fn set(&mut self, property: &dyn Property) {
+        let value = property.any();
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = *prop;
         } else if let Some(prop) = value.downcast_ref::<i64>() {
@@ -764,7 +764,7 @@ impl Property for i8 {
         } else if let Some(prop) = value.downcast_ref::<u8>() {
             *self = *prop as Self;
         } else {
-            panic!("prop value is not {}", std::any::type_name::<Self>());
+            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
         }
     }
 
@@ -799,14 +799,14 @@ impl Property for f32 {
         self.set(value);
     }
 
-    fn set(&mut self, value: &dyn Property) {
-        let value = value.any();
+    fn set(&mut self, property: &dyn Property) {
+        let value = property.any();
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = *prop;
         } else if let Some(prop) = value.downcast_ref::<f64>() {
             *self = *prop as Self;
         } else {
-            panic!("prop value is not {}", std::any::type_name::<Self>());
+            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
         }
     }
 
@@ -841,14 +841,14 @@ impl Property for f64 {
         self.set(value);
     }
 
-    fn set(&mut self, value: &dyn Property) {
-        let value = value.any();
+    fn set(&mut self, property: &dyn Property) {
+        let value = property.any();
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = *prop;
         } else if let Some(prop) = value.downcast_ref::<f32>() {
             *self = *prop as Self;
         } else {
-            panic!("prop value is not {}", std::any::type_name::<Self>());
+            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
         }
     }
 

--- a/crates/bevy_property/src/impl_property/impl_property_std.rs
+++ b/crates/bevy_property/src/impl_property/impl_property_std.rs
@@ -193,666 +193,135 @@ impl Property for bool {
     }
 }
 
-impl Property for usize {
-    #[inline]
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    #[inline]
-    fn any(&self) -> &dyn Any {
-        self
-    }
-
-    #[inline]
-    fn any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    #[inline]
-    fn clone_prop(&self) -> Box<dyn Property> {
-        Box::new(self.clone())
-    }
-
-    #[inline]
-    fn apply(&mut self, value: &dyn Property) {
-        self.set(value);
-    }
-
-    fn set(&mut self, property: &dyn Property) {
-        let value = property.any();
-        if let Some(prop) = value.downcast_ref::<Self>() {
-            *self = *prop;
-        } else if let Some(prop) = value.downcast_ref::<u64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u8>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<isize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i8>() {
-            *self = *prop as Self;
+macro_rules! set_integer {
+    ($this:expr, $value:expr, $else_body:expr) => {{
+        if let Some(prop) = ($value).downcast_ref::<Self>() {
+            *($this) = *prop as Self;
+        } else if let Some(prop) = ($value).downcast_ref::<u64>() {
+            *($this) = *prop as Self;
+        } else if let Some(prop) = ($value).downcast_ref::<u32>() {
+            *($this) = *prop as Self;
+        } else if let Some(prop) = ($value).downcast_ref::<u16>() {
+            *($this) = *prop as Self;
+        } else if let Some(prop) = ($value).downcast_ref::<u8>() {
+            *($this) = *prop as Self;
+        } else if let Some(prop) = ($value).downcast_ref::<isize>() {
+            *($this) = *prop as Self;
+        } else if let Some(prop) = ($value).downcast_ref::<i64>() {
+            *($this) = *prop as Self;
+        } else if let Some(prop) = ($value).downcast_ref::<i32>() {
+            *($this) = *prop as Self;
+        } else if let Some(prop) = ($value).downcast_ref::<i16>() {
+            *($this) = *prop as Self;
+        } else if let Some(prop) = ($value).downcast_ref::<i8>() {
+            *($this) = *prop as Self;
         } else {
-            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
+            $else_body
         }
-    }
+    }};
+}
 
-    fn serializable<'a>(&'a self, _registry: &'a PropertyTypeRegistry) -> Serializable<'a> {
-        Serializable::Borrowed(self)
+macro_rules! integer_property {
+    ($integer_type:ty) => {
+        impl Property for $integer_type {
+            #[inline]
+            fn type_name(&self) -> &str {
+                std::any::type_name::<Self>()
+            }
+
+            #[inline]
+            fn any(&self) -> &dyn Any {
+                self
+            }
+
+            #[inline]
+            fn any_mut(&mut self) -> &mut dyn Any {
+                self
+            }
+
+            #[inline]
+            fn clone_prop(&self) -> Box<dyn Property> {
+                Box::new(self.clone())
+            }
+
+            #[inline]
+            fn apply(&mut self, value: &dyn Property) {
+                self.set(value);
+            }
+
+            fn set(&mut self, property: &dyn Property) {
+                let value = property.any();
+                set_integer!(self, value,
+                    panic!("prop value is not {}, but {}",
+                        std::any::type_name::<Self>(),
+                        property.type_name()
+                    )
+                );
+            }
+
+            fn serializable<'a>(&'a self, _registry: &'a PropertyTypeRegistry) -> Serializable<'a> {
+                Serializable::Borrowed(self)
+            }
+        }
+    };
+}
+
+macro_rules! float_property {
+    ($float_type:ty) => {
+        impl Property for $float_type {
+            #[inline]
+            fn type_name(&self) -> &str {
+                std::any::type_name::<Self>()
+            }
+
+            #[inline]
+            fn any(&self) -> &dyn Any {
+                self
+            }
+
+            #[inline]
+            fn any_mut(&mut self) -> &mut dyn Any {
+                self
+            }
+
+            #[inline]
+            fn clone_prop(&self) -> Box<dyn Property> {
+                Box::new(self.clone())
+            }
+
+            #[inline]
+            fn apply(&mut self, value: &dyn Property) {
+                self.set(value);
+            }
+
+            fn set(&mut self, property: &dyn Property) {
+                let value = property.any();
+                if let Some(prop) = value.downcast_ref::<Self>() {
+                    *self = *prop as Self;
+                } else if let Some(prop) = value.downcast_ref::<f64>() {
+                    *self = *prop as Self;
+                } else {
+                    panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
+                }
+            }
+
+            fn serializable<'a>(&'a self, _registry: &'a PropertyTypeRegistry) -> Serializable<'a> {
+                Serializable::Borrowed(self)
+            }
+        }
     }
 }
 
-impl Property for u64 {
-    #[inline]
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    #[inline]
-    fn any(&self) -> &dyn Any {
-        self
-    }
-
-    #[inline]
-    fn any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    #[inline]
-    fn clone_prop(&self) -> Box<dyn Property> {
-        Box::new(self.clone())
-    }
-
-    #[inline]
-    fn apply(&mut self, value: &dyn Property) {
-        self.set(value);
-    }
-
-    fn set(&mut self, property: &dyn Property) {
-        let value = property.any();
-        if let Some(prop) = value.downcast_ref::<Self>() {
-            *self = *prop;
-        } else if let Some(prop) = value.downcast_ref::<usize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u8>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<isize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i8>() {
-            *self = *prop as Self;
-        } else {
-            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
-        }
-    }
-
-    fn serializable<'a>(&'a self, _registry: &'a PropertyTypeRegistry) -> Serializable<'a> {
-        Serializable::Borrowed(self)
-    }
-}
-
-impl Property for u32 {
-    #[inline]
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    #[inline]
-    fn any(&self) -> &dyn Any {
-        self
-    }
-
-    #[inline]
-    fn any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    #[inline]
-    fn clone_prop(&self) -> Box<dyn Property> {
-        Box::new(self.clone())
-    }
-
-    #[inline]
-    fn apply(&mut self, value: &dyn Property) {
-        self.set(value);
-    }
-
-    fn set(&mut self, property: &dyn Property) {
-        let value = property.any();
-        if let Some(prop) = value.downcast_ref::<Self>() {
-            *self = *prop;
-        } else if let Some(prop) = value.downcast_ref::<u64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<usize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u8>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<isize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i8>() {
-            *self = *prop as Self;
-        } else {
-            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
-        }
-    }
-
-    fn serializable<'a>(&'a self, _registry: &'a PropertyTypeRegistry) -> Serializable<'a> {
-        Serializable::Borrowed(self)
-    }
-}
-
-impl Property for u16 {
-    #[inline]
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    #[inline]
-    fn any(&self) -> &dyn Any {
-        self
-    }
-
-    #[inline]
-    fn any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    #[inline]
-    fn clone_prop(&self) -> Box<dyn Property> {
-        Box::new(self.clone())
-    }
-
-    #[inline]
-    fn apply(&mut self, value: &dyn Property) {
-        self.set(value);
-    }
-
-    fn set(&mut self, property: &dyn Property) {
-        let value = property.any();
-        if let Some(prop) = value.downcast_ref::<Self>() {
-            *self = *prop;
-        } else if let Some(prop) = value.downcast_ref::<u64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<usize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u8>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<isize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i8>() {
-            *self = *prop as Self;
-        } else {
-            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
-        }
-    }
-
-    fn serializable<'a>(&'a self, _registry: &'a PropertyTypeRegistry) -> Serializable<'a> {
-        Serializable::Borrowed(self)
-    }
-}
-
-impl Property for u8 {
-    #[inline]
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    #[inline]
-    fn any(&self) -> &dyn Any {
-        self
-    }
-
-    #[inline]
-    fn any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    #[inline]
-    fn clone_prop(&self) -> Box<dyn Property> {
-        Box::new(self.clone())
-    }
-
-    #[inline]
-    fn apply(&mut self, value: &dyn Property) {
-        self.set(value);
-    }
-
-    fn set(&mut self, property: &dyn Property) {
-        let value = property.any();
-        if let Some(prop) = value.downcast_ref::<Self>() {
-            *self = *prop;
-        } else if let Some(prop) = value.downcast_ref::<u64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<usize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<isize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i8>() {
-            *self = *prop as Self;
-        } else {
-            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
-        }
-    }
-
-    fn serializable<'a>(&'a self, _registry: &'a PropertyTypeRegistry) -> Serializable<'a> {
-        Serializable::Borrowed(self)
-    }
-}
-
-impl Property for isize {
-    #[inline]
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    #[inline]
-    fn any(&self) -> &dyn Any {
-        self
-    }
-
-    #[inline]
-    fn any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    #[inline]
-    fn clone_prop(&self) -> Box<dyn Property> {
-        Box::new(self.clone())
-    }
-
-    #[inline]
-    fn apply(&mut self, value: &dyn Property) {
-        self.set(value);
-    }
-
-    fn set(&mut self, property: &dyn Property) {
-        let value = property.any();
-        if let Some(prop) = value.downcast_ref::<Self>() {
-            *self = *prop;
-        } else if let Some(prop) = value.downcast_ref::<i64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i8>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<usize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u8>() {
-            *self = *prop as Self;
-        } else {
-            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
-        }
-    }
-
-    fn serializable<'a>(&'a self, _registry: &'a PropertyTypeRegistry) -> Serializable<'a> {
-        Serializable::Borrowed(self)
-    }
-}
-
-impl Property for i64 {
-    #[inline]
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    #[inline]
-    fn any(&self) -> &dyn Any {
-        self
-    }
-
-    #[inline]
-    fn any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    #[inline]
-    fn clone_prop(&self) -> Box<dyn Property> {
-        Box::new(self.clone())
-    }
-
-    #[inline]
-    fn apply(&mut self, value: &dyn Property) {
-        self.set(value);
-    }
-
-    fn set(&mut self, property: &dyn Property) {
-        let value = property.any();
-        if let Some(prop) = value.downcast_ref::<Self>() {
-            *self = *prop;
-        } else if let Some(prop) = value.downcast_ref::<isize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i8>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<usize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u8>() {
-            *self = *prop as Self;
-        } else {
-            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
-        }
-    }
-
-    fn serializable<'a>(&'a self, _registry: &'a PropertyTypeRegistry) -> Serializable<'a> {
-        Serializable::Borrowed(self)
-    }
-}
-
-impl Property for i32 {
-    #[inline]
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    #[inline]
-    fn any(&self) -> &dyn Any {
-        self
-    }
-
-    #[inline]
-    fn any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    #[inline]
-    fn clone_prop(&self) -> Box<dyn Property> {
-        Box::new(self.clone())
-    }
-
-    #[inline]
-    fn apply(&mut self, value: &dyn Property) {
-        self.set(value);
-    }
-
-    fn set(&mut self, property: &dyn Property) {
-        let value = property.any();
-        if let Some(prop) = value.downcast_ref::<Self>() {
-            *self = *prop;
-        } else if let Some(prop) = value.downcast_ref::<i64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<isize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i8>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<usize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u8>() {
-            *self = *prop as Self;
-        } else {
-            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
-        }
-    }
-
-    fn serializable<'a>(&'a self, _registry: &'a PropertyTypeRegistry) -> Serializable<'a> {
-        Serializable::Borrowed(self)
-    }
-}
-
-impl Property for i16 {
-    #[inline]
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    #[inline]
-    fn any(&self) -> &dyn Any {
-        self
-    }
-
-    #[inline]
-    fn any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    #[inline]
-    fn clone_prop(&self) -> Box<dyn Property> {
-        Box::new(self.clone())
-    }
-
-    #[inline]
-    fn apply(&mut self, value: &dyn Property) {
-        self.set(value);
-    }
-
-    fn set(&mut self, property: &dyn Property) {
-        let value = property.any();
-        if let Some(prop) = value.downcast_ref::<Self>() {
-            *self = *prop;
-        } else if let Some(prop) = value.downcast_ref::<i64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<isize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i8>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<usize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u8>() {
-            *self = *prop as Self;
-        } else {
-            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
-        }
-    }
-
-    fn serializable<'a>(&'a self, _registry: &'a PropertyTypeRegistry) -> Serializable<'a> {
-        Serializable::Borrowed(self)
-    }
-}
-
-impl Property for i8 {
-    #[inline]
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    #[inline]
-    fn any(&self) -> &dyn Any {
-        self
-    }
-
-    #[inline]
-    fn any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    #[inline]
-    fn clone_prop(&self) -> Box<dyn Property> {
-        Box::new(self.clone())
-    }
-
-    #[inline]
-    fn apply(&mut self, value: &dyn Property) {
-        self.set(value);
-    }
-
-    fn set(&mut self, property: &dyn Property) {
-        let value = property.any();
-        if let Some(prop) = value.downcast_ref::<Self>() {
-            *self = *prop;
-        } else if let Some(prop) = value.downcast_ref::<i64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<i16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<isize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<usize>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u64>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u32>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u16>() {
-            *self = *prop as Self;
-        } else if let Some(prop) = value.downcast_ref::<u8>() {
-            *self = *prop as Self;
-        } else {
-            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
-        }
-    }
-
-    fn serializable<'a>(&'a self, _registry: &'a PropertyTypeRegistry) -> Serializable<'a> {
-        Serializable::Borrowed(self)
-    }
-}
-
-impl Property for f32 {
-    #[inline]
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    #[inline]
-    fn any(&self) -> &dyn Any {
-        self
-    }
-
-    #[inline]
-    fn any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    #[inline]
-    fn clone_prop(&self) -> Box<dyn Property> {
-        Box::new(self.clone())
-    }
-
-    #[inline]
-    fn apply(&mut self, value: &dyn Property) {
-        self.set(value);
-    }
-
-    fn set(&mut self, property: &dyn Property) {
-        let value = property.any();
-        if let Some(prop) = value.downcast_ref::<Self>() {
-            *self = *prop;
-        } else if let Some(prop) = value.downcast_ref::<f64>() {
-            *self = *prop as Self;
-        } else {
-            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
-        }
-    }
-
-    fn serializable<'a>(&'a self, _registry: &'a PropertyTypeRegistry) -> Serializable<'a> {
-        Serializable::Borrowed(self)
-    }
-}
-
-impl Property for f64 {
-    #[inline]
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    #[inline]
-    fn any(&self) -> &dyn Any {
-        self
-    }
-
-    #[inline]
-    fn any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    #[inline]
-    fn clone_prop(&self) -> Box<dyn Property> {
-        Box::new(self.clone())
-    }
-
-    #[inline]
-    fn apply(&mut self, value: &dyn Property) {
-        self.set(value);
-    }
-
-    fn set(&mut self, property: &dyn Property) {
-        let value = property.any();
-        if let Some(prop) = value.downcast_ref::<Self>() {
-            *self = *prop;
-        } else if let Some(prop) = value.downcast_ref::<f32>() {
-            *self = *prop as Self;
-        } else {
-            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
-        }
-    }
-
-    fn serializable<'a>(&'a self, _registry: &'a PropertyTypeRegistry) -> Serializable<'a> {
-        Serializable::Borrowed(self)
-    }
-}
+integer_property!(usize);
+integer_property!(isize);
+integer_property!(u8);
+integer_property!(u16);
+integer_property!(u32);
+integer_property!(u64);
+integer_property!(i8);
+integer_property!(i16);
+integer_property!(i32);
+integer_property!(i64);
+
+float_property!(f32);
+float_property!(f64);

--- a/crates/bevy_property/src/impl_property/impl_property_std.rs
+++ b/crates/bevy_property/src/impl_property/impl_property_std.rs
@@ -144,7 +144,11 @@ impl Property for String {
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = prop.clone();
         } else {
-            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
+            panic!(
+                "prop value is not {}, but {}",
+                std::any::type_name::<Self>(),
+                property.type_name()
+            );
         }
     }
 
@@ -184,7 +188,11 @@ impl Property for bool {
         if let Some(prop) = value.downcast_ref::<Self>() {
             *self = *prop;
         } else {
-            panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
+            panic!(
+                "prop value is not {}, but {}",
+                std::any::type_name::<Self>(),
+                property.type_name()
+            );
         }
     }
 
@@ -195,7 +203,7 @@ impl Property for bool {
 
 macro_rules! set_integer {
     ($this:expr, $value:expr, $else_body:expr) => {{
-        if let Some(prop) = ($value).downcast_ref::<Self>() {
+        if let Some(prop) = ($value).downcast_ref::<usize>() {
             *($this) = *prop as Self;
         } else if let Some(prop) = ($value).downcast_ref::<u64>() {
             *($this) = *prop as Self;
@@ -251,8 +259,11 @@ macro_rules! integer_property {
 
             fn set(&mut self, property: &dyn Property) {
                 let value = property.any();
-                set_integer!(self, value,
-                    panic!("prop value is not {}, but {}",
+                set_integer!(
+                    self,
+                    value,
+                    panic!(
+                        "prop value is not {}, but {}",
                         std::any::type_name::<Self>(),
                         property.type_name()
                     )
@@ -301,7 +312,11 @@ macro_rules! float_property {
                 } else if let Some(prop) = value.downcast_ref::<f64>() {
                     *self = *prop as Self;
                 } else {
-                    panic!("prop value is not {}, but {}", std::any::type_name::<Self>(), property.type_name());
+                    panic!(
+                        "prop value is not {}, but {}",
+                        std::any::type_name::<Self>(),
+                        property.type_name()
+                    );
                 }
             }
 
@@ -309,7 +324,7 @@ macro_rules! float_property {
                 Serializable::Borrowed(self)
             }
         }
-    }
+    };
 }
 
 integer_property!(usize);


### PR DESCRIPTION
The error now reads `prop value is not f32, but u64` instead of `prop value is not f32`.
I've also reduced the size of impl_property_std.rs by using the same impl for all integers and floats respectively via a macro, but I can undo that if you prefer the old way.
And lastly, is it intentional that integers cannot be assigned to floats? The integer assigns are also lossy, so it wouldn't really change semantics. If not, I'd add `set_integer!` to the float impl.