### PR TITLE
Update rand requirement from 0.7 to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ bevy_internal = {path = "crates/bevy_internal", version = "0.4.0", default-featu
 
 [dev-dependencies]
 anyhow = "1.0"
-rand = "0.7.3"
+rand = "0.8.0"
 ron = "0.6.2"
 serde = {version = "1", features = ["derive"]}
 

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = "1.0"
 downcast-rs = "1.2.0"
 notify = { version = "5.0.0-pre.2", optional = true }
 parking_lot = "0.11.0"
-rand = "0.7.3"
+rand = "0.8.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -21,7 +21,7 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.4.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.4.0" }
 bevy_ecs_macros = { path = "macros", version = "0.4.0" }
 fxhash = "0.2"
-rand = "0.7.3"
+rand = "0.8.0"
 serde = "1.0"
 thiserror = "1.0"
 fixedbitset = "0.3.1"

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -66,8 +66,8 @@ fn setup(
     let mut rnd = rand::thread_rng();
 
     for name in contribs {
-        let pos = (rnd.gen_range(-400.0, 400.0), rnd.gen_range(0.0, 400.0));
-        let dir = rnd.gen_range(-1.0, 1.0);
+        let pos = (rnd.gen_range(-400.0..400.0), rnd.gen_range(0.0..400.0));
+        let dir = rnd.gen_range(-1.0..1.0);
         let velocity = Vec3::new(dir * 500.0, 0.0, 0.0);
         let col = gen_color(&mut rnd);
 
@@ -254,7 +254,7 @@ fn collision_system(
         if bottom < ground {
             t.translation.y = ground + SPRITE_SIZE / 2.0;
             // apply an impulse upwards
-            v.translation.y = rnd.gen_range(700.0, 1000.0);
+            v.translation.y = rnd.gen_range(700.0..1000.0);
         }
         if top > ceiling {
             t.translation.y = ceiling - SPRITE_SIZE / 2.0;
@@ -312,9 +312,9 @@ fn contributors() -> Contributors {
 /// Because there is no `Mul<Color> for Color` instead `[f32; 3]` is
 /// used.
 fn gen_color(rng: &mut impl Rng) -> [f32; 3] {
-    let r = rng.gen_range(0.2, 1.0);
-    let g = rng.gen_range(0.2, 1.0);
-    let b = rng.gen_range(0.2, 1.0);
+    let r = rng.gen_range(0.2..1.0);
+    let g = rng.gen_range(0.2..1.0);
+    let b = rng.gen_range(0.2..1.0);
     let v = Vec3::new(r, g, b);
     v.normalize().into()
 }

--- a/examples/3d/spawner.rs
+++ b/examples/3d/spawner.rs
@@ -56,15 +56,15 @@ fn setup(
             mesh: cube_handle.clone(),
             material: materials.add(StandardMaterial {
                 albedo: Color::rgb(
-                    rng.gen_range(0.0, 1.0),
-                    rng.gen_range(0.0, 1.0),
-                    rng.gen_range(0.0, 1.0),
+                    rng.gen_range(0.0..1.0),
+                    rng.gen_range(0.0..1.0),
+                    rng.gen_range(0.0..1.0),
                 ),
                 ..Default::default()
             }),
             transform: Transform::from_xyz(
-                rng.gen_range(-50.0, 50.0),
-                rng.gen_range(-50.0, 50.0),
+                rng.gen_range(-50.0..50.0),
+                rng.gen_range(-50.0..50.0),
                 0.0,
             ),
             ..Default::default()


### PR DESCRIPTION
(no, I don't know why dependabot missed this one. Yes I'm using their PR format.)

Updates the requirements on [rand](https://github.com/rust-random/rand) to permit the latest version.

<details>
<summary>Changelog</summary>

_Sourced from [rand's changelog](https://github.com/rust-random/rand/blob/master/CHANGELOG.md)._

> ## [0.8.0] - 2020-12-18
> ### Platform support
> - The minimum supported Rust version is now 1.36 (https://github.com/rust-random/rand/issues/1011)
> - `getrandom` updated to v0.2 (https://github.com/rust-random/rand/issues/1041)
> - Remove `wasm-bindgen` and `stdweb` feature flags. For details of WASM support,
>   see the [getrandom documentation](https://docs.rs/getrandom/latest). (https://github.com/rust-random/rand/issues/948)
> - `ReadRng::next_u32` and `next_u64` now use little-Endian conversion instead
>   of native-Endian, affecting results on Big-Endian platforms (https://github.com/rust-random/rand/issues/1061)
> - The `nightly` feature no longer implies the `simd_support` feature (https://github.com/rust-random/rand/issues/1048)
> - Fix `simd_support` feature to work on current nightlies (https://github.com/rust-random/rand/issues/1056)
> 
> ### Rngs
> - `ThreadRng` is no longer `Copy` to enable safe usage within thread-local destructors (https://github.com/rust-random/rand/issues/1035)
> - `gen_range(a, b)` was replaced with `gen_range(a..b)`. `gen_range(a..=b)` is
>   also supported. Note that `a` and `b` can no longer be references or SIMD types. (https://github.com/rust-random/rand/issues/744, https://github.com/rust-random/rand/issues/1003)
> - Replace `AsByteSliceMut` with `Fill` and add support for `[bool], [char], [f32], [f64]` (https://github.com/rust-random/rand/issues/940)
> - Restrict `rand::rngs::adapter` to `std` (https://github.com/rust-random/rand/issues/1027; see also https://github.com/rust-random/rand/issues/928)
> - `StdRng`: add new `std_rng` feature flag (enabled by default, but might need
>   to be used if disabling default crate features) (https://github.com/rust-random/rand/issues/948)
> - `StdRng`: Switch from ChaCha20 to ChaCha12 for better performance (https://github.com/rust-random/rand/issues/1028)
> - `SmallRng`: Replace PCG algorithm with xoshiro{128,256}++ (https://github.com/rust-random/rand/issues/1038)
> 
> ### Sequences
> - Add `IteratorRandom::choose_stable` as an alternative to `choose` which does
>   not depend on size hints (https://github.com/rust-random/rand/issues/1057)
> - Improve accuracy and performance of `IteratorRandom::choose` (https://github.com/rust-random/rand/issues/1059)
> - Implement `IntoIterator` for `IndexVec`, replacing the `into_iter` method (https://github.com/rust-random/rand/issues/1007)
> - Add value stability tests for `seq` module (https://github.com/rust-random/rand/issues/933)
> 
> ### Misc
> - Support `PartialEq` and `Eq` for `StdRng`, `SmallRng` and `StepRng` (https://github.com/rust-random/rand/issues/979)
> - Added a `serde1` feature and added Serialize/Deserialize to `UniformInt` and `WeightedIndex` (https://github.com/rust-random/rand/issues/974)
> - Drop some unsafe code (https://github.com/rust-random/rand/issues/962, https://github.com/rust-random/rand/issues/963, https://github.com/rust-random/rand/issues/1011)
> - Reduce packaged crate size (https://github.com/rust-random/rand/issues/983)
> - Migrate to GitHub Actions from Travis+AppVeyor (https://github.com/rust-random/rand/issues/1073)
> 
> ### Distributions
> - `Alphanumeric` samples bytes instead of chars (https://github.com/rust-random/rand/issues/935)
> - `Uniform` now supports `char`, enabling `rng.gen_range('A'..='Z')` (https://github.com/rust-random/rand/issues/1068)
> - Add `UniformSampler::sample_single_inclusive` (https://github.com/rust-random/rand/issues/1003)
> 
> #### Weighted sampling
> - Implement weighted sampling without replacement (https://github.com/rust-random/rand/issues/976, https://github.com/rust-random/rand/issues/1013)
> - `rand::distributions::alias_method::WeightedIndex` was moved to `rand_distr::WeightedAliasIndex`.
>   The simpler alternative `rand::distribution::WeightedIndex` remains. (https://github.com/rust-random/rand/issues/945)
> - Improve treatment of rounding errors in `WeightedIndex::update_weights` (https://github.com/rust-random/rand/issues/956)
> - `WeightedIndex`: return error on NaN instead of panic (https://github.com/rust-random/rand/issues/1005)
> 
> ### Documentation
> - Document types supported by `random` (https://github.com/rust-random/rand/issues/994)
> - Document notes on password generation (https://github.com/rust-random/rand/issues/995)
> - Note that `SmallRng` may not be the best choice for performance and in some
>   other cases (https://github.com/rust-random/rand/issues/1038)
> - Use `doc(cfg)` to annotate feature-gated items (https://github.com/rust-random/rand/issues/1019)
> - Adjust README (https://github.com/rust-random/rand/issues/1065)
</details>

[Commits visible in compare view](https://github.com/rust-random/rand/compare/0.7.3...0.8.0).

---

Closes #1113.

We shouldn't merge this until `uuid` upgrades `rand`, to avoid pulling in two versions of `rand`.