### PR TITLE
[Merged by Bors] - Make TypeRegistration::get_short_name() pub

### DIFF
--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -150,7 +150,7 @@ impl TypeRegistration {
         self.name
     }
 
-    fn get_short_name(full_name: &str) -> String {
+    pub fn get_short_name(full_name: &str) -> String {
         let mut short_name = String::new();
 
         {


### PR DESCRIPTION
This would allow for example `bevy_mod_debugdump` to use it, instead of custom typename shortening.