### PR TITLE
[Merged by Bors] - Add backend feature metadata to make bevy_winit build on docs.rs again

### DIFF
--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -32,3 +32,6 @@ winit = { version = "0.24.0", default-features = false }
 winit = { version = "0.24.0", features = ["web-sys"], default-features = false }
 wasm-bindgen = { version = "0.2" }
 web-sys = "0.3"
+
+[package.metadata.docs.rs]
+features = ["x11"]


### PR DESCRIPTION
The `bevy_winit` crate hasn't been able to build on docs.rs [since 0.2.1](https://docs.rs/crate/bevy_winit/0.4.0). This PR restores the ability of docs.rs to build `bevy_winit` again.

(The choice of backend is essentially arbitrary, but choosing one *is required* for the crate to build)