### PR TITLE
Fix breakout example bug - ball flighlying out when collide paddle and wall at the same time

### DIFF
--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -242,11 +242,8 @@ fn ball_collision_system(
                 }
 
                 // break if this collide is on a solid, otherwise continue check whether a solid is also in collision
-                match *collider {
-                    Collider::Solid => {
-                        break;
-                    }
-                    _ => {}
+                if let Collider::Solid = *collider {
+                    break;
                 }
             }
         }

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -33,6 +33,7 @@ struct Scoreboard {
 enum Collider {
     Solid,
     Scorable,
+    Paddle,
 }
 
 fn setup(
@@ -53,7 +54,7 @@ fn setup(
             ..Default::default()
         })
         .with(Paddle { speed: 500.0 })
-        .with(Collider::Solid)
+        .with(Collider::Paddle)
         // ball
         .spawn(SpriteComponents {
             material: materials.add(Color::rgb(1.0, 0.5, 0.5).into()),
@@ -240,7 +241,13 @@ fn ball_collision_system(
                     *velocity.y_mut() = -velocity.y();
                 }
 
-                break;
+                // break if this collide is on a solid, otherwise continue check whether a solid is also in collision
+                match *collider {
+                    Collider::Solid => {
+                        break;
+                    }
+                    _ => {}
+                }
             }
         }
     }


### PR DESCRIPTION
It seems there is a bug of the breakout example, that when ball is collided with both paddle and the wall, the velocity is evaluated and reflected with paddle first, then that `break` will stop it evaluate if there is other collisions, then the ball will just fly out of the wall. 

It is easy to see the bug if you try hold the ball between the paddle and the bottom wall then follow it until the ball hits left or right wall. Then there is a good chance when ball hit paddle and left/right wall at the same time then just flying off the walls.

This should fix this bug in some degree but might not prevent other potential bugs related to this. For example the ball might hit the corner of two walls and only one axis of velocity will change and it might still able to fly off the walls. I was also thinking about collect all the possible collisions then do proper velocity change based on all the current possible collisions, but that might name the code a bit too complicated for an intro example?