### PR TITLE
[Merged by Bors] - Add Sprite Flipping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,10 @@ name = "sprite"
 path = "examples/2d/sprite.rs"
 
 [[example]]
+name = "sprite_flipping"
+path = "examples/2d/sprite_flipping.rs"
+
+[[example]]
 name = "sprite_sheet"
 path = "examples/2d/sprite_sheet.rs"
 

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -109,7 +109,7 @@ pub fn build_sprite_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescriptor
             topology: PrimitiveTopology::TriangleList,
             strip_index_format: None,
             front_face: FrontFace::Ccw,
-            cull_mode: CullMode::None,
+            cull_mode: CullMode::Back,
             polygon_mode: PolygonMode::Fill,
         },
         ..PipelineDescriptor::new(ShaderStages {

--- a/crates/bevy_sprite/src/render/sprite.vert
+++ b/crates/bevy_sprite/src/render/sprite.vert
@@ -13,12 +13,32 @@ layout(set = 0, binding = 0) uniform Camera {
 layout(set = 2, binding = 0) uniform Transform {
     mat4 Model;
 };
-layout(set = 2, binding = 1) uniform Sprite_size {
+layout(set = 2, binding = 1) uniform Sprite {
     vec2 size;
+    uint flip;
 };
 
 void main() {
-    v_Uv = Vertex_Uv;
+    vec2 uv = Vertex_Uv;
+
+    // Flip the sprite if necessary by flipping the UVs
+
+    uint x_flip_bit = 1; // The X flip bit
+    uint y_flip_bit = 2; // The Y flip bit
+    
+    // Note: Here we subtract f32::EPSILON from the flipped UV coord. This is due to reasons unknown
+    // to me (@zicklag ) that causes the uv's to be slightly offset and causes over/under running of
+    // the sprite UV sampling which is visible when resizing the screen.
+    float epsilon = 0.00000011920929;
+    if ((flip & x_flip_bit) == x_flip_bit) {
+        uv = vec2(1.0 - uv.x - epsilon, uv.y);
+    }
+    if ((flip & y_flip_bit) == y_flip_bit) {
+        uv = vec2(uv.x, 1.0 - uv.y - epsilon);
+    }
+
+    v_Uv = uv;
+
     vec3 position = Vertex_Position * vec3(size, 1.0);
     gl_Position = ViewProj * Model * vec4(position, 1.0);
 }

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -72,6 +72,8 @@ impl<'a> Drawable for DrawableText<'a> {
             let sprite = TextureAtlasSprite {
                 index: tv.atlas_info.glyph_index,
                 color: self.sections[tv.section_index].style.color,
+                flip_x: false,
+                flip_y: false,
             };
 
             // To get the rendering right for non-one scaling factors, we need

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -87,6 +87,7 @@ fn setup(
                 sprite: Sprite {
                     size: Vec2::new(1.0, 1.0) * SPRITE_SIZE,
                     resize_mode: SpriteResizeMode::Manual,
+                    ..Default::default()
                 },
                 material: materials.add(ColorMaterial {
                     color: COL_DESELECTED * col,

--- a/examples/2d/sprite_flipping.rs
+++ b/examples/2d/sprite_flipping.rs
@@ -1,0 +1,29 @@
+use bevy::prelude::*;
+
+fn main() {
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(setup.system())
+        .run();
+}
+
+fn setup(
+    commands: &mut Commands,
+    asset_server: Res<AssetServer>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    let texture_handle = asset_server.load("branding/icon.png");
+    commands
+        .spawn(OrthographicCameraBundle::new_2d())
+        .spawn(SpriteBundle {
+            material: materials.add(texture_handle.into()),
+            sprite: Sprite {
+                // Flip the logo to the left
+                flip_x: true,
+                // And don't flip it upside-down ( the default )
+                flip_y: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -68,6 +68,7 @@ Example | Main | Description
 `sprite` | [`2d/sprite.rs`](./2d/sprite.rs) | Renders a sprite
 `sprite_sheet` | [`2d/sprite_sheet.rs`](./2d/sprite_sheet.rs) | Renders an animated sprite
 `text2d` | [`2d/text2d.rs`](./2d/text2d.rs) | Generates text in 2d
+`sprite_flipping` | [`2d/sprite_flipping.rs`](./2d/sprite_flipping.rs) | Renders a sprite flipped along an axis
 `texture_atlas` | [`2d/texture_atlas.rs`](./2d/texture_atlas.rs) | Generates a texture atlas (sprite sheet) from individual sprites
 
 ## 3D Rendering


### PR DESCRIPTION
OK, here's my attempt at sprite flipping. There are a couple of points that I need review/help on, but I think the UX is about ideal:

```rust
        .spawn(SpriteBundle {
            material: materials.add(texture_handle.into()),
            sprite: Sprite {
                // Flip the sprite along the x axis
                flip: SpriteFlip { x: true, y: false },
                ..Default::default()
            },
            ..Default::default()
        });
```

Now for the issues. The big issue is that for some reason, when flipping the UVs on the sprite, there is a light "bleeding" or whatever you call it where the UV tries to sample past the texture boundry and ends up clipping. This is only noticed when resizing the window, though. You can see a screenshot below.

![image](https://user-images.githubusercontent.com/25393315/107098172-397aaa00-67d4-11eb-8e02-c90c820cd70e.png)

I am quite baffled why the texture sampling is overrunning like it is and could use some guidance if anybody knows what might be wrong.

The other issue, which I just worked around, is that I had to remove the `#[render_resources(from_self)]` annotation from the Spritesheet because the `SpriteFlip` render resource wasn't being picked up properly in the shader when using it. I'm not sure what the cause of that was, but by removing the annotation and re-organizing the shader inputs accordingly the problem was fixed.

I'm not sure if this is the most efficient way to do this or if there is a better way, but I wanted to try it out if only for the learning experience. Let me know what you think!