### PR TITLE
add rebase action

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,21 @@
+name: Automatic Rebase
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  rebase:
+    name: Rebase
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.TOKEN }}
+          persist-credentials: false
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+      - name: Automatic Rebase
+        # this specific hash was hand-validated by @cart. please validate new action code before updating
+        uses: cirrus-actions/rebase@b08442cca46e2ad6c1f3dd24a3320ece8498df75
+        env:
+          GITHUB_TOKEN: ${{ secrets.CART_PAT }}


### PR DESCRIPTION
Bevy organization members can now comment with `/rebase` to start a rebase of a pr 