### PR TITLE
fix example bindings

### DIFF
--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -51,8 +51,8 @@ const FRAGMENT_SHADER: &str = r#"
 layout(location = 0) in vec4 v_Position;
 layout(location = 0) out vec4 o_Target;
 
-layout(set = 1, binding = 1) uniform texture2DArray MyArrayTexture_texture;
-layout(set = 1, binding = 2) uniform sampler MyArrayTexture_texture_sampler;
+layout(set = 2, binding = 0) uniform texture2DArray MyArrayTexture_texture;
+layout(set = 2, binding = 1) uniform sampler MyArrayTexture_texture_sampler;
 
 void main() {
     // Screen-space coordinates determine which layer of the array texture we sample.

--- a/examples/shader/shader_custom_material.rs
+++ b/examples/shader/shader_custom_material.rs
@@ -42,7 +42,7 @@ void main() {
 const FRAGMENT_SHADER: &str = r#"
 #version 450
 layout(location = 0) out vec4 o_Target;
-layout(set = 1, binding = 1) uniform MyMaterial_color {
+layout(set = 2, binding = 0) uniform MyMaterial_color {
     vec4 color;
 };
 void main() {

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -47,7 +47,7 @@ void main() {
 const FRAGMENT_SHADER: &str = r#"
 #version 450
 layout(location = 0) out vec4 o_Target;
-layout(set = 1, binding = 1) uniform MyMaterial_color {
+layout(set = 2, binding = 0) uniform MyMaterial_color {
     vec4 color;
 };
 void main() {


### PR DESCRIPTION
Fixes #999 

Due to the way we handle asset gpu resources, we can no longer intermingle "entity" bindings with "asset" bindings. This fits the binding model constraints well because assets and entities can have different bind frequencies.