### PR TITLE
Use raw-window-handle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,13 @@ default = [
 dynamic = ["bevy_dylib"]
 
 # Rendering support
-render = ["bevy_internal/bevy_pbr", "bevy_internal/bevy_render", "bevy_internal/bevy_sprite", "bevy_internal/bevy_text", "bevy_internal/bevy_ui"]
+render = [
+  "bevy_internal/bevy_pbr",
+  "bevy_internal/bevy_render",
+  "bevy_internal/bevy_sprite",
+  "bevy_internal/bevy_text",
+  "bevy_internal/bevy_ui",
+]
 
 # Optional bevy crates
 bevy_audio = ["bevy_internal/bevy_audio"]
@@ -76,14 +82,14 @@ x11 = ["bevy_internal/x11"]
 subpixel_glyph_atlas = ["bevy_internal/subpixel_glyph_atlas"]
 
 [dependencies]
-bevy_dylib = {path = "crates/bevy_dylib", version = "0.4.0", default-features = false, optional = true}
-bevy_internal = {path = "crates/bevy_internal", version = "0.4.0", default-features = false}
+bevy_dylib = { path = "crates/bevy_dylib", version = "0.4.0", default-features = false, optional = true }
+bevy_internal = { path = "crates/bevy_internal", version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0"
 rand = "0.8.0"
 ron = "0.6.2"
-serde = {version = "1", features = ["derive"]}
+serde = { version = "1", features = ["derive"] }
 
 [[example]]
 name = "hello_world"
@@ -406,3 +412,7 @@ icon = "@mipmap/ic_launcher"
 build_targets = ["aarch64-linux-android", "armv7-linux-androideabi"]
 min_sdk_version = 16
 target_sdk_version = 29
+
+[patch.crates-io]
+# Latest commit breaks the entire ecosystem
+raw-window-handle = { git = "https://github.com/rust-windowing/raw-window-handle", rev = "31d91a932c03b81dc0f3e05e4c11aa7a727b799b" }

--- a/crates/bevy_wgpu/Cargo.toml
+++ b/crates/bevy_wgpu/Cargo.toml
@@ -13,7 +13,6 @@ license = "MIT"
 keywords = ["bevy"]
 
 [features]
-default = ["bevy_winit"]
 trace = ["wgpu/trace"]
 
 [dependencies]
@@ -25,7 +24,6 @@ bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.4.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.4.0" }
 bevy_render = { path = "../bevy_render", version = "0.4.0" }
 bevy_window = { path = "../bevy_window", version = "0.4.0" }
-bevy_winit = { path = "../bevy_winit", optional = true, version = "0.4.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.4.0" }
 
 # other

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -18,6 +18,7 @@ bevy_app = { path = "../bevy_app", version = "0.4.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.4.0" }
 bevy_math = { path = "../bevy_math", version = "0.4.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.4.0" }
+raw-window-handle = "0.3.3"
 
 # other
 

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -47,7 +47,8 @@ impl Plugin for WindowPlugin {
             .add_event::<WindowScaleFactorChanged>()
             .add_event::<WindowBackendScaleFactorChanged>()
             .add_event::<FileDragAndDrop>()
-            .init_resource::<Windows>();
+            .init_resource::<Windows>()
+            .init_thread_local_resource::<WindowHandles>();
 
         if self.add_primary_window {
             let resources = app.resources();

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -27,6 +27,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.4.0" }
 
 # other
 winit = { version = "0.24.0", default-features = false }
+raw-window-handle = "0.3.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 winit = { version = "0.24.0", features = ["web-sys"], default-features = false }


### PR DESCRIPTION
Closes #256

This depends on https://github.com/rust-windowing/raw-window-handle/pull/52, which means that we need a release containing it (https://github.com/rust-windowing/raw-window-handle/issues/58). That however is going to be a churny release, because https://github.com/rust-windowing/raw-window-handle/pull/55 is massively breaking. 

@msiglreith what you have said in https://github.com/rust-windowing/raw-window-handle/issues/54 suggests that this approach is not suitable for android, if I'm understanding that correctly? Would we need to update the `TrustedWindowHandle` every frame on android?