### PR TITLE
Change Name::new to take Into<String> instead of String

### DIFF
--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -20,7 +20,8 @@ impl Default for Name {
 }
 
 impl Name {
-    pub fn new(name: String) -> Self {
+    pub fn new(name: impl Into<String>) -> Self {
+        let name = name.into();
         let mut name = Name { name, hash: 0 };
         name.update_hash();
         name


### PR DESCRIPTION
This reduces verbosity for &'static strings, e.g. `Name::new("a name")` instead of `Name::new("a name".to_string())`.