### PR TITLE
Don't care fetch

### DIFF
--- a/crates/bevy_ecs/src/core/mod.rs
+++ b/crates/bevy_ecs/src/core/mod.rs
@@ -51,7 +51,7 @@ pub use entities::{Entity, EntityReserver, Location, NoSuchEntity};
 pub use entity_builder::{BuiltEntity, EntityBuilder};
 pub use entity_map::*;
 pub use filter::{Added, Changed, EntityFilter, Mutated, Or, QueryFilter, With, Without};
-pub use query::{Batch, BatchedIter, Mut, QueryIter, ReadOnlyFetch, WorldQuery};
+pub use query::{Batch, BatchedIter, DontCare, Mut, QueryIter, ReadOnlyFetch, WorldQuery};
 pub use world::{ArchetypesGeneration, Component, ComponentError, SpawnBatchIter, World};
 pub use world_builder::*;
 

--- a/crates/bevy_ecs/src/core/query.rs
+++ b/crates/bevy_ecs/src/core/query.rs
@@ -237,6 +237,36 @@ impl<'a, T: Fetch<'a>> Fetch<'a> for TryFetch<T> {
     }
 }
 
+/// Especial component type that don't care about the if the entity has it or not;
+/// Use to build queries to check component or entity state;
+#[derive(Debug, Copy, Clone)]
+pub struct DontCare;
+
+impl WorldQuery for DontCare {
+    type Fetch = DontCareFetch;
+}
+
+/// Don't care about the component
+pub struct DontCareFetch;
+unsafe impl ReadOnlyFetch for DontCareFetch {}
+
+impl<'a> Fetch<'a> for DontCareFetch {
+    type Item = DontCare;
+    const DANGLING: Self = DontCareFetch;
+
+    fn access() -> QueryAccess {
+        QueryAccess::None
+    }
+
+    unsafe fn get(_archetype: &'a Archetype, _offset: usize) -> Option<Self> {
+        Some(DontCareFetch)
+    }
+
+    unsafe fn fetch(&self, _n: usize) -> Self::Item {
+        DontCare
+    }
+}
+
 struct ChunkInfo<Q: WorldQuery, F: QueryFilter> {
     fetch: Q::Fetch,
     filter: F::EntityFilter,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -16,7 +16,7 @@ pub mod prelude {
         resource::{ChangedRes, FromResources, Local, Res, ResMut, Resource, Resources},
         schedule::{Schedule, State, StateStage, SystemStage},
         system::{Commands, IntoSystem, Query, System},
-        Added, Bundle, Changed, Component, Entity, In, IntoChainSystem, Mut, Mutated, Or, QuerySet,
-        Ref, RefMut, With, Without, World,
+        Added, Bundle, Changed, Component, DontCare, Entity, In, IntoChainSystem, Mut, Mutated, Or,
+        QuerySet, Ref, RefMut, With, Without, World,
     };
 }


### PR DESCRIPTION
Introduces the `DontCare` component that can be used to create queries dont care if the entity have or not some component;

I run in these two main uses cases:

1. Query if an entity still exists or not:
```
fn sys(query: Query<DontCare>) {
    if query.get(entity).is_ok() {
        // Entity exists
    } else {
        // Entity doesn't exists
    }
}
```

2. Check if some component had been removed:
```
fn sys(query: Query<DontCare, Without<Parent>>) {
    if query.get(entity).is_ok() {
        // Parent got removed from entity
    }
}
```

It's very situacional but also might be useful.

Now that I'm thinking on it maybe this could be easly replaced by simple using `Entity`, oh well ...