### PR TITLE
Add a pressed interaction and change clicked to fire on release

### DIFF
--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -14,6 +14,7 @@ struct ButtonMaterials {
     normal: Handle<ColorMaterial>,
     hovered: Handle<ColorMaterial>,
     pressed: Handle<ColorMaterial>,
+    clicked: Handle<ColorMaterial>,
 }
 
 impl FromResources for ButtonMaterials {
@@ -23,6 +24,7 @@ impl FromResources for ButtonMaterials {
             normal: materials.add(Color::rgb(0.02, 0.02, 0.02).into()),
             hovered: materials.add(Color::rgb(0.05, 0.05, 0.05).into()),
             pressed: materials.add(Color::rgb(0.1, 0.5, 0.1).into()),
+            clicked: materials.add(Color::rgb(1.0, 0.0, 0.0).into()),
         }
     }
 }
@@ -41,12 +43,16 @@ fn button_system(
         let mut text = text_query.get_mut::<Text>(children[0]).unwrap();
         match *interaction {
             Interaction::Clicked => {
-                text.value = "Press".to_string();
-                *material = button_materials.pressed;
+                text.value = "Click".to_string();
+                *material = button_materials.clicked;
             }
             Interaction::Hovered => {
                 text.value = "Hover".to_string();
                 *material = button_materials.hovered;
+            }
+            Interaction::Pressed => {
+                text.value = "Press".to_string();
+                *material = button_materials.pressed;
             }
             Interaction::None => {
                 text.value = "Button".to_string();


### PR DESCRIPTION
Based on the comment [here](https://github.com/bevyengine/bevy/issues/254#issuecomment-683767994) I have changed the Clicked interaction to be set on an entity when you release the mouse button instead of when you press it. The interaction will be "cleaned" up in the next system update.

A new Pressed interaction is now available which is similar in behavior as the current Clicked interaction.

I believe this makes the hover/pressed/click interaction more in line with other UI systems.