### PR TITLE
Use shaderc for aarch64-apple-darwin.

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -44,10 +44,10 @@ parking_lot = "0.11.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 spirv-reflect = "0.2.3"
 
-[target.'cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))'.dependencies]
+[target.'cfg(all(not(target_os = "ios"), not(target_arch = "wasm32"), not(all(target_arch = "aarch64", target_os = "macos"))))'.dependencies]
 bevy-glsl-to-spirv = "0.2.0"
 
-[target.'cfg(target_os = "ios")'.dependencies]
+[target.'cfg(any(target_os = "ios", all(target_arch = "aarch64", target_os = "macos")))'.dependencies]
 shaderc = "0.7.0"
 
 [features]


### PR DESCRIPTION
As suggested by @cart and @mockersf in https://github.com/bevyengine/bevy/issues/928, this pull request switches Apple Silicon devices to use shaderc instead of bevy-glsl-to-spirv. This change, along with the latest unreleased version of winit (https://github.com/rust-windowing/winit/issues/1789), gets Bevy working on Apple Silicon!

<img width="1440" alt="Screen Shot 2020-12-07 at 6 29 38 PM" src="https://user-images.githubusercontent.com/416575/101419591-52dba480-38be-11eb-92ce-f2a6003b8f43.png">
