### PR TITLE
avoid exclusive lock during `update_asset_storage`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,10 +108,10 @@ jobs:
           override: true
 
       - name: Install alsa
-        run: sudo apt-get install --no-install-recommends libasound2-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev
 
       - name: Install udev
-        run: sudo apt-get install --no-install-recommends libudev-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev
 
       - name: Check the format
         run: cargo +nightly fmt --all -- --check

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -392,7 +392,6 @@ impl AssetServer {
     pub(crate) fn update_asset_storage<T: Asset>(&self, assets: &mut Assets<T>) {
         let asset_lifecycles = self.server.asset_lifecycles.read();
         let asset_lifecycle = asset_lifecycles.get(&T::TYPE_UUID).unwrap();
-        let mut asset_sources = self.server.asset_sources.write();
         let channel = asset_lifecycle
             .downcast_ref::<AssetLifecycleChannel<T>>()
             .unwrap();
@@ -402,6 +401,7 @@ impl AssetServer {
                 Ok(AssetLifecycleEvent::Create(result)) => {
                     // update SourceInfo if this asset was loaded from an AssetPath
                     if let HandleId::AssetPathId(id) = result.id {
+                        let mut asset_sources = self.server.asset_sources.write();
                         if let Some(source_info) = asset_sources.get_mut(&id.source_path_id()) {
                             if source_info.version == result.version {
                                 source_info.committed_assets.insert(id.label_id());
@@ -416,6 +416,7 @@ impl AssetServer {
                 }
                 Ok(AssetLifecycleEvent::Free(handle_id)) => {
                     if let HandleId::AssetPathId(id) = handle_id {
+                        let mut asset_sources = self.server.asset_sources.write();
                         if let Some(source_info) = asset_sources.get_mut(&id.source_path_id()) {
                             source_info.committed_assets.remove(&id.label_id());
                             if source_info.is_loaded() {

--- a/crates/bevy_render/src/renderer/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/renderer/render_resource/bind_group.rs
@@ -1,4 +1,4 @@
-use super::{BufferId, RenderResourceBinding, SamplerId, TextureId};
+use super::{BufferId, RenderResourceBinding, RenderResourceId, SamplerId, TextureId};
 use bevy_utils::AHasher;
 use std::{
     hash::{Hash, Hasher},
@@ -45,7 +45,7 @@ impl BindGroupBuilder {
             self.dynamic_uniform_indices.push(dynamic_index);
         }
 
-        binding.hash(&mut self.hasher);
+        self.hash_binding(&binding);
         self.indexed_bindings.push(IndexedBindGroupEntry {
             index,
             entry: binding,
@@ -100,6 +100,25 @@ impl BindGroupBuilder {
             } else {
                 Some(self.dynamic_uniform_indices.into())
             },
+        }
+    }
+
+    fn hash_binding(&mut self, binding: &RenderResourceBinding) {
+        match binding {
+            RenderResourceBinding::Buffer {
+                buffer,
+                range,
+                dynamic_index: _, // dynamic_index is not a part of the binding
+            } => {
+                RenderResourceId::from(*buffer).hash(&mut self.hasher);
+                range.hash(&mut self.hasher);
+            }
+            RenderResourceBinding::Texture(texture) => {
+                RenderResourceId::from(*texture).hash(&mut self.hasher);
+            }
+            RenderResourceBinding::Sampler(sampler) => {
+                RenderResourceId::from(*sampler).hash(&mut self.hasher);
+            }
         }
     }
 }

--- a/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
+++ b/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
@@ -1,13 +1,13 @@
-use super::{BindGroup, BindGroupId, BufferId, RenderResourceId, SamplerId, TextureId};
+use super::{BindGroup, BindGroupId, BufferId, SamplerId, TextureId};
 use crate::{
     pipeline::{BindGroupDescriptor, BindGroupDescriptorId, PipelineDescriptor},
     renderer::RenderResourceContext,
 };
 use bevy_asset::{Asset, Handle, HandleUntyped};
 use bevy_utils::{HashMap, HashSet};
-use std::{hash::Hash, ops::Range};
+use std::ops::Range;
 
-#[derive(Clone, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum RenderResourceBinding {
     Buffer {
         buffer: BufferId,
@@ -47,55 +47,6 @@ impl RenderResourceBinding {
             Some(*sampler)
         } else {
             None
-        }
-    }
-}
-
-impl PartialEq for RenderResourceBinding {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (
-                RenderResourceBinding::Buffer {
-                    buffer: self_buffer,
-                    range: self_range,
-                    dynamic_index: _,
-                },
-                RenderResourceBinding::Buffer {
-                    buffer: other_buffer,
-                    range: other_range,
-                    dynamic_index: _,
-                },
-            ) => self_buffer == other_buffer && self_range == other_range,
-            (
-                RenderResourceBinding::Texture(self_texture),
-                RenderResourceBinding::Texture(other_texture),
-            ) => RenderResourceId::from(*self_texture) == RenderResourceId::from(*other_texture),
-            (
-                RenderResourceBinding::Sampler(self_sampler),
-                RenderResourceBinding::Sampler(other_sampler),
-            ) => RenderResourceId::from(*self_sampler) == RenderResourceId::from(*other_sampler),
-            _ => false,
-        }
-    }
-}
-
-impl Hash for RenderResourceBinding {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        match self {
-            RenderResourceBinding::Buffer {
-                buffer,
-                range,
-                dynamic_index: _, // dynamic_index is not a part of the binding
-            } => {
-                RenderResourceId::from(*buffer).hash(state);
-                range.hash(state);
-            }
-            RenderResourceBinding::Texture(texture) => {
-                RenderResourceId::from(*texture).hash(state);
-            }
-            RenderResourceBinding::Sampler(sampler) => {
-                RenderResourceId::from(*sampler).hash(state);
-            }
         }
     }
 }

--- a/crates/bevy_render/src/texture/image_texture_loader.rs
+++ b/crates/bevy_render/src/texture/image_texture_loader.rs
@@ -65,7 +65,7 @@ impl AssetLoader for ImageTextureLoader {
                     data = i.into_raw();
                 }
                 image::DynamicImage::ImageRgb8(i) => {
-                    let i = image::DynamicImage::ImageRgb8(i).into_rgba();
+                    let i = image::DynamicImage::ImageRgb8(i).into_rgba8();
                     width = i.width();
                     height = i.height();
                     format = TextureFormat::Rgba8UnormSrgb;
@@ -80,7 +80,7 @@ impl AssetLoader for ImageTextureLoader {
                     data = i.into_raw();
                 }
                 image::DynamicImage::ImageBgr8(i) => {
-                    let i = image::DynamicImage::ImageBgr8(i).into_bgra();
+                    let i = image::DynamicImage::ImageBgr8(i).into_bgra8();
 
                     width = i.width();
                     height = i.height();

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -1,6 +1,6 @@
 use crate::Rect;
 use bevy_asset::Handle;
-use bevy_core::Bytes;
+use bevy_core::Byteable;
 use bevy_math::Vec2;
 use bevy_render::{
     color::Color,
@@ -25,9 +25,7 @@ pub struct TextureAtlas {
     pub texture_handles: Option<HashMap<Handle<Texture>, usize>>,
 }
 
-// NOTE: cannot do `unsafe impl Byteable` here because Vec3 takes up the space of a Vec4. If/when glam changes this we can swap out
-// Bytes for Byteable as a micro-optimization. https://github.com/bitshifter/glam-rs/issues/36
-#[derive(Bytes, Debug, RenderResources, RenderResource)]
+#[derive(Debug, RenderResources, RenderResource)]
 #[render_resources(from_self)]
 pub struct TextureAtlasSprite {
     pub color: Color,
@@ -42,6 +40,8 @@ impl Default for TextureAtlasSprite {
         }
     }
 }
+
+unsafe impl Byteable for TextureAtlasSprite {}
 
 impl TextureAtlasSprite {
     pub fn new(index: u32) -> TextureAtlasSprite {


### PR DESCRIPTION
noticed while profiling that one version or another of `update_asset_storage_system` would occasionally take up to 10ms, and that the underlying `update_asset_storage` method was unconditionally taking an exclusive lock it needed very rarely

changed the code so the lock is only taken if an event requiring exclusive access occurs

i did this as the quickest possible fix, i'm open to reconsidering the approach if this is deemed insufficient
