### PR TITLE
transform: add "setter" builder functions and fix examples

### DIFF
--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -32,8 +32,12 @@ impl GlobalTransform {
         GlobalTransform::new(Mat4::from_scale(Vec3::splat(scale)))
     }
 
-    pub fn from_non_uniform_scale(scale: Vec3) -> Self {
-        GlobalTransform::new(Mat4::from_scale(scale))
+    pub fn from_translation_rotation(translation: Vec3, rotation: Quat) -> Self {
+        GlobalTransform::new(Mat4::from_scale_rotation_translation(
+            Vec3::splat(1.0),
+            rotation,
+            translation,
+        ))
     }
 
     pub fn from_translation_rotation_scale(translation: Vec3, rotation: Quat, scale: f32) -> Self {
@@ -44,22 +48,46 @@ impl GlobalTransform {
         ))
     }
 
+    pub fn from_non_uniform_scale(scale: Vec3) -> Self {
+        GlobalTransform::new(Mat4::from_scale(scale))
+    }
+
     pub fn with_translation(mut self, translation: Vec3) -> Self {
-        self.translate(translation);
+        self.set_translation(translation);
         self
     }
 
     pub fn with_rotation(mut self, rotation: Quat) -> Self {
-        self.rotate(rotation);
+        self.set_rotation(rotation);
         self
     }
 
     pub fn with_scale(mut self, scale: f32) -> Self {
-        self.apply_scale(scale);
+        self.set_scale(scale);
         self
     }
 
     pub fn with_non_uniform_scale(mut self, scale: Vec3) -> Self {
+        self.set_non_uniform_scale(scale);
+        self
+    }
+
+    pub fn with_translate(mut self, translation: Vec3) -> Self {
+        self.translate(translation);
+        self
+    }
+
+    pub fn with_rotate(mut self, rotation: Quat) -> Self {
+        self.rotate(rotation);
+        self
+    }
+
+    pub fn with_apply_scale(mut self, scale: f32) -> Self {
+        self.apply_scale(scale);
+        self
+    }
+
+    pub fn with_apply_non_uniform_scale(mut self, scale: Vec3) -> Self {
         self.apply_non_uniform_scale(scale);
         self
     }

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -32,6 +32,14 @@ impl Transform {
         Transform::new(Mat4::from_scale(Vec3::splat(scale)))
     }
 
+    pub fn from_translation_rotation(translation: Vec3, rotation: Quat) -> Self {
+        Transform::new(Mat4::from_scale_rotation_translation(
+            Vec3::splat(1.0),
+            rotation,
+            translation,
+        ))
+    }
+
     pub fn from_translation_rotation_scale(translation: Vec3, rotation: Quat, scale: f32) -> Self {
         Transform::new(Mat4::from_scale_rotation_translation(
             Vec3::splat(scale),
@@ -45,21 +53,41 @@ impl Transform {
     }
 
     pub fn with_translation(mut self, translation: Vec3) -> Self {
-        self.translate(translation);
+        self.set_translation(translation);
         self
     }
 
     pub fn with_rotation(mut self, rotation: Quat) -> Self {
-        self.rotate(rotation);
+        self.set_rotation(rotation);
         self
     }
 
     pub fn with_scale(mut self, scale: f32) -> Self {
-        self.apply_scale(scale);
+        self.set_scale(scale);
         self
     }
 
     pub fn with_non_uniform_scale(mut self, scale: Vec3) -> Self {
+        self.set_non_uniform_scale(scale);
+        self
+    }
+
+    pub fn with_translate(mut self, translation: Vec3) -> Self {
+        self.translate(translation);
+        self
+    }
+
+    pub fn with_rotate(mut self, rotation: Quat) -> Self {
+        self.rotate(rotation);
+        self
+    }
+
+    pub fn with_apply_scale(mut self, scale: f32) -> Self {
+        self.apply_scale(scale);
+        self
+    }
+
+    pub fn with_apply_non_uniform_scale(mut self, scale: Vec3) -> Self {
         self.apply_non_uniform_scale(scale);
         self
     }

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -59,8 +59,10 @@ fn setup(
         .spawn(PbrComponents {
             mesh: quad_handle,
             material: material_handle,
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 1.5))
-                .with_rotation(Quat::from_rotation_x(-std::f32::consts::PI / 5.0)),
+            transform: Transform::from_translation_rotation(
+                Vec3::new(0.0, 0.0, 1.5),
+                Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
+            ),
             draw: Draw {
                 is_transparent: true,
                 ..Default::default()
@@ -71,8 +73,10 @@ fn setup(
         .spawn(PbrComponents {
             mesh: quad_handle,
             material: red_material_handle,
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 0.0))
-                .with_rotation(Quat::from_rotation_x(-std::f32::consts::PI / 5.0)),
+            transform: Transform::from_translation_rotation(
+                Vec3::new(0.0, 0.0, 0.0),
+                Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
+            ),
             draw: Draw {
                 is_transparent: true,
                 ..Default::default()
@@ -83,8 +87,10 @@ fn setup(
         .spawn(PbrComponents {
             mesh: quad_handle,
             material: blue_material_handle,
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, -1.5))
-                .with_rotation(Quat::from_rotation_x(-std::f32::consts::PI / 5.0)),
+            transform: Transform::from_translation_rotation(
+                Vec3::new(0.0, 0.0, -1.5),
+                Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
+            ),
             draw: Draw {
                 is_transparent: true,
                 ..Default::default()

--- a/examples/3d/z_sort_debug.rs
+++ b/examples/3d/z_sort_debug.rs
@@ -21,7 +21,8 @@ struct Rotator;
 /// rotates the parent, which will result in the child also rotating
 fn rotator_system(time: Res<Time>, mut query: Query<(&Rotator, &mut Transform)>) {
     for (_rotator, mut transform) in &mut query.iter() {
-        transform.rotate(Quat::from_rotation_x(3.0 * time.delta_seconds));
+        let rotation = transform.rotation() * Quat::from_rotation_x(3.0 * time.delta_seconds);
+        transform.set_rotation(rotation);
     }
 }
 


### PR DESCRIPTION
Methods like `with_translation` were confusing because "translation" is "property" on Transform. This makes setting up transforms error prone because people gravitate toward `with_translation`, but it applies a translation operation, it doesn't set the "translation" property. I made `with_translation` a "setter" and `with_translate` the "apply translation" builder.

For efficiency, I also added a `from_translation_rotation` method.

This also fixes examples that incorrectly used these builders.