### PR TITLE
fix wavy text

### DIFF
--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -121,7 +121,7 @@ impl<'a> Drawable for DrawableText<'a> {
                     let bounds = outlined.px_bounds();
                     let x = bounds.min.x + glyph_width / 2.0;
                     // the 0.5 accounts for odd-numbered heights (bump up by 1 pixel)
-                    let y = -bounds.max.y + glyph_height / 2.0 + 0.5;
+                    let y = -bounds.max.y + glyph_height / 2.0 - scaled_font.descent() + 0.5;
                     let transform = Mat4::from_translation(caret + Vec3::new(x, y, 0.0));
                     let sprite = TextureAtlasSprite {
                         index: glyph_atlas_info.char_index,

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -122,14 +122,7 @@ impl<'a> Drawable for DrawableText<'a> {
                     let x = bounds.min.x + glyph_width / 2.0;
                     // the 0.5 accounts for odd-numbered heights (bump up by 1 pixel)
                     let y = -bounds.max.y + glyph_height / 2.0 + 0.5;
-                    let transform = Mat4::from_translation(
-                        caret
-                            + Vec3::new(
-                                x,
-                                y,
-                                0.0,
-                            ),
-                    );
+                    let transform = Mat4::from_translation(caret + Vec3::new(x, y, 0.0));
                     let sprite = TextureAtlasSprite {
                         index: glyph_atlas_info.char_index,
                         color: self.style.color,

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -79,6 +79,7 @@ impl<'a> Drawable for DrawableText<'a> {
         let font = &self.font.font;
         let scale = PxScale::from(self.style.font_size);
         let scaled_font = ab_glyph::Font::as_scaled(&font, scale);
+        let offset = (scaled_font.ascent() + scaled_font.descent()) / 2.0;
         let mut caret = self.position;
         let mut last_glyph: Option<Glyph> = None;
 
@@ -119,12 +120,11 @@ impl<'a> Drawable for DrawableText<'a> {
                     )?;
 
                     let bounds = outlined.px_bounds();
-                    let offset = scaled_font.descent() + glyph_height;
                     let transform = Mat4::from_translation(
                         caret
                             + Vec3::new(
-                                0.0 + glyph_width / 2.0 + bounds.min.x,
-                                glyph_height / 2.0 - bounds.min.y - offset,
+                                glyph_width / 2.0 + bounds.min.x,
+                                glyph_height / 2.0 - bounds.max.y + offset,
                                 0.0,
                             ),
                     );

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -79,7 +79,6 @@ impl<'a> Drawable for DrawableText<'a> {
         let font = &self.font.font;
         let scale = PxScale::from(self.style.font_size);
         let scaled_font = ab_glyph::Font::as_scaled(&font, scale);
-        let offset = (scaled_font.ascent() + scaled_font.descent()) / 2.0;
         let mut caret = self.position;
         let mut last_glyph: Option<Glyph> = None;
 
@@ -120,11 +119,14 @@ impl<'a> Drawable for DrawableText<'a> {
                     )?;
 
                     let bounds = outlined.px_bounds();
+                    let x = bounds.min.x + glyph_width / 2.0;
+                    // the 0.5 accounts for odd-numbered heights (bump up by 1 pixel)
+                    let y = -bounds.max.y + glyph_height / 2.0 + 0.5;
                     let transform = Mat4::from_translation(
                         caret
                             + Vec3::new(
-                                glyph_width / 2.0 + bounds.min.x,
-                                glyph_height / 2.0 - bounds.max.y + offset,
+                                x,
+                                y,
                                 0.0,
                             ),
                     );


### PR DESCRIPTION
Addresses #283 

Quick fix for wavy text.

You can see the difference in the "ing" in "Nothing".

Before  
![image](https://user-images.githubusercontent.com/38416468/97081682-95ab2b00-1636-11eb-8502-156415e6cbb6.png)

After  
![image](https://user-images.githubusercontent.com/38416468/97081667-78765c80-1636-11eb-8d11-09e1a1411be4.png)

Here is what it looks like in Word for reference:
![image](https://user-images.githubusercontent.com/38416468/97081771-36014f80-1637-11eb-90db-c5823ea443fb.png)