### PR TITLE
Add missing spawn_local method to Scope in the single threaded executor

### DIFF
--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -127,6 +127,10 @@ pub struct Scope<'scope, T> {
 
 impl<'scope, T: Send + 'scope> Scope<'scope, T> {
     pub fn spawn<Fut: Future<Output = T> + 'scope + Send>(&mut self, f: Fut) {
+        self.spawn_local(f);
+    }
+
+    pub fn spawn_local<Fut: Future<Output = T> + 'scope>(&mut self, f: Fut) {
         let result = Arc::new(Mutex::new(None));
         self.results.push(result.clone());
         let f = async move {


### PR DESCRIPTION
This adds a method that I forgot in #1216 so that the Scope API is the same in the single threaded and non-single threaded cases