### PR TITLE
Add rust minimum version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/bevyengine/bevy"
+rust = "1.43"
 
 [workspace]
 exclude = ["benches"]


### PR DESCRIPTION
Through iterating from 1.36 -> upwards, I have found that the most minimum Rust version one can compile Bevy with is v1.43. Generally these are good to have and regularly test if it still compiles with or not.