### PR TITLE
wasm32: non-spirv shader specialization

### DIFF
--- a/crates/bevy_render/src/pipeline/pipeline_compiler.rs
+++ b/crates/bevy_render/src/pipeline/pipeline_compiler.rs
@@ -70,6 +70,7 @@ pub struct PipelineCompiler {
 impl PipelineCompiler {
     fn compile_shader(
         &mut self,
+        render_resource_context: &dyn RenderResourceContext,
         shaders: &mut Assets<Shader>,
         shader_handle: &Handle<Shader>,
         shader_specialization: &ShaderSpecialization,
@@ -102,7 +103,8 @@ impl PipelineCompiler {
                 .iter()
                 .cloned()
                 .collect::<Vec<String>>();
-            let compiled_shader = shader.get_spirv_shader(Some(&shader_def_vec));
+            let compiled_shader =
+                render_resource_context.get_specialized_shader(shader, Some(&shader_def_vec));
             let specialized_handle = shaders.add(compiled_shader);
             let weak_specialized_handle = specialized_handle.clone_weak();
             specialized_shaders.push(SpecializedShader {
@@ -141,6 +143,7 @@ impl PipelineCompiler {
         let source_descriptor = pipelines.get(source_pipeline).unwrap();
         let mut specialized_descriptor = source_descriptor.clone();
         specialized_descriptor.shader_stages.vertex = self.compile_shader(
+            render_resource_context,
             shaders,
             &specialized_descriptor.shader_stages.vertex,
             &pipeline_specialization.shader_specialization,
@@ -151,6 +154,7 @@ impl PipelineCompiler {
             .as_ref()
             .map(|fragment| {
                 self.compile_shader(
+                    render_resource_context,
                     shaders,
                     fragment,
                     &pipeline_specialization.shader_specialization,

--- a/crates/bevy_render/src/renderer/headless_render_resource_context.rs
+++ b/crates/bevy_render/src/renderer/headless_render_resource_context.rs
@@ -148,4 +148,8 @@ impl RenderResourceContext for HeadlessRenderResourceContext {
     fn get_aligned_texture_size(&self, size: usize) -> usize {
         size
     }
+
+    fn get_specialized_shader(&self, shader: &Shader, _macros: Option<&[String]>) -> Shader {
+        shader.clone()
+    }
 }

--- a/crates/bevy_render/src/renderer/render_resource_context.rs
+++ b/crates/bevy_render/src/renderer/render_resource_context.rs
@@ -29,6 +29,7 @@ pub trait RenderResourceContext: Downcast + Send + Sync + 'static {
     fn create_buffer_with_data(&self, buffer_info: BufferInfo, data: &[u8]) -> BufferId;
     fn create_shader_module(&self, shader_handle: &Handle<Shader>, shaders: &Assets<Shader>);
     fn create_shader_module_from_source(&self, shader_handle: &Handle<Shader>, shader: &Shader);
+    fn get_specialized_shader(&self, shader: &Shader, macros: Option<&[String]>) -> Shader;
     fn remove_buffer(&self, buffer: BufferId);
     fn remove_texture(&self, texture: TextureId);
     fn remove_sampler(&self, sampler: SamplerId);

--- a/crates/bevy_render/src/shader/mod.rs
+++ b/crates/bevy_render/src/shader/mod.rs
@@ -5,12 +5,10 @@ mod shader_defs;
 #[cfg(not(target_arch = "wasm32"))]
 mod shader_reflect;
 
-#[cfg(target_arch = "wasm32")]
-#[path = "shader_reflect_wasm.rs"]
-mod shader_reflect;
-
 pub use shader::*;
 pub use shader_defs::*;
+
+#[cfg(not(target_arch = "wasm32"))]
 pub use shader_reflect::*;
 
 use crate::pipeline::{BindGroupDescriptor, VertexBufferDescriptor};

--- a/crates/bevy_render/src/shader/shader.rs
+++ b/crates/bevy_render/src/shader/shader.rs
@@ -129,6 +129,7 @@ impl Shader {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn reflect_layout(&self, enforce_bevy_conventions: bool) -> Option<ShaderLayout> {
         if let ShaderSource::Spirv(ref spirv) = self.source {
             Some(ShaderLayout::from_spirv(
@@ -138,6 +139,11 @@ impl Shader {
         } else {
             panic!("Cannot reflect layout of non-SpirV shader. Try compiling this shader to SpirV first using self.get_spirv_shader()");
         }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn reflect_layout(&self, _enforce_bevy_conventions: bool) -> Option<ShaderLayout> {
+        panic!("Cannot reflect layout on wasm32");
     }
 }
 

--- a/crates/bevy_render/src/shader/shader.rs
+++ b/crates/bevy_render/src/shader/shader.rs
@@ -23,7 +23,7 @@ impl Into<bevy_glsl_to_spirv::ShaderType> for ShaderStage {
 }
 
 #[cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))]
-fn glsl_to_spirv(
+pub fn glsl_to_spirv(
     glsl_source: &str,
     stage: ShaderStage,
     shader_defs: Option<&[String]>,
@@ -43,7 +43,7 @@ impl Into<shaderc::ShaderKind> for ShaderStage {
 }
 
 #[cfg(target_os = "ios")]
-fn glsl_to_spirv(
+pub fn glsl_to_spirv(
     glsl_source: &str,
     stage: ShaderStage,
     shader_defs: Option<&[String]>,
@@ -126,30 +126,6 @@ impl Shader {
         Shader {
             source: ShaderSource::Spirv(self.get_spirv(macros)),
             stage: self.stage,
-        }
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    pub fn get_spirv_shader(&self, macros: Option<&[String]>) -> Shader {
-        if let ShaderSource::Glsl(source) = &self.source {
-            assert!(source.starts_with("#version"));
-            let eol_index = source.find('\n').unwrap();
-            let (version_str, source) = source.split_at(eol_index);
-            let mut processed = version_str.to_string();
-            processed.push_str("\n");
-            if let Some(macros) = macros {
-                for m in macros.iter() {
-                    processed.push_str(&format!("#define {}\n", m));
-                }
-            }
-            processed.push_str("#define WEBGL\n");
-            processed.push_str(source);
-            Shader {
-                source: ShaderSource::Glsl(processed),
-                stage: self.stage,
-            }
-        } else {
-            panic!("spirv shader is not supported");
         }
     }
 

--- a/crates/bevy_render/src/shader/shader_reflect_wasm.rs
+++ b/crates/bevy_render/src/shader/shader_reflect_wasm.rs
@@ -1,7 +1,0 @@
-use crate::shader::ShaderLayout;
-
-impl ShaderLayout {
-    pub fn from_spirv(_spirv_data: &[u32], _bevy_conventions: bool) -> ShaderLayout {
-        panic!("reflecting shader layout from spirv data is not available");
-    }
-}

--- a/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
+++ b/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
@@ -12,7 +12,7 @@ use bevy_render::{
         BindGroup, BufferId, BufferInfo, RenderResourceBinding, RenderResourceContext,
         RenderResourceId, SamplerId, TextureId,
     },
-    shader::Shader,
+    shader::{glsl_to_spirv, Shader, ShaderSource},
     texture::{Extent3d, SamplerDescriptor, TextureDescriptor},
 };
 use bevy_utils::tracing::trace;
@@ -567,6 +567,17 @@ impl RenderResourceContext for WgpuRenderResourceContext {
             (size + BIND_BUFFER_ALIGNMENT - 1) & !(BIND_BUFFER_ALIGNMENT - 1)
         } else {
             size
+        }
+    }
+
+    fn get_specialized_shader(&self, shader: &Shader, macros: Option<&[String]>) -> Shader {
+        let spirv_data = match shader.source {
+            ShaderSource::Spirv(ref bytes) => bytes.clone(),
+            ShaderSource::Glsl(ref source) => glsl_to_spirv(&source, shader.stage, macros),
+        };
+        Shader {
+            source: ShaderSource::Spirv(spirv_data),
+            ..*shader
         }
     }
 }

--- a/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
+++ b/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
@@ -571,15 +571,9 @@ impl RenderResourceContext for WgpuRenderResourceContext {
     }
 
     fn get_specialized_shader(&self, shader: &Shader, macros: Option<&[String]>) -> Shader {
-        let macros: Vec<String> = macros
-            .unwrap_or(&[])
-            .iter()
-            .chain((&["WGPU".to_string()]).iter())
-            .cloned()
-            .collect();
         let spirv_data = match shader.source {
             ShaderSource::Spirv(ref bytes) => bytes.clone(),
-            ShaderSource::Glsl(ref source) => glsl_to_spirv(&source, shader.stage, Some(&macros)),
+            ShaderSource::Glsl(ref source) => glsl_to_spirv(&source, shader.stage, macros),
         };
         Shader {
             source: ShaderSource::Spirv(spirv_data),

--- a/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
+++ b/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
@@ -571,9 +571,15 @@ impl RenderResourceContext for WgpuRenderResourceContext {
     }
 
     fn get_specialized_shader(&self, shader: &Shader, macros: Option<&[String]>) -> Shader {
+        let macros: Vec<String> = macros
+            .unwrap_or(&[])
+            .iter()
+            .chain((&["WGPU".to_string()]).iter())
+            .cloned()
+            .collect();
         let spirv_data = match shader.source {
             ShaderSource::Spirv(ref bytes) => bytes.clone(),
-            ShaderSource::Glsl(ref source) => glsl_to_spirv(&source, shader.stage, macros),
+            ShaderSource::Glsl(ref source) => glsl_to_spirv(&source, shader.stage, Some(&macros)),
         };
         Shader {
             source: ShaderSource::Spirv(spirv_data),


### PR DESCRIPTION
It implements shader specialization for `wasm32`  (where spirv is not available), by adding preprocessor's #define statements to shader source.