### PR TITLE
Fix Labels

### DIFF
--- a/crates/bevy_core/src/label.rs
+++ b/crates/bevy_core/src/label.rs
@@ -88,6 +88,10 @@ pub(crate) fn entity_labels_system(
         for added_label in labels.labels.difference(&current_labels) {
             if let Some(entities) = entity_labels.label_entities.get_mut(added_label) {
                 entities.push(entity);
+            } else {
+                entity_labels
+                    .label_entities
+                    .insert(added_label.clone(), vec![entity]);
             }
         }
 

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -36,6 +36,7 @@ impl Plugin for CorePlugin {
             .init_resource::<EntityLabels>()
             .init_resource::<FixedTimesteps>()
             .register_type::<Option<String>>()
+            .register_type::<Labels>()
             .register_type::<Range<f32>>()
             .register_type::<Timer>()
             .add_system_to_stage(stage::FIRST, time_system.system())


### PR DESCRIPTION
found two issues with Labels while trying to use them in a scene:
- they are not registered which caused panic `thread 'main' panicked at 'scene contains the unregistered type bevy_core::label::Labels`
- a new label was not added to the `label_entities` hash map so it remained empty