### PR TITLE
avoid exclusive lock during `update_asset_storage`

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -392,7 +392,6 @@ impl AssetServer {
     pub(crate) fn update_asset_storage<T: Asset>(&self, assets: &mut Assets<T>) {
         let asset_lifecycles = self.server.asset_lifecycles.read();
         let asset_lifecycle = asset_lifecycles.get(&T::TYPE_UUID).unwrap();
-        let mut asset_sources = self.server.asset_sources.write();
         let channel = asset_lifecycle
             .downcast_ref::<AssetLifecycleChannel<T>>()
             .unwrap();
@@ -402,6 +401,7 @@ impl AssetServer {
                 Ok(AssetLifecycleEvent::Create(result)) => {
                     // update SourceInfo if this asset was loaded from an AssetPath
                     if let HandleId::AssetPathId(id) = result.id {
+                        let mut asset_sources = self.server.asset_sources.write();
                         if let Some(source_info) = asset_sources.get_mut(&id.source_path_id()) {
                             if source_info.version == result.version {
                                 source_info.committed_assets.insert(id.label_id());
@@ -416,6 +416,7 @@ impl AssetServer {
                 }
                 Ok(AssetLifecycleEvent::Free(handle_id)) => {
                     if let HandleId::AssetPathId(id) = handle_id {
+                        let mut asset_sources = self.server.asset_sources.write();
                         if let Some(source_info) = asset_sources.get_mut(&id.source_path_id()) {
                             source_info.committed_assets.remove(&id.label_id());
                             if source_info.is_loaded() {

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -392,6 +392,7 @@ impl AssetServer {
     pub(crate) fn update_asset_storage<T: Asset>(&self, assets: &mut Assets<T>) {
         let asset_lifecycles = self.server.asset_lifecycles.read();
         let asset_lifecycle = asset_lifecycles.get(&T::TYPE_UUID).unwrap();
+        let mut asset_sources_guard = None;
         let channel = asset_lifecycle
             .downcast_ref::<AssetLifecycleChannel<T>>()
             .unwrap();
@@ -401,7 +402,8 @@ impl AssetServer {
                 Ok(AssetLifecycleEvent::Create(result)) => {
                     // update SourceInfo if this asset was loaded from an AssetPath
                     if let HandleId::AssetPathId(id) = result.id {
-                        let mut asset_sources = self.server.asset_sources.write();
+                        let asset_sources = asset_sources_guard
+                            .get_or_insert_with(|| self.server.asset_sources.write());
                         if let Some(source_info) = asset_sources.get_mut(&id.source_path_id()) {
                             if source_info.version == result.version {
                                 source_info.committed_assets.insert(id.label_id());
@@ -416,7 +418,8 @@ impl AssetServer {
                 }
                 Ok(AssetLifecycleEvent::Free(handle_id)) => {
                     if let HandleId::AssetPathId(id) = handle_id {
-                        let mut asset_sources = self.server.asset_sources.write();
+                        let asset_sources = asset_sources_guard
+                            .get_or_insert_with(|| self.server.asset_sources.write());
                         if let Some(source_info) = asset_sources.get_mut(&id.source_path_id()) {
                             source_info.committed_assets.remove(&id.label_id());
                             if source_info.is_loaded() {


### PR DESCRIPTION
noticed a coarsely held exclusive lock in `update_asset_storage` that was causing contention - occasionally one version or another of the wrapping system would be held for 10+ms in my profiling.

narrowed the lock scope to the point of use. if this solution seems too quick-and-dirty i'm willing to re-examine