### PR TITLE
CI Tuning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
           - os: windows-latest
             toolchain: nightly
     runs-on: ${{ matrix.os }}
-    needs: clean
     steps:
       - uses: actions/checkout@v2
 
@@ -35,11 +34,15 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
         if: runner.os == 'linux'
 
-      - name: Check
-        run: cargo check
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-C debuginfo=0 -D warnings"
+      - name: Check the format
+        run: cargo fmt --all -- --check
+        if: runner.os == 'linux' && matrix.toolchain == 'stable'
+
+      # type complexity must be ignored because we use huge templates for queries
+      # -A clippy::manual-strip: strip_prefix support was added in 1.45. we want to support earlier rust versions
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings -A clippy::type_complexity -A clippy::manual-strip
+        if: runner.os == 'linux' && matrix.toolchain == 'stable'
 
       - name: Build & run tests
         run: cargo test --workspace
@@ -54,7 +57,6 @@ jobs:
         toolchain: [stable, nightly]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    needs: clean
     steps:
       - uses: actions/checkout@v2
 
@@ -80,25 +82,3 @@ jobs:
         run: cargo install cargo-apk
       - name: Build APK
         run: cargo apk build --example android
-
-  clean:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2020-12-07
-          components: rustfmt, clippy
-          override: true
-
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-
-      - name: Check the format
-        run: cargo +nightly-2020-12-07 fmt --all -- --check
-
-      # type complexity must be ignored because we use huge templates for queries
-      # -A clippy::manual-strip: strip_prefix support was added in 1.45. we want to support earlier rust versions
-      - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings -A clippy::type_complexity -A clippy::manual-strip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-desktop:
+  build:
     strategy:
       matrix:
         toolchain: [stable, nightly]
@@ -30,12 +30,6 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: rustfmt, clippy
           override: true
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            target
-          key: ${{ runner.os }}-cargo-check-test-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
@@ -69,12 +63,6 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           target: wasm32-unknown-unknown
           override: true
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            target
-          key: ${{ runner.os }}-cargo-check-test-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Check wasm
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
 
       - name: Build & run tests
         run: cargo test --workspace
-        if: runner.os == 'linux'
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0 -D warnings"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build-desktop:
     strategy:
       matrix:
         toolchain: [stable, nightly]
-        os: [windows-2019, ubuntu-20.04, macos-10.15]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         exclude:
-          - os: macos-10.15
+          - os: macos-latest
             toolchain: nightly
-          - os: windows-2019
+          - os: windows-latest
             toolchain: nightly
     runs-on: ${{ matrix.os }}
     needs: clean
@@ -28,6 +28,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
+          components: rustfmt, clippy
           override: true
 
       - uses: actions/cache@v2
@@ -36,23 +37,19 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-check-test-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Install alsa
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev
-        if: ${{ runner.os == 'Linux' }}
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+        if: runner.os == 'linux'
 
-      - name: Install udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev
-        if: ${{ runner.os == 'Linux' }}
-
-      - name: Build
+      - name: Check
         run: cargo check
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
-      - name: Run tests
+      - name: Build & run tests
         run: cargo test --workspace
-        if: ${{ runner.os == 'Linux' }}
+        if: runner.os == 'linux'
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0 -D warnings"
@@ -61,7 +58,7 @@ jobs:
     strategy:
       matrix:
         toolchain: [stable, nightly]
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     needs: clean
     steps:
@@ -88,13 +85,13 @@ jobs:
   build-android:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install Android targets
-      run: rustup target add aarch64-linux-android armv7-linux-androideabi
-    - name: Install Cargo APK
-      run: cargo install cargo-apk
-    - name: Build APK
-      run: cargo apk build --example android
+      - uses: actions/checkout@v2
+      - name: Install Android targets
+        run: rustup target add aarch64-linux-android armv7-linux-androideabi
+      - name: Install Cargo APK
+        run: cargo install cargo-apk
+      - name: Build APK
+        run: cargo apk build --example android
 
   clean:
     runs-on: ubuntu-latest
@@ -107,11 +104,8 @@ jobs:
           components: rustfmt, clippy
           override: true
 
-      - name: Install alsa
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev
-
-      - name: Install udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
 
       - name: Check the format
         run: cargo +nightly-2020-12-07 fmt --all -- --check

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -2,14 +2,14 @@ name: iOS cron CI
 
 on:
   schedule:
-    - cron:  '0 0 * * *'
+    - cron: "0 0 * * *"
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Prompted by https://github.com/bevyengine/bevy/pull/1309#issuecomment-767111696

- [x] Simplified syntax & linted. Think "rustfmt" for github actions toml files.
- [x] Combined apt updates and installations into a single step (why update twice? why separate installations?)
- [x]  Future-proofed OS selections by using `*-latest`, which never gets old, as opposed to specific version numbers.
- [x] Remove cache step after verifying cache isn't being used and is just wasting time.
- [x] 😄 Merge `clean` job into the linux stable job...which is what I actually started out to do.
- [x] ⚠️ Enable actually building and running tests on Windows and macOS.  Apparently they haven't been running for quite some time, though `cargo check` was.

Before: 8 jobs with typical total runtime of 17m - 18m (CI jobs are _very_ noisy, so total runtime varies quite a bit)
Now: 7 jobs with typical total runtime of 14m. We shaved a few minutes off, and 2 of the remaining builds are actually building and testing now when they weren't before.