### PR TITLE
Prevent double panic in the Drop of TaksPoolInner

### DIFF
--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -69,10 +69,12 @@ impl Drop for TaskPoolInner {
     fn drop(&mut self) {
         self.shutdown_tx.close();
 
+        let panicking = thread::panicking();
         for join_handle in self.threads.drain(..) {
-            join_handle
-                .join()
-                .expect("Task thread panicked while executing.");
+            let res = join_handle.join();
+            if !panicking {
+                res.expect("Task thread panicked while executing.");
+            }
         }
     }
 }


### PR DESCRIPTION
TaskPoolInner would cause failing bevy test (see #1057) to abort the running test suite immediately. 

Here is the problematic situation as I understand it:
- The Drop of TaskPoolInner is called on a panicking thread. (I guess that happen when rust is unwinding from a panic)
- The Drop then try to join on all of his threads. However, at least one of them finish with a panic and return an error on the `join` call.
- `except` panic when receiving an error.
- Panic in panic happens and everyone is sad (I think?). I'm new to rust so I may be wrong here.
- The program abort.

My idea is to only panic when the current thread is not already panicking.