### PR TITLE
Convenient way to add minimal plugins for a headless server

### DIFF
--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -29,21 +29,20 @@ impl Default for RunMode {
     }
 }
 
-/// Configures an App to run its [Schedule](bevy_ecs::Schedule) according to a given [RunMode]
-#[derive(Default)]
-pub struct ScheduleRunnerPlugin {
+#[derive(Copy, Clone, Default)]
+pub struct ScheduleRunnerSettings {
     pub run_mode: RunMode,
 }
 
-impl ScheduleRunnerPlugin {
+impl ScheduleRunnerSettings {
     pub fn run_once() -> Self {
-        ScheduleRunnerPlugin {
+        ScheduleRunnerSettings {
             run_mode: RunMode::Once,
         }
     }
 
     pub fn run_loop(wait_duration: Duration) -> Self {
-        ScheduleRunnerPlugin {
+        ScheduleRunnerSettings {
             run_mode: RunMode::Loop {
                 wait: Some(wait_duration),
             },
@@ -51,14 +50,21 @@ impl ScheduleRunnerPlugin {
     }
 }
 
+/// Configures an App to run its [Schedule](bevy_ecs::Schedule) according to a given [RunMode]
+#[derive(Default)]
+pub struct ScheduleRunnerPlugin {}
+
 impl Plugin for ScheduleRunnerPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        let run_mode = self.run_mode;
+        let settings = app
+            .resources_mut()
+            .get_or_insert_with(ScheduleRunnerSettings::default)
+            .to_owned();
         app.set_runner(move |mut app: App| {
             app.initialize();
 
             let mut app_exit_event_reader = EventReader::<AppExit>::default();
-            match run_mode {
+            match settings.run_mode {
                 RunMode::Once => {
                     app.update();
                 }

--- a/examples/2d/sprite.rs
+++ b/examples/2d/sprite.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();
 }

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .add_system(animate_sprite_system.system())
         .run();

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -4,7 +4,7 @@ use bevy::{asset::LoadState, prelude::*, sprite::TextureAtlasBuilder};
 fn main() {
     App::build()
         .init_resource::<RpgSpriteHandles>()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .add_system(load_atlas.system())
         .run();

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_resource(Msaa { samples: 4 })
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();
 }

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_resource(Msaa { samples: 4 })
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();
 }

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_resource(Msaa { samples: 4 })
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();
 }

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_resource(Msaa { samples: 4 })
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .add_system(rotator_system.system())
         .run();

--- a/examples/3d/spawner.rs
+++ b/examples/3d/spawner.rs
@@ -10,7 +10,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 /// NOTE: Bevy still has a number of optimizations to do in this area. Expect the performance here to go way up in the future
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(PrintDiagnosticsPlugin::default())
         .add_startup_system(setup.system())

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 /// This example shows various ways to configure texture materials in 3D
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();
 }

--- a/examples/3d/z_sort_debug.rs
+++ b/examples/3d/z_sort_debug.rs
@@ -9,7 +9,7 @@ use bevy::{
 /// This example visualizes camera z-ordering by setting the material of rotating cubes to their distance from the camera
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .add_system(rotator_system.system())
         .add_system(camera_order_color_system.system())

--- a/examples/app/empty_defaults.rs
+++ b/examples/app/empty_defaults.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
 
 fn main() {
-    App::build().add_default_plugins().run();
+    App::build().add_plugin_group(DefaultPlugins).run();
 }

--- a/examples/app/headless.rs
+++ b/examples/app/headless.rs
@@ -1,7 +1,7 @@
-use bevy::{app::ScheduleRunnerPlugin, prelude::*};
+use bevy::{app::ScheduleRunnerSettings, prelude::*};
 use std::time::Duration;
 
-// This example disables the default plugins by not registering them during setup.
+// This example only enables a minimal set of plugins required for bevy to run.
 // You can also completely remove rendering / windowing Plugin code from bevy
 // by making your import look like this in your Cargo.toml
 //
@@ -12,15 +12,17 @@ use std::time::Duration;
 fn main() {
     // this app runs once
     App::build()
-        .add_plugin(ScheduleRunnerPlugin::run_once())
+        .add_resource(ScheduleRunnerSettings::run_once())
+        .add_plugin_group(MinimalPlugins)
         .add_system(hello_world_system.system())
         .run();
 
     // this app loops forever at 60 fps
     App::build()
-        .add_plugin(ScheduleRunnerPlugin::run_loop(Duration::from_secs_f64(
+        .add_resource(ScheduleRunnerSettings::run_loop(Duration::from_secs_f64(
             1.0 / 60.0,
         )))
+        .add_plugin_group(MinimalPlugins)
         .add_system(counter.system())
         .run();
 }

--- a/examples/app/plugin.rs
+++ b/examples/app/plugin.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 /// This example illustrates how to create a simple plugin that prints out a message.
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         // plugins are registered as part of the "app building" process
         .add_plugin(PrintMessagePlugin {
             wait_duration: Duration::from_secs(1),

--- a/examples/app/plugin_group.rs
+++ b/examples/app/plugin_group.rs
@@ -3,7 +3,7 @@ use bevy::{app::PluginGroupBuilder, prelude::*};
 /// PluginGroups are a way to group sets of plugins that should be registered together.
 fn main() {
     App::build()
-        // The app.add_default_plugins() you see in all of the examples is just an alias for this:
+        // Two PluginGroups that are included with bevy are DefaultPlugins and MinimalPlugins
         .add_plugin_group(DefaultPlugins)
         // Adding a plugin group adds all plugins in the group by default
         .add_plugin_group(HelloWorldPlugins)

--- a/examples/app/return_after_run.rs
+++ b/examples/app/return_after_run.rs
@@ -7,7 +7,7 @@ fn main() {
             return_from_run: true,
         })
         .add_resource(ClearColor(Color::rgb(0.2, 0.2, 0.8)))
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .run();
     println!("Running another App.");
     App::build()
@@ -15,7 +15,7 @@ fn main() {
             return_from_run: true,
         })
         .add_resource(ClearColor(Color::rgb(0.2, 0.8, 0.2)))
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .run();
     println!("Done.");
 }

--- a/examples/app/thread_pool_resources.rs
+++ b/examples/app/thread_pool_resources.rs
@@ -5,6 +5,6 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_resource(DefaultTaskPoolOptions::with_num_threads(4))
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .run();
 }

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_resource(Msaa { samples: 4 })
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();
 }

--- a/examples/asset/custom_asset.rs
+++ b/examples/asset/custom_asset.rs
@@ -35,7 +35,7 @@ impl AssetLoader for CustomAssetLoader {
 
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .init_resource::<State>()
         .add_asset::<CustomAsset>()
         .init_asset_loader::<CustomAssetLoader>()

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 /// This example illustrates hot reloading mesh changes.
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();
 }

--- a/examples/audio/audio.rs
+++ b/examples/audio/audio.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 /// This example illustrates how to load and play an audio file
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();
 }

--- a/examples/diagnostics/custom_diagnostic.rs
+++ b/examples/diagnostics/custom_diagnostic.rs
@@ -6,7 +6,7 @@ use bevy::{
 /// This example illustrates how to create a custom diagnostic
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         // The "print diagnostics" plugin is optional. It just visualizes our diagnostics in the console
         .add_plugin(PrintDiagnosticsPlugin::default())
         .add_startup_system(setup_diagnostic_system.system())

--- a/examples/diagnostics/print_diagnostics.rs
+++ b/examples/diagnostics/print_diagnostics.rs
@@ -5,7 +5,7 @@ use bevy::{
 
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         // Adds frame time diagnostics
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         // Adds a system that prints diagnostics to the console

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    app::{AppExit, ScheduleRunnerPlugin},
+    app::{AppExit, ScheduleRunnerPlugin, ScheduleRunnerSettings},
     prelude::*,
 };
 use rand::random;
@@ -244,12 +244,14 @@ fn local_state_system(mut state: Local<State>, query: Query<(&Player, &Score)>) 
 fn main() {
     // Bevy apps are created using the builder pattern. We use the builder to add systems, resources, and plugins to our app
     App::build()
-        // Plugins are just a grouped set of app builder calls (just like we're doing here).
-        // We could easily turn our game into a plugin, but you can check out the plugin example for that :)
-        // The plugin below runs our app's "system schedule" once every 5 seconds.
-        .add_plugin(ScheduleRunnerPlugin::run_loop(Duration::from_secs(5)))
         // Resources can be added to our app like this
         .add_resource(State { counter: 0 })
+        // Some systems are configured by adding their settings as a resource
+        .add_resource(ScheduleRunnerSettings::run_loop(Duration::from_secs(5)))
+        // Plugins are just a grouped set of app builder calls (just like we're doing here).
+        // We could easily turn our game into a plugin, but you can check out the plugin example for that :)
+        // The plugin below runs our app's "system schedule" once every 5 seconds (configured above).
+        .add_plugin(ScheduleRunnerPlugin::default())
         // Resources that implement the Default or FromResources trait can be added like this:
         .init_resource::<GameState>()
         // Startup systems run exactly once BEFORE all other systems. These are generally used for

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 /// and a system that prints a message whenever the event is received.
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_event::<MyEvent>()
         .init_resource::<EventTriggerState>()
         .add_system(event_trigger_system.system())

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .add_system(rotate.system())
         .run();

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -73,7 +73,7 @@ fn bounce_system(
 
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(spawn_system.system())
         .add_system(move_system.system())
         .add_system(bounce_system.system())

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -7,7 +7,7 @@ use bevy::{
 /// An implementation of the classic game "Breakout"
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_resource(Scoreboard { score: 0 })
         .add_resource(ClearColor(Color::rgb(0.9, 0.9, 0.9)))
         .add_startup_system(setup.system())

--- a/examples/input/gamepad_input.rs
+++ b/examples/input/gamepad_input.rs
@@ -4,7 +4,7 @@ use bevy_utils::HashSet;
 
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .init_resource::<GamepadLobby>()
         .add_system_to_stage(stage::PRE_UPDATE, connection_system.system())
         .add_system(gamepad_system.system())

--- a/examples/input/gamepad_input_events.rs
+++ b/examples/input/gamepad_input_events.rs
@@ -3,7 +3,7 @@ use bevy_input::gamepad::{GamepadEvent, GamepadEventType};
 
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_system(gamepad_events.system())
         .run();
 }

--- a/examples/input/keyboard_input.rs
+++ b/examples/input/keyboard_input.rs
@@ -5,7 +5,7 @@ use bevy::{
 
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_system(keyboard_input_system.system())
         .run();
 }

--- a/examples/input/keyboard_input_events.rs
+++ b/examples/input/keyboard_input_events.rs
@@ -2,7 +2,7 @@ use bevy::{input::keyboard::KeyboardInput, prelude::*};
 
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_system(print_keyboard_event_system.system())
         .run();
 }

--- a/examples/input/mouse_input.rs
+++ b/examples/input/mouse_input.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_system(mouse_click_system.system())
         .run();
 }

--- a/examples/input/mouse_input_events.rs
+++ b/examples/input/mouse_input_events.rs
@@ -6,7 +6,7 @@ use bevy::{
 
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_system(print_mouse_events_system.system())
         .run();
 }

--- a/examples/input/touch_input.rs
+++ b/examples/input/touch_input.rs
@@ -2,7 +2,7 @@ use bevy::{input::touch::*, prelude::*};
 
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_system(touch_system.system())
         .run();
 }

--- a/examples/input/touch_input_events.rs
+++ b/examples/input/touch_input_events.rs
@@ -2,7 +2,7 @@ use bevy::{input::touch::*, prelude::*};
 
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_system(touch_event_system.system())
         .run();
 }

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -1,8 +1,8 @@
 use bevy::{
     prelude::{
-        shape, AddDefaultPlugins, App, Assets, Camera3dComponents, Color, Commands,
-        IntoQuerySystem, LightComponents, Mesh, Msaa, PbrComponents, ResMut, StandardMaterial,
-        Transform, Vec3, WindowDescriptor,
+        shape, App, Assets, Camera3dComponents, Color, Commands, DefaultPlugins, IntoQuerySystem,
+        LightComponents, Mesh, Msaa, PbrComponents, ResMut, StandardMaterial, Transform, Vec3,
+        WindowDescriptor,
     },
     window::WindowMode,
 };
@@ -17,7 +17,7 @@ extern "C" fn main_rs() {
             ..Default::default()
         })
         .add_resource(Msaa { samples: 4 })
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();
 }

--- a/examples/scene/properties.rs
+++ b/examples/scene/properties.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 /// familiar with "reflection" in other languages, Properties are very similar to that concept.
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         // If you need to deserialize custom property types, register them like this:
         .register_property::<Test>()
         .register_property::<Nested>()

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -3,7 +3,7 @@ use bevy::{prelude::*, type_registry::TypeRegistry};
 /// This example illustrates loading and saving scenes from files
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         // Registering components informs Bevy that they exist. This allows them to be used when loading scenes
         // This step is only required if you want to load your components from scene files.
         // Unregistered components can still be used in your code, but they will be ignored during scene save/load.

--- a/examples/shader/mesh_custom_attribute.rs
+++ b/examples/shader/mesh_custom_attribute.rs
@@ -13,7 +13,7 @@ use bevy::{
 /// This example illustrates how to add a custom attribute to a mesh and use it in a custom shader.
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_asset::<MyMaterialWithVertexColorSupport>()
         .add_startup_system(setup.system())
         .run();

--- a/examples/shader/shader_custom_material.rs
+++ b/examples/shader/shader_custom_material.rs
@@ -13,7 +13,7 @@ use bevy::{
 /// This example illustrates how to create a custom material asset and a shader that uses that material
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_asset::<MyMaterial>()
         .add_startup_system(setup.system())
         .run();

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -14,7 +14,7 @@ use bevy::{
 /// In Bevy, "shader defs" are a way to selectively enable parts of a shader based on values set in a component or asset.
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_asset::<MyMaterial>()
         .add_startup_system(setup.system())
         .add_system_to_stage(

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 /// This example illustrates how to create a button that changes color and text based on its interaction state.
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .init_resource::<ButtonMaterials>()
         .add_startup_system(setup.system())
         .add_system(button_system.system())

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -4,7 +4,7 @@ use bevy::{prelude::*, text::FontAtlasSet};
 fn main() {
     App::build()
         .init_resource::<State>()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .add_system(text_update_system.system())
         .add_system(atlas_render_system.system())

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -6,7 +6,7 @@ use bevy::{
 /// This example illustrates how to create text and update it in a system. It displays the current FPS in the upper left hand corner.
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_startup_system(setup.system())
         .add_system(text_update_system.system())

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 /// This example illustrates the various features of Bevy UI.
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();
 }

--- a/examples/wasm/assets_wasm.rs
+++ b/examples/wasm/assets_wasm.rs
@@ -19,7 +19,7 @@ fn main() {
         .add_resource(AssetServerSettings {
             asset_folder: "/".to_string(),
         })
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_asset::<RustSourceCode>()
         .init_asset_loader::<RustSourceCodeLoader>()
         .add_startup_system(load_asset.system())

--- a/examples/wasm/headless_wasm.rs
+++ b/examples/wasm/headless_wasm.rs
@@ -1,7 +1,10 @@
 #[cfg(target_arch = "wasm32")]
 extern crate console_error_panic_hook;
 
-use bevy::{app::ScheduleRunnerPlugin, prelude::*};
+use bevy::{
+    app::{ScheduleRunnerPlugin, ScheduleRunnerSettings},
+    prelude::*,
+};
 use std::time::Duration;
 
 fn main() {
@@ -12,9 +15,10 @@ fn main() {
     }
 
     App::build()
-        .add_plugin(ScheduleRunnerPlugin::run_loop(Duration::from_secs_f64(
+        .add_resource(ScheduleRunnerSettings::run_loop(Duration::from_secs_f64(
             1.0 / 60.0,
         )))
+        .add_plugin(ScheduleRunnerPlugin::default())
         .add_startup_system(hello_world_system.system())
         .add_system(counter.system())
         .run();

--- a/examples/wasm/winit_wasm.rs
+++ b/examples/wasm/winit_wasm.rs
@@ -22,7 +22,7 @@ fn main() {
             height: 300,
             ..Default::default()
         })
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         // One time greet
         .add_startup_system(hello_wasm_system.system())
         // Track ticks (sanity check, whether game loop is running)

--- a/examples/window/clear_color.rs
+++ b/examples/window/clear_color.rs
@@ -3,6 +3,6 @@ use bevy::{prelude::*, render::pass::ClearColor};
 fn main() {
     App::build()
         .add_resource(ClearColor(Color::rgb(0.5, 0.5, 0.9)))
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .run();
 }

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -16,7 +16,7 @@ use bevy::{
 fn main() {
     App::build()
         .add_resource(Msaa { samples: 4 })
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();
 }

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -11,7 +11,7 @@ fn main() {
             resizable: false,
             ..Default::default()
         })
-        .add_default_plugins()
+        .add_plugin_group(DefaultPlugins)
         .add_system(change_title.system())
         .add_system(toggle_cursor.system())
         .run();

--- a/src/default_plugins.rs
+++ b/src/default_plugins.rs
@@ -47,12 +47,30 @@ impl PluginGroup for DefaultPlugins {
     }
 }
 
+pub struct MinimalPlugins;
+
+impl PluginGroup for MinimalPlugins {
+    fn build(&mut self, group: &mut PluginGroupBuilder) {
+        group.add(bevy_type_registry::TypeRegistryPlugin::default());
+        group.add(bevy_core::CorePlugin::default());
+        group.add(bevy_app::ScheduleRunnerPlugin::run_loop(
+            std::time::Duration::from_secs_f64(1.0 / 60.0),
+        ));
+    }
+}
+
 pub trait AddDefaultPlugins {
     fn add_default_plugins(&mut self) -> &mut Self;
+
+    fn add_minimal_plugins(&mut self) -> &mut Self;
 }
 
 impl AddDefaultPlugins for AppBuilder {
     fn add_default_plugins(&mut self) -> &mut Self {
         self.add_plugin_group(DefaultPlugins)
+    }
+
+    fn add_minimal_plugins(&mut self) -> &mut Self {
+        self.add_plugin_group(MinimalPlugins)
     }
 }

--- a/src/default_plugins.rs
+++ b/src/default_plugins.rs
@@ -1,7 +1,5 @@
 use bevy_app::{PluginGroup, PluginGroupBuilder};
 
-use crate::app::AppBuilder;
-
 pub struct DefaultPlugins;
 
 impl PluginGroup for DefaultPlugins {
@@ -53,24 +51,6 @@ impl PluginGroup for MinimalPlugins {
     fn build(&mut self, group: &mut PluginGroupBuilder) {
         group.add(bevy_type_registry::TypeRegistryPlugin::default());
         group.add(bevy_core::CorePlugin::default());
-        group.add(bevy_app::ScheduleRunnerPlugin::run_loop(
-            std::time::Duration::from_secs_f64(1.0 / 60.0),
-        ));
-    }
-}
-
-pub trait AddDefaultPlugins {
-    fn add_default_plugins(&mut self) -> &mut Self;
-
-    fn add_minimal_plugins(&mut self) -> &mut Self;
-}
-
-impl AddDefaultPlugins for AppBuilder {
-    fn add_default_plugins(&mut self) -> &mut Self {
-        self.add_plugin_group(DefaultPlugins)
-    }
-
-    fn add_minimal_plugins(&mut self) -> &mut Self {
-        self.add_plugin_group(MinimalPlugins)
+        group.add(bevy_app::ScheduleRunnerPlugin::default());
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,7 @@
 pub use crate::{
     app::prelude::*, asset::prelude::*, core::prelude::*, ecs::prelude::*, input::prelude::*,
     math::prelude::*, property::prelude::*, scene::prelude::*, transform::prelude::*,
-    type_registry::RegisterType, window::prelude::*, AddDefaultPlugins, DefaultPlugins,
+    type_registry::RegisterType, window::prelude::*, DefaultPlugins, MinimalPlugins,
 };
 
 #[cfg(feature = "bevy_audio")]


### PR DESCRIPTION
It might be useful to make a way for folks to easily run a minimal bit of bevy (think headless server, CI job, etc.).

In that context, would this be a good approach? I based the actual minimal bit of plugins on https://github.com/bevyengine/bevy/issues/739#issuecomment-717390302  My biggest concern is that the loop duration is hard-coded.

Is there a more ideal way to solve this problem?  Maybe in a separate module+trait? Or just document how to do this? Something else?