### PR TITLE
Adds derive for missing debug implementations

### DIFF
--- a/crates/bevy_app/src/event.rs
+++ b/crates/bevy_app/src/event.rs
@@ -43,7 +43,7 @@ enum State {
 ///
 /// // events are only processed once per reader
 /// assert_eq!(reader.iter(&events).count(), 0);
-/// ```  
+/// ```
 ///
 /// # Details
 ///
@@ -83,6 +83,7 @@ fn map_instance_event<T>(event_instance: &EventInstance<T>) -> &T {
 }
 
 /// Reads events of type `T` in order and tracks which events have already been read.
+#[derive(Debug)]
 pub struct EventReader<T> {
     last_event_count: usize,
     _marker: PhantomData<T>,

--- a/crates/bevy_core/src/time/time.rs
+++ b/crates/bevy_core/src/time/time.rs
@@ -7,6 +7,7 @@ use instant::Instant;
 use std::time::Instant;
 
 /// Tracks elapsed time since the last update and since the App has started
+#[derive(Debug)]
 pub struct Time {
     pub delta: Duration,
     pub instant: Option<Instant>,

--- a/crates/bevy_ecs/hecs/src/archetype.rs
+++ b/crates/bevy_ecs/hecs/src/archetype.rs
@@ -35,6 +35,7 @@ use crate::{borrow::AtomicBorrow, query::Fetch, Access, Component, Query};
 ///
 /// Accessing `Archetype`s is only required for complex dynamic scheduling. To manipulate entities,
 /// go through the `World`.
+#[derive(Debug)]
 pub struct Archetype {
     types: Vec<TypeInfo>,
     state: HashMap<TypeId, TypeState>,
@@ -439,6 +440,7 @@ impl Drop for Archetype {
 }
 
 /// Metadata about a type stored in an archetype
+#[derive(Debug)]
 pub struct TypeState {
     offset: usize,
     borrow: AtomicBorrow,

--- a/crates/bevy_ecs/hecs/src/borrow.rs
+++ b/crates/bevy_ecs/hecs/src/borrow.rs
@@ -22,6 +22,7 @@ use core::{
 
 use crate::{archetype::Archetype, Component, MissingComponent};
 
+#[derive(Debug)]
 pub struct AtomicBorrow(AtomicUsize);
 
 impl AtomicBorrow {

--- a/crates/bevy_ecs/hecs/src/entities.rs
+++ b/crates/bevy_ecs/hecs/src/entities.rs
@@ -58,7 +58,7 @@ impl fmt::Debug for Entity {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(crate) struct Entities {
     pub meta: Vec<EntityMeta>,
     // Reserved entities outside the range of `meta`, having implicit generation 0, archetype 0, and
@@ -333,14 +333,14 @@ impl EntityReserver {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub(crate) struct EntityMeta {
     pub generation: u32,
     pub location: Location,
 }
 
 /// A location of an entity in an archetype
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Location {
     /// The archetype index
     pub archetype: u32,

--- a/crates/bevy_ecs/hecs/src/world.rs
+++ b/crates/bevy_ecs/hecs/src/world.rs
@@ -38,6 +38,7 @@ use crate::{
 ///
 /// The components of entities who have the same set of component types are stored in contiguous
 /// runs, allowing for extremely fast, cache-friendly iteration.
+#[derive(Debug)]
 pub struct World {
     entities: Entities,
     index: HashMap<Vec<TypeId>, u32>,

--- a/crates/bevy_ecs/src/resource/resource_query.rs
+++ b/crates/bevy_ecs/src/resource/resource_query.rs
@@ -47,6 +47,7 @@ impl<'a, T: Resource> Deref for ChangedRes<'a, T> {
 }
 
 /// Shared borrow of a Resource
+#[derive(Debug)]
 pub struct Res<'a, T: Resource> {
     value: &'a T,
 }
@@ -87,6 +88,7 @@ impl<'a, T: Resource> Deref for Res<'a, T> {
 }
 
 /// Unique borrow of a Resource
+#[derive(Debug)]
 pub struct ResMut<'a, T: Resource> {
     _marker: PhantomData<&'a T>,
     value: *mut T,
@@ -139,6 +141,7 @@ impl<'a, T: Resource> UnsafeClone for ResMut<'a, T> {
 
 /// Local<T> resources are unique per-system. Two instances of the same system will each have their own resource.
 /// Local resources are automatically initialized using the FromResources trait.
+#[derive(Debug)]
 pub struct Local<'a, T: Resource + FromResources> {
     value: *mut T,
     _marker: PhantomData<&'a T>,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -7,6 +7,7 @@ use bevy_tasks::ParallelIterator;
 use std::marker::PhantomData;
 
 /// Provides scoped access to a World according to a given [HecsQuery]
+#[derive(Debug)]
 pub struct Query<'a, Q: HecsQuery> {
     pub(crate) world: &'a World,
     pub(crate) archetype_access: &'a ArchetypeAccess,

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -35,7 +35,7 @@ pub trait System: Send + Sync {
 }
 
 /// Provides information about the archetypes a [System] reads and writes
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct ArchetypeAccess {
     pub immutable: FixedBitSet,
     pub mutable: FixedBitSet,

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -2,6 +2,7 @@ use bevy_utils::HashSet;
 use std::hash::Hash;
 
 /// A "press-able" input of type `T`
+#[derive(Debug)]
 pub struct Input<T> {
     pressed: HashSet<T>,
     just_pressed: HashSet<T>,


### PR DESCRIPTION
When instrumenting my own functions for tokio/tracing I ran into missing Debug implementations for a few structs.

This PR adds `#[derive(Debug)] to those structs and those used in their fields.

If this would not be desired, either custom Debug implementations or something like https://crates.io/crates/opaque-debug could be used. Although functionally https://crates.io/crates/derivative is nicer, it pulls in all manner of not-so-nice dependencies like `syn`.