### PR TITLE
use Name on node when loading a gltf file

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -17,7 +17,7 @@ pub use task_pool_options::DefaultTaskPoolOptions;
 pub use time::*;
 
 pub mod prelude {
-    pub use crate::{DefaultTaskPoolOptions, EntityLabels, Labels, Time, Timer};
+    pub use crate::{DefaultTaskPoolOptions, EntityLabels, Labels, Name, Time, Timer};
 }
 
 use bevy_app::{prelude::*, startup_stage};

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use bevy_asset::{AssetIoError, AssetLoader, AssetPath, Handle, LoadContext, LoadedAsset};
-use bevy_core::Labels;
+use bevy_core::Name;
 use bevy_ecs::{bevy_utils::BoxedFuture, World, WorldBuilderSource};
 use bevy_math::Mat4;
 use bevy_pbr::prelude::{PbrBundle, StandardMaterial};
@@ -318,7 +318,7 @@ fn load_node(
     ));
 
     if let Some(name) = gltf_node.name() {
-        node.with(Labels::from(vec![name.to_string()]));
+        node.with(Name::new(name.to_string()));
     }
 
     // create camera node


### PR DESCRIPTION
following #1020, use `Name` instead of `Labels`

also added `Name` to the prelude, and updated an example showing how to use it for a gltf file