### PR TITLE
Add default for texture format

### DIFF
--- a/crates/bevy_pbr/src/render_graph/forward_pipeline/mod.rs
+++ b/crates/bevy_pbr/src/render_graph/forward_pipeline/mod.rs
@@ -34,7 +34,7 @@ pub(crate) fn build_forward_pipeline(shaders: &mut Assets<Shader>) -> PipelineDe
             },
         }),
         color_states: vec![ColorStateDescriptor {
-            format: TextureFormat::Bgra8UnormSrgb,
+            format: TextureFormat::default(),
             color_blend: BlendDescriptor {
                 src_factor: BlendFactor::SrcAlpha,
                 dst_factor: BlendFactor::OneMinusSrcAlpha,

--- a/crates/bevy_render/src/pipeline/pipeline.rs
+++ b/crates/bevy_render/src/pipeline/pipeline.rs
@@ -91,7 +91,7 @@ impl PipelineDescriptor {
                 },
             }),
             color_states: vec![ColorStateDescriptor {
-                format: TextureFormat::Bgra8UnormSrgb,
+                format: TextureFormat::default(),
                 color_blend: BlendDescriptor {
                     src_factor: BlendFactor::SrcAlpha,
                     dst_factor: BlendFactor::OneMinusSrcAlpha,

--- a/crates/bevy_render/src/render_graph/base.rs
+++ b/crates/bevy_render/src/render_graph/base.rs
@@ -209,7 +209,7 @@ impl BaseRenderGraphBuilder for RenderGraph {
                         mip_level_count: 1,
                         sample_count: msaa.samples,
                         dimension: TextureDimension::D2,
-                        format: TextureFormat::Bgra8UnormSrgb,
+                        format: TextureFormat::default(),
                         usage: TextureUsage::OUTPUT_ATTACHMENT,
                     },
                 ),

--- a/crates/bevy_render/src/texture/texture_dimension.rs
+++ b/crates/bevy_render/src/texture/texture_dimension.rs
@@ -206,6 +206,17 @@ impl TextureFormat {
     }
 }
 
+impl Default for TextureFormat {
+    fn default() -> Self {
+        if cfg!(target_os = "android") {
+            // Bgra8UnormSrgb texture missing on some Android devices
+            TextureFormat::Rgba8UnormSrgb
+        } else {
+            TextureFormat::Bgra8UnormSrgb
+        }
+    }
+}
+
 bitflags::bitflags! {
     #[repr(transparent)]
     pub struct TextureUsage: u32 {

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -40,7 +40,7 @@ pub fn build_sprite_sheet_pipeline(shaders: &mut Assets<Shader>) -> PipelineDesc
             },
         }),
         color_states: vec![ColorStateDescriptor {
-            format: TextureFormat::Bgra8UnormSrgb,
+            format: TextureFormat::default(),
             color_blend: BlendDescriptor {
                 src_factor: BlendFactor::SrcAlpha,
                 dst_factor: BlendFactor::OneMinusSrcAlpha,
@@ -88,7 +88,7 @@ pub fn build_sprite_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescriptor
             },
         }),
         color_states: vec![ColorStateDescriptor {
-            format: TextureFormat::Bgra8UnormSrgb,
+            format: TextureFormat::default(),
             color_blend: BlendDescriptor {
                 src_factor: BlendFactor::SrcAlpha,
                 dst_factor: BlendFactor::OneMinusSrcAlpha,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -42,7 +42,7 @@ pub fn build_ui_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescriptor {
             },
         }),
         color_states: vec![ColorStateDescriptor {
-            format: TextureFormat::Bgra8UnormSrgb,
+            format: TextureFormat::default(),
             color_blend: BlendDescriptor {
                 src_factor: BlendFactor::SrcAlpha,
                 dst_factor: BlendFactor::OneMinusSrcAlpha,

--- a/crates/bevy_wgpu/src/wgpu_type_converter.rs
+++ b/crates/bevy_wgpu/src/wgpu_type_converter.rs
@@ -562,7 +562,7 @@ impl WgpuFrom<&Window> for wgpu::SwapChainDescriptor {
     fn from(window: &Window) -> Self {
         wgpu::SwapChainDescriptor {
             usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
-            format: wgpu::TextureFormat::Bgra8UnormSrgb,
+            format: TextureFormat::default().wgpu_into(),
             width: window.width(),
             height: window.height(),
             present_mode: if window.vsync() {

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -134,7 +134,7 @@ fn setup(
                     mip_level_count: 1,
                     sample_count: msaa.samples,
                     dimension: TextureDimension::D2,
-                    format: TextureFormat::Bgra8UnormSrgb,
+                    format: TextureFormat::default(),
                     usage: TextureUsage::OUTPUT_ATTACHMENT,
                 },
             ),


### PR DESCRIPTION
Some android devices can't work with Bgra TextureFormat - so we can replace it with `default()` that will return TextureFormat depending on the target os.