### PR TITLE
remove custom window mode from example

### DIFF
--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, window::WindowMode};
+use bevy::prelude::*;
 
 /// This example illustrates how to customize the default window settings
 fn main() {
@@ -9,7 +9,6 @@ fn main() {
             height: 300,
             vsync: true,
             resizable: false,
-            mode: WindowMode::Fullscreen { use_size: false },
             ..Default::default()
         })
         .add_default_plugins()


### PR DESCRIPTION
As mentioned in #414, this can be a bit unstable on some platforms. We shouldn't use it in examples until we can trust it everywhere.