### PR TITLE
Added CI badge to readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: CI
 
 on:
   # NOTE: temporarily disabled because on-push currently uses up too many resources

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Crates.io](https://img.shields.io/crates/v/bevy.svg)](https://crates.io/crates/bevy)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/bevyengine/bevy/blob/master/LICENSE)
 [![Crates.io](https://img.shields.io/crates/d/bevy.svg)](https://crates.io/crates/bevy)
+[![Rust](https://github.com/bevyengine/bevy/workflows/CI/badge.svg)](https://github.com/bevyengine/bevy/actions)
 
 ## What is Bevy?
 


### PR DESCRIPTION
This adds a badge/shield to the readme that shows the most recent status of CI. I also renamed the workflow `rust.yml` to `ci.yml`, as it is a bit more consistent for what it is doing. This isn't a required change, but the badge uses the workflow name as can be seen below.

![image](https://user-images.githubusercontent.com/14791619/91067690-40847600-e601-11ea-98c1-df934e521545.png)
