### PR TITLE
Allow reconfiguring a Plugin inside a PluginGroup

### DIFF
--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -78,6 +78,18 @@ impl PluginGroupBuilder {
         self
     }
 
+    pub fn reconfigure<T: Plugin>(&mut self, plugin: T) -> &mut Self {
+        self.plugins.remove(&TypeId::of::<T>());
+        self.plugins.insert(
+            TypeId::of::<T>(),
+            PluginEntry {
+                plugin: Box::new(plugin),
+                enabled: true,
+            },
+        );
+        self
+    }
+
     pub fn enable<T: Plugin>(&mut self) -> &mut Self {
         let mut plugin_entry = self
             .plugins

--- a/examples/app/plugin_group.rs
+++ b/examples/app/plugin_group.rs
@@ -13,6 +13,14 @@ fn main() {
         //         .disable::<PrintWorldPlugin>()
         //         .add_before::<PrintHelloPlugin, _>(bevy::diagnostic::LogDiagnosticsPlugin::default())
         // })
+        // Modifications can also include replacing the default configuration of a specific plugin:
+        // .add_plugins_with(DefaultPlugins, |group| {
+        //     group
+        //         .reconfigure(bevy::window::WindowPlugin {
+        //             exit_on_close: false,
+        //             ..Default::default()
+        //         })
+        // })
         .run();
 }
 


### PR DESCRIPTION
This is a simple change that allows one to reconfigure a plugin inside a PluginGroup. I'm not sure if this is to be allowed or not, but it allows plugin crates to provide their own specialized version of the DefaultPlugins.

A good use case would be if a Plugin requires some change to the BaseRenderGraphConfig, but would otherwise play nice with the rest of the DefaultPlugins.

To illustrate how this would work, right now we could disable exit_on_close like this:

```
fn main() {
    App::build()
        .add_plugins_with(DefaultPlugins |group| {
            group.disable::<bevy::window::WindowPlugin>()
        })
        .add_plugin(bevy::window::WindowPlugin {
            add_primary_window: true,
            exit_on_close: false
        })
        .run();
}
```

Now lets imagine a crate that needs such change to work. Such crate would either have to create (and maintain) their own full version of the DefaultPlugins, or force the user to always include the above boilerplate.

With this PR the crate would provide this:
```
pub struct DefaultFooPlugins;

impl PluginGroup for DefaultFooPlugins {
    fn build(&mut self, group: &mut PluginGroupBuilder) {
        let mut default_plugins = DefaultPlugins {};
        default_plugins.build(group);
        group.reconfigure(bevy::window::WindowPlugin {
            add_primary_window: true,
            exit_on_close: false
        });
        group.add(FooPlugin);
    }
}
```
and the user would just have to do this:
```
fn main() {
    App::build()
        // .add_plugins(DefaultPlugins)
        .add_plugins(DefaultFooPlugins)
        .run();
}
```

The 