### PR TITLE
[Merged by Bors] - Change breakout to use fixed timestamp

### DIFF
--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    core::{FixedTimestep},
+    core::FixedTimestep,
     prelude::*,
     render::pass::ClearColor,
     sprite::collide_aabb::{collide, Collision},

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -13,9 +13,8 @@ fn main() {
         .insert_resource(Scoreboard { score: 0 })
         .insert_resource(ClearColor(Color::rgb(0.9, 0.9, 0.9)))
         .add_startup_system(setup.system())
-        .add_stage(
-            FixedUpdateStage,
-            SystemStage::parallel()
+        .add_system_set(
+            SystemSet::new()
                 .with_run_criteria(FixedTimestep::step(TIME_STEP as f64))
                 .with_system(paddle_movement_system.system())
                 .with_system(ball_collision_system.system())
@@ -24,9 +23,6 @@ fn main() {
         .add_system(scoreboard_system.system())
         .run();
 }
-
-#[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
-struct FixedUpdateStage;
 
 struct Paddle {
     speed: f32,

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -1,22 +1,34 @@
 use bevy::{
+    core::{FixedTimestep},
     prelude::*,
     render::pass::ClearColor,
     sprite::collide_aabb::{collide, Collision},
 };
 
 /// An implementation of the classic game "Breakout"
+const TIME_STEP: f32 = 1.0 / 60.0;
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .insert_resource(Scoreboard { score: 0 })
         .insert_resource(ClearColor(Color::rgb(0.9, 0.9, 0.9)))
         .add_startup_system(setup.system())
-        .add_system(paddle_movement_system.system())
-        .add_system(ball_collision_system.system())
-        .add_system(ball_movement_system.system())
+        .add_stage(
+            FixedUpdateStage,
+            SystemStage::parallel()
+                .with_run_criteria(
+                    FixedTimestep::step(TIME_STEP as f64)
+                )
+                .with_system(paddle_movement_system.system())
+                .with_system(ball_collision_system.system())
+                .with_system(ball_movement_system.system()),
+        )
         .add_system(scoreboard_system.system())
         .run();
 }
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
+struct FixedUpdateStage;
 
 struct Paddle {
     speed: f32,
@@ -175,7 +187,6 @@ fn setup(
 }
 
 fn paddle_movement_system(
-    time: Res<Time>,
     keyboard_input: Res<Input<KeyCode>>,
     mut query: Query<(&Paddle, &mut Transform)>,
 ) {
@@ -191,18 +202,15 @@ fn paddle_movement_system(
 
         let translation = &mut transform.translation;
         // move the paddle horizontally
-        translation.x += time.delta_seconds() * direction * paddle.speed;
+        translation.x += direction * paddle.speed;
         // bound the paddle within the walls
         translation.x = translation.x.min(380.0).max(-380.0);
     }
 }
 
-fn ball_movement_system(time: Res<Time>, mut ball_query: Query<(&Ball, &mut Transform)>) {
-    // clamp the timestep to stop the ball from escaping when the game starts
-    let delta_seconds = f32::min(0.2, time.delta_seconds());
-
+fn ball_movement_system(mut ball_query: Query<(&Ball, &mut Transform)>) {
     if let Ok((ball, mut transform)) = ball_query.single_mut() {
-        transform.translation += ball.velocity * delta_seconds;
+        transform.translation += ball.velocity;
     }
 }
 

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -16,9 +16,7 @@ fn main() {
         .add_stage(
             FixedUpdateStage,
             SystemStage::parallel()
-                .with_run_criteria(
-                    FixedTimestep::step(TIME_STEP as f64)
-                )
+                .with_run_criteria(FixedTimestep::step(TIME_STEP as f64))
                 .with_system(paddle_movement_system.system())
                 .with_system(ball_collision_system.system())
                 .with_system(ball_movement_system.system()),
@@ -202,7 +200,7 @@ fn paddle_movement_system(
 
         let translation = &mut transform.translation;
         // move the paddle horizontally
-        translation.x += direction * paddle.speed;
+        translation.x += direction * paddle.speed * TIME_STEP;
         // bound the paddle within the walls
         translation.x = translation.x.min(380.0).max(-380.0);
     }
@@ -210,7 +208,7 @@ fn paddle_movement_system(
 
 fn ball_movement_system(mut ball_query: Query<(&Ball, &mut Transform)>) {
     if let Ok((ball, mut transform)) = ball_query.single_mut() {
-        transform.translation += ball.velocity;
+        transform.translation += ball.velocity * TIME_STEP;
     }
 }
 


### PR DESCRIPTION
This PR fixes https://github.com/bevyengine/bevy/issues/1240, where the ball is escaping the playing field at low framerates.  I did this by moving the movement and physics system into a Fixed Timestep system set and changing the movement steps to a constant.  So we lose the example use of delta_time for changing position, but gain a use of FixedTimestep.

If this is accepted https://github.com/bevyengine/bevy-website/pull/102 will need to be updated to match.