### PR TITLE
Create winit windows before app.initialize()

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -147,6 +147,14 @@ pub fn winit_runner(mut app: App) {
 
     app.resources.insert_thread_local(event_loop.create_proxy());
 
+    // Create Windows and WinitWindows resources, so startup systems
+    // in below app.initialize() have access to them.
+    handle_create_window_events(
+        &mut app.resources,
+        &event_loop,
+        &mut create_window_event_reader,
+    );
+
     app.initialize();
 
     trace!("Entering winit event loop");


### PR DESCRIPTION
This is required so startup systems have access
to Windows and WinitWindows resources.