### PR TITLE
More informative error message on missing stage

### DIFF
--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -156,9 +156,10 @@ impl Schedule {
         name: &str,
         func: F,
     ) -> &mut Self {
-        let stage = self
-            .get_stage_mut::<T>(name)
-            .expect("stage does not exist or is the wrong type");
+        let stage = self.get_stage_mut::<T>(name).expect(&format!(
+            "stage '{}' does not exist or is the wrong type",
+            name
+        ));
         func(stage);
         self
     }

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -156,10 +156,9 @@ impl Schedule {
         name: &str,
         func: F,
     ) -> &mut Self {
-        let stage = self.get_stage_mut::<T>(name).expect(&format!(
-            "stage '{}' does not exist or is the wrong type",
-            name
-        ));
+        let stage = self
+            .get_stage_mut::<T>(name)
+            .unwrap_or_else(|| panic!("stage '{}' does not exist or is the wrong type", name));
         func(stage);
         self
     }


### PR DESCRIPTION
Include the stage name in the error message when a stage is missing to make the error slightly less inscrutable.