### PR TITLE
hidpi swap chains

### DIFF
--- a/crates/bevy_render/src/render_graph/nodes/window_texture_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/window_texture_node.rs
@@ -68,8 +68,8 @@ impl Node for WindowTextureNode {
                 render_resource_context.remove_texture(old_texture);
             }
 
-            self.descriptor.size.width = window.width();
-            self.descriptor.size.height = window.height();
+            self.descriptor.size.width = window.scaled_width();
+            self.descriptor.size.height = window.scaled_height();
             let texture_resource = render_resource_context.create_texture(self.descriptor);
             output.set(WINDOW_TEXTURE, RenderResourceId::Texture(texture_resource));
         }

--- a/crates/bevy_wgpu/src/wgpu_type_converter.rs
+++ b/crates/bevy_wgpu/src/wgpu_type_converter.rs
@@ -564,8 +564,8 @@ impl WgpuFrom<&Window> for wgpu::SwapChainDescriptor {
         wgpu::SwapChainDescriptor {
             usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
             format: TextureFormat::default().wgpu_into(),
-            width: window.width(),
-            height: window.height(),
+            width: window.scaled_width(),
+            height: window.scaled_height(),
             present_mode: if window.vsync() {
                 wgpu::PresentMode::Mailbox
             } else {

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -270,8 +270,8 @@ impl Default for WindowDescriptor {
     fn default() -> Self {
         WindowDescriptor {
             title: "bevy".to_string(),
-            width: 800,
-            height: 600,
+            width: 1280,
+            height: 720,
             vsync: true,
             resizable: true,
             decorations: true,

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -125,6 +125,14 @@ impl Window {
         self.width
     }
 
+    pub fn scaled_width(&self) -> u32 {
+        (self.width as f64 * self.scale_factor) as u32
+    }
+
+    pub fn scaled_height(&self) -> u32 {
+        (self.height as f64 * self.scale_factor) as u32
+    }
+
     #[inline]
     pub fn height(&self) -> u32 {
         self.height
@@ -262,8 +270,8 @@ impl Default for WindowDescriptor {
     fn default() -> Self {
         WindowDescriptor {
             title: "bevy".to_string(),
-            width: 1280,
-            height: 720,
+            width: 800,
+            height: 600,
             vsync: true,
             resizable: true,
             decorations: true,


### PR DESCRIPTION
This scales up the swap chain to the actual display size (instead of the logic size). This makes 3d (and curves in 2d) render "crisply" and adds support for future hidpi work for things like text / hi-res images.