### PR TITLE
add `RunMode::Ticks` to use in test cases

### DIFF
--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -23,7 +23,6 @@ pub mod prelude {
         app::App,
         app_builder::AppBuilder,
         event::{EventReader, Events},
-        schedule_runner::TickCounter,
         stage, DynamicPlugin, Plugin, PluginGroup,
     };
 }

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -23,6 +23,7 @@ pub mod prelude {
         app::App,
         app_builder::AppBuilder,
         event::{EventReader, Events},
+        schedule_runner::TickCounter,
         stage, DynamicPlugin, Plugin, PluginGroup,
     };
 }

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -62,12 +62,15 @@ pub struct ScheduleRunnerPlugin {}
 
 impl Plugin for ScheduleRunnerPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app.init_resource::<TickCounter>();
-
         let settings = app
             .resources_mut()
             .get_or_insert_with(ScheduleRunnerSettings::default)
             .to_owned();
+
+        if matches!(settings.run_mode, RunMode::Ticks(_)) {
+            app.init_resource::<TickCounter>();
+        }
+
         app.set_runner(move |mut app: App| {
             let mut app_exit_event_reader = ManualEventReader::<AppExit>::default();
             match settings.run_mode {
@@ -103,10 +106,6 @@ impl Plugin for ScheduleRunnerPlugin {
                             {
                                 return Err(exit.clone());
                             }
-                        }
-
-                        if let Some(mut ticker) = app.resources.get_mut::<TickCounter>() {
-                            ticker.count += 1;
                         }
 
                         let end_time = Instant::now();

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -48,12 +48,22 @@ impl ScheduleRunnerSettings {
     }
 }
 
+/// Tracks the number of ticks since the app started.
+///
+/// Can be accessed as a [`Resource`], using `Res<TickCounter>`.
+#[derive(Debug, Default)]
+pub struct TickCounter {
+    pub count: usize,
+}
+
 /// Configures an App to run its [Schedule](bevy_ecs::Schedule) according to a given [RunMode]
 #[derive(Default)]
 pub struct ScheduleRunnerPlugin {}
 
 impl Plugin for ScheduleRunnerPlugin {
     fn build(&self, app: &mut AppBuilder) {
+        app.init_resource::<TickCounter>();
+
         let settings = app
             .resources_mut()
             .get_or_insert_with(ScheduleRunnerSettings::default)
@@ -67,6 +77,10 @@ impl Plugin for ScheduleRunnerPlugin {
                 RunMode::Ticks(ticks) => {
                     for _ in 0..ticks {
                         app.update();
+
+                        if let Some(mut ticker) = app.resources.get_mut::<TickCounter>() {
+                            ticker.count += 1;
+                        }
                     }
                 }
                 RunMode::Loop { wait } => {
@@ -89,6 +103,10 @@ impl Plugin for ScheduleRunnerPlugin {
                             {
                                 return Err(exit.clone());
                             }
+                        }
+
+                        if let Some(mut ticker) = app.resources.get_mut::<TickCounter>() {
+                            ticker.count += 1;
                         }
 
                         let end_time = Instant::now();

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -12,6 +12,7 @@ use wasm_bindgen::{prelude::*, JsCast};
 pub enum RunMode {
     Loop { wait: Option<Duration> },
     Once,
+    Ticks(usize),
 }
 
 impl Default for RunMode {
@@ -29,6 +30,12 @@ impl ScheduleRunnerSettings {
     pub fn run_once() -> Self {
         ScheduleRunnerSettings {
             run_mode: RunMode::Once,
+        }
+    }
+
+    pub fn run_ticks(ticks: usize) -> Self {
+        ScheduleRunnerSettings {
+            run_mode: RunMode::Ticks(ticks),
         }
     }
 
@@ -56,6 +63,11 @@ impl Plugin for ScheduleRunnerPlugin {
             match settings.run_mode {
                 RunMode::Once => {
                     app.update();
+                }
+                RunMode::Ticks(ticks) => {
+                    for _ in 0..ticks {
+                        app.update();
+                    }
                 }
                 RunMode::Loop { wait } => {
                     let mut tick = move |app: &mut App,

--- a/examples/app/headless.rs
+++ b/examples/app/headless.rs
@@ -37,19 +37,12 @@ fn hello_world_system() {
     println!("hello world");
 }
 
-fn ticker(mut state: Local<CounterState>) {
-    state.count += 1;
-    println!("{}", state.count);
+fn ticker(ticks: Res<TickCounter>) {
+    println!("{}", ticks.count);
 }
 
-fn counter(mut state: Local<CounterState>) {
-    if state.count % 60 == 0 {
-        println!("{}", state.count);
+fn counter(ticks: Res<TickCounter>) {
+    if ticks.count % 60 == 0 {
+        println!("{}", ticks.count);
     }
-    state.count += 1;
-}
-
-#[derive(Default)]
-struct CounterState {
-    count: u32,
 }

--- a/examples/app/headless.rs
+++ b/examples/app/headless.rs
@@ -37,12 +37,18 @@ fn hello_world_system() {
     println!("hello world");
 }
 
-fn ticker(ticks: Res<TickCounter>) {
+fn ticker(ticks: Res<bevy::app::TickCounter>) {
     println!("{}", ticks.count);
 }
 
-fn counter(ticks: Res<TickCounter>) {
-    if ticks.count % 60 == 0 {
-        println!("{}", ticks.count);
+fn counter(mut state: Local<CounterState>) {
+    if state.count % 60 == 0 {
+        println!("{}", state.count);
     }
+    state.count += 1;
+}
+
+#[derive(Default)]
+struct CounterState {
+    count: u32,
 }

--- a/examples/app/headless.rs
+++ b/examples/app/headless.rs
@@ -16,6 +16,13 @@ fn main() {
         .add_system(hello_world_system.system())
         .run();
 
+    // this app runs 10 times
+    App::build()
+        .insert_resource(ScheduleRunnerSettings::run_ticks(10))
+        .add_plugins(MinimalPlugins)
+        .add_system(ticker.system())
+        .run();
+
     // this app loops forever at 60 fps
     App::build()
         .insert_resource(ScheduleRunnerSettings::run_loop(Duration::from_secs_f64(
@@ -28,6 +35,11 @@ fn main() {
 
 fn hello_world_system() {
     println!("hello world");
+}
+
+fn ticker(mut state: Local<CounterState>) {
+    state.count += 1;
+    println!("{}", state.count);
 }
 
 fn counter(mut state: Local<CounterState>) {


### PR DESCRIPTION
As discussed on Discord, this adds a new `RunMode` that can be used in (but is not limited to) tests.

This allows one to run the loop `x` ticks, before validating the result. Technically, this makes `RunOnce` obsolete, but I left it in to not break any existing code, and to have a slightly nicer API when you only want to run the loop once.