### PR TITLE
[Merged by Bors] - Make vertex buffers optional

### DIFF
--- a/crates/bevy_render/src/pipeline/pipeline_compiler.rs
+++ b/crates/bevy_render/src/pipeline/pipeline_compiler.rs
@@ -235,7 +235,9 @@ impl PipelineCompiler {
 
         //TODO: add other buffers (like instancing) here
         let mut vertex_buffer_descriptors = Vec::<VertexBufferLayout>::default();
-        vertex_buffer_descriptors.push(compiled_vertex_buffer_descriptor);
+        if !pipeline_layout.vertex_buffer_descriptors.is_empty() {
+            vertex_buffer_descriptors.push(compiled_vertex_buffer_descriptor);
+        }
 
         pipeline_layout.vertex_buffer_descriptors = vertex_buffer_descriptors;
         specialized_descriptor.multisample.count = pipeline_specialization.sample_count;


### PR DESCRIPTION
For some cases, like driving a full screen fragment shader, it is sometimes convenient to not have to create and upload a mesh because the necessary vertices are simple to synthesize in the vertex shader. Bevy's existing pipeline compiler assumes that there will always be a vertex buffer. This PR changes that such that vertex buffer descriptor is only added to the pipeline layout if there are vertex attributes in the shader.