### PR TITLE
Explicit execution order ambiguities API

### DIFF
--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -482,9 +482,23 @@ fn topological_order(
 /// Returns vector containing all pairs of indices of systems with ambiguous execution order.
 /// Systems must be topologically sorted beforehand.
 fn find_ambiguities(systems: &[impl SystemContainer]) -> Vec<(usize, usize)> {
+    let ambiguity_set_labels = systems
+        .iter()
+        .flat_map(|container| container.ambiguity_sets())
+        .collect::<HashSet<_>>()
+        .drain()
+        .enumerate()
+        .map(|(index, set)| (set, index))
+        .collect::<HashMap<_, _>>();
+    let mut all_ambiguity_sets = Vec::<FixedBitSet>::with_capacity(systems.len());
     let mut all_dependencies = Vec::<FixedBitSet>::with_capacity(systems.len());
     let mut all_dependants = Vec::<FixedBitSet>::with_capacity(systems.len());
     for (index, container) in systems.iter().enumerate() {
+        let mut ambiguity_sets = FixedBitSet::with_capacity(ambiguity_set_labels.len());
+        for set in container.ambiguity_sets() {
+            ambiguity_sets.insert(ambiguity_set_labels[set]);
+        }
+        all_ambiguity_sets.push(ambiguity_sets);
         let mut dependencies = FixedBitSet::with_capacity(systems.len());
         for &dependency in container.dependencies() {
             dependencies.union_with(&all_dependencies[dependency]);
@@ -522,7 +536,10 @@ fn find_ambiguities(systems: &[impl SystemContainer]) -> Vec<(usize, usize)> {
         for index_b in full_bitset.difference(&relations)
         /*.take(index_a)*/
         {
-            if !processed.contains(index_b) && !systems[index_a].is_compatible(&systems[index_b]) {
+            if !processed.contains(index_b)
+                && all_ambiguity_sets[index_a].is_disjoint(&all_ambiguity_sets[index_b])
+                && !systems[index_a].is_compatible(&systems[index_b])
+            {
                 ambiguities.push((index_a, index_b));
             }
         }
@@ -1209,6 +1226,27 @@ mod tests {
         assert_eq!(ambiguities.len(), 2);
 
         let mut stage = SystemStage::parallel()
+            .with_system(component.system().label("0"))
+            .with_system(
+                resource
+                    .system()
+                    .label("1")
+                    .after("0")
+                    .in_ambiguity_set("a"),
+            )
+            .with_system(empty.system().label("2"))
+            .with_system(component.system().label("3").after("2").before("4"))
+            .with_system(resource.system().label("4").in_ambiguity_set("a"));
+        stage.initialize_systems(&mut world, &mut resources);
+        stage.rebuild_orders_and_dependencies();
+        let ambiguities = find_ambiguities_labels(&stage.parallel);
+        assert!(
+            ambiguities.contains(&("0".into(), "3".into()))
+                || ambiguities.contains(&("3".into(), "0".into()))
+        );
+        assert_eq!(ambiguities.len(), 1);
+
+        let mut stage = SystemStage::parallel()
             .with_system(component.system().label("0").before("2"))
             .with_system(component.system().label("1").before("2"))
             .with_system(component.system().label("2"));
@@ -1238,6 +1276,30 @@ mod tests {
             .with_system(component.system().label("0").before("1").before("2"))
             .with_system(component.system().label("1"))
             .with_system(component.system().label("2"))
+            .with_system(component.system().label("3").after("1").after("2"));
+        stage.initialize_systems(&mut world, &mut resources);
+        stage.rebuild_orders_and_dependencies();
+        let ambiguities = find_ambiguities_labels(&stage.parallel);
+        assert!(
+            ambiguities.contains(&("1".into(), "2".into()))
+                || ambiguities.contains(&("2".into(), "1".into()))
+        );
+        assert_eq!(ambiguities.len(), 1);
+
+        let mut stage = SystemStage::parallel()
+            .with_system(component.system().label("0").before("1").before("2"))
+            .with_system(component.system().label("1").in_ambiguity_set("a"))
+            .with_system(component.system().label("2").in_ambiguity_set("a"))
+            .with_system(component.system().label("3").after("1").after("2"));
+        stage.initialize_systems(&mut world, &mut resources);
+        stage.rebuild_orders_and_dependencies();
+        let ambiguities = find_ambiguities_labels(&stage.parallel);
+        assert_eq!(ambiguities.len(), 0);
+
+        let mut stage = SystemStage::parallel()
+            .with_system(component.system().label("0").before("1").before("2"))
+            .with_system(component.system().label("1").in_ambiguity_set("a"))
+            .with_system(component.system().label("2").in_ambiguity_set("b"))
             .with_system(component.system().label("3").after("1").after("2"));
         stage.initialize_systems(&mut world, &mut resources);
         stage.rebuild_orders_and_dependencies();
@@ -1299,6 +1361,76 @@ mod tests {
                 || ambiguities.contains(&("4".into(), "3".into()))
         );
         assert_eq!(ambiguities.len(), 6);
+
+        let mut stage = SystemStage::parallel()
+            .with_system(
+                component
+                    .system()
+                    .label("0")
+                    .before("1")
+                    .before("2")
+                    .before("3")
+                    .before("4"),
+            )
+            .with_system(component.system().label("1").in_ambiguity_set("a"))
+            .with_system(component.system().label("2").in_ambiguity_set("a"))
+            .with_system(component.system().label("3").in_ambiguity_set("a"))
+            .with_system(component.system().label("4").in_ambiguity_set("a"))
+            .with_system(
+                component
+                    .system()
+                    .label("5")
+                    .after("1")
+                    .after("2")
+                    .after("3")
+                    .after("4"),
+            );
+        stage.initialize_systems(&mut world, &mut resources);
+        stage.rebuild_orders_and_dependencies();
+        let ambiguities = find_ambiguities_labels(&stage.parallel);
+        assert_eq!(ambiguities.len(), 0);
+
+        let mut stage = SystemStage::parallel()
+            .with_system(
+                component
+                    .system()
+                    .label("0")
+                    .before("1")
+                    .before("2")
+                    .before("3")
+                    .before("4"),
+            )
+            .with_system(component.system().label("1").in_ambiguity_set("a"))
+            .with_system(component.system().label("2").in_ambiguity_set("a"))
+            .with_system(
+                component
+                    .system()
+                    .label("3")
+                    .in_ambiguity_set("a")
+                    .in_ambiguity_set("b"),
+            )
+            .with_system(component.system().label("4").in_ambiguity_set("b"))
+            .with_system(
+                component
+                    .system()
+                    .label("5")
+                    .after("1")
+                    .after("2")
+                    .after("3")
+                    .after("4"),
+            );
+        stage.initialize_systems(&mut world, &mut resources);
+        stage.rebuild_orders_and_dependencies();
+        let ambiguities = find_ambiguities_labels(&stage.parallel);
+        assert!(
+            ambiguities.contains(&("1".into(), "4".into()))
+                || ambiguities.contains(&("4".into(), "1".into()))
+        );
+        assert!(
+            ambiguities.contains(&("2".into(), "4".into()))
+                || ambiguities.contains(&("4".into(), "2".into()))
+        );
+        assert_eq!(ambiguities.len(), 2);
 
         let mut stage = SystemStage::parallel()
             .with_system(empty.exclusive_system().label("0"))

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -1481,5 +1481,44 @@ mod tests {
                 || ambiguities.contains(&("5".into(), "2".into()))
         );
         assert_eq!(ambiguities.len(), 6);
+
+        let mut stage = SystemStage::parallel()
+            .with_system(empty.exclusive_system().label("0").before("1").before("3"))
+            .with_system(empty.exclusive_system().label("1").in_ambiguity_set("a"))
+            .with_system(empty.exclusive_system().label("2").after("1"))
+            .with_system(empty.exclusive_system().label("3").in_ambiguity_set("a"))
+            .with_system(empty.exclusive_system().label("4").after("3").before("5"))
+            .with_system(empty.exclusive_system().label("5").in_ambiguity_set("a"))
+            .with_system(empty.exclusive_system().label("6").after("2").after("5"));
+        stage.initialize_systems(&mut world, &mut resources);
+        stage.rebuild_orders_and_dependencies();
+        let ambiguities = find_ambiguities_labels(&stage.exclusive_at_start);
+        assert!(
+            ambiguities.contains(&("2".into(), "3".into()))
+                || ambiguities.contains(&("3".into(), "2".into()))
+        );
+        assert!(
+            ambiguities.contains(&("1".into(), "4".into()))
+                || ambiguities.contains(&("4".into(), "1".into()))
+        );
+        assert!(
+            ambiguities.contains(&("2".into(), "4".into()))
+                || ambiguities.contains(&("4".into(), "2".into()))
+        );
+        assert!(
+            ambiguities.contains(&("2".into(), "5".into()))
+                || ambiguities.contains(&("5".into(), "2".into()))
+        );
+        assert_eq!(ambiguities.len(), 4);
+
+        let mut stage = SystemStage::parallel()
+            .with_system(empty.exclusive_system().label("0").in_ambiguity_set("a"))
+            .with_system(empty.exclusive_system().label("1").in_ambiguity_set("a"))
+            .with_system(empty.exclusive_system().label("2").in_ambiguity_set("a"))
+            .with_system(empty.exclusive_system().label("3").in_ambiguity_set("a"));
+        stage.initialize_systems(&mut world, &mut resources);
+        stage.rebuild_orders_and_dependencies();
+        let ambiguities = find_ambiguities_labels(&stage.exclusive_at_start);
+        assert_eq!(ambiguities.len(), 0);
     }
 }

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -482,14 +482,11 @@ fn topological_order(
 /// Returns vector containing all pairs of indices of systems with ambiguous execution order.
 /// Systems must be topologically sorted beforehand.
 fn find_ambiguities(systems: &[impl SystemContainer]) -> Vec<(usize, usize)> {
-    let ambiguity_set_labels = systems
-        .iter()
-        .flat_map(|container| container.ambiguity_sets())
-        .collect::<HashSet<_>>()
-        .drain()
-        .enumerate()
-        .map(|(index, set)| (set, index))
-        .collect::<HashMap<_, _>>();
+    let mut ambiguity_set_labels = HashMap::default();
+    for set in systems.iter().flat_map(|c| c.ambiguity_sets()) {
+        let len = ambiguity_set_labels.len();
+        ambiguity_set_labels.entry(set).or_insert(len);
+    }
     let mut all_ambiguity_sets = Vec::<FixedBitSet>::with_capacity(systems.len());
     let mut all_dependencies = Vec::<FixedBitSet>::with_capacity(systems.len());
     let mut all_dependants = Vec::<FixedBitSet>::with_capacity(systems.len());

--- a/crates/bevy_ecs/src/schedule/system_container.rs
+++ b/crates/bevy_ecs/src/schedule/system_container.rs
@@ -10,6 +10,7 @@ pub(super) trait SystemContainer {
     fn label(&self) -> &Option<Cow<'static, str>>;
     fn before(&self) -> &[Cow<'static, str>];
     fn after(&self) -> &[Cow<'static, str>];
+    fn ambiguity_sets(&self) -> &[Cow<'static, str>];
     fn is_compatible(&self, other: &Self) -> bool;
 }
 
@@ -20,6 +21,7 @@ pub(super) struct ExclusiveSystemContainer {
     label: Option<Cow<'static, str>>,
     before: Vec<Cow<'static, str>>,
     after: Vec<Cow<'static, str>>,
+    ambiguity_sets: Vec<Cow<'static, str>>,
 }
 
 impl ExclusiveSystemContainer {
@@ -31,6 +33,7 @@ impl ExclusiveSystemContainer {
             label: descriptor.label,
             before: descriptor.before,
             after: descriptor.after,
+            ambiguity_sets: descriptor.ambiguity_sets,
         }
     }
 
@@ -72,6 +75,10 @@ impl SystemContainer for ExclusiveSystemContainer {
         &self.after
     }
 
+    fn ambiguity_sets(&self) -> &[Cow<'static, str>] {
+        &self.ambiguity_sets
+    }
+
     fn is_compatible(&self, _: &Self) -> bool {
         false
     }
@@ -85,6 +92,7 @@ pub struct ParallelSystemContainer {
     label: Option<Cow<'static, str>>,
     before: Vec<Cow<'static, str>>,
     after: Vec<Cow<'static, str>>,
+    ambiguity_sets: Vec<Cow<'static, str>>,
 }
 
 impl SystemContainer for ParallelSystemContainer {
@@ -120,6 +128,10 @@ impl SystemContainer for ParallelSystemContainer {
         &self.after
     }
 
+    fn ambiguity_sets(&self) -> &[Cow<'static, str>] {
+        &self.ambiguity_sets
+    }
+
     fn is_compatible(&self, other: &Self) -> bool {
         self.system()
             .component_access()
@@ -144,6 +156,7 @@ impl ParallelSystemContainer {
             label: descriptor.label,
             before: descriptor.before,
             after: descriptor.after,
+            ambiguity_sets: descriptor.ambiguity_sets,
         }
     }
 

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -7,8 +7,7 @@ pub mod prelude {
 }
 
 use bevy_app::{prelude::*, startup_stage};
-use bevy_ecs::IntoSystem;
-use bevy_ecs::ParallelSystemDescriptorCoercion;
+use bevy_ecs::{IntoSystem, ParallelSystemDescriptorCoercion};
 use bevy_reflect::RegisterTypeBuilder;
 use prelude::{parent_update_system, Children, GlobalTransform, Parent, PreviousParent, Transform};
 


### PR DESCRIPTION
This API allows marking systems as exempt from ambiguity detection with other systems with the same mark. E.g., this will not report any ambiguities:
```rust
SystemStage::parallel()
    .with_system(conflicts_with_everything.system().label("0").before("1").before("2"))
    .with_system(conflicts_with_everything.system().label("1").in_ambiguity_set("a"))
    .with_system(conflicts_with_everything.system().label("2").in_ambiguity_set("a"))
    .with_system(conflicts_with_everything.system().label("3").after("1").after("2"))
```
It's a stopgap solution until some form of #1375 is implemented.