### PR TITLE
Allow startup systems to use Res<Windows> for plugin created windows

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -147,6 +147,14 @@ pub fn winit_runner(mut app: App) {
 
     app.resources.insert_thread_local(event_loop.create_proxy());
 
+    // Make windows creates requested by plugins available to startup systems
+    // by running this before app.initialize().
+    handle_create_window_events(
+        &mut app.resources,
+        &event_loop,
+        &mut create_window_event_reader,
+    );
+
     app.initialize();
 
     trace!("Entering winit event loop");

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -147,7 +147,7 @@ pub fn winit_runner(mut app: App) {
 
     app.resources.insert_thread_local(event_loop.create_proxy());
 
-    // Make windows creates requested by plugins available to startup systems
+    // Make window creates requested by plugins available to startup systems
     // by running this before app.initialize().
     handle_create_window_events(
         &mut app.resources,


### PR DESCRIPTION
We need to call handle_create_window_events to process the create window events which are sent by plugins (most commonly the default window plugin which creates the primary window).

The reason this is important is that if you have a startup_system which uses Windows then it would fail when looking for any of the windows which were supposed to be created by the plugins (in my case, the default primary window).

This code used to exist here, but was removed recently, this PR adds it back.

As an aside, I tried to see if there was anywhere in the codebase where we can drop a test for this since it would be fairly simple. It would involve creating an "App" with just the default plugins and a startup system that attempts to use Res<Windows> to get primary window. I guess we don't have this style of test in the codebase yet, unclear if it's discouraged or just not happened yet.

