### PR TITLE
Make Timer.tick return &Self

### DIFF
--- a/crates/bevy_core/src/time/timer.rs
+++ b/crates/bevy_core/src/time/timer.rs
@@ -35,7 +35,7 @@ impl Timer {
     }
 
     /// Advances the timer by `delta` seconds.
-    pub fn tick(&mut self, delta: f32) {
+    pub fn tick(&mut self, delta: f32) -> &Self {
         let prev_finished = self.elapsed >= self.duration;
         if !prev_finished {
             self.elapsed += delta;
@@ -47,6 +47,7 @@ impl Timer {
         if self.repeating && self.finished {
             self.elapsed %= self.duration;
         }
+        self
     }
 
     pub fn reset(&mut self) {

--- a/crates/bevy_diagnostic/src/print_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/print_diagnostics_plugin.rs
@@ -69,8 +69,7 @@ impl PrintDiagnosticsPlugin {
         time: Res<Time>,
         diagnostics: Res<Diagnostics>,
     ) {
-        state.timer.tick(time.delta_seconds);
-        if state.timer.finished {
+        if state.timer.tick(time.delta_seconds).finished {
             println!("Diagnostics:");
             println!("{}", "-".repeat(93));
             if let Some(ref filter) = state.filter {
@@ -90,8 +89,7 @@ impl PrintDiagnosticsPlugin {
         time: Res<Time>,
         diagnostics: Res<Diagnostics>,
     ) {
-        state.timer.tick(time.delta_seconds);
-        if state.timer.finished {
+        if state.timer.tick(time.delta_seconds).finished {
             println!("Diagnostics (Debug):");
             println!("{}", "-".repeat(93));
             if let Some(ref filter) = state.filter {

--- a/examples/app/plugin.rs
+++ b/examples/app/plugin.rs
@@ -40,8 +40,7 @@ struct PrintMessageState {
 }
 
 fn print_message_system(mut state: ResMut<PrintMessageState>, time: Res<Time>) {
-    state.timer.tick(time.delta_seconds);
-    if state.timer.finished {
+    if state.timer.tick(time.delta_seconds).finished {
         println!("{}", state.message);
     }
 }

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -34,8 +34,7 @@ fn event_trigger_system(
     mut state: ResMut<EventTriggerState>,
     mut my_events: ResMut<Events<MyEvent>>,
 ) {
-    state.event_timer.tick(time.delta_seconds);
-    if state.event_timer.finished {
+    if state.event_timer.tick(time.delta_seconds).finished {
         my_events.send(MyEvent {
             message: "MyEvent just happened!".to_string(),
         });

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -63,9 +63,8 @@ fn atlas_render_system(
 
 fn text_update_system(mut state: ResMut<State>, time: Res<Time>, mut query: Query<&mut Text>) {
     for mut text in query.iter_mut() {
-        state.timer.tick(time.delta_seconds);
         let c = rand::random::<u8>() as char;
-        if !text.value.contains(c) && state.timer.finished {
+        if !text.value.contains(c) && state.timer.tick(time.delta_seconds).finished {
             text.value = format!("{}{}", text.value, c);
             state.timer.reset();
         }

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -62,12 +62,15 @@ fn atlas_render_system(
 }
 
 fn text_update_system(mut state: ResMut<State>, time: Res<Time>, mut query: Query<&mut Text>) {
-    for mut text in query.iter_mut() {
-        let c = rand::random::<u8>() as char;
-        if !text.value.contains(c) && state.timer.tick(time.delta_seconds).finished {
-            text.value = format!("{}{}", text.value, c);
-            state.timer.reset();
+    if state.timer.tick(time.delta_seconds).finished {
+        for mut text in query.iter_mut() {
+            let c = rand::random::<u8>() as char;
+            if !text.value.contains(c) {
+                text.value = format!("{}{}", text.value, c);
+            }
         }
+
+        state.timer.reset();
     }
 }
 


### PR DESCRIPTION
Just a small ergonomics improvement, so that systems that look like this:
```rust
    timer.tick(time.delta_seconds);
    if timer.finished {
      // ...
```
can look like this instead:
```rust
    if timer.tick(time.delta_seconds).finished {
```