### PR TITLE
Moving transform data out of Mat4

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -44,8 +44,8 @@ impl LightRaw {
             far: light.depth.end,
         };
 
-        let proj = perspective.get_projection_matrix() * global_transform.value;
-        let (x, y, z) = global_transform.translation().into();
+        let proj = perspective.get_projection_matrix() * global_transform.compute_matrix();
+        let (x, y, z) = global_transform.translation.into();
         LightRaw {
             proj: proj.to_cols_array_2d(),
             pos: [x, y, z, 1.0],

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -44,7 +44,7 @@ impl LightRaw {
             far: light.depth.end,
         };
 
-        let proj = perspective.get_projection_matrix() * *global_transform.value();
+        let proj = perspective.get_projection_matrix() * global_transform.value;
         let (x, y, z) = global_transform.translation().into();
         LightRaw {
             proj: proj.to_cols_array_2d(),

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -30,7 +30,7 @@ pub fn visible_entities_system(
 ) {
     for (camera, camera_global_transform, mut visible_entities) in &mut camera_query.iter() {
         visible_entities.value.clear();
-        let camera_position = camera_global_transform.translation();
+        let camera_position = camera_global_transform.translation;
 
         let mut no_transform_order = 0.0;
         let mut transparent_entities = Vec::new();
@@ -41,7 +41,7 @@ pub fn visible_entities_system(
 
             let order =
                 if let Ok(global_transform) = draw_transform_query.get::<GlobalTransform>(entity) {
-                    let position = global_transform.translation();
+                    let position = global_transform.translation;
                     // smaller distances are sorted to lower indices by using the distance from the camera
                     FloatOrd(match camera.depth_calculation {
                         DepthCalculation::ZDifference => camera_position.z() - position.z(),

--- a/crates/bevy_render/src/render_graph/nodes/camera_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/camera_node.rs
@@ -120,7 +120,7 @@ pub fn camera_node_system(
 
     let matrix_size = std::mem::size_of::<[[f32; 4]; 4]>();
     let camera_matrix: [f32; 16] =
-        (camera.projection_matrix * global_transform.value().inverse()).to_cols_array();
+        (camera.projection_matrix * global_transform.value.inverse()).to_cols_array();
 
     render_resource_context.write_mapped_buffer(
         staging_buffer,

--- a/crates/bevy_render/src/render_graph/nodes/camera_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/camera_node.rs
@@ -120,7 +120,7 @@ pub fn camera_node_system(
 
     let matrix_size = std::mem::size_of::<[[f32; 4]; 4]>();
     let camera_matrix: [f32; 16] =
-        (camera.projection_matrix * global_transform.value.inverse()).to_cols_array();
+        (camera.projection_matrix * global_transform.compute_matrix().inverse()).to_cols_array();
 
     render_resource_context.write_mapped_buffer(
         staging_buffer,

--- a/crates/bevy_render/src/renderer/render_resource/render_resource.rs
+++ b/crates/bevy_render/src/renderer/render_resource/render_resource.rs
@@ -5,6 +5,7 @@ use bevy_asset::Handle;
 use bevy_core::{Byteable, Bytes};
 pub use bevy_derive::{RenderResource, RenderResources};
 use bevy_math::{Mat4, Vec2, Vec3, Vec4};
+use bevy_transform::components::GlobalTransform;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum RenderResourceType {
@@ -179,6 +180,25 @@ where
     }
 }
 
+impl RenderResource for GlobalTransform {
+    fn resource_type(&self) -> Option<RenderResourceType> {
+        Some(RenderResourceType::Buffer)
+    }
+
+    fn write_buffer_bytes(&self, buffer: &mut [u8]) {
+        let mat4 = self.compute_matrix();
+        mat4.write_bytes(buffer);
+    }
+
+    fn buffer_byte_len(&self) -> Option<usize> {
+        Some(std::mem::size_of::<[f32; 16]>())
+    }
+
+    fn texture(&self) -> Option<Handle<Texture>> {
+        None
+    }
+}
+
 impl RenderResources for bevy_transform::prelude::GlobalTransform {
     fn render_resources_len(&self) -> usize {
         1
@@ -186,7 +206,7 @@ impl RenderResources for bevy_transform::prelude::GlobalTransform {
 
     fn get_render_resource(&self, index: usize) -> Option<&dyn RenderResource> {
         if index == 0 {
-            Some(&self.value)
+            Some(self)
         } else {
             None
         }

--- a/crates/bevy_render/src/renderer/render_resource/render_resource.rs
+++ b/crates/bevy_render/src/renderer/render_resource/render_resource.rs
@@ -186,7 +186,7 @@ impl RenderResources for bevy_transform::prelude::GlobalTransform {
 
     fn get_render_resource(&self, index: usize) -> Option<&dyn RenderResource> {
         if index == 0 {
-            Some(self.value())
+            Some(&self.value)
         } else {
             None
         }

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -4,100 +4,15 @@ use std::fmt;
 
 #[derive(Debug, PartialEq, Clone, Copy, Properties)]
 pub struct GlobalTransform {
-    value: Mat4,
+    pub value: Mat4,
 }
 
 impl GlobalTransform {
-    #[inline(always)]
-    pub fn new(value: Mat4) -> Self {
-        GlobalTransform { value }
-    }
-
     #[inline(always)]
     pub fn identity() -> Self {
         GlobalTransform {
             value: Mat4::identity(),
         }
-    }
-
-    pub fn from_translation(translation: Vec3) -> Self {
-        GlobalTransform::new(Mat4::from_translation(translation))
-    }
-
-    pub fn from_rotation(rotation: Quat) -> Self {
-        GlobalTransform::new(Mat4::from_quat(rotation))
-    }
-
-    pub fn from_scale(scale: f32) -> Self {
-        GlobalTransform::new(Mat4::from_scale(Vec3::splat(scale)))
-    }
-
-    pub fn from_translation_rotation(translation: Vec3, rotation: Quat) -> Self {
-        GlobalTransform::new(Mat4::from_scale_rotation_translation(
-            Vec3::splat(1.0),
-            rotation,
-            translation,
-        ))
-    }
-
-    pub fn from_translation_rotation_scale(translation: Vec3, rotation: Quat, scale: f32) -> Self {
-        GlobalTransform::new(Mat4::from_scale_rotation_translation(
-            Vec3::splat(scale),
-            rotation,
-            translation,
-        ))
-    }
-
-    pub fn from_non_uniform_scale(scale: Vec3) -> Self {
-        GlobalTransform::new(Mat4::from_scale(scale))
-    }
-
-    pub fn with_translation(mut self, translation: Vec3) -> Self {
-        self.set_translation(translation);
-        self
-    }
-
-    pub fn with_rotation(mut self, rotation: Quat) -> Self {
-        self.set_rotation(rotation);
-        self
-    }
-
-    pub fn with_scale(mut self, scale: f32) -> Self {
-        self.set_scale(scale);
-        self
-    }
-
-    pub fn with_non_uniform_scale(mut self, scale: Vec3) -> Self {
-        self.set_non_uniform_scale(scale);
-        self
-    }
-
-    pub fn with_translate(mut self, translation: Vec3) -> Self {
-        self.translate(translation);
-        self
-    }
-
-    pub fn with_rotate(mut self, rotation: Quat) -> Self {
-        self.rotate(rotation);
-        self
-    }
-
-    pub fn with_apply_scale(mut self, scale: f32) -> Self {
-        self.apply_scale(scale);
-        self
-    }
-
-    pub fn with_apply_non_uniform_scale(mut self, scale: Vec3) -> Self {
-        self.apply_non_uniform_scale(scale);
-        self
-    }
-
-    pub fn value(&self) -> &Mat4 {
-        &self.value
-    }
-
-    pub fn value_mut(&mut self) -> &mut Mat4 {
-        &mut self.value
     }
 
     pub fn translation(&self) -> Vec3 {
@@ -120,44 +35,6 @@ impl GlobalTransform {
             self.value.y_axis().truncate().length(),
             self.value.z_axis().truncate().length(),
         )
-    }
-
-    pub fn set_translation(&mut self, translation: Vec3) {
-        *self.value.w_axis_mut() = translation.extend(1.0);
-    }
-
-    pub fn set_rotation(&mut self, rotation: Quat) {
-        self.value =
-            Mat4::from_scale_rotation_translation(self.scale(), rotation, self.translation());
-    }
-
-    pub fn set_scale(&mut self, scale: f32) {
-        self.value = Mat4::from_scale_rotation_translation(
-            Vec3::splat(scale),
-            self.rotation(),
-            self.translation(),
-        );
-    }
-
-    pub fn set_non_uniform_scale(&mut self, scale: Vec3) {
-        self.value =
-            Mat4::from_scale_rotation_translation(scale, self.rotation(), self.translation());
-    }
-
-    pub fn translate(&mut self, translation: Vec3) {
-        *self.value.w_axis_mut() += translation.extend(0.0);
-    }
-
-    pub fn rotate(&mut self, rotation: Quat) {
-        self.value = Mat4::from_quat(rotation) * self.value;
-    }
-
-    pub fn apply_scale(&mut self, scale: f32) {
-        self.value = Mat4::from_scale(Vec3::splat(scale)) * self.value;
-    }
-
-    pub fn apply_non_uniform_scale(&mut self, scale: Vec3) {
-        self.value = Mat4::from_scale(scale) * self.value;
     }
 }
 

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -1,40 +1,121 @@
 use bevy_math::{Mat3, Mat4, Quat, Vec3};
 use bevy_property::Properties;
-use std::fmt;
+use std::ops::Mul;
+
+use super::Transform;
 
 #[derive(Debug, PartialEq, Clone, Copy, Properties)]
 pub struct GlobalTransform {
-    pub value: Mat4,
+    pub translation: Vec3,
+    pub rotation: Quat,
+    pub scale: Vec3,
 }
 
 impl GlobalTransform {
-    #[inline(always)]
+    #[inline]
     pub fn identity() -> Self {
         GlobalTransform {
-            value: Mat4::identity(),
+            translation: Vec3::zero(),
+            rotation: Quat::identity(),
+            scale: Vec3::one(),
         }
     }
 
-    pub fn translation(&self) -> Vec3 {
-        Vec3::from(self.value.w_axis().truncate())
+    #[inline]
+    pub fn from_matrix(matrix: Mat4) -> Self {
+        let (scale, rotation, translation) = matrix.to_scale_rotation_translation();
+
+        GlobalTransform {
+            translation,
+            rotation,
+            scale,
+        }
     }
 
-    pub fn rotation(&self) -> Quat {
-        let scale = self.scale();
-
-        Quat::from_rotation_mat3(&Mat3::from_cols(
-            Vec3::from(self.value.x_axis().truncate()) / scale.x(),
-            Vec3::from(self.value.y_axis().truncate()) / scale.y(),
-            Vec3::from(self.value.z_axis().truncate()) / scale.z(),
-        ))
+    #[inline]
+    pub fn from_translation(translation: Vec3) -> Self {
+        GlobalTransform {
+            translation,
+            ..Default::default()
+        }
     }
 
-    pub fn scale(&self) -> Vec3 {
-        Vec3::new(
-            self.value.x_axis().truncate().length(),
-            self.value.y_axis().truncate().length(),
-            self.value.z_axis().truncate().length(),
-        )
+    #[inline]
+    pub fn from_rotation(rotation: Quat) -> Self {
+        GlobalTransform {
+            rotation,
+            ..Default::default()
+        }
+    }
+
+    #[inline]
+    pub fn from_scale(scale: Vec3) -> Self {
+        GlobalTransform {
+            scale,
+            ..Default::default()
+        }
+    }
+
+    /// Returns transform with the same translation and scale, but rotation so that transform.forward() points at the origin
+    #[inline]
+    pub fn looking_at_origin(self) -> Self {
+        self.looking_at(Vec3::zero(), Vec3::unit_y())
+    }
+
+    /// Returns transform with the same translation and scale, but rotation so that transform.forward() points at target
+    #[inline]
+    pub fn looking_at(mut self, target: Vec3, up: Vec3) -> Self {
+        self.look_at(target, up);
+        self
+    }
+
+    #[inline]
+    pub fn compute_matrix(&self) -> Mat4 {
+        Mat4::from_scale_rotation_translation(self.scale, self.rotation, self.translation)
+    }
+
+    #[inline]
+    pub fn forward(&self) -> Vec3 {
+        self.rotation * Vec3::unit_z()
+    }
+
+    #[inline]
+    /// Rotate the transform by the given rotation
+    pub fn rotate(&mut self, rotation: Quat) {
+        self.rotation *= rotation;
+    }
+
+    #[inline]
+    pub fn mul_transform(&self, transform: Transform) -> GlobalTransform {
+        let translation = self.mul_vec3(transform.translation);
+        let rotation = self.rotation * transform.rotation;
+        let scale = self.scale * transform.scale;
+        GlobalTransform {
+            scale,
+            rotation,
+            translation,
+        }
+    }
+
+    #[inline]
+    pub fn mul_vec3(&self, mut value: Vec3) -> Vec3 {
+        value = self.rotation * value;
+        value = self.scale * value;
+        value += self.translation;
+        value
+    }
+
+    #[inline]
+    pub fn apply_non_uniform_scale(&mut self, scale: Vec3) {
+        self.scale *= scale;
+    }
+
+    #[inline]
+    pub fn look_at(&mut self, target: Vec3, up: Vec3) {
+        let forward = Vec3::normalize(self.translation - target);
+        let right = up.cross(forward).normalize();
+        let up = forward.cross(right);
+        self.rotation = Quat::from_rotation_mat3(&Mat3::from_cols(right, up, forward));
     }
 }
 
@@ -44,8 +125,39 @@ impl Default for GlobalTransform {
     }
 }
 
-impl fmt::Display for GlobalTransform {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.value)
+impl From<Transform> for GlobalTransform {
+    fn from(transform: Transform) -> Self {
+        Self {
+            translation: transform.translation,
+            rotation: transform.rotation,
+            scale: transform.scale,
+        }
+    }
+}
+
+impl Mul<GlobalTransform> for GlobalTransform {
+    type Output = GlobalTransform;
+
+    #[inline]
+    fn mul(self, global_transform: GlobalTransform) -> Self::Output {
+        self.mul_transform(global_transform.into())
+    }
+}
+
+impl Mul<Transform> for GlobalTransform {
+    type Output = GlobalTransform;
+
+    #[inline]
+    fn mul(self, transform: Transform) -> Self::Output {
+        self.mul_transform(transform)
+    }
+}
+
+impl Mul<Vec3> for GlobalTransform {
+    type Output = Vec3;
+
+    #[inline]
+    fn mul(self, value: Vec3) -> Self::Output {
+        self.mul_vec3(value)
     }
 }

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -111,7 +111,7 @@ impl Transform {
 
     /// Rotate the transform by the given rotation
     pub fn rotate(&mut self, rotation: Quat) {
-        self.rotation = self.rotation * rotation;
+        self.rotation *= rotation;
     }
 
     pub fn apply_scale(&mut self, scale: f32) {

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -4,10 +4,9 @@ use std::fmt;
 
 #[derive(Debug, PartialEq, Clone, Copy, Properties)]
 pub struct Transform {
-    translation: Vec3,
-    rotation: Quat,
-    scale: Vec3,
-    matrix_cache: Option<Mat4>,
+    pub translation: Vec3,
+    pub rotation: Quat,
+    pub scale: Vec3,
 }
 
 impl Transform {
@@ -17,7 +16,6 @@ impl Transform {
             translation: Vec3::zero(),
             rotation: Quat::identity(),
             scale: Vec3::one(),
-            matrix_cache: Some(Mat4::identity()),
         }
     }
 
@@ -28,14 +26,12 @@ impl Transform {
             translation,
             rotation,
             scale,
-            matrix_cache: Some(matrix),
         }
     }
 
     pub fn from_translation(translation: Vec3) -> Self {
         Transform {
             translation,
-            matrix_cache: None,
             ..Default::default()
         }
     }
@@ -43,7 +39,6 @@ impl Transform {
     pub fn from_rotation(rotation: Quat) -> Self {
         Transform {
             rotation,
-            matrix_cache: None,
             ..Default::default()
         }
     }
@@ -51,7 +46,6 @@ impl Transform {
     pub fn from_scale(scale: f32) -> Self {
         Transform {
             scale: Vec3::one() * scale,
-            matrix_cache: None,
             ..Default::default()
         }
     }
@@ -59,7 +53,6 @@ impl Transform {
     pub fn from_non_uniform_scale(scale: Vec3) -> Self {
         Transform {
             scale,
-            matrix_cache: None,
             ..Default::default()
         }
     }
@@ -68,32 +61,27 @@ impl Transform {
         Transform {
             translation,
             rotation,
-            matrix_cache: None,
             ..Default::default()
         }
     }
 
     pub fn with_translation(mut self, translation: Vec3) -> Self {
         self.translation = translation;
-        self.matrix_cache = None;
         self
     }
 
     pub fn with_rotation(mut self, rotation: Quat) -> Self {
         self.rotation = rotation;
-        self.matrix_cache = None;
         self
     }
 
     pub fn with_scale(mut self, scale: f32) -> Self {
         self.scale = Vec3::one() * scale;
-        self.matrix_cache = None;
         self
     }
 
     pub fn with_non_uniform_scale(mut self, scale: Vec3) -> Self {
         self.scale = scale;
-        self.matrix_cache = None;
         self
     }
 
@@ -105,46 +93,11 @@ impl Transform {
     /// Returns transform with the same translation and scale, but rotation so that transform.forward() points at target
     pub fn looking_at(mut self, target: Vec3, up: Vec3) -> Self {
         self.look_at(target, up);
-        self.matrix_cache = None;
         self
     }
 
-    pub fn translation(&self) -> &Vec3 {
-        &self.translation
-    }
-
-    pub fn translation_mut(&mut self) -> &mut Vec3 {
-        self.matrix_cache = None;
-        &mut self.translation
-    }
-
-    pub fn rotation(&self) -> &Quat {
-        &self.rotation
-    }
-
-    pub fn rotation_mut(&mut self) -> &mut Quat {
-        self.matrix_cache = None;
-        &mut self.rotation
-    }
-
-    pub fn scale(&self) -> &Vec3 {
-        &self.scale
-    }
-
-    pub fn scale_mut(&mut self) -> &mut Vec3 {
-        self.matrix_cache = None;
-        &mut self.scale
-    }
-
-    pub fn matrix(&mut self) -> Mat4 {
-        if self.matrix_cache.is_none() {
-            self.matrix_cache = Some(Mat4::from_scale_rotation_translation(
-                self.scale,
-                self.rotation,
-                self.translation,
-            ));
-        }
-        self.matrix_cache.unwrap()
+    pub fn compute_matrix(&self) -> Mat4 {
+        Mat4::from_scale_rotation_translation(self.scale, self.rotation, self.translation)
     }
 
     pub fn forward(&self) -> Vec3 {
@@ -154,23 +107,19 @@ impl Transform {
     /// Translates the transform by the given translation relative to its orientation
     pub fn translate(&mut self, translation: Vec3) {
         self.translation += self.rotation * translation;
-        self.matrix_cache = None;
     }
 
     /// Rotate the transform by the given rotation
     pub fn rotate(&mut self, rotation: Quat) {
         self.rotation *= rotation;
-        self.matrix_cache = None;
     }
 
     pub fn apply_scale(&mut self, scale: f32) {
         self.scale *= scale;
-        self.matrix_cache = None;
     }
 
     pub fn apply_non_uniform_scale(&mut self, scale: Vec3) {
         self.scale *= scale;
-        self.matrix_cache = None;
     }
 
     pub fn look_at(&mut self, target: Vec3, up: Vec3) {
@@ -178,7 +127,6 @@ impl Transform {
         let right = up.cross(forward).normalize();
         let up = forward.cross(right);
         self.rotation = Quat::from_rotation_mat3(&Mat3::from_cols(right, up, forward));
-        self.matrix_cache = None;
     }
 }
 
@@ -190,17 +138,6 @@ impl Default for Transform {
 
 impl fmt::Display for Transform {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "translation: {}\nrotation: {}\nscale: {}\nmatrix {}computed",
-            self.translation,
-            self.rotation,
-            self.scale,
-            if self.matrix_cache.is_none() {
-                "not "
-            } else {
-                ""
-            }
-        )
+        write!(f, "{}", self.compute_matrix())
     }
 }

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -4,9 +4,10 @@ use std::fmt;
 
 #[derive(Debug, PartialEq, Clone, Copy, Properties)]
 pub struct Transform {
-    pub translation: Vec3,
-    pub rotation: Quat,
-    pub scale: Vec3,
+    translation: Vec3,
+    rotation: Quat,
+    scale: Vec3,
+    matrix_cache: Option<Mat4>,
 }
 
 impl Transform {
@@ -16,6 +17,7 @@ impl Transform {
             translation: Vec3::zero(),
             rotation: Quat::identity(),
             scale: Vec3::one(),
+            matrix_cache: Some(Mat4::identity()),
         }
     }
 
@@ -26,12 +28,14 @@ impl Transform {
             translation,
             rotation,
             scale,
+            matrix_cache: Some(matrix),
         }
     }
 
     pub fn from_translation(translation: Vec3) -> Self {
         Transform {
             translation,
+            matrix_cache: None,
             ..Default::default()
         }
     }
@@ -39,6 +43,7 @@ impl Transform {
     pub fn from_rotation(rotation: Quat) -> Self {
         Transform {
             rotation,
+            matrix_cache: None,
             ..Default::default()
         }
     }
@@ -46,6 +51,7 @@ impl Transform {
     pub fn from_scale(scale: f32) -> Self {
         Transform {
             scale: Vec3::one() * scale,
+            matrix_cache: None,
             ..Default::default()
         }
     }
@@ -53,6 +59,7 @@ impl Transform {
     pub fn from_non_uniform_scale(scale: Vec3) -> Self {
         Transform {
             scale,
+            matrix_cache: None,
             ..Default::default()
         }
     }
@@ -61,27 +68,32 @@ impl Transform {
         Transform {
             translation,
             rotation,
+            matrix_cache: None,
             ..Default::default()
         }
     }
 
     pub fn with_translation(mut self, translation: Vec3) -> Self {
         self.translation = translation;
+        self.matrix_cache = None;
         self
     }
 
     pub fn with_rotation(mut self, rotation: Quat) -> Self {
         self.rotation = rotation;
+        self.matrix_cache = None;
         self
     }
 
     pub fn with_scale(mut self, scale: f32) -> Self {
         self.scale = Vec3::one() * scale;
+        self.matrix_cache = None;
         self
     }
 
     pub fn with_non_uniform_scale(mut self, scale: Vec3) -> Self {
         self.scale = scale;
+        self.matrix_cache = None;
         self
     }
 
@@ -93,11 +105,46 @@ impl Transform {
     /// Returns transform with the same translation and scale, but rotation so that transform.forward() points at target
     pub fn looking_at(mut self, target: Vec3, up: Vec3) -> Self {
         self.look_at(target, up);
+        self.matrix_cache = None;
         self
     }
 
-    pub fn compute_matrix(&self) -> Mat4 {
-        Mat4::from_scale_rotation_translation(self.scale, self.rotation, self.translation)
+    pub fn translation(&self) -> &Vec3 {
+        &self.translation
+    }
+
+    pub fn translation_mut(&mut self) -> &mut Vec3 {
+        self.matrix_cache = None;
+        &mut self.translation
+    }
+
+    pub fn rotation(&self) -> &Quat {
+        &self.rotation
+    }
+
+    pub fn rotation_mut(&mut self) -> &mut Quat {
+        self.matrix_cache = None;
+        &mut self.rotation
+    }
+
+    pub fn scale(&self) -> &Vec3 {
+        &self.scale
+    }
+
+    pub fn scale_mut(&mut self) -> &mut Vec3 {
+        self.matrix_cache = None;
+        &mut self.scale
+    }
+
+    pub fn matrix(&mut self) -> Mat4 {
+        if self.matrix_cache.is_none() {
+            self.matrix_cache = Some(Mat4::from_scale_rotation_translation(
+                self.scale,
+                self.rotation,
+                self.translation,
+            ));
+        }
+        self.matrix_cache.unwrap()
     }
 
     pub fn forward(&self) -> Vec3 {
@@ -107,19 +154,23 @@ impl Transform {
     /// Translates the transform by the given translation relative to its orientation
     pub fn translate(&mut self, translation: Vec3) {
         self.translation += self.rotation * translation;
+        self.matrix_cache = None;
     }
 
     /// Rotate the transform by the given rotation
     pub fn rotate(&mut self, rotation: Quat) {
         self.rotation *= rotation;
+        self.matrix_cache = None;
     }
 
     pub fn apply_scale(&mut self, scale: f32) {
         self.scale *= scale;
+        self.matrix_cache = None;
     }
 
     pub fn apply_non_uniform_scale(&mut self, scale: Vec3) {
         self.scale *= scale;
+        self.matrix_cache = None;
     }
 
     pub fn look_at(&mut self, target: Vec3, up: Vec3) {
@@ -127,6 +178,7 @@ impl Transform {
         let right = up.cross(forward).normalize();
         let up = forward.cross(right);
         self.rotation = Quat::from_rotation_mat3(&Mat3::from_cols(right, up, forward));
+        self.matrix_cache = None;
     }
 }
 
@@ -138,6 +190,17 @@ impl Default for Transform {
 
 impl fmt::Display for Transform {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.compute_matrix())
+        write!(
+            f,
+            "translation: {}\nrotation: {}\nscale: {}\nmatrix {}computed",
+            self.translation,
+            self.rotation,
+            self.scale,
+            if self.matrix_cache.is_none() {
+                "not "
+            } else {
+                ""
+            }
+        )
     }
 }

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -105,17 +105,6 @@ impl Transform {
     }
 
     /// Translates the transform by the given translation relative to its orientation
-    ///
-    /// # Examples
-    /// ```
-    /// // Moves the transform by two units in the direction it's looking
-    /// use bevy::prelude::*;
-    /// let transform = Transform {
-    ///	    rotation: Quat::from_axis_angle(Vec3::unit_y(), 2.0),
-    ///     ..Default::default()
-    /// };
-    /// transform.translate(Vec3::unit_z() * 2.0);
-    /// ```
     pub fn translate(&mut self, translation: Vec3) {
         self.translation += self.rotation * translation;
     }

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -111,8 +111,8 @@ impl Transform {
     /// // Moves the transform by two units in the direction it's looking
     /// use bevy::prelude::*;
     /// let transform = Transform {
-    ///		rotation: Quat::from_axis_angle(Vec3::unit_y(), 2.0),
-    /// 	..Default::default()
+    ///	    rotation: Quat::from_axis_angle(Vec3::unit_y(), 2.0),
+    ///     ..Default::default()
     /// };
     /// transform.translate(Vec3::unit_z() * 2.0);
     /// ```

--- a/crates/bevy_transform/src/transform_propagate_system.rs
+++ b/crates/bevy_transform/src/transform_propagate_system.rs
@@ -7,18 +7,18 @@ pub fn transform_propagate_system(
     mut transform_query: Query<(&Transform, &mut GlobalTransform, Option<&Children>)>,
 ) {
     for (children, transform, mut global_transform) in &mut root_query.iter() {
-        *global_transform.value_mut() = *transform.value();
+        global_transform.value = *transform.value();
 
         if let Some(children) = children {
             for child in children.0.iter() {
-                propagate_recursive(*global_transform.value(), &mut transform_query, *child);
+                propagate_recursive(&global_transform.value, &mut transform_query, *child);
             }
         }
     }
 }
 
 fn propagate_recursive(
-    parent: Mat4,
+    parent: &Mat4,
     transform_query: &mut Query<(&Transform, &mut GlobalTransform, Option<&Children>)>,
     entity: Entity,
 ) {
@@ -29,8 +29,8 @@ fn propagate_recursive(
             transform_query.get::<Transform>(entity),
             transform_query.get_mut::<GlobalTransform>(entity),
         ) {
-            *global_transform.value_mut() = parent * *transform.value();
-            *global_transform.value()
+            global_transform.value = *parent * *transform.value();
+            global_transform.value
         } else {
             return;
         }
@@ -43,7 +43,7 @@ fn propagate_recursive(
         .unwrap_or_default();
 
     for child in children {
-        propagate_recursive(global_matrix, transform_query, child);
+        propagate_recursive(&global_matrix, transform_query, child);
     }
 }
 
@@ -92,13 +92,13 @@ mod test {
         schedule.run(&mut world, &mut resources);
 
         assert_eq!(
-            *world.get::<GlobalTransform>(children[0]).unwrap().value(),
+            world.get::<GlobalTransform>(children[0]).unwrap().value,
             Mat4::from_translation(Vec3::new(1.0, 0.0, 0.0))
                 * Mat4::from_translation(Vec3::new(0.0, 2.0, 0.0))
         );
 
         assert_eq!(
-            *world.get::<GlobalTransform>(children[1]).unwrap().value(),
+            world.get::<GlobalTransform>(children[1]).unwrap().value,
             Mat4::from_translation(Vec3::new(1.0, 0.0, 0.0))
                 * Mat4::from_translation(Vec3::new(0.0, 0.0, 3.0))
         );
@@ -141,13 +141,13 @@ mod test {
         schedule.run(&mut world, &mut resources);
 
         assert_eq!(
-            *world.get::<GlobalTransform>(children[0]).unwrap().value(),
+            world.get::<GlobalTransform>(children[0]).unwrap().value,
             Mat4::from_translation(Vec3::new(1.0, 0.0, 0.0))
                 * Mat4::from_translation(Vec3::new(0.0, 2.0, 0.0))
         );
 
         assert_eq!(
-            *world.get::<GlobalTransform>(children[1]).unwrap().value(),
+            world.get::<GlobalTransform>(children[1]).unwrap().value,
             Mat4::from_translation(Vec3::new(1.0, 0.0, 0.0))
                 * Mat4::from_translation(Vec3::new(0.0, 0.0, 3.0))
         );

--- a/crates/bevy_transform/src/transform_propagate_system.rs
+++ b/crates/bevy_transform/src/transform_propagate_system.rs
@@ -1,24 +1,23 @@
 use crate::components::*;
 use bevy_ecs::prelude::*;
-use bevy_math::Mat4;
 
 pub fn transform_propagate_system(
     mut root_query: Query<Without<Parent, (Option<&Children>, &Transform, &mut GlobalTransform)>>,
     mut transform_query: Query<(&Transform, &mut GlobalTransform, Option<&Children>)>,
 ) {
     for (children, transform, mut global_transform) in &mut root_query.iter() {
-        global_transform.value = transform.compute_matrix();
+        *global_transform = GlobalTransform::from(*transform);
 
         if let Some(children) = children {
             for child in children.0.iter() {
-                propagate_recursive(&global_transform.value, &mut transform_query, *child);
+                propagate_recursive(&global_transform, &mut transform_query, *child);
             }
         }
     }
 }
 
 fn propagate_recursive(
-    parent: &Mat4,
+    parent: &GlobalTransform,
     transform_query: &mut Query<(&Transform, &mut GlobalTransform, Option<&Children>)>,
     entity: Entity,
 ) {
@@ -29,8 +28,8 @@ fn propagate_recursive(
             transform_query.get::<Transform>(entity),
             transform_query.get_mut::<GlobalTransform>(entity),
         ) {
-            global_transform.value = *parent * transform.compute_matrix();
-            global_transform.value
+            *global_transform = parent.mul_transform(*transform);
+            *global_transform
         } else {
             return;
         }
@@ -52,7 +51,7 @@ mod test {
     use super::*;
     use crate::{hierarchy::BuildChildren, transform_systems};
     use bevy_ecs::{Resources, Schedule, World};
-    use bevy_math::{Mat4, Vec3};
+    use bevy_math::Vec3;
 
     #[test]
     fn did_propagate() {
@@ -92,15 +91,15 @@ mod test {
         schedule.run(&mut world, &mut resources);
 
         assert_eq!(
-            world.get::<GlobalTransform>(children[0]).unwrap().value,
-            Mat4::from_translation(Vec3::new(1.0, 0.0, 0.0))
-                * Mat4::from_translation(Vec3::new(0.0, 2.0, 0.0))
+            *world.get::<GlobalTransform>(children[0]).unwrap(),
+            GlobalTransform::from_translation(Vec3::new(1.0, 0.0, 0.0))
+                * Transform::from_translation(Vec3::new(0.0, 2.0, 0.0))
         );
 
         assert_eq!(
-            world.get::<GlobalTransform>(children[1]).unwrap().value,
-            Mat4::from_translation(Vec3::new(1.0, 0.0, 0.0))
-                * Mat4::from_translation(Vec3::new(0.0, 0.0, 3.0))
+            *world.get::<GlobalTransform>(children[1]).unwrap(),
+            GlobalTransform::from_translation(Vec3::new(1.0, 0.0, 0.0))
+                * Transform::from_translation(Vec3::new(0.0, 0.0, 3.0))
         );
     }
 
@@ -141,15 +140,15 @@ mod test {
         schedule.run(&mut world, &mut resources);
 
         assert_eq!(
-            world.get::<GlobalTransform>(children[0]).unwrap().value,
-            Mat4::from_translation(Vec3::new(1.0, 0.0, 0.0))
-                * Mat4::from_translation(Vec3::new(0.0, 2.0, 0.0))
+            *world.get::<GlobalTransform>(children[0]).unwrap(),
+            GlobalTransform::from_translation(Vec3::new(1.0, 0.0, 0.0))
+                * Transform::from_translation(Vec3::new(0.0, 2.0, 0.0))
         );
 
         assert_eq!(
-            world.get::<GlobalTransform>(children[1]).unwrap().value,
-            Mat4::from_translation(Vec3::new(1.0, 0.0, 0.0))
-                * Mat4::from_translation(Vec3::new(0.0, 0.0, 3.0))
+            *world.get::<GlobalTransform>(children[1]).unwrap(),
+            GlobalTransform::from_translation(Vec3::new(1.0, 0.0, 0.0))
+                * Transform::from_translation(Vec3::new(0.0, 0.0, 3.0))
         );
     }
 }

--- a/crates/bevy_transform/src/transform_propagate_system.rs
+++ b/crates/bevy_transform/src/transform_propagate_system.rs
@@ -3,11 +3,13 @@ use bevy_ecs::prelude::*;
 use bevy_math::Mat4;
 
 pub fn transform_propagate_system(
-    mut root_query: Query<Without<Parent, (Option<&Children>, &Transform, &mut GlobalTransform)>>,
-    mut transform_query: Query<(&Transform, &mut GlobalTransform, Option<&Children>)>,
+    mut root_query: Query<
+        Without<Parent, (Option<&Children>, &mut Transform, &mut GlobalTransform)>,
+    >,
+    mut transform_query: Query<(&mut Transform, &mut GlobalTransform, Option<&Children>)>,
 ) {
-    for (children, transform, mut global_transform) in &mut root_query.iter() {
-        global_transform.value = transform.compute_matrix();
+    for (children, mut transform, mut global_transform) in &mut root_query.iter() {
+        global_transform.value = transform.matrix();
 
         if let Some(children) = children {
             for child in children.0.iter() {
@@ -19,17 +21,17 @@ pub fn transform_propagate_system(
 
 fn propagate_recursive(
     parent: &Mat4,
-    transform_query: &mut Query<(&Transform, &mut GlobalTransform, Option<&Children>)>,
+    transform_query: &mut Query<(&mut Transform, &mut GlobalTransform, Option<&Children>)>,
     entity: Entity,
 ) {
     log::trace!("Updating Transform for {:?}", entity);
 
     let global_matrix = {
-        if let (Ok(transform), Ok(mut global_transform)) = (
-            transform_query.get::<Transform>(entity),
+        if let (Ok(mut transform), Ok(mut global_transform)) = (
+            transform_query.get_mut::<Transform>(entity),
             transform_query.get_mut::<GlobalTransform>(entity),
         ) {
-            global_transform.value = *parent * transform.compute_matrix();
+            global_transform.value = *parent * transform.matrix();
             global_transform.value
         } else {
             return;

--- a/crates/bevy_transform/src/transform_propagate_system.rs
+++ b/crates/bevy_transform/src/transform_propagate_system.rs
@@ -7,7 +7,7 @@ pub fn transform_propagate_system(
     mut transform_query: Query<(&Transform, &mut GlobalTransform, Option<&Children>)>,
 ) {
     for (children, transform, mut global_transform) in &mut root_query.iter() {
-        global_transform.value = *transform.value();
+        global_transform.value = transform.compute_matrix();
 
         if let Some(children) = children {
             for child in children.0.iter() {
@@ -29,7 +29,7 @@ fn propagate_recursive(
             transform_query.get::<Transform>(entity),
             transform_query.get_mut::<GlobalTransform>(entity),
         ) {
-            global_transform.value = *parent * *transform.value();
+            global_transform.value = *parent * transform.compute_matrix();
             global_transform.value
         } else {
             return;

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -203,7 +203,7 @@ pub fn flex_node_system(
     for (entity, mut node, mut transform, parent) in &mut node_transform_query.iter() {
         let layout = flex_surface.get_layout(entity).unwrap();
         node.size = Vec2::new(layout.size.width, layout.size.height);
-        let position = transform.translation_mut();
+        let position = &mut transform.translation;
         position.set_x(layout.location.x + layout.size.width / 2.0);
         position.set_y(layout.location.y + layout.size.height / 2.0);
         if let Some(parent) = parent {

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -203,7 +203,7 @@ pub fn flex_node_system(
     for (entity, mut node, mut transform, parent) in &mut node_transform_query.iter() {
         let layout = flex_surface.get_layout(entity).unwrap();
         node.size = Vec2::new(layout.size.width, layout.size.height);
-        let position = &mut transform.translation;
+        let position = transform.translation_mut();
         position.set_x(layout.location.x + layout.size.width / 2.0);
         position.set_y(layout.location.y + layout.size.height / 2.0);
         if let Some(parent) = parent {

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -76,7 +76,7 @@ pub fn ui_focus_system(
             .iter()
             .filter_map(
                 |(entity, node, global_transform, interaction, focus_policy)| {
-                    let position = global_transform.translation();
+                    let position = global_transform.translation;
                     let ui_position = position.truncate();
                     let extents = node.size / 2.0;
                     let min = ui_position - extents;

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -47,7 +47,7 @@ fn update_node_entity(
     let global_z = z + parent_global_z;
 
     let mut transform = node_query.get_mut::<Transform>(entity).ok()?;
-    transform.translation_mut().set_z(z);
+    transform.translation.set_z(z);
 
     Some(global_z)
 }

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -47,7 +47,7 @@ fn update_node_entity(
     let global_z = z + parent_global_z;
 
     let mut transform = node_query.get_mut::<Transform>(entity).ok()?;
-    transform.translation.set_z(z);
+    transform.translation_mut().set_z(z);
 
     Some(global_z)
 }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -104,7 +104,7 @@ pub fn draw_text_system(
 ) {
     for (mut draw, text, node, global_transform) in &mut query.iter() {
         if let Some(font) = fonts.get(&text.font) {
-            let position = global_transform.translation() - (node.size / 2.0).extend(0.0);
+            let position = global_transform.translation - (node.size / 2.0).extend(0.0);
             let mut drawable_text = DrawableText {
                 font,
                 font_atlas_set: font_atlas_sets

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -39,7 +39,7 @@ fn setup(
         .spawn(Camera2dComponents::default())
         .spawn(SpriteSheetComponents {
             texture_atlas: texture_atlas_handle,
-            transform: Transform::from_scale(6.0),
+            transform: Transform::from_scale(Vec3::splat(6.0)),
             ..Default::default()
         })
         .with(Timer::from_seconds(0.1, true));

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -61,7 +61,11 @@ fn load_atlas(
             .spawn(Camera2dComponents::default())
             // draw a sprite from the atlas
             .spawn(SpriteSheetComponents {
-                transform: Transform::from_scale(4.0).with_translation(Vec3::new(150.0, 0.0, 0.0)),
+                transform: Transform {
+                    translation: Vec3::new(150.0, 0.0, 0.0),
+                    scale: Vec3::splat(4.0),
+                    ..Default::default()
+                },
                 sprite: TextureAtlasSprite::new(vendor_index as u32),
                 texture_atlas: atlas_handle,
                 ..Default::default()

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -36,11 +36,7 @@ fn setup(
         })
         // camera
         .spawn(Camera3dComponents {
-            transform: Transform::new(Mat4::face_toward(
-                Vec3::new(-3.0, 5.0, 8.0),
-                Vec3::new(0.0, 0.0, 0.0),
-                Vec3::new(0.0, 1.0, 0.0),
-            )),
+            transform: Transform::from_translation(Vec3::new(-3.0, 5.0, 8.0)).looking_at_origin(),
             ..Default::default()
         });
 }

--- a/examples/3d/load_model.rs
+++ b/examples/3d/load_model.rs
@@ -44,11 +44,7 @@ fn setup(
         })
         // camera
         .spawn(Camera3dComponents {
-            transform: Transform::new(Mat4::face_toward(
-                Vec3::new(-2.0, 2.0, 6.0),
-                Vec3::new(0.0, 0.0, 0.0),
-                Vec3::new(0.0, 1.0, 0.0),
-            )),
+            transform: Transform::from_translation(Vec3::new(-2.0, 2.0, 6.0)).looking_at_origin(),
             ..Default::default()
         });
 }

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -32,11 +32,7 @@ fn setup(
         })
         // camera
         .spawn(Camera3dComponents {
-            transform: Transform::new(Mat4::face_toward(
-                Vec3::new(-3.0, 3.0, 5.0),
-                Vec3::new(0.0, 0.0, 0.0),
-                Vec3::new(0.0, 1.0, 0.0),
-            )),
+            transform: Transform::from_translation(Vec3::new(-3.0, 3.0, 5.0)).looking_at_origin(),
             ..Default::default()
         });
 }

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -58,11 +58,7 @@ fn setup(
         })
         // camera
         .spawn(Camera3dComponents {
-            transform: Transform::new(Mat4::face_toward(
-                Vec3::new(5.0, 10.0, 10.0),
-                Vec3::new(0.0, 0.0, 0.0),
-                Vec3::new(0.0, 1.0, 0.0),
-            )),
+            transform: Transform::from_translation(Vec3::new(5.0, 10.0, 10.0)).looking_at_origin(),
             ..Default::default()
         });
 }

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -17,7 +17,7 @@ struct Rotator;
 /// rotates the parent, which will result in the child also rotating
 fn rotator_system(time: Res<Time>, mut query: Query<(&Rotator, &mut Transform)>) {
     for (_rotator, mut transform) in &mut query.iter() {
-        transform.rotate(Quat::from_rotation_x(3.0 * time.delta_seconds));
+        transform.rotation *= Quat::from_rotation_x(3.0 * time.delta_seconds);
     }
 }
 

--- a/examples/3d/spawner.rs
+++ b/examples/3d/spawner.rs
@@ -25,7 +25,7 @@ fn move_cubes(
 ) {
     for (mut transform, material_handle) in &mut query.iter() {
         let material = materials.get_mut(&material_handle).unwrap();
-        transform.translate(Vec3::new(1.0, 0.0, 0.0) * time.delta_seconds);
+        transform.translation += Vec3::new(1.0, 0.0, 0.0) * time.delta_seconds;
         material.albedo =
             Color::BLUE * Vec3::splat((3.0 * time.seconds_since_startup as f32).sin());
     }

--- a/examples/3d/spawner.rs
+++ b/examples/3d/spawner.rs
@@ -44,11 +44,7 @@ fn setup(
         })
         // camera
         .spawn(Camera3dComponents {
-            transform: Transform::new(Mat4::face_toward(
-                Vec3::new(0.0, 15.0, 150.0),
-                Vec3::new(0.0, 0.0, 0.0),
-                Vec3::new(0.0, 0.0, 1.0),
-            )),
+            transform: Transform::from_translation(Vec3::new(0.0, 15.0, 150.0)).looking_at_origin(),
             ..Default::default()
         });
 

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -99,11 +99,7 @@ fn setup(
         })
         // camera
         .spawn(Camera3dComponents {
-            transform: Transform::new(Mat4::face_toward(
-                Vec3::new(3.0, 5.0, 8.0),
-                Vec3::new(0.0, 0.0, 0.0),
-                Vec3::new(0.0, 1.0, 0.0),
-            )),
+            transform: Transform::from_translation(Vec3::new(3.0, 5.0, 8.0)).looking_at_origin(),
             ..Default::default()
         });
 }

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -59,10 +59,11 @@ fn setup(
         .spawn(PbrComponents {
             mesh: quad_handle,
             material: material_handle,
-            transform: Transform::from_translation_rotation(
-                Vec3::new(0.0, 0.0, 1.5),
-                Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
-            ),
+            transform: Transform {
+                translation: Vec3::new(0.0, 0.0, 1.5),
+                rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
+                ..Default::default()
+            },
             draw: Draw {
                 is_transparent: true,
                 ..Default::default()
@@ -73,10 +74,11 @@ fn setup(
         .spawn(PbrComponents {
             mesh: quad_handle,
             material: red_material_handle,
-            transform: Transform::from_translation_rotation(
-                Vec3::new(0.0, 0.0, 0.0),
-                Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
-            ),
+            transform: Transform {
+                translation: Vec3::new(0.0, 0.0, 0.0),
+                rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
+                ..Default::default()
+            },
             draw: Draw {
                 is_transparent: true,
                 ..Default::default()
@@ -87,10 +89,11 @@ fn setup(
         .spawn(PbrComponents {
             mesh: quad_handle,
             material: blue_material_handle,
-            transform: Transform::from_translation_rotation(
-                Vec3::new(0.0, 0.0, -1.5),
-                Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
-            ),
+            transform: Transform {
+                translation: Vec3::new(0.0, 0.0, -1.5),
+                rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
+                ..Default::default()
+            },
             draw: Draw {
                 is_transparent: true,
                 ..Default::default()

--- a/examples/3d/z_sort_debug.rs
+++ b/examples/3d/z_sort_debug.rs
@@ -21,7 +21,7 @@ struct Rotator;
 /// rotates the parent, which will result in the child also rotating
 fn rotator_system(time: Res<Time>, mut query: Query<(&Rotator, &mut Transform)>) {
     for (_rotator, mut transform) in &mut query.iter() {
-        transform.rotate(Quat::from_rotation_x(3.0 * time.delta_seconds));
+        transform.rotation *= Quat::from_rotation_x(3.0 * time.delta_seconds);
     }
 }
 

--- a/examples/3d/z_sort_debug.rs
+++ b/examples/3d/z_sort_debug.rs
@@ -21,8 +21,7 @@ struct Rotator;
 /// rotates the parent, which will result in the child also rotating
 fn rotator_system(time: Res<Time>, mut query: Query<(&Rotator, &mut Transform)>) {
     for (_rotator, mut transform) in &mut query.iter() {
-        let rotation = transform.rotation() * Quat::from_rotation_x(3.0 * time.delta_seconds);
-        transform.set_rotation(rotation);
+        transform.rotate(Quat::from_rotation_x(3.0 * time.delta_seconds));
     }
 }
 
@@ -86,11 +85,7 @@ fn setup(
         })
         // camera
         .spawn(Camera3dComponents {
-            transform: Transform::new(Mat4::face_toward(
-                Vec3::new(5.0, 10.0, 10.0),
-                Vec3::new(0.0, 0.0, 0.0),
-                Vec3::new(0.0, 1.0, 0.0),
-            )),
+            transform: Transform::from_translation(Vec3::new(5.0, 10.0, 10.0)).looking_at_origin(),
             ..Default::default()
         });
 }

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -73,11 +73,7 @@ fn setup(
         })
         // camera
         .spawn(Camera3dComponents {
-            transform: Transform::new(Mat4::face_toward(
-                Vec3::new(0.0, 3.0, 10.0),
-                Vec3::new(0.0, 0.0, 0.0),
-                Vec3::new(0.0, 1.0, 0.0),
-            )),
+            transform: Transform::from_translation(Vec3::new(0.0, 3.0, 10.0)).looking_at_origin(),
             ..Default::default()
         });
 }

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -47,11 +47,7 @@ fn setup(
         })
         // camera
         .spawn(Camera3dComponents {
-            transform: Transform::new(Mat4::face_toward(
-                Vec3::new(2.0, 2.0, 6.0),
-                Vec3::new(0.0, 0.0, 0.0),
-                Vec3::new(0.0, 1.0, 0.0),
-            )),
+            transform: Transform::from_translation(Vec3::new(2.0, 2.0, 6.0)).looking_at_origin(),
             ..Default::default()
         });
 }

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -19,7 +19,7 @@ fn setup(
     // Spawn a root entity with no parent
     let parent = commands
         .spawn(SpriteComponents {
-            transform: Transform::from_scale(0.75),
+            transform: Transform::from_scale(Vec3::splat(0.75)),
             material: materials.add(ColorMaterial {
                 color: Color::WHITE,
                 texture: Some(texture),
@@ -30,7 +30,11 @@ fn setup(
         .with_children(|parent| {
             // parent is a ChildBuilder, which has a similar API to Commands
             parent.spawn(SpriteComponents {
-                transform: Transform::from_translation(Vec3::new(250.0, 0.0, 0.0)).with_scale(0.75),
+                transform: Transform {
+                    translation: Vec3::new(250.0, 0.0, 0.0),
+                    scale: Vec3::splat(0.75),
+                    ..Default::default()
+                },
                 material: materials.add(ColorMaterial {
                     color: Color::BLUE,
                     texture: Some(texture),
@@ -47,7 +51,11 @@ fn setup(
     // Similarly, adding a Parent component will automatically add a Children component to the parent.
     commands
         .spawn(SpriteComponents {
-            transform: Transform::from_translation(Vec3::new(-250.0, 0.0, 0.0)).with_scale(0.75),
+            transform: Transform {
+                translation: Vec3::new(-250.0, 0.0, 0.0),
+                scale: Vec3::splat(0.75),
+                ..Default::default()
+            },
             material: materials.add(ColorMaterial {
                 color: Color::RED,
                 texture: Some(texture),
@@ -61,7 +69,11 @@ fn setup(
     // entity has already been spawned.
     let child = commands
         .spawn(SpriteComponents {
-            transform: Transform::from_translation(Vec3::new(0.0, 250.0, 0.0)).with_scale(0.75),
+            transform: Transform {
+                translation: Vec3::new(0.0, 250.0, 0.0),
+                scale: Vec3::splat(0.75),
+                ..Default::default()
+            },
             material: materials.add(ColorMaterial {
                 color: Color::GREEN,
                 texture: Some(texture),

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -15,7 +15,7 @@ fn spawn_system(
         commands
             .spawn(SpriteComponents {
                 material,
-                transform: Transform::from_scale(0.1),
+                transform: Transform::from_scale(Vec3::splat(0.1)),
                 ..Default::default()
             })
             .with(Velocity(
@@ -38,7 +38,7 @@ fn move_system(pool: Res<ComputeTaskPool>, mut sprites: Query<(&mut Transform, &
         .iter()
         .par_iter(32)
         .for_each(&pool, |(mut transform, velocity)| {
-            transform.translate(velocity.0.extend(0.0));
+            transform.translation += velocity.0.extend(0.0);
         });
 }
 

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -62,10 +62,10 @@ fn bounce_system(
         .par_iter(32)
         // Filter out sprites that don't need to be bounced
         .filter(|(transform, _)| {
-            !(left < transform.translation.x()
-                && transform.translation.x() < right
-                && bottom < transform.translation.y()
-                && transform.translation.y() < top)
+            !(left < transform.translation().x()
+                && transform.translation().x() < right
+                && bottom < transform.translation().y()
+                && transform.translation().y() < top)
         })
         // For simplicity, just reverse the velocity; don't use realistic bounces
         .for_each(&pool, |(_, mut v)| {

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -62,10 +62,10 @@ fn bounce_system(
         .par_iter(32)
         // Filter out sprites that don't need to be bounced
         .filter(|(transform, _)| {
-            !(left < transform.translation().x()
-                && transform.translation().x() < right
-                && bottom < transform.translation().y()
-                && transform.translation().y() < top)
+            !(left < transform.translation.x()
+                && transform.translation.x() < right
+                && bottom < transform.translation.y()
+                && transform.translation.y() < top)
         })
         // For simplicity, just reverse the velocity; don't use realistic bounces
         .for_each(&pool, |(_, mut v)| {

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -184,7 +184,7 @@ fn ball_movement_system(time: Res<Time>, mut ball_query: Query<(&Ball, &mut Tran
     let delta_seconds = f32::min(0.2, time.delta_seconds);
 
     for (ball, mut transform) in &mut ball_query.iter() {
-        transform.translate(ball.velocity * delta_seconds);
+        transform.translation += ball.velocity * delta_seconds;
     }
 }
 

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -171,7 +171,7 @@ fn paddle_movement_system(
             direction += 1.0;
         }
 
-        let translation = transform.translation_mut();
+        let translation = &mut transform.translation;
         // move the paddle horizontally
         *translation.x_mut() += time.delta_seconds * direction * paddle.speed;
         // bound the paddle within the walls
@@ -207,9 +207,9 @@ fn ball_collision_system(
         // check collision with walls
         for (collider_entity, collider, transform, sprite) in &mut collider_query.iter() {
             let collision = collide(
-                ball_transform.translation(),
+                ball_transform.translation,
                 ball_size,
-                transform.translation(),
+                transform.translation,
                 sprite.size,
             );
             if let Some(collision) = collision {

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -171,7 +171,7 @@ fn paddle_movement_system(
             direction += 1.0;
         }
 
-        let translation = transform.translation_mut();
+        let translation = &mut transform.translation;
         // move the paddle horizontally
         *translation.x_mut() += time.delta_seconds * direction * paddle.speed;
         // bound the paddle within the walls
@@ -207,9 +207,9 @@ fn ball_collision_system(
         // check collision with walls
         for (collider_entity, collider, transform, sprite) in &mut collider_query.iter() {
             let collision = collide(
-                *ball_transform.translation(),
+                ball_transform.translation,
                 ball_size,
-                *transform.translation(),
+                transform.translation,
                 sprite.size,
             );
             if let Some(collision) = collision {

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -171,7 +171,7 @@ fn paddle_movement_system(
             direction += 1.0;
         }
 
-        let translation = &mut transform.translation;
+        let translation = transform.translation_mut();
         // move the paddle horizontally
         *translation.x_mut() += time.delta_seconds * direction * paddle.speed;
         // bound the paddle within the walls
@@ -207,9 +207,9 @@ fn ball_collision_system(
         // check collision with walls
         for (collider_entity, collider, transform, sprite) in &mut collider_query.iter() {
             let collision = collide(
-                ball_transform.translation,
+                *ball_transform.translation(),
                 ball_size,
-                transform.translation,
+                *transform.translation(),
                 sprite.size,
             );
             if let Some(collision) = collision {

--- a/examples/shader/shader_custom_material.rs
+++ b/examples/shader/shader_custom_material.rs
@@ -108,11 +108,7 @@ fn setup(
         .with(material)
         // camera
         .spawn(Camera3dComponents {
-            transform: Transform::new(Mat4::face_toward(
-                Vec3::new(3.0, 5.0, -8.0),
-                Vec3::new(0.0, 0.0, 0.0),
-                Vec3::new(0.0, 1.0, 0.0),
-            )),
+            transform: Transform::from_translation(Vec3::new(3.0, 5.0, -8.0)).looking_at_origin(),
             ..Default::default()
         });
 }

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -155,11 +155,7 @@ fn setup(
         .with(blue_material)
         // camera
         .spawn(Camera3dComponents {
-            transform: Transform::new(Mat4::face_toward(
-                Vec3::new(3.0, 5.0, -8.0),
-                Vec3::new(0.0, 0.0, 0.0),
-                Vec3::new(0.0, 1.0, 0.0),
-            )),
+            transform: Transform::from_translation(Vec3::new(3.0, 5.0, -8.0)).looking_at_origin(),
             ..Default::default()
         });
 }

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -178,11 +178,7 @@ fn setup(
         })
         // main camera
         .spawn(Camera3dComponents {
-            transform: Transform::new(Mat4::face_toward(
-                Vec3::new(0.0, 0.0, 6.0),
-                Vec3::new(0.0, 0.0, 0.0),
-                Vec3::new(0.0, 1.0, 0.0),
-            )),
+            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 6.0)).looking_at_origin(),
             ..Default::default()
         })
         // second window camera
@@ -192,11 +188,7 @@ fn setup(
                 window: window_id,
                 ..Default::default()
             },
-            transform: Transform::new(Mat4::face_toward(
-                Vec3::new(6.0, 0.0, 0.0),
-                Vec3::new(0.0, 0.0, 0.0),
-                Vec3::new(0.0, 1.0, 0.0),
-            )),
+            transform: Transform::from_translation(Vec3::new(6.0, 0.0, 0.0)).looking_at_origin(),
             ..Default::default()
         });
 }


### PR DESCRIPTION
Concerning #229.

As pointed out @AThilenius, having mutable transform data stored in a matrix results in rotation overlapping with scale and therefore affecting each other over time (see also [this article](https://www.gamasutra.com/view/news/173606/Indepth_Matrices_rotation_scale_and_drifting.php)).

This PR aims to resolve only this issue.
Any feedback and propositions for changes are very welcome!