### PR TITLE
README: explicitly link to Learning section of awesome-bevy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Bevy is still in the _very_ early stages of development. APIs can and will chang
 
 * **[The Bevy Book](https://bevyengine.org/learn/book/introduction):** Bevy's official documentation. The best place to start learning Bevy.
 * **[Bevy Rust API Docs](https://docs.rs/bevy):** Bevy's Rust API docs, which are automatically generated from the doc comments in this repo.
-* **[List of learning resources made by the community.](https://github.com/bevyengine/awesome-bevy#learning)**
+* **[Community-Made Learning Resources](https://github.com/bevyengine/awesome-bevy#learning)**: Community-produced tutorials, documentation, and examples.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Bevy is still in the _very_ early stages of development. APIs can and will chang
 
 * **[The Bevy Book](https://bevyengine.org/learn/book/introduction):** Bevy's official documentation. The best place to start learning Bevy.
 * **[Bevy Rust API Docs](https://docs.rs/bevy):** Bevy's Rust API docs, which are automatically generated from the doc comments in this repo.
+* **[List of learning resources made by the community.](https://github.com/bevyengine/awesome-bevy#learning)**
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Bevy is still in the _very_ early stages of development. APIs can and will chang
 
 * **[The Bevy Book](https://bevyengine.org/learn/book/introduction):** Bevy's official documentation. The best place to start learning Bevy.
 * **[Bevy Rust API Docs](https://docs.rs/bevy):** Bevy's Rust API docs, which are automatically generated from the doc comments in this repo.
-* **[Community-Made Learning Resources](https://github.com/bevyengine/awesome-bevy#learning)**: Community-produced tutorials, documentation, and examples.
+* **[Community-Made Learning Resources](https://github.com/bevyengine/awesome-bevy#learning)**: Tutorials, documentation, and examples made by the Bevy community.
 
 ## Community
 


### PR DESCRIPTION
Add a direct link to the Learning section of awesome-bevy, under the Docs heading.

Motivation:

I know awesome-bevy is literally linked a few lines later down in the Community section:

> **[Awesome Bevy](https://github.com/bevyengine/awesome-bevy):** A collection of awesome Bevy projects.

I think that link is insufficient, because it does not make it clear to newbies that awesome-bevy is also a way to find books and tutorials, not just "projects" (as in showcases or plugins). I suspect many people who are just starting with bevy might ignore it.

I think it should be made clear under the "documentation" section (which is where someone who is just starting to learn bevy is most likely to look) that we specifically have a list of community-made / unofficial learning resources.

I want to direct newcomers to bevy to check out our ever-growing collection of unofficial learning resources as early as possible in their bevy journey.

---

Alternative: put it under "getting started"?