### PR TITLE
[Merged by Bors] - remove dev-dependencies from bevy_ecs

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -30,7 +30,3 @@ bitflags = "1.2.1"
 downcast-rs = "1.2.0"
 parking_lot = "0.11.0"
 lazy_static = { version = "1.4.0" }
-
-[dev-dependencies]
-bencher = "0.1.5"
-criterion = "0.3"


### PR DESCRIPTION
These are no longer used, increase build times, and currently break builds due to a broken criterion dependency on nightly.