### PR TITLE
Possible fix for #1056

### DIFF
--- a/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
@@ -166,10 +166,7 @@ where
             .map(|b| b.item_size)
             .next();
 
-        let resize = match (min_size, current) {
-            (Some(min), Some(current)) if min > current => true,
-            _ => false,
-        };
+        let resize = matches!((min_size, current), (Some(min), Some(current)) if min > current);
 
         if resize || self.buffer_arrays.len() != render_resources.render_resources_len() {
             let mut buffer_arrays = Vec::with_capacity(render_resources.render_resources_len());


### PR DESCRIPTION
I don't want to pretend to be able to explain what's going on here.

This is definitely a hackjob, but it might be the case that it's a hackjob that's well aligned with another recent hack (#1208) around the same code. It's entirely possible that I'm just accidentally fixing this by oversizing the staging buffer or something.

I'm tossing this here so that cart or someone else with experience with this code might determine whether or not it's doing anything useful. I'm happy to just keep my fork patched locally so that I can write game code again for a while if it's no good.

This information is also buried in #1056 but I'll summarize here:

This fixes a panic that occurs in both of these cases:

https://github.com/rparrett/taipo/tree/spritesheet-panic-two (game will play itself until it panics when the crabs start dying)
https://github.com/rparrett/bevy-test/tree/render-panic (just displays a chunk of text one letter at a time)

This seems to be related to font atlases and tweaking font sizes affects time-to-panic. I'm on macOS with a high DPI display. So YMMV.