### PR TITLE
impl ReadOnlyFetch for Or, FetchOr, and FetchMutated

### DIFF
--- a/crates/bevy_ecs/hecs/src/query.rs
+++ b/crates/bevy_ecs/hecs/src/query.rs
@@ -263,6 +263,9 @@ macro_rules! impl_or_query {
                 true $( && $T.should_skip(n) )+
             }
         }
+
+        unsafe impl<$( $T: ReadOnlyFetch ),+> ReadOnlyFetch for Or<($( $T ),+)> {}
+        unsafe impl<$( $T: ReadOnlyFetch ),+> ReadOnlyFetch for FetchOr<($( $T ),+)> {}
     };
 }
 
@@ -320,6 +323,7 @@ impl<'a, T: Component> Query for Mutated<'a, T> {
 
 #[doc(hidden)]
 pub struct FetchMutated<T>(NonNull<T>, NonNull<bool>);
+unsafe impl<T> ReadOnlyFetch for FetchMutated<T> {}
 
 impl<'a, T: Component> Fetch<'a> for FetchMutated<T> {
     type Item = Mutated<'a, T>;


### PR DESCRIPTION
`ReadOnlyFetch` is now implemented on `Or` and `FetchOr`.
An impl for `FetchMutated` has been added for parity with `FetchChanged` and `FetchAdded`.

```rust
// previously would error due to missing implementations
let entities = world
    .query::<(Or<(Mutated<A>, Changed<B>, Added<C>)>, Entity)>()
    .map(|((_a, _b, _c), e)| e)
    .collect::<Vec<Entity>>();
```

If it was intentional to leave these implementations out in #741, I can change this PR a source comment about it.

Fixes #762 