### PR TITLE
Split hierarchy updates and transform propagation to two stages

### DIFF
--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -7,9 +7,14 @@ pub mod prelude {
 }
 
 use bevy_app::{prelude::*, startup_stage};
-use bevy_ecs::IntoSystem;
+use bevy_ecs::{IntoSystem, SystemStage};
 use bevy_reflect::RegisterTypeBuilder;
 use prelude::{parent_update_system, Children, GlobalTransform, Parent, PreviousParent, Transform};
+
+pub mod stage {
+    pub const STARTUP_UPDATE_HIERARCHY: &str = "transform_startup_update_hierarchy";
+    pub const UPDATE_HIERARCHY: &str = "transform_update_hierarchy";
+}
 
 #[derive(Default)]
 pub struct TransformPlugin;
@@ -22,14 +27,27 @@ impl Plugin for TransformPlugin {
             .register_type::<Transform>()
             .register_type::<GlobalTransform>()
             // add transform systems to startup so the first update is "correct"
-            .add_startup_system_to_stage(startup_stage::POST_STARTUP, parent_update_system.system())
+            .add_startup_stage_after(
+                startup_stage::STARTUP,
+                stage::STARTUP_UPDATE_HIERARCHY,
+                SystemStage::parallel(),
+            )
+            .add_startup_system_to_stage(
+                stage::STARTUP_UPDATE_HIERARCHY,
+                parent_update_system.system(),
+            )
             .add_startup_system_to_stage(
                 startup_stage::POST_STARTUP,
                 transform_propagate_system::transform_propagate_system.system(),
             )
-            .add_system_to_stage(stage::POST_UPDATE, parent_update_system.system())
+            .add_stage_after(
+                bevy_app::stage::UPDATE,
+                stage::UPDATE_HIERARCHY,
+                SystemStage::parallel(),
+            )
+            .add_system_to_stage(stage::UPDATE_HIERARCHY, parent_update_system.system())
             .add_system_to_stage(
-                stage::POST_UPDATE,
+                bevy_app::stage::POST_UPDATE,
                 transform_propagate_system::transform_propagate_system.system(),
             );
     }


### PR DESCRIPTION
With hierarchy updates and transform propagation in the same stage,
GlobalTransform may fail to be updated when an entity is added
without using one of the .with_children style functions and Transform
is not changed on further frames. This can happen when creating an
entity with Transform and Parent directly.

The reason for this is that the transform propagation pass relies
on the Children component being set on the parent, but as the
parent update system is run in the same stage, the component
is not yet visible. On the following frame, the Changed<Transform>
constraint filters out the entity, and as a result GlobalTransform
never gets updated.

Fix this by moving parent_update_system to a new UPDATE_HIERARCHY
stage just after the UPDATE stage (and likewise for startup stages).
This ensures that all systems in POST_STARTUP and further can rely
on the hierarchy being set up.