### PR TITLE
Add TransformBuilder API

### DIFF
--- a/crates/bevy_transform/src/components/compose.rs
+++ b/crates/bevy_transform/src/components/compose.rs
@@ -1,16 +1,45 @@
 use crate::components::{NonUniformScale, Rotation, Scale, Transform, Translation};
 use bevy_math::{Mat4, Quat, Vec3};
 
-trait ComposableTransform {
+/// Allows for intuitive composition of tranform components.
+///
+/// Results are of the most specific possible type. For instance
+/// `rotation1.then_rotate(*rotation2)` returns another Rotation, but
+/// `rotation.then_translate(*translation)` returns a Transform.
+///
+/// ```
+/// # use bevy_transform::components::{NonUniformScale, ComposableTransform};
+/// # use bevy_math::{Mat4, Quat, Vec3};
+/// let comp = NonUniformScale::new(1.0, 2.0, 3.0)
+///     .then_scale(4.0)
+///     .then_rotate(Quat::from_rotation_ypr(5.0, 6.0, 7.0))
+///     .then_translate(Vec3::new(8.0, 9.0, 10.0));
+/// let expected = Mat4::from_scale_rotation_translation(
+///     Vec3::new(4.0, 8.0, 12.0),
+///     Quat::from_rotation_ypr(5.0, 6.0, 7.0),
+///     Vec3::new(8.0, 9.0, 10.0),
+/// );
+/// assert!(comp.value.abs_diff_eq(expected, 0.0001));
+/// ```
+pub trait ComposableTransform {
+    /// The resulting type when the current transform is composed with a NonUniformScale
     type WithNonUniformScale;
+    /// The resulting type when the current transform is composed with a Rotation
     type WithRotation;
+    /// The resulting type when the current transform is composed with a Scale
     type WithScale;
+    /// The resulting type when the current transform is composed with a Translation
     type WithTranslation;
 
+    /// Applies a general transform after the current transform
     fn then_transform(self, other: Mat4) -> Transform;
+    /// Applies a non uniform scale after the current transform
     fn then_non_uniform_scale(self, other: Vec3) -> Self::WithNonUniformScale;
+    /// Applies a rotation after the current transform
     fn then_rotate(self, other: Quat) -> Self::WithRotation;
+    /// Applies a uniform scale after the current transform
     fn then_scale(self, other: f32) -> Self::WithScale;
+    /// Applies a translation after the current transform
     fn then_translate(self, other: Vec3) -> Self::WithTranslation;
 }
 

--- a/crates/bevy_transform/src/components/compose.rs
+++ b/crates/bevy_transform/src/components/compose.rs
@@ -1,0 +1,318 @@
+use crate::components::{NonUniformScale, Rotation, Scale, Transform, Translation};
+use bevy_math::{Mat4, Quat, Vec3};
+
+trait ComposableTransform {
+    type WithNonUniformScale;
+    type WithRotation;
+    type WithScale;
+    type WithTranslation;
+
+    fn then_transform(self, other: Mat4) -> Transform;
+    fn then_non_uniform_scale(self, other: Vec3) -> Self::WithNonUniformScale;
+    fn then_rotate(self, other: Quat) -> Self::WithRotation;
+    fn then_scale(self, other: f32) -> Self::WithScale;
+    fn then_translate(self, other: Vec3) -> Self::WithTranslation;
+}
+
+impl ComposableTransform for Transform {
+    type WithNonUniformScale = Transform;
+    type WithRotation = Transform;
+    type WithScale = Transform;
+    type WithTranslation = Transform;
+
+    fn then_transform(self, other: Mat4) -> Transform {
+        Transform {
+            value: other * self.value,
+            sync: false,
+        }
+    }
+
+    fn then_non_uniform_scale(self, other: Vec3) -> Self::WithNonUniformScale {
+        Transform {
+            value: Mat4::from_scale(other) * self.value,
+            sync: false,
+        }
+    }
+
+    fn then_rotate(self, other: Quat) -> Self::WithRotation {
+        Transform {
+            value: Mat4::from_quat(other) * self.value,
+            sync: false,
+        }
+    }
+
+    fn then_scale(self, other: f32) -> Self::WithScale {
+        Transform {
+            value: Mat4::from_scale(Vec3::new(other, other, other)) * self.value,
+            sync: false,
+        }
+    }
+
+    fn then_translate(self, other: Vec3) -> Self::WithTranslation {
+        Transform {
+            value: Mat4::from_translation(other) * self.value,
+            sync: false,
+        }
+    }
+}
+
+impl ComposableTransform for NonUniformScale {
+    type WithNonUniformScale = NonUniformScale;
+    type WithRotation = Transform;
+    type WithScale = NonUniformScale;
+    type WithTranslation = Transform;
+
+    fn then_transform(self, other: Mat4) -> Transform {
+        Transform {
+            value: other * Mat4::from_scale(*self),
+            sync: false,
+        }
+    }
+
+    fn then_non_uniform_scale(self, other: Vec3) -> Self::WithNonUniformScale {
+        NonUniformScale(other * *self)
+    }
+
+    fn then_rotate(self, other: Quat) -> Self::WithRotation {
+        Transform {
+            value: Mat4::from_quat(other) * Mat4::from_scale(*self),
+            sync: false,
+        }
+    }
+
+    fn then_scale(self, other: f32) -> Self::WithScale {
+        NonUniformScale(other * *self)
+    }
+
+    fn then_translate(self, other: Vec3) -> Self::WithTranslation {
+        Transform {
+            value: Mat4::from_translation(other) * Mat4::from_scale(*self),
+            sync: false,
+        }
+    }
+}
+
+impl ComposableTransform for Rotation {
+    type WithNonUniformScale = Transform;
+    type WithRotation = Rotation;
+    type WithScale = Transform;
+    type WithTranslation = Transform;
+
+    fn then_transform(self, other: Mat4) -> Transform {
+        Transform {
+            value: other * Mat4::from_quat(*self),
+            sync: false,
+        }
+    }
+
+    fn then_non_uniform_scale(self, other: Vec3) -> Self::WithNonUniformScale {
+        Transform {
+            value: Mat4::from_scale(other) * Mat4::from_quat(*self),
+            sync: false,
+        }
+    }
+
+    fn then_rotate(self, other: Quat) -> Self::WithRotation {
+        Rotation(other * *self)
+    }
+
+    fn then_scale(self, other: f32) -> Self::WithScale {
+        Transform {
+            value: Mat4::from_scale(Vec3::new(other, other, other)) * Mat4::from_quat(*self),
+            sync: false,
+        }
+    }
+
+    fn then_translate(self, other: Vec3) -> Self::WithTranslation {
+        Transform {
+            value: Mat4::from_translation(other) * Mat4::from_quat(*self),
+            sync: false,
+        }
+    }
+}
+
+impl ComposableTransform for Scale {
+    type WithNonUniformScale = NonUniformScale;
+    type WithRotation = Transform;
+    type WithScale = Scale;
+    type WithTranslation = Transform;
+
+    fn then_transform(self, other: Mat4) -> Transform {
+        Transform {
+            value: other * Mat4::from_scale(Vec3::new(*self, *self, *self)),
+            sync: false,
+        }
+    }
+
+    fn then_non_uniform_scale(self, other: Vec3) -> Self::WithNonUniformScale {
+        NonUniformScale(other * *self)
+    }
+
+    fn then_rotate(self, other: Quat) -> Self::WithRotation {
+        Transform {
+            value: Mat4::from_quat(other) * Mat4::from_scale(Vec3::new(*self, *self, *self)),
+            sync: false,
+        }
+    }
+
+    fn then_scale(self, other: f32) -> Self::WithScale {
+        Scale(other * *self)
+    }
+
+    fn then_translate(self, other: Vec3) -> Self::WithTranslation {
+        Transform {
+            value: Mat4::from_translation(other) * Mat4::from_scale(Vec3::new(*self, *self, *self)),
+            sync: false,
+        }
+    }
+}
+
+impl ComposableTransform for Translation {
+    type WithNonUniformScale = Transform;
+    type WithRotation = Transform;
+    type WithScale = Transform;
+    type WithTranslation = Translation;
+
+    fn then_transform(self, other: Mat4) -> Transform {
+        Transform {
+            value: other * Mat4::from_translation(*self),
+            sync: false,
+        }
+    }
+
+    fn then_non_uniform_scale(self, other: Vec3) -> Self::WithNonUniformScale {
+        Transform {
+            value: Mat4::from_scale(other) * Mat4::from_translation(*self),
+            sync: false,
+        }
+    }
+
+    fn then_rotate(self, other: Quat) -> Self::WithRotation {
+        Transform {
+            value: Mat4::from_quat(other) * Mat4::from_translation(*self),
+            sync: false,
+        }
+    }
+
+    fn then_scale(self, other: f32) -> Self::WithScale {
+        Transform {
+            value: Mat4::from_scale(Vec3::new(other, other, other)) * Mat4::from_translation(*self),
+            sync: false,
+        }
+    }
+
+    fn then_translate(self, other: Vec3) -> Self::WithTranslation {
+        Translation(other + *self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f32::consts::PI;
+
+    #[test]
+    fn test_compose_transform() {
+        let comp = Transform::new(Mat4::from_rotation_x(PI / 3.0))
+            .then_transform(Mat4::from_translation(Vec3::new(1.0, 2.0, 3.0)));
+        let expected = Mat4::from_rotation_translation(
+            Quat::from_rotation_x(PI / 3.0),
+            Vec3::new(1.0, 2.0, 3.0),
+        );
+        assert!(
+            comp.value.abs_diff_eq(expected, 0.0001),
+            "{:?} != {:?}",
+            comp.value,
+            expected
+        );
+    }
+
+    #[test]
+    fn test_compose_non_uniform_scale() {
+        let comp =
+            NonUniformScale::new(1.0, 2.0, 3.0).then_non_uniform_scale(Vec3::new(4.0, 5.0, 6.0));
+        let expected = Vec3::new(4.0, 10.0, 18.0);
+        assert!(
+            comp.abs_diff_eq(expected, 0.0001),
+            "{:?} != {:?}",
+            *comp,
+            expected
+        );
+
+        let comp = NonUniformScale::new(1.0, 2.0, 3.0).then_scale(4.0);
+        let expected = Vec3::new(4.0, 8.0, 12.0);
+        assert!(
+            comp.abs_diff_eq(expected, 0.0001),
+            "{:?} != {:?}",
+            *comp,
+            expected
+        );
+    }
+
+    #[test]
+    fn test_compose_rotation() {
+        let comp =
+            Rotation(Quat::from_rotation_y(PI / 2.0)).then_rotate(Quat::from_rotation_x(PI / 2.0));
+        let expected = Quat::from_axis_angle(Vec3::new(1.0, 1.0, 1.0).normalize(), 2.0 * PI / 3.0);
+        assert!(
+            comp.abs_diff_eq(expected, 0.0001),
+            "{:?} != {:?}",
+            *comp,
+            expected
+        );
+
+        let comp = Rotation(Quat::from_rotation_z(PI / 4.0))
+            .then_rotate(Quat::from_rotation_x(PI / 3.0))
+            .then_rotate(Quat::from_rotation_y(PI / 2.0));
+        let expected = Quat::from_rotation_ypr(PI / 2.0, PI / 3.0, PI / 4.0);
+        assert!(
+            comp.abs_diff_eq(expected, 0.0001),
+            "{:?} != {:?}",
+            *comp,
+            expected
+        );
+    }
+
+    #[test]
+    fn test_compose_scale() {
+        let comp = Scale(2.0).then_scale(3.0);
+        let expected = 6.0;
+        assert!(
+            (*comp - expected).abs() < 0.0001,
+            "{:?} != {:?}",
+            *comp,
+            expected
+        );
+    }
+
+    #[test]
+    fn test_compose_translation() {
+        let comp = Translation::new(1.0, 2.0, 3.0).then_translate(Vec3::new(4.0, 5.0, 6.0));
+        let expected = Vec3::new(5.0, 7.0, 9.0);
+        assert!(
+            comp.abs_diff_eq(expected, 0.0001),
+            "{:?} != {:?}",
+            *comp,
+            expected
+        );
+    }
+
+    #[test]
+    fn test_compose_all() {
+        let comp = NonUniformScale::new(1.0, 2.0, 3.0)
+            .then_scale(4.0)
+            .then_rotate(Quat::from_rotation_ypr(5.0, 6.0, 7.0))
+            .then_translate(Vec3::new(8.0, 9.0, 10.0));
+        let expected = Mat4::from_scale_rotation_translation(
+            Vec3::new(4.0, 8.0, 12.0),
+            Quat::from_rotation_ypr(5.0, 6.0, 7.0),
+            Vec3::new(8.0, 9.0, 10.0),
+        );
+        assert!(
+            comp.value.abs_diff_eq(expected, 0.0001),
+            "{:?} != {:?}",
+            comp.value,
+            expected
+        );
+    }
+}

--- a/crates/bevy_transform/src/components/mod.rs
+++ b/crates/bevy_transform/src/components/mod.rs
@@ -1,4 +1,5 @@
 mod children;
+mod compose;
 mod local_transform;
 mod non_uniform_scale;
 mod parent;
@@ -8,6 +9,7 @@ mod transform;
 mod translation;
 
 pub use children::Children;
+pub use compose::*;
 pub use local_transform::*;
 pub use non_uniform_scale::*;
 pub use parent::{Parent, PreviousParent};


### PR DESCRIPTION
I've seen a few people confused about how to implement rotation and other transforms in the bevy discord help channel. I think something like the TransformBuilder in this PR might make working with transformations easier for some.

There are a couple parts of this API that I'm not fully happy with. For one thing, It's possible to loose information using some of the `build_*()` methods. For example `build_rotation()` discards any translation component of the transform. But I'm not sure what can be done about this short of making a new builder for each possible type of transform, which I think would make the API a lot more confusing.

For another thing, the builder isn't as computationally efficient as it could be. It converts all transformations to a Mat4 internally, then converts back to components during the build step.

For a third, this API doesn't do a whole lot to address people's trouble with quaternions. I think the API could be extended to help with some things, for example `then_look_at(point: &Vec3)`, but it's not clear if it could be extended to help with things like quaternion interpolation. Maybe it could use some methods like `then_rotate_toward(other: &Quat, percent: f32)` or `then_rotate_toward(other: &Quat, angle: f32)`.

Finally, I'm not sure an API like this is necessary or wanted, but I'm creating this PR to get feedback.