### PR TITLE
Implement Copy for ElementState

### DIFF
--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -65,7 +65,7 @@ impl Plugin for InputPlugin {
 }
 
 /// The current "press" state of an element
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ElementState {
     Pressed,
     Released,


### PR DESCRIPTION
It seems like `ElementState` should be a copy type. This addresses a minor annoyance I've encountered where I have to manually clone it to avoid move errors. 