### PR TITLE
Refactor `Box<dyn System>` to BoxedSystem

### DIFF
--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -6,14 +6,14 @@ pub use stage::*;
 pub use stage_executor::*;
 pub use state::*;
 
-use crate::{IntoSystem, Resources, System, World};
+use crate::{BoxedSystem, IntoSystem, Resources, System, World};
 use bevy_utils::HashMap;
 
 #[derive(Default)]
 pub struct Schedule {
     stages: HashMap<String, Box<dyn Stage>>,
     stage_order: Vec<String>,
-    run_criteria: Option<Box<dyn System<In = (), Out = ShouldRun>>>,
+    run_criteria: Option<BoxedSystem<(), ShouldRun>>,
     run_criteria_initialized: bool,
 }
 

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -1,7 +1,8 @@
 use std::{any::TypeId, borrow::Cow};
 
 use crate::{
-    ArchetypeComponent, Resources, System, SystemId, ThreadLocalExecution, TypeAccess, World,
+    ArchetypeComponent, BoxedSystem, Resources, System, SystemId, ThreadLocalExecution, TypeAccess,
+    World,
 };
 use bevy_utils::HashSet;
 use downcast_rs::{impl_downcast, Downcast};
@@ -24,10 +25,10 @@ pub trait Stage: Downcast + Send + Sync {
 impl_downcast!(Stage);
 
 pub struct SystemStage {
-    systems: Vec<Box<dyn System<In = (), Out = ()>>>,
+    systems: Vec<BoxedSystem>,
     system_ids: HashSet<SystemId>,
     executor: Box<dyn SystemStageExecutor>,
-    run_criteria: Option<Box<dyn System<In = (), Out = ShouldRun>>>,
+    run_criteria: Option<BoxedSystem<(), ShouldRun>>,
     run_criteria_initialized: bool,
     uninitialized_systems: Vec<usize>,
     unexecuted_systems: Vec<usize>,
@@ -74,7 +75,7 @@ impl SystemStage {
         self
     }
 
-    pub fn add_system_boxed(&mut self, system: Box<dyn System<In = (), Out = ()>>) -> &mut Self {
+    pub fn add_system_boxed(&mut self, system: BoxedSystem) -> &mut Self {
         if self.system_ids.contains(&system.id()) {
             panic!(
                 "System with id {:?} ({}) already exists",

--- a/crates/bevy_ecs/src/schedule/stage_executor.rs
+++ b/crates/bevy_ecs/src/schedule/stage_executor.rs
@@ -5,12 +5,14 @@ use bevy_utils::tracing::trace;
 use downcast_rs::{impl_downcast, Downcast};
 use fixedbitset::FixedBitSet;
 
-use crate::{ArchetypesGeneration, Resources, System, ThreadLocalExecution, TypeAccess, World};
+use crate::{
+    ArchetypesGeneration, BoxedSystem, Resources, ThreadLocalExecution, TypeAccess, World,
+};
 
 pub trait SystemStageExecutor: Downcast + Send + Sync {
     fn execute_stage(
         &mut self,
-        systems: &mut [Box<dyn System<In = (), Out = ()>>],
+        systems: &mut [BoxedSystem],
         changed_systems: &[usize],
         world: &mut World,
         resources: &mut Resources,
@@ -25,7 +27,7 @@ pub struct SerialSystemStageExecutor;
 impl SystemStageExecutor for SerialSystemStageExecutor {
     fn execute_stage(
         &mut self,
-        systems: &mut [Box<dyn System<In = (), Out = ()>>],
+        systems: &mut [BoxedSystem],
         _changed_systems: &[usize],
         world: &mut World,
         resources: &mut Resources,
@@ -109,7 +111,7 @@ impl ParallelSystemStageExecutor {
     pub fn prepare_to_next_thread_local(
         &mut self,
         world: &World,
-        systems: &mut [Box<dyn System<In = (), Out = ()>>],
+        systems: &mut [BoxedSystem],
         stage_changed: bool,
         next_thread_local_index: usize,
     ) -> Range<usize> {
@@ -291,7 +293,7 @@ impl ParallelSystemStageExecutor {
         &self,
         world: &World,
         resources: &Resources,
-        systems: &mut [Box<dyn System<In = (), Out = ()>>],
+        systems: &mut [BoxedSystem],
         prepared_system_range: Range<usize>,
         compute_pool: &TaskPool,
     ) {
@@ -387,7 +389,7 @@ impl ParallelSystemStageExecutor {
 impl SystemStageExecutor for ParallelSystemStageExecutor {
     fn execute_stage(
         &mut self,
-        systems: &mut [Box<dyn System<In = (), Out = ()>>],
+        systems: &mut [BoxedSystem],
         changed_systems: &[usize],
         world: &mut World,
         resources: &mut Resources,

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -50,3 +50,5 @@ pub trait System: Send + Sync + 'static {
     fn run_thread_local(&mut self, world: &mut World, resources: &mut Resources);
     fn initialize(&mut self, _world: &mut World, _resources: &mut Resources);
 }
+
+pub type BoxedSystem<In = (), Out = ()> = Box<dyn System<In = In, Out = Out>>;

--- a/crates/bevy_pbr/src/render_graph/lights_node.rs
+++ b/crates/bevy_pbr/src/render_graph/lights_node.rs
@@ -3,7 +3,9 @@ use crate::{
     render_graph::uniform,
 };
 use bevy_core::{AsBytes, Byteable};
-use bevy_ecs::{BoxedSystem, Commands, IntoSystem, Local, Query, Res, ResMut, Resources, System, World};
+use bevy_ecs::{
+    BoxedSystem, Commands, IntoSystem, Local, Query, Res, ResMut, Resources, System, World,
+};
 use bevy_render::{
     render_graph::{CommandQueue, Node, ResourceSlots, SystemNode},
     renderer::{

--- a/crates/bevy_pbr/src/render_graph/lights_node.rs
+++ b/crates/bevy_pbr/src/render_graph/lights_node.rs
@@ -3,7 +3,7 @@ use crate::{
     render_graph::uniform,
 };
 use bevy_core::{AsBytes, Byteable};
-use bevy_ecs::{Commands, IntoSystem, Local, Query, Res, ResMut, Resources, System, World};
+use bevy_ecs::{BoxedSystem, Commands, IntoSystem, Local, Query, Res, ResMut, Resources, System, World};
 use bevy_render::{
     render_graph::{CommandQueue, Node, ResourceSlots, SystemNode},
     renderer::{
@@ -51,7 +51,7 @@ struct LightCount {
 unsafe impl Byteable for LightCount {}
 
 impl SystemNode for LightsNode {
-    fn get_system(&self, commands: &mut Commands) -> Box<dyn System<In = (), Out = ()>> {
+    fn get_system(&self, commands: &mut Commands) -> BoxedSystem {
         let system = lights_node_system.system();
         commands.insert_local_resource(
             system.id(),

--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -1,6 +1,6 @@
 use super::{Edge, RenderGraphError, ResourceSlotInfo, ResourceSlots};
 use crate::renderer::RenderContext;
-use bevy_ecs::{Commands, Resources, System, World};
+use bevy_ecs::{BoxedSystem, Commands, Resources, World};
 use bevy_utils::Uuid;
 use downcast_rs::{impl_downcast, Downcast};
 use std::{borrow::Cow, fmt::Debug};
@@ -37,7 +37,7 @@ pub trait Node: Downcast + Send + Sync + 'static {
 impl_downcast!(Node);
 
 pub trait SystemNode: Node {
-    fn get_system(&self, commands: &mut Commands) -> Box<dyn System<In = (), Out = ()>>;
+    fn get_system(&self, commands: &mut Commands) -> BoxedSystem;
 }
 
 #[derive(Debug)]

--- a/crates/bevy_render/src/render_graph/nodes/camera_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/camera_node.rs
@@ -8,7 +8,9 @@ use crate::{
 };
 use bevy_core::AsBytes;
 
-use bevy_ecs::{Commands, IntoSystem, Local, Query, Res, ResMut, Resources, System, World};
+use bevy_ecs::{
+    BoxedSystem, Commands, IntoSystem, Local, Query, Res, ResMut, Resources, System, World,
+};
 use bevy_transform::prelude::*;
 use std::borrow::Cow;
 
@@ -44,7 +46,7 @@ impl Node for CameraNode {
 }
 
 impl SystemNode for CameraNode {
-    fn get_system(&self, commands: &mut Commands) -> Box<dyn System<In = (), Out = ()>> {
+    fn get_system(&self, commands: &mut Commands) -> BoxedSystem {
         let system = camera_node_system.system();
         commands.insert_local_resource(
             system.id(),

--- a/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
@@ -12,8 +12,8 @@ use crate::{
 use bevy_app::{EventReader, Events};
 use bevy_asset::{Asset, AssetEvent, Assets, Handle, HandleId};
 use bevy_ecs::{
-    Changed, Commands, Entity, IntoSystem, Local, Or, Query, QuerySet, Res, ResMut, Resources,
-    System, With, World,
+    BoxedSystem, Changed, Commands, Entity, IntoSystem, Local, Or, Query, QuerySet, Res, ResMut,
+    Resources, System, With, World,
 };
 use bevy_utils::HashMap;
 use renderer::{AssetRenderResourceBindings, BufferId, RenderResourceType, RenderResources};
@@ -401,7 +401,7 @@ impl<T> SystemNode for RenderResourcesNode<T>
 where
     T: renderer::RenderResources,
 {
-    fn get_system(&self, commands: &mut Commands) -> Box<dyn System<In = (), Out = ()>> {
+    fn get_system(&self, commands: &mut Commands) -> BoxedSystem {
         let system = render_resources_node_system::<T>.system();
         commands.insert_local_resource(
             system.id(),
@@ -584,7 +584,7 @@ impl<T> SystemNode for AssetRenderResourcesNode<T>
 where
     T: renderer::RenderResources + Asset,
 {
-    fn get_system(&self, commands: &mut Commands) -> Box<dyn System<In = (), Out = ()>> {
+    fn get_system(&self, commands: &mut Commands) -> BoxedSystem {
         let system = asset_render_resources_node_system::<T>.system();
         commands.insert_local_resource(
             system.id(),


### PR DESCRIPTION
I was tinkering with bevy_ecs, and felt like `Box<dyn System<In = (), Out = ()>>` deserved a more concise name.