### PR TITLE
Add `bevy_window::WindowRedrawRequested` event and `bevy_window::Window::request_redraw` command

### DIFF
--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -38,6 +38,11 @@ pub struct WindowCloseRequested {
 }
 
 #[derive(Debug, Clone)]
+pub struct WindowRedrawRequested {
+    pub id: WindowId,
+}
+
+#[derive(Debug, Clone)]
 pub struct CursorMoved {
     pub id: WindowId,
     pub position: Vec2,

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -38,6 +38,7 @@ impl Plugin for WindowPlugin {
             .add_event::<CreateWindow>()
             .add_event::<WindowCreated>()
             .add_event::<WindowCloseRequested>()
+            .add_event::<WindowRedrawRequested>()
             .add_event::<CloseWindow>()
             .add_event::<CursorMoved>()
             .add_event::<CursorEntered>()

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -114,6 +114,7 @@ pub enum WindowCommand {
     SetPosition {
         position: IVec2,
     },
+    RequestRedraw,
 }
 
 /// Defines the way a window is displayed
@@ -420,6 +421,11 @@ impl Window {
             mode,
             resolution: (self.physical_width, self.physical_height),
         });
+    }
+
+    #[inline]
+    pub fn request_redraw(&mut self) {
+        self.command_queue.push(WindowCommand::RequestRedraw);
     }
 
     #[inline]


### PR DESCRIPTION
Right now, if a user were to build a custom renderer for Bevy, the only logical place to put it is in a normal system that will run on every tick of the app. If you didn't want to re-render every tick, you'd need to manage that yourself.

Winit has the [`winit::event::Event::RedrawRequested`](https://docs.rs/winit/0.24.0/winit/event/enum.Event.html#variant.RedrawRequested) event that is emitted after `winit::event::Event::MainEventsCleared` when (from Winit docs):

- The OS has performed an operation that's invalidated the window's contents (such as resizing the window).
- The application has explicitly requested a redraw via [`winit::window::Window::request_redraw`](https://docs.rs/winit/0.24.0/winit/window/struct.Window.html#method.request_redraw).

This PR leverages this Winit functionality to add two things:

- A new `bevy_window::WindowRedrawRequested` event hooked up to `winit::event::Event::RedrawRequested` in `bevy_winit`.
- A `bevy_window::Window::request_redraw` command that fires the underlying `winit::window::Window::request_redraw` in `bevy_winit`.

Example usage.

```rust
pub fn some_game_system(...) {
    // ...
    // Called somewhere in game only when window needs to be redrawn
    window.request_redraw();
    // ...
}

pub fn window_redraw_system(mut window_redraw_events: EventReader<WindowRedrawRequested>, ...) {
    for event in window_redraw_events.iter() {
        // Trigger custom render to redraw here
        // ...
    }
}
```

I'm using this change in a [plugin I'm working on](https://github.com/dtcristo/bevy_pixels) that integrates Bevy with [Pixels](https://github.com/parasyte/pixels) for rendering. Check out how I'm using this over there.

Happy for discussion if you don't think this should be exposed.