### PR TITLE
scene: only update components for entities in scene

### DIFF
--- a/crates/bevy_reflect/src/impls/bevy_ecs.rs
+++ b/crates/bevy_reflect/src/impls/bevy_ecs.rs
@@ -202,8 +202,10 @@ impl<C: Component + MapEntities> FromType<C> for ReflectMapEntities {
     fn from_type() -> Self {
         ReflectMapEntities {
             map_entities: |world, entity_map| {
-                for mut component in &mut world.query_mut::<&mut C>() {
-                    component.map_entities(entity_map)?;
+                for entity in entity_map.values() {
+                    if let Ok(mut component) = world.get_mut::<C>(entity) {
+                        component.map_entities(entity_map)?;
+                    }
                 }
 
                 Ok(())


### PR DESCRIPTION
fixes #1019 

only update components for entities that are in the scene

can now render two scenes:
![Screenshot 2020-12-07 at 18 30 13](https://user-images.githubusercontent.com/8672791/101384287-85839e00-38ba-11eb-9b81-e020159c342c.png)

looking at entities and their parents / children, they have the expected relations:

```
0v0 -> None - None // my light
1v0 -> None - None // my camera
2v0 -> None - Some(Children([9v0, 10v0, 11v0, 12v0, 13v0, 14v0])) // start of scene 1
15v0 -> None - Some(Children([22v0, 23v0, 24v0, 25v0, 26v0, 27v0])) // start of scene 2
3v0 -> Some(Parent(9v0)) - None
4v0 -> Some(Parent(10v0)) - None
5v0 -> Some(Parent(11v0)) - None
6v0 -> Some(Parent(12v0)) - None
7v0 -> Some(Parent(13v0)) - None
8v0 -> Some(Parent(14v0)) - None
16v0 -> Some(Parent(22v0)) - None
17v0 -> Some(Parent(23v0)) - None
18v0 -> Some(Parent(24v0)) - None
19v0 -> Some(Parent(25v0)) - None
20v0 -> Some(Parent(26v0)) - None
21v0 -> Some(Parent(27v0)) - None
9v0 -> Some(Parent(2v0)) - Some(Children([3v0]))
10v0 -> Some(Parent(2v0)) - Some(Children([4v0]))
11v0 -> Some(Parent(2v0)) - Some(Children([5v0]))
12v0 -> Some(Parent(2v0)) - Some(Children([6v0]))
13v0 -> Some(Parent(2v0)) - Some(Children([7v0]))
14v0 -> Some(Parent(2v0)) - Some(Children([8v0]))
22v0 -> Some(Parent(15v0)) - Some(Children([16v0]))
23v0 -> Some(Parent(15v0)) - Some(Children([17v0]))
24v0 -> Some(Parent(15v0)) - Some(Children([18v0]))
25v0 -> Some(Parent(15v0)) - Some(Children([19v0]))
26v0 -> Some(Parent(15v0)) - Some(Children([20v0]))
27v0 -> Some(Parent(15v0)) - Some(Children([21v0]))
```
