### PR TITLE
Add serialize/deserialize to some input types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ flac = ["bevy_audio/flac"]
 wav = ["bevy_audio/wav"]
 vorbis = ["bevy_audio/vorbis"]
 
+serialize = ["bevy_input/serialize"]
+
 [workspace]
 members = [
     "crates/*",

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -9,7 +9,12 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT"
 keywords = ["bevy"]
 
+[features]
+default = []
+serialize = ["serde"]
+
 [dependencies]
 bevy_app = { path = "../bevy_app", version = "0.1" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.1" }
 bevy_math = { path = "../bevy_math", version = "0.1" }
+serde = { version = "1", features = ["derive"], optional = true }

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -56,6 +56,7 @@ pub fn keyboard_input_system(
 
 /// The key code of a keyboard input.
 #[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u32)]
 pub enum KeyCode {
     /// The '1' key over the letters.

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -13,6 +13,7 @@ pub struct MouseButtonInput {
 
 /// A button on a mouse device
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum MouseButton {
     Left,
     Right,


### PR DESCRIPTION
Adds derives for `Serialize` and `Deserialize` to `KeyCode` and `MouseButton`, configurable by the "serialization" feature.

Since bevy_ecs already depends on serde, it might be worth considering if a feature is really needed for this.

Addresses #174 