### PR TITLE
Add Color::hex fn

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -38,6 +38,7 @@ once_cell = "1.4.0"
 downcast-rs = "1.1.1"
 thiserror = "1.0"
 anyhow = "1.0"
+hex = "0.4.2"
 hexasphere = "0.1.5"
 parking_lot = "0.10"
 

--- a/crates/bevy_render/src/color.rs
+++ b/crates/bevy_render/src/color.rs
@@ -45,7 +45,7 @@ impl Color {
             let g = buf[1] as f32 / 255.0;
             let b = buf[2] as f32 / 255.0;
             Color::rgb(r, g, b)
-        }else {
+        } else {
             // Invalid value, use default color
             Color::default()
         }

--- a/crates/bevy_render/src/color.rs
+++ b/crates/bevy_render/src/color.rs
@@ -37,6 +37,19 @@ impl Color {
     pub const fn rgba(r: f32, g: f32, b: f32, a: f32) -> Color {
         Color { r, g, b, a }
     }
+
+    pub fn hex<T: AsRef<[u8]>>(hex: T) -> Color {
+        let mut buf = [0; 3];
+        if hex::decode_to_slice(hex, &mut buf).is_ok() {
+            let r = buf[0] as f32 / 255.0;
+            let g = buf[1] as f32 / 255.0;
+            let b = buf[2] as f32 / 255.0;
+            Color::rgb(r, g, b)
+        }else {
+            // Invalid value, use default color
+            Color::default()
+        }
+    }
 }
 
 impl Default for Color {


### PR DESCRIPTION
Allows to create color from hex value

```rust
// RGB
Color::hex("FFF").unwrap() == Color::rgb(1.0, 1.0, 1.0)
// RGBA
Color::hex("FFFF").unwrap() == Color::rgba(1.0, 1.0, 1.0, 1.0)
// RRGGBB
Color::hex("FFFFFF").unwrap() == Color::rgb(1.0, 1.0, 1.0)
// RRGGBBAA
Color::hex("FFFFFFFF").unwrap() == Color::rgba(1.0, 1.0, 1.0, 1.0)
```