### PR TITLE
[Merged by Bors] - add Or back to prelude

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -16,7 +16,7 @@ pub mod prelude {
     pub use crate::{
         bundle::Bundle,
         entity::Entity,
-        query::{Added, Changed, Flags, Mutated, QueryState, With, WithBundle, Without},
+        query::{Added, Changed, Flags, Mutated, Or, QueryState, With, WithBundle, Without},
         schedule::{
             AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,
             Schedule, Stage, StageLabel, State, StateStage, SystemLabel, SystemStage,


### PR DESCRIPTION
The bevy ecs v2 rewrite seems to have removed the `Or` query filter from the prelude, which I assume was done on accident, since `With` and `Without` are still there.