### PR TITLE
Mutably iterate and access inner Asset HashMap

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -137,8 +137,14 @@ impl<T: Asset> Assets<T> {
         borrowed
     }
 
+    /// An iterator visiting all key-value pairs in arbitrary order.
     pub fn iter(&self) -> impl Iterator<Item = (HandleId, &T)> {
         self.assets.iter().map(|(k, v)| (*k, v))
+    }
+
+    /// An iterator visiting all key-value pairs in arbitrary order, with mutable references to the values.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (HandleId, &mut T)> {
+        self.assets.iter_mut().map(|(k, v)| (*k, v))
     }
 
     pub fn ids(&self) -> impl Iterator<Item = HandleId> + '_ {
@@ -191,6 +197,16 @@ impl<T: Asset> Assets<T> {
 
     pub fn is_empty(&self) -> bool {
         self.assets.is_empty()
+    }
+
+    /// Returns a reference to the inner assets `HashMap`.
+    pub fn assets(&self) -> &HashMap<HandleId, T> {
+        &self.assets
+    }
+
+    /// Returns a mutable reference to the inner assets `HashMap`.
+    pub fn assets_mut(&mut self) -> &mut HashMap<HandleId, T> {
+        &mut self.assets
     }
 }
 


### PR DESCRIPTION
### Issue
Right now, there may be a reason to not just iterate, but mutably iterate through all Assets in the inner HashMap. Right now, we can only iterate over the references. Further, its good to practice to provide inner ABI to `HashMap`s or `Vec`s mutably and as a reference.

### Fix
I have introduced that ABI which progressed my current project.