### PR TITLE
[Bugfix] add_stage now checks Stage existence

### DIFF
--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -57,6 +57,10 @@ impl Schedule {
     }
 
     pub fn add_stage<S: Stage>(&mut self, name: &str, stage: S) -> &mut Self {
+        if self.stages.get(name).is_some() {
+            panic!("Stage already exists: {}.", name);
+        }
+
         self.stage_order.push(name.to_string());
         self.stages.insert(name.to_string(), Box::new(stage));
         self

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -57,12 +57,11 @@ impl Schedule {
     }
 
     pub fn add_stage<S: Stage>(&mut self, name: &str, stage: S) -> &mut Self {
-        if self.stages.get(name).is_some() {
+        self.stage_order.push(name.to_string());
+        let prev = self.stages.insert(name.to_string(), Box::new(stage));
+        if prev.is_some() {
             panic!("Stage already exists: {}.", name);
         }
-
-        self.stage_order.push(name.to_string());
-        self.stages.insert(name.to_string(), Box::new(stage));
         self
     }
 

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -66,10 +66,6 @@ impl Schedule {
     }
 
     pub fn add_stage_after<S: Stage>(&mut self, target: &str, name: &str, stage: S) -> &mut Self {
-        if self.stages.get(name).is_some() {
-            panic!("Stage already exists: {}.", name);
-        }
-
         let target_index = self
             .stage_order
             .iter()
@@ -78,16 +74,15 @@ impl Schedule {
             .map(|(i, _)| i)
             .unwrap_or_else(|| panic!("Target stage does not exist: {}.", target));
 
-        self.stages.insert(name.to_string(), Box::new(stage));
         self.stage_order.insert(target_index + 1, name.to_string());
+        let prev = self.stages.insert(name.to_string(), Box::new(stage));
+        if prev.is_some() {
+            panic!("Stage already exists: {}.", name);
+        }
         self
     }
 
     pub fn add_stage_before<S: Stage>(&mut self, target: &str, name: &str, stage: S) -> &mut Self {
-        if self.stages.get(name).is_some() {
-            panic!("Stage already exists: {}.", name);
-        }
-
         let target_index = self
             .stage_order
             .iter()
@@ -96,8 +91,11 @@ impl Schedule {
             .map(|(i, _)| i)
             .unwrap_or_else(|| panic!("Target stage does not exist: {}.", target));
 
-        self.stages.insert(name.to_string(), Box::new(stage));
         self.stage_order.insert(target_index, name.to_string());
+        let prev = self.stages.insert(name.to_string(), Box::new(stage));
+        if prev.is_some() {
+            panic!("Stage already exists: {}.", name);
+        }
         self
     }
 


### PR DESCRIPTION
## What's the bug?
`add_stage` never checked whether a given `Stage`-name already exists (which extends to [`with_stage()`](https://github.com/bevyengine/bevy/blob/master/crates/bevy_ecs/src/schedule/mod.rs#L21))
https://github.com/bevyengine/bevy/blob/cc9ed52ea7f72449215f13710fcb6370d02d9ac8/crates/bevy_ecs/src/schedule/mod.rs#L59-L63
instead simply
1. replacing the previously held `Stage` in `Schedule.stages` (effectively removing all systems/schedulers/... attached to that old Stage)
2. Appending the Stage-name to the vector `Schedule.stage_order`, while not removing the already existing one, creating a duplicate

## How is it fixed?
This has been fixed using the same method the other two functions [`add_stage_after`](https://github.com/bevyengine/bevy/blob/master/crates/bevy_ecs/src/schedule/mod.rs#L65) and [`add_stage_before`](https://github.com/bevyengine/bevy/blob/master/crates/bevy_ecs/src/schedule/mod.rs#L83) use:
```rust
if self.stages.get(name).is_some() {
    panic!("Stage already exists: {}.", name);
}
```


This also raises the question: 
- Should these functions even panic when a `Stage`-name is already taken, or should some sort of Error-flow be implemented to allow handling it?

--- 
## Why does it matter?
Since this bug effectively changed system-execution, it could have caused some interesting and hard to debug problems. 
Especially later on, when other Stages are added in relation to this one. `add_stage` is _supposed_ to place a Stage at the end of execution-order at the time of calling ([`Vec::push()`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.push)). Thus anything added via e.g. `add_stage_before(this_broken_stage)` would be _expected_ to execute as e.g. second-last. However `add_stage_before` determines positioning via:
```rust
let target_index = self
  .stage_order
  .iter()
  .enumerate()
  .find(|(_i, stage_name)| *stage_name == target)
  .map(|(i, _)| i)
  .unwrap_or_else(|| panic!("Target stage does not exist: {}.", target))
``` 
This would return the index of the duplicate in `Schedule.stage_order` at the old position, earlier in the execution-order.