### PR TITLE
Update FileAssetIo NotFound error to include full path

### DIFF
--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -45,13 +45,14 @@ impl AssetIo for FileAssetIo {
     fn load_path<'a>(&'a self, path: &'a Path) -> BoxedFuture<'a, Result<Vec<u8>, AssetIoError>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
-            match File::open(self.root_path.join(path)) {
+            let full_path = self.root_path.join(path);
+            match File::open(&full_path) {
                 Ok(mut file) => {
                     file.read_to_end(&mut bytes)?;
                 }
                 Err(e) => {
                     return if e.kind() == std::io::ErrorKind::NotFound {
-                        Err(AssetIoError::NotFound(path.to_owned()))
+                        Err(AssetIoError::NotFound(full_path))
                     } else {
                         Err(e.into())
                     }


### PR DESCRIPTION
When learning bevy I ran into the issue loading an asset and I could not figure out where to place the asset in order for it to be found by "asset_server.load". 

I believe multiple other people also have run into the same issues. Some people assume it should be rooted at the cargo project folder, some believe it might be rooted at the location of the built binary, but none expect that it's a folder called 'assets':

Examples of people potentially confused:
https://discordapp.com/channels/691052431525675048/742884593551802431/775146229880717322
Issue https://github.com/bevyengine/bevy/issues/810
https://discordapp.com/channels/691052431525675048/742884593551802431/775199619504144434

This updates FileAssetIo to include the full path in the error message, this will clearly flag to the developer that the game engine is looking for the assets specifically in this location. This should be enough information for people to resolve the issue by clarifying what the convention is.