### PR TITLE
[Merged by Bors] - fix rustdoc warnings

### DIFF
--- a/crates/bevy_ecs/src/core/access.rs
+++ b/crates/bevy_ecs/src/core/access.rs
@@ -212,7 +212,7 @@ impl QueryAccess {
     }
 }
 
-/// Provides information about the types a [System] reads and writes
+/// Provides information about the types a [System](crate::System) reads and writes
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct TypeAccess<T: Hash + Eq + PartialEq> {
     reads_all: bool,

--- a/crates/bevy_ecs/src/system/query/mod.rs
+++ b/crates/bevy_ecs/src/system/query/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 use bevy_tasks::ParallelIterator;
 use std::marker::PhantomData;
 
-/// Provides scoped access to a World according to a given [HecsQuery]
+/// Provides scoped access to a World according to a given [WorldQuery]
 #[derive(Debug)]
 pub struct Query<'a, Q: WorldQuery, F: QueryFilter = ()> {
     pub(crate) world: &'a World,

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use crate::{serde::Serializable, Reflect, ReflectMut, ReflectRef};
 
-/// An ordered, mutable list of [ReflectValue] items. This corresponds to types like [std::vec::Vec].
+/// An ordered, mutable list of [Reflect] items. This corresponds to types like [std::vec::Vec].
 pub trait List: Reflect {
     fn get(&self, index: usize) -> Option<&dyn Reflect>;
     fn get_mut(&mut self, index: usize) -> Option<&mut dyn Reflect>;

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -34,7 +34,7 @@ pub type Layer = u8;
 /// Cameras with this component will only render entities with intersecting
 /// layers.
 ///
-/// There are 32 layers numbered `0` - [`TOTAL_LAYERS`]. Entities may belong to one or more
+/// There are 32 layers numbered `0` - [`TOTAL_LAYERS`](RenderLayers::TOTAL_LAYERS). Entities may belong to one or more
 /// layers, or no layer at all.
 ///
 /// The [`Default`] instance of `RenderLayers` contains layer `0`, the first layer.

--- a/crates/bevy_render/src/pipeline/binding.rs
+++ b/crates/bevy_render/src/pipeline/binding.rs
@@ -36,7 +36,7 @@ pub enum BindType {
         /// A filtering sampler can only be used with a filterable texture.
         filtering: bool,
         /// Use as a comparison sampler instead of a normal sampler.
-        /// For more info take a look at the analogous functionality in OpenGL: https://www.khronos.org/opengl/wiki/Sampler_Object#Comparison_mode.
+        /// For more info take a look at the analogous functionality in OpenGL: <https://www.khronos.org/opengl/wiki/Sampler_Object#Comparison_mode>.
         comparison: bool,
     },
     Texture {

--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -4,7 +4,7 @@ pub struct WinitConfig {
     /// Configures the winit library to return control to the main thread after
     /// the [run](bevy_app::App::run) loop is exited. Winit strongly recommends
     /// avoiding this when possible. Before using this please read and understand
-    /// the [caveats](winit::platform::desktop::EventLoopExtDesktop::run_return)
+    /// the [caveats](winit::platform::run_return::EventLoopExtRunReturn::run_return)
     /// in the winit documentation.
     ///
     /// This feature is only available on desktop `target_os` configurations.


### PR DESCRIPTION
Every warning is fixed except for 
https://github.com/bevyengine/bevy/blob/b39df9a8d27076a8181c813b38e85833ad713be4/crates/bevy_render/src/texture/texture_descriptor.rs#L61
because I didn't know what the required feature is.
I opened https://github.com/gfx-rs/wgpu/issues/1213 for that.