### PR TITLE
BugFix: thread 'main' panicked at 'index out of bounds:

### DIFF
--- a/crates/bevy_ecs/src/core/archetype.rs
+++ b/crates/bevy_ecs/src/core/archetype.rs
@@ -272,9 +272,9 @@ impl Archetype {
     fn grow(&mut self, increment: usize) {
         unsafe {
             let old_count = self.len;
-            let count = old_count + increment;
+            let new_capacity = self.capacity() + increment;
             self.entities.resize(
-                self.entities.len() + increment,
+                new_capacity,
                 Entity {
                     id: u32::MAX,
                     generation: u32::MAX,
@@ -284,7 +284,7 @@ impl Archetype {
             for type_state in self.state.values_mut() {
                 type_state
                     .component_flags
-                    .resize_with(count, ComponentFlags::empty);
+                    .resize_with(new_capacity, ComponentFlags::empty);
             }
 
             let old_data_size = mem::replace(&mut self.data_size, 0);
@@ -294,7 +294,7 @@ impl Archetype {
                 let ty_state = self.state.get_mut(&ty.id).unwrap();
                 old_offsets.push(ty_state.offset);
                 ty_state.offset = self.data_size;
-                self.data_size += ty.layout.size() * count;
+                self.data_size += ty.layout.size() * new_capacity;
             }
             let new_data = if self.data_size == 0 {
                 NonNull::dangling()


### PR DESCRIPTION
 Invoke `archetype.grow()` while `archetype.capacity() != archetype.len()` will resize `entities` and `data` with different sizes.

so, the this program.

```rust
use bevy::prelude::*;

fn main() {
    let mut world = World::new();
    for _ in 0..100 {
        world.spawn(("abc".to_string(),));
    }
    world.reserve::<(String,)>(100);
    for _ in 0..100 {
        world.spawn(("abc".to_string(),));
    }
}

```

panicked:

```
thread 'main' panicked at 'index out of bounds: the len is 172 but the index is 172', crates\bevy_ecs\src\core\archetype.rs:418:9
stack backtrace:
   0: std::panicking::begin_panic_handler
             at /rustc/1c389ffeff814726dec325f0f2b0c99107df2673\/library\std\src\panicking.rs:493
   1: core::panicking::panic_fmt
             at /rustc/1c389ffeff814726dec325f0f2b0c99107df2673\/library\core\src\panicking.rs:92
   2: core::panicking::panic_bounds_check
             at /rustc/1c389ffeff814726dec325f0f2b0c99107df2673\/library\core\src\panicking.rs:69
   3: core::slice::index::{{impl}}::index_mut<bevy_ecs::core::archetype::ComponentFlags>
             at C:\Users\..\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\slice\index.rs:188
   4: core::slice::index::{{impl}}::index_mut<bevy_ecs::core::archetype::ComponentFlags,usize>
             at C:\Users\..\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\slice\index.rs:26
   5: alloc::vec::{{impl}}::index_mut<bevy_ecs::core::archetype::ComponentFlags,usize,alloc::alloc::Global>
             at C:\Users\..\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\alloc\src\vec.rs:2173
   6: bevy_ecs::core::archetype::Archetype::put_dynamic
             at F:\bevy\crates\bevy_ecs\src\core\archetype.rs:418
   7: bevy_ecs::core::world::{{impl}}::spawn::{{closure}}<tuple<alloc::string::String>>
             at F:\bevy\crates\bevy_ecs\src\core\world.rs:99
   8: bevy_ecs::core::bundle::{{impl}}::put<alloc::string::String,closure-1>
             at F:\bevy\crates\bevy_ecs\src\core\bundle.rs:99
   9: bevy_ecs::core::world::World::spawn<tuple<alloc::string::String>>
             at F:\bevy\crates\bevy_ecs\src\core\world.rs:98
  10: game::main
             at .\src\main.rs:10
  11: core::ops::function::FnOnce::call_once<fn(),tuple<>>
             at C:\Users\..\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ops\function.rs:227
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

this PR fixed this bug.
