### PR TITLE
Add `from_xyz` to `Transform`

### DIFF
--- a/crates/bevy_render/src/entity.rs
+++ b/crates/bevy_render/src/entity.rs
@@ -8,7 +8,6 @@ use crate::{
 use base::MainPass;
 use bevy_asset::Handle;
 use bevy_ecs::Bundle;
-use bevy_math::Vec3;
 use bevy_transform::components::{GlobalTransform, Transform};
 
 /// A component bundle for "mesh" entities
@@ -73,7 +72,7 @@ impl Default for Camera2dBundle {
                 ..Default::default()
             },
             visible_entities: Default::default(),
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, far - 0.1)),
+            transform: Transform::from_xyz(0.0, 0.0, far - 0.1),
             global_transform: Default::default(),
         }
     }

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -12,6 +12,12 @@ pub struct GlobalTransform {
 }
 
 impl GlobalTransform {
+    /// Create a new [`GlobalTransform`] at the position `(x, y, z)`
+    #[inline]
+    pub fn from_xyz(x: f32, y: f32, z: f32) -> Self {
+        Self::from_translation(Vec3::new(x, y, z))
+    }
+
     #[inline]
     pub fn identity() -> Self {
         GlobalTransform {

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -12,6 +12,12 @@ pub struct Transform {
 }
 
 impl Transform {
+    /// Create a new [`Transform`] at the position `(x, y, z)`
+    #[inline]
+    pub fn from_xyz(x: f32, y: f32, z: f32) -> Self {
+        Self::from_translation(Vec3::new(x, y, z))
+    }
+
     #[inline]
     pub fn identity() -> Self {
         Transform {

--- a/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
@@ -72,7 +72,6 @@ mod test {
     use super::*;
     use crate::{hierarchy::BuildChildren, transform_propagate_system::transform_propagate_system};
     use bevy_ecs::{IntoSystem, Resources, Schedule, SystemStage, World};
-    use bevy_math::Vec3;
 
     #[test]
     fn correct_children() {
@@ -92,13 +91,13 @@ mod test {
         let mut parent = None;
         let mut children = Vec::new();
         commands
-            .spawn((Transform::from_translation(Vec3::new(1.0, 0.0, 0.0)),))
+            .spawn((Transform::from_xyz(1.0, 0.0, 0.0),))
             .for_current_entity(|entity| parent = Some(entity))
             .with_children(|parent| {
                 parent
-                    .spawn((Transform::from_translation(Vec3::new(0.0, 2.0, 0.0)),))
+                    .spawn((Transform::from_xyz(0.0, 2.0, 0.0),))
                     .for_current_entity(|entity| children.push(entity))
-                    .spawn((Transform::from_translation(Vec3::new(0.0, 0.0, 3.0)),))
+                    .spawn((Transform::from_xyz(0.0, 0.0, 3.0),))
                     .for_current_entity(|entity| children.push(entity));
             });
         let parent = parent.unwrap();

--- a/crates/bevy_transform/src/transform_propagate_system.rs
+++ b/crates/bevy_transform/src/transform_propagate_system.rs
@@ -72,7 +72,6 @@ mod test {
     use super::*;
     use crate::hierarchy::{parent_update_system, BuildChildren, BuildWorldChildren};
     use bevy_ecs::{Resources, Schedule, SystemStage, World};
-    use bevy_math::Vec3;
 
     #[test]
     fn did_propagate() {
@@ -88,7 +87,7 @@ mod test {
 
         // Root entity
         world.spawn((
-            Transform::from_translation(Vec3::new(1.0, 0.0, 0.0)),
+            Transform::from_xyz(1.0, 0.0, 0.0),
             GlobalTransform::identity(),
         ));
 
@@ -96,18 +95,18 @@ mod test {
         world
             .build()
             .spawn((
-                Transform::from_translation(Vec3::new(1.0, 0.0, 0.0)),
+                Transform::from_xyz(1.0, 0.0, 0.0),
                 GlobalTransform::identity(),
             ))
             .with_children(|parent| {
                 parent
                     .spawn((
-                        Transform::from_translation(Vec3::new(0.0, 2.0, 0.)),
+                        Transform::from_xyz(0.0, 2.0, 0.),
                         GlobalTransform::identity(),
                     ))
                     .for_current_entity(|entity| children.push(entity))
                     .spawn((
-                        Transform::from_translation(Vec3::new(0.0, 0.0, 3.)),
+                        Transform::from_xyz(0.0, 0.0, 3.),
                         GlobalTransform::identity(),
                     ))
                     .for_current_entity(|entity| children.push(entity));
@@ -116,14 +115,12 @@ mod test {
 
         assert_eq!(
             *world.get::<GlobalTransform>(children[0]).unwrap(),
-            GlobalTransform::from_translation(Vec3::new(1.0, 0.0, 0.0))
-                * Transform::from_translation(Vec3::new(0.0, 2.0, 0.0))
+            GlobalTransform::from_xyz(1.0, 0.0, 0.0) * Transform::from_xyz(0.0, 2.0, 0.0)
         );
 
         assert_eq!(
             *world.get::<GlobalTransform>(children[1]).unwrap(),
-            GlobalTransform::from_translation(Vec3::new(1.0, 0.0, 0.0))
-                * Transform::from_translation(Vec3::new(0.0, 0.0, 3.0))
+            GlobalTransform::from_xyz(1.0, 0.0, 0.0) * Transform::from_xyz(0.0, 0.0, 3.0)
         );
     }
 
@@ -145,18 +142,18 @@ mod test {
         let mut children = Vec::new();
         commands
             .spawn((
-                Transform::from_translation(Vec3::new(1.0, 0.0, 0.0)),
+                Transform::from_xyz(1.0, 0.0, 0.0),
                 GlobalTransform::identity(),
             ))
             .with_children(|parent| {
                 parent
                     .spawn((
-                        Transform::from_translation(Vec3::new(0.0, 2.0, 0.0)),
+                        Transform::from_xyz(0.0, 2.0, 0.0),
                         GlobalTransform::identity(),
                     ))
                     .for_current_entity(|entity| children.push(entity))
                     .spawn((
-                        Transform::from_translation(Vec3::new(0.0, 0.0, 3.0)),
+                        Transform::from_xyz(0.0, 0.0, 3.0),
                         GlobalTransform::identity(),
                     ))
                     .for_current_entity(|entity| children.push(entity));
@@ -166,14 +163,12 @@ mod test {
 
         assert_eq!(
             *world.get::<GlobalTransform>(children[0]).unwrap(),
-            GlobalTransform::from_translation(Vec3::new(1.0, 0.0, 0.0))
-                * Transform::from_translation(Vec3::new(0.0, 2.0, 0.0))
+            GlobalTransform::from_xyz(1.0, 0.0, 0.0) * Transform::from_xyz(0.0, 2.0, 0.0)
         );
 
         assert_eq!(
             *world.get::<GlobalTransform>(children[1]).unwrap(),
-            GlobalTransform::from_translation(Vec3::new(1.0, 0.0, 0.0))
-                * Transform::from_translation(Vec3::new(0.0, 0.0, 3.0))
+            GlobalTransform::from_xyz(1.0, 0.0, 0.0) * Transform::from_xyz(0.0, 0.0, 3.0)
         );
     }
 }

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 use bevy_asset::Handle;
 use bevy_ecs::Bundle;
-use bevy_math::Vec3;
 use bevy_render::{
     camera::{Camera, OrthographicProjection, VisibleEntities, WindowOrigin},
     draw::Draw,
@@ -189,7 +188,7 @@ impl Default for CameraUiBundle {
                 ..Default::default()
             },
             visible_entities: Default::default(),
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, far - 0.1)),
+            transform: Transform::from_xyz(0.0, 0.0, far - 0.1),
             global_transform: Default::default(),
         }
     }

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -74,7 +74,7 @@ fn setup(
         // some sprites should be flipped
         let flipped = rnd.gen_bool(0.5);
 
-        let mut transform = Transform::from_translation(Vec3::new(pos.0, pos.1, 0.0));
+        let mut transform = Transform::from_xyz(pos.0, pos.1, 0.0);
         transform.scale.x *= if flipped { -1.0 } else { 1.0 };
 
         commands

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -79,7 +79,7 @@ fn setup(
         // draw the atlas itself
         .spawn(SpriteBundle {
             material: materials.add(texture_atlas_texture.into()),
-            transform: Transform::from_translation(Vec3::new(-300.0, 0.0, 0.0)),
+            transform: Transform::from_xyz(-300.0, 0.0, 0.0),
             ..Default::default()
         });
 }

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -26,17 +26,17 @@ fn setup(
         .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-            transform: Transform::from_translation(Vec3::new(0.0, 0.5, 0.0)),
+            transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..Default::default()
         })
         // light
         .spawn(LightBundle {
-            transform: Transform::from_translation(Vec3::new(4.0, 8.0, 4.0)),
+            transform: Transform::from_xyz(4.0, 8.0, 4.0),
             ..Default::default()
         })
         // camera
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(-2.0, 2.5, 5.0))
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -12,11 +12,11 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn_scene(asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0"))
         .spawn(LightBundle {
-            transform: Transform::from_translation(Vec3::new(4.0, 5.0, 4.0)),
+            transform: Transform::from_xyz(4.0, 5.0, 4.0),
             ..Default::default()
         })
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(0.7, 0.7, 1.0))
+            transform: Transform::from_xyz(0.7, 0.7, 1.0)
                 .looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::unit_y()),
             ..Default::default()
         });

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -27,12 +27,12 @@ fn setup(
         })
         // light
         .spawn(LightBundle {
-            transform: Transform::from_translation(Vec3::new(4.0, 8.0, 4.0)),
+            transform: Transform::from_xyz(4.0, 8.0, 4.0),
             ..Default::default()
         })
         // camera
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(-3.0, 3.0, 5.0))
+            transform: Transform::from_xyz(-3.0, 3.0, 5.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -38,7 +38,7 @@ fn setup(
         .spawn(PbrBundle {
             mesh: cube_handle.clone(),
             material: cube_material_handle.clone(),
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 1.0)),
+            transform: Transform::from_xyz(0.0, 0.0, 1.0),
             ..Default::default()
         })
         .with(Rotator)
@@ -47,18 +47,18 @@ fn setup(
             parent.spawn(PbrBundle {
                 mesh: cube_handle,
                 material: cube_material_handle,
-                transform: Transform::from_translation(Vec3::new(0.0, 0.0, 3.0)),
+                transform: Transform::from_xyz(0.0, 0.0, 3.0),
                 ..Default::default()
             });
         })
         // light
         .spawn(LightBundle {
-            transform: Transform::from_translation(Vec3::new(4.0, 5.0, -4.0)),
+            transform: Transform::from_xyz(4.0, 5.0, -4.0),
             ..Default::default()
         })
         // camera
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(5.0, 10.0, 10.0))
+            transform: Transform::from_xyz(5.0, 10.0, 10.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });

--- a/examples/3d/spawner.rs
+++ b/examples/3d/spawner.rs
@@ -39,12 +39,12 @@ fn setup(
     commands
         // light
         .spawn(LightBundle {
-            transform: Transform::from_translation(Vec3::new(4.0, -4.0, 5.0)),
+            transform: Transform::from_xyz(4.0, -4.0, 5.0),
             ..Default::default()
         })
         // camera
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(0.0, 15.0, 150.0))
+            transform: Transform::from_xyz(0.0, 15.0, 150.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });
@@ -62,11 +62,11 @@ fn setup(
                 ),
                 ..Default::default()
             }),
-            transform: Transform::from_translation(Vec3::new(
+            transform: Transform::from_xyz(
                 rng.gen_range(-50.0, 50.0),
                 rng.gen_range(-50.0, 50.0),
                 0.0,
-            )),
+            ),
             ..Default::default()
         });
     }

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -96,7 +96,7 @@ fn setup(
         })
         // camera
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(3.0, 5.0, 8.0))
+            transform: Transform::from_xyz(3.0, 5.0, 8.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -26,11 +26,11 @@ fn setup(
 ) {
     commands
         .spawn(LightBundle {
-            transform: Transform::from_translation(Vec3::new(4.0, 5.0, 4.0)),
+            transform: Transform::from_xyz(4.0, 5.0, 4.0),
             ..Default::default()
         })
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(1.05, 0.9, 1.5))
+            transform: Transform::from_xyz(1.05, 0.9, 1.5)
                 .looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::unit_y()),
             ..Default::default()
         });
@@ -39,7 +39,7 @@ fn setup(
     // with its parent
     commands
         .spawn((
-            Transform::from_translation(Vec3::new(0.0, 0.0, -1.0)),
+            Transform::from_xyz(0.0, 0.0, -1.0),
             GlobalTransform::default(),
         ))
         .with_children(|parent| {

--- a/examples/3d/z_sort_debug.rs
+++ b/examples/3d/z_sort_debug.rs
@@ -55,7 +55,7 @@ fn setup(
                 shaded: false,
                 ..Default::default()
             }),
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 1.0)),
+            transform: Transform::from_xyz(0.0, 0.0, 1.0),
             ..Default::default()
         })
         .with(Rotator)
@@ -68,7 +68,7 @@ fn setup(
                         shaded: false,
                         ..Default::default()
                     }),
-                    transform: Transform::from_translation(Vec3::new(0.0, 3.0, 0.0)),
+                    transform: Transform::from_xyz(0.0, 3.0, 0.0),
                     ..Default::default()
                 })
                 .spawn(PbrBundle {
@@ -77,13 +77,13 @@ fn setup(
                         shaded: false,
                         ..Default::default()
                     }),
-                    transform: Transform::from_translation(Vec3::new(0.0, -3.0, 0.0)),
+                    transform: Transform::from_xyz(0.0, -3.0, 0.0),
                     ..Default::default()
                 });
         })
         // camera
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(5.0, 10.0, 10.0))
+            transform: Transform::from_xyz(5.0, 10.0, 10.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });

--- a/examples/android/android.rs
+++ b/examples/android/android.rs
@@ -28,17 +28,17 @@ fn setup(
         .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-            transform: Transform::from_translation(Vec3::new(0.0, 0.5, 0.0)),
+            transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..Default::default()
         })
         // light
         .spawn(LightBundle {
-            transform: Transform::from_translation(Vec3::new(4.0, 8.0, 4.0)),
+            transform: Transform::from_xyz(4.0, 8.0, 4.0),
             ..Default::default()
         })
         // camera
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(-2.0, 2.5, 5.0))
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -47,31 +47,31 @@ fn setup(
         .spawn(PbrBundle {
             mesh: monkey_handle,
             material: material_handle.clone(),
-            transform: Transform::from_translation(Vec3::new(-3.0, 0.0, 0.0)),
+            transform: Transform::from_xyz(-3.0, 0.0, 0.0),
             ..Default::default()
         })
         // cube
         .spawn(PbrBundle {
             mesh: cube_handle,
             material: material_handle.clone(),
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),
+            transform: Transform::from_xyz(0.0, 0.0, 0.0),
             ..Default::default()
         })
         // sphere
         .spawn(PbrBundle {
             mesh: sphere_handle,
             material: material_handle,
-            transform: Transform::from_translation(Vec3::new(3.0, 0.0, 0.0)),
+            transform: Transform::from_xyz(3.0, 0.0, 0.0),
             ..Default::default()
         })
         // light
         .spawn(LightBundle {
-            transform: Transform::from_translation(Vec3::new(4.0, 5.0, 4.0)),
+            transform: Transform::from_xyz(4.0, 5.0, 4.0),
             ..Default::default()
         })
         // camera
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(0.0, 3.0, 10.0))
+            transform: Transform::from_xyz(0.0, 3.0, 10.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -26,12 +26,12 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
         .spawn_scene(scene_handle)
         // light
         .spawn(LightBundle {
-            transform: Transform::from_translation(Vec3::new(4.0, 5.0, 4.0)),
+            transform: Transform::from_xyz(4.0, 5.0, 4.0),
             ..Default::default()
         })
         // camera
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(2.0, 2.0, 6.0))
+            transform: Transform::from_xyz(2.0, 2.0, 6.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -49,7 +49,7 @@ fn setup(
         // paddle
         .spawn(SpriteBundle {
             material: materials.add(Color::rgb(0.5, 0.5, 1.0).into()),
-            transform: Transform::from_translation(Vec3::new(0.0, -215.0, 0.0)),
+            transform: Transform::from_xyz(0.0, -215.0, 0.0),
             sprite: Sprite::new(Vec2::new(120.0, 30.0)),
             ..Default::default()
         })
@@ -58,7 +58,7 @@ fn setup(
         // ball
         .spawn(SpriteBundle {
             material: materials.add(Color::rgb(1.0, 0.5, 0.5).into()),
-            transform: Transform::from_translation(Vec3::new(0.0, -50.0, 1.0)),
+            transform: Transform::from_xyz(0.0, -50.0, 1.0),
             sprite: Sprite::new(Vec2::new(30.0, 30.0)),
             ..Default::default()
         })
@@ -97,7 +97,7 @@ fn setup(
         // left
         .spawn(SpriteBundle {
             material: wall_material.clone(),
-            transform: Transform::from_translation(Vec3::new(-bounds.x / 2.0, 0.0, 0.0)),
+            transform: Transform::from_xyz(-bounds.x / 2.0, 0.0, 0.0),
             sprite: Sprite::new(Vec2::new(wall_thickness, bounds.y + wall_thickness)),
             ..Default::default()
         })
@@ -105,7 +105,7 @@ fn setup(
         // right
         .spawn(SpriteBundle {
             material: wall_material.clone(),
-            transform: Transform::from_translation(Vec3::new(bounds.x / 2.0, 0.0, 0.0)),
+            transform: Transform::from_xyz(bounds.x / 2.0, 0.0, 0.0),
             sprite: Sprite::new(Vec2::new(wall_thickness, bounds.y + wall_thickness)),
             ..Default::default()
         })
@@ -113,7 +113,7 @@ fn setup(
         // bottom
         .spawn(SpriteBundle {
             material: wall_material.clone(),
-            transform: Transform::from_translation(Vec3::new(0.0, -bounds.y / 2.0, 0.0)),
+            transform: Transform::from_xyz(0.0, -bounds.y / 2.0, 0.0),
             sprite: Sprite::new(Vec2::new(bounds.x + wall_thickness, wall_thickness)),
             ..Default::default()
         })
@@ -121,7 +121,7 @@ fn setup(
         // top
         .spawn(SpriteBundle {
             material: wall_material,
-            transform: Transform::from_translation(Vec3::new(0.0, bounds.y / 2.0, 0.0)),
+            transform: Transform::from_xyz(0.0, bounds.y / 2.0, 0.0),
             sprite: Sprite::new(Vec2::new(bounds.x + wall_thickness, wall_thickness)),
             ..Default::default()
         })

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -33,7 +33,7 @@ fn setup(
         .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(0.5, 0.4, 0.3).into()),
-            transform: Transform::from_translation(Vec3::new(0.0, 0.5, 0.0)),
+            transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..Default::default()
         })
         // sphere
@@ -43,17 +43,17 @@ fn setup(
                 radius: 0.5,
             })),
             material: materials.add(Color::rgb(0.1, 0.4, 0.8).into()),
-            transform: Transform::from_translation(Vec3::new(1.5, 1.5, 1.5)),
+            transform: Transform::from_xyz(1.5, 1.5, 1.5),
             ..Default::default()
         })
         // light
         .spawn(LightBundle {
-            transform: Transform::from_translation(Vec3::new(4.0, 8.0, 4.0)),
+            transform: Transform::from_xyz(4.0, 8.0, 4.0),
             ..Default::default()
         })
         // camera
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(-2.0, 2.5, 5.0))
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -110,8 +110,7 @@ fn setup(
         .unwrap();
 
     commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(Vec3::new(2.0, 2.0, 2.0))
-            .looking_at(Vec3::default(), Vec3::unit_y()),
+        transform: Transform::from_xyz(2.0, 2.0, 2.0).looking_at(Vec3::default(), Vec3::unit_y()),
         ..Default::default()
     });
 }

--- a/examples/shader/hot_shader_reloading.rs
+++ b/examples/shader/hot_shader_reloading.rs
@@ -67,13 +67,13 @@ fn setup(
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
             )]),
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),
+            transform: Transform::from_xyz(0.0, 0.0, 0.0),
             ..Default::default()
         })
         .with(material)
         // camera
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(3.0, 5.0, -8.0))
+            transform: Transform::from_xyz(3.0, 5.0, -8.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });

--- a/examples/shader/mesh_custom_attribute.rs
+++ b/examples/shader/mesh_custom_attribute.rs
@@ -132,13 +132,13 @@ fn setup(
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
             )]),
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),
+            transform: Transform::from_xyz(0.0, 0.0, 0.0),
             ..Default::default()
         })
         .with(material)
         // camera
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(3.0, 5.0, -8.0))
+            transform: Transform::from_xyz(3.0, 5.0, -8.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });

--- a/examples/shader/shader_custom_material.rs
+++ b/examples/shader/shader_custom_material.rs
@@ -88,13 +88,13 @@ fn setup(
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
             )]),
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),
+            transform: Transform::from_xyz(0.0, 0.0, 0.0),
             ..Default::default()
         })
         .with(material)
         // camera
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(3.0, 5.0, -8.0))
+            transform: Transform::from_xyz(3.0, 5.0, -8.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -109,7 +109,7 @@ fn setup(
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle.clone(),
             )]),
-            transform: Transform::from_translation(Vec3::new(-2.0, 0.0, 0.0)),
+            transform: Transform::from_xyz(-2.0, 0.0, 0.0),
             ..Default::default()
         })
         .with(green_material)
@@ -119,13 +119,13 @@ fn setup(
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
             )]),
-            transform: Transform::from_translation(Vec3::new(2.0, 0.0, 0.0)),
+            transform: Transform::from_xyz(2.0, 0.0, 0.0),
             ..Default::default()
         })
         .with(blue_material)
         // camera
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(3.0, 5.0, -8.0))
+            transform: Transform::from_xyz(3.0, 5.0, -8.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -188,12 +188,12 @@ fn setup_pipeline(
         .spawn_scene(asset_server.load("models/monkey/Monkey.gltf#Scene0"))
         // light
         .spawn(LightBundle {
-            transform: Transform::from_translation(Vec3::new(4.0, 5.0, 4.0)),
+            transform: Transform::from_xyz(4.0, 5.0, 4.0),
             ..Default::default()
         })
         // main camera
         .spawn(Camera3dBundle {
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 6.0))
+            transform: Transform::from_xyz(0.0, 0.0, 6.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         })
@@ -204,7 +204,7 @@ fn setup_pipeline(
                 window: window_id,
                 ..Default::default()
             },
-            transform: Transform::from_translation(Vec3::new(6.0, 0.0, 0.0))
+            transform: Transform::from_xyz(6.0, 0.0, 0.0)
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });


### PR DESCRIPTION
This significantly decreases the amount of boilerplate for the common case of 'Transform at `(x, y, z)`'. This used to require `Transform::from_translation(Vec3::new(x,y,z))`

The second commit was almost entirely performed by regex, which demonstrates how common this pattern is.