### PR TITLE
load assets from an object implementing Read

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,10 @@ name = "custom_loader"
 path = "examples/asset/custom_asset_loading.rs"
 
 [[example]]
+name = "read_loading"
+path = "examples/asset/read_loading.rs"
+
+[[example]]
 name = "audio"
 path = "examples/audio/audio.rs"
 

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -278,7 +278,7 @@ impl AssetServer {
                 assets.set(handle, asset);
                 return Ok(handle);
             }
-            Err(last_error.unwrap())?
+            Err(last_error.unwrap().into())
         } else {
             Err(AssetServerError::MissingAssetHandler)
         }
@@ -311,7 +311,7 @@ impl AssetServer {
                 })
                 .detach();
 
-            return Ok(Handle::from(handle_id));
+            Ok(Handle::from(handle_id))
         } else {
             Err(AssetServerError::MissingAssetHandler)
         }

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -69,6 +69,7 @@ impl TypeToIndex {
     fn get<T: 'static>(&self) -> Option<&Vec<usize>> {
         self.0.get(&std::any::TypeId::of::<T>())
     }
+
     fn insert<T: 'static>(&mut self, index: usize) {
         self.0
             .entry(std::any::TypeId::of::<T>())

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -189,7 +189,7 @@ impl AddAsset for AppBuilder {
                 TLoader::from_resources(self.resources()),
                 asset_channel.sender.clone(),
             );
-            asset_server.add_handler(handler);
+            asset_server.add_handler::<_, TAsset>(handler);
         }
         self
     }

--- a/crates/bevy_asset/src/load_request/mod.rs
+++ b/crates/bevy_asset/src/load_request/mod.rs
@@ -1,6 +1,6 @@
 use crate::{AssetLoader, AssetResult, AssetVersion, HandleId};
 use crossbeam_channel::Sender;
-use std::path::PathBuf;
+use std::{fmt::Debug, path::PathBuf};
 
 #[cfg(not(target_arch = "wasm32"))]
 #[path = "platform_default.rs"]
@@ -12,10 +12,24 @@ mod platform_specific;
 
 pub use platform_specific::*;
 
+pub enum DataOrigin {
+    Path(PathBuf),
+    Read(std::sync::Arc<std::sync::Mutex<Box<(dyn std::io::Read + Send + 'static)>>>),
+}
+
+impl Debug for DataOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Path(path_buf) => f.debug_tuple("DataOrigin::Path").field(path_buf).finish(),
+            Self::Read(_) => f.write_fmt(format_args!("DataOrigin::Read")),
+        }
+    }
+}
+
 /// A request from an [AssetServer](crate::AssetServer) to load an asset.
 #[derive(Debug)]
 pub struct LoadRequest {
-    pub path: PathBuf,
+    pub path: DataOrigin,
     pub handle_id: HandleId,
     pub handler_index: usize,
     pub version: AssetVersion,

--- a/crates/bevy_asset/src/load_request/platform_wasm.rs
+++ b/crates/bevy_asset/src/load_request/platform_wasm.rs
@@ -36,10 +36,8 @@ where
                 let bytes = Uint8Array::new(&data).to_vec();
                 let asset = self.loader.from_bytes(&path, bytes).unwrap();
                 Ok(asset)
-            },
-            crate::DataOrigin::Read(ref _read) => {
-                unimplemented!()
             }
+            crate::DataOrigin::Read(ref _read) => unimplemented!(),
         }
     }
 }

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -30,6 +30,12 @@ pub trait AssetLoader<T>: Send + Sync + 'static {
         let asset = self.from_bytes(asset_path, bytes)?;
         Ok(asset)
     }
+    fn load_from_read(&self, asset_read: &mut dyn std::io::Read) -> Result<T, AssetLoadError> {
+        let mut bytes = Vec::new();
+        asset_read.read_to_end(&mut bytes)?;
+        let asset = self.from_bytes(Path::new(""), bytes)?;
+        Ok(asset)
+    }
 }
 
 /// The result of loading an asset of type `T`

--- a/crates/bevy_render/src/texture/image_texture_loader.rs
+++ b/crates/bevy_render/src/texture/image_texture_loader.rs
@@ -11,24 +11,8 @@ use std::path::Path;
 pub struct ImageTextureLoader;
 
 impl AssetLoader<Texture> for ImageTextureLoader {
-    fn from_bytes(&self, asset_path: &Path, bytes: Vec<u8>) -> Result<Texture> {
+    fn from_bytes(&self, _asset_path: &Path, bytes: Vec<u8>) -> Result<Texture> {
         use bevy_core::AsBytes;
-
-        // Find the image type we expect. A file with the extension "png" should
-        // probably load as a PNG.
-
-        let ext = asset_path.extension().unwrap().to_str().unwrap();
-
-        // NOTE: If more formats are added they can be added here.
-        let img_format = if ext.eq_ignore_ascii_case("png") {
-            image::ImageFormat::Png
-        } else {
-            panic!(
-                "Unexpected image format {:?} for file {}, this is an error in `bevy_render`.",
-                ext,
-                asset_path.display()
-            )
-        };
 
         // Load the image in the expected format.
         // Some formats like PNG allow for R or RG textures too, so the texture
@@ -36,7 +20,7 @@ impl AssetLoader<Texture> for ImageTextureLoader {
         // needs to be added, so the image data needs to be converted in those
         // cases.
 
-        let dyn_img = image::load_from_memory_with_format(bytes.as_slice(), img_format)?;
+        let dyn_img = image::load_from_memory(bytes.as_slice())?;
 
         let width;
         let height;

--- a/examples/asset/read_loading.rs
+++ b/examples/asset/read_loading.rs
@@ -1,0 +1,41 @@
+use bevy::prelude::*;
+
+/// This example illustrates various ways to load assets
+fn main() {
+    App::build()
+        .add_default_plugins()
+        .add_startup_system(setup.system())
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut textures: ResMut<Assets<Texture>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    // You can use `include_bytes!` to load a file as an `&[u8]` at compile time. This will bundle the asset in the binary.
+    // It can then be loaded synchronously:
+    let bytes = include_bytes!("../../assets/branding/icon.png");
+    let texture_handle = asset_server
+        .load_sync_from(&mut textures, &mut bytes.as_ref())
+        .unwrap();
+
+    // Or you can use any object implementing `std::io::Read`.
+    // To load it asynchronously, you then need to wrap it in a `Box`:
+    let file = std::fs::File::open("assets/branding/icon.png").unwrap();
+    let texture_handle_2 = asset_server.load_from(Box::new(file)).unwrap();
+
+    commands
+        .spawn(Camera2dComponents::default())
+        .spawn(SpriteComponents {
+            material: materials.add(texture_handle.into()),
+            transform: Transform::default().with_translation(Vec3::new(-300., 0., 0.)),
+            ..Default::default()
+        })
+        .spawn(SpriteComponents {
+            material: materials.add(texture_handle_2.into()),
+            transform: Transform::default().with_translation(Vec3::new(300., 0., 0.)),
+            ..Default::default()
+        });
+}


### PR DESCRIPTION
as mentioned in #606, my goal is mainly to be able to bundle PNGs for textures in the binary.

I added 3 functions to `AssetServer`:
* `load_sync_from<T: Resource>(&self, assets: &mut Assets<T>, read: &mut dyn std::io::Read) -> Result<Handle<T>, AssetServerError>` that allows the user to synchronously load something that implements `Read`. This function will try all loader for `T` until one works.
* `load_from<T: Resource>(&self, read: Box<(dyn std::io::Read + Send + 'static)>) -> Result<Handle<T>, AssetServerError>` that allows the user to asynchronously load something that implements `Read`. The object must be `Box`ed to be sent between threads. This function will only try the first loader for `T`
* and `load_with_hint_from<T: Resource>(&self, read: Box<(dyn std::io::Read + Send + 'static)>, extension: &str) -> Result<Handle<T>, AssetServerError>`, same as the above with the possibility to provide the extension that match the object being loaded to help type resolution. This function will not use the loader deduced from `T` but from the extension provided.

To be able to load an image without providing its path, I also had to modify the `AssetLoader` implementation for `ImageTextureLoader` to not use the path to check the extension. The only other `AssetLoader` that uses the path when loading is `GltfLoader`, but it seems like it's actually needed in this case.

I am also not sure how to implement this loading in the wasm case, which I left as `unimplemented!()` for now but would welcome pointers on how to do it ([here](https://github.com/bevyengine/bevy/pull/619/files#diff-b4cf82df01b426a99320c372cb0d43deR40))
