### PR TITLE
Removed vertex fallback buffer

### DIFF
--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -1,8 +1,5 @@
 use crate::{
-    pipeline::{
-        PipelineCompiler, PipelineDescriptor, PipelineLayout, PipelineSpecialization,
-        VERTEX_FALLBACK_LAYOUT_NAME,
-    },
+    pipeline::{PipelineCompiler, PipelineDescriptor, PipelineLayout, PipelineSpecialization},
     renderer::{
         BindGroup, BindGroupId, BufferId, BufferUsage, RenderResource, RenderResourceBinding,
         RenderResourceBindings, RenderResourceContext, SharedBuffers,
@@ -255,33 +252,12 @@ impl<'a> DrawContext<'a> {
         draw: &mut Draw,
         render_resource_bindings: &[&RenderResourceBindings],
     ) -> Result<(), DrawError> {
-        let pipeline = self
-            .current_pipeline
-            .as_ref()
-            .ok_or(DrawError::NoPipelineSet)?;
-        let pipeline_descriptor = self
-            .pipelines
-            .get(pipeline)
-            .ok_or(DrawError::NonExistentPipeline)?;
-        let layout = pipeline_descriptor
-            .get_layout()
-            .ok_or(DrawError::PipelineHasNoLayout)?;
-        // figure out if the fallback buffer is needed
-        let need_fallback_buffer = layout
-            .vertex_buffer_descriptors
-            .iter()
-            .any(|x| x.name == VERTEX_FALLBACK_LAYOUT_NAME);
         for bindings in render_resource_bindings.iter() {
             if let Some(index_buffer) = bindings.index_buffer {
                 draw.set_index_buffer(index_buffer, 0);
             }
             if let Some(main_vertex_buffer) = bindings.vertex_attribute_buffer {
                 draw.set_vertex_buffer(0, main_vertex_buffer, 0);
-            }
-            if need_fallback_buffer {
-                if let Some(fallback_vertex_buffer) = bindings.vertex_fallback_buffer {
-                    draw.set_vertex_buffer(1, fallback_vertex_buffer, 0);
-                }
             }
         }
         Ok(())

--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -5,13 +5,12 @@ use crate::{
 use bevy_app::prelude::{EventReader, Events};
 use bevy_asset::{AssetEvent, Assets, Handle};
 use bevy_core::AsBytes;
-use bevy_ecs::{Local, Query, Res, ResMut};
+use bevy_ecs::{Local, Query, Res};
 use bevy_math::*;
 use bevy_type_registry::TypeUuid;
 use std::borrow::Cow;
 
 use crate::pipeline::{InputStepMode, VertexAttributeDescriptor, VertexBufferDescriptor};
-use crate::renderer::BufferId;
 use bevy_utils::HashMap;
 
 pub const INDEX_BUFFER_ASSET_INDEX: u64 = 0;

--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -5,17 +5,18 @@ use crate::{
 use bevy_app::prelude::{EventReader, Events};
 use bevy_asset::{AssetEvent, Assets, Handle};
 use bevy_core::AsBytes;
-use bevy_ecs::{Local, Query, Res};
+use bevy_ecs::{Local, Query, Res, ResMut};
 use bevy_math::*;
 use bevy_type_registry::TypeUuid;
 use std::borrow::Cow;
 
 use crate::pipeline::{InputStepMode, VertexAttributeDescriptor, VertexBufferDescriptor};
+use crate::renderer::BufferId;
 use bevy_utils::HashMap;
 
 pub const INDEX_BUFFER_ASSET_INDEX: u64 = 0;
 pub const VERTEX_ATTRIBUTE_BUFFER_ID: u64 = 10;
-pub const VERTEX_FALLBACK_BUFFER_ID: u64 = 20;
+
 #[derive(Clone, Debug)]
 pub enum VertexAttributeValues {
     Float(Vec<f32>),
@@ -526,7 +527,6 @@ fn remove_current_mesh_resources(
     handle: &Handle<Mesh>,
 ) {
     remove_resource_save(render_resource_context, handle, VERTEX_ATTRIBUTE_BUFFER_ID);
-    remove_resource_save(render_resource_context, handle, VERTEX_FALLBACK_BUFFER_ID);
     remove_resource_save(render_resource_context, handle, INDEX_BUFFER_ASSET_INDEX);
 }
 
@@ -593,20 +593,6 @@ pub fn mesh_resource_provider_system(
                 )),
                 VERTEX_ATTRIBUTE_BUFFER_ID,
             );
-
-            // Fallback buffer
-            // TODO: can be done with a 1 byte buffer + zero stride?
-            render_resource_context.set_asset_resource(
-                changed_mesh_handle,
-                RenderResourceId::Buffer(render_resource_context.create_buffer_with_data(
-                    BufferInfo {
-                        buffer_usage: BufferUsage::VERTEX,
-                        ..Default::default()
-                    },
-                    &vec![0; mesh.count_vertices() * VertexFormat::Float4.get_size() as usize],
-                )),
-                VERTEX_FALLBACK_BUFFER_ID,
-            );
         }
     }
 
@@ -639,13 +625,6 @@ pub fn mesh_resource_provider_system(
                 // set index buffer into binding
                 render_pipelines.bindings.vertex_attribute_buffer =
                     Some(vertex_attribute_buffer_resource);
-            }
-            if let Some(RenderResourceId::Buffer(vertex_attribute_fallback_resource)) =
-                render_resource_context.get_asset_resource(handle, VERTEX_FALLBACK_BUFFER_ID)
-            {
-                // set index buffer into binding
-                render_pipelines.bindings.vertex_fallback_buffer =
-                    Some(vertex_attribute_fallback_resource);
             }
         }
     }

--- a/crates/bevy_render/src/pipeline/pipeline_compiler.rs
+++ b/crates/bevy_render/src/pipeline/pipeline_compiler.rs
@@ -1,8 +1,6 @@
 use super::{state_descriptors::PrimitiveTopology, IndexFormat, PipelineDescriptor};
 use crate::{
-    pipeline::{
-        BindType, InputStepMode, VertexAttributeDescriptor, VertexBufferDescriptor, VertexFormat,
-    },
+    pipeline::{BindType, InputStepMode, VertexBufferDescriptor},
     renderer::RenderResourceContext,
     shader::{Shader, ShaderSource},
 };
@@ -11,7 +9,6 @@ use bevy_property::{Properties, Property};
 use bevy_utils::{HashMap, HashSet};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 
 #[derive(Clone, Eq, PartialEq, Debug, Properties)]
 pub struct PipelineSpecialization {

--- a/crates/bevy_render/src/pipeline/pipeline_compiler.rs
+++ b/crates/bevy_render/src/pipeline/pipeline_compiler.rs
@@ -1,9 +1,13 @@
 use super::{state_descriptors::PrimitiveTopology, IndexFormat, PipelineDescriptor};
 use crate::{
+<<<<<<< Updated upstream
     pipeline::{
         BindType, InputStepMode, VertexAttributeDescriptor, VertexBufferDescriptor, VertexFormat,
         VERTEX_FALLBACK_LAYOUT_NAME,
     },
+=======
+    pipeline::{InputStepMode, VertexAttributeDescriptor, VertexBufferDescriptor, VertexFormat},
+>>>>>>> Stashed changes
     renderer::RenderResourceContext,
     shader::{Shader, ShaderSource},
 };
@@ -206,11 +210,6 @@ impl PipelineCompiler {
             ..Default::default()
         };
 
-        let mut fallback_vertex_buffer_descriptor = VertexBufferDescriptor {
-            name: Cow::Borrowed(VERTEX_FALLBACK_LAYOUT_NAME),
-            stride: VertexFormat::Float4.get_size(), //TODO: use smallest possible format
-            ..Default::default()
-        };
         for shader_vertex_attribute in pipeline_layout.vertex_buffer_descriptors.iter() {
             let shader_vertex_attribute = shader_vertex_attribute
                 .attributes
@@ -229,23 +228,18 @@ impl PipelineCompiler {
                     .attributes
                     .push(compiled_vertex_attribute);
             } else {
-                fallback_vertex_buffer_descriptor
-                    .attributes
-                    .push(VertexAttributeDescriptor {
-                        name: Default::default(),
-                        offset: 0,
-                        format: shader_vertex_attribute.format, //TODO: use smallest possible format
-                        shader_location: shader_vertex_attribute.shader_location,
-                    });
+                panic!(
+                    "Attribute {} is required by shader, but not supplied by mesh. Either remove the attribute from the shader or supply the attribute ({}) to the mesh. ",
+                    shader_vertex_attribute.name,
+                    shader_vertex_attribute.name,
+                );
             }
         }
 
         //TODO: add other buffers (like instancing) here
         let mut vertex_buffer_descriptors = Vec::<VertexBufferDescriptor>::default();
         vertex_buffer_descriptors.push(compiled_vertex_buffer_descriptor);
-        if !fallback_vertex_buffer_descriptor.attributes.is_empty() {
-            vertex_buffer_descriptors.push(fallback_vertex_buffer_descriptor);
-        }
+
         pipeline_layout.vertex_buffer_descriptors = vertex_buffer_descriptors;
         specialized_descriptor.sample_count = pipeline_specialization.sample_count;
         specialized_descriptor.primitive_topology = pipeline_specialization.primitive_topology;

--- a/crates/bevy_render/src/pipeline/pipeline_compiler.rs
+++ b/crates/bevy_render/src/pipeline/pipeline_compiler.rs
@@ -1,13 +1,8 @@
 use super::{state_descriptors::PrimitiveTopology, IndexFormat, PipelineDescriptor};
 use crate::{
-<<<<<<< Updated upstream
     pipeline::{
         BindType, InputStepMode, VertexAttributeDescriptor, VertexBufferDescriptor, VertexFormat,
-        VERTEX_FALLBACK_LAYOUT_NAME,
     },
-=======
-    pipeline::{InputStepMode, VertexAttributeDescriptor, VertexBufferDescriptor, VertexFormat},
->>>>>>> Stashed changes
     renderer::RenderResourceContext,
     shader::{Shader, ShaderSource},
 };

--- a/crates/bevy_render/src/pipeline/vertex_buffer_descriptor.rs
+++ b/crates/bevy_render/src/pipeline/vertex_buffer_descriptor.rs
@@ -14,7 +14,6 @@ pub struct VertexBufferDescriptor {
     pub attributes: Vec<VertexAttributeDescriptor>,
 }
 
-pub const VERTEX_FALLBACK_LAYOUT_NAME: &str = "Fallback";
 impl VertexBufferDescriptor {
     pub fn new_from_attribute(
         attribute: VertexAttributeDescriptor,


### PR DESCRIPTION
I've added this in the initial mesh overhaul, but think it's better to remove it for a few reasons: 

- Obscures the actual problem of undefined data
- Clutters `draw.rs`
- Only needed for some edge cases
