### PR TITLE
make `Plugin::build` consume the plugin

### DIFF
--- a/crates/bevy_app/src/app_builder.rs
+++ b/crates/bevy_app/src/app_builder.rs
@@ -229,14 +229,14 @@ impl AppBuilder {
         self
     }
 
-    pub fn add_plugins<T: PluginGroup>(&mut self, mut group: T) -> &mut Self {
+    pub fn add_plugins<T: PluginGroup>(&mut self, group: T) -> &mut Self {
         let mut plugin_group_builder = PluginGroupBuilder::default();
         group.build(&mut plugin_group_builder);
         plugin_group_builder.finish(self);
         self
     }
 
-    pub fn add_plugins_with<T, F>(&mut self, mut group: T, func: F) -> &mut Self
+    pub fn add_plugins_with<T, F>(&mut self, group: T, func: F) -> &mut Self
     where
         T: PluginGroup,
         F: FnOnce(&mut PluginGroupBuilder) -> &mut PluginGroupBuilder,

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -17,16 +17,16 @@ pub trait Plugin: Any + Send + Sync {
 /// This is necessary because the `Plugin::build` method consumes the plugin,
 /// and therefore cannot be called from `&dyn Plugin`.
 pub trait BoxablePlugin {
-    fn name (&self) -> &str;
-    fn unbox_and_build (self: Box<Self>, app: &mut AppBuilder);
+    fn name(&self) -> &str;
+    fn unbox_and_build(self: Box<Self>, app: &mut AppBuilder);
 }
 
 impl<T: Plugin> BoxablePlugin for T {
-    fn name (&self) -> &str {
-        self.name ()
+    fn name(&self) -> &str {
+        self.name()
     }
-    fn unbox_and_build (self: Box<Self>, app: &mut AppBuilder) {
-        (*self).build (app);
+    fn unbox_and_build(self: Box<Self>, app: &mut AppBuilder) {
+        (*self).build(app);
     }
 }
 

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -25,6 +25,7 @@ impl<T: Plugin> BoxablePlugin for T {
     fn name(&self) -> &str {
         self.name()
     }
+
     fn unbox_and_build(self: Box<Self>, app: &mut AppBuilder) {
         (*self).build(app);
     }

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -5,10 +5,47 @@ use std::any::Any;
 ///
 /// Plugins use [AppBuilder] to configure an [App](crate::App). When an [App](crate::App) registers a plugin, the plugin's [Plugin::build] function is run.
 pub trait Plugin: Any + Send + Sync {
-    fn build(&self, app: &mut AppBuilder);
+    fn build(self, app: &mut AppBuilder);
     fn name(&self) -> &str {
         std::any::type_name::<Self>()
     }
 }
 
-pub type CreatePlugin = unsafe fn() -> *mut dyn Plugin;
+/// An automaticly implemented trait that allows a plugin to be usable when
+/// stored in a type erased box.
+///
+/// This is necessary because the `Plugin::build` method consumes the plugin,
+/// and therefore cannot be called from `&dyn Plugin`.
+pub trait BoxablePlugin {
+    fn name (&self) -> &str;
+    fn unbox_and_build (self: Box<Self>, app: &mut AppBuilder);
+}
+
+impl<T: Plugin> BoxablePlugin for T {
+    fn name (&self) -> &str {
+        self.name ()
+    }
+    fn unbox_and_build (self: Box<Self>, app: &mut AppBuilder) {
+        (*self).build (app);
+    }
+}
+
+/// A plugin stored in a box.
+///
+/// Since `Box<dyn Plugin>` cannot be consumed this type is a reminder of the
+/// correct way to store a plugin in a box.
+///
+/// ## Example
+///
+/// ```ignore
+/// struct CustomPlugin;
+///
+/// impl Plugin for CustomPlugin {...}
+///
+/// let b : BoxedPlugin::new (CustomPlugin)
+///
+/// b.unbox_and_build (app);
+/// ```
+pub type BoxedPlugin = Box<dyn BoxablePlugin>;
+
+pub type CreatePlugin = unsafe fn() -> *mut dyn BoxablePlugin;

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -1,4 +1,4 @@
-use crate::{AppBuilder, Plugin, BoxedPlugin};
+use crate::{AppBuilder, BoxedPlugin, Plugin};
 use bevy_utils::{tracing::debug, HashMap};
 use std::any::TypeId;
 
@@ -98,7 +98,7 @@ impl PluginGroupBuilder {
 
     pub fn finish(mut self, app: &mut AppBuilder) {
         for ty in self.order.iter() {
-            if let Some(PluginEntry{plugin,enabled}) = self.plugins.remove(ty) {
+            if let Some(PluginEntry { plugin, enabled }) = self.plugins.remove(ty) {
                 if enabled {
                     debug!("added plugin: {}", plugin.name());
                     plugin.unbox_and_build(app);

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -50,7 +50,7 @@ impl ScheduleRunnerSettings {
 pub struct ScheduleRunnerPlugin {}
 
 impl Plugin for ScheduleRunnerPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         let settings = app
             .resources_mut()
             .get_or_insert_with(ScheduleRunnerSettings::default)

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -51,7 +51,7 @@ impl Default for AssetServerSettings {
 }
 
 impl Plugin for AssetPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         let task_pool = app
             .resources()
             .get::<IoTaskPool>()

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -18,7 +18,7 @@ use bevy_asset::AddAsset;
 pub struct AudioPlugin;
 
 impl Plugin for AudioPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.init_thread_local_resource::<AudioOutput<AudioSource>>()
             .add_asset::<AudioSource>()
             .init_asset_loader::<Mp3Loader>()

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -24,7 +24,7 @@ use bevy_app::prelude::*;
 pub struct CorePlugin;
 
 impl Plugin for CorePlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         // Setup the default bevy task pools
         app.resources_mut()
             .get_cloned::<DefaultTaskPoolOptions>()

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -12,7 +12,7 @@ pub struct FrameTimeDiagnosticsState {
 }
 
 impl Plugin for FrameTimeDiagnosticsPlugin {
-    fn build(&self, app: &mut bevy_app::AppBuilder) {
+    fn build(self, app: &mut bevy_app::AppBuilder) {
         app.add_startup_system(Self::setup_system)
             .add_resource(FrameTimeDiagnosticsState { frame_count: 0.0 })
             .add_system(Self::diagnostic_system);

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -12,7 +12,7 @@ use bevy_app::prelude::*;
 pub struct DiagnosticsPlugin;
 
 impl Plugin for DiagnosticsPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.init_resource::<Diagnostics>();
     }
 }

--- a/crates/bevy_diagnostic/src/print_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/print_diagnostics_plugin.rs
@@ -28,10 +28,10 @@ impl Default for PrintDiagnosticsPlugin {
 }
 
 impl Plugin for PrintDiagnosticsPlugin {
-    fn build(&self, app: &mut bevy_app::AppBuilder) {
+    fn build(self, app: &mut bevy_app::AppBuilder) {
         app.add_resource(PrintDiagnosticsState {
             timer: Timer::new(self.wait_duration, true),
-            filter: self.filter.clone(),
+            filter: self.filter,
         });
 
         if self.debug {

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -1,9 +1,9 @@
 use libloading::{Library, Symbol};
 
-use bevy_app::{AppBuilder, CreatePlugin, Plugin};
+use bevy_app::{AppBuilder, CreatePlugin, BoxedPlugin};
 
 /// Dynamically links a plugin a the given path. The plugin must export the [CreatePlugin] function.
-pub fn dynamically_load_plugin(path: &str) -> (Library, Box<dyn Plugin>) {
+pub fn dynamically_load_plugin(path: &str) -> (Library, BoxedPlugin) {
     let lib = Library::new(path).unwrap();
 
     unsafe {
@@ -20,7 +20,7 @@ pub trait DynamicPluginExt {
 impl DynamicPluginExt for AppBuilder {
     fn load_plugin(&mut self, path: &str) -> &mut Self {
         let (_lib, plugin) = dynamically_load_plugin(path);
-        plugin.build(self);
+        plugin.unbox_and_build(self);
         self
     }
 }

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -1,6 +1,6 @@
 use libloading::{Library, Symbol};
 
-use bevy_app::{AppBuilder, CreatePlugin, BoxedPlugin};
+use bevy_app::{AppBuilder, BoxedPlugin, CreatePlugin};
 
 /// Dynamically links a plugin a the given path. The plugin must export the [CreatePlugin] function.
 pub fn dynamically_load_plugin(path: &str) -> (Library, BoxedPlugin) {

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -10,7 +10,7 @@ use gilrs_system::{gilrs_event_startup_system, gilrs_event_system};
 pub struct GilrsPlugin;
 
 impl Plugin for GilrsPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         match GilrsBuilder::new()
             .with_default_filters(false)
             .set_update_state(false)

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -9,7 +9,7 @@ use bevy_asset::AddAsset;
 pub struct GltfPlugin;
 
 impl Plugin for GltfPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.init_asset_loader::<GltfLoader>();
     }
 }

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -38,7 +38,7 @@ use gamepad::{
 pub struct InputPlugin;
 
 impl Plugin for InputPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.add_event::<KeyboardInput>()
             .add_event::<MouseButtonInput>()
             .add_event::<MouseMotion>()

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -3,7 +3,7 @@ use bevy_app::{PluginGroup, PluginGroupBuilder};
 pub struct DefaultPlugins;
 
 impl PluginGroup for DefaultPlugins {
-    fn build(&mut self, group: &mut PluginGroupBuilder) {
+    fn build(self, group: &mut PluginGroupBuilder) {
         group.add(bevy_log::LogPlugin::default());
         group.add(bevy_reflect::ReflectPlugin::default());
         group.add(bevy_core::CorePlugin::default());
@@ -49,7 +49,7 @@ impl PluginGroup for DefaultPlugins {
 pub struct MinimalPlugins;
 
 impl PluginGroup for MinimalPlugins {
-    fn build(&mut self, group: &mut PluginGroupBuilder) {
+    fn build(self, group: &mut PluginGroupBuilder) {
         group.add(bevy_reflect::ReflectPlugin::default());
         group.add(bevy_core::CorePlugin::default());
         group.add(bevy_app::ScheduleRunnerPlugin::default());

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -40,7 +40,7 @@ impl Default for LogSettings {
 }
 
 impl Plugin for LogPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         let default_filter = {
             let settings = app.resources_mut().get_or_insert_with(LogSettings::default);
             format!("{},{}", settings.level, settings.filter)

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -24,7 +24,7 @@ use render_graph::add_pbr_graph;
 pub struct PbrPlugin;
 
 impl Plugin for PbrPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.add_asset::<StandardMaterial>()
             .register_type::<Light>()
             .add_system_to_stage(

--- a/crates/bevy_reflect/src/impls/bevy_app.rs
+++ b/crates/bevy_reflect/src/impls/bevy_app.rs
@@ -6,7 +6,7 @@ use bevy_ecs::Entity;
 pub struct ReflectPlugin;
 
 impl Plugin for ReflectPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.init_resource::<TypeRegistryArc>()
             .register_type::<bool>()
             .register_type::<u8>()

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -79,7 +79,7 @@ impl Default for RenderPlugin {
 }
 
 impl Plugin for RenderPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         #[cfg(feature = "png")]
         {
             app.init_asset_loader::<ImageTextureLoader>();

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -26,7 +26,7 @@ pub struct ScenePlugin;
 pub const SCENE_STAGE: &str = "scene";
 
 impl Plugin for ScenePlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.add_asset::<DynamicScene>()
             .add_asset::<Scene>()
             .init_asset_loader::<SceneLoader>()

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -42,7 +42,7 @@ pub const QUAD_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Mesh::TYPE_UUID, 14240461981130137526);
 
 impl Plugin for SpritePlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.add_asset::<ColorMaterial>()
             .add_asset::<TextureAtlas>()
             .register_type::<Sprite>()

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -31,7 +31,7 @@ pub type DefaultTextPipeline = TextPipeline<Entity>;
 pub struct TextPlugin;
 
 impl Plugin for TextPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.add_asset::<Font>()
             .add_asset::<FontAtlasSet>()
             .init_asset_loader::<FontLoader>()

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -14,7 +14,7 @@ use prelude::{parent_update_system, Children, GlobalTransform, Parent, PreviousP
 pub struct TransformPlugin;
 
 impl Plugin for TransformPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.register_type::<Children>()
             .register_type::<Parent>()
             .register_type::<PreviousParent>()

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -36,7 +36,7 @@ pub mod stage {
 }
 
 impl Plugin for UiPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.init_resource::<FlexSurface>()
             .add_stage_before(bevy_app::stage::POST_UPDATE, stage::UI)
             .add_system_to_stage(bevy_app::stage::PRE_UPDATE, ui_focus_system)

--- a/crates/bevy_wgpu/src/diagnostic/wgpu_resource_diagnostics_plugin.rs
+++ b/crates/bevy_wgpu/src/diagnostic/wgpu_resource_diagnostics_plugin.rs
@@ -8,7 +8,7 @@ use bevy_render::renderer::RenderResourceContext;
 pub struct WgpuResourceDiagnosticsPlugin;
 
 impl Plugin for WgpuResourceDiagnosticsPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.add_startup_system(Self::setup_system)
             .add_system(Self::diagnostic_system);
     }

--- a/crates/bevy_wgpu/src/lib.rs
+++ b/crates/bevy_wgpu/src/lib.rs
@@ -19,7 +19,7 @@ use renderer::WgpuRenderResourceContext;
 pub struct WgpuPlugin;
 
 impl Plugin for WgpuPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         let render_system = get_wgpu_render_system(app.resources_mut());
         app.add_system_to_stage(bevy_render::stage::RENDER, render_system)
             .add_system_to_stage(

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -32,7 +32,7 @@ impl Default for WindowPlugin {
 }
 
 impl Plugin for WindowPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.add_event::<WindowResized>()
             .add_event::<CreateWindow>()
             .add_event::<WindowCreated>()

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -26,7 +26,7 @@ use winit::{
 pub struct WinitPlugin;
 
 impl Plugin for WinitPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.init_resource::<WinitWindows>()
             .set_runner(winit_runner)
             .add_system(change_window);

--- a/examples/app/plugin.rs
+++ b/examples/app/plugin.rs
@@ -23,9 +23,9 @@ pub struct PrintMessagePlugin {
 
 impl Plugin for PrintMessagePlugin {
     // this is where we set up our plugin
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         let state = PrintMessageState {
-            message: self.message.clone(),
+            message: self.message,
             timer: Timer::new(self.wait_duration, true),
         };
         app.add_resource(state).add_system(print_message_system);

--- a/examples/app/plugin_group.rs
+++ b/examples/app/plugin_group.rs
@@ -20,7 +20,7 @@ fn main() {
 pub struct HelloWorldPlugins;
 
 impl PluginGroup for HelloWorldPlugins {
-    fn build(&mut self, group: &mut PluginGroupBuilder) {
+    fn build(self, group: &mut PluginGroupBuilder) {
         group.add(PrintHelloPlugin).add(PrintWorldPlugin);
     }
 }
@@ -28,7 +28,7 @@ impl PluginGroup for HelloWorldPlugins {
 pub struct PrintHelloPlugin;
 
 impl Plugin for PrintHelloPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.add_system(print_hello_system);
     }
 }
@@ -40,7 +40,7 @@ fn print_hello_system() {
 pub struct PrintWorldPlugin;
 
 impl Plugin for PrintWorldPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(self, app: &mut AppBuilder) {
         app.add_system(print_world_system);
     }
 }


### PR DESCRIPTION
This patch makes the `build` method of the `Plugin` trait consume the plugin. This allows the plugin to transport non-clone-able configuration data into the build process of the plugin. Because this changes a core trait, it ends up touching a-lot, but in the vast majority of cases the change is just removing a `&` from `self` in the `build` method. It will break most users too, but the fix should in most if not all cases should just be removal of the `&` from `self` in the `build` method. It also changes the signature of the dynamically loaded plugin factory function slightly.

The relevant changes, those not just fixing the signature, are in "crates/bevy_app/src/plugin.rs" and "crates/bevy_app/src/plugin_group.rs".

There are two instances in the existing code base that utilized the plugin to transport data into the build process, the `PrintDiagnosticsPlugin` and the example `PrintMessagePlugin` which no longer needed to clone the data and can instead just transfer ownership.

My use case for this a precursor for one last alternate approach to overriding the `AssetIo` instance used in the `AssetServer`. With this in place, it would be possible to implement overriding the `AssetIo` like so:

```rust
use bevy::asset::AssetPlugin;

app.add_plugins_with(DefaultPlugins, |group| {
    group
        .disable::<AssetPlugin>()
        .add_after::<AssetPlugin, _>(AssetPlugin::with_io (CustomAssetIo))
});
```

This patch is necessary for this approach to work since `AssetIo` does not, and should not, in my opinion, implement `Clone`.

I don't know what future plans may be in store for the plugin system, so this might be taking things in the wrong direction. 