### PR TITLE
PoC wasm thread implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ futures-lite = "1.4"
 wasm-bindgen-futures = "0.4"
 
 [patch.crates-io]
-getrandom = { path = "../getrandom", features = ["std", "js", "custom"] }
+getrandom = { git = "https://github.com/chemicstry/getrandom", branch = "wasm_thread_fix" }
 
 [[example]]
 name = "hello_world"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ serialize = ["bevy_input/serialize"]
 wayland = ["bevy_winit/wayland"]
 x11 = ["bevy_winit/x11"]
 
+# Support wasm threads (web workers). Requires nightly rust
+wasm_threads = ["bevy_tasks/wasm_threads"]
+
 [workspace]
 members = ["crates/*", "crates/bevy_ecs/hecs"]
 exclude = ["benches"]
@@ -93,6 +96,12 @@ anyhow = "1.0"
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 console_error_panic_hook = "0.1.6"
 console_log = { version = "0.2", features = ["color"] }
+wasm-bindgen = "0.2"
+futures-lite = "1.4"
+wasm-bindgen-futures = "0.4"
+
+[patch.crates-io]
+getrandom = { path = "../getrandom", features = ["std", "js", "custom"] }
 
 [[example]]
 name = "hello_world"

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -ex
+
+# A couple of steps are necessary to get this build working which makes it slightly
+# nonstandard compared to most other builds.
+#
+# * First, the Rust standard library needs to be recompiled with atomics
+#   enabled. to do that we use Cargo's unstable `-Zbuild-std` feature.
+#
+# * Next we need to compile everything with the `atomics` and `bulk-memory`
+#   features enabled, ensuring that LLVM will generate atomic instructions,
+#   shared memory, passive segments, etc.
+
+RUSTFLAGS='-C target-feature=+atomics,+bulk-memory' \
+  cargo build --example headless_wasm --target wasm32-unknown-unknown --no-default-features --features wasm_threads --release -Z build-std=std,panic_abort
+
+# Note the usage of `--target no-modules` here which is required for passing
+# the memory import to each wasm module.
+wasm-bindgen \
+  target/wasm32-unknown-unknown/release/examples/headless_wasm.wasm \
+  --out-dir ./examples/wasm/target/ \
+  --target no-modules

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -21,8 +21,11 @@ bevy_math = { path = "../bevy_math", version = "0.2.1" }
 # other
 log = { version = "0.4", features = ["release_max_level_info"] }
 serde = { version = "1.0", features = ["derive"] }
+futures-lite = "1.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }
 web-sys = { version = "0.3", features = [ "Window" ] }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
+wasm-bindgen-futures = "0.4"
+wasm-timer = "0.2"

--- a/crates/bevy_app/src/app_builder.rs
+++ b/crates/bevy_app/src/app_builder.rs
@@ -38,9 +38,9 @@ impl AppBuilder {
         &mut self.app.resources
     }
 
-    pub fn run(&mut self) {
+    pub async fn run(&mut self) {
         let app = std::mem::take(&mut self.app);
-        app.run();
+        app.run().await;
     }
 
     pub fn set_world(&mut self, world: World) -> &mut Self {

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -279,11 +279,11 @@ impl AssetServer {
                 let handlers = self.asset_handlers.read();
                 let request_handler = handlers[load_request.handler_index].clone();
 
-                self.task_pool
-                    .spawn(async move {
-                        request_handler.handle_request(&load_request).await;
-                    })
-                    .detach();
+                // self.task_pool
+                //     .spawn(async move {
+                //         request_handler.handle_request(&load_request).await;
+                //     })
+                //     .detach();
 
                 // TODO: watching each asset explicitly is a simpler implementation, its possible it would be more efficient to watch
                 // folders instead (when possible)

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -10,11 +10,16 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+wasm_threads = []
+
 [dependencies]
 futures-lite = "1.4.0"
 event-listener = "2.4.0"
 async-executor = "1.3.0"
 async-channel = "1.4.2"
 num_cpus = "1"
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"
+wasm_thread = { git = "https://github.com/chemicstry/wasm_thread", branch = "main" }

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -4,14 +4,14 @@ pub use slice::{ParallelSlice, ParallelSliceMut};
 mod task;
 pub use task::Task;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(not(target_arch = "wasm32"), feature = "wasm_threads"))]
 mod task_pool;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(not(target_arch = "wasm32"), feature = "wasm_threads"))]
 pub use task_pool::{Scope, TaskPool, TaskPoolBuilder};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(feature = "wasm_threads")))]
 mod single_threaded_task_pool;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(feature = "wasm_threads")))]
 pub use single_threaded_task_pool::{Scope, TaskPool, TaskPoolBuilder};
 
 mod usages;

--- a/examples/wasm/headless_wasm.html
+++ b/examples/wasm/headless_wasm.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <script src="./target/headless_wasm.js"></script>
+  <script type="text/javascript">
+    wasm_bindgen('./target/headless_wasm_bg.wasm').then(async (wasm) => {
+      await wasm.run();
+    });
+  </script>
+</html>

--- a/examples/wasm/headless_wasm.rs
+++ b/examples/wasm/headless_wasm.rs
@@ -3,21 +3,42 @@ extern crate console_error_panic_hook;
 
 use bevy::{app::ScheduleRunnerPlugin, prelude::*};
 use std::time::Duration;
+use futures_lite::future;
 
-fn main() {
-    #[cfg(target_arch = "wasm32")]
-    {
-        std::panic::set_hook(Box::new(console_error_panic_hook::hook));
-        console_log::init_with_level(log::Level::Debug).expect("cannot initialize console_log");
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use crate::run_app;
+    use wasm_bindgen::prelude::*;
+
+    // Prevent `wasm_bindgen` from autostarting main on all spawned threads
+    #[wasm_bindgen(start)]
+    pub fn dummy_main() {
     }
 
+    // Export explicit run function to start main
+    #[wasm_bindgen]
+    pub async fn run() {
+        console_log::init_with_level(log::Level::Trace).expect("cannot initialize console_log");
+        console_error_panic_hook::set_once();
+        run_app().await;
+    }
+}
+
+fn main() {
+    future::block_on(run_app());
+}
+
+async fn run_app() {
     App::build()
         .add_plugin(ScheduleRunnerPlugin::run_loop(Duration::from_secs_f64(
             1.0 / 60.0,
         )))
         .add_startup_system(hello_world_system.system())
         .add_system(counter.system())
-        .run();
+        .add_system(test1.system())
+        .add_system(test2.system())
+        .add_system(test3.system())
+        .run().await;
 }
 
 fn hello_world_system() {
@@ -29,6 +50,13 @@ fn counter(mut state: Local<CounterState>) {
         log::info!("counter system: {}", state.count);
     }
     state.count += 1;
+}
+
+fn test1() {
+}
+fn test2() {
+}
+fn test3() {
 }
 
 #[derive(Default)]


### PR DESCRIPTION
Opening this as a draft example of implementing wasm threads. This is implemented with the `async` way as discussed on discord.

wasm thread implementation is provided by a [wasm_thread](https://github.com/chemicstry/wasm_thread) that I created for this purpose. It abstracts some annoying cases about web workers, namely it does not require bundling additional worker script and can figure out wasm-bindgen shim script URL automatically so it acts as a normal `std::thread`. The main thread blocking issues are still there though.

The `headless_wasm` example can be built with `build_wasm.sh` script. Serve `examples/wasm` over HTTP and open `headless_wasm.html`. This requires nightly rust, because wasm atomics are not yet stable.

There is also an [issue with `getrandom`](https://github.com/rust-random/getrandom/issues/164) which is currently patched in `Cargo.toml`.