### PR TITLE
Add .vscode to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Cargo.lock
 .cargo/config
 /.idea
+/.vscode


### PR DESCRIPTION
Adds ignore for [launch.json](https://code.visualstudio.com/Docs/editor/debugging) file used for debugging setup in VS Code.

<img width="1011" alt="" src="https://user-images.githubusercontent.com/18026180/91220054-829ddc80-e713-11ea-961b-32978b1f2aea.png">
