### PR TITLE
Render text in 2D scenes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,10 @@ name = "contributors"
 path = "examples/2d/contributors.rs"
 
 [[example]]
+name = "text2d"
+path = "examples/2d/text2d.rs"
+
+[[example]]
 name = "load_gltf"
 path = "examples/3d/load_gltf.rs"
 

--- a/crates/bevy_render/src/render_graph/base.rs
+++ b/crates/bevy_render/src/render_graph/base.rs
@@ -14,7 +14,7 @@ use bevy_reflect::{Reflect, ReflectComponent};
 use bevy_window::WindowId;
 
 /// A component that indicates that an entity should be drawn in the "main pass"
-#[derive(Default, Reflect)]
+#[derive(Clone, Debug, Default, Reflect)]
 #[reflect(Component)]
 pub struct MainPass;
 

--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -37,7 +37,7 @@ pub struct PassNode<Q: WorldQuery> {
 
 impl<Q: WorldQuery> fmt::Debug for PassNode<Q> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("PassNose")
+        f.debug_struct("PassNode")
             .field("descriptor", &self.descriptor)
             .field("inputs", &self.inputs)
             .field("cameras", &self.cameras)

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -22,6 +22,7 @@ bevy_math = { path = "../bevy_math", version = "0.4.0" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.4.0", features = ["bevy"] }
 bevy_render = { path = "../bevy_render", version = "0.4.0" }
 bevy_sprite = { path = "../bevy_sprite", version = "0.4.0" }
+bevy_transform = { path = "../bevy_transform", version = "0.4.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.4.0" }
 
 # other

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -6,6 +6,7 @@ mod font_atlas_set;
 mod font_loader;
 mod glyph_brush;
 mod pipeline;
+mod text2d;
 
 pub use draw::*;
 pub use error::*;
@@ -15,15 +16,20 @@ pub use font_atlas_set::*;
 pub use font_loader::*;
 pub use glyph_brush::*;
 pub use pipeline::*;
+pub use text2d::*;
 
 pub mod prelude {
-    pub use crate::{Font, TextAlignment, TextError, TextStyle};
+    pub use crate::{Font, Text, Text2dBundle, TextAlignment, TextError, TextStyle};
     pub use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
+}
+
+pub mod stage {
+    pub const TEXT2D: &str = "text2d";
 }
 
 use bevy_app::prelude::*;
 use bevy_asset::AddAsset;
-use bevy_ecs::Entity;
+use bevy_ecs::{Entity, IntoSystem, SystemStage};
 
 pub type DefaultTextPipeline = TextPipeline<Entity>;
 
@@ -32,9 +38,19 @@ pub struct TextPlugin;
 
 impl Plugin for TextPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app.add_asset::<Font>()
-            .add_asset::<FontAtlasSet>()
-            .init_asset_loader::<FontLoader>()
-            .add_resource(DefaultTextPipeline::default());
+        app.add_stage_before(
+            bevy_app::stage::POST_UPDATE,
+            stage::TEXT2D,
+            SystemStage::parallel(),
+        )
+        .add_asset::<Font>()
+        .add_asset::<FontAtlasSet>()
+        .init_asset_loader::<FontLoader>()
+        .add_resource(DefaultTextPipeline::default())
+        .add_system_to_stage(stage::TEXT2D, text2d_system.system())
+        .add_system_to_stage(
+            bevy_render::stage::DRAW,
+            text2d::draw_text2d_system.system(),
+        );
     }
 }

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -25,13 +25,9 @@ pub mod prelude {
     pub use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
 }
 
-pub mod stage {
-    pub const TEXT2D: &str = "text2d";
-}
-
 use bevy_app::prelude::*;
 use bevy_asset::AddAsset;
-use bevy_ecs::{Entity, IntoSystem, SystemStage};
+use bevy_ecs::{Entity, IntoSystem};
 
 pub type DefaultTextPipeline = TextPipeline<Entity>;
 
@@ -40,19 +36,14 @@ pub struct TextPlugin;
 
 impl Plugin for TextPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app.add_stage_before(
-            bevy_app::stage::POST_UPDATE,
-            stage::TEXT2D,
-            SystemStage::parallel(),
-        )
-        .add_asset::<Font>()
-        .add_asset::<FontAtlasSet>()
-        .init_asset_loader::<FontLoader>()
-        .add_resource(DefaultTextPipeline::default())
-        .add_system_to_stage(stage::TEXT2D, text2d_system.system())
-        .add_system_to_stage(
-            bevy_render::stage::DRAW,
-            text2d::draw_text2d_system.system(),
-        );
+        app.add_asset::<Font>()
+            .add_asset::<FontAtlasSet>()
+            .init_asset_loader::<FontLoader>()
+            .add_resource(DefaultTextPipeline::default())
+            .add_system_to_stage(bevy_app::stage::POST_UPDATE, text2d_system.system())
+            .add_system_to_stage(
+                bevy_render::stage::DRAW,
+                text2d::draw_text2d_system.system(),
+            );
     }
 }

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -6,6 +6,7 @@ mod font_atlas_set;
 mod font_loader;
 mod glyph_brush;
 mod pipeline;
+mod text;
 mod text2d;
 
 pub use draw::*;
@@ -16,6 +17,7 @@ pub use font_atlas_set::*;
 pub use font_loader::*;
 pub use glyph_brush::*;
 pub use pipeline::*;
+pub use text::*;
 pub use text2d::*;
 
 pub mod prelude {

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -1,0 +1,16 @@
+use bevy_asset::Handle;
+use bevy_math::Size;
+
+use crate::{Font, TextStyle};
+
+#[derive(Debug, Default, Clone)]
+pub struct Text {
+    pub value: String,
+    pub font: Handle<Font>,
+    pub style: TextStyle,
+}
+
+#[derive(Default, Copy, Clone, Debug)]
+pub struct CalculatedSize {
+    pub size: Size,
+}

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -1,0 +1,187 @@
+use bevy_asset::{Assets, Handle};
+use bevy_ecs::{Bundle, Changed, Entity, Local, Query, QuerySet, Res, ResMut, With};
+use bevy_math::Size;
+use bevy_render::{
+    draw::{DrawContext, Drawable},
+    mesh::Mesh,
+    prelude::{Draw, Msaa, Texture, Visible},
+    render_graph::base::MainPass,
+    renderer::RenderResourceBindings,
+};
+use bevy_sprite::{TextureAtlas, QUAD_HANDLE};
+use bevy_transform::prelude::{GlobalTransform, Transform};
+
+use crate::{DefaultTextPipeline, DrawableText, Font, FontAtlasSet, TextError, TextStyle};
+
+impl Default for Text2dBundle {
+    fn default() -> Self {
+        Self {
+            draw: Draw {
+                ..Default::default()
+            },
+            visible: Visible {
+                is_transparent: true,
+                ..Default::default()
+            },
+            text: Default::default(),
+            transform: Default::default(),
+            global_transform: Default::default(),
+            main_pass: MainPass {},
+        }
+    }
+}
+
+#[derive(Bundle, Clone, Debug)]
+pub struct Text2dBundle {
+    pub draw: Draw,
+    pub visible: Visible,
+    pub text: Text,
+    pub transform: Transform,
+    pub global_transform: GlobalTransform,
+    pub main_pass: MainPass,
+}
+
+// TODO: DRY -- this is copy pasta from bevy_ui/src/widget/text.rs
+#[derive(Debug, Default, Clone)]
+pub struct Text {
+    pub value: String,
+    pub font: Handle<Font>,
+    pub style: TextStyle,
+}
+
+pub fn draw_text2d_system(
+    mut context: DrawContext,
+    msaa: Res<Msaa>,
+    meshes: Res<Assets<Mesh>>,
+    mut render_resource_bindings: ResMut<RenderResourceBindings>,
+    text_pipeline: Res<DefaultTextPipeline>,
+    mut query: Query<(Entity, &mut Draw, &Visible, &Text, &GlobalTransform), With<MainPass>>,
+) {
+    let font_quad = meshes.get(&QUAD_HANDLE).unwrap();
+    let vertex_buffer_descriptor = font_quad.get_vertex_buffer_descriptor();
+
+    for (entity, mut draw, visible, text, global_transform) in query.iter_mut() {
+        if !visible.is_visible {
+            continue;
+        }
+
+        if let Some(text_glyphs) = text_pipeline.get_glyphs(&entity) {
+            let position = global_transform.translation; // - (node.size / 2.0).extend(0.0);
+
+            let mut drawable_text = DrawableText {
+                render_resource_bindings: &mut render_resource_bindings,
+                position,
+                msaa: &msaa,
+                text_glyphs: &text_glyphs.glyphs,
+                font_quad_vertex_descriptor: &vertex_buffer_descriptor,
+                style: &text.style,
+            };
+
+            drawable_text.draw(&mut draw, &mut context).unwrap();
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct QueuedText2d {
+    entities: Vec<Entity>,
+}
+
+/// Updates the TextGlyphs with the new computed glyphs from the layout
+pub fn text2d_system(
+    mut queued_text: Local<QueuedText2d>,
+    mut textures: ResMut<Assets<Texture>>,
+    fonts: Res<Assets<Font>>,
+    mut texture_atlases: ResMut<Assets<TextureAtlas>>,
+    mut font_atlas_set_storage: ResMut<Assets<FontAtlasSet>>,
+    mut text_pipeline: ResMut<DefaultTextPipeline>,
+    mut text_queries: QuerySet<(Query<Entity, Changed<Text>>, Query<&Text>)>,
+) {
+    // Adds all entities where the text or the style has changed to the local queue
+    for entity in text_queries.q0_mut().iter_mut() {
+        queued_text.entities.push(entity);
+    }
+
+    if queued_text.entities.is_empty() {
+        return;
+    }
+
+    // Computes all text in the local queue
+    let mut new_queue = Vec::new();
+    let query = text_queries.q1_mut();
+    for entity in queued_text.entities.drain(..) {
+        if let Ok(text) = query.get_mut(entity) {
+            match add_text_to_pipeline(
+                entity,
+                &*text,
+                &mut *textures,
+                &*fonts,
+                &mut *texture_atlases,
+                &mut *font_atlas_set_storage,
+                &mut *text_pipeline,
+            ) {
+                TextPipelineResult::Ok => {
+                    // let text_layout_info = text_pipeline.get_glyphs(&entity).expect(
+                    //     "Failed to get glyphs from the pipeline that have just been computed",
+                    // );
+                    //calculated_size.size = text_layout_info.size;
+                }
+                TextPipelineResult::Reschedule => {
+                    // There was an error processing the text layout, let's add this entity to the queue for further processing
+                    new_queue.push(entity);
+                }
+            }
+        }
+    }
+
+    queued_text.entities = new_queue;
+}
+
+// TODO: DRY - this is copy pasta from bevy_ui/src/widget/text.rs
+enum TextPipelineResult {
+    Ok,
+    Reschedule,
+}
+
+/// Computes the text layout and stores it in the TextPipeline resource.
+#[allow(clippy::too_many_arguments)]
+fn add_text_to_pipeline(
+    entity: Entity,
+    text: &Text,
+    textures: &mut Assets<Texture>,
+    fonts: &Assets<Font>,
+    texture_atlases: &mut Assets<TextureAtlas>,
+    font_atlas_set_storage: &mut Assets<FontAtlasSet>,
+    text_pipeline: &mut DefaultTextPipeline,
+) -> TextPipelineResult {
+    // let node_size = Size::new(
+    //     text_constraint(style.min_size.width, style.size.width, style.max_size.width),
+    //     text_constraint(
+    //         style.min_size.height,
+    //         style.size.height,
+    //         style.max_size.height,
+    //     ),
+    // );
+
+    // How do we get the actual bounds?  Do we need actual bounds?
+    let bounds = Size::new(f32::MAX, f32::MAX);
+
+    match text_pipeline.queue_text(
+        entity,
+        text.font.clone(),
+        &fonts,
+        &text.value,
+        text.style.font_size,
+        text.style.alignment,
+        bounds,
+        font_atlas_set_storage,
+        texture_atlases,
+        textures,
+    ) {
+        Err(TextError::NoSuchFont) => TextPipelineResult::Reschedule,
+        Err(e @ TextError::FailedToAddGlyph(_)) => {
+            panic!("Fatal error when processing text: {}.", e);
+        }
+        Ok(()) => TextPipelineResult::Ok,
+    }
+}

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -84,12 +84,12 @@ pub fn draw_text2d_system(
             let position = global_transform.translation
                 + match text.style.alignment.vertical {
                     VerticalAlign::Top => Vec3::zero(),
-                    VerticalAlign::Center => Vec3::new(0.0, -height / 2.0, 0.0),
+                    VerticalAlign::Center => Vec3::new(0.0, -height * 0.5, 0.0),
                     VerticalAlign::Bottom => Vec3::new(0.0, -height, 0.0),
                 }
                 + match text.style.alignment.horizontal {
                     HorizontalAlign::Left => Vec3::new(-width, 0.0, 0.0),
-                    HorizontalAlign::Center => Vec3::new(-width / 2.0, 0.0, 0.0),
+                    HorizontalAlign::Center => Vec3::new(-width * 0.5, 0.0, 0.0),
                     HorizontalAlign::Right => Vec3::zero(),
                 };
 

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -2,7 +2,7 @@ use super::Node;
 use crate::{
     render::UI_PIPELINE_HANDLE,
     widget::{Button, Image},
-    CalculatedSize, FocusPolicy, Interaction, Style,
+    FocusPolicy, Interaction, Style,
 };
 use bevy_asset::Handle;
 use bevy_ecs::Bundle;
@@ -15,7 +15,7 @@ use bevy_render::{
     prelude::Visible,
 };
 use bevy_sprite::{ColorMaterial, QUAD_HANDLE};
-use bevy_text::Text;
+use bevy_text::{CalculatedSize, Text};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
 #[derive(Bundle, Clone, Debug)]

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -1,7 +1,7 @@
 use super::Node;
 use crate::{
     render::UI_PIPELINE_HANDLE,
-    widget::{Button, Image, Text},
+    widget::{Button, Image},
     CalculatedSize, FocusPolicy, Interaction, Style,
 };
 use bevy_asset::Handle;
@@ -15,6 +15,7 @@ use bevy_render::{
     prelude::Visible,
 };
 use bevy_sprite::{ColorMaterial, QUAD_HANDLE};
+use bevy_text::Text;
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
 #[derive(Bundle, Clone, Debug)]

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -1,8 +1,9 @@
 mod convert;
 
-use crate::{CalculatedSize, Node, Style};
+use crate::{Node, Style};
 use bevy_ecs::{Changed, Entity, Query, Res, ResMut, With, Without};
 use bevy_math::Vec2;
+use bevy_text::CalculatedSize;
 use bevy_transform::prelude::{Children, Parent, Transform};
 use bevy_utils::HashMap;
 use bevy_window::{Window, WindowId, Windows};

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -16,12 +16,7 @@ pub use node::*;
 pub use render::*;
 
 pub mod prelude {
-    pub use crate::{
-        entity::*,
-        node::*,
-        widget::{Button, Text},
-        Anchors, Interaction, Margins,
-    };
+    pub use crate::{entity::*, node::*, widget::Button, Anchors, Interaction, Margins};
 }
 
 use bevy_app::prelude::*;

--- a/crates/bevy_ui/src/node.rs
+++ b/crates/bevy_ui/src/node.rs
@@ -48,11 +48,6 @@ impl AddAssign<f32> for Val {
     }
 }
 
-#[derive(Default, Copy, Clone, Debug)]
-pub struct CalculatedSize {
-    pub size: Size,
-}
-
 #[derive(Clone, PartialEq, Debug, Reflect)]
 pub struct Style {
     pub display: Display,

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,9 +1,9 @@
-use crate::CalculatedSize;
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::{Query, Res, With};
 use bevy_math::Size;
 use bevy_render::texture::Texture;
 use bevy_sprite::ColorMaterial;
+use bevy_text::CalculatedSize;
 
 #[derive(Debug, Clone)]
 pub enum Image {

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,5 +1,5 @@
 use crate::{CalculatedSize, Node, Style, Val};
-use bevy_asset::{Assets, Handle};
+use bevy_asset::Assets;
 use bevy_ecs::{Changed, Entity, Local, Or, Query, QuerySet, Res, ResMut};
 use bevy_math::Size;
 use bevy_render::{
@@ -10,19 +10,12 @@ use bevy_render::{
     texture::Texture,
 };
 use bevy_sprite::{TextureAtlas, QUAD_HANDLE};
-use bevy_text::{DefaultTextPipeline, DrawableText, Font, FontAtlasSet, TextError, TextStyle};
+use bevy_text::{DefaultTextPipeline, DrawableText, Font, FontAtlasSet, Text, TextError};
 use bevy_transform::prelude::GlobalTransform;
 
 #[derive(Debug, Default)]
 pub struct QueuedText {
     entities: Vec<Entity>,
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct Text {
-    pub value: String,
-    pub font: Handle<Font>,
-    pub style: TextStyle,
 }
 
 /// Defines how min_size, size, and max_size affects the bounds of a text
@@ -92,7 +85,6 @@ pub fn text_system(
 
     queued_text.entities = new_queue;
 }
-
 enum TextPipelineResult {
     Ok,
     Reschedule,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,4 +1,4 @@
-use crate::{CalculatedSize, Node, Style, Val};
+use crate::{Node, Style, Val};
 use bevy_asset::Assets;
 use bevy_ecs::{Changed, Entity, Local, Or, Query, QuerySet, Res, ResMut};
 use bevy_math::Size;
@@ -10,7 +10,9 @@ use bevy_render::{
     texture::Texture,
 };
 use bevy_sprite::{TextureAtlas, QUAD_HANDLE};
-use bevy_text::{DefaultTextPipeline, DrawableText, Font, FontAtlasSet, Text, TextError};
+use bevy_text::{
+    CalculatedSize, DefaultTextPipeline, DrawableText, Font, FontAtlasSet, Text, TextError,
+};
 use bevy_transform::prelude::GlobalTransform;
 
 #[derive(Debug, Default)]
@@ -59,76 +61,45 @@ pub fn text_system(
     let query = text_queries.q1_mut();
     for entity in queued_text.entities.drain(..) {
         if let Ok((text, style, mut calculated_size)) = query.get_mut(entity) {
-            match add_text_to_pipeline(
+            let node_size = Size::new(
+                text_constraint(style.min_size.width, style.size.width, style.max_size.width),
+                text_constraint(
+                    style.min_size.height,
+                    style.size.height,
+                    style.max_size.height,
+                ),
+            );
+
+            match text_pipeline.queue_text(
                 entity,
-                &*text,
-                &*style,
-                &mut *textures,
-                &*fonts,
-                &mut *texture_atlases,
+                text.font.clone(),
+                &fonts,
+                &text.value,
+                text.style.font_size,
+                text.style.alignment,
+                node_size,
                 &mut *font_atlas_set_storage,
-                &mut *text_pipeline,
+                &mut *texture_atlases,
+                &mut *textures,
             ) {
-                TextPipelineResult::Ok => {
+                Err(TextError::NoSuchFont) => {
+                    // There was an error processing the text layout, let's add this entity to the queue for further processing
+                    new_queue.push(entity);
+                }
+                Err(e @ TextError::FailedToAddGlyph(_)) => {
+                    panic!("Fatal error when processing text: {}.", e);
+                }
+                Ok(()) => {
                     let text_layout_info = text_pipeline.get_glyphs(&entity).expect(
                         "Failed to get glyphs from the pipeline that have just been computed",
                     );
                     calculated_size.size = text_layout_info.size;
-                }
-                TextPipelineResult::Reschedule => {
-                    // There was an error processing the text layout, let's add this entity to the queue for further processing
-                    new_queue.push(entity);
                 }
             }
         }
     }
 
     queued_text.entities = new_queue;
-}
-enum TextPipelineResult {
-    Ok,
-    Reschedule,
-}
-
-/// Computes the text layout and stores it in the TextPipeline resource.
-#[allow(clippy::too_many_arguments)]
-fn add_text_to_pipeline(
-    entity: Entity,
-    text: &Text,
-    style: &Style,
-    textures: &mut Assets<Texture>,
-    fonts: &Assets<Font>,
-    texture_atlases: &mut Assets<TextureAtlas>,
-    font_atlas_set_storage: &mut Assets<FontAtlasSet>,
-    text_pipeline: &mut DefaultTextPipeline,
-) -> TextPipelineResult {
-    let node_size = Size::new(
-        text_constraint(style.min_size.width, style.size.width, style.max_size.width),
-        text_constraint(
-            style.min_size.height,
-            style.size.height,
-            style.max_size.height,
-        ),
-    );
-
-    match text_pipeline.queue_text(
-        entity,
-        text.font.clone(),
-        &fonts,
-        &text.value,
-        text.style.font_size,
-        text.style.alignment,
-        node_size,
-        font_atlas_set_storage,
-        texture_atlases,
-        textures,
-    ) {
-        Err(TextError::NoSuchFont) => TextPipelineResult::Reschedule,
-        Err(e @ TextError::FailedToAddGlyph(_)) => {
-            panic!("Fatal error when processing text: {}.", e);
-        }
-        Ok(()) => TextPipelineResult::Ok,
-    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -20,7 +20,7 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
                     font_size: 60.0,
                     color: Color::WHITE,
                     alignment: TextAlignment {
-                        vertical: VerticalAlign::Top,
+                        vertical: VerticalAlign::Center,
                         horizontal: HorizontalAlign::Center,
                     },
                 },
@@ -30,6 +30,9 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
 }
 
 fn animate(time: Res<Time>, mut query: Query<&mut Transform, With<Text>>) {
+    // `Transform.translation` will determine the location of the text.
+    // `Transform.scale` and `Transform.rotation` do not yet affect text (though you can set the
+    // size of the text via `Text.style.font_size`)
     for mut transform in query.iter_mut() {
         transform.translation.x = 100.0 * time.seconds_since_startup().sin() as f32;
         transform.translation.y = 100.0 * time.seconds_since_startup().cos() as f32;

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -1,0 +1,37 @@
+use bevy::prelude::*;
+
+fn main() {
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(setup.system())
+        .add_system(animate.system())
+        .run();
+}
+
+fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
+    commands
+        // 2d camera
+        .spawn(Camera2dBundle::default())
+        // texture
+        .spawn(Text2dBundle {
+            text: Text {
+                value: "This text is in the 2D scene.".to_string(),
+                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                style: TextStyle {
+                    font_size: 60.0,
+                    color: Color::WHITE,
+                    alignment: TextAlignment {
+                        vertical: VerticalAlign::Top,
+                        horizontal: HorizontalAlign::Center,
+                    },
+                },
+            },
+            ..Default::default()
+        });
+}
+
+fn animate(time: Res<Time>, mut query: Query<&mut Transform, With<Text>>) {
+    for mut transform in query.iter_mut() {
+        transform.translation.x = 100.0 * time.delta_seconds().sin();
+    }
+}

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -3,7 +3,8 @@ use bevy::{
     prelude::*,
 };
 
-/// This example illustrates how to create text and update it in a system. It displays the current FPS in the upper left hand corner.
+/// This example illustrates how to create UI text and update it in a system. It displays the
+/// current FPS in the upper left hand corner.  For text within a scene, please see the text2d example.
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
@@ -28,7 +29,7 @@ fn text_update_system(diagnostics: Res<Diagnostics>, mut query: Query<&mut Text,
 
 fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
     commands
-        // 2d camera
+        // UI camera
         .spawn(CameraUiBundle::default())
         // texture
         .spawn(TextBundle {


### PR DESCRIPTION
This PR provides the ability to render text within a 2d scene using a `Text2dBundle` viewed by the orthogonal camera provided by the `Camera2dBundle`.  A new `text2d` example is included to demonstrate creating the text and updating its position via its `Transform`.

![text2d](https://user-images.githubusercontent.com/5838512/103142688-b8a09c80-46c4-11eb-92ba-4407042ce30f.gif)


_Huge "Thank You!" to my co-author @PabloMansanet for jumping in and providing a fix when I got stuck figuring out what had gone wrong with alignment. ❤️_ 

- Support for rendering 2D text via a new `Text2dBundle` in the scene viewed by the existing `Camera2dBundle`.
  - Implementation is in a new `bevy_text::text2d` module.
- A new example demonstrating usage of `Text2dBundle` -- `examples/2d/text2d.rs`
- Position is determined via the `Transform`'s translation (`z` being used for depth). However, rotation and scale are ignored this point.
- _Potentially Breaking Change:_ `Text` component struct promoted from `bevy_ui` to `bevy_text`. This component is used to set the string value, font and text style (font size, color, and alignment).
  - Now located at `bevy_text::text::Text`. This is _still_ included in the `bevy` prelude, so nothing breaks if it was being accessed via the prelude.
  - Depending on `bevy_ui` wasn't an option, since it would create a circular dependency.
  - Duplicating the exact same public struct component under a different name seemed wasteful.
- _Potentially Breaking Change:_ `CalculatedSize` component struct promoted from `bevy_ui` to `bevy_text` for the same reason as above.
  - Now located at `bevy_text::text::CalculatedSize`. This is _still_ included in the `bevy` prelude, so nothing breaks if it was being accessed via the prelude.
  - It is less clear to me whether this is the right choice, as this is a much simpler struct.  The name also seems very generic, but so far it is used only for text.  On balance, it felt like it should also make the move.
- `bevy_text` now privately depends on `bevy_transform`
- ~Created a new `TEXT2D` stage right before `POST_UPDATE` (following the pattern that `bevy_ui` took) to run the system to calculate changes to text.~ Update: Changed system to run in the existing `POST_UPDATE` stage.
  - ~Would it make sense to attempt to merge `bevy_ui`'s `TEXT` stage with this `TEXT2D` stage?~
- Sidenote: Fixed a typo in the debug name of the `PassNode` struct in `bevy_render`, which I happened to run across while working on this change.

Resolves https://github.com/bevyengine/bevy/issues/971