### PR TITLE
fallback to remove components one by one when failing to remove a bundle

### DIFF
--- a/crates/bevy_ecs/hecs/src/world.rs
+++ b/crates/bevy_ecs/hecs/src/world.rs
@@ -675,9 +675,8 @@ impl World {
         let to_remove = T::with_static_ids(|ids| ids.iter().copied().collect::<HashSet<_>>());
 
         match self.remove_bundle_internal::<_, T>(entity, to_remove, true) {
-            Ok(Some(bundle)) => Ok(bundle),
+            Ok(bundle) => Ok(bundle),
             Err(err) => Err(err),
-            Ok(None) => unreachable!(),
         }
     }
 
@@ -686,7 +685,7 @@ impl World {
         entity: Entity,
         to_remove: std::collections::HashSet<TypeId, S>,
         check_presence: bool,
-    ) -> Result<Option<T>, ComponentError> {
+    ) -> Result<T, ComponentError> {
         use std::collections::hash_map::Entry;
 
         let loc = self.entities.get_mut(entity)?;
@@ -742,7 +741,7 @@ impl World {
             {
                 self.entities.get_mut(moved).unwrap().index = old_index;
             }
-            Ok(bundle)
+            bundle.ok_or_else(|| ComponentError::MissingComponent(MissingComponent::new::<()>()))
         }
     }
 

--- a/crates/bevy_ecs/hecs/src/world.rs
+++ b/crates/bevy_ecs/hecs/src/world.rs
@@ -675,8 +675,9 @@ impl World {
         let to_remove = T::with_static_ids(|ids| ids.iter().copied().collect::<HashSet<_>>());
 
         match self.remove_bundle_internal::<_, T>(entity, to_remove, true) {
-            Ok(bundle) => Ok(bundle),
+            Ok(Some(bundle)) => Ok(bundle),
             Err(err) => Err(err),
+            Ok(None) => unreachable!(),
         }
     }
 
@@ -685,7 +686,7 @@ impl World {
         entity: Entity,
         to_remove: std::collections::HashSet<TypeId, S>,
         check_presence: bool,
-    ) -> Result<T, ComponentError> {
+    ) -> Result<Option<T>, ComponentError> {
         use std::collections::hash_map::Entry;
 
         let loc = self.entities.get_mut(entity)?;
@@ -741,7 +742,7 @@ impl World {
             {
                 self.entities.get_mut(moved).unwrap().index = old_index;
             }
-            bundle.ok_or_else(|| ComponentError::MissingComponent(MissingComponent::new::<()>()))
+            Ok(bundle)
         }
     }
 

--- a/crates/bevy_ecs/hecs/src/world.rs
+++ b/crates/bevy_ecs/hecs/src/world.rs
@@ -671,17 +671,35 @@ impl World {
     /// assert_eq!(*world.get::<bool>(e).unwrap(), true);
     /// ```
     pub fn remove<T: Bundle>(&mut self, entity: Entity) -> Result<T, ComponentError> {
-        use std::collections::hash_map::Entry;
-
         self.flush();
         let loc = self.entities.get_mut(entity)?;
         unsafe {
-            let removed = T::with_static_ids(|ids| ids.iter().copied().collect::<HashSet<_>>());
+            let to_remove = T::with_static_ids(|ids| ids.iter().copied().collect::<HashSet<_>>());
+
+            let old_index = loc.index;
+            let source_arch = &self.archetypes[loc.archetype as usize];
+            let bundle = T::get(|ty, size| source_arch.get_dynamic(ty, size, old_index))?;
+            match self.remove_bundle_internal(entity, to_remove) {
+                Ok(_) => Ok(bundle),
+                Err(err) => Err(err),
+            }
+        }
+    }
+
+    fn remove_bundle_internal<S: core::hash::BuildHasher>(
+        &mut self,
+        entity: Entity,
+        to_remove: std::collections::HashSet<TypeId, S>,
+    ) -> Result<(), ComponentError> {
+        use std::collections::hash_map::Entry;
+
+        let loc = self.entities.get_mut(entity)?;
+        unsafe {
             let info = self.archetypes[loc.archetype as usize]
                 .types()
                 .iter()
                 .cloned()
-                .filter(|x| !removed.contains(&x.id()))
+                .filter(|x| !to_remove.contains(&x.id()))
                 .collect::<Vec<_>>();
             let elements = info.iter().map(|x| x.id()).collect::<Vec<_>>();
             let target = match self.index.entry(elements) {
@@ -695,8 +713,6 @@ impl World {
                 }
             };
             let old_index = loc.index;
-            let source_arch = &self.archetypes[loc.archetype as usize];
-            let bundle = T::get(|ty, size| source_arch.get_dynamic(ty, size, old_index))?;
             let (source_arch, target_arch) = index2(
                 &mut self.archetypes,
                 loc.archetype as usize,
@@ -723,8 +739,35 @@ impl World {
             {
                 self.entities.get_mut(moved).unwrap().index = old_index;
             }
-            Ok(bundle)
+            Ok(())
         }
+    }
+
+    /// Remove components from `entity`
+    ///
+    /// Fallback method for `remove` when one of the component in `T` is not present in `entity`.
+    /// In this case, the missing component will be skipped.
+    ///
+    /// See `remove`.
+    pub fn remove_one_by_one<T: Bundle>(&mut self, entity: Entity) -> Result<(), ComponentError> {
+        self.flush();
+
+        let to_remove = T::with_static_ids(|ids| ids.iter().copied().collect::<HashSet<_>>());
+        for component_to_remove in to_remove.into_iter() {
+            let loc = self.entities.get(entity)?;
+            if loc.archetype == 0 {
+                return Err(ComponentError::NoSuchEntity);
+            }
+            if self.archetypes[loc.archetype as usize].has_dynamic(component_to_remove) {
+                let mut single_component_hashset = std::collections::HashSet::new();
+                single_component_hashset.insert(component_to_remove);
+                match self.remove_bundle_internal(entity, single_component_hashset) {
+                    Ok(_) | Err(ComponentError::MissingComponent(_)) => (),
+                    Err(err) => return Err(err),
+                };
+            }
+        }
+        Ok(())
     }
 
     /// Remove the `T` component from `entity`

--- a/crates/bevy_ecs/hecs/src/world.rs
+++ b/crates/bevy_ecs/hecs/src/world.rs
@@ -709,17 +709,18 @@ impl World {
                 }
             };
             let old_index = loc.index;
-            let bundle = if check_presence {
-                let source = &self.archetypes[loc.archetype as usize];
-                Some(T::get(|ty, size| source.get_dynamic(ty, size, old_index))?)
-            } else {
-                None
-            };
             let (source_arch, target_arch) = index2(
                 &mut self.archetypes,
                 loc.archetype as usize,
                 target as usize,
             );
+            let bundle = if check_presence {
+                Some(T::get(|ty, size| {
+                    source_arch.get_dynamic(ty, size, old_index)
+                })?)
+            } else {
+                None
+            };
             let target_index = target_arch.allocate(entity);
             loc.archetype = target;
             loc.index = target_index;

--- a/crates/bevy_ecs/hecs/src/world.rs
+++ b/crates/bevy_ecs/hecs/src/world.rs
@@ -709,18 +709,17 @@ impl World {
                 }
             };
             let old_index = loc.index;
+            let bundle = if check_presence {
+                let source = &self.archetypes[loc.archetype as usize];
+                Some(T::get(|ty, size| source.get_dynamic(ty, size, old_index))?)
+            } else {
+                None
+            };
             let (source_arch, target_arch) = index2(
                 &mut self.archetypes,
                 loc.archetype as usize,
                 target as usize,
             );
-            let bundle = if check_presence {
-                Some(T::get(|ty, size| {
-                    source_arch.get_dynamic(ty, size, old_index)
-                })?)
-            } else {
-                None
-            };
             let target_index = target_arch.allocate(entity);
             loc.archetype = target;
             loc.index = target_index;

--- a/crates/bevy_ecs/hecs/src/world.rs
+++ b/crates/bevy_ecs/hecs/src/world.rs
@@ -672,25 +672,20 @@ impl World {
     /// ```
     pub fn remove<T: Bundle>(&mut self, entity: Entity) -> Result<T, ComponentError> {
         self.flush();
-        let loc = self.entities.get_mut(entity)?;
-        unsafe {
-            let to_remove = T::with_static_ids(|ids| ids.iter().copied().collect::<HashSet<_>>());
+        let to_remove = T::with_static_ids(|ids| ids.iter().copied().collect::<HashSet<_>>());
 
-            let old_index = loc.index;
-            let source_arch = &self.archetypes[loc.archetype as usize];
-            let bundle = T::get(|ty, size| source_arch.get_dynamic(ty, size, old_index))?;
-            match self.remove_bundle_internal(entity, to_remove) {
-                Ok(_) => Ok(bundle),
-                Err(err) => Err(err),
-            }
+        match self.remove_bundle_internal::<_, T>(entity, to_remove, true) {
+            Ok(bundle) => Ok(bundle),
+            Err(err) => Err(err),
         }
     }
 
-    fn remove_bundle_internal<S: core::hash::BuildHasher>(
+    fn remove_bundle_internal<S: core::hash::BuildHasher, T: Bundle>(
         &mut self,
         entity: Entity,
         to_remove: std::collections::HashSet<TypeId, S>,
-    ) -> Result<(), ComponentError> {
+        check_presence: bool,
+    ) -> Result<T, ComponentError> {
         use std::collections::hash_map::Entry;
 
         let loc = self.entities.get_mut(entity)?;
@@ -718,6 +713,13 @@ impl World {
                 loc.archetype as usize,
                 target as usize,
             );
+            let bundle = if check_presence {
+                Some(T::get(|ty, size| {
+                    source_arch.get_dynamic(ty, size, old_index)
+                })?)
+            } else {
+                None
+            };
             let target_index = target_arch.allocate(entity);
             loc.archetype = target;
             loc.index = target_index;
@@ -739,7 +741,7 @@ impl World {
             {
                 self.entities.get_mut(moved).unwrap().index = old_index;
             }
-            Ok(())
+            bundle.ok_or_else(|| ComponentError::MissingComponent(MissingComponent::new::<()>()))
         }
     }
 
@@ -761,7 +763,11 @@ impl World {
             if self.archetypes[loc.archetype as usize].has_dynamic(component_to_remove) {
                 let mut single_component_hashset = std::collections::HashSet::new();
                 single_component_hashset.insert(component_to_remove);
-                match self.remove_bundle_internal(entity, single_component_hashset) {
+                match self.remove_bundle_internal::<_, ((),)>(
+                    entity,
+                    single_component_hashset,
+                    false,
+                ) {
                     Ok(_) | Err(ComponentError::MissingComponent(_)) => (),
                     Err(err) => return Err(err),
                 };

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -126,7 +126,20 @@ where
     T: Bundle + Send + Sync + 'static,
 {
     fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) {
-        world.remove::<T>(self.entity).unwrap();
+        if let Err(e) = world.remove::<T>(self.entity) {
+            log::warn!(
+                "Failed to remove components {:?} with error: {}. Falling back to inefficient one-by-one component removing.",
+                std::any::type_name::<T>(),
+                e
+            );
+            if let Err(e) = world.remove_one_by_one::<T>(self.entity) {
+                log::debug!(
+                    "Failed to remove components {:?} with error: {}",
+                    std::any::type_name::<T>(),
+                    e
+                );
+            }
+        }
     }
 }
 
@@ -328,5 +341,35 @@ mod tests {
             .map(|(a, b)| (*a, *b))
             .collect::<Vec<_>>();
         assert_eq!(results2, vec![]);
+    }
+
+    #[test]
+    fn remove_components() {
+        let mut world = World::default();
+        let mut resources = Resources::default();
+        let mut command_buffer = Commands::default();
+        command_buffer.set_entity_reserver(world.get_entity_reserver());
+        command_buffer.spawn((1u32, 2u64));
+        let entity = command_buffer.current_entity().unwrap();
+        command_buffer.apply(&mut world, &mut resources);
+        let results_before = world
+            .query::<(&u32, &u64)>()
+            .iter()
+            .map(|(a, b)| (*a, *b))
+            .collect::<Vec<_>>();
+        assert_eq!(results_before, vec![(1u32, 2u64)]);
+
+        // test component removal
+        command_buffer.remove_one::<u32>(entity);
+        command_buffer.remove::<(u32, u64)>(entity);
+        command_buffer.apply(&mut world, &mut resources);
+        let results_after = world
+            .query::<(&u32, &u64)>()
+            .iter()
+            .map(|(a, b)| (*a, *b))
+            .collect::<Vec<_>>();
+        assert_eq!(results_after, vec![]);
+        let results_after_u64 = world.query::<&u64>().iter().map(|a| *a).collect::<Vec<_>>();
+        assert_eq!(results_after_u64, vec![]);
     }
 }

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -1,7 +1,7 @@
 use super::SystemId;
 use crate::resource::{Resource, Resources};
 use bevy_hecs::{Bundle, Component, DynamicBundle, Entity, EntityReserver, World};
-use bevy_utils::tracing::debug;
+use bevy_utils::tracing::{debug, warn};
 use std::marker::PhantomData;
 
 /// A [World] mutation
@@ -129,13 +129,13 @@ where
         match world.remove::<T>(self.entity) {
             Ok(_) => (),
             Err(bevy_hecs::ComponentError::MissingComponent(e)) => {
-                log::warn!(
+                warn!(
                     "Failed to remove components {:?} with error: {}. Falling back to inefficient one-by-one component removing.",
                     std::any::type_name::<T>(),
                     e
                 );
                 if let Err(e) = world.remove_one_by_one::<T>(self.entity) {
-                    log::debug!(
+                    debug!(
                         "Failed to remove components {:?} with error: {}",
                         std::any::type_name::<T>(),
                         e
@@ -143,7 +143,7 @@ where
                 }
             }
             Err(e) => {
-                log::debug!(
+                debug!(
                     "Failed to remove components {:?} with error: {}",
                     std::any::type_name::<T>(),
                     e

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -364,7 +364,6 @@ mod tests {
         command_buffer.apply(&mut world, &mut resources);
         let results_before = world
             .query::<(&u32, &u64)>()
-            .iter()
             .map(|(a, b)| (*a, *b))
             .collect::<Vec<_>>();
         assert_eq!(results_before, vec![(1u32, 2u64)]);
@@ -375,11 +374,10 @@ mod tests {
         command_buffer.apply(&mut world, &mut resources);
         let results_after = world
             .query::<(&u32, &u64)>()
-            .iter()
             .map(|(a, b)| (*a, *b))
             .collect::<Vec<_>>();
         assert_eq!(results_after, vec![]);
-        let results_after_u64 = world.query::<&u64>().iter().map(|a| *a).collect::<Vec<_>>();
+        let results_after_u64 = world.query::<&u64>().map(|a| *a).collect::<Vec<_>>();
         assert_eq!(results_after_u64, vec![]);
     }
 }

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -377,7 +377,7 @@ mod tests {
             .map(|(a, b)| (*a, *b))
             .collect::<Vec<_>>();
         assert_eq!(results_after, vec![]);
-        let results_after_u64 = world.query::<&u64>().map(|a| *a).collect::<Vec<_>>();
+        let results_after_u64 = world.query::<&u64>().copied().collect::<Vec<_>>();
         assert_eq!(results_after_u64, vec![]);
     }
 }

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -377,7 +377,7 @@ mod tests {
             .map(|(a, b)| (*a, *b))
             .collect::<Vec<_>>();
         assert_eq!(results_after, vec![]);
-        let results_after_u64 = world.query::<&u64>().copied().collect::<Vec<_>>();
+        let results_after_u64 = world.query::<&u64>().map(|a| *a).collect::<Vec<_>>();
         assert_eq!(results_after_u64, vec![]);
     }
 }


### PR DESCRIPTION
fixes #698 
when failing to remove a bundle, issue a warn log and fallback to remove components from bundle one by one instead of panicking.

see #710 for discussion on fallback