### PR TITLE
Just spawn one CameraUiBundle (not 4)

### DIFF
--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -21,7 +21,8 @@ struct TextChanges;
 
 fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
     let font = asset_server.load("fonts/FiraSans-Bold.ttf");
-    commands.spawn(CameraUiBundle::default()).spawn(TextBundle {
+    commands.spawn(CameraUiBundle::default());
+    commands.spawn(TextBundle {
         style: Style {
             align_self: AlignSelf::FlexEnd,
             position_type: PositionType::Absolute,
@@ -43,7 +44,7 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
         },
         ..Default::default()
     });
-    commands.spawn(CameraUiBundle::default()).spawn(TextBundle {
+    commands.spawn(TextBundle {
         style: Style {
             align_self: AlignSelf::FlexEnd,
             position_type: PositionType::Absolute,
@@ -74,7 +75,6 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
         ..Default::default()
     });
     commands
-        .spawn(CameraUiBundle::default())
         .spawn(TextBundle {
             style: Style {
                 align_self: AlignSelf::FlexEnd,
@@ -98,7 +98,7 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
             ..Default::default()
         })
         .with(TextChanges);
-    commands.spawn(CameraUiBundle::default()).spawn(TextBundle {
+    commands.spawn(TextBundle {
         style: Style {
             align_self: AlignSelf::FlexEnd,
             position_type: PositionType::Absolute,


### PR DESCRIPTION
While trying to figure out how to do text in Bevy, I noticed there were four cameras in this example, when you only need one.

Sidenote: If there's any documentation/examples for how to get text into a 2D scene (so it can be part of the game, not the UI), please point me in the right direction!