### PR TITLE
Use embedded glslang for runtime glsl-to-spirv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,12 @@ bevy_wgpu = { path = "crates/bevy_wgpu", optional = true, version = "0.2.1" }
 bevy_winit = { path = "crates/bevy_winit", optional = true, version = "0.2.1" }
 bevy_gilrs = { path = "crates/bevy_gilrs", optional = true, version = "0.2.1" }
 
+# bevy (Android)
+[target.'cfg(target_os = "android")'.dependencies]
+ndk-glue = "0.1"
+log = "0.4"
+android_logger = "0.9"
+
 [dev-dependencies]
 rand = "0.7.3"
 serde = { version = "1", features = ["derive"] }
@@ -309,3 +315,17 @@ required-features = ["bevy_winit"]
 name = "assets_wasm"
 path = "examples/wasm/assets_wasm.rs"
 required-features = ["bevy_winit"]
+
+[[example]]
+name = "bevy_android"
+path = "examples/android/bevy_android.rs"
+crate-type = ["cdylib"]
+
+[package.metadata.android]
+build_targets = [ "aarch64-linux-android", "armv7-linux-androideabi" ]
+target_sdk_version = 29
+min_sdk_version = 29
+
+[[package.metadata.android.feature]]
+name = "android.hardware.vulkan.level"
+version = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,22 @@ default = [
     "mp3",
     "x11",
 ]
+
+supported_android_features = [
+    # cpal is not supported yet
+    # "bevy_audio",
+    "bevy_dynamic_plugin",
+    "bevy_gilrs",
+    "bevy_gltf",
+    "bevy_wgpu",
+    "bevy_winit",
+    "render",
+    "png",
+    "hdr",
+    # "mp3",
+    "x11",
+]
+
 profiler = ["bevy_ecs/profiler", "bevy_diagnostic/profiler"]
 wgpu_trace = ["bevy_wgpu/trace"]
 
@@ -83,17 +99,17 @@ bevy_wgpu = { path = "crates/bevy_wgpu", optional = true, version = "0.2.1" }
 bevy_winit = { path = "crates/bevy_winit", optional = true, version = "0.2.1" }
 bevy_gilrs = { path = "crates/bevy_gilrs", optional = true, version = "0.2.1" }
 
-# bevy (Android)
-[target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = { version = "0.2", features = ["logger"] }
-android_logger = "0.9"
-
 [dev-dependencies]
 rand = "0.7.3"
 serde = { version = "1", features = ["derive"] }
 log = "0.4"
 ron = "0.6"
 anyhow = "1.0"
+
+# bevy (Android)
+[target.'cfg(target_os = "android")'.dependencies]
+ndk-glue = { version = "0.2", features = ["logger"] }
+android_logger = "0.9"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 console_error_panic_hook = "0.1.6"
@@ -322,8 +338,8 @@ crate-type = ["cdylib"]
 
 [package.metadata.android]
 build_targets = [ "aarch64-linux-android", "armv7-linux-androideabi" ]
-target_sdk_version = 29
-min_sdk_version = 29
+target_sdk_version = 28
+min_sdk_version = 28
 
 [[package.metadata.android.feature]]
 name = "android.hardware.vulkan.level"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,8 +85,7 @@ bevy_gilrs = { path = "crates/bevy_gilrs", optional = true, version = "0.2.1" }
 
 # bevy (Android)
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = "0.1"
-log = "0.4"
+ndk-glue = { version = "0.2", features = ["logger"] }
 android_logger = "0.9"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,4 +309,3 @@ required-features = ["bevy_winit"]
 name = "assets_wasm"
 path = "examples/wasm/assets_wasm.rs"
 required-features = ["bevy_winit"]
-

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -48,7 +48,7 @@ parking_lot = "0.11.0"
 spirv-reflect = "0.2.3"
 
 [target.'cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))'.dependencies]
-bevy-glsl-to-spirv = "0.1.7"
+bevy-glsl-to-spirv = "0.2.0"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 shaderc = "0.6.3"

--- a/crates/bevy_render/src/shader/shader.rs
+++ b/crates/bevy_render/src/shader/shader.rs
@@ -28,12 +28,7 @@ fn glsl_to_spirv(
     stage: ShaderStage,
     shader_defs: Option<&[String]>,
 ) -> Vec<u32> {
-    use std::io::Read;
-
-    let mut output = bevy_glsl_to_spirv::compile(glsl_source, stage.into(), shader_defs).unwrap();
-    let mut spv_bytes = Vec::new();
-    output.read_to_end(&mut spv_bytes).unwrap();
-    bytes_to_words(&spv_bytes)
+    bevy_glsl_to_spirv::compile(glsl_source, stage.into(), shader_defs).unwrap()
 }
 
 #[cfg(target_os = "ios")]

--- a/examples/android/bevy_android.rs
+++ b/examples/android/bevy_android.rs
@@ -1,16 +1,6 @@
-#[macro_use] extern crate log;
-extern crate android_logger;
-
-use log::Level;
-use android_logger::Config;
-
 include!("../3d/3d_scene.rs");
 
-#[cfg(target_os = "android")]
-ndk_glue::ndk_glue!(android_main);
-
-#[cfg(target_os = "android")]
+#[cfg_attr(target_os = "android", ndk_glue::main(logger(level = "trace", tag = "bevy_android"), backtrace = "full"))]
 fn android_main() {
-    android_logger::init_once(Config::default().with_min_level(Level::Trace));
     main();
 }

--- a/examples/android/bevy_android.rs
+++ b/examples/android/bevy_android.rs
@@ -1,0 +1,16 @@
+#[macro_use] extern crate log;
+extern crate android_logger;
+
+use log::Level;
+use android_logger::Config;
+
+include!("../3d/3d_scene.rs");
+
+#[cfg(target_os = "android")]
+ndk_glue::ndk_glue!(android_main);
+
+#[cfg(target_os = "android")]
+fn android_main() {
+    android_logger::init_once(Config::default().with_min_level(Level::Trace));
+    main();
+}

--- a/examples/android/bevy_android.rs
+++ b/examples/android/bevy_android.rs
@@ -5,6 +5,6 @@ include!("../3d/3d_scene.rs");
     target_os = "android",
     ndk_glue::main(logger(level = "trace", tag = "bevy_android"), backtrace = "full")
 )]
-fn android_main() {
+pub fn android_main() {
     main();
 }

--- a/examples/android/bevy_android.rs
+++ b/examples/android/bevy_android.rs
@@ -1,6 +1,10 @@
+// Edit to run any single file example from Bevy.
 include!("../3d/3d_scene.rs");
 
-#[cfg_attr(target_os = "android", ndk_glue::main(logger(level = "trace", tag = "bevy_android"), backtrace = "full"))]
+#[cfg_attr(
+    target_os = "android",
+    ndk_glue::main(logger(level = "trace", tag = "bevy_android"), backtrace = "full")
+)]
 fn android_main() {
     main();
 }


### PR DESCRIPTION
Depends on https://github.com/cart/glsl-to-spirv/pull/1
Dependent of https://github.com/bevyengine/bevy/issues/86

This commit adds runtime glsl-to-spriv support to Bevy and opens the door for Android builds without needing to setup anything beyond normal Android NDK environment variables.