### PR TITLE
bevy_render: load .spv assets

### DIFF
--- a/crates/bevy_render/src/pipeline/pipeline_compiler.rs
+++ b/crates/bevy_render/src/pipeline/pipeline_compiler.rs
@@ -2,7 +2,7 @@ use super::{state_descriptors::PrimitiveTopology, IndexFormat, PipelineDescripto
 use crate::{
     pipeline::{BindType, InputStepMode, VertexBufferDescriptor},
     renderer::RenderResourceContext,
-    shader::{Shader, ShaderError, ShaderSource},
+    shader::{Shader, ShaderError},
 };
 use bevy_asset::{Assets, Handle};
 use bevy_reflect::Reflect;
@@ -78,11 +78,6 @@ impl PipelineCompiler {
             .or_insert_with(Vec::new);
 
         let shader = shaders.get(shader_handle).unwrap();
-
-        // don't produce new shader if the input source is already spirv
-        if let ShaderSource::Spirv(_) = shader.source {
-            return Ok(shader_handle.clone_weak());
-        }
 
         if let Some(specialized_shader) =
             specialized_shaders

--- a/crates/bevy_render/src/shader/shader.rs
+++ b/crates/bevy_render/src/shader/shader.rs
@@ -9,7 +9,6 @@ use bevy_asset::{AssetEvent, AssetLoader, Assets, Handle, LoadContext, LoadedAss
 use bevy_ecs::{Local, Res, ResMut};
 use bevy_reflect::TypeUuid;
 use bevy_utils::{tracing::error, BoxedFuture};
-use spirv_reflect::{types::ReflectShaderStageFlags, ShaderModule};
 use std::marker::Copy;
 use thiserror::Error;
 
@@ -146,7 +145,10 @@ impl Shader {
         Shader { stage, source }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_spirv(spirv: &[u8]) -> Result<Shader, ShaderError> {
+        use spirv_reflect::{types::ReflectShaderStageFlags, ShaderModule};
+
         let module = ShaderModule::load_u8_data(spirv)
             .map_err(|msg| ShaderError::Compilation(msg.to_string()))?;
         let stage = match module.get_shader_stage() {
@@ -259,7 +261,10 @@ impl AssetLoader for ShaderLoader {
             let shader = match ext {
                 "vert" => Shader::from_glsl(ShaderStage::Vertex, std::str::from_utf8(bytes)?),
                 "frag" => Shader::from_glsl(ShaderStage::Fragment, std::str::from_utf8(bytes)?),
+                #[cfg(not(target_arch = "wasm32"))]
                 "spv" => Shader::from_spirv(bytes)?,
+                #[cfg(target_arch = "wasm32")]
+                "spv" => panic!("cannot load .spv file on wasm"),
                 _ => panic!("unhandled extension: {}", ext),
             };
 


### PR DESCRIPTION
The shader stage is determined by `spirv_reflect`.
Hot reloading does not work since [the specialized_shaders](https://github.com/bevyengine/bevy/blob/3b2c6ce49b3b9ea8bc5cb68f8d350a80ff928af6/crates/bevy_render/src/pipeline/pipeline_compiler.rs#L317) for spirv-shaders apparently are empty. I'm not sure why that is (I know relatively little about the internals), maybe I can create a follow-up PR once that works as well.