### PR TITLE
Implement Reflect for tuples up to length 12

### DIFF
--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,6 +1,6 @@
 use crate::{
-    map_partial_eq, serde::Serializable, DynamicMap, DynamicTuple, List, ListIter, Map, MapIter,
-    Reflect, ReflectDeserialize, ReflectMut, ReflectRef, Tuple, TupleFieldIter,
+    map_partial_eq, serde::Serializable, DynamicMap, List, ListIter, Map, MapIter, Reflect,
+    ReflectDeserialize, ReflectMut, ReflectRef,
 };
 
 use bevy_reflect_derive::impl_reflect_value;
@@ -27,113 +27,6 @@ impl_reflect_value!(String(Hash, PartialEq, Serialize, Deserialize));
 impl_reflect_value!(Option<T: Serialize + Clone + for<'de> Deserialize<'de> + Reflect + 'static>(Serialize, Deserialize));
 impl_reflect_value!(HashSet<T: Serialize + Hash + Eq + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>(Serialize, Deserialize));
 impl_reflect_value!(Range<T: Serialize + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>(Serialize, Deserialize));
-
-macro_rules! impl_reflect_tuple {
-    {$($index:tt : $name:tt),*} => {
-        impl<$($name: Reflect),*> Tuple for ($($name,)*) {
-            #[inline]
-            fn field(&self, index: usize) -> Option<&dyn Reflect> {
-                match index {
-                    $($index => Some(&self.$index as &dyn Reflect),)*
-                    _ => None,
-                }
-            }
-
-            #[inline]
-            fn field_mut(&mut self, index: usize) -> Option<&mut dyn Reflect> {
-                match index {
-                    $($index => Some(&mut self.$index as &mut dyn Reflect),)*
-                    _ => None,
-                }
-            }
-
-            #[inline]
-            fn field_len(&self) -> usize {
-                let indices: &[usize] = &[$($index as usize),*];
-                indices.len()
-            }
-
-            #[inline]
-            fn iter_fields(&self) -> TupleFieldIter {
-                TupleFieldIter {
-                    tuple: self,
-                    index: 0,
-                }
-            }
-
-            #[inline]
-            fn clone_dynamic(&self) -> DynamicTuple {
-                DynamicTuple {
-                    fields: self
-                        .iter_fields()
-                        .map(|value| value.clone_value())
-                        .collect(),
-                }
-            }
-        }
-
-        impl<$($name: Reflect),*> Reflect for ($($name,)*) {
-            fn type_name(&self) -> &str {
-                std::any::type_name::<Self>()
-            }
-
-            fn any(&self) -> &dyn Any {
-                self
-            }
-
-            fn any_mut(&mut self) -> &mut dyn Any {
-                self
-            }
-
-            fn apply(&mut self, value: &dyn Reflect) {
-                crate::tuple_apply(self, value);
-            }
-
-            fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
-                *self = value.take()?;
-                Ok(())
-            }
-
-            fn reflect_ref(&self) -> ReflectRef {
-                ReflectRef::Tuple(self)
-            }
-
-            fn reflect_mut(&mut self) -> ReflectMut {
-                ReflectMut::Tuple(self)
-            }
-
-            fn clone_value(&self) -> Box<dyn Reflect> {
-                Box::new(self.clone_dynamic())
-            }
-
-            fn reflect_hash(&self) -> Option<u64> {
-                None
-            }
-
-            fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
-                crate::tuple_partial_eq(self, value)
-            }
-
-            fn serializable(&self) -> Option<Serializable> {
-                None
-            }
-        }
-    }
-}
-
-impl_reflect_tuple! {}
-impl_reflect_tuple! {0: A}
-impl_reflect_tuple! {0: A, 1: B}
-impl_reflect_tuple! {0: A, 1: B, 2: C}
-impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D}
-impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E}
-impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F}
-impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G}
-impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H}
-impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I}
-impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J}
-impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K}
-impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L}
 
 impl<T: Reflect> List for Vec<T> {
     fn get(&self, index: usize) -> Option<&dyn Reflect> {

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -29,7 +29,7 @@ impl_reflect_value!(HashSet<T: Serialize + Hash + Eq + Clone + for<'de> Deserial
 impl_reflect_value!(Range<T: Serialize + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>(Serialize, Deserialize));
 
 macro_rules! impl_reflect_tuple {
-    ($($index:tt : $name:tt),*) => {
+    {$($index:tt : $name:tt),*} => {
         impl<$($name: Reflect),*> List for ($($name,)*) {
             fn get(&self, index: usize) -> Option<&dyn Reflect> {
                 match index {
@@ -110,44 +110,19 @@ macro_rules! impl_reflect_tuple {
     }
 }
 
-impl_reflect_tuple!();
-impl_reflect_tuple!(0: A);
-impl_reflect_tuple!(0: A, 1: B);
-impl_reflect_tuple!(0: A, 1: B, 2: C);
-impl_reflect_tuple!(0: A, 1: B, 2: C, 3: D);
-impl_reflect_tuple!(0: A, 1: B, 2: C, 3: D, 4: E);
-impl_reflect_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F);
-impl_reflect_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G);
-impl_reflect_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H);
-impl_reflect_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I);
-impl_reflect_tuple!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J);
-impl_reflect_tuple!(
-    0: A,
-    1: B,
-    2: C,
-    3: D,
-    4: E,
-    5: F,
-    6: G,
-    7: H,
-    8: I,
-    9: J,
-    10: K
-);
-impl_reflect_tuple!(
-    0: A,
-    1: B,
-    2: C,
-    3: D,
-    4: E,
-    5: F,
-    6: G,
-    7: H,
-    8: I,
-    9: J,
-    10: K,
-    11: L
-);
+impl_reflect_tuple! {}
+impl_reflect_tuple! {0: A}
+impl_reflect_tuple! {0: A, 1: B}
+impl_reflect_tuple! {0: A, 1: B, 2: C}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L}
 
 impl<T: Reflect> List for Vec<T> {
     fn get(&self, index: usize) -> Option<&dyn Reflect> {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -208,6 +208,7 @@ mod tests {
             c: Vec<isize>,
             d: HashMap<usize, i8>,
             e: Bar,
+            f: (i32, Vec<isize>, Bar),
         }
 
         #[derive(Reflect, Eq, PartialEq, Debug)]
@@ -224,6 +225,7 @@ mod tests {
             c: vec![1, 2],
             d: hash_map,
             e: Bar { x: 1 },
+            f: (1, vec![1, 2], Bar { x: 1 }),
         };
 
         let mut foo_patch = DynamicStruct::default();
@@ -234,7 +236,7 @@ mod tests {
         list.push(3isize);
         list.push(4isize);
         list.push(5isize);
-        foo_patch.insert("c", list);
+        foo_patch.insert("c", list.clone_dynamic());
 
         let mut map = DynamicMap::default();
         map.insert(2usize, 3i8);
@@ -242,7 +244,13 @@ mod tests {
 
         let mut bar_patch = DynamicStruct::default();
         bar_patch.insert("x", 2u32);
-        foo_patch.insert("e", bar_patch);
+        foo_patch.insert("e", bar_patch.clone_dynamic());
+
+        let mut tuple = DynamicList::default();
+        tuple.push(2i32);
+        tuple.push(list);
+        tuple.push(bar_patch);
+        foo_patch.insert("f", tuple);
 
         foo.apply(&foo_patch);
 
@@ -255,6 +263,7 @@ mod tests {
             c: vec![3, 4, 5],
             d: hash_map,
             e: Bar { x: 2 },
+            f: (2, vec![3, 4, 5], Bar { x: 2 }),
         };
 
         assert_eq!(foo, expected_foo);
@@ -271,6 +280,7 @@ mod tests {
             d: HashMap<usize, i8>,
             e: Bar,
             f: String,
+            g: (i32, Vec<isize>, Bar),
         }
 
         #[derive(Reflect)]
@@ -288,6 +298,7 @@ mod tests {
             d: hash_map,
             e: Bar { x: 1 },
             f: "hi".to_string(),
+            g: (1, vec![1, 2], Bar { x: 1 }),
         };
 
         let mut registry = TypeRegistry::default();
@@ -297,6 +308,7 @@ mod tests {
         registry.register::<Bar>();
         registry.register::<String>();
         registry.register::<i8>();
+        registry.register::<i32>();
 
         let serializer = ReflectSerializer::new(&foo, &registry);
         let serialized = to_string_pretty(&serializer, PrettyConfig::default()).unwrap();

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -3,6 +3,7 @@ mod map;
 mod path;
 mod reflect;
 mod struct_trait;
+mod tuple;
 mod tuple_struct;
 mod type_registry;
 mod type_uuid;
@@ -46,6 +47,7 @@ pub use map::*;
 pub use path::*;
 pub use reflect::*;
 pub use struct_trait::*;
+pub use tuple::*;
 pub use tuple_struct::*;
 pub use type_registry::*;
 pub use type_uuid::*;
@@ -246,10 +248,10 @@ mod tests {
         bar_patch.insert("x", 2u32);
         foo_patch.insert("e", bar_patch.clone_dynamic());
 
-        let mut tuple = DynamicList::default();
-        tuple.push(2i32);
-        tuple.push(list);
-        tuple.push(bar_patch);
+        let mut tuple = DynamicTuple::default();
+        tuple.insert(2i32);
+        tuple.insert(list);
+        tuple.insert(bar_patch);
         foo_patch.insert("f", tuple);
 
         foo.apply(&foo_patch);

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -1,4 +1,4 @@
-use crate::{serde::Serializable, List, Map, Struct, TupleStruct};
+use crate::{serde::Serializable, List, Map, Struct, Tuple, TupleStruct};
 use std::{any::Any, fmt::Debug};
 
 pub use bevy_utils::AHasher as ReflectHasher;
@@ -6,6 +6,7 @@ pub use bevy_utils::AHasher as ReflectHasher;
 pub enum ReflectRef<'a> {
     Struct(&'a dyn Struct),
     TupleStruct(&'a dyn TupleStruct),
+    Tuple(&'a dyn Tuple),
     List(&'a dyn List),
     Map(&'a dyn Map),
     Value(&'a dyn Reflect),
@@ -14,6 +15,7 @@ pub enum ReflectRef<'a> {
 pub enum ReflectMut<'a> {
     Struct(&'a mut dyn Struct),
     TupleStruct(&'a mut dyn TupleStruct),
+    Tuple(&'a dyn Tuple),
     List(&'a mut dyn List),
     Map(&'a mut dyn Map),
     Value(&'a mut dyn Reflect),

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod type_fields {
     pub const MAP: &str = "map";
     pub const STRUCT: &str = "struct";
     pub const TUPLE_STRUCT: &str = "tuple_struct";
+    pub const TUPLE: &str = "tuple";
     pub const LIST: &str = "list";
     pub const VALUE: &str = "value";
 }

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -201,3 +201,110 @@ pub fn tuple_partial_eq<T: Tuple>(a: &T, b: &dyn Reflect) -> Option<bool> {
 
     Some(true)
 }
+
+macro_rules! impl_reflect_tuple {
+    {$($index:tt : $name:tt),*} => {
+        impl<$($name: Reflect),*> Tuple for ($($name,)*) {
+            #[inline]
+            fn field(&self, index: usize) -> Option<&dyn Reflect> {
+                match index {
+                    $($index => Some(&self.$index as &dyn Reflect),)*
+                    _ => None,
+                }
+            }
+
+            #[inline]
+            fn field_mut(&mut self, index: usize) -> Option<&mut dyn Reflect> {
+                match index {
+                    $($index => Some(&mut self.$index as &mut dyn Reflect),)*
+                    _ => None,
+                }
+            }
+
+            #[inline]
+            fn field_len(&self) -> usize {
+                let indices: &[usize] = &[$($index as usize),*];
+                indices.len()
+            }
+
+            #[inline]
+            fn iter_fields(&self) -> TupleFieldIter {
+                TupleFieldIter {
+                    tuple: self,
+                    index: 0,
+                }
+            }
+
+            #[inline]
+            fn clone_dynamic(&self) -> DynamicTuple {
+                DynamicTuple {
+                    fields: self
+                        .iter_fields()
+                        .map(|value| value.clone_value())
+                        .collect(),
+                }
+            }
+        }
+
+        impl<$($name: Reflect),*> Reflect for ($($name,)*) {
+            fn type_name(&self) -> &str {
+                std::any::type_name::<Self>()
+            }
+
+            fn any(&self) -> &dyn Any {
+                self
+            }
+
+            fn any_mut(&mut self) -> &mut dyn Any {
+                self
+            }
+
+            fn apply(&mut self, value: &dyn Reflect) {
+                crate::tuple_apply(self, value);
+            }
+
+            fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+                *self = value.take()?;
+                Ok(())
+            }
+
+            fn reflect_ref(&self) -> ReflectRef {
+                ReflectRef::Tuple(self)
+            }
+
+            fn reflect_mut(&mut self) -> ReflectMut {
+                ReflectMut::Tuple(self)
+            }
+
+            fn clone_value(&self) -> Box<dyn Reflect> {
+                Box::new(self.clone_dynamic())
+            }
+
+            fn reflect_hash(&self) -> Option<u64> {
+                None
+            }
+
+            fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
+                crate::tuple_partial_eq(self, value)
+            }
+
+            fn serializable(&self) -> Option<Serializable> {
+                None
+            }
+        }
+    }
+}
+
+impl_reflect_tuple! {}
+impl_reflect_tuple! {0: A}
+impl_reflect_tuple! {0: A, 1: B}
+impl_reflect_tuple! {0: A, 1: B, 2: C}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K}
+impl_reflect_tuple! {0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J, 10: K, 11: L}

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -1,0 +1,203 @@
+use std::any::Any;
+
+use crate::{serde::Serializable, Reflect, ReflectMut, ReflectRef};
+
+pub trait Tuple: Reflect {
+    fn field(&self, index: usize) -> Option<&dyn Reflect>;
+    fn field_mut(&mut self, index: usize) -> Option<&mut dyn Reflect>;
+    fn field_len(&self) -> usize;
+    fn iter_fields(&self) -> TupleFieldIter;
+    fn clone_dynamic(&self) -> DynamicTuple;
+}
+
+pub struct TupleFieldIter<'a> {
+    pub(crate) tuple: &'a dyn Tuple,
+    pub(crate) index: usize,
+}
+
+impl<'a> TupleFieldIter<'a> {
+    pub fn new(value: &'a dyn Tuple) -> Self {
+        TupleFieldIter {
+            tuple: value,
+            index: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for TupleFieldIter<'a> {
+    type Item = &'a dyn Reflect;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let value = self.tuple.field(self.index);
+        self.index += 1;
+        value
+    }
+}
+
+pub trait GetTupleField {
+    fn get_field<T: Reflect>(&self, index: usize) -> Option<&T>;
+    fn get_field_mut<T: Reflect>(&mut self, index: usize) -> Option<&mut T>;
+}
+
+impl<S: Tuple> GetTupleField for S {
+    fn get_field<T: Reflect>(&self, index: usize) -> Option<&T> {
+        self.field(index)
+            .and_then(|value| value.downcast_ref::<T>())
+    }
+
+    fn get_field_mut<T: Reflect>(&mut self, index: usize) -> Option<&mut T> {
+        self.field_mut(index)
+            .and_then(|value| value.downcast_mut::<T>())
+    }
+}
+
+impl GetTupleField for dyn Tuple {
+    fn get_field<T: Reflect>(&self, index: usize) -> Option<&T> {
+        self.field(index)
+            .and_then(|value| value.downcast_ref::<T>())
+    }
+
+    fn get_field_mut<T: Reflect>(&mut self, index: usize) -> Option<&mut T> {
+        self.field_mut(index)
+            .and_then(|value| value.downcast_mut::<T>())
+    }
+}
+
+#[derive(Default)]
+pub struct DynamicTuple {
+    pub(crate) fields: Vec<Box<dyn Reflect>>,
+}
+
+impl DynamicTuple {
+    pub fn insert_boxed(&mut self, value: Box<dyn Reflect>) {
+        self.fields.push(value);
+    }
+
+    pub fn insert<T: Reflect>(&mut self, value: T) {
+        self.insert_boxed(Box::new(value));
+    }
+}
+
+impl Tuple for DynamicTuple {
+    #[inline]
+    fn field(&self, index: usize) -> Option<&dyn Reflect> {
+        self.fields.get(index).map(|field| &**field)
+    }
+
+    #[inline]
+    fn field_mut(&mut self, index: usize) -> Option<&mut dyn Reflect> {
+        self.fields.get_mut(index).map(|field| &mut **field)
+    }
+
+    #[inline]
+    fn field_len(&self) -> usize {
+        self.fields.len()
+    }
+
+    #[inline]
+    fn iter_fields(&self) -> TupleFieldIter {
+        TupleFieldIter {
+            tuple: self,
+            index: 0,
+        }
+    }
+
+    #[inline]
+    fn clone_dynamic(&self) -> DynamicTuple {
+        DynamicTuple {
+            fields: self
+                .fields
+                .iter()
+                .map(|value| value.clone_value())
+                .collect(),
+        }
+    }
+}
+
+impl Reflect for DynamicTuple {
+    #[inline]
+    fn type_name(&self) -> &str {
+        std::any::type_name::<Self>()
+    }
+
+    #[inline]
+    fn any(&self) -> &dyn Any {
+        self
+    }
+
+    #[inline]
+    fn any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    #[inline]
+    fn clone_value(&self) -> Box<dyn Reflect> {
+        Box::new(self.clone_dynamic())
+    }
+
+    #[inline]
+    fn reflect_ref(&self) -> ReflectRef {
+        ReflectRef::Tuple(self)
+    }
+
+    #[inline]
+    fn reflect_mut(&mut self) -> ReflectMut {
+        ReflectMut::Tuple(self)
+    }
+
+    fn apply(&mut self, value: &dyn Reflect) {
+        tuple_apply(self, value);
+    }
+
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+        *self = value.take()?;
+        Ok(())
+    }
+
+    fn reflect_hash(&self) -> Option<u64> {
+        None
+    }
+
+    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
+        tuple_partial_eq(self, value)
+    }
+
+    fn serializable(&self) -> Option<Serializable> {
+        None
+    }
+}
+
+#[inline]
+pub fn tuple_apply<T: Tuple>(a: &mut T, b: &dyn Reflect) {
+    if let ReflectRef::Tuple(tuple) = b.reflect_ref() {
+        for (i, value) in tuple.iter_fields().enumerate() {
+            if let Some(v) = a.field_mut(i) {
+                v.apply(value)
+            }
+        }
+    } else {
+        panic!("Attempted to apply non-Tuple type to Tuple type.");
+    }
+}
+
+#[inline]
+pub fn tuple_partial_eq<T: Tuple>(a: &T, b: &dyn Reflect) -> Option<bool> {
+    let b = if let ReflectRef::Tuple(tuple) = b.reflect_ref() {
+        tuple
+    } else {
+        return Some(false);
+    };
+
+    if a.field_len() != b.field_len() {
+        return Some(false);
+    }
+
+    for (a_field, b_field) in a.iter_fields().zip(b.iter_fields()) {
+        match a_field.reflect_partial_eq(b_field) {
+            Some(false) | None => return Some(false),
+            Some(true) => {}
+        }
+    }
+
+    Some(true)
+}

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -71,6 +71,10 @@ fn setup() {
         // `TupleStruct` is a trait automatically implemented for tuple structs that derive Reflect. This trait allows you
         // to interact with fields via their indices
         ReflectRef::TupleStruct(_) => {}
+        // `Tuple` is a special trait that can be manually implemented (instead of deriving Reflect). This exposes "tuple"
+        // operations on your type, allowing you to interact with fields via their indices. Tuple is automatically
+        // implemented for tuples of arity 12 or less.
+        ReflectRef::Tuple(_) => {}
         // `List` is a special trait that can be manually implemented (instead of deriving Reflect). This exposes "list"
         // operations on your type, such as indexing and insertion. List is automatically implemented for relevant core
         // types like Vec<T>


### PR DESCRIPTION
Implements `Reflect` and `List` for tuples with 0-12 elements (#1022). Since traits in the standard library are [only implemented for tuples up to length 12](https://doc.rust-lang.org/std/primitive.tuple.html#trait-implementations-1), I figured that the same restriction could apply here.

#### Open questions:
 - Should tuples implement `List`? [`serde_json` serializes tuples as arrays](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=1f75d0c18e74143e043d7da1cf8e5638), so it might make sense to follow that precedent. The downside is that `List::push` can't be implemented for tuples, so it must panic.
 - Should `Reflect::apply` ensure that the other value has the same length as the tuple, or is it safe to allow values with fewer elements for a partial apply? Currently, it will only panic if the incoming value has more elements than the tuple supports.

