### PR TITLE
ecs: fix system name in "conflicting system" error message

### DIFF
--- a/crates/bevy_ecs/src/system/into_system.rs
+++ b/crates/bevy_ecs/src/system/into_system.rs
@@ -62,7 +62,7 @@ impl SystemState {
                 }
             }
             panic!("System {} has conflicting queries. {} conflicts with the component access [{}] in this prior query: {}",
-                core::any::type_name::<Self>(),
+                self.name,
                 self.query_type_names[conflict_index],
                 conflict_name.unwrap_or("Unknown"),
                 conflicts_with_index.map(|index| self.query_type_names[index]).unwrap_or("Unknown"));


### PR DESCRIPTION
#798 made this error message print `SystemState` instead of the actual system name 