### PR TITLE
Add tracing spans to schedules, stages, systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,9 @@ log = "0.4"
 rand = "0.7.3"
 ron = "0.6"
 serde = {version = "1", features = ["derive"]}
+tracing = "0.1.21"
+tracing-chrome = "0.2.0"
+tracing-subscriber = "0.2.15"
 
 # bevy (Android)
 [target.'cfg(target_os = "android")'.dependencies]
@@ -167,6 +170,10 @@ path = "examples/app/return_after_run.rs"
 [[example]]
 name = "thread_pool_resources"
 path = "examples/app/thread_pool_resources.rs"
+
+[[example]]
+name = "tracing"
+path = "examples/app/tracing.rs"
 
 [[example]]
 name = "hot_asset_reloading"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ bevy_wgpu = ["bevy_internal/bevy_wgpu"]
 bevy_winit = ["bevy_internal/bevy_winit"]
 
 profiler = ["bevy_internal/profiler"]
+trace = ["bevy_internal/trace"]
 wgpu_trace = ["bevy_internal/wgpu_trace"]
 
 # Image format support for texture loading (PNG and HDR are enabled by default)

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT"
 keywords = ["bevy"]
 
+[features]
+trace = [ "tracing" ]
+
 [dependencies]
 # bevy
 bevy_derive = { path = "../bevy_derive", version = "0.3.0" }
@@ -21,6 +24,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.3.0" }
 # other
 log = { version = "0.4", features = ["release_max_level_info"] }
 serde = { version = "1.0", features = ["derive"] }
+tracing = { version = "0.1.21", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1,5 +1,7 @@
 use crate::app_builder::AppBuilder;
 use bevy_ecs::{ParallelExecutor, Resources, Schedule, World};
+#[cfg(feature = "trace")]
+use tracing::info_span;
 
 #[allow(clippy::needless_doctest_main)]
 /// Containers of app logic and data
@@ -65,6 +67,10 @@ impl App {
     }
 
     pub fn initialize(&mut self) {
+        #[cfg(feature = "trace")]
+        let startup_schedule_span = info_span!("startup_schedule");
+        #[cfg(feature = "trace")]
+        let _startup_schedule_guard = startup_schedule_span.enter();
         self.startup_schedule
             .initialize(&mut self.world, &mut self.resources);
         self.startup_executor.initialize(&mut self.resources);
@@ -76,7 +82,13 @@ impl App {
     }
 
     pub fn run(mut self) {
+        #[cfg(feature = "trace")]
+        let bevy_app_run_span = info_span!("bevy_app_run");
+        #[cfg(feature = "trace")]
+        let _bevy_app_run_guard = bevy_app_run_span.enter();
+
         self.executor.initialize(&mut self.resources);
+
         let runner = std::mem::replace(&mut self.runner, Box::new(run_once));
         (runner)(self);
     }

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["game-engines", "data-structures"]
 
 [features]
 profiler = []
+trace = [ "tracing" ]
 
 [dependencies]
 bevy_hecs = { path = "hecs", features = ["macros", "serialize"], version = "0.3.0" }
@@ -26,3 +27,4 @@ fixedbitset = "0.3.1"
 downcast-rs = "1.2.0"
 parking_lot = "0.11.0"
 log = { version = "0.4", features = ["release_max_level_info"] }
+tracing = { version = "0.1.21", optional = true }

--- a/crates/bevy_ecs/src/schedule/parallel_executor.rs
+++ b/crates/bevy_ecs/src/schedule/parallel_executor.rs
@@ -546,7 +546,7 @@ impl ExecutorStage {
                     #[cfg(feature = "trace")]
                     let _system_guard = system_span.enter();
                     system.run_thread_local(world, resources);
-                },
+                }
                 ThreadLocalExecution::Immediate => { /* already ran */ }
             }
         }

--- a/crates/bevy_ecs/src/schedule/parallel_executor.rs
+++ b/crates/bevy_ecs/src/schedule/parallel_executor.rs
@@ -7,6 +7,8 @@ use bevy_hecs::{ArchetypesGeneration, TypeAccess, World};
 use bevy_tasks::{ComputeTaskPool, CountdownEvent, TaskPool};
 use fixedbitset::FixedBitSet;
 use std::ops::Range;
+#[cfg(feature = "trace")]
+use tracing::info_span;
 
 /// Executes each schedule stage in parallel by analyzing system dependencies.
 /// System execution order is undefined except under the following conditions:
@@ -48,6 +50,11 @@ impl ParallelExecutor {
     }
 
     pub fn run(&mut self, schedule: &mut Schedule, world: &mut World, resources: &mut Resources) {
+        #[cfg(feature = "trace")]
+        let schedule_span = info_span!("schedule");
+        #[cfg(feature = "trace")]
+        let _schedule_guard = schedule_span.enter();
+
         let schedule_generation = schedule.generation();
         let schedule_changed = schedule.generation() != self.last_schedule_generation;
         if schedule_changed {
@@ -57,6 +64,10 @@ impl ParallelExecutor {
         }
         for (stage_name, executor_stage) in schedule.stage_order.iter().zip(self.stages.iter_mut())
         {
+            #[cfg(feature = "trace")]
+            let stage_span = info_span!("stage", name = stage_name.as_ref());
+            #[cfg(feature = "trace")]
+            let _stage_guard = stage_span.enter();
             log::trace!("run stage {:?}", stage_name);
             if let Some(stage_systems) = schedule.stages.get_mut(stage_name) {
                 executor_stage.run(world, resources, stage_systems, schedule_changed);
@@ -392,6 +403,11 @@ impl ExecutorStage {
                     // Execute the system - in a scope to ensure the system lock is dropped before
                     // triggering dependents
                     {
+                        #[cfg(feature = "trace")]
+                        let system_span = info_span!("system", name = system.name().as_ref());
+                        #[cfg(feature = "trace")]
+                        let _system_guard = system_span.enter();
+
                         log::trace!("run {}", system.name());
                         #[cfg(feature = "profiler")]
                         crate::profiler_start(resources, system.name().clone());
@@ -442,6 +458,11 @@ impl ExecutorStage {
 
             for (system_index, system) in systems.iter().enumerate() {
                 if system.thread_local_execution() == ThreadLocalExecution::Immediate {
+                    #[cfg(feature = "trace")]
+                    let system_span = info_span!("system", name = system.name().as_ref());
+                    #[cfg(feature = "trace")]
+                    let _system_guard = system_span.enter();
+
                     self.thread_local_system_indices.push(system_index);
                 }
             }
@@ -483,6 +504,12 @@ impl ExecutorStage {
             {
                 // if a thread local system is ready to run, run it exclusively on the main thread
                 let system = systems[thread_local_system_index].as_mut();
+
+                #[cfg(feature = "trace")]
+                let system_span = info_span!("system", name = system.name().as_ref());
+                #[cfg(feature = "trace")]
+                let _system_guard = system_span.enter();
+
                 log::trace!("running thread local system {}", system.name());
                 system.run(world, resources);
                 system.run_thread_local(world, resources);
@@ -513,7 +540,13 @@ impl ExecutorStage {
         // "flush"
         for system in systems.iter_mut() {
             match system.thread_local_execution() {
-                ThreadLocalExecution::NextFlush => system.run_thread_local(world, resources),
+                ThreadLocalExecution::NextFlush => {
+                    #[cfg(feature = "trace")]
+                    let system_span = info_span!("system", name = system.name().as_ref());
+                    #[cfg(feature = "trace")]
+                    let _system_guard = system_span.enter();
+                    system.run_thread_local(world, resources);
+                },
                 ThreadLocalExecution::Immediate => { /* already ran */ }
             }
         }

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["game-engines", "graphics", "gui", "rendering"]
 [features]
 profiler = ["bevy_ecs/profiler", "bevy_diagnostic/profiler"]
 wgpu_trace = ["bevy_wgpu/trace"]
+trace = [ "bevy_app/trace", "bevy_ecs/trace" ]
 
 # Image format support for texture loading (PNG and HDR are enabled by default)
 hdr = ["bevy_render/hdr"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,6 +42,7 @@ Example | File | Description
 `headless` | [`app/headless.rs`](./app/headless.rs) | An application that runs without default plugins
 `plugin` | [`app/plugin.rs`](./app/plugin.rs) | Demonstrates the creation and registration of a custom plugin
 `thread_pool_resources` | [`app/thread_pool_resources.rs`](./app/thread_pool_resources.rs) | Creates and customizes the internal thread pool
+`tracing` | [`app/tracing.rs`](./app/tracing.rs) | Demonstrates `trace` feature output. Run with `RUST_LOG=info cargo run --example tracing --features trace` and then open the `trace-1234.json` file (where 1234 is a time since the beginning of the epoch) in `chrome://tracing` in Chrome.
 
 ## Assets
 

--- a/examples/app/tracing.rs
+++ b/examples/app/tracing.rs
@@ -1,0 +1,49 @@
+use bevy::{input::system::exit_on_esc_system, prelude::*};
+use std::{thread, time};
+use tracing::info;
+use tracing_chrome::ChromeLayerBuilder;
+use tracing_subscriber::{fmt, prelude::*, registry::Registry, EnvFilter};
+
+pub fn setup_global_subscriber() -> impl Drop {
+    let fmt_layer = fmt::Layer::default();
+    let filter_layer = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new("info,wgpu=warn"))
+        .unwrap();
+
+    let (chrome_layer, _guard) = ChromeLayerBuilder::new().build();
+
+    let subscriber = Registry::default()
+        .with(filter_layer)
+        .with(fmt_layer)
+        .with(chrome_layer);
+
+    tracing::subscriber::set_global_default(subscriber).expect("Could not set global default");
+    _guard
+}
+
+fn main() {
+    let _guard = setup_global_subscriber();
+
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(a_system.system())
+        .add_system(foo_bar_baz.system())
+        .add_system(exit_on_esc_system.system())
+        .run();
+}
+
+fn a_system(commands: &mut Commands) {
+    let ten_millis = time::Duration::from_millis(10);
+    thread::sleep(ten_millis);
+
+    commands.spawn((GlobalTransform::default(), Transform::default()));
+}
+
+fn foo_bar_baz(query: Query<&Transform>) {
+    for transform in query.iter() {
+        let five_millis = time::Duration::from_millis(5);
+        thread::sleep(five_millis);
+
+        info!(?transform);
+    }
+}


### PR DESCRIPTION
The `tracing` crate allows for gathering data on how much time is spent within a scope, as well as enabling structured logging. `tracing` has a structure similar to the `log` crate where instrumentation using spans or events (events being structured logs within a hierarchy of spans, so much more advanced and useful logs) are made using the `tracing` crate and then there are many other crates that can subscribe to the events to output data in a format useful for analysis and/or visualisation.

If you want to learn more I highly recommend watching this video: https://www.youtube.com/watch?v=JjItsfqFIdo

My motivation was focused on profiling, as I wanted to know how much time was being spent in each system in order to understand where game loop time was being spent. I have been a bit slow in making this PR as I wanted to find some useful ways of analysing and visualising the trace data.

A few good options:
* [`tracing-flame`](https://github.com/tokio-rs/tracing/blob/master/tracing-flame) - captures a trace to a file that can then be used with the `inferno-flamegraph` crate to generate flamegraphs (aggregate time spent within spans) or flamecharts (a timeline of spans for the duration of the capture). These are good but I found clicking around between views in an SVG to be a bit cumbersome.
* [`tracing-chrome`](https://github.com/thoren-d/tracing-chrome) - captures a trace to a file that can be opened in Chrome/Chromium by visiting chrome://tracing and loading the file. This shows a timeline of events that are quick to navigate using the tools (pan / zoom / highlight range / etc). The dependency on Chrome doesn't feel great, but this looks potentially useful and standalone/possible to integrate: https://github.com/catapult-project/catapult/tree/master/tracing
* [`tracing-tracy`](https://crates.io/crates/tracing-tracy) - streams the trace to the [Tracy frame profiler](https://github.com/wolfpld/tracy). This is advanced real-time profiling designed for use with games. I had stability problems on macOS but perhaps on Linux / Windows that are better supported, this is the best option. It can display the timeline of events, statistical aggregates of how much time is being spent in spans, log messages, everything. Here's a screenshot:
<img width="1792" alt="Screenshot 2020-10-22 at 13 36 08" src="https://user-images.githubusercontent.com/302146/98104612-f6d4c900-1e96-11eb-943a-80c4529ae1ba.png">

Unfortunately, it seems the default behaviour of all of these three crates is to not include any of the additional fields added to spans in the visualisation. `tracing` spans must have a static str name and only additional fields can be dynamic. This means that with this current implementation, you can only visualise that a schedule/stage/system has run, and not see what it is. I have made [a modification to tracing-chrome here](https://github.com/superdump/tracing-chrome/commit/0310cd3d4233f5fba1dc04893ed23691e4890be7) that includes the additional fields in the span's name for the visualisation to be able to see what span is what and [similarly for tracing-tracy here](https://github.com/superdump/rust_tracy_client/commit/8cdf8bf5f8fca41d8c6267817f16861711bbd8b8).

To make use of `tracing-chrome` in my project, I did the following:
* `Cargo.toml`
```rust
[features]
default = [ "trace" ]
trace = [ "tracing", "tracing-chrome", "tracing-subscriber", "bevy/trace" ]

[dependencies]
tracing = { version = "0.1.21", optional = true }
tracing-chrome = { git = "https://github.com/superdump/tracing-chrome", branch = "name.fields", optional = true }
tracing-subscriber = { version = "0.2.15", optional = true }
```
* `src/trace.rs`
```rust
use tracing_chrome::ChromeLayerBuilder;
use tracing_subscriber::{fmt, prelude::*, registry::Registry, EnvFilter};

pub fn setup_global_subscriber() -> impl Drop {
    let fmt_layer = fmt::Layer::default();
    let filter_layer = EnvFilter::try_from_default_env()
        .or_else(|_| EnvFilter::try_new("error"))
        .unwrap();

    let (chrome_layer, _guard) = ChromeLayerBuilder::new().build();

    let subscriber = Registry::default()
        .with(filter_layer)
        .with(fmt_layer)
        .with(chrome_layer);

    tracing::subscriber::set_global_default(subscriber).expect("Could not set global default");
    _guard
}
```
* `src/main.rs`
```rust
#[cfg(feature = "trace")]
use crate::trace::setup_global_subscriber;
#[cfg(feature = "trace")]
use tracing::{info, trace_span};

fn main() {
    #[cfg(feature = "trace")]
    let _guard = setup_global_subscriber();

    #[cfg(feature = "trace")]
    let minkraft_span = trace_span!("minkraft");
    #[cfg(feature = "trace")]
    let _minkraft_guard = minkraft_span.enter();

...

    info!("Running {}!", env!("CARGO_PKG_NAME").to_string());
    app_builder.run();
```

You can also enable `bevy/wgpu_trace` but be warned, it is _very_ chatty to the point of impacting performance so I would suggest not using it, or using it sparingly or when you need to.

Note also that in the example code, I added an `EnvFilter`. This allows filtering by setting `RUST_LOG=trace,wgpu=warn` similar to how the `env_logger` crate works with `log`, but in addition it allows filtering of log events and spans based on some more advanced rules. [See here for more information](https://docs.rs/tracing-subscriber/0.2.15/tracing_subscriber/filter/struct.EnvFilter.html#directives).

For sure some of this information should go into some documentation somewhere and I will add that to the PR once we've decided whether this is wanted and/or in what form.