### PR TITLE
fix wasm assets

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -37,7 +37,6 @@ log = { version = "0.4", features = ["release_max_level_info"] }
 notify = { version = "5.0.0-pre.2", optional = true }
 parking_lot = "0.11.0"
 rand = "0.7.3"
-async-trait = "0.1.40"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -1,6 +1,5 @@
 use crate::{filesystem_watcher::FilesystemWatcher, AssetIo, AssetIoError, AssetServer};
 use anyhow::Result;
-use async_trait::async_trait;
 use bevy_ecs::Res;
 use bevy_utils::HashSet;
 use crossbeam_channel::TryRecvError;
@@ -12,6 +11,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
+use bevy_ecs::bevy_utils::BoxedFuture;
 
 pub struct FileAssetIo {
     root_path: PathBuf,
@@ -42,23 +42,24 @@ impl FileAssetIo {
     }
 }
 
-#[async_trait]
 impl AssetIo for FileAssetIo {
-    async fn load_path(&self, path: &Path) -> Result<Vec<u8>, AssetIoError> {
-        let mut bytes = Vec::new();
-        match File::open(self.root_path.join(path)) {
-            Ok(mut file) => {
-                file.read_to_end(&mut bytes)?;
-            }
-            Err(e) => {
-                if e.kind() == std::io::ErrorKind::NotFound {
-                    return Err(AssetIoError::NotFound(path.to_owned()));
-                } else {
-                    return Err(e.into());
+    fn load_path<'a>(&'a self, path: &'a Path) -> BoxedFuture<'a, Result<Vec<u8>, AssetIoError>> {
+        Box::pin(async move {
+            let mut bytes = Vec::new();
+            match File::open(self.root_path.join(path)) {
+                Ok(mut file) => {
+                    file.read_to_end(&mut bytes)?;
+                }
+                Err(e) => {
+                    if e.kind() == std::io::ErrorKind::NotFound {
+                        return Err(AssetIoError::NotFound(path.to_owned()));
+                    } else {
+                        return Err(e.into());
+                    }
                 }
             }
-        }
-        Ok(bytes)
+            Ok(bytes)
+        })
     }
 
     fn read_directory(
@@ -103,7 +104,7 @@ impl AssetIo for FileAssetIo {
     }
 }
 
-#[cfg(feature = "filesystem_watcher")]
+#[cfg(all(feature = "filesystem_watcher", not(target_arch = "wasm32")))]
 pub fn filesystem_watcher_system(asset_server: Res<AssetServer>) {
     let mut changed = HashSet::default();
     let asset_io =

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -1,6 +1,6 @@
 use crate::{filesystem_watcher::FilesystemWatcher, AssetIo, AssetIoError, AssetServer};
 use anyhow::Result;
-use bevy_ecs::Res;
+use bevy_ecs::{bevy_utils::BoxedFuture, Res};
 use bevy_utils::HashSet;
 use crossbeam_channel::TryRecvError;
 use fs::File;
@@ -11,7 +11,6 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use bevy_ecs::bevy_utils::BoxedFuture;
 
 pub struct FileAssetIo {
     root_path: PathBuf,

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -9,13 +9,13 @@ pub use file_asset_io::*;
 pub use wasm_asset_io::*;
 
 use anyhow::Result;
+use bevy_ecs::bevy_utils::BoxedFuture;
 use downcast_rs::{impl_downcast, Downcast};
 use std::{
     io,
     path::{Path, PathBuf},
 };
 use thiserror::Error;
-use bevy_ecs::bevy_utils::BoxedFuture;
 
 /// Errors that occur while loading assets
 #[derive(Error, Debug)]

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -9,13 +9,13 @@ pub use file_asset_io::*;
 pub use wasm_asset_io::*;
 
 use anyhow::Result;
-use async_trait::async_trait;
 use downcast_rs::{impl_downcast, Downcast};
 use std::{
     io,
     path::{Path, PathBuf},
 };
 use thiserror::Error;
+use bevy_ecs::bevy_utils::BoxedFuture;
 
 /// Errors that occur while loading assets
 #[derive(Error, Debug)]
@@ -29,10 +29,8 @@ pub enum AssetIoError {
 }
 
 /// Handles load requests from an AssetServer
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait AssetIo: Downcast + Send + Sync + 'static {
-    async fn load_path(&self, path: &Path) -> Result<Vec<u8>, AssetIoError>;
+    fn load_path<'a>(&'a self, path: &'a Path) -> BoxedFuture<'a, Result<Vec<u8>, AssetIoError>>;
     fn read_directory(
         &self,
         path: &Path,

--- a/crates/bevy_asset/src/io/wasm_asset_io.rs
+++ b/crates/bevy_asset/src/io/wasm_asset_io.rs
@@ -1,11 +1,11 @@
 use crate::{AssetIo, AssetIoError};
 use anyhow::Result;
-use async_trait::async_trait;
 use js_sys::Uint8Array;
 use std::path::{Path, PathBuf};
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::Response;
+use bevy_ecs::bevy_utils::BoxedFuture;
 
 pub struct WasmAssetIo {
     root_path: PathBuf,
@@ -19,18 +19,19 @@ impl WasmAssetIo {
     }
 }
 
-#[async_trait(?Send)]
 impl AssetIo for WasmAssetIo {
-    async fn load_path(&self, path: &Path) -> Result<Vec<u8>, AssetIoError> {
-        let path = self.root_path.join(path);
-        let window = web_sys::window().unwrap();
-        let resp_value = JsFuture::from(window.fetch_with_str(path.to_str().unwrap()))
-            .await
-            .unwrap();
-        let resp: Response = resp_value.dyn_into().unwrap();
-        let data = JsFuture::from(resp.array_buffer().unwrap()).await.unwrap();
-        let bytes = Uint8Array::new(&data).to_vec();
-        Ok(bytes)
+    fn load_path<'a>(&'a self, path: &'a Path) -> BoxedFuture<'a, Result<Vec<u8>, AssetIoError>> {
+        Box::pin(async move {
+            let path = self.root_path.join(path);
+            let window = web_sys::window().unwrap();
+            let resp_value = JsFuture::from(window.fetch_with_str(path.to_str().unwrap()))
+                .await
+                .unwrap();
+            let resp: Response = resp_value.dyn_into().unwrap();
+            let data = JsFuture::from(resp.array_buffer().unwrap()).await.unwrap();
+            let bytes = Uint8Array::new(&data).to_vec();
+            Ok(bytes)
+        })
     }
 
     fn read_directory(

--- a/crates/bevy_asset/src/io/wasm_asset_io.rs
+++ b/crates/bevy_asset/src/io/wasm_asset_io.rs
@@ -1,11 +1,11 @@
 use crate::{AssetIo, AssetIoError};
 use anyhow::Result;
+use bevy_ecs::bevy_utils::BoxedFuture;
 use js_sys::Uint8Array;
 use std::path::{Path, PathBuf};
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::Response;
-use bevy_ecs::bevy_utils::BoxedFuture;
 
 pub struct WasmAssetIo {
     root_path: PathBuf,

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -3,10 +3,10 @@ use std::{future::Future, pin::Pin};
 
 pub use ahash::AHasher;
 
-#[cfg(not(target_arch="wasm32"))]
+#[cfg(not(target_arch = "wasm32"))]
 pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-#[cfg(target_arch="wasm32")]
+#[cfg(target_arch = "wasm32")]
 pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
 pub type HashMap<K, V> = std::collections::HashMap<K, V, RandomState>;

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -3,7 +3,12 @@ use std::{future::Future, pin::Pin};
 
 pub use ahash::AHasher;
 
+#[cfg(not(target_arch="wasm32"))]
 pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+#[cfg(target_arch="wasm32")]
+pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+
 pub type HashMap<K, V> = std::collections::HashMap<K, V, RandomState>;
 pub type HashSet<K> = std::collections::HashSet<K, RandomState>;
 


### PR DESCRIPTION
This PR gets rid of async_trait from AsyncIo trait (so we don't use it anywhere now) and fixes this gltf_loader error for wasm32:

```
error[E0277]: `dyn std::future::Future<Output = std::result::Result<std::vec::Vec<u8>, bevy_asset::AssetIoError>>` cannot be sent between threads safely
  --> crates/bevy_gltf/src/loader.rs:55:9
   |
55 |         Box::pin(async move { Ok(load_gltf(bytes, load_context).await?) })
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn std::future::Future<Output = std::result::Result<std::vec::Vec<u8>, bevy_asset::AssetIoError>>` cannot be sent between threads safely
   |
   = help: the trait `std::marker::Send` is not implemented for `dyn std::future::Future<Output = std::result::Result<std::vec::Vec<u8>, bevy_asset::AssetIoError>>`
   = note: required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<dyn std::future::Future<Output = std::result::Result<std::vec::Vec<u8>, bevy_asset::AssetIoError>>>`
   = note: required because it appears within the type `std::boxed::Box<dyn std::future::Future<Output = std::result::Result<std::vec::Vec<u8>, bevy_asset::AssetIoError>>>`
   = note: required because it appears within the type `std::pin::Pin<std::boxed::Box<dyn std::future::Future<Output = std::result::Result<std::vec::Vec<u8>, bevy_asset::AssetIoError>>>>`
   = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5> {std::future::ResumeTy, &'r bevy_asset::LoadContext<'s>, std::path::PathBuf, bevy_asset::LoadContext<'t0>, &'t1 (dyn bevy_asset::AssetIo + 't2), &'t3 std::path::PathBuf, &'t4 std::path::Path, std::pin::Pin<std::boxed::Box<(dyn std::future::Future<Output = std::result::Result<std::vec::Vec<u8>, bevy_asset::AssetIoError>> + 't5)>>, ()}`
   = note: required because it appears within the type `[static generator@bevy_asset::LoadContext::<'a>::read_asset_bytes::{{closure}}#0 0:&bevy_asset::LoadContext<'_>, 1:std::path::PathBuf for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5> {std::future::ResumeTy, &'r bevy_asset::LoadContext<'s>, std::path::PathBuf, bevy_asset::LoadContext<'t0>, &'t1 (dyn bevy_asset::AssetIo + 't2), &'t3 std::path::PathBuf, &'t4 std::path::Path, std::pin::Pin<std::boxed::Box<(dyn std::future::Future<Output = std::result::Result<std::vec::Vec<u8>, bevy_asset::AssetIoError>> + 't5)>>, ()}]`
   = note: required because it appears within the type `std::future::from_generator::GenFuture<[static generator@bevy_asset::LoadContext::<'a>::read_asset_bytes::{{closure}}#0 0:&bevy_asset::LoadContext<'_>, 1:std::path::PathBuf for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5> {std::future::ResumeTy, &'r bevy_asset::LoadContext<'s>, std::path::PathBuf, bevy_asset::LoadContext<'t0>, &'t1 (dyn bevy_asset::AssetIo + 't2), &'t3 std::path::PathBuf, &'t4 std::path::Path, std::pin::Pin<std::boxed::Box<(dyn std::future::Future<Output = std::result::Result<std::vec::Vec<u8>, bevy_asset::AssetIoError>> + 't5)>>, ()}]>`
   = note: required because it appears within the type `impl std::future::Future`
   = note: required because it appears within the type `impl std::future::Future`
   = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11> {std::future::ResumeTy, &'r gltf::Gltf, &'s bevy_asset::LoadContext<'t0>, &'t1 std::path::Path, std::vec::Vec<std::vec::Vec<u8>>, &'t2 gltf::Document, gltf::iter::Buffers<'t3>, gltf::Buffer<'t4>, &'t5 gltf::Buffer<'t6>, gltf::buffer::Source<'t7>, &'t8 str, bool, std::path::PathBuf, impl std::future::Future, ()}`
   = note: required because it appears within the type `[static generator@crates/bevy_gltf/src/loader.rs:281:38: 312:2 gltf:&gltf::Gltf, load_context:&bevy_asset::LoadContext<'_>, asset_path:&std::path::Path for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11> {std::future::ResumeTy, &'r gltf::Gltf, &'s bevy_asset::LoadContext<'t0>, &'t1 std::path::Path, std::vec::Vec<std::vec::Vec<u8>>, &'t2 gltf::Document, gltf::iter::Buffers<'t3>, gltf::Buffer<'t4>, &'t5 gltf::Buffer<'t6>, gltf::buffer::Source<'t7>, &'t8 str, bool, std::path::PathBuf, impl std::future::Future, ()}]`
   = note: required because it appears within the type `std::future::from_generator::GenFuture<[static generator@crates/bevy_gltf/src/loader.rs:281:38: 312:2 gltf:&gltf::Gltf, load_context:&bevy_asset::LoadContext<'_>, asset_path:&std::path::Path for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11> {std::future::ResumeTy, &'r gltf::Gltf, &'s bevy_asset::LoadContext<'t0>, &'t1 std::path::Path, std::vec::Vec<std::vec::Vec<u8>>, &'t2 gltf::Document, gltf::iter::Buffers<'t3>, gltf::Buffer<'t4>, &'t5 gltf::Buffer<'t6>, gltf::buffer::Source<'t7>, &'t8 str, bool, std::path::PathBuf, impl std::future::Future, ()}]>`
   = note: required because it appears within the type `impl std::future::Future`
   = note: required because it appears within the type `impl std::future::Future`
   = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8> {std::future::ResumeTy, &'r [u8], &'s mut bevy_asset::LoadContext<'t0>, gltf::Gltf, bevy_ecs::World, &'t1 gltf::Gltf, &'t2 bevy_asset::LoadContext<'t3>, &'t4 std::path::Path, impl std::future::Future, ()}`
   = note: required because it appears within the type `[static generator@crates/bevy_gltf/src/loader.rs:67:28: 197:2 bytes:&[u8], load_context:&mut bevy_asset::LoadContext<'_> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8> {std::future::ResumeTy, &'r [u8], &'s mut bevy_asset::LoadContext<'t0>, gltf::Gltf, bevy_ecs::World, &'t1 gltf::Gltf, &'t2 bevy_asset::LoadContext<'t3>, &'t4 std::path::Path, impl std::future::Future, ()}]`
   = note: required because it appears within the type `std::future::from_generator::GenFuture<[static generator@crates/bevy_gltf/src/loader.rs:67:28: 197:2 bytes:&[u8], load_context:&mut bevy_asset::LoadContext<'_> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8> {std::future::ResumeTy, &'r [u8], &'s mut bevy_asset::LoadContext<'t0>, gltf::Gltf, bevy_ecs::World, &'t1 gltf::Gltf, &'t2 bevy_asset::LoadContext<'t3>, &'t4 std::path::Path, impl std::future::Future, ()}]>`
   = note: required because it appears within the type `impl std::future::Future`
   = note: required because it appears within the type `impl std::future::Future`
   = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2> {std::future::ResumeTy, &'r [u8], &'s mut bevy_asset::LoadContext<'t0>, impl std::future::Future, ()}`
   = note: required because it appears within the type `[static generator@crates/bevy_gltf/src/loader.rs:55:29: 55:74 bytes:&[u8], load_context:&mut bevy_asset::LoadContext<'_> for<'r, 's, 't0, 't1, 't2> {std::future::ResumeTy, &'r [u8], &'s mut bevy_asset::LoadContext<'t0>, impl std::future::Future, ()}]`
   = note: required because it appears within the type `std::future::from_generator::GenFuture<[static generator@crates/bevy_gltf/src/loader.rs:55:29: 55:74 bytes:&[u8], load_context:&mut bevy_asset::LoadContext<'_> for<'r, 's, 't0, 't1, 't2> {std::future::ResumeTy, &'r [u8], &'s mut bevy_asset::LoadContext<'t0>, impl std::future::Future, ()}]>`
   = note: required because it appears within the type `impl std::future::Future`
   = note: required for the cast to the object type `dyn std::future::Future<Output = std::result::Result<(), anyhow::Error>> + std::marker::Send`

error: aborting due to previous error

```