### PR TITLE
gamepad: expose raw and filtered gamepad events.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,8 +231,8 @@ name = "gamepad_input"
 path = "examples/input/gamepad_input.rs"
 
 [[example]]
-name = "gamepad_input_event"
-path = "examples/input/gamepad_input_event.rs"
+name = "gamepad_input_events"
+path = "examples/input/gamepad_input_events.rs"
 
 [[example]]
 name = "touch_input"

--- a/crates/bevy_app/src/app_builder.rs
+++ b/crates/bevy_app/src/app_builder.rs
@@ -174,7 +174,8 @@ impl AppBuilder {
             .add_startup_stage(startup_stage::STARTUP)
             .add_startup_stage(startup_stage::POST_STARTUP)
             .add_stage(stage::FIRST)
-            .add_stage(stage::EVENT_UPDATE)
+            .add_stage(stage::PRE_EVENT)
+            .add_stage(stage::EVENT)
             .add_stage(stage::PRE_UPDATE)
             .add_stage(stage::UPDATE)
             .add_stage(stage::POST_UPDATE)
@@ -217,7 +218,7 @@ impl AppBuilder {
         T: Send + Sync + 'static,
     {
         self.add_resource(Events::<T>::default())
-            .add_system_to_stage(stage::EVENT_UPDATE, Events::<T>::update_system.system())
+            .add_system_to_stage(stage::EVENT, Events::<T>::update_system.system())
     }
 
     pub fn add_resource<T>(&mut self, resource: T) -> &mut Self

--- a/crates/bevy_app/src/stage.rs
+++ b/crates/bevy_app/src/stage.rs
@@ -1,8 +1,11 @@
 /// Name of app stage that runs before all other app stages
 pub const FIRST: &str = "first";
 
-/// Name of app stage that updates events. Generally this should run before UPDATE
-pub const EVENT_UPDATE: &str = "event_update";
+/// Name of app stage that runs before EVENT
+pub const PRE_EVENT: &str = "pre_events";
+
+/// Name of app stage that updates events. Runs before UPDATE
+pub const EVENT: &str = "events";
 
 /// Name of app stage responsible for performing setup before an update. Runs before UPDATE.
 pub const PRE_UPDATE: &str = "pre_update";

--- a/crates/bevy_gilrs/src/gilrs_system.rs
+++ b/crates/bevy_gilrs/src/gilrs_system.rs
@@ -1,42 +1,30 @@
 use crate::converter::{convert_axis, convert_button, convert_gamepad_id};
 use bevy_app::Events;
 use bevy_ecs::{Resources, World};
-use bevy_input::prelude::*;
+use bevy_input::{gamepad::GamepadEventRaw, prelude::*};
 use gilrs::{EventType, Gilrs};
 
-pub fn gilrs_event_startup_system(_world: &mut World, resources: &mut Resources) {
-    let gilrs = resources.get_thread_local::<Gilrs>().unwrap();
-    let mut event = resources.get_mut::<Events<GamepadEvent>>().unwrap();
-    event.update();
-    for (id, _) in gilrs.gamepads() {
-        event.send(GamepadEvent(
-            convert_gamepad_id(id),
-            GamepadEventType::Connected,
-        ));
-    }
-}
-
-pub fn girls_event_system(_world: &mut World, resources: &mut Resources) {
+pub fn gilrs_event_system(_world: &mut World, resources: &mut Resources) {
     let mut gilrs = resources.get_thread_local_mut::<Gilrs>().unwrap();
-    let mut event = resources.get_mut::<Events<GamepadEvent>>().unwrap();
+    let mut event = resources.get_mut::<Events<GamepadEventRaw>>().unwrap();
     event.update();
     while let Some(gilrs_event) = gilrs.next_event() {
         match gilrs_event.event {
             EventType::Connected => {
-                event.send(GamepadEvent(
+                event.send(GamepadEventRaw(
                     convert_gamepad_id(gilrs_event.id),
                     GamepadEventType::Connected,
                 ));
             }
             EventType::Disconnected => {
-                event.send(GamepadEvent(
+                event.send(GamepadEventRaw(
                     convert_gamepad_id(gilrs_event.id),
                     GamepadEventType::Disconnected,
                 ));
             }
             EventType::ButtonChanged(gilrs_button, value, _) => {
                 if let Some(button_type) = convert_button(gilrs_button) {
-                    event.send(GamepadEvent(
+                    event.send(GamepadEventRaw(
                         convert_gamepad_id(gilrs_event.id),
                         GamepadEventType::ButtonChanged(button_type, value),
                     ));
@@ -44,7 +32,7 @@ pub fn girls_event_system(_world: &mut World, resources: &mut Resources) {
             }
             EventType::AxisChanged(gilrs_axis, value, _) => {
                 if let Some(axis_type) = convert_axis(gilrs_axis) {
-                    event.send(GamepadEvent(
+                    event.send(GamepadEventRaw(
                         convert_gamepad_id(gilrs_event.id),
                         GamepadEventType::AxisChanged(axis_type, value),
                     ));

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -4,7 +4,7 @@ mod gilrs_system;
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use gilrs::GilrsBuilder;
-use gilrs_system::{gilrs_event_startup_system, girls_event_system};
+use gilrs_system::gilrs_event_system;
 
 #[derive(Default)]
 pub struct GilrsPlugin;
@@ -18,8 +18,11 @@ impl Plugin for GilrsPlugin {
         {
             Ok(gilrs) => {
                 app.add_thread_local_resource(gilrs)
-                    .add_startup_system(gilrs_event_startup_system.thread_local_system())
-                    .add_system_to_stage(stage::FIRST, girls_event_system.thread_local_system());
+                    .add_startup_system(gilrs_event_system.thread_local_system())
+                    .add_system_to_stage(
+                        stage::PRE_EVENT,
+                        gilrs_event_system.thread_local_system(),
+                    );
             }
             Err(err) => log::error!("Failed to start Gilrs. {}", err),
         }

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -27,7 +27,10 @@ use mouse::{mouse_button_input_system, MouseButton, MouseButtonInput, MouseMotio
 use touch::{touch_screen_input_system, TouchInput, Touches};
 
 use bevy_ecs::IntoQuerySystem;
-use gamepad::{gamepad_event_system, GamepadAxis, GamepadButton, GamepadEvent, GamepadSetting};
+use gamepad::{
+    gamepad_event_system, GamepadAxis, GamepadButton, GamepadEvent, GamepadEventRaw,
+    GamepadSettings,
+};
 
 /// Adds keyboard and mouse input to an App
 #[derive(Default)]
@@ -40,30 +43,18 @@ impl Plugin for InputPlugin {
             .add_event::<MouseMotion>()
             .add_event::<MouseWheel>()
             .init_resource::<Input<KeyCode>>()
-            .add_system_to_stage(
-                bevy_app::stage::EVENT_UPDATE,
-                keyboard_input_system.system(),
-            )
+            .add_system_to_stage(bevy_app::stage::EVENT, keyboard_input_system.system())
             .init_resource::<Input<MouseButton>>()
-            .add_system_to_stage(
-                bevy_app::stage::EVENT_UPDATE,
-                mouse_button_input_system.system(),
-            )
+            .add_system_to_stage(bevy_app::stage::EVENT, mouse_button_input_system.system())
             .add_event::<GamepadEvent>()
-            .init_resource::<GamepadSetting>()
+            .add_event::<GamepadEventRaw>()
+            .init_resource::<GamepadSettings>()
             .init_resource::<Input<GamepadButton>>()
             .init_resource::<Axis<GamepadAxis>>()
             .init_resource::<Axis<GamepadButton>>()
-            .add_startup_system_to_stage(
-                bevy_app::startup_stage::POST_STARTUP,
-                gamepad_event_system.system(),
-            )
-            .add_system_to_stage(bevy_app::stage::EVENT_UPDATE, gamepad_event_system.system())
+            .add_system_to_stage(bevy_app::stage::EVENT, gamepad_event_system.system())
             .add_event::<TouchInput>()
             .init_resource::<Touches>()
-            .add_system_to_stage(
-                bevy_app::stage::EVENT_UPDATE,
-                touch_screen_input_system.system(),
-            );
+            .add_system_to_stage(bevy_app::stage::EVENT, touch_screen_input_system.system());
     }
 }

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -30,7 +30,7 @@ impl Plugin for ScenePlugin {
             .add_asset::<Scene>()
             .init_asset_loader::<SceneLoader>()
             .init_resource::<SceneSpawner>()
-            .add_stage_after(stage::EVENT_UPDATE, SCENE_STAGE)
+            .add_stage_after(stage::EVENT, SCENE_STAGE)
             .add_system_to_stage(SCENE_STAGE, scene_spawner_system.thread_local_system());
     }
 }

--- a/examples/input/gamepad_input.rs
+++ b/examples/input/gamepad_input.rs
@@ -40,32 +40,25 @@ fn gamepad_system(
     button_axes: Res<Axis<GamepadButton>>,
     axes: Res<Axis<GamepadAxis>>,
 ) {
-    for gamepad in lobby.gamepads.iter() {
-        let south_button = GamepadButton(*gamepad, GamepadButtonType::South);
-        if button_inputs.just_pressed(south_button) {
-            println!(
-                "{:?} of {:?} is just pressed",
-                GamepadButtonType::South,
-                gamepad
-            );
-        } else if button_inputs.just_released(south_button) {
-            println!(
-                "{:?} of {:?} is just released",
-                GamepadButtonType::South,
-                gamepad
-            );
+    for gamepad in lobby.gamepads.iter().cloned() {
+        if button_inputs.just_pressed(GamepadButton(gamepad, GamepadButtonType::South)) {
+            println!("{:?} just pressed South", gamepad);
+        } else if button_inputs.just_released(GamepadButton(gamepad, GamepadButtonType::South)) {
+            println!("{:?} just released South", gamepad);
         }
 
-        println!(
-            "For {:?}: {:?} is {:.4}, {:?} is {:.4}",
-            gamepad,
-            GamepadButtonType::RightTrigger2,
-            button_axes
-                .get(GamepadButton(*gamepad, GamepadButtonType::RightTrigger2))
-                .unwrap_or(0.0),
-            GamepadAxisType::LeftStickX,
-            axes.get(GamepadAxis(*gamepad, GamepadAxisType::LeftStickX))
-                .unwrap_or(0.0)
-        )
+        let right_trigger = button_axes
+            .get(GamepadButton(gamepad, GamepadButtonType::RightTrigger2))
+            .unwrap();
+        if right_trigger.abs() > 0.01 {
+            println!("{:?} RightTrigger2 value is {}", gamepad, right_trigger);
+        }
+
+        let left_stick_x = axes
+            .get(GamepadAxis(gamepad, GamepadAxisType::LeftStickX))
+            .unwrap();
+        if left_stick_x.abs() > 0.01 {
+            println!("{:?} LeftStickX value is {}", gamepad, left_stick_x);
+        }
     }
 }

--- a/examples/input/gamepad_input_events.rs
+++ b/examples/input/gamepad_input_events.rs
@@ -4,18 +4,15 @@ use bevy_input::gamepad::{GamepadEvent, GamepadEventType};
 fn main() {
     App::build()
         .add_default_plugins()
-        .add_startup_system(gamepad_raw_events.system())
-        .add_system(gamepad_raw_events.system())
+        .add_system(gamepad_events.system())
         .run();
 }
 
-#[derive(Default)]
-struct State {
-    gamepad_event_reader: EventReader<GamepadEvent>,
-}
-
-fn gamepad_raw_events(mut state: Local<State>, gamepad_event: Res<Events<GamepadEvent>>) {
-    for event in state.gamepad_event_reader.iter(&gamepad_event) {
+fn gamepad_events(
+    mut event_reader: Local<EventReader<GamepadEvent>>,
+    gamepad_event: Res<Events<GamepadEvent>>,
+) {
+    for event in event_reader.iter(&gamepad_event) {
         match &event {
             GamepadEvent(gamepad, GamepadEventType::Connected) => {
                 println!("{:?} Connected", gamepad);


### PR DESCRIPTION
The latest gamepad event changes made gamepad events have jitter (due to exposing the raw values). This changes that to use the gamepad settings to filter events. We now have GamepadEvent (filtered) and GamepadeEventRaw (unfiltered).

I also renamed gamepad-related types like XSetting to XSettings and made some example changes to improve clarity and terseness.

@simpuid 