### PR TITLE
Fix set_scale and set_rotation in new Transform api

### DIFF
--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -28,8 +28,19 @@ impl Transform {
         Transform::new(Mat4::from_quat(rotation))
     }
 
-    // TODO: make sure scale is positive
-    pub fn from_scale(scale: Vec3) -> Self {
+    pub fn from_scale(scale: f32) -> Self {
+        Transform::new(Mat4::from_scale(Vec3::splat(scale)))
+    }
+
+    pub fn from_translation_rotation_scale(translation: Vec3, rotation: Quat, scale: f32) -> Self {
+        Transform::new(Mat4::from_scale_rotation_translation(
+            Vec3::splat(scale),
+            rotation,
+            translation,
+        ))
+    }
+
+    pub fn from_non_uniform_scale(scale: Vec3) -> Self {
         Transform::new(Mat4::from_scale(scale))
     }
 
@@ -43,8 +54,13 @@ impl Transform {
         self
     }
 
-    pub fn with_scale(mut self, scale: Vec3) -> Self {
+    pub fn with_scale(mut self, scale: f32) -> Self {
         self.apply_scale(scale);
+        self
+    }
+
+    pub fn with_non_uniform_scale(mut self, scale: Vec3) -> Self {
+        self.apply_non_uniform_scale(scale);
         self
     }
 
@@ -87,14 +103,21 @@ impl Transform {
     }
 
     pub fn set_rotation(&mut self, rotation: Quat) {
-        let rotation = rotation * self.rotation().conjugate();
-        rotation.normalize();
-        self.value = Mat4::from_quat(rotation) * self.value;
+        self.value =
+            Mat4::from_scale_rotation_translation(self.scale(), rotation, self.translation());
     }
 
-    pub fn set_scale(&mut self, scale: Vec3) {
-        let scale = scale / self.scale();
-        self.value = Mat4::from_scale(scale) * self.value;
+    pub fn set_scale(&mut self, scale: f32) {
+        self.value = Mat4::from_scale_rotation_translation(
+            Vec3::splat(scale),
+            self.rotation(),
+            self.translation(),
+        );
+    }
+
+    pub fn set_non_uniform_scale(&mut self, scale: Vec3) {
+        self.value =
+            Mat4::from_scale_rotation_translation(scale, self.rotation(), self.translation());
     }
 
     pub fn translate(&mut self, translation: Vec3) {
@@ -105,7 +128,11 @@ impl Transform {
         self.value = Mat4::from_quat(rotation) * self.value;
     }
 
-    pub fn apply_scale(&mut self, scale: Vec3) {
+    pub fn apply_scale(&mut self, scale: f32) {
+        self.value = Mat4::from_scale(Vec3::splat(scale)) * self.value;
+    }
+
+    pub fn apply_non_uniform_scale(&mut self, scale: Vec3) {
         self.value = Mat4::from_scale(scale) * self.value;
     }
 }

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -39,7 +39,7 @@ fn setup(
         .spawn(Camera2dComponents::default())
         .spawn(SpriteSheetComponents {
             texture_atlas: texture_atlas_handle,
-            transform: Transform::from_scale(Vec3::one() * 6.0),
+            transform: Transform::from_scale(6.0),
             ..Default::default()
         })
         .with(Timer::from_seconds(0.1, true));

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -61,8 +61,7 @@ fn load_atlas(
             .spawn(Camera2dComponents::default())
             // draw a sprite from the atlas
             .spawn(SpriteSheetComponents {
-                transform: Transform::from_translation(Vec3::new(150.0, 0.0, 0.0))
-                    .with_scale(Vec3::one() * 4.0),
+                transform: Transform::from_scale(4.0).with_translation(Vec3::new(150.0, 0.0, 0.0)),
                 sprite: TextureAtlasSprite::new(vendor_index as u32),
                 texture_atlas: atlas_handle,
                 ..Default::default()

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -15,7 +15,7 @@ fn spawn_system(
         commands
             .spawn(SpriteComponents {
                 material,
-                transform: Transform::from_scale(Vec3::one() * 0.1),
+                transform: Transform::from_scale(0.1),
                 ..Default::default()
             })
             .with(Velocity(


### PR DESCRIPTION
The new transform api currently doesn't account for the current translation when rotating and scaling. This results in "incorrect" behavior when setting scale and rotation.

I also changed "scale" to be a "uniform scale". Non uniform scale now has its own set of functions.