### PR TITLE
Align bevy_input::Touch API with other similar APIs 

### DIFF
--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -85,13 +85,13 @@ pub struct TouchSystemState {
 
 #[derive(Debug, Clone, Copy)]
 pub struct Touch {
-    pub id: u64,
-    pub start_position: Vec2,
-    pub start_force: Option<ForceTouch>,
-    pub previous_position: Vec2,
-    pub previous_force: Option<ForceTouch>,
-    pub position: Vec2,
-    pub force: Option<ForceTouch>,
+    id: u64,
+    start_position: Vec2,
+    start_force: Option<ForceTouch>,
+    previous_position: Vec2,
+    previous_force: Option<ForceTouch>,
+    position: Vec2,
+    force: Option<ForceTouch>,
 }
 
 impl Touch {
@@ -101,6 +101,36 @@ impl Touch {
 
     pub fn distance(&self) -> Vec2 {
         self.position - self.start_position
+    }
+
+    #[inline]
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    #[inline]
+    pub fn start_position(&self) -> Vec2 {
+        self.start_position
+    }
+
+    #[inline]
+    pub fn start_force(&self) -> Option<ForceTouch> {
+        self.start_force
+    }
+
+    #[inline]
+    pub fn previous_position(&self) -> Vec2 {
+        self.previous_position
+    }
+
+    #[inline]
+    pub fn position(&self) -> Vec2 {
+        self.position
+    }
+
+    #[inline]
+    pub fn force(&self) -> Option<ForceTouch> {
+        self.force
     }
 }
 

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -56,7 +56,7 @@ pub fn ui_focus_system(
         state.cursor_position = cursor_moved.position;
     }
     if let Some(touch) = touches_input.get_pressed(0) {
-        state.cursor_position = touch.position;
+        state.cursor_position = touch.position();
     }
 
     if mouse_button_input.just_released(MouseButton::Left) || touches_input.just_released(0) {

--- a/examples/input/touch_input.rs
+++ b/examples/input/touch_input.rs
@@ -11,24 +11,26 @@ fn touch_system(touches: Res<Touches>) {
     for touch in touches.iter_just_pressed() {
         println!(
             "just pressed touch with id: {:?}, at: {:?}",
-            touch.id, touch.position
+            touch.id(),
+            touch.position()
         );
     }
 
     for touch in touches.iter_just_released() {
         println!(
             "just released touch with id: {:?}, at: {:?}",
-            touch.id, touch.position
+            touch.id(),
+            touch.position()
         );
     }
 
     for touch in touches.iter_just_cancelled() {
-        println!("cancelled touch with id: {:?}", touch.id);
+        println!("cancelled touch with id: {:?}", touch.id());
     }
 
     // you can also iterate all current touches and retrieve their state like this:
     for touch in touches.iter() {
         println!("active touch: {:?}", touch);
-        println!("  just_pressed: {}", touches.just_pressed(touch.id));
+        println!("  just_pressed: {}", touches.just_pressed(touch.id()));
     }
 }


### PR DESCRIPTION
With the recent changes to APIs in `Time` and `Timer`, I came across Touch which would benefit from the same change. Upon code approval I can add it to the changelog.

My last PR randomly killed itself when I was messing with the git history, odd.