### PR TITLE
Fix deadlock in hot asset reloading (#375)

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -187,16 +187,20 @@ impl AssetServer {
         use notify::event::{Event, EventKind, ModifyKind};
         let mut changed = HashSet::new();
 
-        while let Some(filesystem_watcher) = asset_server.filesystem_watcher.read().as_ref() {
-            let result = match filesystem_watcher.receiver.try_recv() {
-                Ok(result) => result,
-                Err(TryRecvError::Empty) => {
+        loop {
+            let result = {
+                let rwlock_guard = asset_server.filesystem_watcher.read();
+                if let Some(filesystem_watcher) = rwlock_guard.as_ref() {
+                    filesystem_watcher.receiver.try_recv()
+                } else {
                     break;
                 }
+            };
+            let event = match result {
+                Ok(result) => result.unwrap(),
+                Err(TryRecvError::Empty) => break,
                 Err(TryRecvError::Disconnected) => panic!("FilesystemWatcher disconnected"),
             };
-
-            let event = result.unwrap();
             if let Event {
                 kind: EventKind::Modify(ModifyKind::Data(_)),
                 paths,


### PR DESCRIPTION
There is a deadlock in `asset_server.filesystem_watcher_system`: while `asset_server.filesystem_watcher` read lock is kept (scope of this lock is too big, whole `while` block) `asset_server.load_untyped` is called, trying to take write lock on  `asset_server.filesystem_watcher`. The fix is to reduce scope of read lock, so `asset_server.load_untyped` is called with released read lock.
It fixes #375 