### PR TITLE
Upgrade to gilrs 0.8.0 to gain dpad support on macos 

### DIFF
--- a/crates/bevy_gilrs/Cargo.toml
+++ b/crates/bevy_gilrs/Cargo.toml
@@ -16,5 +16,5 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.2.1" }
 bevy_input = { path = "../bevy_input", version = "0.2.1" }
 
 # other
-gilrs = "0.7.4"
+gilrs = "0.8.0"
 log = { version = "0.4", features = ["release_max_level_info"] }


### PR DESCRIPTION
@cart I [contributed dpad support for macos to gilrs](https://gitlab.com/gilrs-project/gilrs/-/merge_requests/50).  This pull request updates us to gilrs 0.8.0 to gain that new feature.  AFAICT there are no breaking changes in my testing on macOS.  I don't see anything else in the [changelog for 0.8.0](https://gitlab.com/gilrs-project/gilrs/-/blob/master/gilrs/CHANGELOG.md#v080-unreleased) that should be a concern.