### PR TITLE
[Merged by Bors] - Implement Reflect for integer glam vectors.

### DIFF
--- a/crates/bevy_reflect/src/impls/bevy_app.rs
+++ b/crates/bevy_reflect/src/impls/bevy_app.rs
@@ -26,7 +26,13 @@ impl Plugin for ReflectPlugin {
             .register_type::<String>();
         #[cfg(feature = "glam")]
         {
-            app.register_type::<glam::Vec2>()
+            app.register_type::<glam::IVec2>()
+                .register_type::<glam::IVec3>()
+                .register_type::<glam::IVec4>()
+                .register_type::<glam::UVec2>()
+                .register_type::<glam::UVec3>()
+                .register_type::<glam::UVec4>()
+                .register_type::<glam::Vec2>()
                 .register_type::<glam::Vec3>()
                 .register_type::<glam::Vec4>()
                 .register_type::<glam::Mat3>()

--- a/crates/bevy_reflect/src/impls/glam.rs
+++ b/crates/bevy_reflect/src/impls/glam.rs
@@ -1,7 +1,13 @@
 use crate::ReflectDeserialize;
 use bevy_reflect_derive::impl_reflect_value;
-use glam::{Mat3, Mat4, Quat, Vec2, Vec3, Vec4};
+use glam::{IVec2, IVec3, IVec4, Mat3, Mat4, Quat, UVec2, UVec3, UVec4, Vec2, Vec3, Vec4};
 
+impl_reflect_value!(IVec2(PartialEq, Serialize, Deserialize));
+impl_reflect_value!(IVec3(PartialEq, Serialize, Deserialize));
+impl_reflect_value!(IVec4(PartialEq, Serialize, Deserialize));
+impl_reflect_value!(UVec2(PartialEq, Serialize, Deserialize));
+impl_reflect_value!(UVec3(PartialEq, Serialize, Deserialize));
+impl_reflect_value!(UVec4(PartialEq, Serialize, Deserialize));
 impl_reflect_value!(Vec2(PartialEq, Serialize, Deserialize));
 impl_reflect_value!(Vec3(PartialEq, Serialize, Deserialize));
 impl_reflect_value!(Vec4(PartialEq, Serialize, Deserialize));


### PR DESCRIPTION
This is a very simple change that allows the (reflected) use of integer glam vectors (UVec2 for instance) in components.