### PR TITLE
Change 'components' to 'bundles' where it makes sense semantically

### DIFF
--- a/crates/bevy_ecs/src/core/world_builder.rs
+++ b/crates/bevy_ecs/src/core/world_builder.rs
@@ -42,24 +42,24 @@ impl<'a> WorldBuilder<'a> {
         self
     }
 
-    pub fn with_bundle(&mut self, components: impl DynamicBundle) -> &mut Self {
+    pub fn with_bundle(&mut self, bundle: impl DynamicBundle) -> &mut Self {
         self.world
-            .insert(self.current_entity.expect("Cannot add component because the 'current entity' is not set. You should spawn an entity first."), components)
+            .insert(self.current_entity.expect("Cannot add bundle because the 'current entity' is not set. You should spawn an entity first."), bundle)
             .unwrap();
         self
     }
 
-    pub fn spawn_batch<I>(&mut self, components_iter: I) -> &mut Self
+    pub fn spawn_batch<I>(&mut self, bundle_iter: I) -> &mut Self
     where
         I: IntoIterator,
         I::Item: Bundle,
     {
-        self.world.spawn_batch(components_iter);
+        self.world.spawn_batch(bundle_iter);
         self
     }
 
-    pub fn spawn(&mut self, components: impl DynamicBundle) -> &mut Self {
-        self.current_entity = Some(self.world.spawn(components));
+    pub fn spawn(&mut self, bundle: impl DynamicBundle) -> &mut Self {
+        self.current_entity = Some(self.world.spawn(bundle));
         self
     }
 

--- a/crates/bevy_transform/src/hierarchy/child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/child_builder.rs
@@ -69,8 +69,8 @@ impl Command for PushChildren {
 }
 
 impl<'a> ChildBuilder<'a> {
-    pub fn spawn(&mut self, components: impl DynamicBundle + Send + Sync + 'static) -> &mut Self {
-        self.commands.spawn(components);
+    pub fn spawn(&mut self, bundle: impl DynamicBundle + Send + Sync + 'static) -> &mut Self {
+        self.commands.spawn(bundle);
         self.push_children
             .children
             .push(self.commands.current_entity().unwrap());
@@ -85,11 +85,8 @@ impl<'a> ChildBuilder<'a> {
         self.push_children.parent
     }
 
-    pub fn with_bundle(
-        &mut self,
-        components: impl DynamicBundle + Send + Sync + 'static,
-    ) -> &mut Self {
-        self.commands.with_bundle(components);
+    pub fn with_bundle(&mut self, bundle: impl DynamicBundle + Send + Sync + 'static) -> &mut Self {
+        self.commands.with_bundle(bundle);
         self
     }
 

--- a/crates/bevy_transform/src/hierarchy/world_child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/world_child_builder.rs
@@ -8,14 +8,14 @@ pub struct WorldChildBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> WorldChildBuilder<'a, 'b> {
-    pub fn spawn(&mut self, components: impl DynamicBundle + Send + Sync + 'static) -> &mut Self {
+    pub fn spawn(&mut self, bundle: impl DynamicBundle + Send + Sync + 'static) -> &mut Self {
         let parent_entity = self
             .parent_entities
             .last()
             .cloned()
             .expect("There should always be a parent at this point.");
         self.world_builder
-            .spawn(components)
+            .spawn(bundle)
             .with_bundle((Parent(parent_entity), PreviousParent(parent_entity)));
         let entity = self.world_builder.current_entity.unwrap();
         {
@@ -38,9 +38,9 @@ impl<'a, 'b> WorldChildBuilder<'a, 'b> {
 
     pub fn with_bundle(
         &mut self,
-        components: impl DynamicBundle + Send + Sync + 'static,
+        bundle: impl DynamicBundle + Send + Sync + 'static,
     ) -> &mut Self {
-        self.world_builder.with_bundle(components);
+        self.world_builder.with_bundle(bundle);
         self
     }
 

--- a/crates/bevy_transform/src/hierarchy/world_child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/world_child_builder.rs
@@ -36,10 +36,7 @@ impl<'a, 'b> WorldChildBuilder<'a, 'b> {
         self
     }
 
-    pub fn with_bundle(
-        &mut self,
-        bundle: impl DynamicBundle + Send + Sync + 'static,
-    ) -> &mut Self {
+    pub fn with_bundle(&mut self, bundle: impl DynamicBundle + Send + Sync + 'static) -> &mut Self {
         self.world_builder.with_bundle(bundle);
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! and it gets more powerful every day!
 //!
 //! ### This Crate
-//! The `bevy` crate is just a container crate that makes it easier to consume Bevy components.
+//! The `bevy` crate is just a container crate that makes it easier to consume Bevy subcrates.
 //! The defaults provide a "full" engine experience, but you can easily enable / disable features
 //! in your project's `Cargo.toml` to meet your specific needs. See Bevy's `Cargo.toml` for a full list of features available.
 //!


### PR DESCRIPTION
Following #863 there is a "bundle" concept that semantically means a specific set of types of components we want to add at one time for some given purpose (my wording).

I searched through the codebase and found the places where "components" was still being used in that context, and changed them to "bundle".  This couldn't be done via regex since there are many other places that "components" is used in a different context, so I did this through manual inspection. Hopefully my interpretation was accurate! 😄 

Some changes similar to these were made in #976 