### PR TITLE
Renderer Optimization Round 1

### DIFF
--- a/crates/bevy_ecs/src/core/world_builder.rs
+++ b/crates/bevy_ecs/src/core/world_builder.rs
@@ -62,4 +62,16 @@ impl<'a> WorldBuilder<'a> {
         self.current_entity = Some(self.world.spawn(components));
         self
     }
+
+    pub fn current_entity(&self) -> Option<Entity> {
+        self.current_entity
+    }
+
+    pub fn for_current_entity(&mut self, f: impl FnOnce(Entity)) -> &mut Self {
+        let current_entity = self
+            .current_entity
+            .expect("The 'current entity' is not set. You should spawn an entity first.");
+        f(current_entity);
+        self
+    }
 }

--- a/crates/bevy_ecs/src/core/world_builder.rs
+++ b/crates/bevy_ecs/src/core/world_builder.rs
@@ -63,6 +63,7 @@ impl<'a> WorldBuilder<'a> {
         self
     }
 
+    #[inline]
     pub fn current_entity(&self) -> Option<Entity> {
         self.current_entity
     }

--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -5,13 +5,13 @@ use crate::{
 use bevy_app::prelude::{EventReader, Events};
 use bevy_asset::{AssetEvent, Assets, Handle};
 use bevy_core::AsBytes;
-use bevy_ecs::{Local, Query, Res};
+use bevy_ecs::{Changed, Entity, Local, Mut, Query, QuerySet, Res, With};
 use bevy_math::*;
 use bevy_reflect::TypeUuid;
 use std::borrow::Cow;
 
 use crate::pipeline::{InputStepMode, VertexAttributeDescriptor, VertexBufferDescriptor};
-use bevy_utils::HashMap;
+use bevy_utils::{HashMap, HashSet};
 
 pub const INDEX_BUFFER_ASSET_INDEX: u64 = 0;
 pub const VERTEX_ATTRIBUTE_BUFFER_ID: u64 = 10;
@@ -321,8 +321,15 @@ fn remove_current_mesh_resources(
 }
 
 #[derive(Default)]
+pub struct MeshEntities {
+    entities: HashSet<Entity>,
+    waiting: HashSet<Entity>,
+}
+
+#[derive(Default)]
 pub struct MeshResourceProviderState {
     mesh_event_reader: EventReader<AssetEvent<Mesh>>,
+    mesh_entities: HashMap<Handle<Mesh>, MeshEntities>,
 }
 
 pub fn mesh_resource_provider_system(
@@ -330,7 +337,10 @@ pub fn mesh_resource_provider_system(
     render_resource_context: Res<Box<dyn RenderResourceContext>>,
     meshes: Res<Assets<Mesh>>,
     mesh_events: Res<Events<AssetEvent<Mesh>>>,
-    mut query: Query<(&Handle<Mesh>, &mut RenderPipelines)>,
+    mut queries: QuerySet<(
+        Query<&mut RenderPipelines, With<Handle<Mesh>>>,
+        Query<(Entity, &Handle<Mesh>, &mut RenderPipelines), Changed<Handle<Mesh>>>,
+    )>,
 ) {
     let mut changed_meshes = bevy_utils::HashSet::<Handle<Mesh>>::default();
     let render_resource_context = &**render_resource_context;
@@ -383,39 +393,77 @@ pub fn mesh_resource_provider_system(
                 )),
                 VERTEX_ATTRIBUTE_BUFFER_ID,
             );
+
+            if let Some(mesh_entities) = state.mesh_entities.get_mut(changed_mesh_handle) {
+                for entity in mesh_entities.waiting.drain() {
+                    if let Ok(render_pipelines) = queries.q0_mut().get_mut(entity) {
+                        mesh_entities.entities.insert(entity);
+                        update_entity_mesh(
+                            render_resource_context,
+                            mesh,
+                            changed_mesh_handle,
+                            entity,
+                            render_pipelines,
+                        );
+                    }
+                }
+            }
         }
     }
 
     // handover buffers to pipeline
-    for (handle, mut render_pipelines) in query.iter_mut() {
+    for (entity, handle, render_pipelines) in queries.q1_mut().iter_mut() {
+        let mesh_entities = state
+            .mesh_entities
+            .entry(handle.clone_weak())
+            .or_insert_with(MeshEntities::default);
         if let Some(mesh) = meshes.get(handle) {
-            for render_pipeline in render_pipelines.pipelines.iter_mut() {
-                render_pipeline.specialization.primitive_topology = mesh.primitive_topology;
-                // TODO: don't allocate a new vertex buffer descriptor for every entity
-                render_pipeline.specialization.vertex_buffer_descriptor =
-                    mesh.get_vertex_buffer_descriptor();
-                render_pipeline.specialization.index_format = mesh
-                    .indices()
-                    .map(|i| i.into())
-                    .unwrap_or(IndexFormat::Uint32);
-            }
-
-            if let Some(RenderResourceId::Buffer(index_buffer_resource)) =
-                render_resource_context.get_asset_resource(handle, INDEX_BUFFER_ASSET_INDEX)
-            {
-                // set index buffer into binding
-                render_pipelines
-                    .bindings
-                    .set_index_buffer(index_buffer_resource);
-            }
-
-            if let Some(RenderResourceId::Buffer(vertex_attribute_buffer_resource)) =
-                render_resource_context.get_asset_resource(handle, VERTEX_ATTRIBUTE_BUFFER_ID)
-            {
-                // set index buffer into binding
-                render_pipelines.bindings.vertex_attribute_buffer =
-                    Some(vertex_attribute_buffer_resource);
-            }
+            mesh_entities.entities.insert(entity);
+            mesh_entities.waiting.remove(&entity);
+            update_entity_mesh(
+                render_resource_context,
+                mesh,
+                handle,
+                entity,
+                render_pipelines,
+            );
+        } else {
+            mesh_entities.waiting.insert(entity);
         }
+    }
+}
+
+fn update_entity_mesh(
+    render_resource_context: &dyn RenderResourceContext,
+    mesh: &Mesh,
+    handle: &Handle<Mesh>,
+    entity: Entity,
+    mut render_pipelines: Mut<RenderPipelines>,
+) {
+    for render_pipeline in render_pipelines.pipelines.iter_mut() {
+        render_pipeline.specialization.primitive_topology = mesh.primitive_topology;
+        // TODO: don't allocate a new vertex buffer descriptor for every entity
+        render_pipeline.specialization.vertex_buffer_descriptor =
+            mesh.get_vertex_buffer_descriptor();
+        render_pipeline.specialization.index_format = mesh
+            .indices()
+            .map(|i| i.into())
+            .unwrap_or(IndexFormat::Uint32);
+    }
+
+    if let Some(RenderResourceId::Buffer(index_buffer_resource)) =
+        render_resource_context.get_asset_resource(handle, INDEX_BUFFER_ASSET_INDEX)
+    {
+        // set index buffer into binding
+        render_pipelines
+            .bindings
+            .set_index_buffer(index_buffer_resource);
+    }
+
+    if let Some(RenderResourceId::Buffer(vertex_attribute_buffer_resource)) =
+        render_resource_context.get_asset_resource(handle, VERTEX_ATTRIBUTE_BUFFER_ID)
+    {
+        // set index buffer into binding
+        render_pipelines.bindings.vertex_attribute_buffer = Some(vertex_attribute_buffer_resource);
     }
 }

--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -402,7 +402,6 @@ pub fn mesh_resource_provider_system(
                             render_resource_context,
                             mesh,
                             changed_mesh_handle,
-                            entity,
                             render_pipelines,
                         );
                     }
@@ -420,13 +419,7 @@ pub fn mesh_resource_provider_system(
         if let Some(mesh) = meshes.get(handle) {
             mesh_entities.entities.insert(entity);
             mesh_entities.waiting.remove(&entity);
-            update_entity_mesh(
-                render_resource_context,
-                mesh,
-                handle,
-                entity,
-                render_pipelines,
-            );
+            update_entity_mesh(render_resource_context, mesh, handle, render_pipelines);
         } else {
             mesh_entities.waiting.insert(entity);
         }
@@ -437,7 +430,6 @@ fn update_entity_mesh(
     render_resource_context: &dyn RenderResourceContext,
     mesh: &Mesh,
     handle: &Handle<Mesh>,
-    entity: Entity,
     mut render_pipelines: Mut<RenderPipelines>,
 ) {
     for render_pipeline in render_pipelines.pipelines.iter_mut() {

--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -244,7 +244,9 @@ where
                         for render_command in draw.render_commands.iter() {
                             match render_command {
                                 RenderCommand::SetPipeline { pipeline } => {
-                                    // TODO: Filter pipelines
+                                    if draw_state.is_pipeline_set(pipeline.clone_weak()) {
+                                        continue;
+                                    }
                                     render_pass.set_pipeline(pipeline);
                                     let descriptor = pipelines.get(pipeline).unwrap();
                                     draw_state.set_pipeline(pipeline, descriptor);
@@ -290,18 +292,27 @@ where
                                     offset,
                                     slot,
                                 } => {
+                                    if draw_state.is_vertex_buffer_set(*slot, *buffer, *offset) {
+                                        continue;
+                                    }
                                     render_pass.set_vertex_buffer(*slot, *buffer, *offset);
-                                    draw_state.set_vertex_buffer(*slot, *buffer);
+                                    draw_state.set_vertex_buffer(*slot, *buffer, *offset);
                                 }
                                 RenderCommand::SetIndexBuffer { buffer, offset } => {
+                                    if draw_state.is_index_buffer_set(*buffer, *offset) {
+                                        continue;
+                                    }
                                     render_pass.set_index_buffer(*buffer, *offset);
-                                    draw_state.set_index_buffer(*buffer)
+                                    draw_state.set_index_buffer(*buffer, *offset)
                                 }
                                 RenderCommand::SetBindGroup {
                                     index,
                                     bind_group,
                                     dynamic_uniform_indices,
                                 } => {
+                                    if dynamic_uniform_indices.is_none() && draw_state.is_bind_group_set(*index, *bind_group) {
+                                        continue;
+                                    }
                                     let pipeline = pipelines.get(draw_state.pipeline.as_ref().unwrap()).unwrap();
                                     let layout = pipeline.get_layout().unwrap();
                                     let bind_group_descriptor = layout.get_bind_group(*index).unwrap();
@@ -329,8 +340,8 @@ where
 struct DrawState {
     pipeline: Option<Handle<PipelineDescriptor>>,
     bind_groups: Vec<Option<BindGroupId>>,
-    vertex_buffers: Vec<Option<BufferId>>,
-    index_buffer: Option<BufferId>,
+    vertex_buffers: Vec<Option<(BufferId, u64)>>,
+    index_buffer: Option<(BufferId, u64)>,
 }
 
 impl DrawState {
@@ -338,12 +349,24 @@ impl DrawState {
         self.bind_groups[index as usize] = Some(bind_group);
     }
 
-    pub fn set_vertex_buffer(&mut self, index: u32, buffer: BufferId) {
-        self.vertex_buffers[index as usize] = Some(buffer);
+    pub fn is_bind_group_set(&self, index: u32, bind_group: BindGroupId) -> bool {
+        self.bind_groups[index as usize] == Some(bind_group)
     }
 
-    pub fn set_index_buffer(&mut self, buffer: BufferId) {
-        self.index_buffer = Some(buffer);
+    pub fn set_vertex_buffer(&mut self, index: u32, buffer: BufferId, offset: u64) {
+        self.vertex_buffers[index as usize] = Some((buffer, offset));
+    }
+
+    pub fn is_vertex_buffer_set(&self, index: u32, buffer: BufferId, offset: u64) -> bool {
+        self.vertex_buffers[index as usize] == Some((buffer, offset))
+    }
+
+    pub fn set_index_buffer(&mut self, buffer: BufferId, offset: u64) {
+        self.index_buffer = Some((buffer, offset));
+    }
+
+    pub fn is_index_buffer_set(&self, buffer: BufferId, offset: u64) -> bool {
+        self.index_buffer == Some((buffer, offset))
     }
 
     pub fn can_draw(&self) -> bool {
@@ -353,6 +376,10 @@ impl DrawState {
 
     pub fn can_draw_indexed(&self) -> bool {
         self.can_draw() && self.index_buffer.is_some()
+    }
+
+    pub fn is_pipeline_set(&self, pipeline: Handle<PipelineDescriptor>) -> bool {
+        self.pipeline == Some(pipeline)
     }
 
     pub fn set_pipeline(

--- a/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
@@ -10,7 +10,9 @@ use crate::{
 };
 
 use bevy_asset::{Asset, Assets, Handle, HandleId};
-use bevy_ecs::{Changed, Commands, Entity, IntoSystem, Local, Query, Res, ResMut, Resources, System, World};
+use bevy_ecs::{
+    Changed, Commands, Entity, IntoSystem, Local, Query, Res, ResMut, Resources, System, World,
+};
 use bevy_utils::HashMap;
 use renderer::{AssetRenderResourceBindings, BufferId, RenderResourceType, RenderResources};
 use std::{hash::Hash, marker::PhantomData, ops::DerefMut};

--- a/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
@@ -11,7 +11,8 @@ use crate::{
 
 use bevy_asset::{Asset, Assets, Handle, HandleId};
 use bevy_ecs::{
-    Changed, Commands, Entity, IntoSystem, Local, Query, Res, ResMut, Resources, System, World,
+    Changed, Commands, Entity, IntoSystem, Local, Query, QuerySet, Res, ResMut, Resources, System,
+    World,
 };
 use bevy_utils::HashMap;
 use renderer::{AssetRenderResourceBindings, BufferId, RenderResourceType, RenderResources};
@@ -82,13 +83,14 @@ impl<I: Hash + Eq> BufferArray<I> {
         }
     }
 
-    pub fn resize(&mut self, render_resource_context: &dyn RenderResourceContext) {
+    pub fn resize(&mut self, render_resource_context: &dyn RenderResourceContext) -> bool {
         if self.len <= self.buffer_capacity {
-            return;
+            return false;
         }
 
         self.allocate_buffer(render_resource_context);
         // TODO: allow shrinking
+        true
     }
 
     pub fn allocate_buffer(&mut self, render_resource_context: &dyn RenderResourceContext) {
@@ -191,12 +193,29 @@ where
     }
 
     /// Resize BufferArray buffers if they aren't large enough
-    fn resize_buffer_arrays(&mut self, render_resource_context: &dyn RenderResourceContext) {
+    fn resize_buffer_arrays(
+        &mut self,
+        render_resource_context: &dyn RenderResourceContext,
+    ) -> bool {
+        let mut resized = false;
         for buffer_array in self.buffer_arrays.iter_mut() {
             if let Some(buffer_array) = buffer_array {
-                buffer_array.resize(render_resource_context);
+                resized |= buffer_array.resize(render_resource_context);
             }
         }
+
+        resized
+    }
+
+    fn set_required_staging_buffer_size_to_max(&mut self) {
+        let mut new_size = 0;
+        for buffer_array in self.buffer_arrays.iter() {
+            if let Some(buffer_array) = buffer_array {
+                new_size += buffer_array.item_size * buffer_array.len;
+            }
+        }
+
+        self.required_staging_buffer_size = new_size;
     }
 
     /// Update the staging buffer to provide enough space to copy data to target buffers.
@@ -240,91 +259,83 @@ where
         staging_buffer: &mut [u8],
     ) {
         for (i, render_resource) in uniforms.iter().enumerate() {
-            match render_resource.resource_type() {
-                Some(RenderResourceType::Buffer) => {
-                    let size = render_resource.buffer_byte_len().unwrap();
-                    let render_resource_name = uniforms.get_render_resource_name(i).unwrap();
-                    let aligned_size =
-                        render_resource_context.get_aligned_uniform_size(size, false);
-                    let buffer_array = self.buffer_arrays[i].as_mut().unwrap();
-                    let range = 0..aligned_size as u64;
-                    let (target_buffer, target_offset) = if dynamic_uniforms {
-                        let binding = buffer_array.get_binding(id).unwrap();
-                        let dynamic_index = if let RenderResourceBinding::Buffer {
-                            dynamic_index: Some(dynamic_index),
-                            ..
-                        } = binding
-                        {
-                            dynamic_index
-                        } else {
-                            panic!("dynamic index should always be set");
-                        };
-                        render_resource_bindings.set(render_resource_name, binding);
-                        (buffer_array.buffer.unwrap(), dynamic_index)
+            if let Some(RenderResourceType::Buffer) = render_resource.resource_type() {
+                let size = render_resource.buffer_byte_len().unwrap();
+                let render_resource_name = uniforms.get_render_resource_name(i).unwrap();
+                let aligned_size = render_resource_context.get_aligned_uniform_size(size, false);
+                let buffer_array = self.buffer_arrays[i].as_mut().unwrap();
+                let range = 0..aligned_size as u64;
+                let (target_buffer, target_offset) = if dynamic_uniforms {
+                    let binding = buffer_array.get_binding(id).unwrap();
+                    let dynamic_index = if let RenderResourceBinding::Buffer {
+                        dynamic_index: Some(dynamic_index),
+                        ..
+                    } = binding
+                    {
+                        dynamic_index
                     } else {
-                        let mut matching_buffer = None;
-                        if let Some(binding) = render_resource_bindings.get(render_resource_name) {
-                            let buffer_id = binding.get_buffer().unwrap();
-                            if let Some(BufferInfo {
-                                size: current_size, ..
-                            }) = render_resource_context.get_buffer_info(buffer_id)
-                            {
-                                if aligned_size == current_size {
-                                    matching_buffer = Some(buffer_id);
-                                } else {
-                                    render_resource_context.remove_buffer(buffer_id);
-                                }
+                        panic!("dynamic index should always be set");
+                    };
+                    render_resource_bindings.set(render_resource_name, binding);
+                    (buffer_array.buffer.unwrap(), dynamic_index)
+                } else {
+                    let mut matching_buffer = None;
+                    if let Some(binding) = render_resource_bindings.get(render_resource_name) {
+                        let buffer_id = binding.get_buffer().unwrap();
+                        if let Some(BufferInfo {
+                            size: current_size, ..
+                        }) = render_resource_context.get_buffer_info(buffer_id)
+                        {
+                            if aligned_size == current_size {
+                                matching_buffer = Some(buffer_id);
+                            } else {
+                                render_resource_context.remove_buffer(buffer_id);
+                            }
+                        }
+                    }
+
+                    let resource = if let Some(matching_buffer) = matching_buffer {
+                        matching_buffer
+                    } else {
+                        let mut usage = BufferUsage::UNIFORM;
+                        if let Some(render_resource_hints) = uniforms.get_render_resource_hints(i) {
+                            if render_resource_hints.contains(RenderResourceHints::BUFFER) {
+                                usage = BufferUsage::STORAGE
                             }
                         }
 
-                        let resource = if let Some(matching_buffer) = matching_buffer {
-                            matching_buffer
-                        } else {
-                            let mut usage = BufferUsage::UNIFORM;
-                            if let Some(render_resource_hints) =
-                                uniforms.get_render_resource_hints(i)
-                            {
-                                if render_resource_hints.contains(RenderResourceHints::BUFFER) {
-                                    usage = BufferUsage::STORAGE
-                                }
-                            }
+                        let buffer = render_resource_context.create_buffer(BufferInfo {
+                            size: aligned_size,
+                            buffer_usage: BufferUsage::COPY_DST | usage,
+                            ..Default::default()
+                        });
 
-                            let buffer = render_resource_context.create_buffer(BufferInfo {
-                                size: aligned_size,
-                                buffer_usage: BufferUsage::COPY_DST | usage,
-                                ..Default::default()
-                            });
-
-                            render_resource_bindings.set(
-                                render_resource_name,
-                                RenderResourceBinding::Buffer {
-                                    buffer,
-                                    range,
-                                    dynamic_index: None,
-                                },
-                            );
-                            buffer
-                        };
-
-                        (resource, 0)
+                        render_resource_bindings.set(
+                            render_resource_name,
+                            RenderResourceBinding::Buffer {
+                                buffer,
+                                range,
+                                dynamic_index: None,
+                            },
+                        );
+                        buffer
                     };
 
-                    render_resource.write_buffer_bytes(
-                        &mut staging_buffer[self.current_staging_buffer_offset
-                            ..(self.current_staging_buffer_offset + size)],
-                    );
+                    (resource, 0)
+                };
 
-                    self.queued_buffer_writes.push(QueuedBufferWrite {
-                        buffer: target_buffer,
-                        target_offset: target_offset as usize,
-                        source_offset: self.current_staging_buffer_offset,
-                        size,
-                    });
-                    self.current_staging_buffer_offset += size;
-                }
-                Some(RenderResourceType::Texture) => { /* ignore textures */ }
-                Some(RenderResourceType::Sampler) => { /* ignore samplers */ }
-                None => { /* ignore None */ }
+                render_resource.write_buffer_bytes(
+                    &mut staging_buffer[self.current_staging_buffer_offset
+                        ..(self.current_staging_buffer_offset + size)],
+                );
+
+                self.queued_buffer_writes.push(QueuedBufferWrite {
+                    buffer: target_buffer,
+                    target_offset: target_offset as usize,
+                    source_offset: self.current_staging_buffer_offset,
+                    size,
+                });
+                self.current_staging_buffer_offset += size;
             }
         }
     }
@@ -423,22 +434,25 @@ impl<I, T: RenderResources> Default for RenderResourcesNodeState<I, T> {
 fn render_resources_node_system<T: RenderResources>(
     mut state: Local<RenderResourcesNodeState<Entity, T>>,
     render_resource_context: Res<Box<dyn RenderResourceContext>>,
-    mut query: Query<(Entity, &T, &Draw, &mut RenderPipelines), Changed<T>>,
+    mut queries: QuerySet<(
+        Query<(Entity, &T, &Draw, &mut RenderPipelines), Changed<T>>,
+        Query<(Entity, &T, &Draw, &mut RenderPipelines)>,
+    )>,
 ) {
     let state = state.deref_mut();
     let uniform_buffer_arrays = &mut state.uniform_buffer_arrays;
     let render_resource_context = &**render_resource_context;
     uniform_buffer_arrays.begin_update();
     // initialize uniform buffer arrays using the first RenderResources
-    if let Some((_, first, _, _)) = query.iter_mut().next() {
+    if let Some((_, first, _, _)) = queries.q0_mut().iter_mut().next() {
         uniform_buffer_arrays.initialize(first, render_resource_context);
     }
 
-    for entity in query.removed::<T>() {
+    for entity in queries.q0().removed::<T>() {
         uniform_buffer_arrays.remove_bindings(*entity);
     }
 
-    for (entity, uniforms, draw, mut render_pipelines) in query.iter_mut() {
+    for (entity, uniforms, draw, mut render_pipelines) in queries.q0_mut().iter_mut() {
         if !draw.is_visible {
             continue;
         }
@@ -451,7 +465,10 @@ fn render_resources_node_system<T: RenderResources>(
         )
     }
 
-    uniform_buffer_arrays.resize_buffer_arrays(render_resource_context);
+    let resized = uniform_buffer_arrays.resize_buffer_arrays(render_resource_context);
+    if resized {
+        uniform_buffer_arrays.set_required_staging_buffer_size_to_max()
+    }
     uniform_buffer_arrays.resize_staging_buffer(render_resource_context);
 
     if let Some(staging_buffer) = state.uniform_buffer_arrays.staging_buffer {
@@ -460,19 +477,41 @@ fn render_resources_node_system<T: RenderResources>(
             staging_buffer,
             0..state.uniform_buffer_arrays.staging_buffer_size as u64,
             &mut |mut staging_buffer, _render_resource_context| {
-                for (entity, uniforms, draw, mut render_pipelines) in query.iter_mut() {
-                    if !draw.is_visible {
-                        continue;
-                    }
+                // if the buffer array was resized, write all entities to the new buffer, otherwise only write changes
+                if resized {
+                    for (entity, uniforms, draw, mut render_pipelines) in
+                        queries.q1_mut().iter_mut()
+                    {
+                        if !draw.is_visible {
+                            continue;
+                        }
 
-                    state.uniform_buffer_arrays.write_uniform_buffers(
-                        entity,
-                        &uniforms,
-                        state.dynamic_uniforms,
-                        render_resource_context,
-                        &mut render_pipelines.bindings,
-                        &mut staging_buffer,
-                    );
+                        state.uniform_buffer_arrays.write_uniform_buffers(
+                            entity,
+                            &uniforms,
+                            state.dynamic_uniforms,
+                            render_resource_context,
+                            &mut render_pipelines.bindings,
+                            &mut staging_buffer,
+                        );
+                    }
+                } else {
+                    for (entity, uniforms, draw, mut render_pipelines) in
+                        queries.q0_mut().iter_mut()
+                    {
+                        if !draw.is_visible {
+                            continue;
+                        }
+
+                        state.uniform_buffer_arrays.write_uniform_buffers(
+                            entity,
+                            &uniforms,
+                            state.dynamic_uniforms,
+                            render_resource_context,
+                            &mut render_pipelines.bindings,
+                            &mut staging_buffer,
+                        );
+                    }
                 }
             },
         );

--- a/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 use bevy_asset::{Asset, Assets, Handle, HandleId};
-use bevy_ecs::{Commands, Entity, IntoSystem, Local, Query, Res, ResMut, Resources, System, World};
+use bevy_ecs::{Changed, Commands, Entity, IntoSystem, Local, Query, Res, ResMut, Resources, System, World};
 use bevy_utils::HashMap;
 use renderer::{AssetRenderResourceBindings, BufferId, RenderResourceType, RenderResources};
 use std::{hash::Hash, marker::PhantomData, ops::DerefMut};
@@ -421,7 +421,7 @@ impl<I, T: RenderResources> Default for RenderResourcesNodeState<I, T> {
 fn render_resources_node_system<T: RenderResources>(
     mut state: Local<RenderResourcesNodeState<Entity, T>>,
     render_resource_context: Res<Box<dyn RenderResourceContext>>,
-    mut query: Query<(Entity, &T, &Draw, &mut RenderPipelines)>,
+    mut query: Query<(Entity, &T, &Draw, &mut RenderPipelines), Changed<T>>,
 ) {
     let state = state.deref_mut();
     let uniform_buffer_arrays = &mut state.uniform_buffer_arrays;

--- a/crates/bevy_render/src/renderer/headless_render_resource_context.rs
+++ b/crates/bevy_render/src/renderer/headless_render_resource_context.rs
@@ -153,6 +153,5 @@ impl RenderResourceContext for HeadlessRenderResourceContext {
         shader.clone()
     }
 
-    fn remove_stale_bind_groups(&self) {
-    }
+    fn remove_stale_bind_groups(&self) {}
 }

--- a/crates/bevy_render/src/renderer/headless_render_resource_context.rs
+++ b/crates/bevy_render/src/renderer/headless_render_resource_context.rs
@@ -152,4 +152,7 @@ impl RenderResourceContext for HeadlessRenderResourceContext {
     fn get_specialized_shader(&self, shader: &Shader, _macros: Option<&[String]>) -> Shader {
         shader.clone()
     }
+
+    fn remove_stale_bind_groups(&self) {
+    }
 }

--- a/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
+++ b/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
@@ -158,14 +158,8 @@ impl RenderResourceBindings {
                         .expect("RenderResourceSet was just changed, so it should exist");
                     render_resource_context.create_bind_group(bind_group_descriptor.id, bind_group);
                 }
-                // TODO: Don't re-create bind groups if they havent changed. this will require cleanup of orphan bind groups and
-                // removal of global context.clear_bind_groups()
-                // PERF: see above
-                BindGroupStatus::Unchanged(id) => {
-                    let bind_group = self
-                        .get_bind_group(id)
-                        .expect("RenderResourceSet was just changed, so it should exist");
-                    render_resource_context.create_bind_group(bind_group_descriptor.id, bind_group);
+                BindGroupStatus::Unchanged(_id) => {
+                    // don't re-create unchanged bind groups
                 }
                 BindGroupStatus::NoMatch => {
                     // ignore unchanged / unmatched render resource sets

--- a/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
+++ b/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
@@ -162,8 +162,13 @@ impl RenderResourceBindings {
                         .expect("RenderResourceSet was just changed, so it should exist");
                     render_resource_context.create_bind_group(bind_group_descriptor.id, bind_group);
                 }
-                BindGroupStatus::Unchanged(_id) => {
-                    // don't re-create unchanged bind groups
+                BindGroupStatus::Unchanged(id) => {
+                    // PERF: this is only required because RenderResourceContext::remove_stale_bind_groups doesn't inform RenderResourceBindings
+                    // when a stale bind group has been removed 
+                    let bind_group = self
+                        .get_bind_group(id)
+                        .expect("RenderResourceSet was just changed, so it should exist");
+                    render_resource_context.create_bind_group(bind_group_descriptor.id, bind_group);
                 }
                 BindGroupStatus::NoMatch => {
                     // ignore unchanged / unmatched render resource sets

--- a/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
+++ b/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
@@ -99,6 +99,9 @@ impl RenderResourceBindings {
                     self.dirty_bind_groups.insert(*id);
                 }
             }
+        } else {
+            // unmatched bind group descriptors might now match
+            self.bind_group_descriptors.retain(|_, value| value.is_some());
         }
     }
 

--- a/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
+++ b/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
@@ -120,6 +120,7 @@ impl RenderResourceBindings {
             self.bind_group_descriptors.insert(descriptor.id, Some(id));
             BindGroupStatus::Changed(id)
         } else {
+            self.bind_group_descriptors.insert(descriptor.id, None);
             BindGroupStatus::NoMatch
         }
     }

--- a/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
+++ b/crates/bevy_render/src/renderer/render_resource/render_resource_bindings.rs
@@ -101,7 +101,8 @@ impl RenderResourceBindings {
             }
         } else {
             // unmatched bind group descriptors might now match
-            self.bind_group_descriptors.retain(|_, value| value.is_some());
+            self.bind_group_descriptors
+                .retain(|_, value| value.is_some());
         }
     }
 
@@ -164,7 +165,7 @@ impl RenderResourceBindings {
                 }
                 BindGroupStatus::Unchanged(id) => {
                     // PERF: this is only required because RenderResourceContext::remove_stale_bind_groups doesn't inform RenderResourceBindings
-                    // when a stale bind group has been removed 
+                    // when a stale bind group has been removed
                     let bind_group = self
                         .get_bind_group(id)
                         .expect("RenderResourceSet was just changed, so it should exist");

--- a/crates/bevy_render/src/renderer/render_resource_context.rs
+++ b/crates/bevy_render/src/renderer/render_resource_context.rs
@@ -62,6 +62,7 @@ pub trait RenderResourceContext: Downcast + Send + Sync + 'static {
         bind_group: &BindGroup,
     );
     fn clear_bind_groups(&self);
+    fn remove_stale_bind_groups(&self);
     /// Reflects the pipeline layout from its shaders.
     ///
     /// If `bevy_conventions` is true, it will be assumed that the shader follows "bevy shader conventions". These allow

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -41,7 +41,7 @@ impl Sprite {
 pub fn sprite_system(
     materials: Res<Assets<ColorMaterial>>,
     textures: Res<Assets<Texture>>,
-    mut query: Query<(&mut Sprite, &Handle<ColorMaterial>), Changed<Sprite>>,
+    mut query: Query<(&mut Sprite, &Handle<ColorMaterial>)>,
 ) {
     for (mut sprite, handle) in query.iter_mut() {
         match sprite.resize_mode {

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -1,6 +1,6 @@
 use crate::ColorMaterial;
 use bevy_asset::{Assets, Handle};
-use bevy_ecs::{Changed, Query, Res};
+use bevy_ecs::{Query, Res};
 use bevy_math::Vec2;
 use bevy_reflect::{Reflect, ReflectDeserialize, TypeUuid};
 use bevy_render::{renderer::RenderResources, texture::Texture};

--- a/crates/bevy_transform/src/hierarchy/world_child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/world_child_builder.rs
@@ -52,6 +52,15 @@ impl<'a, 'b> WorldChildBuilder<'a, 'b> {
     pub fn current_entity(&self) -> Option<Entity> {
         self.world_builder.current_entity
     }
+
+    pub fn for_current_entity(&mut self, f: impl FnOnce(Entity)) -> &mut Self {
+        let current_entity = self
+            .world_builder
+            .current_entity
+            .expect("The 'current entity' is not set. You should spawn an entity first.");
+        f(current_entity);
+        self
+    }
 }
 
 pub trait BuildWorldChildren {

--- a/crates/bevy_transform/src/transform_propagate_system.rs
+++ b/crates/bevy_transform/src/transform_propagate_system.rs
@@ -3,22 +3,29 @@ use bevy_ecs::prelude::*;
 
 pub fn transform_propagate_system(
     mut root_query: Query<
-        (Option<&Children>, &Transform, &mut GlobalTransform),
+        (Entity, Option<&Children>, &Transform, &mut GlobalTransform),
         (Without<Parent>, With<GlobalTransform>),
     >,
     mut transform_query: Query<(&Transform, &mut GlobalTransform), With<Parent>>,
+    changed_transform_query: Query<Entity, Changed<Transform>>,
     children_query: Query<Option<&Children>, (With<Parent>, With<GlobalTransform>)>,
 ) {
-    for (children, transform, mut global_transform) in root_query.iter_mut() {
-        *global_transform = GlobalTransform::from(*transform);
+    for (entity, children, transform, mut global_transform) in root_query.iter_mut() {
+        let mut changed = false;
+        if changed_transform_query.get(entity).is_ok() {
+            *global_transform = GlobalTransform::from(*transform);
+            changed = true;
+        }
 
         if let Some(children) = children {
             for child in children.0.iter() {
                 propagate_recursive(
                     &global_transform,
+                    &changed_transform_query,
                     &mut transform_query,
                     &children_query,
                     *child,
+                    changed,
                 );
             }
         }
@@ -27,13 +34,19 @@ pub fn transform_propagate_system(
 
 fn propagate_recursive(
     parent: &GlobalTransform,
+    changed_transform_query: &Query<Entity, Changed<Transform>>,
     transform_query: &mut Query<(&Transform, &mut GlobalTransform), With<Parent>>,
     children_query: &Query<Option<&Children>, (With<Parent>, With<GlobalTransform>)>,
     entity: Entity,
+    mut changed: bool,
 ) {
+    changed |= changed_transform_query.get(entity).is_ok();
+
     let global_matrix = {
         if let Ok((transform, mut global_transform)) = transform_query.get_mut(entity) {
-            *global_transform = parent.mul_transform(*transform);
+            if changed {
+                *global_transform = parent.mul_transform(*transform);
+            }
             *global_transform
         } else {
             return;
@@ -42,7 +55,14 @@ fn propagate_recursive(
 
     if let Ok(Some(children)) = children_query.get(entity) {
         for child in children.0.iter() {
-            propagate_recursive(&global_matrix, transform_query, children_query, *child);
+            propagate_recursive(
+                &global_matrix,
+                changed_transform_query,
+                transform_query,
+                children_query,
+                *child,
+                changed,
+            );
         }
     }
 }

--- a/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
+++ b/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
@@ -522,6 +522,10 @@ impl RenderResourceContext for WgpuRenderResourceContext {
         self.resources.bind_groups.write().clear();
     }
 
+    fn remove_stale_bind_groups(&self) {
+        self.resources.remove_stale_bind_groups();
+    }
+
     fn get_buffer_info(&self, buffer: BufferId) -> Option<BufferInfo> {
         self.resources.buffer_infos.read().get(&buffer).cloned()
     }

--- a/crates/bevy_wgpu/src/wgpu_render_pass.rs
+++ b/crates/bevy_wgpu/src/wgpu_render_pass.rs
@@ -74,6 +74,10 @@ impl<'a> RenderPass for WgpuRenderPass<'a> {
                     } else {
                         EMPTY
                     };
+                self.wgpu_resources
+                    .used_bind_group_sender
+                    .send(bind_group)
+                    .unwrap();
 
                 trace!(
                     "set bind group {:?} {:?}: {:?}",

--- a/crates/bevy_wgpu/src/wgpu_renderer.rs
+++ b/crates/bevy_wgpu/src/wgpu_renderer.rs
@@ -115,6 +115,6 @@ impl WgpuRenderer {
 
         let render_resource_context = resources.get::<Box<dyn RenderResourceContext>>().unwrap();
         render_resource_context.drop_all_swap_chain_textures();
-        render_resource_context.clear_bind_groups();
+        render_resource_context.remove_stale_bind_groups();
     }
 }

--- a/crates/bevy_wgpu/src/wgpu_resources.rs
+++ b/crates/bevy_wgpu/src/wgpu_resources.rs
@@ -7,6 +7,7 @@ use bevy_render::{
 };
 use bevy_utils::HashMap;
 use bevy_window::WindowId;
+use crossbeam_channel::{Receiver, Sender, TryRecvError};
 use parking_lot::{RwLock, RwLockReadGuard};
 use std::sync::Arc;
 
@@ -45,6 +46,7 @@ pub struct WgpuResourcesReadLock<'a> {
     pub render_pipelines:
         RwLockReadGuard<'a, HashMap<Handle<PipelineDescriptor>, wgpu::RenderPipeline>>,
     pub bind_groups: RwLockReadGuard<'a, HashMap<BindGroupDescriptorId, WgpuBindGroupInfo>>,
+    pub used_bind_group_sender: Sender<BindGroupId>,
 }
 
 impl<'a> WgpuResourcesReadLock<'a> {
@@ -55,6 +57,7 @@ impl<'a> WgpuResourcesReadLock<'a> {
             swap_chain_frames: &self.swap_chain_frames,
             render_pipelines: &self.render_pipelines,
             bind_groups: &self.bind_groups,
+            used_bind_group_sender: &self.used_bind_group_sender,
         }
     }
 }
@@ -67,6 +70,7 @@ pub struct WgpuResourceRefs<'a> {
     pub swap_chain_frames: &'a HashMap<TextureId, wgpu::SwapChainFrame>,
     pub render_pipelines: &'a HashMap<Handle<PipelineDescriptor>, wgpu::RenderPipeline>,
     pub bind_groups: &'a HashMap<BindGroupDescriptorId, WgpuBindGroupInfo>,
+    pub used_bind_group_sender: &'a Sender<BindGroupId>,
 }
 
 #[derive(Default, Clone, Debug)]
@@ -85,6 +89,7 @@ pub struct WgpuResources {
     pub bind_groups: Arc<RwLock<HashMap<BindGroupDescriptorId, WgpuBindGroupInfo>>>,
     pub bind_group_layouts: Arc<RwLock<HashMap<BindGroupDescriptorId, wgpu::BindGroupLayout>>>,
     pub asset_resources: Arc<RwLock<HashMap<(HandleUntyped, u64), RenderResourceId>>>,
+    pub bind_group_counter: BindGroupCounter,
 }
 
 impl WgpuResources {
@@ -95,6 +100,7 @@ impl WgpuResources {
             swap_chain_frames: self.swap_chain_frames.read(),
             render_pipelines: self.render_pipelines.read(),
             bind_groups: self.bind_groups.read(),
+            used_bind_group_sender: self.bind_group_counter.used_bind_group_sender.clone(),
         }
     }
 
@@ -107,6 +113,66 @@ impl WgpuResources {
             bind_group_info.bind_groups.get(&bind_group_id).is_some()
         } else {
             false
+        }
+    }
+
+    pub fn remove_stale_bind_groups(&self) {
+        let mut bind_groups = self.bind_groups.write();
+        self.bind_group_counter
+            .remove_stale_bind_groups(&mut bind_groups);
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BindGroupCounter {
+    pub used_bind_group_sender: Sender<BindGroupId>,
+    pub used_bind_group_receiver: Receiver<BindGroupId>,
+    pub bind_group_usage_counts: Arc<RwLock<HashMap<BindGroupId, u64>>>,
+}
+
+impl BindGroupCounter {
+    pub fn remove_stale_bind_groups(
+        &self,
+        bind_groups: &mut HashMap<BindGroupDescriptorId, WgpuBindGroupInfo>,
+    ) {
+        let mut bind_group_usage_counts = self.bind_group_usage_counts.write();
+        loop {
+            let bind_group = match self.used_bind_group_receiver.try_recv() {
+                Ok(bind_group) => bind_group,
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => panic!("used bind group channel disconnected"),
+            };
+
+            let count = bind_group_usage_counts.entry(bind_group).or_insert(0);
+            // free every two frames
+            *count = 2;
+        }
+
+        for info in bind_groups.values_mut() {
+            info.bind_groups.retain(|id, _| {
+                let retain = {
+                    // if a value hasn't been counted yet, give it two frames of leeway
+                    let count = bind_group_usage_counts.entry(*id).or_insert(2);
+                    *count -= 1;
+                    *count > 0
+                };
+                if !retain {
+                    bind_group_usage_counts.remove(&id);
+                }
+
+                retain
+            })
+        }
+    }
+}
+
+impl Default for BindGroupCounter {
+    fn default() -> Self {
+        let (send, recv) = crossbeam_channel::unbounded();
+        BindGroupCounter {
+            used_bind_group_sender: send,
+            used_bind_group_receiver: recv,
+            bind_group_usage_counts: Default::default(),
         }
     }
 }


### PR DESCRIPTION
Its time to start making the renderer fast! This first round is just picking a lot of low hanging fruit.

I ran my tests using the Bevymark example with 10,000 entities.

### Starting Performance

```rust
// these numbers apply to both moving and non-moving sprites
frame_time    : 0.038522    (avg 0.038975)
fps           : 26.670384   (avg 26.018069)
```

### This PR

```rust
// when sprites are static / don't move
frame_time    : 0.017887    (avg 0.017899)
fps           : 55.642482   (avg 55.782829)
```

```rust
// when sprites are moving
frame_time    : 0.023547    (avg 0.022696)
fps           : 41.949551   (avg 42.599443)
```

### Summary of changes

(applied in order, so each item's numbers includes the previous item's changes)
* Added change detection to RenderResourceNode, Sprites, and Transforms, which improved performance when those values don't change. **(static: 0.0267, dynamic: 0.0336)** 
* Mesh provider system now only updates mesh specialization when it needs to **(static: 0.0250, dynamic: 0.0331)**
* Stop clearing bind groups every frame and remove stale bind groups every other frame. **(static: 0.0265)**
  * this is slightly more expensive on bevymark, but i think its probably still the right thing to do. ill keep an eye on this.
* Store unmatched render resource binding results (which prevents redundant computations per-entity per-frame) **(static: 0.02411)**
* Don't send render pass state change commands when the state has not actually changed **(static: 0.0179, dynamic: 0.0227)** 