### PR TITLE
Fix sprite clipping at same depth

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -31,7 +31,7 @@ pub fn build_sprite_sheet_pipeline(shaders: &mut Assets<Shader>) -> PipelineDesc
         depth_stencil_state: Some(DepthStencilStateDescriptor {
             format: TextureFormat::Depth32Float,
             depth_write_enabled: true,
-            depth_compare: CompareFunction::Less,
+            depth_compare: CompareFunction::LessEqual,
             stencil: StencilStateDescriptor {
                 front: StencilStateFaceDescriptor::IGNORE,
                 back: StencilStateFaceDescriptor::IGNORE,
@@ -79,7 +79,7 @@ pub fn build_sprite_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescriptor
         depth_stencil_state: Some(DepthStencilStateDescriptor {
             format: TextureFormat::Depth32Float,
             depth_write_enabled: true,
-            depth_compare: CompareFunction::Less,
+            depth_compare: CompareFunction::LessEqual,
             stencil: StencilStateDescriptor {
                 front: StencilStateFaceDescriptor::IGNORE,
                 back: StencilStateFaceDescriptor::IGNORE,


### PR DESCRIPTION
Thanks to @Bobox214 for his showcase, which demonstrates the fix nicely.


![clipping_demo](https://user-images.githubusercontent.com/6333127/91621042-b1a88e00-e95f-11ea-8e58-0cc62726ea01.gif)
