### PR TITLE
fix: update image version

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -27,7 +27,7 @@ bevy_window = { path = "../bevy_window", version = "0.3.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.3.0" }
 
 # rendering
-image = { version = "0.23", default-features = false }
+image = { version = "0.23.12", default-features = false }
 
 # misc
 uuid = { version = "0.8", features = ["v4", "serde"] }


### PR DESCRIPTION
`into_bgra8` was added in 0.23.12, and bevy doesn't compile with older versions anymore