### PR TITLE
Optimize Text rendering / SharedBuffers

### DIFF
--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -1,7 +1,7 @@
 use crate::{
     pipeline::{PipelineCompiler, PipelineDescriptor, PipelineLayout, PipelineSpecialization},
     renderer::{
-        BindGroup, BindGroupId, BufferId, BufferUsage, RenderResource, RenderResourceBinding,
+        BindGroup, BindGroupId, BufferId, RenderResource, RenderResourceBinding,
         RenderResourceBindings, RenderResourceContext, SharedBuffers,
     },
     shader::Shader,
@@ -125,7 +125,7 @@ pub struct DrawContext<'a> {
     pub shaders: ResMut<'a, Assets<Shader>>,
     pub pipeline_compiler: ResMut<'a, PipelineCompiler>,
     pub render_resource_context: Res<'a, Box<dyn RenderResourceContext>>,
-    pub shared_buffers: Res<'a, SharedBuffers>,
+    pub shared_buffers: ResMut<'a, SharedBuffers>,
     #[system_param(ignore)]
     pub current_pipeline: Option<Handle<PipelineDescriptor>>,
 }
@@ -135,19 +135,11 @@ pub struct FetchDrawContext;
 
 impl<'a> DrawContext<'a> {
     pub fn get_uniform_buffer<T: RenderResource>(
-        &self,
+        &mut self,
         render_resource: &T,
-    ) -> Result<RenderResourceBinding, DrawError> {
-        self.get_buffer(render_resource, BufferUsage::UNIFORM)
-    }
-
-    pub fn get_buffer<T: RenderResource>(
-        &self,
-        render_resource: &T,
-        buffer_usage: BufferUsage,
     ) -> Result<RenderResourceBinding, DrawError> {
         self.shared_buffers
-            .get_buffer(render_resource, buffer_usage)
+            .get_uniform_buffer(&**self.render_resource_context, render_resource)
             .ok_or(DrawError::BufferAllocationFailure)
     }
 

--- a/crates/bevy_render/src/render_graph/nodes/shared_buffers_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/shared_buffers_node.rs
@@ -16,8 +16,7 @@ impl Node for SharedBuffersNode {
         _input: &ResourceSlots,
         _output: &mut ResourceSlots,
     ) {
-        let shared_buffers = resources.get::<SharedBuffers>().unwrap();
-        let mut command_queue = shared_buffers.reset_command_queue();
-        command_queue.execute(render_context);
+        let mut shared_buffers = resources.get_mut::<SharedBuffers>().unwrap();
+        shared_buffers.apply(render_context);
     }
 }

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -5,10 +5,7 @@ use bevy_render::{
     mesh,
     pipeline::{PipelineSpecialization, VertexBufferDescriptor},
     prelude::Msaa,
-    renderer::{
-        AssetRenderResourceBindings, BindGroup, BufferUsage, RenderResourceBindings,
-        RenderResourceId,
-    },
+    renderer::{AssetRenderResourceBindings, BindGroup, RenderResourceBindings, RenderResourceId},
 };
 use bevy_sprite::TextureAtlasSprite;
 use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
@@ -108,14 +105,8 @@ impl<'a> Drawable for DrawableText<'a> {
 
             let transform = Mat4::from_translation(self.position + tv.position.extend(0.));
 
-            let transform_buffer = context
-                .shared_buffers
-                .get_buffer(&transform, BufferUsage::UNIFORM)
-                .unwrap();
-            let sprite_buffer = context
-                .shared_buffers
-                .get_buffer(&sprite, BufferUsage::UNIFORM)
-                .unwrap();
+            let transform_buffer = context.get_uniform_buffer(&transform).unwrap();
+            let sprite_buffer = context.get_uniform_buffer(&sprite).unwrap();
             let sprite_bind_group = BindGroup::build()
                 .add_binding(0, transform_buffer)
                 .add_binding(1, sprite_buffer)


### PR DESCRIPTION
This one isn't rocket science. Creating buffers every frame is really slow. We now actually _share_ buffers in SharedBuffers. This was the intended design all along, I'm just now getting around to implementing it :smile: 

I used the text_debug example to benchmark.

# Before:

```rust
Diagnostics:
---------------------------------------------------------------------------------------------
fps                                                              : 360.538804  (avg 362.820610)
frame_time                                                       : 0.002983    (avg 0.002756)
```
# After

```rust
Diagnostics:
---------------------------------------------------------------------------------------------
fps                                                              : 1185.222059  (avg 1157.447952)
frame_time                                                       : 0.000818    (avg 0.000871)
```