### PR TITLE
Adjust how `ArchetypeAccess` tracks mutable & immutable deps

### DIFF
--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -46,12 +46,8 @@ impl<'a, Q: HecsQuery> Query<'a, Q> {
         if let Some(location) = self.world.get_entity_location(entity) {
             if self
                 .archetype_access
-                .immutable
+                .accessed
                 .contains(location.archetype as usize)
-                || self
-                    .archetype_access
-                    .mutable
-                    .contains(location.archetype as usize)
             {
                 // SAFE: we have already checked that the entity/component matches our archetype access. and systems are scheduled to run with safe archetype access
                 unsafe {
@@ -71,12 +67,8 @@ impl<'a, Q: HecsQuery> Query<'a, Q> {
         if let Some(location) = self.world.get_entity_location(entity) {
             if self
                 .archetype_access
-                .immutable
+                .accessed
                 .contains(location.archetype as usize)
-                || self
-                    .archetype_access
-                    .mutable
-                    .contains(location.archetype as usize)
             {
                 // SAFE: we have already checked that the entity matches our archetype. and systems are scheduled to run with safe archetype access
                 Ok(unsafe {
@@ -205,11 +197,7 @@ impl<'w, Q: HecsQuery> QueryBorrowChecked<'w, Q> {
             );
         }
 
-        for index in self.archetype_access.immutable.ones() {
-            Q::Fetch::borrow(&self.archetypes[index]);
-        }
-
-        for index in self.archetype_access.mutable.ones() {
+        for index in self.archetype_access.accessed.ones() {
             Q::Fetch::borrow(&self.archetypes[index]);
         }
 
@@ -224,11 +212,7 @@ impl<'w, Q: HecsQuery> Drop for QueryBorrowChecked<'w, Q> {
     #[inline]
     fn drop(&mut self) {
         if self.borrowed {
-            for index in self.archetype_access.immutable.ones() {
-                Q::Fetch::release(&self.archetypes[index]);
-            }
-
-            for index in self.archetype_access.mutable.ones() {
+            for index in self.archetype_access.accessed.ones() {
                 Q::Fetch::release(&self.archetypes[index]);
             }
         }


### PR DESCRIPTION
`ArchetypeAccess` was tracking `immutable` and `mutable` separately.
This means that checking is_compatible requires three checks:
m+m, m+i, i+m.

Instead, continue tracking `mutable` accesses, but instead of
`immutable` track `immutable | mutable` as another `accessed` bit mask.
This drops the comparisons to two (m+a, a+m) and turns out to be
what the rest of the code base wants too, unifying various duplicated
checks and loops.