### PR TITLE
Fix Interaction not resetting to None sometimes

### DIFF
--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -33,3 +33,4 @@ bevy_utils = { path = "../bevy_utils", version = "0.4.0" }
 # other
 stretch = "0.3"
 serde = {version = "1", features = ["derive"]}
+smallvec = "1.4"

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -33,7 +33,6 @@ impl Default for FocusPolicy {
 
 #[derive(Default)]
 pub struct State {
-    hovered_entity: Option<Entity>,
     entities_to_reset: SmallVec<[Entity; 1]>,
 }
 
@@ -66,7 +65,8 @@ pub fn ui_focus_system(
         }
     }
 
-    let mouse_released = mouse_button_input.just_released(MouseButton::Left) || touches_input.just_released(0);
+    let mouse_released =
+        mouse_button_input.just_released(MouseButton::Left) || touches_input.just_released(0);
     if mouse_released {
         for (_entity, _node, _global_transform, interaction, _focus_policy) in node_query.iter_mut()
         {
@@ -80,77 +80,66 @@ pub fn ui_focus_system(
 
     let mouse_clicked =
         mouse_button_input.just_pressed(MouseButton::Left) || touches_input.just_released(0);
-    let mut hovered_entity = None;
 
-    {
-        let mut moused_over_z_sorted_nodes = node_query
-            .iter_mut()
-            .filter_map(
-                |(entity, node, global_transform, interaction, focus_policy)| {
-                    let position = global_transform.translation;
-                    let ui_position = position.truncate();
-                    let extents = node.size / 2.0;
-                    let min = ui_position - extents;
-                    let max = ui_position + extents;
-                    // if the current cursor position is within the bounds of the node, consider it for clicking
-                    if (min.x..max.x).contains(&cursor_position.x)
-                        && (min.y..max.y).contains(&cursor_position.y)
-                    {
-                        Some((entity, focus_policy, interaction, FloatOrd(position.z)))
-                    } else {
-                        if let Some(mut interaction) = interaction {
-                            if *interaction == Interaction::Hovered {
-                                *interaction = Interaction::None;
-                            }
-                        }
-                        None
-                    }
-                },
-            )
-            .collect::<Vec<_>>();
-
-        moused_over_z_sorted_nodes.sort_by_key(|(_, _, _, z)| -*z);
-        for (entity, focus_policy, interaction, _) in moused_over_z_sorted_nodes {
-            if let Some(mut interaction) = interaction {
-                if mouse_clicked {
-                    // only consider nodes with ClickState "clickable"
-                    if *interaction != Interaction::Clicked {
-                        *interaction = Interaction::Clicked;
-                        // if the mouse was simultaneously released, reset this Interaction in the next frame
-                        if mouse_released {
-                            state.entities_to_reset.push(entity);
+    let mut moused_over_z_sorted_nodes = node_query
+        .iter_mut()
+        .filter_map(
+            |(entity, node, global_transform, interaction, focus_policy)| {
+                let position = global_transform.translation;
+                let ui_position = position.truncate();
+                let extents = node.size / 2.0;
+                let min = ui_position - extents;
+                let max = ui_position + extents;
+                // if the current cursor position is within the bounds of the node, consider it for clicking
+                if (min.x..max.x).contains(&cursor_position.x)
+                    && (min.y..max.y).contains(&cursor_position.y)
+                {
+                    Some((entity, focus_policy, interaction, FloatOrd(position.z)))
+                } else {
+                    if let Some(mut interaction) = interaction {
+                        if *interaction == Interaction::Hovered {
+                            *interaction = Interaction::None;
                         }
                     }
-                } else if *interaction == Interaction::None {
-                    *interaction = Interaction::Hovered;
+                    None
                 }
-            }
+            },
+        )
+        .collect::<Vec<_>>();
 
-            hovered_entity = Some(entity);
+    moused_over_z_sorted_nodes.sort_by_key(|(_, _, _, z)| -*z);
 
-            match focus_policy.cloned().unwrap_or(FocusPolicy::Block) {
-                FocusPolicy::Block => {
-                    break;
+    let mut moused_over_z_sorted_nodes = moused_over_z_sorted_nodes.into_iter();
+    // set Clicked or Hovered on top nodes
+    for (entity, focus_policy, interaction, _) in moused_over_z_sorted_nodes.by_ref() {
+        if let Some(mut interaction) = interaction {
+            if mouse_clicked {
+                // only consider nodes with Interaction "clickable"
+                if *interaction != Interaction::Clicked {
+                    *interaction = Interaction::Clicked;
+                    // if the mouse was simultaneously released, reset this Interaction in the next frame
+                    if mouse_released {
+                        state.entities_to_reset.push(entity);
+                    }
                 }
-                FocusPolicy::Pass => { /* allow the next node to be hovered/clicked */ }
+            } else if *interaction == Interaction::None {
+                *interaction = Interaction::Hovered;
             }
+        }
+
+        match focus_policy.cloned().unwrap_or(FocusPolicy::Block) {
+            FocusPolicy::Block => {
+                break;
+            }
+            FocusPolicy::Pass => { /* allow the next node to be hovered/clicked */ }
         }
     }
-
-    // if there is a new hovered entity, but an entity is currently hovered, unhover the old entity
-    if let Some(new_hovered_entity) = hovered_entity {
-        if let Some(old_hovered_entity) = state.hovered_entity {
-            if new_hovered_entity != old_hovered_entity {
-                if let Ok(mut interaction) =
-                    node_query.get_component_mut::<Interaction>(old_hovered_entity)
-                {
-                    if *interaction == Interaction::Hovered {
-                        *interaction = Interaction::None;
-                    }
-                }
-                state.hovered_entity = None;
+    // reset lower nodes to None
+    for (_entity, _focus_policy, interaction, _) in moused_over_z_sorted_nodes {
+        if let Some(mut interaction) = interaction {
+            if *interaction != Interaction::None {
+                *interaction = Interaction::None;
             }
         }
-        state.hovered_entity = hovered_entity;
     }
 }


### PR DESCRIPTION
This corrects two bugs in `ui_focus_system`:
- When clicking and releasing a button in a single frame, it stays stuck in `Interaction::Clicked` until the next mouse click
- It's possible for nodes to not be un-hovered in some cases with `FocusPolicy::Pass`, such as when they get covered by new nodes

I noticed that touch input is using `just_released` instead of `just_pressed` for clicking, which means that the 1st issue may have been a feature for them. With this PR, the buttons would no longer stay stuck in the `Clicked` state after any released touch. If that behaviour was intended I can easily re-introduce it.