### PR TITLE
Init App.schedule systems when running the app

### DIFF
--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -51,7 +51,7 @@ impl Plugin for ScheduleRunnerPlugin {
             let mut app_exit_event_reader = EventReader::<AppExit>::default();
             match run_mode {
                 RunMode::Once => {
-                    app.schedule.run(&mut app.world, &mut app.resources);
+                    app.update();
                 }
                 RunMode::Loop { wait } => loop {
                     let start_time = Instant::now();
@@ -62,7 +62,7 @@ impl Plugin for ScheduleRunnerPlugin {
                         }
                     }
 
-                    app.schedule.run(&mut app.world, &mut app.resources);
+                    app.update();
 
                     if let Some(app_exit_events) = app.resources.get_mut::<Events<AppExit>>() {
                         if app_exit_event_reader.latest(&app_exit_events).is_some() {

--- a/examples/app/headless.rs
+++ b/examples/app/headless.rs
@@ -20,7 +20,7 @@ fn main() {
         .add_plugin(ScheduleRunnerPlugin::run_loop(Duration::from_secs_f64(
             1.0 / 60.0,
         )))
-        .add_system(some_other_system.system())
+        .add_system(counter.system())
         .run();
 }
 
@@ -28,4 +28,14 @@ fn hello_world_system() {
     println!("hello world");
 }
 
-fn some_other_system() {}
+fn counter(mut state: Local<CounterState>) {
+    if state.count % 60 == 0 {
+        println!("{}", state.count);
+    }
+    state.count += 1;
+}
+
+#[derive(Default)]
+struct CounterState {
+    count: u32,
+}


### PR DESCRIPTION
This PR adds `App.schedule.initialize()` call before switching to normal App event loop.
It initializes `Local<>` resources so the systems utilizing it do not crash.

Fixes #221 