### PR TITLE
iOS: use shaderc-rs for glsl to spirv compilation

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -25,7 +25,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.1" }
 
 # rendering
 spirv-reflect = "0.2.3"
-bevy-glsl-to-spirv = "0.1.7"
 image = { version = "0.23", default-features = false }
 
 # misc
@@ -42,6 +41,12 @@ anyhow = "1.0"
 hex = "0.4.2"
 hexasphere = "1.0.0"
 parking_lot = "0.10"
+
+[target.'cfg(not(target_os = "ios"))'.dependencies]
+bevy-glsl-to-spirv = "0.1.7"
+
+[target.'cfg(target_os = "ios")'.dependencies]
+shaderc = "0.6.2"
 
 [features]
 png = ["image/png"]

--- a/crates/bevy_render/src/shader/shader.rs
+++ b/crates/bevy_render/src/shader/shader.rs
@@ -1,7 +1,6 @@
 use super::ShaderLayout;
 use bevy_asset::Handle;
-use bevy_glsl_to_spirv::compile;
-use std::{io::Read, marker::Copy};
+use std::marker::Copy;
 
 /// The stage of a shader
 #[derive(Hash, Eq, PartialEq, Copy, Clone, Debug)]
@@ -11,6 +10,7 @@ pub enum ShaderStage {
     Compute,
 }
 
+#[cfg(not(target_os = "ios"))]
 impl Into<bevy_glsl_to_spirv::ShaderType> for ShaderStage {
     fn into(self) -> bevy_glsl_to_spirv::ShaderType {
         match self {
@@ -21,15 +21,56 @@ impl Into<bevy_glsl_to_spirv::ShaderType> for ShaderStage {
     }
 }
 
+#[cfg(not(target_os = "ios"))]
 fn glsl_to_spirv(
     glsl_source: &str,
     stage: ShaderStage,
     shader_defs: Option<&[String]>,
 ) -> Vec<u32> {
-    let mut output = compile(glsl_source, stage.into(), shader_defs).unwrap();
+    use std::io::Read;
+
+    let mut output = bevy_glsl_to_spirv::compile(glsl_source, stage.into(), shader_defs).unwrap();
     let mut spv_bytes = Vec::new();
     output.read_to_end(&mut spv_bytes).unwrap();
     bytes_to_words(&spv_bytes)
+}
+
+#[cfg(target_os = "ios")]
+impl Into<shaderc::ShaderKind> for ShaderStage {
+    fn into(self) -> shaderc::ShaderKind {
+        match self {
+            ShaderStage::Vertex => shaderc::ShaderKind::Vertex,
+            ShaderStage::Fragment => shaderc::ShaderKind::Fragment,
+            ShaderStage::Compute => shaderc::ShaderKind::Compute,
+        }
+    }
+}
+
+#[cfg(target_os = "ios")]
+fn glsl_to_spirv(
+    glsl_source: &str,
+    stage: ShaderStage,
+    shader_defs: Option<&[String]>,
+) -> Vec<u32> {
+    let mut compiler = shaderc::Compiler::new().unwrap();
+    let mut options = shaderc::CompileOptions::new().unwrap();
+    if let Some(shader_defs) = shader_defs {
+        for def in shader_defs.iter() {
+            options.add_macro_definition(def, None);
+        }
+    }
+
+    let binary_result = compiler
+        .compile_into_spirv(
+            glsl_source,
+            stage.into(),
+            "shader.glsl",
+            "main",
+            Some(&options),
+        )
+        .unwrap();
+
+    binary_result.as_binary().to_vec()
 }
 
 fn bytes_to_words(bytes: &[u8]) -> Vec<u32> {


### PR DESCRIPTION
One of the steps to getting iOS working https://github.com/bevyengine/bevy/issues/87

I tested a few examples on mac `sprite`, `sprite_sheet`, and `3d_scene`. On iOS I tested `3d_scene` and a cut down version of `spawner`.

The motivating change for this was spawning glslValidator (or other processes) isn't going to work on iOS. Plus the `bevy-glsl-to-spirv` code said TODO use shaderc-rs.