### PR TITLE
[Merged by Bors] - convert grayscale images to rgb

### DIFF
--- a/crates/bevy_render/src/texture/image_texture_conversion.rs
+++ b/crates/bevy_render/src/texture/image_texture_conversion.rs
@@ -12,16 +12,18 @@ pub(crate) fn image_to_texture(dyn_img: image::DynamicImage) -> Texture {
 
     match dyn_img {
         image::DynamicImage::ImageLuma8(i) => {
+            let i = image::DynamicImage::ImageLuma8(i).into_rgba8();
             width = i.width();
             height = i.height();
-            format = TextureFormat::R8Unorm;
+            format = TextureFormat::Rgba8UnormSrgb;
 
             data = i.into_raw();
         }
         image::DynamicImage::ImageLumaA8(i) => {
+            let i = image::DynamicImage::ImageLumaA8(i).into_rgba8();
             width = i.width();
             height = i.height();
-            format = TextureFormat::Rg8Unorm;
+            format = TextureFormat::Rgba8UnormSrgb;
 
             data = i.into_raw();
         }


### PR DESCRIPTION
Fixes #1518 

Issue was that images loaded as [`ImageLumaA8`](https://docs.rs/image/0.23.13/image/enum.DynamicImage.html#variant.ImageLumaA8) (grayscale with alpha channel) from `image` were considered as [`Rg8Unorm`](https://docs.rs/wgpu/0.7.0/wgpu/enum.TextureFormat.html#variant.Rg8Unorm) (red green channels) from `wgpu`.
Same for `ImageLuma8` (grayscale) that was converted to `R8Unorm` (only red channel).

As `wgpu` doesn't seem to have grayscale texture formats, I converted the grayscale textures to rgba.

