### PR TITLE
Keyboard modifiers

### DIFF
--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -240,3 +240,66 @@ pub enum KeyCode {
     Paste,
     Cut,
 }
+
+pub mod modifiers {
+    /// Identifies a key modifier
+    #[derive(Debug, Default, Hash, PartialEq, Eq, Clone, Copy)]
+    #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+    pub struct KeyModifiers(u8);
+
+    macro_rules! key_modifiers_accessors {
+        ( $( $mask:ident => $get:ident , $set:ident , $clear:ident ; )* ) => {
+
+            $(
+
+                pub fn $get (&self) -> bool { self.0 & Self::$mask == Self::$mask }
+
+                pub fn $set (&mut self) { self.0 |= Self::$mask; }
+
+                pub fn $clear (&mut self) { self.0 &= !Self::$mask; }
+
+            )*
+
+
+        }
+    }
+
+    impl KeyModifiers {
+        pub const MASK_ALT: u8 = 4;
+        pub const MASK_CTRL: u8 = 2;
+        pub const MASK_LOGO: u8 = 8;
+        pub const MASK_SHIFT: u8 = 1;
+
+        key_modifiers_accessors! {
+            MASK_SHIFT => has_shift, set_shift, clear_shift;
+            MASK_CTRL  => has_ctrl , set_ctrl , clear_ctrl ;
+            MASK_ALT   => has_alt  , set_alt  , clear_alt  ;
+            MASK_LOGO  => has_logo , set_logo , clear_logo ;
+        }
+
+        pub fn from_raw(value: u8) -> Option<Self> {
+            if (value & !(Self::MASK_SHIFT | Self::MASK_CTRL | Self::MASK_ALT | Self::MASK_LOGO))
+                == 0
+            {
+                Some(Self(value))
+            } else {
+                None
+            }
+        }
+    }
+
+    impl std::ops::BitOr for KeyModifiers {
+        type Output = Self;
+
+        fn bitor(self, rhs: Self) -> Self::Output {
+            Self(self.0 | rhs.0)
+        }
+    }
+
+    pub const SHIFT: KeyModifiers = KeyModifiers(KeyModifiers::MASK_SHIFT);
+    pub const CTRL: KeyModifiers = KeyModifiers(KeyModifiers::MASK_CTRL);
+    pub const ALT: KeyModifiers = KeyModifiers(KeyModifiers::MASK_ALT);
+    pub const LOGO: KeyModifiers = KeyModifiers(KeyModifiers::MASK_LOGO);
+}
+
+pub use modifiers::KeyModifiers;

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -23,7 +23,7 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
-use keyboard::{keyboard_input_system, KeyCode, KeyboardInput};
+use keyboard::{keyboard_input_system, KeyCode, KeyModifiers, KeyboardInput};
 use mouse::{mouse_button_input_system, MouseButton, MouseButtonInput, MouseMotion, MouseWheel};
 use touch::{touch_screen_input_system, TouchInput, Touches};
 
@@ -44,6 +44,7 @@ impl Plugin for InputPlugin {
             .add_event::<MouseMotion>()
             .add_event::<MouseWheel>()
             .init_resource::<Input<KeyCode>>()
+            .init_resource::<KeyModifiers>()
             .add_system_to_stage(bevy_app::stage::EVENT, keyboard_input_system)
             .init_resource::<Input<MouseButton>>()
             .add_system_to_stage(bevy_app::stage::EVENT, mouse_button_input_system)

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -1,5 +1,5 @@
 use bevy_input::{
-    keyboard::{KeyCode, KeyboardInput},
+    keyboard::{KeyCode, KeyModifiers, KeyboardInput},
     mouse::MouseButton,
     touch::{ForceTouch, TouchInput, TouchPhase},
     ElementState,
@@ -56,6 +56,23 @@ pub fn convert_touch_input(
         }),
         id: touch_input.id,
     }
+}
+
+pub fn convert_keyboard_modifiers(src: winit::event::ModifiersState) -> KeyModifiers {
+    let mut result = KeyModifiers::default();
+    if src.shift() {
+        result.set_shift();
+    }
+    if src.ctrl() {
+        result.set_ctrl();
+    }
+    if src.alt() {
+        result.set_alt();
+    }
+    if src.logo() {
+        result.set_logo();
+    }
+    result
 }
 
 pub fn convert_virtual_key_code(virtual_key_code: winit::event::VirtualKeyCode) -> KeyCode {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -2,7 +2,7 @@ mod converters;
 mod winit_config;
 mod winit_windows;
 use bevy_input::{
-    keyboard::KeyboardInput,
+    keyboard::{KeyModifiers, KeyboardInput},
     mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
     touch::TouchInput,
 };
@@ -219,6 +219,10 @@ pub fn winit_runner(mut app: App) {
                     let mut keyboard_input_events =
                         app.resources.get_mut::<Events<KeyboardInput>>().unwrap();
                     keyboard_input_events.send(converters::convert_keyboard_input(input));
+                }
+                WindowEvent::ModifiersChanged(modifiers) => {
+                    let mut keyboard_modifiers = app.resources.get_mut::<KeyModifiers>().unwrap();
+                    *keyboard_modifiers = converters::convert_keyboard_modifiers(modifiers);
                 }
                 WindowEvent::CursorMoved { position, .. } => {
                     let mut cursor_moved_events =

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -1,4 +1,8 @@
-use bevy::prelude::*;
+use bevy::{
+    input::keyboard::{modifiers::ALT, KeyModifiers},
+    prelude::*,
+    window::WindowMode,
+};
 
 /// This example illustrates how to customize the default window settings
 fn main() {
@@ -14,6 +18,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_system(change_title)
         .add_system(toggle_cursor)
+        .add_system(toggle_fullscreen)
         .run();
 }
 
@@ -32,5 +37,20 @@ fn toggle_cursor(input: Res<Input<KeyCode>>, mut windows: ResMut<Windows>) {
     if input.just_pressed(KeyCode::Space) {
         window.set_cursor_lock_mode(!window.cursor_locked());
         window.set_cursor_visibility(!window.cursor_visible());
+    }
+}
+
+fn toggle_fullscreen(
+    key_codes: Res<Input<KeyCode>>,
+    key_modifiers: Res<KeyModifiers>,
+    mut windows: ResMut<Windows>,
+) {
+    if key_codes.just_pressed(KeyCode::Return) && *key_modifiers == ALT {
+        let window = windows.get_primary_mut().unwrap();
+        match window.mode() {
+            WindowMode::BorderlessFullscreen => window.set_mode(WindowMode::Windowed),
+            WindowMode::Windowed => window.set_mode(WindowMode::BorderlessFullscreen),
+            _ => (),
+        }
     }
 }


### PR DESCRIPTION
This patch add tracking of keyboard the ctrl, alt, shift & the "logo" modifier keys. The window_settings example is updated to support toggling full screen mode with the 'alt+enter' chord.