### PR TITLE
Explain default behavior of AssetServer in the asset_loading example

### DIFF
--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -16,7 +16,7 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // By default AssetServer will load assets from inside the "assets" folder
-    // This will load "assets/models/cube/cube.gltf#Mesh0/Primitive0" and "assets/models/sphere/sphere.gltf#Mesh0/Primitive0"
+    // For example, the next line will load "assets/models/cube/cube.gltf#Mesh0/Primitive0"
     let cube_handle = asset_server.load("models/cube/cube.gltf#Mesh0/Primitive0");
     let sphere_handle = asset_server.load("models/sphere/sphere.gltf#Mesh0/Primitive0");
 

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -15,7 +15,8 @@ fn setup(
     meshes: Res<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    // You can load individual assets like this:
+    // By default AssetServer will load assets from inside the "assets" folder
+    // This will load "assets/models/cube/cube.gltf#Mesh0/Primitive0" and "assets/models/sphere/sphere.gltf#Mesh0/Primitive0"
     let cube_handle = asset_server.load("models/cube/cube.gltf#Mesh0/Primitive0");
     let sphere_handle = asset_server.load("models/sphere/sphere.gltf#Mesh0/Primitive0");
 


### PR DESCRIPTION
It's unclear where the default `AssetServer` gets its assets from, so I thought it would be beneficial to explain it in the dedicated asset loading example. This is proven to be an issue for people using bevy by #810, and explaining it in the dedicated asset loading example may be beneficial. This would be complimented by #821, as the error would make it clear where bevy was looking for the asset. 

I don't know if it would be beneficial to modify any other examples. I figure that if someone has issues with asset loading they'd probably check the example to see if it has any insight. 