### PR TITLE
Fix default UI node size

### DIFF
--- a/crates/bevy_ui/src/flex/convert.rs
+++ b/crates/bevy_ui/src/flex/convert.rs
@@ -17,13 +17,25 @@ where
     }
 }
 
-fn from_size<T, U>(size: Size<U>) -> stretch::geometry::Size<T>
+fn from_size<T>(size: Size<Val>) -> stretch::geometry::Size<T>
 where
-    T: From<U>,
+    T: From<Val>,
 {
+    let width = if let Val::Undefined = size.width {
+        Val::Auto
+    } else {
+        size.width
+    };
+
+    let height = if let Val::Undefined = size.height {
+        Val::Auto
+    } else {
+        size.height
+    };
+
     stretch::geometry::Size {
-        width: size.width.into(),
-        height: size.height.into(),
+        width: width.into(),
+        height: height.into(),
     }
 }
 

--- a/crates/bevy_ui/src/flex/convert.rs
+++ b/crates/bevy_ui/src/flex/convert.rs
@@ -17,25 +17,13 @@ where
     }
 }
 
-fn from_size<T>(size: Size<Val>) -> stretch::geometry::Size<T>
+fn from_size<T, U>(size: Size<U>) -> stretch::geometry::Size<T>
 where
-    T: From<Val>,
+    T: From<U>,
 {
-    let width = if let Val::Undefined = size.width {
-        Val::Auto
-    } else {
-        size.width
-    };
-
-    let height = if let Val::Undefined = size.height {
-        Val::Auto
-    } else {
-        size.height
-    };
-
     stretch::geometry::Size {
-        width: width.into(),
-        height: height.into(),
+        width: size.width.into(),
+        height: size.height.into(),
     }
 }
 

--- a/crates/bevy_ui/src/node.rs
+++ b/crates/bevy_ui/src/node.rs
@@ -92,9 +92,9 @@ impl Default for Style {
             flex_grow: 0.0,
             flex_shrink: 1.0,
             flex_basis: Val::Auto,
-            size: Default::default(),
-            min_size: Default::default(),
-            max_size: Default::default(),
+            size: Size::new(Val::Auto, Val::Auto),
+            min_size: Size::new(Val::Auto, Val::Auto),
+            max_size: Size::new(Val::Auto, Val::Auto),
             aspect_ratio: Default::default(),
         }
     }


### PR DESCRIPTION
Fixes #291

This changes the default node size (width and height) to `Auto` instead of `Undefined` to match [the Stretch implementation](https://github.com/vislyhq/stretch/blob/6879b9a1cf3c244430bbf8b88bf205c614d72562/src/style.rs#L247).

See comment https://github.com/bevyengine/bevy/issues/291#issuecomment-678807641, I think the solution in this comment would be better, but currently doesn't work with how the crates are structured.