### PR TITLE
let user disable feature png when using only other format

### DIFF
--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -1,6 +1,12 @@
 #[cfg(feature = "hdr")]
 mod hdr_texture_loader;
-#[cfg(feature = "png")]
+#[cfg(any(
+    feature = "png",
+    feature = "dds",
+    feature = "tga",
+    feature = "jpeg",
+    feature = "bmp"
+))]
 mod image_texture_loader;
 mod sampler_descriptor;
 #[allow(clippy::module_inception)]
@@ -10,7 +16,13 @@ mod texture_dimension;
 
 #[cfg(feature = "hdr")]
 pub use hdr_texture_loader::*;
-#[cfg(feature = "png")]
+#[cfg(any(
+    feature = "png",
+    feature = "dds",
+    feature = "tga",
+    feature = "jpeg",
+    feature = "bmp"
+))]
 pub use image_texture_loader::*;
 pub use sampler_descriptor::*;
 pub use texture::*;


### PR DESCRIPTION
feature `png` was the only one checked to import module for texture loading