### PR TITLE
New & updated `spawn*` methods

### DIFF
--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -162,7 +162,10 @@ pub struct CommandsInternal {
 }
 
 impl CommandsInternal {
-    pub fn spawn(&mut self, components: impl DynamicBundle + Send + Sync + 'static) -> &mut Self {
+    pub fn spawn_with_bundle(
+        &mut self,
+        components: impl DynamicBundle + Send + Sync + 'static,
+    ) -> &mut Self {
         let entity = self
             .entity_reserver
             .as_ref()
@@ -171,6 +174,20 @@ impl CommandsInternal {
         self.current_entity = Some(entity);
         self.commands
             .push(Command::WriteWorld(Box::new(Insert { entity, components })));
+        self
+    }
+
+    pub fn spawn_with(&mut self, component: impl Component) -> &mut Self {
+        let entity = self
+            .entity_reserver
+            .as_ref()
+            .expect("entity reserver has not been set")
+            .reserve_entity();
+        self.current_entity = Some(entity);
+        self.commands.push(Command::WriteWorld(Box::new(InsertOne {
+            entity,
+            component,
+        })));
         self
     }
 


### PR DESCRIPTION
These changes are based off of and resolve https://github.com/bevyengine/bevy/issues/607

- Renamed existing `spawn` method to `spawn_with_bundle`, which nicely mirrors the `with_bundle` method.
- Added a new `spawn_with` method which nicely mirrors the existing `with` method.


Note: So far I've just done the root change to see if I'm going the right direction -- none of the usage has been fixed.  If I can get a 👍 that this is the way we want to go, I'll push more commit(s) to follow up with usage and stuff.