### PR TITLE
fix mesh allocation bug and public mesh api improvements

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -20,7 +20,7 @@ use gltf::{
     Primitive,
 };
 use image::{GenericImageView, ImageFormat};
-use std::{borrow::Cow, path::Path};
+use std::path::Path;
 use thiserror::Error;
 
 /// An error that occurs when loading a GLTF file
@@ -90,28 +90,25 @@ async fn load_gltf<'a, 'b>(
                     .read_positions()
                     .map(|v| VertexAttributeValues::Float3(v.collect()))
                 {
-                    mesh.attributes
-                        .insert(Cow::Borrowed(Mesh::ATTRIBUTE_POSITION), vertex_attribute);
+                    mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, vertex_attribute);
                 }
 
                 if let Some(vertex_attribute) = reader
                     .read_normals()
                     .map(|v| VertexAttributeValues::Float3(v.collect()))
                 {
-                    mesh.attributes
-                        .insert(Cow::Borrowed(Mesh::ATTRIBUTE_NORMAL), vertex_attribute);
+                    mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, vertex_attribute);
                 }
 
                 if let Some(vertex_attribute) = reader
                     .read_tex_coords(0)
                     .map(|v| VertexAttributeValues::Float2(v.into_f32().collect()))
                 {
-                    mesh.attributes
-                        .insert(Cow::Borrowed(Mesh::ATTRIBUTE_UV_0), vertex_attribute);
+                    mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, vertex_attribute);
                 }
 
                 if let Some(indices) = reader.read_indices() {
-                    mesh.indices = Some(Indices::U32(indices.into_u32().collect()));
+                    mesh.set_indices(Some(Indices::U32(indices.into_u32().collect())));
                 };
 
                 load_context.set_labeled_asset(&primitive_label, LoadedAsset::new(mesh));

--- a/crates/bevy_render/src/pipeline/pipeline_compiler.rs
+++ b/crates/bevy_render/src/pipeline/pipeline_compiler.rs
@@ -20,7 +20,7 @@ pub struct PipelineSpecialization {
     pub primitive_topology: PrimitiveTopology,
     pub dynamic_bindings: Vec<DynamicBinding>,
     pub index_format: IndexFormat,
-    pub mesh_attribute_layout: VertexBufferDescriptor,
+    pub vertex_buffer_descriptor: VertexBufferDescriptor,
     pub sample_count: u32,
 }
 
@@ -28,11 +28,11 @@ impl Default for PipelineSpecialization {
     fn default() -> Self {
         Self {
             sample_count: 1,
+            index_format: IndexFormat::Uint32,
             shader_specialization: Default::default(),
             primitive_topology: Default::default(),
             dynamic_bindings: Default::default(),
-            index_format: IndexFormat::Uint32,
-            mesh_attribute_layout: Default::default(),
+            vertex_buffer_descriptor: Default::default(),
         }
     }
 }
@@ -172,7 +172,7 @@ impl PipelineCompiler {
         // create a vertex layout that provides all attributes from either the specialized vertex buffers or a zero buffer
         let mut pipeline_layout = specialized_descriptor.layout.as_mut().unwrap();
         // the vertex buffer descriptor of the mesh
-        let mesh_vertex_buffer_descriptor = pipeline_specialization.mesh_attribute_layout.clone();
+        let mesh_vertex_buffer_descriptor = &pipeline_specialization.vertex_buffer_descriptor;
 
         // the vertex buffer descriptor that will be used for this pipeline
         let mut compiled_vertex_buffer_descriptor = VertexBufferDescriptor {

--- a/crates/bevy_render/src/pipeline/render_pipelines.rs
+++ b/crates/bevy_render/src/pipeline/render_pipelines.rs
@@ -1,4 +1,4 @@
-use super::{IndexFormat, PipelineDescriptor, PipelineSpecialization};
+use super::{PipelineDescriptor, PipelineSpecialization};
 use crate::{
     draw::{Draw, DrawContext},
     mesh::{Indices, Mesh},
@@ -91,21 +91,16 @@ pub fn draw_render_pipelines_system(
             continue;
         };
 
-        let (index_range, index_format) = match mesh.indices.as_ref() {
-            Some(Indices::U32(indices)) => (Some(0..indices.len() as u32), IndexFormat::Uint32),
-            Some(Indices::U16(indices)) => (Some(0..indices.len() as u32), IndexFormat::Uint16),
-            None => (None, IndexFormat::Uint32),
+        let index_range = match mesh.indices() {
+            Some(Indices::U32(indices)) => Some(0..indices.len() as u32),
+            Some(Indices::U16(indices)) => Some(0..indices.len() as u32),
+            None => None,
         };
 
         let render_pipelines = &mut *render_pipelines;
         for pipeline in render_pipelines.pipelines.iter_mut() {
             pipeline.specialization.sample_count = msaa.samples;
-            pipeline.specialization.index_format = index_format;
-            pipeline.specialization.mesh_attribute_layout = mesh
-                .attribute_buffer_descriptor_reference
-                .as_ref()
-                .unwrap()
-                .clone();
+            // TODO: move these to mesh.rs?
         }
 
         for render_pipeline in render_pipelines.pipelines.iter() {

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -51,7 +51,7 @@ impl<'a> Drawable for DrawableText<'a> {
             &bevy_sprite::SPRITE_SHEET_PIPELINE_HANDLE,
             &PipelineSpecialization {
                 sample_count: self.msaa.samples,
-                mesh_attribute_layout: self.font_quad_vertex_descriptor.clone(),
+                vertex_buffer_descriptor: self.font_quad_vertex_descriptor.clone(),
                 ..Default::default()
             },
         )?;

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -100,14 +100,8 @@ pub fn draw_text_system(
     mut asset_render_resource_bindings: ResMut<AssetRenderResourceBindings>,
     mut query: Query<(&mut Draw, &Text, &Node, &GlobalTransform)>,
 ) {
-    let font_quad_vertex_descriptor = {
-        let font_quad = meshes.get(&QUAD_HANDLE).unwrap();
-        font_quad
-            .attribute_buffer_descriptor_reference
-            .as_ref()
-            .unwrap()
-            .clone()
-    };
+    let font_quad = meshes.get(&QUAD_HANDLE).unwrap();
+    let vertex_buffer_descriptor = font_quad.get_vertex_buffer_descriptor();
 
     for (mut draw, text, node, global_transform) in query.iter_mut() {
         if let Some(font) = fonts.get(&text.font) {
@@ -123,7 +117,7 @@ pub fn draw_text_system(
                 style: &text.style,
                 text: &text.value,
                 container_size: node.size,
-                font_quad_vertex_descriptor: &font_quad_vertex_descriptor,
+                font_quad_vertex_descriptor: &vertex_buffer_descriptor,
             };
             drawable_text.draw(&mut draw, &mut draw_context).unwrap();
         }

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -23,7 +23,7 @@ fn setup(
     if let Some(sphere) = meshes.get(&sphere_handle) {
         // You might notice that this doesn't run! This is because assets load in parallel without blocking.
         // When an asset has loaded, it will appear in relevant Assets<T> collection.
-        println!("{:?}", sphere.primitive_topology);
+        println!("{:?}", sphere.primitive_topology());
     } else {
         println!("sphere hasn't loaded yet");
     }


### PR DESCRIPTION
Fixes #764 

This removes attribute_buffer_descriptor_reference from Mesh in favor of computing it on demand. This prevents the "mesh asset change event" from triggering . 

I also refactored some things and encapsulated the Mesh fields in favor of accessor methods. This allows us to cut down on user facing boilerplate and makes the backing attribute hashmap an implementation detail.

@julhe I also removed the sorting to cut down on the cost of computing VertexBufferDescriptor. I know I asked you to sort, but now that we're computing the descriptor more frequently its worth optimizing.

Long term I think we should avoid re-computing the VertexBufferDescriptor. Instead we should adopt something like this:

1. whenever a mesh changes (asset change event), calculate the new vertexbufferdescriptor, hash it, and store a mapping between the hash and the descriptor as a resource. also store a mapping between the Mesh and the Hash
2. Instead of storing a copy of the VertexBufferDescriptor in every Entity's RenderPipeline::specialization (which is allocation heavy), store the hash instead.
3. In PipelineCompiler, look up the VertexBufferDescriptor using the specialization's vertexbufferdescriptor hash 