### PR TITLE
Add a way to specify padding/ margins between sprites in a TextureAtlas.

### DIFF
--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -63,28 +63,26 @@ impl TextureAtlas {
     }
 
     /// Generate a `TextureAtlas` by splitting a texture into a grid where each
-    /// cell of the grid is one of the textures in the atlas
+    /// cell of the grid  of `tile_size` is one of the textures in the atlas
     pub fn from_grid(
         texture: Handle<Texture>,
-        size: Vec2,
+        tile_size: Vec2,
         columns: usize,
         rows: usize,
     ) -> TextureAtlas {
-        Self::from_grid_with_padding(texture, size, columns, rows, Vec2::new(0f32, 0f32))
+        Self::from_grid_with_padding(texture, tile_size, columns, rows, Vec2::new(0f32, 0f32))
     }
 
     /// Generate a `TextureAtlas` by splitting a texture into a grid where each
-    /// cell of the grid is one of the textures in the atlas and is separated by
+    /// cell of the grid of `tile_size` is one of the textures in the atlas and is separated by
     /// some `padding` in the texture
     pub fn from_grid_with_padding(
         texture: Handle<Texture>,
-        size: Vec2,
+        tile_size: Vec2,
         columns: usize,
         rows: usize,
         padding: Vec2,
     ) -> TextureAtlas {
-        let texture_width = size.x() / columns as f32;
-        let texture_height = size.y() / rows as f32;
         let mut sprites = Vec::new();
         let mut x_padding = 0.0;
         let mut y_padding = 0.0;
@@ -100,18 +98,18 @@ impl TextureAtlas {
 
                 sprites.push(Rect {
                     min: Vec2::new(
-                        (x as f32 * texture_width) + x_padding,
-                        (y as f32 * texture_height) + y_padding,
+                        tile_size.x() + x_padding,
+                        tile_size.y() + y_padding,
                     ),
                     max: Vec2::new(
-                        (x + 1) as f32 * texture_width,
-                        (y + 1) as f32 * texture_height,
+                        (x + 1) as f32 * tile_size.x(),
+                        (y + 1) as f32 * tile_size.y(),
                     ),
                 })
             }
         }
         TextureAtlas {
-            size,
+            size: Vec2::new(tile_size.x() * columns, tile_size.y() * rows),
             textures: sprites,
             texture,
             texture_handles: None,

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -106,7 +106,7 @@ impl TextureAtlas {
             }
         }
         TextureAtlas {
-            size: Vec2::new(tile_size.x() * columns, tile_size.y() * rows),
+            size: Vec2::new(tile_size.x() * columns as f32, tile_size.y() * rows as f32),
             textures: sprites,
             texture,
             texture_handles: None,

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -92,6 +92,48 @@ impl TextureAtlas {
         }
     }
 
+    /// Generate a `TextureAtlas` by splitting a texture into a grid where each
+    /// cell of the grid is one of the textures in the atlas and is separated by
+    /// some `padding` in the texture
+    pub fn from_grid_with_padding(
+        texture: Handle<Texture>,
+        size: Vec2,
+        columns: usize,
+        rows: usize,
+        padding: Vec2,
+    ) -> TextureAtlas {
+        let texture_width = size.x() / columns as f32;
+        let texture_height = size.y() / rows as f32;
+        let mut sprites = Vec::new();
+        let mut x_padding = 0.0;
+        let mut y_padding = 0.0;
+
+        for y in 0..rows {
+            if y > 0 {
+                y_padding = padding.y();
+            }
+            for x in 0..columns {
+                if x > 0 {
+                    x_padding = padding.x();
+                }
+
+                sprites.push(Rect {
+                    min: Vec2::new((x as f32 * texture_width) + x_padding, (y as f32 * texture_height) + y_padding),
+                    max: Vec2::new(
+                        (x + 1) as f32 * texture_width,
+                        (y + 1) as f32 * texture_height,
+                    ),
+                })
+            }
+        }
+        TextureAtlas {
+            size,
+            textures: sprites,
+            texture,
+            texture_handles: None,
+        }
+    }
+
     /// Add a sprite to the list of textures in the `TextureAtlas`
     ///
     /// # Arguments

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -96,17 +96,23 @@ impl TextureAtlas {
                     x_padding = padding.x();
                 }
 
+                let rect_min = Vec2::new(
+                    (tile_size.x() + x_padding) * x as f32,
+                    (tile_size.y() + y_padding) * y as f32,
+                );
+
                 sprites.push(Rect {
-                    min: Vec2::new(tile_size.x() + x_padding, tile_size.y() + y_padding),
-                    max: Vec2::new(
-                        (x + 1) as f32 * tile_size.x(),
-                        (y + 1) as f32 * tile_size.y(),
-                    ),
+                    min: rect_min,
+                    max: Vec2::new(rect_min.x() + tile_size.x(), rect_min.y() + tile_size.y()),
                 })
             }
         }
+
         TextureAtlas {
-            size: Vec2::new(tile_size.x() * columns as f32, tile_size.y() * rows as f32),
+            size: Vec2::new(
+                ((tile_size.x() + x_padding) * columns as f32) - x_padding,
+                ((tile_size.y() + y_padding) * rows as f32) - y_padding,
+            ),
             textures: sprites,
             texture,
             texture_handles: None,

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -70,7 +70,7 @@ impl TextureAtlas {
         columns: usize,
         rows: usize,
     ) -> TextureAtlas {
-        Self::from_grid_with_padding(texture, size, columns, rows, Vec2(0f32, 0f32))
+        Self::from_grid_with_padding(texture, size, columns, rows, Vec2::new(0f32, 0f32))
     }
 
     /// Generate a `TextureAtlas` by splitting a texture into a grid where each

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -70,26 +70,7 @@ impl TextureAtlas {
         columns: usize,
         rows: usize,
     ) -> TextureAtlas {
-        let texture_width = size.x() / columns as f32;
-        let texture_height = size.y() / rows as f32;
-        let mut sprites = Vec::new();
-        for y in 0..rows {
-            for x in 0..columns {
-                sprites.push(Rect {
-                    min: Vec2::new(x as f32 * texture_width, y as f32 * texture_height),
-                    max: Vec2::new(
-                        (x + 1) as f32 * texture_width,
-                        (y + 1) as f32 * texture_height,
-                    ),
-                })
-            }
-        }
-        TextureAtlas {
-            size,
-            textures: sprites,
-            texture,
-            texture_handles: None,
-        }
+        Self::from_grid_with_padding(texture, size, columns, rows, Vec2(0f32, 0f32))
     }
 
     /// Generate a `TextureAtlas` by splitting a texture into a grid where each

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -99,7 +99,10 @@ impl TextureAtlas {
                 }
 
                 sprites.push(Rect {
-                    min: Vec2::new((x as f32 * texture_width) + x_padding, (y as f32 * texture_height) + y_padding),
+                    min: Vec2::new(
+                        (x as f32 * texture_width) + x_padding,
+                        (y as f32 * texture_height) + y_padding,
+                    ),
                     max: Vec2::new(
                         (x + 1) as f32 * texture_width,
                         (y + 1) as f32 * texture_height,

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -97,10 +97,7 @@ impl TextureAtlas {
                 }
 
                 sprites.push(Rect {
-                    min: Vec2::new(
-                        tile_size.x() + x_padding,
-                        tile_size.y() + y_padding,
-                    ),
+                    min: Vec2::new(tile_size.x() + x_padding, tile_size.y() + y_padding),
                     max: Vec2::new(
                         (x + 1) as f32 * tile_size.x(),
                         (y + 1) as f32 * tile_size.y(),

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -32,8 +32,6 @@ fn setup(
             "assets/textures/rpg/chars/gabe/gabe-idle-run.png",
         )
         .unwrap();
-    let texture = textures.get(&texture_handle).unwrap();
-    // let texture_atlas = TextureAtlas::from_grid(texture_handle, texture.size, 7, 1);
 
     let texture_atlas = TextureAtlas::from_grid(texture_handle, Vec2::new(24.0, 24.0), 7, 1);
     let texture_atlas_handle = texture_atlases.add(texture_atlas);

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -33,7 +33,9 @@ fn setup(
         )
         .unwrap();
     let texture = textures.get(&texture_handle).unwrap();
-    let texture_atlas = TextureAtlas::from_grid(texture_handle, texture.size, 7, 1);
+    // let texture_atlas = TextureAtlas::from_grid(texture_handle, texture.size, 7, 1);
+
+    let texture_atlas = TextureAtlas::from_grid(texture_handle, Vec2::new(24.0, 24.0), 7, 1);
     let texture_atlas_handle = texture_atlases.add(texture_atlas);
     commands
         .spawn(Camera2dComponents::default())


### PR DESCRIPTION
Occasionally, it's useful to be able to specify margins between sprites in a TextureAtlas, like for using Kenney.nl sprite sheets
e.g.
![roguelikeSheet_transparent](https://user-images.githubusercontent.com/9271353/92427816-8130d300-f15b-11ea-9804-ae4f7e31be47.png)
(https://www.kenney.nl/assets/roguelike-rpg-pack)