### PR TITLE
Set cursor updates

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -80,8 +80,7 @@ pub enum WindowCommand {
         visible: bool,
     },
     SetCursorPosition {
-        x: i32,
-        y: i32,
+        position: Vec2,
     },
 }
 
@@ -237,9 +236,9 @@ impl Window {
         self.cursor_position
     }
 
-    pub fn set_cursor_position(&mut self, x: i32, y: i32) {
+    pub fn set_cursor_position(&mut self, position: Vec2) {
         self.command_queue
-            .push(WindowCommand::SetCursorPosition { x, y });
+            .push(WindowCommand::SetCursorPosition { position });
     }
 
     #[allow(missing_docs)]

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -96,9 +96,11 @@ fn change_window(_: &mut World, resources: &mut Resources) {
                 }
                 bevy_window::WindowCommand::SetCursorPosition { position } => {
                     let window = winit_windows.get_window(id).unwrap();
+                    let inner_size = window.inner_size().to_logical::<f32>(window.scale_factor());
                     window
                         .set_cursor_position(winit::dpi::LogicalPosition::new(
-                            position.x, position.y,
+                            position.x,
+                            inner_size.height - position.y,
                         ))
                         .unwrap_or_else(|e| error!("Unable to set cursor position: {}", e));
                 }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -94,10 +94,12 @@ fn change_window(_: &mut World, resources: &mut Resources) {
                     let window = winit_windows.get_window(id).unwrap();
                     window.set_cursor_visible(visible);
                 }
-                bevy_window::WindowCommand::SetCursorPosition { x, y } => {
+                bevy_window::WindowCommand::SetCursorPosition { position } => {
                     let window = winit_windows.get_window(id).unwrap();
                     window
-                        .set_cursor_position(winit::dpi::LogicalPosition::new(x, y))
+                        .set_cursor_position(winit::dpi::LogicalPosition::new(
+                            position.x, position.y,
+                        ))
                         .unwrap_or_else(|e| error!("Unable to set cursor position: {}", e));
                 }
             }


### PR DESCRIPTION
This patch alters the `Window::set_cursor_position` API to take a Vec2 in the same coordinate system as the `CursorMoved` event.

The change to floating point allows more precise positioning in high DPI contexts. The coordinate system change and use of `Vec2` makes things consistent with the `CursorMoved` event.