### PR TITLE
make more information available from loaded GLTF model

### DIFF
--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -89,9 +89,10 @@ impl<'a> LoadContext<'a> {
         self.labeled_assets.insert(None, asset);
     }
 
-    pub fn set_labeled_asset(&mut self, label: &str, asset: LoadedAsset) {
+    pub fn set_labeled_asset<T: Asset>(&mut self, label: &str, asset: LoadedAsset) -> Handle<T> {
         assert!(!label.is_empty());
         self.labeled_assets.insert(Some(label.to_string()), asset);
+        self.get_handle(AssetPath::new_ref(self.path(), Some(label)))
     }
 
     pub fn get_handle<I: Into<HandleId>, T: Asset>(&self, id: I) -> Handle<T> {

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -25,7 +25,7 @@ bevy_math = { path = "../bevy_math", version = "0.4.0" }
 bevy_scene = { path = "../bevy_scene", version = "0.4.0" }
 
 # other
-gltf = { version = "0.15.2", default-features = false, features = ["utils"] }
+gltf = { version = "0.15.2", default-features = false, features = ["utils", "names"] }
 image = { version = "0.23.12", default-features = false }
 thiserror = "1.0"
 anyhow = "1.0"

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["bevy"]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.4.0" }
 bevy_asset = { path = "../bevy_asset", version = "0.4.0" }
+bevy_core = { path = "../bevy_core", version = "0.4.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.4.0" }
 bevy_pbr = { path = "../bevy_pbr", version = "0.4.0" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.4.0", features = ["bevy"] }

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -11,7 +11,8 @@ pub struct GltfPlugin;
 impl Plugin for GltfPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.init_asset_loader::<GltfLoader>()
-            .add_asset::<GltfNode>();
+            .add_asset::<GltfNode>()
+            .add_asset::<GltfMesh>();
     }
 }
 
@@ -21,4 +22,16 @@ pub struct GltfNode {
     pub children: Vec<usize>,
     pub mesh: Option<usize>,
     pub transform: bevy_transform::prelude::Transform,
+}
+
+#[derive(Debug, Clone, bevy_reflect::TypeUuid)]
+#[uuid = "8ceaec9a-926a-4f29-8ee3-578a69f42315"]
+pub struct GltfMesh {
+    pub primitives: Vec<GltfPrimitive>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GltfPrimitive {
+    index: usize,
+    material: Option<usize>,
 }

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 mod loader;
 pub use loader::*;
 
@@ -26,9 +28,13 @@ impl Plugin for GltfPlugin {
 #[uuid = "5c7d5f8a-f7b0-4e45-a09e-406c0372fea2"]
 pub struct Gltf {
     pub scenes: Vec<Handle<Scene>>,
+    pub named_scenes: HashMap<String, Handle<Scene>>,
     pub meshes: Vec<Handle<GltfMesh>>,
+    pub named_meshes: HashMap<String, Handle<GltfMesh>>,
     pub materials: Vec<Handle<StandardMaterial>>,
+    pub named_materials: HashMap<String, Handle<StandardMaterial>>,
     pub nodes: Vec<Handle<GltfNode>>,
+    pub named_nodes: HashMap<String, Handle<GltfNode>>,
     pub default_scene: Option<Handle<Scene>>,
 }
 

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -10,6 +10,15 @@ pub struct GltfPlugin;
 
 impl Plugin for GltfPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app.init_asset_loader::<GltfLoader>();
+        app.init_asset_loader::<GltfLoader>()
+            .add_asset::<GltfNode>();
     }
+}
+
+#[derive(Debug, Clone, bevy_reflect::TypeUuid)]
+#[uuid = "dad74750-1fd6-460f-ac51-0a7937563865"]
+pub struct GltfNode {
+    pub children: Vec<usize>,
+    pub mesh: Option<usize>,
+    pub transform: bevy_transform::prelude::Transform,
 }

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -2,7 +2,11 @@ mod loader;
 pub use loader::*;
 
 use bevy_app::prelude::*;
-use bevy_asset::AddAsset;
+use bevy_asset::{AddAsset, Handle};
+use bevy_pbr::prelude::StandardMaterial;
+use bevy_reflect::TypeUuid;
+use bevy_render::mesh::Mesh;
+use bevy_scene::Scene;
 
 /// Adds support for GLTF file loading to Apps
 #[derive(Default)]
@@ -11,27 +15,40 @@ pub struct GltfPlugin;
 impl Plugin for GltfPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.init_asset_loader::<GltfLoader>()
+            .add_asset::<Gltf>()
             .add_asset::<GltfNode>()
+            .add_asset::<GltfPrimitive>()
             .add_asset::<GltfMesh>();
     }
 }
 
-#[derive(Debug, Clone, bevy_reflect::TypeUuid)]
+#[derive(Debug, TypeUuid)]
+#[uuid = "5c7d5f8a-f7b0-4e45-a09e-406c0372fea2"]
+pub struct Gltf {
+    pub scenes: Vec<Handle<Scene>>,
+    pub meshes: Vec<Handle<GltfMesh>>,
+    pub materials: Vec<Handle<StandardMaterial>>,
+    pub nodes: Vec<Handle<GltfNode>>,
+    pub default_scene: Option<Handle<Scene>>,
+}
+
+#[derive(Debug, Clone, TypeUuid)]
 #[uuid = "dad74750-1fd6-460f-ac51-0a7937563865"]
 pub struct GltfNode {
-    pub children: Vec<usize>,
-    pub mesh: Option<usize>,
+    pub children: Vec<GltfNode>,
+    pub mesh: Option<Handle<GltfMesh>>,
     pub transform: bevy_transform::prelude::Transform,
 }
 
-#[derive(Debug, Clone, bevy_reflect::TypeUuid)]
+#[derive(Debug, Clone, TypeUuid)]
 #[uuid = "8ceaec9a-926a-4f29-8ee3-578a69f42315"]
 pub struct GltfMesh {
     pub primitives: Vec<GltfPrimitive>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, TypeUuid)]
+#[uuid = "cbfca302-82fd-41cb-af77-cab6b3d50af1"]
 pub struct GltfPrimitive {
-    index: usize,
-    material: Option<usize>,
+    pub mesh: Handle<Mesh>,
+    pub material: Option<Handle<StandardMaterial>>,
 }

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -29,6 +29,8 @@ use image::{GenericImageView, ImageFormat};
 use std::path::Path;
 use thiserror::Error;
 
+use crate::{Gltf, GltfNode};
+
 /// An error that occurs when loading a GLTF file
 #[derive(Error, Debug)]
 pub enum GltfError {
@@ -75,18 +77,107 @@ async fn load_gltf<'a, 'b>(
     load_context: &'a mut LoadContext<'b>,
 ) -> Result<(), GltfError> {
     let gltf = gltf::Gltf::from_slice(bytes)?;
-    let mut world = World::default();
     let buffer_data = load_buffers(&gltf, load_context, load_context.path()).await?;
 
-    let world_builder = &mut world.build();
+    let mut materials = vec![];
+    for material in gltf.materials() {
+        let material_label = material_label(&material);
+        let pbr = material.pbr_metallic_roughness();
+        let mut dependencies = Vec::new();
+        let texture_handle = if let Some(info) = pbr.base_color_texture() {
+            match info.texture().source().source() {
+                gltf::image::Source::View { .. } => {
+                    let label = texture_label(&info.texture());
+                    let path = AssetPath::new_ref(load_context.path(), Some(&label));
+                    Some(load_context.get_handle(path))
+                }
+                gltf::image::Source::Uri { uri, .. } => {
+                    let parent = load_context.path().parent().unwrap();
+                    let image_path = parent.join(uri);
+                    let asset_path = AssetPath::new(image_path, None);
+                    let handle = load_context.get_handle(asset_path.clone());
+                    dependencies.push(asset_path);
+                    Some(handle)
+                }
+            }
+        } else {
+            None
+        };
+        let color = pbr.base_color_factor();
+        materials.push(
+            load_context.set_labeled_asset(
+                &material_label,
+                LoadedAsset::new(StandardMaterial {
+                    albedo: Color::rgba(color[0], color[1], color[2], color[3]),
+                    albedo_texture: texture_handle,
+                    ..Default::default()
+                })
+                .with_dependencies(dependencies),
+            ),
+        );
+    }
 
+    let mut meshes = vec![];
+    for mesh in gltf.meshes() {
+        let mut primitives = vec![];
+        for primitive in mesh.primitives() {
+            let primitive_label = primitive_label(&mesh, &primitive);
+            let reader = primitive.reader(|buffer| Some(&buffer_data[buffer.index()]));
+            let primitive_topology = get_primitive_topology(primitive.mode())?;
+
+            let mut mesh = Mesh::new(primitive_topology);
+
+            if let Some(vertex_attribute) = reader
+                .read_positions()
+                .map(|v| VertexAttributeValues::Float3(v.collect()))
+            {
+                mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, vertex_attribute);
+            }
+
+            if let Some(vertex_attribute) = reader
+                .read_normals()
+                .map(|v| VertexAttributeValues::Float3(v.collect()))
+            {
+                mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, vertex_attribute);
+            }
+
+            if let Some(vertex_attribute) = reader
+                .read_tex_coords(0)
+                .map(|v| VertexAttributeValues::Float2(v.into_f32().collect()))
+            {
+                mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, vertex_attribute);
+            }
+
+            if let Some(indices) = reader.read_indices() {
+                mesh.set_indices(Some(Indices::U32(indices.into_u32().collect())));
+            };
+
+            let mesh = load_context.set_labeled_asset(&primitive_label, LoadedAsset::new(mesh));
+            primitives.push(super::GltfPrimitive {
+                mesh,
+                material: primitive
+                    .material()
+                    .index()
+                    .and_then(|i| materials.get(i).cloned()),
+            });
+        }
+        meshes.push(load_context.set_labeled_asset(
+            &mesh_label(&mesh),
+            LoadedAsset::new(super::GltfMesh { primitives }),
+        ));
+    }
+
+    let mut nodes_intermediate = vec![];
     for node in gltf.nodes() {
         let node_label = node_label(&node);
-        load_context.set_labeled_asset(
-            &node_label,
-            LoadedAsset::new(crate::GltfNode {
-                children: node.children().map(|child| child.index()).collect(),
-                mesh: node.mesh().map(|mesh| mesh.index()),
+        nodes_intermediate.push((
+            node_label,
+            GltfNode {
+                children: vec![],
+                mesh: node
+                    .mesh()
+                    .map(|mesh| mesh.index())
+                    .and_then(|i| meshes.get(i).cloned()),
                 transform: match node.transform() {
                     gltf::scene::Transform::Matrix { matrix } => {
                         Transform::from_matrix(bevy_math::Mat4::from_cols_array_2d(&matrix))
@@ -101,57 +192,16 @@ async fn load_gltf<'a, 'b>(
                         scale: bevy_math::Vec3::from(scale),
                     },
                 },
-            }),
-        );
+            },
+            node.children()
+                .map(|child| child.index())
+                .collect::<Vec<_>>(),
+        ))
     }
-
-    for mesh in gltf.meshes() {
-        let mut primitives = vec![];
-        for primitive in mesh.primitives() {
-            primitives.push(super::GltfPrimitive {
-                index: primitive.index(),
-                material: primitive.material().index(),
-            });
-            let primitive_label = primitive_label(&mesh, &primitive);
-            if !load_context.has_labeled_asset(&primitive_label) {
-                let reader = primitive.reader(|buffer| Some(&buffer_data[buffer.index()]));
-                let primitive_topology = get_primitive_topology(primitive.mode())?;
-
-                let mut mesh = Mesh::new(primitive_topology);
-
-                if let Some(vertex_attribute) = reader
-                    .read_positions()
-                    .map(|v| VertexAttributeValues::Float3(v.collect()))
-                {
-                    mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, vertex_attribute);
-                }
-
-                if let Some(vertex_attribute) = reader
-                    .read_normals()
-                    .map(|v| VertexAttributeValues::Float3(v.collect()))
-                {
-                    mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, vertex_attribute);
-                }
-
-                if let Some(vertex_attribute) = reader
-                    .read_tex_coords(0)
-                    .map(|v| VertexAttributeValues::Float2(v.into_f32().collect()))
-                {
-                    mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, vertex_attribute);
-                }
-
-                if let Some(indices) = reader.read_indices() {
-                    mesh.set_indices(Some(Indices::U32(indices.into_u32().collect())));
-                };
-
-                load_context.set_labeled_asset(&primitive_label, LoadedAsset::new(mesh));
-            };
-        }
-        load_context.set_labeled_asset(
-            &mesh_label(&mesh),
-            LoadedAsset::new(super::GltfMesh { primitives }),
-        );
-    }
+    let nodes = resolve_node_hierarchy(nodes_intermediate)
+        .into_iter()
+        .map(|(label, node)| load_context.set_labeled_asset(&label, LoadedAsset::new(node)))
+        .collect::<Vec<bevy_asset::Handle<GltfNode>>>();
 
     for texture in gltf.textures() {
         if let gltf::image::Source::View { view, mime_type } = texture.source().source() {
@@ -168,7 +218,7 @@ async fn load_gltf<'a, 'b>(
             let image = image.into_rgba8();
 
             let texture_label = texture_label(&texture);
-            load_context.set_labeled_asset(
+            load_context.set_labeled_asset::<Texture>(
                 &texture_label,
                 LoadedAsset::new(Texture {
                     data: image.clone().into_vec(),
@@ -185,8 +235,11 @@ async fn load_gltf<'a, 'b>(
         load_material(&material, load_context);
     }
 
+    let mut scenes = vec![];
     for scene in gltf.scenes() {
         let mut err = None;
+        let mut world = World::default();
+        let world_builder = &mut world.build();
         world_builder
             .spawn((Transform::default(), GlobalTransform::default()))
             .with_children(|parent| {
@@ -201,9 +254,22 @@ async fn load_gltf<'a, 'b>(
         if let Some(Err(err)) = err {
             return Err(err);
         }
+        scenes.push(
+            load_context
+                .set_labeled_asset(&scene_label(&scene), LoadedAsset::new(Scene::new(world))),
+        );
     }
 
-    load_context.set_default_asset(LoadedAsset::new(Scene::new(world)));
+    load_context.set_default_asset(LoadedAsset::new(Gltf {
+        default_scene: gltf
+            .default_scene()
+            .and_then(|scene| scenes.get(scene.index()))
+            .cloned(),
+        scenes,
+        meshes,
+        materials,
+        nodes,
+    }));
 
     Ok(())
 }
@@ -373,6 +439,10 @@ fn node_label(node: &gltf::Node) -> String {
     format!("Node{}", node.index())
 }
 
+fn scene_label(scene: &gltf::Scene) -> String {
+    format!("Scene{}", scene.index())
+}
+
 fn texture_sampler(texture: &gltf::Texture) -> Result<SamplerDescriptor, GltfError> {
     let gltf_sampler = texture.sampler();
 
@@ -456,4 +526,153 @@ async fn load_buffers(
     }
 
     Ok(buffer_data)
+}
+
+fn resolve_node_hierarchy(
+    nodes_intermediate: Vec<(String, GltfNode, Vec<usize>)>,
+) -> Vec<(String, GltfNode)> {
+    let mut max_steps = nodes_intermediate.len();
+    let mut nodes_step = nodes_intermediate
+        .into_iter()
+        .enumerate()
+        .map(|(i, (label, node, children))| (i, label, node, children))
+        .collect::<Vec<_>>();
+    let mut nodes = std::collections::HashMap::<usize, (String, GltfNode)>::new();
+    while max_steps > 0 && !nodes_step.is_empty() {
+        if let Some((index, label, node, _)) = nodes_step
+            .iter()
+            .find(|(_, _, _, children)| children.is_empty())
+            .cloned()
+        {
+            nodes.insert(index, (label, node));
+            for (_, _, node, children) in nodes_step.iter_mut() {
+                if let Some((i, _)) = children
+                    .iter()
+                    .enumerate()
+                    .find(|(_, child_index)| **child_index == index)
+                {
+                    children.remove(i);
+
+                    if let Some((_, child_node)) = nodes.get(&index) {
+                        node.children.push(child_node.clone())
+                    }
+                }
+            }
+            nodes_step = nodes_step
+                .into_iter()
+                .filter(|(i, _, _, _)| *i != index)
+                .collect()
+        }
+        max_steps -= 1;
+    }
+
+    let mut nodes_to_sort = nodes.into_iter().collect::<Vec<_>>();
+    nodes_to_sort.sort_by_key(|(i, _)| *i);
+    nodes_to_sort
+        .into_iter()
+        .map(|(_, resolved)| resolved)
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use super::resolve_node_hierarchy;
+    use crate::GltfNode;
+
+    impl GltfNode {
+        fn empty() -> Self {
+            GltfNode {
+                children: vec![],
+                mesh: None,
+                transform: bevy_transform::prelude::Transform::default(),
+            }
+        }
+    }
+    #[test]
+    fn node_hierarchy_single_node() {
+        let result = resolve_node_hierarchy(vec![("l1".to_string(), GltfNode::empty(), vec![])]);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, "l1");
+        assert_eq!(result[0].1.children.len(), 0);
+    }
+
+    #[test]
+    fn node_hierarchy_no_hierarchy() {
+        let result = resolve_node_hierarchy(vec![
+            ("l1".to_string(), GltfNode::empty(), vec![]),
+            ("l2".to_string(), GltfNode::empty(), vec![]),
+        ]);
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].0, "l1");
+        assert_eq!(result[0].1.children.len(), 0);
+        assert_eq!(result[1].0, "l2");
+        assert_eq!(result[1].1.children.len(), 0);
+    }
+
+    #[test]
+    fn node_hierarchy_simple_hierarchy() {
+        let result = resolve_node_hierarchy(vec![
+            ("l1".to_string(), GltfNode::empty(), vec![1]),
+            ("l2".to_string(), GltfNode::empty(), vec![]),
+        ]);
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].0, "l1");
+        assert_eq!(result[0].1.children.len(), 1);
+        assert_eq!(result[1].0, "l2");
+        assert_eq!(result[1].1.children.len(), 0);
+    }
+
+    #[test]
+    fn node_hierarchy_hierarchy() {
+        let result = resolve_node_hierarchy(vec![
+            ("l1".to_string(), GltfNode::empty(), vec![1]),
+            ("l2".to_string(), GltfNode::empty(), vec![2]),
+            ("l3".to_string(), GltfNode::empty(), vec![3, 4, 5]),
+            ("l4".to_string(), GltfNode::empty(), vec![6]),
+            ("l5".to_string(), GltfNode::empty(), vec![]),
+            ("l6".to_string(), GltfNode::empty(), vec![]),
+            ("l7".to_string(), GltfNode::empty(), vec![]),
+        ]);
+
+        assert_eq!(result.len(), 7);
+        assert_eq!(result[0].0, "l1");
+        assert_eq!(result[0].1.children.len(), 1);
+        assert_eq!(result[1].0, "l2");
+        assert_eq!(result[1].1.children.len(), 1);
+        assert_eq!(result[2].0, "l3");
+        assert_eq!(result[2].1.children.len(), 3);
+        assert_eq!(result[3].0, "l4");
+        assert_eq!(result[3].1.children.len(), 1);
+        assert_eq!(result[4].0, "l5");
+        assert_eq!(result[4].1.children.len(), 0);
+        assert_eq!(result[5].0, "l6");
+        assert_eq!(result[5].1.children.len(), 0);
+        assert_eq!(result[6].0, "l7");
+        assert_eq!(result[6].1.children.len(), 0);
+    }
+
+    #[test]
+    fn node_hierarchy_cyclic() {
+        let result = resolve_node_hierarchy(vec![
+            ("l1".to_string(), GltfNode::empty(), vec![1]),
+            ("l2".to_string(), GltfNode::empty(), vec![0]),
+        ]);
+
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn node_hierarchy_missing_node() {
+        let result = resolve_node_hierarchy(vec![
+            ("l1".to_string(), GltfNode::empty(), vec![2]),
+            ("l2".to_string(), GltfNode::empty(), vec![]),
+        ]);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, "l2");
+        assert_eq!(result[0].1.children.len(), 0);
+    }
 }

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -106,7 +106,12 @@ async fn load_gltf<'a, 'b>(
     }
 
     for mesh in gltf.meshes() {
+        let mut primitives = vec![];
         for primitive in mesh.primitives() {
+            primitives.push(super::GltfPrimitive {
+                index: primitive.index(),
+                material: primitive.material().index(),
+            });
             let primitive_label = primitive_label(&mesh, &primitive);
             if !load_context.has_labeled_asset(&primitive_label) {
                 let reader = primitive.reader(|buffer| Some(&buffer_data[buffer.index()]));
@@ -142,6 +147,10 @@ async fn load_gltf<'a, 'b>(
                 load_context.set_labeled_asset(&primitive_label, LoadedAsset::new(mesh));
             };
         }
+        load_context.set_labeled_asset(
+            &mesh_label(&mesh),
+            LoadedAsset::new(super::GltfMesh { primitives }),
+        );
     }
 
     for texture in gltf.textures() {
@@ -338,6 +347,10 @@ fn load_node(
     } else {
         Ok(())
     }
+}
+
+fn mesh_label(mesh: &gltf::Mesh) -> String {
+    format!("Mesh{}", mesh.index())
 }
 
 fn primitive_label(mesh: &gltf::Mesh, primitive: &Primitive) -> String {

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -26,8 +26,7 @@ use gltf::{
     Material, Primitive,
 };
 use image::{GenericImageView, ImageFormat};
-use std::collections::HashMap;
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 use thiserror::Error;
 
 use crate::{Gltf, GltfNode};

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use bevy_asset::{AssetIoError, AssetLoader, AssetPath, Handle, LoadContext, LoadedAsset};
+use bevy_core::Labels;
 use bevy_ecs::{bevy_utils::BoxedFuture, World, WorldBuilderSource};
 use bevy_math::Mat4;
 use bevy_pbr::prelude::{PbrBundle, StandardMaterial};
@@ -315,6 +316,10 @@ fn load_node(
         Transform::from_matrix(Mat4::from_cols_array_2d(&transform.matrix())),
         GlobalTransform::default(),
     ));
+
+    if let Some(name) = gltf_node.name() {
+        node.with(Labels::from(vec![name.to_string()]));
+    }
 
     // create camera node
     if let Some(camera) = gltf_node.camera() {

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -10,7 +10,7 @@ fn main() {
 
 fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
     commands
-        .spawn_scene(asset_server.load("models/FlightHelmet/FlightHelmet.gltf"))
+        .spawn_scene(asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0"))
         .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(4.0, 5.0, 4.0)),
             ..Default::default()

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -12,7 +12,7 @@ fn main() {
 
 fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
     // Load our mesh:
-    let scene_handle = asset_server.load("models/monkey/Monkey.gltf");
+    let scene_handle = asset_server.load("models/monkey/Monkey.gltf#Scene0");
 
     // Tell the asset server to watch for asset changes on disk:
     asset_server.watch_for_changes().unwrap();

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -185,7 +185,7 @@ fn setup_pipeline(
 
     // add entities to the world
     commands
-        .spawn_scene(asset_server.load("models/monkey/Monkey.gltf"))
+        .spawn_scene(asset_server.load("models/monkey/Monkey.gltf#Scene0"))
         // light
         .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(4.0, 5.0, 4.0)),


### PR DESCRIPTION
makes node information available as `"path/to/file.gltf#Node0"`
this helps the user select correct meshes and their transform between each other when picking nodes out of a gltf file

makes list of primitives per mesh and their material available as `"path/to/file.gltf#Mesh0"`
this lets the user get all the primitives for a mesh with the correct material

I am not sure about the asset type names, `Gltf*`, but didn't want confusion with the existing `Node` and `Mesh` types