### PR TITLE
Exposing winit decorations

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -39,7 +39,6 @@ pub struct Window {
     pub title: String,
     pub vsync: bool,
     pub resizable: bool,
-    #[cfg(not(target_arch = "wasm32"))]
     pub decorations: bool,
     pub mode: WindowMode,
     #[cfg(target_arch = "wasm32")]
@@ -67,7 +66,6 @@ impl Window {
             title: window_descriptor.title.clone(),
             vsync: window_descriptor.vsync,
             resizable: window_descriptor.resizable,
-            #[cfg(not(target_arch = "wasm32"))]
             decorations: window_descriptor.decorations,
             mode: window_descriptor.mode,
             #[cfg(target_arch = "wasm32")]
@@ -84,7 +82,6 @@ pub struct WindowDescriptor {
     pub title: String,
     pub vsync: bool,
     pub resizable: bool,
-    #[cfg(not(target_arch = "wasm32"))]
     pub decorations: bool,
     pub mode: WindowMode,
     #[cfg(target_arch = "wasm32")]
@@ -104,7 +101,6 @@ impl Default for WindowDescriptor {
             height: 720,
             vsync: true,
             resizable: true,
-            #[cfg(not(target_arch = "wasm32"))]
             decorations: true,
             mode: WindowMode::Windowed,
             #[cfg(target_arch = "wasm32")]

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -39,6 +39,8 @@ pub struct Window {
     pub title: String,
     pub vsync: bool,
     pub resizable: bool,
+    #[cfg(not(target_arch = "wasm32"))]
+    pub decorations: bool,
     pub mode: WindowMode,
     #[cfg(target_arch = "wasm32")]
     pub canvas: Option<String>,
@@ -65,6 +67,8 @@ impl Window {
             title: window_descriptor.title.clone(),
             vsync: window_descriptor.vsync,
             resizable: window_descriptor.resizable,
+            #[cfg(not(target_arch = "wasm32"))]
+            decorations: window_descriptor.decorations,
             mode: window_descriptor.mode,
             #[cfg(target_arch = "wasm32")]
             canvas: window_descriptor.canvas.clone(),
@@ -80,6 +84,8 @@ pub struct WindowDescriptor {
     pub title: String,
     pub vsync: bool,
     pub resizable: bool,
+    #[cfg(not(target_arch = "wasm32"))]
+    pub decorations: bool,
     pub mode: WindowMode,
     #[cfg(target_arch = "wasm32")]
     pub canvas: Option<String>,
@@ -98,6 +104,8 @@ impl Default for WindowDescriptor {
             height: 720,
             vsync: true,
             resizable: true,
+            #[cfg(not(target_arch = "wasm32"))]
+            decorations: true,
             mode: WindowMode::Windowed,
             #[cfg(target_arch = "wasm32")]
             canvas: None,

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -35,7 +35,8 @@ impl WinitWindows {
             )),
             _ => winit_window_builder
                 .with_inner_size(winit::dpi::PhysicalSize::new(window.width, window.height))
-                .with_resizable(window.resizable),
+                .with_resizable(window.resizable)
+                .with_decorations(window.decorations),
         };
 
         #[allow(unused_mut)]


### PR DESCRIPTION
You can create a window without title bar.
```rust
        descriptor: WindowDescriptor {
            width: 800,
            height: 600,
            vsync: false,
            title: "second window".to_string(),
            decorations:false,// here!
            ..Default::default()
        },
```
