### PR TITLE
Make event example use a local resource

### DIFF
--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -43,7 +43,10 @@ fn event_trigger_system(
 }
 
 // prints events as they come in
-fn event_listener_system(mut my_event_reader: Local<EventReader<MyEvent>>, my_events: Res<Events<MyEvent>>) {
+fn event_listener_system(
+    mut my_event_reader: Local<EventReader<MyEvent>>,
+    my_events: Res<Events<MyEvent>>,
+) {
     for my_event in my_event_reader.iter(&my_events) {
         println!("{}", my_event.message);
     }

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -43,8 +43,8 @@ fn event_trigger_system(
 }
 
 // prints events as they come in
-fn event_listener_system(mut state: Local<EventReader<MyEvent>>, my_events: Res<Events<MyEvent>>) {
-    for my_event in state.iter(&my_events) {
+fn event_listener_system(mut my_event_reader: Local<EventReader<MyEvent>>, my_events: Res<Events<MyEvent>>) {
+    for my_event in my_event_reader.iter(&my_events) {
         println!("{}", my_event.message);
     }
 }

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -49,7 +49,7 @@ struct EventListenerState {
 }
 
 // prints events as they come in
-fn event_listener_system(mut state: ResMut<EventListenerState>, my_events: Res<Events<MyEvent>>) {
+fn event_listener_system(mut state: Local<EventListenerState>, my_events: Res<Events<MyEvent>>) {
     for my_event in state.my_event_reader.iter(&my_events) {
         println!("{}", my_event.message);
     }

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -7,7 +7,6 @@ fn main() {
         .add_default_plugins()
         .add_event::<MyEvent>()
         .init_resource::<EventTriggerState>()
-        .init_resource::<EventListenerState>()
         .add_system(event_trigger_system.system())
         .add_system(event_listener_system.system())
         .run();
@@ -43,14 +42,9 @@ fn event_trigger_system(
     }
 }
 
-#[derive(Default)]
-struct EventListenerState {
-    my_event_reader: EventReader<MyEvent>,
-}
-
 // prints events as they come in
-fn event_listener_system(mut state: Local<EventListenerState>, my_events: Res<Events<MyEvent>>) {
-    for my_event in state.my_event_reader.iter(&my_events) {
+fn event_listener_system(mut state: Local<EventReader<MyEvent>>, my_events: Res<Events<MyEvent>>) {
+    for my_event in state.iter(&my_events) {
         println!("{}", my_event.message);
     }
 }


### PR DESCRIPTION
This removes the EventListenerState global resource in the events example and replaces it with a local resource that is just a raw EventReader.

I think this is a clearer way of handling event listeners. It's how I've been doing it and how I've heard several other people say they do it as well which makes me think it's the style that should be shown in the example.