### PR TITLE
Resource change tracking

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -11,7 +11,7 @@ pub use world::*;
 
 pub mod prelude {
     pub use crate::{
-        resource::{ChangedRes, FromResources, Local, Res, ResMut, Resource, Resources},
+        resource::{ChangedRes, FromResources, Local, OrRes, Res, ResMut, Resource, Resources},
         system::{
             Commands, IntoForEachSystem, IntoQuerySystem, IntoThreadLocalSystem, Query, System,
         },

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -11,7 +11,7 @@ pub use world::*;
 
 pub mod prelude {
     pub use crate::{
-        resource::{FromResources, Local, Res, ResMut, Resource, Resources},
+        resource::{ChangedRes, FromResources, Local, Res, ResMut, Resource, Resources},
         system::{
             Commands, IntoForEachSystem, IntoQuerySystem, IntoThreadLocalSystem, Query, System,
         },

--- a/crates/bevy_ecs/src/resource/resource_query.rs
+++ b/crates/bevy_ecs/src/resource/resource_query.rs
@@ -185,6 +185,8 @@ pub trait FetchResource<'a>: Sized {
 
     #[allow(clippy::missing_safety_doc)]
     unsafe fn get(resources: &'a Resources, system_id: Option<SystemId>) -> Self::Item;
+
+    #[allow(clippy::missing_safety_doc)]
     unsafe fn is_some(_resources: &'a Resources, _system_id: Option<SystemId>) -> bool {
         true
     }

--- a/crates/bevy_ecs/src/resource/resource_query.rs
+++ b/crates/bevy_ecs/src/resource/resource_query.rs
@@ -98,7 +98,7 @@ impl<'a, T: Resource> ResMut<'a, T> {
     ///
     /// # Safety
     /// The pointer must have correct lifetime / storage / ownership
-    pub unsafe fn new((value, mutated): (NonNull<T>, NonNull<bool>)) -> Self {
+    pub unsafe fn new(value: NonNull<T>, mutated: NonNull<bool>) -> Self {
         Self {
             value: value.as_ptr(),
             mutated: mutated.as_ptr(),
@@ -266,7 +266,8 @@ impl<'a, T: Resource> FetchResource<'a> for FetchResourceWrite<T> {
     type Item = ResMut<'a, T>;
 
     unsafe fn get(resources: &'a Resources, _system_id: Option<SystemId>) -> Self::Item {
-        ResMut::new(resources.get_unsafe_ref_with_mutated::<T>(ResourceIndex::Global))
+        let (value, mutated) = resources.get_unsafe_ref_with_mutated::<T>(ResourceIndex::Global);
+        ResMut::new(value, mutated)
     }
 
     fn borrow(resources: &Resources) {

--- a/crates/bevy_ecs/src/resource/resources.rs
+++ b/crates/bevy_ecs/src/resource/resources.rs
@@ -154,20 +154,71 @@ impl Resources {
     #[inline]
     #[allow(clippy::missing_safety_doc)]
     pub unsafe fn get_unsafe_ref<T: Resource>(&self, resource_index: ResourceIndex) -> NonNull<T> {
-        self.resource_data
-            .get(&TypeId::of::<T>())
-            .and_then(|data| {
-                let index = match resource_index {
-                    ResourceIndex::Global => data.default_index?,
-                    ResourceIndex::System(id) => {
-                        data.system_id_to_archetype_index.get(&id.0).cloned()?
-                    }
-                };
+        self.get_unsafe_resource_data_index::<T>(resource_index)
+            .and_then(|(data, index)| {
                 Some(NonNull::new_unchecked(
-                    data.archetype.get::<T>()?.as_ptr().add(index as usize),
+                    data.archetype.get::<T>()?.as_ptr().add(index),
                 ))
             })
             .unwrap_or_else(|| panic!("Resource does not exist {}", std::any::type_name::<T>()))
+    }
+
+    #[inline]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe fn get_unsafe_ref_with_mutated<T: Resource>(
+        &self,
+        resource_index: ResourceIndex,
+    ) -> (NonNull<T>, NonNull<bool>) {
+        self.get_unsafe_resource_data_index::<T>(resource_index)
+            .and_then(|(data, index)| {
+                data.archetype
+                    .get_with_mutated::<T>()
+                    .map(|(resource, mutated)| {
+                        (
+                            NonNull::new_unchecked(resource.as_ptr().add(index)),
+                            NonNull::new_unchecked(mutated.as_ptr().add(index)),
+                        )
+                    })
+            })
+            .unwrap_or_else(|| panic!("Resource does not exist {}", std::any::type_name::<T>()))
+    }
+
+    #[inline]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe fn get_unsafe_ref_with_added_and_mutated<T: Resource>(
+        &self,
+        resource_index: ResourceIndex,
+    ) -> (NonNull<T>, NonNull<bool>, NonNull<bool>) {
+        self.get_unsafe_resource_data_index::<T>(resource_index)
+            .and_then(|(data, index)| {
+                data.archetype.get_with_added_and_mutated::<T>().map(
+                    |(resource, added, mutated)| {
+                        (
+                            NonNull::new_unchecked(resource.as_ptr().add(index)),
+                            NonNull::new_unchecked(added.as_ptr().add(index)),
+                            NonNull::new_unchecked(mutated.as_ptr().add(index)),
+                        )
+                    },
+                )
+            })
+            .unwrap_or_else(|| panic!("Resource does not exist {}", std::any::type_name::<T>()))
+    }
+
+    #[inline]
+    #[allow(clippy::missing_safety_doc)]
+    unsafe fn get_unsafe_resource_data_index<T: Resource>(
+        &self,
+        resource_index: ResourceIndex,
+    ) -> Option<(&ResourceData, usize)> {
+        self.resource_data.get(&TypeId::of::<T>()).and_then(|data| {
+            let index = match resource_index {
+                ResourceIndex::Global => data.default_index?,
+                ResourceIndex::System(id) => {
+                    data.system_id_to_archetype_index.get(&id.0).cloned()?
+                }
+            };
+            Some((data, index as usize))
+        })
     }
 
     pub fn borrow<T: Resource>(&self) {
@@ -191,6 +242,14 @@ impl Resources {
     pub fn release_mut<T: Resource>(&self) {
         if let Some(data) = self.resource_data.get(&TypeId::of::<T>()) {
             data.archetype.release_mut::<T>();
+        }
+    }
+
+    /// Clears each resource's tracker state.
+    /// For example, each resource's component "mutated" state will be reset to `false`.
+    pub fn clear_trackers(&mut self) {
+        for (_, resource_data) in self.resource_data.iter_mut() {
+            resource_data.archetype.clear_trackers();
         }
     }
 }

--- a/crates/bevy_ecs/src/resource/resources.rs
+++ b/crates/bevy_ecs/src/resource/resources.rs
@@ -166,7 +166,7 @@ impl Resources {
     #[inline]
     #[allow(clippy::missing_safety_doc)]
     pub unsafe fn get_unsafe_ref<T: Resource>(&self, resource_index: ResourceIndex) -> NonNull<T> {
-        self.get_unsafe_resource_data_index::<T>(resource_index)
+        self.get_resource_data_index::<T>(resource_index)
             .and_then(|(data, index)| {
                 Some(NonNull::new_unchecked(
                     data.archetype.get::<T>()?.as_ptr().add(index),
@@ -181,7 +181,7 @@ impl Resources {
         &self,
         resource_index: ResourceIndex,
     ) -> (NonNull<T>, NonNull<bool>) {
-        self.get_unsafe_resource_data_index::<T>(resource_index)
+        self.get_resource_data_index::<T>(resource_index)
             .and_then(|(data, index)| {
                 data.archetype
                     .get_with_mutated::<T>()
@@ -201,7 +201,7 @@ impl Resources {
         &self,
         resource_index: ResourceIndex,
     ) -> (NonNull<bool>, NonNull<bool>) {
-        self.get_unsafe_resource_data_index::<T>(resource_index)
+        self.get_resource_data_index::<T>(resource_index)
             .and_then(|(data, index)| {
                 Some((
                     NonNull::new_unchecked(data.archetype.get_added::<T>()?.as_ptr().add(index)),
@@ -212,8 +212,7 @@ impl Resources {
     }
 
     #[inline]
-    #[allow(clippy::missing_safety_doc)]
-    fn get_unsafe_resource_data_index<T: Resource>(
+    fn get_resource_data_index<T: Resource>(
         &self,
         resource_index: ResourceIndex,
     ) -> Option<(&ResourceData, usize)> {

--- a/crates/bevy_ecs/src/resource/resources.rs
+++ b/crates/bevy_ecs/src/resource/resources.rs
@@ -141,14 +141,28 @@ impl Resources {
     }
 
     pub fn query<Q: ResourceQuery>(&self) -> Option<<Q::Fetch as FetchResource>::Item> {
-        unsafe { Q::Fetch::get(&self, None) }
+        unsafe {
+            let g = Q::Fetch::get(&self, None);
+            if g.1 {
+                Some(g.0)
+            } else {
+                None
+            }
+        }
     }
 
     pub fn query_system<Q: ResourceQuery>(
         &self,
         id: SystemId,
     ) -> Option<<Q::Fetch as FetchResource>::Item> {
-        unsafe { Q::Fetch::get(&self, Some(id)) }
+        unsafe {
+            let g = Q::Fetch::get(&self, Some(id));
+            if g.1 {
+                Some(g.0)
+            } else {
+                None
+            }
+        }
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/resource/resources.rs
+++ b/crates/bevy_ecs/src/resource/resources.rs
@@ -140,14 +140,14 @@ impl Resources {
             })
     }
 
-    pub fn query<Q: ResourceQuery>(&self) -> <Q::Fetch as FetchResource>::Item {
+    pub fn query<Q: ResourceQuery>(&self) -> Option<<Q::Fetch as FetchResource>::Item> {
         unsafe { Q::Fetch::get(&self, None) }
     }
 
     pub fn query_system<Q: ResourceQuery>(
         &self,
         id: SystemId,
-    ) -> <Q::Fetch as FetchResource>::Item {
+    ) -> Option<<Q::Fetch as FetchResource>::Item> {
         unsafe { Q::Fetch::get(&self, Some(id)) }
     }
 

--- a/crates/bevy_ecs/src/schedule/parallel_executor.rs
+++ b/crates/bevy_ecs/src/schedule/parallel_executor.rs
@@ -59,6 +59,7 @@ impl ParallelExecutor {
 
         if self.clear_trackers {
             world.clear_trackers();
+            resources.clear_trackers();
         }
 
         self.last_schedule_generation = schedule_generation;

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -159,6 +159,7 @@ impl Schedule {
         }
 
         world.clear_trackers();
+        resources.clear_trackers();
     }
 
     // TODO: move this code to ParallelExecutor

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -176,18 +176,26 @@ impl<'a> FetchResource<'a> for FetchDrawContext {
     }
 
     unsafe fn get(resources: &'a Resources, _system_id: Option<SystemId>) -> Self::Item {
+        let pipelines = {
+            let (value, mutated) = resources
+                .get_unsafe_ref_with_mutated::<Assets<PipelineDescriptor>>(ResourceIndex::Global);
+            ResMut::new(value, mutated)
+        };
+        let shaders = {
+            let (value, mutated) =
+                resources.get_unsafe_ref_with_mutated::<Assets<Shader>>(ResourceIndex::Global);
+            ResMut::new(value, mutated)
+        };
+        let pipeline_compiler = {
+            let (value, mutated) =
+                resources.get_unsafe_ref_with_mutated::<PipelineCompiler>(ResourceIndex::Global);
+            ResMut::new(value, mutated)
+        };
+
         DrawContext {
-            pipelines: ResMut::new(
-                resources.get_unsafe_ref_with_mutated::<Assets<PipelineDescriptor>>(
-                    ResourceIndex::Global,
-                ),
-            ),
-            shaders: ResMut::new(
-                resources.get_unsafe_ref_with_mutated::<Assets<Shader>>(ResourceIndex::Global),
-            ),
-            pipeline_compiler: ResMut::new(
-                resources.get_unsafe_ref_with_mutated::<PipelineCompiler>(ResourceIndex::Global),
-            ),
+            pipelines,
+            shaders,
+            pipeline_compiler,
             render_resource_context: Res::new(
                 resources.get_unsafe_ref::<Box<dyn RenderResourceContext>>(ResourceIndex::Global),
             ),

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -175,35 +175,30 @@ impl<'a> FetchResource<'a> for FetchDrawContext {
         resources.release::<SharedBuffers>();
     }
 
-    unsafe fn get(resources: &'a Resources, _system_id: Option<SystemId>) -> (Self::Item, bool) {
-        (
-            DrawContext {
-                pipelines: ResMut::new(
-                    resources.get_unsafe_ref_with_mutated::<Assets<PipelineDescriptor>>(
-                        ResourceIndex::Global,
-                    ),
+    unsafe fn get(resources: &'a Resources, _system_id: Option<SystemId>) -> Self::Item {
+        DrawContext {
+            pipelines: ResMut::new(
+                resources.get_unsafe_ref_with_mutated::<Assets<PipelineDescriptor>>(
+                    ResourceIndex::Global,
                 ),
-                shaders: ResMut::new(
-                    resources.get_unsafe_ref_with_mutated::<Assets<Shader>>(ResourceIndex::Global),
-                ),
-                pipeline_compiler: ResMut::new(
-                    resources
-                        .get_unsafe_ref_with_mutated::<PipelineCompiler>(ResourceIndex::Global),
-                ),
-                render_resource_context: Res::new(
-                    resources
-                        .get_unsafe_ref::<Box<dyn RenderResourceContext>>(ResourceIndex::Global),
-                ),
-                vertex_buffer_descriptors: Res::new(
-                    resources.get_unsafe_ref::<VertexBufferDescriptors>(ResourceIndex::Global),
-                ),
-                shared_buffers: Res::new(
-                    resources.get_unsafe_ref::<SharedBuffers>(ResourceIndex::Global),
-                ),
-                current_pipeline: None,
-            },
-            true,
-        )
+            ),
+            shaders: ResMut::new(
+                resources.get_unsafe_ref_with_mutated::<Assets<Shader>>(ResourceIndex::Global),
+            ),
+            pipeline_compiler: ResMut::new(
+                resources.get_unsafe_ref_with_mutated::<PipelineCompiler>(ResourceIndex::Global),
+            ),
+            render_resource_context: Res::new(
+                resources.get_unsafe_ref::<Box<dyn RenderResourceContext>>(ResourceIndex::Global),
+            ),
+            vertex_buffer_descriptors: Res::new(
+                resources.get_unsafe_ref::<VertexBufferDescriptors>(ResourceIndex::Global),
+            ),
+            shared_buffers: Res::new(
+                resources.get_unsafe_ref::<SharedBuffers>(ResourceIndex::Global),
+            ),
+            current_pipeline: None,
+        }
     }
 
     fn access() -> TypeAccess {

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -175,8 +175,8 @@ impl<'a> FetchResource<'a> for FetchDrawContext {
         resources.release::<SharedBuffers>();
     }
 
-    unsafe fn get(resources: &'a Resources, _system_id: Option<SystemId>) -> Self::Item {
-        DrawContext {
+    unsafe fn get(resources: &'a Resources, _system_id: Option<SystemId>) -> Option<Self::Item> {
+        Some(DrawContext {
             pipelines: ResMut::new(
                 resources.get_unsafe_ref_with_mutated::<Assets<PipelineDescriptor>>(
                     ResourceIndex::Global,
@@ -198,7 +198,7 @@ impl<'a> FetchResource<'a> for FetchDrawContext {
                 resources.get_unsafe_ref::<SharedBuffers>(ResourceIndex::Global),
             ),
             current_pipeline: None,
-        }
+        })
     }
 
     fn access() -> TypeAccess {

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -175,30 +175,35 @@ impl<'a> FetchResource<'a> for FetchDrawContext {
         resources.release::<SharedBuffers>();
     }
 
-    unsafe fn get(resources: &'a Resources, _system_id: Option<SystemId>) -> Option<Self::Item> {
-        Some(DrawContext {
-            pipelines: ResMut::new(
-                resources.get_unsafe_ref_with_mutated::<Assets<PipelineDescriptor>>(
-                    ResourceIndex::Global,
+    unsafe fn get(resources: &'a Resources, _system_id: Option<SystemId>) -> (Self::Item, bool) {
+        (
+            DrawContext {
+                pipelines: ResMut::new(
+                    resources.get_unsafe_ref_with_mutated::<Assets<PipelineDescriptor>>(
+                        ResourceIndex::Global,
+                    ),
                 ),
-            ),
-            shaders: ResMut::new(
-                resources.get_unsafe_ref_with_mutated::<Assets<Shader>>(ResourceIndex::Global),
-            ),
-            pipeline_compiler: ResMut::new(
-                resources.get_unsafe_ref_with_mutated::<PipelineCompiler>(ResourceIndex::Global),
-            ),
-            render_resource_context: Res::new(
-                resources.get_unsafe_ref::<Box<dyn RenderResourceContext>>(ResourceIndex::Global),
-            ),
-            vertex_buffer_descriptors: Res::new(
-                resources.get_unsafe_ref::<VertexBufferDescriptors>(ResourceIndex::Global),
-            ),
-            shared_buffers: Res::new(
-                resources.get_unsafe_ref::<SharedBuffers>(ResourceIndex::Global),
-            ),
-            current_pipeline: None,
-        })
+                shaders: ResMut::new(
+                    resources.get_unsafe_ref_with_mutated::<Assets<Shader>>(ResourceIndex::Global),
+                ),
+                pipeline_compiler: ResMut::new(
+                    resources
+                        .get_unsafe_ref_with_mutated::<PipelineCompiler>(ResourceIndex::Global),
+                ),
+                render_resource_context: Res::new(
+                    resources
+                        .get_unsafe_ref::<Box<dyn RenderResourceContext>>(ResourceIndex::Global),
+                ),
+                vertex_buffer_descriptors: Res::new(
+                    resources.get_unsafe_ref::<VertexBufferDescriptors>(ResourceIndex::Global),
+                ),
+                shared_buffers: Res::new(
+                    resources.get_unsafe_ref::<SharedBuffers>(ResourceIndex::Global),
+                ),
+                current_pipeline: None,
+            },
+            true,
+        )
     }
 
     fn access() -> TypeAccess {

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -178,11 +178,15 @@ impl<'a> FetchResource<'a> for FetchDrawContext {
     unsafe fn get(resources: &'a Resources, _system_id: Option<SystemId>) -> Self::Item {
         DrawContext {
             pipelines: ResMut::new(
-                resources.get_unsafe_ref::<Assets<PipelineDescriptor>>(ResourceIndex::Global),
+                resources.get_unsafe_ref_with_mutated::<Assets<PipelineDescriptor>>(
+                    ResourceIndex::Global,
+                ),
             ),
-            shaders: ResMut::new(resources.get_unsafe_ref::<Assets<Shader>>(ResourceIndex::Global)),
+            shaders: ResMut::new(
+                resources.get_unsafe_ref_with_mutated::<Assets<Shader>>(ResourceIndex::Global),
+            ),
             pipeline_compiler: ResMut::new(
-                resources.get_unsafe_ref::<PipelineCompiler>(ResourceIndex::Global),
+                resources.get_unsafe_ref_with_mutated::<PipelineCompiler>(ResourceIndex::Global),
             ),
             render_resource_context: Res::new(
                 resources.get_unsafe_ref::<Box<dyn RenderResourceContext>>(ResourceIndex::Global),


### PR DESCRIPTION
Add mutated tracker on resources and ChangedRes query for added or mutated resources.

https://github.com/bevyengine/bevy/issues/62

The ChangedRes<T: Resource> query yields Option<&T>, with None if the resource has not been added or mutated.