### PR TITLE
Replaced BoxedSystem param with SystemRefMut

### DIFF
--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -107,9 +107,15 @@ impl SystemStage {
     }
 
     pub fn run_once(&mut self, world: &mut World, resources: &mut Resources) {
+
+        let mut system_refs = Vec::with_capacity(self.systems.len());
+        for system in self.systems.iter_mut() {
+            system_refs.push(system.as_mut());
+        }
+
         let unexecuted_systems = std::mem::take(&mut self.unexecuted_systems);
         self.executor
-            .execute_stage(&mut self.systems, &unexecuted_systems, world, resources);
+            .execute_stage(&mut system_refs, &unexecuted_systems, world, resources);
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -107,7 +107,6 @@ impl SystemStage {
     }
 
     pub fn run_once(&mut self, world: &mut World, resources: &mut Resources) {
-
         let mut system_refs = Vec::with_capacity(self.systems.len());
         for system in self.systems.iter_mut() {
             system_refs.push(system.as_mut());

--- a/crates/bevy_ecs/src/schedule/stage_executor.rs
+++ b/crates/bevy_ecs/src/schedule/stage_executor.rs
@@ -6,7 +6,7 @@ use downcast_rs::{impl_downcast, Downcast};
 use fixedbitset::FixedBitSet;
 
 use crate::{
-    ArchetypesGeneration, SystemRefMut, Resources, ThreadLocalExecution, TypeAccess, World,
+    ArchetypesGeneration, Resources, SystemRefMut, ThreadLocalExecution, TypeAccess, World,
 };
 
 pub trait SystemStageExecutor: Downcast + Send + Sync {

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -52,3 +52,5 @@ pub trait System: Send + Sync + 'static {
 }
 
 pub type BoxedSystem<In = (), Out = ()> = Box<dyn System<In = In, Out = Out>>;
+pub type SystemRef<'a, In = (), Out = ()> = &'a dyn System<In = In, Out = Out>;
+pub type SystemRefMut<'a, In = (), Out = ()> = &'a mut dyn System<In = In, Out = Out>;


### PR DESCRIPTION
Removes the requirement that systems must be boxed when calling `SystemStageExecutor::execute_stage(..)`.
This gives greater flexibility to Stages on how they wish to store their systems as they can now dynamically create a slice of `SystemRefMut` instead of being forced to store a `Vec<BoxedSystem>` or moving the system into a slice before calling `SystemStageExecutor::execute_stage(..)`. This change also means that stages can now dynamically choose which systems to run by storing a bank of systems and composing a slice of references they wish to pass to the executor. 