### PR TITLE
[Merged by Bors] - feat: clone indices

### DIFF
--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -188,7 +188,7 @@ impl From<Vec<[u8; 4]>> for VertexAttributeValues {
 /// An array of indices into the VertexAttributeValues for a mesh.
 ///
 /// It describes the order in which the vertex attributes should be joined into faces.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Indices {
     U16(Vec<u16>),
     U32(Vec<u32>),

--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -204,7 +204,7 @@ impl From<&Indices> for IndexFormat {
 }
 
 // TODO: allow values to be unloaded after been submitting to the GPU to conserve memory
-#[derive(Debug, TypeUuid)]
+#[derive(Debug, TypeUuid, Clone)]
 #[uuid = "8ecbac0f-f545-4473-ad43-e1f4243af51e"]
 pub struct Mesh {
     primitive_topology: PrimitiveTopology,


### PR DESCRIPTION
Super simple and straight forward. I need this for the tilemap because if I need to update all chunk indices, then I can calculate it once and clone it. Of course, for now I'm just returning the Vec itself then wrapping it but would be nice if I didn't have to do that.