### PR TITLE
Rename query.entity() and query.get()

### DIFF
--- a/crates/bevy_ecs/src/schedule/parallel_executor.rs
+++ b/crates/bevy_ecs/src/schedule/parallel_executor.rs
@@ -564,7 +564,7 @@ mod tests {
             for entity in &mut entities.iter() {
                 // query.get() does a "system permission check" that will fail if the entity is from a
                 // new archetype which hasnt been "prepared yet"
-                query.get::<u32>(entity).unwrap();
+                query.get_component::<u32>(entity).unwrap();
             }
 
             assert_eq!(1, entities.iter().count());
@@ -595,7 +595,7 @@ mod tests {
             for entity in &mut entities.iter() {
                 // query.get() does a "system permission check" that will fail if the entity is from a
                 // new archetype which hasnt been "prepared yet"
-                query.get::<u32>(entity).unwrap();
+                query.get_component::<u32>(entity).unwrap();
             }
 
             assert_eq!(1, entities.iter().count());

--- a/crates/bevy_ecs/src/system/into_system.rs
+++ b/crates/bevy_ecs/src/system/into_system.rs
@@ -437,35 +437,35 @@ mod tests {
         ) {
             let entities = entity_query.iter().collect::<Vec<Entity>>();
             assert!(
-                b_query.get::<B>(entities[0]).is_err(),
+                b_query.get_component::<B>(entities[0]).is_err(),
                 "entity 0 should not have B"
             );
             assert!(
-                b_query.get::<B>(entities[1]).is_ok(),
+                b_query.get_component::<B>(entities[1]).is_ok(),
                 "entity 1 should have B"
             );
             assert!(
-                b_query.get::<A>(entities[1]).is_err(),
+                b_query.get_component::<A>(entities[1]).is_err(),
                 "entity 1 should have A, but b_query shouldn't have access to it"
             );
             assert!(
-                b_query.get::<D>(entities[3]).is_err(),
+                b_query.get_component::<D>(entities[3]).is_err(),
                 "entity 3 should have D, but it shouldn't be accessible from b_query"
             );
             assert!(
-                b_query.get::<C>(entities[2]).is_err(),
+                b_query.get_component::<C>(entities[2]).is_err(),
                 "entity 2 has C, but it shouldn't be accessible from b_query"
             );
             assert!(
-                a_c_query.get::<C>(entities[2]).is_ok(),
+                a_c_query.get_component::<C>(entities[2]).is_ok(),
                 "entity 2 has C, and it should be accessible from a_c_query"
             );
             assert!(
-                a_c_query.get::<D>(entities[3]).is_err(),
+                a_c_query.get_component::<D>(entities[3]).is_err(),
                 "entity 3 should have D, but it shouldn't be accessible from b_query"
             );
             assert!(
-                d_query.get::<D>(entities[3]).is_ok(),
+                d_query.get_component::<D>(entities[3]).is_ok(),
                 "entity 3 should have D"
             );
 

--- a/crates/bevy_ecs/src/system/query/mod.rs
+++ b/crates/bevy_ecs/src/system/query/mod.rs
@@ -75,7 +75,7 @@ impl<'a, Q: HecsQuery> Query<'a, Q> {
     }
 
     /// Gets the query result for the given `entity`
-    pub fn entity(&self, entity: Entity) -> Result<<Q::Fetch as Fetch>::Item, QueryError>
+    pub fn get(&self, entity: Entity) -> Result<<Q::Fetch as Fetch>::Item, QueryError>
     where
         Q::Fetch: ReadOnlyFetch,
     {
@@ -88,7 +88,7 @@ impl<'a, Q: HecsQuery> Query<'a, Q> {
     }
 
     /// Gets the query result for the given `entity`
-    pub fn entity_mut(&mut self, entity: Entity) -> Result<<Q::Fetch as Fetch>::Item, QueryError> {
+    pub fn get_mut(&mut self, entity: Entity) -> Result<<Q::Fetch as Fetch>::Item, QueryError> {
         // SAFE: system runs without conflicts with other systems. same-system queries have runtime borrow checks when they conflict
         unsafe {
             self.world
@@ -111,7 +111,7 @@ impl<'a, Q: HecsQuery> Query<'a, Q> {
 
     /// Gets a reference to the entity's component of the given type. This will fail if the entity does not have
     /// the given component type or if the given component type does not match this query.
-    pub fn get<T: Component>(&self, entity: Entity) -> Result<&T, QueryError> {
+    pub fn get_component<T: Component>(&self, entity: Entity) -> Result<&T, QueryError> {
         if let Some(location) = self.world.get_entity_location(entity) {
             if self
                 .component_access
@@ -133,7 +133,10 @@ impl<'a, Q: HecsQuery> Query<'a, Q> {
 
     /// Gets a mutable reference to the entity's component of the given type. This will fail if the entity does not have
     /// the given component type or if the given component type does not match this query.
-    pub fn get_mut<T: Component>(&mut self, entity: Entity) -> Result<Mut<'_, T>, QueryError> {
+    pub fn get_component_mut<T: Component>(
+        &mut self,
+        entity: Entity,
+    ) -> Result<Mut<'_, T>, QueryError> {
         let location = match self.world.get_entity_location(entity) {
             None => return Err(QueryError::ComponentError(ComponentError::NoSuchEntity)),
             Some(location) => location,
@@ -174,7 +177,7 @@ impl<'a, Q: HecsQuery> Query<'a, Q> {
     /// Sets the entity's component to the given value. This will fail if the entity does not already have
     /// the given component type or if the given component type does not match this query.
     pub fn set<T: Component>(&mut self, entity: Entity, component: T) -> Result<(), QueryError> {
-        let mut current = self.get_mut::<T>(entity)?;
+        let mut current = self.get_component_mut::<T>(entity)?;
         *current = component;
         Ok(())
     }

--- a/crates/bevy_render/src/render_graph/nodes/camera_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/camera_node.rs
@@ -78,15 +78,11 @@ pub fn camera_node_system(
 ) {
     let render_resource_context = &**render_resource_context;
 
-    let (camera, global_transform) =
-        if let Some(camera_entity) = active_cameras.get(&state.camera_name) {
-            (
-                query.get::<Camera>(camera_entity).unwrap(),
-                query.get::<GlobalTransform>(camera_entity).unwrap(),
-            )
-        } else {
-            return;
-        };
+    let (camera, global_transform) = if let Some(entity) = active_cameras.get(&state.camera_name) {
+        query.get(entity).unwrap()
+    } else {
+        return;
+    };
 
     let staging_buffer = if let Some(staging_buffer) = state.staging_buffer {
         render_resource_context.map_buffer(staging_buffer);

--- a/crates/bevy_transform/src/hierarchy/hierarchy.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy.rs
@@ -14,7 +14,7 @@ where
 {
     let parent_result = run(state, entity, parent_result, previous_result);
     previous_result = None;
-    if let Ok(children) = children_query.entity(entity) {
+    if let Ok(children) = children_query.get(entity) {
         for child in children.iter().cloned() {
             previous_result = run_on_hierarchy(
                 children_query,

--- a/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
@@ -14,7 +14,7 @@ pub fn parent_update_system(
     // them from the `Children` of the `PreviousParent`.
     for (entity, previous_parent) in removed_parent_query.iter() {
         log::trace!("Parent was removed from {:?}", entity);
-        if let Ok(mut previous_parent_children) = children_query.entity_mut(previous_parent.0) {
+        if let Ok(mut previous_parent_children) = children_query.get_mut(previous_parent.0) {
             log::trace!(" > Removing {:?} from it's prev parent's children", entity);
             previous_parent_children.0.retain(|e| *e != entity);
             commands.remove_one::<PreviousParent>(entity);
@@ -35,9 +35,7 @@ pub fn parent_update_system(
             }
 
             // Remove from `PreviousParent.Children`.
-            if let Ok(mut previous_parent_children) =
-                children_query.get_mut::<Children>(previous_parent.0)
-            {
+            if let Ok(mut previous_parent_children) = children_query.get_mut(previous_parent.0) {
                 log::trace!(" > Removing {:?} from prev parent's children", entity);
                 (*previous_parent_children).0.retain(|e| *e != entity);
             }
@@ -52,7 +50,7 @@ pub fn parent_update_system(
         // Add to the parent's `Children` (either the real component, or
         // `children_additions`).
         log::trace!("Adding {:?} to it's new parent {:?}", entity, parent.0);
-        if let Ok(mut new_parent_children) = children_query.get_mut::<Children>(parent.0) {
+        if let Ok(mut new_parent_children) = children_query.get_mut(parent.0) {
             // This is the parent
             log::trace!(
                 " > The new parent {:?} already has a `Children`, adding to it.",

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -124,7 +124,9 @@ pub fn ui_focus_system(
     if let Some(new_hovered_entity) = hovered_entity {
         if let Some(old_hovered_entity) = state.hovered_entity {
             if new_hovered_entity != old_hovered_entity {
-                if let Ok(mut interaction) = node_query.get_mut::<Interaction>(old_hovered_entity) {
+                if let Ok(mut interaction) =
+                    node_query.get_component_mut::<Interaction>(old_hovered_entity)
+                {
                     if *interaction == Interaction::Hovered {
                         *interaction = Interaction::None;
                     }

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -41,7 +41,7 @@ fn update_node_entity(
     };
     let global_z = z + parent_global_z;
 
-    if let Ok(mut transform) = node_query.get_mut::<Transform>(entity) {
+    if let Ok(mut transform) = node_query.get_component_mut::<Transform>(entity) {
         transform.translation.set_z(z);
     }
 

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -38,7 +38,7 @@ pub fn text_system(
     // add queued text to atlases
     let mut new_queued_text = Vec::new();
     for entity in queued_text.entities.drain(..) {
-        if let Ok((text, mut calculated_size)) = queries.q1_mut().entity_mut(entity) {
+        if let Ok((text, mut calculated_size)) = queries.q1_mut().get_mut(entity) {
             let font_atlases = font_atlas_sets
                 .get_or_insert_with(text.font.id, || FontAtlasSet::new(text.font.clone_weak()));
             // TODO: this call results in one or more TextureAtlases, whose render resources are created in the RENDER_GRAPH_SYSTEMS

--- a/examples/3d/z_sort_debug.rs
+++ b/examples/3d/z_sort_debug.rs
@@ -32,9 +32,7 @@ fn camera_order_color_system(
 ) {
     for (_camera, visible_entities) in camera_query.iter() {
         for visible_entity in visible_entities.iter() {
-            if let Ok(material_handle) =
-                material_query.get::<Handle<StandardMaterial>>(visible_entity.entity)
-            {
+            if let Ok(material_handle) = material_query.get(visible_entity.entity) {
                 let material = materials.get_mut(&*material_handle).unwrap();
                 let value = 1.0 - (visible_entity.order.0 - 10.0) / 7.0;
                 material.albedo = Color::rgb(value, value, value);

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -96,14 +96,14 @@ fn rotate(
 ) {
     let angle = std::f32::consts::PI / 2.0;
     for (parent, mut children, _) in parents_query.iter_mut() {
-        if let Ok(mut transform) = transform_query.entity_mut(parent) {
+        if let Ok(mut transform) = transform_query.get_mut(parent) {
             transform.rotate(Quat::from_rotation_z(-angle * time.delta_seconds));
         }
 
         // To iterate through the entities children, just treat the Children component as a Vec
         // Alternatively, you could query entities that have a Parent component
         for child in children.iter() {
-            if let Ok(mut transform) = transform_query.entity_mut(*child) {
+            if let Ok(mut transform) = transform_query.get_mut(*child) {
                 transform.rotate(Quat::from_rotation_z(angle * 2.0 * time.delta_seconds));
             }
         }

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -38,7 +38,7 @@ fn button_system(
     mut text_query: Query<&mut Text>,
 ) {
     for (_button, interaction, mut material, children) in interaction_query.iter_mut() {
-        let mut text = text_query.get_mut::<Text>(children[0]).unwrap();
+        let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
             Interaction::Clicked => {
                 text.value = "Press".to_string();


### PR DESCRIPTION
`query.get::<Component>(entity)` is now `query.get_component::<Component>(entity)`

and

`query.entity(entity)` is now `query.get(entity)`

This terminology is both clearer and gives the preferred action (getting the full query) precedence. This should be preferred because individual component lookup is slightly more expensive (due to additional safety checks). However for larger queries its probably still cheaper to do an individual component lookup if all you care about is a single component.