### PR TITLE
[Merged by Bors] - update ColorMaterial when Texture changed

### DIFF
--- a/crates/bevy_sprite/src/color_material.rs
+++ b/crates/bevy_sprite/src/color_material.rs
@@ -57,6 +57,8 @@ impl From<Handle<Texture>> for ColorMaterial {
     }
 }
 
+// Temporary solution for sub-assets change handling, see https://github.com/bevyengine/bevy/issues/1161#issuecomment-780467768
+// TODO: should be removed when pipelined rendering is done
 pub(crate) fn material_texture_detection_system(
     mut texture_to_material: Local<HashMap<Handle<Texture>, HashSet<Handle<ColorMaterial>>>>,
     mut material_to_texture: Local<HashMap<Handle<ColorMaterial>, Handle<Texture>>>,

--- a/crates/bevy_sprite/src/color_material.rs
+++ b/crates/bevy_sprite/src/color_material.rs
@@ -57,7 +57,7 @@ impl From<Handle<Texture>> for ColorMaterial {
     }
 }
 
-pub fn material_texture_detection_system(
+pub(crate) fn material_texture_detection_system(
     mut texture_to_material: Local<HashMap<Handle<Texture>, HashSet<Handle<ColorMaterial>>>>,
     mut material_to_texture: Local<HashMap<Handle<ColorMaterial>, Handle<Texture>>>,
     materials: Res<Assets<ColorMaterial>>,
@@ -147,7 +147,7 @@ pub fn material_texture_detection_system(
     changed_materials
 }
 
-pub fn material_texture_trigger_system(
+pub(crate) fn material_texture_trigger_system(
     In(changed_materials): In<Vec<Handle<ColorMaterial>>>,
     mut material_events: ResMut<Events<AssetEvent<ColorMaterial>>>,
 ) {

--- a/crates/bevy_sprite/src/color_material.rs
+++ b/crates/bevy_sprite/src/color_material.rs
@@ -1,6 +1,6 @@
 use bevy_app::{EventReader, Events, ManualEventReader};
 use bevy_asset::{self, AssetEvent, Assets, Handle};
-use bevy_ecs::{Local, Res, ResMut};
+use bevy_ecs::system::{Local, Res, ResMut};
 use bevy_reflect::TypeUuid;
 use bevy_render::{color::Color, renderer::RenderResources, shader::ShaderDefs, texture::Texture};
 use bevy_utils::{HashMap, HashSet};

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -26,7 +26,7 @@ pub use texture_atlas_builder::*;
 
 use bevy_app::prelude::*;
 use bevy_asset::{AddAsset, Assets, Handle, HandleUntyped};
-use bevy_ecs::{IntoChainSystem, IntoSystem};
+use bevy_ecs::IntoSystem;
 use bevy_math::Vec2;
 use bevy_reflect::TypeUuid;
 use bevy_render::{
@@ -52,9 +52,7 @@ impl Plugin for SpritePlugin {
             .add_system_to_stage(CoreStage::PostUpdate, sprite_system.system())
             .add_system_to_stage(
                 CoreStage::PostUpdate,
-                material_texture_detection_system
-                    .system()
-                    .chain(material_texture_trigger_system.system()),
+                material_texture_detection_system.system(),
             )
             .add_system_to_stage(
                 CoreStage::PostUpdate,

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -26,7 +26,7 @@ pub use texture_atlas_builder::*;
 
 use bevy_app::prelude::*;
 use bevy_asset::{AddAsset, Assets, Handle, HandleUntyped};
-use bevy_ecs::IntoSystem;
+use bevy_ecs::system::IntoSystem;
 use bevy_math::Vec2;
 use bevy_reflect::TypeUuid;
 use bevy_render::{

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -26,7 +26,7 @@ pub use texture_atlas_builder::*;
 
 use bevy_app::prelude::*;
 use bevy_asset::{AddAsset, Assets, Handle, HandleUntyped};
-use bevy_ecs::system::IntoSystem;
+use bevy_ecs::{IntoChainSystem, IntoSystem};
 use bevy_math::Vec2;
 use bevy_reflect::TypeUuid;
 use bevy_render::{
@@ -50,6 +50,12 @@ impl Plugin for SpritePlugin {
             .register_type::<Sprite>()
             .register_type::<SpriteResizeMode>()
             .add_system_to_stage(CoreStage::PostUpdate, sprite_system.system())
+            .add_system_to_stage(
+                CoreStage::PostUpdate,
+                material_texture_detection_system
+                    .system()
+                    .chain(material_texture_trigger_system.system()),
+            )
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 asset_shader_defs_system::<ColorMaterial>.system(),


### PR DESCRIPTION
fixes #1161, fixes #1243

this adds two systems:
- first is keeping an hashmap of textures and their containing color materials, then listening to events on textures to select color materials that should be updated
- second is chained to send a modified event for all color materials that need updating