### PR TITLE
Assets swap() function

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -156,6 +156,24 @@ impl<T: Asset> Assets<T> {
         asset
     }
 
+    pub fn swap<H: Into<HandleId>>(&mut self, handle: H, asset: T) -> Option<T> {
+        let id: HandleId = handle.into();
+        match self.assets.insert(id, asset) {
+            None => {
+                self.events.send(AssetEvent::Created {
+                    handle: Handle::weak(id),
+                });
+                None
+            }
+            Some(previous) => {
+                self.events.send(AssetEvent::Modified {
+                    handle: Handle::weak(id),
+                });
+                Some(previous)
+            }
+        }
+    }
+
     /// Clears the inner asset map, removing all key-value pairs.
     ///
     /// Keeps the allocated memory for reuse.


### PR DESCRIPTION
For issue described in https://github.com/bevyengine/bevy/issues/925

To summarize the use-case where I found this valuable:

I want to be able to refresh a set of Asset Textures in parallel using a task pool (re-draw their contents with new contents). It's not possible to modify all the textures in-place since it would require each task taking a mutable borrow on the entire Assets<Texture> (get_mut takes a mutable borrow on the Assets<Texture>, not an individual asset).

An alternative is to allocate an entirely new texture and then draw into that in parallel, then subsequently (in 1 thread) use Assets' set() api to replace the textures. Unfortunately, though this does parallelize, it also adds an allocation of each texture in order to have a place to draw into.

This PR adds a "swap" api to Assets<T>. This makes it possible to have a Texture pool in my game which I can take textures from (skip allocations), draw into, then using this swap api to reclaim the previous texture out of Assets, recycle it back into a Texture pool, and replace it with a freshly drawn texture.
