### PR TITLE
Fix bug of connection event of gamepad at startup

### DIFF
--- a/crates/bevy_gilrs/src/gilrs_system.rs
+++ b/crates/bevy_gilrs/src/gilrs_system.rs
@@ -4,6 +4,17 @@ use bevy_ecs::{Resources, World};
 use bevy_input::{gamepad::GamepadEventRaw, prelude::*};
 use gilrs::{EventType, Gilrs};
 
+pub fn gilrs_event_startup_system(_world: &mut World, resources: &mut Resources) {
+    let gilrs = resources.get_thread_local::<Gilrs>().unwrap();
+    let mut event = resources.get_mut::<Events<GamepadEventRaw>>().unwrap();
+    for (id, _) in gilrs.gamepads() {
+        event.send(GamepadEventRaw(
+            convert_gamepad_id(id),
+            GamepadEventType::Connected,
+        ));
+    }
+}
+
 pub fn gilrs_event_system(_world: &mut World, resources: &mut Resources) {
     let mut gilrs = resources.get_thread_local_mut::<Gilrs>().unwrap();
     let mut event = resources.get_mut::<Events<GamepadEventRaw>>().unwrap();

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -1,10 +1,10 @@
 mod converter;
 mod gilrs_system;
 
-use bevy_app::prelude::*;
+use bevy_app::{prelude::*, startup_stage::PRE_STARTUP};
 use bevy_ecs::prelude::*;
 use gilrs::GilrsBuilder;
-use gilrs_system::gilrs_event_system;
+use gilrs_system::{gilrs_event_startup_system, gilrs_event_system};
 
 #[derive(Default)]
 pub struct GilrsPlugin;
@@ -18,7 +18,10 @@ impl Plugin for GilrsPlugin {
         {
             Ok(gilrs) => {
                 app.add_thread_local_resource(gilrs)
-                    .add_startup_system(gilrs_event_system.thread_local_system())
+                    .add_startup_system_to_stage(
+                        PRE_STARTUP,
+                        gilrs_event_startup_system.thread_local_system(),
+                    )
                     .add_system_to_stage(
                         stage::PRE_EVENT,
                         gilrs_event_system.thread_local_system(),

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -26,6 +26,7 @@ use keyboard::{keyboard_input_system, KeyCode, KeyboardInput};
 use mouse::{mouse_button_input_system, MouseButton, MouseButtonInput, MouseMotion, MouseWheel};
 use touch::{touch_screen_input_system, TouchInput, Touches};
 
+use bevy_app::startup_stage::STARTUP;
 use bevy_ecs::IntoQuerySystem;
 use gamepad::{
     gamepad_event_system, GamepadAxis, GamepadButton, GamepadEvent, GamepadEventRaw,
@@ -53,6 +54,7 @@ impl Plugin for InputPlugin {
             .init_resource::<Axis<GamepadAxis>>()
             .init_resource::<Axis<GamepadButton>>()
             .add_system_to_stage(bevy_app::stage::EVENT, gamepad_event_system.system())
+            .add_startup_system_to_stage(STARTUP, gamepad_event_system.system())
             .add_event::<TouchInput>()
             .init_resource::<Touches>()
             .add_system_to_stage(bevy_app::stage::EVENT, touch_screen_input_system.system());

--- a/examples/input/gamepad_input.rs
+++ b/examples/input/gamepad_input.rs
@@ -6,8 +6,7 @@ fn main() {
     App::build()
         .add_default_plugins()
         .init_resource::<GamepadLobby>()
-        .add_startup_system(connection_system.system())
-        .add_system(connection_system.system())
+        .add_system_to_stage(stage::PRE_UPDATE, connection_system.system())
         .add_system(gamepad_system.system())
         .run();
 }


### PR DESCRIPTION
First commit removes the floating point equality comparison by modifying the filter function. Now filter function outputs `Option<f32>` instead of `f32` and output is `None` when no change is required.

Second commit fixes the bug which makes it impossible to detect already connected gamepads at game startup. If you plug the gamepad first and then launches the game, connection event wouldn't occur. [Removal of this code](https://github.com/bevyengine/bevy/pull/711/files#diff-6927d2e5e9b24ac37f6f1d4d68cd70d7fcb3e82fff1929bfbf624cfce45797a7L7) causes this bug.

To detect already connected gamepads' connection events at startup, a system must query for events at `POST_STARTUP` stage because `bevy_gilrs` generates raw events at `PRE_STARTUP` stage and `bevy_input` generates filtered events at `STARTUP` stage (it must execute after `bevy_gilrs` system).