### PR TITLE
Separate CI jobs, add job caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,24 +15,73 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: [stable, nightly]
     steps:
       - uses: actions/checkout@v2
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           override: true
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            target
+          key: ${{ runner.os }}-cargo-check-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install alsa
+        run: sudo apt-get install --no-install-recommends libasound2-dev
+
+      - name: Build
+        run: cargo check
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0 -D warnings"
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: [stable, nightly]
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            target
+          key: ${{ runner.os }}-cargo-test-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install alsa
+        run: sudo apt-get install --no-install-recommends libasound2-dev
+
+      - name: Run tests
+        run: cargo test --workspace
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0 -D warnings"
+
+  clean:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
 
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           components: rustfmt, clippy
-
+          override: true
+          
       - name: Install alsa
-        run: sudo apt-get install libasound2-dev
-
-      - name: Build
-        run: cargo check
+        run: sudo apt-get install --no-install-recommends libasound2-dev
 
       - name: Check the format
         run: cargo +nightly fmt --all -- --check
@@ -46,6 +95,3 @@ jobs:
           --
           -D warnings
           -A clippy::type_complexity
-
-      - name: Run tests
-        run: cargo test --workspace


### PR DESCRIPTION
This PR separates CI jobs for better parallelism across runners. There are now 5 separate jobs that run. A build and test for stable and nightly, as well as a "clean" job. Clean includes both `cargo fmt` and `cargo clippy` as they are both quciker than normal `cargo check` or `cargo test`, and so they will complete *around* the same time.

As we can see below, there were definitely some issues with adding caching to CI vanilla. There were a few improvements I added:

- Turn off incremental builds [1](https://internals.rust-lang.org/t/evaluating-github-actions/11292/8), [2](https://github.com/rust-lang/crates.io/pull/1902/files). This decreased the size of the cache from about 2GB to 600MB.
- Added the compiler flag `-C debuginfo=0`, which decreased the size further. I don't think this will have negative effects with `cargo test` or `cargo check`.
- Only save the `target` folder. Normally, both the registry and the git folder are saved. These can be redownloaded fast enough, and would just clutter the zip with more small files to open upon downloading the cache.

|                                 | total time | cache size | open cache time | cargo test time | create cache time |
|---------------------------------|------------|------------|-----------------|-----------------|-------------------|
| stable, no cache                | 8:20       | -          | -               | 8:06            | -                 |
| nightly, no cache               | 7:50       | -          | -               | 7:29            | -                 |
| stable, cache, incremental      | 9:04       | 2202 MB    | 3:34            | 5:07            | ~ 4:00            |
| nightly, cache, incremental     | 8:56       | 2186 MB    | 3:34            | 4:51            | ~ 4:00            |
| stable, cache, non incremental  | 4:22       | 586 MB     | 0:42            | 3:24            | 0:23              |
| nightly, cache, non incremental | 4:52       | 600 MB     | 0:40            | 3:32            | 0:22              |

Likely CI will change further with the addition of more steps, however, this should be a good starting point for separation of jobs. Some unknowns that I will have to examine once this is running on master:

- How does the cache work once a new nightly is released the day after? The cache won't be busted unless `Cargo.lock` changes, so another busting method might be needed for nightlies.