### PR TITLE
Do not assume font handle is present in assets.

### DIFF
--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -52,57 +52,58 @@ impl FontAtlasSet {
         font_size: f32,
         text: &str,
     ) -> f32 {
-        let font = fonts.get(&self.font).unwrap();
-        let scaled_font = ab_glyph::Font::as_scaled(&font.font, font_size);
-        let font_atlases = self
-            .font_atlases
-            .entry(FloatOrd(font_size))
-            .or_insert_with(|| {
-                vec![FontAtlas::new(
-                    textures,
-                    texture_atlases,
-                    Vec2::new(512.0, 512.0),
-                )]
-            });
-
-        let mut last_glyph: Option<Glyph> = None;
         let mut width = 0.0;
-        for character in text.chars() {
-            if character.is_control() {
-                continue;
-            }
-            let glyph = scaled_font.scaled_glyph(character);
-            if let Some(last_glyph) = last_glyph.take() {
-                width += scaled_font.kern(last_glyph.id, glyph.id);
-            }
-            if !font_atlases
-                .iter()
-                .any(|atlas| atlas.get_char_index(character).is_some())
-            {
-                if let Some(outlined_glyph) = scaled_font.outline_glyph(glyph.clone()) {
-                    let glyph_texture = Font::get_outlined_glyph_texture(outlined_glyph);
-                    let add_char_to_font_atlas = |atlas: &mut FontAtlas| -> bool {
-                        atlas.add_char(textures, texture_atlases, character, &glyph_texture)
-                    };
-                    if !font_atlases.iter_mut().any(add_char_to_font_atlas) {
-                        font_atlases.push(FontAtlas::new(
-                            textures,
-                            texture_atlases,
-                            Vec2::new(512.0, 512.0),
-                        ));
-                        if !font_atlases.last_mut().unwrap().add_char(
-                            textures,
-                            texture_atlases,
-                            character,
-                            &glyph_texture,
-                        ) {
-                            panic!("could not add character to newly created FontAtlas");
+        if let Some(font) = fonts.get(&self.font) {
+            let scaled_font = ab_glyph::Font::as_scaled(&font.font, font_size);
+            let font_atlases = self
+                .font_atlases
+                .entry(FloatOrd(font_size))
+                .or_insert_with(|| {
+                    vec![FontAtlas::new(
+                        textures,
+                        texture_atlases,
+                        Vec2::new(512.0, 512.0),
+                    )]
+                });
+
+            let mut last_glyph: Option<Glyph> = None;
+            for character in text.chars() {
+                if character.is_control() {
+                    continue;
+                }
+                let glyph = scaled_font.scaled_glyph(character);
+                if let Some(last_glyph) = last_glyph.take() {
+                    width += scaled_font.kern(last_glyph.id, glyph.id);
+                }
+                if !font_atlases
+                    .iter()
+                    .any(|atlas| atlas.get_char_index(character).is_some())
+                {
+                    if let Some(outlined_glyph) = scaled_font.outline_glyph(glyph.clone()) {
+                        let glyph_texture = Font::get_outlined_glyph_texture(outlined_glyph);
+                        let add_char_to_font_atlas = |atlas: &mut FontAtlas| -> bool {
+                            atlas.add_char(textures, texture_atlases, character, &glyph_texture)
+                        };
+                        if !font_atlases.iter_mut().any(add_char_to_font_atlas) {
+                            font_atlases.push(FontAtlas::new(
+                                textures,
+                                texture_atlases,
+                                Vec2::new(512.0, 512.0),
+                            ));
+                            if !font_atlases.last_mut().unwrap().add_char(
+                                textures,
+                                texture_atlases,
+                                character,
+                                &glyph_texture,
+                            ) {
+                                panic!("could not add character to newly created FontAtlas");
+                            }
                         }
                     }
+                    width += scaled_font.h_advance(glyph.id);
+                    last_glyph = Some(glyph);
                 }
             }
-            width += scaled_font.h_advance(glyph.id);
-            last_glyph = Some(glyph);
         }
 
         width

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -61,21 +61,23 @@ pub fn draw_text_system(
     mut query: Query<(&mut Draw, &Text, &Node, &GlobalTransform)>,
 ) {
     for (mut draw, text, node, global_transform) in &mut query.iter() {
-        let position = global_transform.translation() - (node.size / 2.0).extend(0.0);
-        let mut drawable_text = DrawableText {
-            font: fonts.get(&text.font).unwrap(),
-            font_atlas_set: font_atlas_sets
-                .get(&text.font.as_handle::<FontAtlasSet>())
-                .unwrap(),
-            texture_atlases: &texture_atlases,
-            render_resource_bindings: &mut render_resource_bindings,
-            asset_render_resource_bindings: &mut asset_render_resource_bindings,
-            position,
-            msaa: &msaa,
-            style: &text.style,
-            text: &text.value,
-            container_size: node.size,
-        };
-        drawable_text.draw(&mut draw, &mut draw_context).unwrap();
+        if let Some(font) = fonts.get(&text.font) {
+            let position = global_transform.translation() - (node.size / 2.0).extend(0.0);
+            let mut drawable_text = DrawableText {
+                font,
+                font_atlas_set: font_atlas_sets
+                    .get(&text.font.as_handle::<FontAtlasSet>())
+                    .unwrap(),
+                texture_atlases: &texture_atlases,
+                render_resource_bindings: &mut render_resource_bindings,
+                asset_render_resource_bindings: &mut asset_render_resource_bindings,
+                position,
+                msaa: &msaa,
+                style: &text.style,
+                text: &text.value,
+                container_size: node.size,
+            };
+            drawable_text.draw(&mut draw, &mut draw_context).unwrap();
+        }
     }
 }


### PR DESCRIPTION
This is a tentative fix for #489 

Code changed to not do anything if the font handle is not yet present in the assets<fonts> resource, removing the panicking 'unwraps'.

Not sure if this is the correct, as there could a design assumption broken before arriving to this pieces of code, and I am not yet fluent enough in bevy to know that.

This fixes both testcases ( late loading of font, or referencing inexistent fonts).