### PR TITLE
Added RenderPass::set_scissor_rect

### DIFF
--- a/crates/bevy_render/src/pass/render_pass.rs
+++ b/crates/bevy_render/src/pass/render_pass.rs
@@ -11,6 +11,7 @@ pub trait RenderPass {
     fn set_vertex_buffer(&mut self, start_slot: u32, buffer: BufferId, offset: u64);
     fn set_pipeline(&mut self, pipeline_handle: &Handle<PipelineDescriptor>);
     fn set_viewport(&mut self, x: f32, y: f32, w: f32, h: f32, min_depth: f32, max_depth: f32);
+    fn set_scissor_rect(&mut self, x: u32, y: u32, w: u32, h: u32);
     fn set_stencil_reference(&mut self, reference: u32);
     fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>);
     fn draw_indexed(&mut self, indices: Range<u32>, base_vertex: i32, instances: Range<u32>);

--- a/crates/bevy_wgpu/src/wgpu_render_pass.rs
+++ b/crates/bevy_wgpu/src/wgpu_render_pass.rs
@@ -31,6 +31,11 @@ impl<'a> RenderPass for WgpuRenderPass<'a> {
             .set_viewport(x, y, w, h, min_depth, max_depth);
     }
 
+    fn set_scissor_rect(&mut self, x: u32, y: u32, w: u32, h: u32) {
+        self.render_pass
+            .set_scissor_rect(x, y, w, h);
+    }
+
     fn set_stencil_reference(&mut self, reference: u32) {
         self.render_pass.set_stencil_reference(reference);
     }

--- a/crates/bevy_wgpu/src/wgpu_render_pass.rs
+++ b/crates/bevy_wgpu/src/wgpu_render_pass.rs
@@ -32,8 +32,7 @@ impl<'a> RenderPass for WgpuRenderPass<'a> {
     }
 
     fn set_scissor_rect(&mut self, x: u32, y: u32, w: u32, h: u32) {
-        self.render_pass
-            .set_scissor_rect(x, y, w, h);
+        self.render_pass.set_scissor_rect(x, y, w, h);
     }
 
     fn set_stencil_reference(&mut self, reference: u32) {


### PR DESCRIPTION
Since I needed this for my own project and I feel like this is a reasonable addition to the `RenderPass` trait. AFAIK all rendering APIs support clipping rects.
