### PR TITLE
Add more transform relative vectors

### DIFF
--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -75,6 +75,16 @@ impl GlobalTransform {
     }
 
     #[inline]
+    pub fn right(&self) -> Vec3 {
+        self.rotation * Vec3::unit_x()
+    }
+
+    #[inline]
+    pub fn up(&self) -> Vec3 {
+        self.rotation * Vec3::unit_y()
+    }
+
+    #[inline]
     pub fn forward(&self) -> Vec3 {
         self.rotation * Vec3::unit_z()
     }

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -80,13 +80,28 @@ impl GlobalTransform {
     }
 
     #[inline]
+    pub fn left(&self) -> Vec3 {
+        -self.right()
+    }
+
+    #[inline]
     pub fn up(&self) -> Vec3 {
         self.rotation * Vec3::unit_y()
     }
 
     #[inline]
+    pub fn down(&self) -> Vec3 {
+        -self.up()
+    }
+
+    #[inline]
     pub fn forward(&self) -> Vec3 {
         self.rotation * Vec3::unit_z()
+    }
+
+    #[inline]
+    pub fn backward(&self) -> Vec3 {
+        -self.forward()
     }
 
     #[inline]

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -80,13 +80,28 @@ impl Transform {
     }
 
     #[inline]
+    pub fn left(&self) -> Vec3 {
+        -self.right()
+    }
+
+    #[inline]
     pub fn up(&self) -> Vec3 {
         self.rotation * Vec3::unit_y()
     }
 
     #[inline]
+    pub fn down(&self) -> Vec3 {
+        -self.up()
+    }
+
+    #[inline]
     pub fn forward(&self) -> Vec3 {
         self.rotation * Vec3::unit_z()
+    }
+
+    #[inline]
+    pub fn backward(&self) -> Vec3 {
+        -self.forward()
     }
 
     #[inline]

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -75,6 +75,16 @@ impl Transform {
     }
 
     #[inline]
+    pub fn right(&self) -> Vec3 {
+        self.rotation * Vec3::unit_x()
+    }
+
+    #[inline]
+    pub fn up(&self) -> Vec3 {
+        self.rotation * Vec3::unit_y()
+    }
+
+    #[inline]
     pub fn forward(&self) -> Vec3 {
         self.rotation * Vec3::unit_z()
     }


### PR DESCRIPTION
I added the equivalent of `Transform::forward` for the other two axis's, I used Unity as the base for naming:
https://docs.unity3d.com/ScriptReference/Transform-right.html
https://docs.unity3d.com/ScriptReference/Transform-up.html
https://docs.unity3d.com/ScriptReference/Transform-forward.html

This closes  #1298