### PR TITLE
ui/text example: Use a unit component to identify the target Text

### DIFF
--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -13,8 +13,11 @@ fn main() {
         .run();
 }
 
-fn text_update_system(diagnostics: Res<Diagnostics>, mut query: Query<&mut Text>) {
-    for mut text in &mut query.iter() {
+// A unit struct to help identify the FPS UI component, since there may be many Text components
+struct FpsText;
+
+fn text_update_system(diagnostics: Res<Diagnostics>, mut query: Query<(&mut Text, &FpsText)>) {
+    for (mut text, _tag) in &mut query.iter() {
         if let Some(fps) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
             if let Some(average) = fps.average() {
                 text.value = format!("FPS: {:.2}", average);
@@ -43,5 +46,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 },
             },
             ..Default::default()
-        });
+        })
+        .with(FpsText);
 }


### PR DESCRIPTION
I had a question in the Discord which was basically "how do I identify particular UI components in order to update them?" (https://discordapp.com/channels/691052431525675048/742884593551802431/761384375736205323) and user "s33n" helpfully suggested using a unit component to tag the component I was interested in. I reviewed this example before asking, but it queries all `Text` components. With a change to use a unit tag, similar questions to mine can be answered in this example code.

Let me know if this overcomplicates the example or it's not what you think is best!

Thanks :)

Test plan:
1. `cargo run --example text` to see that the FPS counter is still working
2. Add another `Text` component to ensure that only components with the tag are being updated (then removed extra `Text`).