### PR TITLE
attempt to deal with rounding issue when creating the swap chain

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -78,7 +78,10 @@ pub fn camera_system<T: CameraProjection + Component>(
     for (entity, mut camera, mut camera_projection) in queries.q0_mut().iter_mut() {
         if let Some(window) = windows.get(camera.window) {
             if changed_window_ids.contains(&window.id()) || added_cameras.contains(&entity) {
-                camera_projection.update(window.width() as usize, window.height() as usize);
+                camera_projection.update(
+                    window.logical_width() as usize,
+                    window.logical_height() as usize,
+                );
                 camera.projection_matrix = camera_projection.get_projection_matrix();
                 camera.depth_calculation = camera_projection.depth_calculation();
             }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -78,7 +78,7 @@ pub fn camera_system<T: CameraProjection + Component>(
     for (entity, mut camera, mut camera_projection) in queries.q0_mut().iter_mut() {
         if let Some(window) = windows.get(camera.window) {
             if changed_window_ids.contains(&window.id()) || added_cameras.contains(&entity) {
-                camera_projection.update(window.width(), window.height());
+                camera_projection.update(window.logical_width(), window.logical_height());
                 camera.projection_matrix = camera_projection.get_projection_matrix();
                 camera.depth_calculation = camera_projection.depth_calculation();
             }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -78,10 +78,7 @@ pub fn camera_system<T: CameraProjection + Component>(
     for (entity, mut camera, mut camera_projection) in queries.q0_mut().iter_mut() {
         if let Some(window) = windows.get(camera.window) {
             if changed_window_ids.contains(&window.id()) || added_cameras.contains(&entity) {
-                camera_projection.update(
-                    window.logical_width() as usize,
-                    window.logical_height() as usize,
-                );
+                camera_projection.update(window.width(), window.height());
                 camera.projection_matrix = camera_projection.get_projection_matrix();
                 camera.depth_calculation = camera_projection.depth_calculation();
             }

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 pub trait CameraProjection {
     fn get_projection_matrix(&self) -> Mat4;
-    fn update(&mut self, width: usize, height: usize);
+    fn update(&mut self, width: f32, height: f32);
     fn depth_calculation(&self) -> DepthCalculation;
 }
 
@@ -23,8 +23,8 @@ impl CameraProjection for PerspectiveProjection {
         Mat4::perspective_rh(self.fov, self.aspect_ratio, self.near, self.far)
     }
 
-    fn update(&mut self, width: usize, height: usize) {
-        self.aspect_ratio = width as f32 / height as f32;
+    fn update(&mut self, width: f32, height: f32) {
+        self.aspect_ratio = width / height;
     }
 
     fn depth_calculation(&self) -> DepthCalculation {
@@ -75,11 +75,11 @@ impl CameraProjection for OrthographicProjection {
         )
     }
 
-    fn update(&mut self, width: usize, height: usize) {
+    fn update(&mut self, width: f32, height: f32) {
         match self.window_origin {
             WindowOrigin::Center => {
-                let half_width = width as f32 / 2.0;
-                let half_height = height as f32 / 2.0;
+                let half_width = width / 2.0;
+                let half_height = height / 2.0;
                 self.left = -half_width;
                 self.right = half_width;
                 self.top = half_height;
@@ -87,8 +87,8 @@ impl CameraProjection for OrthographicProjection {
             }
             WindowOrigin::BottomLeft => {
                 self.left = 0.0;
-                self.right = width as f32;
-                self.top = height as f32;
+                self.right = width;
+                self.top = height;
                 self.bottom = 0.0;
             }
         }

--- a/crates/bevy_render/src/render_graph/nodes/window_texture_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/window_texture_node.rs
@@ -68,8 +68,8 @@ impl Node for WindowTextureNode {
                 render_resource_context.remove_texture(old_texture);
             }
 
-            self.descriptor.size.width = window.scaled_width();
-            self.descriptor.size.height = window.scaled_height();
+            self.descriptor.size.width = window.physical_width();
+            self.descriptor.size.height = window.physical_height();
             let texture_resource = render_resource_context.create_texture(self.descriptor);
             output.set(WINDOW_TEXTURE, RenderResourceId::Texture(texture_resource));
         }

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -116,8 +116,8 @@ impl FlexSurface {
                 *node,
                 stretch::style::Style {
                     size: stretch::geometry::Size {
-                        width: stretch::style::Dimension::Points(window.width()),
-                        height: stretch::style::Dimension::Points(window.height()),
+                        width: stretch::style::Dimension::Points(window.logical_width()),
+                        height: stretch::style::Dimension::Points(window.logical_height()),
                     },
                     ..Default::default()
                 },

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -116,8 +116,8 @@ impl FlexSurface {
                 *node,
                 stretch::style::Style {
                     size: stretch::geometry::Size {
-                        width: stretch::style::Dimension::Points(window.logical_width() as f32),
-                        height: stretch::style::Dimension::Points(window.logical_height() as f32),
+                        width: stretch::style::Dimension::Points(window.width()),
+                        height: stretch::style::Dimension::Points(window.height()),
                     },
                     ..Default::default()
                 },

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -116,8 +116,8 @@ impl FlexSurface {
                 *node,
                 stretch::style::Style {
                     size: stretch::geometry::Size {
-                        width: stretch::style::Dimension::Points(window.width() as f32),
-                        height: stretch::style::Dimension::Points(window.height() as f32),
+                        width: stretch::style::Dimension::Points(window.logical_width() as f32),
+                        height: stretch::style::Dimension::Points(window.logical_height() as f32),
                     },
                     ..Default::default()
                 },

--- a/crates/bevy_wgpu/src/wgpu_type_converter.rs
+++ b/crates/bevy_wgpu/src/wgpu_type_converter.rs
@@ -564,8 +564,8 @@ impl WgpuFrom<&Window> for wgpu::SwapChainDescriptor {
         wgpu::SwapChainDescriptor {
             usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
             format: TextureFormat::default().wgpu_into(),
-            width: window.scaled_width(),
-            height: window.scaled_height(),
+            width: window.physical_width(),
+            height: window.physical_height(),
             present_mode: if window.vsync() {
                 wgpu::PresentMode::Mailbox
             } else {

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -5,8 +5,8 @@ use bevy_math::Vec2;
 #[derive(Debug, Clone)]
 pub struct WindowResized {
     pub id: WindowId,
-    pub width: usize,
-    pub height: usize,
+    pub width: f32,
+    pub height: f32,
 }
 
 /// An event that indicates that a new window should be created.

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -126,12 +126,22 @@ impl Window {
     }
 
     #[inline]
-    pub fn width(&self) -> f32 {
+    pub fn width(&self) -> u32 {
+        self.logical_width() as u32
+    }
+
+    #[inline]
+    pub fn height(&self) -> u32 {
+        self.logical_height() as u32
+    }
+
+    #[inline]
+    pub fn logical_width(&self) -> f32 {
         (self.physical_width as f64 / self.scale_factor) as f32
     }
 
     #[inline]
-    pub fn height(&self) -> f32 {
+    pub fn logical_height(&self) -> f32 {
         (self.physical_height as f64 / self.scale_factor) as f32
     }
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -61,8 +61,8 @@ pub enum WindowCommand {
         title: String,
     },
     SetResolution {
-        width: u32,
-        height: u32,
+        physical_width: u32,
+        physical_height: u32,
     },
     SetVsync {
         vsync: bool,
@@ -126,12 +126,12 @@ impl Window {
     }
 
     #[inline]
-    pub fn logical_width(&self) -> f32 {
+    pub fn width(&self) -> f32 {
         (self.physical_width as f64 / self.scale_factor) as f32
     }
 
     #[inline]
-    pub fn logical_height(&self) -> f32 {
+    pub fn height(&self) -> f32 {
         (self.physical_height as f64 / self.scale_factor) as f32
     }
 
@@ -149,6 +149,15 @@ impl Window {
     pub fn set_maximized(&mut self, maximized: bool) {
         self.command_queue
             .push(WindowCommand::SetMaximized { maximized });
+    }
+
+    pub fn set_resolution(&mut self, width: f32, height: f32) {
+        self.physical_width = (width as f64 * self.scale_factor) as u32;
+        self.physical_height = (height as f64 * self.scale_factor) as u32;
+        self.command_queue.push(WindowCommand::SetResolution {
+            physical_width: self.physical_width,
+            physical_height: self.physical_height,
+        });
     }
 
     #[allow(missing_docs)]

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -35,8 +35,8 @@ impl Default for WindowId {
 #[derive(Debug)]
 pub struct Window {
     id: WindowId,
-    width: u32,
-    height: u32,
+    physical_width: u32,
+    physical_height: u32,
     title: String,
     vsync: bool,
     resizable: bool,
@@ -103,8 +103,8 @@ impl Window {
     pub fn new(id: WindowId, window_descriptor: &WindowDescriptor) -> Self {
         Window {
             id,
-            height: window_descriptor.height,
-            width: window_descriptor.width,
+            physical_height: window_descriptor.height,
+            physical_width: window_descriptor.width,
             title: window_descriptor.title.clone(),
             vsync: window_descriptor.vsync,
             resizable: window_descriptor.resizable,
@@ -126,21 +126,23 @@ impl Window {
     }
 
     #[inline]
-    pub fn width(&self) -> u32 {
-        self.width
-    }
-
-    pub fn scaled_width(&self) -> u32 {
-        (self.width as f64 * self.scale_factor) as u32
-    }
-
-    pub fn scaled_height(&self) -> u32 {
-        (self.height as f64 * self.scale_factor) as u32
+    pub fn logical_width(&self) -> f32 {
+        (self.physical_width as f64 / self.scale_factor) as f32
     }
 
     #[inline]
-    pub fn height(&self) -> u32 {
-        self.height
+    pub fn logical_height(&self) -> f32 {
+        (self.physical_height as f64 / self.scale_factor) as f32
+    }
+
+    #[inline]
+    pub fn physical_width(&self) -> u32 {
+        self.physical_width
+    }
+
+    #[inline]
+    pub fn physical_height(&self) -> u32 {
+        self.physical_height
     }
 
     #[inline]
@@ -149,18 +151,11 @@ impl Window {
             .push(WindowCommand::SetMaximized { maximized });
     }
 
-    pub fn set_resolution(&mut self, width: u32, height: u32) {
-        self.width = width;
-        self.height = height;
-        self.command_queue
-            .push(WindowCommand::SetResolution { width, height });
-    }
-
     #[allow(missing_docs)]
     #[inline]
-    pub fn update_resolution_from_backend(&mut self, width: u32, height: u32) {
-        self.width = width;
-        self.height = height;
+    pub fn update_physical_size_from_backend(&mut self, width: u32, height: u32) {
+        self.physical_width = width;
+        self.physical_height = height;
     }
 
     #[allow(missing_docs)]
@@ -265,7 +260,7 @@ impl Window {
         self.mode = mode;
         self.command_queue.push(WindowCommand::SetWindowMode {
             mode,
-            resolution: (self.width, self.height),
+            resolution: (self.physical_width, self.physical_height),
         });
     }
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -161,7 +161,7 @@ impl Window {
             .push(WindowCommand::SetMaximized { maximized });
     }
 
-    pub fn set_resolution(&mut self, width: f32, height: f32) {
+    pub fn set_resolution(&mut self, width: u32, height: u32) {
         self.physical_width = (width as f64 * self.scale_factor) as u32;
         self.physical_height = (height as f64 * self.scale_factor) as u32;
         self.command_queue.push(WindowCommand::SetResolution {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -214,8 +214,8 @@ pub fn winit_runner(mut app: App) {
                         app.resources.get_mut::<Events<WindowResized>>().unwrap();
                     resize_events.send(WindowResized {
                         id: window_id,
-                        height: window.height(),
-                        width: window.width(),
+                        height: window.logical_height(),
+                        width: window.logical_width(),
                     });
                 }
                 WindowEvent::CloseRequested => {
@@ -313,7 +313,7 @@ pub fn winit_runner(mut app: App) {
 
                     // FIXME?: On Android window start is top while on PC/Linux/OSX on bottom
                     if cfg!(target_os = "android") {
-                        let window_height = windows.get_primary().unwrap().height();
+                        let window_height = windows.get_primary().unwrap().logical_height();
                         location.y = window_height - location.y;
                     }
                     touch_input_events.send(converters::convert_touch_input(touch, location));

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -71,9 +71,15 @@ fn change_window(_: &mut World, resources: &mut Resources) {
                     let window = winit_windows.get_window(id).unwrap();
                     window.set_title(&title);
                 }
-                bevy_window::WindowCommand::SetResolution { width, height } => {
+                bevy_window::WindowCommand::SetResolution {
+                    physical_width,
+                    physical_height,
+                } => {
                     let window = winit_windows.get_window(id).unwrap();
-                    window.set_inner_size(winit::dpi::PhysicalSize::new(width, height));
+                    window.set_inner_size(winit::dpi::PhysicalSize::new(
+                        physical_width,
+                        physical_height,
+                    ));
                 }
                 bevy_window::WindowCommand::SetVsync { .. } => (),
                 bevy_window::WindowCommand::SetResizable { resizable } => {
@@ -208,8 +214,8 @@ pub fn winit_runner(mut app: App) {
                         app.resources.get_mut::<Events<WindowResized>>().unwrap();
                     resize_events.send(WindowResized {
                         id: window_id,
-                        height: window.logical_height() as usize,
-                        width: window.logical_width() as usize,
+                        height: window.height(),
+                        width: window.width(),
                     });
                 }
                 WindowEvent::CloseRequested => {
@@ -307,8 +313,8 @@ pub fn winit_runner(mut app: App) {
 
                     // FIXME?: On Android window start is top while on PC/Linux/OSX on bottom
                     if cfg!(target_os = "android") {
-                        let window_height = windows.get_primary().unwrap().logical_height();
-                        location.y = window_height as f32 - location.y;
+                        let window_height = windows.get_primary().unwrap().height();
+                        location.y = window_height - location.y;
                     }
                     touch_input_events.send(converters::convert_touch_input(touch, location));
                 }

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -31,16 +31,16 @@ impl WinitWindows {
                 winit::window::Fullscreen::Exclusive(match use_size {
                     true => get_fitting_videomode(
                         &event_loop.primary_monitor().unwrap(),
-                        window.width(),
-                        window.height(),
+                        window.physical_width(),
+                        window.physical_height(),
                     ),
                     false => get_best_videomode(&event_loop.primary_monitor().unwrap()),
                 }),
             )),
             _ => winit_window_builder
-                .with_inner_size(winit::dpi::LogicalSize::new(
-                    window.width(),
-                    window.height(),
+                .with_inner_size(winit::dpi::PhysicalSize::new(
+                    window.physical_width(),
+                    window.physical_height(),
                 ))
                 .with_resizable(window.resizable())
                 .with_decorations(window.decorations()),
@@ -100,6 +100,8 @@ impl WinitWindows {
             }
         }
 
+        let inner_size = winit_window.inner_size();
+        window.update_physical_size_from_backend(inner_size.width, inner_size.height);
         window.update_scale_factor_from_backend(winit_window.scale_factor());
 
         self.windows.insert(winit_window.id(), winit_window);

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -38,9 +38,9 @@ impl WinitWindows {
                 }),
             )),
             _ => winit_window_builder
-                .with_inner_size(winit::dpi::PhysicalSize::new(
-                    window.physical_width(),
-                    window.physical_height(),
+                .with_inner_size(winit::dpi::LogicalSize::new(
+                    window.width(),
+                    window.height(),
                 ))
                 .with_resizable(window.resizable())
                 .with_decorations(window.decorations()),

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -237,11 +237,11 @@ fn collision_system(
 
     let win = wins.get_primary().unwrap();
 
-    let ceiling = (win.height() / 2) as f32;
-    let ground = -((win.height() / 2) as f32);
+    let ceiling = (win.logical_height() / 2.) as f32;
+    let ground = -((win.logical_height() / 2.) as f32);
 
-    let wall_left = -((win.width() / 2) as f32);
-    let wall_right = (win.width() / 2) as f32;
+    let wall_left = -((win.logical_width() / 2.) as f32);
+    let wall_right = (win.logical_width() / 2.) as f32;
 
     for (mut v, mut t) in q.iter_mut() {
         let left = t.translation.x - SPRITE_SIZE / 2.0;

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -237,11 +237,11 @@ fn collision_system(
 
     let win = wins.get_primary().unwrap();
 
-    let ceiling = win.height() / 2.;
-    let ground = -(win.height() / 2.);
+    let ceiling = win.logical_height() / 2.;
+    let ground = -(win.logical_height() / 2.);
 
-    let wall_left = -(win.width() / 2.);
-    let wall_right = win.width() / 2.;
+    let wall_left = -(win.logical_width() / 2.);
+    let wall_right = win.logical_width() / 2.;
 
     for (mut v, mut t) in q.iter_mut() {
         let left = t.translation.x - SPRITE_SIZE / 2.0;

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -237,11 +237,11 @@ fn collision_system(
 
     let win = wins.get_primary().unwrap();
 
-    let ceiling = (win.logical_height() / 2.) as f32;
-    let ground = -((win.logical_height() / 2.) as f32);
+    let ceiling = win.height() / 2.;
+    let ground = -(win.height() / 2.);
 
-    let wall_left = -((win.logical_width() / 2.) as f32);
-    let wall_right = (win.logical_width() / 2.) as f32;
+    let wall_left = -(win.width() / 2.);
+    let wall_right = win.width() / 2.;
 
     for (mut v, mut t) in q.iter_mut() {
         let left = t.translation.x - SPRITE_SIZE / 2.0;

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -48,12 +48,12 @@ fn bounce_system(
     mut sprites: Query<(&Transform, &mut Velocity)>,
 ) {
     let window = windows.get_primary().expect("No primary window.");
-    let width = window.logical_width();
-    let height = window.logical_height();
-    let left = width as f32 / -2.0;
-    let right = width as f32 / 2.0;
-    let bottom = height as f32 / -2.0;
-    let top = height as f32 / 2.0;
+    let width = window.width();
+    let height = window.height();
+    let left = width / -2.0;
+    let right = width / 2.0;
+    let bottom = height / -2.0;
+    let top = height / 2.0;
     sprites
         // Batch size of 32 is chosen to limit the overhead of
         // ParallelIterator, since negating a vector is very inexpensive.

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -48,8 +48,8 @@ fn bounce_system(
     mut sprites: Query<(&Transform, &mut Velocity)>,
 ) {
     let window = windows.get_primary().expect("No primary window.");
-    let width = window.width();
-    let height = window.height();
+    let width = window.logical_width();
+    let height = window.logical_height();
     let left = width as f32 / -2.0;
     let right = width as f32 / 2.0;
     let bottom = height as f32 / -2.0;

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -48,8 +48,8 @@ fn bounce_system(
     mut sprites: Query<(&Transform, &mut Velocity)>,
 ) {
     let window = windows.get_primary().expect("No primary window.");
-    let width = window.width();
-    let height = window.height();
+    let width = window.logical_width();
+    let height = window.logical_height();
     let left = width / -2.0;
     let right = width / 2.0;
     let bottom = height / -2.0;


### PR DESCRIPTION
 While resizing a window on a high DPI display, some window sizes cause an off by one error when recalculating the physical size of the window. This causes the swap chain to fail to resize until the window resized again to a "good" resolution. The issue is caused by the logical size being stored as an integer which looses precision when calculated from the physical size.

This patch attempts to solve the issue by storing the physical resolution of the window instead of the logical resolution. As part of the effort, `width` & `height` become `logical_width` & `logical_height`, `scaled_width` & `scaled_height` become `physical_width` & `physical_height`. This requires touching a number of things and will probably break downstream users. It also changes the type of the components of the logical size to `f32` so it can better represent sizes that are a fraction of a pixel.