### PR TITLE
Add basic file drag and drop support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,10 @@ name = "custom_loop"
 path = "examples/app/custom_loop.rs"
 
 [[example]]
+name = "drag_and_drop"
+path = "examples/app/drag_and_drop.rs"
+
+[[example]]
 name = "empty_defaults"
 path = "examples/app/empty_defaults.rs"
 

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use super::{WindowDescriptor, WindowId};
 use bevy_math::Vec2;
 
@@ -76,4 +78,14 @@ pub struct WindowScaleFactorChanged {
 pub struct WindowBackendScaleFactorChanged {
     pub id: WindowId,
     pub scale_factor: f64,
+}
+
+/// Events related to files being dragged and dropped on a window.
+#[derive(Debug, Clone)]
+pub enum FileDragAndDrop {
+    DroppedFile { id: WindowId, path_buf: PathBuf },
+
+    HoveredFile { id: WindowId, path_buf: PathBuf },
+
+    HoveredFileCancelled { id: WindowId },
 }

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -11,8 +11,8 @@ pub use windows::*;
 
 pub mod prelude {
     pub use crate::{
-        CursorEntered, CursorLeft, CursorMoved, ReceivedCharacter, Window, WindowDescriptor,
-        Windows,
+        CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, ReceivedCharacter, Window,
+        WindowDescriptor, Windows,
     };
 }
 
@@ -46,6 +46,7 @@ impl Plugin for WindowPlugin {
             .add_event::<WindowFocused>()
             .add_event::<WindowScaleFactorChanged>()
             .add_event::<WindowBackendScaleFactorChanged>()
+            .add_event::<FileDragAndDrop>()
             .init_resource::<Windows>();
 
         if self.add_primary_window {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -1,6 +1,7 @@
 mod converters;
 mod winit_config;
 mod winit_windows;
+
 use bevy_input::{
     keyboard::KeyboardInput,
     mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
@@ -14,7 +15,7 @@ use bevy_ecs::{IntoSystem, Resources, World};
 use bevy_math::Vec2;
 use bevy_utils::tracing::{error, trace, warn};
 use bevy_window::{
-    CreateWindow, CursorEntered, CursorLeft, CursorMoved, ReceivedCharacter,
+    CreateWindow, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, ReceivedCharacter,
     WindowBackendScaleFactorChanged, WindowCloseRequested, WindowCreated, WindowFocused,
     WindowResized, WindowScaleFactorChanged, Windows,
 };
@@ -396,6 +397,27 @@ pub fn winit_runner_with(mut app: App, mut event_loop: EventLoop<()>) {
                             id: window_id,
                             focused,
                         });
+                    }
+                    WindowEvent::DroppedFile(path_buf) => {
+                        let mut events =
+                            app.resources.get_mut::<Events<FileDragAndDrop>>().unwrap();
+                        events.send(FileDragAndDrop::DroppedFile {
+                            id: window_id,
+                            path_buf,
+                        });
+                    }
+                    WindowEvent::HoveredFile(path_buf) => {
+                        let mut events =
+                            app.resources.get_mut::<Events<FileDragAndDrop>>().unwrap();
+                        events.send(FileDragAndDrop::HoveredFile {
+                            id: window_id,
+                            path_buf,
+                        });
+                    }
+                    WindowEvent::HoveredFileCancelled => {
+                        let mut events =
+                            app.resources.get_mut::<Events<FileDragAndDrop>>().unwrap();
+                        events.send(FileDragAndDrop::HoveredFileCancelled { id: window_id });
                     }
                     _ => {}
                 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -80,7 +80,7 @@ Example | File | Description
 Example | File | Description
 --- | --- | ---
 `custom_loop` | [`app/custom_loop.rs`](./app/custom_loop.rs) | Demonstrates how to create a custom runner (to update an app manually).
-`drag_and_drop` | [`app/empty_defaults.rs`](./app/drag_and_drop.rs) | An example that shows how to handle drag and drop in an app.
+`drag_and_drop` | [`app/drag_and_drop.rs`](./app/drag_and_drop.rs) | An example that shows how to handle drag and drop in an app.
 `empty_defaults` | [`app/empty_defaults.rs`](./app/empty_defaults.rs) | An empty application with default plugins
 `empty` | [`app/empty.rs`](./app/empty.rs) | An empty application (does nothing)
 `headless` | [`app/headless.rs`](./app/headless.rs) | An application that runs without default plugins

--- a/examples/README.md
+++ b/examples/README.md
@@ -80,6 +80,7 @@ Example | File | Description
 Example | File | Description
 --- | --- | ---
 `custom_loop` | [`app/custom_loop.rs`](./app/custom_loop.rs) | Demonstrates how to create a custom runner (to update an app manually).
+`drag_and_drop` | [`app/empty_defaults.rs`](./app/drag_and_drop.rs) | An example that shows how to handle drag and drop in an app.
 `empty_defaults` | [`app/empty_defaults.rs`](./app/empty_defaults.rs) | An empty application with default plugins
 `empty` | [`app/empty.rs`](./app/empty.rs) | An empty application (does nothing)
 `headless` | [`app/headless.rs`](./app/headless.rs) | An application that runs without default plugins

--- a/examples/app/drag_and_drop.rs
+++ b/examples/app/drag_and_drop.rs
@@ -1,0 +1,17 @@
+use bevy::prelude::*;
+
+fn main() {
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_system(dropped_file_system.system())
+        .run();
+}
+
+fn dropped_file_system(
+    mut reader: Local<EventReader<FileDragAndDrop>>,
+    events: Res<Events<FileDragAndDrop>>,
+) {
+    for event in reader.iter(&events) {
+        println!("{:?}", event);
+    }
+}

--- a/examples/app/drag_and_drop.rs
+++ b/examples/app/drag_and_drop.rs
@@ -3,11 +3,11 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_system(dropped_file_system.system())
+        .add_system(file_drag_and_drop_system.system())
         .run();
 }
 
-fn dropped_file_system(
+fn file_drag_and_drop_system(
     mut reader: Local<EventReader<FileDragAndDrop>>,
     events: Res<Events<FileDragAndDrop>>,
 ) {


### PR DESCRIPTION
Adds basic drag and drop support to bevy.

It simply exposes the relevant events already found in winit. 
This has been tested on Linux, and because it simply wraps around the winit events, it should work on other systems just fine (hopefully!).

I still want to try wasm/web before merging. (Or someone else, I haven't played with wasm in rust or bevy much yet!)

Let me know if there's anything missing!