### PR TITLE
Sprites created with Draw.is_visible=false are never visible

### DIFF
--- a/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
@@ -499,7 +499,7 @@ fn render_resources_node_system<T: RenderResources>(
             &mut |mut staging_buffer, _render_resource_context| {
                 // if the buffer array was resized, write all entities to the new buffer, otherwise only write changes
                 if resized {
-                    for (entity, uniforms, draw, mut render_pipelines) in
+                    for (entity, uniforms, _draw, mut render_pipelines) in
                         queries.q1_mut().iter_mut()
                     {
                         state.uniform_buffer_arrays.write_uniform_buffers(

--- a/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
@@ -470,11 +470,12 @@ fn render_resources_node_system<T: RenderResources>(
     }
 
     for (entity, uniforms, draw, mut render_pipelines) in queries.q0_mut().iter_mut() {
+        uniform_buffer_arrays.prepare_uniform_buffers(entity, uniforms);
+
         if !draw.is_visible {
             continue;
         }
 
-        uniform_buffer_arrays.prepare_uniform_buffers(entity, uniforms);
         if !setup_uniform_texture_resources::<T>(
             &uniforms,
             render_resource_context,
@@ -501,10 +502,6 @@ fn render_resources_node_system<T: RenderResources>(
                     for (entity, uniforms, draw, mut render_pipelines) in
                         queries.q1_mut().iter_mut()
                     {
-                        if !draw.is_visible {
-                            continue;
-                        }
-
                         state.uniform_buffer_arrays.write_uniform_buffers(
                             entity,
                             &uniforms,


### PR DESCRIPTION
When sprites are created with `draw.is_visible = false`, the bind group containing `Transform` and `Sprite_size` never gets created. I tried to find a proper solution to the problem, but the renderer code is too complicated for me to fully understand at this point. This solution may be a bit of a cop-out, so I'm okay with it not getting merged. A better solution would perhaps be to make sure that all the necessary bind groups are created when the sprite gets created. This PR does however remove the bug, as far as I can tell.