### PR TITLE
bevy_input: fix repeated gamepad events

### DIFF
--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -147,20 +147,22 @@ impl Default for AxisSettings {
 
 impl AxisSettings {
     fn filter(&self, new_value: f32, old_value: Option<f32>) -> Option<f32> {
+        let new_value = if new_value <= self.positive_low && new_value >= self.negative_low {
+            0.0
+        } else if new_value >= self.positive_high {
+            1.0
+        } else if new_value <= self.negative_high {
+            -1.0
+        } else {
+            new_value
+        };
+
         if let Some(old_value) = old_value {
             if (new_value - old_value).abs() <= self.threshold {
                 return None;
             }
         }
-        if new_value <= self.positive_low && new_value >= self.negative_low {
-            return Some(0.0);
-        }
-        if new_value >= self.positive_high {
-            return Some(1.0);
-        }
-        if new_value <= self.negative_high {
-            return Some(-1.0);
-        }
+
         Some(new_value)
     }
 }


### PR DESCRIPTION
Previously, if the actual value of `LeftStickX` was e.g. 0.034 and fluctuated a little
bit (less than the threshold) it would repeatedly send out events,
because it compared the value to the *filtered* old one - 0.0 - which is
more then `0.01` (the threshold) away.

The is fixed by first doing the deadzone and then comparing to the old
value.
Another possible solution would be to store both the actual old value
and the filtered one, but that would add complexity.