### PR TITLE
fix font atlas text width bug

### DIFF
--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -51,62 +51,61 @@ impl FontAtlasSet {
         textures: &mut Assets<Texture>,
         font_size: f32,
         text: &str,
-    ) -> f32 {
+    ) -> Option<f32> {
         let mut width = 0.0;
-        if let Some(font) = fonts.get(&self.font) {
-            let scaled_font = ab_glyph::Font::as_scaled(&font.font, font_size);
-            let font_atlases = self
-                .font_atlases
-                .entry(FloatOrd(font_size))
-                .or_insert_with(|| {
-                    vec![FontAtlas::new(
-                        textures,
-                        texture_atlases,
-                        Vec2::new(512.0, 512.0),
-                    )]
-                });
+        let font = fonts.get(&self.font)?;
+        let scaled_font = ab_glyph::Font::as_scaled(&font.font, font_size);
+        let font_atlases = self
+            .font_atlases
+            .entry(FloatOrd(font_size))
+            .or_insert_with(|| {
+                vec![FontAtlas::new(
+                    textures,
+                    texture_atlases,
+                    Vec2::new(512.0, 512.0),
+                )]
+            });
 
-            let mut last_glyph: Option<Glyph> = None;
-            for character in text.chars() {
-                if character.is_control() {
-                    continue;
-                }
-                let glyph = scaled_font.scaled_glyph(character);
-                if let Some(last_glyph) = last_glyph.take() {
-                    width += scaled_font.kern(last_glyph.id, glyph.id);
-                }
-                if !font_atlases
-                    .iter()
-                    .any(|atlas| atlas.get_char_index(character).is_some())
-                {
-                    if let Some(outlined_glyph) = scaled_font.outline_glyph(glyph.clone()) {
-                        let glyph_texture = Font::get_outlined_glyph_texture(outlined_glyph);
-                        let add_char_to_font_atlas = |atlas: &mut FontAtlas| -> bool {
-                            atlas.add_char(textures, texture_atlases, character, &glyph_texture)
-                        };
-                        if !font_atlases.iter_mut().any(add_char_to_font_atlas) {
-                            font_atlases.push(FontAtlas::new(
-                                textures,
-                                texture_atlases,
-                                Vec2::new(512.0, 512.0),
-                            ));
-                            if !font_atlases.last_mut().unwrap().add_char(
-                                textures,
-                                texture_atlases,
-                                character,
-                                &glyph_texture,
-                            ) {
-                                panic!("could not add character to newly created FontAtlas");
-                            }
+        let mut last_glyph: Option<Glyph> = None;
+        for character in text.chars() {
+            if character.is_control() {
+                continue;
+            }
+            let glyph = scaled_font.scaled_glyph(character);
+            if let Some(last_glyph) = last_glyph.take() {
+                width += scaled_font.kern(last_glyph.id, glyph.id);
+            }
+            if !font_atlases
+                .iter()
+                .any(|atlas| atlas.get_char_index(character).is_some())
+            {
+                if let Some(outlined_glyph) = scaled_font.outline_glyph(glyph.clone()) {
+                    let glyph_texture = Font::get_outlined_glyph_texture(outlined_glyph);
+                    let add_char_to_font_atlas = |atlas: &mut FontAtlas| -> bool {
+                        atlas.add_char(textures, texture_atlases, character, &glyph_texture)
+                    };
+                    if !font_atlases.iter_mut().any(add_char_to_font_atlas) {
+                        font_atlases.push(FontAtlas::new(
+                            textures,
+                            texture_atlases,
+                            Vec2::new(512.0, 512.0),
+                        ));
+                        if !font_atlases.last_mut().unwrap().add_char(
+                            textures,
+                            texture_atlases,
+                            character,
+                            &glyph_texture,
+                        ) {
+                            panic!("could not add character to newly created FontAtlas");
                         }
                     }
-                    width += scaled_font.h_advance(glyph.id);
-                    last_glyph = Some(glyph);
                 }
             }
+            width += scaled_font.h_advance(glyph.id);
+            last_glyph = Some(glyph);
         }
 
-        width
+        Some(width)
     }
 
     pub fn get_glyph_atlas_info(&self, font_size: f32, character: char) -> Option<GlyphAtlasInfo> {


### PR DESCRIPTION
Fixes #517 

This really fixes two bugs:

1. computed text width being set to zero due to width being updated in the wrong place
2. handling the case where text changes, but the font asset hasnt finished loading yet 