### PR TITLE
naming coherence for cameras

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -239,7 +239,7 @@ fn load_node(
                 };
 
                 node.with(Camera {
-                    name: Some(base::camera::CAMERA2D.to_owned()),
+                    name: Some(base::camera::CAMERA_2D.to_owned()),
                     projection_matrix: orthographic_projection.get_projection_matrix(),
                     ..Default::default()
                 });
@@ -258,7 +258,7 @@ fn load_node(
                     perspective_projection.aspect_ratio = aspect_ratio;
                 }
                 node.with(Camera {
-                    name: Some(base::camera::CAMERA3D.to_owned()),
+                    name: Some(base::camera::CAMERA_3D.to_owned()),
                     projection_matrix: perspective_projection.get_projection_matrix(),
                     ..Default::default()
                 });

--- a/crates/bevy_render/src/entity.rs
+++ b/crates/bevy_render/src/entity.rs
@@ -35,7 +35,7 @@ impl Default for Camera3dBundle {
     fn default() -> Self {
         Camera3dBundle {
             camera: Camera {
-                name: Some(base::camera::CAMERA3D.to_string()),
+                name: Some(base::camera::CAMERA_3D.to_string()),
                 ..Default::default()
             },
             perspective_projection: Default::default(),
@@ -63,7 +63,7 @@ impl Default for Camera2dBundle {
         let far = 1000.0;
         Camera2dBundle {
             camera: Camera {
-                name: Some(base::camera::CAMERA2D.to_string()),
+                name: Some(base::camera::CAMERA_2D.to_string()),
                 ..Default::default()
             },
             orthographic_projection: OrthographicProjection {

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -154,11 +154,11 @@ impl Plugin for RenderPlugin {
             render_graph.add_base_graph(config, &msaa);
             let mut active_cameras = resources.get_mut::<ActiveCameras>().unwrap();
             if config.add_3d_camera {
-                active_cameras.add(base::camera::CAMERA3D);
+                active_cameras.add(base::camera::CAMERA_3D);
             }
 
             if config.add_2d_camera {
-                active_cameras.add(base::camera::CAMERA2D);
+                active_cameras.add(base::camera::CAMERA_2D);
             }
         }
     }

--- a/crates/bevy_render/src/render_graph/base.rs
+++ b/crates/bevy_render/src/render_graph/base.rs
@@ -168,11 +168,13 @@ impl BaseRenderGraphBuilder for RenderGraph {
                 .unwrap();
 
             if config.add_3d_camera {
-                self.add_node_edge(node::CAMERA_3D, node::MAIN_PASS).unwrap();
+                self.add_node_edge(node::CAMERA_3D, node::MAIN_PASS)
+                    .unwrap();
             }
 
             if config.add_2d_camera {
-                self.add_node_edge(node::CAMERA_2D, node::MAIN_PASS).unwrap();
+                self.add_node_edge(node::CAMERA_2D, node::MAIN_PASS)
+                    .unwrap();
             }
         }
 

--- a/crates/bevy_render/src/render_graph/base.rs
+++ b/crates/bevy_render/src/render_graph/base.rs
@@ -63,8 +63,8 @@ pub struct BaseRenderGraphConfig {
 
 pub mod node {
     pub const PRIMARY_SWAP_CHAIN: &str = "swapchain";
-    pub const CAMERA3D: &str = "camera3d";
-    pub const CAMERA2D: &str = "camera2d";
+    pub const CAMERA_3D: &str = "camera_3d";
+    pub const CAMERA_2D: &str = "camera_2d";
     pub const TEXTURE_COPY: &str = "texture_copy";
     pub const MAIN_DEPTH_TEXTURE: &str = "main_pass_depth_texture";
     pub const MAIN_SAMPLED_COLOR_ATTACHMENT: &str = "main_pass_sampled_color_attachment";
@@ -73,8 +73,8 @@ pub mod node {
 }
 
 pub mod camera {
-    pub const CAMERA3D: &str = "Camera3d";
-    pub const CAMERA2D: &str = "Camera2d";
+    pub const CAMERA_3D: &str = "Camera3d";
+    pub const CAMERA_2D: &str = "Camera2d";
 }
 
 impl Default for BaseRenderGraphConfig {
@@ -100,11 +100,11 @@ impl BaseRenderGraphBuilder for RenderGraph {
     fn add_base_graph(&mut self, config: &BaseRenderGraphConfig, msaa: &Msaa) -> &mut Self {
         self.add_node(node::TEXTURE_COPY, TextureCopyNode::default());
         if config.add_3d_camera {
-            self.add_system_node(node::CAMERA3D, CameraNode::new(camera::CAMERA3D));
+            self.add_system_node(node::CAMERA_3D, CameraNode::new(camera::CAMERA_3D));
         }
 
         if config.add_2d_camera {
-            self.add_system_node(node::CAMERA2D, CameraNode::new(camera::CAMERA2D));
+            self.add_system_node(node::CAMERA_2D, CameraNode::new(camera::CAMERA_2D));
         }
 
         self.add_node(node::SHARED_BUFFERS, SharedBuffersNode::default());
@@ -153,11 +153,11 @@ impl BaseRenderGraphBuilder for RenderGraph {
             main_pass_node.use_default_clear_color(0);
 
             if config.add_3d_camera {
-                main_pass_node.add_camera(camera::CAMERA3D);
+                main_pass_node.add_camera(camera::CAMERA_3D);
             }
 
             if config.add_2d_camera {
-                main_pass_node.add_camera(camera::CAMERA2D);
+                main_pass_node.add_camera(camera::CAMERA_2D);
             }
 
             self.add_node(node::MAIN_PASS, main_pass_node);
@@ -168,11 +168,11 @@ impl BaseRenderGraphBuilder for RenderGraph {
                 .unwrap();
 
             if config.add_3d_camera {
-                self.add_node_edge(node::CAMERA3D, node::MAIN_PASS).unwrap();
+                self.add_node_edge(node::CAMERA_3D, node::MAIN_PASS).unwrap();
             }
 
             if config.add_2d_camera {
-                self.add_node_edge(node::CAMERA2D, node::MAIN_PASS).unwrap();
+                self.add_node_edge(node::CAMERA_2D, node::MAIN_PASS).unwrap();
             }
         }
 

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -144,7 +144,7 @@ impl Default for ButtonBundle {
 }
 
 #[derive(Bundle, Debug)]
-pub struct UiCameraBundle {
+pub struct CameraUiBundle {
     pub camera: Camera,
     pub orthographic_projection: OrthographicProjection,
     pub visible_entities: VisibleEntities,
@@ -152,14 +152,14 @@ pub struct UiCameraBundle {
     pub global_transform: GlobalTransform,
 }
 
-impl Default for UiCameraBundle {
+impl Default for CameraUiBundle {
     fn default() -> Self {
         // we want 0 to be "closest" and +far to be "farthest" in 2d, so we offset
         // the camera's translation by far and use a right handed coordinate system
         let far = 1000.0;
-        UiCameraBundle {
+        CameraUiBundle {
             camera: Camera {
-                name: Some(crate::camera::UI_CAMERA.to_string()),
+                name: Some(crate::camera::CAMERA_UI.to_string()),
                 ..Default::default()
             },
             orthographic_projection: OrthographicProjection {

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -70,13 +70,13 @@ pub fn build_ui_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescriptor {
 }
 
 pub mod node {
-    pub const UI_CAMERA: &str = "ui_camera";
+    pub const CAMERA_UI: &str = "camera_ui";
     pub const NODE: &str = "node";
     pub const UI_PASS: &str = "ui_pass";
 }
 
 pub mod camera {
-    pub const UI_CAMERA: &str = "UiCamera";
+    pub const CAMERA_UI: &str = "CameraUi";
 }
 
 pub trait UiRenderGraphBuilder {
@@ -110,7 +110,7 @@ impl UiRenderGraphBuilder for RenderGraph {
             sample_count: msaa.samples,
         });
 
-        ui_pass_node.add_camera(camera::UI_CAMERA);
+        ui_pass_node.add_camera(camera::CAMERA_UI);
         self.add_node(node::UI_PASS, ui_pass_node);
 
         self.add_slot_edge(
@@ -148,12 +148,12 @@ impl UiRenderGraphBuilder for RenderGraph {
             .unwrap();
 
         // setup ui camera
-        self.add_system_node(node::UI_CAMERA, CameraNode::new(camera::UI_CAMERA));
-        self.add_node_edge(node::UI_CAMERA, node::UI_PASS).unwrap();
+        self.add_system_node(node::CAMERA_UI, CameraNode::new(camera::CAMERA_UI));
+        self.add_node_edge(node::CAMERA_UI, node::UI_PASS).unwrap();
         self.add_system_node(node::NODE, RenderResourcesNode::<Node>::new(true));
         self.add_node_edge(node::NODE, node::UI_PASS).unwrap();
         let mut active_cameras = resources.get_mut::<ActiveCameras>().unwrap();
-        active_cameras.add(camera::UI_CAMERA);
+        active_cameras.add(camera::CAMERA_UI);
         self
     }
 }

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -56,7 +56,7 @@ fn setup(
 
     commands
         .spawn(Camera2dBundle::default())
-        .spawn(UiCameraBundle::default());
+        .spawn(CameraUiBundle::default());
 
     let mut sel = ContributorSelection {
         order: vec![],

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -45,7 +45,7 @@ fn setup(
     commands
         // cameras
         .spawn(Camera2dBundle::default())
-        .spawn(UiCameraBundle::default())
+        .spawn(CameraUiBundle::default())
         // paddle
         .spawn(SpriteBundle {
             material: materials.add(Color::rgb(0.5, 0.5, 1.0).into()),

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -97,7 +97,7 @@ fn save_scene_system(_world: &mut World, resources: &mut Resources) {
 
 // This is only necessary for the info message in the UI. See examples/ui/text.rs for a standalone text example.
 fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(UiCameraBundle::default()).spawn(TextBundle {
+    commands.spawn(CameraUiBundle::default()).spawn(TextBundle {
         style: Style {
             align_self: AlignSelf::FlexEnd,
             ..Default::default()

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -51,7 +51,7 @@ fn main() {
 fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(Camera2dBundle::default())
-        .spawn(UiCameraBundle::default())
+        .spawn(CameraUiBundle::default())
         .spawn(TextBundle {
             text: Text {
                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -61,7 +61,7 @@ fn setup(
 ) {
     commands
         // ui camera
-        .spawn(UiCameraBundle::default())
+        .spawn(CameraUiBundle::default())
         .spawn(ButtonBundle {
             style: Style {
                 size: Size::new(Val::Px(150.0), Val::Px(65.0)),

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -77,7 +77,7 @@ fn text_update_system(mut state: ResMut<State>, time: Res<Time>, mut query: Quer
 fn setup(commands: &mut Commands, asset_server: Res<AssetServer>, mut state: ResMut<State>) {
     let font_handle = asset_server.load("fonts/FiraSans-Bold.ttf");
     state.handle = font_handle.clone();
-    commands.spawn(UiCameraBundle::default()).spawn(TextBundle {
+    commands.spawn(CameraUiBundle::default()).spawn(TextBundle {
         text: Text {
             value: "a".to_string(),
             font: font_handle,

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -29,7 +29,7 @@ fn text_update_system(diagnostics: Res<Diagnostics>, mut query: Query<&mut Text,
 fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
     commands
         // 2d camera
-        .spawn(UiCameraBundle::default())
+        .spawn(CameraUiBundle::default())
         // texture
         .spawn(TextBundle {
             style: Style {

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -21,7 +21,7 @@ struct TextChanges;
 
 fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
     let font = asset_server.load("fonts/FiraSans-Bold.ttf");
-    commands.spawn(UiCameraBundle::default()).spawn(TextBundle {
+    commands.spawn(CameraUiBundle::default()).spawn(TextBundle {
         style: Style {
             align_self: AlignSelf::FlexEnd,
             position_type: PositionType::Absolute,
@@ -43,7 +43,7 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
         },
         ..Default::default()
     });
-    commands.spawn(UiCameraBundle::default()).spawn(TextBundle {
+    commands.spawn(CameraUiBundle::default()).spawn(TextBundle {
         style: Style {
             align_self: AlignSelf::FlexEnd,
             position_type: PositionType::Absolute,
@@ -74,7 +74,7 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
         ..Default::default()
     });
     commands
-        .spawn(UiCameraBundle::default())
+        .spawn(CameraUiBundle::default())
         .spawn(TextBundle {
             style: Style {
                 align_self: AlignSelf::FlexEnd,
@@ -98,7 +98,7 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
             ..Default::default()
         })
         .with(TextChanges);
-    commands.spawn(UiCameraBundle::default()).spawn(TextBundle {
+    commands.spawn(CameraUiBundle::default()).spawn(TextBundle {
         style: Style {
             align_self: AlignSelf::FlexEnd,
             position_type: PositionType::Absolute,

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -15,7 +15,7 @@ fn setup(
 ) {
     commands
         // ui camera
-        .spawn(UiCameraBundle::default())
+        .spawn(CameraUiBundle::default())
         // root node
         .spawn(NodeBundle {
             style: Style {


### PR DESCRIPTION
Just something that irked me for a while, but not sure if it's worthy of a breaking change...

Basically, it's renaming `UiCameraBundle` to `CameraUiBundle`, to be aligned with `Camera2dBundle` and `Camera3dBundle`

While at it I also changed a few internals const/strings to be coherent

Feel free to close, I can live with it...