### PR TITLE
remove unnecessary semicolons

### DIFF
--- a/crates/bevy_ecs/src/core/query.rs
+++ b/crates/bevy_ecs/src/core/query.rs
@@ -484,7 +484,7 @@ mod tests {
             world
                 .query_filtered::<Entity, Added<Com>>()
                 .collect::<Vec<Entity>>()
-        };
+        }
 
         assert_eq!(get_added::<A>(&world), vec![e1]);
         world.insert(e1, (B(0),)).unwrap();
@@ -519,7 +519,7 @@ mod tests {
 
         fn get_filtered<F: QueryFilter>(world: &mut World) -> Vec<Entity> {
             world.query_filtered::<Entity, F>().collect::<Vec<Entity>>()
-        };
+        }
 
         assert_eq!(get_filtered::<Mutated<A>>(&mut world), vec![e1, e3]);
 
@@ -632,7 +632,7 @@ mod tests {
             world
                 .query_filtered::<Entity, Changed<A>>()
                 .collect::<Vec<Entity>>()
-        };
+        }
         assert_eq!(get_changed(&world), vec![e1]);
         world.clear_trackers();
         assert_eq!(get_changed(&world), vec![]);

--- a/crates/bevy_ecs/src/system/into_system.rs
+++ b/crates/bevy_ecs/src/system/into_system.rs
@@ -425,7 +425,7 @@ mod tests {
             assert_eq!(mutated, 0);
 
             *ran = true;
-        };
+        }
 
         let mut world = World::default();
         let mut resources = Resources::default();


### PR DESCRIPTION
fixes build errors caused by a new rustc warning.