### PR TITLE
Store mouse cursor position in Window

### DIFF
--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -41,6 +41,16 @@ pub struct CursorMoved {
     pub position: Vec2,
 }
 
+#[derive(Debug, Clone)]
+pub struct CursorEntered {
+    pub id: WindowId,
+}
+
+#[derive(Debug, Clone)]
+pub struct CursorLeft {
+    pub id: WindowId,
+}
+
 /// An event that is sent whenever a window receives a character from the OS or underlying system.
 #[derive(Debug, Clone)]
 pub struct ReceivedCharacter {

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -9,7 +9,10 @@ pub use window::*;
 pub use windows::*;
 
 pub mod prelude {
-    pub use crate::{CursorMoved, ReceivedCharacter, Window, WindowDescriptor, Windows};
+    pub use crate::{
+        CursorEntered, CursorLeft, CursorMoved, ReceivedCharacter, Window, WindowDescriptor,
+        Windows,
+    };
 }
 
 use bevy_app::prelude::*;
@@ -36,6 +39,8 @@ impl Plugin for WindowPlugin {
             .add_event::<WindowCloseRequested>()
             .add_event::<CloseWindow>()
             .add_event::<CursorMoved>()
+            .add_event::<CursorEntered>()
+            .add_event::<CursorLeft>()
             .add_event::<ReceivedCharacter>()
             .init_resource::<Windows>();
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,3 +1,4 @@
+use bevy_math::Vec2;
 use bevy_utils::Uuid;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -42,6 +43,7 @@ pub struct Window {
     decorations: bool,
     cursor_visible: bool,
     cursor_locked: bool,
+    cursor_position: Option<Vec2>,
     mode: WindowMode,
     #[cfg(target_arch = "wasm32")]
     pub canvas: Option<String>,
@@ -107,6 +109,7 @@ impl Window {
             decorations: window_descriptor.decorations,
             cursor_visible: window_descriptor.cursor_visible,
             cursor_locked: window_descriptor.cursor_locked,
+            cursor_position: None,
             mode: window_descriptor.mode,
             #[cfg(target_arch = "wasm32")]
             canvas: window_descriptor.canvas.clone(),
@@ -145,13 +148,15 @@ impl Window {
             .push(WindowCommand::SetResolution { width, height });
     }
 
-    #[doc(hidden)]
+    #[allow(missing_docs)]
+    #[inline]
     pub fn update_resolution_from_backend(&mut self, width: u32, height: u32) {
         self.width = width;
         self.height = height;
     }
 
-    #[doc(hidden)]
+    #[allow(missing_docs)]
+    #[inline]
     pub fn update_scale_factor_from_backend(&mut self, scale_factor: f64) {
         self.scale_factor = scale_factor;
     }
@@ -227,9 +232,20 @@ impl Window {
         });
     }
 
+    #[inline]
+    pub fn cursor_position(&self) -> Option<Vec2> {
+        self.cursor_position
+    }
+
     pub fn set_cursor_position(&mut self, x: i32, y: i32) {
         self.command_queue
             .push(WindowCommand::SetCursorPosition { x, y });
+    }
+
+    #[allow(missing_docs)]
+    #[inline]
+    pub fn update_cursor_position_from_backend(&mut self, cursor_position: Option<Vec2>) {
+        self.cursor_position = cursor_position;
     }
 
     #[inline]


### PR DESCRIPTION
This PR adds `cursor_position` field to `Window` and a system to track `CursorMoved` events.

This complements already existing `set_cursor_position` method and aligns with how keyboard input is being handled - allowing for both handling by events or just accessing available state.