### PR TITLE
Add derives to mouse structs

### DIFF
--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{Local, Res, ResMut};
 use bevy_math::Vec2;
 
 /// A mouse button input event
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct MouseButtonInput {
     pub button: MouseButton,
     pub state: ElementState,
@@ -21,7 +21,7 @@ pub enum MouseButton {
 }
 
 /// A mouse motion event
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub struct MouseMotion {
     pub delta: Vec2,
 }
@@ -34,7 +34,7 @@ pub enum MouseScrollUnit {
 }
 
 /// A mouse scroll wheel event, where x represents horizontal scroll and y represents vertical scroll.
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub struct MouseWheel {
     pub unit: MouseScrollUnit,
     pub x: f32,

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -21,20 +21,20 @@ pub enum MouseButton {
 }
 
 /// A mouse motion event
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct MouseMotion {
     pub delta: Vec2,
 }
 
 /// Unit of scroll
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum MouseScrollUnit {
     Line,
     Pixel,
 }
 
 /// A mouse scroll wheel event, where x represents horizontal scroll and y represents vertical scroll.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct MouseWheel {
     pub unit: MouseScrollUnit,
     pub x: f32,

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{Local, Res, ResMut};
 use bevy_math::Vec2;
 
 /// A mouse button input event
-#[derive(Debug, Clone)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub struct MouseButtonInput {
     pub button: MouseButton,
     pub state: ElementState,
@@ -21,20 +21,20 @@ pub enum MouseButton {
 }
 
 /// A mouse motion event
-#[derive(Debug, Clone)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub struct MouseMotion {
     pub delta: Vec2,
 }
 
 /// Unit of scroll
-#[derive(Debug, Clone)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum MouseScrollUnit {
     Line,
     Pixel,
 }
 
 /// A mouse scroll wheel event, where x represents horizontal scroll and y represents vertical scroll.
-#[derive(Debug, Clone)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub struct MouseWheel {
     pub unit: MouseScrollUnit,
     pub x: f32,


### PR DESCRIPTION
This is a proposed fix for issue #269 
This adds Copy, as well as any other derives where possible. 