### PR TITLE
defer render systems until render resource context is ready

### DIFF
--- a/crates/bevy_ecs/src/resource/resource_query.rs
+++ b/crates/bevy_ecs/src/resource/resource_query.rs
@@ -209,6 +209,10 @@ impl<'a, T: Resource> FetchResource<'a> for FetchResourceRead<T> {
         Res::new(resources.get_unsafe_ref::<T>(ResourceIndex::Global))
     }
 
+    unsafe fn is_some(resources: &'a Resources, _system_id: Option<SystemId>) -> bool {
+        resources.contains::<T>()
+    }
+
     fn borrow(resources: &Resources) {
         resources.borrow::<T>();
     }
@@ -276,6 +280,10 @@ impl<'a, T: Resource> FetchResource<'a> for FetchResourceWrite<T> {
         ResMut::new(value, type_state.mutated())
     }
 
+    unsafe fn is_some(resources: &'a Resources, _system_id: Option<SystemId>) -> bool {
+        resources.contains::<T>()
+    }
+
     fn borrow(resources: &Resources) {
         resources.borrow_mut::<T>();
     }
@@ -320,6 +328,11 @@ impl<'a, T: Resource + FromResources> FetchResource<'a> for FetchResourceLocalMu
                 .as_ptr(),
             _marker: Default::default(),
         }
+    }
+
+    unsafe fn is_some(resources: &'a Resources, system_id: Option<SystemId>) -> bool {
+        let id = system_id.expect("Local<T> resources can only be used by systems");
+        resources.get_local::<T>(id).is_some()
     }
 
     fn borrow(resources: &Resources) {

--- a/crates/bevy_render/src/pipeline/render_pipelines.rs
+++ b/crates/bevy_render/src/pipeline/render_pipelines.rs
@@ -3,7 +3,7 @@ use crate::{
     draw::{Draw, DrawContext},
     mesh::{Indices, Mesh},
     prelude::Msaa,
-    renderer::RenderResourceBindings,
+    renderer::{RenderResourceBindings, RenderResourceContext},
 };
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::{Query, Res, ResMut};
@@ -73,6 +73,7 @@ impl Default for RenderPipelines {
 }
 
 pub fn draw_render_pipelines_system(
+    _render_resource_context: Res<Box<dyn RenderResourceContext>>,
     mut draw_context: DrawContext,
     mut render_resource_bindings: ResMut<RenderResourceBindings>,
     msaa: Res<Msaa>,

--- a/crates/bevy_render/src/render_graph/system.rs
+++ b/crates/bevy_render/src/render_graph/system.rs
@@ -1,7 +1,11 @@
 use super::RenderGraph;
+use crate::renderer::RenderResourceContext;
 use bevy_ecs::{Resources, World};
 
 pub fn render_graph_schedule_executor_system(world: &mut World, resources: &mut Resources) {
+    if resources.get::<Box<dyn RenderResourceContext>>().is_none() {
+        return;
+    }
     // run render graph systems
     let (mut system_schedule, commands) = {
         let mut render_graph = resources.get_mut::<RenderGraph>().unwrap();

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -6,7 +6,7 @@ use bevy_render::{
     draw::{Draw, DrawContext, Drawable},
     mesh::Mesh,
     prelude::Msaa,
-    renderer::{AssetRenderResourceBindings, RenderResourceBindings},
+    renderer::{AssetRenderResourceBindings, RenderResourceBindings, RenderResourceContext},
     texture::Texture,
 };
 use bevy_sprite::{TextureAtlas, QUAD_HANDLE};
@@ -90,6 +90,7 @@ pub fn text_system(
 
 #[allow(clippy::too_many_arguments)]
 pub fn draw_text_system(
+    _render_resource_context: Res<Box<dyn RenderResourceContext>>,
     mut draw_context: DrawContext,
     fonts: Res<Assets<Font>>,
     msaa: Res<Msaa>,


### PR DESCRIPTION
First of several patches making possible to create WebGL renderer for bevy.
This one allows to defer few bevy_render systems (`render_graph_schedule_executor_system` and `draw_render_pipelines_system`) until `render_resource_context` is ready (to obtain webgl context cavas is needed, so we need to wait until window is created).
Additionally it turns `mesh_resource_provider_system` and `texture_resource_system` into render graph nodes and removes the `RENDER_RESOURCE` stage (as suggested in @cart's comment - I'm doing it here because these systems also need to be deferred).

On `wgpu` backend nothing will change - `RenderResourceContext::is_ready` returns `true` (as wgpu device is available instantly after creation of WgpuPlugin), so nothing will be deferred.

Related issue: #88 (BTW should I create separate issue for such PR's or it is not necessary?)