### PR TITLE
Split InputPlugin into seperate plugins

### DIFF
--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -41,9 +41,7 @@ impl Plugin for InputPlugin {
         app.add_plugin(KeyboardInputPlugin)
             .add_plugin(MouseInputPlugin)
             .add_plugin(GamepadInputPlugin)
-            .add_event::<TouchInput>()
-            .init_resource::<Touches>()
-            .add_system_to_stage(bevy_app::stage::EVENT, touch_screen_input_system.system());
+            .add_plugin(TouchInputPlugin);
     }
 }
 

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -55,6 +55,18 @@ impl Plugin for InputPlugin {
     }
 }
 
+/// Adds keyboard and mouse input to an App
+#[derive(Default)]
+pub struct KeyboardInputPlugin;
+
+impl Plugin for KeyboardInputPlugin {
+    fn build(&self, app: &mut AppBuilder) {
+        app.add_event::<KeyboardInput>()
+            .init_resource::<Input<KeyCode>>()
+            .add_system_to_stage(bevy_app::stage::EVENT, keyboard_input_system.system());
+    }
+}
+
 /// Adds mouse input to an App
 #[derive(Default)]
 pub struct MouseInputPlugin;

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -88,3 +88,15 @@ impl Plugin for MouseInputPlugin {
             .add_system_to_stage(bevy_app::stage::EVENT, mouse_button_input_system.system());
     }
 }
+
+/// Adds keyboard, mouse, gamepad, and touch input to an App
+#[derive(Default)]
+pub struct TouchInputPlugin;
+
+impl Plugin for InputPlugin {
+    fn build(&self, app: &mut AppBuilder) {
+        app.add_event::<TouchInput>()
+            .init_resource::<Touches>()
+            .add_system_to_stage(bevy_app::stage::EVENT, touch_screen_input_system.system());
+    }
+}

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -38,10 +38,8 @@ pub struct InputPlugin;
 
 impl Plugin for InputPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app.add_event::<KeyboardInput>()
+        app.add_plugin(KeyboardInputPlugin)
             .add_plugin(MouseInputPlugin)
-            .init_resource::<Input<KeyCode>>()
-            .add_system_to_stage(bevy_app::stage::EVENT, keyboard_input_system.system())
             .add_event::<GamepadEvent>()
             .add_event::<GamepadEventRaw>()
             .init_resource::<GamepadSettings>()
@@ -52,6 +50,22 @@ impl Plugin for InputPlugin {
             .add_event::<TouchInput>()
             .init_resource::<Touches>()
             .add_system_to_stage(bevy_app::stage::EVENT, touch_screen_input_system.system());
+    }
+}
+
+/// Adds keyboard and mouse input to an App
+#[derive(Default)]
+pub struct GamepadInputPlugin;
+
+impl Plugin for GamepadInputPlugin {
+    fn build(&self, app: &mut AppBuilder) {
+        app.add_event::<GamepadEvent>()
+            .add_event::<GamepadEventRaw>()
+            .init_resource::<GamepadSettings>()
+            .init_resource::<Input<GamepadButton>>()
+            .init_resource::<Axis<GamepadAxis>>()
+            .init_resource::<Axis<GamepadButton>>()
+            .add_system_to_stage(bevy_app::stage::EVENT, gamepad_event_system.system());
     }
 }
 

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -39,13 +39,9 @@ pub struct InputPlugin;
 impl Plugin for InputPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_event::<KeyboardInput>()
-            .add_event::<MouseButtonInput>()
-            .add_event::<MouseMotion>()
-            .add_event::<MouseWheel>()
+            .add_plugin(MouseInputPlugin)
             .init_resource::<Input<KeyCode>>()
             .add_system_to_stage(bevy_app::stage::EVENT, keyboard_input_system.system())
-            .init_resource::<Input<MouseButton>>()
-            .add_system_to_stage(bevy_app::stage::EVENT, mouse_button_input_system.system())
             .add_event::<GamepadEvent>()
             .add_event::<GamepadEventRaw>()
             .init_resource::<GamepadSettings>()
@@ -65,8 +61,7 @@ pub struct MouseInputPlugin;
 
 impl Plugin for MouseInputPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app
-            .add_event::<MouseButtonInput>()
+        app.add_event::<MouseButtonInput>()
             .add_event::<MouseMotion>()
             .add_event::<MouseWheel>()
             .init_resource::<Input<MouseButton>>()

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -58,3 +58,18 @@ impl Plugin for InputPlugin {
             .add_system_to_stage(bevy_app::stage::EVENT, touch_screen_input_system.system());
     }
 }
+
+/// Adds mouse input to an App
+#[derive(Default)]
+pub struct MouseInputPlugin;
+
+impl Plugin for MouseInputPlugin {
+    fn build(&self, app: &mut AppBuilder) {
+        app
+            .add_event::<MouseButtonInput>()
+            .add_event::<MouseMotion>()
+            .add_event::<MouseWheel>()
+            .init_resource::<Input<MouseButton>>()
+            .add_system_to_stage(bevy_app::stage::EVENT, mouse_button_input_system.system());
+    }
+}

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -91,7 +91,7 @@ impl Plugin for MouseInputPlugin {
 #[derive(Default)]
 pub struct TouchInputPlugin;
 
-impl Plugin for InputPlugin {
+impl Plugin for TouchInputPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_event::<TouchInput>()
             .init_resource::<Touches>()

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -32,7 +32,7 @@ use gamepad::{
     GamepadSettings,
 };
 
-/// Adds keyboard and mouse input to an App
+/// Adds keyboard, mouse, gamepad, and touch input to an App
 #[derive(Default)]
 pub struct InputPlugin;
 
@@ -40,20 +40,14 @@ impl Plugin for InputPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_plugin(KeyboardInputPlugin)
             .add_plugin(MouseInputPlugin)
-            .add_event::<GamepadEvent>()
-            .add_event::<GamepadEventRaw>()
-            .init_resource::<GamepadSettings>()
-            .init_resource::<Input<GamepadButton>>()
-            .init_resource::<Axis<GamepadAxis>>()
-            .init_resource::<Axis<GamepadButton>>()
-            .add_system_to_stage(bevy_app::stage::EVENT, gamepad_event_system.system())
+            .add_plugin(GamepadInputPlugin)
             .add_event::<TouchInput>()
             .init_resource::<Touches>()
             .add_system_to_stage(bevy_app::stage::EVENT, touch_screen_input_system.system());
     }
 }
 
-/// Adds keyboard and mouse input to an App
+/// Adds gamepad input to an App
 #[derive(Default)]
 pub struct GamepadInputPlugin;
 
@@ -69,7 +63,7 @@ impl Plugin for GamepadInputPlugin {
     }
 }
 
-/// Adds keyboard and mouse input to an App
+/// Adds keyboard input to an App
 #[derive(Default)]
 pub struct KeyboardInputPlugin;
 


### PR DESCRIPTION
This PR changes the implementation of InputPlugin to use plugins and splits the 4 supported input types into separate plugins.

I Predict this will:
 - Make the implementation of tests cleaner.
 - Allow more advanced users to only add the resources and systems they actually need.
 - Not appreciably effect dependent codebases.
 - Hurt compile times of bevy_input to an untested degree