### PR TITLE
Fix incorrect rotation value multiplication order

### DIFF
--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -82,16 +82,6 @@ impl GlobalTransform {
         self
     }
 
-    pub fn with_apply_scale(mut self, scale: f32) -> Self {
-        self.apply_scale(scale);
-        self
-    }
-
-    pub fn with_apply_non_uniform_scale(mut self, scale: Vec3) -> Self {
-        self.apply_non_uniform_scale(scale);
-        self
-    }
-
     pub fn value(&self) -> &Mat4 {
         &self.value
     }
@@ -149,15 +139,7 @@ impl GlobalTransform {
     }
 
     pub fn rotate(&mut self, rotation: Quat) {
-        self.value = Mat4::from_quat(rotation) * self.value;
-    }
-
-    pub fn apply_scale(&mut self, scale: f32) {
-        self.value = Mat4::from_scale(Vec3::splat(scale)) * self.value;
-    }
-
-    pub fn apply_non_uniform_scale(&mut self, scale: Vec3) {
-        self.value = Mat4::from_scale(scale) * self.value;
+        self.value = self.value * Mat4::from_quat(rotation);
     }
 }
 

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -82,16 +82,6 @@ impl Transform {
         self
     }
 
-    pub fn with_apply_scale(mut self, scale: f32) -> Self {
-        self.apply_scale(scale);
-        self
-    }
-
-    pub fn with_apply_non_uniform_scale(mut self, scale: Vec3) -> Self {
-        self.apply_non_uniform_scale(scale);
-        self
-    }
-
     pub fn value(&self) -> &Mat4 {
         &self.value
     }
@@ -154,14 +144,6 @@ impl Transform {
 
     pub fn rotate(&mut self, rotation: Quat) {
         self.value = self.value * Mat4::from_quat(rotation);
-    }
-
-    pub fn apply_scale(&mut self, scale: f32) {
-        self.value = Mat4::from_scale(Vec3::splat(scale)) * self.value;
-    }
-
-    pub fn apply_non_uniform_scale(&mut self, scale: Vec3) {
-        self.value = Mat4::from_scale(scale) * self.value;
     }
 }
 

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -153,7 +153,7 @@ impl Transform {
     }
 
     pub fn rotate(&mut self, rotation: Quat) {
-        self.value = Mat4::from_quat(rotation) * self.value;
+        self.value = self.value * Mat4::from_quat(rotation);
     }
 
     pub fn apply_scale(&mut self, scale: f32) {


### PR DESCRIPTION
Without this, the rotation is applied before any translation, causing it act as if (0, 0, 0) is the rotation origin, instead of rotating around its own local origin.