### PR TITLE
Tweaks to TextureAtlasBuilder.finish()

### DIFF
--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -86,28 +86,37 @@ impl TextureAtlasBuilder {
 
         while rect_placements.is_none() {
             if current_width > max_width || current_height > max_height {
-                rect_placements = None;
                 break;
             }
+
+            let last_attempt = current_height == max_height || current_width == max_width;
+
             let mut target_bins = std::collections::BTreeMap::new();
             target_bins.insert(0, TargetBin::new(current_width, current_height, 1));
-            atlas_texture = Texture::new_fill(
-                Vec2::new(current_width as f32, current_height as f32),
-                &[0, 0, 0, 0],
-                TextureFormat::Rgba8UnormSrgb,
-            );
+
             rect_placements = match pack_rects(
                 &self.rects_to_place,
                 target_bins,
                 &volume_heuristic,
                 &contains_smallest_box,
             ) {
-                Ok(rect_placements) => Some(rect_placements),
+                Ok(rect_placements) => {
+                    atlas_texture = Texture::new_fill(
+                        Vec2::new(current_width as f32, current_height as f32),
+                        &[0, 0, 0, 0],
+                        TextureFormat::Rgba8UnormSrgb,
+                    );
+                    Some(rect_placements)
+                }
                 Err(rectangle_pack::RectanglePackError::NotEnoughBinSpace) => {
-                    current_width *= 2;
-                    current_height *= 2;
+                    current_height = bevy_math::clamp(current_height * 2, 0, max_height);
+                    current_width = bevy_math::clamp(current_width * 2, 0, max_width);
                     None
                 }
+            };
+
+            if last_attempt {
+                break;
             }
         }
 

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -89,7 +89,7 @@ impl TextureAtlasBuilder {
                 break;
             }
 
-            let last_attempt = current_height == max_height || current_width == max_width;
+            let last_attempt = current_height == max_height && current_width == max_width;
 
             let mut target_bins = std::collections::BTreeMap::new();
             target_bins.insert(0, TargetBin::new(current_width, current_height, 1));


### PR DESCRIPTION
This does a couple things:

- We don't enforce that initial and max sizes are powers of 2, but when finding a size that fits we multiple by 2 in every iteration. This logic is updated so that we at least try the max_size value that the user provided, before this change it would just jump over it and exit early without trying the largest size the user specified. This means that previously we could return _NotEnoughSpace_ even though the max size provided is actually greater than the space you need.
- Minor: Move the Texture::new_fill() call so that we only call it if pack_rects returns successfully.
- Minor: Remove unnecessary "rect_placements = None" on line 89.

Tested by tweaking our examples/2d/texture_atlas.rs with various initial/max sizes.
