### PR TITLE
Bump entities to u128 to avoid collisions (#117)

### DIFF
--- a/crates/bevy_ecs/hecs/src/archetype.rs
+++ b/crates/bevy_ecs/hecs/src/archetype.rs
@@ -38,7 +38,7 @@ pub struct Archetype {
     types: Vec<TypeInfo>,
     state: HashMap<TypeId, TypeState>,
     len: u32,
-    entities: Box<[u32]>,
+    entities: Box<[u128]>,
     // UnsafeCell allows unique references into `data` to be constructed while shared references
     // containing the `Archetype` exist
     data: UnsafeCell<NonNull<u8>>,
@@ -226,16 +226,16 @@ impl Archetype {
     }
 
     #[allow(missing_docs)]
-    pub fn iter_entities(&self) -> impl Iterator<Item = &u32> {
+    pub fn iter_entities(&self) -> impl Iterator<Item = &u128> {
         self.entities.iter().take(self.len as usize)
     }
 
     #[inline]
-    pub(crate) fn entities(&self) -> NonNull<u32> {
+    pub(crate) fn entities(&self) -> NonNull<u128> {
         unsafe { NonNull::new_unchecked(self.entities.as_ptr() as *mut _) }
     }
 
-    pub(crate) fn entity_id(&self, index: u32) -> u32 {
+    pub(crate) fn entity_id(&self, index: u32) -> u128 {
         self.entities[index as usize]
     }
 
@@ -263,7 +263,7 @@ impl Archetype {
 
     /// # Safety
     /// Every type must be written immediately after this call
-    pub unsafe fn allocate(&mut self, id: u32) -> u32 {
+    pub unsafe fn allocate(&mut self, id: u128) -> u32 {
         if self.len as usize == self.entities.len() {
             self.grow(self.len.max(self.grow_size));
         }
@@ -341,7 +341,7 @@ impl Archetype {
     }
 
     /// Returns the ID of the entity moved into `index`, if any
-    pub(crate) unsafe fn remove(&mut self, index: u32) -> Option<u32> {
+    pub(crate) unsafe fn remove(&mut self, index: u32) -> Option<u128> {
         let last = self.len - 1;
         for ty in &self.types {
             let removed = self
@@ -380,7 +380,7 @@ impl Archetype {
         &mut self,
         index: u32,
         mut f: impl FnMut(*mut u8, TypeId, usize, bool, bool),
-    ) -> Option<u32> {
+    ) -> Option<u128> {
         let last = self.len - 1;
         for ty in &self.types {
             let moved = self

--- a/crates/bevy_ecs/hecs/src/entities.rs
+++ b/crates/bevy_ecs/hecs/src/entities.rs
@@ -9,18 +9,18 @@ use std::error::Error;
 ///
 /// Obtained from `World::spawn`. Can be stored to refer to an entity in the future.
 #[derive(Debug, Clone, Copy, Hash, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Entity(u32);
+pub struct Entity(u128);
 
 #[allow(clippy::new_without_default)]
 impl Entity {
     #[allow(missing_docs)]
     pub fn new() -> Self {
-        Self(rand::random::<u32>())
+        Self(rand::random::<u128>())
     }
 
     #[allow(missing_docs)]
     #[inline]
-    pub fn from_id(id: u32) -> Self {
+    pub fn from_id(id: u128) -> Self {
         Self(id)
     }
 
@@ -30,7 +30,7 @@ impl Entity {
     /// with both live and dead entities. Useful for compactly representing entities within a
     /// specific snapshot of the world, such as when serializing.
     #[inline]
-    pub fn id(self) -> u32 {
+    pub fn id(self) -> u128 {
         self.0
     }
 }

--- a/crates/bevy_ecs/hecs/src/query.rs
+++ b/crates/bevy_ecs/hecs/src/query.rs
@@ -76,7 +76,7 @@ pub enum Access {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct EntityFetch(NonNull<u32>);
+pub struct EntityFetch(NonNull<u128>);
 
 impl Query for Entity {
     type Fetch = EntityFetch;

--- a/crates/bevy_ecs/hecs/src/serde.rs
+++ b/crates/bevy_ecs/hecs/src/serde.rs
@@ -8,6 +8,6 @@ impl Serialize for Entity {
     where
         S: Serializer,
     {
-        serializer.serialize_u32(self.id())
+        serializer.serialize_u128(self.id())
     }
 }

--- a/crates/bevy_ecs/src/resource/resources.rs
+++ b/crates/bevy_ecs/src/resource/resources.rs
@@ -94,7 +94,7 @@ impl Resources {
         use std::cmp::Ordering;
         match index.cmp(&archetype.len()) {
             Ordering::Equal => {
-                unsafe { archetype.allocate(index) };
+                unsafe { archetype.allocate(index as u128) };
             }
             Ordering::Greater => panic!("attempted to access index beyond 'current_capacity + 1'"),
             Ordering::Less => (),

--- a/crates/bevy_property/src/impl_property/impl_property_bevy_ecs.rs
+++ b/crates/bevy_property/src/impl_property/impl_property_bevy_ecs.rs
@@ -8,7 +8,7 @@ impl_property!(Entity, serialize_entity, deserialize_entity);
 mod private {
     use serde::{Deserialize, Serialize};
     #[derive(Serialize, Deserialize)]
-    pub(super) struct Entity(pub(super) u32);
+    pub(super) struct Entity(pub(super) u128);
 }
 
 fn serialize_entity(entity: &Entity) -> Serializable {

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -11,7 +11,7 @@ pub struct Scene {
 }
 
 pub struct Entity {
-    pub entity: u32,
+    pub entity: u128,
     pub components: Vec<DynamicProperties>,
 }
 

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 use uuid::Uuid;
 
 struct InstanceInfo {
-    entity_map: HashMap<u32, bevy_ecs::Entity>,
+    entity_map: HashMap<u128, bevy_ecs::Entity>,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -182,7 +182,7 @@ impl<'a, 'de> Visitor<'de> for SceneEntityVisiter<'a> {
                     if id.is_some() {
                         return Err(Error::duplicate_field(ENTITY_FIELD_ENTITY));
                     }
-                    id = Some(map.next_value::<u32>()?);
+                    id = Some(map.next_value::<u128>()?);
                 }
                 EntityField::Components => {
                     if components.is_some() {

--- a/crates/bevy_transform/src/components/parent.rs
+++ b/crates/bevy_transform/src/components/parent.rs
@@ -11,7 +11,7 @@ pub struct Parent(pub Entity);
 // ways to handle cases like this.
 impl FromResources for Parent {
     fn from_resources(_resources: &bevy_ecs::Resources) -> Self {
-        Parent(Entity::from_id(u32::MAX))
+        Parent(Entity::from_id(u128::MAX))
     }
 }
 


### PR DESCRIPTION
Resolves #369 
Also lets [ecs_bench_suit](https://github.com/rust-gamedev/ecs_bench_suite) run the `add_remove` bench for bevy_ecs