### PR TITLE
Don't panic on error when loading assets

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -21,6 +21,7 @@ filesystem_watcher = ["notify"]
 bevy_app = { path = "../bevy_app", version = "0.4.0" }
 bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.4.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.4.0" }
+bevy_log = { path = "../bevy_log", version = "0.4.0" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.4.0", features = ["bevy"] }
 bevy_tasks = { path = "../bevy_tasks", version = "0.4.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.4.0" }

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use anyhow::Result;
 use bevy_ecs::Res;
+use bevy_log::warn;
 use bevy_tasks::TaskPool;
 use bevy_utils::{HashMap, Uuid};
 use crossbeam_channel::TryRecvError;
@@ -224,7 +225,18 @@ impl AssetServer {
         };
 
         // load the asset bytes
-        let bytes = self.server.asset_io.load_path(asset_path.path()).await?;
+        let bytes = match self.server.asset_io.load_path(asset_path.path()).await {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                let mut asset_sources = self.server.asset_sources.write();
+                let source_info = asset_sources
+                    .get_mut(&asset_path_id.source_path_id())
+                    .expect("`AssetSource` should exist at this point.");
+                source_info.load_state = LoadState::Failed;
+                return Err(AssetServerError::PathLoaderError(err));
+            }
+        };
+
 
         // load the asset source using the corresponding AssetLoader
         let mut load_context = LoadContext::new(
@@ -295,7 +307,9 @@ impl AssetServer {
         self.server
             .task_pool
             .spawn(async move {
-                server.load_async(owned_path, force).await.unwrap();
+                if let Err(err) = server.load_async(owned_path, force).await {
+                    warn!("Asset failed to load: {:?}", err);
+                }
             })
             .detach();
         asset_path.into()

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -237,7 +237,6 @@ impl AssetServer {
             }
         };
 
-
         // load the asset source using the corresponding AssetLoader
         let mut load_context = LoadContext::new(
             asset_path.path(),

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -24,11 +24,11 @@ use thiserror::Error;
 /// Errors that occur while loading assets
 #[derive(Error, Debug)]
 pub enum AssetIoError {
-    #[error("path not found")]
+    #[error("path not found: {0}")]
     NotFound(PathBuf),
-    #[error("encountered an io error while loading asset")]
+    #[error("encountered an io error while loading asset: {0}")]
     Io(#[from] io::Error),
-    #[error("failed to watch path")]
+    #[error("failed to watch path: {0}")]
     PathWatchError(PathBuf),
 }
 


### PR DESCRIPTION
Right now, loading an asset that doesn't exist causes the IO task to panic. Instead, we can toss a warning and set the load state to `Failed` so applications can decide how to handle the failure. As @cart [mentioned here](https://discord.com/channels/691052431525675048/749332104487108618/802289376088162325), eventually the reason for failing can get broadcast as an event. But this PR is a step towards that.