### PR TITLE
Add convenience function to set every dimension's address mode

### DIFF
--- a/crates/bevy_render/src/texture/sampler_descriptor.rs
+++ b/crates/bevy_render/src/texture/sampler_descriptor.rs
@@ -16,6 +16,15 @@ pub struct SamplerDescriptor {
     pub anisotropy_clamp: Option<NonZeroU8>,
 }
 
+impl SamplerDescriptor {
+    /// Sets the address mode for all dimensions of the sampler descriptor.
+    pub fn set_address_mode(&mut self, address_mode: AddressMode) {
+        self.address_mode_u = address_mode;
+        self.address_mode_v = address_mode;
+        self.address_mode_w = address_mode;
+    }
+}
+
 impl Default for SamplerDescriptor {
     fn default() -> Self {
         SamplerDescriptor {


### PR DESCRIPTION
This adds a `fn set_address_mode(&mut self, address_mode: AddressMode)` on `SamplerDescriptor` to set `address_mode_u`, `address_mode_v`, and `address_mode_w` to the same `AddressMode`. This is just a convenience function to avoid having to copy and paste three setters every time.