### PR TITLE
Remove duplicate code in camera system.

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -57,19 +57,6 @@ pub fn camera_system<T: CameraProjection + Component>(
         changed_window_ids.push(event.id);
     }
 
-    // handle resize events. latest events are handled first because we only want to resize each window once
-    for event in state
-        .window_created_event_reader
-        .iter(&window_created_events)
-        .rev()
-    {
-        if changed_window_ids.contains(&event.id) {
-            continue;
-        }
-
-        changed_window_ids.push(event.id);
-    }
-
     let mut added_cameras = vec![];
     for (entity, _camera) in &mut queries.q1().iter() {
         added_cameras.push(entity);


### PR DESCRIPTION
While I was exploring the Camera code, I ran into what I think is a duplicated loop with regard to window resizing events. I ran some examples with and without the extra loop and they seemed to work fine. 

Figured I'd toss a quick PR, if this is unneeded or I'm missing something about what's happening, I apologize! 