### PR TITLE
Hierarchy

### DIFF
--- a/crates/bevy_transform/src/components/parent.rs
+++ b/crates/bevy_transform/src/components/parent.rs
@@ -26,7 +26,7 @@ impl MapEntities for Parent {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct PreviousParent(pub Option<Entity>);
+pub struct PreviousParent(pub Entity);
 
 impl Deref for Parent {
     type Target = Entity;

--- a/crates/bevy_transform/src/hierarchy/child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/child_builder.rs
@@ -15,10 +15,7 @@ impl Command for InsertChildren {
     fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) {
         for child in self.children.iter() {
             world
-                .insert(
-                    *child,
-                    (Parent(self.parent), PreviousParent(Some(self.parent))),
-                )
+                .insert(*child, (Parent(self.parent), PreviousParent(self.parent)))
                 .unwrap();
         }
         {
@@ -53,10 +50,7 @@ impl Command for PushChildren {
     fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) {
         for child in self.children.iter() {
             world
-                .insert(
-                    *child,
-                    (Parent(self.parent), PreviousParent(Some(self.parent))),
-                )
+                .insert(*child, (Parent(self.parent), PreviousParent(self.parent)))
                 .unwrap();
         }
         {
@@ -255,11 +249,11 @@ mod tests {
 
         assert_eq!(
             *world.get::<PreviousParent>(child1).unwrap(),
-            PreviousParent(Some(parent))
+            PreviousParent(parent)
         );
         assert_eq!(
             *world.get::<PreviousParent>(child2).unwrap(),
-            PreviousParent(Some(parent))
+            PreviousParent(parent)
         );
     }
 
@@ -291,11 +285,11 @@ mod tests {
 
         assert_eq!(
             *world.get::<PreviousParent>(child1).unwrap(),
-            PreviousParent(Some(parent))
+            PreviousParent(parent)
         );
         assert_eq!(
             *world.get::<PreviousParent>(child2).unwrap(),
-            PreviousParent(Some(parent))
+            PreviousParent(parent)
         );
 
         commands.insert_children(parent, 1, &entities[3..]);
@@ -310,11 +304,11 @@ mod tests {
         assert_eq!(*world.get::<Parent>(child4).unwrap(), Parent(parent));
         assert_eq!(
             *world.get::<PreviousParent>(child3).unwrap(),
-            PreviousParent(Some(parent))
+            PreviousParent(parent)
         );
         assert_eq!(
             *world.get::<PreviousParent>(child4).unwrap(),
-            PreviousParent(Some(parent))
+            PreviousParent(parent)
         );
     }
 }

--- a/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
@@ -19,6 +19,7 @@ pub fn parent_update_system(
         {
             log::trace!(" > Removing {:?} from it's prev parent's children", entity);
             previous_parent_children.0.retain(|e| *e != entity);
+            commands.remove_one::<PreviousParent>(entity);
         }
     }
 

--- a/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
@@ -14,13 +14,11 @@ pub fn parent_update_system(
     // them from the `Children` of the `PreviousParent`.
     for (entity, previous_parent) in &mut removed_parent_query.iter() {
         log::trace!("Parent was removed from {:?}", entity);
-        if let Some(previous_parent_entity) = previous_parent.0 {
-            if let Ok(mut previous_parent_children) =
-                children_query.get_mut::<Children>(previous_parent_entity)
-            {
-                log::trace!(" > Removing {:?} from it's prev parent's children", entity);
-                previous_parent_children.0.retain(|e| *e != entity);
-            }
+        if let Ok(mut previous_parent_children) =
+            children_query.get_mut::<Children>(previous_parent.0)
+        {
+            log::trace!(" > Removing {:?} from it's prev parent's children", entity);
+            previous_parent_children.0.retain(|e| *e != entity);
         }
     }
 
@@ -31,28 +29,25 @@ pub fn parent_update_system(
     for (entity, parent, possible_previous_parent) in &mut changed_parent_query.iter() {
         log::trace!("Parent changed for {:?}", entity);
         if let Some(mut previous_parent) = possible_previous_parent {
-            // If the `PreviousParent` is not None.
-            if let Some(previous_parent_entity) = previous_parent.0 {
-                // New and previous point to the same Entity, carry on, nothing to see here.
-                if previous_parent_entity == parent.0 {
-                    log::trace!(" > But the previous parent is the same, ignoring...");
-                    continue;
-                }
+            // New and previous point to the same Entity, carry on, nothing to see here.
+            if previous_parent.0 == parent.0 {
+                log::trace!(" > But the previous parent is the same, ignoring...");
+                continue;
+            }
 
-                // Remove from `PreviousParent.Children`.
-                if let Ok(mut previous_parent_children) =
-                    children_query.get_mut::<Children>(previous_parent_entity)
-                {
-                    log::trace!(" > Removing {:?} from prev parent's children", entity);
-                    (*previous_parent_children).0.retain(|e| *e != entity);
-                }
+            // Remove from `PreviousParent.Children`.
+            if let Ok(mut previous_parent_children) =
+                children_query.get_mut::<Children>(previous_parent.0)
+            {
+                log::trace!(" > Removing {:?} from prev parent's children", entity);
+                (*previous_parent_children).0.retain(|e| *e != entity);
             }
 
             // Set `PreviousParent = Parent`.
-            *previous_parent = PreviousParent(Some(parent.0));
+            *previous_parent = PreviousParent(parent.0);
         } else {
             log::trace!("Adding missing PreviousParent to {:?}", entity);
-            commands.insert_one(entity, PreviousParent(Some(parent.0)));
+            commands.insert_one(entity, PreviousParent(parent.0));
         };
 
         // Add to the parent's `Children` (either the real component, or

--- a/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
@@ -3,22 +3,11 @@ use bevy_ecs::{Commands, Entity, IntoQuerySystem, Query, System, Without};
 use bevy_utils::HashMap;
 use smallvec::SmallVec;
 
-pub fn missing_previous_parent_system(
-    mut commands: Commands,
-    mut query: Query<Without<PreviousParent, (Entity, &Parent)>>,
-) {
-    // Add missing `PreviousParent` components
-    for (entity, _parent) in &mut query.iter() {
-        log::trace!("Adding missing PreviousParent to {:?}", entity);
-        commands.insert_one(entity, PreviousParent(None));
-    }
-}
-
 pub fn parent_update_system(
     mut commands: Commands,
     mut removed_parent_query: Query<Without<Parent, (Entity, &PreviousParent)>>,
     // TODO: ideally this only runs when the Parent component has changed
-    mut changed_parent_query: Query<(Entity, &Parent, &mut PreviousParent)>,
+    mut changed_parent_query: Query<(Entity, &Parent, Option<&mut PreviousParent>)>,
     children_query: Query<&mut Children>,
 ) {
     // Entities with a missing `Parent` (ie. ones that have a `PreviousParent`), remove
@@ -39,28 +28,32 @@ pub fn parent_update_system(
     let mut children_additions = HashMap::<Entity, SmallVec<[Entity; 8]>>::default();
 
     // Entities with a changed Parent (that also have a PreviousParent, even if None)
-    for (entity, parent, mut previous_parent) in &mut changed_parent_query.iter() {
+    for (entity, parent, possible_previous_parent) in &mut changed_parent_query.iter() {
         log::trace!("Parent changed for {:?}", entity);
+        if let Some(mut previous_parent) = possible_previous_parent {
+            // If the `PreviousParent` is not None.
+            if let Some(previous_parent_entity) = previous_parent.0 {
+                // New and previous point to the same Entity, carry on, nothing to see here.
+                if previous_parent_entity == parent.0 {
+                    log::trace!(" > But the previous parent is the same, ignoring...");
+                    continue;
+                }
 
-        // If the `PreviousParent` is not None.
-        if let Some(previous_parent_entity) = previous_parent.0 {
-            // New and previous point to the same Entity, carry on, nothing to see here.
-            if previous_parent_entity == parent.0 {
-                log::trace!(" > But the previous parent is the same, ignoring...");
-                continue;
+                // Remove from `PreviousParent.Children`.
+                if let Ok(mut previous_parent_children) =
+                    children_query.get_mut::<Children>(previous_parent_entity)
+                {
+                    log::trace!(" > Removing {:?} from prev parent's children", entity);
+                    (*previous_parent_children).0.retain(|e| *e != entity);
+                }
             }
 
-            // Remove from `PreviousParent.Children`.
-            if let Ok(mut previous_parent_children) =
-                children_query.get_mut::<Children>(previous_parent_entity)
-            {
-                log::trace!(" > Removing {:?} from prev parent's children", entity);
-                (*previous_parent_children).0.retain(|e| *e != entity);
-            }
-        }
-
-        // Set `PreviousParent = Parent`.
-        *previous_parent = PreviousParent(Some(parent.0));
+            // Set `PreviousParent = Parent`.
+            *previous_parent = PreviousParent(Some(parent.0));
+        } else {
+            log::trace!("Adding missing PreviousParent to {:?}", entity);
+            commands.insert_one(entity, PreviousParent(Some(parent.0)));
+        };
 
         // Add to the parent's `Children` (either the real component, or
         // `children_additions`).
@@ -99,10 +92,7 @@ pub fn parent_update_system(
 }
 
 pub fn hierarchy_maintenance_systems() -> Vec<Box<dyn System>> {
-    vec![
-        missing_previous_parent_system.system(),
-        parent_update_system.system(),
-    ]
+    vec![parent_update_system.system()]
 }
 
 #[cfg(test)]

--- a/crates/bevy_transform/src/hierarchy/world_child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/world_child_builder.rs
@@ -16,7 +16,7 @@ impl<'a, 'b> WorldChildBuilder<'a, 'b> {
             .expect("There should always be a parent at this point.");
         self.world_builder
             .spawn(components)
-            .with_bundle((Parent(parent_entity), PreviousParent(Some(parent_entity))));
+            .with_bundle((Parent(parent_entity), PreviousParent(parent_entity)));
         let entity = self.world_builder.current_entity.unwrap();
         {
             let world = &mut self.world_builder.world;


### PR DESCRIPTION
If you spawn an entity with a parent component, it takes two ticks right now for that entity to get added to the list of children of its new parent. In the first tick, _missing_previous_parent_system_ adds a PreviousParent(None) to the entity, which will be added after _parent_update_system_ has run. Since _parent_update_system_ queries for entities with a previous parent, the child list of the new parent is not yet updated. In the second tick, _parent_update_system_ picks the entity up and updates the child list of the parent.
This caused a panic for me when I tried to despawn the parent recursively one tick after the creation of its new child (_parent_update_system_ then tries to insert a new child list for an entity that just got despawned). Merging the two systems fixes that and allows to get rid of the Optional in the PreviousParent struct.