### PR TITLE
Re-export bevy_ecs and bevy_app from bevy_core

### DIFF
--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -24,4 +24,5 @@ pub mod prelude {
         plugin::Plugin,
         stage, DynamicPlugin,
     };
+    pub use bevy_ecs::prelude::*;
 }

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -15,7 +15,6 @@ pub use bevy_derive::DynamicPlugin;
 pub use event::*;
 pub use plugin::*;
 pub use schedule_runner::*;
-pub use bevy_ecs as ecs;
 
 pub mod prelude {
     pub use crate::{
@@ -24,6 +23,5 @@ pub mod prelude {
         event::{EventReader, Events},
         plugin::Plugin,
         stage, DynamicPlugin,
-        ecs::prelude::*,
     };
 }

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -15,6 +15,7 @@ pub use bevy_derive::DynamicPlugin;
 pub use event::*;
 pub use plugin::*;
 pub use schedule_runner::*;
+pub use bevy_ecs as ecs;
 
 pub mod prelude {
     pub use crate::{
@@ -23,6 +24,6 @@ pub mod prelude {
         event::{EventReader, Events},
         plugin::Plugin,
         stage, DynamicPlugin,
+        ecs::prelude::*,
     };
-    pub use bevy_ecs::prelude::*;
 }

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
 use bevy_math::{Mat3, Mat4, Quat, Vec2, Vec3};
 use bevy_type_registry::RegisterType;
 

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -3,17 +3,18 @@ mod float_ord;
 mod label;
 mod time;
 
+pub use bevy_app as app;
+pub use bevy_ecs as ecs;
 pub use bytes::*;
 pub use float_ord::*;
 pub use label::*;
 pub use time::*;
 
 pub mod prelude {
-    pub use crate::{EntityLabels, Labels, Time, Timer};
+    pub use crate::{app::prelude::*, ecs::prelude::*, EntityLabels, Labels, Time, Timer};
 }
 
-use bevy_app::prelude::*;
-use bevy_ecs::prelude::*;
+use crate::prelude::*;
 use bevy_math::{Mat3, Mat4, Quat, Vec2, Vec3};
 use bevy_type_registry::RegisterType;
 

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -13,7 +13,6 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
-use bevy_ecs::prelude::*;
 use bevy_math::{Mat3, Mat4, Quat, Vec2, Vec3};
 use bevy_type_registry::RegisterType;
 


### PR DESCRIPTION
It seems since in order to add any systems to an app, you will always need to depend on bevy_ecs anyway, it would make sense to re-export it directly from bevy_app for those not using the core crate. 

My first commit exported *just* the prelude from bevy_ecs, but the second one is patterned more like the way the umbrella crate re-exports its dependencies. The downside is that now any ecs items will be available at `bevy_ecs::*`, `bevy::ecs::*`, **and** `bevy_app::ecs::*`, so I left that as a separate commit in case you'd rather me revert it.