### PR TITLE
Add received character

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,6 +237,10 @@ name = "keyboard_input_events"
 path = "examples/input/keyboard_input_events.rs"
 
 [[example]]
+name = "char_input_events"
+path = "examples/input/char_input_events.rs"
+
+[[example]]
 name = "gamepad_input"
 path = "examples/input/gamepad_input.rs"
 

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -40,3 +40,10 @@ pub struct CursorMoved {
     pub id: WindowId,
     pub position: Vec2,
 }
+
+/// An event that is sent whenever a window receives a character from the OS or underlying system.
+#[derive(Debug, Clone)]
+pub struct ReceivedCharacter {
+    pub id: WindowId,
+    pub char: char,
+}

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -9,7 +9,7 @@ pub use window::*;
 pub use windows::*;
 
 pub mod prelude {
-    pub use crate::{CursorMoved, Window, WindowDescriptor, Windows};
+    pub use crate::{CursorMoved, ReceivedCharacter, Window, WindowDescriptor, Windows};
 }
 
 use bevy_app::prelude::*;
@@ -37,6 +37,7 @@ impl Plugin for WindowPlugin {
             .add_event::<WindowCloseRequested>()
             .add_event::<CloseWindow>()
             .add_event::<CursorMoved>()
+            .add_event::<ReceivedCharacter>()
             .init_resource::<Windows>();
 
         if self.add_primary_window {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -13,7 +13,8 @@ use bevy_app::{prelude::*, AppExit};
 use bevy_ecs::{IntoThreadLocalSystem, Resources, World};
 use bevy_math::Vec2;
 use bevy_window::{
-    CreateWindow, CursorMoved, Window, WindowCloseRequested, WindowCreated, WindowResized, Windows,
+    CreateWindow, CursorMoved, ReceivedCharacter, Window, WindowCloseRequested, WindowCreated,
+    WindowResized, Windows,
 };
 use winit::{
     event::{self, DeviceEvent, Event, WindowEvent},
@@ -271,6 +272,20 @@ pub fn winit_runner(mut app: App) {
                         touch.location.y = window_height as f64 - touch.location.y;
                     }
                     touch_input_events.send(converters::convert_touch_input(touch));
+                }
+                WindowEvent::ReceivedCharacter(c) => {
+                    let mut char_input_events = app
+                        .resources
+                        .get_mut::<Events<ReceivedCharacter>>()
+                        .unwrap();
+
+                    let winit_windows = app.resources.get_mut::<WinitWindows>().unwrap();
+                    let window_id = winit_windows.get_window_id(winit_window_id).unwrap();
+
+                    char_input_events.send(ReceivedCharacter {
+                        id: window_id,
+                        char: c,
+                    })
                 }
                 _ => {}
             },

--- a/examples/input/char_input_events.rs
+++ b/examples/input/char_input_events.rs
@@ -1,0 +1,23 @@
+use bevy::{prelude::*, window::ReceivedCharacter};
+
+fn main() {
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_system(print_char_event_system.system())
+        .run();
+}
+
+#[derive(Default)]
+struct State {
+    event_reader: EventReader<ReceivedCharacter>,
+}
+
+/// This system prints out all char events as they come in
+fn print_char_event_system(
+    mut state: Local<State>,
+    char_input_events: Res<Events<ReceivedCharacter>>,
+) {
+    for event in state.event_reader.iter(&char_input_events) {
+        println!("{:?}: '{}'", event, event.char);
+    }
+}


### PR DESCRIPTION
Based on the comments and information from #782, this is a new approach to providing a form of simple text input in bevy.

This is an alternative PR to #804, where the event is in `bevy_window` and includes a `WindowId`, making it window-focused as opposed to #804 where it's "device"-focused.

Only _one_ of either this PR or #804 should realistically be merged.