### PR TITLE
Update example system in documentation

### DIFF
--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -206,7 +206,7 @@ impl Commands {
     ///     b: Component2,
     /// }
     ///
-    /// fn example_system(mut commands: Commands) {
+    /// fn example_system(mut commands: &mut Commands) {
     ///     // Create a new entity with a component bundle.
     ///     commands.spawn(ExampleBundle {
     ///         a: Component1,


### PR DESCRIPTION
The existing snippet fails to compile with

```
no method named `system` found for fn item `fn(bevy::prelude::Commands) {example_system}` in the current scope
```