### PR TITLE
Make Interaction component required in focus.rs

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -81,10 +81,8 @@ pub fn ui_focus_system(
                     && (min.y()..max.y()).contains(&state.cursor_position.y())
                 {
                     return Some((entity, focus_policy, interaction, FloatOrd(position.z())));
-                } else {
-                    if *interaction == Interaction::Hovered {
-                        *interaction = Interaction::None;
-                    }
+                } else if *interaction == Interaction::Hovered {
+                    *interaction = Interaction::None;
                 }
                 None
             })


### PR DESCRIPTION
non-interactive nodes should not impact interactive components' focus
So Interaction component should not be optional when handling focus.

In my case i'm using UI parenting to create "elaborate" ui items, and children (because some are on top) are basically preventing the parent from being interactive (ie modify properly its Interaction component).
Maybe i'm missing or misusing something, but it seems to me that entities that dont have an Interaction component should not interact with others that have one.

Thanks a lot for your work!