### PR TITLE
Rename Assets::get_id_mut -> Assets::get_with_id_mut

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -61,10 +61,10 @@ impl<T: Resource> Assets<T> {
     }
 
     pub fn get_with_id(&self, id: HandleId) -> Option<&T> {
-        self.assets.get(&Handle::from_id(id))
+        self.get(&Handle::from_id(id))
     }
 
-    pub fn get_id_mut(&mut self, id: HandleId) -> Option<&mut T> {
+    pub fn get_with_id_mut(&mut self, id: HandleId) -> Option<&mut T> {
         self.get_mut(&Handle::from_id(id))
     }
 


### PR DESCRIPTION
This is being proposed to make `get_with_id_mut` more parallel with the non-mutable version `get_with_id`.

This PR comes from the discussion on: https://github.com/bevyengine/bevy/pull/323