### PR TITLE
Implement 3d texture as assets

### DIFF
--- a/crates/bevy_derive/src/render_resource.rs
+++ b/crates/bevy_derive/src/render_resource.rs
@@ -28,6 +28,9 @@ pub fn derive_render_resource(input: TokenStream) -> TokenStream {
             fn texture(&self) -> Option<#bevy_asset_path::Handle<#bevy_render_path::texture::Texture>> {
                 None
             }
+            fn texture3d(&self) -> Option<#bevy_asset_path::Handle<#bevy_render_path::texture::Texture3D>> {
+                None
+            }
 
         }
     })

--- a/crates/bevy_render/src/color.rs
+++ b/crates/bevy_render/src/color.rs
@@ -1,4 +1,4 @@
-use super::texture::Texture;
+use super::texture::{Texture, Texture3D};
 use crate::{
     impl_render_resource_bytes,
     renderer::{RenderResource, RenderResourceType},

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -23,7 +23,7 @@ pub mod prelude {
         pass::ClearColor,
         pipeline::RenderPipelines,
         shader::Shader,
-        texture::Texture,
+        texture::{Texture, Texture3D},
     };
 }
 
@@ -50,7 +50,7 @@ use std::ops::Range;
 use texture::HdrTextureLoader;
 #[cfg(feature = "png")]
 use texture::ImageTextureLoader;
-use texture::TextureResourceSystemState;
+use texture::{TextureResourceSystemState, Texture3DResourceSystemState};
 
 /// The names of "render" App stages
 pub mod stage {
@@ -96,6 +96,7 @@ impl Plugin for RenderPlugin {
             .add_stage_after(stage::RENDER, stage::POST_RENDER)
             .add_asset::<Mesh>()
             .add_asset::<Texture>()
+            .add_asset::<Texture3D>()
             .add_asset::<Shader>()
             .add_asset::<PipelineDescriptor>()
             .register_component::<Camera>()
@@ -116,6 +117,7 @@ impl Plugin for RenderPlugin {
             .init_resource::<RenderResourceBindings>()
             .init_resource::<VertexBufferDescriptors>()
             .init_resource::<TextureResourceSystemState>()
+            .init_resource::<Texture3DResourceSystemState>()
             .init_resource::<AssetRenderResourceBindings>()
             .init_resource::<ActiveCameras>()
             .add_system_to_stage(
@@ -147,6 +149,10 @@ impl Plugin for RenderPlugin {
             .add_system_to_stage(
                 stage::RENDER_RESOURCE,
                 Texture::texture_resource_system.system(),
+            )
+            .add_system_to_stage(
+                stage::RENDER_RESOURCE,
+                Texture3D::texture3d_resource_system.system(),
             )
             .add_system_to_stage(
                 stage::RENDER_GRAPH_SYSTEMS,

--- a/crates/bevy_render/src/renderer/render_resource/render_resource.rs
+++ b/crates/bevy_render/src/renderer/render_resource/render_resource.rs
@@ -1,5 +1,5 @@
 use super::{BufferId, SamplerId, TextureId};
-use crate::texture::Texture;
+use crate::texture::{Texture, Texture3D};
 use bevy_asset::Handle;
 
 use bevy_core::{Byteable, Bytes};
@@ -77,6 +77,7 @@ pub trait RenderResource {
     fn buffer_byte_len(&self) -> Option<usize>;
     // TODO: consider making these panic by default, but return non-options
     fn texture(&self) -> Option<Handle<Texture>>;
+    fn texture3d(&self) -> Option<Handle<Texture3D>>;
 }
 
 pub trait RenderResources: Send + Sync + 'static {
@@ -138,6 +139,10 @@ macro_rules! impl_render_resource_bytes {
             fn texture(&self) -> Option<Handle<Texture>> {
                 None
             }
+
+            fn texture3d(&self) -> Option<Handle<Texture3D>> {
+                None
+            }
         }
     };
 }
@@ -175,6 +180,10 @@ where
     }
 
     fn texture(&self) -> Option<Handle<Texture>> {
+        None
+    }
+
+    fn texture3d(&self) -> Option<Handle<Texture3D>> {
         None
     }
 }

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -5,6 +5,7 @@ mod image_texture_loader;
 mod sampler_descriptor;
 #[allow(clippy::module_inception)]
 mod texture;
+mod texture3d;
 mod texture_descriptor;
 mod texture_dimension;
 
@@ -14,5 +15,6 @@ pub use hdr_texture_loader::*;
 pub use image_texture_loader::*;
 pub use sampler_descriptor::*;
 pub use texture::*;
+pub use texture3d::*;
 pub use texture_descriptor::*;
 pub use texture_dimension::*;

--- a/crates/bevy_render/src/texture/sampler_descriptor.rs
+++ b/crates/bevy_render/src/texture/sampler_descriptor.rs
@@ -1,4 +1,4 @@
-use super::Texture;
+use super::{Texture, Texture3D};
 use crate::pipeline::CompareFunction;
 use std::num::NonZeroU8;
 
@@ -36,6 +36,23 @@ impl Default for SamplerDescriptor {
 
 impl From<&Texture> for SamplerDescriptor {
     fn from(_texture: &Texture) -> Self {
+        SamplerDescriptor {
+            address_mode_u: AddressMode::ClampToEdge,
+            address_mode_v: AddressMode::ClampToEdge,
+            address_mode_w: AddressMode::ClampToEdge,
+            mag_filter: FilterMode::Nearest,
+            min_filter: FilterMode::Linear,
+            mipmap_filter: FilterMode::Nearest,
+            lod_min_clamp: 0.0,
+            lod_max_clamp: std::f32::MAX,
+            compare_function: None,
+            anisotropy_clamp: None,
+        }
+    }
+}
+
+impl From<&Texture3D> for SamplerDescriptor {
+    fn from(_texture: &Texture3D) -> Self {
         SamplerDescriptor {
             address_mode_u: AddressMode::ClampToEdge,
             address_mode_v: AddressMode::ClampToEdge,

--- a/crates/bevy_render/src/texture/texture3d.rs
+++ b/crates/bevy_render/src/texture/texture3d.rs
@@ -1,26 +1,23 @@
-use super::{SamplerDescriptor, Texture3D, TextureDescriptor, TextureFormat};
+use super::{SamplerDescriptor, Texture, TextureDescriptor, TextureFormat, TEXTURE_ASSET_INDEX, SAMPLER_ASSET_INDEX};
 use crate::renderer::{
     RenderResource, RenderResourceContext, RenderResourceId, RenderResourceType,
 };
 use bevy_app::prelude::{EventReader, Events};
 use bevy_asset::{AssetEvent, Assets, Handle};
 use bevy_ecs::{Res, ResMut};
-use bevy_math::Vec2;
+use bevy_math::Vec3;
 use bevy_utils::HashSet;
 
-pub const TEXTURE_ASSET_INDEX: usize = 0;
-pub const SAMPLER_ASSET_INDEX: usize = 1;
-
 #[derive(Clone)]
-pub struct Texture {
+pub struct Texture3D {
     pub data: Vec<u8>,
-    pub size: Vec2,
+    pub size: Vec3,
     pub format: TextureFormat,
 }
 
-impl Default for Texture {
+impl Default for Texture3D {
     fn default() -> Self {
-        Texture {
+        Texture3D {
             data: Default::default(),
             size: Default::default(),
             format: TextureFormat::Rgba8UnormSrgb,
@@ -28,17 +25,17 @@ impl Default for Texture {
     }
 }
 
-impl Texture {
-    pub fn new(size: Vec2, data: Vec<u8>, format: TextureFormat) -> Self {
+impl Texture3D {
+    pub fn new(size: Vec3, data: Vec<u8>, format: TextureFormat) -> Self {
         debug_assert_eq!(
-            size.x() as usize * size.y() as usize * format.pixel_size(),
+            size.x() as usize * size.y() as usize * size.z() as usize * format.pixel_size(),
             data.len(),
             "Pixel data, size and format have to match",
         );
         Self { data, size, format }
     }
 
-    pub fn new_fill(size: Vec2, pixel: &[u8], format: TextureFormat) -> Self {
+    pub fn new_fill(size: Vec3, pixel: &[u8], format: TextureFormat) -> Self {
         let mut value = Self::default();
         value.format = format;
         value.resize(size);
@@ -59,23 +56,20 @@ impl Texture {
         value
     }
 
-    pub fn aspect(&self) -> f32 {
-        self.size.y() / self.size.x()
-    }
-
-    pub fn resize(&mut self, size: Vec2) {
+    pub fn resize(&mut self, size: Vec3) {
         self.size = size;
         let width = size.x() as usize;
         let height = size.y() as usize;
+        let depth = size.z() as usize;
         self.data
-            .resize(width * height * self.format.pixel_size(), 0);
+            .resize(width * height * depth * self.format.pixel_size(), 0);
     }
 
-    pub fn texture_resource_system(
-        mut state: ResMut<TextureResourceSystemState>,
+    pub fn texture3d_resource_system(
+        mut state: ResMut<Texture3DResourceSystemState>,
         render_resource_context: Res<Box<dyn RenderResourceContext>>,
-        textures: Res<Assets<Texture>>,
-        texture_events: Res<Events<AssetEvent<Texture>>>,
+        textures: Res<Assets<Texture3D>>,
+        texture_events: Res<Events<AssetEvent<Texture3D>>>,
     ) {
         let render_resource_context = &**render_resource_context;
         let mut changed_textures = HashSet::default();
@@ -121,7 +115,7 @@ impl Texture {
 
     fn remove_current_texture_resources(
         render_resource_context: &dyn RenderResourceContext,
-        handle: Handle<Texture>,
+        handle: Handle<Texture3D>,
     ) {
         if let Some(RenderResourceId::Texture(resource)) =
             render_resource_context.get_asset_resource(handle, TEXTURE_ASSET_INDEX)
@@ -139,11 +133,11 @@ impl Texture {
 }
 
 #[derive(Default)]
-pub struct TextureResourceSystemState {
-    event_reader: EventReader<AssetEvent<Texture>>,
+pub struct Texture3DResourceSystemState {
+    event_reader: EventReader<AssetEvent<Texture3D>>,
 }
 
-impl RenderResource for Option<Handle<Texture>> {
+impl RenderResource for Option<Handle<Texture3D>> {
     fn resource_type(&self) -> Option<RenderResourceType> {
         self.map(|_texture| RenderResourceType::Texture)
     }
@@ -155,15 +149,15 @@ impl RenderResource for Option<Handle<Texture>> {
     }
 
     fn texture(&self) -> Option<Handle<Texture>> {
-        *self
+        None
     }
 
     fn texture3d(&self) -> Option<Handle<Texture3D>> {
-        None
+        *self
     }
 }
 
-impl RenderResource for Handle<Texture> {
+impl RenderResource for Handle<Texture3D> {
     fn resource_type(&self) -> Option<RenderResourceType> {
         Some(RenderResourceType::Texture)
     }
@@ -175,10 +169,10 @@ impl RenderResource for Handle<Texture> {
     }
 
     fn texture(&self) -> Option<Handle<Texture>> {
-        Some(*self)
+        None
     }
 
     fn texture3d(&self) -> Option<Handle<Texture3D>> {
-        None
+        Some(*self)
     }
 }

--- a/crates/bevy_render/src/texture/texture_descriptor.rs
+++ b/crates/bevy_render/src/texture/texture_descriptor.rs
@@ -1,4 +1,4 @@
-use super::{Extent3d, Texture, TextureDimension, TextureFormat, TextureUsage};
+use super::{Extent3d, Texture, Texture3D, TextureDimension, TextureFormat, TextureUsage};
 
 /// Describes a texture
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -22,6 +22,23 @@ impl From<&Texture> for TextureDescriptor {
             mip_level_count: 1,
             sample_count: 1,
             dimension: TextureDimension::D2,
+            format: texture.format,
+            usage: TextureUsage::SAMPLED | TextureUsage::COPY_DST,
+        }
+    }
+}
+
+impl From<&Texture3D> for TextureDescriptor {
+    fn from(texture: &Texture3D) -> Self {
+        TextureDescriptor {
+            size: Extent3d {
+                width: texture.size.x() as u32,
+                height: texture.size.y() as u32,
+                depth: texture.size.z() as u32,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: TextureDimension::D3,
             format: texture.format,
             usage: TextureUsage::SAMPLED | TextureUsage::COPY_DST,
         }


### PR DESCRIPTION
This is a simple pr that implements 3d textures as a mostly-copy of 2d textures.

One big, potentially breaking change is that now `RenderResource` requires an implementation of `fn texture3d`, which works just like `fn texture`. The derive macro has been updated to support this.

I haven't tested this yet properly, so I'm making it a draft until I've verified that this works.