### PR TITLE
[Merged by Bors] - Add FromReflect trait to convert dynamic types to concrete types

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -10,14 +10,25 @@ use crate::{
     Asset, Assets,
 };
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
-use bevy_reflect::{Reflect, ReflectDeserialize};
+use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize};
 use bevy_utils::Uuid;
 use crossbeam_channel::{Receiver, Sender};
 use serde::{Deserialize, Serialize};
 
 /// A unique, stable asset id
 #[derive(
-    Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize, Reflect,
+    Debug,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    Hash,
+    Ord,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    Reflect,
+    FromReflect,
 )]
 #[reflect_value(Serialize, Deserialize, PartialEq, Hash)]
 pub enum HandleId {
@@ -58,7 +69,7 @@ impl HandleId {
 ///
 /// Handles contain a unique id that corresponds to a specific asset in the [Assets](crate::Assets)
 /// collection.
-#[derive(Component, Reflect)]
+#[derive(Component, Reflect, FromReflect)]
 #[reflect(Component)]
 pub struct Handle<T>
 where
@@ -75,6 +86,13 @@ where
 enum HandleType {
     Weak,
     Strong(Sender<RefChange>),
+}
+
+// FIXME: This only is needed because `Handle`'s field `handle_type` is currently ignored for reflection
+impl Default for HandleType {
+    fn default() -> Self {
+        Self::Weak
+    }
 }
 
 impl Debug for HandleType {

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -6,7 +6,9 @@ use crate::{
     entity::{Entity, EntityMap, MapEntities, MapEntitiesError},
     world::{FromWorld, World},
 };
-use bevy_reflect::{impl_reflect_value, FromType, Reflect, ReflectDeserialize};
+use bevy_reflect::{
+    impl_from_reflect_value, impl_reflect_value, FromType, Reflect, ReflectDeserialize,
+};
 
 #[derive(Clone)]
 pub struct ReflectComponent {
@@ -121,6 +123,7 @@ impl<C: Component + Reflect + FromWorld> FromType<C> for ReflectComponent {
 }
 
 impl_reflect_value!(Entity(Hash, PartialEq, Serialize, Deserialize));
+impl_from_reflect_value!(Entity);
 
 #[derive(Clone)]
 pub struct ReflectMapEntities {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
@@ -1,0 +1,151 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Field, Generics, Ident, Index, Member, Path};
+
+pub fn impl_struct(
+    struct_name: &Ident,
+    generics: &Generics,
+    bevy_reflect_path: &Path,
+    active_fields: &[(&Field, usize)],
+    ignored_fields: &[(&Field, usize)],
+) -> TokenStream {
+    let field_names = active_fields
+        .iter()
+        .map(|(field, index)| {
+            field
+                .ident
+                .as_ref()
+                .map(|i| i.to_string())
+                .unwrap_or_else(|| index.to_string())
+        })
+        .collect::<Vec<String>>();
+    let field_idents = active_fields
+        .iter()
+        .map(|(field, index)| {
+            field
+                .ident
+                .as_ref()
+                .map(|ident| Member::Named(ident.clone()))
+                .unwrap_or_else(|| Member::Unnamed(Index::from(*index)))
+        })
+        .collect::<Vec<_>>();
+
+    let field_types = active_fields
+        .iter()
+        .map(|(field, _index)| field.ty.clone())
+        .collect::<Vec<_>>();
+    let field_count = active_fields.len();
+    let ignored_field_idents = ignored_fields
+        .iter()
+        .map(|(field, index)| {
+            field
+                .ident
+                .as_ref()
+                .map(|ident| Member::Named(ident.clone()))
+                .unwrap_or_else(|| Member::Unnamed(Index::from(*index)))
+        })
+        .collect::<Vec<_>>();
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    // Add FromReflect bound for each active field
+    let mut where_from_reflect_clause = if where_clause.is_some() {
+        quote! {#where_clause}
+    } else if field_count > 0 {
+        quote! {where}
+    } else {
+        quote! {}
+    };
+    where_from_reflect_clause.extend(quote! {
+        #(#field_types: #bevy_reflect_path::FromReflect,)*
+    });
+
+    TokenStream::from(quote! {
+        impl #impl_generics #bevy_reflect_path::FromReflect for #struct_name #ty_generics #where_from_reflect_clause
+        {
+            fn from_reflect(reflect: &dyn #bevy_reflect_path::Reflect) -> Option<Self> {
+                use #bevy_reflect_path::Struct;
+                if let #bevy_reflect_path::ReflectRef::Struct(ref_struct) = reflect.reflect_ref() {
+                    Some(
+                        Self{
+                            #(#field_idents: {
+                                <#field_types as #bevy_reflect_path::FromReflect>::from_reflect(ref_struct.field(#field_names)?)?
+                            },)*
+                            #(#ignored_field_idents: Default::default(),)*
+                        }
+                    )
+                } else {
+                    None
+                }
+            }
+        }
+    })
+}
+
+pub fn impl_tuple_struct(
+    struct_name: &Ident,
+    generics: &Generics,
+    bevy_reflect_path: &Path,
+    active_fields: &[(&Field, usize)],
+    ignored_fields: &[(&Field, usize)],
+) -> TokenStream {
+    let field_idents = active_fields
+        .iter()
+        .map(|(_field, index)| Member::Unnamed(Index::from(*index)))
+        .collect::<Vec<_>>();
+    let field_types = active_fields
+        .iter()
+        .map(|(field, _index)| field.ty.clone())
+        .collect::<Vec<_>>();
+    let field_count = active_fields.len();
+    let field_indices = (0..field_count).collect::<Vec<usize>>();
+    let ignored_field_idents = ignored_fields
+        .iter()
+        .map(|(_field, index)| Member::Unnamed(Index::from(*index)))
+        .collect::<Vec<_>>();
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    // Add FromReflect bound for each active field
+    let mut where_from_reflect_clause = if where_clause.is_some() {
+        quote! {#where_clause}
+    } else if field_count > 0 {
+        quote! {where}
+    } else {
+        quote! {}
+    };
+    where_from_reflect_clause.extend(quote! {
+        #(#field_types: #bevy_reflect_path::FromReflect,)*
+    });
+
+    TokenStream::from(quote! {
+        impl #impl_generics #bevy_reflect_path::FromReflect for #struct_name #ty_generics #where_from_reflect_clause
+        {
+            fn from_reflect(reflect: &dyn #bevy_reflect_path::Reflect) -> Option<Self> {
+                use #bevy_reflect_path::TupleStruct;
+                if let #bevy_reflect_path::ReflectRef::TupleStruct(ref_tuple_struct) = reflect.reflect_ref() {
+                    Some(
+                        Self{
+                            #(#field_idents:
+                                <#field_types as #bevy_reflect_path::FromReflect>::from_reflect(ref_tuple_struct.field(#field_indices)?)?
+                            ,)*
+                            #(#ignored_field_idents: Default::default(),)*
+                        }
+                    )
+                } else {
+                    None
+                }
+            }
+        }
+    })
+}
+
+pub fn impl_value(type_name: &Ident, generics: &Generics, bevy_reflect_path: &Path) -> TokenStream {
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    TokenStream::from(quote! {
+        impl #impl_generics #bevy_reflect_path::FromReflect for #type_name #ty_generics #where_clause  {
+            fn from_reflect(reflect: &dyn #bevy_reflect_path::Reflect) -> Option<Self> {
+                Some(reflect.any().downcast_ref::<#type_name #ty_generics>()?.clone())
+            }
+        }
+    })
+}

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -822,8 +822,7 @@ pub fn derive_from_reflect(input: TokenStream) -> TokenStream {
         };
 
         if let Some(ident) = meta_list.path.get_ident() {
-            if ident == REFLECT_ATTRIBUTE_NAME {
-            } else if ident == REFLECT_VALUE_ATTRIBUTE_NAME {
+            if ident == REFLECT_VALUE_ATTRIBUTE_NAME {
                 derive_type = DeriveType::Value;
             }
         }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate proc_macro;
 
+mod from_reflect;
 mod reflect_trait;
 mod type_uuid;
 
@@ -739,4 +740,119 @@ pub fn external_type_uuid(tokens: proc_macro::TokenStream) -> proc_macro::TokenS
 #[proc_macro_attribute]
 pub fn reflect_trait(args: TokenStream, input: TokenStream) -> TokenStream {
     reflect_trait::reflect_trait(args, input)
+}
+
+#[proc_macro_derive(FromReflect)]
+pub fn derive_from_reflect(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let unit_struct_punctuated = Punctuated::new();
+    let (fields, mut derive_type) = match &ast.data {
+        Data::Struct(DataStruct {
+            fields: Fields::Named(fields),
+            ..
+        }) => (&fields.named, DeriveType::Struct),
+        Data::Struct(DataStruct {
+            fields: Fields::Unnamed(fields),
+            ..
+        }) => (&fields.unnamed, DeriveType::TupleStruct),
+        Data::Struct(DataStruct {
+            fields: Fields::Unit,
+            ..
+        }) => (&unit_struct_punctuated, DeriveType::UnitStruct),
+        _ => (&unit_struct_punctuated, DeriveType::Value),
+    };
+
+    let fields_and_args = fields
+        .iter()
+        .enumerate()
+        .map(|(i, f)| {
+            (
+                f,
+                f.attrs
+                    .iter()
+                    .find(|a| *a.path.get_ident().as_ref().unwrap() == REFLECT_ATTRIBUTE_NAME)
+                    .map(|a| {
+                        syn::custom_keyword!(ignore);
+                        let mut attribute_args = PropAttributeArgs { ignore: None };
+                        a.parse_args_with(|input: ParseStream| {
+                            if input.parse::<Option<ignore>>()?.is_some() {
+                                attribute_args.ignore = Some(true);
+                                return Ok(());
+                            }
+                            Ok(())
+                        })
+                        .expect("Invalid 'property' attribute format.");
+
+                        attribute_args
+                    }),
+                i,
+            )
+        })
+        .collect::<Vec<(&Field, Option<PropAttributeArgs>, usize)>>();
+    let active_fields = fields_and_args
+        .iter()
+        .filter(|(_field, attrs, _i)| {
+            attrs.is_none()
+                || match attrs.as_ref().unwrap().ignore {
+                    Some(ignore) => !ignore,
+                    None => true,
+                }
+        })
+        .map(|(f, _attr, i)| (*f, *i))
+        .collect::<Vec<(&Field, usize)>>();
+    let ignored_fields = fields_and_args
+        .iter()
+        .filter(|(_field, attrs, _i)| {
+            attrs
+                .as_ref()
+                .map(|attrs| attrs.ignore.unwrap_or(false))
+                .unwrap_or(false)
+        })
+        .map(|(f, _attr, i)| (*f, *i))
+        .collect::<Vec<(&Field, usize)>>();
+
+    let bevy_reflect_path = BevyManifest::default().get_path("bevy_reflect");
+    let type_name = &ast.ident;
+
+    for attribute in ast.attrs.iter().filter_map(|attr| attr.parse_meta().ok()) {
+        let meta_list = if let Meta::List(meta_list) = attribute {
+            meta_list
+        } else {
+            continue;
+        };
+
+        if let Some(ident) = meta_list.path.get_ident() {
+            if ident == REFLECT_ATTRIBUTE_NAME {
+            } else if ident == REFLECT_VALUE_ATTRIBUTE_NAME {
+                derive_type = DeriveType::Value;
+            }
+        }
+    }
+
+    match derive_type {
+        DeriveType::Struct | DeriveType::UnitStruct => from_reflect::impl_struct(
+            type_name,
+            &ast.generics,
+            &bevy_reflect_path,
+            &active_fields,
+            &ignored_fields,
+        ),
+        DeriveType::TupleStruct => from_reflect::impl_tuple_struct(
+            type_name,
+            &ast.generics,
+            &bevy_reflect_path,
+            &active_fields,
+            &ignored_fields,
+        ),
+        DeriveType::Value => from_reflect::impl_value(type_name, &ast.generics, &bevy_reflect_path),
+    }
+}
+
+#[proc_macro]
+pub fn impl_from_reflect_value(input: TokenStream) -> TokenStream {
+    let reflect_value_def = parse_macro_input!(input as ReflectDef);
+
+    let bevy_reflect_path = BevyManifest::default().get_path("bevy_reflect");
+    let ty = &reflect_value_def.type_name;
+    from_reflect::impl_value(ty, &reflect_value_def.generics, &bevy_reflect_path)
 }

--- a/crates/bevy_reflect/src/impls/glam.rs
+++ b/crates/bevy_reflect/src/impls/glam.rs
@@ -1,6 +1,6 @@
 use crate as bevy_reflect;
 use crate::ReflectDeserialize;
-use bevy_reflect_derive::impl_reflect_value;
+use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_value};
 use glam::{IVec2, IVec3, IVec4, Mat3, Mat4, Quat, UVec2, UVec3, UVec4, Vec2, Vec3, Vec4};
 
 impl_reflect_value!(IVec2(PartialEq, Serialize, Deserialize));
@@ -15,3 +15,16 @@ impl_reflect_value!(Vec4(PartialEq, Serialize, Deserialize));
 impl_reflect_value!(Mat3(PartialEq, Serialize, Deserialize));
 impl_reflect_value!(Mat4(PartialEq, Serialize, Deserialize));
 impl_reflect_value!(Quat(PartialEq, Serialize, Deserialize));
+
+impl_from_reflect_value!(IVec2);
+impl_from_reflect_value!(IVec3);
+impl_from_reflect_value!(IVec4);
+impl_from_reflect_value!(UVec2);
+impl_from_reflect_value!(UVec3);
+impl_from_reflect_value!(UVec4);
+impl_from_reflect_value!(Vec2);
+impl_from_reflect_value!(Vec3);
+impl_from_reflect_value!(Vec4);
+impl_from_reflect_value!(Mat3);
+impl_from_reflect_value!(Mat4);
+impl_from_reflect_value!(Quat);

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn reflect_complex_patch() {
-        #[derive(Reflect, Eq, PartialEq, Debug)]
+        #[derive(Reflect, Eq, PartialEq, Debug, FromReflect)]
         #[reflect(PartialEq)]
         struct Foo {
             a: u32,
@@ -204,17 +204,25 @@ mod tests {
             d: HashMap<usize, i8>,
             e: Bar,
             f: (i32, Vec<isize>, Bar),
+            g: Vec<(Baz, HashMap<usize, Bar>)>,
         }
 
-        #[derive(Reflect, Eq, PartialEq, Debug)]
+        #[derive(Reflect, Eq, PartialEq, Clone, Debug, FromReflect)]
         #[reflect(PartialEq)]
         struct Bar {
             x: u32,
         }
 
+        #[derive(Reflect, Eq, PartialEq, Debug, FromReflect)]
+        struct Baz(String);
+
         let mut hash_map = HashMap::default();
         hash_map.insert(1, 1);
         hash_map.insert(2, 2);
+
+        let mut hash_map_baz = HashMap::default();
+        hash_map_baz.insert(1, Bar { x: 0 });
+
         let mut foo = Foo {
             a: 1,
             _b: 1,
@@ -222,6 +230,7 @@ mod tests {
             d: hash_map,
             e: Bar { x: 1 },
             f: (1, vec![1, 2], Bar { x: 1 }),
+            g: vec![(Baz("string".to_string()), hash_map_baz)],
         };
 
         let mut foo_patch = DynamicStruct::default();
@@ -248,11 +257,36 @@ mod tests {
         tuple.insert(bar_patch);
         foo_patch.insert("f", tuple);
 
+        let mut composite = DynamicList::default();
+        composite.push({
+            let mut tuple = DynamicTuple::default();
+            tuple.insert({
+                let mut tuple_struct = DynamicTupleStruct::default();
+                tuple_struct.insert("new_string".to_string());
+                tuple_struct
+            });
+            tuple.insert({
+                let mut map = DynamicMap::default();
+                map.insert(1usize, {
+                    let mut struct_ = DynamicStruct::default();
+                    struct_.insert("x", 7u32);
+                    struct_
+                });
+                map
+            });
+            tuple
+        });
+        foo_patch.insert("g", composite);
+
         foo.apply(&foo_patch);
 
         let mut hash_map = HashMap::default();
         hash_map.insert(1, 1);
         hash_map.insert(2, 3);
+
+        let mut hash_map_baz = HashMap::default();
+        hash_map_baz.insert(1, Bar { x: 7 });
+
         let expected_foo = Foo {
             a: 2,
             _b: 1,
@@ -260,9 +294,28 @@ mod tests {
             d: hash_map,
             e: Bar { x: 2 },
             f: (2, vec![3, 4, 5], Bar { x: 2 }),
+            g: vec![(Baz("new_string".to_string()), hash_map_baz.clone())],
         };
 
         assert_eq!(foo, expected_foo);
+
+        let new_foo = Foo::from_reflect(&foo_patch)
+            .expect("error while creating a concrete type from a dynamic type");
+
+        let mut hash_map = HashMap::default();
+        hash_map.insert(2, 3);
+
+        let expected_new_foo = Foo {
+            a: 2,
+            _b: 0,
+            c: vec![3, 4, 5],
+            d: hash_map,
+            e: Bar { x: 2 },
+            f: (2, vec![3, 4, 5], Bar { x: 2 }),
+            g: vec![(Baz("new_string".to_string()), hash_map_baz)],
+        };
+
+        assert_eq!(new_foo, expected_new_foo);
     }
 
     #[test]

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -326,7 +326,7 @@ mod tests {
             bar: C,
         }
 
-        #[derive(Reflect)]
+        #[derive(Reflect, FromReflect)]
         struct C {
             baz: f32,
         }

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -48,7 +48,7 @@ pub unsafe trait Reflect: Any + Send + Sync {
 }
 
 pub trait FromReflect: Reflect + Sized {
-    /// Creates a clone of a reflected value, converting it to a concrete type if it was a dynamic types (e.g. [DynamicStruct])
+    /// Creates a clone of a reflected value, converting it to a concrete type if it was a dynamic types (e.g. [`DynamicStruct`](crate::DynamicStruct))
     fn from_reflect(reflect: &dyn Reflect) -> Option<Self>;
 }
 

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -47,6 +47,11 @@ pub unsafe trait Reflect: Any + Send + Sync {
     fn serializable(&self) -> Option<Serializable>;
 }
 
+pub trait FromReflect: Reflect + Sized {
+    /// Creates a clone of a reflected value, converting it to a concrete type if it was a dynamic types (e.g. [DynamicStruct])
+    fn from_reflect(reflect: &dyn Reflect) -> Option<Self>;
+}
+
 impl Debug for dyn Reflect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Reflect({})", self.type_name())

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use crate::{serde::Serializable, Reflect, ReflectMut, ReflectRef};
+use crate::{serde::Serializable, FromReflect, Reflect, ReflectMut, ReflectRef};
 
 pub trait Tuple: Reflect {
     fn field(&self, index: usize) -> Option<&dyn Reflect>;
@@ -327,6 +327,23 @@ macro_rules! impl_reflect_tuple {
 
             fn serializable(&self) -> Option<Serializable> {
                 None
+            }
+        }
+
+        impl<$($name: FromReflect),*> FromReflect for ($($name,)*)
+        {
+            fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
+                if let ReflectRef::Tuple(_ref_tuple) = reflect.reflect_ref() {
+                    Some(
+                        (
+                            $(
+                                <$name as FromReflect>::from_reflect(_ref_tuple.field($index)?)?,
+                            )*
+                        )
+                    )
+                } else {
+                    None
+                }
             }
         }
     }

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -5,11 +5,11 @@ pub use colorspace::*;
 use crate::color::{HslRepresentation, SrgbColorSpace};
 use bevy_core::Bytes;
 use bevy_math::{Vec3, Vec4};
-use bevy_reflect::{Reflect, ReflectDeserialize};
+use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize};
 use serde::{Deserialize, Serialize};
 use std::ops::{Add, AddAssign, Mul, MulAssign};
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]
 #[reflect(PartialEq, Serialize, Deserialize)]
 pub enum Color {
     /// sRGBA color

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -41,8 +41,7 @@ impl Plugin for TextPlugin {
     fn build(&self, app: &mut App) {
         app.add_asset::<Font>()
             .add_asset::<FontAtlasSet>()
-            // TODO: uncomment when #2215 is fixed
-            // .register_type::<Text>()
+            .register_type::<Text>()
             .register_type::<VerticalAlign>()
             .register_type::<HorizontalAlign>()
             .init_asset_loader::<FontLoader>()

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -1,7 +1,7 @@
 use bevy_asset::Handle;
 use bevy_ecs::{prelude::Component, reflect::ReflectComponent};
 use bevy_math::Size;
-use bevy_reflect::{Reflect, ReflectDeserialize};
+use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize};
 use bevy_render::color::Color;
 use serde::{Deserialize, Serialize};
 
@@ -65,7 +65,7 @@ impl Text {
     }
 }
 
-#[derive(Debug, Default, Clone, Reflect)]
+#[derive(Debug, Default, Clone, FromReflect, Reflect)]
 pub struct TextSection {
     pub value: String,
     pub style: TextStyle,
@@ -134,7 +134,7 @@ impl From<VerticalAlign> for glyph_brush_layout::VerticalAlign {
     }
 }
 
-#[derive(Clone, Debug, Reflect)]
+#[derive(Clone, Debug, Reflect, FromReflect)]
 pub struct TextStyle {
     pub font: Handle<Font>,
     pub font_size: f32,


### PR DESCRIPTION
Dynamic types (`DynamicStruct`, `DynamicTupleStruct`, `DynamicTuple`, `DynamicList` and `DynamicMap`) are used when deserializing scenes, but currently they can only be applied to existing concrete types. This leads to issues when trying to spawn non trivial deserialized scene.
For components, the issue is avoided by requiring that reflected components implement ~~`FromResources`~~ `FromWorld` (or `Default`). When spawning, a new concrete type is created that way, and the dynamic type is applied to it. Unfortunately, some components don't have any valid implementation of these traits.
In addition, any `Vec` or `HashMap` inside a component will panic when a dynamic type is pushed into it (for instance, `Text` panics when adding a text section).

To solve this issue, this PR adds the `FromReflect` trait that creates a concrete type from a dynamic type that represent it, derives the trait alongside the `Reflect` trait, drops the ~~`FromResources`~~ `FromWorld` requirement on reflected components, ~~and enables reflection for UI and Text bundles~~. It also adds the requirement that fields ignored with `#[reflect(ignore)]` implement `Default`, since we need to initialize them somehow.