### PR TITLE
Rename add_resource to insert_resource

### DIFF
--- a/crates/bevy_app/src/app_builder.rs
+++ b/crates/bevy_app/src/app_builder.rs
@@ -214,8 +214,8 @@ impl AppBuilder {
             .add_system_to_stage(stage::EVENT, Events::<T>::update_system.system())
     }
 
-    /// Adds a resource to the current [App] and overwrites any resource previously added of the same type.
-    pub fn add_resource<T>(&mut self, resource: T) -> &mut Self
+    /// Inserts a resource to the current [App] and overwrites any resource previously added of the same type.
+    pub fn insert_resource<T>(&mut self, resource: T) -> &mut Self
     where
         T: Send + Sync + 'static,
     {

--- a/crates/bevy_app/src/app_builder.rs
+++ b/crates/bevy_app/src/app_builder.rs
@@ -223,7 +223,7 @@ impl AppBuilder {
         self
     }
 
-    pub fn add_thread_local_resource<T>(&mut self, resource: T) -> &mut Self
+    pub fn insert_thread_local_resource<T>(&mut self, resource: T) -> &mut Self
     where
         T: 'static,
     {

--- a/crates/bevy_app/src/app_builder.rs
+++ b/crates/bevy_app/src/app_builder.rs
@@ -210,7 +210,7 @@ impl AppBuilder {
     where
         T: Send + Sync + 'static,
     {
-        self.add_resource(Events::<T>::default())
+        self.insert_resource(Events::<T>::default())
             .add_system_to_stage(stage::EVENT, Events::<T>::update_system.system())
     }
 

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -217,7 +217,7 @@ impl AddAsset for AppBuilder {
             asset_server.register_asset_type::<T>()
         };
 
-        self.add_resource(assets)
+        self.insert_resource(assets)
             .add_system_to_stage(
                 super::stage::ASSET_EVENTS,
                 Assets::<T>::asset_event_system.system(),

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -85,7 +85,7 @@ impl Plugin for AssetPlugin {
 
             let asset_server = AssetServer::with_boxed_io(source, task_pool);
 
-            app.add_resource(asset_server);
+            app.insert_resource(asset_server);
         }
 
         app.add_stage_before(

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -14,7 +14,7 @@ pub struct FrameTimeDiagnosticsState {
 impl Plugin for FrameTimeDiagnosticsPlugin {
     fn build(&self, app: &mut bevy_app::AppBuilder) {
         app.add_startup_system(Self::setup_system.system())
-            .add_resource(FrameTimeDiagnosticsState { frame_count: 0.0 })
+            .insert_resource(FrameTimeDiagnosticsState { frame_count: 0.0 })
             .add_system(Self::diagnostic_system.system());
     }
 }

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -30,7 +30,7 @@ impl Default for LogDiagnosticsPlugin {
 
 impl Plugin for LogDiagnosticsPlugin {
     fn build(&self, app: &mut bevy_app::AppBuilder) {
-        app.add_resource(LogDiagnosticsState {
+        app.insert_resource(LogDiagnosticsState {
             timer: Timer::new(self.wait_duration, true),
             filter: self.filter.clone(),
         });

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -18,7 +18,7 @@ impl Plugin for GilrsPlugin {
             .build()
         {
             Ok(gilrs) => {
-                app.add_thread_local_resource(gilrs)
+                app.insert_thread_local_resource(gilrs)
                     .add_startup_system_to_stage(PRE_STARTUP, gilrs_event_startup_system.system())
                     .add_system_to_stage(stage::PRE_EVENT, gilrs_event_system.system());
             }

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -39,7 +39,7 @@ impl Plugin for TextPlugin {
         app.add_asset::<Font>()
             .add_asset::<FontAtlasSet>()
             .init_asset_loader::<FontLoader>()
-            .add_resource(DefaultTextPipeline::default())
+            .insert_resource(DefaultTextPipeline::default())
             .add_system_to_stage(bevy_app::stage::POST_UPDATE, text2d_system.system())
             .add_system_to_stage(
                 bevy_render::stage::DRAW,

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -5,7 +5,7 @@ fn main() {
     App::build()
         .init_resource::<RpgSpriteHandles>()
         .add_plugins(DefaultPlugins)
-        .add_resource(State::new(AppState::Setup))
+        .insert_resource(State::new(AppState::Setup))
         .add_stage_after(stage::UPDATE, STAGE, StateStage::<AppState>::default())
         .on_state_enter(STAGE, AppState::Setup, load_textures.system())
         .on_state_update(STAGE, AppState::Setup, check_textures.system())

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::build()
-        .add_resource(Msaa { samples: 4 })
+        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::build()
-        .add_resource(Msaa { samples: 4 })
+        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 /// but cheap) to 8 (crisp but expensive)
 fn main() {
     App::build()
-        .add_resource(Msaa { samples: 4 })
+        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 /// are propagated to their descendants
 fn main() {
     App::build()
-        .add_resource(Msaa { samples: 4 })
+        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
         .add_system(rotator_system.system())

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -2,9 +2,9 @@ use bevy::{prelude::*, scene::InstanceId};
 
 fn main() {
     App::build()
-        .add_resource(Msaa { samples: 4 })
+        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
-        .add_resource(SceneInstance::default())
+        .insert_resource(SceneInstance::default())
         .add_startup_system(setup.system())
         .add_system(scene_update.system())
         .add_system(move_scene_entities.system())

--- a/examples/android/android.rs
+++ b/examples/android/android.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 #[bevy_main]
 fn main() {
     App::build()
-        .add_resource(Msaa { samples: 2 })
+        .insert_resource(Msaa { samples: 2 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();

--- a/examples/app/custom_loop.rs
+++ b/examples/app/custom_loop.rs
@@ -22,7 +22,7 @@ fn print_system(input: Res<Input>) {
 
 fn main() {
     App::build()
-        .add_resource(Input(String::new()))
+        .insert_resource(Input(String::new()))
         .set_runner(my_runner)
         .add_system(print_system.system())
         .run();

--- a/examples/app/headless.rs
+++ b/examples/app/headless.rs
@@ -11,14 +11,14 @@ use bevy::{app::ScheduleRunnerSettings, prelude::*, utils::Duration};
 fn main() {
     // this app runs once
     App::build()
-        .add_resource(ScheduleRunnerSettings::run_once())
+        .insert_resource(ScheduleRunnerSettings::run_once())
         .add_plugins(MinimalPlugins)
         .add_system(hello_world_system.system())
         .run();
 
     // this app loops forever at 60 fps
     App::build()
-        .add_resource(ScheduleRunnerSettings::run_loop(Duration::from_secs_f64(
+        .insert_resource(ScheduleRunnerSettings::run_loop(Duration::from_secs_f64(
             1.0 / 60.0,
         )))
         .add_plugins(MinimalPlugins)

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         // Uncomment this to override the default log settings:
-        // .add_resource(bevy::log::LogSettings {
+        // .insert_resource(bevy::log::LogSettings {
         //     level: bevy::log::Level::TRACE,
         //     filter: "wgpu=warn,bevy_ecs=info".to_string(),
         // })

--- a/examples/app/plugin.rs
+++ b/examples/app/plugin.rs
@@ -28,7 +28,7 @@ impl Plugin for PrintMessagePlugin {
             message: self.message.clone(),
             timer: Timer::new(self.wait_duration, true),
         };
-        app.add_resource(state)
+        app.insert_resource(state)
             .add_system(print_message_system.system());
     }
 }

--- a/examples/app/return_after_run.rs
+++ b/examples/app/return_after_run.rs
@@ -3,19 +3,19 @@ use bevy::{prelude::*, render::pass::ClearColor, winit::WinitConfig};
 fn main() {
     println!("Running first App.");
     App::build()
-        .add_resource(WinitConfig {
+        .insert_resource(WinitConfig {
             return_from_run: true,
         })
-        .add_resource(ClearColor(Color::rgb(0.2, 0.2, 0.8)))
+        .insert_resource(ClearColor(Color::rgb(0.2, 0.2, 0.8)))
         .add_plugins(DefaultPlugins)
         .add_system(system1.system())
         .run();
     println!("Running another App.");
     App::build()
-        .add_resource(WinitConfig {
+        .insert_resource(WinitConfig {
             return_from_run: true,
         })
-        .add_resource(ClearColor(Color::rgb(0.2, 0.8, 0.2)))
+        .insert_resource(ClearColor(Color::rgb(0.2, 0.8, 0.2)))
         .add_plugins_with(DefaultPlugins, |group| {
             group.disable::<bevy::log::LogPlugin>()
         })

--- a/examples/app/thread_pool_resources.rs
+++ b/examples/app/thread_pool_resources.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 /// certain number of threads).
 fn main() {
     App::build()
-        .add_resource(DefaultTaskPoolOptions::with_num_threads(4))
+        .insert_resource(DefaultTaskPoolOptions::with_num_threads(4))
         .add_plugins(DefaultPlugins)
         .run();
 }

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 /// This example illustrates various ways to load assets
 fn main() {
     App::build()
-        .add_resource(Msaa { samples: 4 })
+        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();

--- a/examples/asset/custom_asset_io.rs
+++ b/examples/asset/custom_asset_io.rs
@@ -69,7 +69,7 @@ impl Plugin for CustomAssetIoPlugin {
 
         // the asset server is constructed and added the resource manager
 
-        app.add_resource(AssetServer::new(asset_io, task_pool));
+        app.insert_resource(AssetServer::new(asset_io, task_pool));
     }
 }
 

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -244,9 +244,9 @@ fn main() {
     // Bevy apps are created using the builder pattern. We use the builder to add systems, resources, and plugins to our app
     App::build()
         // Resources can be added to our app like this
-        .add_resource(State { counter: 0 })
+        .insert_resource(State { counter: 0 })
         // Some systems are configured by adding their settings as a resource
-        .add_resource(ScheduleRunnerSettings::run_loop(Duration::from_secs(5)))
+        .insert_resource(ScheduleRunnerSettings::run_loop(Duration::from_secs(5)))
         // Plugins are just a grouped set of app builder calls (just like we're doing here).
         // We could easily turn our game into a plugin, but you can check out the plugin example for that :)
         // The plugin below runs our app's "system schedule" once every 5 seconds (configured above).

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -5,7 +5,7 @@ fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .init_resource::<ButtonMaterials>()
-        .add_resource(State::new(AppState::Menu))
+        .insert_resource(State::new(AppState::Menu))
         .add_stage_after(stage::UPDATE, STAGE, StateStage::<AppState>::default())
         .on_state_enter(STAGE, AppState::Menu, setup_menu.system())
         .on_state_update(STAGE, AppState::Menu, menu.system())

--- a/examples/ecs/system_chaining.rs
+++ b/examples/ecs/system_chaining.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::build()
-        .add_resource(Message("42".to_string()))
+        .insert_resource(Message("42".to_string()))
         .add_system(parse_message_system.system().chain(handler_system.system()))
         .run();
 }

--- a/examples/ecs/timers.rs
+++ b/examples/ecs/timers.rs
@@ -3,7 +3,7 @@ use bevy::{log::info, prelude::*};
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_resource(Countdown::default())
+        .insert_resource(Countdown::default())
         .add_startup_system(setup_system.system())
         .add_system(countdown_system.system())
         .add_system(timer_system.system())

--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -15,10 +15,10 @@ enum GameState {
 
 fn main() {
     App::build()
-        .add_resource(Msaa { samples: 4 })
+        .insert_resource(Msaa { samples: 4 })
         .init_resource::<Game>()
         .add_plugins(DefaultPlugins)
-        .add_resource(State::new(GameState::Playing))
+        .insert_resource(State::new(GameState::Playing))
         .add_startup_system(setup_cameras.system())
         .add_stage_after(stage::UPDATE, STAGE, StateStage::<GameState>::default())
         .on_state_enter(STAGE, GameState::Playing, setup.system())

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -8,8 +8,8 @@ use bevy::{
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_resource(Scoreboard { score: 0 })
-        .add_resource(ClearColor(Color::rgb(0.9, 0.9, 0.9)))
+        .insert_resource(Scoreboard { score: 0 })
+        .insert_resource(ClearColor(Color::rgb(0.9, 0.9, 0.9)))
         .add_startup_system(setup.system())
         .add_system(paddle_movement_system.system())
         .add_system(ball_collision_system.system())

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -4,13 +4,13 @@ use bevy::{prelude::*, window::WindowMode};
 #[bevy_main]
 fn main() {
     App::build()
-        .add_resource(WindowDescriptor {
+        .insert_resource(WindowDescriptor {
             vsync: true,
             resizable: false,
             mode: WindowMode::BorderlessFullscreen,
             ..Default::default()
         })
-        .add_resource(Msaa { samples: 4 })
+        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -28,7 +28,7 @@ impl FromResources for BirdMaterial {
 
 fn main() {
     App::build()
-        .add_resource(WindowDescriptor {
+        .insert_resource(WindowDescriptor {
             title: "BevyMark".to_string(),
             width: 800.,
             height: 600.,
@@ -38,7 +38,7 @@ fn main() {
         })
         .add_plugins(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
-        .add_resource(BevyCounter { count: 0 })
+        .insert_resource(BevyCounter { count: 0 })
         .init_resource::<BirdMaterial>()
         .add_startup_system(setup.system())
         .add_system(mouse_handler.system())

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -5,7 +5,7 @@ use bevy::{prelude::*, text::FontAtlasSet};
 fn main() {
     App::build()
         .init_resource::<State>()
-        .add_resource(ClearColor(Color::BLACK))
+        .insert_resource(ClearColor(Color::BLACK))
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
         .add_system(text_update_system.system())

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -6,7 +6,7 @@ use bevy::{
 /// This example is for debugging text layout
 fn main() {
     App::build()
-        .add_resource(WindowDescriptor {
+        .insert_resource(WindowDescriptor {
             vsync: false,
             ..Default::default()
         })

--- a/examples/wasm/assets_wasm.rs
+++ b/examples/wasm/assets_wasm.rs
@@ -7,7 +7,7 @@ use bevy::{
 
 fn main() {
     App::build()
-        .add_resource(AssetServerSettings {
+        .insert_resource(AssetServerSettings {
             asset_folder: "/".to_string(),
         })
         .add_plugins(DefaultPlugins)

--- a/examples/wasm/headless_wasm.rs
+++ b/examples/wasm/headless_wasm.rs
@@ -7,7 +7,7 @@ use bevy::{
 
 fn main() {
     App::build()
-        .add_resource(ScheduleRunnerSettings::run_loop(Duration::from_secs_f64(
+        .insert_resource(ScheduleRunnerSettings::run_loop(Duration::from_secs_f64(
             1.0 / 60.0,
         )))
         .add_plugin(ScheduleRunnerPlugin::default())

--- a/examples/wasm/winit_wasm.rs
+++ b/examples/wasm/winit_wasm.rs
@@ -8,7 +8,7 @@ use bevy::{
 
 fn main() {
     App::build()
-        .add_resource(WindowDescriptor {
+        .insert_resource(WindowDescriptor {
             width: 300.,
             height: 300.,
             ..Default::default()

--- a/examples/window/clear_color.rs
+++ b/examples/window/clear_color.rs
@@ -2,7 +2,7 @@ use bevy::{prelude::*, render::pass::ClearColor};
 
 fn main() {
     App::build()
-        .add_resource(ClearColor(Color::rgb(0.5, 0.5, 0.9)))
+        .insert_resource(ClearColor(Color::rgb(0.5, 0.5, 0.9)))
         .add_plugins(DefaultPlugins)
         .run();
 }

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -15,8 +15,8 @@ use bevy::{
 /// This example creates a second window and draws a mesh from two different cameras.
 fn main() {
     App::build()
-        .add_resource(Msaa { samples: 4 })
-        .add_resource(State::new(AppState::CreateWindow))
+        .insert_resource(Msaa { samples: 4 })
+        .insert_resource(State::new(AppState::CreateWindow))
         .add_plugins(DefaultPlugins)
         .add_stage_after(
             stage::UPDATE,

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 /// This example illustrates how to customize the default window settings
 fn main() {
     App::build()
-        .add_resource(WindowDescriptor {
+        .insert_resource(WindowDescriptor {
             width: 500.,
             height: 300.,
             ..Default::default()

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 /// This example illustrates how to customize the default window settings
 fn main() {
     App::build()
-        .add_resource(WindowDescriptor {
+        .insert_resource(WindowDescriptor {
             title: "I am a window!".to_string(),
             width: 500.,
             height: 300.,


### PR DESCRIPTION
Renames `AppBuilder::add_resource` to `AppBuilder::insert_resource` for consistency with the Commands version. Also does the same for `add_thread_local_resource`.

A straightforward fix of #1352.