### PR TITLE
add more methods to Assets for clearing and allocation reduction

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -104,6 +104,28 @@ impl<T: Resource> Assets<T> {
         self.assets.remove(&handle)
     }
 
+    /// Clears the inner asset map, removing all key-value pairs.
+    ///
+    /// Keeps the allocated memory for reuse.
+    pub fn clear(&mut self) {
+        self.assets.clear()
+    }
+
+    /// Reserves capacity for at least additional more elements to be inserted into the assets.
+    ///
+    /// The collection may reserve more space to avoid frequent reallocations.
+    pub fn reserve(&mut self, additional: usize) {
+        self.assets.reserve(additional)
+    }
+
+    /// Shrinks the capacity of the asset map as much as possible.
+    ///
+    /// It will drop down as much as possible while maintaining the internal rules and possibly
+    /// leaving some space in accordance with the resize policy.
+    pub fn shrink_to_fit(&mut self) {
+        self.assets.shrink_to_fit()
+    }
+
     pub fn asset_event_system(
         mut events: ResMut<Events<AssetEvent<T>>>,
         mut assets: ResMut<Assets<T>>,


### PR DESCRIPTION
There should be methods to remove assets from memory as well as methods to shrink the `Asset`'s inner `HashMap` to the reduced size. I have a situation where this comes in handy where I want to drop temporary textures that are only held during the loading state of the game and not hold them in memory while the game is running. This fixes that issue.