### PR TITLE
Add SamplerDescriptor to Texture (#399)

### DIFF
--- a/crates/bevy_render/src/texture/sampler_descriptor.rs
+++ b/crates/bevy_render/src/texture/sampler_descriptor.rs
@@ -1,9 +1,8 @@
-use super::Texture;
 use crate::pipeline::CompareFunction;
 use std::num::NonZeroU8;
 
 /// Describes a sampler
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct SamplerDescriptor {
     pub address_mode_u: AddressMode,
     pub address_mode_v: AddressMode,
@@ -19,23 +18,6 @@ pub struct SamplerDescriptor {
 
 impl Default for SamplerDescriptor {
     fn default() -> Self {
-        SamplerDescriptor {
-            address_mode_u: AddressMode::ClampToEdge,
-            address_mode_v: AddressMode::ClampToEdge,
-            address_mode_w: AddressMode::ClampToEdge,
-            mag_filter: FilterMode::Nearest,
-            min_filter: FilterMode::Linear,
-            mipmap_filter: FilterMode::Nearest,
-            lod_min_clamp: 0.0,
-            lod_max_clamp: std::f32::MAX,
-            compare_function: None,
-            anisotropy_clamp: None,
-        }
-    }
-}
-
-impl From<&Texture> for SamplerDescriptor {
-    fn from(_texture: &Texture) -> Self {
         SamplerDescriptor {
             address_mode_u: AddressMode::ClampToEdge,
             address_mode_v: AddressMode::ClampToEdge,

--- a/crates/bevy_render/src/texture/texture.rs
+++ b/crates/bevy_render/src/texture/texture.rs
@@ -18,6 +18,7 @@ pub struct Texture {
     pub data: Vec<u8>,
     pub size: Vec2,
     pub format: TextureFormat,
+    pub sampler: SamplerDescriptor,
 }
 
 impl Default for Texture {
@@ -26,6 +27,7 @@ impl Default for Texture {
             data: Default::default(),
             size: Default::default(),
             format: TextureFormat::Rgba8UnormSrgb,
+            sampler: Default::default(),
         }
     }
 }
@@ -37,7 +39,12 @@ impl Texture {
             data.len(),
             "Pixel data, size and format have to match",
         );
-        Self { data, size, format }
+        Self {
+            data,
+            size,
+            format,
+            ..Default::default()
+        }
     }
 
     pub fn new_fill(size: Vec2, pixel: &[u8], format: TextureFormat) -> Self {
@@ -104,8 +111,7 @@ impl Texture {
                 let texture_descriptor: TextureDescriptor = texture.into();
                 let texture_resource = render_resource_context.create_texture(texture_descriptor);
 
-                let sampler_descriptor: SamplerDescriptor = texture.into();
-                let sampler_resource = render_resource_context.create_sampler(&sampler_descriptor);
+                let sampler_resource = render_resource_context.create_sampler(&texture.sampler);
 
                 render_resource_context.set_asset_resource(
                     texture_handle,


### PR DESCRIPTION
GLTF loader now grabs (some) sampler information from the respective
GLTF sampler struct.

---

Please let me know whether the construction of `SamplerDescriptor` from a GLTF sampler is too convoluted this way. My previous attempt can be viewed [here](https://github.com/W4RH4WK/bevy/commit/0701056ceab55613bc817b7da619110e0e807d61#diff-4bad6321ea999887884bc321768f82c3bbd5aaeaf1b2ae4dca6e871b330426ebR276-R297), which is more *procedural*.