### PR TITLE
Suggest -Zrun-dsymutil-no for macOS fast compiles

### DIFF
--- a/.cargo/config_fast_builds
+++ b/.cargo/config_fast_builds
@@ -10,7 +10,7 @@ rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]
 # NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
 # `brew install michaeleisel/zld/zld`
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Zshare-generics=y"]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Zshare-generics=y", "-Zrun-dsymutil=no"]
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+- [Another fast compile flag for macOS][552]
+
+[552]: https://github.com/bevyengine/bevy/pull/552
+
 ## Version 0.2.1 (2020-9-20)
 
 ### Fixed


### PR DESCRIPTION
This keeps original object files around after compilation in the event that debug information is needed.

Resolves #527 