### PR TITLE
do not spend time drawing text with is_visible = false

### DIFF
--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -153,22 +153,24 @@ pub fn draw_text_system(
     let vertex_buffer_descriptor = font_quad.get_vertex_buffer_descriptor();
 
     for (entity, mut draw, text, node, global_transform) in query.iter_mut() {
-        if draw.is_visible {
-            if let Some(text_glyphs) = text_pipeline.get_glyphs(&entity) {
-                let position = global_transform.translation - (node.size / 2.0).extend(0.0);
+        if !draw.is_visible {
+            continue;
+        }
 
-                let mut drawable_text = DrawableText {
-                    render_resource_bindings: &mut render_resource_bindings,
-                    asset_render_resource_bindings: &mut asset_render_resource_bindings,
-                    position,
-                    msaa: &msaa,
-                    text_glyphs: &text_glyphs.glyphs,
-                    font_quad_vertex_descriptor: &vertex_buffer_descriptor,
-                    style: &text.style,
-                };
+        if let Some(text_glyphs) = text_pipeline.get_glyphs(&entity) {
+            let position = global_transform.translation - (node.size / 2.0).extend(0.0);
 
-                drawable_text.draw(&mut draw, &mut context).unwrap();
-            }
+            let mut drawable_text = DrawableText {
+                render_resource_bindings: &mut render_resource_bindings,
+                asset_render_resource_bindings: &mut asset_render_resource_bindings,
+                position,
+                msaa: &msaa,
+                text_glyphs: &text_glyphs.glyphs,
+                font_quad_vertex_descriptor: &vertex_buffer_descriptor,
+                style: &text.style,
+            };
+
+            drawable_text.draw(&mut draw, &mut context).unwrap();
         }
     }
 }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -153,20 +153,22 @@ pub fn draw_text_system(
     let vertex_buffer_descriptor = font_quad.get_vertex_buffer_descriptor();
 
     for (entity, mut draw, text, node, global_transform) in query.iter_mut() {
-        if let Some(text_glyphs) = text_pipeline.get_glyphs(&entity) {
-            let position = global_transform.translation - (node.size / 2.0).extend(0.0);
+        if draw.is_visible {
+            if let Some(text_glyphs) = text_pipeline.get_glyphs(&entity) {
+                let position = global_transform.translation - (node.size / 2.0).extend(0.0);
 
-            let mut drawable_text = DrawableText {
-                render_resource_bindings: &mut render_resource_bindings,
-                asset_render_resource_bindings: &mut asset_render_resource_bindings,
-                position,
-                msaa: &msaa,
-                text_glyphs: &text_glyphs.glyphs,
-                font_quad_vertex_descriptor: &vertex_buffer_descriptor,
-                style: &text.style,
-            };
+                let mut drawable_text = DrawableText {
+                    render_resource_bindings: &mut render_resource_bindings,
+                    asset_render_resource_bindings: &mut asset_render_resource_bindings,
+                    position,
+                    msaa: &msaa,
+                    text_glyphs: &text_glyphs.glyphs,
+                    font_quad_vertex_descriptor: &vertex_buffer_descriptor,
+                    style: &text.style,
+                };
 
-            drawable_text.draw(&mut draw, &mut context).unwrap();
+                drawable_text.draw(&mut draw, &mut context).unwrap();
+            }
         }
     }
 }


### PR DESCRIPTION
I have found that all the process of drawing text are performed, even when the is_visible property of draw is set to false (althought it didn't drawed them before). This should allow instanced invisible text to consume nearly no ressource. For an exemple, on a debug build with 100 texts on firafont-bold, it run at around 1 fps wihout this patch, and at 60 fps with this patch.