### PR TITLE
Fix ui depth system

### DIFF
--- a/crates/bevy_transform/src/hierarchy/hierarchy.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy.rs
@@ -1,37 +1,6 @@
 use crate::components::{Children, Parent};
-use bevy_ecs::{Command, Commands, Entity, Query, Resources, World};
+use bevy_ecs::{Command, Commands, Entity, Resources, World};
 use bevy_utils::tracing::debug;
-
-pub fn run_on_hierarchy<T, S>(
-    children_query: &Query<&Children>,
-    state: &mut S,
-    entity: Entity,
-    parent_result: Option<T>,
-    mut previous_result: Option<T>,
-    run: &mut dyn FnMut(&mut S, Entity, Option<T>, Option<T>) -> Option<T>,
-) -> Option<T>
-where
-    T: Clone,
-{
-    let parent_result = run(state, entity, parent_result, previous_result);
-    previous_result = None;
-    if let Ok(children) = children_query.get(entity) {
-        for child in children.iter().cloned() {
-            previous_result = run_on_hierarchy(
-                children_query,
-                state,
-                child,
-                parent_result.clone(),
-                previous_result,
-                run,
-            );
-        }
-    } else {
-        previous_result = parent_result;
-    }
-
-    previous_result
-}
 
 #[derive(Debug)]
 pub struct DespawnRecursive {

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -43,11 +43,9 @@ fn update_hierarchy(
                 previous_result,
             );
         }
-    } else {
-        previous_result = Some(parent_result);
     }
 
-    previous_result
+    previous_result.or(Some(parent_result))
 }
 
 fn update_node_entity(
@@ -163,11 +161,11 @@ mod tests {
             ("1-2-0".to_owned(), 1),
             ("1-2-1".to_owned(), 2),
             ("1-2-2".to_owned(), 3),
-            ("1-2-3".to_owned(), 1),
-            ("1-3".to_owned(), 8),
+            ("1-2-3".to_owned(), 4),
+            ("1-3".to_owned(), 11),
             // 2 has no transform
             ("2-0".to_owned(), 1),
-            ("2-1".to_owned(), 1),
+            ("2-1".to_owned(), 2),
             ("2-1-0".to_owned(), 1),
         ];
         assert_eq!(actual_result, expected_result);

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -47,3 +47,105 @@ fn update_node_entity(
 
     Some(global_z)
 }
+
+#[cfg(test)]
+mod tests {
+    use bevy_ecs::{Commands, IntoSystem, Resources, Schedule, World};
+    use bevy_transform::{components::Transform, hierarchy::BuildChildren};
+
+    use crate::Node;
+
+    use super::{ui_z_system, UI_Z_STEP};
+
+    fn node_with_transform(name: &str) -> (String, Node, Transform) {
+        (name.to_owned(), Node::default(), Transform::default())
+    }
+
+    fn node_without_transform(name: &str) -> (String, Node) {
+        (name.to_owned(), Node::default())
+    }
+
+    fn get_steps(transform: &Transform) -> u32 {
+        (transform.translation.z / UI_Z_STEP).round() as u32
+    }
+
+    #[test]
+    fn test_ui_z_system() {
+        let mut world = World::default();
+        let mut resources = Resources::default();
+        let mut commands = Commands::default();
+        commands.set_entity_reserver(world.get_entity_reserver());
+
+        commands.spawn(node_with_transform("0"));
+
+        commands
+            .spawn(node_with_transform("1"))
+            .with_children(|parent| {
+                parent
+                    .spawn(node_with_transform("1-0"))
+                    .with_children(|parent| {
+                        parent.spawn(node_with_transform("1-0-0"));
+                        parent.spawn(node_without_transform("1-0-1"));
+                        parent.spawn(node_with_transform("1-0-2"));
+                    });
+                parent.spawn(node_with_transform("1-1"));
+                parent
+                    .spawn(node_without_transform("1-2"))
+                    .with_children(|parent| {
+                        parent.spawn(node_with_transform("1-2-0"));
+                        parent.spawn(node_with_transform("1-2-1"));
+                        parent
+                            .spawn(node_with_transform("1-2-2"))
+                            .with_children(|_| ());
+                        parent.spawn(node_with_transform("1-2-3"));
+                    });
+                parent.spawn(node_with_transform("1-3"));
+            });
+
+        commands
+            .spawn(node_without_transform("2"))
+            .with_children(|parent| {
+                parent
+                    .spawn(node_with_transform("2-0"))
+                    .with_children(|_parent| ());
+                parent
+                    .spawn(node_with_transform("2-1"))
+                    .with_children(|parent| {
+                        parent.spawn(node_with_transform("2-1-0"));
+                    });
+            });
+        commands.apply(&mut world, &mut resources);
+
+        let mut schedule = Schedule::default();
+        schedule.add_stage("update");
+        schedule.add_system_to_stage("update", ui_z_system.system());
+        schedule.initialize(&mut world, &mut resources);
+        schedule.run(&mut world, &mut resources);
+
+        let mut actual_result = world
+            .query::<(&String, &Transform)>()
+            .map(|(name, transform)| (name.clone(), get_steps(transform)))
+            .collect::<Vec<(String, u32)>>();
+        actual_result.sort_unstable_by_key(|(name, _)| name.clone());
+        let expected_result = vec![
+            ("0".to_owned(), 1),
+            ("1".to_owned(), 1),
+            ("1-0".to_owned(), 1),
+            ("1-0-0".to_owned(), 1),
+            // 1-0-1 has no transform
+            ("1-0-2".to_owned(), 3),
+            ("1-1".to_owned(), 5),
+            // 1-2 has no transform
+            ("1-2-0".to_owned(), 1),
+            ("1-2-1".to_owned(), 2),
+            ("1-2-2".to_owned(), 3),
+            ("1-2-3".to_owned(), 1),
+            ("1-3".to_owned(), 8),
+            // 2 has no transform
+            ("2-0".to_owned(), 1),
+            ("2-1".to_owned(), 1),
+            ("2-1-0".to_owned(), 1),
+        ];
+        assert_eq!(actual_result, expected_result);
+    }
+}


### PR DESCRIPTION
The current UI depth system looks a bit odd in some places. In particular, it treats nodes without children and nodes with empty children lists differently, and it effectively discards the results of previous computations when it progresses from one hierarchy tree to the next. I think that was not intentional and changed it to a system where the global z for each node increases by 1 in each step in a depth first traversal. I also added a unit test to make the changes in behavior transparent. 
Two open points:
* The ordering of the root nodes is somewhat arbitrary (depends on archetypes and entity index, I suppose). From a user perspective I would expect that more recently spawned UI elements are shown in front, or alternatively that I could set an order and put elements in front.
* The depth system traverses the children of nodes without transforms, the transform-propagate system does not. This could be fixed by moving the children query inside the if-let statement that checks for the transform. Alternatively, the propagate system could be changed to treat missing transforms as the identity.