### PR TITLE
Add Void Linux to linux dependencies file

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -24,6 +24,11 @@ sudo pacman -S libx11 pkgconf alsa-lib
 sudo eopkg install pkg-config libx11-devel g++ alsa-lib-devel
 ```
 
+## Void
+```bash
+sudo xbps-install -S pkgconf alsa-lib-devel libX11-devel eudev-libudev-devel
+```
+
 ## NixOS
 
 Add a `build.rs` file to your project with the following:


### PR DESCRIPTION
This adds [Void Linux](https://voidlinux.org/) to the linux deps file. It's fairly similar to the rest, except for `eudev-libudev-devel` (what a mouthful), which is required because of the lack of `systemd` on Void.

Figured I'd add it above NixOS since that one is way more verbose than the rest, but happy to move it below if desired :)