### PR TITLE
[Merged by Bors] - keep track of type name in NodeState

### DIFF
--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -108,6 +108,7 @@ impl Edges {
 pub struct NodeState {
     pub id: NodeId,
     pub name: Option<Cow<'static, str>>,
+    pub type_name: &'static str,
     pub node: Box<dyn Node>,
     pub input_slots: ResourceSlots,
     pub output_slots: ResourceSlots,
@@ -131,6 +132,7 @@ impl NodeState {
             input_slots: ResourceSlots::from(node.input()),
             output_slots: ResourceSlots::from(node.output()),
             node: Box::new(node),
+            type_name: std::any::type_name::<T>(),
             edges: Edges {
                 id,
                 input_edges: Vec::new(),


### PR DESCRIPTION
Adds the original type_name to `NodeState`, enabling plugins like [this](https://github.com/jakobhellermann/bevy_mod_debugdump).
This does increase the `NodeState` type by 16 bytes, but it is already 176 so it's not that big of an increase.