### PR TITLE
fix scene loading

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -3,6 +3,7 @@ use crate::{
 };
 use bevy_app::{prelude::Events, AppBuilder};
 use bevy_ecs::{FromResources, ResMut};
+use bevy_reflect::RegisterTypeBuilder;
 use bevy_utils::HashMap;
 use crossbeam_channel::Sender;
 use std::fmt::Debug;
@@ -219,6 +220,7 @@ impl AddAsset for AppBuilder {
         self.add_resource(assets)
             .add_system_to_stage(super::stage::ASSET_EVENTS, Assets::<T>::asset_event_system)
             .add_system_to_stage(crate::stage::LOAD_ASSETS, update_asset_storage_system::<T>)
+            .register_type::<Handle<T>>()
             .add_event::<AssetEvent<T>>()
     }
 

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -9,7 +9,7 @@ use crate::{
     path::{AssetPath, AssetPathId},
     Asset, Assets,
 };
-use bevy_reflect::{Reflect, ReflectDeserialize};
+use bevy_reflect::{Reflect, ReflectComponent, ReflectDeserialize};
 use bevy_utils::Uuid;
 use crossbeam_channel::{Receiver, Sender};
 use serde::{Deserialize, Serialize};
@@ -57,9 +57,10 @@ impl HandleId {
 ///
 /// Handles contain a unique id that corresponds to a specific asset in the [Assets](crate::Assets) collection.
 #[derive(Reflect)]
+#[reflect(Component)]
 pub struct Handle<T>
 where
-    T: 'static,
+    T: Asset,
 {
     pub id: HandleId,
     #[reflect(ignore)]
@@ -82,17 +83,6 @@ impl Debug for HandleType {
     }
 }
 
-impl<T> Handle<T> {
-    // TODO: remove "uuid" parameter whenever rust support type constraints in const fns
-    pub const fn weak_from_u64(uuid: Uuid, id: u64) -> Self {
-        Self {
-            id: HandleId::new(uuid, id),
-            handle_type: HandleType::Weak,
-            marker: PhantomData,
-        }
-    }
-}
-
 impl<T: Asset> Handle<T> {
     pub(crate) fn strong(id: HandleId, ref_change_sender: Sender<RefChange>) -> Self {
         ref_change_sender.send(RefChange::Increment(id)).unwrap();
@@ -111,7 +101,7 @@ impl<T: Asset> Handle<T> {
         }
     }
 
-    pub fn as_weak<U>(&self) -> Handle<U> {
+    pub fn as_weak<U: Asset>(&self) -> Handle<U> {
         Handle {
             id: self.id,
             handle_type: HandleType::Weak,
@@ -152,7 +142,7 @@ impl<T: Asset> Handle<T> {
     }
 }
 
-impl<T> Drop for Handle<T> {
+impl<T: Asset> Drop for Handle<T> {
     fn drop(&mut self) {
         match self.handle_type {
             HandleType::Strong(ref sender) => {
@@ -164,8 +154,14 @@ impl<T> Drop for Handle<T> {
     }
 }
 
-impl<T> From<Handle<T>> for HandleId {
+impl<T: Asset> From<Handle<T>> for HandleId {
     fn from(value: Handle<T>) -> Self {
+        value.id
+    }
+}
+
+impl From<HandleUntyped> for HandleId {
+    fn from(value: HandleUntyped) -> Self {
         value.id
     }
 }
@@ -176,33 +172,33 @@ impl From<&str> for HandleId {
     }
 }
 
-impl<T> From<&Handle<T>> for HandleId {
+impl<T: Asset> From<&Handle<T>> for HandleId {
     fn from(value: &Handle<T>) -> Self {
         value.id
     }
 }
 
-impl<T> Hash for Handle<T> {
+impl<T: Asset> Hash for Handle<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         Hash::hash(&self.id, state);
     }
 }
 
-impl<T> PartialEq for Handle<T> {
+impl<T: Asset> PartialEq for Handle<T> {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
     }
 }
 
-impl<T> Eq for Handle<T> {}
+impl<T: Asset> Eq for Handle<T> {}
 
-impl<T> PartialOrd for Handle<T> {
+impl<T: Asset> PartialOrd for Handle<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.id.cmp(&other.id))
     }
 }
 
-impl<T> Ord for Handle<T> {
+impl<T: Asset> Ord for Handle<T> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.id.cmp(&other.id)
     }
@@ -214,7 +210,7 @@ impl<T: Asset> Default for Handle<T> {
     }
 }
 
-impl<T> Debug for Handle<T> {
+impl<T: Asset> Debug for Handle<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         let name = std::any::type_name::<T>().split("::").last().unwrap();
         write!(f, "{:?}Handle<{}>({:?})", self.handle_type, name, self.id)
@@ -231,8 +227,8 @@ impl<T: Asset> Clone for Handle<T> {
 }
 
 // SAFE: T is phantom data and Handle::id is an integer
-unsafe impl<T> Send for Handle<T> {}
-unsafe impl<T> Sync for Handle<T> {}
+unsafe impl<T: Asset> Send for Handle<T> {}
+unsafe impl<T: Asset> Sync for Handle<T> {}
 
 /// A non-generic version of [Handle]
 ///
@@ -244,6 +240,13 @@ pub struct HandleUntyped {
 }
 
 impl HandleUntyped {
+    pub const fn weak_from_u64(uuid: Uuid, id: u64) -> Self {
+        Self {
+            id: HandleId::new(uuid, id),
+            handle_type: HandleType::Weak,
+        }
+    }
+
     pub(crate) fn strong(id: HandleId, ref_change_sender: Sender<RefChange>) -> Self {
         ref_change_sender.send(RefChange::Increment(id)).unwrap();
         Self {

--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -1,17 +1,17 @@
 use crate::{AudioSource, Decodable};
-use bevy_asset::Handle;
+use bevy_asset::{Asset, Handle};
 use parking_lot::RwLock;
 use std::{collections::VecDeque, fmt};
 
 /// The external struct used to play audio
 pub struct Audio<P = AudioSource>
 where
-    P: Decodable,
+    P: Asset + Decodable,
 {
     pub queue: RwLock<VecDeque<Handle<P>>>,
 }
 
-impl<P> fmt::Debug for Audio<P>
+impl<P: Asset> fmt::Debug for Audio<P>
 where
     P: Decodable,
 {
@@ -22,7 +22,7 @@ where
 
 impl<P> Default for Audio<P>
 where
-    P: Decodable,
+    P: Asset + Decodable,
 {
     fn default() -> Self {
         Self {
@@ -33,7 +33,7 @@ where
 
 impl<P> Audio<P>
 where
-    P: Decodable,
+    P: Asset + Decodable,
     <P as Decodable>::Decoder: rodio::Source + Send + Sync,
     <<P as Decodable>::Decoder as Iterator>::Item: rodio::Sample + Send + Sync,
 {

--- a/crates/bevy_core/src/label.rs
+++ b/crates/bevy_core/src/label.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::prelude::*;
-use bevy_reflect::Reflect;
+use bevy_reflect::{Reflect, ReflectComponent};
 use bevy_utils::{HashMap, HashSet};
 use std::{
     borrow::Cow,
@@ -9,6 +9,7 @@ use std::{
 
 /// A collection of labels
 #[derive(Default, Reflect)]
+#[reflect(Component)]
 pub struct Labels {
     labels: HashSet<Cow<'static, str>>,
 }

--- a/crates/bevy_pbr/src/entity.rs
+++ b/crates/bevy_pbr/src/entity.rs
@@ -25,7 +25,7 @@ impl Default for PbrBundle {
     fn default() -> Self {
         Self {
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
-                FORWARD_PIPELINE_HANDLE,
+                FORWARD_PIPELINE_HANDLE.typed(),
             )]),
             mesh: Default::default(),
             material: Default::default(),

--- a/crates/bevy_pbr/src/render_graph/forward_pipeline/mod.rs
+++ b/crates/bevy_pbr/src/render_graph/forward_pipeline/mod.rs
@@ -1,4 +1,4 @@
-use bevy_asset::{Assets, Handle};
+use bevy_asset::{Assets, HandleUntyped};
 use bevy_reflect::TypeUuid;
 use bevy_render::{
     pipeline::{
@@ -10,8 +10,8 @@ use bevy_render::{
     texture::TextureFormat,
 };
 
-pub const FORWARD_PIPELINE_HANDLE: Handle<PipelineDescriptor> =
-    Handle::weak_from_u64(PipelineDescriptor::TYPE_UUID, 13148362314012771389);
+pub const FORWARD_PIPELINE_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 13148362314012771389);
 
 pub(crate) fn build_forward_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescriptor {
     PipelineDescriptor {

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -2,10 +2,11 @@ use super::CameraProjection;
 use bevy_app::prelude::{EventReader, Events};
 use bevy_ecs::{Added, Component, Entity, Local, Query, QuerySet, Res};
 use bevy_math::Mat4;
-use bevy_reflect::Reflect;
+use bevy_reflect::{Reflect, ReflectComponent};
 use bevy_window::{WindowCreated, WindowId, WindowResized, Windows};
 
 #[derive(Default, Debug, Reflect)]
+#[reflect(Component)]
 pub struct Camera {
     pub projection_matrix: Mat4,
     pub name: Option<String>,

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -1,6 +1,6 @@
 use super::DepthCalculation;
 use bevy_math::Mat4;
-use bevy_reflect::{Reflect, ReflectDeserialize};
+use bevy_reflect::{Reflect, ReflectComponent, ReflectDeserialize};
 use serde::{Deserialize, Serialize};
 
 pub trait CameraProjection {
@@ -10,6 +10,7 @@ pub trait CameraProjection {
 }
 
 #[derive(Debug, Clone, Reflect)]
+#[reflect(Component)]
 pub struct PerspectiveProjection {
     pub fov: f32,
     pub aspect_ratio: f32,
@@ -51,6 +52,7 @@ pub enum WindowOrigin {
 }
 
 #[derive(Debug, Clone, Reflect)]
+#[reflect(Component)]
 pub struct OrthographicProjection {
     pub left: f32,
     pub right: f32,

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -2,7 +2,7 @@ use super::{Camera, DepthCalculation};
 use crate::Draw;
 use bevy_core::FloatOrd;
 use bevy_ecs::{Entity, Query, With};
-use bevy_reflect::Reflect;
+use bevy_reflect::{Reflect, ReflectComponent};
 use bevy_transform::prelude::GlobalTransform;
 
 #[derive(Debug)]
@@ -12,6 +12,7 @@ pub struct VisibleEntity {
 }
 
 #[derive(Default, Debug, Reflect)]
+#[reflect(Component)]
 pub struct VisibleEntities {
     #[reflect(ignore)]
     pub value: Vec<VisibleEntity>,

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::{Query, Res, ResMut, SystemParam};
-use bevy_reflect::Reflect;
+use bevy_reflect::{Reflect, ReflectComponent};
 use std::{ops::Range, sync::Arc};
 use thiserror::Error;
 
@@ -45,6 +45,7 @@ pub enum RenderCommand {
 
 /// A component that indicates how to draw an entity.
 #[derive(Debug, Clone, Reflect)]
+#[reflect(Component)]
 pub struct Draw {
     pub is_visible: bool,
     pub is_transparent: bool,

--- a/crates/bevy_render/src/pipeline/render_pipelines.rs
+++ b/crates/bevy_render/src/pipeline/render_pipelines.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::{Query, Res, ResMut};
-use bevy_reflect::Reflect;
+use bevy_reflect::{Reflect, ReflectComponent};
 use bevy_utils::HashSet;
 
 #[derive(Debug, Default, Clone, Reflect)]
@@ -40,6 +40,7 @@ impl RenderPipeline {
 }
 
 #[derive(Debug, Clone, Reflect)]
+#[reflect(Component)]
 pub struct RenderPipelines {
     pub pipelines: Vec<RenderPipeline>,
     #[reflect(ignore)]

--- a/crates/bevy_render/src/render_graph/base.rs
+++ b/crates/bevy_render/src/render_graph/base.rs
@@ -10,11 +10,12 @@ use crate::{
     texture::{Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsage},
     Color,
 };
-use bevy_reflect::Reflect;
+use bevy_reflect::{Reflect, ReflectComponent};
 use bevy_window::WindowId;
 
 /// A component that indicates that an entity should be drawn in the "main pass"
 #[derive(Default, Reflect)]
+#[reflect(Component)]
 pub struct MainPass;
 
 #[derive(Debug)]

--- a/crates/bevy_sprite/src/entity.rs
+++ b/crates/bevy_sprite/src/entity.rs
@@ -27,9 +27,9 @@ pub struct SpriteBundle {
 impl Default for SpriteBundle {
     fn default() -> Self {
         Self {
-            mesh: QUAD_HANDLE,
+            mesh: QUAD_HANDLE.typed(),
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
-                SPRITE_PIPELINE_HANDLE,
+                SPRITE_PIPELINE_HANDLE.typed(),
             )]),
             draw: Draw {
                 is_transparent: true,
@@ -65,13 +65,13 @@ impl Default for SpriteSheetBundle {
     fn default() -> Self {
         Self {
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
-                SPRITE_SHEET_PIPELINE_HANDLE,
+                SPRITE_SHEET_PIPELINE_HANDLE.typed(),
             )]),
             draw: Draw {
                 is_transparent: true,
                 ..Default::default()
             },
-            mesh: QUAD_HANDLE,
+            mesh: QUAD_HANDLE.typed(),
             main_pass: MainPass,
             sprite: Default::default(),
             texture_atlas: Default::default(),

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -25,7 +25,7 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
-use bevy_asset::{AddAsset, Assets, Handle};
+use bevy_asset::{AddAsset, Assets, Handle, HandleUntyped};
 use bevy_math::Vec2;
 use bevy_reflect::{RegisterTypeBuilder, TypeUuid};
 use bevy_render::{
@@ -38,7 +38,8 @@ use sprite::sprite_system;
 #[derive(Default)]
 pub struct SpritePlugin;
 
-pub const QUAD_HANDLE: Handle<Mesh> = Handle::weak_from_u64(Mesh::TYPE_UUID, 14240461981130137526);
+pub const QUAD_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(Mesh::TYPE_UUID, 14240461981130137526);
 
 impl Plugin for SpritePlugin {
     fn build(&self, app: &mut AppBuilder) {

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -1,5 +1,5 @@
 use crate::{ColorMaterial, Sprite, TextureAtlas, TextureAtlasSprite};
-use bevy_asset::{Assets, Handle};
+use bevy_asset::{Assets, HandleUntyped};
 use bevy_ecs::Resources;
 use bevy_reflect::TypeUuid;
 use bevy_render::{
@@ -13,11 +13,11 @@ use bevy_render::{
     texture::TextureFormat,
 };
 
-pub const SPRITE_PIPELINE_HANDLE: Handle<PipelineDescriptor> =
-    Handle::weak_from_u64(PipelineDescriptor::TYPE_UUID, 2785347840338765446);
+pub const SPRITE_PIPELINE_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 2785347840338765446);
 
-pub const SPRITE_SHEET_PIPELINE_HANDLE: Handle<PipelineDescriptor> =
-    Handle::weak_from_u64(PipelineDescriptor::TYPE_UUID, 9016885805180281612);
+pub const SPRITE_SHEET_PIPELINE_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 9016885805180281612);
 
 pub fn build_sprite_sheet_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescriptor {
     PipelineDescriptor {

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -3,6 +3,7 @@ use bevy_render::{
     color::Color,
     draw::{Draw, DrawContext, DrawError, Drawable},
     mesh,
+    mesh::Mesh,
     pipeline::{PipelineSpecialization, VertexBufferDescriptor},
     prelude::Msaa,
     renderer::{AssetRenderResourceBindings, BindGroup, RenderResourceBindings, RenderResourceId},
@@ -58,7 +59,7 @@ impl<'a> Drawable for DrawableText<'a> {
     fn draw(&mut self, draw: &mut Draw, context: &mut DrawContext) -> Result<(), DrawError> {
         context.set_pipeline(
             draw,
-            &bevy_sprite::SPRITE_SHEET_PIPELINE_HANDLE,
+            &bevy_sprite::SPRITE_SHEET_PIPELINE_HANDLE.typed(),
             &PipelineSpecialization {
                 sample_count: self.msaa.samples,
                 vertex_buffer_descriptor: self.font_quad_vertex_descriptor.clone(),
@@ -69,7 +70,10 @@ impl<'a> Drawable for DrawableText<'a> {
         let render_resource_context = &**context.render_resource_context;
 
         if let Some(RenderResourceId::Buffer(vertex_attribute_buffer_id)) = render_resource_context
-            .get_asset_resource(&bevy_sprite::QUAD_HANDLE, mesh::VERTEX_ATTRIBUTE_BUFFER_ID)
+            .get_asset_resource(
+                &bevy_sprite::QUAD_HANDLE.typed::<Mesh>(),
+                mesh::VERTEX_ATTRIBUTE_BUFFER_ID,
+            )
         {
             draw.set_vertex_buffer(0, vertex_attribute_buffer_id, 0);
         } else {
@@ -78,7 +82,10 @@ impl<'a> Drawable for DrawableText<'a> {
 
         let mut indices = 0..0;
         if let Some(RenderResourceId::Buffer(quad_index_buffer)) = render_resource_context
-            .get_asset_resource(&bevy_sprite::QUAD_HANDLE, mesh::INDEX_BUFFER_ASSET_INDEX)
+            .get_asset_resource(
+                &bevy_sprite::QUAD_HANDLE.typed::<Mesh>(),
+                mesh::INDEX_BUFFER_ASSET_INDEX,
+            )
         {
             draw.set_index_buffer(quad_index_buffer, 0);
             if let Some(buffer_info) = render_resource_context.get_buffer_info(quad_index_buffer) {

--- a/crates/bevy_transform/src/components/children.rs
+++ b/crates/bevy_transform/src/components/children.rs
@@ -1,10 +1,10 @@
 use bevy_ecs::{Entity, MapEntities};
-use bevy_reflect::{Reflect, ReflectMapEntities};
+use bevy_reflect::{Reflect, ReflectComponent, ReflectMapEntities};
 use smallvec::SmallVec;
 use std::ops::Deref;
 
 #[derive(Default, Clone, Debug, Reflect)]
-#[reflect(MapEntities)]
+#[reflect(Component, MapEntities)]
 pub struct Children(pub(crate) SmallVec<[Entity; 8]>);
 
 impl MapEntities for Children {

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -1,9 +1,10 @@
 use super::Transform;
 use bevy_math::{Mat3, Mat4, Quat, Vec3};
-use bevy_reflect::Reflect;
+use bevy_reflect::{Reflect, ReflectComponent};
 use std::ops::Mul;
 
 #[derive(Debug, PartialEq, Clone, Copy, Reflect)]
+#[reflect(Component)]
 pub struct GlobalTransform {
     pub translation: Vec3,
     pub rotation: Quat,

--- a/crates/bevy_transform/src/components/parent.rs
+++ b/crates/bevy_transform/src/components/parent.rs
@@ -1,9 +1,9 @@
 use bevy_ecs::{Entity, FromResources, MapEntities};
-use bevy_reflect::{Reflect, ReflectMapEntities};
+use bevy_reflect::{Reflect, ReflectComponent, ReflectMapEntities};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Reflect)]
-#[reflect(MapEntities)]
+#[reflect(Component, MapEntities)]
 pub struct Parent(pub Entity);
 
 // TODO: We need to impl either FromResources or Default so Parent can be registered as Properties.
@@ -41,7 +41,7 @@ impl DerefMut for Parent {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Reflect)]
-#[reflect(MapEntities)]
+#[reflect(Component, MapEntities)]
 pub struct PreviousParent(pub(crate) Entity);
 
 impl MapEntities for PreviousParent {

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -31,9 +31,9 @@ pub struct NodeBundle {
 impl Default for NodeBundle {
     fn default() -> Self {
         NodeBundle {
-            mesh: QUAD_HANDLE,
+            mesh: QUAD_HANDLE.typed(),
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
-                UI_PIPELINE_HANDLE,
+                UI_PIPELINE_HANDLE.typed(),
             )]),
             node: Default::default(),
             style: Default::default(),
@@ -62,9 +62,9 @@ pub struct ImageBundle {
 impl Default for ImageBundle {
     fn default() -> Self {
         ImageBundle {
-            mesh: QUAD_HANDLE,
+            mesh: QUAD_HANDLE.typed(),
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
-                UI_PIPELINE_HANDLE,
+                UI_PIPELINE_HANDLE.typed(),
             )]),
             node: Default::default(),
             image: Default::default(),
@@ -127,9 +127,9 @@ impl Default for ButtonBundle {
     fn default() -> Self {
         ButtonBundle {
             button: Button,
-            mesh: QUAD_HANDLE,
+            mesh: QUAD_HANDLE.typed(),
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
-                UI_PIPELINE_HANDLE,
+                UI_PIPELINE_HANDLE.typed(),
             )]),
             interaction: Default::default(),
             focus_policy: Default::default(),

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -1,5 +1,5 @@
 use crate::Node;
-use bevy_asset::{Assets, Handle};
+use bevy_asset::{Assets, HandleUntyped};
 use bevy_ecs::Resources;
 use bevy_reflect::TypeUuid;
 use bevy_render::{
@@ -18,8 +18,8 @@ use bevy_render::{
     texture::TextureFormat,
 };
 
-pub const UI_PIPELINE_HANDLE: Handle<PipelineDescriptor> =
-    Handle::weak_from_u64(PipelineDescriptor::TYPE_UUID, 3234320022263993878);
+pub const UI_PIPELINE_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 3234320022263993878);
 
 pub fn build_ui_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescriptor {
     PipelineDescriptor {


### PR DESCRIPTION
Fixes #986 

We were largely just missing a bunch of `#[reflect(Component)]` calls, but also some type registrations. We now automatically register `Handle<T>` when an asset is registered.

I did need to make `Handle<T>::from_weak_u64` non-const to make the derive work (I moved that method to HandleUntyped). I'm considering a manual Handle reflect impl instead (which would probably allow us to keep const `Handle<T>`