### PR TITLE
Add write_buffer to the rendering abstraction.

### DIFF
--- a/crates/bevy_pbr/src/render_graph/lights_node.rs
+++ b/crates/bevy_pbr/src/render_graph/lights_node.rs
@@ -12,6 +12,7 @@ use bevy_render::{
     },
 };
 use bevy_transform::prelude::*;
+use std::mem;
 
 /// A Render Graph [Node] that write light data from the ECS to GPU buffers
 #[derive(Default)]
@@ -45,10 +46,78 @@ impl Node for LightsNode {
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct LightCount {
-    pub num_lights: [u32; 4],
+    count: u32,
+    _padding: [u32; 3],
+}
+
+impl LightCount {
+    fn new(count: u32) -> Self {
+        Self {
+            count,
+            _padding: [0; 3],
+        }
+    }
 }
 
 unsafe impl Byteable for LightCount {}
+
+#[repr(C)]
+struct LightNodeRaw<L: ?Sized = [LightRaw]> {
+    count: LightCount,
+    lights: L,
+}
+
+impl LightNodeRaw {
+    fn create(max_lights: usize) -> Box<Self> {
+        use std::alloc::{alloc_zeroed, Layout};
+
+        // SAFETY: This should work, I asked on the rust discord and they didn't
+        // immediately kill me.
+        // Could depend on https://docs.rs/slice-dst/ instead.
+        unsafe {
+            #[repr(C)]
+            struct Repr {
+                ptr: *const u8,
+                size: usize,
+            }
+
+            let layout = Layout::from_size_align(
+                std::mem::size_of::<LightCount>() + std::mem::size_of::<LightRaw>() * max_lights,
+                mem::align_of::<LightNodeRaw<[LightRaw; 0]>>(),
+            ).unwrap();
+
+            let ptr = alloc_zeroed(layout);
+            assert!(!ptr.is_null());
+
+            Box::from_raw(mem::transmute(Repr {
+                ptr,
+                size: max_lights,
+            }))
+        }
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        unsafe {
+            std::slice::from_raw_parts(
+                &self.count as *const LightCount as *const u8,
+                std::mem::size_of::<LightCount>() + std::mem::size_of::<LightRaw>() * self.lights.len(),
+            )
+        }
+    }
+}
+
+#[test]
+fn test_create_light_node_raw() {
+    let raw = LightNodeRaw::create(2);
+
+    drop(raw);
+}
+
+impl Default for Box<LightNodeRaw> {
+    fn default() -> Self {
+        LightNodeRaw::create(0)
+    }
+}
 
 impl SystemNode for LightsNode {
     fn get_system(&self, commands: &mut Commands) -> Box<dyn System> {
@@ -56,10 +125,9 @@ impl SystemNode for LightsNode {
         commands.insert_local_resource(
             system.id(),
             LightsNodeSystemState {
-                command_queue: self.command_queue.clone(),
                 max_lights: self.max_lights,
                 light_buffer: None,
-                staging_buffer: None,
+                raw: LightNodeRaw::create(self.max_lights),
             },
         );
         system
@@ -70,86 +138,52 @@ impl SystemNode for LightsNode {
 #[derive(Default)]
 pub struct LightsNodeSystemState {
     light_buffer: Option<BufferId>,
-    staging_buffer: Option<BufferId>,
-    command_queue: CommandQueue,
     max_lights: usize,
+    raw: Box<LightNodeRaw>,
 }
 
 pub fn lights_node_system(
     mut state: Local<LightsNodeSystemState>,
     render_resource_context: Res<Box<dyn RenderResourceContext>>,
     // TODO: this write on RenderResourceBindings will prevent this system from running in parallel with other systems that do the same
+    //
+    // If the `light_buffer` could be created when creating this system, this
+    // wouldn't need to be here.
     mut render_resource_bindings: ResMut<RenderResourceBindings>,
+    // PERF: Use `Either` + `Changed` (+ `Removed`?) queries.
     mut query: Query<(&Light, &Transform, &Translation)>,
 ) {
-    let state = &mut state;
-    let render_resource_context = &**render_resource_context;
+    let max_lights = state.max_lights;
 
-    let light_count = query.iter().iter().count();
-    let size = std::mem::size_of::<LightRaw>();
-    let light_count_size = std::mem::size_of::<LightCount>();
-    let light_array_size = size * light_count;
-    let light_array_max_size = size * state.max_lights;
-    let current_light_uniform_size = light_count_size + light_array_size;
-    let max_light_uniform_size = light_count_size + light_array_max_size;
-
-    if let Some(staging_buffer) = state.staging_buffer {
-        if light_count == 0 {
-            return;
-        }
-
-        render_resource_context.map_buffer(staging_buffer);
-    } else {
+    let camera_buffer = *state.light_buffer.get_or_insert_with(|| {
+        let size = std::mem::size_of::<LightCount>() + std::mem::size_of::<LightRaw>() * max_lights;
         let buffer = render_resource_context.create_buffer(BufferInfo {
-            size: max_light_uniform_size,
-            buffer_usage: BufferUsage::UNIFORM | BufferUsage::COPY_SRC | BufferUsage::COPY_DST,
-            ..Default::default()
+            size,
+            buffer_usage: BufferUsage::UNIFORM | BufferUsage::COPY_DST,
+            mapped_at_creation: false,
         });
         render_resource_bindings.set(
             uniform::LIGHTS,
             RenderResourceBinding::Buffer {
                 buffer,
-                range: 0..max_light_uniform_size as u64,
+                range: 0..size as u64,
                 dynamic_index: None,
             },
         );
-        state.light_buffer = Some(buffer);
+        buffer
+    });
 
-        let staging_buffer = render_resource_context.create_buffer(BufferInfo {
-            size: max_light_uniform_size,
-            buffer_usage: BufferUsage::COPY_SRC | BufferUsage::MAP_WRITE,
-            mapped_at_creation: true,
-        });
-        state.staging_buffer = Some(staging_buffer);
+    let mut count = 0;
+    for ((light, transform, translation), light_raw) in query
+        .iter()
+        .iter()
+        .zip(state.raw.lights.iter_mut())
+    {
+        count += 1;
+        *light_raw = LightRaw::from(&light, &transform.value, &translation);
     }
 
-    let staging_buffer = state.staging_buffer.unwrap();
-    render_resource_context.write_mapped_buffer(
-        staging_buffer,
-        0..current_light_uniform_size as u64,
-        &mut |data, _renderer| {
-            // light count
-            data[0..light_count_size].copy_from_slice([light_count as u32, 0, 0, 0].as_bytes());
+    state.raw.count = LightCount::new(count);
 
-            // light array
-            for ((light, transform, translation), slot) in query
-                .iter()
-                .iter()
-                .zip(data[light_count_size..current_light_uniform_size].chunks_exact_mut(size))
-            {
-                slot.copy_from_slice(
-                    LightRaw::from(&light, &transform.value, &translation).as_bytes(),
-                );
-            }
-        },
-    );
-    render_resource_context.unmap_buffer(staging_buffer);
-    let light_buffer = state.light_buffer.unwrap();
-    state.command_queue.copy_buffer_to_buffer(
-        staging_buffer,
-        0,
-        light_buffer,
-        0,
-        max_light_uniform_size as u64,
-    );
+    render_resource_context.write_buffer(camera_buffer, 0, state.raw.as_bytes());
 }

--- a/crates/bevy_pbr/src/render_graph/lights_node.rs
+++ b/crates/bevy_pbr/src/render_graph/lights_node.rs
@@ -2,7 +2,7 @@ use crate::{
     light::{Light, LightRaw},
     render_graph::uniform,
 };
-use bevy_core::{AsBytes, Byteable};
+use bevy_core::Byteable;
 use bevy_ecs::{Commands, IntoQuerySystem, Local, Query, Res, ResMut, Resources, System, World};
 use bevy_render::{
     render_graph::{CommandQueue, Node, ResourceSlots, SystemNode},
@@ -84,7 +84,8 @@ impl LightNodeRaw {
             let layout = Layout::from_size_align(
                 std::mem::size_of::<LightCount>() + std::mem::size_of::<LightRaw>() * max_lights,
                 mem::align_of::<LightNodeRaw<[LightRaw; 0]>>(),
-            ).unwrap();
+            )
+            .unwrap();
 
             let ptr = alloc_zeroed(layout);
             assert!(!ptr.is_null());
@@ -100,7 +101,8 @@ impl LightNodeRaw {
         unsafe {
             std::slice::from_raw_parts(
                 &self.count as *const LightCount as *const u8,
-                std::mem::size_of::<LightCount>() + std::mem::size_of::<LightRaw>() * self.lights.len(),
+                std::mem::size_of::<LightCount>()
+                    + std::mem::size_of::<LightRaw>() * self.lights.len(),
             )
         }
     }
@@ -174,10 +176,8 @@ pub fn lights_node_system(
     });
 
     let mut count = 0;
-    for ((light, transform, translation), light_raw) in query
-        .iter()
-        .iter()
-        .zip(state.raw.lights.iter_mut())
+    for ((light, transform, translation), light_raw) in
+        query.iter().iter().zip(state.raw.lights.iter_mut())
     {
         count += 1;
         *light_raw = LightRaw::from(&light, &transform.value, &translation);

--- a/crates/bevy_pbr/src/render_graph/lights_node.rs
+++ b/crates/bevy_pbr/src/render_graph/lights_node.rs
@@ -157,7 +157,7 @@ pub fn lights_node_system(
 ) {
     let max_lights = state.max_lights;
 
-    let camera_buffer = *state.light_buffer.get_or_insert_with(|| {
+    let light_buffer = *state.light_buffer.get_or_insert_with(|| {
         let size = std::mem::size_of::<LightCount>() + std::mem::size_of::<LightRaw>() * max_lights;
         let buffer = render_resource_context.create_buffer(BufferInfo {
             size,
@@ -185,5 +185,5 @@ pub fn lights_node_system(
 
     state.raw.count = LightCount::new(count);
 
-    render_resource_context.write_buffer(camera_buffer, 0, state.raw.as_bytes());
+    render_resource_context.write_buffer(light_buffer, 0, state.raw.as_bytes());
 }

--- a/crates/bevy_render/src/render_graph/nodes/camera_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/camera_node.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use bevy_core::AsBytes;
 
-use bevy_ecs::{Commands, IntoQuerySystem, Local, Query, Res, ResMut, Resources, System, World, Mutated};
+use bevy_ecs::{Commands, IntoQuerySystem, Local, Query, Res, ResMut, Resources, System, World};
 use bevy_transform::prelude::*;
 use std::borrow::Cow;
 
@@ -75,7 +75,7 @@ pub fn camera_node_system(
     // PERF: Once `Either` queries are merged (#218), this should be changed
     // to: Query<Either<Mutated<Camera>, Mutated<Transform>>>
     //
-    // However, since `<gpu>.write_buffer` is much faster than `<gpu>.map_buffer + <gpu>.write_mapped_buffer`,
+    // However, since `<gpu>.write_buffer` is much faster than `<gpu>.map_buffer` + `<gpu>.write_mapped_buffer`,
     // we're still better of than before.
     query: Query<(&Camera, &Transform)>,
 ) {

--- a/crates/bevy_render/src/renderer/headless_render_resource_context.rs
+++ b/crates/bevy_render/src/renderer/headless_render_resource_context.rs
@@ -69,6 +69,8 @@ impl RenderResourceContext for HeadlessRenderResourceContext {
 
     fn unmap_buffer(&self, _id: BufferId) {}
 
+    fn write_buffer(&self, _id: BufferId, _offset: u64, _data: &[u8]) {}
+
     fn create_buffer_with_data(&self, buffer_info: BufferInfo, _data: &[u8]) -> BufferId {
         let buffer = BufferId::new();
         self.add_buffer_info(buffer, buffer_info);

--- a/crates/bevy_render/src/renderer/render_resource_context.rs
+++ b/crates/bevy_render/src/renderer/render_resource_context.rs
@@ -17,6 +17,7 @@ pub trait RenderResourceContext: Downcast + Send + Sync + 'static {
     fn create_sampler(&self, sampler_descriptor: &SamplerDescriptor) -> SamplerId;
     fn create_texture(&self, texture_descriptor: TextureDescriptor) -> TextureId;
     fn create_buffer(&self, buffer_info: BufferInfo) -> BufferId;
+    fn write_buffer(&self, id: BufferId, offset: u64, data: &[u8]);
     // TODO: remove RenderResourceContext here
     fn write_mapped_buffer(
         &self,

--- a/crates/bevy_wgpu/src/lib.rs
+++ b/crates/bevy_wgpu/src/lib.rs
@@ -33,7 +33,8 @@ impl Plugin for WgpuPlugin {
 
 pub fn wgpu_render_system(resources: &mut Resources) -> impl FnMut(&mut World, &mut Resources) {
     let mut wgpu_renderer = pollster::block_on(WgpuRenderer::new());
-    let resource_context = WgpuRenderResourceContext::new(wgpu_renderer.device.clone());
+    let resource_context =
+        WgpuRenderResourceContext::new(wgpu_renderer.device.clone(), wgpu_renderer.queue.clone());
     resources.insert::<Box<dyn RenderResourceContext>>(Box::new(resource_context.clone()));
     resources.insert(SharedBuffers::new(Box::new(resource_context)));
     move |world, resources| {

--- a/crates/bevy_wgpu/src/renderer/wgpu_render_graph_executor.rs
+++ b/crates/bevy_wgpu/src/renderer/wgpu_render_graph_executor.rs
@@ -17,7 +17,7 @@ impl WgpuRenderGraphExecutor {
         world: &World,
         resources: &Resources,
         device: Arc<wgpu::Device>,
-        queue: &mut wgpu::Queue,
+        queue: &wgpu::Queue,
         stages: &mut [StageBorrow],
     ) {
         let mut render_resource_context = resources

--- a/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
+++ b/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
@@ -22,13 +22,15 @@ use wgpu::util::DeviceExt;
 #[derive(Clone)]
 pub struct WgpuRenderResourceContext {
     pub device: Arc<wgpu::Device>,
+    pub queue: Arc<wgpu::Queue>,
     pub resources: WgpuResources,
 }
 
 impl WgpuRenderResourceContext {
-    pub fn new(device: Arc<wgpu::Device>) -> Self {
+    pub fn new(device: Arc<wgpu::Device>, queue: Arc<wgpu::Queue>) -> Self {
         WgpuRenderResourceContext {
             device,
+            queue,
             resources: WgpuResources::default(),
         }
     }
@@ -548,5 +550,11 @@ impl RenderResourceContext for WgpuRenderResourceContext {
         let buffers = self.resources.buffers.read();
         let buffer = buffers.get(&id).unwrap();
         buffer.unmap();
+    }
+
+    fn write_buffer(&self, id: BufferId, offset: u64, data: &[u8]) {
+        let buffers = self.resources.buffers.read();
+        let buffer = buffers.get(&id).unwrap();
+        self.queue.write_buffer(buffer, offset, data);
     }
 }

--- a/crates/bevy_wgpu/src/wgpu_renderer.rs
+++ b/crates/bevy_wgpu/src/wgpu_renderer.rs
@@ -10,7 +10,7 @@ use std::{ops::Deref, sync::Arc};
 pub struct WgpuRenderer {
     pub instance: wgpu::Instance,
     pub device: Arc<wgpu::Device>,
-    pub queue: wgpu::Queue,
+    pub queue: Arc<wgpu::Queue>,
     pub window_resized_event_reader: EventReader<WindowResized>,
     pub window_created_event_reader: EventReader<WindowCreated>,
     pub intialized: bool,
@@ -44,6 +44,7 @@ impl WgpuRenderer {
             .await
             .unwrap();
         let device = Arc::new(device);
+        let queue = Arc::new(queue);
         WgpuRenderer {
             instance,
             device,

--- a/crates/bevy_wgpu/src/wgpu_renderer.rs
+++ b/crates/bevy_wgpu/src/wgpu_renderer.rs
@@ -96,7 +96,7 @@ impl WgpuRenderer {
             world,
             resources,
             self.device.clone(),
-            &mut self.queue,
+            &self.queue,
             &mut borrowed,
         );
     }

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -1,9 +1,13 @@
 use bevy::prelude::*;
+use bevy::diagnostic::{FrameTimeDiagnosticsPlugin, PrintDiagnosticsPlugin};
+
 
 fn main() {
     App::build()
         .add_resource(Msaa { samples: 4 })
         .add_default_plugins()
+        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugin(PrintDiagnosticsPlugin::default())
         .add_startup_system(setup.system())
         .run();
 }

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -1,6 +1,7 @@
-use bevy::prelude::*;
-use bevy::diagnostic::{FrameTimeDiagnosticsPlugin, PrintDiagnosticsPlugin};
-
+use bevy::{
+    diagnostic::{FrameTimeDiagnosticsPlugin, PrintDiagnosticsPlugin},
+    prelude::*,
+};
 
 fn main() {
     App::build()


### PR DESCRIPTION
This pr adds `write_buffer` to the rendering abstraction. Additionally, the `CameraNode` and `LightsNode` render graph nodes are modifed to use `write_buffer` instead of staging buffers and expensive mapping.