### PR TITLE
Don't resize when viewport 0x0

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -116,7 +116,7 @@ pub fn winit_runner(mut app: App) {
                 event: WindowEvent::Resized(size),
                 window_id: winit_window_id,
                 ..
-            } => {
+            } => if size.width != 0 && size.height != 0 {
                 let winit_windows = app.resources.get_mut::<WinitWindows>().unwrap();
                 let mut windows = app.resources.get_mut::<Windows>().unwrap();
                 let window_id = winit_windows.get_window_id(winit_window_id).unwrap();

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -116,23 +116,20 @@ pub fn winit_runner(mut app: App) {
                 event: WindowEvent::Resized(size),
                 window_id: winit_window_id,
                 ..
-            } => {
-                if size.width != 0 && size.height != 0 {
-                    let winit_windows = app.resources.get_mut::<WinitWindows>().unwrap();
-                    let mut windows = app.resources.get_mut::<Windows>().unwrap();
-                    let window_id = winit_windows.get_window_id(winit_window_id).unwrap();
-                    let mut window = windows.get_mut(window_id).unwrap();
-                    window.width = size.width;
-                    window.height = size.height;
+            } if size.width != 0 && size.height != 0 => {
+                let winit_windows = app.resources.get_mut::<WinitWindows>().unwrap();
+                let mut windows = app.resources.get_mut::<Windows>().unwrap();
+                let window_id = winit_windows.get_window_id(winit_window_id).unwrap();
+                let mut window = windows.get_mut(window_id).unwrap();
+                window.width = size.width;
+                window.height = size.height;
 
-                    let mut resize_events =
-                        app.resources.get_mut::<Events<WindowResized>>().unwrap();
-                    resize_events.send(WindowResized {
-                        id: window_id,
-                        height: window.height as usize,
-                        width: window.width as usize,
-                    });
-                }
+                let mut resize_events = app.resources.get_mut::<Events<WindowResized>>().unwrap();
+                resize_events.send(WindowResized {
+                    id: window_id,
+                    height: window.height as usize,
+                    width: window.width as usize,
+                });
             }
             event::Event::WindowEvent {
                 event,

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -112,6 +112,9 @@ pub fn winit_runner(mut app: App) {
         }
 
         match event {
+            // This event is restricted to only sending resize-events when the width or height are not 0.
+            // This prevents crashing on minimizing/resizing, and should be removed when https://github.com/gfx-rs/wgpu-rs/issues/316
+            // is fixed.
             event::Event::WindowEvent {
                 event: WindowEvent::Resized(size),
                 window_id: winit_window_id,

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -116,20 +116,23 @@ pub fn winit_runner(mut app: App) {
                 event: WindowEvent::Resized(size),
                 window_id: winit_window_id,
                 ..
-            } => if size.width != 0 && size.height != 0 {
-                let winit_windows = app.resources.get_mut::<WinitWindows>().unwrap();
-                let mut windows = app.resources.get_mut::<Windows>().unwrap();
-                let window_id = winit_windows.get_window_id(winit_window_id).unwrap();
-                let mut window = windows.get_mut(window_id).unwrap();
-                window.width = size.width;
-                window.height = size.height;
+            } => {
+                if size.width != 0 && size.height != 0 {
+                    let winit_windows = app.resources.get_mut::<WinitWindows>().unwrap();
+                    let mut windows = app.resources.get_mut::<Windows>().unwrap();
+                    let window_id = winit_windows.get_window_id(winit_window_id).unwrap();
+                    let mut window = windows.get_mut(window_id).unwrap();
+                    window.width = size.width;
+                    window.height = size.height;
 
-                let mut resize_events = app.resources.get_mut::<Events<WindowResized>>().unwrap();
-                resize_events.send(WindowResized {
-                    id: window_id,
-                    height: window.height as usize,
-                    width: window.width as usize,
-                });
+                    let mut resize_events =
+                        app.resources.get_mut::<Events<WindowResized>>().unwrap();
+                    resize_events.send(WindowResized {
+                        id: window_id,
+                        height: window.height as usize,
+                        width: window.width as usize,
+                    });
+                }
             }
             event::Event::WindowEvent {
                 event,


### PR DESCRIPTION
 This is a hack to prevent wgpu from crashing bevy when size set to a width or height of 0. Wgpu currently crashes on its swapchain under this condition, winit sends a resize event (of 0x0) on minimize, and if the user click and drag resizes to 0 width or 0 height it crashes as well. 

 You will not get an event of a 0 width or 0 height resize, so if you want to check for minimized you would need to check window flags on the winit window (I don't think you should check 0x0 for minimized regardless)

 This should be removed when https://github.com/gfx-rs/wgpu-rs/issues/316 is fixed

Fixes #170 