### PR TITLE
[Merged by Bors] - fix flip of contributor bird

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -109,7 +109,7 @@ pub fn build_sprite_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescriptor
             topology: PrimitiveTopology::TriangleList,
             strip_index_format: None,
             front_face: FrontFace::Ccw,
-            cull_mode: CullMode::Back,
+            cull_mode: CullMode::None,
             polygon_mode: PolygonMode::Fill,
         },
         ..PipelineDescriptor::new(ShaderStages {

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -74,8 +74,7 @@ fn setup(
         // some sprites should be flipped
         let flipped = rnd.gen_bool(0.5);
 
-        let mut transform = Transform::from_xyz(pos.0, pos.1, 0.0);
-        transform.scale.x *= if flipped { -1.0 } else { 1.0 };
+        let transform = Transform::from_xyz(pos.0, pos.1, 0.0);
 
         commands
             .spawn((Contributor { color: col },))
@@ -87,6 +86,7 @@ fn setup(
                 sprite: Sprite {
                     size: Vec2::new(1.0, 1.0) * SPRITE_SIZE,
                     resize_mode: SpriteResizeMode::Manual,
+                    flip_x: flipped,
                     ..Default::default()
                 },
                 material: materials.add(ColorMaterial {


### PR DESCRIPTION
Since 89217171b49eebba527b575eb0a89df0c3533ac6, some birds in example `contributors` where not colored.

Fix is to use `flip_x` of `Sprite` instead of setting `transform.scale.x` to `-1` as described in #1407.


It may be an unintended side effect, as now we can't easily display a colored sprite while changing it's scale from `1` to `-1`, we would have to change it's scale from `1` to `0`, then flip it, then change scale from `0` to `1`.