### PR TITLE
ecs: replace "bool" component states with bitflags

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -24,6 +24,7 @@ rand = "0.7.3"
 serde = "1.0"
 thiserror = "1.0"
 fixedbitset = "0.3.1"
+bitflags = "1.2.1"
 downcast-rs = "1.2.0"
 parking_lot = "0.11.0"
 lazy_static = { version = "1.4.0" }

--- a/crates/bevy_ecs/src/core/borrow.rs
+++ b/crates/bevy_ecs/src/core/borrow.rs
@@ -14,13 +14,12 @@
 
 // modified by Bevy contributors
 
+use crate::{Archetype, Component, ComponentFlags, MissingComponent};
 use core::{
     fmt::Debug,
     ops::{Deref, DerefMut},
     sync::atomic::{AtomicUsize, Ordering},
 };
-
-use crate::{Archetype, Component, MissingComponent};
 
 /// Atomically enforces Rust-style borrow checking at runtime
 #[derive(Debug)]
@@ -125,7 +124,7 @@ where
 pub struct RefMut<'a, T: Component> {
     archetype: &'a Archetype,
     target: &'a mut T,
-    modified: &'a mut bool,
+    flags: &'a mut ComponentFlags,
 }
 
 impl<'a, T: Component> RefMut<'a, T> {
@@ -142,7 +141,7 @@ impl<'a, T: Component> RefMut<'a, T> {
         Ok(Self {
             archetype,
             target: &mut *target.as_ptr().add(index),
-            modified: &mut *type_state.mutated().as_ptr().add(index),
+            flags: &mut *type_state.component_flags().as_ptr().add(index),
         })
     }
 }
@@ -166,7 +165,7 @@ impl<'a, T: Component> Deref for RefMut<'a, T> {
 
 impl<'a, T: Component> DerefMut for RefMut<'a, T> {
     fn deref_mut(&mut self) -> &mut T {
-        *self.modified = true;
+        self.flags.insert(ComponentFlags::MUTATED);
         self.target
     }
 }

--- a/crates/bevy_ecs/src/core/mod.rs
+++ b/crates/bevy_ecs/src/core/mod.rs
@@ -44,7 +44,7 @@ mod world;
 mod world_builder;
 
 pub use access::{ArchetypeComponent, QueryAccess, TypeAccess};
-pub use archetype::{Archetype, TypeState};
+pub use archetype::{Archetype, ComponentFlags, TypeState};
 pub use borrow::{AtomicBorrow, Ref, RefMut};
 pub use bundle::{Bundle, DynamicBundle, MissingComponent};
 pub use entities::{Entity, EntityReserver, Location, NoSuchEntity};


### PR DESCRIPTION
This simplifies the apis involved, reduces the amount of work required to retrieve multiple flags, and makes it easier to add new flags in the future.

I was hoping this would also significantly boost insertion / archetype move benchmarks, but we only got a ~3% boost on insertion. Thats still something i guess!