### PR TITLE
Rendering masks

### DIFF
--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -24,37 +24,46 @@ impl VisibleEntities {
     }
 }
 
-/// A mask that describes which rendering group an entity belongs to.
+/// A mask describes which rendering group an entity belongs to.
+///
 /// Cameras with this component will only render entities with a matching
 /// mask.
+///
+/// The [`Default`] instance of `RenderingMask` returns a mask that contains
+/// no groups.
 #[derive(Copy, Clone, Debug, Reflect, PartialEq, Eq, PartialOrd, Ord)]
 #[reflect(Component)]
 pub struct RenderingMask(pub u32);
 
 impl Default for RenderingMask {
     fn default() -> Self {
-        RenderingMask(1)
+        RenderingMask(0)
     }
 }
 
 impl RenderingMask {
+    /// Create new `RenderingMask` with the given rendering group set.
     pub fn group(n: u8) -> Self {
-        RenderingMask::default().with_group(n)
+        RenderingMask::default().set_group(n)
     }
 
-    pub fn with_group(mut self, group: u8) -> Self {
+    /// Set the given group on the mask.
+    /// This may be called multiple times to allow an entity to belong
+    /// to multiple rendering groups.
+    pub fn set_group(mut self, group: u8) -> Self {
         self.0 |= 1 << group;
         self
     }
 
-    pub fn without_group(mut self, group: u8) -> Self {
+    /// Unset the given rendering group from the mask.
+    pub fn unset_group(mut self, group: u8) -> Self {
         self.0 |= 0 << group;
         self
     }
 
-    /// Determine if a `RenderingMask` matches.
+    /// Determine if a `RenderingMask` matches another.
     /// `RenderingMask`s match if the first mask contains any of the groups
-    /// in the second, or if both masks are `0`.
+    /// in the other, or if both masks contain no groups.
     pub fn matches(&self, other: &RenderingMask) -> bool {
         ((self.0 & other.0) > 0) || (self.0 == 0 && other.0 == 0)
     }
@@ -72,8 +81,12 @@ mod rendering_mask_tests {
         assert!(RenderingMask::group(0).matches(&RenderingMask(1)));
         // a mask will match another mask containing any similar groups
         assert!(RenderingMask::group(0)
-            .with_group(3)
+            .set_group(3)
             .matches(&RenderingMask::group(3)));
+        // default masks match each other
+        assert!(RenderingMask::default().matches(&RenderingMask::default()));
+        // masks with differing groups do not match
+        assert_eq!(RenderingMask::group(0).matches(&RenderingMask::group(1)), false);
     }
 }
 
@@ -95,17 +108,13 @@ pub fn visible_entities_system(
 
         let mut no_transform_order = 0.0;
         let mut transparent_entities = Vec::new();
-        for (entity, visible, maybe_ent_mask) in visible_query.iter() {
+        for (entity, visible, maybe_entity_mask) in visible_query.iter() {
             if !visible.is_visible {
                 continue;
             }
 
-            let camera_mask = maybe_camera_mask
-                .copied()
-                .unwrap_or_else(|| RenderingMask(0));
-            let entity_mask = maybe_ent_mask
-                .copied()
-                .unwrap_or_else(|| RenderingMask(0));
+            let camera_mask = maybe_camera_mask.copied().unwrap_or_default();
+            let entity_mask = maybe_entity_mask.copied().unwrap_or_default();
             if !camera_mask.matches(&entity_mask) {
                 continue;
             }

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -33,7 +33,7 @@ pub struct RenderingMask(pub u32);
 
 impl Default for RenderingMask {
     fn default() -> Self {
-        RenderingMask(0)
+        RenderingMask(1)
     }
 }
 
@@ -43,12 +43,12 @@ impl RenderingMask {
     }
 
     pub fn with_group(mut self, group: u8) -> Self {
-        self.0 = self.0 | (1 << group);
+        self.0 |= 1 << group;
         self
     }
 
     pub fn without_group(mut self, group: u8) -> Self {
-        self.0 = self.0 | (0 << group);
+        self.0 |= 0 << group;
         self
     }
 
@@ -101,10 +101,10 @@ pub fn visible_entities_system(
             }
 
             let camera_mask = maybe_camera_mask
-                .map(|m| *m)
+                .copied()
                 .unwrap_or_else(|| RenderingMask(0));
             let entity_mask = maybe_ent_mask
-                .map(|m| *m)
+                .copied()
                 .unwrap_or_else(|| RenderingMask(0));
             if !camera_mask.matches(&entity_mask) {
                 continue;

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -29,43 +29,72 @@ impl VisibleEntities {
 /// Cameras with this component will only render entities with a matching
 /// mask.
 ///
-/// The [`Default`] instance of `RenderingMask` returns a mask that contains
-/// no groups.
+/// There are 32 groups numbered `0` - `31`. A mask may belong to one or more
+/// groups, or no group at all.
+///
+/// An entity with a mask belonging to no groups is invisible.
+///
+/// The [`Default`] instance of `RenderingMask` returns a mask belonging to
+/// group `0`, the first group.
 #[derive(Copy, Clone, Debug, Reflect, PartialEq, Eq, PartialOrd, Ord)]
 #[reflect(Component)]
-pub struct RenderingMask(pub u32);
+pub struct RenderingMask(u32);
 
+/// Defaults to a mask belonging to group `0`, the first group.
 impl Default for RenderingMask {
     fn default() -> Self {
-        RenderingMask(0)
+        RenderingMask(1)
     }
 }
 
 impl RenderingMask {
-    /// Create new `RenderingMask` with the given rendering group set.
+    /// Create a new `RenderingMask` belonging to the given rendering group.
     pub fn group(n: u8) -> Self {
-        RenderingMask::default().set_group(n)
+        RenderingMask(0).with_group(n)
     }
 
-    /// Set the given group on the mask.
+    /// Create a new `RenderingMask` that belongs to all rendering groups.
+    pub fn all_groups() -> Self {
+        RenderingMask(u32::MAX)
+    }
+
+    /// Create a new `RenderingMask` that belongs to no rendering groups.
+    pub fn no_groups() -> Self {
+        RenderingMask(0)
+    }
+
+    /// Add the given group to the mask.
+    ///
     /// This may be called multiple times to allow an entity to belong
-    /// to multiple rendering groups.
-    pub fn set_group(mut self, group: u8) -> Self {
+    /// to multiple rendering groups. The maximum group is 31.
+    ///
+    /// # Panics
+    /// Panics when called with a group greater than 31.
+    pub fn with_group(mut self, group: u8) -> Self {
+        assert!(group < 32, "RenderingMask only supports groups 0 to 31");
         self.0 |= 1 << group;
         self
     }
 
-    /// Unset the given rendering group from the mask.
-    pub fn unset_group(mut self, group: u8) -> Self {
+    /// Removes the given rendering group from the mask.
+    ///
+    /// # Panics
+    /// Panics when called with a group greater than 31.
+    pub fn without_group(mut self, group: u8) -> Self {
+        assert!(group < 32, "RenderingMask only supports groups 0 to 31");
         self.0 |= 0 << group;
         self
     }
 
     /// Determine if a `RenderingMask` matches another.
+    ///
     /// `RenderingMask`s match if the first mask contains any of the groups
-    /// in the other, or if both masks contain no groups.
+    /// in the other.
+    ///
+    /// A `RenderingMask` belonging to no groups will not match any other
+    /// mask, even another belonging to no groups.
     pub fn matches(&self, other: &RenderingMask) -> bool {
-        ((self.0 & other.0) > 0) || (self.0 == 0 && other.0 == 0)
+        (self.0 & other.0) > 0
     }
 }
 
@@ -75,20 +104,39 @@ mod rendering_mask_tests {
 
     #[test]
     fn rendering_mask_sanity() {
-        // groups match groups
-        assert!(RenderingMask::group(1).matches(&RenderingMask::group(1)));
-        // a group of 0 means the mask is just 1 bit
-        assert!(RenderingMask::group(0).matches(&RenderingMask(1)));
-        // a mask will match another mask containing any similar groups
-        assert!(RenderingMask::group(0)
-            .set_group(3)
-            .matches(&RenderingMask::group(3)));
-        // default masks match each other
-        assert!(RenderingMask::default().matches(&RenderingMask::default()));
-        // masks with differing groups do not match
+        assert_eq!(RenderingMask::group(0).0, 1, "group 0 is mask 1");
+        assert_eq!(RenderingMask::group(1).0, 2, "group 1 is mask 2");
+        assert_eq!(RenderingMask::group(0).with_group(1).0, 3, "group 0 + 1 is mask 3");
+        assert!(
+            RenderingMask::group(1).matches(&RenderingMask::group(1)),
+            "groups match like groups"
+        );
+        assert!(
+            RenderingMask::group(0).matches(&RenderingMask(1)),
+            "a group of 0 means the mask is just 1 bit"
+        );
+
+        assert!(
+            RenderingMask::group(0)
+                .with_group(3)
+                .matches(&RenderingMask::group(3)),
+            "a mask will match another mask containing any similar groups"
+        );
+
+        assert!(
+            RenderingMask::default().matches(&RenderingMask::default()),
+            "default masks match each other"
+        );
+
         assert_eq!(
             RenderingMask::group(0).matches(&RenderingMask::group(1)),
-            false
+            false,
+            "masks with differing groups do not match"
+        );
+        assert_eq!(
+            RenderingMask(0).matches(&RenderingMask(0)),
+            false,
+            "empty masks don't match"
         );
     }
 }
@@ -108,6 +156,7 @@ pub fn visible_entities_system(
     {
         visible_entities.value.clear();
         let camera_position = camera_global_transform.translation;
+        let camera_mask = maybe_camera_mask.copied().unwrap_or_default();
 
         let mut no_transform_order = 0.0;
         let mut transparent_entities = Vec::new();
@@ -116,7 +165,6 @@ pub fn visible_entities_system(
                 continue;
             }
 
-            let camera_mask = maybe_camera_mask.copied().unwrap_or_default();
             let entity_mask = maybe_entity_mask.copied().unwrap_or_default();
             if !camera_mask.matches(&entity_mask) {
                 continue;

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -26,14 +26,14 @@ impl VisibleEntities {
 
 /// A mask that describes which rendering group an entity belongs to.
 /// Cameras with this component will only render entities with a matching
-/// mask. 
+/// mask.
 #[derive(Copy, Clone, Debug, Reflect, PartialEq, Eq, PartialOrd, Ord)]
 #[reflect(Component)]
 pub struct RenderingMask(pub u32);
 
 impl Default for RenderingMask {
     fn default() -> Self {
-        RenderingMask( 0 )
+        RenderingMask(0)
     }
 }
 
@@ -56,11 +56,9 @@ impl RenderingMask {
     /// `RenderingMask`s match if the first mask contains any of the groups
     /// in the second, or if both masks are `0`.
     pub fn matches(&self, other: &RenderingMask) -> bool {
-        ((self.0 & other.0) > 0)
-            || (self.0 == 0 && other.0 == 0)
+        ((self.0 & other.0) > 0) || (self.0 == 0 && other.0 == 0)
     }
 }
-
 
 #[cfg(test)]
 mod rendering_mask_tests {
@@ -73,16 +71,25 @@ mod rendering_mask_tests {
         // a group of 0 means the mask is just 1 bit
         assert!(RenderingMask::group(0).matches(&RenderingMask(1)));
         // a mask will match another mask containing any similar groups
-        assert!(RenderingMask::group(0).with_group(3).matches(&RenderingMask::group(3)));
+        assert!(RenderingMask::group(0)
+            .with_group(3)
+            .matches(&RenderingMask::group(3)));
     }
 }
 
 pub fn visible_entities_system(
-    mut camera_query: Query<(&Camera, &GlobalTransform, &mut VisibleEntities, Option<&RenderingMask>)>,
+    mut camera_query: Query<(
+        &Camera,
+        &GlobalTransform,
+        &mut VisibleEntities,
+        Option<&RenderingMask>,
+    )>,
     visible_query: Query<(Entity, &Visible, Option<&RenderingMask>)>,
     visible_transform_query: Query<&GlobalTransform, With<Visible>>,
 ) {
-    for (camera, camera_global_transform, mut visible_entities, maybe_camera_mask) in camera_query.iter_mut() {
+    for (camera, camera_global_transform, mut visible_entities, maybe_camera_mask) in
+        camera_query.iter_mut()
+    {
         visible_entities.value.clear();
         let camera_position = camera_global_transform.translation;
 
@@ -93,8 +100,12 @@ pub fn visible_entities_system(
                 continue;
             }
 
-            let camera_mask = maybe_camera_mask.map(|m| *m).unwrap_or_else(|| RenderingMask(0));
-            let entity_mask = maybe_ent_mask.map(|m| *m).unwrap_or_else(|| RenderingMask(0));
+            let camera_mask = maybe_camera_mask
+                .map(|m| *m)
+                .unwrap_or_else(|| RenderingMask(0));
+            let entity_mask = maybe_ent_mask
+                .map(|m| *m)
+                .unwrap_or_else(|| RenderingMask(0));
             if !camera_mask.matches(&entity_mask) {
                 continue;
             }

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -106,7 +106,11 @@ mod rendering_mask_tests {
     fn rendering_mask_sanity() {
         assert_eq!(RenderingMask::group(0).0, 1, "group 0 is mask 1");
         assert_eq!(RenderingMask::group(1).0, 2, "group 1 is mask 2");
-        assert_eq!(RenderingMask::group(0).with_group(1).0, 3, "group 0 + 1 is mask 3");
+        assert_eq!(
+            RenderingMask::group(0).with_group(1).0,
+            3,
+            "group 0 + 1 is mask 3"
+        );
         assert!(
             RenderingMask::group(1).matches(&RenderingMask::group(1)),
             "groups match like groups"

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -26,8 +26,7 @@ impl VisibleEntities {
 
 /// A mask that describes which rendering group an entity belongs to.
 /// Cameras with this component will only render entities with a matching
-/// mask. In other words, only an entity with a matching camera will be
-/// rendered.
+/// mask. 
 #[derive(Debug, Reflect, PartialEq, Eq, PartialOrd, Ord)]
 #[reflect(Component)]
 pub struct RenderingMask(pub u8);

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -24,19 +24,81 @@ impl VisibleEntities {
     }
 }
 
+/// A mask that describes which rendering group an entity belongs to.
+/// Cameras with this component will only render entities with a matching
+/// mask. In other words, only an entity with a matching camera will be
+/// rendered.
+#[derive(Debug, Reflect, PartialEq, Eq, PartialOrd, Ord)]
+#[reflect(Component)]
+pub struct RenderingMask(pub u8);
+
+impl Default for RenderingMask {
+    fn default() -> Self {
+        RenderingMask( 0 )
+    }
+}
+
+impl RenderingMask {
+    pub fn group(n: u8) -> Self {
+        RenderingMask::default().with_group(n)
+    }
+
+    pub fn with_group(mut self, group: u8) -> Self {
+        self.0 = self.0 | (1 << group);
+        self
+    }
+
+    pub fn without_group(mut self, group: u8) -> Self {
+        self.0 = self.0 | (0 << group);
+        self
+    }
+
+    pub fn matches(&self, other: &RenderingMask) -> bool {
+        (self.0 & other.0) > 0
+    }
+}
+
+
+#[cfg(test)]
+mod rendering_mask_tests {
+    use super::RenderingMask;
+
+    #[test]
+    fn rendering_mask_sanity() {
+        // groups match groups
+        assert!(RenderingMask::group(1).matches(&RenderingMask::group(1)));
+        // a group of 0 means the mask is just 1 bit
+        assert!(RenderingMask::group(0).matches(&RenderingMask(1)));
+        // a mask will match another mask containing any similar groups
+        assert!(RenderingMask::group(0).with_group(3).matches(&RenderingMask::group(3)));
+    }
+}
+
 pub fn visible_entities_system(
-    mut camera_query: Query<(&Camera, &GlobalTransform, &mut VisibleEntities)>,
-    visible_query: Query<(Entity, &Visible)>,
+    mut camera_query: Query<(&Camera, &GlobalTransform, &mut VisibleEntities, Option<&RenderingMask>)>,
+    visible_query: Query<(Entity, &Visible, Option<&RenderingMask>)>,
     visible_transform_query: Query<&GlobalTransform, With<Visible>>,
 ) {
-    for (camera, camera_global_transform, mut visible_entities) in camera_query.iter_mut() {
+    for (camera, camera_global_transform, mut visible_entities, maybe_camera_mask) in camera_query.iter_mut() {
         visible_entities.value.clear();
         let camera_position = camera_global_transform.translation;
 
         let mut no_transform_order = 0.0;
         let mut transparent_entities = Vec::new();
-        for (entity, visible) in visible_query.iter() {
+        for (entity, visible, maybe_ent_mask) in visible_query.iter() {
             if !visible.is_visible {
+                continue;
+            }
+
+            if let Some(camera_mask) = maybe_camera_mask {
+                if let Some(entity_mask) = maybe_ent_mask {
+                    if !camera_mask.matches(entity_mask) {
+                        continue;
+                    }
+                } else {
+                    continue;
+                }
+            } else if maybe_ent_mask.is_some() {
                 continue;
             }
 

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -49,7 +49,7 @@ pub struct RenderLayers(LayerMask);
 impl std::fmt::Debug for RenderLayers {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("RenderLayers")
-            .field(&self.layers_iter().collect::<Vec<_>>())
+            .field(&self.iter().collect::<Vec<_>>())
             .finish()
     }
 }
@@ -115,7 +115,7 @@ impl RenderLayers {
     }
 
     /// Get an iterator of the layers.
-    pub fn layers_iter(&self) -> impl Iterator<Item = Layer> {
+    pub fn iter(&self) -> impl Iterator<Item = Layer> {
         let total: Layer = std::convert::TryInto::try_into(Self::TOTAL_LAYERS).unwrap();
         let mask = *self;
         (0..total).filter(move |g| RenderLayers::layer(*g).intersects(&mask))
@@ -179,7 +179,7 @@ mod rendering_mask_tests {
         );
         assert_eq!(
             RenderLayers::from_layers(&[0, 2, 16, 30])
-                .layers_iter()
+                .iter()
                 .collect::<Vec<_>>(),
             vec![0, 2, 16, 30],
             "from_layers and get_layers should roundtrip"

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -56,14 +56,14 @@ impl std::fmt::Debug for RenderLayers {
 
 impl std::iter::FromIterator<Layer> for RenderLayers {
     fn from_iter<T: IntoIterator<Item = Layer>>(i: T) -> Self {
-        i.into_iter().fold(RenderLayers(0), |mask, g| mask.with(g))
+        i.into_iter().fold(Self::none(), |mask, g| mask.with(g))
     }
 }
 
 /// Defaults to containing to layer `0`, the first layer.
 impl Default for RenderLayers {
     fn default() -> Self {
-        RenderLayers(1)
+        RenderLayers::layer(0)
     }
 }
 
@@ -88,7 +88,7 @@ impl RenderLayers {
 
     /// Create a `RenderLayers` from a list of layers.
     pub fn from_layers(layers: &[Layer]) -> Self {
-        layers.iter().fold(RenderLayers(0), |mask, g| mask.with(*g))
+        layers.iter().copied().collect()
     }
 
     /// Add the given layer.

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -86,7 +86,10 @@ mod rendering_mask_tests {
         // default masks match each other
         assert!(RenderingMask::default().matches(&RenderingMask::default()));
         // masks with differing groups do not match
-        assert_eq!(RenderingMask::group(0).matches(&RenderingMask::group(1)), false);
+        assert_eq!(
+            RenderingMask::group(0).matches(&RenderingMask::group(1)),
+            false
+        );
     }
 }
 


### PR DESCRIPTION
**tl;dr** adds `RenderLayers` to link groups of entities to cameras.

This describes which rendering layers an entity belongs to. A layer is a collection of entities that only get rendered by cameras in that layer.

Entities and cameras without a `RenderLayers` component can be considered to belong to the "default" layer (layer 0), which is the same as entities and cameras with the component `RenderLayers::default()`. 

Entities and cameras can belong to multiple layers: 

```
commands
    .spawn(...)
    .with(
        RenderLayers::layer(0) // starts with just layer 0
            .with(1) // also sets layer 1
    )
```

Using a mask of u32 we have 32 possible rendering layers, 0-31 plus the empty mask `RenderLayers::none()`.

More takeaways:
* by default, entities belong to layer 0
* entities without a mask belong to layer 0
* entities with a mask without any layers (`RenderLayers::none()`) are invisible, as if they had the component `Visible { is_visible: false }`
