### PR TITLE
Update 2d examples: Bundle -> Components

### DIFF
--- a/examples/2d/sprite.rs
+++ b/examples/2d/sprite.rs
@@ -14,8 +14,8 @@ fn setup(
 ) {
     let texture_handle = asset_server.load("branding/icon.png");
     commands
-        .spawn(Camera2dBundle::default())
-        .spawn(SpriteBundle {
+        .spawn(Camera2dComponents::default())
+        .spawn(SpriteComponents {
             material: materials.add(texture_handle.into()),
             ..Default::default()
         });

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -31,8 +31,8 @@ fn setup(
     let texture_atlas = TextureAtlas::from_grid(texture_handle, Vec2::new(24.0, 24.0), 7, 1);
     let texture_atlas_handle = texture_atlases.add(texture_atlas);
     commands
-        .spawn(Camera2dBundle::default())
-        .spawn(SpriteSheetBundle {
+        .spawn(Camera2dComponents::default())
+        .spawn(SpriteSheetComponents {
             texture_atlas: texture_atlas_handle,
             transform: Transform::from_scale(Vec3::splat(6.0)),
             ..Default::default()

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -50,9 +50,9 @@ fn load_atlas(
 
         // set up a scene to display our texture atlas
         commands
-            .spawn(Camera2dBundle::default())
+            .spawn(Camera2dComponents::default())
             // draw a sprite from the atlas
-            .spawn(SpriteSheetBundle {
+            .spawn(SpriteSheetComponents {
                 transform: Transform {
                     translation: Vec3::new(150.0, 0.0, 0.0),
                     scale: Vec3::splat(4.0),
@@ -63,7 +63,7 @@ fn load_atlas(
                 ..Default::default()
             })
             // draw the atlas itself
-            .spawn(SpriteBundle {
+            .spawn(SpriteComponents {
                 material: materials.add(texture_atlas_texture.into()),
                 transform: Transform::from_translation(Vec3::new(-300.0, 0.0, 0.0)),
                 ..Default::default()

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -1,4 +1,4 @@
-use bevy::{asset::LoadState, prelude::*, sprite::TextureAtlasBuilder};
+use bevy::{asset::LoadState, prelude::*, sprite::TextureAtlasBuilder, Camera2dComponents, SpriteComponents};
 
 /// In this example we generate a new texture atlas (sprite sheet) from a folder containing individual sprites
 fn main() {


### PR DESCRIPTION
Simple syntax fix. Bundles were renamed to components.