### PR TITLE
Add reflection for enum types

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -318,6 +318,14 @@ fn impl_struct(
             fn reflect_partial_eq(&self, value: &dyn #bevy_reflect_path::Reflect) -> Option<bool> {
                 #partial_eq_fn
             }
+
+            fn as_reflect(&self) -> &dyn #bevy_reflect_path::Reflect {
+                self
+            }
+
+            fn as_reflect_mut(&mut self) -> &mut dyn #bevy_reflect_path::Reflect {
+                self
+            }
         }
     })
 }
@@ -437,6 +445,14 @@ fn impl_tuple_struct(
             fn reflect_partial_eq(&self, value: &dyn #bevy_reflect_path::Reflect) -> Option<bool> {
                 #partial_eq_fn
             }
+
+            fn as_reflect(&self) -> &dyn #bevy_reflect_path::Reflect {
+                self
+            }
+
+            fn as_reflect_mut(&mut self) -> &mut dyn #bevy_reflect_path::Reflect {
+                self
+            }
         }
     })
 }
@@ -511,6 +527,14 @@ fn impl_value(
 
             fn serializable(&self) -> Option<#bevy_reflect_path::serde::Serializable> {
                 #serialize_fn
+            }
+
+            fn as_reflect(&self) -> &dyn #bevy_reflect_path::Reflect {
+                self
+            }
+
+            fn as_reflect_mut(&mut self) -> &mut dyn #bevy_reflect_path::Reflect {
+                self
             }
         }
     })

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -665,12 +665,8 @@ fn impl_enum(
             Ident::new("unused", Span::call_site())
         };
         let wrapper_name = match &variant.fields {
-            Fields::Named(struct_fields) => {
-                quote!(#struct_fields).to_string()
-            }
-            Fields::Unnamed(tuple_fields) => {
-                quote!(#tuple_fields).to_string()
-            }
+            Fields::Named(struct_fields) => quote!(#struct_fields).to_string(),
+            Fields::Unnamed(tuple_fields) => quote!(#tuple_fields).to_string(),
             Fields::Unit => "unused".to_string(),
         };
         let reflect_variant = {
@@ -880,7 +876,7 @@ fn impl_enum(
         wrapper_ident,
         wrapper_name,
         variant_index,
-        variant_name,
+        _variant_name,
         _variant_ident,
         variant_and_fields_ident,
         fields,
@@ -1030,7 +1026,7 @@ fn impl_enum(
         wrapper_ident,
         wrapper_name,
         variant_index,
-        variant_name,
+        _variant_name,
         _variant_ident,
         variant_and_fields_ident,
         fields,

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -934,18 +934,10 @@ fn impl_enum(
             field_indices.push(i);
         }
         let fields_len = field_indices.len();
-        let mut match_fields = quote!();
-        for (i, _variant_ident) in variant_idents.iter().enumerate() {
-            if i == *variant_index {
-                match_fields.extend(quote!(
-                    #variant_with_fields_ident => (#(#field_idents,)*),
-                ));
-            } else {
-                match_fields.extend(quote!(
-                    #variant_with_fields_ident => unreachable!(),
-                ));
-            }
-        }
+        let match_fields = quote!(
+            #variant_with_fields_ident => (#(#field_idents,)*),
+            _ => unreachable!(),
+        );
         let match_fields_mut = quote!(let (#(#field_idents,)*) = match &mut self.0 {
             #match_fields
         };);
@@ -1077,18 +1069,10 @@ fn impl_enum(
             field_indices.push(index);
         }
         let fields_len = field_indices.len();
-        let mut match_fields = quote!();
-        for (i, _variant_ident) in variant_idents.iter().enumerate() {
-            if i == *variant_index {
-                match_fields.extend(quote!(
-                    #variant_with_fields_ident => (#(#field_idents,)*),
-                ));
-            } else {
-                match_fields.extend(quote!(
-                    #variant_with_fields_ident => unreachable!(),
-                ));
-            }
-        }
+        let match_fields = quote!(
+            #variant_with_fields_ident => (#(#field_idents,)*),
+            _ => unreachable!(),
+        );
         let match_fields_mut = quote!(let (#(#field_idents,)*) = match &mut self.0 {
             #match_fields
         };);

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -425,6 +425,14 @@ fn impl_struct(
     })
 }
 
+fn tuple_field_name(i: usize) -> String {
+    format!("t{}", i)
+}
+
+fn tuple_field_ident(i: usize) -> Ident {
+    Ident::new(tuple_field_name(i).as_str(), Span::call_site())
+}
+
 fn impl_tuple_struct(
     struct_name: &Ident,
     generics: &Generics,
@@ -589,12 +597,12 @@ fn impl_value(
             }
 
             #[inline]
-            fn apply(&mut self, value: &dyn #bevy_reflect_path::Reflect) { // FIXME
+            fn apply(&mut self, value: &dyn #bevy_reflect_path::Reflect) {
                 let value = value.any();
                 if let Some(value) = value.downcast_ref::<Self>() {
                     *self = value.clone();
                 } else {
-                    panic!("Attempted to apply non-enum type to enum type.");
+                    panic!("Value is not {}.", std::any::type_name::<Self>());
                 }
             }
 
@@ -648,52 +656,56 @@ fn impl_enum(
     let mut tuple_wrappers = Vec::new();
     let mut variant_names = Vec::new();
     let mut variant_idents = Vec::new();
-    let mut variant_and_fields_idents = Vec::new();
     let mut reflect_variants = Vec::new();
     let mut reflect_variants_mut = Vec::new();
+    let mut variant_with_fields_idents = Vec::new();
+    let mut variant_without_fields_idents = Vec::new();
     for (variant, variant_index) in active_variants.iter() {
-        let ident = &variant.ident;
-        let variant_name = format!("{}::{}", enum_name, variant.ident);
         let variant_ident = {
+            let ident = &variant.ident;
+            quote!(#enum_name::#ident)
+        };
+        let variant_name = variant_ident.to_string();
+        let variant_without_fields_ident = {
             match &variant.fields {
                 Fields::Named(_struct_fields) => {
-                    quote!(#enum_name::#ident {..})
+                    quote!(#variant_ident {..})
                 }
                 Fields::Unnamed(tuple) => {
                     let tuple_fields = &tuple.unnamed;
                     if tuple_fields.len() == 1 {
-                        quote!(#enum_name::#ident (_))
+                        quote!(#variant_ident (_))
                     } else {
-                        quote!(#enum_name::#ident (..))
+                        quote!(#variant_ident (..))
                     }
                 }
                 Fields::Unit => {
-                    quote!(#enum_name::#ident)
+                    quote!(#variant_ident)
                 }
             }
         };
-        let variant_and_fields_ident = {
+        let variant_with_fields_ident = {
             match &variant.fields {
                 Fields::Named(struct_fields) => {
-                    let field_names = struct_fields
+                    let field_idents = struct_fields
                         .named
                         .iter()
                         .map(|field| field.ident.as_ref().unwrap())
                         .collect::<Vec<_>>();
-                    quote!(#enum_name::#ident {#(#field_names,)*})
+                    quote!(#variant_ident {#(#field_idents,)*})
                 }
                 Fields::Unnamed(tuple_fields) => {
-                    let field_names = (0..tuple_fields.unnamed.len())
-                        .map(|i| Ident::new(format!("t{}", i).as_str(), Span::call_site()))
+                    let field_idents = (0..tuple_fields.unnamed.len())
+                        .map(|i| tuple_field_ident(i))
                         .collect::<Vec<_>>();
                     if tuple_fields.unnamed.len() == 1 {
-                        quote!(#enum_name::#ident (new_type))
+                        quote!(#variant_ident (new_type))
                     } else {
-                        quote!(#enum_name::#ident (#(#field_names,)*))
+                        quote!(#variant_ident (#(#field_idents,)*))
                     }
                 }
                 Fields::Unit => {
-                    quote!(#enum_name::#ident)
+                    quote!(#variant_ident)
                 }
             }
         };
@@ -763,9 +775,7 @@ fn impl_enum(
                     wrapper_ident,
                     wrapper_name,
                     variant_index,
-                    variant_name.clone(),
-                    variant_ident.clone(),
-                    variant_and_fields_ident.clone(),
+                    variant_with_fields_ident.clone(),
                     struct_fields.clone(),
                 ));
             }
@@ -775,9 +785,7 @@ fn impl_enum(
                         wrapper_ident,
                         wrapper_name,
                         variant_index,
-                        variant_name.clone(),
-                        variant_ident.clone(),
-                        variant_and_fields_ident.clone(),
+                        variant_with_fields_ident.clone(),
                         tuple_fields.clone(),
                     ));
                 }
@@ -787,9 +795,10 @@ fn impl_enum(
         variant_indices.push(variant_index);
         variant_names.push(variant_name);
         variant_idents.push(variant_ident);
-        variant_and_fields_idents.push(variant_and_fields_ident);
         reflect_variants.push(reflect_variant);
         reflect_variants_mut.push(reflect_variant_mut);
+        variant_with_fields_idents.push(variant_with_fields_ident);
+        variant_without_fields_idents.push(variant_without_fields_ident);
     }
     let hash_fn = reflect_attrs.get_hash_impl(&bevy_reflect_path);
     let serialize_fn = reflect_attrs.get_serialize_impl(&bevy_reflect_path);
@@ -809,19 +818,19 @@ fn impl_enum(
         impl #impl_generics #bevy_reflect_path::Enum for #enum_name#ty_generics #where_clause {
             fn variant(&self) -> #bevy_reflect_path::EnumVariant<'_> {
                 match self {
-                    #(#variant_and_fields_idents => #reflect_variants,)*
+                    #(#variant_with_fields_idents => #reflect_variants,)*
                 }
             }
 
             fn variant_mut(&mut self) -> #bevy_reflect_path::EnumVariantMut<'_> {
                 match self {
-                    #(#variant_and_fields_idents => #reflect_variants_mut,)*
+                    #(#variant_with_fields_idents => #reflect_variants_mut,)*
                 }
             }
 
             fn variant_info(&self) -> #bevy_reflect_path::VariantInfo<'_> {
                 let index = match self {
-                    #(#variant_idents => #variant_indices,)*
+                    #(#variant_without_fields_idents => #variant_indices,)*
                 };
                 #bevy_reflect_path::VariantInfo {
                     index,
@@ -865,7 +874,7 @@ fn impl_enum(
             #[inline]
             fn clone_value(&self) -> Box<dyn #bevy_reflect_path::Reflect> {
                 use #bevy_reflect_path::Enum;
-                Box::new(self.clone()) // FIXME: should it be clone_dynamic?
+                Box::new(self.clone()) // FIXME: should be clone_dynamic, so that Clone is not a required bound
             }
             #[inline]
             fn set(&mut self, value: Box<dyn #bevy_reflect_path::Reflect>) -> Result<(), Box<dyn #bevy_reflect_path::Reflect>> {
@@ -874,11 +883,11 @@ fn impl_enum(
             }
 
             #[inline]
-            fn apply(&mut self, value: &dyn #bevy_reflect_path::Reflect) { // FIXME
+            fn apply(&mut self, value: &dyn #bevy_reflect_path::Reflect) {
                 use #bevy_reflect_path::Enum;
                 let value = value.any();
                 if let Some(value) = value.downcast_ref::<Self>() {
-                    *self = value.clone();
+                    *self = value.clone_value();
                 } else {
                     panic!("Attempted to apply non-enum type to enum type.");
                 }
@@ -913,15 +922,8 @@ fn impl_enum(
             }
         }
     });
-    for (
-        wrapper_ident,
-        wrapper_name,
-        variant_index,
-        _variant_name,
-        _variant_ident,
-        variant_and_fields_ident,
-        fields,
-    ) in struct_wrappers
+    for (wrapper_ident, wrapper_name, variant_index, variant_with_fields_ident, fields) in
+        struct_wrappers
     {
         let mut field_names = Vec::new();
         let mut field_idents = Vec::new();
@@ -933,14 +935,14 @@ fn impl_enum(
         }
         let fields_len = field_indices.len();
         let mut match_fields = quote!();
-        for (i, variant_ident) in variant_idents.iter().enumerate() {
+        for (i, _variant_ident) in variant_idents.iter().enumerate() {
             if i == *variant_index {
                 match_fields.extend(quote!(
-                    #variant_and_fields_ident => (#(#field_idents,)*),
+                    #variant_with_fields_ident => (#(#field_idents,)*),
                 ));
             } else {
                 match_fields.extend(quote!(
-                    #variant_ident => unreachable!(),
+                    #variant_with_fields_ident => unreachable!(),
                 ));
             }
         }
@@ -1063,36 +1065,27 @@ fn impl_enum(
             }
         }));
     }
-    for (
-        wrapper_ident,
-        wrapper_name,
-        variant_index,
-        _variant_name,
-        _variant_ident,
-        variant_and_fields_ident,
-        fields,
-    ) in tuple_wrappers
+    for (wrapper_ident, wrapper_name, variant_index, variant_with_fields_ident, fields) in
+        tuple_wrappers
     {
         let mut field_names = Vec::new();
         let mut field_idents = Vec::new();
         let mut field_indices = Vec::new();
         for (index, _field) in fields.unnamed.iter().enumerate() {
-            let field_name = format!("t{}", index); // FIXME: done in 2 places
-            let field_ident = Ident::new(field_name.as_str(), Span::call_site());
-            field_names.push(field_name);
-            field_idents.push(field_ident);
+            field_names.push(tuple_field_name(index));
+            field_idents.push(tuple_field_ident(index));
             field_indices.push(index);
         }
         let fields_len = field_indices.len();
         let mut match_fields = quote!();
-        for (i, variant_ident) in variant_idents.iter().enumerate() {
+        for (i, _variant_ident) in variant_idents.iter().enumerate() {
             if i == *variant_index {
                 match_fields.extend(quote!(
-                    #variant_and_fields_ident => (#(#field_idents,)*),
+                    #variant_with_fields_ident => (#(#field_idents,)*),
                 ));
             } else {
                 match_fields.extend(quote!(
-                    #variant_ident => unreachable!(),
+                    #variant_with_fields_ident => unreachable!(),
                 ));
             }
         }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -954,7 +954,7 @@ fn impl_enum(
         };);
         token_stream.extend(TokenStream::from(quote! {
             #[repr(transparent)]
-            pub struct #wrapper_ident(TestEnum);
+            pub struct #wrapper_ident(#enum_name);
             impl #bevy_reflect_path::Reflect for #wrapper_ident {
                 fn type_name(&self) -> &str {
                     #wrapper_name
@@ -1097,7 +1097,7 @@ fn impl_enum(
         };);
         token_stream.extend(TokenStream::from(quote! {
             #[repr(transparent)]
-            pub struct #wrapper_ident(TestEnum);
+            pub struct #wrapper_ident(#enum_name);
             impl #bevy_reflect_path::Reflect for #wrapper_ident {
                 fn type_name(&self) -> &str {
                     #wrapper_name

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -887,7 +887,7 @@ fn impl_enum(
                 use #bevy_reflect_path::Enum;
                 let value = value.any();
                 if let Some(value) = value.downcast_ref::<Self>() {
-                    *self = value.clone_value();
+                    *self = value.clone(); //FIXME: should apply the variant instead
                 } else {
                     panic!("Attempted to apply non-enum type to enum type.");
                 }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -727,7 +727,7 @@ fn impl_enum(
                 Fields::Named(_struct_fields) => {
                     quote!({
                         let wrapper_ref = unsafe { std::mem::transmute::< &Self, &#wrapper_ident >(self) };
-                        #bevy_reflect_path::EnumVariant::Struct(wrapper_ref as &dyn Struct)
+                        #bevy_reflect_path::EnumVariant::Struct(wrapper_ref as &dyn #bevy_reflect_path::Struct)
                     })
                 }
                 Fields::Unnamed(tuple_fields) => {
@@ -736,7 +736,7 @@ fn impl_enum(
                     } else {
                         quote!({
                             let wrapper_ref = unsafe { std::mem::transmute::< &Self, &#wrapper_ident >(self) };
-                            #bevy_reflect_path::EnumVariant::Tuple(wrapper_ref as &dyn Tuple)
+                            #bevy_reflect_path::EnumVariant::Tuple(wrapper_ref as &dyn #bevy_reflect_path::Tuple)
                         })
                     }
                 }
@@ -750,7 +750,7 @@ fn impl_enum(
                 Fields::Named(_struct_fields) => {
                     quote!({
                         let wrapper_ref = unsafe { std::mem::transmute::< &mut Self, &mut #wrapper_ident >(self) };
-                        #bevy_reflect_path::EnumVariantMut::Struct(wrapper_ref as &mut dyn Struct)
+                        #bevy_reflect_path::EnumVariantMut::Struct(wrapper_ref as &mut dyn #bevy_reflect_path::Struct)
                     })
                 }
                 Fields::Unnamed(tuple) => {
@@ -760,7 +760,7 @@ fn impl_enum(
                     } else {
                         quote!({
                             let wrapper_ref = unsafe { std::mem::transmute::< &mut Self, &mut #wrapper_ident >(self) };
-                            #bevy_reflect_path::EnumVariantMut::Tuple(wrapper_ref as &mut dyn Tuple)
+                            #bevy_reflect_path::EnumVariantMut::Tuple(wrapper_ref as &mut dyn #bevy_reflect_path::Tuple)
                         })
                     }
                 }
@@ -1051,11 +1051,11 @@ fn impl_enum(
                     #fields_len
                 }
 
-                fn iter_fields(&self) -> bevy::reflect::FieldIter {
-                    FieldIter::new(self)
+                fn iter_fields(&self) -> #bevy_reflect_path::FieldIter {
+                    #bevy_reflect_path::FieldIter::new(self)
                 }
 
-                fn clone_dynamic(&self) -> bevy::reflect::DynamicStruct {
+                fn clone_dynamic(&self) -> #bevy_reflect_path::DynamicStruct {
                     #match_fields
                     let mut dynamic = #bevy_reflect_path::DynamicStruct::default();
                     dynamic.set_name(self.type_name().to_string());
@@ -1172,11 +1172,11 @@ fn impl_enum(
                     #fields_len
                 }
 
-                fn iter_fields(&self) -> bevy::reflect::TupleFieldIter {
-                    TupleFieldIter::new(self)
+                fn iter_fields(&self) -> #bevy_reflect_path::TupleFieldIter {
+                    #bevy_reflect_path::TupleFieldIter::new(self)
                 }
 
-                fn clone_dynamic(&self) -> bevy::reflect::DynamicTuple {
+                fn clone_dynamic(&self) -> #bevy_reflect_path::DynamicTuple {
                     #match_fields
                     let mut dynamic = #bevy_reflect_path::DynamicTuple::default();
                     #(dynamic.insert_boxed(#field_idents.clone_value());)*

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -665,7 +665,11 @@ fn impl_enum(
             let ident = &variant.ident;
             quote!(#enum_name::#ident)
         };
-        let variant_name = variant_ident.to_string();
+        let variant_name = variant_ident
+            .to_string()
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect::<String>();
         let variant_without_fields_ident = {
             match &variant.fields {
                 Fields::Named(_struct_fields) => {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -696,7 +696,7 @@ fn impl_enum(
                 }
                 Fields::Unnamed(tuple_fields) => {
                     let field_idents = (0..tuple_fields.unnamed.len())
-                        .map(|i| tuple_field_ident(i))
+                        .map(tuple_field_ident)
                         .collect::<Vec<_>>();
                     if tuple_fields.unnamed.len() == 1 {
                         quote!(#variant_ident (new_type))

--- a/crates/bevy_reflect/src/enum_trait.rs
+++ b/crates/bevy_reflect/src/enum_trait.rs
@@ -1,0 +1,53 @@
+use crate::{Reflect, Struct, Tuple};
+
+pub trait Enum: Reflect {
+    fn variant(&self) -> EnumVariant<'_>;
+    fn variant_mut(&mut self) -> EnumVariantMut<'_>;
+    fn variant_info(&self) -> VariantInfo<'_>;
+    fn iter_variants_info(&self) -> VariantInfoIter<'_>;
+    fn get_index_name(&self, index: usize) -> Option<&str>;
+    fn get_index_from_name(&self, name: &str) -> Option<usize>;
+}
+pub struct VariantInfo<'a> {
+    pub index: usize,
+    pub name: &'a str,
+}
+pub struct VariantInfoIter<'a> {
+    pub(crate) value: &'a dyn Enum,
+    pub(crate) index: usize,
+    pub(crate) len: usize,
+}
+impl<'a> Iterator for VariantInfoIter<'a> {
+    type Item = VariantInfo<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index == self.len {
+            return None;
+        }
+        let item = VariantInfo {
+            index: self.index,
+            name: self.value.get_index_name(self.index).unwrap(),
+        };
+        self.index += 1;
+        Some(item)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = self.len - self.index;
+        (size, Some(size))
+    }
+}
+impl<'a> ExactSizeIterator for VariantInfoIter<'a> {}
+
+pub enum EnumVariant<'a> {
+    Unit,
+    NewType(&'a dyn Reflect),
+    Tuple(&'a dyn Tuple),
+    Struct(&'a dyn Struct),
+}
+pub enum EnumVariantMut<'a> {
+    Unit,
+    NewType(&'a mut dyn Reflect),
+    Tuple(&'a mut dyn Tuple),
+    Struct(&'a mut dyn Struct),
+}

--- a/crates/bevy_reflect/src/enum_trait.rs
+++ b/crates/bevy_reflect/src/enum_trait.rs
@@ -1,4 +1,4 @@
-use crate::{Reflect, Struct, Tuple};
+use crate::{Reflect, ReflectRef, Struct, Tuple};
 
 pub trait Enum: Reflect {
     fn variant(&self) -> EnumVariant<'_>;
@@ -8,6 +8,7 @@ pub trait Enum: Reflect {
     fn get_index_name(&self, index: usize) -> Option<&str>;
     fn get_index_from_name(&self, name: &str) -> Option<usize>;
 }
+#[derive(PartialEq, Eq)]
 pub struct VariantInfo<'a> {
     pub index: usize,
     pub name: &'a str,
@@ -15,29 +16,27 @@ pub struct VariantInfo<'a> {
 pub struct VariantInfoIter<'a> {
     pub(crate) value: &'a dyn Enum,
     pub(crate) index: usize,
-    pub(crate) len: usize,
+}
+impl<'a> VariantInfoIter<'a> {
+    pub fn new(value: &'a dyn Enum) -> Self {
+        Self { value, index: 0 }
+    }
 }
 impl<'a> Iterator for VariantInfoIter<'a> {
     type Item = VariantInfo<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.index == self.len {
-            return None;
-        }
-        let item = VariantInfo {
-            index: self.index,
-            name: self.value.get_index_name(self.index).unwrap(),
-        };
+        let value = self
+            .value
+            .get_index_name(self.index)
+            .map(|name| VariantInfo {
+                index: self.index,
+                name,
+            });
         self.index += 1;
-        Some(item)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let size = self.len - self.index;
-        (size, Some(size))
+        value
     }
 }
-impl<'a> ExactSizeIterator for VariantInfoIter<'a> {}
 
 pub enum EnumVariant<'a> {
     Unit,
@@ -50,4 +49,55 @@ pub enum EnumVariantMut<'a> {
     NewType(&'a mut dyn Reflect),
     Tuple(&'a mut dyn Tuple),
     Struct(&'a mut dyn Struct),
+}
+
+#[inline]
+pub fn enum_partial_eq<E: Enum>(enum_a: &E, reflect_b: &dyn Reflect) -> Option<bool> {
+    let enum_b = if let ReflectRef::Enum(e) = reflect_b.reflect_ref() {
+        e
+    } else {
+        return Some(false);
+    };
+
+    if enum_a.variant_info() != enum_b.variant_info() {
+        return Some(false);
+    }
+
+    let variant_b = enum_b.variant();
+    match enum_a.variant() {
+        EnumVariant::Unit => {
+            if let EnumVariant::Unit = variant_b {
+            } else {
+                return Some(false);
+            }
+        }
+        EnumVariant::NewType(t_a) => {
+            if let EnumVariant::NewType(t_b) = variant_b {
+                if let Some(false) | None = t_b.reflect_partial_eq(t_a) {
+                    return Some(false);
+                }
+            } else {
+                return Some(false);
+            }
+        }
+        EnumVariant::Tuple(t_a) => {
+            if let EnumVariant::Tuple(t_b) = variant_b {
+                if let Some(false) | None = t_b.reflect_partial_eq(t_a.as_reflect()) {
+                    return Some(false);
+                }
+            } else {
+                return Some(false);
+            }
+        }
+        EnumVariant::Struct(s_a) => {
+            if let EnumVariant::Struct(s_b) = variant_b {
+                if let Some(false) | None = s_b.reflect_partial_eq(s_a.as_reflect()) {
+                    return Some(false);
+                }
+            } else {
+                return Some(false);
+            }
+        }
+    }
+    Some(true)
 }

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -93,4 +93,12 @@ where
     fn serializable(&self) -> Option<Serializable> {
         None
     }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
 }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,6 +1,7 @@
 use crate::{
-    map_partial_eq, serde::Serializable, DynamicMap, List, ListIter, Map, MapIter, Reflect,
-    ReflectDeserialize, ReflectMut, ReflectRef,
+    map_partial_eq, serde::Serializable, DynamicMap, Enum, EnumVariant, EnumVariantMut,
+    GetTypeRegistration, List, ListIter, Map, MapIter, Reflect, ReflectDeserialize, ReflectMut,
+    ReflectRef, TypeRegistration, VariantInfo, VariantInfoIter,
 };
 
 use bevy_reflect_derive::impl_reflect_value;
@@ -29,7 +30,6 @@ impl_reflect_value!(isize(Hash, PartialEq, Serialize, Deserialize));
 impl_reflect_value!(f32(Serialize, Deserialize));
 impl_reflect_value!(f64(Serialize, Deserialize));
 impl_reflect_value!(String(Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(Option<T: Serialize + Clone + for<'de> Deserialize<'de> + Reflect + 'static>(Serialize, Deserialize));
 impl_reflect_value!(HashSet<T: Serialize + Hash + Eq + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>(Serialize, Deserialize));
 impl_reflect_value!(Range<T: Serialize + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>(Serialize, Deserialize));
 
@@ -278,5 +278,132 @@ impl Reflect for Cow<'static, str> {
 
     fn serializable(&self) -> Option<Serializable> {
         Some(Serializable::Borrowed(self))
+    }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+}
+
+impl<T: Reflect + Clone + Send + Sync + 'static> GetTypeRegistration for Option<T> {
+    fn get_type_registration() -> TypeRegistration {
+        TypeRegistration::of::<Option<T>>()
+    }
+}
+impl<T: Reflect + Clone + Send + Sync + 'static> Enum for Option<T> {
+    fn variant(&self) -> EnumVariant<'_> {
+        match self {
+            Option::Some(new_type) => EnumVariant::NewType(new_type as &dyn Reflect),
+            Option::None => EnumVariant::Unit,
+        }
+    }
+
+    fn variant_mut(&mut self) -> EnumVariantMut<'_> {
+        match self {
+            Option::Some(new_type) => EnumVariantMut::NewType(new_type as &mut dyn Reflect),
+            Option::None => EnumVariantMut::Unit,
+        }
+    }
+
+    fn variant_info(&self) -> VariantInfo<'_> {
+        let index = match self {
+            Option::Some(_) => 0usize,
+            Option::None => 1usize,
+        };
+        VariantInfo {
+            index,
+            name: self.get_index_name(index).unwrap(),
+        }
+    }
+
+    fn get_index_name(&self, index: usize) -> Option<&'_ str> {
+        match index {
+            0usize => Some("Option::Some"),
+            1usize => Some("Option::None"),
+            _ => None,
+        }
+    }
+
+    fn get_index_from_name(&self, name: &str) -> Option<usize> {
+        match name {
+            "Option::Some" => Some(0usize),
+            "Option::None" => Some(1usize),
+            _ => None,
+        }
+    }
+
+    fn iter_variants_info(&self) -> VariantInfoIter<'_> {
+        VariantInfoIter::new(self)
+    }
+}
+impl<T: Reflect + Clone + Send + Sync + 'static> Reflect for Option<T> {
+    #[inline]
+    fn type_name(&self) -> &str {
+        std::any::type_name::<Self>()
+    }
+
+    #[inline]
+    fn any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn clone_value(&self) -> Box<dyn Reflect> {
+        Box::new(self.clone())
+    }
+
+    #[inline]
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+        *self = value.take()?;
+        Ok(())
+    }
+
+    #[inline]
+    fn apply(&mut self, value: &dyn Reflect) {
+        let value = value.any();
+        if let Some(value) = value.downcast_ref::<Self>() {
+            *self = value.clone();
+        } else {
+            {
+                panic!("Enum is not {}.", &std::any::type_name::<Self>());
+            };
+        }
+    }
+
+    fn reflect_ref(&self) -> ReflectRef {
+        ReflectRef::Enum(self)
+    }
+
+    fn reflect_mut(&mut self) -> ReflectMut {
+        ReflectMut::Enum(self)
+    }
+
+    fn serializable(&self) -> Option<Serializable> {
+        None
+    }
+
+    fn reflect_hash(&self) -> Option<u64> {
+        None
+    }
+
+    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
+        crate::enum_partial_eq(self, value)
+    }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
     }
 }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -109,6 +109,14 @@ impl<T: Reflect> Reflect for Vec<T> {
     fn serializable(&self) -> Option<Serializable> {
         None
     }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
 }
 
 impl<K: Reflect + Clone + Eq + Hash, V: Reflect + Clone> Map for HashMap<K, V> {
@@ -202,6 +210,14 @@ impl<K: Reflect + Clone + Eq + Hash, V: Reflect + Clone> Reflect for HashMap<K, 
 
     fn serializable(&self) -> Option<Serializable> {
         None
+    }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
     }
 }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1,3 +1,4 @@
+mod enum_trait;
 mod list;
 mod map;
 mod path;
@@ -41,6 +42,7 @@ pub mod prelude {
     };
 }
 
+pub use enum_trait::*;
 pub use impls::*;
 pub use list::*;
 pub use map::*;

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -122,6 +122,14 @@ impl Reflect for DynamicList {
     fn serializable(&self) -> Option<Serializable> {
         None
     }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
 }
 
 pub struct ListIter<'a> {

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -141,6 +141,14 @@ impl Reflect for DynamicMap {
     fn serializable(&self) -> Option<Serializable> {
         None
     }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
 }
 
 pub struct MapIter<'a> {

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -39,6 +39,8 @@ pub trait Reflect: Any + Send + Sync {
     fn reflect_partial_eq(&self, _value: &dyn Reflect) -> Option<bool>;
     /// Returns a serializable value, if serialization is supported. Otherwise `None` will be returned.
     fn serializable(&self) -> Option<Serializable>;
+    fn as_reflect(&self) -> &dyn Reflect;
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect;
 }
 
 impl Debug for dyn Reflect {

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -1,4 +1,4 @@
-use crate::{serde::Serializable, List, Map, Struct, Tuple, TupleStruct};
+use crate::{serde::Serializable, Enum, List, Map, Struct, Tuple, TupleStruct};
 use std::{any::Any, fmt::Debug};
 
 pub use bevy_utils::AHasher as ReflectHasher;
@@ -9,6 +9,7 @@ pub enum ReflectRef<'a> {
     Tuple(&'a dyn Tuple),
     List(&'a dyn List),
     Map(&'a dyn Map),
+    Enum(&'a dyn Enum),
     Value(&'a dyn Reflect),
 }
 
@@ -18,6 +19,7 @@ pub enum ReflectMut<'a> {
     Tuple(&'a mut dyn Tuple),
     List(&'a mut dyn List),
     Map(&'a mut dyn Map),
+    Enum(&'a mut dyn Enum),
     Value(&'a mut dyn Reflect),
 }
 

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -77,6 +77,9 @@ impl<'a> Serialize for ReflectSerializer<'a> {
                 value,
             }
             .serialize(serializer),
+            ReflectRef::Enum(_value) => {
+                todo!()
+            }
         }
     }
 }

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -227,6 +227,14 @@ impl Reflect for DynamicStruct {
     fn serializable(&self) -> Option<Serializable> {
         None
     }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
 }
 
 #[inline]

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -165,6 +165,14 @@ impl Reflect for DynamicTuple {
     fn serializable(&self) -> Option<Serializable> {
         None
     }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
 }
 
 #[inline]
@@ -290,6 +298,14 @@ macro_rules! impl_reflect_tuple {
 
             fn serializable(&self) -> Option<Serializable> {
                 None
+            }
+
+            fn as_reflect(&self) -> &dyn Reflect {
+                self
+            }
+
+            fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+                self
             }
         }
     }

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -182,6 +182,14 @@ impl Reflect for DynamicTupleStruct {
     fn serializable(&self) -> Option<Serializable> {
         None
     }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
 }
 
 #[inline]

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -75,6 +75,9 @@ fn setup() {
         // operations on your type, allowing you to interact with fields via their indices. Tuple is automatically
         // implemented for tuples of arity 12 or less.
         ReflectRef::Tuple(_) => {}
+        // `Enum` is a trait automatically implemented for enums that derive Reflect. This trait allows you
+        // to interact list possible variants and interact with the currently active one
+        ReflectRef::Enum(_) => {}
         // `List` is a special trait that can be manually implemented (instead of deriving Reflect). This exposes "list"
         // operations on your type, such as indexing and insertion. List is automatically implemented for relevant core
         // types like Vec<T>


### PR DESCRIPTION
Enumerated types should be reflected like all other types. This is motivated and discussed in #1306.

Wanted features:
- [X] get the current variant, its name (e.g. TestEnum::A), and its discriminant
- [X] list the name and discriminant of all possible variants
- [ ] ~~support C-like enums with explicit discriminants~~
- [X] extend Reflect::reflect_ref()
- [X] extend #[derive(Reflect)]
- [ ] serialize and deserialize
- [ ] set current value to another variant (constructing it with Default if supported)
- [ ] DynamicEnums
