### PR TITLE
Change 2D camera defaults

### DIFF
--- a/crates/bevy_render/src/entity.rs
+++ b/crates/bevy_render/src/entity.rs
@@ -96,6 +96,8 @@ impl OrthographicCameraBundle {
             orthographic_projection: OrthographicProjection {
                 far,
                 depth_calculation: DepthCalculation::ZDifference,
+                scaling_mode: ScalingMode::FixedVertical,
+                scale: 1024.,
                 ..Default::default()
             },
             visible_entities: Default::default(),


### PR DESCRIPTION
The default shouldn't be to change how much of the world you see based on your window size. 