### PR TITLE
introduce error management when updating render graph

### DIFF
--- a/crates/bevy_pbr/src/render_graph/lights_node.rs
+++ b/crates/bevy_pbr/src/render_graph/lights_node.rs
@@ -37,8 +37,9 @@ impl Node for LightsNode {
         render_context: &mut dyn RenderContext,
         _input: &ResourceSlots,
         _output: &mut ResourceSlots,
-    ) {
+    ) -> Result<(), ()> {
         self.command_queue.execute(render_context);
+        Ok(())
     }
 }
 

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -343,7 +343,8 @@ mod tests {
             _: &mut dyn RenderContext,
             _: &ResourceSlots,
             _: &mut ResourceSlots,
-        ) {
+        ) -> Result<(), ()> {
+            Ok(())
         }
     }
 
@@ -417,7 +418,8 @@ mod tests {
                 _: &mut dyn RenderContext,
                 _: &ResourceSlots,
                 _: &mut ResourceSlots,
-            ) {
+            ) -> Result<(), ()> {
+                Ok(())
             }
         }
 

--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -31,7 +31,7 @@ pub trait Node: Downcast + Send + Sync + 'static {
         render_context: &mut dyn RenderContext,
         input: &ResourceSlots,
         output: &mut ResourceSlots,
-    );
+    ) -> Result<(), ()>;
 }
 
 impl_downcast!(Node);

--- a/crates/bevy_render/src/render_graph/nodes/camera_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/camera_node.rs
@@ -38,8 +38,9 @@ impl Node for CameraNode {
         render_context: &mut dyn RenderContext,
         _input: &ResourceSlots,
         _output: &mut ResourceSlots,
-    ) {
+    ) -> Result<(), ()> {
         self.command_queue.execute(render_context);
+        Ok(())
     }
 }
 

--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -156,7 +156,7 @@ where
         render_context: &mut dyn RenderContext,
         input: &ResourceSlots,
         _output: &mut ResourceSlots,
-    ) {
+    ) -> Result<(), ()> {
         let render_resource_bindings = resources.get::<RenderResourceBindings>().unwrap();
         let pipelines = resources.get::<Assets<PipelineDescriptor>>().unwrap();
         let active_cameras = resources.get::<ActiveCameras>().unwrap();
@@ -168,8 +168,12 @@ where
                 }
             }
             if let Some(input_index) = self.color_attachment_input_indices[i] {
-                color_attachment.attachment =
-                    TextureAttachment::Id(input.get(input_index).unwrap().get_texture().unwrap());
+                if let Some(resource_id) = input.get(input_index) {
+                    color_attachment.attachment =
+                        TextureAttachment::Id(resource_id.get_texture().unwrap());
+                } else {
+                    return Err(());
+                }
             }
             if let Some(input_index) = self.color_resolve_target_indices[i] {
                 color_attachment.resolve_target = Some(TextureAttachment::Id(
@@ -335,6 +339,7 @@ where
                 }
             },
         );
+        Ok(())
     }
 }
 

--- a/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
@@ -392,8 +392,9 @@ where
         render_context: &mut dyn RenderContext,
         _input: &ResourceSlots,
         _output: &mut ResourceSlots,
-    ) {
+    ) -> Result<(), ()> {
         self.command_queue.execute(render_context);
+        Ok(())
     }
 }
 
@@ -575,8 +576,9 @@ where
         render_context: &mut dyn RenderContext,
         _input: &ResourceSlots,
         _output: &mut ResourceSlots,
-    ) {
+    ) -> Result<(), ()> {
         self.command_queue.execute(render_context);
+        Ok(())
     }
 }
 

--- a/crates/bevy_render/src/render_graph/nodes/shared_buffers_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/shared_buffers_node.rs
@@ -15,8 +15,9 @@ impl Node for SharedBuffersNode {
         render_context: &mut dyn RenderContext,
         _input: &ResourceSlots,
         _output: &mut ResourceSlots,
-    ) {
+    ) -> Result<(), ()> {
         let mut shared_buffers = resources.get_mut::<SharedBuffers>().unwrap();
         shared_buffers.apply(render_context);
+        Ok(())
     }
 }

--- a/crates/bevy_render/src/render_graph/nodes/texture_copy_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/texture_copy_node.rs
@@ -21,7 +21,7 @@ impl Node for TextureCopyNode {
         render_context: &mut dyn RenderContext,
         _input: &ResourceSlots,
         _output: &mut ResourceSlots,
-    ) {
+    ) -> Result<(), ()> {
         let texture_events = resources.get::<Events<AssetEvent<Texture>>>().unwrap();
         let textures = resources.get::<Assets<Texture>>().unwrap();
         let mut copied_textures = HashSet::new();
@@ -84,5 +84,6 @@ impl Node for TextureCopyNode {
                 AssetEvent::Removed { .. } => {}
             }
         }
+        Ok(())
     }
 }

--- a/crates/bevy_render/src/render_graph/schedule.rs
+++ b/crates/bevy_render/src/render_graph/schedule.rs
@@ -309,7 +309,8 @@ mod tests {
             _: &mut dyn RenderContext,
             _: &ResourceSlots,
             _: &mut ResourceSlots,
-        ) {
+        ) -> Result<(), ()> {
+            Ok(())
         }
     }
 

--- a/crates/bevy_wgpu/Cargo.toml
+++ b/crates/bevy_wgpu/Cargo.toml
@@ -23,6 +23,7 @@ bevy_asset = { path = "../bevy_asset", version = "0.4.0" }
 bevy_core = { path = "../bevy_core", version = "0.4.0" }
 bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.4.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.4.0" }
+bevy_log = { path = "../bevy_log", version = "0.4.0" }
 bevy_render = { path = "../bevy_render", version = "0.4.0" }
 bevy_window = { path = "../bevy_window", version = "0.4.0" }
 bevy_winit = { path = "../bevy_winit", optional = true, version = "0.4.0" }

--- a/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
+++ b/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
@@ -152,7 +152,7 @@ impl WgpuRenderResourceContext {
         let mut window_swap_chains = self.resources.window_swap_chains.write();
         let mut swap_chain_outputs = self.resources.swap_chain_frames.write();
 
-        let window_swap_chain = window_swap_chains.get_mut(&window_id).unwrap();
+        let window_swap_chain = window_swap_chains.get_mut(&window_id)?;
         let next_texture = window_swap_chain.get_current_frame().ok()?;
         let id = TextureId::new();
         swap_chain_outputs.insert(id, next_texture);


### PR DESCRIPTION
fixes #1069 

while investigating this issue, it seems to be:
- creating a new window is done through an event that is treated asynchronously, at the beginning of a frame
- updating the render graph to use it is done synchronously in the current frame

I tried fixing it by calling `handle_create_window_events` more often or at the appropriate time, but it's hard due to the fact it has a `event_loop` param.

The other way to fix this is to make the render graph more error resilient.

To do this, the `update` function of a node now returns a `Result<(),()>`, and the graph will just ignore errors. Similarly, the various `panic!` calls in the loop have been replaced by a `warning!` and a `break` to continue to the next node.

If this approach to fix the issue is taken, there is still to do:
* the warning messages are useless as the user can't really do anything about them
* the `Result<(),()>` type should use at least a real error type
* there may be a few cases where `panic!` is actually a better behaviour, I'm not sure how to identify them