### PR TITLE
Fix unresolved import in window settings example

### DIFF
--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -1,5 +1,4 @@
-use bevy::prelude::*;
-use bevy_window::WindowMode;
+use bevy::{prelude::*, window::WindowMode};
 
 /// This example illustrates how to customize the default window settings
 fn main() {


### PR DESCRIPTION
Got an unresolved import of 'bevy_window' with the window settings example. Hopefully this is the correct way to resolve it.