### PR TITLE
Check asset-path existence. Previously App just crashed if not

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -270,7 +270,18 @@ impl AssetServer {
 
     pub fn load_untyped<P: AsRef<Path>>(&self, path: P) -> Result<HandleId, AssetServerError> {
         let path = path.as_ref();
+
+        if !path.exists() {
+            return Err(AssetServerError::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound, 
+                format!("{} does not exist.", path.to_string_lossy())
+            )))
+        }
+
+        // Check for extension, since folder-paths don't have an extension, they also fail this test
+        // Is this also true for all unix-based OS?
         if let Some(ref extension) = path.extension() {
+            // Look up whether an appropriate handling mechanism for this extension exists, otherwise yield error
             if let Some(index) = self.extension_to_handler_index.get(
                 extension
                     .to_str()

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -273,9 +273,9 @@ impl AssetServer {
 
         if !path.exists() {
             return Err(AssetServerError::Io(std::io::Error::new(
-                std::io::ErrorKind::NotFound, 
-                format!("{} does not exist.", path.to_string_lossy())
-            )))
+                std::io::ErrorKind::NotFound,
+                format!("{} does not exist.", path.to_string_lossy()),
+            )));
         }
 
         // Check for extension, since folder-paths don't have an extension, they also fail this test

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -270,18 +270,7 @@ impl AssetServer {
 
     pub fn load_untyped<P: AsRef<Path>>(&self, path: P) -> Result<HandleId, AssetServerError> {
         let path = path.as_ref();
-
-        if !path.exists() {
-            return Err(AssetServerError::Io(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("{} does not exist.", path.to_string_lossy()),
-            )));
-        }
-
-        // Check for extension, since folder-paths don't have an extension, they also fail this test
-        // Is this also true for all unix-based OS?
         if let Some(ref extension) = path.extension() {
-            // Look up whether an appropriate handling mechanism for this extension exists, otherwise yield error
             if let Some(index) = self.extension_to_handler_index.get(
                 extension
                     .to_str()

--- a/crates/bevy_asset/src/load_request.rs
+++ b/crates/bevy_asset/src/load_request.rs
@@ -38,11 +38,20 @@ where
     }
 
     fn load_asset(&self, load_request: &LoadRequest) -> Result<TAsset, AssetLoadError> {
-        let mut file = File::open(&load_request.path)?;
-        let mut bytes = Vec::new();
-        file.read_to_end(&mut bytes)?;
-        let asset = self.loader.from_bytes(&load_request.path, bytes)?;
-        Ok(asset)
+        match File::open(&load_request.path) {
+            Ok(mut file) => {
+                let mut bytes = Vec::new();
+                file.read_to_end(&mut bytes)?;
+                let asset = self.loader.from_bytes(&load_request.path, bytes)?;
+                Ok(asset)
+            }
+            Err(e) => {
+                return Err(AssetLoadError::Io(std::io::Error::new(
+                    e.kind(), //std::io::ErrorKind::NotFound,
+                    format!("{}", load_request.path.display()),
+                )));
+            }
+        }
     }
 }
 

--- a/crates/bevy_asset/src/load_request.rs
+++ b/crates/bevy_asset/src/load_request.rs
@@ -45,12 +45,10 @@ where
                 let asset = self.loader.from_bytes(&load_request.path, bytes)?;
                 Ok(asset)
             }
-            Err(e) => {
-                return Err(AssetLoadError::Io(std::io::Error::new(
-                    e.kind(), //std::io::ErrorKind::NotFound,
-                    format!("{}", load_request.path.display()),
-                )));
-            }
+            Err(e) => Err(AssetLoadError::Io(std::io::Error::new(
+                e.kind(),
+                format!("{}", load_request.path.display()),
+            ))),
         }
     }
 }


### PR DESCRIPTION
AssetServer.load_untyped does not check the existence of a provided path, only whether the path itself has a valid format (e.g. the file-extension).
This leads to the application crashing if the filename is missspelled (Fire <-> Fira):
```rust
let wrong_path = std::path::Path::new("assets/fonts/FireSans-Bold.ttf");
let correct_path = std::path::Path::new("assets/fonts/FiraSans-Bold.ttf");

let maybe_font = asset_server.load(wrong_path);
```
```
ERROR bevy_asset::loader > Failed to load asset: Io(Os { code: 2, kind: NotFound, message: "Das System kann die angegebene Datei nicht finden." })
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', E:\Workspaces\Rust\Bevy\clone\crates\bevy_text\src\font_atlas_set.rs:53:42
```
This might be intended/desired behaviour, such that the typo is fixed right away.

----
My Issue with this:
1. The error-message does not provide information on which file could not be found, which makes it difficult to find the typo in case of a lot of assets.
2. Crashing is ungraceful and pretty demotivating for newcomers

My Fix:
1. Check existence and Return Error-Code with File-path (Much slower performance, so not feasible if the function is used in asset-streaming for large worlds?)
2. User can choose to internally handle error by e.g. having fall-back assets (could also be used to allow modding by having a `default_asset/` and `mod_asset/` folder?) 

