### PR TITLE
Fix deprecation warning when running cargo fmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,5 @@
 unstable_features = true
-merge_imports = true
+imports_granularity = "Crate"
 use_field_init_shorthand = true
 reorder_impl_items = true
 newline_style = "Unix"


### PR DESCRIPTION
Replace `merge_imports` with `imports_granularity=Crate`

See rust-lang/rustfmt#4634