### PR TITLE
Made gilrs crate public within bevy so we can reference the plugin ou…

### DIFF
--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -82,6 +82,11 @@ pub mod audio {
     pub use bevy_audio::*;
 }
 
+#[cfg(feature = "bevy_gilrs")]
+pub mod gilrs {
+    pub use bevy_gilrs::*;
+}
+
 #[cfg(feature = "bevy_gltf")]
 pub mod gltf {
     //! Support for GLTF file loading.

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -26,3 +26,6 @@ pub use crate::ui::prelude::*;
 
 #[cfg(feature = "bevy_dynamic_plugin")]
 pub use crate::dynamic_plugin::*;
+
+#[cfg(feature = "bevy_gilrs")]
+pub use crate::gilrs::*;


### PR DESCRIPTION
…tside of DefaultPlugins.

Not sure if leaving this out was intentional, but I've been trying to use only the plugins I need instead of "DefaultPlugins", and I haven't been able to get access to gilrs without depending on the public crate separately from bevy.

ie. I've had to do the following without this PR
```toml
[dependencies]
bevy = "0.4"
bevy_gilrs = "0.4"
```