### PR TITLE
Add `libudev-dev` to Ubuntu dependencies

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -6,7 +6,7 @@ If you don't see your distro present in the list, feel free to add the instructi
 
 ## Ubuntu 20.04
 ```bash
-sudo apt-get install pkg-config libx11-dev libasound2-dev
+sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev
 ```
 
 ## Fedora 32


### PR DESCRIPTION
Bevy seems to now depend on `libudev-sys` (and thus `libudev-dev`):

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "`\"pkg-config\" \"--libs\" \"--cflags\" \"libudev\"` did not exit successfully: exit code: 1\n--- stderr\nPackage libudev was not found in the pkg-config search path.\nPerhaps you should add the directory containing `libudev.pc\'\nto the PKG_CONFIG_PATH environment variable\nNo package \'libudev\' found\n"', /home/zooce/.cargo/registry/src/github.com-1ecc6299db9ec823/libudev-sys-0.1.4/build.rs:38:41
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: build failed
```

This PR adds `libudev-dev` to the Ubuntu 20.04 dependencies.