### PR TITLE
Shader UI

### DIFF
--- a/crates/bevy_ui/src/flex/convert.rs
+++ b/crates/bevy_ui/src/flex/convert.rs
@@ -53,7 +53,7 @@ pub fn from_style(scale_factor: f64, value: &Style) -> stretch::style::Style {
         flex_grow: value.flex_grow,
         flex_shrink: value.flex_shrink,
         flex_basis: from_val(scale_factor, value.flex_basis),
-        size: from_val_size(scale_factor,  value.size),
+        size: from_val_size(scale_factor, value.size),
         min_size: from_val_size(scale_factor, value.min_size),
         max_size: from_val_size(scale_factor, value.max_size),
         aspect_ratio: match value.aspect_ratio {

--- a/crates/bevy_ui/src/flex/convert.rs
+++ b/crates/bevy_ui/src/flex/convert.rs
@@ -53,7 +53,7 @@ pub fn from_style(scale_factor: f64, value: &Style) -> stretch::style::Style {
         flex_grow: value.flex_grow,
         flex_shrink: value.flex_shrink,
         flex_basis: from_val(scale_factor, value.flex_basis),
-        size: from_val_size(scale_factor, value.size),
+        size: from_val_size(scale_factor,  value.size),
         min_size: from_val_size(scale_factor, value.min_size),
         max_size: from_val_size(scale_factor, value.max_size),
         aspect_ratio: match value.aspect_ratio {

--- a/crates/bevy_ui/src/flex/convert.rs
+++ b/crates/bevy_ui/src/flex/convert.rs
@@ -49,7 +49,7 @@ pub fn from_style(scale_factor: f64, value: &Style) -> stretch::style::Style {
         position: from_rect(scale_factor, value.position),
         margin: from_rect(scale_factor, value.margin),
         padding: from_rect(scale_factor, value.padding),
-        border: from_rect(scale_factor, value.border),
+        border: from_rect(scale_factor, Rect::all(Val::Px(value.border.thickness))),
         flex_grow: value.flex_grow,
         flex_shrink: value.flex_shrink,
         flex_basis: from_val(scale_factor, value.flex_basis),

--- a/crates/bevy_ui/src/node.rs
+++ b/crates/bevy_ui/src/node.rs
@@ -12,7 +12,28 @@ use std::ops::{Add, AddAssign};
 #[reflect(Component)]
 pub struct Node {
     pub size: Vec2,
+    #[render_resources(buffer)]
+    pub(crate) bounds: Vec<Bounds>,
 }
+
+#[derive(Debug, Copy, Clone, RenderResource, Reflect)]
+pub(crate) struct Bounds {
+    pub offset: Vec2,
+    pub size: Vec2,
+    pub radius: f32,
+    pub thickness: f32,
+}
+
+impl Default for Bounds {
+    fn default() -> Self {
+        Self {
+            size: Vec2::new(100000000., 100000000.),
+            ..Default::default()
+        }
+    }
+}
+
+unsafe impl Byteable for Bounds {}
 
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
 #[reflect_value(PartialEq, Serialize, Deserialize)]
@@ -98,6 +119,8 @@ pub struct Style {
     pub max_size: Size<Val>,
     #[render_resources(ignore)]
     pub aspect_ratio: Option<f32>,
+    #[render_resources(ignore)]
+    pub overflow: Overflow,
 }
 
 
@@ -145,6 +168,7 @@ impl Default for Style {
             min_size: Size::new(Val::Auto, Val::Auto),
             max_size: Size::new(Val::Auto, Val::Auto),
             aspect_ratio: Default::default(),
+            overflow: Default::default(),
         }
     }
 }
@@ -259,18 +283,20 @@ impl Default for JustifyContent {
 }
 
 // TODO: add support for overflow settings
-// #[derive(Copy, Clone, PartialEq, Debug)]
-// pub enum Overflow {
-//     Visible,
-//     Hidden,
-//     Scroll,
-// }
+#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
+#[reflect_value(PartialEq, Serialize, Deserialize)]
+pub enum Overflow {
+    Visible,
+    Hidden,
+    // This option needs more discussion
+    // Scroll,
+}
 
-// impl Default for Overflow {
-//     fn default() -> Overflow {
-//         Overflow::Visible
-//     }
-// }
+impl Default for Overflow {
+    fn default() -> Overflow {
+        Overflow::Visible
+    }
+}
 
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
 #[reflect_value(PartialEq, Serialize, Deserialize)]

--- a/crates/bevy_ui/src/node.rs
+++ b/crates/bevy_ui/src/node.rs
@@ -1,6 +1,10 @@
+use bevy_core::Byteable;
 use bevy_math::{Rect, Size, Vec2};
 use bevy_reflect::{Reflect, ReflectComponent, ReflectDeserialize};
-use bevy_render::renderer::RenderResources;
+use bevy_render::{
+    prelude::Color,
+    renderer::{RenderResource, RenderResources},
+};
 use serde::{Deserialize, Serialize};
 use std::ops::{Add, AddAssign};
 
@@ -53,28 +57,69 @@ pub struct CalculatedSize {
     pub size: Size,
 }
 
-#[derive(Clone, PartialEq, Debug, Reflect)]
+#[derive(Clone, PartialEq, Debug, RenderResources, Reflect)]
 pub struct Style {
+    #[render_resources(ignore)]
     pub display: Display,
+    #[render_resources(ignore)]
     pub position_type: PositionType,
+    #[render_resources(ignore)]
     pub direction: Direction,
+    #[render_resources(ignore)]
     pub flex_direction: FlexDirection,
+    #[render_resources(ignore)]
     pub flex_wrap: FlexWrap,
+    #[render_resources(ignore)]
     pub align_items: AlignItems,
+    #[render_resources(ignore)]
     pub align_self: AlignSelf,
+    #[render_resources(ignore)]
     pub align_content: AlignContent,
+    #[render_resources(ignore)]
     pub justify_content: JustifyContent,
+    #[render_resources(ignore)]
     pub position: Rect<Val>,
+    #[render_resources(ignore)]
     pub margin: Rect<Val>,
+    #[render_resources(ignore)]
     pub padding: Rect<Val>,
-    pub border: Rect<Val>,
+    pub border: Border,
+    #[render_resources(ignore)]
     pub flex_grow: f32,
+    #[render_resources(ignore)]
     pub flex_shrink: f32,
+    #[render_resources(ignore)]
     pub flex_basis: Val,
+    #[render_resources(ignore)]
     pub size: Size<Val>,
+    #[render_resources(ignore)]
     pub min_size: Size<Val>,
+    #[render_resources(ignore)]
     pub max_size: Size<Val>,
+    #[render_resources(ignore)]
     pub aspect_ratio: Option<f32>,
+}
+
+
+#[derive(Debug, Clone, PartialEq, RenderResources, Reflect, RenderResource)]
+#[reflect(Component)]
+#[render_resources(from_self)]
+pub struct Border {
+    pub color: Color,
+    pub radius: f32,
+    pub thickness: f32,
+}
+
+unsafe impl Byteable for Border {}
+
+impl Default for Border {
+    fn default() -> Self {
+        Self {
+            radius: 0.,
+            thickness: 0.,
+            color: Color::RED,
+        }
+    }
 }
 
 impl Default for Style {

--- a/crates/bevy_ui/src/node.rs
+++ b/crates/bevy_ui/src/node.rs
@@ -118,7 +118,6 @@ pub struct Style {
     pub overflow: Overflow,
 }
 
-
 #[derive(Debug, Clone, PartialEq, RenderResources, Reflect, RenderResource)]
 #[reflect(Component)]
 #[render_resources(from_self)]

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -90,7 +90,10 @@ impl UiRenderGraphBuilder for RenderGraph {
         let mut pipelines = resources.get_mut::<Assets<PipelineDescriptor>>().unwrap();
         let mut shaders = resources.get_mut::<Assets<Shader>>().unwrap();
         let msaa = resources.get::<Msaa>().unwrap();
-        pipelines.set_untracked(UI_PIPELINE_HANDLE, build_ui_pipeline(&mut shaders, msaa.samples));
+        pipelines.set_untracked(
+            UI_PIPELINE_HANDLE,
+            build_ui_pipeline(&mut shaders, msaa.samples),
+        );
 
         let mut ui_pass_node = PassNode::<(&Node, &Style)>::new(PassDescriptor {
             color_attachments: vec![msaa.color_attachment_descriptor(

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -152,7 +152,7 @@ impl UiRenderGraphBuilder for RenderGraph {
         // setup ui camera
         self.add_system_node(node::CAMERA_UI, CameraNode::new(camera::CAMERA_UI));
         self.add_node_edge(node::CAMERA_UI, node::UI_PASS).unwrap();
-        self.add_system_node(node::NODE, RenderResourcesNode::<Node>::new(true));
+        self.add_system_node(node::NODE, RenderResourcesNode::<Node>::new(false));
         self.add_node_edge(node::NODE, node::UI_PASS).unwrap();
         self.add_system_node(node::STYLE, RenderResourcesNode::<Style>::new(true));
         self.add_node_edge(node::STYLE, node::UI_PASS).unwrap();

--- a/crates/bevy_ui/src/render/ui.frag
+++ b/crates/bevy_ui/src/render/ui.frag
@@ -38,7 +38,7 @@ layout(set = 1, binding = 2) uniform Style_border {
 layout(set = 2, binding = 1) uniform texture2D ColorMaterial_texture;
 layout(set = 2, binding = 2) uniform sampler ColorMaterial_texture_sampler;
 # endif
-
+#define saturate(x)        clamp(x, 0.0, 1.0)
 
 float aastep(float threshold, float value, float factor) {
     float afwidth = length(vec2(dFdx(value), dFdy(value))) * 0.70710678118654757 * factor;
@@ -68,11 +68,11 @@ void calcinner(in Bounds bounds, inout float overflow_mask) {
     float m = max(r-t, 0.0);
     float R2 = 1.0 - aastep(m*m, dot(calc, calc));
 
-    vec2 T = clamp(0.0.xx, 1.0.xx, pos + t - half_size);
+    vec2 T = min(1.0.xx, pos + t - half_size);
 
     vec2 B2 = 1.0 - aastep(half_size, pos + r);
 
-    overflow_mask *= T.x *  T.y * clamp(0.0, 1.0, B2.x + B2.y + R2);
+    overflow_mask *= T.x *  T.y * saturate(B2.x + B2.y + R2);
 }
 
 void main() {
@@ -108,7 +108,7 @@ void main() {
     float border_sides = dot(step(half_size, pos + t), B2.yx);
     float border = min(t, min(1.0, border_corners + border_sides));
 
-    float inner = 1.0 - clamp(0.0, 1.0, border + outside);
+    float inner = 1.0 - saturate(border + outside);
 
     o_Target = inner * color + border * _border.color;
 

--- a/crates/bevy_ui/src/render/ui.frag
+++ b/crates/bevy_ui/src/render/ui.frag
@@ -44,7 +44,16 @@ float aastep(float threshold, float value, float factor) {
     float afwidth = length(vec2(dFdx(value), dFdy(value))) * 0.70710678118654757 * factor;
     return smoothstep(threshold-afwidth, threshold+afwidth, value);
 }
+vec2 aastep(vec2 threshold, vec2 value, float factor) {
+    vec2 dfx = dFdx(value);
+    vec2 dfy = dFdy(value);
+    vec2 afwidth = vec2(length(vec2(dfx.x, dfy.x)), length(vec2(dfx.y, dfy.y))) * 0.70710678118654757 * factor;
+    return smoothstep(threshold-afwidth, threshold+afwidth, value);
+}
 float aastep(float threshold, float value) {
+    return aastep(threshold, value, 1.0);
+}
+vec2 aastep(vec2 threshold, vec2 value) {
     return aastep(threshold, value, 1.0);
 }
 
@@ -57,12 +66,11 @@ void calcinner(in Bounds bounds, inout float overflow_mask) {
     vec2 calc = pos + r - half_size;
 
     float m = max(r-t, 0.0);
-    calc += 0.5;
-    float R2 = 1.0 - aastep(m*m, dot(calc, calc), 5.0);
+    float R2 = 1.0 - aastep(m*m, dot(calc, calc));
 
     vec2 T = clamp(0.0.xx, 1.0.xx, pos + t - half_size);
 
-    vec2 B2 = 1.0 - step(0.0, pos + r - half_size);
+    vec2 B2 = 1.0 - aastep(half_size, pos + r);
 
     overflow_mask *= T.x *  T.y * clamp(0.0, 1.0, B2.x + B2.y + R2);
 }
@@ -91,7 +99,7 @@ void main() {
     float m = max(r-t, 0.0);
     float R = aastep(m*m, c_dist_sq * 1.005);
 
-    vec2 B = step(half_size, pos + r);
+    vec2 B = aastep(half_size, pos + r);
     vec2 B2 = 1.0.xx - B;
 
     float outside = B.x * B.y * O;

--- a/crates/bevy_ui/src/render/ui.frag
+++ b/crates/bevy_ui/src/render/ui.frag
@@ -8,6 +8,20 @@ layout(set = 2, binding = 0) uniform ColorMaterial_color {
     vec4 Color;
 };
 
+layout(set = 1, binding = 1) uniform Node_size {
+    vec2 NodeSize;
+};
+
+struct Border {
+    vec4 color;
+    float radius;
+    float thickness;
+};
+
+layout(set = 1, binding = 2) uniform Style_border {
+    Border _border;
+};
+
 # ifdef COLORMATERIAL_TEXTURE 
 layout(set = 2, binding = 1) uniform texture2D ColorMaterial_texture;
 layout(set = 2, binding = 2) uniform sampler ColorMaterial_texture_sampler;
@@ -20,5 +34,35 @@ void main() {
         sampler2D(ColorMaterial_texture, ColorMaterial_texture_sampler),
         v_Uv);
 # endif
-    o_Target = color;
+    float t = _border.thickness;
+    float r = _border.radius;
+
+    float aa = clamp(1.0, 20.0, 4 * t);
+
+    vec2 pos = abs(v_Uv - 0.5) * NodeSize;
+
+    //https://www.desmos.com/calculator/1ttzhiy51j
+
+    vec2 half_size = NodeSize / 2;
+    vec2 calc = pos + r - half_size;
+    float c_dist_sq = dot(calc, calc);
+
+    float O = smoothstep(-aa, aa, c_dist_sq - r*r);
+    float O2 = 1.0 - O;
+
+    float m = max(r-t, 0);
+    float R = smoothstep(-aa, aa, c_dist_sq - m*m);
+
+    vec2 B = step(0.0, pos + r - half_size);
+    vec2 B2 = 1.0.xx - B;
+
+    float outside = B.x * B.y * O;
+    
+    float border_corners = B.x * B.y * R * O2;
+    float border_sides = dot(step(0.0, pos + t - half_size), B2.yx);
+    float border = min(1.0, border_corners + border_sides);
+
+    float inner = 1 - clamp(0.0, 1.0, border + outside);
+
+    o_Target = inner * color + border * _border.color;
 }

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -3,6 +3,7 @@ use bevy::prelude::*;
 /// This example illustrates the various features of Bevy UI.
 fn main() {
     App::build()
+        .add_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();
@@ -32,43 +33,35 @@ fn setup(
                 .spawn(NodeBundle {
                     style: Style {
                         size: Size::new(Val::Px(200.0), Val::Percent(100.0)),
-                        border: Rect::all(Val::Px(2.0)),
+                        align_items: AlignItems::FlexEnd,
+                        border: Border {
+                            radius: 10.,
+                            color: Color::rgb(0.65, 0.65, 0.65),
+                            thickness: 2.,
+                        },
                         ..Default::default()
                     },
-                    material: materials.add(Color::rgb(0.65, 0.65, 0.65).into()),
+                    material: materials.add(Color::rgb(0.15, 0.15, 0.15).into()),
                     ..Default::default()
                 })
                 .with_children(|parent| {
-                    parent
-                        // left vertical fill (content)
-                        .spawn(NodeBundle {
-                            style: Style {
-                                size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
-                                align_items: AlignItems::FlexEnd,
+                    // text
+                    parent.spawn(TextBundle {
+                        style: Style {
+                            margin: Rect::all(Val::Px(5.0)),
+                            ..Default::default()
+                        },
+                        text: Text {
+                            value: "Text Example".to_string(),
+                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                            style: TextStyle {
+                                font_size: 30.0,
+                                color: Color::WHITE,
                                 ..Default::default()
                             },
-                            material: materials.add(Color::rgb(0.15, 0.15, 0.15).into()),
-                            ..Default::default()
-                        })
-                        .with_children(|parent| {
-                            // text
-                            parent.spawn(TextBundle {
-                                style: Style {
-                                    margin: Rect::all(Val::Px(5.0)),
-                                    ..Default::default()
-                                },
-                                text: Text {
-                                    value: "Text Example".to_string(),
-                                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                    style: TextStyle {
-                                        font_size: 30.0,
-                                        color: Color::WHITE,
-                                        ..Default::default()
-                                    },
-                                },
-                                ..Default::default()
-                            });
-                        });
+                        },
+                        ..Default::default()
+                    });
                 })
                 // right vertical fill
                 .spawn(NodeBundle {
@@ -89,21 +82,15 @@ fn setup(
                             bottom: Val::Px(10.0),
                             ..Default::default()
                         },
-                        border: Rect::all(Val::Px(20.0)),
+                        border: Border {
+                            radius: 50.,
+                            color: Color::rgb(0.4, 0.4, 1.0),
+                            thickness: 20.,
+                        },
                         ..Default::default()
                     },
-                    material: materials.add(Color::rgb(0.4, 0.4, 1.0).into()),
+                    material: materials.add(Color::rgb(0.8, 0.8, 1.0).into()),
                     ..Default::default()
-                })
-                .with_children(|parent| {
-                    parent.spawn(NodeBundle {
-                        style: Style {
-                            size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
-                            ..Default::default()
-                        },
-                        material: materials.add(Color::rgb(0.8, 0.8, 1.0).into()),
-                        ..Default::default()
-                    });
                 })
                 // render order test: reddest in the back, whitest in the front (flex center)
                 .spawn(NodeBundle {

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -75,7 +75,7 @@ fn setup(
                 // absolute positioning
                 .spawn(NodeBundle {
                     style: Style {
-                        size: Size::new(Val::Px(200.0), Val::Px(200.0)),
+                        size: Size::new(Val::Px(200.0), Val::Percent(50.0)),
                         position_type: PositionType::Absolute,
                         position: Rect {
                             left: Val::Px(210.0),
@@ -83,14 +83,26 @@ fn setup(
                             ..Default::default()
                         },
                         border: Border {
-                            radius: 50.,
-                            color: Color::rgb(0.4, 0.4, 1.0),
-                            thickness: 20.,
+                            radius: 20.,
+                            color: Color::rgba(0.0, 1.0, 0.0, 0.25), //Color::rgb(0.4, 0.4, 1.0),
+                            thickness: 2.,
                         },
+                        overflow: Overflow::Hidden,
                         ..Default::default()
                     },
                     material: materials.add(Color::rgb(0.8, 0.8, 1.0).into()),
                     ..Default::default()
+                })
+                .with_children(|parent| {
+                    parent.spawn(NodeBundle {
+                        style: Style {
+                            size: Size::new(Val::Px(100.0), Val::Px(300.0)),
+                            align_self: AlignSelf::Center,
+                            ..Default::default()
+                        },
+                        material: materials.add(Color::RED.into()),
+                        ..Default::default()
+                    });
                 })
                 // render order test: reddest in the back, whitest in the front (flex center)
                 .spawn(NodeBundle {


### PR DESCRIPTION
This PR implements Overflow::Hidden, rounded corners and borders by extending the UI fragment shader. There are various bugs: anti-aliasing is broken for rounded overflows, overflow mask randomly shifts 1px up or down on certain node widths and text is entirely ignored, but its ready enough to talk over.