### PR TITLE
Simple tree-structure print of Scheduler

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -48,6 +48,10 @@ fn run_once(mut app: App) {
 }
 
 impl App {
+    pub fn print_stage_schedule(&self) -> String {
+        self.schedule.print_schedule()
+    }
+
     pub fn build() -> AppBuilder {
         AppBuilder::default()
     }

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -229,7 +229,7 @@ impl Stage for Schedule {
                 Some(stage) => {
                     let mut names = stage.system_names();
                     for (m, name) in names.iter_mut().enumerate() {
-                        let mut system_symbol = level_shift.clone();
+                        let mut system_symbol = level_shift;
                         if m == 0 {
                             system_symbol = UTF8_SYMBOLS.ell;
                         }

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -25,7 +25,7 @@ impl Schedule {
         for (line_number, name) in system_names.iter().enumerate() {
             schedule.push_str(&format!("{}\t{}\n", line_number, name));
         }
-        
+
         schedule
     }
 
@@ -227,7 +227,7 @@ impl Stage for Schedule {
             match self.stages.get(stage_name) {
                 None => (),
                 Some(stage) => {
-                    let mut names = stage.system_names(); 
+                    let mut names = stage.system_names();
                     for (m, name) in names.iter_mut().enumerate() {
                         let mut system_symbol = level_shift.clone();
                         if m == 0 {
@@ -235,14 +235,12 @@ impl Stage for Schedule {
                         }
                         let prefix = format!("{}{}", system_prefix, system_symbol);
                         *name = prefix + &*name;
-                        
                     }
                     system_names.extend(names);
-                    
                 }
             };
         }
-        
+
         system_names
     }
 }

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -19,6 +19,8 @@ pub trait Stage: Downcast + Send + Sync {
 
     /// Runs the stage. This happens once per update (after [Stage::initialize] is called).
     fn run(&mut self, world: &mut World, resources: &mut Resources);
+
+    fn system_names(&self) -> Vec<String>;
 }
 
 impl_downcast!(Stage);
@@ -104,6 +106,8 @@ impl SystemStage {
     }
 }
 
+use super::UTF8_SYMBOLS;
+
 impl Stage for SystemStage {
     fn initialize(&mut self, world: &mut World, resources: &mut Resources) {
         if let Some(ref mut run_criteria) = self.run_criteria {
@@ -141,6 +145,24 @@ impl Stage for SystemStage {
                 }
             }
         }
+    }
+
+    fn system_names(&self) -> Vec<String> {
+        let mut system_names = Vec::with_capacity(self.systems.len());
+        
+        system_names.push("  SystemStage".to_owned());
+        for (n, system) in self.systems.iter().enumerate() {
+            let mut symbol = UTF8_SYMBOLS.tee;
+            if n == self.systems.len() - 1 {
+                symbol = UTF8_SYMBOLS.ell;
+            };
+
+            let string = format!("  {}  {}", symbol, system.name());
+            system_names.push(string);
+
+        }
+        
+        system_names
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -149,7 +149,7 @@ impl Stage for SystemStage {
 
     fn system_names(&self) -> Vec<String> {
         let mut system_names = Vec::with_capacity(self.systems.len());
-        
+
         system_names.push("  SystemStage".to_owned());
         for (n, system) in self.systems.iter().enumerate() {
             let mut symbol = UTF8_SYMBOLS.tee;
@@ -159,9 +159,8 @@ impl Stage for SystemStage {
 
             let string = format!("  {}  {}", symbol, system.name());
             system_names.push(string);
-
         }
-        
+
         system_names
     }
 }

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -194,6 +194,14 @@ impl<T: Resource + Clone> Stage for StateStage<T> {
             current_state_stages.update.run(world, resources);
         }
     }
+
+    fn system_names(&self) -> Vec<String> {
+        let mut self_name = Vec::with_capacity(1);
+        
+        self_name.push("StateStage".to_owned());
+
+        self_name
+    }
 }
 #[derive(Debug, Error)]
 pub enum StateError {

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -197,7 +197,7 @@ impl<T: Resource + Clone> Stage for StateStage<T> {
 
     fn system_names(&self) -> Vec<String> {
         let mut self_name = Vec::with_capacity(1);
-        
+
         self_name.push("StateStage".to_owned());
 
         self_name


### PR DESCRIPTION
### Implemented a way to print out the current Scheduler

Extends the [`Stage`](https://docs.rs/bevy/0.4.0/bevy/ecs/struct.State.html)-Trait by a `system_names()` function, that returns a `Vec<String>`, in a very very basic way.

EDIT: Systems are printed in relation to the `Stage`/`Scheduler` they belong to, **BUT NOT** in the order they are executed in! No checking for serial or parallel execution happens


 The current implementation **does some formatting**, which may not be ideal for every use-case. So maybe i should add a 
`(..., recursion_depth: usize)` parameter and `-> (Vec<recur_depth: usize, stage_type: String, stage_name: String>` return, which would allow non-formatted ouput, such that formatting can be done depending on the usecase after the fact. It could then _maybe_ also be used for displaying in an editor with hot-linking to source-code, which I think is impossible with this implementation?

To use this, call for example:
```rust
println!(format!("{}", appbuilder.app.print_stage_schedule());
```
on the `AppBuilder` after adding systems, but before `app.run()`.

--- 

Output example: https://gist.github.com/Telzhaak/2a19de3337e25ccde729b1f5437c29da