### PR TITLE
Document part of bevy_ecs::Commands

### DIFF
--- a/crates/bevy_ecs/src/core/bundle.rs
+++ b/crates/bevy_ecs/src/core/bundle.rs
@@ -22,6 +22,8 @@ use std::{
 };
 
 /// A dynamically typed collection of components
+///
+/// See [Bundle]
 pub trait DynamicBundle {
     /// Invoke a callback on the fields' type IDs, sorted by descending alignment then id
     #[doc(hidden)]
@@ -38,6 +40,8 @@ pub trait DynamicBundle {
 }
 
 /// A statically typed collection of components
+///
+/// See [DynamicBundle]
 pub trait Bundle: DynamicBundle {
     #[doc(hidden)]
     fn with_static_ids<T>(f: impl FnOnce(&[TypeId]) -> T) -> T;

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -194,7 +194,7 @@ impl Commands {
     ///
     /// Note that `components` is a bundle. If you would like to spawn an entity with a single component, consider wrapping the component in a tuple (which `DynamicBundle` is implemented for).
     ///
-    /// See `set_current_entity`, `insert`.
+    /// See [`Commands::set_current_entity`], [`Commands::insert`].
     ///
     /// # Example
     ///
@@ -249,7 +249,7 @@ impl Commands {
 
     /// Inserts a bundle of components into `entity`.
     ///
-    /// See `World::insert`.
+    /// See [`World::insert`].
     pub fn insert(
         &mut self,
         entity: Entity,
@@ -260,7 +260,7 @@ impl Commands {
 
     /// Inserts a single component into `entity`.
     ///
-    /// See `World::insert_one`.
+    /// See [`World::insert_one`].
     pub fn insert_one(&mut self, entity: Entity, component: impl Component) -> &mut Self {
         self.add_command(InsertOne { entity, component })
     }
@@ -280,7 +280,7 @@ impl Commands {
         })
     }
 
-    /// See `World::remove_one`.
+    /// See [`World::remove_one`].
     pub fn remove_one<T>(&mut self, entity: Entity) -> &mut Self
     where
         T: Component,
@@ -291,7 +291,7 @@ impl Commands {
         })
     }
 
-    /// See `World::remove`.
+    /// See [`World::remove`].
     pub fn remove<T>(&mut self, entity: Entity) -> &mut Self
     where
         T: Bundle + Send + Sync + 'static,
@@ -304,7 +304,7 @@ impl Commands {
 
     /// Adds a bundle of components to the current entity.
     ///
-    /// See `with`, `current_entity`.
+    /// See [`Commands::with`], [`Commands::current_entity`].
     pub fn with_bundle(
         &mut self,
         components: impl DynamicBundle + Send + Sync + 'static,
@@ -319,7 +319,7 @@ impl Commands {
 
     /// Adds a single component to the current entity.
     ///
-    /// See `with_bundle`, `current_entity`.
+    /// See [`Commands::with_bundle`], [`Commands::current_entity`].
     ///
     /// # Warning
     ///
@@ -362,13 +362,13 @@ impl Commands {
         self
     }
 
-    /// Adds a command directly to the command list. If `command` is boxed, call `add_command_boxed`.
+    /// Adds a command directly to the command list. Prefer this to `add_command_boxed` if the type of |command| is statically known.
     pub fn add_command<C: Command + 'static>(&mut self, command: C) -> &mut Self {
         self.commands.push(Box::new(command));
         self
     }
 
-    /// See `add_command`.
+    /// See [`Commands::add_command`].
     pub fn add_command_boxed(&mut self, command: Box<dyn Command>) -> &mut Self {
         self.commands.push(command);
         self

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -243,6 +243,8 @@ impl Commands {
     }
 
     /// Despawns only the specified entity, ignoring any other consideration.
+    ///
+    /// Note that this does not recursively despawn and entity's children.
     pub fn despawn(&mut self, entity: Entity) -> &mut Self {
         self.add_command(Despawn { entity })
     }

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -234,7 +234,7 @@ impl Commands {
         self
     }
 
-    /// Equivalent to iterating of `bundles_iter` and calling [`Self::spawn`] on each bundle, but slightly more performant.
+    /// Equivalent to iterating `bundles_iter` and calling [`Self::spawn`] on each bundle, but slightly more performant.
     pub fn spawn_batch<I>(&mut self, bundles_iter: I) -> &mut Self
     where
         I: IntoIterator + Send + Sync + 'static,


### PR DESCRIPTION
Here is a first pass at adding some clarification to `Commands`, which is a type that most folks need to use and can sometimes be confusing. This is not meant to be a "final draft" but are intended just to help answer some common questions for new users before bevy has more thorough docs.

I've specifically tried to address which methods should be called with bundles vs single components. This changeset renames some usages of `components` to `bundle`.

I'd also like to document the following, but need some further guidance for:
- `insert_local_resource`: I'm unsure what `SystemId` is in relation to `Resources` (is it just like a namespace for archetypes?)
- `despawn`: I'd like to clarify what "other considerations" the existing comment is referring to (currently documented as: `Despawns only the specified entity, ignoring any other consideration.`)