### PR TITLE
Migrate to rodio 0.12 using thread local resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   - New methods `Color::rgb_linear` and `Color::rgba_linear` will accept colors already in linear sRGB (the old behavior)
   - Individual color-components must now be accessed through setters and getters: `.r`, `.g`, `.b`, `.a`, `.set_r`, `.set_g`, `.set_b`, `.set_a`, and the corresponding methods with the `*_linear` suffix.
 - Despawning an entity multiple times causes a debug-level log message to be emitted instead of a panic [649] [651]
+- Breaking Change: Migrated to rodio 0.12, this means:
+  - Playing an mp3 no longer sometimes panics in debug mode
+  - New method of playing audio can be found in the audio example (an intermediary `Audio` struct is used instead of `AudioOutput` directly)
 
 [696]: https://github.com/bevyengine/bevy/pull/696
 [689]: https://github.com/bevyengine/bevy/pull/689

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -22,7 +22,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.2.1" }
 
 # other
 anyhow = "1.0"
-rodio = { version = "0.11", default-features = false }
+rodio = { version = "0.12", default-features = false }
 parking_lot = "0.11.0"
 
 [features]

--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -1,0 +1,43 @@
+use crate::{AudioSource, Decodable};
+use bevy_asset::Handle;
+use parking_lot::RwLock;
+use std::{collections::VecDeque, fmt};
+
+/// The external struct used to play audio
+pub struct Audio<P = AudioSource>
+where
+    P: Decodable,
+{
+    pub queue: RwLock<VecDeque<Handle<P>>>,
+}
+
+impl<P> fmt::Debug for Audio<P>
+where
+    P: Decodable,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Audio").field("queue", &self.queue).finish()
+    }
+}
+
+impl<P> Default for Audio<P>
+where
+    P: Decodable,
+{
+    fn default() -> Self {
+        Self {
+            queue: Default::default(),
+        }
+    }
+}
+
+impl<P> Audio<P>
+where
+    P: Decodable,
+    <P as Decodable>::Decoder: rodio::Source + Send + Sync,
+    <<P as Decodable>::Decoder as Iterator>::Item: rodio::Sample + Send + Sync,
+{
+    pub fn play(&self, audio_source: Handle<P>) {
+        self.queue.write().push_front(audio_source);
+    }
+}

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -1,16 +1,18 @@
+mod audio;
 mod audio_output;
 mod audio_source;
 
+pub use audio::*;
 pub use audio_output::*;
 pub use audio_source::*;
 
 pub mod prelude {
-    pub use crate::{AudioOutput, AudioSource, Decodable};
+    pub use crate::{Audio, AudioOutput, AudioSource, Decodable};
 }
 
 use bevy_app::prelude::*;
 use bevy_asset::AddAsset;
-use bevy_ecs::IntoQuerySystem;
+use bevy_ecs::IntoThreadLocalSystem;
 
 /// Adds support for audio playback to an App
 #[derive(Default)]
@@ -18,12 +20,13 @@ pub struct AudioPlugin;
 
 impl Plugin for AudioPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app.init_resource::<AudioOutput<AudioSource>>()
+        app.init_thread_local_resource::<AudioOutput<AudioSource>>()
             .add_asset::<AudioSource>()
             .init_asset_loader::<Mp3Loader>()
+            .init_resource::<Audio<AudioSource>>()
             .add_system_to_stage(
                 stage::POST_UPDATE,
-                play_queued_audio_system::<AudioSource>.system(),
+                play_queued_audio_system::<AudioSource>.thread_local_system(),
             );
     }
 }

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -13,4 +13,4 @@ license = "MIT"
 keywords = ["bevy"]
 
 [dependencies]
-ahash = "0.4.5"
+ahash = "0.5.3"

--- a/examples/audio/audio.rs
+++ b/examples/audio/audio.rs
@@ -8,7 +8,7 @@ fn main() {
         .run();
 }
 
-fn setup(asset_server: Res<AssetServer>, audio_output: Res<AudioOutput>) {
+fn setup(asset_server: Res<AssetServer>, audio: Res<Audio>) {
     let music = asset_server.load("sounds/Windless Slopes.mp3");
-    audio_output.play(music);
+    audio.play(music);
 }


### PR DESCRIPTION
**Checklist**

I confirm that I have done the following (if applicable):

- [x] Added a changelog entry
- [ ] Added respective unit tests (no unit tests added, should I add some?)

rodio 0.12 seems to fix a bunch of audio panics and crashes. In its current state audio is a little clunky to use (because audio must be played on the main thread, in a separate system than most of the app logic is going to be in) but it's usable and hopefully can be made better later.
