### PR TITLE
Replaced deprecated fmt option by successor

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,5 @@
 unstable_features = true
-merge_imports = true
+imports_granularity = "Crate"
 use_field_init_shorthand = true
 reorder_impl_items = true
 newline_style = "Unix"


### PR DESCRIPTION
`merge_imports` was deprecated since 2021-01-27 in v1.4.33, and `imports_granularity` should be used instead. See [changelog](https://github.com/rust-lang/rustfmt/blob/302107ee9ad608f8e6b26c6cde34eda556c524f5/CHANGELOG.md#added-1).