### PR TITLE
Reflect Diff-ing

### DIFF
--- a/crates/bevy_reflect/README.md
+++ b/crates/bevy_reflect/README.md
@@ -21,7 +21,7 @@ struct Foo {
     a: u32,
     b: Bar
     c: Vec<i32>,
-    d: Vec<Bar>,
+    d: Vec<Baz>,
 }
 
 // this will automatically implement the Reflect trait and the TupleStruct trait (because the type is a tuple struct)

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -318,6 +318,10 @@ fn impl_struct(
             fn partial_eq(&self, value: &dyn #bevy_reflect_path::Reflect) -> Option<bool> {
                 #partial_eq_fn
             }
+
+            fn diff<'a>(&'a self, value: &'a dyn #bevy_reflect_path::Reflect) -> Result<Option<Box<dyn #bevy_reflect_path::Reflect>>, #bevy_reflect_path::DiffError<'a>> {
+                #bevy_reflect_path::struct_diff(self, value)
+            }
         }
     })
 }
@@ -437,6 +441,10 @@ fn impl_tuple_struct(
             fn partial_eq(&self, value: &dyn #bevy_reflect_path::Reflect) -> Option<bool> {
                 #partial_eq_fn
             }
+
+            fn diff<'a>(&'a self, value: &'a dyn #bevy_reflect_path::Reflect) -> Result<Option<Box<dyn #bevy_reflect_path::Reflect>>, #bevy_reflect_path::DiffError<'a>> {
+                #bevy_reflect_path::tuple_struct_diff(self, value)
+            }
         }
     })
 }
@@ -511,6 +519,20 @@ fn impl_value(
 
             fn serializable(&self) -> Option<#bevy_reflect_path::serde::Serializable> {
                 #serialize_fn
+            }
+
+            fn diff<'a>(&'a self, value: &'a dyn #bevy_reflect_path::Reflect) -> Result<Option<Box<dyn #bevy_reflect_path::Reflect>>, #bevy_reflect_path::DiffError<'a>> {
+                if let Some(equal) = self.partial_eq(value) {
+                    if equal {
+                        Ok(None)
+                    } else {
+                        Ok(Some(value.clone_value()))
+                    }
+                } else {
+                    Err(#bevy_reflect_path::DiffError::TypeDoesNotSupportPartialEq {
+                        type_name: self.type_name(),
+                    })
+                }
             }
         }
     })

--- a/crates/bevy_reflect/src/impls/bevy_app.rs
+++ b/crates/bevy_reflect/src/impls/bevy_app.rs
@@ -1,6 +1,5 @@
-use crate::{impl_reflect_value, GetTypeRegistration, ReflectDeserialize, TypeRegistryArc};
+use crate::{GetTypeRegistration, TypeRegistryArc};
 use bevy_app::{AppBuilder, Plugin};
-use bevy_ecs::Entity;
 
 #[derive(Default)]
 pub struct ReflectPlugin;
@@ -39,8 +38,6 @@ impl Plugin for ReflectPlugin {
         }
     }
 }
-
-impl_reflect_value!(Entity(Hash, PartialEq, Serialize, Deserialize));
 
 pub trait RegisterTypeBuilder {
     fn register_type<T: GetTypeRegistration>(&mut self) -> &mut Self;

--- a/crates/bevy_reflect/src/impls/bevy_ecs.rs
+++ b/crates/bevy_reflect/src/impls/bevy_ecs.rs
@@ -1,9 +1,12 @@
-use crate::{FromType, Reflect};
+use crate::{FromType, Reflect, ReflectDeserialize};
 use bevy_ecs::{
     Archetype, Component, Entity, EntityMap, FromResources, MapEntities, MapEntitiesError,
     Resources, World,
 };
+use bevy_reflect_derive::impl_reflect_value;
 use std::marker::PhantomData;
+
+impl_reflect_value!(Entity(Hash, PartialEq, Serialize, Deserialize));
 
 #[derive(Clone)]
 pub struct ReflectComponent {

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -1,7 +1,9 @@
 use smallvec::{Array, SmallVec};
 use std::any::Any;
 
-use crate::{serde::Serializable, List, ListIter, Reflect, ReflectMut, ReflectRef};
+use crate::{
+    list_diff, serde::Serializable, DiffError, List, ListIter, Reflect, ReflectMut, ReflectRef,
+};
 
 impl<T: Array + Send + Sync + 'static> List for SmallVec<T>
 where
@@ -92,5 +94,12 @@ where
 
     fn serializable(&self) -> Option<Serializable> {
         None
+    }
+
+    fn diff<'a>(
+        &'a self,
+        value: &'a dyn Reflect,
+    ) -> Result<Option<Box<dyn Reflect>>, DiffError<'a>> {
+        list_diff(self, value)
     }
 }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,6 +1,6 @@
 use crate::{
-    map_partial_eq, serde::Serializable, DynamicMap, List, ListIter, Map, MapIter, Reflect,
-    ReflectDeserialize, ReflectMut, ReflectRef,
+    list_diff, map_diff, map_partial_eq, serde::Serializable, DiffError, DynamicMap, List,
+    ListIter, Map, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef,
 };
 
 use bevy_reflect_derive::impl_reflect_value;
@@ -21,8 +21,8 @@ impl_reflect_value!(i32(Hash, PartialEq, Serialize, Deserialize));
 impl_reflect_value!(i64(Hash, PartialEq, Serialize, Deserialize));
 impl_reflect_value!(i128(Hash, PartialEq, Serialize, Deserialize));
 impl_reflect_value!(isize(Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(f32(Serialize, Deserialize));
-impl_reflect_value!(f64(Serialize, Deserialize));
+impl_reflect_value!(f32(PartialEq, Serialize, Deserialize));
+impl_reflect_value!(f64(PartialEq, Serialize, Deserialize));
 impl_reflect_value!(String(Hash, PartialEq, Serialize, Deserialize));
 impl_reflect_value!(Option<T: Serialize + Clone + for<'de> Deserialize<'de> + Reflect + 'static>(Serialize, Deserialize));
 impl_reflect_value!(HashSet<T: Serialize + Hash + Eq + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>(Serialize, Deserialize));
@@ -103,6 +103,13 @@ impl<T: Reflect> Reflect for Vec<T> {
 
     fn serializable(&self) -> Option<Serializable> {
         None
+    }
+
+    fn diff<'a>(
+        &'a self,
+        value: &'a dyn Reflect,
+    ) -> Result<Option<Box<dyn Reflect>>, DiffError<'a>> {
+        list_diff(self, value)
     }
 }
 
@@ -197,5 +204,12 @@ impl<K: Reflect + Clone + Eq + Hash, V: Reflect + Clone> Reflect for HashMap<K, 
 
     fn serializable(&self) -> Option<Serializable> {
         None
+    }
+
+    fn diff<'a>(
+        &'a self,
+        value: &'a dyn Reflect,
+    ) -> Result<Option<Box<dyn Reflect>>, DiffError<'a>> {
+        map_diff(self, value)
     }
 }


### PR DESCRIPTION
This enables "diff-ing" `Reflect` values. The general idea is that you can do:

```rust
let a = Foo { x: 1, y: 2 };
let b = Foo { x: 1, y: 3 };

let diff = a.diff(&b).unwrap();

// diff will be None if they are the same

if let Some(diff) = diff {
  // `diff` is a DynamicStruct that contains { y: 3 }
} else {
  // diff will be None if `a` and `b` are the same
}
```

A "rule" that should always hold true for diffs is: *for a given `let diff = a.diff(&b)`, calling `a.apply(&diff)` should produce a value equivalent to `b`*

Because of this, this implementation currently has one big caveat: we only return a real "diff" for `Struct` types. Every other type is treated as a "value type". They will return the "full" value if there is any mismatch.

* `Map`: we can't store `Map` diffs in DynamicMap because it doesn't encode "removed values". If there is any difference, the diff will contain the "full" `Map` value.
  * The "rule" above _doesn't_ apply to maps yet because we don't clear the map when we call `apply`. 
* `List`: we can't store `List` diffs in DynamicList because it doesn't encode "removed values" or allow for sparse indexing. The diff will contain the "full" `List` value.
  * The "rule" above _doesn't_ apply to lists yet because we don't clear the list when we call `apply`. 
* `TupleStruct`: DynamicTupleStruct doesn't support sparse indexing so we must include every field.

I'm considering a couple of options for the cases above:
1. just embrace "diff everything else as a value type" (ex: change apply() to clear collection values)
2. Return new "diff types" that encode the necessary information. This increases the api surface, but also gives us more flexibility.