### PR TITLE
Add sub index to `TextureAtlas` and `TextureAtlasBuilder`

### DIFF
--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -144,12 +144,21 @@ impl TextureAtlas {
         self.textures.is_empty()
     }
 
-    /// Retrieves the textures's index from a given texture handle and sub-index.
-    pub fn get_texture_index(&self, texture: &Handle<Texture>, index: &usize) -> Option<usize> {
+    /// Retrievs the texture's from a given texture handle and sub index.
+    pub fn get_texture_index_with_sub_index(
+        &self,
+        texture: &Handle<Texture>,
+        sub_index: &usize,
+    ) -> Option<usize> {
         self.texture_handles.as_ref().and_then(|texture_handles| {
             texture_handles
                 .get(texture)
-                .and_then(|indexes| indexes.get(index).cloned())
+                .and_then(|indexes| indexes.get(sub_index).cloned())
         })
+    }
+
+    /// Retrieves the texture's index from a given texture handle.
+    pub fn get_texture_index(&self, texture: &Handle<Texture>) -> Option<usize> {
+        self.get_texture_index_with_sub_index(texture, &0)
     }
 }

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -21,8 +21,10 @@ pub struct TextureAtlas {
     /// The specific areas of the atlas where each texture can be found
     #[render_resources(buffer)]
     pub textures: Vec<Rect>,
+    /// Contains the handle to the index in the texture, which then contains the
+    /// indexes of the textures.
     #[render_resources(ignore)]
-    pub texture_handles: Option<HashMap<Handle<Texture>, usize>>,
+    pub texture_handles: Option<HashMap<Handle<Texture>, HashMap<usize, usize>>>,
 }
 
 #[derive(Debug, RenderResources, RenderResource)]
@@ -54,7 +56,7 @@ impl TextureAtlasSprite {
 
 impl TextureAtlas {
     /// Create a new `TextureAtlas` that has a texture, but does not have
-    /// any individual sprites specified
+    /// any individual sprites specified.
     pub fn new_empty(texture: Handle<Texture>, dimensions: Vec2) -> Self {
         Self {
             texture,
@@ -65,7 +67,7 @@ impl TextureAtlas {
     }
 
     /// Generate a `TextureAtlas` by splitting a texture into a grid where each
-    /// cell of the grid  of `tile_size` is one of the textures in the atlas
+    /// cell of the grid of `tile_size` is one of the textures in the atlas.
     pub fn from_grid(
         texture: Handle<Texture>,
         tile_size: Vec2,
@@ -76,8 +78,8 @@ impl TextureAtlas {
     }
 
     /// Generate a `TextureAtlas` by splitting a texture into a grid where each
-    /// cell of the grid of `tile_size` is one of the textures in the atlas and is separated by
-    /// some `padding` in the texture
+    /// cell of the grid of `tile_size` is one of the textures in the atlas and
+    /// is separated by some `padding` in the texture.
     pub fn from_grid_with_padding(
         texture: Handle<Texture>,
         tile_size: Vec2,
@@ -121,28 +123,33 @@ impl TextureAtlas {
         }
     }
 
-    /// Add a sprite to the list of textures in the `TextureAtlas`
+    /// Add a sprite to the list of textures in the `TextureAtlas`.
     ///
     /// # Arguments
     ///
-    /// * `rect` - The section of the atlas that contains the texture to be added,
-    /// from the top-left corner of the texture to the bottom-right corner
+    /// * `rect` - The section of the atlas that contains the texture to be
+    /// added, from the top-left corner of the texture to the bottom-right
+    /// corner
     pub fn add_texture(&mut self, rect: Rect) {
         self.textures.push(rect);
     }
 
-    /// How many textures are in the `TextureAtlas`
+    /// How many textures are in the `TextureAtlas`, also known as length.
     pub fn len(&self) -> usize {
         self.textures.len()
     }
 
+    /// If there are textures or not contained within.
     pub fn is_empty(&self) -> bool {
         self.textures.is_empty()
     }
 
-    pub fn get_texture_index(&self, texture: &Handle<Texture>) -> Option<usize> {
-        self.texture_handles
-            .as_ref()
-            .and_then(|texture_handles| texture_handles.get(texture).cloned())
+    /// Retrieves the textures's index from a given texture handle and sub-index.
+    pub fn get_texture_index(&self, texture: &Handle<Texture>, index: &usize) -> Option<usize> {
+        self.texture_handles.as_ref().and_then(|texture_handles| {
+            texture_handles
+                .get(texture)
+                .and_then(|indexes| indexes.get(index).cloned())
+        })
     }
 }

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -45,7 +45,7 @@ fn load_atlas(
         let texture_atlas_texture = texture_atlas.texture.clone();
         let vendor_handle =
             asset_server.get_handle("textures/rpg/chars/vendor/generic-rpg-vendor.png");
-        let vendor_index = texture_atlas.get_texture_index(&vendor_handle).unwrap();
+        let vendor_index = texture_atlas.get_texture_index(&vendor_handle, &0).unwrap();
         let atlas_handle = texture_atlases.add(texture_atlas);
 
         // set up a scene to display our texture atlas

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -45,7 +45,7 @@ fn load_atlas(
         let texture_atlas_texture = texture_atlas.texture.clone();
         let vendor_handle =
             asset_server.get_handle("textures/rpg/chars/vendor/generic-rpg-vendor.png");
-        let vendor_index = texture_atlas.get_texture_index(&vendor_handle, &0).unwrap();
+        let vendor_index = texture_atlas.get_texture_index(&vendor_handle).unwrap();
         let atlas_handle = texture_atlases.add(texture_atlas);
 
         // set up a scene to display our texture atlas


### PR DESCRIPTION
My motivation behind this one is that there should be a way to preserve the ability to split a texture into sub-textures stored with sub-indexes. This allows someone to push an entire sprite animation into a texture atlas and retain all the indexes for that animation. For my own use, this allows me to integrate `Auto Tile` into the `bevy_tilemap` by getting the tile by using both the texture handle and the index of the position from left to right and down.

The only downside is that I have to break the API for `TextureAtlas::get_texture_index`. I wanted to avoid this and add in a new method but, I couldn't think of anything beyond the long name of `get_texture_index_with_sub_index`. Having a 2nd method would preserve 100% of the APIs being used by using an index of 0 by default.

EDIT: Will I added `get_texture_index_with_sub_index` anyways, unless someone can come up with a shorter name.