### PR TITLE
Remove redundant texture copies in TextureCopyNode

### DIFF
--- a/crates/bevy_render/src/render_graph/nodes/texture_copy_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/texture_copy_node.rs
@@ -6,6 +6,7 @@ use crate::{
 use bevy_app::prelude::{EventReader, Events};
 use bevy_asset::{AssetEvent, Assets};
 use bevy_ecs::{Resources, World};
+use bevy_utils::HashSet;
 
 #[derive(Default)]
 pub struct TextureCopyNode {
@@ -23,10 +24,15 @@ impl Node for TextureCopyNode {
     ) {
         let texture_events = resources.get::<Events<AssetEvent<Texture>>>().unwrap();
         let textures = resources.get::<Assets<Texture>>().unwrap();
+        let mut synced_textures = HashSet::new();
         for event in self.texture_event_reader.iter(&texture_events) {
             match event {
                 AssetEvent::Created { handle } | AssetEvent::Modified { handle } => {
                     if let Some(texture) = textures.get(handle) {
+                        if synced_textures.contains(&handle.id) {
+                            return;
+                        }
+
                         let texture_descriptor: TextureDescriptor = texture.into();
                         let width = texture.size.x() as usize;
                         let aligned_width = render_context
@@ -67,6 +73,8 @@ impl Node for TextureCopyNode {
                             texture_descriptor.size,
                         );
                         render_context.resources().remove_buffer(texture_buffer);
+
+                        synced_textures.insert(&handle.id);
                     }
                 }
                 AssetEvent::Removed { .. } => {}

--- a/crates/bevy_render/src/render_graph/nodes/texture_copy_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/texture_copy_node.rs
@@ -6,7 +6,7 @@ use crate::{
 use bevy_app::prelude::{EventReader, Events};
 use bevy_asset::{AssetEvent, Assets};
 use bevy_ecs::{Resources, World};
-use bevy_utils::HashSet;
+use bevy_utils::{AHashExt, HashSet};
 
 #[derive(Default)]
 pub struct TextureCopyNode {

--- a/crates/bevy_render/src/render_graph/nodes/texture_copy_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/texture_copy_node.rs
@@ -24,12 +24,12 @@ impl Node for TextureCopyNode {
     ) {
         let texture_events = resources.get::<Events<AssetEvent<Texture>>>().unwrap();
         let textures = resources.get::<Assets<Texture>>().unwrap();
-        let mut synced_textures = HashSet::new();
+        let mut copied_textures = HashSet::new();
         for event in self.texture_event_reader.iter(&texture_events) {
             match event {
                 AssetEvent::Created { handle } | AssetEvent::Modified { handle } => {
                     if let Some(texture) = textures.get(handle) {
-                        if synced_textures.contains(&handle.id) {
+                        if copied_textures.contains(&handle.id) {
                             return;
                         }
 
@@ -74,7 +74,7 @@ impl Node for TextureCopyNode {
                         );
                         render_context.resources().remove_buffer(texture_buffer);
 
-                        synced_textures.insert(&handle.id);
+                        copied_textures.insert(&handle.id);
                     }
                 }
                 AssetEvent::Removed { .. } => {}

--- a/crates/bevy_render/src/render_graph/nodes/texture_copy_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/texture_copy_node.rs
@@ -30,7 +30,7 @@ impl Node for TextureCopyNode {
                 AssetEvent::Created { handle } | AssetEvent::Modified { handle } => {
                     if let Some(texture) = textures.get(handle) {
                         if copied_textures.contains(&handle.id) {
-                            return;
+                            continue;
                         }
 
                         let texture_descriptor: TextureDescriptor = texture.into();


### PR DESCRIPTION
For each AssetEvent::Modified event, TextureCopyNode will do 1 copy from each Texture into a buffer in the render_context. Every time a system calls Assets.get_mut to retrieve a Texture from a Handle<Texture> it will trigger the AssetEvent::Modified event. If you have multiple systems which need to retrieve the same texture, this causes TextureCopyNode to spend time copying the data for the same texture multiple times, once for each call to get_mut that happened for that Texture (as well as the time spent copying, it also raises the peak memory). A Gist which contains sample code which uses the same Texture from multiple systems: https://gist.github.com/rod-salazar/f45608644f042de036c09bf2565aba69

This change makes it so that we only do the copy once per texture handle.

The assumption this change makes is that we only need to synchronize between the a particular Texture's data and the render_context once since this TextureCopyNode happens after the calls to get_mut.

I ran into this scenario in a different way though. When I was writing some code which attempted to call texture.get_mut in a loop, where sometimes I would ask for the same texture multiple times. In this case, my loop caused hundreds of copies for what I thought was just a harmless lookup in the assets using get_mut.
