### PR TITLE
Warn about missing bind group / vertex buffer indices in can_draw

### DIFF
--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -276,7 +276,10 @@ impl<'a> DrawContext<'a> {
                     }
                 }
             }
-            debug!("No (asset) render resource binding found for {:?}", bind_group_descriptor);
+            debug!(
+                "No (asset) render resource binding found for {:?}",
+                bind_group_descriptor
+            );
         }
 
         Ok(())

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -9,6 +9,7 @@ use crate::{
 use bevy_asset::{Asset, Assets, Handle};
 use bevy_ecs::{Query, Res, ResMut, SystemParam};
 use bevy_reflect::{Reflect, ReflectComponent};
+use bevy_utils::tracing::debug;
 use std::{ops::Range, sync::Arc};
 use thiserror::Error;
 
@@ -275,6 +276,7 @@ impl<'a> DrawContext<'a> {
                     }
                 }
             }
+            debug!("No (asset) render resource binding found for {:?}", bind_group_descriptor);
         }
 
         Ok(())

--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::{ReadOnlyFetch, Resources, World, WorldQuery};
-use bevy_utils::tracing::debug;
+use bevy_utils::tracing::{debug, warn};
 use std::{fmt, marker::PhantomData, ops::Deref};
 
 #[derive(Debug)]
@@ -370,8 +370,21 @@ impl DrawState {
     }
 
     pub fn can_draw(&self) -> bool {
-        self.bind_groups.iter().all(|b| b.is_some())
-            && self.vertex_buffers.iter().all(|v| v.is_some())
+        self.bind_groups
+            .iter()
+            .enumerate()
+            .filter(|(_, b)| b.is_none())
+            .map(|(i, _b)| warn!("Bind group (GLSL layout set) {} is missing", i))
+            .count()
+            == 0
+            && self
+                .vertex_buffers
+                .iter()
+                .enumerate()
+                .filter(|(_, v)| v.is_none())
+                .map(|(i, _v)| warn!("Vertex buffer (GLSL layout location) {} is missing", i))
+                .count()
+                == 0
     }
 
     pub fn can_draw_indexed(&self) -> bool {

--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -373,16 +373,26 @@ impl DrawState {
         self.bind_groups
             .iter()
             .enumerate()
-            .filter(|(_, b)| b.is_none())
-            .map(|(i, _b)| warn!("Bind group (GLSL layout set) {} is missing", i))
+            .filter(|(i, b)| {
+                let is_none = b.is_none();
+                if is_none {
+                    warn!("Bind group (GLSL layout set) {} is missing", i);
+                }
+                is_none
+            })
             .count()
             == 0
             && self
                 .vertex_buffers
                 .iter()
                 .enumerate()
-                .filter(|(_, v)| v.is_none())
-                .map(|(i, _v)| warn!("Vertex buffer (GLSL layout location) {} is missing", i))
+                .filter(|(i, v)| {
+                    let is_none = v.is_none();
+                    if is_none {
+                        warn!("Vertex buffer (GLSL layout location) {} is missing", i);
+                    }
+                    is_none
+                })
                 .count()
                 == 0
     }


### PR DESCRIPTION
This is useful to guide developers to why their custom shaders / meshes may not
be drawing.

I think also adding some `debug!()` in `DrawContext::set_bind_groups_from_bindings_internal()` in the cases where bindings don't match up could be useful so that one can see the warning, bump the log level to debug, and then maybe get some insight as to what exactly is wrong there.