### PR TITLE
Update glam to 0.12.0

### DIFF
--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -13,5 +13,5 @@ license = "MIT"
 keywords = ["bevy"]
 
 [dependencies]
-glam = { version = "0.11.0", features = ["serde"] }
+glam = { version = "0.12.0", features = ["serde"] }
 bevy_reflect = { path = "../bevy_reflect", version = "0.4.0", features = ["bevy"] }

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -30,7 +30,7 @@ parking_lot = "0.11.0"
 thiserror = "1.0"
 serde = "1"
 smallvec = { version = "1.4", features = ["serde"], optional = true }
-glam = { version = "0.11.0", features = ["serde"], optional = true }
+glam = { version = "0.12.0", features = ["serde"], optional = true }
 
 [dev-dependencies]
 ron = "0.6.2"


### PR DESCRIPTION
### Added

* Added `f64` primitive type support
  * vectors: `DVec2`, `DVec3` and `DVec4`
  * square matrices: `DMat2`, `DMat3` and `DMat4`
  * a quaternion type: `DQuat`
* Added `i32` primitive type support
  * vectors: `IVec2`, `IVec3` and `IVec4`
* Added `u32` primitive type support
  * vectors: `UVec2`, `UVec3` and `UVec4`
* Added `bool` primitive type support
  * vectors: `BVec2`, `BVec3` and `BVec4`

### Changed

* `Vec2Mask`, `Vec3Mask` and `Vec4Mask` have been replaced by `BVec2`, `BVec3`,
  `BVec3A`, `BVec4` and `BVec4A`. These types are used by some vector methods
  and are not typically referenced directly. This is a breaking change.

### Removed

* `build.rs` has been removed.
