### PR TITLE
Switch to default PartialEq implementation for RenderResourceBinding

### DIFF
--- a/crates/bevy_render/src/renderer/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/renderer/render_resource/bind_group.rs
@@ -1,4 +1,4 @@
-use super::{BufferId, RenderResourceBinding, SamplerId, TextureId};
+use super::{BufferId, RenderResourceBinding, RenderResourceId, SamplerId, TextureId};
 use bevy_utils::AHasher;
 use std::{
     hash::{Hash, Hasher},
@@ -45,7 +45,7 @@ impl BindGroupBuilder {
             self.dynamic_uniform_indices.push(dynamic_index);
         }
 
-        binding.hash(&mut self.hasher);
+        self.hash_binding(&binding);
         self.indexed_bindings.push(IndexedBindGroupEntry {
             index,
             entry: binding,
@@ -100,6 +100,25 @@ impl BindGroupBuilder {
             } else {
                 Some(self.dynamic_uniform_indices.into())
             },
+        }
+    }
+
+    fn hash_binding(&mut self, binding: &RenderResourceBinding) {
+        match binding {
+            RenderResourceBinding::Buffer {
+                buffer,
+                range,
+                dynamic_index: _, // dynamic_index is not a part of the binding
+            } => {
+                RenderResourceId::from(*buffer).hash(&mut self.hasher);
+                range.hash(&mut self.hasher);
+            }
+            RenderResourceBinding::Texture(texture) => {
+                RenderResourceId::from(*texture).hash(&mut self.hasher);
+            }
+            RenderResourceBinding::Sampler(sampler) => {
+                RenderResourceId::from(*sampler).hash(&mut self.hasher);
+            }
         }
     }
 }

--- a/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
+++ b/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
@@ -1,11 +1,11 @@
-use super::{BindGroup, BindGroupId, BufferId, RenderResourceId, SamplerId, TextureId};
+use super::{BindGroup, BindGroupId, BufferId, SamplerId, TextureId};
 use crate::{
     pipeline::{BindGroupDescriptor, BindGroupDescriptorId, PipelineDescriptor},
     renderer::RenderResourceContext,
 };
 use bevy_asset::{Asset, Handle, HandleUntyped};
 use bevy_utils::{HashMap, HashSet};
-use std::{hash::Hash, ops::Range};
+use std::ops::Range;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum RenderResourceBinding {
@@ -47,27 +47,6 @@ impl RenderResourceBinding {
             Some(*sampler)
         } else {
             None
-        }
-    }
-}
-
-impl Hash for RenderResourceBinding {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        match self {
-            RenderResourceBinding::Buffer {
-                buffer,
-                range,
-                dynamic_index: _, // dynamic_index is not a part of the binding
-            } => {
-                RenderResourceId::from(*buffer).hash(state);
-                range.hash(state);
-            }
-            RenderResourceBinding::Texture(texture) => {
-                RenderResourceId::from(*texture).hash(state);
-            }
-            RenderResourceBinding::Sampler(sampler) => {
-                RenderResourceId::from(*sampler).hash(state);
-            }
         }
     }
 }

--- a/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
+++ b/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
@@ -7,7 +7,7 @@ use bevy_asset::{Asset, Handle, HandleUntyped};
 use bevy_utils::{HashMap, HashSet};
 use std::{hash::Hash, ops::Range};
 
-#[derive(Clone, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum RenderResourceBinding {
     Buffer {
         buffer: BufferId,
@@ -47,34 +47,6 @@ impl RenderResourceBinding {
             Some(*sampler)
         } else {
             None
-        }
-    }
-}
-
-impl PartialEq for RenderResourceBinding {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (
-                RenderResourceBinding::Buffer {
-                    buffer: self_buffer,
-                    range: self_range,
-                    dynamic_index: _,
-                },
-                RenderResourceBinding::Buffer {
-                    buffer: other_buffer,
-                    range: other_range,
-                    dynamic_index: _,
-                },
-            ) => self_buffer == other_buffer && self_range == other_range,
-            (
-                RenderResourceBinding::Texture(self_texture),
-                RenderResourceBinding::Texture(other_texture),
-            ) => RenderResourceId::from(*self_texture) == RenderResourceId::from(*other_texture),
-            (
-                RenderResourceBinding::Sampler(self_sampler),
-                RenderResourceBinding::Sampler(other_sampler),
-            ) => RenderResourceId::from(*self_sampler) == RenderResourceId::from(*other_sampler),
-            _ => false,
         }
     }
 }


### PR DESCRIPTION
This should fix #858.

I'm a noob in rendering, but I assumed that changing the dynamic index of a binding should invalidate it. It works (in my example I can see materials changed), though I'm not sure about the performance implications of this. I guess excluding dynamic index from `PartialEq` implementation was done on purpose. Probably there's a better way to solve the issue.