### PR TITLE
Rich text

### DIFF
--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -34,3 +34,7 @@ anyhow = "1.0"
 ab_glyph = "0.2.6"
 glyph_brush_layout = "0.2.1"
 thiserror = "1.0"
+
+[dev-dependencies]
+# doctests
+bevy_ui = { path = "../bevy_ui", version = "0.4.0" }

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -34,7 +34,3 @@ anyhow = "1.0"
 ab_glyph = "0.2.6"
 glyph_brush_layout = "0.2.1"
 thiserror = "1.0"
-
-[dev-dependencies]
-# doctests
-bevy_ui = { path = "../bevy_ui", version = "0.4.0" }

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -1,7 +1,5 @@
-use bevy_asset::Handle;
 use bevy_math::{Mat4, Vec3};
 use bevy_render::{
-    color::Color,
     draw::{Draw, DrawContext, DrawError, Drawable},
     mesh,
     mesh::Mesh,
@@ -10,41 +8,8 @@ use bevy_render::{
     renderer::{BindGroup, RenderResourceBindings, RenderResourceId},
 };
 use bevy_sprite::TextureAtlasSprite;
-use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
 
-use crate::{Font, PositionedGlyph, TextSection};
-
-#[derive(Debug, Clone, Copy)]
-pub struct TextAlignment {
-    pub vertical: VerticalAlign,
-    pub horizontal: HorizontalAlign,
-}
-
-impl Default for TextAlignment {
-    fn default() -> Self {
-        TextAlignment {
-            vertical: VerticalAlign::Top,
-            horizontal: HorizontalAlign::Left,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct TextStyle {
-    pub font: Handle<Font>,
-    pub font_size: f32,
-    pub color: Color,
-}
-
-impl Default for TextStyle {
-    fn default() -> Self {
-        Self {
-            font: Default::default(),
-            font_size: 12.0,
-            color: Color::WHITE,
-        }
-    }
-}
+use crate::{PositionedGlyph, TextSection};
 
 pub struct DrawableText<'a> {
     pub render_resource_bindings: &'a mut RenderResourceBindings,

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -11,7 +11,7 @@ use bevy_render::{
 use bevy_sprite::TextureAtlasSprite;
 use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
 
-use crate::PositionedGlyph;
+use crate::{PositionedGlyph, TextSection};
 
 #[derive(Debug, Clone, Copy)]
 pub struct TextAlignment {
@@ -32,7 +32,6 @@ impl Default for TextAlignment {
 pub struct TextStyle {
     pub font_size: f32,
     pub color: Color,
-    pub alignment: TextAlignment,
 }
 
 impl Default for TextStyle {
@@ -40,7 +39,6 @@ impl Default for TextStyle {
         Self {
             color: Color::WHITE,
             font_size: 12.0,
-            alignment: TextAlignment::default(),
         }
     }
 }
@@ -49,7 +47,8 @@ pub struct DrawableText<'a> {
     pub render_resource_bindings: &'a mut RenderResourceBindings,
     pub position: Vec3,
     pub scale_factor: f32,
-    pub style: &'a TextStyle,
+    // pub style: &'a TextStyle,
+    pub sections: &'a [TextSection],
     pub text_glyphs: &'a Vec<PositionedGlyph>,
     pub msaa: &'a Msaa,
     pub font_quad_vertex_descriptor: &'a VertexBufferDescriptor,
@@ -103,7 +102,7 @@ impl<'a> Drawable for DrawableText<'a> {
 
             let sprite = TextureAtlasSprite {
                 index: tv.atlas_info.glyph_index,
-                color: self.style.color,
+                color: self.sections[tv.section_index].style.color,
             };
 
             // To get the rendering right for non-one scaling factors, we need

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -47,7 +47,6 @@ pub struct DrawableText<'a> {
     pub render_resource_bindings: &'a mut RenderResourceBindings,
     pub position: Vec3,
     pub scale_factor: f32,
-    // pub style: &'a TextStyle,
     pub sections: &'a [TextSection],
     pub text_glyphs: &'a Vec<PositionedGlyph>,
     pub msaa: &'a Msaa,

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -1,3 +1,4 @@
+use bevy_asset::Handle;
 use bevy_math::{Mat4, Vec3};
 use bevy_render::{
     color::Color,
@@ -11,7 +12,7 @@ use bevy_render::{
 use bevy_sprite::TextureAtlasSprite;
 use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
 
-use crate::{PositionedGlyph, TextSection};
+use crate::{Font, PositionedGlyph, TextSection};
 
 #[derive(Debug, Clone, Copy)]
 pub struct TextAlignment {
@@ -30,6 +31,7 @@ impl Default for TextAlignment {
 
 #[derive(Clone, Debug)]
 pub struct TextStyle {
+    pub font: Handle<Font>,
     pub font_size: f32,
     pub color: Color,
 }
@@ -37,8 +39,9 @@ pub struct TextStyle {
 impl Default for TextStyle {
     fn default() -> Self {
         Self {
-            color: Color::WHITE,
+            font: Default::default(),
             font_size: 12.0,
+            color: Color::WHITE,
         }
     }
 }

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -21,7 +21,7 @@ pub use text::*;
 pub use text2d::*;
 
 pub mod prelude {
-    pub use crate::{Font, Text, Text2dBundle, TextAlignment, TextError, TextStyle};
+    pub use crate::{Font, Text, Text2dBundle, TextAlignment, TextError, TextSection, TextStyle};
     pub use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
 }
 

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -22,7 +22,7 @@ pub use text2d::*;
 
 pub mod prelude {
     pub use crate::{
-        BasicText, Font, Text, Text2dBundle, TextAlignment, TextError, TextSection, TextStyle,
+        Font, Text, Text2dBundle, TextAlignment, TextError, TextSection, TextStyle,
     };
     pub use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
 }

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -21,7 +21,9 @@ pub use text::*;
 pub use text2d::*;
 
 pub mod prelude {
-    pub use crate::{Font, Text, Text2dBundle, TextAlignment, TextError, TextSection, TextStyle};
+    pub use crate::{
+        BasicText, Font, Text, Text2dBundle, TextAlignment, TextError, TextSection, TextStyle,
+    };
     pub use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
 }
 

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -21,9 +21,7 @@ pub use text::*;
 pub use text2d::*;
 
 pub mod prelude {
-    pub use crate::{
-        Font, Text, Text2dBundle, TextAlignment, TextError, TextSection, TextStyle,
-    };
+    pub use crate::{Font, Text, Text2dBundle, TextAlignment, TextError, TextSection, TextStyle};
     pub use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
 }
 

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -10,7 +10,8 @@ use bevy_utils::HashMap;
 use glyph_brush_layout::{FontId, SectionText};
 
 use crate::{
-    error::TextError, glyph_brush::GlyphBrush, Font, FontAtlasSet, PositionedGlyph, TextAlignment,
+    error::TextError, glyph_brush::GlyphBrush, scale_value, Font, FontAtlasSet, PositionedGlyph,
+    TextAlignment, TextSection,
 };
 
 pub struct TextPipeline<ID> {
@@ -35,7 +36,7 @@ pub struct TextLayoutInfo {
 }
 
 impl<ID: Hash + Eq> TextPipeline<ID> {
-    pub fn get_or_insert_font_id(&mut self, handle: Handle<Font>, font: &Font) -> FontId {
+    pub fn get_or_insert_font_id(&mut self, handle: &Handle<Font>, font: &Font) -> FontId {
         let brush = &mut self.brush;
         *self
             .map_font_id
@@ -51,30 +52,38 @@ impl<ID: Hash + Eq> TextPipeline<ID> {
     pub fn queue_text(
         &mut self,
         id: ID,
-        font_handle: Handle<Font>,
         fonts: &Assets<Font>,
-        text: &str,
-        font_size: f32,
+        sections: &[TextSection],
+        scale_factor: f64,
         text_alignment: TextAlignment,
         bounds: Size,
         font_atlas_set_storage: &mut Assets<FontAtlasSet>,
         texture_atlases: &mut Assets<TextureAtlas>,
         textures: &mut Assets<Texture>,
     ) -> Result<(), TextError> {
-        let font = fonts.get(font_handle.id).ok_or(TextError::NoSuchFont)?;
-        let font_id = self.get_or_insert_font_id(font_handle, font);
+        let mut scaled_fonts = Vec::new();
+        let sections = sections
+            .iter()
+            .map(|section| {
+                let font = fonts.get(section.font.id).ok_or(TextError::NoSuchFont)?;
+                let font_id = self.get_or_insert_font_id(&section.font, font);
+                let font_size = scale_value(section.style.font_size, scale_factor);
 
-        let section = SectionText {
-            font_id,
-            scale: PxScale::from(font_size),
-            text,
-        };
+                scaled_fonts.push(ab_glyph::Font::as_scaled(&font.font, font_size));
 
-        let scaled_font = ab_glyph::Font::as_scaled(&font.font, font_size);
+                let section = SectionText {
+                    font_id,
+                    scale: PxScale::from(section.style.font_size),
+                    text: &section.value,
+                };
+
+                Ok(section)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         let section_glyphs = self
             .brush
-            .compute_glyphs(&[section], bounds, text_alignment)?;
+            .compute_glyphs(&sections, bounds, text_alignment)?;
 
         if section_glyphs.is_empty() {
             self.glyph_map.insert(
@@ -93,6 +102,7 @@ impl<ID: Hash + Eq> TextPipeline<ID> {
         let mut max_y: f32 = std::f32::MIN;
 
         for section_glyph in section_glyphs.iter() {
+            let scaled_font = scaled_fonts[section_glyph.section_index];
             let glyph = &section_glyph.glyph;
             min_x = min_x.min(glyph.position.x);
             min_y = min_y.min(glyph.position.y - scaled_font.ascent());
@@ -104,6 +114,7 @@ impl<ID: Hash + Eq> TextPipeline<ID> {
 
         let glyphs = self.brush.process_glyphs(
             section_glyphs,
+            &sections,
             font_atlas_set_storage,
             fonts,
             texture_atlases,

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -73,7 +73,7 @@ impl<ID: Hash + Eq> TextPipeline<ID> {
 
                 let section = SectionText {
                     font_id,
-                    scale: PxScale::from(section.style.font_size),
+                    scale: PxScale::from(font_size),
                     text: &section.value,
                 };
 

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -65,8 +65,10 @@ impl<ID: Hash + Eq> TextPipeline<ID> {
         let sections = sections
             .iter()
             .map(|section| {
-                let font = fonts.get(section.font.id).ok_or(TextError::NoSuchFont)?;
-                let font_id = self.get_or_insert_font_id(&section.font, font);
+                let font = fonts
+                    .get(section.style.font.id)
+                    .ok_or(TextError::NoSuchFont)?;
+                let font_id = self.get_or_insert_font_id(&section.style.font, font);
                 let font_size = scale_value(section.style.font_size, scale_factor);
 
                 scaled_fonts.push(ab_glyph::Font::as_scaled(&font.font, font_size));

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -101,9 +101,9 @@ impl<ID: Hash + Eq> TextPipeline<ID> {
         let mut max_x: f32 = std::f32::MIN;
         let mut max_y: f32 = std::f32::MIN;
 
-        for section_glyph in section_glyphs.iter() {
-            let scaled_font = scaled_fonts[section_glyph.section_index];
-            let glyph = &section_glyph.glyph;
+        for sg in section_glyphs.iter() {
+            let scaled_font = scaled_fonts[sg.section_index];
+            let glyph = &sg.glyph;
             min_x = min_x.min(glyph.position.x);
             min_y = min_y.min(glyph.position.y - scaled_font.ascent());
             max_x = max_x.max(glyph.position.x + scaled_font.h_advance(glyph.id));

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -1,6 +1,9 @@
+use bevy_asset::Handle;
 use bevy_math::Size;
+use bevy_render::color::Color;
+use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
 
-use crate::{TextAlignment, TextStyle};
+use crate::Font;
 
 #[derive(Debug, Default, Clone)]
 pub struct Text {
@@ -65,6 +68,38 @@ impl From<BasicText> for Text {
 pub struct TextSection {
     pub value: String,
     pub style: TextStyle,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct TextAlignment {
+    pub vertical: VerticalAlign,
+    pub horizontal: HorizontalAlign,
+}
+
+impl Default for TextAlignment {
+    fn default() -> Self {
+        TextAlignment {
+            vertical: VerticalAlign::Top,
+            horizontal: HorizontalAlign::Left,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TextStyle {
+    pub font: Handle<Font>,
+    pub font_size: f32,
+    pub color: Color,
+}
+
+impl Default for TextStyle {
+    fn default() -> Self {
+        Self {
+            font: Default::default(),
+            font_size: 12.0,
+            color: Color::WHITE,
+        }
+    }
 }
 
 #[derive(Default, Copy, Clone, Debug)]

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -11,54 +11,52 @@ pub struct Text {
     pub alignment: TextAlignment,
 }
 
-/// This is a transient helper type for basic text (text with only one section).
-/// Under the hood we require, use, construct and interact with the new "sectioned" [`Text`] type.
-/// Intended usage is:
-/// ```
-/// # use bevy_ecs::Commands;
-/// # use bevy_text::BasicText;
-/// # use bevy_ui::entity::TextBundle;
-/// # fn system(commands: &mut Commands) {
-/// commands.spawn(TextBundle {
-///     text: BasicText {
-///         value: "hello world!".to_string(),
-///         ..Default::default()
-///     }.into(),
-///     ..Default::default()
-/// });
-/// # }
-/// ```
-/// or
-/// ```
-/// # use bevy_ecs::Commands;
-/// # use bevy_text::{BasicText, Text};
-/// # use bevy_ui::entity::TextBundle;
-/// # fn system(commands: &mut Commands) {
-/// commands.spawn(TextBundle {
-///     text: Text::from(BasicText {
-///         value: "hello world?".to_string(),
-///         ..Default::default()
-///     }),
-///     ..Default::default()
-/// });
-/// # }
-/// ```
-#[derive(Debug, Default, Clone)]
-pub struct BasicText {
-    pub value: String,
-    pub style: TextStyle,
-    pub alignment: TextAlignment,
-}
-
-impl From<BasicText> for Text {
-    fn from(source: BasicText) -> Self {
-        let BasicText {
-            value,
-            style,
-            alignment,
-        } = source;
+impl Text {
+    /// Constructs a [`Text`] with (initially) one section.
+    ///
+    /// ```
+    /// # use bevy_text::{Font, Text, TextAlignment, TextStyle};
+    /// # use bevy_render::color::Color;
+    /// # use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
+    /// # use bevy_asset::{AssetServer, Handle};
+    /// # let font_handle: Handle<Font> = Default::default();
+    /// #
+    /// // basic usage
+    /// let hello_world = Text::with_section(
+    ///     "hello world!".to_string(),
+    ///     TextStyle {
+    ///         font: font_handle.clone(),
+    ///         font_size: 60.0,
+    ///         color: Color::WHITE,
+    ///     },
+    ///     TextAlignment {
+    ///         vertical: VerticalAlign::Center,
+    ///         horizontal: HorizontalAlign::Center,
+    ///     },
+    /// );
+    ///
+    /// let hello_bevy = Text::with_section(
+    ///     // accepts a String or any type that converts into a String, such as &str
+    ///     "hello bevy!",
+    ///     TextStyle {
+    ///         font: font_handle,
+    ///         font_size: 60.0,
+    ///         color: Color::WHITE,
+    ///     },
+    ///     // you can still use Default
+    ///     Default::default(),
+    /// );
+    /// ```
+    pub fn with_section<S: Into<String>>(
+        value: S,
+        style: TextStyle,
+        alignment: TextAlignment,
+    ) -> Self {
         Self {
-            sections: vec![TextSection { value, style }],
+            sections: vec![TextSection {
+                value: value.into(),
+                style,
+            }],
             alignment,
         }
     }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -12,24 +12,34 @@ pub struct Text {
 /// This is a transient helper type for basic text (text with only one section).
 /// Under the hood we require, use, construct and interact with the new "sectioned" [`Text`] type.
 /// Intended usage is:
-/// ```compile_fail
+/// ```
+/// # use bevy_ecs::Commands;
+/// # use bevy_text::BasicText;
+/// # use bevy_ui::entity::TextBundle;
+/// # fn system(commands: &mut Commands) {
 /// commands.spawn(TextBundle {
 ///     text: BasicText {
-///         value: "hello world!",
+///         value: "hello world!".to_string(),
 ///         ..Default::default()
 ///     }.into(),
 ///     ..Default::default()
 /// });
+/// # }
 /// ```
 /// or
-/// ```compile_fail
+/// ```
+/// # use bevy_ecs::Commands;
+/// # use bevy_text::{BasicText, Text};
+/// # use bevy_ui::entity::TextBundle;
+/// # fn system(commands: &mut Commands) {
 /// commands.spawn(TextBundle {
 ///     text: Text::from(BasicText {
-///         value: "hello world?",
+///         value: "hello world?".to_string(),
 ///         ..Default::default()
 ///     }),
 ///     ..Default::default()
 /// });
+/// # }
 /// ```
 #[derive(Debug, Default, Clone)]
 pub struct BasicText {

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -1,7 +1,6 @@
-use bevy_asset::Handle;
 use bevy_math::Size;
 
-use crate::{Font, TextAlignment, TextStyle};
+use crate::{TextAlignment, TextStyle};
 
 #[derive(Debug, Default, Clone)]
 pub struct Text {
@@ -44,7 +43,6 @@ pub struct Text {
 #[derive(Debug, Default, Clone)]
 pub struct BasicText {
     pub value: String,
-    pub font: Handle<Font>,
     pub style: TextStyle,
     pub alignment: TextAlignment,
 }
@@ -53,12 +51,11 @@ impl From<BasicText> for Text {
     fn from(source: BasicText) -> Self {
         let BasicText {
             value,
-            font,
             style,
             alignment,
         } = source;
         Self {
-            sections: vec![TextSection { value, font, style }],
+            sections: vec![TextSection { value, style }],
             alignment,
         }
     }
@@ -67,7 +64,6 @@ impl From<BasicText> for Text {
 #[derive(Debug, Default, Clone)]
 pub struct TextSection {
     pub value: String,
-    pub font: Handle<Font>,
     pub style: TextStyle,
 }
 

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -15,10 +15,11 @@ impl Text {
     /// Constructs a [`Text`] with (initially) one section.
     ///
     /// ```
-    /// # use bevy_text::{Font, Text, TextAlignment, TextStyle};
-    /// # use bevy_render::color::Color;
-    /// # use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
     /// # use bevy_asset::{AssetServer, Handle};
+    /// # use bevy_render::color::Color;
+    /// # use bevy_text::{Font, Text, TextAlignment, TextStyle};
+    /// # use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
+    /// #
     /// # let font_handle: Handle<Font> = Default::default();
     /// #
     /// // basic usage

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -12,7 +12,7 @@ pub struct Text {
 /// This is a transient helper type for basic text (text with only one section).
 /// Under the hood we require, use, construct and interact with the new "sectioned" [`Text`] type.
 /// Intended usage is:
-/// ```no_run
+/// ```compile_fail
 /// commands.spawn(TextBundle {
 ///     text: BasicText {
 ///         value: "hello world!",
@@ -22,7 +22,7 @@ pub struct Text {
 /// });
 /// ```
 /// or
-/// ```no_run
+/// ```compile_fail
 /// commands.spawn(TextBundle {
 ///     text: Text::from(BasicText {
 ///         value: "hello world?",

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -1,10 +1,16 @@
 use bevy_asset::Handle;
 use bevy_math::Size;
 
-use crate::{Font, TextStyle};
+use crate::{Font, TextAlignment, TextStyle};
 
 #[derive(Debug, Default, Clone)]
 pub struct Text {
+    pub sections: Vec<TextSection>,
+    pub alignment: TextAlignment,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct TextSection {
     pub value: String,
     pub font: Handle<Font>,
     pub style: TextStyle,

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -9,6 +9,51 @@ pub struct Text {
     pub alignment: TextAlignment,
 }
 
+/// This is a transient helper type for basic text (text with only one section).
+/// Under the hood we require, use, construct and interact with the new "sectioned" [`Text`] type.
+/// Intended usage is:
+/// ```no_run
+/// commands.spawn(TextBundle {
+///     text: BasicText {
+///         value: "hello world!",
+///         ..Default::default()
+///     }.into(),
+///     ..Default::default()
+/// });
+/// ```
+/// or
+/// ```no_run
+/// commands.spawn(TextBundle {
+///     text: Text::from(BasicText {
+///         value: "hello world?",
+///         ..Default::default()
+///     }),
+///     ..Default::default()
+/// });
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct BasicText {
+    pub value: String,
+    pub font: Handle<Font>,
+    pub style: TextStyle,
+    pub alignment: TextAlignment,
+}
+
+impl From<BasicText> for Text {
+    fn from(source: BasicText) -> Self {
+        let BasicText {
+            value,
+            font,
+            style,
+            alignment,
+        } = source;
+        Self {
+            sections: vec![TextSection { value, font, style }],
+            alignment,
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct TextSection {
     pub value: String,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -90,12 +90,12 @@ pub fn draw_text2d_system(
 
         if let Some(text_glyphs) = text_pipeline.get_glyphs(&entity) {
             let position = global_transform.translation
-                + match text.style.alignment.vertical {
+                + match text.alignment.vertical {
                     VerticalAlign::Top => Vec3::zero(),
                     VerticalAlign::Center => Vec3::new(0.0, -height * 0.5, 0.0),
                     VerticalAlign::Bottom => Vec3::new(0.0, -height, 0.0),
                 }
-                + match text.style.alignment.horizontal {
+                + match text.alignment.horizontal {
                     HorizontalAlign::Left => Vec3::new(-width, 0.0, 0.0),
                     HorizontalAlign::Center => Vec3::new(-width * 0.5, 0.0, 0.0),
                     HorizontalAlign::Right => Vec3::zero(),
@@ -108,7 +108,7 @@ pub fn draw_text2d_system(
                 text_glyphs: &text_glyphs.glyphs,
                 font_quad_vertex_descriptor: &vertex_buffer_descriptor,
                 scale_factor,
-                style: &text.style,
+                sections: &text.sections,
             };
 
             drawable_text.draw(&mut draw, &mut context).unwrap();
@@ -158,11 +158,10 @@ pub fn text2d_system(
         if let Ok((text, mut calculated_size)) = query.get_mut(entity) {
             match text_pipeline.queue_text(
                 entity,
-                text.font.clone(),
                 &fonts,
-                &text.value,
-                scale_value(text.style.font_size, scale_factor),
-                text.style.alignment,
+                &text.sections,
+                scale_factor,
+                text.alignment,
                 Size::new(f32::MAX, f32::MAX),
                 &mut *font_atlas_set_storage,
                 &mut *texture_atlases,
@@ -191,6 +190,6 @@ pub fn text2d_system(
     queued_text.entities = new_queue;
 }
 
-fn scale_value(value: f32, factor: f64) -> f32 {
+pub fn scale_value(value: f32, factor: f64) -> f32 {
     (value as f64 * factor) as f32
 }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -93,11 +93,10 @@ pub fn text_system(
 
             match text_pipeline.queue_text(
                 entity,
-                text.font.clone(),
                 &fonts,
-                &text.value,
-                scale_value(text.style.font_size, scale_factor),
-                text.style.alignment,
+                &text.sections,
+                scale_factor,
+                text.alignment,
                 node_size,
                 &mut *font_atlas_set_storage,
                 &mut *texture_atlases,
@@ -160,7 +159,7 @@ pub fn draw_text_system(
                 msaa: &msaa,
                 text_glyphs: &text_glyphs.glyphs,
                 font_quad_vertex_descriptor: &vertex_buffer_descriptor,
-                style: &text.style,
+                sections: &text.sections,
             };
 
             drawable_text.draw(&mut draw, &mut context).unwrap();

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -120,7 +120,6 @@ fn setup(
                         style: TextStyle {
                             font_size: 60.0,
                             color: Color::WHITE,
-                            ..Default::default()
                         },
                     },
                     TextSection {
@@ -129,7 +128,6 @@ fn setup(
                         style: TextStyle {
                             font_size: 60.0,
                             color: Color::WHITE,
-                            ..Default::default()
                         },
                     },
                 ],

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -40,7 +40,7 @@ struct Velocity {
 const GRAVITY: f32 = -9.821 * 100.0;
 const SPRITE_SIZE: f32 = 75.0;
 
-const COL_DESELECTED: Color = Color::rgb_linear(0.03, 0.03, 0.03);
+const COL_DESELECTED: Color = Color::rgba_linear(0.03, 0.03, 0.03, 0.92);
 const COL_SELECTED: Color = Color::WHITE;
 
 const SHOWCASE_TIMER_SECS: f32 = 3.0;
@@ -326,8 +326,14 @@ fn contributors() -> Contributors {
 /// Because there is no `Mul<Color> for Color` instead `[f32; 3]` is
 /// used.
 fn gen_color(rng: &mut impl Rng) -> [f32; 3] {
-    let r = rng.gen_range(0.3..1.0);
-    let g = rng.gen_range(0.3..1.0);
-    let b = rng.gen_range(0.3..1.0);
-    [r, g, b]
+    loop {
+        let rgb = rng.gen();
+        if luminance(rgb) >= 0.6 {
+            break rgb;
+        }
+    }
+}
+
+fn luminance([r, g, b]: [f32; 3]) -> f32 {
+    0.299 * r + 0.587 * g + 0.114 * b
 }

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -41,7 +41,7 @@ const GRAVITY: f32 = -9.821 * 100.0;
 const SPRITE_SIZE: f32 = 75.0;
 
 const COL_DESELECTED: Color = Color::rgb_linear(0.03, 0.03, 0.03);
-const COL_SELECTED: Color = Color::rgb_linear(5.0, 5.0, 5.0);
+const COL_SELECTED: Color = Color::WHITE;
 
 const SHOWCASE_TIMER_SECS: f32 = 3.0;
 
@@ -113,13 +113,27 @@ fn setup(
                 ..Default::default()
             },
             text: Text {
-                value: "Contributor showcase".to_string(),
-                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                style: TextStyle {
-                    font_size: 60.0,
-                    color: Color::WHITE,
-                    ..Default::default()
-                },
+                sections: vec![
+                    TextSection {
+                        value: "Contributor showcase".to_string(),
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        style: TextStyle {
+                            font_size: 60.0,
+                            color: Color::WHITE,
+                            ..Default::default()
+                        },
+                    },
+                    TextSection {
+                        value: "".to_string(),
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        style: TextStyle {
+                            font_size: 60.0,
+                            color: Color::WHITE,
+                            ..Default::default()
+                        },
+                    },
+                ],
+                ..Default::default()
             },
             ..Default::default()
         });
@@ -195,7 +209,9 @@ fn select(
 
     trans.translation.z = 100.0;
 
-    text.value = format!("Contributor: {}", name);
+    text.sections[0].value = "Contributor: ".to_string();
+    text.sections[1].value = name.to_string();
+    text.sections[1].style.color = mat.color;
 
     Some(())
 }
@@ -312,9 +328,8 @@ fn contributors() -> Contributors {
 /// Because there is no `Mul<Color> for Color` instead `[f32; 3]` is
 /// used.
 fn gen_color(rng: &mut impl Rng) -> [f32; 3] {
-    let r = rng.gen_range(0.2..1.0);
-    let g = rng.gen_range(0.2..1.0);
-    let b = rng.gen_range(0.2..1.0);
-    let v = Vec3::new(r, g, b);
-    v.normalize().into()
+    let r = rng.gen_range(0.3..1.0);
+    let g = rng.gen_range(0.3..1.0);
+    let b = rng.gen_range(0.3..1.0);
+    [r, g, b]
 }

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -116,16 +116,16 @@ fn setup(
                 sections: vec![
                     TextSection {
                         value: "Contributor showcase".to_string(),
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                         style: TextStyle {
+                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                             font_size: 60.0,
                             color: Color::WHITE,
                         },
                     },
                     TextSection {
                         value: "".to_string(),
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                         style: TextStyle {
+                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                             font_size: 60.0,
                             color: Color::WHITE,
                         },

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -14,15 +14,17 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
         .spawn(Camera2dBundle::default())
         .spawn(Text2dBundle {
             text: Text {
-                value: "This text is in the 2D scene.".to_string(),
-                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                style: TextStyle {
-                    font_size: 60.0,
-                    color: Color::WHITE,
-                    alignment: TextAlignment {
-                        vertical: VerticalAlign::Center,
-                        horizontal: HorizontalAlign::Center,
+                sections: vec![TextSection {
+                    value: "This text is in the 2D scene.".to_string(),
+                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    style: TextStyle {
+                        font_size: 60.0,
+                        color: Color::WHITE,
                     },
+                }],
+                alignment: TextAlignment {
+                    vertical: VerticalAlign::Center,
+                    horizontal: HorizontalAlign::Center,
                 },
             },
             ..Default::default()

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -15,8 +15,8 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
         .spawn(Text2dBundle {
             text: BasicText {
                 value: "This text is in the 2D scene.".to_string(),
-                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 style: TextStyle {
+                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                     font_size: 60.0,
                     color: Color::WHITE,
                 },

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -13,20 +13,19 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
         // 2d camera
         .spawn(Camera2dBundle::default())
         .spawn(Text2dBundle {
-            text: Text {
-                sections: vec![TextSection {
-                    value: "This text is in the 2D scene.".to_string(),
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                    style: TextStyle {
-                        font_size: 60.0,
-                        color: Color::WHITE,
-                    },
-                }],
+            text: BasicText {
+                value: "This text is in the 2D scene.".to_string(),
+                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                style: TextStyle {
+                    font_size: 60.0,
+                    color: Color::WHITE,
+                },
                 alignment: TextAlignment {
                     vertical: VerticalAlign::Center,
                     horizontal: HorizontalAlign::Center,
                 },
-            },
+            }
+            .into(),
             ..Default::default()
         });
 }

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -13,19 +13,18 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
         // 2d camera
         .spawn(Camera2dBundle::default())
         .spawn(Text2dBundle {
-            text: BasicText {
-                value: "This text is in the 2D scene.".to_string(),
-                style: TextStyle {
+            text: Text::with_section(
+                "This text is in the 2D scene.",
+                TextStyle {
                     font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                     font_size: 60.0,
                     color: Color::WHITE,
                 },
-                alignment: TextAlignment {
+                TextAlignment {
                     vertical: VerticalAlign::Center,
                     horizontal: HorizontalAlign::Center,
                 },
-            }
-            .into(),
+            ),
             ..Default::default()
         });
 }

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -53,13 +53,15 @@ fn setup_menu(
         .with_children(|parent| {
             parent.spawn(TextBundle {
                 text: Text {
-                    value: "Play".to_string(),
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                    style: TextStyle {
-                        font_size: 40.0,
-                        color: Color::rgb(0.9, 0.9, 0.9),
-                        ..Default::default()
-                    },
+                    sections: vec![TextSection {
+                        value: "Play".to_string(),
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        style: TextStyle {
+                            font_size: 40.0,
+                            color: Color::rgb(0.9, 0.9, 0.9),
+                        },
+                    }],
+                    ..Default::default()
                 },
                 ..Default::default()
             });

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -52,16 +52,15 @@ fn setup_menu(
         })
         .with_children(|parent| {
             parent.spawn(TextBundle {
-                text: BasicText {
-                    value: "Play".to_string(),
-                    style: TextStyle {
+                text: Text::with_section(
+                    "Play",
+                    TextStyle {
                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                         font_size: 40.0,
                         color: Color::rgb(0.9, 0.9, 0.9),
                     },
-                    ..Default::default()
-                }
-                .into(),
+                    Default::default(),
+                ),
                 ..Default::default()
             });
         });

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -52,17 +52,16 @@ fn setup_menu(
         })
         .with_children(|parent| {
             parent.spawn(TextBundle {
-                text: Text {
-                    sections: vec![TextSection {
-                        value: "Play".to_string(),
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                        style: TextStyle {
-                            font_size: 40.0,
-                            color: Color::rgb(0.9, 0.9, 0.9),
-                        },
-                    }],
+                text: BasicText {
+                    value: "Play".to_string(),
+                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    style: TextStyle {
+                        font_size: 40.0,
+                        color: Color::rgb(0.9, 0.9, 0.9),
+                    },
                     ..Default::default()
-                },
+                }
+                .into(),
                 ..Default::default()
             });
         });

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -54,8 +54,8 @@ fn setup_menu(
             parent.spawn(TextBundle {
                 text: BasicText {
                     value: "Play".to_string(),
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                     style: TextStyle {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                         font_size: 40.0,
                         color: Color::rgb(0.9, 0.9, 0.9),
                     },

--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -152,15 +152,15 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>, mut game: ResM
 
     // scoreboard
     commands.spawn(TextBundle {
-        text: Text {
-            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-            value: "Score:".to_string(),
-            style: TextStyle {
-                color: Color::rgb(0.5, 0.5, 1.0),
+        text: Text::with_section(
+            "Score:",
+            TextStyle {
+                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 font_size: 40.0,
-                ..Default::default()
+                color: Color::rgb(0.5, 0.5, 1.0),
             },
-        },
+            Default::default(),
+        ),
         style: Style {
             position_type: PositionType::Absolute,
             position: Rect {
@@ -338,7 +338,7 @@ fn rotate_bonus(game: Res<Game>, time: Res<Time>, mut transforms: Query<&mut Tra
 // update the score displayed during the game
 fn scoreboard_system(game: Res<Game>, mut query: Query<&mut Text>) {
     for mut text in query.iter_mut() {
-        text.value = format!("Sugar Rush: {}", game.score);
+        text.sections[0].value = format!("Sugar Rush: {}", game.score);
     }
 }
 
@@ -369,15 +369,15 @@ fn display_score(
         })
         .with_children(|parent| {
             parent.spawn(TextBundle {
-                text: Text {
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                    value: format!("Cake eaten: {}", game.cake_eaten),
-                    style: TextStyle {
-                        color: Color::rgb(0.5, 0.5, 1.0),
+                text: Text::with_section(
+                    format!("Cake eaten: {}", game.cake_eaten),
+                    TextStyle {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                         font_size: 80.0,
-                        ..Default::default()
+                        color: Color::rgb(0.5, 0.5, 1.0),
                     },
-                },
+                    Default::default(),
+                ),
                 ..Default::default()
             });
         });

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -70,19 +70,19 @@ fn setup(
             text: Text {
                 sections: vec![
                     TextSection {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                         value: "Score: ".to_string(),
                         style: TextStyle {
-                            color: Color::rgb(0.5, 0.5, 1.0),
+                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                             font_size: 40.0,
+                            color: Color::rgb(0.5, 0.5, 1.0),
                         },
                     },
                     TextSection {
-                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
                         value: "".to_string(),
                         style: TextStyle {
-                            color: Color::rgb(0.9, 0.3, 1.0),
-                            font_size: 60.0,
+                            font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                            font_size: 40.0,
+                            color: Color::rgb(1.0, 0.5, 0.5),
                         },
                     },
                 ],

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -68,13 +68,25 @@ fn setup(
         // scoreboard
         .spawn(TextBundle {
             text: Text {
-                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                value: "Score:".to_string(),
-                style: TextStyle {
-                    color: Color::rgb(0.5, 0.5, 1.0),
-                    font_size: 40.0,
-                    ..Default::default()
-                },
+                sections: vec![
+                    TextSection {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        value: "Score: ".to_string(),
+                        style: TextStyle {
+                            color: Color::rgb(0.5, 0.5, 1.0),
+                            font_size: 40.0,
+                        },
+                    },
+                    TextSection {
+                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                        value: "".to_string(),
+                        style: TextStyle {
+                            color: Color::rgb(0.9, 0.3, 1.0),
+                            font_size: 60.0,
+                        },
+                    },
+                ],
+                ..Default::default()
             },
             style: Style {
                 position_type: PositionType::Absolute,
@@ -191,7 +203,7 @@ fn ball_movement_system(time: Res<Time>, mut ball_query: Query<(&Ball, &mut Tran
 
 fn scoreboard_system(scoreboard: Res<Scoreboard>, mut query: Query<&mut Text>) {
     for mut text in query.iter_mut() {
-        text.value = format!("Score: {}", scoreboard.score);
+        text.sections[1].value = scoreboard.score.to_string();
     }
 }
 

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -102,16 +102,15 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
             align_self: AlignSelf::FlexEnd,
             ..Default::default()
         },
-        text: BasicText {
-            value: "Nothing to see in this window! Check the console output!".to_string(),
-            style: TextStyle {
+        text: Text::with_section(
+            "Nothing to see in this window! Check the console output!",
+            TextStyle {
                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 font_size: 50.0,
                 color: Color::WHITE,
             },
-            ..Default::default()
-        }
-        .into(),
+            Default::default(),
+        ),
         ..Default::default()
     });
 }

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -102,17 +102,16 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
             align_self: AlignSelf::FlexEnd,
             ..Default::default()
         },
-        text: Text {
-            sections: vec![TextSection {
-                value: "Nothing to see in this window! Check the console output!".to_string(),
-                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                style: TextStyle {
-                    font_size: 50.0,
-                    color: Color::WHITE,
-                },
-            }],
+        text: BasicText {
+            value: "Nothing to see in this window! Check the console output!".to_string(),
+            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+            style: TextStyle {
+                font_size: 50.0,
+                color: Color::WHITE,
+            },
             ..Default::default()
-        },
+        }
+        .into(),
         ..Default::default()
     });
 }

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -103,13 +103,15 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
             ..Default::default()
         },
         text: Text {
-            value: "Nothing to see in this window! Check the console output!".to_string(),
-            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-            style: TextStyle {
-                font_size: 50.0,
-                color: Color::WHITE,
-                ..Default::default()
-            },
+            sections: vec![TextSection {
+                value: "Nothing to see in this window! Check the console output!".to_string(),
+                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                style: TextStyle {
+                    font_size: 50.0,
+                    color: Color::WHITE,
+                },
+            }],
+            ..Default::default()
         },
         ..Default::default()
     });

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -104,8 +104,8 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
         },
         text: BasicText {
             value: "Nothing to see in this window! Check the console output!".to_string(),
-            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
             style: TextStyle {
+                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 font_size: 50.0,
                 color: Color::WHITE,
             },

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -54,13 +54,41 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
         .spawn(CameraUiBundle::default())
         .spawn(TextBundle {
             text: Text {
-                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                value: "Bird Count:".to_string(),
-                style: TextStyle {
-                    color: Color::rgb(0.0, 1.0, 0.0),
-                    font_size: 40.0,
-                    ..Default::default()
-                },
+                sections: vec![
+                    TextSection {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        value: "Bird Count: ".to_string(),
+                        style: TextStyle {
+                            color: Color::rgb(0.0, 1.0, 0.0),
+                            font_size: 40.0,
+                        },
+                    },
+                    TextSection {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        value: "".to_string(),
+                        style: TextStyle {
+                            color: Color::rgb(0.0, 1.0, 1.0),
+                            font_size: 40.0,
+                        },
+                    },
+                    TextSection {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        value: "\nAverage FPS: ".to_string(),
+                        style: TextStyle {
+                            color: Color::rgb(0.0, 1.0, 0.0),
+                            font_size: 40.0,
+                        },
+                    },
+                    TextSection {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        value: "".to_string(),
+                        style: TextStyle {
+                            color: Color::rgb(0.0, 1.0, 1.0),
+                            font_size: 40.0,
+                        },
+                    },
+                ],
+                ..Default::default()
             },
             style: Style {
                 position_type: PositionType::Absolute,
@@ -150,7 +178,8 @@ fn counter_system(
     if let Some(fps) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
         if let Some(average) = fps.average() {
             for mut text in query.iter_mut() {
-                text.value = format!("Bird Count: {}\nAverage FPS: {:.2}", counter.count, average);
+                text.sections[1].value = format!("{}", counter.count);
+                text.sections[3].value = format!("{:.2}", average);
             }
         }
     };

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -56,35 +56,35 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
             text: Text {
                 sections: vec![
                     TextSection {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                         value: "Bird Count: ".to_string(),
                         style: TextStyle {
-                            color: Color::rgb(0.0, 1.0, 0.0),
+                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                             font_size: 40.0,
+                            color: Color::rgb(0.0, 1.0, 0.0),
                         },
                     },
                     TextSection {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                         value: "".to_string(),
                         style: TextStyle {
-                            color: Color::rgb(0.0, 1.0, 1.0),
+                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                             font_size: 40.0,
+                            color: Color::rgb(0.0, 1.0, 1.0),
                         },
                     },
                     TextSection {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                         value: "\nAverage FPS: ".to_string(),
                         style: TextStyle {
-                            color: Color::rgb(0.0, 1.0, 0.0),
+                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                             font_size: 40.0,
+                            color: Color::rgb(0.0, 1.0, 0.0),
                         },
                     },
                     TextSection {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                         value: "".to_string(),
                         style: TextStyle {
-                            color: Color::rgb(0.0, 1.0, 1.0),
+                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                             font_size: 40.0,
+                            color: Color::rgb(0.0, 1.0, 1.0),
                         },
                     },
                 ],

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -39,15 +39,15 @@ fn button_system(
         let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
             Interaction::Clicked => {
-                text.value = "Press".to_string();
+                text.sections[0].value = "Press".to_string();
                 *material = button_materials.pressed.clone();
             }
             Interaction::Hovered => {
-                text.value = "Hover".to_string();
+                text.sections[0].value = "Hover".to_string();
                 *material = button_materials.hovered.clone();
             }
             Interaction::None => {
-                text.value = "Button".to_string();
+                text.sections[0].value = "Button".to_string();
                 *material = button_materials.normal.clone();
             }
         }
@@ -79,13 +79,15 @@ fn setup(
         .with_children(|parent| {
             parent.spawn(TextBundle {
                 text: Text {
-                    value: "Button".to_string(),
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                    style: TextStyle {
-                        font_size: 40.0,
-                        color: Color::rgb(0.9, 0.9, 0.9),
-                        ..Default::default()
-                    },
+                    sections: vec![TextSection {
+                        value: "Button".to_string(),
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        style: TextStyle {
+                            font_size: 40.0,
+                            color: Color::rgb(0.9, 0.9, 0.9),
+                        },
+                    }],
+                    ..Default::default()
                 },
                 ..Default::default()
             });

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -80,8 +80,8 @@ fn setup(
             parent.spawn(TextBundle {
                 text: BasicText {
                     value: "Button".to_string(),
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                     style: TextStyle {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                         font_size: 40.0,
                         color: Color::rgb(0.9, 0.9, 0.9),
                     },

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -78,17 +78,16 @@ fn setup(
         })
         .with_children(|parent| {
             parent.spawn(TextBundle {
-                text: Text {
-                    sections: vec![TextSection {
-                        value: "Button".to_string(),
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                        style: TextStyle {
-                            font_size: 40.0,
-                            color: Color::rgb(0.9, 0.9, 0.9),
-                        },
-                    }],
+                text: BasicText {
+                    value: "Button".to_string(),
+                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    style: TextStyle {
+                        font_size: 40.0,
+                        color: Color::rgb(0.9, 0.9, 0.9),
+                    },
                     ..Default::default()
-                },
+                }
+                .into(),
                 ..Default::default()
             });
         });

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -78,16 +78,15 @@ fn setup(
         })
         .with_children(|parent| {
             parent.spawn(TextBundle {
-                text: BasicText {
-                    value: "Button".to_string(),
-                    style: TextStyle {
+                text: Text::with_section(
+                    "Button",
+                    TextStyle {
                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                         font_size: 40.0,
                         color: Color::rgb(0.9, 0.9, 0.9),
                     },
-                    ..Default::default()
-                }
-                .into(),
+                    Default::default(),
+                ),
                 ..Default::default()
             });
         });

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -80,16 +80,15 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>, mut state: Res
     let font_handle = asset_server.load("fonts/FiraSans-Bold.ttf");
     state.handle = font_handle.clone();
     commands.spawn(CameraUiBundle::default()).spawn(TextBundle {
-        text: BasicText {
-            value: "a".to_string(),
-            style: TextStyle {
+        text: Text::with_section(
+            "a",
+            TextStyle {
                 font: font_handle,
                 font_size: 60.0,
                 color: Color::YELLOW,
             },
-            ..Default::default()
-        }
-        .into(),
+            Default::default(),
+        ),
         ..Default::default()
     });
 }

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -81,17 +81,16 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>, mut state: Res
     let font_handle = asset_server.load("fonts/FiraSans-Bold.ttf");
     state.handle = font_handle.clone();
     commands.spawn(CameraUiBundle::default()).spawn(TextBundle {
-        text: Text {
-            sections: vec![TextSection {
-                value: "a".to_string(),
-                font: font_handle,
-                style: TextStyle {
-                    font_size: 60.0,
-                    color: Color::MIDNIGHT_BLUE,
-                },
-            }],
+        text: BasicText {
+            value: "a".to_string(),
+            font: font_handle,
+            style: TextStyle {
+                font_size: 60.0,
+                color: Color::MIDNIGHT_BLUE,
+            },
             ..Default::default()
-        },
+        }
+        .into(),
         ..Default::default()
     });
 }

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -1,6 +1,6 @@
 use bevy::{prelude::*, text::FontAtlasSet};
 
-// TODO: This is now broken.
+// TODO: This is now broken. See #1243
 /// This example illustrates how FontAtlases are populated. Bevy uses FontAtlases under the hood to optimize text rendering.
 fn main() {
     App::build()

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -5,6 +5,7 @@ use bevy::{prelude::*, text::FontAtlasSet};
 fn main() {
     App::build()
         .init_resource::<State>()
+        .add_resource(ClearColor(Color::BLACK))
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
         .add_system(text_update_system.system())
@@ -35,14 +36,12 @@ fn atlas_render_system(
     font_atlas_sets: Res<Assets<FontAtlasSet>>,
     texture_atlases: Res<Assets<TextureAtlas>>,
 ) {
-    let count = font_atlas_sets.iter().count();
     if let Some(set) = font_atlas_sets.get(&state.handle.as_weak::<FontAtlasSet>()) {
         if let Some((_size, font_atlas)) = set.iter().next() {
             let x_offset = state.atlas_count as f32;
             if state.atlas_count == font_atlas.len() as u32 {
                 return;
             }
-            dbg!(count);
             let texture_atlas = texture_atlases
                 .get(&font_atlas[state.atlas_count as usize].texture_atlas)
                 .unwrap();
@@ -83,10 +82,10 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>, mut state: Res
     commands.spawn(CameraUiBundle::default()).spawn(TextBundle {
         text: BasicText {
             value: "a".to_string(),
-            font: font_handle,
             style: TextStyle {
+                font: font_handle,
                 font_size: 60.0,
-                color: Color::MIDNIGHT_BLUE,
+                color: Color::YELLOW,
             },
             ..Default::default()
         }

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -1,5 +1,6 @@
 use bevy::{prelude::*, text::FontAtlasSet};
 
+// TODO: This is now broken.
 /// This example illustrates how FontAtlases are populated. Bevy uses FontAtlases under the hood to optimize text rendering.
 fn main() {
     App::build()
@@ -34,12 +35,14 @@ fn atlas_render_system(
     font_atlas_sets: Res<Assets<FontAtlasSet>>,
     texture_atlases: Res<Assets<TextureAtlas>>,
 ) {
+    let count = font_atlas_sets.iter().count();
     if let Some(set) = font_atlas_sets.get(&state.handle.as_weak::<FontAtlasSet>()) {
         if let Some((_size, font_atlas)) = set.iter().next() {
             let x_offset = state.atlas_count as f32;
             if state.atlas_count == font_atlas.len() as u32 {
                 return;
             }
+            dbg!(count);
             let texture_atlas = texture_atlases
                 .get(&font_atlas[state.atlas_count as usize].texture_atlas)
                 .unwrap();
@@ -65,8 +68,8 @@ fn text_update_system(mut state: ResMut<State>, time: Res<Time>, mut query: Quer
     if state.timer.tick(time.delta_seconds()).finished() {
         for mut text in query.iter_mut() {
             let c = rand::random::<u8>() as char;
-            if !text.value.contains(c) {
-                text.value = format!("{}{}", text.value, c);
+            if !text.sections[0].value.contains(c) {
+                text.sections[0].value.push(c);
             }
         }
 
@@ -79,13 +82,15 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>, mut state: Res
     state.handle = font_handle.clone();
     commands.spawn(CameraUiBundle::default()).spawn(TextBundle {
         text: Text {
-            value: "a".to_string(),
-            font: font_handle,
-            style: TextStyle {
-                font_size: 60.0,
-                color: Color::WHITE,
-                ..Default::default()
-            },
+            sections: vec![TextSection {
+                value: "a".to_string(),
+                font: font_handle,
+                style: TextStyle {
+                    font_size: 60.0,
+                    color: Color::MIDNIGHT_BLUE,
+                },
+            }],
+            ..Default::default()
         },
         ..Default::default()
     });

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -4,7 +4,8 @@ use bevy::{
 };
 
 /// This example illustrates how to create UI text and update it in a system. It displays the
-/// current FPS in the upper left hand corner.  For text within a scene, please see the text2d example.
+/// current FPS in the top left corner, as well as text that changes colour in the bottom right.
+/// For text within a scene, please see the text2d example.
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
@@ -37,17 +38,21 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
                 },
                 ..Default::default()
             },
-            // construct a `BasicText`
-            text: BasicText {
-                value: "hello bevy!".to_string(),
-                style: TextStyle {
+            // Use the `Text::with_section` constructor
+            text: Text::with_section(
+                // Accepts a `String` or any type that converts into a `String`, such as `&str`
+                "hello\nbevy!",
+                TextStyle {
                     font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                     font_size: 100.0,
                     color: Color::WHITE,
                 },
-                ..Default::default()
-            }
-            .into(), // convert it to `Text`
+                // Note: You can use `Default::default()` in place of the `TextAlignment`
+                TextAlignment {
+                    horizontal: HorizontalAlign::Center,
+                    ..Default::default()
+                },
+            ),
             ..Default::default()
         })
         .with(ColorText)
@@ -57,9 +62,9 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
                 align_self: AlignSelf::FlexEnd,
                 ..Default::default()
             },
-            // use `Text` directly
+            // Use `Text` directly
             text: Text {
-                // construct a `Vec` of `TextSection`s
+                // Construct a `Vec` of `TextSection`s
                 sections: vec![
                     TextSection {
                         value: "FPS: ".to_string(),
@@ -99,12 +104,12 @@ fn text_update_system(diagnostics: Res<Diagnostics>, mut query: Query<&mut Text,
 fn text_color_system(time: Res<Time>, mut query: Query<&mut Text, With<ColorText>>) {
     for mut text in query.iter_mut() {
         let seconds = time.seconds_since_startup() as f32;
-        // Although we constructed this with a `BasicText`,
-        // we converted it to a `Text` so we still update the only section
+        // We used the `Text::with_section` helper method, but it is still just a `Text`,
+        // so to update it, we are still updating the one and only section
         text.sections[0]
             .style
             .color
-            .set_r((1.50 * seconds).sin() / 2.0 + 0.5)
+            .set_r((1.25 * seconds).sin() / 2.0 + 0.5)
             .set_g((0.75 * seconds).sin() / 2.0 + 0.5)
             .set_b((0.50 * seconds).sin() / 2.0 + 0.5);
     }

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -21,7 +21,7 @@ fn text_update_system(diagnostics: Res<Diagnostics>, mut query: Query<&mut Text,
     for mut text in query.iter_mut() {
         if let Some(fps) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
             if let Some(average) = fps.average() {
-                text.value = format!("FPS: {:.2}", average);
+                text.sections[1].value = format!("{:.2}", average);
             }
         }
     }
@@ -38,13 +38,25 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
                 ..Default::default()
             },
             text: Text {
-                value: "FPS:".to_string(),
-                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                style: TextStyle {
-                    font_size: 60.0,
-                    color: Color::WHITE,
-                    ..Default::default()
-                },
+                sections: vec![
+                    TextSection {
+                        value: "FPS: ".to_string(),
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        style: TextStyle {
+                            font_size: 60.0,
+                            color: Color::WHITE,
+                        },
+                    },
+                    TextSection {
+                        value: "".to_string(),
+                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                        style: TextStyle {
+                            font_size: 60.0,
+                            color: Color::RED,
+                        },
+                    },
+                ],
+                ..Default::default()
             },
             ..Default::default()
         })

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -52,7 +52,7 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
                         style: TextStyle {
                             font: asset_server.load("fonts/FiraMono-Medium.ttf"),
                             font_size: 60.0,
-                            color: Color::RED,
+                            color: Color::GOLD,
                         },
                     },
                 ],

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -41,16 +41,16 @@ fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
                 sections: vec![
                     TextSection {
                         value: "FPS: ".to_string(),
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                         style: TextStyle {
+                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                             font_size: 60.0,
                             color: Color::WHITE,
                         },
                     },
                     TextSection {
                         value: "".to_string(),
-                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
                         style: TextStyle {
+                            font: asset_server.load("fonts/FiraMono-Medium.ttf"),
                             font_size: 60.0,
                             color: Color::RED,
                         },

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -33,16 +33,15 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
             },
             ..Default::default()
         },
-        text: BasicText {
-            value: "This is\ntext with\nline breaks\nin the top left".to_string(),
-            style: TextStyle {
+        text: Text::with_section(
+            "This is\ntext with\nline breaks\nin the top left",
+            TextStyle {
                 font: font.clone(),
                 font_size: 50.0,
                 color: Color::WHITE,
             },
-            alignment: TextAlignment::default(),
-        }
-        .into(),
+            Default::default(),
+        ),
         ..Default::default()
     });
     commands.spawn(TextBundle {
@@ -60,20 +59,18 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
             },
             ..Default::default()
         },
-        text: BasicText {
-                value:
-                    "This text is very long, has a limited width, is centred, is positioned in the top right and is also coloured pink."
-                        .to_string(),
-                        style: TextStyle {
+        text: Text::with_section(
+                    "This text is very long, has a limited width, is centred, is positioned in the top right and is also coloured pink.",
+                        TextStyle {
                     font: font.clone(),
                     font_size: 50.0,
                     color: Color::rgb(0.8, 0.2, 0.7),
                 },
-            alignment: TextAlignment {
+            TextAlignment {
                 horizontal: HorizontalAlign::Center,
                 vertical: VerticalAlign::Center,
             },
-        }.into(),
+        ),
         ..Default::default()
     });
     commands
@@ -139,7 +136,7 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
                         },
                     },
                 ],
-                alignment: TextAlignment::default(),
+                alignment: Default::default(),
             },
             ..Default::default()
         })
@@ -159,17 +156,15 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
             },
             ..Default::default()
         },
-        text: BasicText {
-            value: "This\ntext has\nline breaks and also a set width in the bottom left"
-                .to_string(),
-            style: TextStyle {
+        text: Text::with_section(
+            "This\ntext has\nline breaks and also a set width in the bottom left".to_string(),
+            TextStyle {
                 font,
                 font_size: 50.0,
                 color: Color::WHITE,
             },
-            alignment: TextAlignment::default(),
-        }
-        .into(),
+            Default::default(),
+        ),
         ..Default::default()
     });
 }
@@ -201,8 +196,8 @@ fn change_text_system(
             frame_time * 1000.0,
         );
 
-        text.sections[2].value = format!("{:.1}", fps,);
+        text.sections[2].value = format!("{:.1}", fps);
 
-        text.sections[4].value = format!("{:.3}", frame_time * 1000.0,);
+        text.sections[4].value = format!("{:.3}", frame_time * 1000.0);
     }
 }

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -35,8 +35,8 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
         },
         text: BasicText {
             value: "This is\ntext with\nline breaks\nin the top left".to_string(),
-            font: font.clone(),
             style: TextStyle {
+                font: font.clone(),
                 font_size: 50.0,
                 color: Color::WHITE,
             },
@@ -64,8 +64,8 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
                 value:
                     "This text is very long, has a limited width, is centred, is positioned in the top right and is also coloured pink."
                         .to_string(),
-                font: font.clone(),
-                style: TextStyle {
+                        style: TextStyle {
+                    font: font.clone(),
                     font_size: 50.0,
                     color: Color::rgb(0.8, 0.2, 0.7),
                 },
@@ -92,48 +92,48 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
                 sections: vec![
                     TextSection {
                         value: "This text changes in the bottom right".to_string(),
-                        font: font.clone(),
                         style: TextStyle {
+                            font: font.clone(),
                             font_size: 30.0,
                             color: Color::WHITE,
                         },
                     },
                     TextSection {
                         value: "\nThis text changes in the bottom right - ".to_string(),
-                        font: font.clone(),
                         style: TextStyle {
+                            font: font.clone(),
                             font_size: 30.0,
                             color: Color::RED,
                         },
                     },
                     TextSection {
                         value: "".to_string(),
-                        font: font.clone(),
                         style: TextStyle {
+                            font: font.clone(),
                             font_size: 30.0,
                             color: Color::ORANGE_RED,
                         },
                     },
                     TextSection {
                         value: " fps, ".to_string(),
-                        font: font.clone(),
                         style: TextStyle {
+                            font: font.clone(),
                             font_size: 30.0,
                             color: Color::YELLOW,
                         },
                     },
                     TextSection {
                         value: "".to_string(),
-                        font: font.clone(),
                         style: TextStyle {
+                            font: font.clone(),
                             font_size: 30.0,
                             color: Color::GREEN,
                         },
                     },
                     TextSection {
                         value: " ms/frame".to_string(),
-                        font: font.clone(),
                         style: TextStyle {
+                            font: font.clone(),
                             font_size: 30.0,
                             color: Color::BLUE,
                         },
@@ -162,8 +162,8 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
         text: BasicText {
             value: "This\ntext has\nline breaks and also a set width in the bottom left"
                 .to_string(),
-            font,
             style: TextStyle {
+                font,
                 font_size: 50.0,
                 color: Color::WHITE,
             },

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -33,17 +33,16 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
             },
             ..Default::default()
         },
-        text: Text {
-            sections: vec![TextSection {
-                value: "This is\ntext with\nline breaks\nin the top left".to_string(),
-                font: font.clone(),
-                style: TextStyle {
-                    font_size: 50.0,
-                    color: Color::WHITE,
-                },
-            }],
+        text: BasicText {
+            value: "This is\ntext with\nline breaks\nin the top left".to_string(),
+            font: font.clone(),
+            style: TextStyle {
+                font_size: 50.0,
+                color: Color::WHITE,
+            },
             alignment: TextAlignment::default(),
-        },
+        }
+        .into(),
         ..Default::default()
     });
     commands.spawn(TextBundle {
@@ -61,8 +60,7 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
             },
             ..Default::default()
         },
-        text: Text {
-            sections: vec![TextSection {
+        text: BasicText {
                 value:
                     "This text is very long, has a limited width, is centred, is positioned in the top right and is also coloured pink."
                         .to_string(),
@@ -71,12 +69,11 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
                     font_size: 50.0,
                     color: Color::rgb(0.8, 0.2, 0.7),
                 },
-            }],
             alignment: TextAlignment {
                 horizontal: HorizontalAlign::Center,
                 vertical: VerticalAlign::Center,
             },
-        },
+        }.into(),
         ..Default::default()
     });
     commands
@@ -162,18 +159,17 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
             },
             ..Default::default()
         },
-        text: Text {
-            sections: vec![TextSection {
-                value: "This\ntext has\nline breaks and also a set width in the bottom left"
-                    .to_string(),
-                font,
-                style: TextStyle {
-                    font_size: 50.0,
-                    color: Color::WHITE,
-                },
-            }],
+        text: BasicText {
+            value: "This\ntext has\nline breaks and also a set width in the bottom left"
+                .to_string(),
+            font,
+            style: TextStyle {
+                font_size: 50.0,
+                color: Color::WHITE,
+            },
             alignment: TextAlignment::default(),
-        },
+        }
+        .into(),
         ..Default::default()
     });
 }

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -34,13 +34,15 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
             ..Default::default()
         },
         text: Text {
-            value: "This is\ntext with\nline breaks\nin the top left".to_string(),
-            font: font.clone(),
-            style: TextStyle {
-                font_size: 50.0,
-                color: Color::WHITE,
-                alignment: TextAlignment::default(),
-            },
+            sections: vec![TextSection {
+                value: "This is\ntext with\nline breaks\nin the top left".to_string(),
+                font: font.clone(),
+                style: TextStyle {
+                    font_size: 50.0,
+                    color: Color::WHITE,
+                },
+            }],
+            alignment: TextAlignment::default(),
         },
         ..Default::default()
     });
@@ -60,16 +62,19 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
             ..Default::default()
         },
         text: Text {
-            value: "This is very long text with limited width in the top right and is also pink"
-                .to_string(),
-            font: font.clone(),
-            style: TextStyle {
-                font_size: 50.0,
-                color: Color::rgb(0.8, 0.2, 0.7),
-                alignment: TextAlignment {
-                    horizontal: HorizontalAlign::Center,
-                    vertical: VerticalAlign::Center,
+            sections: vec![TextSection {
+                value:
+                    "This text is very long, has a limited width, is centred, is positioned in the top right and is also coloured pink."
+                        .to_string(),
+                font: font.clone(),
+                style: TextStyle {
+                    font_size: 50.0,
+                    color: Color::rgb(0.8, 0.2, 0.7),
                 },
+            }],
+            alignment: TextAlignment {
+                horizontal: HorizontalAlign::Center,
+                vertical: VerticalAlign::Center,
             },
         },
         ..Default::default()
@@ -87,13 +92,57 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
                 ..Default::default()
             },
             text: Text {
-                value: "This text changes in the bottom right".to_string(),
-                font: font.clone(),
-                style: TextStyle {
-                    font_size: 30.0,
-                    color: Color::WHITE,
-                    alignment: TextAlignment::default(),
-                },
+                sections: vec![
+                    TextSection {
+                        value: "This text changes in the bottom right".to_string(),
+                        font: font.clone(),
+                        style: TextStyle {
+                            font_size: 30.0,
+                            color: Color::WHITE,
+                        },
+                    },
+                    TextSection {
+                        value: "\nThis text changes in the bottom right - ".to_string(),
+                        font: font.clone(),
+                        style: TextStyle {
+                            font_size: 30.0,
+                            color: Color::RED,
+                        },
+                    },
+                    TextSection {
+                        value: "".to_string(),
+                        font: font.clone(),
+                        style: TextStyle {
+                            font_size: 30.0,
+                            color: Color::ORANGE_RED,
+                        },
+                    },
+                    TextSection {
+                        value: " fps, ".to_string(),
+                        font: font.clone(),
+                        style: TextStyle {
+                            font_size: 30.0,
+                            color: Color::YELLOW,
+                        },
+                    },
+                    TextSection {
+                        value: "".to_string(),
+                        font: font.clone(),
+                        style: TextStyle {
+                            font_size: 30.0,
+                            color: Color::GREEN,
+                        },
+                    },
+                    TextSection {
+                        value: " ms/frame".to_string(),
+                        font: font.clone(),
+                        style: TextStyle {
+                            font_size: 30.0,
+                            color: Color::BLUE,
+                        },
+                    },
+                ],
+                alignment: TextAlignment::default(),
             },
             ..Default::default()
         })
@@ -114,14 +163,16 @@ fn infotext_system(commands: &mut Commands, asset_server: Res<AssetServer>) {
             ..Default::default()
         },
         text: Text {
-            value: "This\ntext has\nline breaks and also a set width in the bottom left"
-                .to_string(),
-            font,
-            style: TextStyle {
-                font_size: 50.0,
-                color: Color::WHITE,
-                alignment: TextAlignment::default(),
-            },
+            sections: vec![TextSection {
+                value: "This\ntext has\nline breaks and also a set width in the bottom left"
+                    .to_string(),
+                font,
+                style: TextStyle {
+                    font_size: 50.0,
+                    color: Color::WHITE,
+                },
+            }],
+            alignment: TextAlignment::default(),
         },
         ..Default::default()
     });
@@ -148,10 +199,14 @@ fn change_text_system(
             }
         }
 
-        text.value = format!(
+        text.sections[0].value = format!(
             "This text changes in the bottom right - {:.1} fps, {:.3} ms/frame",
             fps,
             frame_time * 1000.0,
         );
+
+        text.sections[2].value = format!("{:.1}", fps,);
+
+        text.sections[4].value = format!("{:.3}", frame_time * 1000.0,);
     }
 }

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -59,8 +59,8 @@ fn setup(
                                 },
                                 text: BasicText {
                                     value: "Text Example".to_string(),
-                                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                                     style: TextStyle {
+                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                                         font_size: 30.0,
                                         color: Color::WHITE,
                                     },

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -57,17 +57,16 @@ fn setup(
                                     margin: Rect::all(Val::Px(5.0)),
                                     ..Default::default()
                                 },
-                                text: Text {
-                                    sections: vec![TextSection {
-                                        value: "Text Example".to_string(),
-                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                        style: TextStyle {
-                                            font_size: 30.0,
-                                            color: Color::WHITE,
-                                        },
-                                    }],
+                                text: BasicText {
+                                    value: "Text Example".to_string(),
+                                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                    style: TextStyle {
+                                        font_size: 30.0,
+                                        color: Color::WHITE,
+                                    },
                                     ..Default::default()
-                                },
+                                }
+                                .into(),
                                 ..Default::default()
                             });
                         });

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -58,13 +58,15 @@ fn setup(
                                     ..Default::default()
                                 },
                                 text: Text {
-                                    value: "Text Example".to_string(),
-                                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                    style: TextStyle {
-                                        font_size: 30.0,
-                                        color: Color::WHITE,
-                                        ..Default::default()
-                                    },
+                                    sections: vec![TextSection {
+                                        value: "Text Example".to_string(),
+                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                        style: TextStyle {
+                                            font_size: 30.0,
+                                            color: Color::WHITE,
+                                        },
+                                    }],
+                                    ..Default::default()
                                 },
                                 ..Default::default()
                             });

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -57,16 +57,15 @@ fn setup(
                                     margin: Rect::all(Val::Px(5.0)),
                                     ..Default::default()
                                 },
-                                text: BasicText {
-                                    value: "Text Example".to_string(),
-                                    style: TextStyle {
+                                text: Text::with_section(
+                                    "Text Example",
+                                    TextStyle {
                                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                                         font_size: 30.0,
                                         color: Color::WHITE,
                                     },
-                                    ..Default::default()
-                                }
-                                .into(),
+                                    Default::default(),
+                                ),
                                 ..Default::default()
                             });
                         });

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -52,13 +52,15 @@ fn setup(
                             ..Default::default()
                         },
                         text: Text {
-                            value: "Example text".to_string(),
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                            style: TextStyle {
-                                font_size: 30.0,
-                                color: Color::WHITE,
-                                ..Default::default()
-                            },
+                            sections: vec![TextSection {
+                                value: "Example text".to_string(),
+                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                style: TextStyle {
+                                    font_size: 30.0,
+                                    color: Color::WHITE,
+                                },
+                            }],
+                            ..Default::default()
                         },
                         ..Default::default()
                     });

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -53,8 +53,8 @@ fn setup(
                         },
                         text: BasicText {
                             value: "Example text".to_string(),
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                             style: TextStyle {
+                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                                 font_size: 30.0,
                                 color: Color::WHITE,
                             },

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -51,16 +51,15 @@ fn setup(
                             align_self: AlignSelf::FlexEnd,
                             ..Default::default()
                         },
-                        text: BasicText {
-                            value: "Example text".to_string(),
-                            style: TextStyle {
+                        text: Text::with_section(
+                            "Example text",
+                            TextStyle {
                                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                                 font_size: 30.0,
                                 color: Color::WHITE,
                             },
-                            ..Default::default()
-                        }
-                        .into(),
+                            Default::default(),
+                        ),
                         ..Default::default()
                     });
                 });

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -51,17 +51,16 @@ fn setup(
                             align_self: AlignSelf::FlexEnd,
                             ..Default::default()
                         },
-                        text: Text {
-                            sections: vec![TextSection {
-                                value: "Example text".to_string(),
-                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                style: TextStyle {
-                                    font_size: 30.0,
-                                    color: Color::WHITE,
-                                },
-                            }],
+                        text: BasicText {
+                            value: "Example text".to_string(),
+                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                            style: TextStyle {
+                                font_size: 30.0,
+                                color: Color::WHITE,
+                            },
                             ..Default::default()
-                        },
+                        }
+                        .into(),
                         ..Default::default()
                     });
                 });


### PR DESCRIPTION
Refer #1222

This takes advantage of [glyph_brush_layout](https://crates.io/crates/glyph_brush_layout)'s `SectionText` API.

Currently the `Text` component has an assumption that there is exactly one section only, so all I've done is create a "sections" API to connect it to glyph_brush_layout's API. I've made as few changes as possible otherwise.

However, I've updated all examples with text in them, including enhancing them with multiple text sections where I thought it made sense.

This is a breaking change, so this will need a changelog entry - I wasn't sure where to put this, so please advise.

We can potentially flatten the API further; see the questions below.

# New API

The new API is as follows:
```rust
// Component
pub struct Text {
    // pub value: String,             // moved to TextSection
    // pub font: Handle<Font>,        // moved to TextSection
    // pub style: TextStyle,          // moved to TextSection
    pub sections: Vec<TextSection>,   // +
    pub alignment: TextAlignment,     // +
}

pub struct TextSection {              // new
    pub value: String,                // +
    pub font: Handle<Font>,           // +
    pub style: TextStyle,             // +
}

pub struct TextStyle {
    pub font_size: f32,
    pub color: Color,
    // pub alignment: TextAlignment,  // moved to Text
}
```

## Questions

It might make sense to either:

1. spread the members of `TextStyle` into `TextSection`, or
2. move `font` from `TextSection` into `TextStyle`

# Example

Example below:

![image](https://user-images.githubusercontent.com/38416468/104604572-76152300-56b8-11eb-892c-19089e5c34bc.png)
_The "Score: " and the "10" have different fonts, font sizes, and colours_

```rust
fn setup(
    commands: &mut Commands,
    mut materials: ResMut<Assets<ColorMaterial>>,
    asset_server: Res<AssetServer>,
) {
    // Add the game's entities to our world
    commands
        // ...
        // scoreboard
        .spawn(TextBundle {
            text: Text {
                sections: vec![
                    TextSection {
                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                        value: "Score: ".to_string(),
                        style: TextStyle {
                            color: Color::rgb(0.5, 0.5, 1.0),
                            font_size: 40.0,
                        },
                    },
                    TextSection {
                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
                        value: "".to_string(),
                        style: TextStyle {
                            color: Color::rgb(0.9, 0.3, 1.0),
                            font_size: 60.0,
                        },
                    },
                ],
                ..Default::default()
            },
            style: Style {
                position_type: PositionType::Absolute,
                position: Rect {
                    top: Val::Px(5.0),
                    left: Val::Px(5.0),
                    ..Default::default()
                },
                ..Default::default()
            },
            ..Default::default()
        });
    // ...
}

fn scoreboard_system(scoreboard: Res<Scoreboard>, mut query: Query<&mut Text>) {
    for mut text in query.iter_mut() {
        text.sections[1].value = scoreboard.score.to_string();
    }
}

```