### PR TITLE
store PipelineSpecialization.dynamic_bindings in HashSet

### DIFF
--- a/crates/bevy_render/src/pipeline/pipeline_compiler.rs
+++ b/crates/bevy_render/src/pipeline/pipeline_compiler.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 pub struct PipelineSpecialization {
     pub shader_specialization: ShaderSpecialization,
     pub primitive_topology: PrimitiveTopology,
-    pub dynamic_bindings: Vec<String>,
+    pub dynamic_bindings: HashSet<String>,
     pub index_format: IndexFormat,
     pub vertex_buffer_descriptor: VertexBufferDescriptor,
     pub sample_count: u32,

--- a/crates/bevy_render/src/pipeline/render_pipelines.rs
+++ b/crates/bevy_render/src/pipeline/render_pipelines.rs
@@ -8,6 +8,7 @@ use crate::{
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::{Query, Res, ResMut};
 use bevy_reflect::Reflect;
+use bevy_utils::HashSet;
 
 #[derive(Debug, Default, Clone, Reflect)]
 pub struct RenderPipeline {
@@ -110,7 +111,7 @@ pub fn draw_render_pipelines_system(
                     .bindings
                     .iter_dynamic_bindings()
                     .map(|name| name.to_string())
-                    .collect::<Vec<String>>();
+                    .collect::<HashSet<String>>();
                 pipeline.dynamic_bindings_generation =
                     render_pipelines.bindings.dynamic_bindings_generation();
             }


### PR DESCRIPTION
I've just noticed many compilations of the same pipeline (with the same specialization) - it seems it is because RenderResourceBindings.iter_dynamic_bindings() iterates HashMap (so order is nondeterministic) and we are storing result in Vec<String>.

I noticed this bug on web app with bevy_webgl2 backend, but it seems native applications using wgpu renderer may be also affected.