### PR TITLE
Implement WASM support for bevy_winit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,3 +270,8 @@ required-features = []
 name = "headless_wasm"
 path = "examples/wasm/headless_wasm.rs"
 required-features = []
+
+[[example]]
+name = "winit_wasm"
+path = "examples/wasm/winit_wasm.rs"
+required-features = []

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -30,4 +30,4 @@ serde = { version = "1.0", features = ["derive"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }
 web-sys = { version = "0.3", features = [ "Window" ] }
-wasm-timer = "0.2.5"
+instant = "0.1.6"

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -6,10 +6,10 @@ use crate::{
 };
 use std::time::Duration;
 
+#[cfg(target_arch = "wasm32")]
+use instant::Instant;
 #[cfg(not(target_arch = "wasm32"))]
 use std::{thread, time::Instant};
-#[cfg(target_arch = "wasm32")]
-use wasm_timer::Instant;
 
 #[cfg(target_arch = "wasm32")]
 use std::{cell::RefCell, rc::Rc};

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -26,3 +26,6 @@ bevy_property = { path = "../bevy_property", version = "0.1" }
 bevy_type_registry = { path = "../bevy_type_registry", version = "0.1" }
 bevy_math = { path = "../bevy_math", version = "0.1" }
 bevy_utils = { path = "../bevy_utils", version = "0.1" }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+instant = "0.1.6"

--- a/crates/bevy_core/src/time/time.rs
+++ b/crates/bevy_core/src/time/time.rs
@@ -1,5 +1,10 @@
 use bevy_ecs::ResMut;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+#[cfg(target_arch = "wasm32")]
+use instant::Instant;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
 
 /// Tracks elapsed time since the last update and since the App has started
 pub struct Time {

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -25,3 +25,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.1" }
 # other
 uuid = { version = "0.8", features = ["v4", "serde"] }
 parking_lot = "0.11.0"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+instant = "0.1.6"

--- a/crates/bevy_diagnostic/src/system_profiler.rs
+++ b/crates/bevy_diagnostic/src/system_profiler.rs
@@ -2,7 +2,12 @@ use crate::{Diagnostic, DiagnosticId, Diagnostics};
 use bevy_ecs::{Profiler, Res, ResMut};
 use bevy_utils::HashMap;
 use parking_lot::RwLock;
-use std::{borrow::Cow, sync::Arc, time::Instant};
+use std::{borrow::Cow, sync::Arc};
+
+#[cfg(target_arch = "wasm32")]
+use instant::Instant;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
 
 #[derive(Debug)]
 struct SystemRunInfo {

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -28,3 +28,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.1" }
 # other
 winit = { version = "0.22.2", package = "cart-tmp-winit", default-features = false }
 log = { version = "0.4", features = ["release_max_level_info"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+winit = { version = "0.22.2", package = "cart-tmp-winit", features = ["web-sys"] }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -71,7 +71,7 @@ where
     target_os = "netbsd",
     target_os = "openbsd"
 )))]
-fn run_return<F>(event_loop: &mut EventLoop<()>, event_handler: F)
+fn run_return<F>(_event_loop: &mut EventLoop<()>, _event_handler: F)
 where
     F: FnMut(Event<'_, ()>, &EventLoopWindowTarget<()>, &mut ControlFlow),
 {

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -105,3 +105,9 @@ fn get_best_videomode(monitor: &winit::monitor::MonitorHandle) -> winit::monitor
 
     modes.first().unwrap().clone()
 }
+
+// WARNING: this only works under the assumption that wasm runtime is single threaded
+#[cfg(target_arch = "wasm32")]
+unsafe impl Send for WinitWindows {}
+#[cfg(target_arch = "wasm32")]
+unsafe impl Sync for WinitWindows {}

--- a/examples/wasm/winit_wasm.rs
+++ b/examples/wasm/winit_wasm.rs
@@ -1,0 +1,35 @@
+extern crate console_error_panic_hook;
+use bevy::prelude::*;
+use std::panic;
+
+fn main() {
+    panic::set_hook(Box::new(console_error_panic_hook::hook));
+    console_log::init_with_level(log::Level::Debug).expect("cannot initialize console_log");
+
+    App::build()
+        .add_default_plugins()
+        .add_startup_system(hello_wasm_system.system())
+        .add_system(counter.system())
+        .run();
+}
+
+fn hello_wasm_system() {
+    log::info!("hello wasm");
+}
+
+fn counter(mut state: Local<CounterState>, time: Res<Time>) {
+    if state.count % 60 == 0 {
+        log::info!(
+            "tick {} @ {:?} [Δ{}]",
+            state.count,
+            time.time_since_startup(),
+            time.delta_seconds
+        );
+    }
+    state.count += 1;
+}
+
+#[derive(Default)]
+struct CounterState {
+    count: u32,
+}


### PR DESCRIPTION
This modifies the rest of default plugins to build for `wasm32` and twists `bevy_winit` to run.

The main problem is that winit Window is not Send + Sync, but since our WASM runtime is single threaded,
we can safely fake it.

![Zrzut ekranu z 2020-09-16 22-02-02](https://user-images.githubusercontent.com/147687/93387340-59cbbb80-f869-11ea-8e33-a8ecf5b8e2ec.png)

Also, replaced wasm_timer::Instant with instant::Instant as it is used by winit WASM implementation, so the code won't duplicate.

To build the example use:
```sh
cargo build --example winit_wasm --target wasm32-unknown-unknown --no-default-features --features bevy_winit
```
and modify `index.html` to run it.