### PR TITLE
Resize mode for sprite

### DIFF
--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -20,7 +20,7 @@ pub use texture_atlas_builder::*;
 pub mod prelude {
     pub use crate::{
         entity::{SpriteComponents, SpriteSheetComponents},
-        ColorMaterial, Sprite, TextureAtlas, TextureAtlasSprite,
+        ColorMaterial, Sprite, SpriteResizeMode, TextureAtlas, TextureAtlasSprite,
     };
 }
 

--- a/crates/bevy_sprite/src/render/sprite.vert
+++ b/crates/bevy_sprite/src/render/sprite.vert
@@ -13,12 +13,12 @@ layout(set = 0, binding = 0) uniform Camera {
 layout(set = 2, binding = 0) uniform Transform {
     mat4 Model;
 };
-layout(set = 2, binding = 1) uniform Sprite {
-    vec2 Sprite_size;
+layout(set = 2, binding = 1) uniform Sprite_size {
+    vec2 size;
 };
 
 void main() {
     v_Uv = Vertex_Uv;
-    vec3 position = Vertex_Position * vec3(Sprite_size, 1.0);
+    vec3 position = Vertex_Position * vec3(size, 1.0);
     gl_Position = ViewProj * Model * vec4(position, 1.0);
 }

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -49,9 +49,7 @@ fn setup(
         .spawn(SpriteComponents {
             material: materials.add(Color::rgb(0.2, 0.2, 0.8).into()),
             translation: Translation(Vec3::new(0.0, -215.0, 0.0)),
-            sprite: Sprite {
-                size: Vec2::new(120.0, 30.0),
-            },
+            sprite: Sprite::new(Vec2::new(120.0, 30.0)),
             ..Default::default()
         })
         .with(Paddle { speed: 500.0 })
@@ -60,9 +58,7 @@ fn setup(
         .spawn(SpriteComponents {
             material: materials.add(Color::rgb(0.8, 0.2, 0.2).into()),
             translation: Translation(Vec3::new(0.0, -50.0, 1.0)),
-            sprite: Sprite {
-                size: Vec2::new(30.0, 30.0),
-            },
+            sprite: Sprite::new(Vec2::new(30.0, 30.0)),
             ..Default::default()
         })
         .with(Ball {
@@ -100,9 +96,7 @@ fn setup(
         .spawn(SpriteComponents {
             material: wall_material,
             translation: Translation(Vec3::new(-bounds.x() / 2.0, 0.0, 0.0)),
-            sprite: Sprite {
-                size: Vec2::new(wall_thickness, bounds.y() + wall_thickness),
-            },
+            sprite: Sprite::new(Vec2::new(wall_thickness, bounds.y() + wall_thickness)),
             ..Default::default()
         })
         .with(Collider::Solid)
@@ -110,9 +104,7 @@ fn setup(
         .spawn(SpriteComponents {
             material: wall_material,
             translation: Translation(Vec3::new(bounds.x() / 2.0, 0.0, 0.0)),
-            sprite: Sprite {
-                size: Vec2::new(wall_thickness, bounds.y() + wall_thickness),
-            },
+            sprite: Sprite::new(Vec2::new(wall_thickness, bounds.y() + wall_thickness)),
             ..Default::default()
         })
         .with(Collider::Solid)
@@ -120,9 +112,7 @@ fn setup(
         .spawn(SpriteComponents {
             material: wall_material,
             translation: Translation(Vec3::new(0.0, -bounds.y() / 2.0, 0.0)),
-            sprite: Sprite {
-                size: Vec2::new(bounds.x() + wall_thickness, wall_thickness),
-            },
+            sprite: Sprite::new(Vec2::new(bounds.x() + wall_thickness, wall_thickness)),
             ..Default::default()
         })
         .with(Collider::Solid)
@@ -130,9 +120,7 @@ fn setup(
         .spawn(SpriteComponents {
             material: wall_material,
             translation: Translation(Vec3::new(0.0, bounds.y() / 2.0, 0.0)),
-            sprite: Sprite {
-                size: Vec2::new(bounds.x() + wall_thickness, wall_thickness),
-            },
+            sprite: Sprite::new(Vec2::new(bounds.x() + wall_thickness, wall_thickness)),
             ..Default::default()
         })
         .with(Collider::Solid);
@@ -158,7 +146,7 @@ fn setup(
                 // brick
                 .spawn(SpriteComponents {
                     material: materials.add(Color::rgb(0.2, 0.2, 0.8).into()),
-                    sprite: Sprite { size: brick_size },
+                    sprite: Sprite::new(brick_size),
                     translation: Translation(brick_position),
                     ..Default::default()
                 })


### PR DESCRIPTION
Related issue and discussion: #411

Tested on `sprite`, `breakout` and `texture_atlas` examples on macOS. 
Also tested in project from #411 on iOS and macOS with `Automatic` and `Manual` modes.
`ResizeMode` is exposed in case developer would need to change `resize_mode` value in systems.

Most (if not all) of the credit goes to @TheNeikos