### PR TITLE
Allow calling winit with the 'run_return' variant of the run function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,10 @@ name = "plugin"
 path = "examples/app/plugin.rs"
 
 [[example]]
+name = "return_after_run"
+path = "examples/app/return_after_run.rs"
+
+[[example]]
 name = "thread_pool_resources"
 path = "examples/app/thread_pool_resources.rs"
 

--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -1,0 +1,15 @@
+/// A resource for configuring usage of the `rust_winit` library.
+#[derive(Default)]
+pub struct WinitConfig {
+    /// Configures the winit library to return control to the main thread after
+    /// the [run](bevy_app::App::run) loop is exited. Winit strongly recommends
+    /// avoiding this when possible. Before using this please read and understand
+    /// the [caveats](winit::platform::desktop::EventLoopExtDesktop::run_return)
+    /// in the winit documentation.
+    ///
+    /// This feature is only available on desktop `target_os` configurations.
+    /// Namely `windows`, `macos`, `linux`, `dragonfly`, `freebsd`, `netbsd`, and
+    /// `openbsd`. If set to true on an unsupported platform
+    /// [run](bevy_app::App::run) will panic.
+    pub return_from_run: bool,
+}

--- a/examples/app/return_after_run.rs
+++ b/examples/app/return_after_run.rs
@@ -1,0 +1,21 @@
+use bevy::{prelude::*, render::pass::ClearColor, winit::WinitConfig};
+
+fn main() {
+    println!("Running first App.");
+    App::build()
+        .add_resource(WinitConfig {
+            return_from_run: true,
+        })
+        .add_resource(ClearColor(Color::rgb(0.2, 0.2, 0.8)))
+        .add_default_plugins()
+        .run();
+    println!("Running another App.");
+    App::build()
+        .add_resource(WinitConfig {
+            return_from_run: true,
+        })
+        .add_resource(ClearColor(Color::rgb(0.2, 0.8, 0.2)))
+        .add_default_plugins()
+        .run();
+    println!("Done.");
+}


### PR DESCRIPTION
This adds a new WinitConfig resource that can be used to configure the behavior of winit.
When `return_from_run` is set to `true`, `App::run()` will return on `target_os` configurations that
support it. On non-desktop targets the `return_from_run` setting is ignored.

Closes bevyengine/bevy#167.