### PR TITLE
Fix FloatOrd hash being different for different NaN values

### DIFF
--- a/crates/bevy_core/src/float_ord.rs
+++ b/crates/bevy_core/src/float_ord.rs
@@ -40,7 +40,12 @@ impl Eq for FloatOrd {}
 
 impl Hash for FloatOrd {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write(self.0.as_bytes());
+        if self.0.is_nan() {
+            // Ensure all NaN representations hash to the same value
+            state.write(f32::NAN.as_bytes())
+        } else {
+            state.write(self.0.as_bytes());
+        }
     }
 }
 

--- a/crates/bevy_core/src/float_ord.rs
+++ b/crates/bevy_core/src/float_ord.rs
@@ -43,6 +43,9 @@ impl Hash for FloatOrd {
         if self.0.is_nan() {
             // Ensure all NaN representations hash to the same value
             state.write(f32::NAN.as_bytes())
+        } else if self.0 == 0.0 {
+            // Ensure both zeroes hash to the same value
+            state.write(0.0f32.as_bytes())
         } else {
             state.write(self.0.as_bytes());
         }


### PR DESCRIPTION
There are multiple representations of `NaN` possible. The `Eq` impl treats them as equal, so the `Hash` impl should hash them to the same value as well. 