### PR TITLE
Use raw-window-handle to tie wgpu with winit

### DIFF
--- a/crates/bevy_wgpu/src/wgpu_renderer.rs
+++ b/crates/bevy_wgpu/src/wgpu_renderer.rs
@@ -6,7 +6,7 @@ use bevy_render::{
     renderer::RenderResourceContext,
 };
 use bevy_window::{WindowCreated, WindowResized, Windows};
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 pub struct WgpuRenderer {
     pub instance: wgpu::Instance,
     pub device: Arc<wgpu::Device>,
@@ -70,13 +70,9 @@ impl WgpuRenderer {
             let window = windows
                 .get(window_created_event.id)
                 .expect("Received window created event for non-existent window");
-            #[cfg(feature = "bevy_winit")]
-            {
-                let winit_windows = resources.get::<bevy_winit::WinitWindows>().unwrap();
-                let winit_window = winit_windows.get_window(window.id).unwrap();
-                let surface = unsafe { self.instance.create_surface(winit_window.deref()) };
-                render_resource_context.set_window_surface(window.id, surface);
-            }
+
+            let surface = unsafe { self.instance.create_surface(window) };
+            render_resource_context.set_window_surface(window.id, surface);
         }
     }
 

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -17,3 +17,4 @@ bevy_math = { path = "../bevy_math", version = "0.1" }
 
 # other
 uuid = { version = "0.8", features = ["v4", "serde"] }
+raw-window-handle = "0.3"

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,4 +1,11 @@
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 use uuid::Uuid;
+
+#[derive(Debug)]
+pub struct BevyRawWindowHandle(pub RawWindowHandle);
+
+unsafe impl Send for BevyRawWindowHandle {}
+unsafe impl Sync for BevyRawWindowHandle {}
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct WindowId(Uuid);
@@ -40,6 +47,7 @@ pub struct Window {
     pub vsync: bool,
     pub resizable: bool,
     pub mode: WindowMode,
+    pub raw_window_handle: BevyRawWindowHandle,
 }
 
 /// Defines the way a window is displayed
@@ -55,9 +63,14 @@ pub enum WindowMode {
 }
 
 impl Window {
-    pub fn new(id: WindowId, window_descriptor: &WindowDescriptor) -> Self {
+    pub fn new(
+        id: WindowId,
+        raw_window_handle: BevyRawWindowHandle,
+        window_descriptor: &WindowDescriptor,
+    ) -> Self {
         Window {
             id,
+            raw_window_handle,
             height: window_descriptor.height,
             width: window_descriptor.width,
             title: window_descriptor.title.clone(),
@@ -65,6 +78,12 @@ impl Window {
             resizable: window_descriptor.resizable,
             mode: window_descriptor.mode,
         }
+    }
+}
+
+unsafe impl HasRawWindowHandle for Window {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        self.raw_window_handle.0
     }
 }
 

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -24,3 +24,5 @@ bevy_window = { path = "../bevy_window", version = "0.1" }
 # other
 winit = { version = "0.22.2", package = "cart-tmp-winit", default-features = false}
 log = { version = "0.4", features = ["release_max_level_info"] }
+raw-window-handle = "0.3"
+

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -12,7 +12,7 @@ use bevy_app::{prelude::*, AppExit};
 use bevy_ecs::Resources;
 use bevy_math::Vec2;
 use bevy_window::{
-    CreateWindow, CursorMoved, Window, WindowCloseRequested, WindowCreated, WindowResized, Windows,
+    CreateWindow, CursorMoved, WindowCloseRequested, WindowCreated, WindowResized, Windows,
 };
 use event::Event;
 use winit::{
@@ -231,8 +231,7 @@ fn handle_create_window_events(
     let create_window_events = resources.get::<Events<CreateWindow>>().unwrap();
     let mut window_created_events = resources.get_mut::<Events<WindowCreated>>().unwrap();
     for create_window_event in create_window_event_reader.iter(&create_window_events) {
-        let window = Window::new(create_window_event.id, &create_window_event.descriptor);
-        winit_windows.create_window(event_loop, &window);
+        let window = winit_windows.create_window(event_loop, &create_window_event);
         let window_id = window.id;
         windows.add(window);
         window_created_events.send(WindowCreated { id: window_id });


### PR DESCRIPTION
This makes it possible for other backends like SDL2 to be integrated. https://github.com/aclysma/prototype_bevy_sdl2 demonstrates this being used.

There is some unsafety in wrapping RawWIndowHandle in BevyRawWindowHandle to force it to be Send/Sync. The resources within the RawWindowHandle are raw FFI pointers. On one hand, since they're just pointers there's a good chance they are safe as long as they aren't in practice used from multiple threads - and it does work on macOS. On the other hand, I have not reviewed the API docs in detail for every platform RawWindowHandle is compatible with and those platforms might prohibit using those resources in certain ways from a different thread.

I'm creating this as a draft so that we can discuss if this is a possible approach, or if someone can come up with an alternative. For example, perhaps a handler could be made available to the windowing code so that the wire-up with the rendering API to create the surface can happen immediately in the windowing code.