### PR TITLE
Runners explicitly call App.initialize()

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -63,7 +63,7 @@ impl App {
             .run(&mut self.schedule, &mut self.world, &mut self.resources);
     }
 
-    pub fn run(mut self) {
+    pub fn initialize(&mut self) {
         self.startup_schedule
             .initialize(&mut self.world, &mut self.resources);
         self.startup_executor.initialize(&mut self.resources);
@@ -72,7 +72,9 @@ impl App {
             &mut self.world,
             &mut self.resources,
         );
+    }
 
+    pub fn run(mut self) {
         self.executor.initialize(&mut self.resources);
         let runner = std::mem::replace(&mut self.runner, Box::new(run_once));
         (runner)(self);

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -55,6 +55,8 @@ impl Plugin for ScheduleRunnerPlugin {
     fn build(&self, app: &mut AppBuilder) {
         let run_mode = self.run_mode;
         app.set_runner(move |mut app: App| {
+            app.initialize();
+
             let mut app_exit_event_reader = EventReader::<AppExit>::default();
             match run_mode {
                 RunMode::Once => {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -148,6 +148,8 @@ pub fn winit_runner(mut app: App) {
         &mut create_window_event_reader,
     );
 
+    app.initialize();
+
     log::debug!("Entering winit event loop");
 
     let should_return_from_run = app


### PR DESCRIPTION
This change moves `startup_schedule` to a separate `app.initialize()` function that needs to be called by the runner function.

This allows the runner function to modify/prepare app environment for startup systems requirements. For example runner can insert its own resource for startup systems to use.