### PR TITLE
Improve `bevy` crate's docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,51 +37,100 @@
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
 
-mod default_plugins;
 pub mod prelude;
 
-pub use bevy_app as app;
-pub use bevy_asset as asset;
-pub use bevy_core as core;
-pub use bevy_diagnostic as diagnostic;
-pub use bevy_ecs as ecs;
-pub use bevy_input as input;
-pub use bevy_math as math;
-pub use bevy_property as property;
-pub use bevy_scene as scene;
-pub use bevy_tasks as tasks;
-pub use bevy_transform as transform;
-pub use bevy_type_registry as type_registry;
-pub use bevy_utils as utils;
-pub use bevy_window as window;
+mod default_plugins;
 pub use default_plugins::*;
 
+pub mod app {
+    pub use bevy_app::*;
+}
+pub mod asset {
+    pub use bevy_asset::*;
+}
+pub mod core {
+    pub use bevy_core::*;
+}
+pub mod diagnostic {
+    pub use bevy_diagnostic::*;
+}
+pub mod ecs {
+    pub use bevy_ecs::*;
+}
+pub mod input {
+    pub use bevy_input::*;
+}
+pub mod math {
+    pub use bevy_math::*;
+}
+pub mod property {
+    pub use bevy_property::*;
+}
+pub mod scene {
+    pub use bevy_scene::*;
+}
+pub mod tasks {
+    pub use bevy_tasks::*;
+}
+pub mod transform {
+    pub use bevy_transform::*;
+}
+pub mod type_registry {
+    pub use bevy_type_registry::*;
+}
+pub mod utils {
+    pub use bevy_utils::*;
+}
+pub mod window {
+    pub use bevy_window::*;
+}
+
 #[cfg(feature = "bevy_audio")]
-pub use bevy_audio as audio;
+pub mod audio {
+    pub use bevy_audio::*;
+}
 
 #[cfg(feature = "bevy_gltf")]
-pub use bevy_gltf as gltf;
+pub mod gltf {
+    pub use bevy_gltf::*;
+}
 
 #[cfg(feature = "bevy_pbr")]
-pub use bevy_pbr as pbr;
+pub mod pbr {
+    pub use bevy_pbr::*;
+}
 
 #[cfg(feature = "bevy_render")]
-pub use bevy_render as render;
+pub mod render {
+    pub use bevy_render::*;
+}
 
 #[cfg(feature = "bevy_sprite")]
-pub use bevy_sprite as sprite;
+pub mod sprite {
+    pub use bevy_sprite::*;
+}
 
 #[cfg(feature = "bevy_text")]
-pub use bevy_text as text;
+pub mod text {
+    pub use bevy_text::*;
+}
 
 #[cfg(feature = "bevy_ui")]
-pub use bevy_ui as ui;
+pub mod ui {
+    pub use bevy_ui::*;
+}
 
 #[cfg(feature = "bevy_winit")]
-pub use bevy_winit as winit;
+pub mod winit {
+    pub use bevy_winit::*;
+}
 
 #[cfg(feature = "bevy_wgpu")]
-pub use bevy_wgpu as wgpu;
+pub mod wgpu {
+    pub use bevy_wgpu::*;
+}
 
 #[cfg(feature = "bevy_dynamic_plugin")]
-pub use bevy_dynamic_plugin as dynamic_plugin;
+pub mod dynamic_plugin {
+    pub use bevy_dynamic_plugin::*;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,9 @@
 //! The defaults provide a "full" engine experience, but you can easily enable / disable features
 //! in your project's `Cargo.toml` to meet your specific needs. See Bevy's `Cargo.toml` for a full list of features available.
 //!
-//! If you prefer it, you can also consume the individual bevy crates directly.
+//! If you prefer, you can also consume the individual bevy crates directly.
+//! Each module in this crates, except for the prelude, can be found on crates.io
+//! with `bevy_` appended to the front, e.g. `app` -> [`bevy_app`](https://docs.rs/bevy_app/0.2.1/bevy_app/).
 
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub mod render {
 
 #[cfg(feature = "bevy_sprite")]
 pub mod sprite {
-    // Items for sprites, rects, texture atlases, etc.
+    //! Items for sprites, rects, texture atlases, etc.
     pub use bevy_sprite::*;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,61 +39,84 @@
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
 
+/// `use bevy::prelude::*;` to import common components, bundles, and plugins.
 pub mod prelude;
 
 mod default_plugins;
 pub use default_plugins::*;
 
 pub mod app {
+    //! Build bevy applications, create plugins, and read events.
     pub use bevy_app::*;
 }
+
 pub mod asset {
+    //! Load and store assets and resources for Apps
     pub use bevy_asset::*;
 }
+
 pub mod core {
+    //! Contains core plugins and utilities for time.
     pub use bevy_core::*;
 }
+
 pub mod diagnostic {
+    //! Useful diagnostic plugins and types for bevy apps.
     pub use bevy_diagnostic::*;
 }
+
 pub mod ecs {
+    //! Bevy's entity-componenet-system.
     pub use bevy_ecs::*;
 }
+
 pub mod input {
+    //! Resources and events for inputs, e.g. mouse/keyboard, touch, gamepads, etc.
     pub use bevy_input::*;
 }
+
 pub mod math {
     pub use bevy_math::*;
 }
+
 pub mod property {
+    //! Dynamically interact with struct fields and names.
     pub use bevy_property::*;
 }
+
 pub mod scene {
     pub use bevy_scene::*;
 }
+
 pub mod tasks {
     pub use bevy_tasks::*;
 }
+
 pub mod transform {
     pub use bevy_transform::*;
 }
+
 pub mod type_registry {
     pub use bevy_type_registry::*;
 }
+
 pub mod utils {
     pub use bevy_utils::*;
 }
+
 pub mod window {
     pub use bevy_window::*;
 }
 
 #[cfg(feature = "bevy_audio")]
 pub mod audio {
+    //! Provides types and plugins audio playback.
     pub use bevy_audio::*;
 }
 
 #[cfg(feature = "bevy_gltf")]
 pub mod gltf {
+    //! Support for GLTF file loading to Apps.
     pub use bevy_gltf::*;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub mod diagnostic {
 }
 
 pub mod ecs {
-    //! Bevy's entity-componenet-system.
+    //! Bevy's entity-component-system.
     pub use bevy_ecs::*;
 }
 
@@ -122,7 +122,7 @@ pub mod gltf {
 
 #[cfg(feature = "bevy_pbr")]
 pub mod pbr {
-    //! Physically based rendering
+    //! Physically based rendering. **Note**: true PBR has not yet been implemented; the name `pbr` is aspirational.
     pub use bevy_pbr::*;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //! in your project's `Cargo.toml` to meet your specific needs. See Bevy's `Cargo.toml` for a full list of features available.
 //!
 //! If you prefer, you can also consume the individual bevy crates directly.
-//! Each module in this crates, except for the prelude, can be found on crates.io
+//! Each module in the root of this crate, except for the prelude, can be found on crates.io
 //! with `bevy_` appended to the front, e.g. `app` -> [`bevy_app`](https://docs.rs/bevy_app/0.2.1/bevy_app/).
 
 #![doc(
@@ -46,7 +46,7 @@ mod default_plugins;
 pub use default_plugins::*;
 
 pub mod app {
-    //! Build bevy applications, create plugins, and read events.
+    //! Build bevy apps, create plugins, and read events.
     pub use bevy_app::*;
 }
 
@@ -110,18 +110,19 @@ pub mod window {
 
 #[cfg(feature = "bevy_audio")]
 pub mod audio {
-    //! Provides types and plugins audio playback.
+    //! Provides types and plugins for audio playback.
     pub use bevy_audio::*;
 }
 
 #[cfg(feature = "bevy_gltf")]
 pub mod gltf {
-    //! Support for GLTF file loading to Apps.
+    //! Support for GLTF file loading.
     pub use bevy_gltf::*;
 }
 
 #[cfg(feature = "bevy_pbr")]
 pub mod pbr {
+    //! Physically based rendering
     pub use bevy_pbr::*;
 }
 
@@ -132,6 +133,7 @@ pub mod render {
 
 #[cfg(feature = "bevy_sprite")]
 pub mod sprite {
+    // Items for sprites, rects, texture atlases, etc.
     pub use bevy_sprite::*;
 }
 


### PR DESCRIPTION
With this change, we now include each crate's items into a module of `bevy` instead of directly re-exporting.

<details>

<summary>screenshots</summary>

### Current:
![screenshot 8977](https://user-images.githubusercontent.com/6868531/97638159-60c21e00-1a12-11eb-8707-41737fb5758a.png)

### Proposed change:
![screenshot 8976](https://user-images.githubusercontent.com/6868531/97638163-63247800-1a12-11eb-9690-2218fc8ab68a.png)

</details>

The motivation is to make navigating and searching `bevy`'s types from docs.rs easier for users.

For example, if a user sees `AppExit` or `ScheduleRunnerPlugin` in a bevy example, they might first search from `bevy` on docs.rs, but they will be met with no results. The user must now know which crate to click from the re-exports list to find any types that were not exposed in the prelude.

<details>

<summary>screenshots</summary>

### Current:
![image](https://user-images.githubusercontent.com/6868531/97638466-f52c8080-1a12-11eb-9d8f-87512fa322fd.png)
![image](https://user-images.githubusercontent.com/6868531/97638380-cf9f7700-1a12-11eb-8412-71e9b3e7aa59.png)

### Proposed change:
![screenshot 8980](https://user-images.githubusercontent.com/6868531/97638713-84d22f00-1a13-11eb-83de-f7cd696460d2.png)
![screenshot 8979](https://user-images.githubusercontent.com/6868531/97638721-87348900-1a13-11eb-94ac-ab2f26a9b028.png)

</details>

Currently, the only way to have a "global" search is to build docs locally, and this tends to mix other crates in the search results. With this change, the user will be able to find both while searching from the main `bevy` crate on docs.rs.

In addition, it allows for easily navigating the modules on the sidebar while in `bevy`'s docs, and when the user wants to return `bevy`'s crate root, they can now press the bevy icon.

<details>

<summary>screenshots</summary>

### Current:
![screenshot 8981](https://user-images.githubusercontent.com/6868531/97638891-eb574d00-1a13-11eb-86fa-b9e0f9cfca4e.png)

### Proposed change:
![screenshot 8973](https://user-images.githubusercontent.com/6868531/97638904-ef836a80-1a13-11eb-817f-cf3fef86d06b.png)

</details>

Notes were added next to the modules that show up from the `bevy` crate root (but not to all yet)

![image](https://user-images.githubusercontent.com/6868531/97643001-f2cf2400-1a1c-11eb-82eb-07bc8be74146.png)
