### PR TITLE
Add char input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,6 +237,10 @@ name = "keyboard_input_events"
 path = "examples/input/keyboard_input_events.rs"
 
 [[example]]
+name = "char_input_events"
+path = "examples/input/char_input_events.rs"
+
+[[example]]
 name = "gamepad_input"
 path = "examples/input/gamepad_input.rs"
 

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -4,6 +4,7 @@ mod input;
 pub mod keyboard;
 pub mod mouse;
 pub mod system;
+pub mod text;
 pub mod touch;
 
 pub use axis::*;
@@ -25,6 +26,7 @@ pub mod prelude {
 use bevy_app::prelude::*;
 use keyboard::{keyboard_input_system, KeyCode, KeyboardInput};
 use mouse::{mouse_button_input_system, MouseButton, MouseButtonInput, MouseMotion, MouseWheel};
+use text::CharInput;
 use touch::{touch_screen_input_system, TouchInput, Touches};
 
 use bevy_app::startup_stage::STARTUP;
@@ -41,6 +43,7 @@ pub struct InputPlugin;
 impl Plugin for InputPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_event::<KeyboardInput>()
+            .add_event::<CharInput>()
             .add_event::<MouseButtonInput>()
             .add_event::<MouseMotion>()
             .add_event::<MouseWheel>()

--- a/crates/bevy_input/src/text.rs
+++ b/crates/bevy_input/src/text.rs
@@ -1,0 +1,9 @@
+// This is a really basic newtype wrapper since there _may_ be more that needs to be added eventually.
+// Also, having an event that's just of `char` is not exactly the best idea...
+
+// As well, unlike the other inputs, there's no system for syncing the events to the Input<T> type.
+// This is because the "press-able" style of Input<T> doesn't map well to character/text inputs.
+
+/// A character input event as sent by the OS or otherwise underlying system.
+#[derive(Debug, Clone)]
+pub struct CharInput(pub char);

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -4,6 +4,7 @@ mod winit_windows;
 use bevy_input::{
     keyboard::KeyboardInput,
     mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
+    text::CharInput,
     touch::TouchInput,
 };
 pub use winit_config::*;
@@ -271,6 +272,12 @@ pub fn winit_runner(mut app: App) {
                         touch.location.y = window_height as f64 - touch.location.y;
                     }
                     touch_input_events.send(converters::convert_touch_input(touch));
+                }
+                WindowEvent::ReceivedCharacter(c) => {
+                    let mut char_input_events =
+                        app.resources.get_mut::<Events<CharInput>>().unwrap();
+
+                    char_input_events.send(CharInput(c))
                 }
                 _ => {}
             },

--- a/examples/input/char_input_events.rs
+++ b/examples/input/char_input_events.rs
@@ -1,0 +1,20 @@
+use bevy::{input::text::CharInput, prelude::*};
+
+fn main() {
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_system(print_char_event_system.system())
+        .run();
+}
+
+#[derive(Default)]
+struct State {
+    event_reader: EventReader<CharInput>,
+}
+
+/// This system prints out all char events as they come in
+fn print_char_event_system(mut state: Local<State>, char_input_events: Res<Events<CharInput>>) {
+    for event in state.event_reader.iter(&char_input_events) {
+        println!("{:?}: '{}'", event, event.0);
+    }
+}


### PR DESCRIPTION
Based on the comments and information from #782, this is an alternative approach to providing a form of simple text input in bevy.

This adds the `CharInput` event to `bevy_input` and modifies `bevy_winit` to dispatch the event when the winit `ReceivedCharacter` event fires.

Only _one_ of either this PR or #805 should realistically be merged.