### PR TITLE
Allowing glTFs to be loaded that don't have uvs and normals

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -76,22 +76,18 @@ fn load_node(buffer_data: &[Vec<u8>], node: &gltf::Node, depth: i32) -> Result<M
             let primitive_topology = get_primitive_topology(primitive.mode())?;
             let mut mesh = Mesh::new(primitive_topology);
 
-            let vertex_attribute = match reader.read_positions().map(|v| VertexAttribute::position(v.collect())){
-                Some(x) => x,
-                None => return Err(GltfError::BufferFormatUnsupported) //TODO: return proper error message
-            };
-
-            let total_vertices = vertex_attribute.values.len();
-            mesh.attributes.push(vertex_attribute);
-
+            if let Some(vertex_attribute) = reader
+                .read_positions()
+                .map(|v| VertexAttribute::position(v.collect()))
+            {
+                mesh.attributes.push(vertex_attribute);
+            }
 
             if let Some(vertex_attribute) = reader
                 .read_normals()
                 .map(|v| VertexAttribute::normal(v.collect()))
             {
                 mesh.attributes.push(vertex_attribute);
-            } else {
-                mesh.attributes.push(VertexAttribute::normal(vec![[0.0, 0.0, 0.0]; total_vertices]));
             }
 
             if let Some(vertex_attribute) = reader
@@ -99,8 +95,6 @@ fn load_node(buffer_data: &[Vec<u8>], node: &gltf::Node, depth: i32) -> Result<M
                 .map(|v| VertexAttribute::uv(v.into_f32().collect()))
             {
                 mesh.attributes.push(vertex_attribute);
-            } else {
-                mesh.attributes.push(VertexAttribute::uv(vec![[0.0, 0.0]; total_vertices]));
             }
 
             if let Some(indices) = reader.read_indices() {

--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -150,7 +150,7 @@ impl Mesh {
                     if !fill_missing_attributes {
                         return Err(MeshToVertexBufferError::MissingVertexAttribute {
                             attribute_name: vertex_attribute.name.clone(),
-                        })
+                        });
                     }
                 }
             }

--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -125,6 +125,7 @@ impl Mesh {
     pub fn get_vertex_buffer_bytes(
         &self,
         vertex_buffer_descriptor: &VertexBufferDescriptor,
+        fill_missing_attributes: bool,
     ) -> Result<Vec<u8>, MeshToVertexBufferError> {
         let length = self.attributes.first().map(|a| a.values.len()).unwrap_or(0);
         let mut bytes = vec![0; vertex_buffer_descriptor.stride as usize * length];
@@ -146,9 +147,11 @@ impl Mesh {
                     }
                 }
                 None => {
-                    return Err(MeshToVertexBufferError::MissingVertexAttribute {
-                        attribute_name: vertex_attribute.name.clone(),
-                    })
+                    if !fill_missing_attributes {
+                        return Err(MeshToVertexBufferError::MissingVertexAttribute {
+                            attribute_name: vertex_attribute.name.clone(),
+                        })
+                    }
                 }
             }
         }
@@ -530,7 +533,7 @@ pub fn mesh_resource_provider_system(
     for changed_mesh_handle in changed_meshes.iter() {
         if let Some(mesh) = meshes.get(changed_mesh_handle) {
             let vertex_bytes = mesh
-                .get_vertex_buffer_bytes(&vertex_buffer_descriptor)
+                .get_vertex_buffer_bytes(&vertex_buffer_descriptor, true)
                 .unwrap();
             // TODO: use a staging buffer here
             let vertex_buffer = render_resource_context.create_buffer_with_data(
@@ -644,7 +647,7 @@ mod tests {
 
         let descriptor = Vertex::as_vertex_buffer_descriptor();
         assert_eq!(
-            mesh.get_vertex_buffer_bytes(descriptor).unwrap(),
+            mesh.get_vertex_buffer_bytes(descriptor, true).unwrap(),
             expected_vertices.as_bytes(),
             "buffer bytes are equal"
         );


### PR DESCRIPTION
### Issue
Bevy will panic when rendering a glTF mesh that doesn't have UVs and normals

### Fix
UVs and normal attributes will now be filled up with zeros. 

Generally I think it is a better approach to fill up missing attributes with zeros. That will make it easier to deal with different meshs from render side.

### Risks
It is now mandatory for the mesh to contain a position attribute. I really can't think of a case were a mesh wouldn't contain that, but may someone else has. 🤔 