### PR TITLE
Fix hot asset reloading on Windows

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -13,6 +13,7 @@ use std::{
     sync::Arc,
     thread,
 };
+
 use thiserror::Error;
 
 /// The type used for asset versioning
@@ -184,7 +185,6 @@ impl AssetServer {
 
     #[cfg(feature = "filesystem_watcher")]
     pub fn filesystem_watcher_system(asset_server: Res<AssetServer>) {
-        use notify::event::{Event, EventKind, ModifyKind};
         let mut changed = HashSet::default();
 
         loop {
@@ -201,8 +201,8 @@ impl AssetServer {
                 Err(TryRecvError::Empty) => break,
                 Err(TryRecvError::Disconnected) => panic!("FilesystemWatcher disconnected"),
             };
-            if let Event {
-                kind: EventKind::Modify(ModifyKind::Data(_)),
+            if let notify::event::Event {
+                kind: notify::event::EventKind::Modify(_),
                 paths,
                 ..
             } = event


### PR DESCRIPTION
Fixes #348

The change to use fully qualified names is to work around https://github.com/rust-analyzer/rust-analyzer/issues/1165. This let me jump into the `notify` source and find https://github.com/notify-rs/notify/blob/05da071c09b2e50b68630430ff02023410f9e40a/src/windows.rs#L377-L381, showing that in Windows environments, only `ModifyKind::Any` is used.