### PR TITLE
suppress wgpu warnings by default

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -33,7 +33,7 @@ pub struct LogSettings {
 impl Default for LogSettings {
     fn default() -> Self {
         Self {
-            filter: "wgpu=warn".to_string(),
+            filter: "wgpu=error".to_string(),
             level: Level::INFO,
         }
     }


### PR DESCRIPTION
They are generally unactionable and noisy. They scare users constantly / make them assume they are doing something wrong. Almost without exception they are:

* Warnings about gaps in Naga validation layers. Naga is still pretty new and it can't fully validate shaders. Disabling the validation layers also produces a warning that the validation layers are disabled.
* Warnings about unsupported features / fallbacks (ex: falling back to Fifo vsync when Mailbox isn't supported)

These can still be opted into by setting the `RUST_LOG=wgpu=warn` environment variable.