### PR TITLE
Add Archetype TypeInfo::type_name accessor

### DIFF
--- a/crates/bevy_ecs/src/core/archetype.rs
+++ b/crates/bevy_ecs/src/core/archetype.rs
@@ -519,6 +519,12 @@ impl TypeInfo {
     pub(crate) unsafe fn drop(&self, data: *mut u8) {
         (self.drop)(data)
     }
+
+    #[allow(missing_docs)]
+    #[inline]
+    pub fn type_name(&self) -> &'static str {
+        self.type_name
+    }
 }
 
 impl PartialOrd for TypeInfo {


### PR DESCRIPTION
This adds an accessor to get the type name from Archetype.

I use this in ECS debugger when the Reflect is not available, to at least show the name of the Component type.