### PR TITLE
Allow wgpu backend to be configured from the environment

### DIFF
--- a/crates/bevy_wgpu/src/lib.rs
+++ b/crates/bevy_wgpu/src/lib.rs
@@ -44,7 +44,43 @@ pub fn get_wgpu_render_system(resources: &mut Resources) -> impl FnMut(&mut Worl
 
 #[derive(Default, Clone)]
 pub struct WgpuOptions {
+    backend: WgpuBackend,
     power_pref: WgpuPowerOptions,
+}
+
+#[derive(Clone)]
+pub enum WgpuBackend {
+    Auto,
+    Vulkan,
+    Metal,
+    Dx12,
+    Dx11,
+    GL,
+    BrowserWgpu,
+}
+
+impl WgpuBackend {
+    fn from_env() -> Self {
+        if let Ok(backend) = std::env::var("BEVY_WGPU_BACKEND") {
+            match backend.to_lowercase().as_str() {
+                "vulkan" => WgpuBackend::Vulkan,
+                "metal" => WgpuBackend::Metal,
+                "dx12" => WgpuBackend::Dx12,
+                "dx11" => WgpuBackend::Dx11,
+                "gl" => WgpuBackend::GL,
+                "webgpu" => WgpuBackend::BrowserWgpu,
+                other => panic!("Unknown backend: {}", other),
+            }
+        } else {
+            WgpuBackend::Auto
+        }
+    }
+}
+
+impl Default for WgpuBackend {
+    fn default() -> Self {
+        Self::from_env()
+    }
 }
 
 #[derive(Clone)]

--- a/crates/bevy_wgpu/src/wgpu_renderer.rs
+++ b/crates/bevy_wgpu/src/wgpu_renderer.rs
@@ -1,6 +1,6 @@
 use crate::{
     renderer::{WgpuRenderGraphExecutor, WgpuRenderResourceContext},
-    WgpuOptions, WgpuPowerOptions,
+    WgpuBackend, WgpuOptions, WgpuPowerOptions,
 };
 use bevy_app::prelude::*;
 use bevy_ecs::{Resources, World};
@@ -22,7 +22,16 @@ pub struct WgpuRenderer {
 
 impl WgpuRenderer {
     pub async fn new(options: WgpuOptions) -> Self {
-        let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
+        let backend = match options.backend {
+            WgpuBackend::Auto => wgpu::BackendBit::PRIMARY,
+            WgpuBackend::Vulkan => wgpu::BackendBit::VULKAN,
+            WgpuBackend::Metal => wgpu::BackendBit::METAL,
+            WgpuBackend::Dx12 => wgpu::BackendBit::DX12,
+            WgpuBackend::Dx11 => wgpu::BackendBit::DX11,
+            WgpuBackend::GL => wgpu::BackendBit::GL,
+            WgpuBackend::BrowserWgpu => wgpu::BackendBit::BROWSER_WEBGPU,
+        };
+        let instance = wgpu::Instance::new(backend);
 
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {


### PR DESCRIPTION
Multiple backends for wgpu can be available in a system.
Allow force changing the default pick through an environment variable.

This should be useful for setting the backend BackendBit::GL that will allow us to access gfx-backend-gl backend of gfx.