### PR TITLE
Fix example return_after_run

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -73,12 +73,14 @@ impl Plugin for LogPlugin {
                     .build();
                 app.resources_mut().insert_thread_local(guard);
                 let subscriber = subscriber.with(chrome_layer);
-                let _ = bevy_utils::tracing::subscriber::set_global_default(subscriber);
+                bevy_utils::tracing::subscriber::set_global_default(subscriber)
+                    .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
             }
 
             #[cfg(not(feature = "tracing-chrome"))]
             {
-                let _ = bevy_utils::tracing::subscriber::set_global_default(subscriber);
+                bevy_utils::tracing::subscriber::set_global_default(subscriber)
+                    .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
             }
         }
 
@@ -88,13 +90,15 @@ impl Plugin for LogPlugin {
             let subscriber = subscriber.with(tracing_wasm::WASMLayer::new(
                 tracing_wasm::WASMLayerConfig::default(),
             ));
-            let _ = bevy_utils::tracing::subscriber::set_global_default(subscriber);
+            bevy_utils::tracing::subscriber::set_global_default(subscriber)
+                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
         }
 
         #[cfg(target_os = "android")]
         {
             let subscriber = subscriber.with(android_tracing::AndroidLayer::default());
-            let _ = bevy_utils::tracing::subscriber::set_global_default(subscriber);
+            bevy_utils::tracing::subscriber::set_global_default(subscriber)
+                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
         }
     }
 }

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -73,14 +73,12 @@ impl Plugin for LogPlugin {
                     .build();
                 app.resources_mut().insert_thread_local(guard);
                 let subscriber = subscriber.with(chrome_layer);
-                bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                    .expect("Could not set global default tracing subscriber.");
+                let _ = bevy_utils::tracing::subscriber::set_global_default(subscriber);
             }
 
             #[cfg(not(feature = "tracing-chrome"))]
             {
-                bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                    .expect("Could not set global default tracing subscriber.");
+                let _ = bevy_utils::tracing::subscriber::set_global_default(subscriber);
             }
         }
 
@@ -90,15 +88,13 @@ impl Plugin for LogPlugin {
             let subscriber = subscriber.with(tracing_wasm::WASMLayer::new(
                 tracing_wasm::WASMLayerConfig::default(),
             ));
-            bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                .expect("Could not set global default tracing subscriber.");
+            let _ = bevy_utils::tracing::subscriber::set_global_default(subscriber);
         }
 
         #[cfg(target_os = "android")]
         {
             let subscriber = subscriber.with(android_tracing::AndroidLayer::default());
-            bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                .expect("Could not set global default tracing subscriber.");
+            let _ = bevy_utils::tracing::subscriber::set_global_default(subscriber);
         }
     }
 }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -336,11 +336,19 @@ pub fn winit_runner(mut app: App) {
                     let mut focused_events =
                         app.resources.get_mut::<Events<WindowFocused>>().unwrap();
                     let winit_windows = app.resources.get_mut::<WinitWindows>().unwrap();
-                    let window_id = winit_windows.get_window_id(winit_window_id).unwrap();
-                    focused_events.send(WindowFocused {
-                        id: window_id,
-                        focused,
-                    });
+                    match (winit_windows.get_window_id(winit_window_id), focused) {
+                        (Some(window_id), _) => focused_events.send(WindowFocused {
+                            id: window_id,
+                            focused,
+                        }),
+                        // unfocus event for an unknown window, ignore it
+                        (None, false) => (),
+                        // focus event on an unknown window, this is an error
+                        _ => panic!(
+                            "Focused(true) event on unknown window {:?}",
+                            winit_window_id
+                        ),
+                    }
                 }
                 _ => {}
             },

--- a/examples/app/return_after_run.rs
+++ b/examples/app/return_after_run.rs
@@ -8,6 +8,7 @@ fn main() {
         })
         .add_resource(ClearColor(Color::rgb(0.2, 0.2, 0.8)))
         .add_plugins(DefaultPlugins)
+        .add_system(system1.system())
         .run();
     println!("Running another App.");
     App::build()
@@ -15,7 +16,18 @@ fn main() {
             return_from_run: true,
         })
         .add_resource(ClearColor(Color::rgb(0.2, 0.8, 0.2)))
-        .add_plugins(DefaultPlugins)
+        .add_plugins_with(DefaultPlugins, |group| {
+            group.disable::<bevy::log::LogPlugin>()
+        })
+        .add_system(system2.system())
         .run();
     println!("Done.");
+}
+
+fn system1() {
+    info!("logging from first app");
+}
+
+fn system2() {
+    info!("logging from second app");
 }


### PR DESCRIPTION
## First crash

Example return_after_run is currently crashing when closing the first window:
```
     Running `target/debug/examples/return_after_run`
Running first App.
Running another App.
thread 'main' panicked at 'Could not set global default tracing subscriber.: SetGlobalDefaultError { _no_construct: () }', crates/bevy_log/src/lib.rs:83:22
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The issue is that as the default plugins setup a global tracing subscriber, doing it a second time fails. https://docs.rs/tracing/0.1.22/tracing/dispatcher/fn.set_global_default.html for more information

My fix is to ignore errors, as it just means that there is already a subscriber configured.

As an added bonus, the user can now set up their own subscriber however they want.

## Second crash

The example was still crashing:
```
     Running `target/debug/examples/return_after_run`
Running first App.
Running another App.
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', crates/bevy_winit/src/lib.rs:343:66
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After some investigation, it's because the event loop for the second app receives an event `Focused(false)` from the window of the first app. It can be reproduced when using only winit, and looking at how it works it may be platform dependant (I'm on macOS) and events are just translated from the OS, so not something fixable.

My fix is to ignore `Focused(false)` events for unknown window, as they are pretty much meaningless anyway. I kept the crash for a `Focused(true)` event on an unknown window.

## It runs!

Now it works :)
```
     Running `target/debug/examples/return_after_run`
Running first App.
Running another App.
Done.
```
