### PR TITLE
Don't panic when despawning entity multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@
   - This allows drop-in use of colors from most applications.
   - New methods `Color::rgb_linear` and `Color::rgba_linear` will accept colors already in linear sRGB (the old behavior)
   - Individual color-components must now be accessed through setters and getters: `.r`, `.g`, `.b`, `.a`, `.set_r`, `.set_g`, `.set_b`, `.set_a`, and the corresponding methods with the `*_linear` suffix.
-- Despawning an entity multiple times causes a debug-level log message to be emitted instead of a panic
+- Despawning an entity multiple times causes a debug-level log message to be emitted instead of a panic [649]
 
 [552]: https://github.com/bevyengine/bevy/pull/552
 [616]: https://github.com/bevyengine/bevy/pull/616
+[649]: https://github.com/bevyengine/bevy/pull/649
 
 ## Version 0.2.1 (2020-9-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - This allows drop-in use of colors from most applications.
   - New methods `Color::rgb_linear` and `Color::rgba_linear` will accept colors already in linear sRGB (the old behavior)
   - Individual color-components must now be accessed through setters and getters: `.r`, `.g`, `.b`, `.a`, `.set_r`, `.set_g`, `.set_b`, `.set_a`, and the corresponding methods with the `*_linear` suffix.
+- Despawning an entity multiple times causes a debug-level log message to be emitted instead of a panic
 
 [552]: https://github.com/bevyengine/bevy/pull/552
 [616]: https://github.com/bevyengine/bevy/pull/616


### PR DESCRIPTION
Emit a debug log message instead of a panic when despawning an entity which has already been despawned.

Is this the right approach? Are there other ways to despawn that need to be addressed?

Resolves #487 