### PR TITLE
Downstream memory leak fix in `Archetype::grow()` from `hecs`

### DIFF
--- a/crates/bevy_ecs/hecs/src/archetype.rs
+++ b/crates/bevy_ecs/hecs/src/archetype.rs
@@ -304,6 +304,13 @@ impl Archetype {
                         new_data.as_ptr().add(new_off),
                         ty.layout.size() * old_count,
                     );
+                    dealloc(
+                        (*self.data.get()).as_ptr().cast(),
+                        Layout::from_size_align_unchecked(
+                            old_data_size,
+                            self.types.first().map_or(1, |x| x.layout.align()),
+                        ),
+                    );
                 }
             }
 


### PR DESCRIPTION
See https://github.com/Ralith/hecs/pull/80. Please do double-check that this actually needed for `bevy_ecs`.