### PR TITLE
Improve usability of StateStage and cut down on "magic"

### DIFF
--- a/crates/bevy_app/src/app_builder.rs
+++ b/crates/bevy_app/src/app_builder.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use crate::{
     app::{App, AppExit},
     event::Events,
@@ -7,8 +5,8 @@ use crate::{
     stage, startup_stage, PluginGroup, PluginGroupBuilder,
 };
 use bevy_ecs::{
-    clear_trackers_system, FromResources, IntoStage, IntoSystem, Resource, Resources, RunOnce,
-    Schedule, Stage, State, StateStage, System, SystemStage, World,
+    clear_trackers_system, FromResources, IntoSystem, Resource, Resources, RunOnce, Schedule,
+    Stage, StateStage, System, SystemStage, World,
 };
 use bevy_utils::tracing::debug;
 
@@ -56,16 +54,12 @@ impl AppBuilder {
         self
     }
 
-    pub fn add_stage<Params, S: IntoStage<Params>>(
-        &mut self,
-        name: &'static str,
-        stage: S,
-    ) -> &mut Self {
+    pub fn add_stage<S: Stage>(&mut self, name: &'static str, stage: S) -> &mut Self {
         self.app.schedule.add_stage(name, stage);
         self
     }
 
-    pub fn add_stage_after<Params, S: IntoStage<Params>>(
+    pub fn add_stage_after<S: Stage>(
         &mut self,
         target: &'static str,
         name: &'static str,
@@ -75,7 +69,7 @@ impl AppBuilder {
         self
     }
 
-    pub fn add_stage_before<Params, S: IntoStage<Params>>(
+    pub fn add_stage_before<S: Stage>(
         &mut self,
         target: &'static str,
         name: &'static str,
@@ -85,11 +79,7 @@ impl AppBuilder {
         self
     }
 
-    pub fn add_startup_stage<Params, S: IntoStage<Params>>(
-        &mut self,
-        name: &'static str,
-        stage: S,
-    ) -> &mut Self {
+    pub fn add_startup_stage<S: Stage>(&mut self, name: &'static str, stage: S) -> &mut Self {
         self.app
             .schedule
             .stage(stage::STARTUP, |schedule: &mut Schedule| {
@@ -98,7 +88,7 @@ impl AppBuilder {
         self
     }
 
-    pub fn add_startup_stage_after<Params, S: IntoStage<Params>>(
+    pub fn add_startup_stage_after<S: Stage>(
         &mut self,
         target: &'static str,
         name: &'static str,
@@ -112,7 +102,7 @@ impl AppBuilder {
         self
     }
 
-    pub fn add_startup_stage_before<Params, S: IntoStage<Params>>(
+    pub fn add_startup_stage_before<S: Stage>(
         &mut self,
         target: &'static str,
         name: &'static str,
@@ -141,6 +131,51 @@ impl AppBuilder {
         IntoS: IntoSystem<Params, S>,
     {
         self.add_system_to_stage(stage::UPDATE, system)
+    }
+
+    pub fn on_state_enter<T: Clone + Resource, S, Params, IntoS>(
+        &mut self,
+        stage: &str,
+        state: T,
+        system: IntoS,
+    ) -> &mut Self
+    where
+        S: System<In = (), Out = ()>,
+        IntoS: IntoSystem<Params, S>,
+    {
+        self.stage(stage, |stage: &mut StateStage<T>| {
+            stage.on_state_enter(state, system)
+        })
+    }
+
+    pub fn on_state_update<T: Clone + Resource, S, Params, IntoS>(
+        &mut self,
+        stage: &str,
+        state: T,
+        system: IntoS,
+    ) -> &mut Self
+    where
+        S: System<In = (), Out = ()>,
+        IntoS: IntoSystem<Params, S>,
+    {
+        self.stage(stage, |stage: &mut StateStage<T>| {
+            stage.on_state_update(state, system)
+        })
+    }
+
+    pub fn on_state_exit<T: Clone + Resource, S, Params, IntoS>(
+        &mut self,
+        stage: &str,
+        state: T,
+        system: IntoS,
+    ) -> &mut Self
+    where
+        S: System<In = (), Out = ()>,
+        IntoS: IntoSystem<Params, S>,
+    {
+        self.stage(stage, |stage: &mut StateStage<T>| {
+            stage.on_state_exit(state, system)
+        })
     }
 
     pub fn add_startup_system_to_stage<S, Params, IntoS>(
@@ -205,53 +240,6 @@ impl AppBuilder {
     {
         self.add_resource(Events::<T>::default())
             .add_system_to_stage(stage::EVENT, Events::<T>::update_system)
-    }
-
-    pub fn state_stage_name<T: Any>() -> String {
-        format!("state({})", std::any::type_name::<T>())
-    }
-
-    pub fn add_state<T: Clone + Resource>(&mut self, initial: T) -> &mut Self {
-        self.add_resource(State::new(initial));
-        self.app.schedule.add_stage_after(
-            stage::UPDATE,
-            &Self::state_stage_name::<T>(),
-            StateStage::<T>::default(),
-        );
-        self
-    }
-
-    pub fn on_state_enter<T: Clone + Resource, Params, S: IntoStage<Params>>(
-        &mut self,
-        value: T,
-        stage: S,
-    ) -> &mut Self {
-        self.stage(
-            &Self::state_stage_name::<T>(),
-            |state_stage: &mut StateStage<T>| state_stage.on_state_enter(value, stage),
-        )
-    }
-
-    pub fn on_state_update<T: Clone + Resource, Params, S: IntoStage<Params>>(
-        &mut self,
-        value: T,
-        stage: S,
-    ) -> &mut Self {
-        self.stage(
-            &Self::state_stage_name::<T>(),
-            |state_stage: &mut StateStage<T>| state_stage.on_state_update(value, stage),
-        )
-    }
-
-    pub fn on_state_exit<T: Clone + Resource, Params, S: IntoStage<Params>>(
-        &mut self,
-        value: T,
-        stage: S,
-    ) -> &mut Self {
-        self.stage(
-            &Self::state_stage_name::<T>(),
-            |state_stage: &mut StateStage<T>| state_stage.on_state_exit(value, stage),
-        )
     }
 
     /// Adds a resource to the current [App] and overwrites any resource previously added of the same type.

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -14,7 +14,7 @@ pub mod prelude {
     pub use crate::{
         core::WorldBuilderSource,
         resource::{ChangedRes, FromResources, Local, Res, ResMut, Resource, Resources},
-        schedule::{Schedule, State, SystemStage, StateStage},
+        schedule::{Schedule, State, StateStage, SystemStage},
         system::{Commands, IntoSystem, Query, System},
         Added, Bundle, Changed, Component, Entity, In, IntoChainSystem, Mut, Mutated, Or, QuerySet,
         Ref, RefMut, With, Without, World,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -14,7 +14,7 @@ pub mod prelude {
     pub use crate::{
         core::WorldBuilderSource,
         resource::{ChangedRes, FromResources, Local, Res, ResMut, Resource, Resources},
-        schedule::{Schedule, State, SystemStage},
+        schedule::{Schedule, State, SystemStage, StateStage},
         system::{Commands, IntoSystem, Query, System},
         Added, Bundle, Changed, Component, Entity, In, IntoChainSystem, Mut, Mutated, Or, QuerySet,
         Ref, RefMut, With, Without, World,

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -18,27 +18,17 @@ pub struct Schedule {
 }
 
 impl Schedule {
-    pub fn with_stage<Params, S: IntoStage<Params>>(mut self, name: &str, stage: S) -> Self {
-        self.add_stage(name, stage.into_stage());
+    pub fn with_stage<S: Stage>(mut self, name: &str, stage: S) -> Self {
+        self.add_stage(name, stage);
         self
     }
 
-    pub fn with_stage_after<Params, S: IntoStage<Params>>(
-        mut self,
-        target: &str,
-        name: &str,
-        stage: S,
-    ) -> Self {
+    pub fn with_stage_after<S: Stage>(mut self, target: &str, name: &str, stage: S) -> Self {
         self.add_stage_after(target, name, stage);
         self
     }
 
-    pub fn with_stage_before<Params, S: IntoStage<Params>>(
-        mut self,
-        target: &str,
-        name: &str,
-        stage: S,
-    ) -> Self {
+    pub fn with_stage_before<S: Stage>(mut self, target: &str, name: &str, stage: S) -> Self {
         self.add_stage_before(target, name, stage);
         self
     }
@@ -75,19 +65,13 @@ impl Schedule {
         self
     }
 
-    pub fn add_stage<Params, S: IntoStage<Params>>(&mut self, name: &str, stage: S) -> &mut Self {
+    pub fn add_stage<S: Stage>(&mut self, name: &str, stage: S) -> &mut Self {
         self.stage_order.push(name.to_string());
-        self.stages
-            .insert(name.to_string(), Box::new(stage.into_stage()));
+        self.stages.insert(name.to_string(), Box::new(stage));
         self
     }
 
-    pub fn add_stage_after<Params, S: IntoStage<Params>>(
-        &mut self,
-        target: &str,
-        name: &str,
-        stage: S,
-    ) -> &mut Self {
+    pub fn add_stage_after<S: Stage>(&mut self, target: &str, name: &str, stage: S) -> &mut Self {
         if self.stages.get(name).is_some() {
             panic!("Stage already exists: {}.", name);
         }
@@ -100,18 +84,12 @@ impl Schedule {
             .map(|(i, _)| i)
             .unwrap_or_else(|| panic!("Target stage does not exist: {}.", target));
 
-        self.stages
-            .insert(name.to_string(), Box::new(stage.into_stage()));
+        self.stages.insert(name.to_string(), Box::new(stage));
         self.stage_order.insert(target_index + 1, name.to_string());
         self
     }
 
-    pub fn add_stage_before<Params, S: IntoStage<Params>>(
-        &mut self,
-        target: &str,
-        name: &str,
-        stage: S,
-    ) -> &mut Self {
+    pub fn add_stage_before<S: Stage>(&mut self, target: &str, name: &str, stage: S) -> &mut Self {
         if self.stages.get(name).is_some() {
             panic!("Stage already exists: {}.", name);
         }
@@ -124,8 +102,7 @@ impl Schedule {
             .map(|(i, _)| i)
             .unwrap_or_else(|| panic!("Target stage does not exist: {}.", target));
 
-        self.stages
-            .insert(name.to_string(), Box::new(stage.into_stage()));
+        self.stages.insert(name.to_string(), Box::new(stage));
         self.stage_order.insert(target_index, name.to_string());
         self
     }

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -174,29 +174,6 @@ impl<S: System<In = (), Out = ()>> From<S> for SystemStage {
     }
 }
 
-pub trait IntoStage<Params> {
-    type Stage: Stage;
-    fn into_stage(self) -> Self::Stage;
-}
-
-impl<Params, S: System<In = (), Out = ()>, IntoS: IntoSystem<Params, S>> IntoStage<(Params, S)>
-    for IntoS
-{
-    type Stage = SystemStage;
-
-    fn into_stage(self) -> Self::Stage {
-        SystemStage::single(self)
-    }
-}
-
-impl<S: Stage> IntoStage<()> for S {
-    type Stage = S;
-
-    fn into_stage(self) -> Self::Stage {
-        self
-    }
-}
-
 pub struct RunOnce {
     ran: bool,
     system_id: SystemId,

--- a/crates/bevy_ecs/src/system/into_system.rs
+++ b/crates/bevy_ecs/src/system/into_system.rs
@@ -330,7 +330,7 @@ mod tests {
         let mut update = SystemStage::parallel();
         update.add_system(incr_e_on_flip);
         schedule.add_stage("update", update);
-        schedule.add_stage("clear_trackers", clear_trackers_system);
+        schedule.add_stage("clear_trackers", SystemStage::single(clear_trackers_system));
 
         schedule.initialize_and_run(&mut world, &mut resources);
         assert_eq!(*(world.get::<i32>(ent).unwrap()), 1);
@@ -364,7 +364,7 @@ mod tests {
         let mut update = SystemStage::parallel();
         update.add_system(incr_e_on_flip);
         schedule.add_stage("update", update);
-        schedule.add_stage("clear_trackers", clear_trackers_system);
+        schedule.add_stage("clear_trackers", SystemStage::single(clear_trackers_system));
 
         schedule.initialize_and_run(&mut world, &mut resources);
         assert_eq!(*(world.get::<i32>(ent).unwrap()), 1);

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -1,16 +1,19 @@
-use bevy::{asset::LoadState, prelude::*, sprite::TextureAtlasBuilder};
+use bevy::{asset::LoadState, ecs::StateStage, prelude::*, sprite::TextureAtlasBuilder};
 
 /// In this example we generate a new texture atlas (sprite sheet) from a folder containing individual sprites
 fn main() {
     App::build()
         .init_resource::<RpgSpriteHandles>()
         .add_plugins(DefaultPlugins)
-        .add_state(AppState::Setup)
-        .on_state_enter(AppState::Setup, load_textures)
-        .on_state_update(AppState::Setup, check_textures)
-        .on_state_enter(AppState::Finshed, setup)
+        .add_resource(State::new(AppState::Setup))
+        .add_stage_after(stage::UPDATE, STAGE, StateStage::<AppState>::default())
+        .on_state_enter(STAGE, AppState::Setup, load_textures)
+        .on_state_update(STAGE, AppState::Setup, check_textures)
+        .on_state_enter(STAGE, AppState::Finshed, setup)
         .run();
 }
+
+const STAGE: &str = "app_state";
 
 #[derive(Clone)]
 enum AppState {

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -1,4 +1,4 @@
-use bevy::{asset::LoadState, ecs::StateStage, prelude::*, sprite::TextureAtlasBuilder};
+use bevy::{asset::LoadState, prelude::*, sprite::TextureAtlasBuilder};
 
 /// In this example we generate a new texture atlas (sprite sheet) from a folder containing individual sprites
 fn main() {

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::StateStage, prelude::*};
+use bevy::prelude::*;
 
 /// This example illustrates how to use States to control transitioning from a Menu state to an InGame state.
 fn main() {

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -1,23 +1,22 @@
-use bevy::prelude::*;
+use bevy::{ecs::StateStage, prelude::*};
 
 /// This example illustrates how to use States to control transitioning from a Menu state to an InGame state.
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .init_resource::<ButtonMaterials>()
-        .add_state(AppState::Menu)
-        .on_state_enter(AppState::Menu, setup_menu)
-        .on_state_update(AppState::Menu, menu)
-        .on_state_exit(AppState::Menu, cleanup_menu)
-        .on_state_enter(AppState::InGame, setup_game)
-        .on_state_update(
-            AppState::InGame,
-            SystemStage::parallel()
-                .with_system(movement)
-                .with_system(change_color),
-        )
+        .add_resource(State::new(AppState::Menu))
+        .add_stage_after(stage::UPDATE, STAGE, StateStage::<AppState>::default())
+        .on_state_enter(STAGE, AppState::Menu, setup_menu)
+        .on_state_update(STAGE, AppState::Menu, menu)
+        .on_state_exit(STAGE, AppState::Menu, cleanup_menu)
+        .on_state_enter(STAGE, AppState::InGame, setup_game)
+        .on_state_update(STAGE, AppState::InGame, movement)
+        .on_state_update(STAGE, AppState::InGame, change_color)
         .run();
 }
+
+const STAGE: &str = "app_state";
 
 #[derive(Clone)]
 enum AppState {


### PR DESCRIPTION
## The Problem

The "right" way to use StateStage was a bit unclear and there was too much "implicit" behavior. Additionally it was cumbersome for the "common case", which is "appending systems to a state's lifecycle event stage". This pr aims to improve the situation:

## This PR

### remove IntoStage trait

Builder functions that need Stages now just take stages directly instead of taking IntoStage. IntoStage made it easy to use either a Stage or a System when stages are needed, but it caused more confusion than it was worth.

### StateStages now have default SystemStage handlers for their lifecycle events

This makes the internal implementation simpler / reduces branching. It also cuts down on user facing boilerplate.

### on_state_X functions now take Systems

on_state_X take systems instead of Stages. These methods assume that the lifecycle stage is a SystemStage (which is true by default).

### removed app.add_state()

This was too "magical". It created a new stage after UPDATE with an arbitrary name. This has been replaced with the less ergonomic, but _much_ clearer:
```rust
app
    .add_resource(State::new(AppState::Menu))
    .add_stage_after(stage::UPDATE, STAGE, StateStage::<AppState>::default())
```


## Usage

```rust
// generally this is the only pattern people will need
app
    .add_resource(State::new(AppState::Menu))
    .add_stage_after(stage::UPDATE, STAGE, StateStage::<AppState>::default())
    .on_state_enter(STAGE, AppState::Menu, setup_menu)
    .on_state_update(STAGE, AppState::Menu, menu)
    .on_state_exit(STAGE, AppState::Menu, cleanup_menu)
    .on_state_enter(STAGE, AppState::InGame, setup_game)
    .on_state_update(STAGE, AppState::InGame, movement)
    .on_state_update(STAGE, AppState::InGame, change_color)


// for more complicated scenarios you can do things like this
app
    .add_stage_after(stage::UPDATE, STAGE, StateStage::<AppState>::default())
    .stage(STAGE, |stage: &mut StateStage<AppState>|
        stage
            .on_state_enter(AppState::Menu, some_system)
            .set_enter_stage(AppState::InGame, MyCustomStage::new())
            .exit_stage(AppState::InGame, |stage: &mut SystemStage|
                stage.add_system(some_other_system)
            )
    )

```

Related: #1053 #1021 