### PR TITLE
Derive Clone for SpriteSheetBundle and SpriteBundle

### DIFF
--- a/crates/bevy_sprite/src/entity.rs
+++ b/crates/bevy_sprite/src/entity.rs
@@ -12,7 +12,7 @@ use bevy_render::{
 };
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
-#[derive(Bundle)]
+#[derive(Bundle, Clone)]
 pub struct SpriteBundle {
     pub sprite: Sprite,
     pub mesh: Handle<Mesh>, // TODO: maybe abstract this out

--- a/crates/bevy_sprite/src/entity.rs
+++ b/crates/bevy_sprite/src/entity.rs
@@ -48,7 +48,7 @@ impl Default for SpriteBundle {
 
 /// A Bundle of components for drawing a single sprite from a sprite sheet (also referred
 /// to as a `TextureAtlas`)
-#[derive(Bundle)]
+#[derive(Bundle, Clone)]
 pub struct SpriteSheetBundle {
     /// The specific sprite from the texture atlas to be drawn
     pub sprite: TextureAtlasSprite,

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -6,7 +6,7 @@ use bevy_reflect::{Reflect, ReflectDeserialize, TypeUuid};
 use bevy_render::{renderer::RenderResources, texture::Texture};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default, RenderResources, TypeUuid, Reflect)]
+#[derive(Debug, Default, Clone, RenderResources, TypeUuid, Reflect)]
 #[uuid = "7233c597-ccfa-411f-bd59-9af349432ada"]
 pub struct Sprite {
     pub size: Vec2,

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -25,7 +25,7 @@ pub struct TextureAtlas {
     pub texture_handles: Option<HashMap<Handle<Texture>, usize>>,
 }
 
-#[derive(Debug, RenderResources, RenderResource)]
+#[derive(Debug, RenderResources, RenderResource, Clone)]
 #[render_resources(from_self)]
 pub struct TextureAtlasSprite {
     pub color: Color,


### PR DESCRIPTION
Derive `Clone` for:

- `SpriteSheetBundle`
- `TextureAtlasSprite`
- `SpriteBundle`
- `Sprite`

Justification: `Clone` is also implemented for `ImageBundle` which is relatively similar.