### PR TITLE
Fix ToC links in examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -21,19 +21,19 @@ git checkout v0.3.0
 
 ### Table of Contents
 
-- [Hello, World!](#hello--world-)
+- [Hello, World!](#hello-world)
 - [2D Rendering](#2d-rendering)
 - [3D Rendering](#3d-rendering)
 - [Application](#application)
 - [Assets](#assets)
 - [Audio](#audio)
 - [Diagnostics](#diagnostics)
-- [ECS (Entity Component System)](#ecs--entity-component-system-)
+- [ECS (Entity Component System)](#ecs-entity-component-system)
 - [Games](#games)
 - [Input](#input)
 - [Scene](#scene)
 - [Shaders](#shaders)
-- [UI (User Interface)](#ui--user-interface-)
+- [UI (User Interface)](#ui-user-interface)
 - [Window](#window)
 - [WASM](#wasm)
 - [iOS](#ios)


### PR DESCRIPTION
[rendered](https://github.com/memoryruins/bevy/tree/example-toc-fix/examples)

Extra dashes slipped into the ToC links originally, but markdown ignores the positions of punctuation in titles (e.g. parentheses and exclamation marks). It led to the following links not jumping to the correct part of the page😅