### PR TITLE
Feature to disable libloading (helpful for WASM support)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,17 @@ readme = "README.md"
 exclude = ["assets/**/*", "tools/**/*", ".github/**/*", "crates/**/*"]
 
 [features]
-default = ["bevy_audio", "bevy_gltf", "bevy_wgpu", "bevy_winit", "png", "hdr", "mp3", "x11"]
+default = [
+    "bevy_audio", "bevy_gltf", "bevy_wgpu", "bevy_winit",
+    "dynamic_plugins", "png", "hdr", "mp3", "x11"
+]
 profiler = ["bevy_ecs/profiler", "bevy_diagnostic/profiler"]
 wgpu_trace = ["bevy_wgpu/trace"]
+dynamic_plugins = [
+    "bevy_core/dynamic_plugins",
+    "bevy_app/dynamic_plugins",
+    "bevy_type_registry/dynamic_plugins",
+]
 
 # Image format support for texture loading (PNG and HDR are enabled by default)
 png = ["bevy_render/png"]

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -9,12 +9,15 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT"
 keywords = ["bevy"]
 
+[features]
+dynamic_plugins = ["libloading"]
+
 [dependencies]
 # bevy
 bevy_derive = { path = "../bevy_derive", version = "0.1" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.1" }
 
 # other
-libloading = "0.6"
+libloading = { version = "0.6", optional = true }
 log = { version = "0.4", features = ["release_max_level_info"] }
 serde = { version = "1.0", features = ["derive"]}

--- a/crates/bevy_app/src/app_builder.rs
+++ b/crates/bevy_app/src/app_builder.rs
@@ -1,7 +1,9 @@
+#[cfg(feature = "dynamic_plugins")]
+use crate::plugin::dynamically_load_plugin;
 use crate::{
     app::{App, AppExit},
     event::Events,
-    plugin::{dynamically_load_plugin, Plugin},
+    plugin::Plugin,
     stage, startup_stage,
 };
 use bevy_ecs::{FromResources, IntoQuerySystem, Resources, System, World};
@@ -220,6 +222,7 @@ impl AppBuilder {
         self
     }
 
+    #[cfg(feature = "dynamic_plugins")]
     pub fn load_plugin(&mut self, path: &str) -> &mut Self {
         let (_lib, plugin) = dynamically_load_plugin(path);
         log::debug!("loaded plugin: {}", plugin.name());

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -1,4 +1,5 @@
 use crate::AppBuilder;
+#[cfg(feature = "dynamic_plugins")]
 use libloading::{Library, Symbol};
 use std::any::Any;
 
@@ -14,6 +15,7 @@ pub trait Plugin: Any + Send + Sync {
 
 pub type CreatePlugin = unsafe fn() -> *mut dyn Plugin;
 
+#[cfg(feature = "dynamic_plugins")]
 /// Dynamically links a plugin a the given path. The plugin must export the [CreatePlugin] function.
 pub fn dynamically_load_plugin(path: &str) -> (Library, Box<dyn Plugin>) {
     let lib = Library::new(path).unwrap();

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT"
 keywords = ["bevy"]
 
+[features]
+dynamic_plugins = ["bevy_app/dynamic_plugins", "bevy_type_registry/dynamic_plugins"]
+
 [dependencies]
 bevy_app = { path = "../bevy_app", version = "0.1" }
 bevy_derive = { path = "../bevy_derive", version = "0.1" }

--- a/crates/bevy_type_registry/Cargo.toml
+++ b/crates/bevy_type_registry/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT"
 keywords = ["bevy"]
 
+[features]
+dynamic_plugins = ["bevy_app/dynamic_plugins"]
+
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.1" }


### PR DESCRIPTION
`libloading` is currently the only crate preventing `bevy_core` from compiling to WebAssembly, and AFAIK this is unlikely to change any time remotely soon. Other sub-crates have other issues, and I have not tested all functionality on WASM, but this may be the first step to resolving https://github.com/bevyengine/bevy/issues/88