### PR TITLE
More query filter usage

### DIFF
--- a/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
@@ -1,13 +1,15 @@
 use crate::components::*;
-use bevy_ecs::{Commands, Entity, IntoSystem, Query, System, Without};
+use bevy_ecs::{Changed, Commands, Entity, IntoSystem, Query, System, Without};
 use bevy_utils::HashMap;
 use smallvec::SmallVec;
 
 pub fn parent_update_system(
     commands: &mut Commands,
     removed_parent_query: Query<(Entity, &PreviousParent), Without<Parent>>,
-    // TODO: ideally this only runs when the Parent component has changed
-    mut changed_parent_query: Query<(Entity, &Parent, Option<&mut PreviousParent>)>,
+    mut changed_parent_query: Query<
+        (Entity, &Parent, Option<&mut PreviousParent>),
+        Changed<Parent>,
+    >,
     mut children_query: Query<&mut Children>,
 ) {
     // Entities with a missing `Parent` (ie. ones that have a `PreviousParent`), remove

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -9,7 +9,7 @@ pub const UI_Z_STEP: f32 = 0.001;
 
 pub fn ui_z_system(
     root_node_query: Query<Entity, (With<Node>, Without<Parent>)>,
-    mut node_query: Query<(Entity, &Node, &mut Transform)>,
+    mut node_query: Query<(Entity, &mut Transform), With<Node>>,
     children_query: Query<&Children>,
 ) {
     let mut current_global_z = 0.0;
@@ -29,7 +29,7 @@ pub fn ui_z_system(
 }
 
 fn update_node_entity(
-    node_query: &mut Query<(Entity, &Node, &mut Transform)>,
+    node_query: &mut Query<(Entity, &mut Transform), With<Node>>,
     entity: Entity,
     parent_result: Option<f32>,
     previous_result: Option<f32>,

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,6 +1,6 @@
 use crate::CalculatedSize;
 use bevy_asset::{Assets, Handle};
-use bevy_ecs::{Query, Res};
+use bevy_ecs::{Query, Res, With};
 use bevy_math::Size;
 use bevy_render::texture::Texture;
 use bevy_sprite::ColorMaterial;
@@ -19,9 +19,9 @@ impl Default for Image {
 pub fn image_node_system(
     materials: Res<Assets<ColorMaterial>>,
     textures: Res<Assets<Texture>>,
-    mut query: Query<(&Image, &mut CalculatedSize, &Handle<ColorMaterial>)>,
+    mut query: Query<(&mut CalculatedSize, &Handle<ColorMaterial>), With<Image>>,
 ) {
-    for (_image, mut calculated_size, material_handle) in query.iter_mut() {
+    for (mut calculated_size, material_handle) in query.iter_mut() {
         if let Some(texture) = materials
             .get(material_handle)
             .and_then(|material| material.texture.as_ref())

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -130,12 +130,12 @@ fn setup(
 fn select_system(
     mut materials: ResMut<Assets<ColorMaterial>>,
     mut sel: ResMut<ContributorSelection>,
-    mut dq: Query<(&ContributorDisplay, Mut<Text>)>,
-    mut tq: Query<(&SelectTimer, Mut<Timer>)>,
+    mut dq: Query<Mut<Text>, With<ContributorDisplay>>,
+    mut tq: Query<Mut<Timer>, With<SelectTimer>>,
     mut q: Query<(&Contributor, &Handle<ColorMaterial>, &mut Transform)>,
 ) {
     let mut timer_fired = false;
-    for (_, mut t) in tq.iter_mut() {
+    for mut t in tq.iter_mut() {
         if !t.just_finished {
             continue;
         }
@@ -165,7 +165,7 @@ fn select_system(
     let (name, e) = &sel.order[sel.idx];
 
     if let Ok((c, handle, mut tr)) = q.get_mut(*e) {
-        for (_, mut text) in dq.iter_mut() {
+        for mut text in dq.iter_mut() {
             select(
                 &mut *materials,
                 handle.clone(),
@@ -230,7 +230,7 @@ fn velocity_system(time: Res<Time>, mut q: Query<Mut<Velocity>>) {
 /// force.
 fn collision_system(
     wins: Res<Windows>,
-    mut q: Query<(&Contributor, Mut<Velocity>, Mut<Transform>)>,
+    mut q: Query<(Mut<Velocity>, Mut<Transform>), With<Contributor>>,
 ) {
     let mut rnd = rand::thread_rng();
 
@@ -242,7 +242,7 @@ fn collision_system(
     let wall_left = -((win.width() / 2) as f32);
     let wall_right = (win.width() / 2) as f32;
 
-    for (_, mut v, mut t) in q.iter_mut() {
+    for (mut v, mut t) in q.iter_mut() {
         let left = t.translation.x() - SPRITE_SIZE / 2.0;
         let right = t.translation.x() + SPRITE_SIZE / 2.0;
         let top = t.translation.y() + SPRITE_SIZE / 2.0;

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -15,8 +15,8 @@ fn main() {
 struct Rotator;
 
 /// rotates the parent, which will result in the child also rotating
-fn rotator_system(time: Res<Time>, mut query: Query<(&Rotator, &mut Transform)>) {
-    for (_rotator, mut transform) in query.iter_mut() {
+fn rotator_system(time: Res<Time>, mut query: Query<&mut Transform, With<Rotator>>) {
+    for mut transform in query.iter_mut() {
         transform.rotation *= Quat::from_rotation_x(3.0 * time.delta_seconds);
     }
 }

--- a/examples/3d/z_sort_debug.rs
+++ b/examples/3d/z_sort_debug.rs
@@ -19,18 +19,18 @@ fn main() {
 struct Rotator;
 
 /// rotates the parent, which will result in the child also rotating
-fn rotator_system(time: Res<Time>, mut query: Query<(&Rotator, &mut Transform)>) {
-    for (_rotator, mut transform) in query.iter_mut() {
+fn rotator_system(time: Res<Time>, mut query: Query<&mut Transform, With<Rotator>>) {
+    for mut transform in query.iter_mut() {
         transform.rotation *= Quat::from_rotation_x(3.0 * time.delta_seconds);
     }
 }
 
 fn camera_order_color_system(
     mut materials: ResMut<Assets<StandardMaterial>>,
-    camera_query: Query<(&Camera, &VisibleEntities)>,
+    camera_query: Query<&VisibleEntities, With<Camera>>,
     material_query: Query<&Handle<StandardMaterial>>,
 ) {
-    for (_camera, visible_entities) in camera_query.iter() {
+    for visible_entities in camera_query.iter() {
         for visible_entity in visible_entities.iter() {
             if let Ok(material_handle) = material_query.get(visible_entity.entity) {
                 let material = materials.get_mut(&*material_handle).unwrap();

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -91,11 +91,11 @@ fn setup(
 fn rotate(
     commands: &mut Commands,
     time: Res<Time>,
-    mut parents_query: Query<(Entity, &mut Children, &Sprite)>,
+    mut parents_query: Query<(Entity, &mut Children), With<Sprite>>,
     mut transform_query: Query<&mut Transform, With<Sprite>>,
 ) {
     let angle = std::f32::consts::PI / 2.0;
-    for (parent, mut children, _) in parents_query.iter_mut() {
+    for (parent, mut children) in parents_query.iter_mut() {
         if let Ok(mut transform) = transform_query.get_mut(parent) {
             transform.rotate(Quat::from_rotation_z(-angle * time.delta_seconds));
         }

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -30,12 +30,12 @@ impl FromResources for ButtonMaterials {
 fn button_system(
     button_materials: Res<ButtonMaterials>,
     mut interaction_query: Query<
-        (&Button, &Interaction, &mut Handle<ColorMaterial>, &Children),
-        Mutated<Interaction>,
+        (&Interaction, &mut Handle<ColorMaterial>, &Children),
+        (Mutated<Interaction>, With<Button>),
     >,
     mut text_query: Query<&mut Text>,
 ) {
-    for (_button, interaction, mut material, children) in interaction_query.iter_mut() {
+    for (interaction, mut material, children) in interaction_query.iter_mut() {
         let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
             Interaction::Clicked => {

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -16,8 +16,8 @@ fn main() {
 // A unit struct to help identify the FPS UI component, since there may be many Text components
 struct FpsText;
 
-fn text_update_system(diagnostics: Res<Diagnostics>, mut query: Query<(&mut Text, &FpsText)>) {
-    for (mut text, _tag) in query.iter_mut() {
+fn text_update_system(diagnostics: Res<Diagnostics>, mut query: Query<&mut Text, With<FpsText>>) {
+    for mut text in query.iter_mut() {
         if let Some(fps) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
             if let Some(average) = fps.average() {
                 text.value = format!("FPS: {:.2}", average);


### PR DESCRIPTION
This Changes PR changes several Queries to us the With<> Filter, instead of getting the component and discarding it.

Also, parent_update_system now uses `Changed<Parent>`, as mentioned in its Todo comment.