### PR TITLE
Low power default option [#366]

### DIFF
--- a/crates/bevy_wgpu/src/wgpu_renderer.rs
+++ b/crates/bevy_wgpu/src/wgpu_renderer.rs
@@ -1,4 +1,7 @@
-use crate::renderer::{WgpuRenderGraphExecutor, WgpuRenderResourceContext};
+use crate::{
+    renderer::{WgpuRenderGraphExecutor, WgpuRenderResourceContext},
+    WgpuOptions, WgpuPowerOptions,
+};
 use bevy_app::prelude::*;
 use bevy_ecs::{Resources, World};
 use bevy_render::{
@@ -18,11 +21,16 @@ pub struct WgpuRenderer {
 }
 
 impl WgpuRenderer {
-    pub async fn new() -> Self {
+    pub async fn new(options: WgpuOptions) -> Self {
         let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
+
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
-                power_preference: wgpu::PowerPreference::HighPerformance,
+                power_preference: match options.power_pref {
+                    WgpuPowerOptions::HighPerformance => wgpu::PowerPreference::HighPerformance,
+                    WgpuPowerOptions::Adaptive => wgpu::PowerPreference::Default,
+                    WgpuPowerOptions::LowPower => wgpu::PowerPreference::LowPower,
+                },
                 compatible_surface: None,
             })
             .await


### PR DESCRIPTION
Adding a `low_power` feature to bevy, that changes from using the High Performance graphics card to the default one. This is meant to provide a workable solution for https://github.com/bevyengine/bevy/issues/366 until such a time as the underlying issue is resolved, without requiring developers to clone the bevy repository and make changes to it.

I was unsure whether doing something like this would match the standards/expectations for bevy, but I figured it's worth creating a PR just in case.

The actual problem & solution used here were found by https://github.com/fopsdev & @MGlolenstine