### PR TITLE
Add an accessor for the labels of an entity

### DIFF
--- a/crates/bevy_core/src/label.rs
+++ b/crates/bevy_core/src/label.rs
@@ -70,6 +70,12 @@ impl EntityLabels {
             .map(|entities| entities.as_slice())
             .unwrap_or(&[])
     }
+
+    pub fn get_labels(&self, entity: &Entity) -> Option<impl Iterator<Item = &str>> {
+        self.entity_labels
+            .get(entity)
+            .map(|label_set| label_set.iter().map(|label| label.as_ref()))
+    }
 }
 
 pub(crate) fn entity_labels_system(


### PR DESCRIPTION
There was only an accessor to get all entities with a specific label, this PR adds one to get all labels of a specific entity.
This is useful for debugging purposes.