### PR TITLE
(WIP) Adds UiRenderGraphConfig analogous to BaseRenderGraphConfig

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -25,7 +25,7 @@ use bevy_render::render_graph::RenderGraph;
 use update::ui_z_system;
 
 pub struct UiPlugin {
-    ui_render_graph_config: Option<UiRenderGraphConfig>,
+    pub ui_render_graph_config: Option<UiRenderGraphConfig>,
 }
 
 impl Default for UiPlugin {

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -24,8 +24,17 @@ use bevy_ecs::{IntoSystem, ParallelSystemDescriptorCoercion, SystemStage};
 use bevy_render::render_graph::RenderGraph;
 use update::ui_z_system;
 
-#[derive(Default)]
-pub struct UiPlugin;
+pub struct UiPlugin {
+    ui_render_graph_config: Option<UiRenderGraphConfig>,
+}
+
+impl Default for UiPlugin {
+    fn default() -> Self {
+        Self {
+            ui_render_graph_config: Some(UiRenderGraphConfig::default()),
+        }
+    }
+}
 
 pub mod stage {
     pub const UI: &str = "ui";
@@ -56,6 +65,8 @@ impl Plugin for UiPlugin {
 
         let resources = app.resources();
         let mut render_graph = resources.get_mut::<RenderGraph>().unwrap();
-        render_graph.add_ui_graph(resources);
+        if let Some(ref config) = self.ui_render_graph_config {
+            render_graph.add_ui_graph(config, resources);
+        }
     }
 }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -77,12 +77,24 @@ pub mod camera {
     pub const CAMERA_UI: &str = "CameraUi";
 }
 
+pub struct UiRenderGraphConfig {
+    connect_ui_pass_to_main_depth_texture: bool,
+}
+
+impl Default for UiRenderGraphConfig {
+    fn default() -> Self {
+        Self {
+            connect_ui_pass_to_main_depth_texture: true,
+        }
+    }
+}
+
 pub trait UiRenderGraphBuilder {
-    fn add_ui_graph(&mut self, resources: &Resources) -> &mut Self;
+    fn add_ui_graph(&mut self, config: &UiRenderGraphConfig, resources: &Resources) -> &mut Self;
 }
 
 impl UiRenderGraphBuilder for RenderGraph {
-    fn add_ui_graph(&mut self, resources: &Resources) -> &mut Self {
+    fn add_ui_graph(&mut self, config: &UiRenderGraphConfig, resources: &Resources) -> &mut Self {
         let mut pipelines = resources.get_mut::<Assets<PipelineDescriptor>>().unwrap();
         let mut shaders = resources.get_mut::<Assets<Shader>>().unwrap();
         let msaa = resources.get::<Msaa>().unwrap();
@@ -123,13 +135,15 @@ impl UiRenderGraphBuilder for RenderGraph {
         )
         .unwrap();
 
-        self.add_slot_edge(
-            base::node::MAIN_DEPTH_TEXTURE,
-            WindowTextureNode::OUT_TEXTURE,
-            node::UI_PASS,
-            "depth",
-        )
-        .unwrap();
+        if config.connect_ui_pass_to_main_depth_texture {
+            self.add_slot_edge(
+                base::node::MAIN_DEPTH_TEXTURE,
+                WindowTextureNode::OUT_TEXTURE,
+                node::UI_PASS,
+                "depth",
+            )
+            .unwrap();
+        }
 
         if msaa.samples > 1 {
             self.add_slot_edge(

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -78,7 +78,7 @@ pub mod camera {
 }
 
 pub struct UiRenderGraphConfig {
-    connect_ui_pass_to_main_depth_texture: bool,
+    pub connect_ui_pass_to_main_depth_texture: bool,
 }
 
 impl Default for UiRenderGraphConfig {


### PR DESCRIPTION
Because I added a post processing pass between Main and Swap Chain, I had a need to have UI use another Depth Texture. 

This PR adds a UiRenderGraphConfig analogous to BaseRenderGraphConfig.

I haven't yet added all the options or fixed up usages throughout Bevy, because I first wanted to hear back whether this seems like a worthwhile approach.