### PR TITLE
Fix in rendering resources node for despawning 

### DIFF
--- a/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
@@ -90,6 +90,8 @@ where
         for buffer_status in self.uniform_arrays.iter_mut() {
             if let Some((_name, buffer_status)) = buffer_status {
                 buffer_status.changed_item_count = 0;
+                buffer_status.current_index = 0;
+                buffer_status.indices.clear();
                 buffer_status.current_offset = 0;
                 buffer_status.changed_size = 0;
             }


### PR DESCRIPTION
This should fix both issue #134 and #135 .

This fix has the drawback to reset the stored indices each frame, so the get_or_assign_index function will always assign.
But the underlying issue is in the incoherency between the changed_item_count which evolves with new/dead/drawn/invisible rendering components, while the indices were created once and for all.

Impact on spawner.rs example seems in the 0.3%.

I have not added the changes to fix the rendering issue with Draw.is_visible=false, as I have already done a PR for that (#230)