### PR TITLE
Mutable mesh accessors: indices_mut and attribute_mut

### DIFF
--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -219,7 +219,10 @@ impl Mesh {
         self.attributes.get(&name.into())
     }
 
-    pub fn attribute_mut(&mut self, name: impl Into<Cow<'static, str>>) -> Option<&mut VertexAttributeValues> {
+    pub fn attribute_mut(
+        &mut self,
+        name: impl Into<Cow<'static, str>>,
+    ) -> Option<&mut VertexAttributeValues> {
         self.attributes.get_mut(&name.into())
     }
 

--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -219,12 +219,20 @@ impl Mesh {
         self.attributes.get(&name.into())
     }
 
+    pub fn attribute_mut(&mut self, name: impl Into<Cow<'static, str>>) -> Option<&mut VertexAttributeValues> {
+        self.attributes.get_mut(&name.into())
+    }
+
     pub fn set_indices(&mut self, indices: Option<Indices>) {
         self.indices = indices;
     }
 
     pub fn indices(&self) -> Option<&Indices> {
         self.indices.as_ref()
+    }
+
+    pub fn indices_mut(&mut self) -> Option<&mut Indices> {
+        self.indices.as_mut()
     }
 
     pub fn get_index_buffer_bytes(&self) -> Option<Vec<u8>> {


### PR DESCRIPTION
Hello,

In current bevy render, the only way to set attributes on a mesh is to set all values which involves a lot of cloning. For faster updating of dynamic meshes, I propose in this pull request to add two new accessors to Mesh so that it is possible to edit its values directly. 

In this example, the iterator is copied directly to the mesh
```rust
let pos = sub.attribute_mut(Mesh::ATTRIBUTE_POSITION).unwrap();
if let VertexAttributeValues::Float3(ref mut pos) = pos {
    pos.clear();
    pos.extend(triangles.vertices.iter().map(|v| [v.pos.x, v.pos.y, 0.0f32]));
}
```
avoiding a collect() needed by the current approach

```rust
sub.set_attribute(Mesh::ATTRIBUTE_POSITION, VertexAttributeValues::Float3(triangles.vertices.iter().map(|v| [v.pos.x, v.pos.y, 0.0f32]).collect()));
```