### PR TITLE
Prevent ImageBundles from causing constant layout recalculations

### DIFF
--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -31,6 +31,7 @@ pub fn image_node_system(
                 width: texture.size.width as f32,
                 height: texture.size.height as f32,
             };
+            // Update only if size has changed to avoid needless layout calculations
             if size != calculated_size.size {
                 calculated_size.size = size;
             }

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -27,10 +27,13 @@ pub fn image_node_system(
             .and_then(|material| material.texture.as_ref())
             .and_then(|texture_handle| textures.get(texture_handle))
         {
-            calculated_size.size = Size {
+            let size = Size {
                 width: texture.size.width as f32,
                 height: texture.size.height as f32,
             };
+            if size != calculated_size.size {
+                calculated_size.size = size;
+            }
         }
     }
 }


### PR DESCRIPTION
The complete UI layout is recalculated when a `CalculatedSize` is updated, and `image_node_system` updates them every frame for images. The fix checks if the size has actually changed.