### PR TITLE
Cursor lock crash fix

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -86,7 +86,7 @@ fn change_window(_: &mut World, resources: &mut Resources) {
                 }
                 bevy_window::WindowCommand::SetCursorLockMode { locked } => {
                     let window = winit_windows.get_window(id).unwrap();
-                    window.set_cursor_grab(locked).unwrap();
+                    let _ = window.set_cursor_grab(locked);
                 }
                 bevy_window::WindowCommand::SetCursorVisibility { visible } => {
                     let window = winit_windows.get_window(id).unwrap();

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -71,9 +71,7 @@ impl WinitWindows {
 
         let winit_window = winit_window_builder.build(&event_loop).unwrap();
 
-        winit_window
-            .set_cursor_grab(window.cursor_locked())
-            .unwrap();
+        let _ = winit_window.set_cursor_grab(window.cursor_locked());
         winit_window.set_cursor_visible(window.cursor_visible());
 
         self.window_id_to_winit


### PR DESCRIPTION
In case cursor locking isn't supported by platform (like iOS) winit's `window.set_cursor_grab` would return `Err`. Unwrapping it results in panic.
This should fix #697 