### PR TITLE
Use instant::Instant with wasm-bindgen feature

### DIFF
--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -29,4 +29,4 @@ serde = { version = "1.0", features = ["derive"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }
 web-sys = { version = "0.3", features = [ "Window" ] }
-instant = "0.1.6"
+instant = { version = "0.1", features = ["wasm-bindgen"] }

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -31,4 +31,4 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.2.1" }
 log = { version = "0.4", features = ["release_max_level_info"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-instant = "0.1.6"
+instant = { version = "0.1", features = ["wasm-bindgen"] }

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -27,4 +27,4 @@ uuid = { version = "0.8", features = ["v4", "serde"] }
 parking_lot = "0.11.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-instant = "0.1.6"
+instant = { version = "0.1", features = ["wasm-bindgen"] }


### PR DESCRIPTION
We need to activate a feature for `instant` to actually generate different code for wasm target.

(It worked before, because winit indirectly activates this feature)