### PR TITLE
Adopt a Fetch pattern for SystemParams

### DIFF
--- a/crates/bevy_app/src/app_builder.rs
+++ b/crates/bevy_app/src/app_builder.rs
@@ -24,7 +24,7 @@ impl Default for AppBuilder {
         app_builder
             .add_default_stages()
             .add_event::<AppExit>()
-            .add_system_to_stage(stage::LAST, clear_trackers_system);
+            .add_system_to_stage(stage::LAST, clear_trackers_system.system());
         app_builder
     }
 }
@@ -125,68 +125,48 @@ impl AppBuilder {
         self
     }
 
-    pub fn add_system<S, Params, IntoS>(&mut self, system: IntoS) -> &mut Self
-    where
-        S: System<In = (), Out = ()>,
-        IntoS: IntoSystem<Params, S>,
-    {
+    pub fn add_system<S: System<In = (), Out = ()>>(&mut self, system: S) -> &mut Self {
         self.add_system_to_stage(stage::UPDATE, system)
     }
 
-    pub fn on_state_enter<T: Clone + Resource, S, Params, IntoS>(
+    pub fn on_state_enter<T: Clone + Resource, S: System<In = (), Out = ()>>(
         &mut self,
         stage: &str,
         state: T,
-        system: IntoS,
-    ) -> &mut Self
-    where
-        S: System<In = (), Out = ()>,
-        IntoS: IntoSystem<Params, S>,
-    {
+        system: S,
+    ) -> &mut Self {
         self.stage(stage, |stage: &mut StateStage<T>| {
             stage.on_state_enter(state, system)
         })
     }
 
-    pub fn on_state_update<T: Clone + Resource, S, Params, IntoS>(
+    pub fn on_state_update<T: Clone + Resource, S: System<In = (), Out = ()>>(
         &mut self,
         stage: &str,
         state: T,
-        system: IntoS,
-    ) -> &mut Self
-    where
-        S: System<In = (), Out = ()>,
-        IntoS: IntoSystem<Params, S>,
-    {
+        system: S,
+    ) -> &mut Self {
         self.stage(stage, |stage: &mut StateStage<T>| {
             stage.on_state_update(state, system)
         })
     }
 
-    pub fn on_state_exit<T: Clone + Resource, S, Params, IntoS>(
+    pub fn on_state_exit<T: Clone + Resource, S: System<In = (), Out = ()>>(
         &mut self,
         stage: &str,
         state: T,
-        system: IntoS,
-    ) -> &mut Self
-    where
-        S: System<In = (), Out = ()>,
-        IntoS: IntoSystem<Params, S>,
-    {
+        system: S,
+    ) -> &mut Self {
         self.stage(stage, |stage: &mut StateStage<T>| {
             stage.on_state_exit(state, system)
         })
     }
 
-    pub fn add_startup_system_to_stage<S, Params, IntoS>(
+    pub fn add_startup_system_to_stage<S: System<In = (), Out = ()>>(
         &mut self,
         stage_name: &'static str,
-        system: IntoS,
-    ) -> &mut Self
-    where
-        S: System<In = (), Out = ()>,
-        IntoS: IntoSystem<Params, S>,
-    {
+        system: S,
+    ) -> &mut Self {
         self.app
             .schedule
             .stage(stage::STARTUP, |schedule: &mut Schedule| {
@@ -195,11 +175,7 @@ impl AppBuilder {
         self
     }
 
-    pub fn add_startup_system<S, Params, IntoS>(&mut self, system: IntoS) -> &mut Self
-    where
-        S: System<In = (), Out = ()>,
-        IntoS: IntoSystem<Params, S>,
-    {
+    pub fn add_startup_system<S: System<In = (), Out = ()>>(&mut self, system: S) -> &mut Self {
         self.add_startup_system_to_stage(startup_stage::STARTUP, system)
     }
 
@@ -221,15 +197,11 @@ impl AppBuilder {
         .add_stage(stage::LAST, SystemStage::parallel())
     }
 
-    pub fn add_system_to_stage<S, Params, IntoS>(
+    pub fn add_system_to_stage<S: System<In = (), Out = ()>>(
         &mut self,
         stage_name: &'static str,
-        system: IntoS,
-    ) -> &mut Self
-    where
-        S: System<In = (), Out = ()>,
-        IntoS: IntoSystem<Params, S>,
-    {
+        system: S,
+    ) -> &mut Self {
         self.app.schedule.add_system_to_stage(stage_name, system);
         self
     }
@@ -239,7 +211,7 @@ impl AppBuilder {
         T: Send + Sync + 'static,
     {
         self.add_resource(Events::<T>::default())
-            .add_system_to_stage(stage::EVENT, Events::<T>::update_system)
+            .add_system_to_stage(stage::EVENT, Events::<T>::update_system.system())
     }
 
     /// Adds a resource to the current [App] and overwrites any resource previously added of the same type.

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -2,7 +2,7 @@ use crate::{
     update_asset_storage_system, Asset, AssetLoader, AssetServer, Handle, HandleId, RefChange,
 };
 use bevy_app::{prelude::Events, AppBuilder};
-use bevy_ecs::{FromResources, ResMut};
+use bevy_ecs::{FromResources, IntoSystem, ResMut};
 use bevy_reflect::RegisterTypeBuilder;
 use bevy_utils::HashMap;
 use crossbeam_channel::Sender;
@@ -218,8 +218,14 @@ impl AddAsset for AppBuilder {
         };
 
         self.add_resource(assets)
-            .add_system_to_stage(super::stage::ASSET_EVENTS, Assets::<T>::asset_event_system)
-            .add_system_to_stage(crate::stage::LOAD_ASSETS, update_asset_storage_system::<T>)
+            .add_system_to_stage(
+                super::stage::ASSET_EVENTS,
+                Assets::<T>::asset_event_system.system(),
+            )
+            .add_system_to_stage(
+                crate::stage::LOAD_ASSETS,
+                update_asset_storage_system::<T>.system(),
+            )
             .register_type::<Handle<T>>()
             .add_event::<AssetEvent<T>>()
     }

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -13,7 +13,7 @@ mod path;
 
 pub use asset_server::*;
 pub use assets::*;
-use bevy_ecs::SystemStage;
+use bevy_ecs::{IntoSystem, SystemStage};
 use bevy_reflect::RegisterTypeBuilder;
 use bevy_tasks::IoTaskPool;
 pub use handle::*;
@@ -88,13 +88,13 @@ impl Plugin for AssetPlugin {
         .register_type::<HandleId>()
         .add_system_to_stage(
             bevy_app::stage::PRE_UPDATE,
-            asset_server::free_unused_assets_system,
+            asset_server::free_unused_assets_system.system(),
         );
 
         #[cfg(all(
             feature = "filesystem_watcher",
             all(not(target_arch = "wasm32"), not(target_os = "android"))
         ))]
-        app.add_system_to_stage(stage::LOAD_ASSETS, io::filesystem_watcher_system);
+        app.add_system_to_stage(stage::LOAD_ASSETS, io::filesystem_watcher_system.system());
     }
 }

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -12,6 +12,7 @@ pub mod prelude {
 
 use bevy_app::prelude::*;
 use bevy_asset::AddAsset;
+use bevy_ecs::IntoSystem;
 
 /// Adds support for audio playback to an App
 #[derive(Default)]
@@ -23,6 +24,9 @@ impl Plugin for AudioPlugin {
             .add_asset::<AudioSource>()
             .init_asset_loader::<Mp3Loader>()
             .init_resource::<Audio<AudioSource>>()
-            .add_system_to_stage(stage::POST_UPDATE, play_queued_audio_system::<AudioSource>);
+            .add_system_to_stage(
+                stage::POST_UPDATE,
+                play_queued_audio_system::<AudioSource>.system(),
+            );
     }
 }

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -6,6 +6,7 @@ mod time;
 
 use std::ops::Range;
 
+use bevy_ecs::IntoSystem;
 use bevy_reflect::RegisterTypeBuilder;
 pub use bytes::*;
 pub use float_ord::*;
@@ -37,7 +38,7 @@ impl Plugin for CorePlugin {
             .register_type::<Option<String>>()
             .register_type::<Range<f32>>()
             .register_type::<Timer>()
-            .add_system_to_stage(stage::FIRST, time_system)
-            .add_system_to_stage(stage::PRE_UPDATE, entity_labels_system);
+            .add_system_to_stage(stage::FIRST, time_system.system())
+            .add_system_to_stage(stage::PRE_UPDATE, entity_labels_system.system());
     }
 }

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -1,7 +1,7 @@
 use crate::{Diagnostic, DiagnosticId, Diagnostics};
 use bevy_app::prelude::*;
 use bevy_core::Time;
-use bevy_ecs::{Res, ResMut};
+use bevy_ecs::{IntoSystem, Res, ResMut};
 
 /// Adds "frame time" diagnostic to an App, specifically "frame time", "fps" and "frame count"
 #[derive(Default)]
@@ -13,9 +13,9 @@ pub struct FrameTimeDiagnosticsState {
 
 impl Plugin for FrameTimeDiagnosticsPlugin {
     fn build(&self, app: &mut bevy_app::AppBuilder) {
-        app.add_startup_system(Self::setup_system)
+        app.add_startup_system(Self::setup_system.system())
             .add_resource(FrameTimeDiagnosticsState { frame_count: 0.0 })
-            .add_system(Self::diagnostic_system);
+            .add_system(Self::diagnostic_system.system());
     }
 }
 

--- a/crates/bevy_diagnostic/src/print_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/print_diagnostics_plugin.rs
@@ -1,7 +1,7 @@
 use super::{Diagnostic, DiagnosticId, Diagnostics};
 use bevy_app::prelude::*;
 use bevy_core::{Time, Timer};
-use bevy_ecs::{Res, ResMut};
+use bevy_ecs::{IntoSystem, Res, ResMut};
 use bevy_utils::Duration;
 
 /// An App Plugin that prints diagnostics to the console
@@ -35,9 +35,12 @@ impl Plugin for PrintDiagnosticsPlugin {
         });
 
         if self.debug {
-            app.add_system_to_stage(stage::POST_UPDATE, Self::print_diagnostics_debug_system);
+            app.add_system_to_stage(
+                stage::POST_UPDATE,
+                Self::print_diagnostics_debug_system.system(),
+            );
         } else {
-            app.add_system_to_stage(stage::POST_UPDATE, Self::print_diagnostics_system);
+            app.add_system_to_stage(stage::POST_UPDATE, Self::print_diagnostics_system.system());
         }
     }
 }

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -33,33 +33,24 @@ impl Schedule {
         self
     }
 
-    pub fn with_run_criteria<S, Params, IntoS>(mut self, system: IntoS) -> Self
-    where
-        S: System<In = (), Out = ShouldRun>,
-        IntoS: IntoSystem<Params, S>,
-    {
+    pub fn with_run_criteria<S: System<In = (), Out = ShouldRun>>(mut self, system: S) -> Self {
         self.set_run_criteria(system);
         self
     }
 
-    pub fn with_system_in_stage<S, Params, IntoS>(
+    pub fn with_system_in_stage<S: System<In = (), Out = ()>>(
         mut self,
         stage_name: &'static str,
-        system: IntoS,
-    ) -> Self
-    where
-        S: System<In = (), Out = ()>,
-        IntoS: IntoSystem<Params, S>,
-    {
+        system: S,
+    ) -> Self {
         self.add_system_to_stage(stage_name, system);
         self
     }
 
-    pub fn set_run_criteria<S, Params, IntoS>(&mut self, system: IntoS) -> &mut Self
-    where
-        S: System<In = (), Out = ShouldRun>,
-        IntoS: IntoSystem<Params, S>,
-    {
+    pub fn set_run_criteria<S: System<In = (), Out = ShouldRun>>(
+        &mut self,
+        system: S,
+    ) -> &mut Self {
         self.run_criteria = Some(Box::new(system.system()));
         self.run_criteria_initialized = false;
         self
@@ -107,15 +98,11 @@ impl Schedule {
         self
     }
 
-    pub fn add_system_to_stage<S, Params, IntoS>(
+    pub fn add_system_to_stage<S: System<In = (), Out = ()>>(
         &mut self,
         stage_name: &'static str,
-        system: IntoS,
-    ) -> &mut Self
-    where
-        S: System<In = (), Out = ()>,
-        IntoS: IntoSystem<Params, S>,
-    {
+        system: S,
+    ) -> &mut Self {
         let stage = self
             .get_stage_mut::<SystemStage>(stage_name)
             .unwrap_or_else(|| {
@@ -124,7 +111,7 @@ impl Schedule {
                     stage_name
                 )
             });
-        stage.add_system(system);
+        stage.add_system(system.system());
         self
     }
 
@@ -221,7 +208,7 @@ mod tests {
         resource::{Res, ResMut, Resources},
         schedule::{ParallelSystemStageExecutor, Schedule, SystemStage},
         system::Query,
-        Commands, Entity, World,
+        Commands, Entity, IntoSystem, World,
     };
     use bevy_tasks::{ComputeTaskPool, TaskPool};
     use fixedbitset::FixedBitSet;
@@ -255,10 +242,10 @@ mod tests {
 
         let mut schedule = Schedule::default();
         let mut pre_archetype_change = SystemStage::parallel();
-        pre_archetype_change.add_system(insert);
+        pre_archetype_change.add_system(insert.system());
         schedule.add_stage("PreArchetypeChange", pre_archetype_change);
         let mut post_archetype_change = SystemStage::parallel();
-        post_archetype_change.add_system(read);
+        post_archetype_change.add_system(read.system());
         schedule.add_stage("PostArchetypeChange", post_archetype_change);
 
         schedule.initialize_and_run(&mut world, &mut resources);
@@ -285,8 +272,8 @@ mod tests {
         }
 
         let mut update = SystemStage::parallel();
-        update.add_system(insert);
-        update.add_system(read);
+        update.add_system(insert.system());
+        update.add_system(read.system());
 
         let mut schedule = Schedule::default();
         schedule.add_stage("update", update);
@@ -356,10 +343,10 @@ mod tests {
             completed_systems.insert(READ_U64_SYSTEM_NAME);
         }
 
-        stage_a.add_system(read_u32);
-        stage_a.add_system(write_float);
-        stage_a.add_system(read_u32_write_u64);
-        stage_a.add_system(read_u64);
+        stage_a.add_system(read_u32.system());
+        stage_a.add_system(write_float.system());
+        stage_a.add_system(read_u32_write_u64.system());
+        stage_a.add_system(read_u64.system());
 
         // B systems
 
@@ -387,9 +374,9 @@ mod tests {
             completed_systems.insert(WRITE_F32_SYSTEM_NAME);
         }
 
-        stage_b.add_system(write_u64);
-        stage_b.add_system(thread_local_system);
-        stage_b.add_system(write_f32);
+        stage_b.add_system(write_u64.system());
+        stage_b.add_system(thread_local_system.system());
+        stage_b.add_system(write_f32.system());
 
         // C systems
 
@@ -424,10 +411,10 @@ mod tests {
             completed_systems.insert(WRITE_F64_RES_SYSTEM_NAME);
         }
 
-        stage_c.add_system(read_f64_res);
-        stage_c.add_system(read_isize_res);
-        stage_c.add_system(read_isize_write_f64_res);
-        stage_c.add_system(write_f64_res);
+        stage_c.add_system(read_f64_res.system());
+        stage_c.add_system(read_isize_res.system());
+        stage_c.add_system(read_isize_write_f64_res.system());
+        stage_c.add_system(write_f64_res.system());
 
         fn run_and_validate(schedule: &mut Schedule, world: &mut World, resources: &mut Resources) {
             schedule.initialize_and_run(world, resources);

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -1,8 +1,7 @@
 use std::{any::TypeId, borrow::Cow};
 
 use crate::{
-    ArchetypeComponent, IntoSystem, Resources, System, SystemId, ThreadLocalExecution, TypeAccess,
-    World,
+    ArchetypeComponent, Resources, System, SystemId, ThreadLocalExecution, TypeAccess, World,
 };
 use bevy_utils::HashSet;
 use downcast_rs::{impl_downcast, Downcast};
@@ -47,9 +46,7 @@ impl SystemStage {
         }
     }
 
-    pub fn single<Params, S: System<In = (), Out = ()>, Into: IntoSystem<Params, S>>(
-        system: Into,
-    ) -> Self {
+    pub fn single<S: System<In = (), Out = ()>>(system: S) -> Self {
         Self::serial().with_system(system)
     }
 
@@ -61,31 +58,19 @@ impl SystemStage {
         Self::new(Box::new(ParallelSystemStageExecutor::default()))
     }
 
-    pub fn with_system<S, Params, IntoS>(mut self, system: IntoS) -> Self
-    where
-        S: System<In = (), Out = ()>,
-        IntoS: IntoSystem<Params, S>,
-    {
-        self.add_system_boxed(Box::new(system.system()));
+    pub fn with_system<S: System<In = (), Out = ()>>(mut self, system: S) -> Self {
+        self.add_system_boxed(Box::new(system));
         self
     }
 
-    pub fn with_run_criteria<S, Params, IntoS>(mut self, system: IntoS) -> Self
-    where
-        S: System<In = (), Out = ShouldRun>,
-        IntoS: IntoSystem<Params, S>,
-    {
-        self.run_criteria = Some(Box::new(system.system()));
+    pub fn with_run_criteria<S: System<In = (), Out = ShouldRun>>(mut self, system: S) -> Self {
+        self.run_criteria = Some(Box::new(system));
         self.run_criteria_initialized = false;
         self
     }
 
-    pub fn add_system<S, Params, IntoS>(&mut self, system: IntoS) -> &mut Self
-    where
-        S: System<In = (), Out = ()>,
-        IntoS: IntoSystem<Params, S>,
-    {
-        self.add_system_boxed(Box::new(system.system()));
+    pub fn add_system<S: System<In = (), Out = ()>>(&mut self, system: S) -> &mut Self {
+        self.add_system_boxed(Box::new(system));
         self
     }
 

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -1,4 +1,4 @@
-use crate::{IntoSystem, Resource, Resources, Stage, System, SystemStage, World};
+use crate::{Resource, Resources, Stage, System, SystemStage, World};
 use bevy_utils::HashMap;
 use std::{mem::Discriminant, ops::Deref};
 use thiserror::Error;
@@ -51,30 +51,30 @@ impl<T> StateStage<T> {
         self
     }
 
-    pub fn on_state_enter<Params, S: System<In = (), Out = ()>, IntoS: IntoSystem<Params, S>>(
+    pub fn on_state_enter<S: System<In = (), Out = ()>>(
         &mut self,
         state: T,
-        system: IntoS,
+        system: S,
     ) -> &mut Self {
         self.enter_stage(state, |system_stage: &mut SystemStage| {
             system_stage.add_system(system)
         })
     }
 
-    pub fn on_state_exit<Params, S: System<In = (), Out = ()>, IntoS: IntoSystem<Params, S>>(
+    pub fn on_state_exit<S: System<In = (), Out = ()>>(
         &mut self,
         state: T,
-        system: IntoS,
+        system: S,
     ) -> &mut Self {
         self.exit_stage(state, |system_stage: &mut SystemStage| {
             system_stage.add_system(system)
         })
     }
 
-    pub fn on_state_update<Params, S: System<In = (), Out = ()>, IntoS: IntoSystem<Params, S>>(
+    pub fn on_state_update<S: System<In = (), Out = ()>>(
         &mut self,
         state: T,
-        system: IntoS,
+        system: S,
     ) -> &mut Self {
         self.update_stage(state, |system_stage: &mut SystemStage| {
             system_stage.add_system(system)

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -2,6 +2,7 @@ mod converter;
 mod gilrs_system;
 
 use bevy_app::{prelude::*, startup_stage::PRE_STARTUP};
+use bevy_ecs::IntoSystem;
 use bevy_utils::tracing::error;
 use gilrs::GilrsBuilder;
 use gilrs_system::{gilrs_event_startup_system, gilrs_event_system};
@@ -18,8 +19,8 @@ impl Plugin for GilrsPlugin {
         {
             Ok(gilrs) => {
                 app.add_thread_local_resource(gilrs)
-                    .add_startup_system_to_stage(PRE_STARTUP, gilrs_event_startup_system)
-                    .add_system_to_stage(stage::PRE_EVENT, gilrs_event_system);
+                    .add_startup_system_to_stage(PRE_STARTUP, gilrs_event_startup_system.system())
+                    .add_system_to_stage(stage::PRE_EVENT, gilrs_event_system.system());
             }
             Err(err) => error!("Failed to start Gilrs. {}", err),
         }

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -7,6 +7,7 @@ pub mod system;
 pub mod touch;
 
 pub use axis::*;
+use bevy_ecs::IntoSystem;
 pub use input::*;
 
 pub mod prelude {
@@ -43,20 +44,23 @@ impl Plugin for InputPlugin {
             .add_event::<MouseMotion>()
             .add_event::<MouseWheel>()
             .init_resource::<Input<KeyCode>>()
-            .add_system_to_stage(bevy_app::stage::EVENT, keyboard_input_system)
+            .add_system_to_stage(bevy_app::stage::EVENT, keyboard_input_system.system())
             .init_resource::<Input<MouseButton>>()
-            .add_system_to_stage(bevy_app::stage::EVENT, mouse_button_input_system)
+            .add_system_to_stage(bevy_app::stage::EVENT, mouse_button_input_system.system())
             .add_event::<GamepadEvent>()
             .add_event::<GamepadEventRaw>()
             .init_resource::<GamepadSettings>()
             .init_resource::<Input<GamepadButton>>()
             .init_resource::<Axis<GamepadAxis>>()
             .init_resource::<Axis<GamepadButton>>()
-            .add_system_to_stage(bevy_app::stage::EVENT, gamepad_event_system)
-            .add_startup_system_to_stage(bevy_app::startup_stage::STARTUP, gamepad_event_system)
+            .add_system_to_stage(bevy_app::stage::EVENT, gamepad_event_system.system())
+            .add_startup_system_to_stage(
+                bevy_app::startup_stage::STARTUP,
+                gamepad_event_system.system(),
+            )
             .add_event::<TouchInput>()
             .init_resource::<Touches>()
-            .add_system_to_stage(bevy_app::stage::EVENT, touch_screen_input_system);
+            .add_system_to_stage(bevy_app::stage::EVENT, touch_screen_input_system.system());
     }
 }
 

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -4,6 +4,7 @@ mod entity;
 mod light;
 mod material;
 
+use bevy_ecs::IntoSystem;
 pub use entity::*;
 pub use light::*;
 pub use material::*;
@@ -29,7 +30,7 @@ impl Plugin for PbrPlugin {
             .register_type::<Light>()
             .add_system_to_stage(
                 stage::POST_UPDATE,
-                shader::asset_shader_defs_system::<StandardMaterial>,
+                shader::asset_shader_defs_system::<StandardMaterial>.system(),
             )
             .init_resource::<AmbientLight>();
         let resources = app.resources();

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -147,9 +147,6 @@ pub struct DrawContext<'a> {
     pub current_pipeline: Option<Handle<PipelineDescriptor>>,
 }
 
-#[derive(Debug)]
-pub struct FetchDrawContext;
-
 impl<'a> DrawContext<'a> {
     pub fn get_uniform_buffer<T: RenderResource>(
         &mut self,

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -11,7 +11,7 @@ pub mod renderer;
 pub mod shader;
 pub mod texture;
 
-use bevy_ecs::SystemStage;
+use bevy_ecs::{IntoSystem, SystemStage};
 use bevy_reflect::RegisterTypeBuilder;
 use draw::Visible;
 pub use once_cell;
@@ -136,30 +136,48 @@ impl Plugin for RenderPlugin {
         .init_resource::<TextureResourceSystemState>()
         .init_resource::<AssetRenderResourceBindings>()
         .init_resource::<ActiveCameras>()
-        .add_system_to_stage(bevy_app::stage::PRE_UPDATE, draw::clear_draw_system)
-        .add_system_to_stage(bevy_app::stage::POST_UPDATE, camera::active_cameras_system)
         .add_system_to_stage(
-            bevy_app::stage::POST_UPDATE,
-            camera::camera_system::<OrthographicProjection>,
+            bevy_app::stage::PRE_UPDATE,
+            draw::clear_draw_system.system(),
         )
         .add_system_to_stage(
             bevy_app::stage::POST_UPDATE,
-            camera::camera_system::<PerspectiveProjection>,
+            camera::active_cameras_system.system(),
+        )
+        .add_system_to_stage(
+            bevy_app::stage::POST_UPDATE,
+            camera::camera_system::<OrthographicProjection>.system(),
+        )
+        .add_system_to_stage(
+            bevy_app::stage::POST_UPDATE,
+            camera::camera_system::<PerspectiveProjection>.system(),
         )
         // registration order matters here. this must come after all camera_system::<T> systems
         .add_system_to_stage(
             bevy_app::stage::POST_UPDATE,
-            camera::visible_entities_system,
+            camera::visible_entities_system.system(),
         )
-        .add_system_to_stage(stage::RENDER_RESOURCE, shader::shader_update_system)
-        .add_system_to_stage(stage::RENDER_RESOURCE, mesh::mesh_resource_provider_system)
-        .add_system_to_stage(stage::RENDER_RESOURCE, Texture::texture_resource_system)
+        .add_system_to_stage(
+            stage::RENDER_RESOURCE,
+            shader::shader_update_system.system(),
+        )
+        .add_system_to_stage(
+            stage::RENDER_RESOURCE,
+            mesh::mesh_resource_provider_system.system(),
+        )
+        .add_system_to_stage(
+            stage::RENDER_RESOURCE,
+            Texture::texture_resource_system.system(),
+        )
         .add_system_to_stage(
             stage::RENDER_GRAPH_SYSTEMS,
-            render_graph::render_graph_schedule_executor_system,
+            render_graph::render_graph_schedule_executor_system.system(),
         )
-        .add_system_to_stage(stage::DRAW, pipeline::draw_render_pipelines_system)
-        .add_system_to_stage(stage::POST_RENDER, shader::clear_shader_defs_system);
+        .add_system_to_stage(stage::DRAW, pipeline::draw_render_pipelines_system.system())
+        .add_system_to_stage(
+            stage::POST_RENDER,
+            shader::clear_shader_defs_system.system(),
+        );
 
         if app.resources().get::<Msaa>().is_none() {
             app.init_resource::<Msaa>();

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -5,7 +5,7 @@ mod scene_loader;
 mod scene_spawner;
 pub mod serde;
 
-use bevy_ecs::SystemStage;
+use bevy_ecs::{IntoSystem, SystemStage};
 pub use command::*;
 pub use dynamic_scene::*;
 pub use scene::*;
@@ -33,6 +33,6 @@ impl Plugin for ScenePlugin {
             .init_asset_loader::<SceneLoader>()
             .init_resource::<SceneSpawner>()
             .add_stage_after(stage::EVENT, SCENE_STAGE, SystemStage::parallel())
-            .add_system_to_stage(SCENE_STAGE, scene_spawner_system);
+            .add_system_to_stage(SCENE_STAGE, scene_spawner_system.system());
     }
 }

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -9,6 +9,7 @@ mod sprite;
 mod texture_atlas;
 mod texture_atlas_builder;
 
+use bevy_ecs::IntoSystem;
 pub use color_material::*;
 pub use dynamic_texture_atlas_builder::*;
 pub use rect::*;
@@ -46,10 +47,10 @@ impl Plugin for SpritePlugin {
         app.add_asset::<ColorMaterial>()
             .add_asset::<TextureAtlas>()
             .register_type::<Sprite>()
-            .add_system_to_stage(stage::POST_UPDATE, sprite_system)
+            .add_system_to_stage(stage::POST_UPDATE, sprite_system.system())
             .add_system_to_stage(
                 stage::POST_UPDATE,
-                asset_shader_defs_system::<ColorMaterial>,
+                asset_shader_defs_system::<ColorMaterial>.system(),
             );
 
         let resources = app.resources_mut();

--- a/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
@@ -71,7 +71,7 @@ pub fn parent_update_system(
 mod test {
     use super::*;
     use crate::{hierarchy::BuildChildren, transform_propagate_system::transform_propagate_system};
-    use bevy_ecs::{Resources, Schedule, SystemStage, World};
+    use bevy_ecs::{IntoSystem, Resources, Schedule, SystemStage, World};
     use bevy_math::Vec3;
 
     #[test]
@@ -80,8 +80,8 @@ mod test {
         let mut resources = Resources::default();
 
         let mut update_stage = SystemStage::parallel();
-        update_stage.add_system(parent_update_system);
-        update_stage.add_system(transform_propagate_system);
+        update_stage.add_system(parent_update_system.system());
+        update_stage.add_system(transform_propagate_system.system());
 
         let mut schedule = Schedule::default();
         schedule.add_stage("update", update_stage);

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -7,6 +7,7 @@ pub mod prelude {
 }
 
 use bevy_app::{prelude::*, startup_stage};
+use bevy_ecs::IntoSystem;
 use bevy_reflect::RegisterTypeBuilder;
 use prelude::{parent_update_system, Children, GlobalTransform, Parent, PreviousParent, Transform};
 
@@ -21,15 +22,15 @@ impl Plugin for TransformPlugin {
             .register_type::<Transform>()
             .register_type::<GlobalTransform>()
             // add transform systems to startup so the first update is "correct"
-            .add_startup_system_to_stage(startup_stage::POST_STARTUP, parent_update_system)
+            .add_startup_system_to_stage(startup_stage::POST_STARTUP, parent_update_system.system())
             .add_startup_system_to_stage(
                 startup_stage::POST_STARTUP,
-                transform_propagate_system::transform_propagate_system,
+                transform_propagate_system::transform_propagate_system.system(),
             )
-            .add_system_to_stage(stage::POST_UPDATE, parent_update_system)
+            .add_system_to_stage(stage::POST_UPDATE, parent_update_system.system())
             .add_system_to_stage(
                 stage::POST_UPDATE,
-                transform_propagate_system::transform_propagate_system,
+                transform_propagate_system::transform_propagate_system.system(),
             );
     }
 }

--- a/crates/bevy_transform/src/transform_propagate_system.rs
+++ b/crates/bevy_transform/src/transform_propagate_system.rs
@@ -80,8 +80,8 @@ mod test {
         let mut resources = Resources::default();
 
         let mut update_stage = SystemStage::parallel();
-        update_stage.add_system(parent_update_system);
-        update_stage.add_system(transform_propagate_system);
+        update_stage.add_system(parent_update_system.system());
+        update_stage.add_system(transform_propagate_system.system());
 
         let mut schedule = Schedule::default();
         schedule.add_stage("update", update_stage);
@@ -133,8 +133,8 @@ mod test {
         let mut resources = Resources::default();
 
         let mut update_stage = SystemStage::parallel();
-        update_stage.add_system(parent_update_system);
-        update_stage.add_system(transform_propagate_system);
+        update_stage.add_system(parent_update_system.system());
+        update_stage.add_system(transform_propagate_system.system());
 
         let mut schedule = Schedule::default();
         schedule.add_stage("update", update_stage);

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -25,7 +25,7 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
-use bevy_ecs::SystemStage;
+use bevy_ecs::{IntoSystem, SystemStage};
 use bevy_render::render_graph::RenderGraph;
 use update::ui_z_system;
 
@@ -44,13 +44,13 @@ impl Plugin for UiPlugin {
                 stage::UI,
                 SystemStage::parallel(),
             )
-            .add_system_to_stage(bevy_app::stage::PRE_UPDATE, ui_focus_system)
+            .add_system_to_stage(bevy_app::stage::PRE_UPDATE, ui_focus_system.system())
             // add these stages to front because these must run before transform update systems
-            .add_system_to_stage(stage::UI, widget::text_system)
-            .add_system_to_stage(stage::UI, widget::image_node_system)
-            .add_system_to_stage(stage::UI, ui_z_system)
-            .add_system_to_stage(stage::UI, flex_node_system)
-            .add_system_to_stage(bevy_render::stage::DRAW, widget::draw_text_system);
+            .add_system_to_stage(stage::UI, widget::text_system.system())
+            .add_system_to_stage(stage::UI, widget::image_node_system.system())
+            .add_system_to_stage(stage::UI, ui_z_system.system())
+            .add_system_to_stage(stage::UI, flex_node_system.system())
+            .add_system_to_stage(bevy_render::stage::DRAW, widget::draw_text_system.system());
 
         let resources = app.resources();
         let mut render_graph = resources.get_mut::<RenderGraph>().unwrap();

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -48,7 +48,7 @@ fn update_hierarchy(
 }
 #[cfg(test)]
 mod tests {
-    use bevy_ecs::{Commands, Resources, Schedule, SystemStage, World};
+    use bevy_ecs::{Commands, IntoSystem, Resources, Schedule, SystemStage, World};
     use bevy_transform::{components::Transform, hierarchy::BuildChildren};
 
     use crate::Node;
@@ -116,7 +116,7 @@ mod tests {
 
         let mut schedule = Schedule::default();
         let mut update_stage = SystemStage::parallel();
-        update_stage.add_system(ui_z_system);
+        update_stage.add_system(ui_z_system.system());
         schedule.add_stage("update", update_stage);
         schedule.initialize_and_run(&mut world, &mut resources);
 

--- a/crates/bevy_wgpu/src/diagnostic/wgpu_resource_diagnostics_plugin.rs
+++ b/crates/bevy_wgpu/src/diagnostic/wgpu_resource_diagnostics_plugin.rs
@@ -1,7 +1,7 @@
 use crate::renderer::WgpuRenderResourceContext;
 use bevy_app::prelude::*;
 use bevy_diagnostic::{Diagnostic, DiagnosticId, Diagnostics};
-use bevy_ecs::{Res, ResMut};
+use bevy_ecs::{IntoSystem, Res, ResMut};
 use bevy_render::renderer::RenderResourceContext;
 
 #[derive(Default)]
@@ -9,8 +9,8 @@ pub struct WgpuResourceDiagnosticsPlugin;
 
 impl Plugin for WgpuResourceDiagnosticsPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app.add_startup_system(Self::setup_system)
-            .add_system(Self::diagnostic_system);
+        app.add_startup_system(Self::setup_system.system())
+            .add_system(Self::diagnostic_system.system());
     }
 }
 

--- a/crates/bevy_wgpu/src/lib.rs
+++ b/crates/bevy_wgpu/src/lib.rs
@@ -11,7 +11,7 @@ pub use wgpu_renderer::*;
 pub use wgpu_resources::*;
 
 use bevy_app::prelude::*;
-use bevy_ecs::{Resources, World};
+use bevy_ecs::{IntoSystem, Resources, World};
 use bevy_render::renderer::{shared_buffers_update_system, RenderResourceContext, SharedBuffers};
 use renderer::WgpuRenderResourceContext;
 
@@ -21,10 +21,10 @@ pub struct WgpuPlugin;
 impl Plugin for WgpuPlugin {
     fn build(&self, app: &mut AppBuilder) {
         let render_system = get_wgpu_render_system(app.resources_mut());
-        app.add_system_to_stage(bevy_render::stage::RENDER, render_system)
+        app.add_system_to_stage(bevy_render::stage::RENDER, render_system.system())
             .add_system_to_stage(
                 bevy_render::stage::POST_RENDER,
-                shared_buffers_update_system,
+                shared_buffers_update_system.system(),
             );
     }
 }

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -3,6 +3,7 @@ mod system;
 mod window;
 mod windows;
 
+use bevy_ecs::IntoSystem;
 pub use event::*;
 pub use system::*;
 pub use window::*;
@@ -59,7 +60,7 @@ impl Plugin for WindowPlugin {
         }
 
         if self.exit_on_close {
-            app.add_system(exit_on_window_close_system);
+            app.add_system(exit_on_window_close_system.system());
         }
     }
 }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -10,7 +10,7 @@ pub use winit_config::*;
 pub use winit_windows::*;
 
 use bevy_app::{prelude::*, AppExit};
-use bevy_ecs::{Resources, World};
+use bevy_ecs::{IntoSystem, Resources, World};
 use bevy_math::Vec2;
 use bevy_utils::tracing::{error, trace};
 use bevy_window::{
@@ -29,7 +29,7 @@ impl Plugin for WinitPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.init_resource::<WinitWindows>()
             .set_runner(winit_runner)
-            .add_system(change_window);
+            .add_system(change_window.system());
     }
 }
 

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -9,11 +9,11 @@ use std::{
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(velocity_system)
-        .add_system(move_system)
-        .add_system(collision_system)
-        .add_system(select_system)
+        .add_startup_system(setup.system())
+        .add_system(velocity_system.system())
+        .add_system(move_system.system())
+        .add_system(collision_system.system())
+        .add_system(select_system.system())
         .run();
 }
 

--- a/examples/2d/sprite.rs
+++ b/examples/2d/sprite.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -3,8 +3,8 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(animate_sprite_system)
+        .add_startup_system(setup.system())
+        .add_system(animate_sprite_system.system())
         .run();
 }
 

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -7,9 +7,9 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_resource(State::new(AppState::Setup))
         .add_stage_after(stage::UPDATE, STAGE, StateStage::<AppState>::default())
-        .on_state_enter(STAGE, AppState::Setup, load_textures)
-        .on_state_update(STAGE, AppState::Setup, check_textures)
-        .on_state_enter(STAGE, AppState::Finshed, setup)
+        .on_state_enter(STAGE, AppState::Setup, load_textures.system())
+        .on_state_update(STAGE, AppState::Setup, check_textures.system())
+        .on_state_enter(STAGE, AppState::Finshed, setup.system())
         .run();
 }
 

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -4,7 +4,7 @@ fn main() {
     App::build()
         .add_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -4,7 +4,7 @@ fn main() {
     App::build()
         .add_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -7,7 +7,7 @@ fn main() {
     App::build()
         .add_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -6,8 +6,8 @@ fn main() {
     App::build()
         .add_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(rotator_system)
+        .add_startup_system(setup.system())
+        .add_system(rotator_system.system())
         .run();
 }
 

--- a/examples/3d/spawner.rs
+++ b/examples/3d/spawner.rs
@@ -13,8 +13,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(PrintDiagnosticsPlugin::default())
-        .add_startup_system(setup)
-        .add_system(move_cubes)
+        .add_startup_system(setup.system())
+        .add_system(move_cubes.system())
         .run();
 }
 

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/3d/z_sort_debug.rs
+++ b/examples/3d/z_sort_debug.rs
@@ -10,9 +10,9 @@ use bevy::{
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(rotator_system)
-        .add_system(camera_order_color_system)
+        .add_startup_system(setup.system())
+        .add_system(rotator_system.system())
+        .add_system(camera_order_color_system.system())
         .run();
 }
 

--- a/examples/android/android.rs
+++ b/examples/android/android.rs
@@ -6,7 +6,7 @@ fn main() {
     App::build()
         .add_resource(Msaa { samples: 2 })
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/app/custom_loop.rs
+++ b/examples/app/custom_loop.rs
@@ -24,6 +24,6 @@ fn main() {
     App::build()
         .add_resource(Input(String::new()))
         .set_runner(my_runner)
-        .add_system(print_system)
+        .add_system(print_system.system())
         .run();
 }

--- a/examples/app/headless.rs
+++ b/examples/app/headless.rs
@@ -13,7 +13,7 @@ fn main() {
     App::build()
         .add_resource(ScheduleRunnerSettings::run_once())
         .add_plugins(MinimalPlugins)
-        .add_system(hello_world_system)
+        .add_system(hello_world_system.system())
         .run();
 
     // this app loops forever at 60 fps
@@ -22,7 +22,7 @@ fn main() {
             1.0 / 60.0,
         )))
         .add_plugins(MinimalPlugins)
-        .add_system(counter)
+        .add_system(counter.system())
         .run();
 }
 

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -9,7 +9,7 @@ fn main() {
         //     filter: "wgpu=warn,bevy_ecs=info".to_string(),
         // })
         .add_plugins(DefaultPlugins)
-        .add_system(log_system)
+        .add_system(log_system.system())
         .run();
 }
 

--- a/examples/app/plugin.rs
+++ b/examples/app/plugin.rs
@@ -28,7 +28,8 @@ impl Plugin for PrintMessagePlugin {
             message: self.message.clone(),
             timer: Timer::new(self.wait_duration, true),
         };
-        app.add_resource(state).add_system(print_message_system);
+        app.add_resource(state)
+            .add_system(print_message_system.system());
     }
 }
 

--- a/examples/app/plugin_group.rs
+++ b/examples/app/plugin_group.rs
@@ -29,7 +29,7 @@ pub struct PrintHelloPlugin;
 
 impl Plugin for PrintHelloPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app.add_system(print_hello_system);
+        app.add_system(print_hello_system.system());
     }
 }
 
@@ -41,7 +41,7 @@ pub struct PrintWorldPlugin;
 
 impl Plugin for PrintWorldPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app.add_system(print_world_system);
+        app.add_system(print_world_system.system());
     }
 }
 

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -5,7 +5,7 @@ fn main() {
     App::build()
         .add_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/asset/custom_asset.rs
+++ b/examples/asset/custom_asset.rs
@@ -39,8 +39,8 @@ fn main() {
         .init_resource::<State>()
         .add_asset::<CustomAsset>()
         .init_asset_loader::<CustomAssetLoader>()
-        .add_startup_system(setup)
-        .add_system(print_on_load)
+        .add_startup_system(setup.system())
+        .add_system(print_on_load.system())
         .run();
 }
 

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/audio/audio.rs
+++ b/examples/audio/audio.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/diagnostics/custom_diagnostic.rs
+++ b/examples/diagnostics/custom_diagnostic.rs
@@ -9,8 +9,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // The "print diagnostics" plugin is optional. It just visualizes our diagnostics in the console
         .add_plugin(PrintDiagnosticsPlugin::default())
-        .add_startup_system(setup_diagnostic_system)
-        .add_system(my_system)
+        .add_startup_system(setup_diagnostic_system.system())
+        .add_system(my_system.system())
         .run();
 }
 

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -257,9 +257,9 @@ fn main() {
         .init_resource::<GameState>()
         // Startup systems run exactly once BEFORE all other systems. These are generally used for
         // app initialization code (ex: adding entities and resources)
-        .add_startup_system(startup_system)
+        .add_startup_system(startup_system.system())
         // my_system calls converts normal rust functions into ECS systems:
-        .add_system(print_message_system)
+        .add_system(print_message_system.system())
         //
         // SYSTEM EXECUTION ORDER
         //
@@ -278,17 +278,17 @@ fn main() {
         // and the next stage won't start until all systems in the current stage have finished.
         // add_system(system) adds systems to the UPDATE stage by default
         // However we can manually specify the stage if we want to. The following is equivalent to add_system(score_system)
-        .add_system_to_stage(stage::UPDATE, score_system)
+        .add_system_to_stage(stage::UPDATE, score_system.system())
         // We can also create new stages. Here is what our games stage order will look like:
         // "before_round": new_player_system, new_round_system
         // "update": print_message_system, score_system
         // "after_round": score_check_system, game_over_system
         .add_stage_before(stage::UPDATE, "before_round", SystemStage::parallel())
         .add_stage_after(stage::UPDATE, "after_round", SystemStage::parallel())
-        .add_system_to_stage("before_round", new_round_system)
-        .add_system_to_stage("before_round", new_player_system)
-        .add_system_to_stage("after_round", score_check_system)
-        .add_system_to_stage("after_round", game_over_system)
+        .add_system_to_stage("before_round", new_round_system.system())
+        .add_system_to_stage("before_round", new_player_system.system())
+        .add_system_to_stage("after_round", score_check_system.system())
+        .add_system_to_stage("after_round", game_over_system.system())
         // score_check_system will run before game_over_system because score_check_system modifies GameState and game_over_system
         // reads GameState. This works, but it's a bit confusing. In practice, it would be clearer to create a new stage that runs
         // before "after_round"

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -7,8 +7,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_event::<MyEvent>()
         .init_resource::<EventTriggerState>()
-        .add_system(event_trigger_system)
-        .add_system(event_listener_system)
+        .add_system(event_trigger_system.system())
+        .add_system(event_listener_system.system())
         .run();
 }
 

--- a/examples/ecs/fixed_timestep.rs
+++ b/examples/ecs/fixed_timestep.rs
@@ -9,7 +9,7 @@ fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         // this system will run once every update (it should match your screen's refresh rate)
-        .add_system(update)
+        .add_system(update.system())
         // add a new stage that runs every two seconds
         .add_stage_after(
             stage::UPDATE,
@@ -20,7 +20,7 @@ fn main() {
                         // labels are optional. they provide a way to access the current FixedTimestep state from within a system
                         .with_label(LABEL),
                 )
-                .with_system(fixed_update),
+                .with_system(fixed_update.system()),
         )
         .run();
 }

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -3,8 +3,8 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(rotate)
+        .add_startup_system(setup.system())
+        .add_system(rotate.system())
         .run();
 }
 

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -74,8 +74,8 @@ fn bounce_system(
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(spawn_system)
-        .add_system(move_system)
-        .add_system(bounce_system)
+        .add_startup_system(spawn_system.system())
+        .add_system(move_system.system())
+        .add_system(bounce_system.system())
         .run();
 }

--- a/examples/ecs/startup_system.rs
+++ b/examples/ecs/startup_system.rs
@@ -2,8 +2,8 @@ use bevy::prelude::*;
 
 fn main() {
     App::build()
-        .add_startup_system(startup_system)
-        .add_system(normal_system)
+        .add_startup_system(startup_system.system())
+        .add_system(normal_system.system())
         .run();
 }
 

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -7,12 +7,12 @@ fn main() {
         .init_resource::<ButtonMaterials>()
         .add_resource(State::new(AppState::Menu))
         .add_stage_after(stage::UPDATE, STAGE, StateStage::<AppState>::default())
-        .on_state_enter(STAGE, AppState::Menu, setup_menu)
-        .on_state_update(STAGE, AppState::Menu, menu)
-        .on_state_exit(STAGE, AppState::Menu, cleanup_menu)
-        .on_state_enter(STAGE, AppState::InGame, setup_game)
-        .on_state_update(STAGE, AppState::InGame, movement)
-        .on_state_update(STAGE, AppState::InGame, change_color)
+        .on_state_enter(STAGE, AppState::Menu, setup_menu.system())
+        .on_state_update(STAGE, AppState::Menu, menu.system())
+        .on_state_exit(STAGE, AppState::Menu, cleanup_menu.system())
+        .on_state_enter(STAGE, AppState::InGame, setup_game.system())
+        .on_state_update(STAGE, AppState::InGame, movement.system())
+        .on_state_update(STAGE, AppState::InGame, change_color.system())
         .run();
 }
 

--- a/examples/ecs/system_chaining.rs
+++ b/examples/ecs/system_chaining.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_resource(Message("42".to_string()))
-        .add_system(parse_message_system.chain(handler_system))
+        .add_system(parse_message_system.system().chain(handler_system.system()))
         .run();
 }
 

--- a/examples/ecs/timers.rs
+++ b/examples/ecs/timers.rs
@@ -4,9 +4,9 @@ fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .add_resource(Countdown::default())
-        .add_startup_system(setup_system)
-        .add_system(countdown_system)
-        .add_system(timer_system)
+        .add_startup_system(setup_system.system())
+        .add_system(countdown_system.system())
+        .add_system(timer_system.system())
         .run();
 }
 

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -10,11 +10,11 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_resource(Scoreboard { score: 0 })
         .add_resource(ClearColor(Color::rgb(0.9, 0.9, 0.9)))
-        .add_startup_system(setup)
-        .add_system(paddle_movement_system)
-        .add_system(ball_collision_system)
-        .add_system(ball_movement_system)
-        .add_system(scoreboard_system)
+        .add_startup_system(setup.system())
+        .add_system(paddle_movement_system.system())
+        .add_system(ball_collision_system.system())
+        .add_system(ball_movement_system.system())
+        .add_system(scoreboard_system.system())
         .run();
 }
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
 fn main() {
-    App::build().add_system(hello_world_system).run();
+    App::build().add_system(hello_world_system.system()).run();
 }
 
 fn hello_world_system() {

--- a/examples/input/char_input_events.rs
+++ b/examples/input/char_input_events.rs
@@ -3,7 +3,7 @@ use bevy::{prelude::*, window::ReceivedCharacter};
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_system(print_char_event_system)
+        .add_system(print_char_event_system.system())
         .run();
 }
 

--- a/examples/input/gamepad_input.rs
+++ b/examples/input/gamepad_input.rs
@@ -8,8 +8,8 @@ fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .init_resource::<GamepadLobby>()
-        .add_system_to_stage(stage::PRE_UPDATE, connection_system)
-        .add_system(gamepad_system)
+        .add_system_to_stage(stage::PRE_UPDATE, connection_system.system())
+        .add_system(gamepad_system.system())
         .run();
 }
 

--- a/examples/input/gamepad_input_events.rs
+++ b/examples/input/gamepad_input_events.rs
@@ -6,7 +6,7 @@ use bevy::{
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_system(gamepad_events)
+        .add_system(gamepad_events.system())
         .run();
 }
 

--- a/examples/input/keyboard_input.rs
+++ b/examples/input/keyboard_input.rs
@@ -6,7 +6,7 @@ use bevy::{
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_system(keyboard_input_system)
+        .add_system(keyboard_input_system.system())
         .run();
 }
 

--- a/examples/input/keyboard_input_events.rs
+++ b/examples/input/keyboard_input_events.rs
@@ -3,7 +3,7 @@ use bevy::{input::keyboard::KeyboardInput, prelude::*};
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_system(print_keyboard_event_system)
+        .add_system(print_keyboard_event_system.system())
         .run();
 }
 

--- a/examples/input/mouse_input.rs
+++ b/examples/input/mouse_input.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_system(mouse_click_system)
+        .add_system(mouse_click_system.system())
         .run();
 }
 

--- a/examples/input/mouse_input_events.rs
+++ b/examples/input/mouse_input_events.rs
@@ -7,7 +7,7 @@ use bevy::{
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_system(print_mouse_events_system)
+        .add_system(print_mouse_events_system.system())
         .run();
 }
 

--- a/examples/input/touch_input.rs
+++ b/examples/input/touch_input.rs
@@ -3,7 +3,7 @@ use bevy::{input::touch::*, prelude::*};
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_system(touch_system)
+        .add_system(touch_system.system())
         .run();
 }
 

--- a/examples/input/touch_input_events.rs
+++ b/examples/input/touch_input_events.rs
@@ -3,7 +3,7 @@ use bevy::{input::touch::*, prelude::*};
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_system(touch_event_system)
+        .add_system(touch_event_system.system())
         .run();
 }
 

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -12,7 +12,7 @@ fn main() {
         })
         .add_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 /// set up a simple 3D scene

--- a/examples/reflection/generic_reflection.rs
+++ b/examples/reflection/generic_reflection.rs
@@ -8,7 +8,7 @@ fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .register_type::<MyType<u32>>()
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/reflection/reflection.rs
+++ b/examples/reflection/reflection.rs
@@ -15,7 +15,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .register_type::<Foo>()
         .register_type::<Bar>()
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/reflection/trait_reflection.rs
+++ b/examples/reflection/trait_reflection.rs
@@ -3,7 +3,7 @@ use bevy::{prelude::*, reflect::TypeRegistry};
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .register_type::<MyType>()
         .run();
 }

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -6,10 +6,10 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .register_type::<ComponentA>()
         .register_type::<ComponentB>()
-        .add_startup_system(save_scene_system)
-        .add_startup_system(load_scene_system)
-        .add_startup_system(infotext_system)
-        .add_system(print_system)
+        .add_startup_system(save_scene_system.system())
+        .add_startup_system(load_scene_system.system())
+        .add_startup_system(infotext_system.system())
+        .add_system(print_system.system())
         .run();
 }
 

--- a/examples/shader/hot_shader_reloading.rs
+++ b/examples/shader/hot_shader_reloading.rs
@@ -16,7 +16,7 @@ fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .add_asset::<MyMaterial>()
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/shader/mesh_custom_attribute.rs
+++ b/examples/shader/mesh_custom_attribute.rs
@@ -15,7 +15,7 @@ fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .add_asset::<MyMaterialWithVertexColorSupport>()
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/shader/shader_custom_material.rs
+++ b/examples/shader/shader_custom_material.rs
@@ -15,7 +15,7 @@ fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .add_asset::<MyMaterial>()
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -16,8 +16,11 @@ fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .add_asset::<MyMaterial>()
-        .add_startup_system(setup)
-        .add_system_to_stage(stage::POST_UPDATE, asset_shader_defs_system::<MyMaterial>)
+        .add_startup_system(setup.system())
+        .add_system_to_stage(
+            stage::POST_UPDATE,
+            asset_shader_defs_system::<MyMaterial>.system(),
+        )
         .run();
 }
 

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -40,11 +40,11 @@ fn main() {
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_resource(BevyCounter { count: 0 })
         .init_resource::<BirdMaterial>()
-        .add_startup_system(setup)
-        .add_system(mouse_handler)
-        .add_system(movement_system)
-        .add_system(collision_system)
-        .add_system(counter_system)
+        .add_startup_system(setup.system())
+        .add_system(mouse_handler.system())
+        .add_system(movement_system.system())
+        .add_system(collision_system.system())
+        .add_system(counter_system.system())
         .run();
 }
 

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -5,8 +5,8 @@ fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .init_resource::<ButtonMaterials>()
-        .add_startup_system(setup)
-        .add_system(button_system)
+        .add_startup_system(setup.system())
+        .add_system(button_system.system())
         .run();
 }
 

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -5,9 +5,9 @@ fn main() {
     App::build()
         .init_resource::<State>()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(text_update_system)
-        .add_system(atlas_render_system)
+        .add_startup_system(setup.system())
+        .add_system(text_update_system.system())
+        .add_system(atlas_render_system.system())
         .run();
 }
 

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -8,8 +8,8 @@ fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
-        .add_startup_system(setup)
-        .add_system(text_update_system)
+        .add_startup_system(setup.system())
+        .add_system(text_update_system.system())
         .run();
 }
 

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -12,8 +12,8 @@ fn main() {
         })
         .add_plugins(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin)
-        .add_startup_system(infotext_system)
-        .add_system(change_text_system)
+        .add_startup_system(infotext_system.system())
+        .add_system(change_text_system.system())
         .run();
 }
 

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/wasm/assets_wasm.rs
+++ b/examples/wasm/assets_wasm.rs
@@ -13,8 +13,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_asset::<RustSourceCode>()
         .init_asset_loader::<RustSourceCodeLoader>()
-        .add_startup_system(load_asset)
-        .add_system(print_asset)
+        .add_startup_system(load_asset.system())
+        .add_system(print_asset.system())
         .run();
 }
 

--- a/examples/wasm/headless_wasm.rs
+++ b/examples/wasm/headless_wasm.rs
@@ -12,8 +12,8 @@ fn main() {
         )))
         .add_plugin(ScheduleRunnerPlugin::default())
         .add_plugin(LogPlugin::default())
-        .add_startup_system(hello_world_system)
-        .add_system(counter)
+        .add_startup_system(hello_world_system.system())
+        .add_system(counter.system())
         .run();
 }
 

--- a/examples/wasm/hello_wasm.rs
+++ b/examples/wasm/hello_wasm.rs
@@ -3,7 +3,7 @@ use bevy::{log::LogPlugin, prelude::*};
 fn main() {
     App::build()
         .add_plugin(LogPlugin::default())
-        .add_system(hello_wasm_system)
+        .add_system(hello_wasm_system.system())
         .run();
 }
 

--- a/examples/wasm/winit_wasm.rs
+++ b/examples/wasm/winit_wasm.rs
@@ -15,12 +15,12 @@ fn main() {
         })
         .add_plugins(DefaultPlugins)
         // One time greet
-        .add_startup_system(hello_wasm_system)
+        .add_startup_system(hello_wasm_system.system())
         // Track ticks (sanity check, whether game loop is running)
-        .add_system(counter)
+        .add_system(counter.system())
         // Track input events
         .init_resource::<TrackInputState>()
-        .add_system(track_input_events)
+        .add_system(track_input_events.system())
         .run();
 }
 

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -17,7 +17,7 @@ fn main() {
     App::build()
         .add_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_startup_system(setup.system())
         .run();
 }
 

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -12,8 +12,8 @@ fn main() {
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)
-        .add_system(change_title)
-        .add_system(toggle_cursor)
+        .add_system(change_title.system())
+        .add_system(toggle_cursor.system())
         .run();
 }
 


### PR DESCRIPTION
Resolves #1032 

Unfortunately the SystemParam approach currently used on master suffers from a safety hole. You can annotate system parameters like `Res<'static, X>` and suddenly we have a static pointer to a non-static resource! Thats bad!

To resolve this, I have adopted a "Fetch" pattern for SystemParams (the pattern used by WorldQueries).

This accomplishes two things:
* Makes it impossible to convert a function with static references to a system
* Removes the need to hack lifetimes inside of SystemParams, making the implementation much safer.

There is one major downside to this approach. We can no longer use this syntax:

```rust
app.add_system(movement)
```

Instead we must go back to doing this:

```rust
app.add_system(movement.system())
```

Yeah yeah ... I'm not happy about it either. But safety comes first. I'm hoping we find a [magic implementation with no compromises](https://github.com/bevyengine/bevy/issues/1032#issuecomment-744973676), but until then something needs to give. And it can't be safety! 

I encourage anyone interested to play around with the "minimal" examples in the link above. Maybe you can discover an ideal implementation.