### PR TITLE
Add remove bundle to bevy_ecs commands

### DIFF
--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -112,6 +112,23 @@ where
     }
 }
 
+pub(crate) struct Remove<T>
+where
+    T: Bundle + Send + Sync + 'static,
+{
+    entity: Entity,
+    phantom: PhantomData<T>,
+}
+
+impl<T> WorldWriter for Remove<T>
+where
+    T: Bundle + Send + Sync + 'static,
+{
+    fn write(self: Box<Self>, world: &mut World) {
+        world.remove::<T>(self.entity).unwrap();
+    }
+}
+
 pub trait ResourcesWriter: Send + Sync {
     fn write(self: Box<Self>, resources: &mut Resources);
 }
@@ -314,6 +331,16 @@ impl Commands {
         T: Component,
     {
         self.write_world(RemoveOne::<T> {
+            entity,
+            phantom: PhantomData,
+        })
+    }
+
+    pub fn remove<T>(&mut self, entity: Entity) -> &mut Self
+    where
+        T: Bundle + Send + Sync + 'static,
+    {
+        self.write_world(Remove::<T> {
             entity,
             phantom: PhantomData,
         })

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -125,6 +125,7 @@ where
     T: Bundle + Send + Sync + 'static,
 {
     fn write(self: Box<Self>, world: &mut World) {
+        // TODO: need equivalent of world.get::<T>(self.entity).is_ok() check from RemoveOne?
         world.remove::<T>(self.entity).unwrap();
     }
 }

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -125,7 +125,6 @@ where
     T: Bundle + Send + Sync + 'static,
 {
     fn write(self: Box<Self>, world: &mut World) {
-        // TODO: need equivalent of world.get::<T>(self.entity).is_ok() check from RemoveOne?
         world.remove::<T>(self.entity).unwrap();
     }
 }


### PR DESCRIPTION
This PR exposes `world.remove()` in the commands.

Still pretty new to Rust - hope this is alright.  Tested manually by adding a `remove()` command to the end of the sprite_sheets example.