### PR TITLE
use wasm-friendly instant::Instant everywhere

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ anyhow = "1.0"
 rand = "0.7.3"
 ron = "0.6"
 serde = {version = "1", features = ["derive"]}
+instant = "0.1"
 
 [[example]]
 name = "hello_world"
@@ -336,7 +337,7 @@ apk_label = "Bevy Example"
 assets = "assets"
 res = "assets/android-res"
 icon = "@mipmap/ic_launcher"
-build_targets = ["aarch64-linux-android", "armv7-linux-androideabi"] 
+build_targets = ["aarch64-linux-android", "armv7-linux-androideabi"]
 min_sdk_version = 16
 target_sdk_version = 29
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,6 @@ anyhow = "1.0"
 rand = "0.7.3"
 ron = "0.6"
 serde = {version = "1", features = ["derive"]}
-instant = "0.1"
 
 [[example]]
 name = "hello_world"

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -23,8 +23,8 @@ bevy_utils = { path = "../bevy_utils", version = "0.3.0" }
 
 # other
 serde = { version = "1.0", features = ["derive"] }
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }
 web-sys = { version = "0.3", features = [ "Window" ] }
-instant = { version = "0.1", features = ["wasm-bindgen"] }

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -23,7 +23,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.3.0" }
 
 # other
 serde = { version = "1.0", features = ["derive"] }
-instant = { version = "0.1", features = ["wasm-bindgen"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -4,12 +4,7 @@ use crate::{
     event::{EventReader, Events},
     plugin::Plugin,
 };
-use std::time::Duration;
-
-#[cfg(target_arch = "wasm32")]
-use instant::Instant;
-#[cfg(not(target_arch = "wasm32"))]
-use std::{thread, time::Instant};
+use instant::{Duration, Instant};
 
 #[cfg(target_arch = "wasm32")]
 use std::{cell::RefCell, rc::Rc};
@@ -104,7 +99,7 @@ impl Plugin for ScheduleRunnerPlugin {
                     {
                         while let Ok(delay) = tick(&mut app, wait) {
                             if let Some(delay) = delay {
-                                thread::sleep(delay);
+                                std::thread::sleep(delay);
                             }
                         }
                     }

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -4,7 +4,7 @@ use crate::{
     event::{EventReader, Events},
     plugin::Plugin,
 };
-use instant::{Duration, Instant};
+use bevy_utils::{Duration, Instant};
 
 #[cfg(target_arch = "wasm32")]
 use std::{cell::RefCell, rc::Rc};

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -22,4 +22,3 @@ bevy_type_registry = { path = "../bevy_type_registry", version = "0.3.0" }
 bevy_math = { path = "../bevy_math", version = "0.3.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.3.0" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.3.0" }
-instant = { version = "0.1", features = ["wasm-bindgen"] }

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -22,6 +22,4 @@ bevy_type_registry = { path = "../bevy_type_registry", version = "0.3.0" }
 bevy_math = { path = "../bevy_math", version = "0.3.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.3.0" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.3.0" }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { version = "0.1", features = ["wasm-bindgen"] }

--- a/crates/bevy_core/src/time/time.rs
+++ b/crates/bevy_core/src/time/time.rs
@@ -1,10 +1,5 @@
 use bevy_ecs::ResMut;
-use std::time::Duration;
-
-#[cfg(target_arch = "wasm32")]
-use instant::Instant;
-#[cfg(not(target_arch = "wasm32"))]
-use std::time::Instant;
+use instant::{Duration, Instant};
 
 /// Tracks elapsed time since the last update and since the App has started
 #[derive(Debug)]

--- a/crates/bevy_core/src/time/time.rs
+++ b/crates/bevy_core/src/time/time.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::ResMut;
-use instant::{Duration, Instant};
+use bevy_utils::{Duration, Instant};
 
 /// Tracks elapsed time since the last update and since the App has started
 #[derive(Debug)]

--- a/crates/bevy_core/src/time/timer.rs
+++ b/crates/bevy_core/src/time/timer.rs
@@ -1,7 +1,7 @@
 use crate::time::Time;
 use bevy_ecs::prelude::*;
 use bevy_property::Properties;
-use instant::Duration;
+use bevy_utils::Duration;
 
 /// Tracks elapsed time. Enters the finished state once `duration` is reached.
 ///

--- a/crates/bevy_core/src/time/timer.rs
+++ b/crates/bevy_core/src/time/timer.rs
@@ -1,7 +1,7 @@
 use crate::time::Time;
 use bevy_ecs::prelude::*;
 use bevy_property::Properties;
-use std::time::Duration;
+use instant::Duration;
 
 /// Tracks elapsed time. Enters the finished state once `duration` is reached.
 ///

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -23,6 +23,4 @@ bevy_utils = { path = "../bevy_utils", version = "0.3.0" }
 # other
 uuid = { version = "0.8", features = ["v4", "serde"] }
 parking_lot = "0.11.0"
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { version = "0.1", features = ["wasm-bindgen"] }

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -23,4 +23,3 @@ bevy_utils = { path = "../bevy_utils", version = "0.3.0" }
 # other
 uuid = { version = "0.8", features = ["v4", "serde"] }
 parking_lot = "0.11.0"
-instant = { version = "0.1", features = ["wasm-bindgen"] }

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -1,8 +1,6 @@
 use bevy_utils::HashMap;
-use std::{
-    collections::VecDeque,
-    time::{Duration, SystemTime},
-};
+use instant::{Duration, Instant};
+use std::collections::VecDeque;
 use uuid::Uuid;
 
 /// Unique identifier for a [Diagnostic]
@@ -24,7 +22,7 @@ impl Default for DiagnosticId {
 /// A single measurement of a [Diagnostic]
 #[derive(Debug)]
 pub struct DiagnosticMeasurement {
-    pub time: SystemTime,
+    pub time: Instant,
     pub value: f64,
 }
 
@@ -41,7 +39,7 @@ pub struct Diagnostic {
 
 impl Diagnostic {
     pub fn add_measurement(&mut self, value: f64) {
-        let time = SystemTime::now();
+        let time = Instant::now();
         if self.history.len() == self.max_history_length {
             if let Some(removed_diagnostic) = self.history.pop_back() {
                 self.sum -= removed_diagnostic.value;
@@ -90,7 +88,7 @@ impl Diagnostic {
 
         if let Some(oldest) = self.history.back() {
             if let Some(newest) = self.history.front() {
-                return newest.time.duration_since(oldest.time).ok();
+                return Some(newest.time.duration_since(oldest.time));
             }
         }
 

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -1,5 +1,4 @@
-use bevy_utils::HashMap;
-use instant::{Duration, Instant};
+use bevy_utils::{Duration, HashMap, Instant};
 use std::collections::VecDeque;
 use uuid::Uuid;
 

--- a/crates/bevy_diagnostic/src/print_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/print_diagnostics_plugin.rs
@@ -2,7 +2,7 @@ use super::{Diagnostic, DiagnosticId, Diagnostics};
 use bevy_app::prelude::*;
 use bevy_core::{Time, Timer};
 use bevy_ecs::{Res, ResMut};
-use std::time::Duration;
+use instant::Duration;
 
 /// An App Plugin that prints diagnostics to the console
 pub struct PrintDiagnosticsPlugin {

--- a/crates/bevy_diagnostic/src/print_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/print_diagnostics_plugin.rs
@@ -2,7 +2,7 @@ use super::{Diagnostic, DiagnosticId, Diagnostics};
 use bevy_app::prelude::*;
 use bevy_core::{Time, Timer};
 use bevy_ecs::{Res, ResMut};
-use instant::Duration;
+use bevy_utils::Duration;
 
 /// An App Plugin that prints diagnostics to the console
 pub struct PrintDiagnosticsPlugin {

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -20,6 +20,7 @@ futures-lite = "1.4.0"
 event-listener = "2.4.0"
 async-executor = "1.3.0"
 async-channel = "1.4.2"
+instant = "0.1"
 num_cpus = "1"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -20,7 +20,7 @@ futures-lite = "1.4.0"
 event-listener = "2.4.0"
 async-executor = "1.3.0"
 async-channel = "1.4.2"
-instant = "0.1"
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 num_cpus = "1"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"

--- a/crates/bevy_tasks/examples/busy_behavior.rs
+++ b/crates/bevy_tasks/examples/busy_behavior.rs
@@ -10,12 +10,12 @@ fn main() {
         .num_threads(4)
         .build();
 
-    let t0 = std::time::Instant::now();
+    let t0 = instant::Instant::now();
     pool.scope(|s| {
         for i in 0..40 {
             s.spawn(async move {
-                let now = std::time::Instant::now();
-                while std::time::Instant::now() - now < std::time::Duration::from_millis(100) {
+                let now = instant::Instant::now();
+                while instant::Instant::now() - now < instant::Duration::from_millis(100) {
                     // spin, simulating work being done
                 }
 
@@ -28,6 +28,6 @@ fn main() {
         }
     });
 
-    let t1 = std::time::Instant::now();
+    let t1 = instant::Instant::now();
     println!("all tasks finished in {} secs", (t1 - t0).as_secs_f32());
 }

--- a/crates/bevy_tasks/examples/idle_behavior.rs
+++ b/crates/bevy_tasks/examples/idle_behavior.rs
@@ -13,8 +13,8 @@ fn main() {
         for i in 0..1 {
             s.spawn(async move {
                 println!("Blocking for 10 seconds");
-                let now = std::time::Instant::now();
-                while std::time::Instant::now() - now < std::time::Duration::from_millis(10000) {
+                let now = instant::Instant::now();
+                while instant::Instant::now() - now < instant::Duration::from_millis(10000) {
                     // spin, simulating work being done
                 }
 

--- a/crates/bevy_tasks/src/countdown_event.rs
+++ b/crates/bevy_tasks/src/countdown_event.rs
@@ -99,7 +99,7 @@ pub fn countdown_event_ready() {
         std::thread::spawn(move || futures_lite::future::block_on(countdown_event_clone.listen()));
 
     // Pause to give the new thread time to start blocking (ugly hack)
-    std::thread::sleep(std::time::Duration::from_millis(100));
+    std::thread::sleep(instant::Duration::from_millis(100));
 
     countdown_event.decrement();
     handle.join().unwrap();
@@ -121,7 +121,7 @@ pub fn event_resets_if_listeners_are_cleared() {
     // Verify that we are still blocked
     assert_eq!(
         false,
-        listener2.wait_timeout(std::time::Duration::from_millis(10))
+        listener2.wait_timeout(instant::Duration::from_millis(10))
     );
 
     // Notify all and verify the remaining listener is notified

--- a/crates/bevy_tasks/src/countdown_event.rs
+++ b/crates/bevy_tasks/src/countdown_event.rs
@@ -99,7 +99,7 @@ pub fn countdown_event_ready() {
         std::thread::spawn(move || futures_lite::future::block_on(countdown_event_clone.listen()));
 
     // Pause to give the new thread time to start blocking (ugly hack)
-    std::thread::sleep(bevy_utils::Duration::from_millis(100));
+    std::thread::sleep(instant::Duration::from_millis(100));
 
     countdown_event.decrement();
     handle.join().unwrap();

--- a/crates/bevy_tasks/src/countdown_event.rs
+++ b/crates/bevy_tasks/src/countdown_event.rs
@@ -99,7 +99,7 @@ pub fn countdown_event_ready() {
         std::thread::spawn(move || futures_lite::future::block_on(countdown_event_clone.listen()));
 
     // Pause to give the new thread time to start blocking (ugly hack)
-    std::thread::sleep(instant::Duration::from_millis(100));
+    std::thread::sleep(bevy_utils::Duration::from_millis(100));
 
     countdown_event.decrement();
     handle.join().unwrap();

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["bevy"]
 [dependencies]
 ahash = "0.5.3"
 tracing = {version = "0.1", features = ["release_max_level_info"]}
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = {version = "0.2.0", features = ["js"]}

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -1,7 +1,7 @@
-use ahash::RandomState;
-use std::{future::Future, pin::Pin};
-
 pub use ahash::AHasher;
+use ahash::RandomState;
+pub use instant::{Duration, Instant};
+use std::{future::Future, pin::Pin};
 pub use tracing;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/examples/app/headless.rs
+++ b/examples/app/headless.rs
@@ -1,5 +1,4 @@
-use bevy::{app::ScheduleRunnerSettings, prelude::*};
-use instant::Duration;
+use bevy::{app::ScheduleRunnerSettings, prelude::*, utils::Duration};
 
 // This example only enables a minimal set of plugins required for bevy to run.
 // You can also completely remove rendering / windowing Plugin code from bevy

--- a/examples/app/headless.rs
+++ b/examples/app/headless.rs
@@ -1,5 +1,5 @@
 use bevy::{app::ScheduleRunnerSettings, prelude::*};
-use std::time::Duration;
+use instant::Duration;
 
 // This example only enables a minimal set of plugins required for bevy to run.
 // You can also completely remove rendering / windowing Plugin code from bevy

--- a/examples/app/plugin.rs
+++ b/examples/app/plugin.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use std::time::Duration;
+use instant::Duration;
 
 /// Plugins are the foundation of Bevy. They are scoped sets of components, resources, and systems
 /// that provide a specific piece of functionality (generally the smaller the scope, the better).

--- a/examples/app/plugin.rs
+++ b/examples/app/plugin.rs
@@ -1,5 +1,4 @@
-use bevy::prelude::*;
-use instant::Duration;
+use bevy::{prelude::*, utils::Duration};
 
 /// Plugins are the foundation of Bevy. They are scoped sets of components, resources, and systems
 /// that provide a specific piece of functionality (generally the smaller the scope, the better).

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -3,7 +3,7 @@ use bevy::{
     prelude::*,
 };
 use rand::random;
-use std::time::Duration;
+use instant::Duration;
 
 /// This is a guided introduction to Bevy's "Entity Component System" (ECS)
 /// All Bevy app logic is built using the ECS pattern, so definitely pay attention!

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -1,8 +1,8 @@
 use bevy::{
     app::{AppExit, ScheduleRunnerPlugin, ScheduleRunnerSettings},
     prelude::*,
+    utils::Duration,
 };
-use instant::Duration;
 use rand::random;
 
 /// This is a guided introduction to Bevy's "Entity Component System" (ECS)

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -2,8 +2,8 @@ use bevy::{
     app::{AppExit, ScheduleRunnerPlugin, ScheduleRunnerSettings},
     prelude::*,
 };
-use rand::random;
 use instant::Duration;
+use rand::random;
 
 /// This is a guided introduction to Bevy's "Entity Component System" (ECS)
 /// All Bevy app logic is built using the ECS pattern, so definitely pay attention!

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -37,7 +37,7 @@ struct ComponentA {
 struct ComponentB {
     pub value: String,
     #[property(ignore)]
-    pub time_since_startup: std::time::Duration,
+    pub time_since_startup: instant::Duration,
 }
 
 impl FromResources for ComponentB {

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, type_registry::TypeRegistry};
+use bevy::{prelude::*, type_registry::TypeRegistry, utils::Duration};
 
 /// This example illustrates loading and saving scenes from files
 fn main() {
@@ -37,7 +37,7 @@ struct ComponentA {
 struct ComponentB {
     pub value: String,
     #[property(ignore)]
-    pub time_since_startup: instant::Duration,
+    pub time_since_startup: Duration,
 }
 
 impl FromResources for ComponentB {

--- a/examples/wasm/headless_wasm.rs
+++ b/examples/wasm/headless_wasm.rs
@@ -2,8 +2,8 @@ use bevy::{
     app::{ScheduleRunnerPlugin, ScheduleRunnerSettings},
     log::LogPlugin,
     prelude::*,
+    utils::Duration,
 };
-use instant::Duration;
 
 fn main() {
     App::build()

--- a/examples/wasm/headless_wasm.rs
+++ b/examples/wasm/headless_wasm.rs
@@ -3,7 +3,7 @@ use bevy::{
     log::LogPlugin,
     prelude::*,
 };
-use std::time::Duration;
+use instant::Duration;
 
 fn main() {
     App::build()


### PR DESCRIPTION
It removes conditional compilation directives and uses instant::{Duration, Instant} instead of std::time::{Duration, Instant}
Fixes #881 It should have minimal impact for bevy on native architectures, because instant::Instant is simply type alias to std::time::Instant there.