### PR TITLE
add bevymark benchmark example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,6 +267,10 @@ name = "shader_defs"
 path = "examples/shader/shader_defs.rs"
 
 [[example]]
+name = "bevymark"
+path = "examples/tools/bevymark.rs"
+
+[[example]]
 name = "button"
 path = "examples/ui/button.rs"
 

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -4,7 +4,7 @@ use bevy::{
 };
 
 const BIRDS_PER_SECOND: u32 = 1000;
-const GRAVITY: f32 = -9.8;
+const GRAVITY: f32 = -9.8 * 100.0;
 const MAX_VELOCITY: f32 = 750.;
 const BIRD_SCALE: f32 = 0.15;
 const HALF_BIRD_SIZE: f32 = 256. * BIRD_SCALE * 0.5;
@@ -16,20 +16,30 @@ struct Bird {
     velocity: Vec3,
 }
 
+struct BirdMaterial(Handle<ColorMaterial>);
+
+impl FromResources for BirdMaterial {
+    fn from_resources(resources: &Resources) -> Self {
+        let mut color_materials = resources.get_mut::<Assets<ColorMaterial>>().unwrap();
+        let asset_server = resources.get_mut::<AssetServer>().unwrap();
+        BirdMaterial(color_materials.add(asset_server.load("branding/icon.png").into()))
+    }
+}
+
 fn main() {
     App::build()
         .add_resource(WindowDescriptor {
             title: "BevyMark".to_string(),
-            width: 1000,
-            height: 800,
+            width: 800,
+            height: 600,
             vsync: true,
             resizable: false,
             ..Default::default()
         })
-        .add_default_plugins()
+        .add_plugins(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_resource(BevyCounter { count: 0 })
-        .add_resource(Option::<Handle<ColorMaterial>>::None)
+        .init_resource::<BirdMaterial>()
         .add_startup_system(setup.system())
         .add_system(mouse_handler.system())
         .add_system(movement_system.system())
@@ -38,31 +48,18 @@ fn main() {
         .run();
 }
 
-fn setup(
-    mut commands: Commands,
-    asset_server: Res<AssetServer>,
-    mut materials: ResMut<Assets<ColorMaterial>>,
-    mut out_material_handle: ResMut<Option<Handle<ColorMaterial>>>,
-) {
-    *out_material_handle = Some(
-        materials.add(
-            asset_server
-                .load("assets/branding/icon.png")
-                .unwrap()
-                .into(),
-        ),
-    );
-
+fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(Camera2dComponents::default())
         .spawn(UiCameraComponents::default())
         .spawn(TextComponents {
             text: Text {
-                font: asset_server.load("assets/fonts/FiraSans-Bold.ttf").unwrap(),
+                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 value: "Bird Count:".to_string(),
                 style: TextStyle {
                     color: Color::rgb(0.0, 1.0, 0.0),
                     font_size: 40.0,
+                    ..Default::default()
                 },
             },
             style: Style {
@@ -79,11 +76,11 @@ fn setup(
 }
 
 fn mouse_handler(
-    mut commands: Commands,
+    commands: &mut Commands,
     time: Res<Time>,
     mouse_button_input: Res<Input<MouseButton>>,
     window: Res<WindowDescriptor>,
-    material_handle: Res<Option<Handle<ColorMaterial>>>,
+    bird_material: Res<BirdMaterial>,
     mut counter: ResMut<BevyCounter>,
 ) {
     if mouse_button_input.pressed(MouseButton::Left) {
@@ -93,12 +90,13 @@ fn mouse_handler(
 
         for count in 0..spawn_count {
             let bird_position = Vec3::new(bird_x, bird_y, (counter.count + count) as f32 * 0.00001);
+            let mut transform = Transform::from_translation(bird_position);
+            transform.scale = Vec3::new(BIRD_SCALE, BIRD_SCALE, BIRD_SCALE);
 
             commands
                 .spawn(SpriteComponents {
-                    material: material_handle.unwrap(),
-                    translation: Translation(bird_position),
-                    scale: Scale(BIRD_SCALE),
+                    material: bird_material.0.clone(),
+                    transform,
                     draw: Draw {
                         is_transparent: true,
                         ..Default::default()
@@ -118,27 +116,23 @@ fn mouse_handler(
     }
 }
 
-fn movement_system(time: Res<Time>, mut bird_query: Query<(&mut Bird, &mut Translation)>) {
-    for (mut bird, mut translation) in &mut bird_query.iter() {
-        translation.0 += bird.velocity * time.delta_seconds;
-
-        let new_y = bird.velocity.y() + GRAVITY;
-        bird.velocity.set_y(new_y);
+fn movement_system(time: Res<Time>, mut bird_query: Query<(&mut Bird, &mut Transform)>) {
+    for (mut bird, mut transform) in bird_query.iter_mut() {
+        *transform.translation.x_mut() += bird.velocity.x() * time.delta_seconds;
+        *transform.translation.y_mut() += bird.velocity.y() * time.delta_seconds;
+        *bird.velocity.y_mut() += GRAVITY * time.delta_seconds;
     }
 }
 
-fn collision_system(
-    window: Res<WindowDescriptor>,
-    mut bird_query: Query<(&mut Bird, &Translation)>,
-) {
+fn collision_system(window: Res<WindowDescriptor>, mut bird_query: Query<(&mut Bird, &Transform)>) {
     let half_width = window.width as f32 * 0.5;
     let half_height = window.height as f32 * 0.5;
 
-    for (mut bird, translation) in &mut bird_query.iter() {
+    for (mut bird, transform) in bird_query.iter_mut() {
         let x_vel = bird.velocity.x();
         let y_vel = bird.velocity.y();
-        let x_pos = translation.x();
-        let y_pos = translation.y();
+        let x_pos = transform.translation.x();
+        let y_pos = transform.translation.y();
 
         if (x_vel > 0. && x_pos + HALF_BIRD_SIZE > half_width)
             || (x_vel <= 0. && x_pos - HALF_BIRD_SIZE < -(half_width))
@@ -156,18 +150,11 @@ fn counter_system(
     counter: Res<BevyCounter>,
     mut query: Query<&mut Text>,
 ) {
-    let mut fps_value = 0.;
-
     if let Some(fps) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
         if let Some(average) = fps.average() {
-            fps_value = average;
+            for mut text in query.iter_mut() {
+                text.value = format!("Bird Count: {}\nAverage FPS: {:.2}", counter.count, average);
+            }
         }
     };
-
-    for mut text in &mut query.iter() {
-        text.value = format!(
-            "Bird Count: {}\nAverage FPS: {:.2}",
-            counter.count, fps_value,
-        );
-    }
 }

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -30,7 +30,6 @@ fn main() {
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_resource(BevyCounter { count: 0 })
         .add_resource(Option::<Handle<ColorMaterial>>::None)
-        .add_resource(Option::<Vec2>::None)
         .add_startup_system(setup.system())
         .add_system(mouse_handler.system())
         .add_system(movement_system.system())

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -59,12 +59,10 @@ fn setup(
         .spawn(UiCameraComponents::default())
         .spawn(TextComponents {
             text: Text {
-                font: asset_server
-                    .load("assets/fonts/FiraMono-Medium.ttf")
-                    .unwrap(),
+                font: asset_server.load("assets/fonts/FiraSans-Bold.ttf").unwrap(),
                 value: "Bird Count:".to_string(),
                 style: TextStyle {
-                    color: Color::rgb(0.0, 0.9, 0.0),
+                    color: Color::rgb(0.0, 1.0, 0.0),
                     font_size: 40.0,
                 },
             },

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, PrintDiagnosticsPlugin},
+    diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin},
     prelude::*,
 };
 
@@ -28,7 +28,6 @@ fn main() {
         })
         .add_default_plugins()
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
-        .add_plugin(PrintDiagnosticsPlugin::default())
         .add_resource(BevyCounter { count: 0 })
         .add_resource(Option::<Handle<ColorMaterial>>::None)
         .add_resource(Option::<Vec2>::None)
@@ -155,8 +154,24 @@ fn collision_system(
     }
 }
 
-fn counter_system(counter: Res<BevyCounter>, mut query: Query<&mut Text>) {
+fn counter_system(
+    diagnostics: Res<Diagnostics>,
+    counter: Res<BevyCounter>,
+    mut query: Query<&mut Text>,
+) {
+    let mut fps_value = 0.;
+
+    if let Some(fps) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
+        if let Some(average) = fps.average() {
+            fps_value = average;
+        }
+    };
+
     for mut text in &mut query.iter() {
-        text.value = format!("Bird Count: {}", counter.count)
+        text.value = format!(
+            "Bird Count: {}\nAverage FPS: {:.2}",
+            counter.count,
+            fps_value,
+        );
     }
 }

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -1,0 +1,162 @@
+use bevy::{
+    diagnostic::{FrameTimeDiagnosticsPlugin, PrintDiagnosticsPlugin},
+    prelude::*,
+};
+
+const BIRDS_PER_SECOND: u32 = 1000;
+const GRAVITY: f32 = -9.8;
+const MAX_VELOCITY: f32 = 750.;
+const BIRD_SCALE: f32 = 0.15;
+const HALF_BIRD_SIZE: f32 = 256. * BIRD_SCALE * 0.5;
+struct BevyCounter {
+    pub count: u128,
+}
+
+struct Bird {
+    velocity: Vec3,
+}
+
+fn main() {
+    App::build()
+        .add_resource(WindowDescriptor {
+            title: "BevyMark".to_string(),
+            width: 1000,
+            height: 800,
+            vsync: true,
+            resizable: false,
+            ..Default::default()
+        })
+        .add_default_plugins()
+        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugin(PrintDiagnosticsPlugin::default())
+        .add_resource(BevyCounter { count: 0 })
+        .add_resource(Option::<Handle<ColorMaterial>>::None)
+        .add_resource(Option::<Vec2>::None)
+        .add_startup_system(setup.system())
+        .add_system(mouse_handler.system())
+        .add_system(movement_system.system())
+        .add_system(collision_system.system())
+        .add_system(counter_system.system())
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    mut out_material_handle: ResMut<Option<Handle<ColorMaterial>>>,
+) {
+    *out_material_handle = Some(
+        materials.add(
+            asset_server
+                .load("assets/branding/icon.png")
+                .unwrap()
+                .into(),
+        ),
+    );
+
+    commands
+        .spawn(Camera2dComponents::default())
+        .spawn(UiCameraComponents::default())
+        .spawn(TextComponents {
+            text: Text {
+                font: asset_server
+                    .load("assets/fonts/FiraMono-Medium.ttf")
+                    .unwrap(),
+                value: "Bird Count:".to_string(),
+                style: TextStyle {
+                    color: Color::rgb(0.0, 0.9, 0.0),
+                    font_size: 40.0,
+                },
+            },
+            style: Style {
+                position_type: PositionType::Absolute,
+                position: Rect {
+                    top: Val::Px(5.0),
+                    left: Val::Px(5.0),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+}
+
+fn mouse_handler(
+    mut commands: Commands,
+    time: Res<Time>,
+    mouse_button_input: Res<Input<MouseButton>>,
+    window: Res<WindowDescriptor>,
+    material_handle: Res<Option<Handle<ColorMaterial>>>,
+    mut counter: ResMut<BevyCounter>,
+) {
+    if mouse_button_input.pressed(MouseButton::Left) {
+        let spawn_count = (BIRDS_PER_SECOND as f32 * time.delta_seconds) as u128;
+        let bird_x = (window.width as i32 / -2) as f32 + HALF_BIRD_SIZE;
+        let bird_y = (window.height / 2) as f32 - HALF_BIRD_SIZE;
+
+        for count in 0..spawn_count {
+            let bird_position = Vec3::new(bird_x, bird_y, (counter.count + count) as f32 * 0.00001);
+
+            commands
+                .spawn(SpriteComponents {
+                    material: material_handle.unwrap(),
+                    translation: Translation(bird_position),
+                    scale: Scale(BIRD_SCALE),
+                    draw: Draw {
+                        is_transparent: true,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .with(Bird {
+                    velocity: Vec3::new(
+                        rand::random::<f32>() * MAX_VELOCITY - (MAX_VELOCITY * 0.5),
+                        0.,
+                        0.,
+                    ),
+                });
+        }
+
+        counter.count += spawn_count;
+    }
+}
+
+fn movement_system(time: Res<Time>, mut bird_query: Query<(&mut Bird, &mut Translation)>) {
+    for (mut bird, mut translation) in &mut bird_query.iter() {
+        translation.0 += bird.velocity * time.delta_seconds;
+
+        let new_y = bird.velocity.y() + GRAVITY;
+        bird.velocity.set_y(new_y);
+    }
+}
+
+fn collision_system(
+    window: Res<WindowDescriptor>,
+    mut bird_query: Query<(&mut Bird, &Translation)>,
+) {
+    let half_width = window.width as f32 * 0.5;
+    let half_height = window.height as f32 * 0.5;
+
+    for (mut bird, translation) in &mut bird_query.iter() {
+        let x_vel = bird.velocity.x();
+        let y_vel = bird.velocity.y();
+        let x_pos = translation.x();
+        let y_pos = translation.y();
+
+        if (x_vel > 0. && x_pos + HALF_BIRD_SIZE > half_width)
+            || (x_vel <= 0. && x_pos - HALF_BIRD_SIZE < -(half_width))
+        {
+            bird.velocity.set_x(-x_vel);
+        }
+        if y_vel < 0. && y_pos - HALF_BIRD_SIZE < -half_height {
+            bird.velocity.set_y(-y_vel);
+        }
+    }
+}
+
+fn counter_system(counter: Res<BevyCounter>, mut query: Query<&mut Text>) {
+    for mut text in &mut query.iter() {
+        text.value = format!("Bird Count: {}", counter.count)
+    }
+}

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -170,8 +170,7 @@ fn counter_system(
     for mut text in &mut query.iter() {
         text.value = format!(
             "Bird Count: {}\nAverage FPS: {:.2}",
-            counter.count,
-            fps_value,
+            counter.count, fps_value,
         );
     }
 }


### PR DESCRIPTION
Added a "bunnymark" example we can all use for testing performance as the engine progresses. Wasn't sure where to put this, so I just made a new folder called "Tools." Perhaps we can put future 3d benchmarks in there as well?

![bevymark](https://user-images.githubusercontent.com/7035551/90890740-8a007580-e3f5-11ea-8951-623a14b5449e.gif)

Run the example with `cargo run --release --example bevymark

Click in the screens pace to spawn some sprites.
Check the for FPS output.