### PR TITLE
Don't panic, do debug, when failing to remove component(s)

### DIFF
--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -109,7 +109,7 @@ where
         if world.get::<T>(self.entity).is_ok() {
             if let Err(e) = world.remove_one::<T>(self.entity) {
                 log::debug!(
-                    "Failed to remove component {:?}: {}",
+                    "Failed to remove component {:?} with error: {}",
                     std::any::type_name::<T>(),
                     e
                 )
@@ -134,7 +134,7 @@ where
     fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) {
         if let Err(e) = world.remove::<T>(self.entity) {
             log::debug!(
-                "Failed to remove component {:?}: {}",
+                "Failed to remove components {:?} with error: {}",
                 std::any::type_name::<T>(),
                 e
             )

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -107,7 +107,13 @@ where
 {
     fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) {
         if world.get::<T>(self.entity).is_ok() {
-            world.remove_one::<T>(self.entity).unwrap();
+            if let Err(e) = world.remove_one::<T>(self.entity) {
+                log::debug!(
+                    "Failed to remove component {:?}: {}",
+                    std::any::type_name::<T>(),
+                    e
+                )
+            }
         }
     }
 }
@@ -126,7 +132,13 @@ where
     T: Bundle + Send + Sync + 'static,
 {
     fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) {
-        world.remove::<T>(self.entity).unwrap();
+        if let Err(e) = world.remove::<T>(self.entity) {
+            log::debug!(
+                "Failed to remove component {:?}: {}",
+                std::any::type_name::<T>(),
+                e
+            )
+        }
     }
 }
 


### PR DESCRIPTION
Resolves #698 by never panicking and always debugging when attempting to `remove` components (or `remove_one` a component) fails.