### PR TITLE
Subpixel text positioning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,9 @@ serialize = ["bevy_internal/serialize"]
 wayland = ["bevy_internal/wayland"]
 x11 = ["bevy_internal/x11"]
 
+# enable rendering of font glyphs using subpixel accuracy
+subpixel_glyph_atlas = ["bevy_internal/subpixel_glyph_atlas"]
+
 [dependencies]
 bevy_dylib = {path = "crates/bevy_dylib", version = "0.4.0", default-features = false, optional = true}
 bevy_internal = {path = "crates/bevy_internal", version = "0.4.0", default-features = false}

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -38,6 +38,9 @@ serialize = ["bevy_input/serialize"]
 wayland = ["bevy_winit/wayland"]
 x11 = ["bevy_winit/x11"]
 
+# enable rendering of font glyphs using subpixel accuracy
+subpixel_glyph_atlas = ["bevy_text/subpixel_glyph_atlas"]
+
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.4.0" }

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT"
 keywords = ["bevy"]
 
+[features]
+subpixel_glyph_atlas = []
+
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.4.0" }

--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -1,13 +1,44 @@
-use ab_glyph::GlyphId;
+use ab_glyph::{GlyphId, Point};
 use bevy_asset::{Assets, Handle};
 use bevy_math::Vec2;
 use bevy_render::texture::{Extent3d, Texture, TextureDimension, TextureFormat};
 use bevy_sprite::{DynamicTextureAtlasBuilder, TextureAtlas};
 use bevy_utils::HashMap;
 
+#[cfg(feature = "subpixel_glyph_atlas")]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct SubpixelOffset {
+    x: u16,
+    y: u16,
+}
+
+#[cfg(feature = "subpixel_glyph_atlas")]
+impl From<Point> for SubpixelOffset {
+    fn from(p: Point) -> Self {
+        fn f(v: f32) -> u16 {
+            ((v % 1.) * (u16::MAX as f32)) as u16
+        }
+        Self {
+            x: f(p.x),
+            y: f(p.y),
+        }
+    }
+}
+
+#[cfg(not(feature = "subpixel_glyph_atlas"))]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct SubpixelOffset;
+
+#[cfg(not(feature = "subpixel_glyph_atlas"))]
+impl From<Point> for SubpixelOffset {
+    fn from(_: Point) -> Self {
+        Self
+    }
+}
+
 pub struct FontAtlas {
     pub dynamic_texture_atlas_builder: DynamicTextureAtlasBuilder,
-    pub glyph_to_atlas_index: HashMap<GlyphId, u32>,
+    pub glyph_to_atlas_index: HashMap<(GlyphId, SubpixelOffset), u32>,
     pub texture_atlas: Handle<TextureAtlas>,
 }
 
@@ -31,12 +62,19 @@ impl FontAtlas {
         }
     }
 
-    pub fn get_glyph_index(&self, glyph_id: GlyphId) -> Option<u32> {
-        self.glyph_to_atlas_index.get(&glyph_id).copied()
+    pub fn get_glyph_index(
+        &self,
+        glyph_id: GlyphId,
+        subpixel_offset: SubpixelOffset,
+    ) -> Option<u32> {
+        self.glyph_to_atlas_index
+            .get(&(glyph_id, subpixel_offset))
+            .copied()
     }
 
-    pub fn has_glyph(&self, glyph_id: GlyphId) -> bool {
-        self.glyph_to_atlas_index.contains_key(&glyph_id)
+    pub fn has_glyph(&self, glyph_id: GlyphId, subpixel_offset: SubpixelOffset) -> bool {
+        self.glyph_to_atlas_index
+            .contains_key(&(glyph_id, subpixel_offset))
     }
 
     pub fn add_glyph(
@@ -44,6 +82,7 @@ impl FontAtlas {
         textures: &mut Assets<Texture>,
         texture_atlases: &mut Assets<TextureAtlas>,
         glyph_id: GlyphId,
+        subpixel_offset: SubpixelOffset,
         texture: &Texture,
     ) -> bool {
         let texture_atlas = texture_atlases.get_mut(&self.texture_atlas).unwrap();
@@ -51,7 +90,8 @@ impl FontAtlas {
             self.dynamic_texture_atlas_builder
                 .add_texture(texture_atlas, textures, texture)
         {
-            self.glyph_to_atlas_index.insert(glyph_id, index);
+            self.glyph_to_atlas_index
+                .insert((glyph_id, subpixel_offset), index);
             true
         } else {
             false

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -76,12 +76,10 @@ impl GlyphBrush {
             let SectionGlyph {
                 section_index: _,
                 byte_index: _,
-                mut glyph,
+                glyph,
                 font_id: _,
             } = sg;
             let glyph_id = glyph.id;
-            let base_x = glyph.position.x.floor();
-            glyph.position.x = 0.;
             if let Some(outlined_glyph) = font.font.outline_glyph(glyph) {
                 let bounds = outlined_glyph.px_bounds();
                 let handle_font_atlas: Handle<FontAtlasSet> = handle.as_weak();
@@ -100,9 +98,7 @@ impl GlyphBrush {
                 let glyph_width = glyph_rect.width();
                 let glyph_height = glyph_rect.height();
 
-                let x = base_x + bounds.min.x + glyph_width / 2.0 - min_x;
-                // the 0.5 accounts for odd-numbered heights (bump up by 1 pixel)
-                // max_y = text block height, and up is negative (whereas for transform, up is positive)
+                let x = bounds.min.x + glyph_width / 2.0 - min_x;
                 let y = max_y - bounds.max.y + glyph_height / 2.0;
                 let position = Vec2::new(x, y);
 

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -71,3 +71,9 @@ Vorbis audio format support.
 ### wayland
 
 Enable this to use Wayland display server protocol other than X11.
+
+### subpixel_glyph_atlas
+
+Enable this to cache glyphs using subpixel accuracy. This increases texture
+memory usage as each position requires a separate sprite in the glyph atlas, but
+provide more accurate character spacing.


### PR DESCRIPTION
This PR adds a feature to support sub-pixel glyph positioning. This requires creating multiple atlas sprites per glyph based on the sub-pixel offset of the glyph in its layout. As this will increase the amount of texture memory required I placed it behind a feature gate which is not enabled by default.

In the example below you can see several differences in the rendering of glyphs, in particular the final 'e' is different from the first one, and the spacing of the adjacent 'l' is better.

![example-subpixel](https://user-images.githubusercontent.com/266735/103470515-10c04a00-4d28-11eb-9b2b-fb42c0c1c139.png)

By getting the placement correct, the glyphs in the right justified text in the text_debug example no longer jiggle.

https://user-images.githubusercontent.com/266735/103470563-76acd180-4d28-11eb-821f-a0509d8771ca.mp4

https://user-images.githubusercontent.com/266735/103470564-79a7c200-4d28-11eb-860b-366a59222346.mp4


