### PR TITLE
Update dependencies for Enable Fast Compiles

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -9,6 +9,11 @@ If you don't see your distro present in the list, feel free to add the instructi
 ```bash
 sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev
 ```
+If you want to Enable Fast Compiles
+```bash
+sudo apt-get install clang
+```
+
 ### Windows Subsystem for Linux (WSL 2)
 
 Graphics and audio need to be configured for them to work with WSL 2 backend. 


### PR DESCRIPTION
Added clang as an optional dependency to avoid frustration of running into compile error the first time you run a cargo build