### PR TITLE
[Merged by Bors] - Fix staging buffer required size calculation (fixes #1056)

### DIFF
--- a/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
@@ -216,7 +216,9 @@ where
             }
         }
 
-        self.required_staging_buffer_size = new_size;
+        if new_size > self.required_staging_buffer_size {
+            self.required_staging_buffer_size = new_size;
+        }
     }
 
     /// Update the staging buffer to provide enough space to copy data to target buffers.
@@ -698,6 +700,12 @@ fn asset_render_resources_node_system<T: RenderResources + Asset>(
 
     let resized = uniform_buffer_arrays.resize_buffer_arrays(render_resource_context);
     if resized {
+        // full asset copy needed, make sure there is also space for unchanged assets
+        for (asset_handle, asset) in assets.iter() {
+            if !changed_assets.contains_key(&asset_handle) {
+                uniform_buffer_arrays.prepare_uniform_buffers(asset_handle, asset);
+            }
+        }
         uniform_buffer_arrays.set_required_staging_buffer_size_to_max()
     }
     uniform_buffer_arrays.resize_staging_buffer(render_resource_context);


### PR DESCRIPTION
Fix staging buffer required size calculation (fixes #1056)

The `required_staging_buffer_size` is currently calculated differently in two places, each will be correct in different situations:

* `prepare_staging_buffers()` based on actual `buffer_byte_len()`
* `set_required_staging_buffer_size_to_max()` based on item_size

In the case of render assets, `prepare_staging_buffers()` would only operate over changed assets. If some of the assets didn't change, their size wouldn't be taken into account for the `required_staging_buffer_size`. In some cases, this meant the buffers wouldn't be resized when they should. Now `prepare_staging_buffers()` is called over all assets, which may hit performance but at least gets the size right.

Shortly after `prepare_staging_buffers()`,  `set_required_staging_buffer_size_to_max()` would unconditionally overwrite the previously computed value, even if using `item_size` made no sense. Now it only overwrites the value if bigger.

This can be considered a short term hack, but should prevent a few hard to debug panics.