### PR TITLE
When a task scope produces <= 1 task to run, run it on the calling thread immediately

### DIFF
--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -167,44 +167,50 @@ impl TaskPool {
         let executor: &async_executor::Executor = &*self.executor;
         let executor: &'scope async_executor::Executor = unsafe { mem::transmute(executor) };
 
-        let fut = async move {
-            let mut scope = Scope {
-                executor,
-                spawned: Vec::new(),
-            };
-
-            f(&mut scope);
-
-            let mut results = Vec::with_capacity(scope.spawned.len());
-            for task in scope.spawned {
-                results.push(task.await);
-            }
-
-            results
+        let mut scope = Scope {
+            executor,
+            spawned: Vec::new(),
         };
 
-        // Pin the future on the stack.
-        pin!(fut);
+        f(&mut scope);
 
-        // SAFETY: This function blocks until all futures complete, so we do not read/write the
-        // data from futures outside of the 'scope lifetime. However, rust has no way of knowing
-        // this so we must convert to 'static here to appease the compiler as it is unable to
-        // validate safety.
-        let fut: Pin<&mut (dyn Future<Output = Vec<T>> + Send)> = fut;
-        let fut: Pin<&'static mut (dyn Future<Output = Vec<T>> + Send + 'static)> =
-            unsafe { mem::transmute(fut) };
+        if scope.spawned.is_empty() {
+            Vec::default()
+        } else if scope.spawned.len() == 1 {
+            vec![future::block_on(&mut scope.spawned[0])]
+        } else {
+            let fut = async move {
+                let mut results = Vec::with_capacity(scope.spawned.len());
+                for task in scope.spawned {
+                    results.push(task.await);
+                }
 
-        // The thread that calls scope() will participate in driving tasks in the pool forward
-        // until the tasks that are spawned by this scope() call complete. (If the caller of scope()
-        // happens to be a thread in this thread pool, and we only have one thread in the pool, then
-        // simply calling future::block_on(spawned) would deadlock.)
-        let mut spawned = self.executor.spawn(fut);
-        loop {
-            if let Some(result) = future::block_on(future::poll_once(&mut spawned)) {
-                break result;
+                results
+            };
+
+            // Pin the future on the stack.
+            pin!(fut);
+
+            // SAFETY: This function blocks until all futures complete, so we do not read/write the
+            // data from futures outside of the 'scope lifetime. However, rust has no way of knowing
+            // this so we must convert to 'static here to appease the compiler as it is unable to
+            // validate safety.
+            let fut: Pin<&mut (dyn Future<Output = Vec<T>> + Send)> = fut;
+            let fut: Pin<&'static mut (dyn Future<Output = Vec<T>> + Send + 'static)> =
+                unsafe { mem::transmute(fut) };
+
+            // The thread that calls scope() will participate in driving tasks in the pool forward
+            // until the tasks that are spawned by this scope() call complete. (If the caller of scope()
+            // happens to be a thread in this thread pool, and we only have one thread in the pool, then
+            // simply calling future::block_on(spawned) would deadlock.)
+            let mut spawned = self.executor.spawn(fut);
+            loop {
+                if let Some(result) = future::block_on(future::poll_once(&mut spawned)) {
+                    break result;
+                }
+
+                self.executor.try_tick();
             }
-
-            self.executor.try_tick();
         }
     }
 


### PR DESCRIPTION
This is an additional change continuing on from https://github.com/bevyengine/bevy/pull/892

The rationale for this change is that if we have just a single task to perform, it's almost always better to perform it immediately rather than pass the work to another thread and blocking-wait on it (thereby tying up two threads.)

I don't see significant gains (or losses) from this in practice when profiling. To me the data indicates that the main thread is already consistently picking up the task before a worker thread can (and doesn't appear that we are even waking another thread?) While the benefits from thread behavior are inconclusive, this does remove some allocations when hitting the fast path of <= 1 task to perform in a scope. 

# Original

This is a baseline from before we fixed the deadlock. It shows what it looks like when the main thread is constantly blocked waiting on other threads. Frames averaged ~6.98ms

![image](https://user-images.githubusercontent.com/316070/100404847-3b2b3300-3017-11eb-88ab-77e9d432aa35.png)

![image](https://user-images.githubusercontent.com/316070/100404959-788fc080-3017-11eb-8b0a-65714568ebac.png)

# Recent Commit

The main thread has very high occupancy and there are clear runs where the main thread executed a bunch of systems without going out to other threads. (The top bar labeled "main" is almost fully green.) Frames averaged ~5.96ms

![image](https://user-images.githubusercontent.com/316070/100405062-b12f9a00-3017-11eb-8743-c068a01b5dea.png)

![image](https://user-images.githubusercontent.com/316070/100405573-b7724600-3018-11eb-88cf-0cb938bed598.png)

# This PR

I don't see a significant difference.  Frames averaged ~5.72ms. ~4% difference is too narrow for me to draw any conclusion at this point.

![image](https://user-images.githubusercontent.com/316070/100405414-63676180-3018-11eb-8eaa-1171b7473cc4.png)

![image](https://user-images.githubusercontent.com/316070/100405495-96115a00-3018-11eb-8f2d-cb91045b79bf.png)

### Methodology

Ran a single time in release, profiled with superluminal, code was instrumented as shown here: https://github.com/aclysma/bevy/commit/0782fe47ea1a57b4f891239bb278c54d9b16c469