### PR TITLE
Fix Un-Renamed add_resource Compile Error

### DIFF
--- a/crates/bevy_app/src/app_builder.rs
+++ b/crates/bevy_app/src/app_builder.rs
@@ -240,7 +240,7 @@ impl AppBuilder {
         // so we would need to be extremely certain this is correct
         if !self.resources().contains::<R>() {
             let resource = R::from_resources(&self.resources());
-            self.add_resource(resource);
+            self.insert_resource(resource);
         }
 
         self


### PR DESCRIPTION
Fixes build error introduced by #1356 when merged into master.

https://github.com/bevyengine/bevy/runs/1798743382#step:6:251

It's worth nothing that Bors does eliminate these kinds of failures and also allows safely telling bors to merge something without having to manually wait for CI to be successful first if you wanted me to set that up sometime. :slightly_smiling_face: 