### PR TITLE
[Merged by Bors] - Add getter for RenderGraph Node uuid

### DIFF
--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -13,6 +13,10 @@ impl NodeId {
     pub fn new() -> Self {
         NodeId(Uuid::new_v4())
     }
+
+    pub fn uuid(&self) -> &Uuid {
+        &self.0
+}
 }
 
 pub trait Node: Downcast + Send + Sync + 'static {

--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -16,7 +16,7 @@ impl NodeId {
 
     pub fn uuid(&self) -> &Uuid {
         &self.0
-}
+    }
 }
 
 pub trait Node: Downcast + Send + Sync + 'static {


### PR DESCRIPTION
`RenderGraph` errors only give the `Uuid` of the node. So for my graphviz dot based visualization of the `RenderGraph` I really wanted to show it to the user. I think it makes sense to have it accessible for at least debugging purposes.