### PR TITLE
Insert custom local system resources

### DIFF
--- a/crates/bevy_ecs/src/resource/resource_query.rs
+++ b/crates/bevy_ecs/src/resource/resource_query.rs
@@ -297,9 +297,13 @@ impl<'a, T: Resource + FromResources> ResourceQuery for Local<'a, T> {
     type Fetch = FetchResourceLocalMut<T>;
 
     fn initialize(resources: &mut Resources, id: Option<SystemId>) {
-        let value = T::from_resources(resources);
         let id = id.expect("Local<T> resources can only be used by systems");
-        resources.insert_local(id, value);
+
+        // Only add the local resource if it doesn't already exist for this system
+        if resources.get_local::<T>(id).is_none() {
+            let value = T::from_resources(resources);
+            resources.insert_local(id, value);
+        }
     }
 }
 


### PR DESCRIPTION
This modifies some of the traits on `Local<T>` causing it to only initialize `T` using `FromResources` if the resource `T` doesn't yet exist on the system. This allows having a `Local<T>` on a system which you then initialize later using whatever value of `T` you'd like.

In addition, this adds some convenience functions to `AppBuilder` that allow easily adding a custom `T` value to a given system.