### PR TITLE
Add entries, ToC, and releases note on examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,16 @@ To run an example, use the command `cargo run --example <Example>`, and add the 
 cargo run --features wayland --example hello_world
 ```
 
+### ⚠️ Note: for users of releases on crates.io,
+
+Due to changes and additions to APIs, there are often differences between the development examples and the released versions of Bevy on crates.io.
+If you are using a release version from [crates.io](https://crates.io/crates/bevy), view the examples by checking out the appropriate git tag, e.g., users of `0.3` should use the examples on [https://github.com/bevyengine/bevy/tree/v0.3.0/examples](https://github.com/bevyengine/bevy/tree/v0.3.0/examples)
+
+If you have cloned bevy's repo locally, `git checkout` with the appropriate version tag.
+```
+git checkout v0.3.0
+```
+
 ## Hello, World!
 
 Example | Main | Description

--- a/examples/README.md
+++ b/examples/README.md
@@ -70,7 +70,7 @@ Example | File | Description
 
 Example | File | Description
 --- | --- | ---
-`custom_loop` | [`app/custom_loop.rs`](./app/custom_loop.rs) | Demonstrates hot to create a custom runner (to update an app manually).
+`custom_loop` | [`app/custom_loop.rs`](./app/custom_loop.rs) | Demonstrates how to create a custom runner (to update an app manually).
 `empty` | [`app/empty.rs`](./app/empty.rs) | An empty application (does nothing)
 `empty_defaults` | [`app/empty_defaults.rs`](./app/empty_defaults.rs) | An empty application with default plugins
 `headless` | [`app/headless.rs`](./app/headless.rs) | An application that runs without default plugins

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,6 +49,7 @@ Example | Main | Description
 
 Example | Main | Description
 --- | --- | ---
+`contributors` | [`2d/contributors.rs`](./2d/contributors.rs) | Displays each contributor as a bouncy bevy-ball!
 `sprite` | [`2d/sprite.rs`](./2d/sprite.rs) | Renders a sprite
 `sprite_sheet` | [`2d/sprite_sheet.rs`](./2d/sprite_sheet.rs) | Renders an animated sprite
 `texture_atlas` | [`2d/texture_atlas.rs`](./2d/texture_atlas.rs) | Generates a texture atlas (sprite sheet) from individual sprites
@@ -69,6 +70,7 @@ Example | File | Description
 
 Example | File | Description
 --- | --- | ---
+`custom_loop` | [`app/custom_loop.rs`](./app/custom_loop.rs) | Demonstrates hot to create a custom runner (to update an app manually).
 `empty` | [`app/empty.rs`](./app/empty.rs) | An empty application (does nothing)
 `empty_defaults` | [`app/empty_defaults.rs`](./app/empty_defaults.rs) | An empty application with default plugins
 `headless` | [`app/headless.rs`](./app/headless.rs) | An application that runs without default plugins
@@ -81,6 +83,7 @@ Example | File | Description
 Example | File | Description
 --- | --- | ---
 `asset_loading` | [`asset/asset_loading.rs`](./asset/asset_loading.rs) | Demonstrates various methods to load assets
+`custom_asset` | [`asset/custom_asset.rs`](./asset/custom_asset.rs) | Implements a custom asset loader
 `hot_asset_reloading` | [`asset/hot_asset_reloading.rs`](./asset/hot_asset_reloading.rs) | Demonstrates automatic reloading of assets when modified on disk
 
 ## Audio
@@ -102,6 +105,7 @@ Example | File | Description
 --- | --- | ---
 `event` | [`ecs/event.rs`](./ecs/event.rs) | Illustrates event creation, activation, and reception
 `ecs_guide` | [`ecs/ecs_guide.rs`](./ecs/ecs_guide.rs) | Full guide to Bevy's ECS
+`hierarchy` | [`ecs/hierarchy.rs`](./ecs/hierarchy.rs) | Creates a hierarchy of parents and children entities
 `parallel_query` | [`ecs/parallel_query.rs`](./ecs/parallel_query.rs) | Illustrates parallel queries with `ParallelIterator`
 `startup_system` | [`ecs/startup_system.rs`](./ecs/startup_system.rs) | Demonstrates a startup system (one that runs once when the app starts up)
 
@@ -115,10 +119,15 @@ Example | File | Description
 
 Example | File | Description
 --- | --- | ---
+`char_input_events` | [`input/char_input_events.rs`](./input/char_input_events.rs) | Prints out all chars as they are inputted.
+`gamepad_input` | [`input/gamepad_input.rs`](./input/gamepad_input.rs) | Shows handling of gamepad input, connections, and disconnections
+`gamepad_input_events` | [`input/gamepad_input_events.rs`](./input/gamepad_input_events.rs) | Iterates and prints gamepad input and connection events
 `mouse_input` | [`input/mouse_input.rs`](./input/mouse_input.rs) | Demonstrates handling a mouse button press/release
 `mouse_input_events` | [`input/mouse_input_events.rs`](./input/mouse_input_events.rs) | Prints out all mouse events (buttons, movement, etc.)
 `keyboard_input` | [`input/keyboard_input.rs`](./input/keyboard_input.rs) | Demonstrates handling a key press/release
 `keyboard_input_events` | [`input/keyboard_input_events.rs`](./input/keyboard_input_events.rs) | Prints out all keyboard events
+`touch_input` | [`input/touch_input.rs`](./input/touch_input.rs) | Displays touch presses, releases, and cancels
+`touch_input_events` | [`input/touch_input_events.rs`](./input/touch_input_input_events.rs) | Prints out all touch inputs
 
 ## Scene
 
@@ -131,6 +140,7 @@ Example | File | Description
 
 Example | File | Description
 --- | --- | ---
+`mesh_custom_attribute` | [`shader/mesh_custom_attribute.rs`](./shader/mesh_custom_attribute.rs) | Illustrates how to add a custom attribute to a mesh and use it in a custom shader
 `shader_custom_material` | [`shader/shader_custom_material.rs`](./shader/shader_custom_material.rs) | Illustrates creating a custom material and a shader that uses it
 `shader_defs` | [`shader/shader_defs.rs`](./shader/shader_defs.rs) | Demonstrates creating a custom material that uses "shaders defs" (a tool to selectively toggle parts of a shader)
 
@@ -176,6 +186,14 @@ Then serve `examples/wasm` dir to browser. i.e.
 ```sh
 basic-http-server examples/wasm
 ```
+
+Example | File | Description
+--- | --- | ---
+`hello_wasm` | [`wasm/hello_wasm.rs`](./wasm/hello_wasm.rs) | Runs a minimal example that logs "hello world" to the browser's console
+`headless_wasm` | [`wasm/headless_wasm.rs`](./wasm/headless_wasm.rs) | Sets up a schedule runner and continually logs a counter to the browser's console
+`assets_wasm` | [`wasm/assets_wasm.rs`](./wasm/assets_wasm.rs) | Demonstrates how to load assets from wasm
+`winit_wasm` | [`wasm/winit_wasm.rs`](./wasm/winit_wasm.rs) | Logs user input to the browser's console. Requires the `bevy_winit` features
+
 
 ## iOS
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,28 @@ If you have cloned bevy's repo locally, `git checkout` with the appropriate vers
 git checkout v0.3.0
 ```
 
+---
+
+### Table of Contents
+
+- [Hello, World!](#hello--world-)
+- [2D Rendering](#2d-rendering)
+- [3D Rendering](#3d-rendering)
+- [Application](#application)
+- [Assets](#assets)
+- [Audio](#audio)
+- [Diagnostics](#diagnostics)
+- [ECS (Entity Component System)](#ecs--entity-component-system-)
+- [Games](#games)
+- [Input](#input)
+- [Scene](#scene)
+- [Shaders](#shaders)
+- [UI (User Interface)](#ui--user-interface-)
+- [Window](#window)
+- [WASM](#wasm)
+- [iOS](#ios)
+- [Android](#android)
+
 ## Hello, World!
 
 Example | Main | Description


### PR DESCRIPTION
[rendered](https://github.com/memoryruins/bevy/blob/example-readme-notes/examples/README.md)

- notes difference between development and release examples
- adds a table of contents for the categories
- adds missing example entries


