### PR TITLE
use FnOnce in Commands and ChildBuilder where possible

### DIFF
--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -298,7 +298,7 @@ impl Commands {
         commands.current_entity
     }
 
-    pub fn for_current_entity(&mut self, mut f: impl FnMut(Entity)) -> &mut Self {
+    pub fn for_current_entity(&mut self, f: impl FnOnce(Entity)) -> &mut Self {
         {
             let commands = self.commands.lock();
             let current_entity = commands

--- a/crates/bevy_transform/src/hierarchy/child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/child_builder.rs
@@ -94,7 +94,7 @@ impl<'a> ChildBuilder<'a> {
         self
     }
 
-    pub fn for_current_entity(&mut self, mut func: impl FnMut(Entity)) -> &mut Self {
+    pub fn for_current_entity(&mut self, func: impl FnOnce(Entity)) -> &mut Self {
         let current_entity = self
             .commands
             .current_entity
@@ -105,13 +105,13 @@ impl<'a> ChildBuilder<'a> {
 }
 
 pub trait BuildChildren {
-    fn with_children(&mut self, f: impl FnMut(&mut ChildBuilder)) -> &mut Self;
+    fn with_children(&mut self, f: impl FnOnce(&mut ChildBuilder)) -> &mut Self;
     fn push_children(&mut self, parent: Entity, children: &[Entity]) -> &mut Self;
     fn insert_children(&mut self, parent: Entity, index: usize, children: &[Entity]) -> &mut Self;
 }
 
 impl BuildChildren for Commands {
-    fn with_children(&mut self, mut parent: impl FnMut(&mut ChildBuilder)) -> &mut Self {
+    fn with_children(&mut self, parent: impl FnOnce(&mut ChildBuilder)) -> &mut Self {
         {
             let mut commands = self.commands.lock();
             let current_entity = commands.current_entity.expect("Cannot add children because the 'current entity' is not set. You should spawn an entity first.");
@@ -159,7 +159,7 @@ impl BuildChildren for Commands {
 }
 
 impl<'a> BuildChildren for ChildBuilder<'a> {
-    fn with_children(&mut self, mut spawn_children: impl FnMut(&mut ChildBuilder)) -> &mut Self {
+    fn with_children(&mut self, spawn_children: impl FnOnce(&mut ChildBuilder)) -> &mut Self {
         let current_entity = self.commands.current_entity.expect("Cannot add children because the 'current entity' is not set. You should spawn an entity first.");
         self.commands.current_entity = None;
         let push_children = {

--- a/crates/bevy_transform/src/hierarchy/world_child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/world_child_builder.rs
@@ -50,13 +50,13 @@ impl<'a, 'b> WorldChildBuilder<'a, 'b> {
 }
 
 pub trait BuildWorldChildren {
-    fn with_children(&mut self, spawn_children: impl FnMut(&mut WorldChildBuilder)) -> &mut Self;
+    fn with_children(&mut self, spawn_children: impl FnOnce(&mut WorldChildBuilder)) -> &mut Self;
 }
 
 impl<'a> BuildWorldChildren for WorldBuilder<'a> {
     fn with_children(
         &mut self,
-        mut spawn_children: impl FnMut(&mut WorldChildBuilder),
+        spawn_children: impl FnOnce(&mut WorldChildBuilder),
     ) -> &mut Self {
         {
             let current_entity = self.current_entity.expect("Cannot add children because the 'current entity' is not set. You should spawn an entity first.");
@@ -74,7 +74,7 @@ impl<'a> BuildWorldChildren for WorldBuilder<'a> {
 impl<'a, 'b> BuildWorldChildren for WorldChildBuilder<'a, 'b> {
     fn with_children(
         &mut self,
-        mut spawn_children: impl FnMut(&mut WorldChildBuilder),
+        spawn_children: impl FnOnce(&mut WorldChildBuilder),
     ) -> &mut Self {
         let current_entity = self
             .world_builder

--- a/crates/bevy_transform/src/hierarchy/world_child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/world_child_builder.rs
@@ -54,10 +54,7 @@ pub trait BuildWorldChildren {
 }
 
 impl<'a> BuildWorldChildren for WorldBuilder<'a> {
-    fn with_children(
-        &mut self,
-        spawn_children: impl FnOnce(&mut WorldChildBuilder),
-    ) -> &mut Self {
+    fn with_children(&mut self, spawn_children: impl FnOnce(&mut WorldChildBuilder)) -> &mut Self {
         {
             let current_entity = self.current_entity.expect("Cannot add children because the 'current entity' is not set. You should spawn an entity first.");
             let mut builder = WorldChildBuilder {
@@ -72,10 +69,7 @@ impl<'a> BuildWorldChildren for WorldBuilder<'a> {
 }
 
 impl<'a, 'b> BuildWorldChildren for WorldChildBuilder<'a, 'b> {
-    fn with_children(
-        &mut self,
-        spawn_children: impl FnOnce(&mut WorldChildBuilder),
-    ) -> &mut Self {
+    fn with_children(&mut self, spawn_children: impl FnOnce(&mut WorldChildBuilder)) -> &mut Self {
         let current_entity = self
             .world_builder
             .current_entity


### PR DESCRIPTION
resolves #531 

Functions `with_children` and `for_current_entity` on `Commands` and `ChildBuilder` now take `FnOnce` rather than `FnMut`.