### PR TITLE
Add support for OTF fonts

### DIFF
--- a/crates/bevy_text/src/font_loader.rs
+++ b/crates/bevy_text/src/font_loader.rs
@@ -20,6 +20,6 @@ impl AssetLoader for FontLoader {
     }
 
     fn extensions(&self) -> &[&str] {
-        &["ttf"]
+        &["ttf", "otf"]
     }
 }


### PR DESCRIPTION
I saw some talk about OTF on discord, and cord seemed that this should do the trick.

I tested this by running the text_debug example with both the ttf and otf versions of [this font](https://github.com/belluzj/fantasque-sans/releases/tag/v1.8.0) and everything seems fine.