### PR TITLE
Update icosphere dependency and add a limit to subdivisions.

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -38,7 +38,7 @@ once_cell = "1.4.0"
 downcast-rs = "1.1.1"
 thiserror = "1.0"
 anyhow = "1.0"
-hexasphere = "0.1.5"
+hexasphere = "1.0.0"
 parking_lot = "0.10"
 
 [features]

--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -411,6 +411,15 @@ pub mod shape {
 
     impl From<Icosphere> for Mesh {
         fn from(sphere: Icosphere) -> Self {
+            if sphere.subdivisions >= 80 {
+                let temp_sphere = Hexasphere::new(sphere.subdivisions, |_| ());
+
+                panic!(
+                    "Cannot create an icosphere of {} subdivisions due to there being too many vertices being generated: {} (Limited to 65535 vertices or 79 subdivisions)",
+                    sphere.subdivisions,
+                    temp_sphere.raw_points().len()
+                );
+            }
             let hexasphere = Hexasphere::new(sphere.subdivisions, |point| {
                 let inclination = point.z().acos();
                 let azumith = point.y().atan2(point.x());


### PR DESCRIPTION
The newest version of `hexasphere` is essentially the same as the one being used currently, it just happens to be that I made an error when publishing `0.1.7` and had to yank it. Unfortunately, the theoretical `0.1.8` would've broken compatibility for standalone users of `0.1.7` (but not `0.1.6`), so I decided to bump it to `1.0.0`.

The limit to subdivisions occurs because subdivision 80 produces 65612 vertices, which is more than currently supported by the 16 bit indices (which caps out at 65535 vertices).