### PR TITLE
Compile time generated type info for bundles

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -134,7 +134,7 @@ fn gen_bundle_impl(
                         ::std::mem::transmute::<::std::any::TypeId, u64>(left.id()) < std::mem::transmute::<::std::any::TypeId, u64>(right.id())
                     }
                 }
-    
+
                 let mut types = [#(::#crate_path::TypeInfo::of::<#tys>()),*];
                 let mut i = 1;
                 while i < types.len() {
@@ -146,7 +146,7 @@ fn gen_bundle_impl(
                     }
                     types[j] = temp;
                     i += 1;
-                }    
+                }
                 types
             };
 

--- a/crates/bevy_ecs/src/core/archetype.rs
+++ b/crates/bevy_ecs/src/core/archetype.rs
@@ -75,7 +75,7 @@ impl Archetype {
         }
         Self {
             state,
-            types,
+            types: types.to_vec(),
             entities: Vec::new(),
             len: 0,
             data: UnsafeCell::new(NonNull::dangling()),
@@ -482,7 +482,7 @@ pub struct TypeInfo {
 
 impl TypeInfo {
     /// Metadata for `T`
-    pub fn of<T: 'static>() -> Self {
+    pub const fn of<T: 'static>() -> Self {
         unsafe fn drop_ptr<T>(x: *mut u8) {
             x.cast::<T>().drop_in_place()
         }
@@ -497,13 +497,13 @@ impl TypeInfo {
 
     #[allow(missing_docs)]
     #[inline]
-    pub fn id(&self) -> TypeId {
+    pub const fn id(&self) -> TypeId {
         self.id
     }
 
     #[allow(missing_docs)]
     #[inline]
-    pub fn layout(&self) -> Layout {
+    pub const fn layout(&self) -> Layout {
         self.layout
     }
 
@@ -513,7 +513,7 @@ impl TypeInfo {
 
     #[allow(missing_docs)]
     #[inline]
-    pub fn type_name(&self) -> &'static str {
+    pub const fn type_name(&self) -> &'static str {
         self.type_name
     }
 }

--- a/crates/bevy_ecs/src/core/bundle.rs
+++ b/crates/bevy_ecs/src/core/bundle.rs
@@ -119,7 +119,7 @@ macro_rules! tuple_impl {
                         mem::transmute::<TypeId, u64>(left.id()) < mem::transmute::<TypeId, u64>(right.id())
                     }
                 }
-    
+
                 let mut types = [$(TypeInfo::of::<$name>()),*];
                 let mut i = 1;
                 while i < types.len() {
@@ -131,7 +131,7 @@ macro_rules! tuple_impl {
                     }
                     types[j] = temp;
                     i += 1;
-                }    
+                }
                 types
             };
 

--- a/crates/bevy_ecs/src/core/entity_builder.rs
+++ b/crates/bevy_ecs/src/core/entity_builder.rs
@@ -16,8 +16,8 @@
 
 use std::{
     alloc::{alloc, dealloc, Layout},
-    collections::HashMap,
     any::TypeId,
+    collections::HashMap,
     mem::{self, MaybeUninit},
     ptr,
 };
@@ -59,7 +59,11 @@ impl EntityBuilder {
 
     /// Add `component` to the entity
     pub fn add<T: Component>(&mut self, component: T) -> &mut Self {
-        if self.offsets.insert(TypeId::of::<T>(), self.cursor).is_some() {
+        if self
+            .offsets
+            .insert(TypeId::of::<T>(), self.cursor)
+            .is_some()
+        {
             return self;
         }
         let end = self.cursor + mem::size_of::<T>();
@@ -122,9 +126,7 @@ impl EntityBuilder {
                 max_align as *mut _
             };
             for ty in self.info.drain(..) {
-                let offset = *self.offsets
-                    .get(&ty.id())
-                    .unwrap();
+                let offset = *self.offsets.get(&ty.id()).unwrap();
                 ptr::copy_nonoverlapping(
                     self.storage[offset..offset + ty.layout().size()]
                         .as_ptr()
@@ -174,9 +176,7 @@ impl DynamicBundle for BuiltEntity<'_> {
 
     unsafe fn put(self, mut f: impl FnMut(*mut u8, TypeId, usize) -> bool) {
         for ty in self.builder.info.drain(..) {
-            let offset = *self.builder.offsets
-                .get(&ty.id())
-                .unwrap();
+            let offset = *self.builder.offsets.get(&ty.id()).unwrap();
             let ptr = self.builder.storage.as_mut_ptr().add(offset).cast();
             if !f(ptr, ty.id(), ty.layout().size()) {
                 ty.drop(ptr);

--- a/crates/bevy_ecs/src/core/filter.rs
+++ b/crates/bevy_ecs/src/core/filter.rs
@@ -178,10 +178,7 @@ impl<T: Bundle> QueryFilter for WithType<T> {
 
     #[inline]
     fn get_entity_filter(archetype: &Archetype) -> Option<Self::EntityFilter> {
-        if T::TYPES
-            .iter()
-            .all(|info| archetype.has_type(info.id()))
-        {
+        if T::TYPES.iter().all(|info| archetype.has_type(info.id())) {
             Some(AnyEntityFilter)
         } else {
             None

--- a/crates/bevy_ecs/src/core/filter.rs
+++ b/crates/bevy_ecs/src/core/filter.rs
@@ -169,7 +169,7 @@ impl<T: Bundle> QueryFilter for WithType<T> {
 
     fn access() -> QueryAccess {
         QueryAccess::union(
-            T::static_type_info()
+            T::TYPES
                 .iter()
                 .map(|info| QueryAccess::With(info.id(), Box::new(QueryAccess::None)))
                 .collect::<Vec<QueryAccess>>(),
@@ -178,7 +178,7 @@ impl<T: Bundle> QueryFilter for WithType<T> {
 
     #[inline]
     fn get_entity_filter(archetype: &Archetype) -> Option<Self::EntityFilter> {
-        if T::static_type_info()
+        if T::TYPES
             .iter()
             .all(|info| archetype.has_type(info.id()))
         {

--- a/crates/bevy_ecs/src/core/world.rs
+++ b/crates/bevy_ecs/src/core/world.rs
@@ -85,7 +85,8 @@ impl World {
         let archetype_id = bundle.with_ids(|ids| {
             self.index.get(ids).copied().unwrap_or_else(|| {
                 let x = self.archetypes.len() as u32;
-                self.archetypes.push(Archetype::new(bundle.type_info().to_vec()));
+                self.archetypes
+                    .push(Archetype::new(bundle.type_info().to_vec()));
                 self.index.insert(ids.to_vec(), x);
                 self.archetype_generation += 1;
                 x

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1,3 +1,8 @@
+#![feature(const_fn_fn_ptr_basics)]
+#![feature(const_fn_transmute)]
+#![feature(const_type_id)]
+#![feature(const_type_name)]
+
 mod core;
 mod resource;
 mod schedule;

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -194,7 +194,7 @@ impl Commands {
     ///
     /// # Example
     ///
-    /// ``` 
+    /// ```
     /// #![feature(const_fn_fn_ptr_basics)]
     /// #![feature(const_fn_transmute)]
     /// #![feature(const_type_id)]
@@ -340,7 +340,7 @@ impl Commands {
     /// #![feature(const_type_name)]
     ///
     /// # use bevy_ecs::prelude::*;
-    /// 
+    ///
     /// struct Component1;
     /// struct Component2;
     ///

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -194,7 +194,12 @@ impl Commands {
     ///
     /// # Example
     ///
-    /// ```
+    /// ``` 
+    /// #![feature(const_fn_fn_ptr_basics)]
+    /// #![feature(const_fn_transmute)]
+    /// #![feature(const_type_id)]
+    /// #![feature(const_type_name)]
+    ///
     /// # use bevy_ecs::prelude::*;
     ///
     /// struct Component1;
@@ -329,8 +334,13 @@ impl Commands {
     /// `with` can be chained with [`Self::spawn`].
     ///
     /// ```
-    /// # use bevy_ecs::prelude::*;
+    /// #![feature(const_fn_fn_ptr_basics)]
+    /// #![feature(const_fn_transmute)]
+    /// #![feature(const_type_id)]
+    /// #![feature(const_type_name)]
     ///
+    /// # use bevy_ecs::prelude::*;
+    /// 
     /// struct Component1;
     /// struct Component2;
     ///


### PR DESCRIPTION
The change alters how static type data for bundles are generated, so no allocations and sorting should happen any more during an app execution. It requires some nightly features for const evaluation one of which I don't like. It's `transmute` used to compare type identifiers since ordering isn't defined as a constant function. Others should be settled soon in `stable` toolchain, so will be removed at that point.

Another thing which bothers me is consants declared by `Bundle` tuple, but decided to use them instead of local static items in functions since the last is just another layer of abstraction and found that that's how some things done in Rust's standard library.

Unfortunately, I don't know how to run old tests from `bench.rs` and will highly appreciate any information on it. My attemps to make them work or even be detected ended by nothing.