### PR TITLE
Add systemd-devel for Fedora Linux dependencies

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -11,7 +11,7 @@ sudo apt-get install pkg-config libx11-dev libasound2-dev
 
 ## Fedora 32
 ```bash
-sudo dnf install gcc-c++ libX11-devel alsa-lib-devel
+sudo dnf install gcc-c++ libX11-devel alsa-lib-devel systemd-devel
 ```
 
 ## Arch / Manjaro


### PR DESCRIPTION
It is required for the dependency crate libudev-sys (error about missing libudev.pc)