### PR TITLE
Adding push constants support

### DIFF
--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -42,7 +42,7 @@ pub enum RenderCommand {
     SetPushConstants {
         stages: BindingShaderStage,
         offset: u32,
-        data: Arc<[u8]>,
+        data: Vec<u8>,
     },
     DrawIndexed {
         indices: Range<u32>,
@@ -115,7 +115,7 @@ impl Draw {
         });
     }
 
-    pub fn set_push_constants(&mut self, stages: BindingShaderStage, offset: u32, data: Arc<[u8]>) {
+    pub fn set_push_constants(&mut self, stages: BindingShaderStage, offset: u32, data: Vec<u8>) {
         self.render_command(RenderCommand::SetPushConstants {
             stages,
             offset,

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -1,6 +1,7 @@
 use crate::{
     pipeline::{
-        IndexFormat, PipelineCompiler, PipelineDescriptor, PipelineLayout, PipelineSpecialization,
+        BindingShaderStage, IndexFormat, PipelineCompiler, PipelineDescriptor, PipelineLayout,
+        PipelineSpecialization,
     },
     renderer::{
         AssetRenderResourceBindings, BindGroup, BindGroupId, BufferId, RenderResource,
@@ -16,7 +17,6 @@ use bevy_ecs::{
 use bevy_reflect::Reflect;
 use std::{ops::Range, sync::Arc};
 use thiserror::Error;
-use crate::pipeline::BindingShaderStage;
 
 /// A queued command for the renderer
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -42,7 +42,7 @@ pub enum RenderCommand {
     SetPushConstants {
         stages: BindingShaderStage,
         offset: u32,
-        data: Arc<[u8]>
+        data: Arc<[u8]>,
     },
     DrawIndexed {
         indices: Range<u32>,

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -16,6 +16,7 @@ use bevy_ecs::{
 use bevy_reflect::Reflect;
 use std::{ops::Range, sync::Arc};
 use thiserror::Error;
+use crate::pipeline::BindingShaderStage;
 
 /// A queued command for the renderer
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -37,6 +38,11 @@ pub enum RenderCommand {
         index: u32,
         bind_group: BindGroupId,
         dynamic_uniform_indices: Option<Arc<[u32]>>,
+    },
+    SetPushConstants {
+        stages: BindingShaderStage,
+        offset: u32,
+        data: Arc<[u8]>
     },
     DrawIndexed {
         indices: Range<u32>,
@@ -106,6 +112,14 @@ impl Draw {
             buffer,
             offset,
             index_format,
+        });
+    }
+
+    pub fn set_push_constants(&mut self, stages: BindingShaderStage, offset: u32, data: Arc<[u8]>) {
+        self.render_command(RenderCommand::SetPushConstants {
+            stages,
+            offset,
+            data,
         });
     }
 

--- a/crates/bevy_render/src/pass/render_pass.rs
+++ b/crates/bevy_render/src/pass/render_pass.rs
@@ -1,10 +1,9 @@
 use crate::{
-    pipeline::{BindGroupDescriptorId, IndexFormat, PipelineDescriptor},
+    pipeline::{BindGroupDescriptorId, BindingShaderStage, IndexFormat, PipelineDescriptor},
     renderer::{BindGroupId, BufferId, RenderContext},
 };
 use bevy_asset::Handle;
 use std::ops::Range;
-use crate::pipeline::BindingShaderStage;
 
 pub trait RenderPass {
     fn get_render_context(&self) -> &dyn RenderContext;

--- a/crates/bevy_render/src/pass/render_pass.rs
+++ b/crates/bevy_render/src/pass/render_pass.rs
@@ -4,11 +4,13 @@ use crate::{
 };
 use bevy_asset::Handle;
 use std::ops::Range;
+use crate::pipeline::BindingShaderStage;
 
 pub trait RenderPass {
     fn get_render_context(&self) -> &dyn RenderContext;
     fn set_index_buffer(&mut self, buffer: BufferId, offset: u64, index_format: IndexFormat);
     fn set_vertex_buffer(&mut self, start_slot: u32, buffer: BufferId, offset: u64);
+    fn set_push_constants(&mut self, stages: BindingShaderStage, offset: u32, data: &[u8]);
     fn set_pipeline(&mut self, pipeline_handle: &Handle<PipelineDescriptor>);
     fn set_viewport(&mut self, x: f32, y: f32, w: f32, h: f32, min_depth: f32, max_depth: f32);
     fn set_scissor_rect(&mut self, x: u32, y: u32, w: u32, h: u32);

--- a/crates/bevy_render/src/pipeline/pipeline_layout.rs
+++ b/crates/bevy_render/src/pipeline/pipeline_layout.rs
@@ -1,12 +1,13 @@
 use super::{BindGroupDescriptor, VertexBufferLayout};
-use crate::shader::ShaderLayout;
+use crate::{pipeline::BindingShaderStage, shader::ShaderLayout};
 use bevy_utils::HashMap;
-use std::hash::Hash;
+use std::{hash::Hash, ops::Range};
 
 #[derive(Clone, Debug, Default)]
 pub struct PipelineLayout {
     pub bind_groups: Vec<BindGroupDescriptor>,
     pub vertex_buffer_descriptors: Vec<VertexBufferLayout>,
+    pub push_constant_ranges: Vec<PushConstantRange>,
 }
 
 impl PipelineLayout {
@@ -65,6 +66,8 @@ impl PipelineLayout {
         PipelineLayout {
             bind_groups: bind_groups_result,
             vertex_buffer_descriptors,
+            // TODO: get push constant ranges from shader layout
+            push_constant_ranges: vec![],
         }
     }
 }
@@ -102,4 +105,14 @@ impl UniformProperty {
             UniformProperty::Array(property, length) => property.get_size() * *length as u64,
         }
     }
+}
+
+#[derive(Hash, Clone, Debug)]
+pub struct PushConstantRange {
+    /// Stage push constant range is visible from. Each stage can only be served by at most one range.
+    /// One range can serve multiple stages however.
+    pub stages: BindingShaderStage,
+    /// Range in push constant memory to use for the stage. Must be less than [`Limits::max_push_constant_size`].
+    /// Start and end must be aligned to the 4s.
+    pub range: Range<u32>,
 }

--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -338,6 +338,13 @@ where
                                     );
                                     draw_state.set_bind_group(*index, *bind_group);
                                 }
+                                RenderCommand::SetPushConstants {
+                                    stages,
+                                    offset,
+                                    data,
+                                } => {
+                                    render_pass.set_push_constants(*stages, *offset, data);
+                                }
                             }
                         }
                     }

--- a/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
+++ b/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs
@@ -444,13 +444,18 @@ impl RenderResourceContext for WgpuRenderResourceContext {
             .iter()
             .map(|bind_group| bind_group_layouts.get(&bind_group.id).unwrap())
             .collect::<Vec<&wgpu::BindGroupLayout>>();
+        let push_constant_ranges: Vec<wgpu::PushConstantRange> = layout
+            .push_constant_ranges
+            .iter()
+            .map(|range| range.clone().wgpu_into())
+            .collect();
 
         let pipeline_layout = self
             .device
             .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: None,
                 bind_group_layouts: bind_group_layouts.as_slice(),
-                push_constant_ranges: &[],
+                push_constant_ranges: &push_constant_ranges,
             });
 
         let owned_vertex_buffer_descriptors = layout

--- a/crates/bevy_wgpu/src/wgpu_render_pass.rs
+++ b/crates/bevy_wgpu/src/wgpu_render_pass.rs
@@ -2,12 +2,11 @@ use crate::{renderer::WgpuRenderContext, wgpu_type_converter::WgpuInto, WgpuReso
 use bevy_asset::Handle;
 use bevy_render::{
     pass::RenderPass,
-    pipeline::{BindGroupDescriptorId, IndexFormat, PipelineDescriptor},
+    pipeline::{BindGroupDescriptorId, BindingShaderStage, IndexFormat, PipelineDescriptor},
     renderer::{BindGroupId, BufferId, RenderContext},
 };
 use bevy_utils::tracing::trace;
 use std::ops::Range;
-use bevy_render::pipeline::BindingShaderStage;
 
 #[derive(Debug)]
 pub struct WgpuRenderPass<'a> {

--- a/crates/bevy_wgpu/src/wgpu_render_pass.rs
+++ b/crates/bevy_wgpu/src/wgpu_render_pass.rs
@@ -7,6 +7,7 @@ use bevy_render::{
 };
 use bevy_utils::tracing::trace;
 use std::ops::Range;
+use bevy_render::pipeline::BindingShaderStage;
 
 #[derive(Debug)]
 pub struct WgpuRenderPass<'a> {
@@ -44,6 +45,11 @@ impl<'a> RenderPass for WgpuRenderPass<'a> {
         let buffer = self.wgpu_resources.buffers.get(&buffer_id).unwrap();
         self.render_pass
             .set_index_buffer(buffer.slice(offset..), index_format.wgpu_into());
+    }
+
+    fn set_push_constants(&mut self, stages: BindingShaderStage, offset: u32, data: &[u8]) {
+        self.render_pass
+            .set_push_constants(stages.wgpu_into(), offset, data);
     }
 
     fn draw_indexed(&mut self, indices: Range<u32>, base_vertex: i32, instances: Range<u32>) {

--- a/crates/bevy_wgpu/src/wgpu_type_converter.rs
+++ b/crates/bevy_wgpu/src/wgpu_type_converter.rs
@@ -3,11 +3,11 @@ use bevy_render::{
     color::Color,
     pass::{LoadOp, Operations},
     pipeline::{
-        BindType, BlendFactor, BlendOperation, BlendState, ColorTargetState, ColorWrite,
-        CompareFunction, CullMode, DepthBiasState, DepthStencilState, FrontFace, IndexFormat,
-        InputStepMode, MultisampleState, PolygonMode, PrimitiveState, PrimitiveTopology,
-        StencilFaceState, StencilOperation, StencilState, VertexAttribute, VertexBufferLayout,
-        VertexFormat,
+        BindType, BindingShaderStage, BlendFactor, BlendOperation, BlendState, ColorTargetState,
+        ColorWrite, CompareFunction, CullMode, DepthBiasState, DepthStencilState, FrontFace,
+        IndexFormat, InputStepMode, MultisampleState, PolygonMode, PrimitiveState,
+        PrimitiveTopology, PushConstantRange, StencilFaceState, StencilOperation, StencilState,
+        VertexAttribute, VertexBufferLayout, VertexFormat,
     },
     renderer::BufferUsage,
     texture::{
@@ -18,7 +18,6 @@ use bevy_render::{
 };
 use bevy_window::Window;
 use wgpu::BufferBindingType;
-use bevy_render::pipeline::BindingShaderStage;
 
 pub trait WgpuFrom<T> {
     fn from(val: T) -> Self;
@@ -244,6 +243,15 @@ impl WgpuFrom<BindingShaderStage> for wgpu::ShaderStage {
             wgpu_val.insert(wgpu::ShaderStage::COMPUTE);
         }
         wgpu_val
+    }
+}
+
+impl WgpuFrom<PushConstantRange> for wgpu::PushConstantRange {
+    fn from(val: PushConstantRange) -> Self {
+        wgpu::PushConstantRange {
+            stages: val.stages.wgpu_into(),
+            range: val.range,
+        }
     }
 }
 

--- a/crates/bevy_wgpu/src/wgpu_type_converter.rs
+++ b/crates/bevy_wgpu/src/wgpu_type_converter.rs
@@ -18,6 +18,7 @@ use bevy_render::{
 };
 use bevy_window::Window;
 use wgpu::BufferBindingType;
+use bevy_render::pipeline::BindingShaderStage;
 
 pub trait WgpuFrom<T> {
     fn from(val: T) -> Self;
@@ -227,6 +228,22 @@ impl WgpuFrom<&BindType> for wgpu::BindingType {
                 format: (*format).wgpu_into(),
             },
         }
+    }
+}
+
+impl WgpuFrom<BindingShaderStage> for wgpu::ShaderStage {
+    fn from(val: BindingShaderStage) -> Self {
+        let mut wgpu_val = wgpu::ShaderStage::NONE;
+        if val.contains(BindingShaderStage::VERTEX) {
+            wgpu_val.insert(wgpu::ShaderStage::VERTEX);
+        }
+        if val.contains(BindingShaderStage::FRAGMENT) {
+            wgpu_val.insert(wgpu::ShaderStage::FRAGMENT);
+        }
+        if val.contains(BindingShaderStage::COMPUTE) {
+            wgpu_val.insert(wgpu::ShaderStage::COMPUTE);
+        }
+        wgpu_val
     }
 }
 


### PR DESCRIPTION
This PR adds Push Constants support to the bevy rendering engine. This exposes the wgpu push constants API to the user.

However, we might want to coordinate with #547. Push Constants requires enabling the push constant feature and setting an appropriate resource limit. Therefore we might need to wait for #547, or maybe get this merged without enabling the push constants feature by default.