### PR TITLE
Query Filters

### DIFF
--- a/crates/bevy_ecs/hecs/src/access.rs
+++ b/crates/bevy_ecs/hecs/src/access.rs
@@ -282,10 +282,11 @@ impl<T: Hash + Eq + PartialEq + Copy> TypeAccess<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ArchetypeComponent, Entity, Fetch, Query, TypeAccess, With, World};
+    use crate::{ArchetypeComponent, Entity, Fetch, Query, QueryAccess, TypeAccess, World};
     use std::vec;
 
     struct A;
+    #[derive(Clone, Eq, PartialEq, Debug)]
     struct B;
     struct C;
 
@@ -344,7 +345,7 @@ mod tests {
         );
 
         let mut a_with_b_type_access = TypeAccess::default();
-        <With<B, &A> as Query>::Fetch::access()
+        QueryAccess::with::<B>(<&A as Query>::Fetch::access())
             .get_world_archetype_access(&world, Some(&mut a_with_b_type_access));
 
         assert_eq!(
@@ -353,7 +354,7 @@ mod tests {
         );
 
         let mut a_with_b_option_c_type_access = TypeAccess::default();
-        <With<B, (&A, Option<&mut C>)> as Query>::Fetch::access()
+        QueryAccess::with::<B>(<(&A, Option<&mut C>) as Query>::Fetch::access())
             .get_world_archetype_access(&world, Some(&mut a_with_b_option_c_type_access));
 
         assert_eq!(

--- a/crates/bevy_ecs/hecs/src/filter.rs
+++ b/crates/bevy_ecs/hecs/src/filter.rs
@@ -1,0 +1,245 @@
+use crate::{archetype::Archetype, Component, QueryAccess};
+use core::{any::TypeId, marker::PhantomData, ptr::NonNull};
+use std::{boxed::Box, vec};
+
+pub trait QueryFilter: Sized {
+    type EntityFilter: EntityFilter;
+    fn access() -> QueryAccess;
+    fn get_entity_filter(archetype: &Archetype) -> Option<Self::EntityFilter>;
+}
+
+pub trait EntityFilter: Sized {
+    const DANGLING: Self;
+
+    /// # Safety
+    /// This might access archetype data in an unsafe manner. In general filters should be read-only and they should only access
+    /// the data they have claimed in `access()`.
+    unsafe fn matches_entity(&self, _offset: usize) -> bool;
+}
+
+pub struct AnyEntityFilter;
+
+impl EntityFilter for AnyEntityFilter {
+    const DANGLING: Self = AnyEntityFilter;
+
+    #[inline]
+    unsafe fn matches_entity(&self, _offset: usize) -> bool {
+        true
+    }
+}
+
+pub struct Or<T>(pub T);
+
+/// Query transformer that retrieves components of type `T` that have been mutated since the start of the frame.
+/// Added components do not count as mutated.
+pub struct Mutated<T>(NonNull<bool>, PhantomData<T>);
+
+/// Query transformer that retrieves components of type `T` that have been added since the start of the frame.
+pub struct Added<T>(NonNull<bool>, PhantomData<T>);
+
+/// Query transformer that retrieves components of type `T` that have either been mutated or added since the start of the frame.
+pub struct Changed<T>(NonNull<bool>, NonNull<bool>, PhantomData<T>);
+
+impl QueryFilter for () {
+    type EntityFilter = AnyEntityFilter;
+
+    fn access() -> QueryAccess {
+        QueryAccess::None
+    }
+
+    #[inline]
+    fn get_entity_filter(_archetype: &Archetype) -> Option<Self::EntityFilter> {
+        Some(AnyEntityFilter)
+    }
+}
+
+impl<T: Component> QueryFilter for Added<T> {
+    type EntityFilter = Self;
+
+    fn access() -> QueryAccess {
+        QueryAccess::read::<T>()
+    }
+
+    #[inline]
+    fn get_entity_filter(archetype: &Archetype) -> Option<Self::EntityFilter> {
+        archetype
+            .get_type_state(TypeId::of::<T>())
+            .map(|state| Added(state.added(), Default::default()))
+    }
+}
+
+impl<T: Component> EntityFilter for Added<T> {
+    const DANGLING: Self = Added(NonNull::dangling(), PhantomData::<T>);
+
+    #[inline]
+    unsafe fn matches_entity(&self, offset: usize) -> bool {
+        *self.0.as_ptr().add(offset)
+    }
+}
+
+impl<T: Component> QueryFilter for Mutated<T> {
+    type EntityFilter = Self;
+
+    fn access() -> QueryAccess {
+        QueryAccess::read::<T>()
+    }
+
+    #[inline]
+    fn get_entity_filter(archetype: &Archetype) -> Option<Self::EntityFilter> {
+        archetype
+            .get_type_state(TypeId::of::<T>())
+            .map(|state| Mutated(state.mutated(), Default::default()))
+    }
+}
+
+impl<T: Component> EntityFilter for Mutated<T> {
+    const DANGLING: Self = Mutated(NonNull::dangling(), PhantomData::<T>);
+
+    unsafe fn matches_entity(&self, offset: usize) -> bool {
+        *self.0.as_ptr().add(offset)
+    }
+}
+
+impl<T: Component> QueryFilter for Changed<T> {
+    type EntityFilter = Self;
+
+    fn access() -> QueryAccess {
+        QueryAccess::read::<T>()
+    }
+
+    #[inline]
+    fn get_entity_filter(archetype: &Archetype) -> Option<Self::EntityFilter> {
+        archetype
+            .get_type_state(TypeId::of::<T>())
+            .map(|state| Changed(state.added(), state.mutated(), Default::default()))
+    }
+}
+
+impl<T: Component> EntityFilter for Changed<T> {
+    const DANGLING: Self = Changed(NonNull::dangling(), NonNull::dangling(), PhantomData::<T>);
+
+    #[inline]
+    unsafe fn matches_entity(&self, offset: usize) -> bool {
+        *self.0.as_ptr().add(offset) || *self.1.as_ptr().add(offset)
+    }
+}
+
+pub struct Without<T>(PhantomData<T>);
+
+impl<T: Component> QueryFilter for Without<T> {
+    type EntityFilter = AnyEntityFilter;
+
+    fn access() -> QueryAccess {
+        QueryAccess::without::<T>(QueryAccess::None)
+    }
+
+    #[inline]
+    fn get_entity_filter(archetype: &Archetype) -> Option<Self::EntityFilter> {
+        if archetype.has_type(TypeId::of::<T>()) {
+            None
+        } else {
+            Some(AnyEntityFilter)
+        }
+    }
+}
+
+pub struct With<T>(PhantomData<T>);
+
+impl<T: Component> QueryFilter for With<T> {
+    type EntityFilter = AnyEntityFilter;
+
+    fn access() -> QueryAccess {
+        QueryAccess::with::<T>(QueryAccess::None)
+    }
+
+    #[inline]
+    fn get_entity_filter(archetype: &Archetype) -> Option<Self::EntityFilter> {
+        if archetype.has_type(TypeId::of::<T>()) {
+            Some(AnyEntityFilter)
+        } else {
+            None
+        }
+    }
+}
+
+macro_rules! impl_query_filter_tuple {
+    ($($filter: ident),*) => {
+        #[allow(unused_variables)]
+        #[allow(non_snake_case)]
+        impl<$($filter: QueryFilter),*> QueryFilter for ($($filter,)*) {
+            type EntityFilter = ($($filter::EntityFilter,)*);
+
+            fn access() -> QueryAccess {
+                QueryAccess::union(vec![
+                    $($filter::access(),)+
+                ])
+            }
+
+            fn get_entity_filter(archetype: &Archetype) -> Option<Self::EntityFilter> {
+                Some(($($filter::get_entity_filter(archetype)?,)*))
+            }
+
+        }
+
+        #[allow(unused_variables)]
+        #[allow(non_snake_case)]
+        impl<$($filter: EntityFilter),*> EntityFilter for ($($filter,)*) {
+            const DANGLING: Self = ($($filter::DANGLING,)*);
+            unsafe fn matches_entity(&self, offset: usize) -> bool {
+                let ($($filter,)*) = self;
+                true $(&& $filter.matches_entity(offset))*
+            }
+        }
+
+        #[allow(unused_variables)]
+        #[allow(non_snake_case)]
+        impl<$($filter: QueryFilter),*> QueryFilter for Or<($($filter,)*)> {
+            type EntityFilter = Or<($(Option<<$filter as QueryFilter>::EntityFilter>,)*)>;
+            fn access() -> QueryAccess {
+                QueryAccess::union(vec![
+                    $(QueryAccess::Optional(Box::new($filter::access())),)+
+                ])
+            }
+
+            fn get_entity_filter(archetype: &Archetype) -> Option<Self::EntityFilter> {
+                let mut matches_something = false;
+                $(
+                    let $filter = $filter::get_entity_filter(archetype);
+                    matches_something = matches_something || $filter.is_some();
+                )*
+                if matches_something {
+                    Some(Or(($($filter,)*)))
+                } else {
+                    None
+                }
+            }
+
+        }
+        #[allow(unused_variables)]
+        #[allow(non_snake_case)]
+        impl<$($filter: EntityFilter),*> EntityFilter for Or<($(Option<$filter>,)*)> {
+            const DANGLING: Self = Or(($(Some($filter::DANGLING),)*));
+            unsafe fn matches_entity(&self, offset: usize) -> bool {
+                let Or(($($filter,)*)) = self;
+                false $(|| $filter.as_ref().map_or(false, |filter|filter.matches_entity(offset)))*
+            }
+        }
+    };
+}
+
+impl_query_filter_tuple!(A);
+impl_query_filter_tuple!(A, B);
+impl_query_filter_tuple!(A, B, C);
+impl_query_filter_tuple!(A, B, C, D);
+impl_query_filter_tuple!(A, B, C, D, E);
+impl_query_filter_tuple!(A, B, C, D, E, F);
+impl_query_filter_tuple!(A, B, C, D, E, F, G);
+impl_query_filter_tuple!(A, B, C, D, E, F, G, H);
+impl_query_filter_tuple!(A, B, C, D, E, F, G, H, I);
+impl_query_filter_tuple!(A, B, C, D, E, F, G, H, I, J);
+impl_query_filter_tuple!(A, B, C, D, E, F, G, H, I, J, K);
+impl_query_filter_tuple!(A, B, C, D, E, F, G, H, I, J, K, L);
+impl_query_filter_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M);
+impl_query_filter_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N);
+impl_query_filter_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
+impl_query_filter_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);

--- a/crates/bevy_ecs/hecs/src/lib.rs
+++ b/crates/bevy_ecs/hecs/src/lib.rs
@@ -69,6 +69,7 @@ mod borrow;
 mod bundle;
 mod entities;
 mod entity_builder;
+mod filter;
 mod query;
 #[cfg(feature = "serde")]
 mod serde;
@@ -80,10 +81,8 @@ pub use borrow::{AtomicBorrow, Ref, RefMut};
 pub use bundle::{Bundle, DynamicBundle, MissingComponent};
 pub use entities::{Entity, EntityReserver, Location, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, EntityBuilder};
-pub use query::{
-    Added, Batch, BatchedIter, Changed, Mut, Mutated, Or, Query, QueryIter, ReadOnlyFetch, With,
-    Without,
-};
+pub use filter::{Added, Changed, EntityFilter, Mutated, Or, QueryFilter, With, Without};
+pub use query::{Batch, BatchedIter, Mut, Query, QueryIter, ReadOnlyFetch};
 pub use world::{ArchetypesGeneration, Component, ComponentError, SpawnBatchIter, World};
 
 // Unstable implementation details needed by the macros

--- a/crates/bevy_ecs/hecs/tests/tests.rs
+++ b/crates/bevy_ecs/hecs/tests/tests.rs
@@ -251,7 +251,6 @@ fn query_batched() {
         .flat_map(|x| x)
         .map(|e| e)
         .collect::<Vec<_>>();
-    dbg!(&entities);
     assert_eq!(entities.len(), 3);
     assert!(entities.contains(&a));
     assert!(entities.contains(&b));
@@ -355,22 +354,22 @@ fn added_tracking() {
     let a = world.spawn((123,));
 
     assert_eq!(world.query::<&i32>().count(), 1);
-    assert_eq!(world.query::<Added<i32>>().count(), 1);
+    assert_eq!(world.query_filtered::<(), Added<i32>>().count(), 1);
     assert_eq!(world.query_mut::<&i32>().count(), 1);
-    assert_eq!(world.query_mut::<Added<i32>>().count(), 1);
+    assert_eq!(world.query_filtered_mut::<(), Added<i32>>().count(), 1);
     assert!(world.query_one::<&i32>(a).is_ok());
-    assert!(world.query_one::<Added<i32>>(a).is_ok());
+    assert!(world.query_one_filtered::<(), Added<i32>>(a).is_ok());
     assert!(world.query_one_mut::<&i32>(a).is_ok());
-    assert!(world.query_one_mut::<Added<i32>>(a).is_ok());
+    assert!(world.query_one_filtered_mut::<(), Added<i32>>(a).is_ok());
 
     world.clear_trackers();
 
     assert_eq!(world.query::<&i32>().count(), 1);
-    assert_eq!(world.query::<Added<i32>>().count(), 0);
+    assert_eq!(world.query_filtered::<(), Added<i32>>().count(), 0);
     assert_eq!(world.query_mut::<&i32>().count(), 1);
-    assert_eq!(world.query_mut::<Added<i32>>().count(), 0);
+    assert_eq!(world.query_filtered_mut::<(), Added<i32>>().count(), 0);
     assert!(world.query_one_mut::<&i32>(a).is_ok());
-    assert!(world.query_one_mut::<Added<i32>>(a).is_err());
+    assert!(world.query_one_filtered_mut::<(), Added<i32>>(a).is_err());
 }
 
 #[test]

--- a/crates/bevy_ecs/src/system/into_system.rs
+++ b/crates/bevy_ecs/src/system/into_system.rs
@@ -220,7 +220,7 @@ mod tests {
     fn query_system_gets() {
         fn query_system(
             mut ran: ResMut<bool>,
-            entity_query: Query<With<A, Entity>>,
+            entity_query: Query<Entity, With<A>>,
             b_query: Query<&B>,
             a_c_query: Query<(&A, &C)>,
             d_query: Query<&D>,
@@ -281,9 +281,9 @@ mod tests {
         use crate::{Added, Changed, Mutated, Or};
         let query_system = move |mut ran: ResMut<bool>,
                                  set: QuerySet<(
-            Query<Or<(Changed<A>, Changed<B>)>>,
-            Query<Or<(Added<A>, Added<B>)>>,
-            Query<Or<(Mutated<A>, Mutated<B>)>>,
+            Query<(), Or<(Changed<A>, Changed<B>)>>,
+            Query<(), Or<(Added<A>, Added<B>)>>,
+            Query<(), Or<(Mutated<A>, Mutated<B>)>>,
         )>| {
             let changed = set.q0().iter().count();
             let added = set.q1().iter().count();

--- a/crates/bevy_ecs/src/system/query/query_set.rs
+++ b/crates/bevy_ecs/src/system/query/query_set.rs
@@ -1,6 +1,7 @@
 use crate::Query;
 use bevy_hecs::{
-    impl_query_set, ArchetypeComponent, Fetch, Query as HecsQuery, QueryAccess, TypeAccess, World,
+    impl_query_set, ArchetypeComponent, Fetch, Query as HecsQuery, QueryAccess, QueryFilter,
+    TypeAccess, World,
 };
 
 pub struct QuerySet<T: QueryTuple> {

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -40,7 +40,7 @@ pub fn camera_system<T: CameraProjection + Component>(
     windows: Res<Windows>,
     mut queries: QuerySet<(
         Query<(Entity, &mut Camera, &mut T)>,
-        Query<(Entity, Added<Camera>)>,
+        Query<Entity, Added<Camera>>,
     )>,
 ) {
     let mut changed_window_ids = Vec::new();
@@ -71,7 +71,7 @@ pub fn camera_system<T: CameraProjection + Component>(
     }
 
     let mut added_cameras = vec![];
-    for (entity, _camera) in &mut queries.q1().iter() {
+    for entity in &mut queries.q1().iter() {
         added_cameras.push(entity);
     }
     for (entity, mut camera, mut camera_projection) in queries.q0_mut().iter_mut() {

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -26,7 +26,7 @@ impl VisibleEntities {
 pub fn visible_entities_system(
     mut camera_query: Query<(&Camera, &GlobalTransform, &mut VisibleEntities)>,
     draw_query: Query<(Entity, &Draw)>,
-    draw_transform_query: Query<With<Draw, &GlobalTransform>>,
+    draw_transform_query: Query<&GlobalTransform, With<Draw>>,
 ) {
     for (camera, camera_global_transform, mut visible_entities) in camera_query.iter_mut() {
         visible_entities.value.clear();

--- a/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
@@ -5,7 +5,7 @@ use smallvec::SmallVec;
 
 pub fn parent_update_system(
     commands: &mut Commands,
-    removed_parent_query: Query<Without<Parent, (Entity, &PreviousParent)>>,
+    removed_parent_query: Query<(Entity, &PreviousParent), Without<Parent>>,
     // TODO: ideally this only runs when the Parent component has changed
     mut changed_parent_query: Query<(Entity, &Parent, Option<&mut PreviousParent>)>,
     mut children_query: Query<&mut Children>,

--- a/crates/bevy_transform/src/transform_propagate_system.rs
+++ b/crates/bevy_transform/src/transform_propagate_system.rs
@@ -3,13 +3,11 @@ use bevy_ecs::prelude::*;
 
 pub fn transform_propagate_system(
     mut root_query: Query<
-        Without<
-            Parent,
-            With<GlobalTransform, (Option<&Children>, &Transform, &mut GlobalTransform)>,
-        >,
+        (Option<&Children>, &Transform, &mut GlobalTransform),
+        (Without<Parent>, With<GlobalTransform>),
     >,
-    mut transform_query: Query<With<Parent, (&Transform, &mut GlobalTransform)>>,
-    children_query: Query<With<Parent, With<GlobalTransform, Option<&Children>>>>,
+    mut transform_query: Query<(&Transform, &mut GlobalTransform), With<Parent>>,
+    children_query: Query<Option<&Children>, (With<Parent>, With<GlobalTransform>)>,
 ) {
     for (children, transform, mut global_transform) in root_query.iter_mut() {
         *global_transform = GlobalTransform::from(*transform);
@@ -29,8 +27,8 @@ pub fn transform_propagate_system(
 
 fn propagate_recursive(
     parent: &GlobalTransform,
-    transform_query: &mut Query<With<Parent, (&Transform, &mut GlobalTransform)>>,
-    children_query: &Query<With<Parent, With<GlobalTransform, Option<&Children>>>>,
+    transform_query: &mut Query<(&Transform, &mut GlobalTransform), With<Parent>>,
+    children_query: &Query<Option<&Children>, (With<Parent>, With<GlobalTransform>)>,
     entity: Entity,
 ) {
     log::trace!("Updating Transform for {:?}", entity);

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -160,10 +160,13 @@ unsafe impl Sync for FlexSurface {}
 pub fn flex_node_system(
     windows: Res<Windows>,
     mut flex_surface: ResMut<FlexSurface>,
-    root_node_query: Query<With<Node, Without<Parent, Entity>>>,
-    node_query: Query<With<Node, (Entity, Changed<Style>, Option<&CalculatedSize>)>>,
-    changed_size_query: Query<With<Node, (Entity, &Style, Changed<CalculatedSize>)>>,
-    children_query: Query<With<Node, (Entity, Changed<Children>)>>,
+    root_node_query: Query<Entity, (With<Node>, Without<Parent>)>,
+    node_query: Query<(Entity, &Style, Option<&CalculatedSize>), (With<Node>, Changed<Style>)>,
+    changed_size_query: Query<
+        (Entity, &Style, &CalculatedSize),
+        (With<Node>, Changed<CalculatedSize>),
+    >,
+    children_query: Query<(Entity, &Children), (With<Node>, Changed<Children>)>,
     mut node_transform_query: Query<(Entity, &mut Node, &mut Transform, Option<&Parent>)>,
 ) {
     // update window root nodes

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -8,7 +8,7 @@ use bevy_transform::{
 pub const UI_Z_STEP: f32 = 0.001;
 
 pub fn ui_z_system(
-    root_node_query: Query<With<Node, Without<Parent, Entity>>>,
+    root_node_query: Query<Entity, (With<Node>, Without<Parent>)>,
     mut node_query: Query<(Entity, &Node, &mut Transform)>,
     children_query: Query<&Children>,
 ) {

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -32,7 +32,7 @@ pub fn text_system(
     mut font_atlas_sets: ResMut<Assets<FontAtlasSet>>,
     mut texture_atlases: ResMut<Assets<TextureAtlas>>,
     mut queries: QuerySet<(
-        Query<(Entity, Changed<Text>, &mut CalculatedSize)>,
+        Query<(Entity, &Text, &mut CalculatedSize), Changed<Text>>,
         Query<(&Text, &mut CalculatedSize)>,
     )>,
 ) {

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -92,7 +92,7 @@ fn rotate(
     commands: &mut Commands,
     time: Res<Time>,
     mut parents_query: Query<(Entity, &mut Children, &Sprite)>,
-    mut transform_query: Query<With<Sprite, &mut Transform>>,
+    mut transform_query: Query<&mut Transform, With<Sprite>>,
 ) {
     let angle = std::f32::consts::PI / 2.0;
     for (parent, mut children, _) in parents_query.iter_mut() {

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -65,7 +65,7 @@ fn load_scene_system(asset_server: Res<AssetServer>, mut scene_spawner: ResMut<S
 
 // This system prints all ComponentA components in our world. Try making a change to a ComponentA in load_scene_example.scn.
 // You should immediately see the changes appear in the console.
-fn print_system(query: Query<(Entity, Changed<ComponentA>)>) {
+fn print_system(query: Query<(Entity, &ComponentA), Changed<ComponentA>>) {
     for (entity, component_a) in query.iter() {
         println!("  Entity({})", entity.id());
         println!(

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -29,12 +29,10 @@ impl FromResources for ButtonMaterials {
 
 fn button_system(
     button_materials: Res<ButtonMaterials>,
-    mut interaction_query: Query<(
-        &Button,
+    mut interaction_query: Query<
+        (&Button, &Interaction, &mut Handle<ColorMaterial>, &Children),
         Mutated<Interaction>,
-        &mut Handle<ColorMaterial>,
-        &Children,
-    )>,
+    >,
     mut text_query: Query<&mut Text>,
 ) {
     for (_button, interaction, mut material, children) in interaction_query.iter_mut() {


### PR DESCRIPTION
This breaks out a new `QueryFilter` type from `HecsQuery`.  HecsQueries like `Changed<T>`, `With<T>`, and `Without<T>` have become `QueryFilters`. The new Query interface now looks like this:  `Query<Q: HecsQuery, F: QueryFilter = ()>`

Ex:

`Query<&A>` -> `Query<&A>` (no change)
`Query<With<X, With<Y, (&A, &mut B)>>>` -> `Query<(&A, &mut B), (With<X>, With<Y>)>`
`Query<Changed<A>>` -> `Query<&A, Changed<A>>`

All direct world query functions now have "filtered" variants. Ex: `world.query<Q: HecsQuery>` and `world.query_filtered<Q: HecsQuery, F: QueryFilter>` variants.

This resolves a number of issues:

* Queries like `With<X, With<Y, (&A, &mut B)>>` are hard to visually parse
* It is currently a bit unclear what components will be returned by a query
* You can't filter "change state" without also grabbing the component
* There is no good way to get a mutable reference to a Changed<T> (it currently returns a read-only reference). Note that there is a pr out (#625) to resolve this by turning Changed<T>  into Changed<&T> and Changed<&mut T>, which we would probably merge if we dont go with this pr.
* Each new "component filter" requires a new "smart pointer" type 

This is how a "real" system changes:

### Before
```rust
pub fn flex_node_system(
    windows: Res<Windows>,
    mut flex_surface: ResMut<FlexSurface>,
    root_node_query: Query<With<Node, Without<Parent, Entity>>>,
    node_query: Query<With<Node, (Entity, Changed<Style>, Option<&CalculatedSize>)>>,
    changed_size_query: Query<With<Node, (Entity, &Style, Changed<CalculatedSize>)>>,
    children_query: Query<With<Node, (Entity, Changed<Children>)>>,
    mut node_transform_query: Query<(Entity, &mut Node, &mut Transform, Option<&Parent>)>,
) {
}
```

### After

```rust
pub fn flex_node_system(
    windows: Res<Windows>,
    mut flex_surface: ResMut<FlexSurface>,
    root_node_query: Query<Entity, (With<Node>, Without<Parent>)>,
    node_query: Query<(Entity, &Style, Option<&CalculatedSize>), (With<Node>, Changed<Style>)>,
    changed_size_query: Query<
        (Entity, &Style, &CalculatedSize),
        (With<Node>, Changed<CalculatedSize>),
    >,
    children_query: Query<(Entity, &Children), (With<Node>, Changed<Children>)>,
    mut node_transform_query: Query<(Entity, &mut Node, &mut Transform, Option<&Parent>)>,
) {
}
```