### PR TITLE
Fix pixel format conversion in bevy_gltf

### DIFF
--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -26,7 +26,7 @@ bevy_type_registry = { path = "../bevy_type_registry", version = "0.3.0" }
 
 # other
 gltf = { version = "0.15.2", default-features = false, features = ["utils"] }
-image = { version = "0.23", default-features = false }
+image = { version = "0.23.12", default-features = false }
 thiserror = "1.0"
 anyhow = "1.0"
 base64 = "0.12.3"

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -44,8 +44,6 @@ pub enum GltfError {
     BufferFormatUnsupported,
     #[error("Invalid image mime type.")]
     InvalidImageMimeType(String),
-    #[error("Failed to convert image to rgb8.")]
-    ImageRgb8ConversionFailure,
     #[error("Failed to load an image.")]
     ImageError(#[from] image::ImageError),
     #[error("Failed to load an asset path.")]

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -131,9 +131,7 @@ async fn load_gltf<'a, 'b>(
             }?;
             let image = image::load_from_memory_with_format(buffer, format)?;
             let size = image.dimensions();
-            let image = image
-                .as_rgba8()
-                .ok_or(GltfError::ImageRgb8ConversionFailure)?;
+            let image = image.into_rgba8();
 
             let texture_label = texture_label(&texture);
             load_context.set_labeled_asset(

--- a/crates/bevy_render/src/texture/image_texture_loader.rs
+++ b/crates/bevy_render/src/texture/image_texture_loader.rs
@@ -65,7 +65,7 @@ impl AssetLoader for ImageTextureLoader {
                     data = i.into_raw();
                 }
                 image::DynamicImage::ImageRgb8(i) => {
-                    let i = image::DynamicImage::ImageRgb8(i).into_rgba();
+                    let i = image::DynamicImage::ImageRgb8(i).into_rgba8();
                     width = i.width();
                     height = i.height();
                     format = TextureFormat::Rgba8UnormSrgb;
@@ -80,7 +80,7 @@ impl AssetLoader for ImageTextureLoader {
                     data = i.into_raw();
                 }
                 image::DynamicImage::ImageBgr8(i) => {
-                    let i = image::DynamicImage::ImageBgr8(i).into_bgra();
+                    let i = image::DynamicImage::ImageBgr8(i).into_bgra8();
 
                     width = i.width();
                     height = i.height();


### PR DESCRIPTION
closes #896

It looks like `GltfError::ImageRgb8ConversionError` isn't used anywhere else
internally, should I remove it? It would be a breaking change.