### PR TITLE
Remove outdated Documentation

### DIFF
--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -107,7 +107,6 @@ fn score_system(mut query: Query<(&Player, &mut Score)>) {
 
 // This system runs on all entities with the "Player" and "Score" components, but it also
 // accesses the "GameRules" resource to determine if a player has won.
-// NOTE: resources must always come before worlds/queries in system functions
 fn score_check_system(
     game_rules: Res<GameRules>,
     mut game_state: ResMut<GameState>,
@@ -174,7 +173,6 @@ fn startup_system(commands: &mut Commands, mut game_state: ResMut<GameState>) {
 // Normal systems cannot safely access the World instance directly because they run in parallel.
 // Our World contains all of our components, so mutating arbitrary parts of it in parallel is not thread safe.
 // Command buffers give us the ability to queue up changes to our World without directly accessing it
-// NOTE: Command buffers must always come before resources and queries in system functions
 fn new_player_system(
     commands: &mut Commands,
     game_rules: Res<GameRules>,


### PR DESCRIPTION
These two lines can be removed, as the argument order of systems is no longer fixed.