### PR TITLE
Add AppBuilder::asset_loader_from_instance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ bevy_gilrs = { path = "crates/bevy_gilrs", optional = true, version = "0.2.1" }
 rand = "0.7.3"
 serde = { version = "1", features = ["derive"] }
 log = "0.4"
+ron = "0.6"
 
 #wasm
 console_error_panic_hook = "0.1.6"
@@ -171,6 +172,10 @@ path = "examples/asset/hot_asset_reloading.rs"
 [[example]]
 name = "asset_loading"
 path = "examples/asset/asset_loading.rs"
+
+[[example]]
+name = "custom_loader"
+path = "examples/asset/custom_asset_loading.rs"
 
 [[example]]
 name = "audio"

--- a/assets/data/test_data.data1
+++ b/assets/data/test_data.data1
@@ -1,0 +1,3 @@
+ MyCustomData (
+    num: 42
+)

--- a/assets/data/test_data.data2
+++ b/assets/data/test_data.data2
@@ -1,0 +1,3 @@
+ MySecondCustomData (
+    is_set: true
+)

--- a/examples/asset/custom_asset_loading.rs
+++ b/examples/asset/custom_asset_loading.rs
@@ -1,0 +1,76 @@
+use bevy::{asset::AssetLoader, prelude::*};
+use ron::de::from_bytes;
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Deserialize)]
+pub struct MyCustomData {
+    pub num: i32,
+}
+
+#[derive(Deserialize)]
+pub struct MySecondCustomData {
+    pub is_set: bool,
+}
+
+// create a custom loader for data files
+#[derive(Default)]
+pub struct DataFileLoader {
+    matching_extensions: Vec<&'static str>,
+}
+
+impl DataFileLoader {
+    pub fn from_extensions(matching_extensions: Vec<&'static str>) -> Self {
+        DataFileLoader {
+            matching_extensions,
+        }
+    }
+}
+
+impl<TAsset> AssetLoader<TAsset> for DataFileLoader
+where
+    for<'de> TAsset: Deserialize<'de>,
+{
+    fn from_bytes(&self, _asset_path: &Path, bytes: Vec<u8>) -> Result<TAsset, anyhow::Error> {
+        Ok(from_bytes::<TAsset>(bytes.as_slice())?)
+    }
+
+    fn extensions(&self) -> &[&str] {
+        self.matching_extensions.as_slice()
+    }
+}
+
+/// This example illustrates various ways to load assets
+fn main() {
+    App::build()
+        .add_default_plugins()
+        .add_asset::<MyCustomData>()
+        .add_asset_loader_from_instance::<MyCustomData, DataFileLoader>(
+            DataFileLoader::from_extensions(vec!["data1"]),
+        )
+        .add_asset::<MySecondCustomData>()
+        .add_asset_loader_from_instance::<MySecondCustomData, DataFileLoader>(
+            DataFileLoader::from_extensions(vec!["data2"]),
+        )
+        .add_startup_system(setup.system())
+        .run();
+}
+
+fn setup(
+    asset_server: Res<AssetServer>,
+    mut data1s: ResMut<Assets<MyCustomData>>,
+    mut data2s: ResMut<Assets<MySecondCustomData>>,
+) {
+    let data1_handle = asset_server
+        .load_sync(&mut data1s, "assets/data/test_data.data1")
+        .unwrap();
+    let data2_handle = asset_server
+        .load_sync(&mut data2s, "assets/data/test_data.data2")
+        .unwrap();
+
+    let data1 = data1s.get(&data1_handle).unwrap();
+    println!("Data 1 loaded with value {}", data1.num);
+
+    let data2 = data2s.get(&data2_handle).unwrap();
+    println!("Data 2 loaded with value {}", data2.is_set);
+}


### PR DESCRIPTION
For support of the discussion in https://github.com/bevyengine/bevy/discussions/578

This PR adds support for providing a concrete instance of an AssetLoader to the `AppBuilder::add_asset_loader_from_instance` function, which potentially allows for more complex asset loading cases.

The example in the discussion is that it allows for the same loader code to be used to load many different asset types with different extensions. 

An example is provided in the `example/assets` folder. I'm not sure if I'm doing the right thing adding `ron` to the `Cargo.toml` - it is already a dependency but in the `bevy_assets` crate. 