### PR TITLE
add bevy_render::pass::ClearColor to prelude

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -20,6 +20,7 @@ pub mod prelude {
         draw::Draw,
         entity::*,
         mesh::{shape, Mesh},
+        pass::ClearColor,
         pipeline::RenderPipelines,
         shader::Shader,
         texture::Texture,


### PR DESCRIPTION
It is common for users to want to set their clear color.

This use case is seemingly more common than enabling MSAA, but `Msaa` is in the prelude and `ClearColor` isn't, which struck me as weird.