### PR TITLE
Recommend `.cargo/config.toml` over `.cargo/config`

### DIFF
--- a/.cargo/config_fast_builds
+++ b/.cargo/config_fast_builds
@@ -1,4 +1,4 @@
-# Rename this file to `config` to enable "fast build" configuration. Please read the notes below.
+# Rename this file to `config.toml` to enable "fast build" configuration. Please read the notes below.
 
 # NOTE: For maximum performance, build using a nightly compiler
 # If you are using rust stable, remove the "-Zshare-generics=y" below.


### PR DESCRIPTION
As of Rust version 1.39.0, `config.toml` is the preferred filename for
`cargo`s configuration file. Incidentally added a newline at EOF.

https://doc.rust-lang.org/cargo/reference/config.html