### PR TITLE
Adds profiling for non-thread-local-systems

### DIFF
--- a/crates/bevy_ecs/src/schedule/parallel_executor.rs
+++ b/crates/bevy_ecs/src/schedule/parallel_executor.rs
@@ -377,7 +377,11 @@ impl ExecutorStage {
                     {
                         let mut system = system.lock();
                         log::trace!("run {}", system.name());
+                        #[cfg(feature = "profiler")]
+                        crate::profiler_start(resources, system.name().clone());
                         system.run(world_ref, resources_ref);
+                        #[cfg(feature = "profiler")]
+                        crate::profiler_stop(resources, system.name().clone());
                     }
 
                     // Notify dependents that this task is done


### PR DESCRIPTION
Profiler is only implemented for thread-local-systems. This adds calls for profiling non-thread-local-systems to parallel_executor.

Given that this runs off of the main thread, the contribution of these systems to frametime doesn't match the profiler output. It might be worth profiling these separately and at synchronization, or something. But at least this change increases visibility. 