### PR TITLE
Add possibility to apply offset to orthographic projection origin

### DIFF
--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -1,5 +1,5 @@
 use super::DepthCalculation;
-use bevy_math::Mat4;
+use bevy_math::{Mat4, Vec2};
 use bevy_property::{Properties, Property};
 use serde::{Deserialize, Serialize};
 
@@ -47,6 +47,10 @@ impl Default for PerspectiveProjection {
 pub enum WindowOrigin {
     Center,
     BottomLeft,
+    /// Sets origin to center of window with pixel offset applied
+    CenterOffset(Vec2),
+    /// Sets origin to bottom left of window with pixel offset applied
+    BottomLeftOffset(Vec2),
 }
 
 #[derive(Debug, Clone, Properties)]
@@ -87,6 +91,24 @@ impl CameraProjection for OrthographicProjection {
                 self.right = width as f32;
                 self.top = height as f32;
                 self.bottom = 0.0;
+            }
+            WindowOrigin::CenterOffset(offset) => {
+                let (x_offset, y_offset) = (offset.x(), offset.y());
+
+                let half_width = width as f32 / 2.0;
+                let half_height = height as f32 / 2.0;
+                self.left = -half_width + x_offset;
+                self.right = half_width + x_offset;
+                self.top = half_height + y_offset;
+                self.bottom = -half_height + y_offset;
+            }
+            WindowOrigin::BottomLeftOffset(offset) => {
+                let (x_offset, y_offset) = (offset.x(), offset.y());
+
+                self.left = x_offset;
+                self.right = width as f32 + x_offset;
+                self.top = height as f32 + y_offset;
+                self.bottom = y_offset;
             }
         }
     }


### PR DESCRIPTION
When adjusting the scale of `Camera2dComponents`, the location of the `WindowOrigin` of the orthographic projection affects how the scale appears and around what point on the screen it scales. In making my game, I found it to be limiting that the only two options for `WindowOrigin` are `Center` and `BottomLeft`. I considered adding other points in the screen, but decided that it would be most flexible to just allow the user to specify an exact offset from these points.

The offset is currently in pixels, but I am wondering whether it would make sense to add or replace that with a proportion of window size. This way,  the user could specify, for example, that the offset is half of the screen size up and a quarter of the screen to the left. This would also allow for a refactor to make the update function cleaner by just using offsets.

If we want to keep the offsets as just pixel amounts, that works for me as well. lmk