### PR TITLE
[Merged by Bors] - Fix warning in scene example

### DIFF
--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -6,15 +6,15 @@
         "type": "bevy_transform::components::transform::Transform",
         "struct": {
           "translation": {
-            "type": "glam::f32::vec3::Vec3",
+            "type": "glam::vec3::Vec3",
             "value": (0.0, 0.0, 0.0),
           },
           "rotation": {
-            "type": "glam::f32::quat::Quat",
+            "type": "glam::quat::Quat",
             "value": (0.0, 0.0, 0.0, 1.0),
           },
           "scale": {
-            "type": "glam::f32::vec3::Vec3",
+            "type": "glam::vec3::Vec3",
             "value": (1.0, 1.0, 1.0),
           },
         },


### PR DESCRIPTION
I noticed the following error when trying out the `scene` example

```bash
Feb 13 22:11:13.997  WARN bevy_asset::asset_server: encountered an error while loading an asset: No registration found for glam::f32::vec3::Vec3
```

This PR fixes the error and makes the scene file load correctly