### PR TITLE
revert default vsync mode to Fifo

### DIFF
--- a/crates/bevy_wgpu/src/wgpu_type_converter.rs
+++ b/crates/bevy_wgpu/src/wgpu_type_converter.rs
@@ -640,7 +640,7 @@ impl WgpuFrom<&Window> for wgpu::SwapChainDescriptor {
             width: window.physical_width(),
             height: window.physical_height(),
             present_mode: if window.vsync() {
-                wgpu::PresentMode::Mailbox
+                wgpu::PresentMode::Fifo
             } else {
                 wgpu::PresentMode::Immediate
             },


### PR DESCRIPTION
The mailbox option doesn't do framelimiting on some devices. we need to rely on vsync for framelimiting until bevy supports framelimiting internally.

short term solution to #1343