### PR TITLE
[Merged by Bors] - Wireframe Rendering Pipeline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,10 @@ name = "update_gltf_scene"
 path = "examples/3d/update_gltf_scene.rs"
 
 [[example]]
+name = "wireframe"
+path = "examples/3d/wireframe.rs"
+
+[[example]]
 name = "z_sort_debug"
 path = "examples/3d/z_sort_debug.rs"
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -10,6 +10,7 @@ pub mod render_graph;
 pub mod renderer;
 pub mod shader;
 pub mod texture;
+pub mod wireframe;
 
 use bevy_ecs::{IntoExclusiveSystem, IntoSystem, SystemStage};
 use bevy_reflect::RegisterTypeBuilder;

--- a/crates/bevy_render/src/wireframe/mod.rs
+++ b/crates/bevy_render/src/wireframe/mod.rs
@@ -1,0 +1,130 @@
+use crate::{
+    pipeline::{
+    BlendFactor, BlendOperation, ColorWrite,
+    CompareFunction, CullMode, FrontFace, PipelineDescriptor,
+    PolygonMode, RenderPipeline,
+    },
+    prelude::*,
+    shader::{Shader, ShaderStage, ShaderStages},
+    texture::TextureFormat,
+};
+use bevy_app::prelude::*;
+use bevy_asset::{Assets, Handle, HandleUntyped};
+use bevy_ecs::{Entity, World, ResMut, Res, Query};
+use bevy_reflect::TypeUuid;
+use crate::draw::DrawContext;
+use crate::renderer::RenderResourceBindings;
+use crate::mesh::Indices;
+use crate::pipeline::{PipelineSpecialization, VertexBufferLayout};
+use bevy_ecs::IntoSystem;
+use bevy_utils::HashSet;
+
+mod pipeline;
+
+pub const WIREFRAME_PIPELINE_HANDLE: HandleUntyped =
+HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 0x137c75ab7e9ad7f5);
+
+#[derive(Debug, Default)]
+pub struct WireframePlugin;
+
+impl Plugin for WireframePlugin {
+    fn build(&self, app: &mut AppBuilder) {
+        app
+            .add_system_to_stage(crate::stage::DRAW, draw_wireframes_system.system());
+        let resources = app.resources();
+        let mut shaders = resources.get_mut::<Assets<Shader>>().unwrap();
+        let mut pipelines = resources.get_mut::<Assets<PipelineDescriptor>>().unwrap();
+        pipelines.set(
+            WIREFRAME_PIPELINE_HANDLE,
+            pipeline::build_wireframe_pipeline(&mut shaders),
+        );
+    }
+}
+
+
+
+pub fn draw_wireframes_system(
+    mut draw_context: DrawContext,
+    mut render_resource_bindings: ResMut<RenderResourceBindings>,
+    msaa: Res<Msaa>,
+    meshes: Res<Assets<Mesh>>,
+    mut query: Query<(&mut Draw, &mut RenderPipelines, &Handle<Mesh>, &Visible)>,
+) {
+    for (mut draw, mut render_pipelines, mesh_handle, visible) in query.iter_mut() {
+        if !visible.is_visible {
+            continue;
+        }
+
+        // don't render if the mesh isn't loaded yet
+        let mesh = if let Some(mesh) = meshes.get(mesh_handle) {
+            mesh
+        } else {
+            continue;
+        };
+
+        let index_range = match mesh.indices() {
+            Some(Indices::U32(indices)) => Some(0..indices.len() as u32),
+            Some(Indices::U16(indices)) => Some(0..indices.len() as u32),
+            None => None,
+        };
+
+        let mut render_pipeline = RenderPipeline::specialized(
+            WIREFRAME_PIPELINE_HANDLE.typed(),
+            PipelineSpecialization {
+                sample_count: msaa.samples,
+                strip_index_format: None,
+                shader_specialization: Default::default(),
+                primitive_topology: mesh.primitive_topology(),
+                dynamic_bindings: Default::default(),
+                vertex_buffer_layout: mesh.get_vertex_buffer_layout(),
+            },
+        );
+        if render_pipeline.dynamic_bindings_generation
+            != render_pipelines.bindings.dynamic_bindings_generation()
+        {
+            render_pipeline.specialization.dynamic_bindings = render_pipelines
+                .bindings
+                .iter_dynamic_bindings()
+                .map(|name| name.to_string())
+                .collect::<HashSet<String>>();
+            render_pipeline.dynamic_bindings_generation =
+                render_pipelines.bindings.dynamic_bindings_generation();
+            for (handle, _) in render_pipelines.bindings.iter_assets() {
+                if let Some(bindings) = draw_context
+                    .asset_render_resource_bindings
+                    .get_untyped(handle)
+                {
+                    for binding in bindings.iter_dynamic_bindings() {
+                        render_pipeline
+                            .specialization
+                            .dynamic_bindings
+                            .insert(binding.to_string());
+                    }
+                }
+            }
+        }
+
+        let render_resource_bindings = &mut [
+            &mut render_pipelines.bindings,
+            &mut render_resource_bindings,
+        ];
+        draw_context
+            .set_pipeline(
+                &mut draw,
+                &render_pipeline.pipeline,
+                &render_pipeline.specialization,
+            )
+            .unwrap();
+        draw_context
+            .set_bind_groups_from_bindings(&mut draw, render_resource_bindings)
+            .unwrap();
+        draw_context
+            .set_vertex_buffers_from_bindings(&mut draw, &[&render_pipelines.bindings])
+            .unwrap();
+        if let Some(indices) = index_range.clone() {
+            draw.draw_indexed(indices, 0, 0..1);
+        } else {
+            draw.draw(0..mesh.count_vertices() as u32, 0..1)
+        }
+    }
+}

--- a/crates/bevy_render/src/wireframe/mod.rs
+++ b/crates/bevy_render/src/wireframe/mod.rs
@@ -45,7 +45,6 @@ impl Plugin for WireframePlugin {
 
 pub fn draw_wireframes_system(
     mut draw_context: DrawContext,
-    mut render_resource_bindings: ResMut<RenderResourceBindings>,
     msaa: Res<Msaa>,
     meshes: Res<Assets<Mesh>>,
     mut query: Query<(&mut Draw, &mut RenderPipelines, &Handle<Mesh>, &Visible)>,
@@ -89,25 +88,8 @@ pub fn draw_wireframes_system(
                 .collect::<HashSet<String>>();
             render_pipeline.dynamic_bindings_generation =
                 render_pipelines.bindings.dynamic_bindings_generation();
-            for (handle, _) in render_pipelines.bindings.iter_assets() {
-                if let Some(bindings) = draw_context
-                    .asset_render_resource_bindings
-                    .get_untyped(handle)
-                {
-                    for binding in bindings.iter_dynamic_bindings() {
-                        render_pipeline
-                            .specialization
-                            .dynamic_bindings
-                            .insert(binding.to_string());
-                    }
-                }
-            }
         }
 
-        let render_resource_bindings = &mut [
-            &mut render_pipelines.bindings,
-            &mut render_resource_bindings,
-        ];
         draw_context
             .set_pipeline(
                 &mut draw,
@@ -116,7 +98,9 @@ pub fn draw_wireframes_system(
             )
             .unwrap();
         draw_context
-            .set_bind_groups_from_bindings(&mut draw, render_resource_bindings)
+            .set_bind_groups_from_bindings(&mut draw, &mut [
+                &mut render_pipelines.bindings,
+            ])
             .unwrap();
         draw_context
             .set_vertex_buffers_from_bindings(&mut draw, &[&render_pipelines.bindings])

--- a/crates/bevy_render/src/wireframe/mod.rs
+++ b/crates/bevy_render/src/wireframe/mod.rs
@@ -22,7 +22,7 @@ pub struct WireframePlugin;
 impl Plugin for WireframePlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.init_resource::<WireframeConfig>()
-            .add_system_to_stage(crate::stage::DRAW, draw_wireframes_system.system());
+            .add_system_to_stage(crate::RenderStage::Draw, draw_wireframes_system.system());
         let resources = app.resources();
         let mut shaders = resources.get_mut::<Assets<Shader>>().unwrap();
         let mut pipelines = resources.get_mut::<Assets<PipelineDescriptor>>().unwrap();

--- a/crates/bevy_render/src/wireframe/pipeline.rs
+++ b/crates/bevy_render/src/wireframe/pipeline.rs
@@ -1,0 +1,37 @@
+use crate::{
+    pipeline::{
+        BlendFactor, BlendOperation, ColorWrite,
+        CompareFunction, CullMode, FrontFace,
+        PolygonMode,
+
+            },
+    prelude::*,
+    shader::{Shader, ShaderStage, ShaderStages},
+    texture::TextureFormat,
+};
+use bevy_app::prelude::*;
+use bevy_asset::{Assets, Handle};
+use crate::pipeline::{PrimitiveState, PrimitiveTopology, DepthStencilState, StencilState, StencilFaceState, DepthBiasState, MultisampleState, PipelineDescriptor};
+
+pub(crate) fn build_wireframe_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescriptor {
+    PipelineDescriptor {
+        name: Some("wireframe".into()),
+        primitive: PrimitiveState {
+            topology: PrimitiveTopology::TriangleList,
+            strip_index_format: None,
+            front_face: FrontFace::Ccw,
+            cull_mode: CullMode::None,
+            polygon_mode: PolygonMode::Line,
+        },
+        ..PipelineDescriptor::default_config(ShaderStages {
+            vertex: shaders.add(Shader::from_glsl(
+                ShaderStage::Vertex,
+                include_str!("wireframe.vert"),
+            )),
+            fragment: Some(shaders.add(Shader::from_glsl(
+                ShaderStage::Fragment,
+                include_str!("wireframe.frag"),
+            ))),
+        })
+    }
+}

--- a/crates/bevy_render/src/wireframe/pipeline.rs
+++ b/crates/bevy_render/src/wireframe/pipeline.rs
@@ -1,17 +1,10 @@
 use crate::{
     pipeline::{
-        BlendFactor, BlendOperation, ColorWrite,
-        CompareFunction, CullMode, FrontFace,
-        PolygonMode,
-
-            },
-    prelude::*,
+        CullMode, FrontFace, PipelineDescriptor, PolygonMode, PrimitiveState, PrimitiveTopology,
+    },
     shader::{Shader, ShaderStage, ShaderStages},
-    texture::TextureFormat,
 };
-use bevy_app::prelude::*;
-use bevy_asset::{Assets, Handle};
-use crate::pipeline::{PrimitiveState, PrimitiveTopology, DepthStencilState, StencilState, StencilFaceState, DepthBiasState, MultisampleState, PipelineDescriptor};
+use bevy_asset::Assets;
 
 pub(crate) fn build_wireframe_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescriptor {
     PipelineDescriptor {

--- a/crates/bevy_render/src/wireframe/wireframe.frag
+++ b/crates/bevy_render/src/wireframe/wireframe.frag
@@ -1,0 +1,8 @@
+#version 450
+
+layout(location = 0) out vec4 o_Target;
+
+
+void main() {
+    o_Target = vec4(1.0, 1.0, 1.0, 1.0);
+}

--- a/crates/bevy_render/src/wireframe/wireframe.vert
+++ b/crates/bevy_render/src/wireframe/wireframe.vert
@@ -1,0 +1,16 @@
+#version 450
+
+layout(location = 0) in vec3 Vertex_Position;
+
+layout(set = 0, binding = 0) uniform Camera {
+    mat4 ViewProj;
+};
+
+layout(set = 1, binding = 0) uniform Transform {
+    mat4 Model;
+};
+
+void main() {
+    vec3 v_Position = (Model * vec4(Vertex_Position, 1.0)).xyz;
+    gl_Position = ViewProj * vec4(v_Position, 1.0);
+}

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_internal::render::wireframe::WireframePlugin;
+use bevy_internal::render::wireframe::{WireframePlugin, Wireframe};
 use bevy_internal::wgpu::{WgpuOptions, WgpuFeatures};
 
 fn main() {
@@ -30,6 +30,7 @@ fn setup(
             material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
             ..Default::default()
         })
+        .with(Wireframe)
         // cube
         .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -1,9 +1,17 @@
 use bevy::prelude::*;
+use bevy_internal::render::wireframe::WireframePlugin;
+use bevy_internal::wgpu::{WgpuOptions, WgpuFeatures};
 
 fn main() {
     App::build()
         .insert_resource(Msaa { samples: 4 })
+        .insert_resource(WgpuOptions {
+            name: Some("3d_scene"),
+            features: WgpuFeatures::NON_FILL_POLYGON_MODE,
+            ..Default::default()
+        })
         .add_plugins(DefaultPlugins)
+        .add_plugin(WireframePlugin)
         .add_startup_system(setup.system())
         .run();
 }

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -1,6 +1,8 @@
 use bevy::prelude::*;
-use bevy_internal::render::wireframe::{WireframePlugin, Wireframe};
-use bevy_internal::wgpu::{WgpuOptions, WgpuFeatures};
+use bevy_internal::{
+    render::wireframe::{Wireframe, WireframePlugin},
+    wgpu::{WgpuFeatures, WgpuOptions},
+};
 
 fn main() {
     App::build()

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -1,18 +1,15 @@
 use bevy::prelude::*;
 use bevy_internal::{
     render::wireframe::{Wireframe, WireframeConfig, WireframePlugin},
-    wgpu::{WgpuFeatures, WgpuOptions},
+    wgpu::{WgpuFeature, WgpuFeatures, WgpuOptions},
 };
-use bevy_internal::wgpu::WgpuFeature;
 
 fn main() {
     App::build()
         .insert_resource(Msaa { samples: 4 })
         .insert_resource(WgpuOptions {
             features: WgpuFeatures {
-                features: vec![
-                    WgpuFeature::NonFillPolygonMode
-                ]
+                features: vec![WgpuFeature::NonFillPolygonMode],
             },
             ..Default::default()
         })

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -3,13 +3,17 @@ use bevy_internal::{
     render::wireframe::{Wireframe, WireframeConfig, WireframePlugin},
     wgpu::{WgpuFeatures, WgpuOptions},
 };
+use bevy_internal::wgpu::WgpuFeature;
 
 fn main() {
     App::build()
         .insert_resource(Msaa { samples: 4 })
         .insert_resource(WgpuOptions {
-            name: Some("3d_scene"),
-            features: WgpuFeatures::NON_FILL_POLYGON_MODE,
+            features: WgpuFeatures {
+                features: vec![
+                    WgpuFeature::NonFillPolygonMode
+                ]
+            },
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)
@@ -25,6 +29,7 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
+    // To draw the wireframe on all entities, set this to 'true'
     wireframe_config.global = false;
     // add entities to the world
     commands
@@ -34,7 +39,6 @@ fn setup(
             material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
             ..Default::default()
         })
-        .with(Wireframe)
         // cube
         .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
@@ -42,6 +46,7 @@ fn setup(
             transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..Default::default()
         })
+        .with(Wireframe) // This enables wireframe drawing on this entity
         // light
         .spawn(LightBundle {
             transform: Transform::from_xyz(4.0, 8.0, 4.0),

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_internal::{
-    render::wireframe::{Wireframe, WireframePlugin},
+    render::wireframe::{Wireframe, WireframeConfig, WireframePlugin},
     wgpu::{WgpuFeatures, WgpuOptions},
 };
 
@@ -21,9 +21,11 @@ fn main() {
 /// set up a simple 3D scene
 fn setup(
     commands: &mut Commands,
+    mut wireframe_config: ResMut<WireframeConfig>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
+    wireframe_config.global = false;
     // add entities to the world
     commands
         // plane

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -1,9 +1,21 @@
 use bevy::prelude::*;
+use bevy_internal::{
+    render::wireframe::{Wireframe, WireframeConfig, WireframePlugin},
+    wgpu::{WgpuFeature, WgpuFeatures, WgpuOptions},
+};
 
 fn main() {
     App::build()
         .insert_resource(Msaa { samples: 4 })
+        .insert_resource(WgpuOptions {
+            features: WgpuFeatures {
+                // The Wireframe requires NonFillPolygonMode feature
+                features: vec![WgpuFeature::NonFillPolygonMode],
+            },
+            ..Default::default()
+        })
         .add_plugins(DefaultPlugins)
+        .add_plugin(WireframePlugin)
         .add_startup_system(setup.system())
         .run();
 }
@@ -11,9 +23,12 @@ fn main() {
 /// set up a simple 3D scene
 fn setup(
     commands: &mut Commands,
+    mut wireframe_config: ResMut<WireframeConfig>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
+    // To draw the wireframe on all entities, set this to 'true'
+    wireframe_config.global = false;
     // add entities to the world
     commands
         // plane
@@ -29,6 +44,7 @@ fn setup(
             transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..Default::default()
         })
+        .with(Wireframe) // This enables wireframe drawing on this entity
         // light
         .spawn(LightBundle {
             transform: Transform::from_xyz(4.0, 8.0, 4.0),


### PR DESCRIPTION
This PR implements wireframe rendering.

Usage:

This is now ready as soon as #1401 gets merged.


Usage:

```rust
    app
        .insert_resource(WgpuOptions {
            name: Some("3d_scene"),
            features: WgpuFeatures::NON_FILL_POLYGON_MODE,
            ..Default::default()
        }) // To enable the NON_FILL_POLYGON_MODE feature
        .add_plugin(WireframePlugin)
        .run();

```

Now we just need to add the Wireframe component on an entity, and it'll draw. its wireframe.


We can also enable wireframe drawing globally by setting the global property in the `WireframeConfig` resource to `true`.

