### PR TITLE
Use exact version of async-executor in bevy_tasks

### DIFF
--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -13,6 +13,6 @@ edition = "2018"
 [dependencies]
 futures-lite = "1.4.0"
 event-listener = "2.4.0"
-async-executor = "1.1.1"
+async-executor = "=1.1.1"
 async-channel = "1.4.2"
 num_cpus = "1"


### PR DESCRIPTION
Version 1.3.1 of async-executor requires a lifetime on Executor. Due
to the way that cargo fetches dependencies, without the '=' or 
Cargo.lock file, cargo can compile with a later version leading to 
compilation errors.