### PR TITLE
Change`TextureAtlasBuilder` into expected Builder conventions

### DIFF
--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -41,11 +41,6 @@ impl Default for TextureAtlasBuilder {
 pub type TextureAtlasBuilderResult<T> = Result<T, TextureAtlasBuilderError>;
 
 impl TextureAtlasBuilder {
-    /// Constructs a new texture atlas builder.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Sets the initial size of the atlas in pixels.
     pub fn initial_size(mut self, size: Vec2) -> Self {
         self.initial_size = size;

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -59,11 +59,11 @@ impl TextureAtlasBuilder {
     }
 
     /// Adds a texture to be copied to the texture atlas.
-    pub fn add_texture(&mut self, texture_handle: Handle<Texture>, width: u32, height: u32) {
+    pub fn add_texture(&mut self, texture_handle: Handle<Texture>, texture: &Texture) {
         self.rects_to_place.push_rect(
             texture_handle,
             None,
-            RectToInsert::new(width, height, 1),
+            RectToInsert::new(texture.size.width, texture.size.height, 1),
         )
     }
 

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -22,9 +22,9 @@ pub struct TextureAtlasBuilder {
     /// The grouped rects which must be placed with a key value pair of a
     /// texture handle to an index.
     rects_to_place: GroupedRectsToPlace<Handle<Texture>>,
-    /// The sprite size in pixels.
+    /// The initial atlas size in pixels.
     initial_size: Vec2,
-    /// The absolute maximum size of a sprite sheet in pixels.
+    /// The absolute maximum size of the texture atlas in pixels.
     max_size: Vec2,
 }
 

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -38,11 +38,7 @@ fn load_atlas(
     {
         for handle in rpg_sprite_handles.handles.iter() {
             let texture = textures.get(handle).unwrap();
-            texture_atlas_builder.add_texture(
-                handle.clone_weak().typed::<Texture>(),
-                texture.size.width,
-                texture.size.height,
-            );
+            texture_atlas_builder.add_texture(handle.clone_weak().typed::<Texture>(), texture);
         }
 
         let texture_atlas = texture_atlas_builder.finish(&mut textures).unwrap();

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -38,7 +38,7 @@ fn load_atlas(
     {
         for handle in rpg_sprite_handles.handles.iter() {
             let texture = textures.get(handle).unwrap();
-            texture_atlas_builder.add_texture(handle.clone_weak().typed::<Texture>(), &texture);
+            texture_atlas_builder.add_texture(handle.clone_weak().typed::<Texture>(), texture.size.width, texture.size.height);
         }
 
         let texture_atlas = texture_atlas_builder.finish(&mut textures).unwrap();

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -38,7 +38,11 @@ fn load_atlas(
     {
         for handle in rpg_sprite_handles.handles.iter() {
             let texture = textures.get(handle).unwrap();
-            texture_atlas_builder.add_texture(handle.clone_weak().typed::<Texture>(), texture.size.width, texture.size.height);
+            texture_atlas_builder.add_texture(
+                handle.clone_weak().typed::<Texture>(),
+                texture.size.width,
+                texture.size.height,
+            );
         }
 
         let texture_atlas = texture_atlas_builder.finish(&mut textures).unwrap();


### PR DESCRIPTION
The old API wasn't actual builder format. When making my SpriteSheet and using it as an example, I improved it on my own and decided to implement those changes back to Bevy for the TextureAtlasBuilder.

This is a light API breaking change.