### PR TITLE
[Merged by Bors] - better error message on failed derive

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -503,7 +503,7 @@ fn derive_label(input: DeriveInput, label_type: Ident) -> TokenStream2 {
     quote! {
         impl #crate_path::#label_type for #ident {
             fn dyn_clone(&self) -> Box<dyn #crate_path::#label_type> {
-                Box::new(self.clone())
+                Box::new(Clone::clone(self))
             }
         }
     }


### PR DESCRIPTION
Before, when deriving `SystemLabel` for a type without `Clone`, the error message was:
```
the trait `SystemLabel` is not implemented for `&TransformSystem`
```
Now it is
```
the trait `Clone` is not implemented for `TransformSystem`
```
which directly shows what's needed to fix the problem.