### PR TITLE
Update async-executor to 1.3.0 (urgent)

### DIFF
--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -13,6 +13,6 @@ edition = "2018"
 [dependencies]
 futures-lite = "1.4.0"
 event-listener = "2.4.0"
-async-executor = "1.1.1"
+async-executor = "1.3.0"
 async-channel = "1.4.2"
 num_cpus = "1"

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -83,7 +83,7 @@ pub struct TaskPool {
     /// This has to be separate from TaskPoolInner because we have to create an Arc<Executor> to
     /// pass into the worker threads, and we must create the worker threads before we can create the
     /// Vec<Task<T>> contained within TaskPoolInner
-    executor: Arc<async_executor::Executor>,
+    executor: Arc<async_executor::Executor<'static>>,
 
     /// Inner state of the pool
     inner: Arc<TaskPoolInner>,
@@ -219,20 +219,13 @@ impl Default for TaskPool {
 }
 
 pub struct Scope<'scope, T> {
-    executor: &'scope async_executor::Executor,
+    executor: &'scope async_executor::Executor<'scope>,
     spawned: Vec<async_executor::Task<T>>,
 }
 
-impl<'scope, T: Send + 'static> Scope<'scope, T> {
+impl<'scope, T: Send + 'scope> Scope<'scope, T> {
     pub fn spawn<Fut: Future<Output = T> + 'scope + Send>(&mut self, f: Fut) {
-        // SAFETY: This function blocks until all futures complete, so we do not read/write the
-        // data from futures outside of the 'scope lifetime. However, rust has no way of knowing
-        // this so we must convert to 'static here to appease the compiler as it is unable to
-        // validate safety.
-        let fut: Pin<Box<dyn Future<Output = T> + 'scope + Send>> = Box::pin(f);
-        let fut: Pin<Box<dyn Future<Output = T> + 'static + Send>> = unsafe { mem::transmute(fut) };
-
-        let task = self.executor.spawn(fut);
+        let task = self.executor.spawn(f);
         self.spawned.push(task);
     }
 }


### PR DESCRIPTION
For anyone who stumbles on this issue wondering what went wrong:

The easiest fix until this PR is merged is to add this as a dependency to your `Cargo.toml`:

```toml
[dependencies]
async-executor = "=1.2.0"
```

------------------

Hey, I sneaked in a small breaking change into `async-executor` without respecting semantic versioning rules.

The change is to parametrize executors over a lifetime, i.e. turn `Executor` into `Executor<'a>`. This way, we can have non-static executors, spawn non-static futures, and await their non-static results! :)

Rather than bumping `async-executor` to v2.0, I chose to sneak in the breaking change into v1.3.0 for the following reasons:

* `async-executor` v1.x is still very new and few projects are using it.
* Most projects using it are not affected by the breaking change (yours is one of the two unfortunate ones I found).
* Bumping to v2.0 would require `smol` to go v2.0 too, thus creating a lot of churn.

The short story is: respecting semver rules would overall cause us more pain that just merging this one pull request. The other affected project, `async-global-executor`, is already fixed).

Anyways, apologies for that! I hope you can just quickly merge this in and move on :)

Cheers! This looks like a cool project, I'm actually gonna go look what's inside...

**TL;DR** for anyone whose code is broken right now: add `async-executor = "=1.2.0"` to `Cargo.toml` as a temporary workaround.