### PR TITLE
Backtraces on commands apply

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ trace_chrome = ["bevy_internal/trace_chrome"]
 trace = ["bevy_internal/trace"]
 wgpu_trace = ["bevy_internal/wgpu_trace"]
 
+commands_backtraces = ["bevy_internal/commands_backtraces"]
+
 # Image format support for texture loading (PNG and HDR are enabled by default)
 hdr = ["bevy_internal/hdr"]
 png = ["bevy_internal/png"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ trace_chrome = ["bevy_internal/trace_chrome"]
 trace = ["bevy_internal/trace"]
 wgpu_trace = ["bevy_internal/wgpu_trace"]
 
-commands_backtraces = ["bevy_internal/commands_backtraces"]
+command_backtraces = ["bevy_internal/command_backtraces"]
 
 # Image format support for texture loading (PNG and HDR are enabled by default)
 hdr = ["bevy_internal/hdr"]

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["game-engines", "data-structures"]
 
 [features]
 trace = []
-commands_backtraces = []
+command_backtraces = []
 
 [dependencies]
 bevy_tasks = { path = "../bevy_tasks", version = "0.3.0" }

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["game-engines", "data-structures"]
 
 [features]
 trace = []
+commands_backtraces = []
 
 [dependencies]
 bevy_tasks = { path = "../bevy_tasks", version = "0.3.0" }

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -21,6 +21,7 @@ commands_backtraces = []
 bevy_tasks = { path = "../bevy_tasks", version = "0.3.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.3.0" }
 bevy_ecs_macros = { path = "macros", version = "0.3.0" }
+anyhow = "1.0"
 rand = "0.7.3"
 serde = "1.0"
 thiserror = "1.0"

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(backtrace)]
 mod core;
 mod resource;
 mod schedule;

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(backtrace)]
+#![cfg_attr(feature = "command_backtraces", feature(backtrace))]
 mod core;
 mod resource;
 mod schedule;

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -6,6 +6,9 @@ use crate::{
 use bevy_utils::tracing::{debug, warn};
 use std::marker::PhantomData;
 
+#[cfg(feature = "commands_backtraces")]
+use std::backtrace::Backtrace;
+
 /// A [World] mutation
 pub trait Command: Send + Sync {
     fn write(self: Box<Self>, world: &mut World, resources: &mut Resources);
@@ -184,6 +187,8 @@ impl<T: Resource> Command for InsertLocalResource<T> {
 #[derive(Default)]
 pub struct Commands {
     commands: Vec<Box<dyn Command>>,
+    #[cfg(feature = "commands_backtraces")]
+    backtraces: Vec<Backtrace>,
     current_entity: Option<Entity>,
     entity_reserver: Option<EntityReserver>,
 }
@@ -197,6 +202,10 @@ impl Commands {
             .reserve_entity();
         self.current_entity = Some(entity);
         self.commands.push(Box::new(Insert { entity, components }));
+        #[cfg(feature = "commands_backtraces")]
+        {
+            self.backtraces.push(Backtrace::capture());
+        }
         self
     }
 
@@ -269,6 +278,10 @@ impl Commands {
             entity: current_entity,
             components,
         }));
+        #[cfg(feature = "commands_backtraces")]
+        {
+            self.backtraces.push(Backtrace::capture());
+        }
         self
     }
 
@@ -278,21 +291,42 @@ impl Commands {
             entity: current_entity,
             component,
         }));
+        #[cfg(feature = "commands_backtraces")]
+        {
+            self.backtraces.push(Backtrace::capture());
+        }
         self
     }
 
     pub fn add_command<C: Command + 'static>(&mut self, command: C) -> &mut Self {
         self.commands.push(Box::new(command));
+        #[cfg(feature = "commands_backtraces")]
+        {
+            self.backtraces.push(Backtrace::capture());
+        }
         self
     }
 
     pub fn add_command_boxed(&mut self, command: Box<dyn Command>) -> &mut Self {
         self.commands.push(command);
+        #[cfg(feature = "commands_backtraces")]
+        {
+            self.backtraces.push(Backtrace::capture());
+        }
         self
     }
 
+    #[cfg(not(feature = "commands_backtraces"))]
     pub fn apply(&mut self, world: &mut World, resources: &mut Resources) {
         for command in self.commands.drain(..) {
+            command.write(world, resources);
+        }
+    }
+
+    #[cfg(feature = "commands_backtraces")]
+    pub fn apply(&mut self, world: &mut World, resources: &mut Resources) {
+        for (command, backtrace) in self.commands.drain(..).zip(self.backtraces.drain(..)) {
+            println!("Applying command from here: {}", backtrace);
             command.write(world, resources);
         }
     }

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -4,7 +4,7 @@ use crate::{
     Bundle, Component, ComponentError, DynamicBundle, Entity, EntityReserver, World,
 };
 use bevy_utils::tracing::{debug, warn};
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use std::marker::PhantomData;
 
 #[cfg(feature = "command_backtraces")]

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -3,8 +3,8 @@ use crate::{
     resource::{Resource, Resources},
     Bundle, Component, ComponentError, DynamicBundle, Entity, EntityReserver, World,
 };
+use anyhow::{anyhow, bail, Result};
 use bevy_utils::tracing::{debug, warn};
-use anyhow::{bail, Result};
 use std::marker::PhantomData;
 
 #[cfg(feature = "command_backtraces")]
@@ -81,7 +81,7 @@ where
     fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) -> Result<()> {
         world
             .insert(self.entity, self.components)
-            .map_err(|e| e.into())
+            .map_err(|e| anyhow!("{:?}", e))
     }
 }
 
@@ -101,7 +101,7 @@ where
     fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) -> Result<()> {
         world
             .insert(self.entity, (self.component,))
-            .map_err(|e| e.into())
+            .map_err(|e| anyhow!("{:?}", e))
     }
 }
 
@@ -122,7 +122,7 @@ where
         if world.get::<T>(self.entity).is_ok() {
             world
                 .remove_one::<T>(self.entity)
-                .map_err(|e| e.into())
+                .map_err(|e| anyhow!("{:?}", e))
                 .map(|_| ())
         } else {
             bail!("No such entity {:?}", self.entity)

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -217,11 +217,7 @@ impl Commands {
             .expect("entity reserver has not been set")
             .reserve_entity();
         self.current_entity = Some(entity);
-        self.commands.push(Box::new(Insert { entity, components }));
-        #[cfg(feature = "command_backtraces")]
-        {
-            self.backtraces.push(Backtrace::capture());
-        }
+        self.add_command(Insert { entity, components });
         self
     }
 
@@ -290,37 +286,24 @@ impl Commands {
         components: impl DynamicBundle + Send + Sync + 'static,
     ) -> &mut Self {
         let current_entity =  self.current_entity.expect("Cannot add components because the 'current entity' is not set. You should spawn an entity first.");
-        self.commands.push(Box::new(Insert {
+        self.add_command(Insert {
             entity: current_entity,
             components,
-        }));
-        #[cfg(feature = "command_backtraces")]
-        {
-            self.backtraces.push(Backtrace::capture());
-        }
+        });
         self
     }
 
     pub fn with(&mut self, component: impl Component) -> &mut Self {
         let current_entity =  self.current_entity.expect("Cannot add component because the 'current entity' is not set. You should spawn an entity first.");
-        self.commands.push(Box::new(InsertOne {
+        self.add_command(InsertOne {
             entity: current_entity,
             component,
-        }));
-        #[cfg(feature = "command_backtraces")]
-        {
-            self.backtraces.push(Backtrace::capture());
-        }
+        });
         self
     }
 
     pub fn add_command<C: Command + 'static>(&mut self, command: C) -> &mut Self {
-        self.commands.push(Box::new(command));
-        #[cfg(feature = "command_backtraces")]
-        {
-            self.backtraces.push(Backtrace::capture());
-        }
-        self
+        self.add_command_boxed(Box::new(command))
     }
 
     pub fn add_command_boxed(&mut self, command: Box<dyn Command>) -> &mut Self {

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -7,7 +7,7 @@ use bevy_utils::tracing::{debug, warn};
 use anyhow::{bail, Context, Result};
 use std::marker::PhantomData;
 
-#[cfg(feature = "commands_backtraces")]
+#[cfg(feature = "command_backtraces")]
 use std::backtrace::Backtrace;
 
 /// A [World] mutation
@@ -203,7 +203,7 @@ impl<T: Resource> Command for InsertLocalResource<T> {
 #[derive(Default)]
 pub struct Commands {
     commands: Vec<Box<dyn Command>>,
-    #[cfg(feature = "commands_backtraces")]
+    #[cfg(feature = "command_backtraces")]
     backtraces: Vec<Backtrace>,
     current_entity: Option<Entity>,
     entity_reserver: Option<EntityReserver>,
@@ -218,7 +218,7 @@ impl Commands {
             .reserve_entity();
         self.current_entity = Some(entity);
         self.commands.push(Box::new(Insert { entity, components }));
-        #[cfg(feature = "commands_backtraces")]
+        #[cfg(feature = "command_backtraces")]
         {
             self.backtraces.push(Backtrace::capture());
         }
@@ -294,7 +294,7 @@ impl Commands {
             entity: current_entity,
             components,
         }));
-        #[cfg(feature = "commands_backtraces")]
+        #[cfg(feature = "command_backtraces")]
         {
             self.backtraces.push(Backtrace::capture());
         }
@@ -307,7 +307,7 @@ impl Commands {
             entity: current_entity,
             component,
         }));
-        #[cfg(feature = "commands_backtraces")]
+        #[cfg(feature = "command_backtraces")]
         {
             self.backtraces.push(Backtrace::capture());
         }
@@ -316,7 +316,7 @@ impl Commands {
 
     pub fn add_command<C: Command + 'static>(&mut self, command: C) -> &mut Self {
         self.commands.push(Box::new(command));
-        #[cfg(feature = "commands_backtraces")]
+        #[cfg(feature = "command_backtraces")]
         {
             self.backtraces.push(Backtrace::capture());
         }
@@ -325,21 +325,21 @@ impl Commands {
 
     pub fn add_command_boxed(&mut self, command: Box<dyn Command>) -> &mut Self {
         self.commands.push(command);
-        #[cfg(feature = "commands_backtraces")]
+        #[cfg(feature = "command_backtraces")]
         {
             self.backtraces.push(Backtrace::capture());
         }
         self
     }
 
-    #[cfg(not(feature = "commands_backtraces"))]
+    #[cfg(not(feature = "command_backtraces"))]
     pub fn apply(&mut self, world: &mut World, resources: &mut Resources) {
         for command in self.commands.drain(..) {
             command.write(world, resources).unwrap();
         }
     }
 
-    #[cfg(feature = "commands_backtraces")]
+    #[cfg(feature = "command_backtraces")]
     pub fn apply(&mut self, world: &mut World, resources: &mut Resources) {
         for (command, backtrace) in self.commands.drain(..).zip(self.backtraces.drain(..)) {
             if let Err(e) = command.write(world, resources) {

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -18,6 +18,8 @@ wgpu_trace = ["bevy_wgpu/trace"]
 trace = [ "bevy_app/trace", "bevy_ecs/trace" ]
 trace_chrome = [ "bevy_log/tracing-chrome" ]
 
+commands_backtraces = [ "bevy_ecs/commands_backtraces" ]
+
 # Image format support for texture loading (PNG and HDR are enabled by default)
 hdr = ["bevy_render/hdr"]
 png = ["bevy_render/png"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -18,7 +18,7 @@ wgpu_trace = ["bevy_wgpu/trace"]
 trace = [ "bevy_app/trace", "bevy_ecs/trace" ]
 trace_chrome = [ "bevy_log/tracing-chrome" ]
 
-commands_backtraces = [ "bevy_ecs/commands_backtraces" ]
+command_backtraces = [ "bevy_ecs/command_backtraces" ]
 
 # Image format support for texture loading (PNG and HDR are enabled by default)
 hdr = ["bevy_render/hdr"]

--- a/crates/bevy_scene/src/command.rs
+++ b/crates/bevy_scene/src/command.rs
@@ -12,7 +12,7 @@ impl Command for SpawnScene {
     fn write(self: Box<Self>, _world: &mut World, resources: &mut Resources) -> Result<()> {
         let mut spawner = resources
             .get_mut::<SceneSpawner>()
-            .ok_or(anyhow!("SceneSpawner resource missing"))?;
+            .ok_or_else(|| anyhow!("SceneSpawner resource missing"))?;
         spawner.spawn(self.scene_handle);
         Ok(())
     }

--- a/crates/bevy_scene/src/command.rs
+++ b/crates/bevy_scene/src/command.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Result};
 use bevy_asset::Handle;
 use bevy_ecs::{Command, Commands, Resources, World};
 
@@ -8,9 +9,12 @@ pub struct SpawnScene {
 }
 
 impl Command for SpawnScene {
-    fn write(self: Box<Self>, _world: &mut World, resources: &mut Resources) {
-        let mut spawner = resources.get_mut::<SceneSpawner>().unwrap();
+    fn write(self: Box<Self>, _world: &mut World, resources: &mut Resources) -> Result<()> {
+        let mut spawner = resources
+            .get_mut::<SceneSpawner>()
+            .ok_or(anyhow!("SceneSpawner resource missing"))?;
         spawner.spawn(self.scene_handle);
+        Ok(())
     }
 }
 

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -23,3 +23,4 @@ bevy_utils = { path = "../bevy_utils", version = "0.3.0" }
 
 # other
 smallvec = { version = "1.4", features = ["serde"] }
+anyhow = "1.0"

--- a/crates/bevy_transform/src/hierarchy/child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/child_builder.rs
@@ -1,4 +1,5 @@
 use crate::prelude::{Children, Parent, PreviousParent};
+use anyhow::Result;
 use bevy_ecs::{Command, Commands, Component, DynamicBundle, Entity, Resources, World};
 use smallvec::SmallVec;
 
@@ -10,11 +11,9 @@ pub struct InsertChildren {
 }
 
 impl Command for InsertChildren {
-    fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) {
+    fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) -> Result<()> {
         for child in self.children.iter() {
-            world
-                .insert(*child, (Parent(self.parent), PreviousParent(self.parent)))
-                .unwrap();
+            world.insert(*child, (Parent(self.parent), PreviousParent(self.parent)))?;
         }
         {
             let mut added = false;
@@ -27,7 +26,9 @@ impl Command for InsertChildren {
             if !added {
                 world
                     .insert_one(self.parent, Children(self.children))
-                    .unwrap();
+                    .map_err(|e| e.into())
+            } else {
+                Ok(())
             }
         }
     }
@@ -45,11 +46,9 @@ pub struct ChildBuilder<'a> {
 }
 
 impl Command for PushChildren {
-    fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) {
+    fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) -> Result<()> {
         for child in self.children.iter() {
-            world
-                .insert(*child, (Parent(self.parent), PreviousParent(self.parent)))
-                .unwrap();
+            world.insert(*child, (Parent(self.parent), PreviousParent(self.parent)))?
         }
         {
             let mut added = false;
@@ -62,7 +61,9 @@ impl Command for PushChildren {
             if !added {
                 world
                     .insert_one(self.parent, Children(self.children))
-                    .unwrap();
+                    .map_err(|e| e.into())
+            } else {
+                Ok(())
             }
         }
     }

--- a/crates/bevy_transform/src/hierarchy/child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/child_builder.rs
@@ -1,5 +1,5 @@
 use crate::prelude::{Children, Parent, PreviousParent};
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use bevy_ecs::{Command, Commands, Component, DynamicBundle, Entity, Resources, World};
 use smallvec::SmallVec;
 
@@ -13,7 +13,9 @@ pub struct InsertChildren {
 impl Command for InsertChildren {
     fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) -> Result<()> {
         for child in self.children.iter() {
-            world.insert(*child, (Parent(self.parent), PreviousParent(self.parent)))?;
+            world
+                .insert(*child, (Parent(self.parent), PreviousParent(self.parent)))
+                .map_err(|e| anyhow!("{:?}", e))?;
         }
         {
             let mut added = false;
@@ -26,7 +28,7 @@ impl Command for InsertChildren {
             if !added {
                 world
                     .insert_one(self.parent, Children(self.children))
-                    .map_err(|e| e.into())
+                    .map_err(|e| anyhow!("{:?}", e))
             } else {
                 Ok(())
             }
@@ -48,7 +50,9 @@ pub struct ChildBuilder<'a> {
 impl Command for PushChildren {
     fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) -> Result<()> {
         for child in self.children.iter() {
-            world.insert(*child, (Parent(self.parent), PreviousParent(self.parent)))?
+            world
+                .insert(*child, (Parent(self.parent), PreviousParent(self.parent)))
+                .map_err(|e| anyhow!("{:?}", e))?
         }
         {
             let mut added = false;
@@ -61,7 +65,7 @@ impl Command for PushChildren {
             if !added {
                 world
                     .insert_one(self.parent, Children(self.children))
-                    .map_err(|e| e.into())
+                    .map_err(|e| anyhow!("{:?}", e))
             } else {
                 Ok(())
             }

--- a/crates/bevy_transform/src/hierarchy/hierarchy.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy.rs
@@ -1,4 +1,5 @@
 use crate::components::{Children, Parent};
+use anyhow::Result;
 use bevy_ecs::{Command, Commands, Entity, Query, Resources, World};
 use bevy_utils::tracing::debug;
 
@@ -68,8 +69,9 @@ fn despawn_with_children_recursive_inner(world: &mut World, entity: Entity) {
 }
 
 impl Command for DespawnRecursive {
-    fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) {
+    fn write(self: Box<Self>, world: &mut World, _resources: &mut Resources) -> Result<()> {
         despawn_with_children_recursive(world, self.entity);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
I often run into a bad debugging experience where a Command fails during writing and it's very hard to track down which system actually caused the issue because the backtrace is all inside bevy_ecs. I'd like to have backtraces captured when the Command was actually written to the buffer.

This change adds a new feature flag called "command_backtraces" which causes a failed Command to print a trace of the stack when it was added to the buffer as well as a trace of the actual failure point. It is gated by a feature because it depends on std::backtrace which is a nightly only API and because recording the backtraces will have some performance impact (though I haven't actually measured how large it is).

The primary thing I am concerned about in this PR is the way I've introduced the Result return into Command implementations. I don't feel like I have good intuition about best practice error handling in Rust so I'd love feedback about clarity and idiomicity (which is surely a word?).