### PR TITLE
Add method `add_textures` to `TextureAtlasBuilder`

### DIFF
--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -22,7 +22,7 @@ pub struct TextureAtlas {
     #[render_resources(buffer)]
     pub textures: Vec<Rect>,
     #[render_resources(ignore)]
-    pub texture_handles: Option<HashMap<(Handle<Texture>, u32), usize>>,
+    pub texture_handles: Option<HashMap<(Handle<Texture>, usize), usize>>,
 }
 
 #[derive(Debug, RenderResources, RenderResource)]
@@ -140,7 +140,7 @@ impl TextureAtlas {
         self.textures.is_empty()
     }
 
-    pub fn get_texture_index(&self, texture: &Handle<Texture>, sub_index: u32) -> Option<usize> {
+    pub fn get_texture_index(&self, texture: &Handle<Texture>, sub_index: usize) -> Option<usize> {
         self.texture_handles.as_ref().and_then(|texture_handles| {
             texture_handles
                 .get(&(texture.clone_weak(), sub_index))

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -22,7 +22,7 @@ pub struct TextureAtlas {
     #[render_resources(buffer)]
     pub textures: Vec<Rect>,
     #[render_resources(ignore)]
-    pub texture_handles: Option<HashMap<Handle<Texture>, usize>>,
+    pub texture_handles: Option<HashMap<(Handle<Texture>, u32), usize>>,
 }
 
 #[derive(Debug, RenderResources, RenderResource)]
@@ -140,9 +140,11 @@ impl TextureAtlas {
         self.textures.is_empty()
     }
 
-    pub fn get_texture_index(&self, texture: &Handle<Texture>) -> Option<usize> {
-        self.texture_handles
-            .as_ref()
-            .and_then(|texture_handles| texture_handles.get(texture).cloned())
+    pub fn get_texture_index(&self, texture: &Handle<Texture>, sub_index: u32) -> Option<usize> {
+        self.texture_handles.as_ref().and_then(|texture_handles| {
+            texture_handles
+                .get(&(texture.clone_weak(), sub_index))
+                .cloned()
+        })
     }
 }

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 #[derive(Debug)]
 pub struct TextureAtlasBuilder {
     pub textures: Vec<Handle<Texture>>,
-    pub rects_to_place: GroupedRectsToPlace<(Handle<Texture>, u32)>,
+    pub rects_to_place: GroupedRectsToPlace<(Handle<Texture>, usize)>,
     pub initial_size: Vec2,
     pub max_size: Vec2,
 }
@@ -58,7 +58,7 @@ impl TextureAtlasBuilder {
 
         for y in 0..height {
             for x in 0..width {
-                let index = (y * width) + x;
+                let index = ((y * width) + x) as usize;
                 self.rects_to_place.push_rect(
                     (texture_handle.clone_weak(), index),
                     None,

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -45,7 +45,7 @@ fn load_atlas(
         let texture_atlas_texture = texture_atlas.texture.clone();
         let vendor_handle =
             asset_server.get_handle("textures/rpg/chars/vendor/generic-rpg-vendor.png");
-        let vendor_index = texture_atlas.get_texture_index(&vendor_handle).unwrap();
+        let vendor_index = texture_atlas.get_texture_index(&vendor_handle, 0).unwrap();
         let atlas_handle = texture_atlases.add(texture_atlas);
 
         // set up a scene to display our texture atlas


### PR DESCRIPTION
Bit of preface, I ran into an issue where I couldn't add a texture that has many tiles that I want a separate index to for the renderer. For instance, importing a whole sprite sheet with a bunch of loose tiles as is done in many of the examples.

This change aims to allow for more flexibility to adding sprites that may be tiles to the `TextureAtlas` through the `TextureAtlasBuilder`

I did test it out with the examples but haven't yet quite tried it out with my own library as I'm a little bit behind in this regard. I hope this will be a welcomed addition else I will need to make my own `TileAtlas` and `TileAtlasBuilder` which would essentially be the same thing for the tile lib.

## Added

* `TextureAtlasBuilder::add_textures`: effectively is the same as `TextureAtlasBuilder::add_texture` however you can specify a `cell_size: Vec2` to get the correct index values and emplace all tiles separately.

## Changed

* `TextureAtlas::get_texture_index`: added a `sub_index: usize` field incase there is a sub index to get. Internally, unfortunately, the IDs, and there for key values, were constructed from `Handle<Texture>` but to make them unique for this to work they had to change from `HashMap<Handle<Texture>, usize>` to `HashMap<(Handle<Texture>, usize), usize>`.
* `2d\texture_atlas.rs` example had to be updated to reflect this change.