### PR TITLE
Warn if there is no UI camera

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -37,6 +37,7 @@ impl Plugin for CorePlugin {
         app.init_resource::<Time>()
             .init_resource::<EntityLabels>()
             .init_resource::<FixedTimesteps>()
+            .init_resource::<ValidationConfig>()
             .register_type::<Option<String>>()
             .register_type::<Name>()
             .register_type::<Labels>()
@@ -45,5 +46,31 @@ impl Plugin for CorePlugin {
             .add_system_to_stage(stage::FIRST, time_system.system())
             .add_startup_system_to_stage(startup_stage::POST_STARTUP, entity_labels_system.system())
             .add_system_to_stage(stage::POST_UPDATE, entity_labels_system.system());
+    }
+}
+
+/// Configures which validation checks are run.
+///
+/// By default, they are all enabled in debug mode but
+/// disabled in release mode.
+pub struct ValidationConfig {
+    /// Checks whether the world contains no ui camera but ui nodes.
+    pub missing_ui_cam: bool,
+    #[doc(hidden)]
+    #[allow(unused)]
+    // we cannot use `#[non_exhaustive]`, since that wouldn't allow `ValidationConfig { ..Default::default() }`
+    pub non_exhaustive: (),
+}
+
+impl Default for ValidationConfig {
+    fn default() -> Self {
+        #[cfg(debug_assertions)]
+        let default_value = true;
+        #[cfg(not(debug_assertions))]
+        let default_value = false;
+        ValidationConfig {
+            missing_ui_cam: default_value,
+            non_exhaustive: (),
+        }
     }
 }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -55,11 +55,19 @@ impl Plugin for UiPlugin {
             )
             .add_system_to_stage(stage::UI, flex_node_system.system().label(system::FLEX))
             .add_system_to_stage(stage::UI, ui_z_system.system())
-            .add_system_to_stage(bevy_render::stage::DRAW, widget::draw_text_system.system())
-            .add_startup_system_to_stage(
+            .add_system_to_stage(bevy_render::stage::DRAW, widget::draw_text_system.system());
+
+        let add_ui_cam_validation_system = app
+            .resources()
+            .get::<bevy_core::ValidationConfig>()
+            .map_or(false, |config| config.missing_ui_cam);
+
+        if add_ui_cam_validation_system {
+            app.add_startup_system_to_stage(
                 bevy_app::startup_stage::POST_STARTUP,
                 warn_no_ui_cam.system(),
             );
+        }
 
         let resources = app.resources();
         let mut render_graph = resources.get_mut::<RenderGraph>().unwrap();


### PR DESCRIPTION
fixes the UI part of #1432.

A system is added to `POST_STARTUP` which checks whether the world contains any `Node`s but no ui cam and logs
```sh
WARN bevy_ui: The world contains ui nodes but no ui camera. Consider spawning a UiCameraBundle.
```

To opt out, a `ValidationConfig` is added to `bevy_core`. IMO adding a separate resource for every future validation system (e.g. #1439) would quickly become too complicated.
