### PR TITLE
Break out Visible component from Draw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ current changes on git with [previous release tags][git_tag_comparison].
   - Created getters to get `Time` state and made members private.
   - Modifying `Time`'s values directly is no longer possible outside of bevy.
 - [Use `mailbox` instead of `fifo` for vsync on supported systems][920]
+- [Break out Visible component from Draw][1034]
+  - Users setting `Draw::is_visible` or `Draw::is_transparent` should now set `Visible::is_visible` and `Visible::is_transparent`
 
 ### Fixed
 
@@ -68,6 +70,7 @@ current changes on git with [previous release tags][git_tag_comparison].
 [934]: https://github.com/bevyengine/bevy/pull/934
 [945]: https://github.com/bevyengine/bevy/pull/945
 [955]: https://github.com/bevyengine/bevy/pull/955
+[1034]: https://github.com/bevyengine/bevy/pull/1034
 
 ## Version 0.3.0 (2020-11-03)
 

--- a/crates/bevy_pbr/src/entity.rs
+++ b/crates/bevy_pbr/src/entity.rs
@@ -5,6 +5,7 @@ use bevy_render::{
     draw::Draw,
     mesh::Mesh,
     pipeline::{RenderPipeline, RenderPipelines},
+    prelude::Visible,
     render_graph::base::MainPass,
 };
 use bevy_transform::prelude::{GlobalTransform, Transform};
@@ -16,6 +17,7 @@ pub struct PbrBundle {
     pub material: Handle<StandardMaterial>,
     pub main_pass: MainPass,
     pub draw: Draw,
+    pub visible: Visible,
     pub render_pipelines: RenderPipelines,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
@@ -28,6 +30,7 @@ impl Default for PbrBundle {
                 FORWARD_PIPELINE_HANDLE.typed(),
             )]),
             mesh: Default::default(),
+            visible: Default::default(),
             material: Default::default(),
             main_pass: Default::default(),
             draw: Default::default(),

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -1,5 +1,5 @@
 use super::{Camera, DepthCalculation};
-use crate::Draw;
+use crate::prelude::Visible;
 use bevy_core::FloatOrd;
 use bevy_ecs::{Entity, Query, With};
 use bevy_reflect::{Reflect, ReflectComponent};
@@ -26,8 +26,8 @@ impl VisibleEntities {
 
 pub fn visible_entities_system(
     mut camera_query: Query<(&Camera, &GlobalTransform, &mut VisibleEntities)>,
-    draw_query: Query<(Entity, &Draw)>,
-    draw_transform_query: Query<&GlobalTransform, With<Draw>>,
+    visible_query: Query<(Entity, &Visible)>,
+    visible_transform_query: Query<&GlobalTransform, With<Visible>>,
 ) {
     for (camera, camera_global_transform, mut visible_entities) in camera_query.iter_mut() {
         visible_entities.value.clear();
@@ -35,12 +35,12 @@ pub fn visible_entities_system(
 
         let mut no_transform_order = 0.0;
         let mut transparent_entities = Vec::new();
-        for (entity, draw) in draw_query.iter() {
-            if !draw.is_visible {
+        for (entity, visible) in visible_query.iter() {
+            if !visible.is_visible {
                 continue;
             }
 
-            let order = if let Ok(global_transform) = draw_transform_query.get(entity) {
+            let order = if let Ok(global_transform) = visible_transform_query.get(entity) {
                 let position = global_transform.translation;
                 // smaller distances are sorted to lower indices by using the distance from the camera
                 FloatOrd(match camera.depth_calculation {
@@ -53,7 +53,7 @@ pub fn visible_entities_system(
                 order
             };
 
-            if draw.is_transparent {
+            if visible.is_transparent {
                 transparent_entities.push(VisibleEntity { entity, order })
             } else {
                 visible_entities.value.push(VisibleEntity { entity, order })

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -43,12 +43,27 @@ pub enum RenderCommand {
     },
 }
 
+#[derive(Debug, Clone, Reflect)]
+#[reflect(Component)]
+pub struct Visible {
+    pub is_visible: bool,
+    // TODO: consider moving this to materials
+    pub is_transparent: bool,
+}
+
+impl Default for Visible {
+    fn default() -> Self {
+        Visible {
+            is_visible: true,
+            is_transparent: false,
+        }
+    }
+}
+
 /// A component that indicates how to draw an entity.
 #[derive(Debug, Clone, Reflect)]
 #[reflect(Component)]
 pub struct Draw {
-    pub is_visible: bool,
-    pub is_transparent: bool,
     #[reflect(ignore)]
     pub render_commands: Vec<RenderCommand>,
 }
@@ -56,8 +71,6 @@ pub struct Draw {
 impl Default for Draw {
     fn default() -> Self {
         Self {
-            is_visible: true,
-            is_transparent: false,
             render_commands: Default::default(),
         }
     }

--- a/crates/bevy_render/src/entity.rs
+++ b/crates/bevy_render/src/entity.rs
@@ -1,6 +1,7 @@
 use crate::{
     camera::{Camera, OrthographicProjection, PerspectiveProjection, VisibleEntities},
     pipeline::RenderPipelines,
+    prelude::Visible,
     render_graph::base,
     Draw, Mesh,
 };
@@ -15,6 +16,7 @@ use bevy_transform::components::{GlobalTransform, Transform};
 pub struct MeshBundle {
     pub mesh: Handle<Mesh>,
     pub draw: Draw,
+    pub visible: Visible,
     pub render_pipelines: RenderPipelines,
     pub main_pass: MainPass,
     pub transform: Transform,

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -12,13 +12,14 @@ pub mod shader;
 pub mod texture;
 
 use bevy_reflect::RegisterTypeBuilder;
+use draw::Visible;
 pub use once_cell;
 
 pub mod prelude {
     pub use crate::{
         base::Msaa,
         color::Color,
-        draw::Draw,
+        draw::{Draw, Visible},
         entity::*,
         mesh::{shape, Mesh},
         pass::ClearColor,
@@ -105,6 +106,7 @@ impl Plugin for RenderPlugin {
             .add_asset::<PipelineDescriptor>()
             .register_type::<Camera>()
             .register_type::<Draw>()
+            .register_type::<Visible>()
             .register_type::<RenderPipelines>()
             .register_type::<OrthographicProjection>()
             .register_type::<PerspectiveProjection>()

--- a/crates/bevy_render/src/pipeline/render_pipelines.rs
+++ b/crates/bevy_render/src/pipeline/render_pipelines.rs
@@ -2,7 +2,7 @@ use super::{PipelineDescriptor, PipelineSpecialization};
 use crate::{
     draw::{Draw, DrawContext},
     mesh::{Indices, Mesh},
-    prelude::Msaa,
+    prelude::{Msaa, Visible},
     renderer::RenderResourceBindings,
 };
 use bevy_asset::{Assets, Handle};
@@ -82,10 +82,10 @@ pub fn draw_render_pipelines_system(
     mut render_resource_bindings: ResMut<RenderResourceBindings>,
     msaa: Res<Msaa>,
     meshes: Res<Assets<Mesh>>,
-    mut query: Query<(&mut Draw, &mut RenderPipelines, &Handle<Mesh>)>,
+    mut query: Query<(&mut Draw, &mut RenderPipelines, &Handle<Mesh>, &Visible)>,
 ) {
-    for (mut draw, mut render_pipelines, mesh_handle) in query.iter_mut() {
-        if !draw.is_visible {
+    for (mut draw, mut render_pipelines, mesh_handle, visible) in query.iter_mut() {
+        if !visible.is_visible {
             continue;
         }
 

--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -6,6 +6,7 @@ use crate::{
         BindGroupDescriptor, BindType, BindingDescriptor, BindingShaderStage, PipelineDescriptor,
         UniformProperty,
     },
+    prelude::Visible,
     render_graph::{Node, ResourceSlotInfo, ResourceSlots},
     renderer::{
         BindGroup, BindGroupId, BufferId, RenderContext, RenderResourceBindings, RenderResourceType,
@@ -236,8 +237,10 @@ where
                             continue;
                         };
 
-                        if !draw.is_visible {
-                            continue;
+                        if let Ok(visible) = world.get::<Visible>(visible_entity.entity) {
+                            if !visible.is_visible {
+                                continue;
+                            }
                         }
 
                         // each Draw component contains an ordered list of render commands. we turn those into actual render commands here

--- a/crates/bevy_sprite/src/entity.rs
+++ b/crates/bevy_sprite/src/entity.rs
@@ -7,7 +7,7 @@ use bevy_ecs::Bundle;
 use bevy_render::{
     mesh::Mesh,
     pipeline::{RenderPipeline, RenderPipelines},
-    prelude::Draw,
+    prelude::{Draw, Visible},
     render_graph::base::MainPass,
 };
 use bevy_transform::prelude::{GlobalTransform, Transform};
@@ -19,6 +19,7 @@ pub struct SpriteBundle {
     pub material: Handle<ColorMaterial>,
     pub main_pass: MainPass,
     pub draw: Draw,
+    pub visible: Visible,
     pub render_pipelines: RenderPipelines,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
@@ -31,12 +32,13 @@ impl Default for SpriteBundle {
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 SPRITE_PIPELINE_HANDLE.typed(),
             )]),
-            draw: Draw {
+            visible: Visible {
                 is_transparent: true,
                 ..Default::default()
             },
-            sprite: Default::default(),
             main_pass: MainPass,
+            draw: Default::default(),
+            sprite: Default::default(),
             material: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),
@@ -54,6 +56,7 @@ pub struct SpriteSheetBundle {
     pub texture_atlas: Handle<TextureAtlas>,
     /// Data pertaining to how the sprite is drawn on the screen
     pub draw: Draw,
+    pub visible: Visible,
     pub render_pipelines: RenderPipelines,
     pub main_pass: MainPass,
     pub mesh: Handle<Mesh>, // TODO: maybe abstract this out
@@ -67,12 +70,13 @@ impl Default for SpriteSheetBundle {
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 SPRITE_SHEET_PIPELINE_HANDLE.typed(),
             )]),
-            draw: Draw {
+            visible: Visible {
                 is_transparent: true,
                 ..Default::default()
             },
-            mesh: QUAD_HANDLE.typed(),
             main_pass: MainPass,
+            mesh: QUAD_HANDLE.typed(),
+            draw: Default::default(),
             sprite: Default::default(),
             texture_atlas: Default::default(),
             transform: Default::default(),

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -12,6 +12,7 @@ use bevy_render::{
     draw::Draw,
     mesh::Mesh,
     pipeline::{RenderPipeline, RenderPipelines},
+    prelude::Visible,
 };
 use bevy_sprite::{ColorMaterial, QUAD_HANDLE};
 use bevy_transform::prelude::{GlobalTransform, Transform};
@@ -23,6 +24,7 @@ pub struct NodeBundle {
     pub mesh: Handle<Mesh>, // TODO: maybe abstract this out
     pub material: Handle<ColorMaterial>,
     pub draw: Draw,
+    pub visible: Visible,
     pub render_pipelines: RenderPipelines,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
@@ -35,6 +37,7 @@ impl Default for NodeBundle {
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 UI_PIPELINE_HANDLE.typed(),
             )]),
+            visible: Default::default(),
             node: Default::default(),
             style: Default::default(),
             material: Default::default(),
@@ -54,6 +57,7 @@ pub struct ImageBundle {
     pub mesh: Handle<Mesh>, // TODO: maybe abstract this out
     pub material: Handle<ColorMaterial>,
     pub draw: Draw,
+    pub visible: Visible,
     pub render_pipelines: RenderPipelines,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
@@ -72,6 +76,7 @@ impl Default for ImageBundle {
             style: Default::default(),
             material: Default::default(),
             draw: Default::default(),
+            visible: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),
         }
@@ -83,6 +88,7 @@ pub struct TextBundle {
     pub node: Node,
     pub style: Style,
     pub draw: Draw,
+    pub visible: Visible,
     pub text: Text,
     pub calculated_size: CalculatedSize,
     pub focus_policy: FocusPolicy,
@@ -95,6 +101,9 @@ impl Default for TextBundle {
         TextBundle {
             focus_policy: FocusPolicy::Pass,
             draw: Draw {
+                ..Default::default()
+            },
+            visible: Visible {
                 is_transparent: true,
                 ..Default::default()
             },
@@ -118,6 +127,7 @@ pub struct ButtonBundle {
     pub mesh: Handle<Mesh>, // TODO: maybe abstract this out
     pub material: Handle<ColorMaterial>,
     pub draw: Draw,
+    pub visible: Visible,
     pub render_pipelines: RenderPipelines,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
@@ -137,6 +147,7 @@ impl Default for ButtonBundle {
             style: Default::default(),
             material: Default::default(),
             draw: Default::default(),
+            visible: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),
         }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -5,7 +5,7 @@ use bevy_math::Size;
 use bevy_render::{
     draw::{Draw, DrawContext, Drawable},
     mesh::Mesh,
-    prelude::Msaa,
+    prelude::{Msaa, Visible},
     renderer::RenderResourceBindings,
     texture::Texture,
 };
@@ -146,13 +146,13 @@ pub fn draw_text_system(
     meshes: Res<Assets<Mesh>>,
     mut render_resource_bindings: ResMut<RenderResourceBindings>,
     text_pipeline: Res<DefaultTextPipeline>,
-    mut query: Query<(Entity, &mut Draw, &Text, &Node, &GlobalTransform)>,
+    mut query: Query<(Entity, &mut Draw, &Visible, &Text, &Node, &GlobalTransform)>,
 ) {
     let font_quad = meshes.get(&QUAD_HANDLE).unwrap();
     let vertex_buffer_descriptor = font_quad.get_vertex_buffer_descriptor();
 
-    for (entity, mut draw, text, node, global_transform) in query.iter_mut() {
-        if !draw.is_visible {
+    for (entity, mut draw, visible, text, node, global_transform) in query.iter_mut() {
+        if !visible.is_visible {
             continue;
         }
 

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -58,7 +58,7 @@ fn setup(
                 rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
                 ..Default::default()
             },
-            draw: Draw {
+            visible: Visible {
                 is_transparent: true,
                 ..Default::default()
             },
@@ -73,7 +73,7 @@ fn setup(
                 rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
                 ..Default::default()
             },
-            draw: Draw {
+            visible: Visible {
                 is_transparent: true,
                 ..Default::default()
             },
@@ -88,7 +88,7 @@ fn setup(
                 rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
                 ..Default::default()
             },
-            draw: Draw {
+            visible: Visible {
                 is_transparent: true,
                 ..Default::default()
             },

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -97,7 +97,7 @@ fn mouse_handler(
                 .spawn(SpriteBundle {
                     material: bird_material.0.clone(),
                     transform,
-                    draw: Draw {
+                    visible: Visible {
                         is_transparent: true,
                         ..Default::default()
                     },

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -115,7 +115,7 @@ fn setup(
                         ..Default::default()
                     },
                     material: materials.add(Color::NONE.into()),
-                    draw: Draw {
+                    visible: Visible {
                         is_transparent: true,
                         ..Default::default()
                     },
@@ -188,7 +188,7 @@ fn setup(
                                         ..Default::default()
                                     },
                                     material: materials.add(Color::rgba(1.0, 0.9, 0.9, 0.4).into()),
-                                    draw: Draw {
+                                    visible: Visible {
                                         is_transparent: true,
                                         ..Default::default()
                                     },
@@ -206,7 +206,7 @@ fn setup(
                         ..Default::default()
                     },
                     material: materials.add(Color::NONE.into()),
-                    draw: Draw {
+                    visible: Visible {
                         is_transparent: true,
                         ..Default::default()
                     },
@@ -221,7 +221,7 @@ fn setup(
                         },
                         material: materials
                             .add(asset_server.load("branding/bevy_logo_dark_big.png").into()),
-                        draw: Draw {
+                        visible: Visible {
                             is_transparent: true,
                             ..Default::default()
                         },


### PR DESCRIPTION
Alternative to #1008 

The issue is that we currently incrementally update gpu bind resources when a given type T changes, but we filter the Changed results based on draw.is_visible. If something is initially invisible, it will show up in RenderResourcesNode's `Changed<T>` query then get filterered out because draw.is_visible is false.

The fix is to also update bindings when visibility changes. We can't use `Changed<Draw>`, because it changes every frame (when draw commands are queued). Therefore, it makes sense to break out the Visibility fields so we can respond to their changes separately.

This also just feels cleaner because draw commands and "visibility state" are tangentially related concepts at best.