### PR TITLE
Created crate bevy_net - provides TCP/UDP socket and listener functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 exclude = ["assets/**/*", "tools/**/*", ".github/**/*", "crates/**/*"]
 
 [features]
-default = ["bevy_audio", "bevy_gltf", "bevy_wgpu", "bevy_winit", "png", "hdr", "mp3"]
+default = ["bevy_audio", "bevy_net", "bevy_gltf", "bevy_wgpu", "bevy_winit", "png", "hdr", "mp3"]
 profiler = ["bevy_ecs/profiler", "bevy_diagnostic/profiler"]
 wgpu_trace = ["bevy_wgpu/trace"]
 
@@ -57,6 +57,7 @@ bevy_window = { path = "crates/bevy_window", version = "0.1" }
 
 # bevy (optional)
 bevy_audio = { path = "crates/bevy_audio", optional = true, version = "0.1" }
+bevy_net = { path = "crates/bevy_net", optional = true, version = "0.1" }
 bevy_gltf = { path = "crates/bevy_gltf", optional = true, version = "0.1" }
 bevy_wgpu = { path = "crates/bevy_wgpu", optional = true, version = "0.1" }
 bevy_winit = { path = "crates/bevy_winit", optional = true, version = "0.1" }
@@ -184,6 +185,14 @@ path = "examples/input/keyboard_input.rs"
 [[example]]
 name = "keyboard_input_events"
 path = "examples/input/keyboard_input_events.rs"
+
+[[example]]
+name = "net_client"
+path = "examples/net/net_client.rs"
+
+[[example]]
+name = "net_server"
+path = "examples/net/net_server.rs"
 
 [[example]]
 name = "scene"

--- a/crates/bevy_net/Cargo.toml
+++ b/crates/bevy_net/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bevy_net"
+version = "0.1.0"
+edition = "2018"
+authors = ["Bevy Contributors <bevyengine@gmail.com>", "0x22fe <developer@0x22fe.com>"]
+description = "Provides basic network functionality for Bevy Engine"
+homepage = "https://bevyengine.org"
+repository = "https://github.com/bevyengine/bevy"
+license = "MIT"
+keywords = ["bevy"]
+
+[dependencies]
+# bevy
+bevy_app = { path = "../bevy_app", version = "0.1" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.1" }
+
+# other
+uuid = { version = "0.8", features = ["v4", "serde"] }

--- a/crates/bevy_net/src/common.rs
+++ b/crates/bevy_net/src/common.rs
@@ -1,0 +1,45 @@
+use uuid::Uuid;
+use std::net::{IpAddr, SocketAddr};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct NetId(Uuid);
+
+impl NetId {
+    pub fn new() -> Self {
+        NetId(Uuid::new_v4())
+    }
+}
+
+/// Network error type
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum NetError
+{
+    UnknownError,
+
+    OpenError,
+    CloseError,
+
+    SendError,
+    ReceiveError,
+
+    AcceptError,
+    QuitError
+}
+
+pub type SocketAddress = SocketAddr;
+pub type IpAddress = IpAddr;
+pub type Port = u16;
+
+pub type SocketId = NetId;
+pub type ListenerId = NetId;
+
+/// Connection protocol
+/// TCP has sockets/listeners, but UDP can use sockets/listeners interchangeably
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum NetProtocol
+{
+    /// UDP (User Datagram Protocol)
+    Udp,
+    /// TCP (Transmission Control Protocol)
+    Tcp,
+}

--- a/crates/bevy_net/src/event.rs
+++ b/crates/bevy_net/src/event.rs
@@ -1,0 +1,119 @@
+use crate::common::{SocketId, SocketAddress, Port, NetError, NetProtocol, ListenerId};
+
+// Socket events
+
+/// An event that is sent whenever a socket should be opened
+/// The `port` field must be specified when using UDP
+#[derive(Debug, Clone)]
+pub struct OpenSocket {
+    pub new_id: SocketId,
+    pub remote_address: SocketAddress,
+    pub protocol: NetProtocol,
+    pub port: Option<Port>,
+}
+
+/// An event that is sent whenever a socket is opened (connected)
+#[derive(Debug, Clone)]
+pub struct SocketOpened {
+    pub id: SocketId,
+}
+
+/// An event that is sent whenever a socket should send data
+#[derive(Debug, Clone)]
+pub struct SendSocket {
+    pub id: SocketId,
+    pub tx_data: Vec<u8>
+}
+
+/// An event that is sent whenever a socket sent data
+#[derive(Debug, Clone)]
+pub struct SocketSent {
+    pub id: SocketId,
+    pub len: usize
+}
+
+/// An event that is sent whenever a socket receives data
+#[derive(Debug, Clone)]
+pub struct SocketReceive {
+    pub id: SocketId,
+    pub rx_data: Vec<u8>
+}
+
+/// An event that is sent whenever a socket has an error
+#[derive(Debug, Clone)]
+pub struct SocketError {
+    pub id: SocketId,
+    pub err: NetError
+}
+
+/// An event that is sent whenever a socket should be closed
+#[derive(Debug, Clone)]
+pub struct CloseSocket {
+    pub id: SocketId,
+}
+
+/// An event that is sent whenever a socket is closed
+#[derive(Debug, Clone)]
+pub struct SocketClosed {
+    pub id: SocketId,
+}
+
+// Listener events
+
+/// An event that is sent whenever a listener should be created
+#[derive(Debug, Clone)]
+pub struct CreateListener {
+    pub new_id: ListenerId,
+    pub port: Port,
+    pub protocol: NetProtocol
+}
+
+/// An event that is sent whenever a listener is opened
+#[derive(Debug, Clone)]
+pub struct ListenerCreated {
+    pub id: ListenerId,
+}
+
+/*
+/// An event that is sent whenever a listener receives a connection request
+#[derive(Debug, Clone)]
+pub struct ListenerRequest {
+    pub id: ListenerId,
+    pub remote_addr: SocketAddress
+}
+
+/// An event that is sent whenever a listener should respond to a connection request
+#[derive(Debug, Clone)]
+pub struct HandleListener {
+    pub id: ListenerId,
+    pub remote_addr: SocketAddress,
+    pub accept: bool
+}
+*/
+
+/// An event that is sent whenever a listener creates a connection
+#[derive(Debug, Clone)]
+pub struct ListenerConnected {
+    pub id: ListenerId,
+    pub socket_id: SocketId,
+    pub socket_address: SocketAddress
+}
+
+/// An event that is sent whenever a listener has an error
+#[derive(Debug, Clone)]
+pub struct ListenerError {
+    pub id: ListenerId,
+    pub err: NetError,
+}
+
+/// An event that is sent whenever a listener should be closed
+#[derive(Debug, Clone)]
+pub struct CloseListener {
+    pub id: ListenerId,
+}
+
+/// An event that is sent whenever a listener is closed
+#[derive(Debug, Clone)]
+pub struct ListenerClosed {
+    pub id: ListenerId,
+}

--- a/crates/bevy_net/src/lib.rs
+++ b/crates/bevy_net/src/lib.rs
@@ -1,0 +1,56 @@
+use bevy_app::prelude::*;
+use bevy_ecs::IntoQuerySystem;
+pub use common::*;
+pub use event::*;
+pub use listeners::*;
+pub use sockets::*;
+use system::*;
+
+mod common;
+mod event;
+mod system;
+mod socket;
+mod sockets;
+mod listeners;
+mod listener;
+
+pub mod prelude {
+    pub use crate::{listener::Listener, listeners::Listeners, socket::Socket, sockets::Sockets};
+    pub use crate::common::{IpAddress, ListenerId, Port, SocketAddress, SocketId};
+}
+
+/// Adds sockets and listeners to an app
+#[derive(Default)]
+pub struct NetPlugin;
+
+impl Plugin for NetPlugin {
+    fn build(&self, app: &mut AppBuilder) {
+        app.add_event::<OpenSocket>()
+            .add_event::<SocketOpened>()
+            .add_event::<SocketError>()
+            .add_event::<SendSocket>()
+            .add_event::<SocketSent>()
+            .add_event::<SocketReceive>()
+            .add_event::<CloseSocket>()
+            .add_event::<SocketClosed>()
+            .init_resource::<Sockets>()
+            .add_systems_to_stage(
+                bevy_app::stage::EVENT_UPDATE,
+                vec![open_socket_events_system.system(),
+                     socket_receive_system.system(),
+                     send_socket_events_system.system(),
+                     close_socket_events_system.system()])
+            .add_event::<CreateListener>()
+            .add_event::<ListenerCreated>()
+            .add_event::<ListenerError>()
+            .add_event::<ListenerConnected>()
+            .add_event::<CloseListener>()
+            .add_event::<ListenerClosed>()
+            .init_resource::<Listeners>()
+            .add_systems_to_stage(
+                bevy_app::stage::EVENT_UPDATE,
+                vec![create_listener_events_system.system(),
+                     listener_connection_system.system(),
+                     close_listener_events_system.system()]);
+    }
+}

--- a/crates/bevy_net/src/listener.rs
+++ b/crates/bevy_net/src/listener.rs
@@ -1,0 +1,199 @@
+use std::io::ErrorKind;
+use std::net::{TcpListener, UdpSocket};
+
+use crate::{IpAddress, Port, SocketAddress, SocketId};
+use crate::common::{ListenerId, NetProtocol};
+use crate::socket::{Socket, SocketTcp, SocketUdp};
+
+/// 1 MB buffer for UDP "connections"
+const DEFAULT_UDP_BUFFER: usize = 1_000_000;
+
+pub trait Listener: Send + Sync
+{
+    /// Retrieve listener ID
+    fn get_id(&self) -> ListenerId;
+    /// Set listener ID
+    fn set_id(&mut self, id: ListenerId);
+
+    /// Returns listener type
+    fn get_type(&self) -> NetProtocol;
+
+    /// Creates a new listener.
+    /// Listens on localhost:<port> for incoming connections.
+    /// Optionally specify the listener's ID
+    fn listen(port: Port, listener_id: Option<ListenerId>) -> Result<Self, ()>
+        where Self: Sized;
+
+    /// Check and accept an incoming connection
+    fn check_incoming(&mut self) -> Result<Option<Box<dyn Socket>>, ()>;
+
+    /// Check for connection errors
+    fn check_err(&mut self) -> Result<(), ()>;
+
+    /// Close the listener (deny new connections)
+    fn close(&mut self) -> Result<(), ()>;
+}
+
+/// TCP listener
+pub struct ListenerTcp
+{
+    id: ListenerId,
+    listener: TcpListener,
+    connections: Vec<SocketId>,
+    open: bool,
+}
+
+impl Listener for ListenerTcp
+{
+    fn get_id(&self) -> SocketId {
+        self.id
+    }
+
+    fn set_id(&mut self, id: SocketId) {
+        self.id = id;
+    }
+
+    fn get_type(&self) -> NetProtocol {
+        NetProtocol::Tcp
+    }
+
+    fn listen(port: u16, listener_id: Option<ListenerId>) -> Result<Self, ()> where Self: Sized {
+        let addr = SocketAddress::new(IpAddress::from([127, 0, 0, 1]), port);
+        let listener = TcpListener::bind(addr).map_err(|_| ())?;
+
+        listener.set_nonblocking(true).map_err(|_| ())?;
+
+        Ok(ListenerTcp {
+            id: listener_id.unwrap_or(ListenerId::new()),
+            connections: vec![],
+            open: true,
+            listener,
+        })
+    }
+
+    fn check_incoming(&mut self) -> Result<Option<Box<dyn Socket>>, ()> {
+        match self.listener.accept() {
+            Ok(connection) => {
+                let socket = Box::new(SocketTcp::from_existing(connection.0));
+                self.connections.push(socket.get_id());
+                Ok(Some(socket))
+            }
+            Err(err) => if err.kind() == ErrorKind::WouldBlock {
+                Ok(None)
+            } else {
+                Err(())
+            }
+        }
+    }
+
+    fn check_err(&mut self) -> Result<(), ()> {
+        if let Ok(e) = self.listener.take_error() {
+            if let Some(_) = e {
+                Err(())
+            } else {
+                Ok(())
+            }
+        } else {
+            Err(())
+        }
+    }
+
+    fn close(&mut self) -> Result<(), ()> {
+        self.open = false;
+        Ok(())
+    }
+}
+
+/// UDP listener type
+pub struct ListenerUdp
+{
+    id: ListenerId,
+    listener: UdpSocket,
+    connections: Vec<SocketId>,
+    buf: Vec<u8>,
+    open: bool,
+}
+
+impl Listener for ListenerUdp
+{
+    fn get_id(&self) -> SocketId {
+        self.id
+    }
+
+    fn set_id(&mut self, id: SocketId) {
+        self.id = id;
+    }
+
+    fn get_type(&self) -> NetProtocol {
+        NetProtocol::Udp
+    }
+
+    fn listen(port: u16, listener_id: Option<ListenerId>) -> Result<Self, ()> where Self: Sized {
+        let addr = SocketAddress::new(IpAddress::from([127, 0, 0, 1]), port);
+        let listener = UdpSocket::bind(addr).map_err(|_| ())?;
+        listener.set_nonblocking(true).map_err(|_| ())?;
+
+        Ok(ListenerUdp {
+            id: listener_id.unwrap_or(ListenerId::new()),
+            connections: vec![],
+            buf: vec![0; DEFAULT_UDP_BUFFER],
+            open: true,
+            listener,
+        })
+    }
+
+    /// For UDP, this function will create a new socket on a new port.
+    /// If you wish to use the same port (meaning no new socket) please call the `read_incoming` method instead
+    fn check_incoming(&mut self) -> Result<Option<Box<dyn Socket>>, ()> {
+        // As UDP is connectionless, we have to receive some data in order to establish a "connection"
+        match self.listener.peek_from(&mut self.buf) {
+            Ok(connection) => {
+                let socket = Box::new(SocketUdp::connect(connection.1,
+                                                         None,
+                                                         None,
+                                                         Some(DEFAULT_UDP_BUFFER))?);
+                self.connections.push(socket.get_id());
+                Ok(Some(socket))
+            }
+            Err(err) => if err.kind() == ErrorKind::WouldBlock {
+                Ok(None)
+            } else {
+                Err(())
+            }
+        }
+    }
+
+    fn check_err(&mut self) -> Result<(), ()> {
+        if let Ok(e) = self.listener.take_error() {
+            if let Some(_) = e {
+                Err(())
+            } else {
+                Ok(())
+            }
+        } else {
+            Err(())
+        }
+    }
+
+    fn close(&mut self) -> Result<(), ()> {
+        self.open = false;
+        Ok(())
+    }
+}
+
+impl ListenerUdp
+{
+    /// Read incoming data without opening a new connection.
+    /// Returns the data read and the remote address
+    pub fn read_incoming(&mut self) -> Result<Option<(&Vec<u8>, SocketAddress)>, ()>
+    {
+        match self.listener.recv_from(&mut self.buf) {
+            Ok(connection) => Ok(Some((&self.buf, connection.1))),
+            Err(err) => if err.kind() == ErrorKind::WouldBlock {
+                Ok(None)
+            } else {
+                Err(())
+            }
+        }
+    }
+}

--- a/crates/bevy_net/src/listeners.rs
+++ b/crates/bevy_net/src/listeners.rs
@@ -1,0 +1,31 @@
+use super::listener::Listener;
+use super::common::ListenerId;
+
+use std::collections::HashMap;
+
+#[derive(Default)]
+pub struct Listeners {
+    listeners: HashMap<ListenerId, Box<dyn Listener>>,
+}
+
+impl Listeners {
+    pub fn add(&mut self, listener: Box<dyn Listener>) {
+        self.listeners.insert(listener.get_id(), listener);
+    }
+
+    pub fn get(&self, id: ListenerId) -> Option<&Box<dyn Listener>> {
+        self.listeners.get(&id)
+    }
+
+    pub fn get_mut(&mut self, id: ListenerId) -> Option<&mut Box<dyn Listener>> {
+        self.listeners.get_mut(&id)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Box<dyn Listener>> {
+        self.listeners.values()
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Box<dyn Listener>> {
+        self.listeners.values_mut()
+    }
+}

--- a/crates/bevy_net/src/socket.rs
+++ b/crates/bevy_net/src/socket.rs
@@ -1,0 +1,238 @@
+use std::io::{ErrorKind, Read, Write};
+use std::net::{Shutdown, TcpStream, ToSocketAddrs, UdpSocket};
+
+use crate::{IpAddress, Port, SocketAddress};
+use crate::common::{NetProtocol, SocketId};
+
+/// 1MB default buffer size
+pub const DEFAULT_BUFFER_SIZE: usize = 1_000_000;
+
+pub trait Socket: Send + Sync
+{
+    /// Establish a new connection.
+    /// Optionally, specify the socket ID, socket port (for UDP, leave empty for a random port), and size of the internal buffer
+    fn connect<A: ToSocketAddrs>(address: A,
+                                 socket_id: Option<SocketId>,
+                                 socket_port: Option<Port>,
+                                 buffer_size: Option<usize>) -> Result<Self, ()>
+        where Self: Sized;
+
+    /// Send data over the socket
+    fn send(&mut self, data: &[u8]) -> Result<usize, ()>;
+
+    /// Retrieve any data received.
+    /// Limits the size of the returned buffer to the value of buf_size
+    fn receive(&mut self) -> Result<Vec<u8>, ()>;
+
+    /// Check whether a connection error has occurred
+    fn check_err(&mut self) -> Result<(), ()>;
+
+    /// Returns whether the socket was shutdown successfully
+    fn close(&mut self) -> Result<(), ()>;
+
+    /// Retrieve socket ID
+    fn get_id(&self) -> SocketId;
+    /// Set socket ID
+    fn set_id(&mut self, id: SocketId);
+
+    /// Retrieve maximum internal buffer size (used to store received data)
+    fn get_buf_size(&self) -> usize;
+    /// Set maximum internal buffer size
+    fn set_buf_size(&mut self, buf_size: usize);
+
+    /// Get socket protocol
+    fn get_type(&self) -> NetProtocol;
+
+    /// Get remote address
+    fn get_remote_address(&self) -> Result<SocketAddress, ()>;
+}
+
+/// TCP socket type
+pub struct SocketTcp
+{
+    id: SocketId,
+    buf: Vec<u8>,
+    socket: TcpStream,
+}
+
+impl Socket for SocketTcp
+{
+    fn connect<A: ToSocketAddrs>(address: A,
+                                 socket_id: Option<SocketId>,
+                                 _: Option<Port>,
+                                 buffer_size: Option<usize>) -> Result<Self, ()> {
+        let socket = TcpStream::connect(address).map_err(|_| ())?;
+        socket.set_nonblocking(true).map_err(|_| ())?;
+
+        Ok(SocketTcp {
+            id: socket_id.unwrap_or(SocketId::new()),
+            buf: vec![0; buffer_size.unwrap_or(DEFAULT_BUFFER_SIZE)],
+            socket,
+        })
+    }
+
+    fn send(&mut self, data: &[u8]) -> Result<usize, ()>
+    {
+        self.socket.write(data).map_err(|_| ())
+    }
+
+    fn receive(&mut self) -> Result<Vec<u8>, ()>
+    {
+        match self.socket.read(&mut self.buf[..]) {
+            Ok(c) => Ok(Vec::from(&self.buf[0..c])),
+            Err(e) => if e.kind() == ErrorKind::WouldBlock {
+                Ok(vec![])
+            } else {
+                Err(())
+            }
+        }
+    }
+
+    fn check_err(&mut self) -> Result<(), ()>
+    {
+        if let Ok(e) = self.socket.take_error() {
+            if let Some(_) = e {
+                Err(())
+            } else {
+                Ok(())
+            }
+        } else {
+            Err(())
+        }
+    }
+
+    fn close(&mut self) -> Result<(), ()>
+    {
+        self.socket.shutdown(Shutdown::Both)
+            .map_err(|_| ())
+    }
+
+    fn get_id(&self) -> SocketId {
+        self.id
+    }
+
+    fn set_id(&mut self, id: SocketId) {
+        self.id = id;
+    }
+
+    fn get_buf_size(&self) -> usize {
+        self.buf.len()
+    }
+
+    fn set_buf_size(&mut self, buf_size: usize) {
+        self.buf = vec![0; buf_size];
+    }
+
+    fn get_type(&self) -> NetProtocol {
+        NetProtocol::Tcp
+    }
+
+    fn get_remote_address(&self) -> Result<SocketAddress, ()> {
+        self.socket.peer_addr().map_err(|_| ())
+    }
+}
+
+impl SocketTcp
+{
+    /// Creates a socket from an existing TCP connection
+    pub fn from_existing(socket: TcpStream) -> Self
+    {
+        Self {
+            id: SocketId::new(),
+            buf: vec![0; DEFAULT_BUFFER_SIZE],
+            socket,
+        }
+    }
+}
+
+/// UDP socket type
+pub struct SocketUdp
+{
+    id: SocketId,
+    buf: Vec<u8>,
+    socket: UdpSocket,
+}
+
+impl Socket for SocketUdp
+{
+    /// If no port is specified, a random port is chosen (UDP)
+    fn connect<A: ToSocketAddrs>(address: A,
+                                 socket_id: Option<SocketId>,
+                                 socket_port: Option<Port>,
+                                 buffer_size: Option<usize>) -> Result<Self, ()> {
+        // The default port 0 will result in a random port being chosen
+        let socket = UdpSocket::bind(
+            SocketAddress::new(IpAddress::from([127, 0, 0, 1]),
+                               // If unspecified set the port to 0 for a random port
+                               socket_port.unwrap_or(0)))
+            .map_err(|_| ())?;
+
+        socket.connect(address).map_err(|_| ())?;
+        socket.set_nonblocking(true).map_err(|_| ())?;
+
+        Ok(SocketUdp {
+            id: socket_id.unwrap_or(SocketId::new()),
+            buf: vec![0; buffer_size.unwrap_or(DEFAULT_BUFFER_SIZE)],
+            socket,
+        })
+    }
+
+    fn send(&mut self, data: &[u8]) -> Result<usize, ()>
+    {
+        self.socket.send(data).map_err(|_| ())
+    }
+
+    fn receive(&mut self) -> Result<Vec<u8>, ()>
+    {
+        match self.socket.recv(&mut self.buf[..]) {
+            Ok(c) => Ok(Vec::from(&self.buf[0..c])),
+            Err(e) => if e.kind() == ErrorKind::WouldBlock {
+                Ok(vec![])
+            } else {
+                Err(())
+            }
+        }
+    }
+
+    fn check_err(&mut self) -> Result<(), ()>
+    {
+        if let Ok(e) = self.socket.take_error() {
+            if let Some(_) = e {
+                Err(())
+            } else {
+                Ok(())
+            }
+        } else {
+            Err(())
+        }
+    }
+
+    fn close(&mut self) -> Result<(), ()>
+    {
+        Ok(())
+    }
+
+    fn get_id(&self) -> SocketId {
+        self.id
+    }
+
+    fn set_id(&mut self, id: SocketId) {
+        self.id = id;
+    }
+
+    fn get_buf_size(&self) -> usize {
+        self.buf.len()
+    }
+
+    fn set_buf_size(&mut self, buf_size: usize) {
+        self.buf = vec![0; buf_size];
+    }
+
+    fn get_type(&self) -> NetProtocol {
+        NetProtocol::Udp
+    }
+
+    fn get_remote_address(&self) -> Result<SocketAddress, ()> {
+        self.socket.peer_addr().map_err(|_| ())
+    }
+}

--- a/crates/bevy_net/src/sockets.rs
+++ b/crates/bevy_net/src/sockets.rs
@@ -1,0 +1,31 @@
+use std::collections::HashMap;
+
+use super::common::SocketId;
+use super::socket::Socket;
+
+#[derive(Default)]
+pub struct Sockets {
+    sockets: HashMap<SocketId, Box<dyn Socket>>,
+}
+
+impl Sockets {
+    pub fn add(&mut self, socket: Box<dyn Socket>) {
+        self.sockets.insert(socket.get_id(), socket);
+    }
+
+    pub fn get(&self, id: SocketId) -> Option<&Box<dyn Socket>> {
+        self.sockets.get(&id)
+    }
+
+    pub fn get_mut(&mut self, id: SocketId) -> Option<&mut Box<dyn Socket>> {
+        self.sockets.get_mut(&id)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item=&Box<dyn Socket>> {
+        self.sockets.values()
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item=&mut Box<dyn Socket>> {
+        self.sockets.values_mut()
+    }
+}

--- a/crates/bevy_net/src/system.rs
+++ b/crates/bevy_net/src/system.rs
@@ -1,0 +1,223 @@
+use bevy_app::{
+    prelude::{EventReader, Events},
+};
+use bevy_ecs::{Local, Res, ResMut};
+
+use crate::{CloseListener, CreateListener, ListenerClosed, ListenerConnected, ListenerCreated, ListenerError, Listeners, NetError, SocketClosed, SocketReceive, SocketAddress, IpAddress};
+use crate::common::NetProtocol;
+use crate::event::{CloseSocket, OpenSocket, SendSocket, SocketError, SocketOpened, SocketSent};
+use crate::listener::{Listener, ListenerTcp, ListenerUdp};
+use crate::socket::{Socket, SocketTcp, SocketUdp};
+use crate::sockets::Sockets;
+
+// Socket systems
+
+// Handle socket open
+pub fn open_socket_events_system(
+    mut sockets: ResMut<Sockets>,
+    mut state: Local<EventReader<OpenSocket>>,
+    open_socket_events: Res<Events<OpenSocket>>,
+    mut socket_opened_events: ResMut<Events<SocketOpened>>,
+    mut socket_error_events: ResMut<Events<SocketError>>,
+) {
+    for open_socket_event in state.iter(&open_socket_events) {
+        let sock = match open_socket_event.protocol {
+            NetProtocol::Udp => Result::<Box<dyn Socket>, ()>::from(SocketUdp::connect(open_socket_event.remote_address,
+                                                                                       Some(open_socket_event.new_id),
+                                                                                       open_socket_event.port,
+                                                                                       None).map(|s| Box::new(s) as Box<dyn Socket>)),
+            NetProtocol::Tcp => Result::<Box<dyn Socket>, ()>::from(SocketTcp::connect(open_socket_event.remote_address,
+                                                                                       Some(open_socket_event.new_id),
+                                                                                       open_socket_event.port,
+                                                                                       None).map(|s| Box::new(s) as Box<dyn Socket>)),
+        };
+
+        if let Ok(socket) = sock {
+            sockets.add(socket);
+            socket_opened_events.send(SocketOpened {
+                id: open_socket_event.new_id
+            });
+        } else {
+            socket_error_events.send(SocketError {
+                id: open_socket_event.new_id,
+                err: NetError::OpenError,
+            });
+        }
+    }
+}
+
+// Handle socket sending
+pub fn send_socket_events_system(
+    mut sockets: ResMut<Sockets>,
+    mut state: Local<EventReader<SendSocket>>,
+    send_socket_events: Res<Events<SendSocket>>,
+    mut socket_sent_events: ResMut<Events<SocketSent>>,
+    mut socket_error_events: ResMut<Events<SocketError>>,
+) {
+    for send_socket_event in state.iter(&send_socket_events) {
+        if let Ok(len) = sockets.get_mut(send_socket_event.id)
+            .expect("Non-existent socket ID")
+            .send(&send_socket_event.tx_data) {
+            socket_sent_events.send(SocketSent {
+                id: send_socket_event.id,
+                len,
+            });
+        } else {
+            socket_error_events.send(SocketError {
+                id: send_socket_event.id,
+                err: NetError::SendError,
+            });
+        }
+    }
+}
+
+// Handle socket receiving
+pub fn socket_receive_system(
+    mut sockets: ResMut<Sockets>,
+    mut socket_receive_events: ResMut<Events<SocketReceive>>,
+    mut socket_error_events: ResMut<Events<SocketError>>,
+) {
+    for socket in sockets.iter_mut() {
+        if let Ok(data) = socket.receive() {
+            socket_receive_events.send(SocketReceive {
+                id: socket.get_id(),
+                rx_data: data,
+            });
+        } else {
+            socket_error_events.send(SocketError {
+                id: socket.get_id(),
+                err: NetError::ReceiveError,
+            });
+        }
+
+        // Check for connection errors
+        if let Err(_) = socket.check_err() {
+            socket_error_events.send(SocketError {
+                id: socket.get_id(),
+                err: NetError::UnknownError,
+            });
+        }
+    }
+}
+
+// Close socket connections
+pub fn close_socket_events_system(
+    mut state: Local<EventReader<CloseSocket>>,
+    mut sockets: ResMut<Sockets>,
+    close_socket_events: Res<Events<CloseSocket>>,
+    mut socket_closed_events: ResMut<Events<SocketClosed>>,
+    mut socket_error_events: ResMut<Events<SocketError>>,
+) {
+    for close_socket_event in state.iter(&close_socket_events)
+    {
+        let socket = sockets.get_mut(close_socket_event.id)
+            .expect("Non-existent socket ID");
+        if socket.close().is_ok() {
+            socket_closed_events.send(SocketClosed {
+                id: close_socket_event.id
+            });
+        } else {
+            socket_error_events.send(SocketError {
+                id: close_socket_event.id,
+                err: NetError::CloseError,
+            });
+        }
+    }
+}
+
+// Listener systems
+// Todo - Maybe add methods for UDP receiving/sending without a new socket
+
+// Handle listener creation
+pub fn create_listener_events_system(
+    mut listeners: ResMut<Listeners>,
+    mut state: Local<EventReader<CreateListener>>,
+    create_listener_events: Res<Events<CreateListener>>,
+    mut listener_created_events: ResMut<Events<ListenerCreated>>,
+    mut listener_error_events: ResMut<Events<ListenerError>>,
+) {
+    for create_listener_event in state.iter(&create_listener_events) {
+        let list = match create_listener_event.protocol {
+            NetProtocol::Udp => Result::<Box<dyn Listener>, ()>::from(ListenerUdp::listen(create_listener_event.port,
+                                                                                          Some(create_listener_event.new_id))
+                .map(|l| Box::new(l) as Box<dyn Listener>)),
+            NetProtocol::Tcp => Result::<Box<dyn Listener>, ()>::from(ListenerTcp::listen(create_listener_event.port,
+                                                                                          Some(create_listener_event.new_id))
+                .map(|l| Box::new(l) as Box<dyn Listener>)),
+        };
+
+        if let Ok(listener) = list {
+            listeners.add(listener);
+            listener_created_events.send(ListenerCreated {
+                id: create_listener_event.new_id
+            });
+        } else {
+            listener_error_events.send(ListenerError {
+                id: create_listener_event.new_id,
+                err: NetError::OpenError,
+            });
+        }
+    }
+}
+
+// Handle listener connections
+pub fn listener_connection_system(
+    mut listeners: ResMut<Listeners>,
+    mut sockets: ResMut<Sockets>,
+    mut listener_connected_events: ResMut<Events<ListenerConnected>>,
+    mut listener_error_events: ResMut<Events<ListenerError>>,
+) {
+    for listener in listeners.iter_mut() {
+        if let Ok(data) = listener.check_incoming() {
+            if let Some(socket) = data {
+                let socket_id = socket.get_id();
+                let remote = socket.get_remote_address()
+                    .unwrap_or(SocketAddress::new(IpAddress::from([0, 0, 0, 0]), 0));
+                sockets.add(socket);
+                listener_connected_events.send(ListenerConnected {
+                    id: listener.get_id(),
+                    socket_id: socket_id,
+                    socket_address: remote
+                });
+            }
+        } else {
+            listener_error_events.send(ListenerError {
+                id: listener.get_id(),
+                err: NetError::AcceptError,
+            });
+        }
+
+        // Check for connection errors
+        if let Err(_) = listener.check_err() {
+            listener_error_events.send(ListenerError {
+                id: listener.get_id(),
+                err: NetError::UnknownError,
+            });
+        }
+    }
+}
+
+// Handle listener close
+pub fn close_listener_events_system(
+    mut listeners: ResMut<Listeners>,
+    mut state: Local<EventReader<CloseListener>>,
+    close_listener_events: Res<Events<CloseListener>>,
+    mut listener_closed_events: ResMut<Events<ListenerClosed>>,
+    mut listener_error_events: ResMut<Events<ListenerError>>,
+) {
+    for close_listener_event in state.iter(&close_listener_events)
+    {
+        let listener = listeners.get_mut(close_listener_event.id)
+            .expect("Non-existent listener ID");
+        if listener.close().is_ok() {
+            listener_closed_events.send(ListenerClosed {
+                id: close_listener_event.id
+            });
+        } else {
+            listener_error_events.send(ListenerError {
+                id: close_listener_event.id,
+                err: NetError::CloseError,
+            });
+        }
+    }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -82,6 +82,13 @@ Example | File | Description
 `keyboard_input` | [`input/keyboard_input.rs`](./input/keyboard_input.rs) | Demonstrates handling a key press/release
 `keyboard_input_events` | [`input/keyboard_input_events.rs`](./input/keyboard_input_events.rs) | Prints out all keyboard events
 
+## Net
+
+Example | File | Description
+--- | --- | ---
+`net_client` | [`net/net_client.rs`](./net/net_client.rs) | Demonstrates creating and sending data over a TCP connection
+`net_server` | [`net/net_server.rs`](./net/net_server.rs) | Demonstrates creating and listening for data over a TCP connection
+
 ## Scene
 
 Example | File | Description

--- a/examples/net/net_client.rs
+++ b/examples/net/net_client.rs
@@ -1,0 +1,56 @@
+use bevy::{prelude::*};
+use bevy_net::{NetPlugin, NetProtocol, OpenSocket, SendSocket, SocketError};
+
+const REMOTE_PORT: Port = 4000;
+const HOST_UDP_PORT: Port = 2000;
+const SOCKET_PROTOCOL: NetProtocol = NetProtocol::Tcp;
+
+// This example sends data to a localhost TCP (or UDP if changed) server running on port <REMOTE_PORT>
+// If using TCP, run the following commnand to receive data in the terminal: `netcat -l <REMOTE_PORT>`
+// If using UDP, run: `netcat -ul <REMOTE_PORT>`
+// Remember to run the command prior to running the example (especially for TCP)
+fn main() {
+    App::build()
+        .add_plugin(NetPlugin)
+        .add_resource(SocketId::new())
+        .add_startup_system(setup.system())
+        .add_default_plugins()
+        .add_system_to_stage(stage::UPDATE, send_data_system.system())
+        .add_system_to_stage(stage::UPDATE, handle_error_system.system())
+        .run();
+}
+
+fn setup(
+    socket_id: Res<SocketId>,
+    mut socket_open: ResMut<Events<OpenSocket>>,
+) {
+    // Open a socket to localhost:<REMOTE_PORT>
+    socket_open.send(OpenSocket {
+        new_id: *socket_id,
+        remote_address: SocketAddress::new(IpAddress::from([127, 0, 0, 1]), REMOTE_PORT),
+        port: if SOCKET_PROTOCOL == NetProtocol::Udp { Some(HOST_UDP_PORT) } else { None },
+        protocol: SOCKET_PROTOCOL,
+    });
+}
+
+fn send_data_system(
+    time: Res<Time>,
+    socket_id: Res<SocketId>,
+    mut socket_send: ResMut<Events<SendSocket>>,
+) {
+    // Create and send a simple message through the socket
+    let message = format!("Around {:.3} second(s) have elapsed since the app started\n", time.seconds_since_startup);
+    socket_send.send(SendSocket {
+        id: *socket_id,
+        tx_data: message.into_bytes(),
+    });
+}
+
+fn handle_error_system(
+    mut state: Local<EventReader<SocketError>>,
+    socket_error_events: Res<Events<SocketError>>,
+) {
+    for socket_error_event in state.iter(&socket_error_events) {
+        eprintln!("Socket error (ID: {:?}): \"{:?}\"", socket_error_event.id, socket_error_event.err);
+    }
+}

--- a/examples/net/net_server.rs
+++ b/examples/net/net_server.rs
@@ -1,0 +1,59 @@
+use bevy::{prelude::*};
+use bevy_net::{CreateListener, ListenerConnected, ListenerError, NetPlugin, NetProtocol, SendSocket};
+
+const HOST_PORT: Port = 4000;
+const LISTENER_PROTOCOL: NetProtocol = NetProtocol::Tcp;
+
+// This example receives data from a TCP (or UDP if changed) connection on port <HOST_PORT>
+// If using TCP, run the following commnand to start sending data in the terminal: `netcat localhost <HOST_PORT>`
+// If using UDP, run: `netcat -u localhost <HOST_PORT>`
+// To send data with netcat, simply type whatever you want to send and press the `Enter` key,
+// (sends with a newline) or the combination `Ctrl` + `D` to send as-is
+// Remember to run the command after running the example (especially for TCP)
+fn main() {
+    App::build()
+        .add_plugin(NetPlugin)
+        .add_resource(ListenerId::new())
+        .add_startup_system(setup.system())
+        .add_default_plugins()
+        .add_system_to_stage(stage::UPDATE, accept_connections_system.system())
+        .add_system_to_stage(stage::UPDATE, handle_error_system.system())
+        .run();
+}
+
+fn setup(
+    listener_id: Res<ListenerId>,
+    mut listener_create: ResMut<Events<CreateListener>>,
+) {
+    // Open a listener on <HOST_PORT>
+    listener_create.send(CreateListener {
+        new_id: *listener_id,
+        port: HOST_PORT,
+        protocol: LISTENER_PROTOCOL,
+    });
+}
+
+fn accept_connections_system(
+    listener_id: Res<ListenerId>,
+    mut socket_send: ResMut<Events<SendSocket>>,
+    mut state: Local<EventReader<ListenerConnected>>,
+    mut listener_connected_events: Res<Events<ListenerConnected>>,
+) {
+    // Accept connections and respond with message
+    for listener_connected_event in state.iter(&listener_connected_events) {
+        println!("Received a new connection from {:?}", listener_connected_event.socket_address);
+        socket_send.send(SendSocket {
+            id: listener_connected_event.socket_id,
+            tx_data: format!("Hello!\n").into_bytes(),
+        })
+    }
+}
+
+fn handle_error_system(
+    mut state: Local<EventReader<ListenerError>>,
+    listener_error_events: Res<Events<ListenerError>>,
+) {
+    for listener_error_event in state.iter(&listener_error_events) {
+        eprintln!("Listener error (ID: {:?}): \"{:?}\"", listener_error_event.id, listener_error_event.err);
+    }
+}

--- a/src/add_default_plugins.rs
+++ b/src/add_default_plugins.rs
@@ -32,6 +32,9 @@ impl AddDefaultPlugins for AppBuilder {
         #[cfg(feature = "bevy_wgpu")]
         self.add_plugin(bevy_wgpu::WgpuPlugin::default());
 
+        #[cfg(feature = "bevy_net")]
+        self.add_plugin(bevy_net::NetPlugin::default());
+
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,3 +70,6 @@ pub use bevy_winit as winit;
 
 #[cfg(feature = "bevy_wgpu")]
 pub use bevy_wgpu as wgpu;
+
+#[cfg(feature = "bevy_net")]
+pub use bevy_net as net;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,3 +7,6 @@ pub use crate::{
 
 #[cfg(feature = "bevy_audio")]
 pub use crate::audio::prelude::*;
+
+#[cfg(feature = "bevy_net")]
+pub use crate::net::prelude::*;


### PR DESCRIPTION
This crate is optional and is enabled with the feature "bevy_net". It is an ECS-friendly wrapper for networking primitives. This pull request also has tested and working examples for a TCP client and server. This doesn't provide any high-level scene-related functionality, so it should be fine to merge into master without worrying about major design decisions. If not, any feedback is appreciated.