### PR TITLE
Reduce the API surface of `bevy_ecs::Query`

### DIFF
--- a/crates/bevy_ecs/src/system/query/mod.rs
+++ b/crates/bevy_ecs/src/system/query/mod.rs
@@ -31,7 +31,7 @@ impl<'a, Q: HecsQuery> Query<'a, Q> {
     /// This will create a Query that could violate memory safety rules. Make sure that this is only called in
     /// ways that ensure the Queries have unique mutable access.
     #[inline]
-    pub unsafe fn new(
+    pub(crate) unsafe fn new(
         world: &'a World,
         component_access: &'a TypeAccess<ArchetypeComponent>,
     ) -> Self {

--- a/crates/bevy_ecs/src/system/query/mod.rs
+++ b/crates/bevy_ecs/src/system/query/mod.rs
@@ -59,15 +59,6 @@ impl<'a, Q: HecsQuery> Query<'a, Q> {
         unsafe { self.world.query_unchecked() }
     }
 
-    /// Iterates over the query results
-    /// # Safety
-    /// This allows aliased mutability. You must make sure this call does not result in multiple mutable references to the same component
-    #[inline]
-    pub unsafe fn iter_unsafe(&self) -> QueryIter<'_, Q> {
-        // SAFE: system runs without conflicts with other systems. same-system queries have runtime borrow checks when they conflict
-        self.world.query_unchecked()
-    }
-
     #[inline]
     pub fn par_iter(&self, batch_size: usize) -> ParIter<'_, Q>
     where
@@ -106,19 +97,6 @@ impl<'a, Q: HecsQuery> Query<'a, Q> {
                 .query_one_unchecked::<Q>(entity)
                 .map_err(|_err| QueryError::NoSuchEntity)
         }
-    }
-
-    /// Gets the query result for the given `entity`
-    /// # Safety
-    /// This allows aliased mutability. You must make sure this call does not result in multiple mutable references to the same component
-    #[inline]
-    pub unsafe fn get_unsafe(
-        &self,
-        entity: Entity,
-    ) -> Result<<Q::Fetch as Fetch>::Item, QueryError> {
-        self.world
-            .query_one_unchecked::<Q>(entity)
-            .map_err(|_err| QueryError::NoSuchEntity)
     }
 
     /// Gets a reference to the entity's component of the given type. This will fail if the entity does not have
@@ -167,19 +145,6 @@ impl<'a, Q: HecsQuery> Query<'a, Q> {
         } else {
             Err(QueryError::CannotWriteArchetype)
         }
-    }
-
-    /// Gets a mutable reference to the entity's component of the given type. This will fail if the entity does not have
-    /// the given component type
-    /// # Safety
-    /// This allows aliased mutability. You must make sure this call does not result in multiple mutable references to the same component
-    pub unsafe fn get_component_unsafe<T: Component>(
-        &self,
-        entity: Entity,
-    ) -> Result<Mut<'_, T>, QueryError> {
-        self.world
-            .get_mut_unchecked(entity)
-            .map_err(QueryError::ComponentError)
     }
 
     pub fn removed<C: Component>(&self) -> &[Entity] {

--- a/crates/bevy_ecs/src/system/query/query_set.rs
+++ b/crates/bevy_ecs/src/system/query/query_set.rs
@@ -20,7 +20,7 @@ impl<T: QueryTuple> QuerySet<T> {
     /// # Safety
     /// This will create a set of Query types that could violate memory safety rules. Make sure that this is only called in
     /// ways that ensure the Queries have unique mutable access.
-    pub unsafe fn new(world: &World, component_access: &TypeAccess<ArchetypeComponent>) -> Self {
+    pub(crate) unsafe fn new(world: &World, component_access: &TypeAccess<ArchetypeComponent>) -> Self {
         QuerySet {
             value: T::new(world, component_access),
         }

--- a/crates/bevy_ecs/src/system/query/query_set.rs
+++ b/crates/bevy_ecs/src/system/query/query_set.rs
@@ -20,7 +20,10 @@ impl<T: QueryTuple> QuerySet<T> {
     /// # Safety
     /// This will create a set of Query types that could violate memory safety rules. Make sure that this is only called in
     /// ways that ensure the Queries have unique mutable access.
-    pub(crate) unsafe fn new(world: &World, component_access: &TypeAccess<ArchetypeComponent>) -> Self {
+    pub(crate) unsafe fn new(
+        world: &World,
+        component_access: &TypeAccess<ArchetypeComponent>,
+    ) -> Self {
         QuerySet {
             value: T::new(world, component_access),
         }


### PR DESCRIPTION
`Query::new` and `QuerySet::new` functions were marked and documented as `unsafe` in # 798, which essentially closes #796. Before closing #796, I wanted to see what would happen if these were marked as `pub(crate)`. Everything in bevy's repo continues to build since the usages are only in `bevy_ecs`. As mentioned in the issue, it is unlikely a user will create their own `IntoSystem` impl.

In addition, `Query::iter_unsafe`, `Query::get_unsafe` and `Query::get_component_unsafe` are not used in any of bevy's crates. I imagine the latter methods were added to mirror some of `World`'s methods like `World::query_unchecked`, but I believe there is some value in reducing the API surface of `bevy_ecs::Query` for learnability and leaving the unsafe interfaces to direct interactions with `World`.

These changes are split into two commits. I would understand if only the first or none of these changes are desired, but I wanted to open this to float the idea.