### PR TITLE
Add label to transform propagation system

### DIFF
--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -1,4 +1,4 @@
-pub const TRANSFORM_LABEL: &'static str = "transform_propagation";
+pub const TRANSFORM_PROPAGATION: &'static str = "transform_propagation";
 
 pub mod components;
 pub mod hierarchy;
@@ -34,7 +34,7 @@ impl Plugin for TransformPlugin {
                 stage::POST_UPDATE,
                 transform_propagate_system::transform_propagate_system
                     .system()
-                    .label(TRANSFORM_LABEL),
+                    .label(TRANSFORM_PROPAGATION),
             );
     }
 }

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -32,7 +32,9 @@ impl Plugin for TransformPlugin {
             .add_system_to_stage(stage::POST_UPDATE, parent_update_system.system())
             .add_system_to_stage(
                 stage::POST_UPDATE,
-                transform_propagate_system::transform_propagate_system.system().label(TRANSFORM_LABEL),
+                transform_propagate_system::transform_propagate_system
+                    .system()
+                    .label(TRANSFORM_LABEL),
             );
     }
 }

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -1,3 +1,5 @@
+const TRANSFORM_LABEL: String = String::from("transform_propagation");
+
 pub mod components;
 pub mod hierarchy;
 pub mod transform_propagate_system;
@@ -30,7 +32,7 @@ impl Plugin for TransformPlugin {
             .add_system_to_stage(stage::POST_UPDATE, parent_update_system.system())
             .add_system_to_stage(
                 stage::POST_UPDATE,
-                transform_propagate_system::transform_propagate_system.system(),
+                transform_propagate_system::transform_propagate_system.system().label(TRANSFORM_LABEL),
             );
     }
 }

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -1,4 +1,4 @@
-pub const TRANSFORM_PROPAGATION: &'static str = "transform_propagation";
+pub const TRANSFORM_PROPAGATION: &str = "transform_propagation";
 
 pub mod components;
 pub mod hierarchy;

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -1,4 +1,4 @@
-const TRANSFORM_LABEL: String = String::from("transform_propagation");
+pub const TRANSFORM_LABEL: String = String::from("transform_propagation");
 
 pub mod components;
 pub mod hierarchy;

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -1,4 +1,4 @@
-pub const TRANSFORM_LABEL: String = String::from("transform_propagation");
+pub const TRANSFORM_LABEL: &'static str = "transform_propagation";
 
 pub mod components;
 pub mod hierarchy;
@@ -9,7 +9,7 @@ pub mod prelude {
 }
 
 use bevy_app::{prelude::*, startup_stage};
-use bevy_ecs::IntoSystem;
+use bevy_ecs::{IntoSystem, ParallelSystemDescriptorCoercion};
 use bevy_reflect::RegisterTypeBuilder;
 use prelude::{parent_update_system, Children, GlobalTransform, Parent, PreviousParent, Transform};
 


### PR DESCRIPTION
Adds a label to the `GlobalTransform` transform propagation system. This is needed due to recent changes in the scheduler. I've been experiencing issues with systems running prior to `GlobalTransform`s being updated. A label is needed on the propagation system to allow me to specify a system dependency.