### PR TITLE
WIP: Android activity lifecycle management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -407,6 +407,9 @@ apk_label = "Bevy Example"
 assets = "assets"
 res = "assets/android-res"
 icon = "@mipmap/ic_launcher"
-build_targets = ["aarch64-linux-android", "armv7-linux-androideabi"]
+build_targets = ["aarch64-linux-android"] #, "armv7-linux-androideabi"]
 min_sdk_version = 16
 target_sdk_version = 29
+
+[patch.crates-io]
+winit = { git = "https://github.com/blaind/winit.git", rev = "a1dab8f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,4 +412,4 @@ min_sdk_version = 16
 target_sdk_version = 29
 
 [patch.crates-io]
-winit = { git = "https://github.com/blaind/winit.git", rev = "a1dab8f" }
+winit = { git = "https://github.com/blaind/winit.git", rev = "5544c75" }

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -32,3 +32,6 @@ winit = { version = "0.24.0", default-features = false }
 winit = { version = "0.24.0", features = ["web-sys"], default-features = false }
 wasm-bindgen = { version = "0.2" }
 web-sys = "0.3"
+
+[target.'cfg(target_os = "android")'.dependencies]
+ndk-glue = { version = "0.2" }

--- a/examples/android/android.rs
+++ b/examples/android/android.rs
@@ -4,11 +4,14 @@ use bevy::prelude::*;
 #[bevy_main]
 fn main() {
     App::build()
-        .add_resource(Msaa { samples: 2 })
+        //.add_resource(Msaa { samples: 2 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
+        .add_system(rotate.system())
         .run();
 }
+
+struct Rotation;
 
 /// set up a simple 3D scene
 fn setup(
@@ -30,7 +33,8 @@ fn setup(
             material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
             transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..Default::default()
-        })
+        }).with(Rotation)
+
         // light
         .spawn(LightBundle {
             transform: Transform::from_xyz(4.0, 8.0, 4.0),
@@ -42,4 +46,16 @@ fn setup(
                 .looking_at(Vec3::default(), Vec3::unit_y()),
             ..Default::default()
         });
+}
+
+fn rotate(
+    time: Res<Time>,
+    mut transform_query: Query<&mut Transform, With<Rotation>>,
+) {
+    let angle = std::f32::consts::PI / 2.0;
+
+    for mut transform in transform_query.iter_mut() {
+        transform.rotate(Quat::from_rotation_y(angle * 0.5 * time.delta_seconds()));
+    }
+
 }


### PR DESCRIPTION
This is a proof-of-concept implementation of Android activity lifecycles into `bevy_winit` crate. 

For background, see:
* https://github.com/bevyengine/bevy/issues/86#issuecomment-766100761
* https://developer.android.com/guide/components/activities/activity-lifecycle

Various comments:
* Now, this code probably messes up winit crate for other platforms than android, how to implement android-specific parts properly?
* Winit would require upstream patches. So far, it seems that winit events do not align with Android lifecycle very well. Winit mostly handles resume/suspended states, but in addition to these android has also the window lost states
* Current winit patches: https://github.com/rust-windowing/winit/compare/master...blaind:master
* The code should be simplified
* This has been tested only on one Android phone with one operating system, are the event flows similar in all Android versions?

So far, this handles the following cases:
* Starting up an app in background (when running cargo apk run ...)
* Clicking home button when activity is running
* Resuming to the activity
* Handling screen locking and resume correctly

Also, `SaveInstanceState` and the accompanying resume state (?) need to be handled.

<details>
  <summary>Various logs of lifecycle events</summary

Log of lifecycle events reported by android (added println! statement in winit crate)
```
// first startup
01-23 19:26:35.358 14645 14696 I RustStdoutStderr: ndk_glue event: Start
01-23 19:26:35.358 14645 14696 I RustStdoutStderr: ndk_glue event: Resume
01-23 19:26:35.895 14645 14696 I RustStdoutStderr: ndk_glue event: InputQueueCreated
01-23 19:26:35.911 14645 14696 I RustStdoutStderr: ndk_glue event: WindowCreated
01-23 19:26:35.926 14645 14696 I RustStdoutStderr: ndk_glue event: WindowResized
01-23 19:26:35.940 14645 14696 I RustStdoutStderr: ndk_glue event: ContentRectChanged
01-23 19:26:35.972 14645 14696 I RustStdoutStderr: ndk_glue event: WindowRedrawNeeded
01-23 19:26:35.990 14645 14696 I RustStdoutStderr: ndk_glue event: WindowHasFocus

// pressing home button
01-23 19:26:42.530 14645 14696 I RustStdoutStderr: ndk_glue event: Pause
01-23 19:26:42.547 14645 14696 I RustStdoutStderr: ndk_glue event: WindowLostFocus
01-23 19:26:42.574 14645 14696 I RustStdoutStderr: ndk_glue event: Stop
01-23 19:26:42.580 14645 14696 I RustStdoutStderr: ndk_glue event: SaveInstanceState
01-23 19:26:42.613 14645 14696 I RustStdoutStderr: ndk_glue event: WindowDestroyed

// opening the activity back
01-23 19:27:11.866 14645 14696 I RustStdoutStderr: ndk_glue event: Start
01-23 19:27:11.867 14645 14696 I RustStdoutStderr: ndk_glue event: Resume
01-23 19:27:11.946 14645 14696 I RustStdoutStderr: ndk_glue event: WindowCreated
01-23 19:27:11.963 14645 14696 I RustStdoutStderr: ndk_glue event: WindowResized
01-23 19:27:11.981 14645 14696 I RustStdoutStderr: ndk_glue event: WindowHasFocus
01-23 19:27:12.045 14645 14696 I RustStdoutStderr: ndk_glue event: WindowRedrawNeeded

// screenlock on
01-23 19:27:24.228 14645 14696 I RustStdoutStderr: ndk_glue event: Pause
01-23 19:27:24.228 14645 14696 I RustStdoutStderr: ndk_glue event: Stop
01-23 19:27:24.228 14645 14696 I RustStdoutStderr: ndk_glue event: SaveInstanceState
01-23 19:27:24.758 14645 14696 I RustStdoutStderr: ndk_glue event: WindowLostFocus

// screenlock back
01-23 19:27:39.680 14645 14696 I RustStdoutStderr: ndk_glue event: Start
01-23 19:27:39.680 14645 14696 I RustStdoutStderr: ndk_glue event: Resume

// rotating screen
01-23 19:29:00.263 15025 15051 I RustStdoutStderr: ndk_glue event: ConfigChanged
01-23 19:29:00.322 15025 15051 I RustStdoutStderr: ndk_glue event: WindowResized
01-23 19:29:00.341 15025 15051 I RustStdoutStderr: ndk_glue event: ContentRectChanged
01-23 19:29:00.376 15025 15051 I RustStdoutStderr: ndk_glue event: WindowRedrawNeeded
01-23 19:29:00.399 15025 15051 I RustStdoutStderr: ndk_glue event: WindowRedrawNeeded

// pulling top bar down
01-23 19:31:49.498 15537 15554 I RustStdoutStderr: ndk_glue event: WindowLostFocus
01-23 19:31:50.068 15537 15554 I RustStdoutStderr: ndk_glue event: WindowHasFocus
```
Log printed with various debug items in bevy crate as well:

```
// start activity
01-23 20:16:58.212 22561 22588 I RustStdoutStderr: ndk_glue event: Start
01-23 20:16:58.212 22561 22588 I RustStdoutStderr: ndk_glue event: Resume
01-23 20:16:58.212 22561 22588 I RustStdoutStderr: ndk_glue event: InputQueueCreated
01-23 20:16:58.212 22561 22588 I RustStdoutStderr: ndk_glue event: WindowCreated
01-23 20:16:58.212 22561 22588 I RustStdoutStderr: ndk_glue event: WindowResized
01-23 20:16:58.212 22561 22588 I RustStdoutStderr: runnable window event (running=NotInitialized), event: Resized(PhysicalSize { width: 1080, height: 2220 })
01-23 20:16:58.213 22561 22588 I RustStdoutStderr: ndk_glue event: ContentRectChanged
01-23 20:16:58.213 22561 22588 I RustStdoutStderr: ndk_glue event: WindowHasFocus
01-23 20:16:58.213 22561 22588 I RustStdoutStderr: runnable window event (running=NotInitialized), event: Focused(true)
01-23 20:16:58.213 22561 22588 I RustStdoutStderr: runnable: focused=true, running=NotInitialized
01-23 20:16:58.213 22561 22588 I RustStdoutStderr: runnable state change from NotInitialized to Running
01-23 20:16:58.734 22561 22588 I RustStdoutStderr: ndk_glue event: WindowRedrawNeeded

// home button
01-23 20:17:19.323 22561 22588 I RustStdoutStderr: ndk_glue event: Pause
01-23 20:17:19.323 22561 22588 I RustStdoutStderr: runnable state change from Running to WindowLost
01-23 20:17:19.327 22561 22588 I RustStdoutStderr: ndk_glue event: WindowLostFocus
01-23 20:17:19.327 22561 22588 I RustStdoutStderr: runnable window event (running=WindowLost), event: Focused(false)
01-23 20:17:19.327 22561 22588 I RustStdoutStderr: runnable: focused=false, running=WindowLost
01-23 20:17:19.354 22561 22588 I RustStdoutStderr: ndk_glue event: Stop
01-23 20:17:19.354 22561 22588 I RustStdoutStderr: ndk_glue event: SaveInstanceState
01-23 20:17:19.381 22561 22588 I RustStdoutStderr: ndk_glue event: WindowDestroyed
01-23 20:17:19.381 22561 22588 I RustStdoutStderr: runnable state change from WindowLost to WindowLost



// return to activity
01-23 20:17:31.825 22561 22588 I RustStdoutStderr: ndk_glue event: Start
01-23 20:17:31.830 22561 22588 I RustStdoutStderr: ndk_glue event: Resume
01-23 20:17:31.855 22561 22588 I RustStdoutStderr: ndk_glue event: WindowCreated
01-23 20:17:31.855 22561 22588 I RustStdoutStderr: ndk_glue event: WindowResized
01-23 20:17:31.856 22561 22588 I RustStdoutStderr: runnable window event (running=WindowLost), event: Resized(PhysicalSize { width: 1080, height: 2220 })
01-23 20:17:31.857 22561 22588 I RustStdoutStderr: ndk_glue event: WindowHasFocus
01-23 20:17:31.857 22561 22588 I RustStdoutStderr: runnable window event (running=WindowLost), event: Focused(true)
01-23 20:17:31.857 22561 22588 I RustStdoutStderr: runnable: focused=true, running=WindowLost
01-23 20:17:31.857 22561 22588 I RustStdoutStderr: runnable state change from WindowLost to WaitForWindow
01-23 20:17:31.896 22561 22588 I RustStdoutStderr: runnable state change from WaitForWindow to Running
01-23 20:17:31.920 22561 22588 I RustStdoutStderr: ndk_glue event: WindowRedrawNeeded


// pull top bar down and back up
01-23 20:17:40.581 22561 22588 I RustStdoutStderr: ndk_glue event: WindowLostFocus
01-23 20:17:40.581 22561 22588 I RustStdoutStderr: runnable window event (running=Running), event: Focused(false)
01-23 20:17:40.581 22561 22588 I RustStdoutStderr: runnable: focused=false, running=Running
01-23 20:17:40.976 22561 22588 I RustStdoutStderr: ndk_glue event: WindowHasFocus
01-23 20:17:40.976 22561 22588 I RustStdoutStderr: runnable window event (running=Running), event: Focused(true)
01-23 20:17:40.976 22561 22588 I RustStdoutStderr: runnable: focused=true, running=Running

// screen lock
01-23 20:18:00.012 22561 22588 I RustStdoutStderr: ndk_glue event: Pause
01-23 20:18:00.012 22561 22588 I RustStdoutStderr: runnable state change from Running to WindowLost
01-23 20:18:00.012 22561 22588 I RustStdoutStderr: ndk_glue event: Stop
01-23 20:18:00.012 22561 22588 I RustStdoutStderr: ndk_glue event: SaveInstanceState
01-23 20:18:00.461 22561 22588 I RustStdoutStderr: ndk_glue event: WindowLostFocus
01-23 20:18:00.461 22561 22588 I RustStdoutStderr: runnable window event (running=WindowLost), event: Focused(false)
01-23 20:18:00.461 22561 22588 I RustStdoutStderr: runnable: focused=false, running=WindowLost


// open screen lock
01-23 20:18:14.527 22561 22588 I RustStdoutStderr: ndk_glue event: Start
01-23 20:18:14.535 22561 22588 I RustStdoutStderr: ndk_glue event: Resume
01-23 20:18:14.569 22561 22588 I RustStdoutStderr: ndk_glue event: WindowCreated
01-23 20:18:14.570 22561 22588 I RustStdoutStderr: ndk_glue event: WindowResized
01-23 20:18:14.571 22561 22588 I RustStdoutStderr: runnable window event (running=WindowLost), event: Resized(PhysicalSize { width: 1080, height: 2220 })
01-23 20:18:14.589 22561 22588 I RustStdoutStderr: ndk_glue event: WindowRedrawNeeded
01-23 20:18:14.606 22561 22588 I RustStdoutStderr: ndk_glue event: WindowRedrawNeeded
01-23 20:18:14.667 22561 22588 I RustStdoutStderr: ndk_glue event: WindowHasFocus
01-23 20:18:14.667 22561 22588 I RustStdoutStderr: runnable window event (running=WindowLost), event: Focused(true)
01-23 20:18:14.667 22561 22588 I RustStdoutStderr: runnable: focused=true, running=WindowLost
01-23 20:18:14.667 22561 22588 I RustStdoutStderr: runnable state change from WindowLost to WaitForWindow
01-23 20:18:14.723 22561 22588 I RustStdoutStderr: runnable state change from WaitForWindow to Running
```
</details>
