### PR TITLE
render: Export entity module outside of prelude

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -2,6 +2,7 @@ pub mod batch;
 pub mod camera;
 pub mod color;
 pub mod draw;
+pub mod entity;
 pub mod mesh;
 pub mod pass;
 pub mod pipeline;
@@ -10,7 +11,6 @@ pub mod renderer;
 pub mod shader;
 pub mod texture;
 
-mod entity;
 pub use once_cell;
 
 pub mod prelude {


### PR DESCRIPTION
It's a preference of some people to not use prelude modules at all in order to make their imports more explicit. Currently, items like `Camera3dComponent` are only exported in a prelude module, making an explicit import look like

`use bevy::prelude::Camera3dComponent`

which feels a bit hackish. This change doesn't remove such components from the prelude, but just re-exports them at the crate's (`bevy_render` in this case) root.