### PR TITLE
Allow for usage of GLTF primitives that have no texcoords

### DIFF
--- a/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.frag
+++ b/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.frag
@@ -10,7 +10,9 @@ struct Light {
 
 layout(location = 0) in vec3 v_Position;
 layout(location = 1) in vec3 v_Normal;
+# ifdef STANDARDMATERIAL_ALBEDO_TEXTURE
 layout(location = 2) in vec2 v_Uv;
+# endif
 
 layout(location = 0) out vec4 o_Target;
 

--- a/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.vert
+++ b/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.vert
@@ -2,11 +2,15 @@
 
 layout(location = 0) in vec3 Vertex_Position;
 layout(location = 1) in vec3 Vertex_Normal;
+# ifdef STANDARDMATERIAL_ALBEDO_TEXTURE
 layout(location = 2) in vec2 Vertex_Uv;
+# endif
 
 layout(location = 0) out vec3 v_Position;
 layout(location = 1) out vec3 v_Normal;
+# ifdef STANDARDMATERIAL_ALBEDO_TEXTURE
 layout(location = 2) out vec2 v_Uv;
+# endif
 
 layout(set = 0, binding = 0) uniform Camera {
     mat4 ViewProj;
@@ -19,6 +23,9 @@ layout(set = 2, binding = 0) uniform Transform {
 void main() {
     v_Normal = mat3(Model) * Vertex_Normal;
     v_Position = (Model * vec4(Vertex_Position, 1.0)).xyz;
+# ifdef STANDARDMATERIAL_ALBEDO_TEXTURE
     v_Uv = Vertex_Uv;
+# endif
+
     gl_Position = ViewProj * vec4(v_Position, 1.0);
 }


### PR DESCRIPTION
I purchased a model from cgtrader.com where the gltf file describes the model using just base colors (no textures and no texcoords on primitives, which is valid gltf), and it panics when bevy tries to load the gltf and compile the pipeline.

Bevy GLTF loader creates the mesh with no UV attributes, as expected. When it attempts to compile the pipeline we get an error saying that it expected a Vertex_Uv attribute but it's not supplied by the mesh.

`
thread 'Compute Task Pool (5)' panicked at 'Attribute Vertex_Uv is required by shader, but not supplied by mesh. Either remove the attribute from the shader or supply the attribute (Vertex_Uv) to the mesh. ', crates\bevy_render\src\pipeline\pipeline_compiler.rs:223:17
`

This changes makes it so that the forward shader uv attributes get enabled with STANDARDMATERIAL_ALBEDO_TEXTURE since the gltf loader uses PbrBundle/StandardMaterial. The uv attribute today is only used when STANDARDMATERIAL_ALBEDO_TEXTURE  is enabled in the fragment shader.

Tested FlightHelmet and my gltf which has no texcoords, both work now.