### PR TITLE
Option to give existing canvas element as winit window

### DIFF
--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -24,3 +24,4 @@ uuid = { version = "0.8", features = ["v4", "serde"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "0.8", features = ["wasm-bindgen"] }
+web-sys = "0.3"

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -40,6 +40,8 @@ pub struct Window {
     pub vsync: bool,
     pub resizable: bool,
     pub mode: WindowMode,
+    #[cfg(target_arch = "wasm32")]
+    pub canvas: Option<String>,
 }
 
 /// Defines the way a window is displayed
@@ -64,6 +66,8 @@ impl Window {
             vsync: window_descriptor.vsync,
             resizable: window_descriptor.resizable,
             mode: window_descriptor.mode,
+            #[cfg(target_arch = "wasm32")]
+            canvas: window_descriptor.canvas.clone(),
         }
     }
 }
@@ -77,6 +81,8 @@ pub struct WindowDescriptor {
     pub vsync: bool,
     pub resizable: bool,
     pub mode: WindowMode,
+    #[cfg(target_arch = "wasm32")]
+    pub canvas: Option<String>,
 
     // this is a manual implementation of the non exhaustive pattern,
     // especially made to allow ..Default::default()
@@ -93,6 +99,8 @@ impl Default for WindowDescriptor {
             vsync: true,
             resizable: true,
             mode: WindowMode::Windowed,
+            #[cfg(target_arch = "wasm32")]
+            canvas: None,
             __non_exhaustive: (),
         }
     }

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -31,4 +31,5 @@ log = { version = "0.4", features = ["release_max_level_info"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 winit = { version = "0.22.2", package = "cart-tmp-winit", features = ["web-sys"] }
+wasm-bindgen = { version = "0.2" }
 web-sys = "0.3"


### PR DESCRIPTION
This PR extends `WindowDescriptor` resource with `canvas` field.
This is a [Document.querySelector()](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) string allowing pointing `winit` to an existing HTMLCanvasElement to use.

This allows embedding Bevy game in an existing web page.