### PR TITLE
Bump changelog version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Changelog
 
-While we try to keep the `Unreleased` changes updated, it is often behind master and does not include
-all merged pull requests. To see a list of all changes since the latest release, you may compare 
-master using the [git tags for releases](https://github.com/bevyengine/bevy/tags).
+While we try to keep the `Unreleased` changes updated, it is often behind and does not include
+all merged pull requests. To see a list of all changes since the latest release, you may compare
+current changes on git with [previous release tags][git_tag_comparison].
 
-For example,
-[https://github.com/bevyengine/bevy/compare/v0.3.0...master](https://github.com/bevyengine/bevy/compare/v0.0.3...master)
-to view all changes since the `0.3.0` release.
+[git_tag_comparison]: https://github.com/bevyengine/bevy/compare/v0.3.0...master
 
 
 ## Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,20 @@ all merged pull requests. To see a list of all changes since the latest release,
 master using the [git tags for releases](https://github.com/bevyengine/bevy/tags).
 
 For example,
-[https://github.com/bevyengine/bevy/compare/v0.2.1...master](https://github.com/bevyengine/bevy/compare/v0.2.1...master)
-to view all changes since the `0.2.1` release.
+[https://github.com/bevyengine/bevy/compare/v0.3.0...master](https://github.com/bevyengine/bevy/compare/v0.0.3...master)
+to view all changes since the `0.3.0` release.
+
 
 ## Unreleased
+
+### Added
+
+### Changed
+
+### Fixed
+
+
+## Version 0.3.0 (2020-11-03)
 
 ### Added
 


### PR DESCRIPTION
This bumps the version of the changelog sooner than later but doesn't add any new entries.

[rendered](https://github.com/memoryruins/bevy/blob/bump/CHANGELOG.md)