### PR TITLE
Fix formatting / clippy warnings

### DIFF
--- a/crates/bevy_pbr/src/render_graph/forward_pipeline/mod.rs
+++ b/crates/bevy_pbr/src/render_graph/forward_pipeline/mod.rs
@@ -3,7 +3,7 @@ use bevy_render::{
     pipeline::{
         BlendDescriptor, BlendFactor, BlendOperation, ColorStateDescriptor, ColorWrite,
         CompareFunction, CullMode, DepthStencilStateDescriptor, FrontFace, PipelineDescriptor,
-        RasterizationStateDescriptor, StencilStateFaceDescriptor, StencilStateDescriptor,
+        RasterizationStateDescriptor, StencilStateDescriptor, StencilStateFaceDescriptor,
     },
     shader::{Shader, ShaderStage, ShaderStages},
     texture::TextureFormat,

--- a/crates/bevy_render/src/pipeline/pipeline.rs
+++ b/crates/bevy_render/src/pipeline/pipeline.rs
@@ -4,7 +4,7 @@ use super::{
         CompareFunction, CullMode, DepthStencilStateDescriptor, FrontFace, IndexFormat,
         PrimitiveTopology, RasterizationStateDescriptor, StencilStateFaceDescriptor,
     },
-    BindType, DynamicBinding, PipelineLayout, VertexBufferDescriptors, StencilStateDescriptor,
+    BindType, DynamicBinding, PipelineLayout, StencilStateDescriptor, VertexBufferDescriptors,
 };
 use crate::{
     shader::{Shader, ShaderStages},

--- a/crates/bevy_render/src/renderer/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/renderer/render_resource/bind_group.rs
@@ -46,8 +46,10 @@ impl BindGroupBuilder {
         }
 
         binding.hash(&mut self.hasher);
-        self.indexed_bindings
-            .push(IndexedBindGroupEntry { index, entry: binding });
+        self.indexed_bindings.push(IndexedBindGroupEntry {
+            index,
+            entry: binding,
+        });
         self
     }
 

--- a/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
+++ b/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
@@ -16,7 +16,7 @@ use bevy_render::{
     texture::{Extent3d, SamplerDescriptor, TextureDescriptor},
 };
 use bevy_window::{Window, WindowId};
-use std::{ops::Range, sync::Arc, borrow::Cow};
+use std::{borrow::Cow, ops::Range, sync::Arc};
 use wgpu::util::DeviceExt;
 
 #[derive(Clone)]

--- a/crates/bevy_wgpu/src/wgpu_type_converter.rs
+++ b/crates/bevy_wgpu/src/wgpu_type_converter.rs
@@ -5,8 +5,8 @@ use bevy_render::{
         BindType, BlendDescriptor, BlendFactor, BlendOperation, ColorStateDescriptor, ColorWrite,
         CompareFunction, CullMode, DepthStencilStateDescriptor, FrontFace, IndexFormat,
         InputStepMode, PrimitiveTopology, RasterizationStateDescriptor, StencilOperation,
-        StencilStateFaceDescriptor, VertexAttributeDescriptor, VertexBufferDescriptor,
-        VertexFormat, StencilStateDescriptor,
+        StencilStateDescriptor, StencilStateFaceDescriptor, VertexAttributeDescriptor,
+        VertexBufferDescriptor, VertexFormat,
     },
     renderer::BufferUsage,
     texture::{
@@ -535,7 +535,6 @@ impl WgpuFrom<SamplerDescriptor> for wgpu::SamplerDescriptor<'_> {
             lod_max_clamp: sampler_descriptor.lod_max_clamp,
             compare: sampler_descriptor.compare_function.map(|c| c.wgpu_into()),
             anisotropy_clamp: sampler_descriptor.anisotropy_clamp,
-            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
Some improperly formatted code was pushed on master, thus the CI fails on pull requests.