### PR TITLE
Change schedule run in ScheduleRunnerPlugin to use app.update

### DIFF
--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -51,7 +51,7 @@ impl Plugin for ScheduleRunnerPlugin {
             let mut app_exit_event_reader = EventReader::<AppExit>::default();
             match run_mode {
                 RunMode::Once => {
-                    app.schedule.run(&mut app.world, &mut app.resources);
+                    app.update();
                 }
                 RunMode::Loop { wait } => loop {
                     let start_time = Instant::now();
@@ -62,7 +62,7 @@ impl Plugin for ScheduleRunnerPlugin {
                         }
                     }
 
-                    app.schedule.run(&mut app.world, &mut app.resources);
+                    app.update();
 
                     if let Some(app_exit_events) = app.resources.get_mut::<Events<AppExit>>() {
                         if app_exit_event_reader.latest(&app_exit_events).is_some() {


### PR DESCRIPTION
Currently the schedule runner doesn't call update, so the resource initialized isn't called so things like Local<> fail. This also uses the more advanced executor over just the schedule, but I'm not sure if it's wrong in this case (everything i tried ran fine, though).