### PR TITLE
Fix archetypes_generation being incorrectly updated for systems

### DIFF
--- a/crates/bevy_ecs/src/schedule/parallel_executor.rs
+++ b/crates/bevy_ecs/src/schedule/parallel_executor.rs
@@ -282,6 +282,7 @@ impl ExecutorStage {
         systems: &[Arc<Mutex<Box<dyn System>>>],
         schedule_changed: bool,
     ) {
+        let start_archetypes_generation = world.archetypes_generation();
         let compute_pool = resources
             .get_cloned::<bevy_tasks::ComputeTaskPool>()
             .unwrap();
@@ -388,7 +389,11 @@ impl ExecutorStage {
             }
         }
 
-        self.last_archetypes_generation = world.archetypes_generation();
+        // If world's archetypes_generation is the same as it was before running any systems then
+        // we can assume that all systems have correct archetype accesses.
+        if start_archetypes_generation == world.archetypes_generation() {
+            self.last_archetypes_generation = world.archetypes_generation();
+        }
     }
 }
 


### PR DESCRIPTION
The issue for this (#294) mentioned query systems not having this issue but it turns out they have the same issue, except instead of panicking they'll just run anyway and let you have multiple mutable borrows on the same components. This PR fixes it for both types of systems but it's probably worth investigating why one panics and the other is just UB.

resolves #294
resolves #259 