### PR TITLE
[Merged by Bors] - improve error message when asset type hasn't beed added to app

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -436,10 +436,11 @@ impl AssetServer {
                 asset_lifecycle.create_asset(asset_path.into(), asset_value, load_context.version);
             } else {
                 panic!(
-                    "Failed to find AssetLifecycle for label '{:?}', which has an asset type {}. \
+                    "Failed to find AssetLifecycle for label '{:?}', which has an asset type {} (UUID {:?}). \
                         Are you sure this asset type has been added to your app builder?",
                     label,
-                    asset_value.display_type()
+                    asset_value.type_name(),
+                    asset_value.type_uuid(),
                 );
             }
         }

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -435,7 +435,12 @@ impl AssetServer {
                     AssetPath::new_ref(&load_context.path, label.as_ref().map(|l| l.as_str()));
                 asset_lifecycle.create_asset(asset_path.into(), asset_value, load_context.version);
             } else {
-                panic!("Failed to find AssetLifecycle for label {:?}, which has an asset type {:?}. Are you sure that is a registered asset type?", label, asset_value.type_uuid());
+                panic!(
+                    "Failed to find AssetLifecycle for label '{:?}', which has an asset type {}. \
+                        Are you sure this asset type has been added to your app builder?",
+                    label,
+                    asset_value.display_type()
+                );
             }
         }
     }

--- a/crates/bevy_reflect/src/type_uuid.rs
+++ b/crates/bevy_reflect/src/type_uuid.rs
@@ -7,8 +7,7 @@ pub trait TypeUuid {
 
 pub trait TypeUuidDynamic {
     fn type_uuid(&self) -> Uuid;
-    /// Helper to display the type in a readable manner to the user
-    fn display_type(&self) -> String;
+    fn type_name(&self) -> &'static str;
 }
 
 impl<T> TypeUuidDynamic for T
@@ -19,11 +18,7 @@ where
         Self::TYPE_UUID
     }
 
-    fn display_type(&self) -> String {
-        format!(
-            "{:?} (UUID {:?})",
-            std::any::type_name::<Self>(),
-            self.type_uuid()
-        )
+    fn type_name(&self) -> &'static str {
+        std::any::type_name::<Self>()
     }
 }

--- a/crates/bevy_reflect/src/type_uuid.rs
+++ b/crates/bevy_reflect/src/type_uuid.rs
@@ -7,6 +7,8 @@ pub trait TypeUuid {
 
 pub trait TypeUuidDynamic {
     fn type_uuid(&self) -> Uuid;
+    /// Helper to display the type in a readable manner to the user
+    fn display_type(&self) -> String;
 }
 
 impl<T> TypeUuidDynamic for T
@@ -15,5 +17,13 @@ where
 {
     fn type_uuid(&self) -> Uuid {
         Self::TYPE_UUID
+    }
+
+    fn display_type(&self) -> String {
+        format!(
+            "{:?} (UUID {:?})",
+            std::any::type_name::<Self>(),
+            self.type_uuid()
+        )
     }
 }


### PR DESCRIPTION
Error message noticed in #1475 

When an asset type hasn't been added to the app but a load was attempted, the error message wasn't helpful:
```
thread 'IO Task Pool (0)' panicked at 'Failed to find AssetLifecycle for label Some("Mesh0/Primitive0"), which has an asset type 8ecbac0f-f545-4473-ad43-e1f4243af51e. Are you sure that is a registered asset type?', /.cargo/git/checkouts/bevy-f7ffde730c324c74/89a41bc/crates/bevy_asset/src/asset_server.rs:435:17
```
means that 
```rust
.add_asset::<bevy::render::prelude::Mesh>()
```
needs to be added.

* type name was not given, only UUID, which may make it hard to identify type across bevy/plugins
* instruction were not helpful as the `register_asset_type` method is not public

new error message:
```
thread 'IO Task Pool (1)' panicked at 'Failed to find AssetLifecycle for label 'Some("Mesh0/Primitive0")', which has an asset type "bevy_render::mesh::mesh::Mesh" (UUID 8ecbac0f-f545-4473-ad43-e1f4243af51e). Are you sure this asset type has been added to your app builder?', /bevy/crates/bevy_asset/src/asset_server.rs:435:17
```