### PR TITLE
Add support for gltf::Material::unlit

### DIFF
--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -26,7 +26,7 @@ bevy_math = { path = "../bevy_math", version = "0.4.0" }
 bevy_scene = { path = "../bevy_scene", version = "0.4.0" }
 
 # other
-gltf = { version = "0.15.2", default-features = false, features = ["utils", "names"] }
+gltf = { version = "0.15.2", default-features = false, features = ["utils", "names", "KHR_materials_unlit"] }
 image = { version = "0.23.12", default-features = false }
 thiserror = "1.0"
 anyhow = "1.0"

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -298,7 +298,7 @@ fn load_material(material: &Material, load_context: &mut LoadContext) -> Handle<
         LoadedAsset::new(StandardMaterial {
             albedo: Color::rgba(color[0], color[1], color[2], color[3]),
             albedo_texture: texture_handle,
-            unlit: !material.unlit(),
+            unlit: material.unlit(),
         })
         .with_dependencies(dependencies),
     )

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -298,9 +298,8 @@ fn load_material(material: &Material, load_context: &mut LoadContext) -> Handle<
         LoadedAsset::new(StandardMaterial {
             albedo: Color::rgba(color[0], color[1], color[2], color[3]),
             albedo_texture: texture_handle,
-            shaded: !material.unlit(),
-            ..Default::default()
-        })
+            shaded: !material.unlit()
+          })
         .with_dependencies(dependencies),
     )
 }

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -298,6 +298,7 @@ fn load_material(material: &Material, load_context: &mut LoadContext) -> Handle<
         LoadedAsset::new(StandardMaterial {
             albedo: Color::rgba(color[0], color[1], color[2], color[3]),
             albedo_texture: texture_handle,
+            shaded: !material.unlit(),
             ..Default::default()
         })
         .with_dependencies(dependencies),

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -298,7 +298,7 @@ fn load_material(material: &Material, load_context: &mut LoadContext) -> Handle<
         LoadedAsset::new(StandardMaterial {
             albedo: Color::rgba(color[0], color[1], color[2], color[3]),
             albedo_texture: texture_handle,
-            shaded: !material.unlit(),
+            unlit: !material.unlit(),
         })
         .with_dependencies(dependencies),
     )

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -298,8 +298,8 @@ fn load_material(material: &Material, load_context: &mut LoadContext) -> Handle<
         LoadedAsset::new(StandardMaterial {
             albedo: Color::rgba(color[0], color[1], color[2], color[3]),
             albedo_texture: texture_handle,
-            shaded: !material.unlit()
-          })
+            shaded: !material.unlit(),
+        })
         .with_dependencies(dependencies),
     )
 }

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -46,7 +46,7 @@ impl Plugin for PbrPlugin {
             Handle::<StandardMaterial>::default(),
             StandardMaterial {
                 albedo: Color::PINK,
-                shaded: false,
+                unlit: true,
                 albedo_texture: None,
             },
         );

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -11,7 +11,7 @@ pub struct StandardMaterial {
     pub albedo_texture: Option<Handle<Texture>>,
     #[render_resources(ignore)]
     #[shader_def]
-    pub shaded: bool,
+    pub unlit: bool,
 }
 
 impl Default for StandardMaterial {
@@ -19,7 +19,7 @@ impl Default for StandardMaterial {
         StandardMaterial {
             albedo: Color::rgb(1.0, 1.0, 1.0),
             albedo_texture: None,
-            shaded: true,
+            unlit: false,
         }
     }
 }

--- a/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.frag
+++ b/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.frag
@@ -41,7 +41,7 @@ void main() {
         v_Uv);
 # endif
 
-# ifdef STANDARDMATERIAL_SHADED
+# ifndef STANDARDMATERIAL_UNLIT
     vec3 normal = normalize(v_Normal);
     // accumulate color
     vec3 color = AmbientColor;

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -29,7 +29,7 @@ fn setup(
     // this material renders the texture normally
     let material_handle = materials.add(StandardMaterial {
         albedo_texture: Some(texture_handle.clone()),
-        shaded: false,
+        unlit: true,
         ..Default::default()
     });
 
@@ -37,14 +37,14 @@ fn setup(
     let red_material_handle = materials.add(StandardMaterial {
         albedo: Color::rgba(1.0, 0.0, 0.0, 0.5),
         albedo_texture: Some(texture_handle.clone()),
-        shaded: false,
+        unlit: true,
     });
 
     // and lets make this one blue! (and also slightly transparent)
     let blue_material_handle = materials.add(StandardMaterial {
         albedo: Color::rgba(0.0, 0.0, 1.0, 0.5),
         albedo_texture: Some(texture_handle),
-        shaded: false,
+        unlit: true,
     });
 
     // add entities to the world

--- a/examples/3d/z_sort_debug.rs
+++ b/examples/3d/z_sort_debug.rs
@@ -52,7 +52,7 @@ fn setup(
         .spawn(PbrBundle {
             mesh: cube_handle.clone(),
             material: materials.add(StandardMaterial {
-                shaded: false,
+                unlit: true,
                 ..Default::default()
             }),
             transform: Transform::from_xyz(0.0, 0.0, 1.0),
@@ -65,7 +65,7 @@ fn setup(
                 .spawn(PbrBundle {
                     mesh: cube_handle.clone(),
                     material: materials.add(StandardMaterial {
-                        shaded: false,
+                        unlit: true,
                         ..Default::default()
                     }),
                     transform: Transform::from_xyz(0.0, 3.0, 0.0),
@@ -74,7 +74,7 @@ fn setup(
                 .spawn(PbrBundle {
                     mesh: cube_handle,
                     material: materials.add(StandardMaterial {
-                        shaded: false,
+                        unlit: true,
                         ..Default::default()
                     }),
                     transform: Transform::from_xyz(0.0, -3.0, 0.0),


### PR DESCRIPTION
This PR enables materials loaded from a gLTF file to use the "KHR_materials_unlit" extension to disable lighting via the [`Material::unlit`](https://docs.rs/gltf/0.15.2/gltf/struct.Material.html#method.unlit) method.