### PR TITLE
Dynamic Systems and Components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ png = ["bevy_render/png"]
 hdr = ["bevy_render/hdr"]
 
 # Enable the dynamic systems and components API ( useful for developing scripting solutions )
-dynamic-api = ["bevy_ecs/dynamic-api", "bevy_scene/dynamic-api"]
+dynamic_api = ["bevy_ecs/dynamic_api", "bevy_scene/dynamic_api"]
 
 # Audio format support (MP3 is enabled by default)
 mp3 = ["bevy_audio/mp3"]
@@ -224,12 +224,12 @@ path = "examples/ecs/hierarchy.rs"
 [[example]]
 name = "dynamic_systems"
 path = "examples/ecs/dynamic_systems.rs"
-required-features = ["dynamic-api"]
+required-features = ["dynamic_api"]
 
 [[example]]
 name = "dynamic_components"
 path = "examples/ecs/dynamic_components.rs"
-required-features = ["dynamic-api"]
+required-features = ["dynamic_api"]
 
 [[example]]
 name = "breakout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ render = ["bevy_pbr", "bevy_render", "bevy_sprite", "bevy_text", "bevy_ui"]
 png = ["bevy_render/png"]
 hdr = ["bevy_render/hdr"]
 
+# Enable the dynamic systems and components API ( useful for developing scripting solutions )
+dynamic-api = ["bevy_ecs/dynamic-api", "bevy_scene/dynamic-api"]
+
 # Audio format support (MP3 is enabled by default)
 mp3 = ["bevy_audio/mp3"]
 flac = ["bevy_audio/flac"]
@@ -90,6 +93,8 @@ serde = { version = "1", features = ["derive"] }
 log = "0.4"
 ron = "0.6"
 anyhow = "1.0"
+lazy_static = "1.4.0"
+
 
 # bevy (Android)
 [target.'cfg(target_os = "android")'.dependencies]
@@ -215,6 +220,16 @@ path = "examples/ecs/parallel_query.rs"
 [[example]]
 name = "hierarchy"
 path = "examples/ecs/hierarchy.rs"
+
+[[example]]
+name = "dynamic_systems"
+path = "examples/ecs/dynamic_systems.rs"
+required-features = ["dynamic-api"]
+
+[[example]]
+name = "dynamic_components"
+path = "examples/ecs/dynamic_components.rs"
+required-features = ["dynamic-api"]
 
 [[example]]
 name = "breakout"

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["game-engines", "data-structures"]
 
 [features]
 profiler = []
+dynamic-api = ["bevy_hecs/dynamic-api"]
 
 [dependencies]
 bevy_hecs = { path = "hecs", features = ["macros", "serialize"], version = "0.3.0" }

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["game-engines", "data-structures"]
 
 [features]
 profiler = []
-dynamic-api = ["bevy_hecs/dynamic-api"]
+dynamic_api = ["bevy_hecs/dynamic_api"]
 
 [dependencies]
 bevy_hecs = { path = "hecs", features = ["macros", "serialize"], version = "0.3.0" }

--- a/crates/bevy_ecs/hecs/Cargo.toml
+++ b/crates/bevy_ecs/hecs/Cargo.toml
@@ -25,6 +25,8 @@ std = []
 # Enables derive(Bundle)
 macros = ["bevy_hecs_macros", "lazy_static"]
 serialize = ["serde"]
+# Enables the dynamic components and systems APIs
+dynamic-api = ["std"]
 
 [dependencies]
 bevy_hecs_macros = { path = "macros", version = "0.3.0", optional = true }

--- a/crates/bevy_ecs/hecs/Cargo.toml
+++ b/crates/bevy_ecs/hecs/Cargo.toml
@@ -26,7 +26,7 @@ std = []
 macros = ["bevy_hecs_macros", "lazy_static"]
 serialize = ["serde"]
 # Enables the dynamic components and systems APIs
-dynamic-api = ["std"]
+dynamic_api = ["std"]
 
 [dependencies]
 bevy_hecs_macros = { path = "macros", version = "0.3.0", optional = true }

--- a/crates/bevy_ecs/hecs/src/archetype.rs
+++ b/crates/bevy_ecs/hecs/src/archetype.rs
@@ -526,7 +526,7 @@ impl TypeInfo {
     }
 
     /// Get the [`TypeInfo`] for an external type with the given layout and drop function
-    #[cfg(feature = "dynamic-api")]
+    #[cfg(feature = "dynamic_api")]
     pub fn of_external(external_id: u64, layout: Layout, drop: unsafe fn(*mut u8)) -> Self {
         TypeInfo {
             id: ComponentId::ExternalId(external_id),

--- a/crates/bevy_ecs/hecs/src/entity_builder.rs
+++ b/crates/bevy_ecs/hecs/src/entity_builder.rs
@@ -81,7 +81,7 @@ impl EntityBuilder {
     }
 
     /// Add a dynamic component given the component ID, the layout and the raw data slice
-    #[cfg(feature = "dynamic-api")]
+    #[cfg(feature = "dynamic_api")]
     pub fn add_dynamic(&mut self, info: TypeInfo, data: &[u8]) -> &mut Self {
         self.add_with_typeinfo(info, data, false);
         self
@@ -231,10 +231,10 @@ impl Drop for BuiltEntity<'_> {
 
 #[cfg(test)]
 mod test {
-    #[cfg(feature = "dynamic-api")]
+    #[cfg(feature = "dynamic_api")]
     use super::*;
 
-    #[cfg(feature = "dynamic-api")]
+    #[cfg(feature = "dynamic_api")]
     #[test]
     #[should_panic(expected = "Data length does not match component size")]
     fn dynamic_data_invalid_length_panics() {

--- a/crates/bevy_ecs/hecs/src/lib.rs
+++ b/crates/bevy_ecs/hecs/src/lib.rs
@@ -84,7 +84,9 @@ pub use query::{
     Added, Batch, BatchedIter, Changed, Mut, Mutated, Or, Query, QueryIter, ReadOnlyFetch, With,
     Without,
 };
-pub use world::{ArchetypesGeneration, Component, ComponentError, SpawnBatchIter, World};
+pub use world::{
+    ArchetypesGeneration, Component, ComponentError, ComponentId, SpawnBatchIter, World,
+};
 
 // Unstable implementation details needed by the macros
 #[doc(hidden)]

--- a/crates/bevy_ecs/hecs/src/lib.rs
+++ b/crates/bevy_ecs/hecs/src/lib.rs
@@ -74,15 +74,15 @@ mod query;
 mod serde;
 mod world;
 
-pub use access::{ArchetypeComponent, QueryAccess, TypeAccess};
+pub use access::{Access, ArchetypeComponent, QueryAccess, TypeAccess};
 pub use archetype::{Archetype, TypeState};
 pub use borrow::{AtomicBorrow, Ref, RefMut};
 pub use bundle::{Bundle, DynamicBundle, MissingComponent};
 pub use entities::{Entity, EntityReserver, Location, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, EntityBuilder};
 pub use query::{
-    Added, Batch, BatchedIter, Changed, Mut, Mutated, Or, Query, QueryIter, ReadOnlyFetch, With,
-    Without,
+    Added, Batch, BatchedIter, Changed, DynamicFetch, DynamicFetchResult, DynamicQuery, Mut,
+    Mutated, Or, Query, QueryIter, ReadOnlyFetch, With, Without,
 };
 pub use world::{
     ArchetypesGeneration, Component, ComponentError, ComponentId, SpawnBatchIter, World,

--- a/crates/bevy_ecs/hecs/src/query.rs
+++ b/crates/bevy_ecs/hecs/src/query.rs
@@ -17,12 +17,16 @@
 use core::{
     marker::PhantomData,
     ops::{Deref, DerefMut},
-    ptr::NonNull,
+    ptr::{slice_from_raw_parts, slice_from_raw_parts_mut, NonNull},
 };
-
 use std::vec;
 
-use crate::{access::QueryAccess, archetype::Archetype, Component, Entity, MissingComponent};
+use bevy_utils::HashMap;
+
+use crate::{
+    access::QueryAccess, archetype::Archetype, ArchetypeComponent, Component, ComponentId, Entity,
+    MissingComponent, TypeAccess, TypeInfo,
+};
 
 /// A collection of component types to fetch from a `World`
 pub trait Query {
@@ -41,24 +45,27 @@ pub trait Fetch<'a>: Sized {
     /// Type of value to be fetched
     type Item;
 
+    /// The query state
+    type State;
+
     /// A value on which `get` may never be called
     #[allow(clippy::declare_interior_mutable_const)] // no const fn in traits
     const DANGLING: Self;
 
     /// How this query will access `archetype`, if at all
-    fn access() -> QueryAccess;
+    fn access(state: &Self::State) -> QueryAccess;
 
     /// Construct a `Fetch` for `archetype` if it should be traversed
     ///
     /// # Safety
     /// `offset` must be in bounds of `archetype`
-    unsafe fn get(archetype: &'a Archetype, offset: usize) -> Option<Self>;
+    unsafe fn get(state: &Self::State, archetype: &'a Archetype, offset: usize) -> Option<Self>;
 
     /// if this returns true, the nth item should be skipped during iteration
     ///
     /// # Safety
     /// shouldn't be called if there is no current item
-    unsafe fn should_skip(&self, _n: usize) -> bool {
+    unsafe fn should_skip(&self, _state: &Self::State, _n: usize) -> bool {
         false
     }
 
@@ -69,7 +76,137 @@ pub trait Fetch<'a>: Sized {
     /// - `release` must not be called while `'a` is still live
     /// - Bounds-checking must be performed externally
     /// - Any resulting borrows must be legal (e.g. no &mut to something another iterator might access)
-    unsafe fn fetch(&self, n: usize) -> Self::Item;
+    unsafe fn fetch(&self, state: &Self::State, n: usize) -> Self::Item;
+}
+
+#[derive(Debug, Clone)]
+pub struct DynamicQuery {
+    pub access: QueryAccess,
+    pub component_info: HashMap<ComponentId, TypeInfo>,
+}
+
+impl DynamicQuery {
+    pub fn register_info(&mut self, info: TypeInfo) -> ComponentId {
+        let id = info.id;
+        self.component_info.insert(id, info);
+
+        id
+    }
+}
+
+impl Default for DynamicQuery {
+    fn default() -> Self {
+        DynamicQuery {
+            access: QueryAccess::None,
+            component_info: Default::default(),
+        }
+    }
+}
+
+impl Query for DynamicQuery {
+    type Fetch = DynamicFetch;
+}
+
+/// The result of a dynamic component query, containing references to the component's bytes
+#[derive(Debug)]
+pub struct DynamicFetchResult<'w> {
+    pub entity: Entity,
+    /// the list of immutable components returned
+    pub immutable: HashMap<ComponentId, &'w [u8]>,
+    /// the list of mutable components returned
+    pub mutable: HashMap<ComponentId, &'w mut [u8]>,
+}
+
+/// A [`Fetch`] implementation for dynamic queries
+#[derive(Debug, Clone)]
+pub struct DynamicFetch {
+    // Optional only so that we have a way to specify `DANGLING` as a const
+    access: Option<TypeAccess<(NonNull<u8>, TypeInfo)>>,
+    entity: NonNull<Entity>,
+}
+
+impl<'w> Fetch<'w> for DynamicFetch {
+    type Item = DynamicFetchResult<'w>;
+    type State = DynamicQuery;
+
+    const DANGLING: Self = Self {
+        access: None,
+        entity: NonNull::dangling(),
+    };
+
+    fn access(query: &Self::State) -> QueryAccess {
+        query.access.clone()
+    }
+
+    unsafe fn get(query: &Self::State, archetype: &'w Archetype, offset: usize) -> Option<Self> {
+        let mut access = TypeAccess::default();
+        let map_access = |access: &ArchetypeComponent| {
+            let info = query
+                .component_info
+                .get(&access.component)
+                .expect("Missing component info for component in query");
+
+            (
+                archetype
+                    .get_dynamic(info.id, info.layout.size(), offset)
+                    .expect("Archetype missing component"),
+                *info,
+            )
+        };
+
+        query
+            .access
+            .get_access(
+                archetype,
+                0, // TODO(zicklag): Is this fine as zero? I think it is unused in this context.
+                Some(&mut access),
+            )
+            // Create a `DynamicFetch` by mapping the component query to the `TypeInfo`
+            .map(|_| DynamicFetch {
+                access: Some(TypeAccess::new(
+                    access.iter_reads().map(map_access).collect(),
+                    access.iter_writes().map(map_access).collect(),
+                )),
+                entity: archetype.entities(),
+            })
+    }
+
+    unsafe fn fetch(&self, _query: &Self::State, n: usize) -> Self::Item {
+        let mut immutable = HashMap::default();
+        let mut mutable = HashMap::default();
+        let access = self
+            .access
+            .as_ref()
+            .expect("Attempted to fetch from dangling `DynamicFetch`");
+
+        // Collect immutable components
+        for (nonnull, info) in access.iter_reads() {
+            immutable.insert(
+                info.id,
+                &*slice_from_raw_parts(
+                    nonnull.as_ptr().add(n * info.layout.size()),
+                    info.layout.size(),
+                ),
+            );
+        }
+
+        // Collect mutable components
+        for (nonnull, info) in access.iter_writes() {
+            mutable.insert(
+                info.id,
+                &mut *slice_from_raw_parts_mut(
+                    nonnull.as_ptr().add(n * info.layout.size()),
+                    info.layout.size(),
+                ),
+            );
+        }
+
+        DynamicFetchResult {
+            entity: *self.entity.as_ptr().add(n),
+            immutable,
+            mutable,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -83,23 +220,24 @@ impl Query for Entity {
 
 impl<'a> Fetch<'a> for EntityFetch {
     type Item = Entity;
+    type State = ();
 
     const DANGLING: Self = Self(NonNull::dangling());
 
     #[inline]
-    unsafe fn get(archetype: &'a Archetype, offset: usize) -> Option<Self> {
+    unsafe fn get(_state: &Self::State, archetype: &'a Archetype, offset: usize) -> Option<Self> {
         Some(EntityFetch(NonNull::new_unchecked(
             archetype.entities().as_ptr().add(offset),
         )))
     }
 
     #[inline]
-    unsafe fn fetch(&self, n: usize) -> Self::Item {
+    unsafe fn fetch(&self, _state: &Self::State, n: usize) -> Self::Item {
         *self.0.as_ptr().add(n)
     }
 
     #[inline]
-    fn access() -> QueryAccess {
+    fn access(_state: &Self::State) -> QueryAccess {
         QueryAccess::None
     }
 }
@@ -116,22 +254,23 @@ impl<T> UnfilteredFetch for FetchRead<T> {}
 
 impl<'a, T: Component> Fetch<'a> for FetchRead<T> {
     type Item = &'a T;
+    type State = ();
 
     const DANGLING: Self = Self(NonNull::dangling());
 
-    unsafe fn get(archetype: &'a Archetype, offset: usize) -> Option<Self> {
+    unsafe fn get(_state: &Self::State, archetype: &'a Archetype, offset: usize) -> Option<Self> {
         archetype
             .get::<T>()
             .map(|x| Self(NonNull::new_unchecked(x.as_ptr().add(offset))))
     }
 
     #[inline]
-    unsafe fn fetch(&self, n: usize) -> &'a T {
+    unsafe fn fetch(&self, _state: &Self::State, n: usize) -> &'a T {
         &*self.0.as_ptr().add(n)
     }
 
     #[inline]
-    fn access() -> QueryAccess {
+    fn access(_state: &Self::State) -> QueryAccess {
         QueryAccess::read::<T>()
     }
 }
@@ -140,7 +279,10 @@ impl<'a, T: Component> Query for &'a mut T {
     type Fetch = FetchMut<T>;
 }
 
-impl<T: Query> Query for Option<T> {
+impl<T: Query> Query for Option<T>
+where
+    T::Fetch: for<'a> Fetch<'a, State = ()>,
+{
     type Fetch = TryFetch<T::Fetch>;
 }
 
@@ -201,10 +343,11 @@ impl<T> UnfilteredFetch for FetchMut<T> {}
 
 impl<'a, T: Component> Fetch<'a> for FetchMut<T> {
     type Item = Mut<'a, T>;
+    type State = ();
 
     const DANGLING: Self = Self(NonNull::dangling(), NonNull::dangling());
 
-    unsafe fn get(archetype: &'a Archetype, offset: usize) -> Option<Self> {
+    unsafe fn get(_state: &Self::State, archetype: &'a Archetype, offset: usize) -> Option<Self> {
         archetype
             .get_with_type_state::<T>()
             .map(|(components, type_state)| {
@@ -216,7 +359,7 @@ impl<'a, T: Component> Fetch<'a> for FetchMut<T> {
     }
 
     #[inline]
-    unsafe fn fetch(&self, n: usize) -> Mut<'a, T> {
+    unsafe fn fetch(&self, _state: &Self::State, n: usize) -> Mut<'a, T> {
         Mut {
             value: &mut *self.0.as_ptr().add(n),
             mutated: &mut *self.1.as_ptr().add(n),
@@ -224,43 +367,47 @@ impl<'a, T: Component> Fetch<'a> for FetchMut<T> {
     }
 
     #[inline]
-    fn access() -> QueryAccess {
+    fn access(_state: &Self::State) -> QueryAccess {
         QueryAccess::write::<T>()
     }
 }
 
 macro_rules! impl_or_query {
     ( $( $T:ident ),+ ) => {
-        impl<$( $T: Query ),+> Query for Or<($( $T ),+)> {
+        impl<$( $T: Query ),+> Query for Or<($( $T ),+)>
+        where
+            $($T::Fetch: for<'a> Fetch<'a, State = ()>),+
+        {
             type Fetch = FetchOr<($( $T::Fetch ),+)>;
         }
 
-        impl<'a, $( $T: Fetch<'a> ),+> Fetch<'a> for FetchOr<($( $T ),+)> {
+        impl<'a, $( $T: Fetch<'a, State=()> ),+> Fetch<'a> for FetchOr<($( $T ),+)> {
             type Item = ($( $T::Item ),+);
+            type State = ();
 
             const DANGLING: Self = Self(($( $T::DANGLING ),+));
 
-            fn access() -> QueryAccess {
+            fn access(_state: &Self::State, ) -> QueryAccess {
                 QueryAccess::union(vec![
-                    $($T::access(),)+
+                    $($T::access(&()),)+
                 ])
             }
 
 
-            unsafe fn get(archetype: &'a Archetype, offset: usize) -> Option<Self> {
-                Some(Self(( $( $T::get(archetype, offset)?),+ )))
+            unsafe fn get(_state: &Self::State, archetype: &'a Archetype, offset: usize) -> Option<Self> {
+                Some(Self(( $( $T::get(&(), archetype, offset)?),+ )))
             }
 
             #[allow(non_snake_case)]
-            unsafe fn fetch(&self, n: usize) -> Self::Item {
+            unsafe fn fetch(&self, _state: &Self::State, n: usize) -> Self::Item {
                 let ($( $T ),+) = &self.0;
-                ($( $T.fetch(n) ),+)
+                ($( $T.fetch(&(), n) ),+)
             }
 
              #[allow(non_snake_case)]
-            unsafe fn should_skip(&self, n: usize) -> bool {
+            unsafe fn should_skip(&self, _state: &Self::State, n: usize) -> bool {
                 let ($( $T ),+) = &self.0;
-                true $( && $T.should_skip(n) )+
+                true $( && $T.should_skip(&(), n) )+
             }
         }
 
@@ -327,15 +474,16 @@ unsafe impl<T> ReadOnlyFetch for FetchMutated<T> {}
 
 impl<'a, T: Component> Fetch<'a> for FetchMutated<T> {
     type Item = Mutated<'a, T>;
+    type State = ();
 
     const DANGLING: Self = Self(NonNull::dangling(), NonNull::dangling());
 
     #[inline]
-    fn access() -> QueryAccess {
+    fn access(_state: &Self::State) -> QueryAccess {
         QueryAccess::read::<T>()
     }
 
-    unsafe fn get(archetype: &'a Archetype, offset: usize) -> Option<Self> {
+    unsafe fn get(_state: &Self::State, archetype: &'a Archetype, offset: usize) -> Option<Self> {
         archetype
             .get_with_type_state::<T>()
             .map(|(components, type_state)| {
@@ -346,13 +494,13 @@ impl<'a, T: Component> Fetch<'a> for FetchMutated<T> {
             })
     }
 
-    unsafe fn should_skip(&self, n: usize) -> bool {
+    unsafe fn should_skip(&self, _state: &Self::State, n: usize) -> bool {
         // skip if the current item wasn't mutated
         !*self.1.as_ptr().add(n)
     }
 
     #[inline]
-    unsafe fn fetch(&self, n: usize) -> Self::Item {
+    unsafe fn fetch(&self, _state: &Self::State, n: usize) -> Self::Item {
         Mutated {
             value: &*self.0.as_ptr().add(n),
         }
@@ -383,15 +531,16 @@ unsafe impl<T> ReadOnlyFetch for FetchAdded<T> {}
 
 impl<'a, T: Component> Fetch<'a> for FetchAdded<T> {
     type Item = Added<'a, T>;
+    type State = ();
 
     const DANGLING: Self = Self(NonNull::dangling(), NonNull::dangling());
 
     #[inline]
-    fn access() -> QueryAccess {
+    fn access(_state: &Self::State) -> QueryAccess {
         QueryAccess::read::<T>()
     }
 
-    unsafe fn get(archetype: &'a Archetype, offset: usize) -> Option<Self> {
+    unsafe fn get(_state: &Self::State, archetype: &'a Archetype, offset: usize) -> Option<Self> {
         archetype
             .get_with_type_state::<T>()
             .map(|(components, type_state)| {
@@ -402,13 +551,13 @@ impl<'a, T: Component> Fetch<'a> for FetchAdded<T> {
             })
     }
 
-    unsafe fn should_skip(&self, n: usize) -> bool {
+    unsafe fn should_skip(&self, _state: &Self::State, n: usize) -> bool {
         // skip if the current item wasn't added
         !*self.1.as_ptr().add(n)
     }
 
     #[inline]
-    unsafe fn fetch(&self, n: usize) -> Self::Item {
+    unsafe fn fetch(&self, _state: &Self::State, n: usize) -> Self::Item {
         Added {
             value: &*self.0.as_ptr().add(n),
         }
@@ -439,6 +588,7 @@ unsafe impl<T> ReadOnlyFetch for FetchChanged<T> {}
 
 impl<'a, T: Component> Fetch<'a> for FetchChanged<T> {
     type Item = Changed<'a, T>;
+    type State = ();
 
     const DANGLING: Self = Self(
         NonNull::dangling(),
@@ -447,11 +597,11 @@ impl<'a, T: Component> Fetch<'a> for FetchChanged<T> {
     );
 
     #[inline]
-    fn access() -> QueryAccess {
+    fn access(_state: &Self::State) -> QueryAccess {
         QueryAccess::read::<T>()
     }
 
-    unsafe fn get(archetype: &'a Archetype, offset: usize) -> Option<Self> {
+    unsafe fn get(_state: &Self::State, archetype: &'a Archetype, offset: usize) -> Option<Self> {
         archetype
             .get_with_type_state::<T>()
             .map(|(components, type_state)| {
@@ -463,13 +613,13 @@ impl<'a, T: Component> Fetch<'a> for FetchChanged<T> {
             })
     }
 
-    unsafe fn should_skip(&self, n: usize) -> bool {
+    unsafe fn should_skip(&self, _state: &Self::State, n: usize) -> bool {
         // skip if the current item wasn't added or mutated
         !*self.1.as_ptr().add(n) && !*self.2.as_ptr().add(n)
     }
 
     #[inline]
-    unsafe fn fetch(&self, n: usize) -> Self::Item {
+    unsafe fn fetch(&self, _state: &Self::State, n: usize) -> Self::Item {
         Changed {
             value: &*self.0.as_ptr().add(n),
         }
@@ -481,26 +631,29 @@ pub struct TryFetch<T>(Option<T>);
 unsafe impl<T> ReadOnlyFetch for TryFetch<T> where T: ReadOnlyFetch {}
 impl<T> UnfilteredFetch for TryFetch<T> where T: UnfilteredFetch {}
 
-impl<'a, T: Fetch<'a>> Fetch<'a> for TryFetch<T> {
+impl<'a, T: Fetch<'a, State = ()>> Fetch<'a> for TryFetch<T> {
     type Item = Option<T::Item>;
+    type State = ();
 
     const DANGLING: Self = Self(None);
 
     #[inline]
-    fn access() -> QueryAccess {
-        QueryAccess::optional(T::access())
+    fn access(_state: &Self::State) -> QueryAccess {
+        QueryAccess::optional(T::access(&()))
     }
 
-    unsafe fn get(archetype: &'a Archetype, offset: usize) -> Option<Self> {
-        Some(Self(T::get(archetype, offset)))
+    unsafe fn get(_state: &Self::State, archetype: &'a Archetype, offset: usize) -> Option<Self> {
+        Some(Self(T::get(&(), archetype, offset)))
     }
 
-    unsafe fn fetch(&self, n: usize) -> Option<T::Item> {
-        Some(self.0.as_ref()?.fetch(n))
+    unsafe fn fetch(&self, _state: &Self::State, n: usize) -> Option<T::Item> {
+        Some(self.0.as_ref()?.fetch(&(), n))
     }
 
-    unsafe fn should_skip(&self, n: usize) -> bool {
-        self.0.as_ref().map_or(false, |fetch| fetch.should_skip(n))
+    unsafe fn should_skip(&self, _state: &Self::State, n: usize) -> bool {
+        self.0
+            .as_ref()
+            .map_or(false, |fetch| fetch.should_skip(&(), n))
     }
 }
 
@@ -522,41 +675,45 @@ impl<'a, T: Fetch<'a>> Fetch<'a> for TryFetch<T> {
 /// ```
 pub struct Without<T, Q>(PhantomData<(Q, fn(T))>);
 
-impl<T: Component, Q: Query> Query for Without<T, Q> {
+impl<T: Component, Q: Query> Query for Without<T, Q>
+where
+    Q::Fetch: for<'a> Fetch<'a, State = ()>,
+{
     type Fetch = FetchWithout<T, Q::Fetch>;
 }
 
 #[doc(hidden)]
 pub struct FetchWithout<T, F>(F, PhantomData<fn(T)>);
-unsafe impl<'a, T: Component, F: Fetch<'a>> ReadOnlyFetch for FetchWithout<T, F> where
+unsafe impl<'a, T: Component, F: Fetch<'a, State = ()>> ReadOnlyFetch for FetchWithout<T, F> where
     F: ReadOnlyFetch
 {
 }
 impl<T, F> UnfilteredFetch for FetchWithout<T, F> where F: UnfilteredFetch {}
 
-impl<'a, T: Component, F: Fetch<'a>> Fetch<'a> for FetchWithout<T, F> {
+impl<'a, T: Component, F: Fetch<'a, State = ()>> Fetch<'a> for FetchWithout<T, F> {
     type Item = F::Item;
+    type State = ();
 
     const DANGLING: Self = Self(F::DANGLING, PhantomData);
 
     #[inline]
-    fn access() -> QueryAccess {
-        QueryAccess::without::<T>(F::access())
+    fn access(_state: &Self::State) -> QueryAccess {
+        QueryAccess::without::<T>(F::access(&()))
     }
 
-    unsafe fn get(archetype: &'a Archetype, offset: usize) -> Option<Self> {
+    unsafe fn get(_state: &Self::State, archetype: &'a Archetype, offset: usize) -> Option<Self> {
         if archetype.has::<T>() {
             return None;
         }
-        Some(Self(F::get(archetype, offset)?, PhantomData))
+        Some(Self(F::get(&(), archetype, offset)?, PhantomData))
     }
 
-    unsafe fn fetch(&self, n: usize) -> F::Item {
-        self.0.fetch(n)
+    unsafe fn fetch(&self, _state: &Self::State, n: usize) -> F::Item {
+        self.0.fetch(&(), n)
     }
 
-    unsafe fn should_skip(&self, n: usize) -> bool {
-        self.0.should_skip(n)
+    unsafe fn should_skip(&self, _state: &Self::State, n: usize) -> bool {
+        self.0.should_skip(&(), n)
     }
 }
 
@@ -580,7 +737,10 @@ impl<'a, T: Component, F: Fetch<'a>> Fetch<'a> for FetchWithout<T, F> {
 /// ```
 pub struct With<T, Q>(PhantomData<(Q, fn(T))>);
 
-impl<T: Component, Q: Query> Query for With<T, Q> {
+impl<T: Component, Q: Query> Query for With<T, Q>
+where
+    Q::Fetch: for<'a> Fetch<'a, State = ()>,
+{
     type Fetch = FetchWith<T, Q::Fetch>;
 }
 
@@ -589,29 +749,30 @@ pub struct FetchWith<T, F>(F, PhantomData<fn(T)>);
 unsafe impl<'a, T: Component, F: Fetch<'a>> ReadOnlyFetch for FetchWith<T, F> where F: ReadOnlyFetch {}
 impl<T, F> UnfilteredFetch for FetchWith<T, F> where F: UnfilteredFetch {}
 
-impl<'a, T: Component, F: Fetch<'a>> Fetch<'a> for FetchWith<T, F> {
+impl<'a, T: Component, F: Fetch<'a, State = ()>> Fetch<'a> for FetchWith<T, F> {
     type Item = F::Item;
+    type State = ();
 
     const DANGLING: Self = Self(F::DANGLING, PhantomData);
 
     #[inline]
-    fn access() -> QueryAccess {
-        QueryAccess::with::<T>(F::access())
+    fn access(_state: &Self::State) -> QueryAccess {
+        QueryAccess::with::<T>(F::access(&()))
     }
 
-    unsafe fn get(archetype: &'a Archetype, offset: usize) -> Option<Self> {
+    unsafe fn get(_state: &Self::State, archetype: &'a Archetype, offset: usize) -> Option<Self> {
         if !archetype.has::<T>() {
             return None;
         }
-        Some(Self(F::get(archetype, offset)?, PhantomData))
+        Some(Self(F::get(&(), archetype, offset)?, PhantomData))
     }
 
-    unsafe fn fetch(&self, n: usize) -> F::Item {
-        self.0.fetch(n)
+    unsafe fn fetch(&self, _state: &Self::State, n: usize) -> F::Item {
+        self.0.fetch(&(), n)
     }
 
-    unsafe fn should_skip(&self, n: usize) -> bool {
-        self.0.should_skip(n)
+    unsafe fn should_skip(&self, _state: &Self::State, n: usize) -> bool {
+        self.0.should_skip(&(), n)
     }
 }
 
@@ -621,14 +782,15 @@ struct ChunkInfo<Q: Query> {
 }
 
 /// Iterator over the set of entities with the components in `Q`
-pub struct QueryIter<'w, Q: Query> {
+pub struct QueryIter<'s, 'w, Q: Query, S> {
     archetypes: &'w [Archetype],
     archetype_index: usize,
     chunk_info: ChunkInfo<Q>,
     chunk_position: usize,
+    state: &'s S,
 }
 
-impl<'w, Q: Query> QueryIter<'w, Q> {
+impl<'s, 'w, Q: Query, S> QueryIter<'s, 'w, Q, S> {
     // #[allow(clippy::declare_interior_mutable_const)] // no trait bounds on const fns
     // const EMPTY: Q::Fetch = Q::Fetch::DANGLING;
     const EMPTY: ChunkInfo<Q> = ChunkInfo {
@@ -638,17 +800,21 @@ impl<'w, Q: Query> QueryIter<'w, Q> {
 
     /// Creates a new QueryIter
     #[inline]
-    pub(crate) fn new(archetypes: &'w [Archetype]) -> Self {
+    pub(crate) fn new(archetypes: &'w [Archetype], state: &'s S) -> Self {
         Self {
             archetypes,
             archetype_index: 0,
             chunk_info: Self::EMPTY,
             chunk_position: 0,
+            state,
         }
     }
 }
 
-impl<'w, Q: Query> Iterator for QueryIter<'w, Q> {
+impl<'s, 'w, Q: Query, S> Iterator for QueryIter<'s, 'w, Q, S>
+where
+    Q::Fetch: for<'a> Fetch<'a, State = S>,
+{
     type Item = <Q::Fetch as Fetch<'w>>::Item;
 
     #[inline]
@@ -659,7 +825,7 @@ impl<'w, Q: Query> Iterator for QueryIter<'w, Q> {
                     let archetype = self.archetypes.get(self.archetype_index)?;
                     self.archetype_index += 1;
                     self.chunk_position = 0;
-                    self.chunk_info = Q::Fetch::get(archetype, 0)
+                    self.chunk_info = Q::Fetch::get(self.state, archetype, 0)
                         .map(|fetch| ChunkInfo {
                             fetch,
                             len: archetype.len(),
@@ -671,13 +837,17 @@ impl<'w, Q: Query> Iterator for QueryIter<'w, Q> {
                 if self
                     .chunk_info
                     .fetch
-                    .should_skip(self.chunk_position as usize)
+                    .should_skip(self.state, self.chunk_position as usize)
                 {
                     self.chunk_position += 1;
                     continue;
                 }
 
-                let item = Some(self.chunk_info.fetch.fetch(self.chunk_position as usize));
+                let item = Some(
+                    self.chunk_info
+                        .fetch
+                        .fetch(self.state, self.chunk_position as usize),
+                );
                 self.chunk_position += 1;
                 return item;
             }
@@ -687,38 +857,42 @@ impl<'w, Q: Query> Iterator for QueryIter<'w, Q> {
 
 // if the Fetch is an UnfilteredFetch, then we can cheaply compute the length of the query by getting
 // the length of each matching archetype
-impl<'w, Q: Query> ExactSizeIterator for QueryIter<'w, Q>
+impl<'s, 'w, Q: Query, S> ExactSizeIterator for QueryIter<'s, 'w, Q, S>
 where
-    Q::Fetch: UnfilteredFetch,
+    Q::Fetch: UnfilteredFetch + for<'a> Fetch<'a, State = S>,
 {
     fn len(&self) -> usize {
         self.archetypes
             .iter()
-            .filter(|&archetype| unsafe { Q::Fetch::get(archetype, 0).is_some() })
+            .filter(|&archetype| unsafe { Q::Fetch::get(self.state, archetype, 0).is_some() })
             .map(|x| x.len())
             .sum()
     }
 }
 
-struct ChunkIter<Q: Query> {
+struct ChunkIter<'s, Q: Query, S> {
     fetch: Q::Fetch,
     position: usize,
     len: usize,
+    state: &'s S,
 }
 
-impl<Q: Query> ChunkIter<Q> {
+impl<'s, Q: Query, S> ChunkIter<'s, Q, S>
+where
+    Q::Fetch: for<'a> Fetch<'a, State = S>,
+{
     unsafe fn next<'a>(&mut self) -> Option<<Q::Fetch as Fetch<'a>>::Item> {
         loop {
             if self.position == self.len {
                 return None;
             }
 
-            if self.fetch.should_skip(self.position as usize) {
+            if self.fetch.should_skip(self.state, self.position as usize) {
                 self.position += 1;
                 continue;
             }
 
-            let item = Some(self.fetch.fetch(self.position as usize));
+            let item = Some(self.fetch.fetch(self.state, self.position as usize));
             self.position += 1;
             return item;
         }
@@ -726,31 +900,36 @@ impl<Q: Query> ChunkIter<Q> {
 }
 
 /// Batched version of `QueryIter`
-pub struct BatchedIter<'w, Q: Query> {
+pub struct BatchedIter<'s, 'w, Q: Query, S> {
     archetypes: &'w [Archetype],
     archetype_index: usize,
     batch_size: usize,
     batch: usize,
+    state: &'s S,
     _marker: PhantomData<Q>,
 }
 
-impl<'w, Q: Query> BatchedIter<'w, Q> {
-    pub(crate) fn new(archetypes: &'w [Archetype], batch_size: usize) -> Self {
+impl<'s, 'w, Q: Query, S> BatchedIter<'s, 'w, Q, S> {
+    pub(crate) fn new(archetypes: &'w [Archetype], batch_size: usize, state: &'s S) -> Self {
         Self {
             archetypes,
             archetype_index: 0,
             batch_size,
             batch: 0,
+            state,
             _marker: Default::default(),
         }
     }
 }
 
-unsafe impl<'w, Q: Query> Send for BatchedIter<'w, Q> {}
-unsafe impl<'w, Q: Query> Sync for BatchedIter<'w, Q> {}
+unsafe impl<'s, 'w, Q: Query, S> Send for BatchedIter<'s, 'w, Q, S> {}
+unsafe impl<'s, 'w, Q: Query, S> Sync for BatchedIter<'s, 'w, Q, S> {}
 
-impl<'w, Q: Query> Iterator for BatchedIter<'w, Q> {
-    type Item = Batch<'w, Q>;
+impl<'s, 'w, Q: Query, S: 's> Iterator for BatchedIter<'s, 'w, Q, S>
+where
+    Q::Fetch: for<'a> Fetch<'a, State = S>,
+{
+    type Item = Batch<'s, 'w, Q, S>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -761,7 +940,7 @@ impl<'w, Q: Query> Iterator for BatchedIter<'w, Q> {
                 self.batch = 0;
                 continue;
             }
-            if let Some(fetch) = unsafe { Q::Fetch::get(archetype, offset) } {
+            if let Some(fetch) = unsafe { Q::Fetch::get(self.state, archetype, offset) } {
                 self.batch += 1;
                 return Some(Batch {
                     _marker: PhantomData,
@@ -769,6 +948,7 @@ impl<'w, Q: Query> Iterator for BatchedIter<'w, Q> {
                         fetch,
                         position: 0,
                         len: self.batch_size.min(archetype.len() - offset),
+                        state: self.state,
                     },
                 });
             } else {
@@ -784,12 +964,15 @@ impl<'w, Q: Query> Iterator for BatchedIter<'w, Q> {
 }
 
 /// A sequence of entities yielded by `BatchedIter`
-pub struct Batch<'q, Q: Query> {
+pub struct Batch<'s, 'q, Q: Query, S> {
     _marker: PhantomData<&'q ()>,
-    state: ChunkIter<Q>,
+    state: ChunkIter<'s, Q, S>,
 }
 
-impl<'q, 'w, Q: Query> Iterator for Batch<'q, Q> {
+impl<'s, 'q, 'w, Q: Query, S> Iterator for Batch<'s, 'q, Q, S>
+where
+    Q::Fetch: for<'a> Fetch<'a, State = S>,
+{
     type Item = <Q::Fetch as Fetch<'q>>::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -798,43 +981,47 @@ impl<'q, 'w, Q: Query> Iterator for Batch<'q, Q> {
     }
 }
 
-unsafe impl<'q, Q: Query> Send for Batch<'q, Q> {}
-unsafe impl<'q, Q: Query> Sync for Batch<'q, Q> {}
+unsafe impl<'s, 'q, Q: Query, S> Send for Batch<'s, 'q, Q, S> {}
+unsafe impl<'s, 'q, Q: Query, S> Sync for Batch<'q, 's, Q, S> {}
 
 macro_rules! tuple_impl {
     ($($name: ident),*) => {
-        impl<'a, $($name: Fetch<'a>),*> Fetch<'a> for ($($name,)*) {
+        impl<'a, $($name: Fetch<'a, State = ()>),*> Fetch<'a> for ($($name,)*) {
             type Item = ($($name::Item,)*);
+            type State = ();
             const DANGLING: Self = ($($name::DANGLING,)*);
 
             #[allow(unused_variables, unused_mut)]
-            fn access() -> QueryAccess {
+            fn access(_state: &Self::State) -> QueryAccess {
                 QueryAccess::union(vec![
-                    $($name::access(),)*
+                    $($name::access(&()),)*
                 ])
             }
 
             #[allow(unused_variables)]
-            unsafe fn get(archetype: &'a Archetype, offset: usize) -> Option<Self> {
-                Some(($($name::get(archetype, offset)?,)*))
+            unsafe fn get(_state: &Self::State, archetype: &'a Archetype, offset: usize) -> Option<Self> {
+                Some(($($name::get(&(), archetype, offset)?,)*))
             }
 
             #[allow(unused_variables)]
-            unsafe fn fetch(&self, n: usize) -> Self::Item {
+            unsafe fn fetch(&self, _state: &Self::State, n: usize) -> Self::Item {
                 #[allow(non_snake_case)]
                 let ($($name,)*) = self;
-                ($($name.fetch(n),)*)
+                ($($name.fetch(&(), n),)*)
             }
 
             #[allow(unused_variables)]
-            unsafe fn should_skip(&self, n: usize) -> bool {
+            unsafe fn should_skip(&self, _state: &Self::State, n: usize) -> bool {
                 #[allow(non_snake_case)]
                 let ($($name,)*) = self;
-                $($name.should_skip(n)||)* false
+                $($name.should_skip(&(), n)||)* false
             }
         }
 
-        impl<$($name: Query),*> Query for ($($name,)*) {
+        impl<$($name: Query),*> Query for ($($name,)*)
+        where
+            $($name::Fetch: for<'a> Fetch<'a, State = ()>),*
+        {
             type Fetch = ($($name::Fetch,)*);
         }
 

--- a/crates/bevy_ecs/hecs/src/world.rs
+++ b/crates/bevy_ecs/hecs/src/world.rs
@@ -637,7 +637,7 @@ impl World {
             let arch = &mut self.archetypes[loc.archetype as usize];
             let mut info = arch.types().to_vec();
             for ty in components.type_info() {
-                #[cfg(feature = "dynamic-api")]
+                #[cfg(feature = "dynamic_api")]
                 // If this is a dynamic component
                 if let ComponentId::ExternalId(id) = ty.id() {
                     // If we've previously registered a component under this ID
@@ -1038,12 +1038,12 @@ impl From<MissingComponent> for ComponentError {
     }
 }
 
-#[cfg(feature = "dynamic-api")]
+#[cfg(feature = "dynamic_api")]
 use std::{cmp::Ordering, hash::Hasher};
 
 /// Uniquely identifies a type of component. This is conceptually similar to
 /// Rust's [`TypeId`], but allows for external type IDs to be defined.
-#[cfg(feature = "dynamic-api")]
+#[cfg(feature = "dynamic_api")]
 #[derive(Eq, PartialEq, Debug, Clone, Copy)]
 pub enum ComponentId {
     /// A Rust-native [`TypeId`]
@@ -1053,7 +1053,7 @@ pub enum ComponentId {
     ExternalId(u64),
 }
 
-#[cfg(feature = "dynamic-api")]
+#[cfg(feature = "dynamic_api")]
 #[allow(clippy::derive_hash_xor_eq)] // Fine because we uphold k1 == k2 ⇒ hash(k1) == hash(k2)
 impl Hash for ComponentId {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -1068,7 +1068,7 @@ impl Hash for ComponentId {
     }
 }
 
-#[cfg(feature = "dynamic-api")]
+#[cfg(feature = "dynamic_api")]
 impl Ord for ComponentId {
     fn cmp(&self, other: &Self) -> Ordering {
         if self == other {
@@ -1090,14 +1090,14 @@ impl Ord for ComponentId {
     }
 }
 
-#[cfg(feature = "dynamic-api")]
+#[cfg(feature = "dynamic_api")]
 impl PartialOrd for ComponentId {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-#[cfg(feature = "dynamic-api")]
+#[cfg(feature = "dynamic_api")]
 impl From<TypeId> for ComponentId {
     fn from(item: TypeId) -> Self {
         ComponentId::RustTypeId(item)
@@ -1106,12 +1106,12 @@ impl From<TypeId> for ComponentId {
 
 /// A component identifier
 ///
-/// Without the `dynamic-api` feature enabled, this is just a newtype around a Rust [`TypeId`].
-#[cfg(not(feature = "dynamic-api"))]
+/// Without the `dynamic_api` feature enabled, this is just a newtype around a Rust [`TypeId`].
+#[cfg(not(feature = "dynamic_api"))]
 #[derive(Eq, PartialEq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
 pub struct ComponentId(pub TypeId);
 
-#[cfg(not(feature = "dynamic-api"))]
+#[cfg(not(feature = "dynamic_api"))]
 impl From<TypeId> for ComponentId {
     fn from(item: TypeId) -> Self {
         ComponentId(item)
@@ -1264,7 +1264,7 @@ where
 mod test {
     #[test]
     #[should_panic(expected = "Attempted to insert dynamic component with a different layout")]
-    #[cfg(feature = "dynamic-api")]
+    #[cfg(feature = "dynamic_api")]
     fn inconsistent_dynamic_component_info_panics() {
         use super::*;
         use crate::EntityBuilder;

--- a/crates/bevy_ecs/src/resource/resource_query.rs
+++ b/crates/bevy_ecs/src/resource/resource_query.rs
@@ -219,7 +219,7 @@ impl<'a, T: Resource> FetchResource<'a> for FetchResourceRead<T> {
 
     fn access() -> TypeAccess<TypeId> {
         let mut access = TypeAccess::default();
-        access.add_read(TypeId::of::<T>());
+        access.add_read(TypeId::of::<T>().into());
         access
     }
 }
@@ -254,7 +254,7 @@ impl<'a, T: Resource> FetchResource<'a> for FetchResourceChanged<T> {
 
     fn access() -> TypeAccess<TypeId> {
         let mut access = TypeAccess::default();
-        access.add_read(TypeId::of::<T>());
+        access.add_read(TypeId::of::<T>().into());
         access
     }
 }
@@ -286,7 +286,7 @@ impl<'a, T: Resource> FetchResource<'a> for FetchResourceWrite<T> {
 
     fn access() -> TypeAccess<TypeId> {
         let mut access = TypeAccess::default();
-        access.add_write(TypeId::of::<T>());
+        access.add_write(TypeId::of::<T>().into());
         access
     }
 }
@@ -332,7 +332,7 @@ impl<'a, T: Resource + FromResources> FetchResource<'a> for FetchResourceLocalMu
 
     fn access() -> TypeAccess<TypeId> {
         let mut access = TypeAccess::default();
-        access.add_write(TypeId::of::<T>());
+        access.add_write(TypeId::of::<T>().into());
         access
     }
 }

--- a/crates/bevy_ecs/src/resource/resource_query.rs
+++ b/crates/bevy_ecs/src/resource/resource_query.rs
@@ -1,6 +1,6 @@
 use super::{FromResources, Resources};
 use crate::{system::SystemId, Resource, ResourceIndex};
-use bevy_hecs::{smaller_tuples_too, TypeAccess};
+use bevy_hecs::{smaller_tuples_too, ComponentId, TypeAccess};
 use core::{
     ops::{Deref, DerefMut},
     ptr::NonNull,
@@ -181,7 +181,7 @@ pub trait FetchResource<'a>: Sized {
     /// Type of value to be fetched
     type Item: UnsafeClone;
 
-    fn access() -> TypeAccess<TypeId>;
+    fn access() -> TypeAccess<ComponentId>;
     fn borrow(resources: &Resources);
     fn release(resources: &Resources);
 
@@ -217,7 +217,7 @@ impl<'a, T: Resource> FetchResource<'a> for FetchResourceRead<T> {
         resources.release::<T>();
     }
 
-    fn access() -> TypeAccess<TypeId> {
+    fn access() -> TypeAccess<ComponentId> {
         let mut access = TypeAccess::default();
         access.add_read(TypeId::of::<T>().into());
         access
@@ -252,7 +252,7 @@ impl<'a, T: Resource> FetchResource<'a> for FetchResourceChanged<T> {
         resources.release::<T>();
     }
 
-    fn access() -> TypeAccess<TypeId> {
+    fn access() -> TypeAccess<ComponentId> {
         let mut access = TypeAccess::default();
         access.add_read(TypeId::of::<T>().into());
         access
@@ -284,7 +284,7 @@ impl<'a, T: Resource> FetchResource<'a> for FetchResourceWrite<T> {
         resources.release_mut::<T>();
     }
 
-    fn access() -> TypeAccess<TypeId> {
+    fn access() -> TypeAccess<ComponentId> {
         let mut access = TypeAccess::default();
         access.add_write(TypeId::of::<T>().into());
         access
@@ -330,7 +330,7 @@ impl<'a, T: Resource + FromResources> FetchResource<'a> for FetchResourceLocalMu
         resources.release_mut::<T>();
     }
 
-    fn access() -> TypeAccess<TypeId> {
+    fn access() -> TypeAccess<ComponentId> {
         let mut access = TypeAccess::default();
         access.add_write(TypeId::of::<T>().into());
         access
@@ -363,7 +363,7 @@ macro_rules! tuple_impl {
             }
 
             #[allow(unused_mut)]
-            fn access() -> TypeAccess<TypeId> {
+            fn access() -> TypeAccess<ComponentId> {
                 let mut access = TypeAccess::default();
                 $(access.union(&$name::access());)*
                 access
@@ -424,7 +424,7 @@ macro_rules! tuple_impl_or {
             }
 
             #[allow(unused_mut)]
-            fn access() -> TypeAccess<TypeId> {
+            fn access() -> TypeAccess<ComponentId> {
                 let mut access = TypeAccess::default();
                 $(access.union(&$name::access());)*
                 access

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -1,6 +1,11 @@
 use crate::resource::Resources;
-use bevy_hecs::{ArchetypeComponent, TypeAccess, World};
-use std::{any::TypeId, borrow::Cow};
+use bevy_hecs::{ArchetypeComponent, ComponentId, TypeAccess, World};
+use std::borrow::Cow;
+
+#[cfg(feature = "dynamic-api")]
+use crate::StatefulQuery;
+#[cfg(feature = "dynamic-api")]
+use bevy_hecs::DynamicQuery;
 
 /// Determines the strategy used to run the `run_thread_local` function in a [System]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
@@ -25,9 +30,146 @@ pub trait System: Send + Sync {
     fn id(&self) -> SystemId;
     fn update(&mut self, world: &World);
     fn archetype_component_access(&self) -> &TypeAccess<ArchetypeComponent>;
-    fn resource_access(&self) -> &TypeAccess<TypeId>;
+    fn resource_access(&self) -> &TypeAccess<ComponentId>;
     fn thread_local_execution(&self) -> ThreadLocalExecution;
     fn run(&mut self, world: &World, resources: &Resources);
     fn run_thread_local(&mut self, world: &mut World, resources: &mut Resources);
     fn initialize(&mut self, _world: &mut World, _resources: &mut Resources) {}
+}
+
+#[cfg(feature = "dynamic-api")]
+pub struct DynamicSystem<S> {
+    pub name: String,
+    pub state: S,
+    system_id: SystemId,
+    system_archetype_component_access: TypeAccess<ArchetypeComponent>,
+    query_archetype_component_accesses: Vec<TypeAccess<ArchetypeComponent>>,
+    resource_access: TypeAccess<ComponentId>,
+    settings: DynamicSystemSettings<S>,
+}
+
+#[cfg(feature = "dynamic-api")]
+pub struct DynamicSystemSettings<S> {
+    pub workload: fn(&mut S, &Resources, &mut [StatefulQuery<DynamicQuery, DynamicQuery>]),
+    pub queries: Vec<DynamicQuery>,
+    pub thread_local_execution: ThreadLocalExecution,
+    pub thread_local_system: fn(&mut S, &mut World, &mut Resources),
+    pub init_function: fn(&mut S, &mut World, &mut Resources),
+    pub resource_access: TypeAccess<ComponentId>,
+}
+
+#[cfg(feature = "dynamic-api")]
+impl<S> Default for DynamicSystemSettings<S> {
+    fn default() -> Self {
+        Self {
+            workload: |_, _, _| (),
+            queries: Default::default(),
+            thread_local_execution: ThreadLocalExecution::NextFlush,
+            thread_local_system: |_, _, _| (),
+            init_function: |_, _, _| (),
+            resource_access: Default::default(),
+        }
+    }
+}
+
+#[cfg(feature = "dynamic-api")]
+impl<S> DynamicSystem<S> {
+    pub fn new(name: String, state: S) -> Self {
+        DynamicSystem {
+            name,
+            state,
+            system_id: SystemId::new(),
+            resource_access: Default::default(),
+            system_archetype_component_access: Default::default(),
+            query_archetype_component_accesses: Default::default(),
+            settings: Default::default(),
+        }
+    }
+
+    pub fn settings(mut self, settings: DynamicSystemSettings<S>) -> Self {
+        self.settings = settings;
+        self
+    }
+}
+
+#[cfg(feature = "dynamic-api")]
+impl<S: Send + Sync> System for DynamicSystem<S> {
+    fn name(&self) -> std::borrow::Cow<'static, str> {
+        self.name.clone().into()
+    }
+
+    fn id(&self) -> SystemId {
+        self.system_id
+    }
+
+    fn update(&mut self, world: &World) {
+        let Self {
+            query_archetype_component_accesses,
+            system_archetype_component_access,
+            settings,
+            ..
+        } = self;
+
+        // Clear previous archetype access list
+        system_archetype_component_access.clear();
+
+        for (query, component_access) in settings
+            .queries
+            .iter()
+            .zip(query_archetype_component_accesses.iter_mut())
+        {
+            // Update the component access with the archetypes in the world
+            component_access.clear();
+            query
+                .access
+                .get_world_archetype_access(world, Some(component_access));
+
+            // Make sure the query doesn't collide with any existing queries
+            if component_access
+                .get_conflict(system_archetype_component_access)
+                .is_some()
+            {
+                panic!("Dynamic system has conflicting queries.");
+            }
+        }
+    }
+
+    fn archetype_component_access(&self) -> &TypeAccess<ArchetypeComponent> {
+        &self.system_archetype_component_access
+    }
+
+    fn resource_access(&self) -> &TypeAccess<ComponentId> {
+        &self.resource_access
+    }
+
+    fn thread_local_execution(&self) -> ThreadLocalExecution {
+        self.settings.thread_local_execution
+    }
+
+    fn run(&mut self, world: &World, resources: &Resources) {
+        let mut queries = self
+            .settings
+            .queries
+            .iter()
+            .zip(self.query_archetype_component_accesses.iter())
+            // TODO: Try to avoid cloning the query here
+            .map(|(query, access)| StatefulQuery::new(world, access, query.clone()))
+            .collect::<Vec<_>>();
+
+        (self.settings.workload)(&mut self.state, resources, queries.as_mut_slice());
+    }
+
+    fn run_thread_local(&mut self, world: &mut World, resources: &mut Resources) {
+        (self.settings.thread_local_system)(&mut self.state, world, resources);
+    }
+
+    fn initialize(&mut self, world: &mut World, resources: &mut Resources) {
+        // Initialize the archetype component accesses with blank accesses
+        for _ in &self.settings.queries {
+            self.query_archetype_component_accesses
+                .push(TypeAccess::<ArchetypeComponent>::default());
+        }
+
+        (self.settings.init_function)(&mut self.state, world, resources);
+    }
 }

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -2,9 +2,9 @@ use crate::resource::Resources;
 use bevy_hecs::{ArchetypeComponent, ComponentId, TypeAccess, World};
 use std::borrow::Cow;
 
-#[cfg(feature = "dynamic-api")]
+#[cfg(feature = "dynamic_api")]
 use crate::StatefulQuery;
-#[cfg(feature = "dynamic-api")]
+#[cfg(feature = "dynamic_api")]
 use bevy_hecs::DynamicQuery;
 
 /// Determines the strategy used to run the `run_thread_local` function in a [System]
@@ -37,7 +37,7 @@ pub trait System: Send + Sync {
     fn initialize(&mut self, _world: &mut World, _resources: &mut Resources) {}
 }
 
-#[cfg(feature = "dynamic-api")]
+#[cfg(feature = "dynamic_api")]
 pub struct DynamicSystem<S> {
     pub name: String,
     pub state: S,
@@ -48,7 +48,7 @@ pub struct DynamicSystem<S> {
     settings: DynamicSystemSettings<S>,
 }
 
-#[cfg(feature = "dynamic-api")]
+#[cfg(feature = "dynamic_api")]
 pub struct DynamicSystemSettings<S> {
     pub workload: fn(&mut S, &Resources, &mut [StatefulQuery<DynamicQuery, DynamicQuery>]),
     pub queries: Vec<DynamicQuery>,
@@ -58,7 +58,7 @@ pub struct DynamicSystemSettings<S> {
     pub resource_access: TypeAccess<ComponentId>,
 }
 
-#[cfg(feature = "dynamic-api")]
+#[cfg(feature = "dynamic_api")]
 impl<S> Default for DynamicSystemSettings<S> {
     fn default() -> Self {
         Self {
@@ -72,7 +72,7 @@ impl<S> Default for DynamicSystemSettings<S> {
     }
 }
 
-#[cfg(feature = "dynamic-api")]
+#[cfg(feature = "dynamic_api")]
 impl<S> DynamicSystem<S> {
     pub fn new(name: String, state: S) -> Self {
         DynamicSystem {
@@ -92,7 +92,7 @@ impl<S> DynamicSystem<S> {
     }
 }
 
-#[cfg(feature = "dynamic-api")]
+#[cfg(feature = "dynamic_api")]
 impl<S: Send + Sync> System for DynamicSystem<S> {
     fn name(&self) -> std::borrow::Cow<'static, str> {
         self.name.clone().into()

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -210,11 +210,11 @@ impl<'a> FetchResource<'a> for FetchDrawContext {
 
     fn access() -> TypeAccess<TypeId> {
         let mut access = TypeAccess::default();
-        access.add_write(TypeId::of::<Assets<PipelineDescriptor>>());
-        access.add_write(TypeId::of::<Assets<Shader>>());
-        access.add_write(TypeId::of::<PipelineCompiler>());
-        access.add_read(TypeId::of::<Box<dyn RenderResourceContext>>());
-        access.add_read(TypeId::of::<SharedBuffers>());
+        access.add_write(TypeId::of::<Assets<PipelineDescriptor>>().into());
+        access.add_write(TypeId::of::<Assets<Shader>>().into());
+        access.add_write(TypeId::of::<PipelineCompiler>().into());
+        access.add_read(TypeId::of::<Box<dyn RenderResourceContext>>().into());
+        access.add_read(TypeId::of::<SharedBuffers>().into());
         access
     }
 }

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -11,8 +11,8 @@ use crate::{
 };
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::{
-    FetchResource, Query, Res, ResMut, ResourceIndex, ResourceQuery, Resources, SystemId,
-    TypeAccess, UnsafeClone,
+    ComponentId, FetchResource, Query, Res, ResMut, ResourceIndex, ResourceQuery, Resources,
+    SystemId, TypeAccess, UnsafeClone,
 };
 use bevy_property::Properties;
 use std::{any::TypeId, ops::Range, sync::Arc};
@@ -208,7 +208,7 @@ impl<'a> FetchResource<'a> for FetchDrawContext {
         }
     }
 
-    fn access() -> TypeAccess<TypeId> {
+    fn access() -> TypeAccess<ComponentId> {
         let mut access = TypeAccess::default();
         access.add_write(TypeId::of::<Assets<PipelineDescriptor>>().into());
         access.add_write(TypeId::of::<Assets<Shader>>().into());

--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 use bevy_asset::{Assets, Handle};
-use bevy_ecs::{HecsQuery, ReadOnlyFetch, Resources, World};
+use bevy_ecs::{Fetch, HecsQuery, ReadOnlyFetch, Resources, World};
 use std::{fmt, marker::PhantomData, ops::Deref};
 
 #[derive(Debug)]
@@ -141,7 +141,7 @@ impl<Q: HecsQuery> PassNode<Q> {
 
 impl<Q: HecsQuery + Send + Sync + 'static> Node for PassNode<Q>
 where
-    Q::Fetch: ReadOnlyFetch,
+    Q::Fetch: ReadOnlyFetch + for<'a> Fetch<'a, State = ()>,
 {
     fn input(&self) -> &[ResourceSlotInfo] {
         &self.inputs

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT"
 keywords = ["bevy"]
 
+[features]
+dynamic-api = ["bevy_ecs/dynamic-api"]
+
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.3.0" }

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 keywords = ["bevy"]
 
 [features]
-dynamic-api = ["bevy_ecs/dynamic-api"]
+dynamic_api = ["bevy_ecs/dynamic_api"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -1,6 +1,6 @@
 use crate::{serde::SceneSerializer, Scene};
 use anyhow::Result;
-#[cfg(feature = "dynamic-api")]
+#[cfg(feature = "dynamic_api")]
 use bevy_ecs::ComponentId;
 use bevy_ecs::{EntityMap, Resources, World};
 use bevy_property::{DynamicProperties, PropertyTypeRegistry};
@@ -42,14 +42,14 @@ impl DynamicScene {
                     })
                 }
                 for type_info in archetype.types() {
-                    #[cfg(feature = "dynamic-api")]
+                    #[cfg(feature = "dynamic_api")]
                     let id = match type_info.id() {
                         ComponentId::RustTypeId(id) => id,
                         ComponentId::ExternalId(_) => {
                             todo!("Handle external type ids in Bevy scene")
                         }
                     };
-                    #[cfg(not(feature = "dynamic-api"))]
+                    #[cfg(not(feature = "dynamic_api"))]
                     let id = type_info.id().0;
 
                     if let Some(component_registration) = component_registry.get(&id) {

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -1,7 +1,7 @@
 use crate::{DynamicScene, Scene};
 use bevy_app::prelude::*;
 use bevy_asset::{AssetEvent, Assets, Handle};
-#[cfg(feature = "dynamic-api")]
+#[cfg(feature = "dynamic_api")]
 use bevy_ecs::ComponentId;
 use bevy_ecs::{EntityMap, Resources, World};
 use bevy_type_registry::TypeRegistry;
@@ -163,14 +163,14 @@ impl SceneSpawner {
                     .entry(*scene_entity)
                     .or_insert_with(|| world.reserve_entity());
                 for type_info in archetype.types() {
-                    #[cfg(feature = "dynamic-api")]
+                    #[cfg(feature = "dynamic_api")]
                     let id = match type_info.id() {
                         ComponentId::RustTypeId(id) => id,
                         ComponentId::ExternalId(_) => {
                             todo!("Handle external type ids in Bevy scene")
                         }
                     };
-                    #[cfg(not(feature = "dynamic-api"))]
+                    #[cfg(not(feature = "dynamic_api"))]
                     let id = type_info.id().0;
 
                     if let Some(component_registration) = component_registry.get(&id) {

--- a/examples/ecs/dynamic_components.rs
+++ b/examples/ecs/dynamic_components.rs
@@ -1,0 +1,159 @@
+//! This example demonstrates how to create systems and queryies for those systems at runtime
+//!
+//! The primary use-case for doing so would be allow for integrations with scripting languages,
+//! where you do no have the information about what systems exist or what queries they will make.
+//!
+//! In this example the components are `repr(C)` Rust structs that are spawned from Rust code. To
+//! see how to also spawn entities with runtime created Components check out the
+
+use std::{alloc::Layout, time::Duration};
+
+use bevy::prelude::*;
+use bevy_app::{RunMode, ScheduleRunnerPlugin, ScheduleRunnerSettings};
+use bevy_ecs::{
+    DynamicQuery, DynamicSystem, DynamicSystemSettings, EntityBuilder, QueryAccess, TypeInfo,
+};
+
+// Set our component IDs. These should probably be hashes of a human-friendly but unique type
+// identifier, depending on your scripting implementation needs. These identifiers should have data
+// in the last 7 bits. See this comment for more info:
+// https://users.rust-lang.org/t/requirements-for-hashes-in-hashbrown-hashmaps/50567/2?u=zicklag.
+const POS_COMPONENT_ID: u64 = 242237625853274575;
+const VEL_COMPONENT_ID: u64 = 6820197023594215835;
+
+lazy_static::lazy_static! {
+    static ref POS_INFO: TypeInfo = TypeInfo::of_external(
+        POS_COMPONENT_ID,
+        Layout::from_size_align(2, 1).unwrap(),
+        |_| (),
+    );
+
+    static ref VEL_INFO: TypeInfo = TypeInfo::of_external(
+        VEL_COMPONENT_ID,
+        Layout::from_size_align(2, 1).unwrap(),
+        |_| (),
+    );
+}
+
+/// Create a system for spawning the scene
+fn spawn_scene(world: &mut World, _resources: &mut Resources) {
+    // Here we will spawn our dynamically created components
+
+    // For each entity we want to create, we must create an `EntityBuilder` that contains all of
+    // that entity's components. We're going to create a couple entities, each with two components,
+    // one representing a Position and one representing a Velocity. Each of these will be made up of
+    // two bytes for simplicity, one representing the x and y position/velocity.
+
+    // We create our first entity
+    let mut builder = EntityBuilder::new();
+    // Then we add our "Position component"
+    let entity1 = builder
+        .add_dynamic(
+            // We must specify the component information
+            *POS_INFO,
+            // And provide the raw byte data data for the component
+            vec![
+                0, // X position byte
+                0, // Y position byte
+            ]
+            .as_slice(),
+        )
+        // Next we add our "Velocity component"
+        .add_dynamic(
+            *VEL_INFO,
+            vec![
+                0, // X position byte
+                1, // Y position byte
+            ]
+            .as_slice(),
+        )
+        .build();
+
+    // And let's create another entity
+    let mut builder = EntityBuilder::new();
+    let entity2 = builder
+        .add_dynamic(
+            *POS_INFO,
+            vec![
+                0, // X position byte
+                0, // Y position byte
+            ]
+            .as_slice(),
+        )
+        .add_dynamic(
+            *VEL_INFO,
+            vec![
+                2, // X position byte
+                0, // Y position byte
+            ]
+            .as_slice(),
+        )
+        .build();
+
+    // Now we can spawn our entities
+    world.spawn(entity1);
+    world.spawn(entity2);
+}
+
+fn main() {
+    // A Dynamic component query which can be constructed at runtime to represent which components
+    // we want a dynamic system to access.
+    //
+    // Notice that the sizes and IDs of the components can be specified at runtime and allow for
+    // storage of any data as an array of bytes.
+    let mut query = DynamicQuery::default();
+
+    // First we add the info for the components we'll be querying and get their component ids
+    let pos_id = query.register_info(*POS_INFO);
+    let vel_id = query.register_info(*VEL_INFO);
+
+    // Then we structure our query based on the relationships between the components that we want to
+    // query
+    query.access = QueryAccess::Union(vec![
+        QueryAccess::Read(vel_id, "velocity"),
+        QueryAccess::Write(pos_id, "position"),
+    ]);
+
+    // Create a dynamic system with the query we constructed
+    let pos_vel_system =
+        DynamicSystem::new("pos_vel_system".into(), () /* system local state */).settings(
+            DynamicSystemSettings {
+                queries: vec![query],
+                workload: |_state, _resources, queries| {
+                    // Print a spacer
+                    println!("-----");
+
+                    // Iterate over the query
+                    for mut components in queries[0].iter_mut() {
+                        // Would panic if we had not set `query.entity = true`
+                        let entity = components.entity;
+                        let pos_bytes = components.mutable.get_mut(&POS_INFO.id()).unwrap();
+                        let vel_bytes = components.immutable.get(&VEL_INFO.id()).unwrap();
+
+                        // Add the X velocity to the X position
+                        pos_bytes[0] += vel_bytes[0];
+                        // And the same with the Y
+                        pos_bytes[1] += vel_bytes[1];
+
+                        // Print out the position and velocity
+                        println!(
+                            "Entity: {:?}\tPosition: {:?}\tVelocity: {:?}",
+                            entity, pos_bytes, vel_bytes
+                        );
+                    }
+                },
+                ..Default::default()
+            },
+        );
+
+    App::build()
+        .add_resource(ScheduleRunnerSettings {
+            run_mode: RunMode::Loop {
+                wait: Some(Duration::from_secs(1)),
+            },
+        })
+        .add_plugin(ScheduleRunnerPlugin::default())
+        .add_startup_system(spawn_scene.thread_local_system())
+        .add_system(Box::new(pos_vel_system))
+        .run();
+}

--- a/examples/ecs/dynamic_systems.rs
+++ b/examples/ecs/dynamic_systems.rs
@@ -1,0 +1,153 @@
+//! This example demonstrates how to create systems and queries at runtime
+//!
+//! The primary use-case for doing so would be allow for integrations with scripting languages,
+//! where you do no have the information about what systems exist, or what queries they will make,
+//! at compile time.
+//!
+//! In this example the components are Rust structs that are spawned from Rust code. To see how to
+//! also spawn entities with runtime created Components check out the `dynamic_components` example.
+
+use std::time::Duration;
+
+use bevy::prelude::*;
+use bevy_app::{RunMode, ScheduleRunnerPlugin, ScheduleRunnerSettings};
+use bevy_ecs::{DynamicQuery, DynamicSystem, DynamicSystemSettings, QueryAccess, TypeInfo};
+
+lazy_static::lazy_static! {
+    static ref POS_INFO: TypeInfo = TypeInfo::of::<Pos>();
+    static ref VEL_INFO: TypeInfo = TypeInfo::of::<Vel>();
+}
+
+// Define our components
+
+#[derive(Debug, Clone, Copy)]
+struct Pos {
+    x: f32,
+    y: f32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Vel {
+    x: f32,
+    y: f32,
+}
+
+/// Create a system for spawning the scene
+fn spawn_scene(world: &mut World, _resources: &mut Resources) {
+    #[rustfmt::skip]
+    world.spawn_batch(vec![
+        (
+            Pos {
+                x: 0.,
+                y: 0.
+            },
+            Vel {
+                x: 0.,
+                y: -1.,
+            }
+        ),
+        (
+            Pos {
+                x: 0.,
+                y: 0.
+            },
+            Vel {
+                x: 0.,
+                y: 1.,
+            }
+        ),
+        (
+            Pos {
+                x: 1.,
+                y: 1.
+            },
+            Vel {
+                x: -0.5,
+                y: 0.5,
+            }
+        ),
+    ]);
+}
+
+fn main() {
+    // Create a DynamicQuery which can be to outline which components we want a dynamic system to
+    // access.
+    //
+    // Notice that the sizes and IDs of the components must be specified at runtime but this allows
+    // for storage of any data type as an array of bytes.
+    let mut query = DynamicQuery::default();
+
+    // First we add the info for the components we'll be querying and get their component ids
+    let pos_id = query.register_info(*POS_INFO);
+    let vel_id = query.register_info(*VEL_INFO);
+
+    // Then we structure our query based on the relationships between the components that we want to
+    // query
+    query.access = QueryAccess::union(vec![
+        QueryAccess::Read(vel_id, "velocity"),
+        QueryAccess::Write(pos_id, "position"),
+    ]);
+
+    // Create a dynamic system
+    let pos_vel_system = DynamicSystem::new(
+        "pos_vel_system".into(),
+        (), /* system local state, can be any type */
+    )
+    .settings(
+        // Specify the settings for our dynamic system
+        DynamicSystemSettings {
+            // Specify all of our queries
+            queries: vec![
+                // In this case we only have one query, but there could be multiple
+                query,
+            ],
+            workload: |_state, _resources, queries| {
+                println!("-----");
+                // Iterate over the first ( and only ) query and get the component results
+                for mut components in queries[0].iter_mut() {
+                    let pos_id = POS_INFO.id();
+                    let vel_id = VEL_INFO.id();
+                    // We reference the slices from our mutable and immutable components vectors. The
+                    // indices of the components in the vectors will correspond to the indices that
+                    // they were at in the query we created earlier.
+                    let pos_bytes = components.mutable.get_mut(&pos_id).unwrap();
+                    let vel_bytes = components.immutable.get(&vel_id).unwrap();
+
+                    // Here we have a couple of utility functions to cast the slices back to their
+                    // original types.
+                    unsafe fn from_slice_mut<T>(s: &mut [u8]) -> &mut T {
+                        debug_assert_eq!(std::mem::size_of::<T>(), s.len());
+                        &mut *(s.as_mut_ptr() as *mut T)
+                    }
+                    unsafe fn from_slice<T>(s: &[u8]) -> &T {
+                        debug_assert_eq!(std::mem::size_of::<T>(), s.len());
+                        &*(s.as_ptr() as *mut T)
+                    }
+
+                    // Instead of interacting with the raw bytes of our components, we first cast them to
+                    // their Rust structs
+                    let mut pos: &mut Pos = unsafe { from_slice_mut(pos_bytes) };
+                    let vel: &Vel = unsafe { from_slice(vel_bytes) };
+
+                    // Now we can operate on our components like we would normally in Rust
+                    pos.x += vel.x;
+                    pos.y += vel.y;
+
+                    println!("{:?}\t\t{:?}", pos, vel);
+                }
+            },
+            ..Default::default()
+        },
+    );
+
+    App::build()
+        .add_resource(ScheduleRunnerSettings {
+            run_mode: RunMode::Loop {
+                wait: Some(Duration::from_secs(1)),
+            },
+        })
+        .add_plugin(ScheduleRunnerPlugin::default())
+        .add_startup_system(spawn_scene.thread_local_system())
+        .add_system(Box::new(pos_vel_system))
+        .run();
+}


### PR DESCRIPTION
**Related to:** #32
**Resolves:** #142

> **Note:** How this is related to #32 ( `StableTypeId` discussion ) this is related to #32 because it changes the `TypeId` struct used to identify components, but it does not directly address the problem of dynamic loading of *Rust* plugins. See https://github.com/bevyengine/bevy/issues/32#issuecomment-703303754.

This PR will attempt to establish the ability to create systems and components that have been determined at runtime instead of compile time. I'm going to try to implement this in one PR because I won't be sure about the sufficiency of the design until I actually get a working example of a dynamically registered system and component ( which I will include with this PR ).

> **Note:** If we want to merge pieces of this PR one at a time, I am perfectly fine with that. I am making sure that each step is cleanly separated into it's own commit and can easily be ported to an individual PR.

I'm going to try to attack this problem one step at a time:

## Steps

### Non-Rust Component Ids

**Status:** Completed in commit: "Implement Custom Component Ids"

Currently bevy_hecs uses `std::any::TypeId` to uniquely identify the component IDs, but this does not allow us to define components that have a non-Rust origin. The first commit in the PR has migrated all of the internals of the bevy ECS to use a new `ComponentId` instead that is defined as:

```rust
/// Uniquely identifies a type of component. This is conceptually similar to
/// Rust's [`TypeId`], but allows for external type IDs to be defined.
#[derive(Eq, PartialEq, Hash, Debug, Clone, Copy)]
pub enum ComponentId {
    /// A Rust-native [`TypeId`]
    RustTypeId(TypeId),
    /// An arbitrary ID that allows you to identify types defined outside of
    /// this Rust compilation
    ExternalId(u64),
}
```

### Establish Dynamic Queries

**Status:** Completed in commit: "Implement Dynamic Systems"

This adds a new state type parameter to the `Fetch` trait. This allows compile-time constructed queries like to be constructed with `State = ()` and runtime constructed queries with the state parameter set to a `DynamicComponentQuery`.

### Establish Dynamic Component Insertion

**Status:** Completed in commit: "Add Dynamic Component Support"

This adds a new implementation of the `Bundle` trait, `RuntimeBundle` which can be used to insert untyped components at runtime by providing a buffer of bytes and the required type information.

### Create Examples

**Status:** Completed in respective commits

We also have new examples for [dynamic_systems](https://github.com/bevyengine/bevy/pull/623/files#diff-777410c396be88b0799383c2a72f84b58bab5b9e00b5ffa90cc8eb0b5ea61b54) and [dynamic_components](https://github.com/bevyengine/bevy/pull/623/files#diff-c61f4d14067644eaf8d54a034df564c56adb139ce774e63d218f95f66b69c709).

## Remaining Work

The biggest thing necessary at this point is a solid review. There's a lot of code changed, but thankfully not a ton of new logic. The bulk of the changes are repetitive changes required to add the necessary type parameters and such for the new `Fetch` `State type parameter.

Otherwise, there are a couple of `todo!()`'s in `bevy_scene` because I don't know enough about the Bevy scene architecture to integrate scenes with external components yet. I think that could reasonably be left to a separate PR, but I'm fine either way.