### PR TITLE
Add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug Report
+about: Report a bug to help us improve!
+title: ''
+labels: 'bug'
+assignees: ''
+---
+
+**Bevy version**
+
+The release number or commit hash of the version you're using
+
+**Operating system & version**
+
+e.g. Windows 10, Ubuntu 18.04, iOS 14
+
+**What you did**
+
+The steps you took to uncover this bug. Please list full reproduction steps if
+feasible.
+
+**What you expected to happen**
+
+What you think should've happened if everything was working properly
+
+**What actually happened**
+
+The actual result of the actions you described
+
+**Additional information**
+
+Any additional information you would like to add such as screenshots, logs, etc.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature Request
+about: Propose a new feature!
+title: ''
+labels: 'enhancement'
+assignees: ''
+---
+
+**What problem does this solve or what need does it fill?**
+
+A description of why this particular feature should be added
+
+**Describe the solution would you like?**
+
+The solution you propose for the problem presented
+
+**Describe the alternative(s) you've considered?**
+
+Other solutions to solve and/or work around the problem presented
+
+**Additional context**
+
+Any other information you would like to add such as related previous work,
+screenshots, benchmarks, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+**Checklist**
+
+I confirm that I have done the following (if applicable):
+
+- [] Added a changelog entry
+- [] Added respective unit tests


### PR DESCRIPTION
These are largely based on Amethyst's templates, the main difference being the exclusion of the "I've tested CI locally" boxes. Feedback is welcome.

Resolves #326 