### PR TITLE
Tracing chrome span names

### DIFF
--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -18,7 +18,7 @@ bevy_app = { path = "../bevy_app", version = "0.3.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.3.0" }
 
 tracing-subscriber = {version = "0.2.15", features = ["registry"]}
-tracing-chrome = { version = "0.2.0", optional = true } 
+tracing-chrome = { version = "0.3.0", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_log-sys = "0.2.0"

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -12,12 +12,9 @@ pub use bevy_utils::tracing::{
 };
 
 use bevy_app::{AppBuilder, Plugin};
-use tracing_subscriber::{
-    fmt::{format::DefaultFields, FormattedFields},
-    prelude::*,
-    registry::Registry,
-    EnvFilter,
-};
+#[cfg(feature = "tracing-chrome")]
+use tracing_subscriber::fmt::{format::DefaultFields, FormattedFields};
+use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 
 /// Adds logging to Apps.
 #[derive(Default)]

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -12,7 +12,12 @@ pub use bevy_utils::tracing::{
 };
 
 use bevy_app::{AppBuilder, Plugin};
-use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
+use tracing_subscriber::{
+    fmt::{format::DefaultFields, FormattedFields},
+    prelude::*,
+    registry::Registry,
+    EnvFilter,
+};
 
 /// Adds logging to Apps.
 #[derive(Default)]
@@ -55,7 +60,20 @@ impl Plugin for LogPlugin {
             let subscriber = subscriber.with(fmt_layer);
             #[cfg(feature = "tracing-chrome")]
             {
-                let (chrome_layer, guard) = tracing_chrome::ChromeLayerBuilder::new().build();
+                let (chrome_layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
+                    .name_fn(Box::new(|event_or_span| match event_or_span {
+                        tracing_chrome::EventOrSpan::Event(event) => event.metadata().name().into(),
+                        tracing_chrome::EventOrSpan::Span(span) => {
+                            if let Some(fields) =
+                                span.extensions().get::<FormattedFields<DefaultFields>>()
+                            {
+                                format!("{}: {}", span.metadata().name(), fields.fields.as_str())
+                            } else {
+                                span.metadata().name().into()
+                            }
+                        }
+                    }))
+                    .build();
                 app.resources_mut().insert_thread_local(guard);
                 let subscriber = subscriber.with(chrome_layer);
                 bevy_utils::tracing::subscriber::set_global_default(subscriber)


### PR DESCRIPTION
This should work in theory but for some reason the tracing-chrome profile data is not being properly flushed to the .json file it creates. I wonder if the thread-local resource isn't doing what we want it to?