### PR TITLE
wgpu: use mailbox instead of fifo for vsync

### DIFF
--- a/crates/bevy_wgpu/src/wgpu_type_converter.rs
+++ b/crates/bevy_wgpu/src/wgpu_type_converter.rs
@@ -567,7 +567,7 @@ impl WgpuFrom<&Window> for wgpu::SwapChainDescriptor {
             width: window.width(),
             height: window.height(),
             present_mode: if window.vsync() {
-                wgpu::PresentMode::Fifo
+                wgpu::PresentMode::Mailbox
             } else {
                 wgpu::PresentMode::Immediate
             },


### PR DESCRIPTION
This has lower latency (for the platforms that support it). It will fall back to Fifo for platforms that don't support it.  _Hopefully_ this will resolve the "input lag" problem for most people.

Its worth pointing out that this doesn't actually resolve the lag problem for _me_ on linux/gnome-x11/nvidia gtx 1070/proprietary driver. Its possible that some aspect of that combination doesn't support "mailbox".

With that setup (and a 100fps monitor) i get 3 frames of lag.

If i disable vsync entirely, i get 1 frame of lag.

This resolved the lag problem for @zachreizner, who suggested this change in the first place.