### PR TITLE
Make Changed, Mutated and Added work on Queries

### DIFF
--- a/crates/bevy_ecs/hecs/src/query.rs
+++ b/crates/bevy_ecs/hecs/src/query.rs
@@ -367,7 +367,7 @@ impl_or_query!(Q1, Q2, Q3, Q4, Q5, Q6, Q7, Q8, Q9, Q10);
 ///     *b += 1;
 /// }
 /// let components = world
-///     .query_mut::<Or<(Mutated<bool>, Mutated<i32>, Mutated<f64>, Mutated<Option<i32>>)>>()
+///     .query_mut::<Or<(Mutated<&bool>, Mutated<&i32>, Mutated<&f64>, Mutated<&Option<i32>>)>>()
 ///     .iter()
 ///     .map(|(b, i, f, o)| (*b, *i))
 ///     .collect::<Vec<_>>();

--- a/crates/bevy_ecs/hecs/tests/tests.rs
+++ b/crates/bevy_ecs/hecs/tests/tests.rs
@@ -372,14 +372,14 @@ fn added_tracking() {
     let a = world.spawn((123,));
 
     assert_eq!(world.query::<&i32>().iter().count(), 1);
-    assert_eq!(world.query::<Added<i32>>().iter().count(), 1);
+    assert_eq!(world.query::<Added<&i32>>().iter().count(), 1);
     assert_eq!(world.query_mut::<&i32>().iter().count(), 1);
-    assert_eq!(world.query_mut::<Added<i32>>().iter().count(), 1);
+    assert_eq!(world.query_mut::<Added<&i32>>().iter().count(), 1);
     assert!(world.query_one::<&i32>(a).unwrap().get().is_some());
-    assert!(world.query_one::<Added<i32>>(a).unwrap().get().is_some());
+    assert!(world.query_one::<Added<&i32>>(a).unwrap().get().is_some());
     assert!(world.query_one_mut::<&i32>(a).unwrap().get().is_some());
     assert!(world
-        .query_one_mut::<Added<i32>>(a)
+        .query_one_mut::<Added<&i32>>(a)
         .unwrap()
         .get()
         .is_some());
@@ -387,12 +387,12 @@ fn added_tracking() {
     world.clear_trackers();
 
     assert_eq!(world.query::<&i32>().iter().count(), 1);
-    assert_eq!(world.query::<Added<i32>>().iter().count(), 0);
+    assert_eq!(world.query::<Added<&i32>>().iter().count(), 0);
     assert_eq!(world.query_mut::<&i32>().iter().count(), 1);
-    assert_eq!(world.query_mut::<Added<i32>>().iter().count(), 0);
+    assert_eq!(world.query_mut::<Added<&i32>>().iter().count(), 0);
     assert!(world.query_one_mut::<&i32>(a).unwrap().get().is_some());
     assert!(world
-        .query_one_mut::<Added<i32>>(a)
+        .query_one_mut::<Added<&i32>>(a)
         .unwrap()
         .get()
         .is_none());

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -39,7 +39,7 @@ pub fn camera_system<T: CameraProjection + Component>(
     window_created_events: Res<Events<WindowCreated>>,
     windows: Res<Windows>,
     mut query: Query<(Entity, &mut Camera, &mut T)>,
-    mut query_added: Query<(Entity, Added<Camera>)>,
+    mut query_added: Query<(Entity, Added<&Camera>)>,
 ) {
     let mut changed_window_ids = Vec::new();
     // handle resize events. latest events are handled first because we only want to resize each window once

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -161,9 +161,9 @@ pub fn flex_node_system(
     windows: Res<Windows>,
     mut flex_surface: ResMut<FlexSurface>,
     mut root_node_query: Query<With<Node, Without<Parent, Entity>>>,
-    mut node_query: Query<With<Node, (Entity, Changed<Style>, Option<&CalculatedSize>)>>,
-    mut changed_size_query: Query<With<Node, (Entity, &Style, Changed<CalculatedSize>)>>,
-    mut children_query: Query<With<Node, (Entity, Changed<Children>)>>,
+    mut node_query: Query<With<Node, (Entity, Changed<&Style>, Option<&CalculatedSize>)>>,
+    mut changed_size_query: Query<With<Node, (Entity, &Style, Changed<&CalculatedSize>)>>,
+    mut children_query: Query<With<Node, (Entity, Changed<&Children>)>>,
     mut node_transform_query: Query<(Entity, &mut Node, &mut Transform, Option<&Parent>)>,
 ) {
     // update window root nodes

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -30,7 +30,7 @@ pub fn text_system(
     fonts: Res<Assets<Font>>,
     mut font_atlas_sets: ResMut<Assets<FontAtlasSet>>,
     mut texture_atlases: ResMut<Assets<TextureAtlas>>,
-    mut query: Query<(Entity, Changed<Text>, &mut CalculatedSize)>,
+    mut query: Query<(Entity, Changed<&Text>, &mut CalculatedSize)>,
     mut text_query: Query<(&Text, &mut CalculatedSize)>,
 ) {
     // add queued text to atlases

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -65,7 +65,7 @@ fn load_scene_system(asset_server: Res<AssetServer>, mut scene_spawner: ResMut<S
 
 // This system prints all ComponentA components in our world. Try making a change to a ComponentA in load_scene_example.scn.
 // You should immediately see the changes appear in the console.
-fn print_system(mut query: Query<(Entity, Changed<ComponentA>)>) {
+fn print_system(mut query: Query<(Entity, Changed<&ComponentA>)>) {
     for (entity, component_a) in &mut query.iter() {
         println!("  Entity({})", entity.id());
         println!(

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -31,7 +31,7 @@ fn button_system(
     button_materials: Res<ButtonMaterials>,
     mut interaction_query: Query<(
         &Button,
-        Mutated<Interaction>,
+        Mutated<&Interaction>,
         &mut Handle<ColorMaterial>,
         &Children,
     )>,


### PR DESCRIPTION
This allows you to use `Changed<&mut T>`, for example.

In theory, Changed, Added and Mutated could be abstracted over
but the savings in typing is probably counteracted by the
amount of added complexity.