### PR TITLE
Expose a pointer of EventLoopProxy to process custom messages

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -22,6 +22,9 @@ use winit::{
 #[derive(Default)]
 pub struct WinitPlugin;
 
+#[derive(Debug)]
+pub struct EventLoopProxyPtr(pub usize);
+
 impl Plugin for WinitPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app
@@ -80,6 +83,11 @@ pub fn winit_runner(mut app: App) {
     let mut event_loop = EventLoop::new();
     let mut create_window_event_reader = EventReader::<CreateWindow>::default();
     let mut app_exit_event_reader = EventReader::<AppExit>::default();
+
+    app.resources
+        .insert_thread_local(EventLoopProxyPtr(
+            Box::into_raw(Box::new(event_loop.create_proxy())) as usize,
+        ));
 
     handle_create_window_events(
         &mut app.resources,


### PR DESCRIPTION
An exmaple usage is:
```rust
fn main() {
    App::build()
        ................
        .add_system(process_messages.thread_local_system())
        ................
        .run();
}

fn process_messages(_world: &mut World, resources: &mut Resources) {
    use bevy::window::WindowCreated;
    use bevy::winit::{EventLoopProxyPtr, WinitWindows};
    use winit::platform::windows::WindowExtWindows;

    let mut window_created_event_reader = EventReader::<WindowCreated>::default();
    let window_created_events = resources.get::<Events<WindowCreated>>().unwrap();
    if let Some(window_created) = window_created_event_reader.latest(&window_created_events) {
        if window_created.id.is_primary() {
            let winit_windows = resources.get::<WinitWindows>().unwrap();
            let event_proxy_ptr = resources.get_thread_local::<EventLoopProxyPtr>().unwrap();
            let main_window = winit_windows.get_window(window_created.id).unwrap();
            dbg!(main_window.hwnd());
            unsafe {
                let res = commctrl::SetWindowSubclass(
                    main_window.hwnd() as HWND,
                    Some(subclass_proc),
                    0x10000,
                    event_proxy_ptr.0 as DWORD_PTR,
                );
                dbg!(res);
            }
        }
    }
}

use winapi::{
    shared::{
        basetsd::{DWORD_PTR, UINT_PTR},
        minwindef::{LPARAM, LRESULT, UINT, WPARAM},
        windef::HWND,
    },
    um::commctrl,
};

unsafe extern "system" fn subclass_proc(
    hwnd: HWND,
    msg: UINT,
    wparam: WPARAM,
    lparam: LPARAM,
    _id: UINT_PTR,
    _data: DWORD_PTR,
) -> LRESULT {
    match msg {
        6012 => {
            println!("custom message received");
            0
        }
        _ => commctrl::DefSubclassProc(hwnd, msg, wparam, lparam),
    }
}
```

For more info, see https://github.com/rust-windowing/winit/issues/1052