### PR TITLE
Support gl_InstanceIndex in shaders

### DIFF
--- a/crates/bevy_render/src/shader/mod.rs
+++ b/crates/bevy_render/src/shader/mod.rs
@@ -22,3 +22,4 @@ pub struct ShaderLayout {
 }
 
 pub const GL_VERTEX_INDEX: &str = "gl_VertexIndex";
+pub const GL_INSTANCE_INDEX: &str = "gl_InstanceIndex";

--- a/crates/bevy_render/src/shader/shader_reflect.rs
+++ b/crates/bevy_render/src/shader/shader_reflect.rs
@@ -3,7 +3,7 @@ use crate::{
         BindGroupDescriptor, BindType, BindingDescriptor, BindingShaderStage, InputStepMode,
         UniformProperty, VertexAttributeDescriptor, VertexBufferDescriptor, VertexFormat,
     },
-    shader::{ShaderLayout, GL_VERTEX_INDEX},
+    shader::{ShaderLayout, GL_INSTANCE_INDEX, GL_VERTEX_INDEX},
     texture::{TextureComponentType, TextureViewDimension},
 };
 use bevy_core::AsBytes;
@@ -31,7 +31,9 @@ impl ShaderLayout {
                 // obtain attribute descriptors from reflection
                 let mut vertex_attribute_descriptors = Vec::new();
                 for input_variable in module.enumerate_input_variables(None).unwrap() {
-                    if input_variable.name == GL_VERTEX_INDEX {
+                    if input_variable.name == GL_VERTEX_INDEX
+                        || input_variable.name == GL_INSTANCE_INDEX
+                    {
                         continue;
                     }
                     // reflect vertex attribute descriptor and record it


### PR DESCRIPTION
In order to write useful shaders for instanced rendering it's necessary to have access to the gl_InstanceIndex builtin. Bevy's current shader reflection incorrectly identifies gl_InstanceIndex as a vertex attribute, preventing it from being used. This skips gl_InstanceIndex in the reflection code in the same way that gl_VertexIndex is already being skipped.

A more complete solution might be to enumerate _all_ glsl builtins rather than just special casing them as needed but I decided to keep this change minimal because this seemed like code that was likely to be rewritten soon anyway. If someone thinks it's worth expanding to the more general version, I'm happy to do that in this PR.