### PR TITLE
[Merged by Bors] - Frustum Culling (for Sprites)

### DIFF
--- a/crates/bevy_render/src/camera/active_cameras.rs
+++ b/crates/bevy_render/src/camera/active_cameras.rs
@@ -9,6 +9,7 @@ use bevy_utils::HashMap;
 
 #[derive(Debug, Default)]
 pub struct ActiveCamera {
+    pub name: String,
     pub entity: Option<Entity>,
     pub bindings: RenderResourceBindings,
 }
@@ -21,7 +22,10 @@ pub struct ActiveCameras {
 impl ActiveCameras {
     pub fn add(&mut self, name: &str) {
         self.cameras
-            .insert(name.to_string(), ActiveCamera::default());
+            .insert(name.to_string(), ActiveCamera {
+                name: name.to_string(),
+                ..Default::default()
+            });
     }
 
     pub fn get(&self, name: &str) -> Option<&ActiveCamera> {
@@ -30,6 +34,14 @@ impl ActiveCameras {
 
     pub fn get_mut(&mut self, name: &str) -> Option<&mut ActiveCamera> {
         self.cameras.get_mut(name)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item=&ActiveCamera> {
+        self.cameras.values()
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item=&mut ActiveCamera> {
+        self.cameras.values_mut()
     }
 }
 

--- a/crates/bevy_render/src/camera/active_cameras.rs
+++ b/crates/bevy_render/src/camera/active_cameras.rs
@@ -21,11 +21,13 @@ pub struct ActiveCameras {
 
 impl ActiveCameras {
     pub fn add(&mut self, name: &str) {
-        self.cameras
-            .insert(name.to_string(), ActiveCamera {
+        self.cameras.insert(
+            name.to_string(),
+            ActiveCamera {
                 name: name.to_string(),
                 ..Default::default()
-            });
+            },
+        );
     }
 
     pub fn get(&self, name: &str) -> Option<&ActiveCamera> {
@@ -36,11 +38,11 @@ impl ActiveCameras {
         self.cameras.get_mut(name)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item=&ActiveCamera> {
+    pub fn iter(&self) -> impl Iterator<Item = &ActiveCamera> {
         self.cameras.values()
     }
 
-    pub fn iter_mut(&mut self) -> impl Iterator<Item=&mut ActiveCamera> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut ActiveCamera> {
         self.cameras.values_mut()
     }
 }

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -1,7 +1,7 @@
 use super::{Camera, DepthCalculation};
-use crate::{draw::WithinFrustum, prelude::Visible};
+use crate::{draw::OutsideFrustum, prelude::Visible};
 use bevy_core::FloatOrd;
-use bevy_ecs::{entity::Entity, query::With, reflect::ReflectComponent, system::Query};
+use bevy_ecs::{entity::Entity, query::Without, reflect::ReflectComponent, system::Query};
 use bevy_reflect::Reflect;
 use bevy_transform::prelude::GlobalTransform;
 
@@ -204,8 +204,8 @@ pub fn visible_entities_system(
         &mut VisibleEntities,
         Option<&RenderLayers>,
     )>,
-    visible_query: Query<(Entity, &Visible, Option<&RenderLayers>), With<WithinFrustum>>,
-    visible_transform_query: Query<&GlobalTransform, With<WithinFrustum>>,
+    visible_query: Query<(Entity, &Visible, Option<&RenderLayers>), Without<OutsideFrustum>>,
+    visible_transform_query: Query<&GlobalTransform, Without<OutsideFrustum>>,
 ) {
     for (camera, camera_global_transform, mut visible_entities, maybe_camera_mask) in
         camera_query.iter_mut()

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -1,5 +1,5 @@
 use super::{Camera, DepthCalculation};
-use crate::prelude::Visible;
+use crate::{draw::WithinFrustum, prelude::Visible};
 use bevy_core::FloatOrd;
 use bevy_ecs::{entity::Entity, query::With, reflect::ReflectComponent, system::Query};
 use bevy_reflect::Reflect;
@@ -204,8 +204,8 @@ pub fn visible_entities_system(
         &mut VisibleEntities,
         Option<&RenderLayers>,
     )>,
-    visible_query: Query<(Entity, &Visible, Option<&RenderLayers>)>,
-    visible_transform_query: Query<&GlobalTransform, With<Visible>>,
+    visible_query: Query<(Entity, &Visible, Option<&RenderLayers>), With<WithinFrustum>>,
+    visible_transform_query: Query<&GlobalTransform, With<WithinFrustum>>,
 ) {
     for (camera, camera_global_transform, mut visible_entities, maybe_camera_mask) in
         camera_query.iter_mut()

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -70,7 +70,7 @@ impl Default for Visible {
 /// Any Sprite or AtlasTextureSprite will have this removed if they are outside the camera frustum and thus not be rendered.
 #[derive(Debug, Default, Clone, Reflect)]
 #[reflect(Component)]
-pub struct WithinFrustum;
+pub struct OutsideFrustum;
 
 /// A component that indicates how to draw an entity.
 #[derive(Debug, Clone, Reflect)]

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -66,8 +66,13 @@ impl Default for Visible {
     }
 }
 
-/// Viewable is used for frustum culling.
-/// Any Sprite or AtlasTextureSprite will have this removed if they are outside the camera frustum and thus not be rendered.
+/// A component that indicates that an entity is outside the view frustum.
+/// Any entity with this component will be ignored during rendering.
+///
+/// # Note
+/// This does not handle multiple "views" properly as it is a "global" filter.
+/// This will be resolved in the future. For now, disable frustum culling if you
+/// need to support multiple views (ex: set the `SpriteSettings::frustum_culling_enabled` resource).
 #[derive(Debug, Default, Clone, Reflect)]
 #[reflect(Component)]
 pub struct OutsideFrustum;

--- a/crates/bevy_render/src/draw.rs
+++ b/crates/bevy_render/src/draw.rs
@@ -66,6 +66,12 @@ impl Default for Visible {
     }
 }
 
+/// Viewable is used for frustum culling.
+/// Any Sprite or AtlasTextureSprite will have this removed if they are outside the camera frustum and thus not be rendered.
+#[derive(Debug, Default, Clone, Reflect)]
+#[reflect(Component)]
+pub struct WithinFrustum;
+
 /// A component that indicates how to draw an entity.
 #[derive(Debug, Clone, Reflect)]
 #[reflect(Component)]

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -17,7 +17,8 @@ use bevy_ecs::{
     system::{IntoExclusiveSystem, IntoSystem},
 };
 use bevy_transform::TransformSystem;
-use draw::Visible;
+use draw::{Visible, WithinFrustum};
+
 pub use once_cell;
 
 pub mod prelude {
@@ -137,6 +138,7 @@ impl Plugin for RenderPlugin {
         .register_type::<DepthCalculation>()
         .register_type::<Draw>()
         .register_type::<Visible>()
+        .register_type::<WithinFrustum>()
         .register_type::<RenderPipelines>()
         .register_type::<OrthographicProjection>()
         .register_type::<PerspectiveProjection>()

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -17,7 +17,7 @@ use bevy_ecs::{
     system::{IntoExclusiveSystem, IntoSystem},
 };
 use bevy_transform::TransformSystem;
-use draw::{Visible, WithinFrustum};
+use draw::{OutsideFrustum, Visible};
 
 pub use once_cell;
 
@@ -138,7 +138,7 @@ impl Plugin for RenderPlugin {
         .register_type::<DepthCalculation>()
         .register_type::<Draw>()
         .register_type::<Visible>()
-        .register_type::<WithinFrustum>()
+        .register_type::<OutsideFrustum>()
         .register_type::<RenderPipelines>()
         .register_type::<OrthographicProjection>()
         .register_type::<PerspectiveProjection>()

--- a/crates/bevy_render/src/pipeline/render_pipelines.rs
+++ b/crates/bevy_render/src/pipeline/render_pipelines.rs
@@ -1,13 +1,13 @@
 use super::{PipelineDescriptor, PipelineSpecialization};
 use crate::{
-    draw::{Draw, DrawContext, WithinFrustum},
+    draw::{Draw, DrawContext, OutsideFrustum},
     mesh::{Indices, Mesh},
     prelude::{Msaa, Visible},
     renderer::RenderResourceBindings,
 };
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::{
-    query::With,
+    query::Without,
     reflect::ReflectComponent,
     system::{Query, Res, ResMut},
 };
@@ -89,7 +89,7 @@ pub fn draw_render_pipelines_system(
     meshes: Res<Assets<Mesh>>,
     mut query: Query<
         (&mut Draw, &mut RenderPipelines, &Handle<Mesh>, &Visible),
-        With<WithinFrustum>,
+        Without<OutsideFrustum>,
     >,
 ) {
     for (mut draw, mut render_pipelines, mesh_handle, visible) in query.iter_mut() {

--- a/crates/bevy_render/src/pipeline/render_pipelines.rs
+++ b/crates/bevy_render/src/pipeline/render_pipelines.rs
@@ -1,12 +1,13 @@
 use super::{PipelineDescriptor, PipelineSpecialization};
 use crate::{
-    draw::{Draw, DrawContext},
+    draw::{Draw, DrawContext, WithinFrustum},
     mesh::{Indices, Mesh},
     prelude::{Msaa, Visible},
     renderer::RenderResourceBindings,
 };
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::{
+    query::With,
     reflect::ReflectComponent,
     system::{Query, Res, ResMut},
 };
@@ -86,7 +87,10 @@ pub fn draw_render_pipelines_system(
     mut render_resource_bindings: ResMut<RenderResourceBindings>,
     msaa: Res<Msaa>,
     meshes: Res<Assets<Mesh>>,
-    mut query: Query<(&mut Draw, &mut RenderPipelines, &Handle<Mesh>, &Visible)>,
+    mut query: Query<
+        (&mut Draw, &mut RenderPipelines, &Handle<Mesh>, &Visible),
+        With<WithinFrustum>,
+    >,
 ) {
     for (mut draw, mut render_pipelines, mesh_handle, visible) in query.iter_mut() {
         if !visible.is_visible {

--- a/crates/bevy_render/src/shader/shader_defs.rs
+++ b/crates/bevy_render/src/shader/shader_defs.rs
@@ -1,9 +1,9 @@
 use bevy_asset::{Asset, Assets, Handle};
 
-use crate::{draw::WithinFrustum, pipeline::RenderPipelines, Texture};
+use crate::{draw::OutsideFrustum, pipeline::RenderPipelines, Texture};
 pub use bevy_derive::ShaderDefs;
 use bevy_ecs::{
-    query::With,
+    query::Without,
     system::{Query, Res},
 };
 
@@ -64,7 +64,7 @@ impl ShaderDef for Option<Handle<Texture>> {
 }
 
 /// Updates [RenderPipelines] with the latest [ShaderDefs]
-pub fn shader_defs_system<T>(mut query: Query<(&T, &mut RenderPipelines), With<WithinFrustum>>)
+pub fn shader_defs_system<T>(mut query: Query<(&T, &mut RenderPipelines), Without<OutsideFrustum>>)
 where
     T: ShaderDefs + Send + Sync + 'static,
 {
@@ -97,7 +97,7 @@ pub fn clear_shader_defs_system(mut query: Query<&mut RenderPipelines>) {
 /// Updates [RenderPipelines] with the latest [ShaderDefs] from a given asset type
 pub fn asset_shader_defs_system<T: Asset>(
     assets: Res<Assets<T>>,
-    mut query: Query<(&Handle<T>, &mut RenderPipelines), With<WithinFrustum>>,
+    mut query: Query<(&Handle<T>, &mut RenderPipelines), Without<OutsideFrustum>>,
 ) where
     T: ShaderDefs + Send + Sync + 'static,
 {

--- a/crates/bevy_render/src/shader/shader_defs.rs
+++ b/crates/bevy_render/src/shader/shader_defs.rs
@@ -1,8 +1,11 @@
 use bevy_asset::{Asset, Assets, Handle};
 
-use crate::{pipeline::RenderPipelines, Texture};
+use crate::{draw::WithinFrustum, pipeline::RenderPipelines, Texture};
 pub use bevy_derive::ShaderDefs;
-use bevy_ecs::system::{Query, Res};
+use bevy_ecs::{
+    query::With,
+    system::{Query, Res},
+};
 
 /// Something that can either be "defined" or "not defined". This is used to determine if a "shader
 /// def" should be considered "defined"
@@ -61,7 +64,7 @@ impl ShaderDef for Option<Handle<Texture>> {
 }
 
 /// Updates [RenderPipelines] with the latest [ShaderDefs]
-pub fn shader_defs_system<T>(mut query: Query<(&T, &mut RenderPipelines)>)
+pub fn shader_defs_system<T>(mut query: Query<(&T, &mut RenderPipelines), With<WithinFrustum>>)
 where
     T: ShaderDefs + Send + Sync + 'static,
 {
@@ -94,7 +97,7 @@ pub fn clear_shader_defs_system(mut query: Query<&mut RenderPipelines>) {
 /// Updates [RenderPipelines] with the latest [ShaderDefs] from a given asset type
 pub fn asset_shader_defs_system<T: Asset>(
     assets: Res<Assets<T>>,
-    mut query: Query<(&Handle<T>, &mut RenderPipelines)>,
+    mut query: Query<(&Handle<T>, &mut RenderPipelines), With<WithinFrustum>>,
 ) where
     T: ShaderDefs + Send + Sync + 'static,
 {

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -24,6 +24,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.4.0", features = ["bevy"
 bevy_render = { path = "../bevy_render", version = "0.4.0" }
 bevy_transform = { path = "../bevy_transform", version = "0.4.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.4.0" }
+bevy_window = { path = "../bevy_window", version = "0.4.0" }
 
 # other
 rectangle-pack = "0.2"

--- a/crates/bevy_sprite/src/frustum_culling.rs
+++ b/crates/bevy_sprite/src/frustum_culling.rs
@@ -56,7 +56,7 @@ pub fn sprites(
                 if culled_sprites.get(entity).is_ok() {
                     commands.entity(entity).remove::<OutsideFrustum>();
                 }
-            } else {
+            } else if culled_sprites.get(entity).is_err() {
                 commands.entity(entity).insert(OutsideFrustum);
             }
         }
@@ -101,7 +101,7 @@ pub fn atlases(
                         if culled_sprites.get(entity).is_ok() {
                             commands.entity(entity).remove::<OutsideFrustum>();
                         }
-                    } else {
+                    } else if culled_sprites.get(entity).is_err() {
                         commands.entity(entity).insert(OutsideFrustum);
                     }
                 }

--- a/crates/bevy_sprite/src/frustum_culling.rs
+++ b/crates/bevy_sprite/src/frustum_culling.rs
@@ -1,0 +1,120 @@
+use bevy_asset::{Assets, Handle};
+use bevy_ecs::prelude::{Commands, Entity, Query, Res, With, Without};
+use bevy_math::Vec2;
+use bevy_render::{camera::Camera, draw::WithinFrustum, render_graph::base::MainPass};
+use bevy_transform::components::Transform;
+use bevy_window::Windows;
+
+use crate::{Sprite, TextureAtlas, TextureAtlasSprite};
+
+struct Rect {
+    position: Vec2,
+    size: Vec2,
+}
+
+impl Rect {
+    #[inline]
+    pub fn is_intersecting(&self, other: Rect) -> bool {
+        self.position.distance(other.position) < (self.get_radius() + other.get_radius())
+    }
+
+    #[inline]
+    pub fn get_radius(&self) -> f32 {
+        let half_size = self.size / Vec2::splat(2.0);
+        (half_size.x.powf(2.0) + half_size.y.powf(2.0)).sqrt()
+    }
+}
+
+pub fn sprites(
+    mut commands: Commands,
+    windows: Res<Windows>,
+    cameras: Query<&Transform, With<Camera>>,
+    visible: Query<&WithinFrustum, With<Sprite>>,
+    sprites: Query<(Entity, &Transform, &Sprite)>,
+) {
+    let window_size = if let Some(window) = windows.get_primary() {
+        Vec2::new(window.width(), window.height())
+    } else {
+        return;
+    };
+
+    for camera_transform in cameras.iter() {
+        let camera_size = window_size * camera_transform.scale.truncate();
+
+        let rect = Rect {
+            position: camera_transform.translation.truncate(),
+            size: camera_size,
+        };
+
+        for (entity, drawable_transform, sprite) in sprites.iter() {
+            let sprite_rect = Rect {
+                position: drawable_transform.translation.truncate(),
+                size: sprite.size,
+            };
+
+            if rect.is_intersecting(sprite_rect) {
+                if visible.get(entity).is_err() {
+                    commands.entity(entity).insert(WithinFrustum);
+                }
+            } else if visible.get(entity).is_ok() {
+                commands.entity(entity).remove::<WithinFrustum>();
+            }
+        }
+    }
+}
+
+pub fn atlases(
+    mut commands: Commands,
+    windows: Res<Windows>,
+    textures: Res<Assets<TextureAtlas>>,
+    cameras: Query<&Transform, With<Camera>>,
+    visible: Query<&WithinFrustum, With<TextureAtlasSprite>>,
+    sprites: Query<(
+        Entity,
+        &Transform,
+        &TextureAtlasSprite,
+        &Handle<TextureAtlas>,
+    )>,
+) {
+    let window = windows.get_primary().unwrap();
+    let window_size = Vec2::new(window.width(), window.height());
+
+    for camera_transform in cameras.iter() {
+        let camera_size = window_size * camera_transform.scale.truncate();
+
+        let rect = Rect {
+            position: camera_transform.translation.truncate(),
+            size: camera_size,
+        };
+
+        for (entity, drawable_transform, sprite, atlas_handle) in sprites.iter() {
+            if let Some(atlas) = textures.get(atlas_handle) {
+                if let Some(sprite) = atlas.textures.get(sprite.index as usize) {
+                    let size = Vec2::new(sprite.width(), sprite.height());
+
+                    let sprite_rect = Rect {
+                        position: drawable_transform.translation.truncate(),
+                        size,
+                    };
+
+                    if rect.is_intersecting(sprite_rect) {
+                        if visible.get(entity).is_err() {
+                            commands.entity(entity).insert(WithinFrustum);
+                        }
+                    } else if visible.get(entity).is_ok() {
+                        commands.entity(entity).remove::<WithinFrustum>();
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub fn other(
+    mut commands: Commands,
+    query: Query<Entity, (With<MainPass>, Without<Sprite>, Without<TextureAtlasSprite>)>,
+) {
+    for entity in query.iter() {
+        commands.entity(entity).insert(WithinFrustum);
+    }
+}

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -34,7 +34,7 @@ use bevy_ecs::{
 use bevy_math::Vec2;
 use bevy_reflect::TypeUuid;
 use bevy_render::{
-    draw::WithinFrustum,
+    draw::OutsideFrustum,
     mesh::{shape, Mesh},
     pipeline::PipelineDescriptor,
     render_graph::RenderGraph,
@@ -57,7 +57,6 @@ impl Plugin for SpritePlugin {
             .add_system_to_stage(CoreStage::PostUpdate, sprite_system.system())
             .add_system_to_stage(CoreStage::PostUpdate, frustum_culling::sprites.system())
             .add_system_to_stage(CoreStage::PostUpdate, frustum_culling::atlases.system())
-            .add_system_to_stage(CoreStage::PostUpdate, frustum_culling::other.system())
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 material_texture_detection_system.system(),
@@ -69,7 +68,7 @@ impl Plugin for SpritePlugin {
 
         let world = app.world_mut();
         world
-            .register_component(ComponentDescriptor::new::<WithinFrustum>(
+            .register_component(ComponentDescriptor::new::<OutsideFrustum>(
                 StorageType::SparseSet,
             ))
             .unwrap();

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -2,13 +2,13 @@ use crate::ColorMaterial;
 use bevy_asset::{Assets, Handle};
 use bevy_core::Bytes;
 use bevy_ecs::{
-    query::With,
+    query::Without,
     system::{Query, Res},
 };
 use bevy_math::Vec2;
 use bevy_reflect::{Reflect, ReflectDeserialize, TypeUuid};
 use bevy_render::{
-    draw::WithinFrustum,
+    draw::OutsideFrustum,
     renderer::{RenderResource, RenderResourceType, RenderResources},
     texture::Texture,
 };
@@ -80,7 +80,7 @@ impl Sprite {
 pub fn sprite_system(
     materials: Res<Assets<ColorMaterial>>,
     textures: Res<Assets<Texture>>,
-    mut query: Query<(&mut Sprite, &Handle<ColorMaterial>), With<WithinFrustum>>,
+    mut query: Query<(&mut Sprite, &Handle<ColorMaterial>), Without<OutsideFrustum>>,
 ) {
     for (mut sprite, handle) in query.iter_mut() {
         match sprite.resize_mode {

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -1,10 +1,14 @@
 use crate::ColorMaterial;
 use bevy_asset::{Assets, Handle};
 use bevy_core::Bytes;
-use bevy_ecs::system::{Query, Res};
+use bevy_ecs::{
+    query::With,
+    system::{Query, Res},
+};
 use bevy_math::Vec2;
 use bevy_reflect::{Reflect, ReflectDeserialize, TypeUuid};
 use bevy_render::{
+    draw::WithinFrustum,
     renderer::{RenderResource, RenderResourceType, RenderResources},
     texture::Texture,
 };
@@ -76,7 +80,7 @@ impl Sprite {
 pub fn sprite_system(
     materials: Res<Assets<ColorMaterial>>,
     textures: Res<Assets<Texture>>,
-    mut query: Query<(&mut Sprite, &Handle<ColorMaterial>)>,
+    mut query: Query<(&mut Sprite, &Handle<ColorMaterial>), With<WithinFrustum>>,
 ) {
     for (mut sprite, handle) in query.iter_mut() {
         match sprite.resize_mode {

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -2,12 +2,12 @@ use bevy_asset::Assets;
 use bevy_ecs::{
     bundle::Bundle,
     entity::Entity,
-    query::{Changed, With},
+    query::{Changed, With, Without},
     system::{Local, Query, QuerySet, Res, ResMut},
 };
 use bevy_math::{Size, Vec3};
 use bevy_render::{
-    draw::{DrawContext, Drawable, WithinFrustum},
+    draw::{DrawContext, Drawable, OutsideFrustum},
     mesh::Mesh,
     prelude::{Draw, Msaa, Texture, Visible},
     render_graph::base::MainPass,
@@ -72,7 +72,7 @@ pub fn draw_text2d_system(
             &GlobalTransform,
             &Text2dSize,
         ),
-        (With<MainPass>, With<WithinFrustum>),
+        (With<MainPass>, Without<OutsideFrustum>),
     >,
 ) {
     let font_quad = meshes.get(&QUAD_HANDLE).unwrap();

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
 };
 use bevy_math::{Size, Vec3};
 use bevy_render::{
-    draw::{DrawContext, Drawable},
+    draw::{DrawContext, Drawable, WithinFrustum},
     mesh::Mesh,
     prelude::{Draw, Msaa, Texture, Visible},
     render_graph::base::MainPass,
@@ -72,7 +72,7 @@ pub fn draw_text2d_system(
             &GlobalTransform,
             &Text2dSize,
         ),
-        With<MainPass>,
+        (With<MainPass>, With<WithinFrustum>),
     >,
 ) {
     let font_quad = meshes.get(&QUAD_HANDLE).unwrap();

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -2,12 +2,12 @@ use crate::{CalculatedSize, Node, Style, Val};
 use bevy_asset::Assets;
 use bevy_ecs::{
     entity::Entity,
-    query::{Changed, Or, With},
+    query::{Changed, Or, Without},
     system::{Local, Query, QuerySet, Res, ResMut},
 };
 use bevy_math::Size;
 use bevy_render::{
-    draw::{Draw, DrawContext, Drawable, WithinFrustum},
+    draw::{Draw, DrawContext, Drawable, OutsideFrustum},
     mesh::Mesh,
     prelude::{Msaa, Visible},
     renderer::RenderResourceBindings,
@@ -138,7 +138,7 @@ pub fn draw_text_system(
     text_pipeline: Res<DefaultTextPipeline>,
     mut query: Query<
         (Entity, &mut Draw, &Visible, &Text, &Node, &GlobalTransform),
-        With<WithinFrustum>,
+        Without<OutsideFrustum>,
     >,
 ) {
     let scale_factor = if let Some(window) = windows.get_primary() {

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -2,12 +2,12 @@ use crate::{CalculatedSize, Node, Style, Val};
 use bevy_asset::Assets;
 use bevy_ecs::{
     entity::Entity,
-    query::{Changed, Or},
+    query::{Changed, Or, With},
     system::{Local, Query, QuerySet, Res, ResMut},
 };
 use bevy_math::Size;
 use bevy_render::{
-    draw::{Draw, DrawContext, Drawable},
+    draw::{Draw, DrawContext, Drawable, WithinFrustum},
     mesh::Mesh,
     prelude::{Msaa, Visible},
     renderer::RenderResourceBindings,
@@ -136,7 +136,10 @@ pub fn draw_text_system(
     meshes: Res<Assets<Mesh>>,
     mut render_resource_bindings: ResMut<RenderResourceBindings>,
     text_pipeline: Res<DefaultTextPipeline>,
-    mut query: Query<(Entity, &mut Draw, &Visible, &Text, &Node, &GlobalTransform)>,
+    mut query: Query<
+        (Entity, &mut Draw, &Visible, &Text, &Node, &GlobalTransform),
+        With<WithinFrustum>,
+    >,
 ) {
     let scale_factor = if let Some(window) = windows.get_primary() {
         window.scale_factor()


### PR DESCRIPTION
This PR adds two systems to the sprite module that culls Sprites and AtlasSprites that are not within the camera's view.
This is achieved by removing / adding a new  `Viewable` Component dynamically.

Some of the render queries now use a `With<Viewable>` filter to only process the sprites that are actually on screen, which improves performance drastically for scene swith a large amount of sprites off-screen.

https://streamable.com/vvzh2u

This scene shows a map with a 320x320 tiles, with a grid size of 64p.
This is exactly 102400 Sprites in the entire scene.

Without this PR, this scene runs with 1 to 4 FPS.

With this PR..
.. at 720p, there are around 600 visible sprites and runs at ~215 FPS
.. at 1440p there are around 2000 visible sprites and runs at ~135 FPS

The Systems this PR adds take around 1.2ms (with 100K+ sprites in the scene)

Note:
This is only implemented for Sprites and AtlasTextureSprites.
There is no culling for 3D in this PR.