### PR TITLE
WASM asset loading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ log = "0.4"
 #wasm
 console_error_panic_hook = "0.1.6"
 console_log = { version = "0.2", features = ["color"] }
+anyhow = "1.0"
 
 [[example]]
 name = "hello_world"
@@ -280,4 +281,9 @@ required-features = []
 [[example]]
 name = "winit_wasm"
 path = "examples/wasm/winit_wasm.rs"
+required-features = ["bevy_winit"]
+
+[[example]]
+name = "assets_wasm"
+path = "examples/wasm/assets_wasm.rs"
 required-features = ["bevy_winit"]

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -34,3 +34,10 @@ thiserror = "1.0"
 log = { version = "0.4", features = ["release_max_level_info"] }
 notify = { version = "5.0.0-pre.2", optional = true }
 parking_lot = "0.11.0"
+async-trait = "0.1.40"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = { version = "0.2" }
+web-sys = { version = "0.3", features = ["Request", "Window", "Response"]}
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"

--- a/crates/bevy_asset/src/load_request/mod.rs
+++ b/crates/bevy_asset/src/load_request/mod.rs
@@ -1,0 +1,31 @@
+use crate::{AssetLoader, AssetResult, AssetVersion, HandleId};
+use crossbeam_channel::Sender;
+use std::path::PathBuf;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[path = "platform_default.rs"]
+mod platform_specific;
+
+#[cfg(target_arch = "wasm32")]
+#[path = "platform_wasm.rs"]
+mod platform_specific;
+
+pub use platform_specific::*;
+
+/// A request from an [AssetServer](crate::AssetServer) to load an asset.
+#[derive(Debug)]
+pub struct LoadRequest {
+    pub path: PathBuf,
+    pub handle_id: HandleId,
+    pub handler_index: usize,
+    pub version: AssetVersion,
+}
+
+pub(crate) struct ChannelAssetHandler<TLoader, TAsset>
+where
+    TLoader: AssetLoader<TAsset>,
+    TAsset: 'static,
+{
+    sender: Sender<AssetResult<TAsset>>,
+    loader: TLoader,
+}

--- a/crates/bevy_asset/src/load_request/platform_wasm.rs
+++ b/crates/bevy_asset/src/load_request/platform_wasm.rs
@@ -1,0 +1,62 @@
+use super::{ChannelAssetHandler, LoadRequest};
+use crate::{AssetLoadError, AssetLoader, AssetResult, Handle};
+use anyhow::Result;
+use async_trait::async_trait;
+use crossbeam_channel::Sender;
+
+use js_sys::Uint8Array;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
+use web_sys::Response;
+
+#[async_trait(?Send)]
+pub trait AssetLoadRequestHandler: Send + Sync + 'static {
+    async fn handle_request(&self, load_request: &LoadRequest);
+    fn extensions(&self) -> &[&str];
+}
+
+impl<TLoader, TAsset> ChannelAssetHandler<TLoader, TAsset>
+where
+    TLoader: AssetLoader<TAsset>,
+{
+    pub fn new(loader: TLoader, sender: Sender<AssetResult<TAsset>>) -> Self {
+        ChannelAssetHandler { sender, loader }
+    }
+
+    async fn load_asset(&self, load_request: &LoadRequest) -> Result<TAsset, AssetLoadError> {
+        // TODO - get rid of some unwraps below (do some retrying maybe?)
+        let window = web_sys::window().unwrap();
+        let resp_value = JsFuture::from(window.fetch_with_str(load_request.path.to_str().unwrap()))
+            .await
+            .unwrap();
+        let resp: Response = resp_value.dyn_into().unwrap();
+        let data = JsFuture::from(resp.array_buffer().unwrap()).await.unwrap();
+        let bytes = Uint8Array::new(&data).to_vec();
+        let asset = self.loader.from_bytes(&load_request.path, bytes).unwrap();
+        Ok(asset)
+    }
+}
+
+#[async_trait(?Send)]
+impl<TLoader, TAsset> AssetLoadRequestHandler for ChannelAssetHandler<TLoader, TAsset>
+where
+    TLoader: AssetLoader<TAsset> + 'static,
+    TAsset: Send + 'static,
+{
+    async fn handle_request(&self, load_request: &LoadRequest) {
+        let asset = self.load_asset(load_request).await;
+        let asset_result = AssetResult {
+            handle: Handle::from(load_request.handle_id),
+            result: asset,
+            path: load_request.path.clone(),
+            version: load_request.version,
+        };
+        self.sender
+            .send(asset_result)
+            .expect("loaded asset should have been sent");
+    }
+
+    fn extensions(&self) -> &[&str] {
+        self.loader.extensions()
+    }
+}

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -16,3 +16,5 @@ event-listener = "2.4.0"
 async-executor = "1.3.0"
 async-channel = "1.4.2"
 num_cpus = "1"
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = "0.4"

--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -82,6 +82,32 @@ impl TaskPool {
             .map(|result| result.lock().unwrap().take().unwrap())
             .collect()
     }
+
+    // Spawns a static future onto the JS event loop. For now it is returning FakeTask
+    // instance with no-op detach method. Returning real Task is possible here, but tricky:
+    // future is running on JS event loop, Task is running on async_executor::LocalExecutor
+    // so some proxy future is needed. Moreover currently we don't have long-living
+    // LocalExecutor here (above `spawn` implementation creates temporary one)
+    // But for typical use cases it seems that current implementation should be sufficient:
+    // caller can spawn long-running future writing results to some channel / event queue
+    // and simply call detach on returned Task (like AssetServer does) - spawned future
+    // can write results to some channed / event queue.
+
+    pub fn spawn<T>(&self, future: impl Future<Output = T> + 'static) -> FakeTask
+    where
+        T: 'static,
+    {
+        wasm_bindgen_futures::spawn_local(async move {
+            future.await;
+        });
+        FakeTask
+    }
+}
+
+pub struct FakeTask;
+
+impl FakeTask {
+    pub fn detach(self) {}
 }
 
 pub struct Scope<'scope, T> {

--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -91,7 +91,7 @@ impl TaskPool {
     // But for typical use cases it seems that current implementation should be sufficient:
     // caller can spawn long-running future writing results to some channel / event queue
     // and simply call detach on returned Task (like AssetServer does) - spawned future
-    // can write results to some channed / event queue.
+    // can write results to some channel / event queue.
 
     pub fn spawn<T>(&self, future: impl Future<Output = T> + 'static) -> FakeTask
     where

--- a/examples/wasm/assets_wasm.rs
+++ b/examples/wasm/assets_wasm.rs
@@ -1,0 +1,65 @@
+extern crate console_error_panic_hook;
+use bevy::{asset::AssetLoader, prelude::*};
+use std::{panic, path::PathBuf};
+
+fn main() {
+    panic::set_hook(Box::new(console_error_panic_hook::hook));
+    console_log::init_with_level(log::Level::Debug).expect("cannot initialize console_log");
+
+    App::build()
+        .add_default_plugins()
+        .add_asset::<RustSourceCode>()
+        .add_asset_loader::<RustSourceCode, RustSourceCodeLoader>()
+        .add_startup_system(asset_system.system())
+        .add_system(asset_events.system())
+        .run();
+}
+
+fn asset_system(asset_server: Res<AssetServer>) {
+    asset_server
+        .load::<Handle<RustSourceCode>, _>(PathBuf::from("assets_wasm.rs"))
+        .unwrap();
+    log::info!("hello wasm");
+}
+
+#[derive(Debug)]
+pub struct RustSourceCode(pub String);
+
+#[derive(Default)]
+pub struct RustSourceCodeLoader;
+impl AssetLoader<RustSourceCode> for RustSourceCodeLoader {
+    fn from_bytes(
+        &self,
+        _asset_path: &std::path::Path,
+        bytes: Vec<u8>,
+    ) -> Result<RustSourceCode, anyhow::Error> {
+        Ok(RustSourceCode(String::from_utf8(bytes)?))
+    }
+
+    fn extensions(&self) -> &[&str] {
+        static EXT: &[&str] = &["rs"];
+        EXT
+    }
+}
+
+#[derive(Default)]
+pub struct AssetEventsState {
+    reader: EventReader<AssetEvent<RustSourceCode>>,
+}
+
+pub fn asset_events(
+    mut state: Local<AssetEventsState>,
+    rust_sources: Res<Assets<RustSourceCode>>,
+    events: Res<Events<AssetEvent<RustSourceCode>>>,
+) {
+    for event in state.reader.iter(&events) {
+        match event {
+            AssetEvent::Created { handle } => {
+                if let Some(code) = rust_sources.get(handle) {
+                    log::info!("code: {}", code.0);
+                }
+            }
+            _ => continue,
+        };
+    }
+}


### PR DESCRIPTION
This PR adds basic asset loading support for wasm32 target (see assets_wasm example).
Currently only AssetServer.load is implemented (`AssetServer.load_sync makes` no sense in web context, load_asset_folder is tricky, because it will need some html parsing, but it seems doable in the future).
