### PR TITLE
Optimize Asset Gpu Data Transfer

### DIFF
--- a/crates/bevy_render/src/pipeline/render_pipelines.rs
+++ b/crates/bevy_render/src/pipeline/render_pipelines.rs
@@ -114,6 +114,19 @@ pub fn draw_render_pipelines_system(
                     .collect::<HashSet<String>>();
                 pipeline.dynamic_bindings_generation =
                     render_pipelines.bindings.dynamic_bindings_generation();
+                for (handle, _) in render_pipelines.bindings.iter_assets() {
+                    if let Some(bindings) = draw_context
+                        .asset_render_resource_bindings
+                        .get_untyped(handle)
+                    {
+                        for binding in bindings.iter_dynamic_bindings() {
+                            pipeline
+                                .specialization
+                                .dynamic_bindings
+                                .insert(binding.to_string());
+                        }
+                    }
+                }
             }
         }
 

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -5,7 +5,7 @@ use bevy_render::{
     mesh,
     pipeline::{PipelineSpecialization, VertexBufferDescriptor},
     prelude::Msaa,
-    renderer::{AssetRenderResourceBindings, BindGroup, RenderResourceBindings, RenderResourceId},
+    renderer::{BindGroup, RenderResourceBindings, RenderResourceId},
 };
 use bevy_sprite::TextureAtlasSprite;
 use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
@@ -46,7 +46,6 @@ impl Default for TextStyle {
 
 pub struct DrawableText<'a> {
     pub render_resource_bindings: &'a mut RenderResourceBindings,
-    pub asset_render_resource_bindings: &'a mut AssetRenderResourceBindings,
     pub position: Vec3,
     pub style: &'a TextStyle,
     pub text_glyphs: &'a Vec<PositionedGlyph>,
@@ -92,11 +91,7 @@ impl<'a> Drawable for DrawableText<'a> {
         context.set_bind_groups_from_bindings(draw, &mut [self.render_resource_bindings])?;
 
         for tv in self.text_glyphs {
-            let atlas_render_resource_bindings = self
-                .asset_render_resource_bindings
-                .get_mut(&tv.atlas_info.texture_atlas)
-                .unwrap();
-            context.set_bind_groups_from_bindings(draw, &mut [atlas_render_resource_bindings])?;
+            context.set_asset_bind_groups(draw, &tv.atlas_info.texture_atlas)?;
 
             let sprite = TextureAtlasSprite {
                 index: tv.atlas_info.glyph_index,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -6,7 +6,7 @@ use bevy_render::{
     draw::{Draw, DrawContext, Drawable},
     mesh::Mesh,
     prelude::Msaa,
-    renderer::{AssetRenderResourceBindings, RenderResourceBindings},
+    renderer::RenderResourceBindings,
     texture::Texture,
 };
 use bevy_sprite::{TextureAtlas, QUAD_HANDLE};
@@ -145,7 +145,6 @@ pub fn draw_text_system(
     msaa: Res<Msaa>,
     meshes: Res<Assets<Mesh>>,
     mut render_resource_bindings: ResMut<RenderResourceBindings>,
-    mut asset_render_resource_bindings: ResMut<AssetRenderResourceBindings>,
     text_pipeline: Res<DefaultTextPipeline>,
     mut query: Query<(Entity, &mut Draw, &Text, &Node, &GlobalTransform)>,
 ) {
@@ -162,7 +161,6 @@ pub fn draw_text_system(
 
             let mut drawable_text = DrawableText {
                 render_resource_bindings: &mut render_resource_bindings,
-                asset_render_resource_bindings: &mut asset_render_resource_bindings,
                 position,
                 msaa: &msaa,
                 text_glyphs: &text_glyphs.glyphs,


### PR DESCRIPTION
This gives a nice boost when most assets dont change, with a _very minor_ regression when many assets are changing.

* Asset render resource bindings are now directly shared between all entities that reference the asset
* We now only update asset render resources when they have changed
* Reduced hashing in a number of areas

## Bevymark Results (10,000 static entities) 

This got a nice boost because the entity textures don't change.

### Before

```rust
Diagnostics:
---------------------------------------------------------------------------------------------
frame_time                                                       : 0.018833    (avg 0.018690)
fps                                                              : 57.069353   (avg 55.020985)
```

### After

```rust
Diagnostics:
---------------------------------------------------------------------------------------------
frame_time                                                       : 0.013772    (avg 0.014135)
fps                                                              : 70.948812   (avg 71.042812)
```


## Spawner Example Results (10,000 moving entities with individual changing textures) 

This has regressed _slightly_ due to the added change detection.

### Before

```rust
Diagnostics:
---------------------------------------------------------------------------------------------
frame_time                                                       : 0.038409    (avg 0.037628)
fps                                                              : 24.700086   (avg 25.714331)
```

### After

```rust
Diagnostics:
---------------------------------------------------------------------------------------------
frame_time                                                       : 0.039960    (avg 0.039978)
fps                                                              : 25.022038   (avg 25.050537)
```