### PR TITLE
Texture atlas format and conversion

### DIFF
--- a/crates/bevy_render/src/texture/image_texture_loader.rs
+++ b/crates/bevy_render/src/texture/image_texture_loader.rs
@@ -187,25 +187,25 @@ pub(crate) fn texture_to_image(texture: &Texture) -> Option<image::DynamicImage>
             texture.size.height,
             texture.data.clone(),
         )
-        .map(|buffer| image::DynamicImage::ImageLuma8(buffer)),
+        .map(image::DynamicImage::ImageLuma8),
         TextureFormat::Rg8Unorm => image::ImageBuffer::from_raw(
             texture.size.width,
             texture.size.height,
             texture.data.clone(),
         )
-        .map(|buffer| image::DynamicImage::ImageLumaA8(buffer)),
+        .map(image::DynamicImage::ImageLumaA8),
         TextureFormat::Rgba8UnormSrgb => image::ImageBuffer::from_raw(
             texture.size.width,
             texture.size.height,
             texture.data.clone(),
         )
-        .map(|buffer| image::DynamicImage::ImageRgba8(buffer)),
+        .map(image::DynamicImage::ImageRgba8),
         TextureFormat::Bgra8UnormSrgb => image::ImageBuffer::from_raw(
             texture.size.width,
             texture.size.height,
             texture.data.clone(),
         )
-        .map(|buffer| image::DynamicImage::ImageBgra8(buffer)),
+        .map(image::DynamicImage::ImageBgra8),
         _ => None,
     }
 }

--- a/crates/bevy_render/src/texture/image_texture_loader.rs
+++ b/crates/bevy_render/src/texture/image_texture_loader.rs
@@ -16,8 +16,6 @@ impl AssetLoader for ImageTextureLoader {
         load_context: &'a mut LoadContext,
     ) -> BoxedFuture<'a, Result<()>> {
         Box::pin(async move {
-            use bevy_core::AsBytes;
-
             // Find the image type we expect. A file with the extension "png" should
             // probably load as a PNG.
 
@@ -41,118 +39,7 @@ impl AssetLoader for ImageTextureLoader {
 
             let dyn_img = image::load_from_memory_with_format(bytes, img_format)?;
 
-            let width;
-            let height;
-
-            let data: Vec<u8>;
-            let format: TextureFormat;
-
-            match dyn_img {
-                image::DynamicImage::ImageLuma8(i) => {
-                    width = i.width();
-                    height = i.height();
-                    format = TextureFormat::R8Unorm;
-
-                    data = i.into_raw();
-                }
-                image::DynamicImage::ImageLumaA8(i) => {
-                    width = i.width();
-                    height = i.height();
-                    format = TextureFormat::Rg8Unorm;
-
-                    data = i.into_raw();
-                }
-                image::DynamicImage::ImageRgb8(i) => {
-                    let i = image::DynamicImage::ImageRgb8(i).into_rgba8();
-                    width = i.width();
-                    height = i.height();
-                    format = TextureFormat::Rgba8UnormSrgb;
-
-                    data = i.into_raw();
-                }
-                image::DynamicImage::ImageRgba8(i) => {
-                    width = i.width();
-                    height = i.height();
-                    format = TextureFormat::Rgba8UnormSrgb;
-
-                    data = i.into_raw();
-                }
-                image::DynamicImage::ImageBgr8(i) => {
-                    let i = image::DynamicImage::ImageBgr8(i).into_bgra8();
-
-                    width = i.width();
-                    height = i.height();
-                    format = TextureFormat::Bgra8UnormSrgb;
-
-                    data = i.into_raw();
-                }
-                image::DynamicImage::ImageBgra8(i) => {
-                    width = i.width();
-                    height = i.height();
-                    format = TextureFormat::Bgra8UnormSrgb;
-
-                    data = i.into_raw();
-                }
-                image::DynamicImage::ImageLuma16(i) => {
-                    width = i.width();
-                    height = i.height();
-                    format = TextureFormat::R16Uint;
-
-                    let raw_data = i.into_raw();
-
-                    data = raw_data.as_slice().as_bytes().to_owned();
-                }
-                image::DynamicImage::ImageLumaA16(i) => {
-                    width = i.width();
-                    height = i.height();
-                    format = TextureFormat::Rg16Uint;
-
-                    let raw_data = i.into_raw();
-
-                    data = raw_data.as_slice().as_bytes().to_owned();
-                }
-
-                image::DynamicImage::ImageRgb16(image) => {
-                    width = image.width();
-                    height = image.height();
-                    format = TextureFormat::Rgba16Uint;
-
-                    let mut local_data =
-                        Vec::with_capacity(width as usize * height as usize * format.pixel_size());
-
-                    for pixel in image.into_raw().chunks_exact(3) {
-                        // TODO unsafe_get in release builds?
-                        let r = pixel[0];
-                        let g = pixel[1];
-                        let b = pixel[2];
-                        let a = u16::max_value();
-
-                        local_data.extend_from_slice(&r.to_ne_bytes());
-                        local_data.extend_from_slice(&g.to_ne_bytes());
-                        local_data.extend_from_slice(&b.to_ne_bytes());
-                        local_data.extend_from_slice(&a.to_ne_bytes());
-                    }
-
-                    data = local_data;
-                }
-                image::DynamicImage::ImageRgba16(i) => {
-                    width = i.width();
-                    height = i.height();
-                    format = TextureFormat::Rgba16Uint;
-
-                    let raw_data = i.into_raw();
-
-                    data = raw_data.as_slice().as_bytes().to_owned();
-                }
-            }
-
-            let texture = Texture::new(
-                Extent3d::new(width, height, 1),
-                TextureDimension::D2,
-                data,
-                format,
-            );
-            load_context.set_default_asset(LoadedAsset::new(texture));
+            load_context.set_default_asset(LoadedAsset::new(image_to_texture(dyn_img)));
             Ok(())
         })
     }
@@ -171,5 +58,154 @@ mod tests {
         for ext in FILE_EXTENSIONS {
             assert!(image::ImageFormat::from_extension(ext).is_some())
         }
+    }
+}
+
+/// Helper method to convert a `DynamicImage` to a `Texture`
+pub(crate) fn image_to_texture(dyn_img: image::DynamicImage) -> Texture {
+    use bevy_core::AsBytes;
+
+    let width;
+    let height;
+
+    let data: Vec<u8>;
+    let format: TextureFormat;
+
+    match dyn_img {
+        image::DynamicImage::ImageLuma8(i) => {
+            width = i.width();
+            height = i.height();
+            format = TextureFormat::R8Unorm;
+
+            data = i.into_raw();
+        }
+        image::DynamicImage::ImageLumaA8(i) => {
+            width = i.width();
+            height = i.height();
+            format = TextureFormat::Rg8Unorm;
+
+            data = i.into_raw();
+        }
+        image::DynamicImage::ImageRgb8(i) => {
+            let i = image::DynamicImage::ImageRgb8(i).into_rgba8();
+            width = i.width();
+            height = i.height();
+            format = TextureFormat::Rgba8UnormSrgb;
+
+            data = i.into_raw();
+        }
+        image::DynamicImage::ImageRgba8(i) => {
+            width = i.width();
+            height = i.height();
+            format = TextureFormat::Rgba8UnormSrgb;
+
+            data = i.into_raw();
+        }
+        image::DynamicImage::ImageBgr8(i) => {
+            let i = image::DynamicImage::ImageBgr8(i).into_bgra8();
+
+            width = i.width();
+            height = i.height();
+            format = TextureFormat::Bgra8UnormSrgb;
+
+            data = i.into_raw();
+        }
+        image::DynamicImage::ImageBgra8(i) => {
+            width = i.width();
+            height = i.height();
+            format = TextureFormat::Bgra8UnormSrgb;
+
+            data = i.into_raw();
+        }
+        image::DynamicImage::ImageLuma16(i) => {
+            width = i.width();
+            height = i.height();
+            format = TextureFormat::R16Uint;
+
+            let raw_data = i.into_raw();
+
+            data = raw_data.as_slice().as_bytes().to_owned();
+        }
+        image::DynamicImage::ImageLumaA16(i) => {
+            width = i.width();
+            height = i.height();
+            format = TextureFormat::Rg16Uint;
+
+            let raw_data = i.into_raw();
+
+            data = raw_data.as_slice().as_bytes().to_owned();
+        }
+
+        image::DynamicImage::ImageRgb16(image) => {
+            width = image.width();
+            height = image.height();
+            format = TextureFormat::Rgba16Uint;
+
+            let mut local_data =
+                Vec::with_capacity(width as usize * height as usize * format.pixel_size());
+
+            for pixel in image.into_raw().chunks_exact(3) {
+                // TODO unsafe_get in release builds?
+                let r = pixel[0];
+                let g = pixel[1];
+                let b = pixel[2];
+                let a = u16::max_value();
+
+                local_data.extend_from_slice(&r.to_ne_bytes());
+                local_data.extend_from_slice(&g.to_ne_bytes());
+                local_data.extend_from_slice(&b.to_ne_bytes());
+                local_data.extend_from_slice(&a.to_ne_bytes());
+            }
+
+            data = local_data;
+        }
+        image::DynamicImage::ImageRgba16(i) => {
+            width = i.width();
+            height = i.height();
+            format = TextureFormat::Rgba16Uint;
+
+            let raw_data = i.into_raw();
+
+            data = raw_data.as_slice().as_bytes().to_owned();
+        }
+    }
+
+    Texture::new(
+        Extent3d::new(width, height, 1),
+        TextureDimension::D2,
+        data,
+        format,
+    )
+}
+
+/// Helper method to convert a `Texture` to a `DynamicImage`. Not all `Texture` formats are
+/// covered, it will return `None` if the format is not supported
+pub(crate) fn texture_to_image(texture: &Texture) -> Option<image::DynamicImage> {
+    match texture.format {
+        TextureFormat::R8Unorm => image::ImageBuffer::from_raw(
+            texture.size.width,
+            texture.size.height,
+            texture.data.clone(),
+        )
+        .map(|buffer| image::DynamicImage::ImageLuma8(buffer)),
+        TextureFormat::Rg8Unorm => image::ImageBuffer::from_raw(
+            texture.size.width,
+            texture.size.height,
+            texture.data.clone(),
+        )
+        .map(|buffer| image::DynamicImage::ImageLumaA8(buffer)),
+        TextureFormat::Rgba8UnormSrgb => image::ImageBuffer::from_raw(
+            texture.size.width,
+            texture.size.height,
+            texture.data.clone(),
+        )
+        .map(|buffer| image::DynamicImage::ImageRgba8(buffer)),
+        TextureFormat::Bgra8UnormSrgb => image::ImageBuffer::from_raw(
+            texture.size.width,
+            texture.size.height,
+            texture.data.clone(),
+        )
+        .map(|buffer| image::DynamicImage::ImageBgra8(buffer)),
+        _ => None,
     }
 }

--- a/crates/bevy_render/src/texture/texture.rs
+++ b/crates/bevy_render/src/texture/texture.rs
@@ -131,6 +131,13 @@ impl Texture {
     /// - `TextureFormat::Rg8Unorm`
     /// - `TextureFormat::Rgba8UnormSrgb`
     /// - `TextureFormat::Bgra8UnormSrgb`
+    #[cfg(any(
+        feature = "png",
+        feature = "dds",
+        feature = "tga",
+        feature = "jpeg",
+        feature = "bmp"
+    ))]
     pub fn convert(&self, new_format: TextureFormat) -> Option<Self> {
         super::texture_to_image(self)
             .and_then(|img| match new_format {

--- a/crates/bevy_render/src/texture/texture.rs
+++ b/crates/bevy_render/src/texture/texture.rs
@@ -125,6 +125,30 @@ impl Texture {
         });
     }
 
+    /// Convert a texture from a format to another
+    /// Only a few formats are supported as input and output:
+    /// - `TextureFormat::R8Unorm`
+    /// - `TextureFormat::Rg8Unorm`
+    /// - `TextureFormat::Rgba8UnormSrgb`
+    /// - `TextureFormat::Bgra8UnormSrgb`
+    pub fn convert(&self, new_format: TextureFormat) -> Option<Self> {
+        super::texture_to_image(self)
+            .and_then(|img| match new_format {
+                TextureFormat::R8Unorm => Some(image::DynamicImage::ImageLuma8(img.into_luma8())),
+                TextureFormat::Rg8Unorm => {
+                    Some(image::DynamicImage::ImageLumaA8(img.into_luma_alpha8()))
+                }
+                TextureFormat::Rgba8UnormSrgb => {
+                    Some(image::DynamicImage::ImageRgba8(img.into_rgba8()))
+                }
+                TextureFormat::Bgra8UnormSrgb => {
+                    Some(image::DynamicImage::ImageBgra8(img.into_bgra8()))
+                }
+                _ => None,
+            })
+            .map(|img| super::image_to_texture(img))
+    }
+
     pub fn texture_resource_system(
         render_resource_context: Res<Box<dyn RenderResourceContext>>,
         textures: Res<Assets<Texture>>,

--- a/crates/bevy_render/src/texture/texture.rs
+++ b/crates/bevy_render/src/texture/texture.rs
@@ -146,7 +146,7 @@ impl Texture {
                 }
                 _ => None,
             })
-            .map(|img| super::image_to_texture(img))
+            .map(super::image_to_texture)
     }
 
     pub fn texture_resource_system(

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -18,6 +18,7 @@ bevy_app = { path = "../bevy_app", version = "0.4.0" }
 bevy_asset = { path = "../bevy_asset", version = "0.4.0" }
 bevy_core = { path = "../bevy_core", version = "0.4.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.4.0" }
+bevy_log = { path = "../bevy_log", version = "0.4.0" }
 bevy_math = { path = "../bevy_math", version = "0.4.0" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.4.0", features = ["bevy"] }
 bevy_render = { path = "../bevy_render", version = "0.4.0" }

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -68,7 +68,7 @@ impl TextureAtlasBuilder {
         self
     }
 
-    /// Control wether the added texture should be converted to the atlas format, if different.
+    /// Control whether the added texture should be converted to the atlas format, if different.
     pub fn auto_format_conversion(mut self, auto_format_conversion: bool) -> Self {
         self.auto_format_conversion = auto_format_conversion;
         self

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -105,26 +105,24 @@ impl TextureAtlasBuilder {
                 atlas_texture.data[begin..end]
                     .copy_from_slice(&texture.data[texture_begin..texture_end]);
             }
-        } else {
-            if let Some(converted_texture) = texture.convert(self.format) {
-                debug!(
-                    "Converting texture from '{:?}' to '{:?}'",
-                    texture.format, self.format
-                );
-                for (texture_y, bound_y) in (rect_y..rect_y + rect_height).enumerate() {
-                    let begin = (bound_y * atlas_width + rect_x) * format_size;
-                    let end = begin + rect_width * format_size;
-                    let texture_begin = texture_y * rect_width * format_size;
-                    let texture_end = texture_begin + rect_width * format_size;
-                    atlas_texture.data[begin..end]
-                        .copy_from_slice(&converted_texture.data[texture_begin..texture_end]);
-                }
-            } else {
-                error!(
-                    "Error converting texture from '{:?}' to '{:?}', ignoring",
-                    texture.format, self.format
-                );
+        } else if let Some(converted_texture) = texture.convert(self.format) {
+            debug!(
+                "Converting texture from '{:?}' to '{:?}'",
+                texture.format, self.format
+            );
+            for (texture_y, bound_y) in (rect_y..rect_y + rect_height).enumerate() {
+                let begin = (bound_y * atlas_width + rect_x) * format_size;
+                let end = begin + rect_width * format_size;
+                let texture_begin = texture_y * rect_width * format_size;
+                let texture_end = texture_begin + rect_width * format_size;
+                atlas_texture.data[begin..end]
+                    .copy_from_slice(&converted_texture.data[texture_begin..texture_end]);
             }
+        } else {
+            error!(
+                "Error converting texture from '{:?}' to '{:?}', ignoring",
+                texture.format, self.format
+            );
         }
     }
 


### PR DESCRIPTION
fixes #553 

* adds a method to set the texture atlas format
* automatic conversion into target format if needed. This can be disabled, in which case finishing the builder will return an error if there are different texture formats