### PR TITLE
Add support for scale to OrthograpicProjection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,10 @@ name = "3d_scene"
 path = "examples/3d/3d_scene.rs"
 
 [[example]]
+name = "orthographic"
+path = "examples/3d/orthographic.rs"
+
+[[example]]
 name = "spawner"
 path = "examples/3d/spawner.rs"
 

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -51,13 +51,14 @@ pub enum WindowOrigin {
 
 #[derive(Debug, Clone, Properties)]
 pub struct OrthographicProjection {
+    pub near: f32,
+    pub far: f32,
+    pub scale: f32,
+    pub window_origin: WindowOrigin,
     pub left: f32,
     pub right: f32,
     pub bottom: f32,
     pub top: f32,
-    pub near: f32,
-    pub far: f32,
-    pub window_origin: WindowOrigin,
 }
 
 impl CameraProjection for OrthographicProjection {
@@ -75,8 +76,8 @@ impl CameraProjection for OrthographicProjection {
     fn update(&mut self, width: usize, height: usize) {
         match self.window_origin {
             WindowOrigin::Center => {
-                let half_width = width as f32 / 2.0;
-                let half_height = height as f32 / 2.0;
+                let half_width = (width as f32 * self.scale) / 2.0;
+                let half_height = (height as f32 * self.scale) / 2.0;
                 self.left = -half_width;
                 self.right = half_width;
                 self.top = half_height;
@@ -84,8 +85,8 @@ impl CameraProjection for OrthographicProjection {
             }
             WindowOrigin::BottomLeft => {
                 self.left = 0.0;
-                self.right = width as f32;
-                self.top = height as f32;
+                self.right = width as f32 * self.scale;
+                self.top = height as f32 * self.scale;
                 self.bottom = 0.0;
             }
         }
@@ -105,6 +106,7 @@ impl Default for OrthographicProjection {
             top: 0.0,
             near: 0.0,
             far: 1000.0,
+            scale: 1.0,
             window_origin: WindowOrigin::Center,
         }
     }

--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -1,0 +1,69 @@
+use bevy::prelude::*;
+use bevy_render::{
+    camera::{OrthographicProjection, VisibleEntities},
+    render_graph::base::camera::CAMERA3D,
+};
+
+fn main() {
+    App::build()
+        .add_resource(Msaa { samples: 4 })
+        .add_default_plugins()
+        .add_startup_system(setup.system())
+        .run();
+}
+
+/// set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // add entities to the world
+    commands
+        // plane
+        .spawn(PbrComponents {
+            mesh: meshes.add(Mesh::from(shape::Plane { size: 10.0 })),
+            material: materials.add(Color::rgb(0.1, 0.2, 0.1).into()),
+            ..Default::default()
+        })
+        // cube
+        .spawn(PbrComponents {
+            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            material: materials.add(Color::rgb(0.5, 0.4, 0.3).into()),
+            translation: Translation::new(0.0, 1.0, 0.0),
+            ..Default::default()
+        })
+        // sphere
+        .spawn(PbrComponents {
+            mesh: meshes.add(Mesh::from(shape::Icosphere {
+                subdivisions: 4,
+                radius: 0.5,
+            })),
+            material: materials.add(Color::rgb(0.1, 0.4, 0.8).into()),
+            translation: Translation::new(1.5, 1.5, 1.5),
+            // scale: Scale(100.),
+            ..Default::default()
+        })
+        // light
+        .spawn(LightComponents {
+            translation: Translation::new(4.0, 8.0, 4.0),
+            ..Default::default()
+        })
+        // At the moment, we cannot use Camera3dComponents with an orthographic projection, so create it manually
+        .spawn((
+            bevy_render::camera::Camera {
+                name: Some(CAMERA3D.to_string()),
+                ..Default::default()
+            },
+            Transform::new_sync_disabled(Mat4::face_toward(
+                Vec3::new(100.0, 100.0, 100.0),
+                Vec3::new(0.0, 0.0, 0.0),
+                Vec3::new(0.0, 1.0, 0.0),
+            )),
+            OrthographicProjection {
+                scale: 1.0 / 50.0,
+                ..Default::default()
+            },
+            VisibleEntities::default(),
+        ));
+}


### PR DESCRIPTION
Example: 
![image](https://user-images.githubusercontent.com/36049421/91051572-328e1f80-e618-11ea-80bd-03258cfa3eeb.png)

Before this change, it was impossible to get a larger (or smaller) image from an `OrthographicProjection` - this is what the new example looks like with `scale` set to `1` (old behaviour):
![image](https://user-images.githubusercontent.com/36049421/91051495-1db18c00-e618-11ea-9e1e-47996db1e418.png)

Notes: 
The scale could be inverted, but this interpretation also makes sense
Maybe there's a better name than scale - what do other engines call this?
Maybe it could use the `Scale` component - would require passing a `scale` parameter to `CameraProjection::update`, which would be meaningless for `PerspectiveProjection`, unless it effected `fov` somehow