### PR TITLE
Enable dynamic mutable access to component data 

### DIFF
--- a/crates/bevy_ecs/src/core/archetype.rs
+++ b/crates/bevy_ecs/src/core/archetype.rs
@@ -223,12 +223,7 @@ impl Archetype {
 
     /// # Safety
     /// `index` must be in-bounds
-    pub(crate) unsafe fn get_dynamic(
-        &self,
-        ty: TypeId,
-        size: usize,
-        index: usize,
-    ) -> Option<NonNull<u8>> {
+    pub unsafe fn get_dynamic(&self, ty: TypeId, size: usize, index: usize) -> Option<NonNull<u8>> {
         debug_assert!(index < self.len);
         Some(NonNull::new_unchecked(
             (*self.data.get())

--- a/crates/bevy_reflect/src/impls/bevy_ecs.rs
+++ b/crates/bevy_reflect/src/impls/bevy_ecs.rs
@@ -41,7 +41,10 @@ impl ReflectComponent {
 
     /// # Safety
     /// This does not do bound checks on entity_index. You must make sure entity_index is within bounds before calling.
-    /// To avoid having multiple mutable pointers to the same data, this method can only be called in a thread-local system.
+    /// This method does not prevent you from having two mutable pointers to the same data, violating Rust's aliasing rules. To avoid this:
+    /// * Only call this method in a thread-local system to avoid sharing across threads.
+    /// * Don't call this method more than once in the same scope for a given component.
+    #[allow(clippy::mut_from_ref)]
     pub unsafe fn reflect_component_mut<'a>(
         &self,
         archetype: &'a Archetype,

--- a/crates/bevy_reflect/src/impls/bevy_ecs.rs
+++ b/crates/bevy_reflect/src/impls/bevy_ecs.rs
@@ -10,6 +10,7 @@ pub struct ReflectComponent {
     add_component: fn(&mut World, resources: &Resources, Entity, &dyn Reflect),
     apply_component: fn(&mut World, Entity, &dyn Reflect),
     reflect_component: unsafe fn(&Archetype, usize) -> &dyn Reflect,
+    reflect_component_mut: unsafe fn(&Archetype, usize) -> &mut dyn Reflect,
     copy_component: fn(&World, &mut World, &Resources, Entity, Entity),
 }
 
@@ -36,6 +37,17 @@ impl ReflectComponent {
         entity_index: usize,
     ) -> &'a dyn Reflect {
         (self.reflect_component)(archetype, entity_index)
+    }
+
+    /// # Safety
+    /// This does not do bound checks on entity_index. You must make sure entity_index is within bounds before calling.
+    /// To avoid having multiple mutable pointers to the same data, this method can only be called in a thread-local system.
+    pub unsafe fn reflect_component_mut<'a>(
+        &self,
+        archetype: &'a Archetype,
+        entity_index: usize,
+    ) -> &'a mut dyn Reflect {
+        (self.reflect_component_mut)(archetype, entity_index)
     }
 
     pub fn copy_component(
@@ -85,6 +97,13 @@ impl<C: Component + Reflect + FromResources> FromType<C> for ReflectComponent {
                     // the type has been looked up by the caller, so this is safe
                     let ptr = archetype.get::<C>().unwrap().as_ptr().add(index);
                     ptr.as_ref().unwrap()
+                }
+            },
+            reflect_component_mut: |archetype, index| {
+                unsafe {
+                    // the type has been looked up by the caller, so this is safe
+                    let ptr = archetype.get::<C>().unwrap().as_ptr().add(index);
+                    &mut *ptr
                 }
             },
         }


### PR DESCRIPTION
I'm working on developing a world visualizer/editor for Bevy. See a demo: https://discord.com/channels/691052431525675048/692648638823923732/801608361463513089

To work, the tool needs to get mutable access to every component in the world, as well as find a method for displaying the component in a UI. Right now, I'm using this strategy:

1. Maintain a mapping from `TypeId` to pre-registered types that implement the `Inspectable` trait in `bevy-inspector-egui` ([see here](https://github.com/willcrichton/bevy_world_visualizer/blob/c248a70de876447fdc89b82df86ea8cb148bcd72/src/lib.rs#L142-L148)). For these types, I use `archetype.get_dynamic` to get the component data as `*mut u8` then transmute it to the appropriate type.
2. If `Inspectable` is not implemented, then try to cast the component to `&mut dyn Reflect` using `ReflectComponent`, then use `bevy-inspector-egui` to generate a generic UI for components implementing Reflect.

This PR adds two changes to make this possible. First, it publicly exposes `Archetype::get_dynamic`. Second, it adds a new method `ReflectComponent::reflect_component_mut` that returns `&mut dyn Reflect` instead of just `&dyn Reflect`.

Note: obviously the proliferation of unsafe code and transmute is concerning here. If there's a different approach that works without these changes, I'd be happy to hear.