### PR TITLE
Fix `RenderResources` index slicing

### DIFF
--- a/crates/bevy_derive/src/render_resources.rs
+++ b/crates/bevy_derive/src/render_resources.rs
@@ -160,11 +160,11 @@ pub fn derive_render_resources(input: TokenStream) -> TokenStream {
                 }
 
                 fn get_render_resource_name(&self, index: usize) -> Option<&str> {
-                    Some(#render_resource_names_ident[index])
+                    #render_resource_names_ident.get(index).copied()
                 }
 
                 fn get_render_resource_hints(&self, index: usize) -> Option<#bevy_render_path::renderer::RenderResourceHints> {
-                    #render_resource_hints_ident[index].clone()
+                    #render_resource_hints_ident.get(index).and_then(|o| *o)
                 }
 
                 fn iter(&self) -> #bevy_render_path::renderer::RenderResourceIterator {


### PR DESCRIPTION
This is a small patch fix. Since `RenderResources` is typically implemented through the proc macro, internally should be hygienic enough to not cause unexpected panics. This patch fixes for example `clippy::indexing_slicing` which is a some-what common clippy check.

Going through a few of the clippy lints in `bevy_tilemap` and fixing whats up as suggested, this was one of them. Obviously I can't fix it without fixing it on `bevy` first or implementing `RenderResources` by hand.