### PR TITLE
Debug text example: render fps and frame time

### DIFF
--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -130,9 +130,9 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
 fn change_text_system(
     time: Res<Time>,
     diagnostics: Res<Diagnostics>,
-    mut query: Query<(&mut Text, &TextChanges)>,
+    mut query: Query<&mut Text, With<TextChanges>>,
 ) {
-    for (mut text, _text_changes) in query.iter_mut() {
+    for mut text in query.iter_mut() {
         let mut fps = 0.0;
         if let Some(fps_diagnostic) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
             if let Some(fps_avg) = fps_diagnostic.average() {

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -141,7 +141,8 @@ fn change_text_system(
         }
 
         let mut frame_time = time.delta_seconds_f64();
-        if let Some(frame_time_diagnostic) = diagnostics.get(FrameTimeDiagnosticsPlugin::FRAME_TIME) {
+        if let Some(frame_time_diagnostic) = diagnostics.get(FrameTimeDiagnosticsPlugin::FRAME_TIME)
+        {
             if let Some(frame_time_avg) = frame_time_diagnostic.average() {
                 frame_time = frame_time_avg;
             }

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -140,10 +140,17 @@ fn change_text_system(
             }
         }
 
+        let mut frame_time = time.delta_seconds_f64();
+        if let Some(frame_time_diagnostic) = diagnostics.get(FrameTimeDiagnosticsPlugin::FRAME_TIME) {
+            if let Some(frame_time_avg) = frame_time_diagnostic.average() {
+                frame_time = frame_time_avg;
+            }
+        }
+
         text.value = format!(
             "This text changes in the bottom right - {:.1} fps, {:.3} ms/frame",
             fps,
-            time.delta_seconds_f64() * 1000.0,
+            frame_time * 1000.0,
         );
     }
 }

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -6,6 +6,10 @@ use bevy::{
 /// This example is for debugging text layout
 fn main() {
     App::build()
+        .add_resource(WindowDescriptor {
+            vsync: false,
+            ..Default::default()
+        })
         .add_plugins(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin)
         .add_startup_system(infotext_system)

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -1,10 +1,13 @@
-use bevy::prelude::*;
-extern crate rand;
+use bevy::{
+    diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin},
+    prelude::*,
+};
 
 /// This example is for debugging text layout
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
+        .add_plugin(FrameTimeDiagnosticsPlugin)
         .add_startup_system(infotext_system)
         .add_system(change_text_system)
         .run();
@@ -83,7 +86,7 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
                 value: "This text changes in the bottom right".to_string(),
                 font: font.clone(),
                 style: TextStyle {
-                    font_size: 50.0,
+                    font_size: 30.0,
                     color: Color::WHITE,
                     alignment: TextAlignment::default(),
                 },
@@ -120,11 +123,23 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
     });
 }
 
-fn change_text_system(mut query: Query<(&mut Text, &TextChanges)>) {
+fn change_text_system(
+    time: Res<Time>,
+    diagnostics: Res<Diagnostics>,
+    mut query: Query<(&mut Text, &TextChanges)>,
+) {
     for (mut text, _text_changes) in query.iter_mut() {
+        let mut fps = 0.0;
+        if let Some(fps_diagnostic) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
+            if let Some(fps_avg) = fps_diagnostic.average() {
+                fps = fps_avg;
+            }
+        }
+
         text.value = format!(
-            "This text changes in the bottom right {}",
-            rand::random::<u16>(),
+            "This text changes in the bottom right - {:.1} fps, {:.3} ms/frame",
+            fps,
+            time.delta_seconds_f64() * 1000.0,
         );
     }
 }


### PR DESCRIPTION
I saw @cart's PR #972 and was curious about how much it improved the impact of text rendering on frame rate in general so that one can have a HUD displaying frame time and frame rate. The answer (on a MacBook Pro 16" with Radeon Pro 5500M) is... before:

![Screenshot 2020-12-02 at 16 38 44](https://user-images.githubusercontent.com/302146/100894504-da8b7280-34bc-11eb-9def-2deeb62e9af1.png)

...after:

![Screenshot 2020-12-02 at 16 45 37](https://user-images.githubusercontent.com/302146/100895440-d875e380-34bd-11eb-9137-8cc856aec824.png)

Note that I disabled vsync in the example to see how fast it can really go! :)