### PR TITLE
Fix lock order to remove the chance of deadlock

### DIFF
--- a/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
+++ b/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
@@ -227,8 +227,8 @@ impl RenderResourceContext for WgpuRenderResourceContext {
     }
 
     fn remove_buffer(&self, buffer: BufferId) {
-        let mut buffers = self.resources.buffers.write();
         let mut buffer_infos = self.resources.buffer_infos.write();
+        let mut buffers = self.resources.buffers.write();
 
         buffers.remove(&buffer);
         buffer_infos.remove(&buffer);


### PR DESCRIPTION
Because the buffers and buffer_infos locks were being acquired in different orders in different parts of the code there was the opportunity for a deadlock which I saw happen semi-regularly in situations where many sprites were being spawned per frame. This makes the order consistent and has fixed the deadlock in my application.