### PR TITLE
Remove field from QueryAccess::With and QueryAccess::Without

### DIFF
--- a/crates/bevy_ecs/src/core/filter.rs
+++ b/crates/bevy_ecs/src/core/filter.rs
@@ -130,7 +130,7 @@ impl<T: Component> QueryFilter for Without<T> {
     type EntityFilter = AnyEntityFilter;
 
     fn access() -> QueryAccess {
-        QueryAccess::without::<T>(QueryAccess::None)
+        QueryAccess::without::<T>()
     }
 
     #[inline]
@@ -149,7 +149,7 @@ impl<T: Component> QueryFilter for With<T> {
     type EntityFilter = AnyEntityFilter;
 
     fn access() -> QueryAccess {
-        QueryAccess::with::<T>(QueryAccess::None)
+        QueryAccess::with::<T>()
     }
 
     #[inline]
@@ -171,7 +171,7 @@ impl<T: Bundle> QueryFilter for WithType<T> {
         QueryAccess::union(
             T::static_type_info()
                 .iter()
-                .map(|info| QueryAccess::With(info.id(), Box::new(QueryAccess::None)))
+                .map(|info| QueryAccess::With(info.id()))
                 .collect::<Vec<QueryAccess>>(),
         )
     }


### PR DESCRIPTION
I noticed the `QueryAccess::With` and `QueryAccess::Without` variants are only ever created with `QueryAccess::None` in their second field (except tests). Also `QueryAccess::With(type_id, query_access)` is equivalent to
```rust
QueryAccess::Union(vec![QueryAccess::With(type_id, QueryAccess::None), query_access])
```
so there should never be a case where this field is strictly neccessary.

Removing this field means one less allocation each time one of the variants is constructed. Hope I didn't miss anything.