### PR TITLE
More Doctest changes

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -12,8 +12,8 @@ use bevy_utils::tracing::info_span;
 /// ## Example
 /// Here is a simple "Hello World" Bevy app:
 /// ```
-///use bevy_app::prelude::*;
-///use bevy_ecs::prelude::*;
+///# use bevy_app::prelude::*;
+///# use bevy_ecs::prelude::*;
 ///
 ///fn main() {
 ///    App::build()

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -206,7 +206,7 @@ impl Commands {
     ///     b: Component2,
     /// }
     ///
-    /// fn example_system(mut commands: &mut Commands) {
+    /// fn example_system(commands: &mut Commands) {
     ///     // Create a new entity with a component bundle.
     ///     commands.spawn(ExampleBundle {
     ///         a: Component1,
@@ -218,6 +218,8 @@ impl Commands {
     ///     // Create a new entity with two components.
     ///     commands.spawn((Component1, Component2));
     /// }
+    ///
+    /// # example_system.system();
     /// ```
     pub fn spawn(&mut self, bundle: impl DynamicBundle + Send + Sync + 'static) -> &mut Self {
         let entity = self
@@ -332,7 +334,7 @@ impl Commands {
     /// struct Component1;
     /// struct Component2;
     ///
-    /// fn example_system(mut commands: Commands) {
+    /// fn example_system(commands: &mut Commands) {
     ///     // Create a new entity with a `Component1` and `Component2`.
     ///     commands.spawn((Component1,)).with(Component2);
     ///
@@ -349,6 +351,8 @@ impl Commands {
     ///         b: Component2,
     ///     });
     /// }
+    ///
+    /// # example_system.system();
     /// ```
     pub fn with(&mut self, component: impl Component) -> &mut Self {
         let current_entity =  self.current_entity.expect("Cannot add component because the 'current entity' is not set. You should spawn an entity first.");

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -195,7 +195,7 @@ impl Commands {
     /// # Example
     ///
     /// ```
-    /// use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::prelude::*;
     ///
     /// struct Component1;
     /// struct Component2;
@@ -329,7 +329,7 @@ impl Commands {
     /// `with` can be chained with [`Self::spawn`].
     ///
     /// ```
-    /// use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::prelude::*;
     ///
     /// struct Component1;
     /// struct Component2;


### PR DESCRIPTION
This is a continuation of #1403

* Adds `example_system.system()` to verify the tests in CI
* Fixes another doctest
* Hides use statements, like all other doctests