### PR TITLE
Set CI to run on master commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,8 @@
 name: CI
 
 on:
-  # NOTE: temporarily disabled because on-push currently uses up too many resources
-  # push:
-  #   branches: [master]
-  schedule:
-    - cron:  '0 21 * * *'
+  push:
+    branches: [master]
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
This allows CI to be run on commits that are merged into master. Further discussion is in #238.