### PR TITLE
Add support for android file system

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -43,3 +43,6 @@ wasm-bindgen = { version = "0.2" }
 web-sys = { version = "0.3", features = ["Request", "Window", "Response"]}
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
+
+[target.'cfg(target_os = "android")'.dependencies]
+ndk-glue = { version = "0.2" }

--- a/crates/bevy_asset/src/io/android_asset_io.rs
+++ b/crates/bevy_asset/src/io/android_asset_io.rs
@@ -1,8 +1,10 @@
 use crate::{AssetIo, AssetIoError};
 use anyhow::Result;
 use bevy_ecs::bevy_utils::BoxedFuture;
-use std::path::{Path, PathBuf};
-use std::ffi::CString;
+use std::{
+    ffi::CString,
+    path::{Path, PathBuf},
+};
 
 pub struct AndroidAssetIo {
     root_path: PathBuf,

--- a/crates/bevy_asset/src/io/android_asset_io.rs
+++ b/crates/bevy_asset/src/io/android_asset_io.rs
@@ -1,0 +1,49 @@
+use crate::{AssetIo, AssetIoError};
+use anyhow::Result;
+use bevy_ecs::bevy_utils::BoxedFuture;
+use std::path::{Path, PathBuf};
+use std::ffi::CString;
+
+pub struct AndroidAssetIo {
+    root_path: PathBuf,
+}
+
+impl AndroidAssetIo {
+    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+        AndroidAssetIo {
+            root_path: path.as_ref().to_owned(),
+        }
+    }
+}
+
+impl AssetIo for AndroidAssetIo {
+    fn load_path<'a>(&'a self, path: &'a Path) -> BoxedFuture<'a, Result<Vec<u8>, AssetIoError>> {
+        Box::pin(async move {
+            let asset_manager = ndk_glue::native_activity().asset_manager();
+            let mut opened_asset = asset_manager
+                .open(&CString::new(path.to_str().unwrap()).unwrap())
+                .ok_or(AssetIoError::NotFound(path.to_path_buf()))?;
+            let bytes = opened_asset.get_buffer()?;
+            Ok(bytes.to_vec())
+        })
+    }
+
+    fn read_directory(
+        &self,
+        _path: &Path,
+    ) -> Result<Box<dyn Iterator<Item = PathBuf>>, AssetIoError> {
+        Ok(Box::new(std::iter::empty::<PathBuf>()))
+    }
+
+    fn watch_path_for_changes(&self, _path: &Path) -> Result<(), AssetIoError> {
+        Ok(())
+    }
+
+    fn watch_for_changes(&self) -> Result<(), AssetIoError> {
+        Ok(())
+    }
+
+    fn is_directory(&self, path: &Path) -> bool {
+        self.root_path.join(path).is_dir()
+    }
+}

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -103,7 +103,7 @@ impl AssetIo for FileAssetIo {
     }
 }
 
-#[cfg(all(feature = "filesystem_watcher", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "filesystem_watcher", all(not(target_arch = "wasm32"), not(target_os = "android"))))]
 pub fn filesystem_watcher_system(asset_server: Res<AssetServer>) {
     let mut changed = HashSet::default();
     let asset_io =

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -103,7 +103,10 @@ impl AssetIo for FileAssetIo {
     }
 }
 
-#[cfg(all(feature = "filesystem_watcher", all(not(target_arch = "wasm32"), not(target_os = "android"))))]
+#[cfg(all(
+    feature = "filesystem_watcher",
+    all(not(target_arch = "wasm32"), not(target_os = "android"))
+))]
 pub fn filesystem_watcher_system(asset_server: Res<AssetServer>) {
     let mut changed = HashSet::default();
     let asset_io =

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -1,12 +1,16 @@
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
 mod file_asset_io;
 #[cfg(target_arch = "wasm32")]
 mod wasm_asset_io;
+#[cfg(target_os = "android")]
+mod android_asset_io;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
 pub use file_asset_io::*;
 #[cfg(target_arch = "wasm32")]
 pub use wasm_asset_io::*;
+#[cfg(target_os = "android")]
+pub use android_asset_io::*;
 
 use anyhow::Result;
 use bevy_ecs::bevy_utils::BoxedFuture;

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -1,16 +1,16 @@
+#[cfg(target_os = "android")]
+mod android_asset_io;
 #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
 mod file_asset_io;
 #[cfg(target_arch = "wasm32")]
 mod wasm_asset_io;
-#[cfg(target_os = "android")]
-mod android_asset_io;
 
+#[cfg(target_os = "android")]
+pub use android_asset_io::*;
 #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
 pub use file_asset_io::*;
 #[cfg(target_arch = "wasm32")]
 pub use wasm_asset_io::*;
-#[cfg(target_os = "android")]
-pub use android_asset_io::*;
 
 use anyhow::Result;
 use bevy_ecs::bevy_utils::BoxedFuture;

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -1,6 +1,9 @@
 mod asset_server;
 mod assets;
-#[cfg(all(feature = "filesystem_watcher", all(not(target_arch = "wasm32"), not(target_os = "android"))))]
+#[cfg(all(
+    feature = "filesystem_watcher",
+    all(not(target_arch = "wasm32"), not(target_os = "android"))
+))]
 mod filesystem_watcher;
 mod handle;
 mod info;
@@ -80,7 +83,10 @@ impl Plugin for AssetPlugin {
                 asset_server::free_unused_assets_system.system(),
             );
 
-        #[cfg(all(feature = "filesystem_watcher", all(not(target_arch = "wasm32"), not(target_os = "android"))))]
+        #[cfg(all(
+            feature = "filesystem_watcher",
+            all(not(target_arch = "wasm32"), not(target_os = "android"))
+        ))]
         app.add_system_to_stage(stage::LOAD_ASSETS, io::filesystem_watcher_system.system());
     }
 }

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -1,6 +1,6 @@
 mod asset_server;
 mod assets;
-#[cfg(all(feature = "filesystem_watcher", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "filesystem_watcher", all(not(target_arch = "wasm32"), not(target_os = "android"))))]
 mod filesystem_watcher;
 mod handle;
 mod info;
@@ -62,10 +62,12 @@ impl Plugin for AssetPlugin {
                 .resources_mut()
                 .get_or_insert_with(AssetServerSettings::default);
 
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
             let source = FileAssetIo::new(&settings.asset_folder);
             #[cfg(target_arch = "wasm32")]
             let source = WasmAssetIo::new(&settings.asset_folder);
+            #[cfg(target_os = "android")]
+            let source = AndroidAssetIo::new(&settings.asset_folder);
             AssetServer::new(source, task_pool)
         };
 
@@ -78,7 +80,7 @@ impl Plugin for AssetPlugin {
                 asset_server::free_unused_assets_system.system(),
             );
 
-        #[cfg(all(feature = "filesystem_watcher", not(target_arch = "wasm32")))]
+        #[cfg(all(feature = "filesystem_watcher", all(not(target_arch = "wasm32"), not(target_os = "android"))))]
         app.add_system_to_stage(stage::LOAD_ASSETS, io::filesystem_watcher_system.system());
     }
 }


### PR DESCRIPTION
Adds support for the Android file system. I didn't add the part with `shaderc/glslang` and `rodio` forks with android support because they are not on `crates.io` but this part works well.

Screenshot:

<img height="400" src="https://user-images.githubusercontent.com/24860875/97015406-38d74400-1554-11eb-8e8e-bc2854e50d3b.jpg"></img>
