### PR TITLE
Run parent-update and transform-propagation during the "post-startup" stage (instead of "startup")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ current changes on git with [previous release tags][git_tag_comparison].
 - [Use `instant::Instant` for WASM compatibility][895]
 - [Fixed duplicated children when spawning a Scene][904]
 - [Corrected behaviour of the UI depth system][905]
+- [Run parent-update and transform-propagation during the "post-startup" stage][955]
 
 [821]: https://github.com/bevyengine/bevy/pull/821
 [829]: https://github.com/bevyengine/bevy/pull/829
@@ -59,6 +60,7 @@ current changes on git with [previous release tags][git_tag_comparison].
 [926]: https://github.com/bevyengine/bevy/pull/926
 [931]: https://github.com/bevyengine/bevy/pull/931
 [934]: https://github.com/bevyengine/bevy/pull/934
+[955]: https://github.com/bevyengine/bevy/pull/955
 
 ## Version 0.3.0 (2020-11-03)
 

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -6,7 +6,7 @@ pub mod prelude {
     pub use crate::{components::*, hierarchy::*, TransformPlugin};
 }
 
-use bevy_app::prelude::*;
+use bevy_app::{prelude::*, startup_stage};
 use bevy_reflect::RegisterTypeBuilder;
 use prelude::{parent_update_system, Children, GlobalTransform, Parent, PreviousParent, Transform};
 
@@ -21,8 +21,11 @@ impl Plugin for TransformPlugin {
             .register_type::<Transform>()
             .register_type::<GlobalTransform>()
             // add transform systems to startup so the first update is "correct"
-            .add_startup_system(parent_update_system)
-            .add_startup_system(transform_propagate_system::transform_propagate_system)
+            .add_startup_system_to_stage(startup_stage::POST_STARTUP, parent_update_system)
+            .add_startup_system_to_stage(
+                startup_stage::POST_STARTUP,
+                transform_propagate_system::transform_propagate_system,
+            )
             .add_system_to_stage(stage::POST_UPDATE, parent_update_system)
             .add_system_to_stage(
                 stage::POST_UPDATE,


### PR DESCRIPTION
Hi, 

Currently, `parent_update_system` and `transform_propagate_system` are registerd to run both at startup and for each update.

When running for ecah update they are in the stage `POST_UPDATE`. It makes sense, because it make sure they run after potential creation/update of `Transform` that would happen during the `UPDATE` stage.

But when running at startup, these two systems were in the default (`STARTUP`) stage. So if the user spawn entities during that stage (which is very likely, since it's the default), then the entities spawned by the user may have a incorrect `GlobalTransform` for the first update.

This discrepency looks very much like a small mistake. I assume that, If it is correct to run these two system during the `POST_UPDATE` of each update, then the correct things to do at startup is to run during the `POST_STARTUP`.

I hope it makes sense.

Thanks for this awseome work!