### PR TITLE
set is_transparent to true by default for UI bundles

### DIFF
--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -37,7 +37,10 @@ impl Default for NodeBundle {
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 UI_PIPELINE_HANDLE.typed(),
             )]),
-            visible: Default::default(),
+            visible: Visible {
+                is_transparent: true,
+                ..Default::default()
+            },
             node: Default::default(),
             style: Default::default(),
             material: Default::default(),
@@ -76,7 +79,10 @@ impl Default for ImageBundle {
             style: Default::default(),
             material: Default::default(),
             draw: Default::default(),
-            visible: Default::default(),
+            visible: Visible {
+                is_transparent: true,
+                ..Default::default()
+            },
             transform: Default::default(),
             global_transform: Default::default(),
         }
@@ -147,7 +153,10 @@ impl Default for ButtonBundle {
             style: Default::default(),
             material: Default::default(),
             draw: Default::default(),
-            visible: Default::default(),
+            visible: Visible {
+                is_transparent: true,
+                ..Default::default()
+            },
             transform: Default::default(),
             global_transform: Default::default(),
         }

--- a/examples/asset/custom_asset_io.rs
+++ b/examples/asset/custom_asset_io.rs
@@ -85,7 +85,7 @@ fn main() {
             // asset system are initialized correctly.
             group.add_before::<bevy::asset::AssetPlugin, _>(CustomAssetIoPlugin)
         })
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -89,16 +89,13 @@ fn mouse_handler(
         let bird_y = (window.height / 2.) - HALF_BIRD_SIZE;
 
         for count in 0..spawn_count {
-            let bird_position = Vec3::new(bird_x, bird_y, (counter.count + count) as f32 * 0.00001);
-            let mut transform = Transform::from_translation(bird_position);
-            transform.scale = Vec3::new(BIRD_SCALE, BIRD_SCALE, BIRD_SCALE);
-
+            let bird_z = (counter.count + count) as f32 * 0.00001;
             commands
                 .spawn(SpriteBundle {
                     material: bird_material.0.clone(),
-                    transform,
-                    visible: Visible {
-                        is_transparent: true,
+                    transform: Transform {
+                        translation: Vec3::new(bird_x, bird_y, bird_z),
+                        scale: Vec3::splat(BIRD_SCALE),
                         ..Default::default()
                     },
                     ..Default::default()

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -115,10 +115,6 @@ fn setup(
                         ..Default::default()
                     },
                     material: materials.add(Color::NONE.into()),
-                    visible: Visible {
-                        is_transparent: true,
-                        ..Default::default()
-                    },
                     ..Default::default()
                 })
                 .with_children(|parent| {
@@ -188,10 +184,6 @@ fn setup(
                                         ..Default::default()
                                     },
                                     material: materials.add(Color::rgba(1.0, 0.9, 0.9, 0.4).into()),
-                                    visible: Visible {
-                                        is_transparent: true,
-                                        ..Default::default()
-                                    },
                                     ..Default::default()
                                 });
                         });
@@ -206,10 +198,6 @@ fn setup(
                         ..Default::default()
                     },
                     material: materials.add(Color::NONE.into()),
-                    visible: Visible {
-                        is_transparent: true,
-                        ..Default::default()
-                    },
                     ..Default::default()
                 })
                 .with_children(|parent| {
@@ -221,10 +209,6 @@ fn setup(
                         },
                         material: materials
                             .add(asset_server.load("branding/bevy_logo_dark_big.png").into()),
-                        visible: Visible {
-                            is_transparent: true,
-                            ..Default::default()
-                        },
                         ..Default::default()
                     });
                 });


### PR DESCRIPTION
as discussed in https://github.com/bevyengine/bevy/issues/64#issuecomment-744822890

I set it to `true` by default for all UI bundles (`NodeBundle`, `ImageBundle`, `ButtonBundle`), as it was already the case for `TextBundle`, `SpriteBundle`, and `SpriteSheetBundle`.