### PR TITLE
bevy_reflect incorrectly looks for bevy in dev-deps

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/modules.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/modules.rs
@@ -29,7 +29,9 @@ impl Modules {
 
 pub fn get_modules() -> Modules {
     let mut manifest = Manifest::new().unwrap();
+    // Only look for regular dependencies in the first pass.
     manifest.dependencies = Dependencies::Release;
+
     if let Some(package) = manifest.find(|name| name == "bevy") {
         Modules::meta(&package.name)
     } else if let Some(package) = manifest.find(|name| name == "bevy_internal") {
@@ -37,7 +39,19 @@ pub fn get_modules() -> Modules {
     } else if let Some(_package) = manifest.find(|name| name == "bevy_reflect") {
         Modules::external()
     } else {
-        Modules::internal()
+        // If reflect is not found as a regular dependency,
+        // try dev-dependencies.
+        manifest.dependencies = Dependencies::Dev;
+
+        if let Some(package) = manifest.find(|name| name == "bevy") {
+            Modules::meta(&package.name)
+        } else if let Some(package) = manifest.find(|name| name == "bevy_internal") {
+            Modules::meta(&package.name)
+        } else if let Some(_package) = manifest.find(|name| name == "bevy_reflect") {
+            Modules::external()
+        } else {
+            Modules::internal()
+        }
     }
 }
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/modules.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/modules.rs
@@ -1,4 +1,4 @@
-use find_crate::Manifest;
+use find_crate::{Dependencies, Manifest};
 use proc_macro::TokenStream;
 use syn::Path;
 
@@ -28,7 +28,8 @@ impl Modules {
 }
 
 pub fn get_modules() -> Modules {
-    let manifest = Manifest::new().unwrap();
+    let mut manifest = Manifest::new().unwrap();
+    manifest.dependencies = Dependencies::Release;
     if let Some(package) = manifest.find(|name| name == "bevy") {
         Modules::meta(&package.name)
     } else if let Some(package) = manifest.find(|name| name == "bevy_internal") {


### PR DESCRIPTION
When trying to determine how it should mention itself in derive macros, the crate finder incorrectly assumes it can use `bevy::reflect` if bevy is available as a dev dependency. This PR fixes this behavior by ignoring dev-dependencies.