### PR TITLE
bevy_render: delegate buffer aligning to RenderResourceContext

### DIFF
--- a/crates/bevy_render/src/render_graph/nodes/texture_copy_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/texture_copy_node.rs
@@ -12,11 +12,6 @@ pub struct TextureCopyNode {
     pub texture_event_reader: EventReader<AssetEvent<Texture>>,
 }
 
-pub const ALIGNMENT: usize = 256;
-fn get_aligned(data_size: f32) -> usize {
-    ALIGNMENT * ((data_size / ALIGNMENT as f32).ceil() as usize)
-}
-
 impl Node for TextureCopyNode {
     fn update(
         &mut self,
@@ -34,7 +29,9 @@ impl Node for TextureCopyNode {
                     if let Some(texture) = textures.get(handle) {
                         let texture_descriptor: TextureDescriptor = texture.into();
                         let width = texture.size.x() as usize;
-                        let aligned_width = get_aligned(texture.size.x());
+                        let aligned_width = render_context
+                            .resources()
+                            .get_aligned_texture_size(texture.size.x() as usize);
                         let format_size = texture.format.pixel_size();
                         let mut aligned_data =
                             vec![0; format_size * aligned_width * texture.size.y() as usize];

--- a/crates/bevy_render/src/renderer/headless_render_resource_context.rs
+++ b/crates/bevy_render/src/renderer/headless_render_resource_context.rs
@@ -140,4 +140,12 @@ impl RenderResourceContext for HeadlessRenderResourceContext {
     ) -> bool {
         false
     }
+
+    fn get_aligned_uniform_size(&self, size: usize, _dynamic: bool) -> usize {
+        size
+    }
+
+    fn get_aligned_texture_size(&self, size: usize) -> usize {
+        size
+    }
 }

--- a/crates/bevy_render/src/renderer/render_resource_context.rs
+++ b/crates/bevy_render/src/renderer/render_resource_context.rs
@@ -33,7 +33,8 @@ pub trait RenderResourceContext: Downcast + Send + Sync + 'static {
     fn remove_texture(&self, texture: TextureId);
     fn remove_sampler(&self, sampler: SamplerId);
     fn get_buffer_info(&self, buffer: BufferId) -> Option<BufferInfo>;
-
+    fn get_aligned_uniform_size(&self, size: usize, dynamic: bool) -> usize;
+    fn get_aligned_texture_size(&self, data_size: usize) -> usize;
     fn set_asset_resource_untyped(
         &self,
         handle: HandleUntyped,

--- a/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
+++ b/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
@@ -26,6 +26,9 @@ pub struct WgpuRenderResourceContext {
     pub resources: WgpuResources,
 }
 
+pub const BIND_BUFFER_ALIGNMENT: usize = 256;
+pub const TEXTURE_ALIGNMENT: usize = 256;
+
 impl WgpuRenderResourceContext {
     pub fn new(device: Arc<wgpu::Device>) -> Self {
         WgpuRenderResourceContext {
@@ -552,5 +555,17 @@ impl RenderResourceContext for WgpuRenderResourceContext {
         let buffers = self.resources.buffers.read();
         let buffer = buffers.get(&id).unwrap();
         buffer.unmap();
+    }
+
+    fn get_aligned_texture_size(&self, size: usize) -> usize {
+        (size + TEXTURE_ALIGNMENT - 1) & !(TEXTURE_ALIGNMENT - 1)
+    }
+
+    fn get_aligned_uniform_size(&self, size: usize, dynamic: bool) -> usize {
+        if dynamic {
+            (size + BIND_BUFFER_ALIGNMENT - 1) & !(BIND_BUFFER_ALIGNMENT - 1)
+        } else {
+            size
+        }
     }
 }


### PR DESCRIPTION
`WebGL2` has different uniform / texture aligning requirements than `wgpu`. This PR moves uniform / texture aligning code to RenderResourceContext. Current aligning behaviour for `wgpu` should be preserved. 