### PR TITLE
Enforce uniqueness in Children

### DIFF
--- a/crates/bevy_transform/src/components/children.rs
+++ b/crates/bevy_transform/src/components/children.rs
@@ -2,7 +2,7 @@ use bevy_ecs::{Entity, MapEntities};
 use bevy_reflect::{Reflect, ReflectComponent, ReflectMapEntities};
 use bevy_utils::HashMap;
 use smallvec::SmallVec;
-use std::{collections::hash_map::Entry, ops::Deref};
+use std::ops::Deref;
 
 #[derive(Default, Clone, Debug, Reflect)]
 #[reflect(Component, MapEntities)]

--- a/crates/bevy_transform/src/components/children.rs
+++ b/crates/bevy_transform/src/components/children.rs
@@ -1,15 +1,14 @@
-use std::collections::hash_map::Entry;
-use bevy_utils::HashMap;
 use bevy_ecs::{Entity, MapEntities};
 use bevy_reflect::{Reflect, ReflectComponent, ReflectMapEntities};
+use bevy_utils::HashMap;
 use smallvec::SmallVec;
-use std::ops::Deref;
+use std::{collections::hash_map::Entry, ops::Deref};
 
 #[derive(Default, Clone, Debug, Reflect)]
 #[reflect(Component, MapEntities)]
 pub struct Children {
     order: SmallVec<[Entity; 8]>,
-    uniqueness: HashMap<Entity, usize>
+    uniqueness: HashMap<Entity, usize>,
 }
 
 impl MapEntities for Children {
@@ -49,10 +48,10 @@ impl Children {
 
         uniqueness.entry(entity).or_insert_with(|| {
             order.push(entity);
-            order.len()-1
+            order.len() - 1
         });
 
-        let desired_index = order.len()-1;
+        let desired_index = order.len() - 1;
         let current_index = uniqueness[&entity];
         if current_index != desired_index {
             self.swap(current_index, desired_index);

--- a/crates/bevy_transform/src/components/children.rs
+++ b/crates/bevy_transform/src/components/children.rs
@@ -4,7 +4,7 @@ use bevy_utils::HashMap;
 use smallvec::SmallVec;
 use std::ops::Deref;
 
-#[derive(Default, Clone, Debug, Reflect)]
+#[derive(Default, Clone, Debug, Reflect, PartialEq, Eq)]
 #[reflect(Component, MapEntities)]
 pub struct Children {
     order: SmallVec<[Entity; 8]>,
@@ -86,8 +86,11 @@ impl Children {
     }
 
     pub(crate) fn insert(&mut self, index: usize, entities: &[Entity]) {
+        let initial_count = self.order.len();
         self.extend(entities.iter().cloned());
-        let mut desired_index = index;
+        let actually_inserted = self.order.len() - initial_count;
+        let mut desired_index =
+            (index as i32 - (entities.len() as i32 - actually_inserted as i32)).max(0) as usize;
         for entity in entities {
             let current_index = self.uniqueness[entity];
             if current_index != desired_index {

--- a/crates/bevy_transform/src/components/children.rs
+++ b/crates/bevy_transform/src/components/children.rs
@@ -1,3 +1,5 @@
+use std::collections::hash_map::Entry;
+use bevy_utils::HashMap;
 use bevy_ecs::{Entity, MapEntities};
 use bevy_reflect::{Reflect, ReflectComponent, ReflectMapEntities};
 use smallvec::SmallVec;
@@ -5,14 +7,17 @@ use std::ops::Deref;
 
 #[derive(Default, Clone, Debug, Reflect)]
 #[reflect(Component, MapEntities)]
-pub struct Children(pub(crate) SmallVec<[Entity; 8]>);
+pub struct Children {
+    order: SmallVec<[Entity; 8]>,
+    uniqueness: HashMap<Entity, usize>
+}
 
 impl MapEntities for Children {
     fn map_entities(
         &mut self,
         entity_map: &bevy_ecs::EntityMap,
     ) -> Result<(), bevy_ecs::MapEntitiesError> {
-        for entity in self.0.iter_mut() {
+        for entity in self.order.iter_mut() {
             *entity = entity_map.get(*entity)?;
         }
 
@@ -21,13 +26,81 @@ impl MapEntities for Children {
 }
 
 impl Children {
-    pub fn with(entity: &[Entity]) -> Self {
-        Self(SmallVec::from_slice(entity))
+    pub fn with(entities: &[Entity]) -> Self {
+        let mut children = Self::default();
+        for entity in entities {
+            children.push(*entity);
+        }
+        children
     }
 
     /// Swaps the child at `a_index` with the child at `b_index`
     pub fn swap(&mut self, a_index: usize, b_index: usize) {
-        self.0.swap(a_index, b_index);
+        let a_entity = self.order[a_index];
+        let b_entity = self.order[b_index];
+        self.order.swap(a_index, b_index);
+        self.uniqueness.insert(a_entity, b_index);
+        self.uniqueness.insert(b_entity, a_index);
+    }
+
+    pub(crate) fn push(&mut self, entity: Entity) {
+        let order = &mut self.order;
+        let uniqueness = &mut self.uniqueness;
+
+        uniqueness.entry(entity).or_insert_with(|| {
+            order.push(entity);
+            order.len()-1
+        });
+
+        let desired_index = order.len()-1;
+        let current_index = uniqueness[&entity];
+        if current_index != desired_index {
+            self.swap(current_index, desired_index);
+        }
+    }
+
+    pub(crate) fn retain<F: FnMut(&Entity) -> bool>(&mut self, mut f: F) {
+        let order = &mut self.order;
+        let uniqueness = &mut self.uniqueness;
+
+        let mut offset = 0;
+        order.retain(|e| {
+            if f(e) {
+                *uniqueness.get_mut(e).unwrap() -= offset;
+                true
+            } else {
+                offset += 1;
+                uniqueness.remove(e);
+                false
+            }
+        });
+    }
+
+    pub fn contains(&self, entity: &Entity) -> bool {
+        self.uniqueness.contains_key(entity)
+    }
+
+    pub(crate) fn extend<T: IntoIterator<Item = Entity>>(&mut self, iter: T) {
+        for entity in iter {
+            self.push(entity);
+        }
+    }
+
+    pub(crate) fn insert(&mut self, index: usize, entities: &[Entity]) {
+        self.extend(entities.iter().cloned());
+        let mut desired_index = index;
+        for entity in entities {
+            let current_index = self.uniqueness[entity];
+            if current_index != desired_index {
+                self.swap(current_index, desired_index);
+            }
+            desired_index += 1;
+        }
+    }
+
+    pub(crate) fn take(&mut self) -> SmallVec<[Entity; 8]> {
+        self.uniqueness.clear();
+        std::mem::take(&mut self.order)
     }
 }
 
@@ -35,6 +108,6 @@ impl Deref for Children {
     type Target = [Entity];
 
     fn deref(&self) -> &Self::Target {
-        &self.0[..]
+        &self.order[..]
     }
 }

--- a/crates/bevy_transform/src/hierarchy/child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/child_builder.rs
@@ -239,7 +239,12 @@ mod tests {
         let expected_children: SmallVec<[Entity; 8]> = smallvec![child1, child2, child3];
 
         assert_eq!(
-            world.get::<Children>(parent).unwrap().iter().cloned().collect::<SmallVec<[Entity; 8]>>(),
+            world
+                .get::<Children>(parent)
+                .unwrap()
+                .iter()
+                .cloned()
+                .collect::<SmallVec<[Entity; 8]>>(),
             expected_children
         );
         assert_eq!(*world.get::<Parent>(child1).unwrap(), Parent(parent));
@@ -275,7 +280,12 @@ mod tests {
 
         let expected_children: SmallVec<[Entity; 8]> = smallvec![child1, child2];
         assert_eq!(
-            world.get::<Children>(parent).unwrap().iter().cloned().collect::<SmallVec<[Entity; 8]>>(),
+            world
+                .get::<Children>(parent)
+                .unwrap()
+                .iter()
+                .cloned()
+                .collect::<SmallVec<[Entity; 8]>>(),
             expected_children
         );
         assert_eq!(*world.get::<Parent>(child1).unwrap(), Parent(parent));
@@ -295,7 +305,12 @@ mod tests {
 
         let expected_children: SmallVec<[Entity; 8]> = smallvec![child1, child3, child4, child2];
         assert_eq!(
-            world.get::<Children>(parent).unwrap().iter().cloned().collect::<SmallVec<[Entity; 8]>>(),
+            world
+                .get::<Children>(parent)
+                .unwrap()
+                .iter()
+                .cloned()
+                .collect::<SmallVec<[Entity; 8]>>(),
             expected_children
         );
         assert_eq!(*world.get::<Parent>(child3).unwrap(), Parent(parent));
@@ -326,10 +341,14 @@ mod tests {
         commands.push_children(parent, &[child1, child1, child2, child1]);
         commands.apply(&mut world, &mut resources);
 
-
         let expected_children: SmallVec<[Entity; 8]> = smallvec![child2, child1];
         assert_eq!(
-            world.get::<Children>(parent).unwrap().iter().cloned().collect::<SmallVec<[Entity; 8]>>(),
+            world
+                .get::<Children>(parent)
+                .unwrap()
+                .iter()
+                .cloned()
+                .collect::<SmallVec<[Entity; 8]>>(),
             expected_children
         );
 
@@ -338,7 +357,12 @@ mod tests {
 
         let expected_children: SmallVec<[Entity; 8]> = smallvec![child1, child2];
         assert_eq!(
-            world.get::<Children>(parent).unwrap().iter().cloned().collect::<SmallVec<[Entity; 8]>>(),
+            world
+                .get::<Children>(parent)
+                .unwrap()
+                .iter()
+                .cloned()
+                .collect::<SmallVec<[Entity; 8]>>(),
             expected_children
         );
     }

--- a/crates/bevy_transform/src/hierarchy/child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/child_builder.rs
@@ -193,7 +193,6 @@ mod tests {
     use super::BuildChildren;
     use crate::prelude::{Children, Parent, PreviousParent};
     use bevy_ecs::{Commands, Entity, Resources, World};
-    use smallvec::{smallvec, SmallVec};
 
     #[test]
     fn build_children() {

--- a/crates/bevy_transform/src/hierarchy/child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/child_builder.rs
@@ -17,14 +17,9 @@ impl Command for InsertChildren {
                 .unwrap();
         }
         {
-            let mut added = false;
             if let Ok(mut children) = world.get_mut::<Children>(self.parent) {
                 children.insert(self.index, &self.children);
-                added = true;
-            }
-
-            // NOTE: ideally this is just an else statement, but currently that _incorrectly_ fails borrow-checking
-            if !added {
+            } else {
                 world
                     .insert_one(self.parent, Children::with(&self.children))
                     .unwrap();
@@ -52,14 +47,9 @@ impl Command for PushChildren {
                 .unwrap();
         }
         {
-            let mut added = false;
             if let Ok(mut children) = world.get_mut::<Children>(self.parent) {
                 children.extend(self.children.iter().cloned());
-                added = true;
-            }
-
-            // NOTE: ideally this is just an else statement, but currently that _incorrectly_ fails borrow-checking
-            if !added {
+            } else {
                 world
                     .insert_one(self.parent, Children::with(&self.children))
                     .unwrap();

--- a/crates/bevy_transform/src/hierarchy/hierarchy.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy.rs
@@ -11,7 +11,7 @@ pub fn despawn_with_children_recursive(world: &mut World, entity: Entity) {
     // first, make the entity's own parent forget about it
     if let Ok(parent) = world.get::<Parent>(entity).map(|parent| parent.0) {
         if let Ok(mut children) = world.get_mut::<Children>(parent) {
-            children.0.retain(|c| *c != entity);
+            children.retain(|c| *c != entity);
         }
     }
 
@@ -22,7 +22,7 @@ pub fn despawn_with_children_recursive(world: &mut World, entity: Entity) {
 // Should only be called by `despawn_with_children_recursive`!
 fn despawn_with_children_recursive_inner(world: &mut World, entity: Entity) {
     if let Ok(mut children) = world.get_mut::<Children>(entity) {
-        for e in std::mem::take(&mut children.0) {
+        for e in children.take() {
             despawn_with_children_recursive(world, e);
         }
     }

--- a/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
@@ -15,7 +15,7 @@ pub fn parent_update_system(
     // them from the `Children` of the `PreviousParent`.
     for (entity, previous_parent) in removed_parent_query.iter() {
         if let Ok(mut previous_parent_children) = children_query.get_mut(previous_parent.0) {
-            previous_parent_children.0.retain(|e| *e != entity);
+            previous_parent_children.retain(|e| *e != entity);
             commands.remove_one::<PreviousParent>(entity);
         }
     }
@@ -33,7 +33,7 @@ pub fn parent_update_system(
 
             // Remove from `PreviousParent.Children`.
             if let Ok(mut previous_parent_children) = children_query.get_mut(previous_parent.0) {
-                (*previous_parent_children).0.retain(|e| *e != entity);
+                (*previous_parent_children).retain(|e| *e != entity);
             }
 
             // Set `PreviousParent = Parent`.
@@ -47,10 +47,10 @@ pub fn parent_update_system(
         if let Ok(mut new_parent_children) = children_query.get_mut(parent.0) {
             // This is the parent
             debug_assert!(
-                !(*new_parent_children).0.contains(&entity),
+                !(*new_parent_children).contains(&entity),
                 "children already added"
             );
-            (*new_parent_children).0.push(entity);
+            (*new_parent_children).push(entity);
         } else {
             // The parent doesn't have a children entity, lets add it
             children_additions
@@ -109,7 +109,6 @@ mod test {
             world
                 .get::<Children>(parent)
                 .unwrap()
-                .0
                 .iter()
                 .cloned()
                 .collect::<Vec<_>>(),

--- a/crates/bevy_transform/src/hierarchy/world_child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/world_child_builder.rs
@@ -22,14 +22,14 @@ impl<'a, 'b> WorldChildBuilder<'a, 'b> {
             let world = &mut self.world_builder.world;
             let mut added = false;
             if let Ok(mut children) = world.get_mut::<Children>(parent_entity) {
-                children.0.push(entity);
+                children.push(entity);
                 added = true;
             }
 
             // NOTE: ideally this is just an else statement, but currently that _incorrectly_ fails borrow-checking
             if !added {
                 world
-                    .insert_one(parent_entity, Children(smallvec::smallvec![entity]))
+                    .insert_one(parent_entity, Children::with(&[entity]))
                     .unwrap();
             }
         }

--- a/crates/bevy_transform/src/transform_propagate_system.rs
+++ b/crates/bevy_transform/src/transform_propagate_system.rs
@@ -18,7 +18,7 @@ pub fn transform_propagate_system(
         }
 
         if let Some(children) = children {
-            for child in children.0.iter() {
+            for child in children.iter() {
                 propagate_recursive(
                     &global_transform,
                     &changed_transform_query,
@@ -54,7 +54,7 @@ fn propagate_recursive(
     };
 
     if let Ok(Some(children)) = children_query.get(entity) {
-        for child in children.0.iter() {
+        for child in children.iter() {
             propagate_recursive(
                 &global_matrix,
                 changed_transform_query,


### PR DESCRIPTION
This changes the Children container to guarantee uniqueness while still keeping an order and allowing reordering.

I have taken the stance that if an Entity is re-inserted it should be moved to the position in the list it would have occupied had it actually been inserted, which potentially repositions other children. I'm not 100% sure what the least surprising behavior is. I think you could make a case that a re-inserted child should stay it it's old position instead.

This change makes operating on children slightly more expensive (except in the case of membership tests, which get cheaper). I haven't done any benchmarking but I suspect the performance changes only become relevant when an application is doing a very large amount of hierarchy manipulation. I've chosen simpler implementations in favor of more optimal one in several places so there is some clear opportunity for improvement.

This passes all existing tests and adds a small amount of additional testing specific to child duplication. It runs my personal project, which does quite a bit of hierarchy manipulation, without any problem.

@payload has a different solution to this problem in #1076 which includes more extensive tests. Even if we choose to use this version of the change I think it's worth bringing over some of @palyoad's tests.