### PR TITLE
Modify Derive to allow unit structs for RenderResources.

### DIFF
--- a/crates/bevy_derive/src/render_resources.rs
+++ b/crates/bevy_derive/src/render_resources.rs
@@ -2,7 +2,8 @@ use crate::modules::{get_modules, get_path};
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
-    parse::ParseStream, parse_macro_input, Data, DataStruct, DeriveInput, Field, Fields, Path,
+    parse::ParseStream, parse_macro_input, punctuated::Punctuated, Data, DataStruct, DeriveInput,
+    Field, Fields, Path,
 };
 
 #[derive(Default)]
@@ -72,11 +73,17 @@ pub fn derive_render_resources(input: TokenStream) -> TokenStream {
             }
         })
     } else {
+        let empty = Punctuated::new();
+
         let fields = match &ast.data {
             Data::Struct(DataStruct {
                 fields: Fields::Named(fields),
                 ..
             }) => &fields.named,
+            Data::Struct(DataStruct {
+                fields: Fields::Unit,
+                ..
+            }) => &empty,
             _ => panic!("Expected a struct with named fields."),
         };
         let field_attributes = fields

--- a/examples/shader/mesh_custom_attribute.rs
+++ b/examples/shader/mesh_custom_attribute.rs
@@ -21,7 +21,7 @@ fn main() {
 
 #[derive(RenderResources, Default, TypeUuid)]
 #[uuid = "0320b9b8-b3a3-4baa-8bfa-c94008177b17"]
-struct MyMaterialWithVertexColorSupport {}
+struct MyMaterialWithVertexColorSupport;
 
 const VERTEX_SHADER: &str = r#"
 #version 450


### PR DESCRIPTION
This allows the following syntax:
```rs
#[derive(RenderResources)]
struct MyMaterial;
```
Whereas the following used to be required:
```rs
#[derive(RenderResources)]
struct MyMaterial {}
```