### PR TITLE
assets: replace Path/PathBuf with &str/String

### DIFF
--- a/crates/bevy_asset/src/info.rs
+++ b/crates/bevy_asset/src/info.rs
@@ -1,7 +1,6 @@
 use crate::{path::AssetPath, LabelId};
 use bevy_utils::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
 use uuid::Uuid;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -20,7 +19,7 @@ pub struct AssetMeta {
 #[derive(Clone, Debug)]
 pub struct SourceInfo {
     pub meta: Option<SourceMeta>,
-    pub path: PathBuf,
+    pub path: String,
     pub asset_types: HashMap<LabelId, Uuid>,
     pub load_state: LoadState,
     pub committed_assets: HashSet<LabelId>,

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -11,33 +11,30 @@ pub use wasm_asset_io::*;
 use anyhow::Result;
 use bevy_ecs::bevy_utils::BoxedFuture;
 use downcast_rs::{impl_downcast, Downcast};
-use std::{
-    io,
-    path::{Path, PathBuf},
-};
+use std::io;
 use thiserror::Error;
 
 /// Errors that occur while loading assets
 #[derive(Error, Debug)]
 pub enum AssetIoError {
     #[error("Path not found")]
-    NotFound(PathBuf),
+    NotFound(String),
     #[error("Encountered an io error while loading asset.")]
     Io(#[from] io::Error),
     #[error("Failed to watch path")]
-    PathWatchError(PathBuf),
+    PathWatchError(String),
 }
 
 /// Handles load requests from an AssetServer
 pub trait AssetIo: Downcast + Send + Sync + 'static {
-    fn load_path<'a>(&'a self, path: &'a Path) -> BoxedFuture<'a, Result<Vec<u8>, AssetIoError>>;
-    fn read_directory(
-        &self,
-        path: &Path,
-    ) -> Result<Box<dyn Iterator<Item = PathBuf>>, AssetIoError>;
-    fn is_directory(&self, path: &Path) -> bool;
-    fn watch_path_for_changes(&self, path: &Path) -> Result<(), AssetIoError>;
+    fn load_path<'a>(&'a self, path: &'a str) -> BoxedFuture<'a, Result<Vec<u8>, AssetIoError>>;
+    fn read_directory(&self, path: &str) -> Result<Box<dyn Iterator<Item = String>>, AssetIoError>;
+    fn is_directory(&self, path: &str) -> bool;
+    fn watch_path_for_changes(&self, path: &str) -> Result<(), AssetIoError>;
     fn watch_for_changes(&self) -> Result<(), AssetIoError>;
+    fn extension<'a>(&self, path: &'a str) -> Option<&'a str>;
+    fn parent<'a>(&self, path: &'a str) -> Option<&'a str>;
+    fn sibling(&self, path: &str, sibling: &str) -> Option<String>;
 }
 
 impl_downcast!(AssetIo);

--- a/crates/bevy_asset/src/io/wasm_asset_io.rs
+++ b/crates/bevy_asset/src/io/wasm_asset_io.rs
@@ -20,7 +20,7 @@ impl WasmAssetIo {
 }
 
 impl AssetIo for WasmAssetIo {
-    fn load_path<'a>(&'a self, path: &'a Path) -> BoxedFuture<'a, Result<Vec<u8>, AssetIoError>> {
+    fn load_path<'a>(&'a self, path: &'a str) -> BoxedFuture<'a, Result<Vec<u8>, AssetIoError>> {
         Box::pin(async move {
             let path = self.root_path.join(path);
             let window = web_sys::window().unwrap();
@@ -36,12 +36,12 @@ impl AssetIo for WasmAssetIo {
 
     fn read_directory(
         &self,
-        _path: &Path,
-    ) -> Result<Box<dyn Iterator<Item = PathBuf>>, AssetIoError> {
-        Ok(Box::new(std::iter::empty::<PathBuf>()))
+        _path: &str,
+    ) -> Result<Box<dyn Iterator<Item = String>>, AssetIoError> {
+        Ok(Box::new(std::iter::empty::<String>()))
     }
 
-    fn watch_path_for_changes(&self, _path: &Path) -> Result<(), AssetIoError> {
+    fn watch_path_for_changes(&self, _path: &str) -> Result<(), AssetIoError> {
         Ok(())
     }
 
@@ -49,7 +49,21 @@ impl AssetIo for WasmAssetIo {
         Ok(())
     }
 
-    fn is_directory(&self, path: &Path) -> bool {
+    fn is_directory(&self, path: &str) -> bool {
         self.root_path.join(path).is_dir()
+    }
+
+    fn extension<'a>(&self, path: &'a str) -> Option<&'a str> {
+        Path::new(path).extension().and_then(|e| e.to_str())
+    }
+
+    fn parent<'a>(&self, path: &'a str) -> Option<&'a str> {
+        Path::new(path).parent().and_then(|e| e.to_str())
+    }
+
+    fn sibling(&self, path: &str, sibling: &str) -> Option<String> {
+        Path::new(path)
+            .parent()
+            .map(|e| e.join(sibling).to_string_lossy().to_string())
     }
 }

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -9,13 +9,13 @@ use std::{
 
 #[derive(Debug, Hash, Clone, Serialize, Deserialize)]
 pub struct AssetPath<'a> {
-    path: Cow<'a, Path>,
+    path: Cow<'a, str>,
     label: Option<Cow<'a, str>>,
 }
 
 impl<'a> AssetPath<'a> {
     #[inline]
-    pub fn new_ref(path: &'a Path, label: Option<&'a str>) -> AssetPath<'a> {
+    pub fn new_ref(path: &'a str, label: Option<&'a str>) -> AssetPath<'a> {
         AssetPath {
             path: Cow::Borrowed(path),
             label: label.map(|val| Cow::Borrowed(val)),
@@ -23,7 +23,7 @@ impl<'a> AssetPath<'a> {
     }
 
     #[inline]
-    pub fn new(path: PathBuf, label: Option<String>) -> AssetPath<'a> {
+    pub fn new(path: String, label: Option<String>) -> AssetPath<'a> {
         AssetPath {
             path: Cow::Owned(path),
             label: label.map(Cow::Owned),
@@ -41,14 +41,14 @@ impl<'a> AssetPath<'a> {
     }
 
     #[inline]
-    pub fn path(&self) -> &Path {
+    pub fn path(&self) -> &str {
         &self.path
     }
 
     #[inline]
     pub fn to_owned(&self) -> AssetPath<'static> {
         AssetPath {
-            path: Cow::Owned(self.path.to_path_buf()),
+            path: Cow::Owned(self.path.to_string()),
             label: self
                 .label
                 .as_ref()
@@ -72,8 +72,8 @@ pub struct SourcePathId(u64);
 )]
 pub struct LabelId(u64);
 
-impl<'a> From<&'a Path> for SourcePathId {
-    fn from(value: &'a Path) -> Self {
+impl<'a> From<&'a str> for SourcePathId {
+    fn from(value: &'a str) -> Self {
         let mut hasher = get_hasher();
         value.hash(&mut hasher);
         SourcePathId(hasher.finish())
@@ -143,7 +143,7 @@ impl<'a> From<&'a str> for AssetPath<'a> {
         let path = Path::new(parts.next().expect("path must be set"));
         let label = parts.next();
         AssetPath {
-            path: Cow::Borrowed(path),
+            path: Cow::Borrowed(path.to_str().unwrap()),
             label: label.map(|label| Cow::Borrowed(label)),
         }
     }
@@ -152,7 +152,7 @@ impl<'a> From<&'a str> for AssetPath<'a> {
 impl<'a> From<&'a Path> for AssetPath<'a> {
     fn from(path: &'a Path) -> Self {
         AssetPath {
-            path: Cow::Borrowed(path),
+            path: Cow::Borrowed(path.to_str().unwrap()),
             label: None,
         }
     }
@@ -160,6 +160,15 @@ impl<'a> From<&'a Path> for AssetPath<'a> {
 
 impl<'a> From<PathBuf> for AssetPath<'a> {
     fn from(path: PathBuf) -> Self {
+        AssetPath {
+            path: Cow::Owned(path.to_string_lossy().to_string()),
+            label: None,
+        }
+    }
+}
+
+impl<'a> From<String> for AssetPath<'a> {
+    fn from(path: String) -> Self {
         AssetPath {
             path: Cow::Owned(path),
             label: None,

--- a/crates/bevy_render/src/texture/image_texture_loader.rs
+++ b/crates/bevy_render/src/texture/image_texture_loader.rs
@@ -22,7 +22,7 @@ impl AssetLoader for ImageTextureLoader {
             // Find the image type we expect. A file with the extension "png" should
             // probably load as a PNG.
 
-            let ext = load_context.path().extension().unwrap().to_str().unwrap();
+            let ext = load_context.extension().unwrap();
 
             // NOTE: If more formats are added they can be added here.
             let img_format = if ext.eq_ignore_ascii_case("png") {
@@ -31,7 +31,7 @@ impl AssetLoader for ImageTextureLoader {
                 panic!(
                     "Unexpected image format {:?} for file {}, this is an error in `bevy_render`.",
                     ext,
-                    load_context.path().display()
+                    load_context.path()
                 )
             };
 


### PR DESCRIPTION
This is just a semantic change, as &str/String behaves like Path/PathBuf.

The goal is to limit the knowledge that paths are actually `Path` to inside `FileAssetIo`. In case of implementing a custom `AssetIo`, those paths may not be actually `Path` but just internal IDs, or URIs. In those case, exposing those paths as `Path` may cause issues as an asset loader could check directly for the extension, or try to explore the filesystem itself without going back to the `AssetIo` implementation which should be the only one dealing with the actual file addressing.