### PR TITLE
Fix potential bug when using multiple lights.

### DIFF
--- a/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.frag
+++ b/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.frag
@@ -53,6 +53,10 @@ void main() {
         // add light contribution
         color += diffuse * light.color.xyz;
     }
+
+    // average the lights so that we will never get something with > 1.0
+    color /= max(float(NumLights.x), 1.0);
+
     output_color.xyz *= color;
 # endif
 


### PR DESCRIPTION
If multiple lights are close enough to the normal line and if any value in the albedo is sufficiently high, we can get values greater than `1.0` on `o_Target`. This will average the influence of all of the lights. 

If PBR will be delayed by much more, it may be worthwhile to add a distance based weighted average.