### PR TITLE
[Merged by Bors] - Many-to-many system labels

### DIFF
--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -232,19 +232,19 @@ impl SystemStage {
         ) {
             if let Err(DependencyGraphError::GraphCycles(cycle)) = sort_systems(systems) {
                 use std::fmt::Write;
-                let mut string = format!("Found a dependency cycle in {}:", systems_description);
-                writeln!(string).unwrap();
+                let mut message = format!("Found a dependency cycle in {}:", systems_description);
+                writeln!(message).unwrap();
                 for (name, labels) in &cycle {
-                    writeln!(string, " - {}", name).unwrap();
+                    writeln!(message, " - {}", name).unwrap();
                     writeln!(
-                        string,
+                        message,
                         "    wants to be after (because of labels {:?})",
                         labels
                     )
                     .unwrap();
                 }
-                writeln!(string, " - {}", cycle[0].0).unwrap();
-                panic!("{}", string);
+                writeln!(message, " - {}", cycle[0].0).unwrap();
+                panic!("{}", message);
             }
         }
         sort_systems_unwrap(&mut self.parallel, "parallel systems");

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -244,7 +244,7 @@ impl SystemStage {
                     .unwrap();
                 }
                 writeln!(string, " - {}", cycle[0].0).unwrap();
-                panic!(string);
+                panic!("{}", string);
             }
         }
         sort_systems_unwrap(&mut self.parallel, "parallel systems");

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -438,20 +438,16 @@ fn topological_order(
     while let Some(node) = unvisited.iter().next().cloned() {
         if check_if_cycles_and_visit(&node, graph, &mut sorted, &mut unvisited, &mut current) {
             let mut cycle = Vec::new();
-            for index in 0..current.len() - 1 {
+            let last_window = [*current.last().unwrap(), current[0]];
+            let mut windows = current
+                .windows(2)
+                .chain(std::iter::once(&last_window as &[usize]));
+            while let Some(&[dependant, dependency]) = windows.next() {
                 cycle.push((
-                    systems[current[index]].name(),
-                    graph[&current[index]][&current[index + 1]]
-                        .iter()
-                        .cloned()
-                        .collect(),
+                    systems[dependant].name(),
+                    graph[&dependant][&dependency].iter().cloned().collect(),
                 ));
             }
-            let last = *current.last().unwrap();
-            cycle.push((
-                systems[last].name(),
-                graph[&last][&current[0]].iter().cloned().collect(),
-            ));
             return Err(DependencyGraphError::GraphCycles(cycle));
         }
     }

--- a/crates/bevy_ecs/src/schedule/system_container.rs
+++ b/crates/bevy_ecs/src/schedule/system_container.rs
@@ -12,7 +12,7 @@ pub(super) trait SystemContainer {
     fn dependencies(&self) -> &[usize];
     fn set_dependencies(&mut self, dependencies: impl IntoIterator<Item = usize>);
     fn system_set(&self) -> usize;
-    fn label(&self) -> &Option<BoxedSystemLabel>;
+    fn labels(&self) -> &[BoxedSystemLabel];
     fn before(&self) -> &[BoxedSystemLabel];
     fn after(&self) -> &[BoxedSystemLabel];
     fn ambiguity_sets(&self) -> &[BoxedAmbiguitySetLabel];
@@ -23,7 +23,7 @@ pub(super) struct ExclusiveSystemContainer {
     system: Box<dyn ExclusiveSystem>,
     dependencies: Vec<usize>,
     set: usize,
-    label: Option<BoxedSystemLabel>,
+    labels: Vec<BoxedSystemLabel>,
     before: Vec<BoxedSystemLabel>,
     after: Vec<BoxedSystemLabel>,
     ambiguity_sets: Vec<BoxedAmbiguitySetLabel>,
@@ -35,7 +35,7 @@ impl ExclusiveSystemContainer {
             system: descriptor.system,
             dependencies: Vec::new(),
             set,
-            label: descriptor.label,
+            labels: descriptor.labels,
             before: descriptor.before,
             after: descriptor.after,
             ambiguity_sets: descriptor.ambiguity_sets,
@@ -49,8 +49,9 @@ impl ExclusiveSystemContainer {
 
 impl SystemContainer for ExclusiveSystemContainer {
     fn display_name(&self) -> Cow<'static, str> {
-        self.label
-            .as_ref()
+        // TODO: sensible display names.
+        self.labels
+            .get(0)
             .map(|l| Cow::Owned(format!("{:?}", l)))
             .unwrap_or_else(|| self.system.name())
     }
@@ -68,8 +69,8 @@ impl SystemContainer for ExclusiveSystemContainer {
         self.set
     }
 
-    fn label(&self) -> &Option<BoxedSystemLabel> {
-        &self.label
+    fn labels(&self) -> &[BoxedSystemLabel] {
+        &self.labels
     }
 
     fn before(&self) -> &[BoxedSystemLabel] {
@@ -94,7 +95,7 @@ pub struct ParallelSystemContainer {
     pub(crate) should_run: bool,
     dependencies: Vec<usize>,
     set: usize,
-    label: Option<BoxedSystemLabel>,
+    labels: Vec<BoxedSystemLabel>,
     before: Vec<BoxedSystemLabel>,
     after: Vec<BoxedSystemLabel>,
     ambiguity_sets: Vec<BoxedAmbiguitySetLabel>,
@@ -102,8 +103,9 @@ pub struct ParallelSystemContainer {
 
 impl SystemContainer for ParallelSystemContainer {
     fn display_name(&self) -> Cow<'static, str> {
-        self.label
-            .as_ref()
+        // TODO: sensible display names.
+        self.labels
+            .get(0)
             .map(|l| Cow::Owned(format!("{:?}", l)))
             .unwrap_or_else(|| self.system().name())
     }
@@ -121,8 +123,8 @@ impl SystemContainer for ParallelSystemContainer {
         self.set
     }
 
-    fn label(&self) -> &Option<BoxedSystemLabel> {
-        &self.label
+    fn labels(&self) -> &[BoxedSystemLabel] {
+        &self.labels
     }
 
     fn before(&self) -> &[BoxedSystemLabel] {
@@ -154,7 +156,7 @@ impl ParallelSystemContainer {
             should_run: false,
             set,
             dependencies: Vec::new(),
-            label: descriptor.label,
+            labels: descriptor.labels,
             before: descriptor.before,
             after: descriptor.after,
             ambiguity_sets: descriptor.ambiguity_sets,

--- a/crates/bevy_ecs/src/schedule/system_descriptor.rs
+++ b/crates/bevy_ecs/src/schedule/system_descriptor.rs
@@ -13,8 +13,9 @@ use crate::{
 /// * At end, accepts exclusive systems; runs after parallel systems' command buffers have
 /// been applied.
 ///
-/// All systems can have a label attached to them; other systems in the same group can then specify
-/// that they have to run before or after the system with that label using the `before` and `after` methods.
+/// All systems can have one or several labels attached to them; other systems in the same group
+/// can then specify that they have to run before or after systems with that label using the
+/// `before` and `after` methods.
 ///
 /// # Example
 /// ```
@@ -96,13 +97,13 @@ fn new_parallel_descriptor(system: BoxedSystem<(), ()>) -> ParallelSystemDescrip
 }
 
 pub trait ParallelSystemDescriptorCoercion {
-    /// Assigns a label to the system.
+    /// Assigns a label to the system; there can be more than one, and it doesn't have to be unique.
     fn label(self, label: impl SystemLabel) -> ParallelSystemDescriptor;
 
-    /// Specifies that the system should run before the system with given label.
+    /// Specifies that the system should run before systems with the  given label.
     fn before(self, label: impl SystemLabel) -> ParallelSystemDescriptor;
 
-    /// Specifies that the system should run after the system with given label.
+    /// Specifies that the system should run after systems with the given label.
     fn after(self, label: impl SystemLabel) -> ParallelSystemDescriptor;
 
     /// Specifies that the system is exempt from execution order ambiguity detection
@@ -200,13 +201,13 @@ fn new_exclusive_descriptor(system: Box<dyn ExclusiveSystem>) -> ExclusiveSystem
 }
 
 pub trait ExclusiveSystemDescriptorCoercion {
-    /// Assigns a label to the system.
+    /// Assigns a label to the system; there can be more than one, and it doesn't have to be unique.
     fn label(self, label: impl SystemLabel) -> ExclusiveSystemDescriptor;
 
-    /// Specifies that the system should run before the system with given label.
+    /// Specifies that the system should run before systems with the given label.
     fn before(self, label: impl SystemLabel) -> ExclusiveSystemDescriptor;
 
-    /// Specifies that the system should run after the system with given label.
+    /// Specifies that the system should run after systems with the given label.
     fn after(self, label: impl SystemLabel) -> ExclusiveSystemDescriptor;
 
     /// Specifies that the system is exempt from execution order ambiguity detection

--- a/crates/bevy_ecs/src/schedule/system_descriptor.rs
+++ b/crates/bevy_ecs/src/schedule/system_descriptor.rs
@@ -79,7 +79,7 @@ impl From<ExclusiveSystemCoerced> for SystemDescriptor {
 /// Encapsulates a parallel system and information on when it run in a `SystemStage`.
 pub struct ParallelSystemDescriptor {
     pub(crate) system: BoxedSystem<(), ()>,
-    pub(crate) label: Option<BoxedSystemLabel>,
+    pub(crate) labels: Vec<BoxedSystemLabel>,
     pub(crate) before: Vec<BoxedSystemLabel>,
     pub(crate) after: Vec<BoxedSystemLabel>,
     pub(crate) ambiguity_sets: Vec<BoxedAmbiguitySetLabel>,
@@ -88,7 +88,7 @@ pub struct ParallelSystemDescriptor {
 fn new_parallel_descriptor(system: BoxedSystem<(), ()>) -> ParallelSystemDescriptor {
     ParallelSystemDescriptor {
         system,
-        label: None,
+        labels: Vec::new(),
         before: Vec::new(),
         after: Vec::new(),
         ambiguity_sets: Vec::new(),
@@ -112,7 +112,7 @@ pub trait ParallelSystemDescriptorCoercion {
 
 impl ParallelSystemDescriptorCoercion for ParallelSystemDescriptor {
     fn label(mut self, label: impl SystemLabel) -> ParallelSystemDescriptor {
-        self.label = Some(Box::new(label));
+        self.labels.push(Box::new(label));
         self
     }
 
@@ -181,7 +181,7 @@ pub(crate) enum InsertionPoint {
 /// Encapsulates an exclusive system and information on when it run in a `SystemStage`.
 pub struct ExclusiveSystemDescriptor {
     pub(crate) system: Box<dyn ExclusiveSystem>,
-    pub(crate) label: Option<BoxedSystemLabel>,
+    pub(crate) labels: Vec<BoxedSystemLabel>,
     pub(crate) before: Vec<BoxedSystemLabel>,
     pub(crate) after: Vec<BoxedSystemLabel>,
     pub(crate) ambiguity_sets: Vec<BoxedAmbiguitySetLabel>,
@@ -191,7 +191,7 @@ pub struct ExclusiveSystemDescriptor {
 fn new_exclusive_descriptor(system: Box<dyn ExclusiveSystem>) -> ExclusiveSystemDescriptor {
     ExclusiveSystemDescriptor {
         system,
-        label: None,
+        labels: Vec::new(),
         before: Vec::new(),
         after: Vec::new(),
         ambiguity_sets: Vec::new(),
@@ -226,7 +226,7 @@ pub trait ExclusiveSystemDescriptorCoercion {
 
 impl ExclusiveSystemDescriptorCoercion for ExclusiveSystemDescriptor {
     fn label(mut self, label: impl SystemLabel) -> ExclusiveSystemDescriptor {
-        self.label = Some(Box::new(label));
+        self.labels.push(Box::new(label));
         self
     }
 

--- a/crates/bevy_ecs/src/schedule/system_descriptor.rs
+++ b/crates/bevy_ecs/src/schedule/system_descriptor.rs
@@ -13,7 +13,7 @@ use crate::{
 /// * At end, accepts exclusive systems; runs after parallel systems' command buffers have
 /// been applied.
 ///
-/// All systems can have one or several labels attached to them; other systems in the same group
+/// Systems can have one or more labels attached to them; other systems in the same group
 /// can then specify that they have to run before or after systems with that label using the
 /// `before` and `after` methods.
 ///


### PR DESCRIPTION
* Systems can now have more than one label attached to them.
* System labels no longer have to be unique in the stage.

Code like this is now possible:
```rust
SystemStage::parallel()
    .with_system(system_0.system().label("group one").label("first"))
    .with_system(system_1.system().label("group one").after("first"))
    .with_system(system_2.system().after("group one"))
```

I've opted to use only the system name in ambiguity reporting, which previously was only a fallback; this, obviously, is because labels aren't one-to-one with systems anymore. We could allow users to name systems to improve this; we'll then have to think about whether or not we want to allow using the name as a label (this would, effectively, introduce implicit labelling, not all implications of which are clear to me yet wrt many-to-many labels).

Dependency cycle errors are reported using the system names and only the labels that form the cycle, with each system-system "edge" in the cycle represented as one or several labels.

Slightly unrelated: `.before()` and `.after()` with a label not attached to any system no longer crashes, and logs a warning instead. This is necessary to, for example, allow plugins to specify execution order with systems of potentially missing other plugins.