### PR TITLE
Change Interaction::None to NoInteraction

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -10,12 +10,12 @@ use smallvec::SmallVec;
 pub enum Interaction {
     Clicked,
     Hovered,
-    None,
+    NoInteraction,
 }
 
 impl Default for Interaction {
     fn default() -> Self {
-        Interaction::None
+        Interaction::NoInteraction
     }
 }
 
@@ -61,7 +61,7 @@ pub fn ui_focus_system(
     // reset entities that were both clicked and released in the last frame
     for entity in state.entities_to_reset.drain(..) {
         if let Ok(mut interaction) = node_query.get_component_mut::<Interaction>(entity) {
-            *interaction = Interaction::None;
+            *interaction = Interaction::NoInteraction;
         }
     }
 
@@ -72,7 +72,7 @@ pub fn ui_focus_system(
         {
             if let Some(mut interaction) = interaction {
                 if *interaction == Interaction::Clicked {
-                    *interaction = Interaction::None;
+                    *interaction = Interaction::NoInteraction;
                 }
             }
         }
@@ -98,7 +98,7 @@ pub fn ui_focus_system(
                 } else {
                     if let Some(mut interaction) = interaction {
                         if *interaction == Interaction::Hovered {
-                            *interaction = Interaction::None;
+                            *interaction = Interaction::NoInteraction;
                         }
                     }
                     None
@@ -122,7 +122,7 @@ pub fn ui_focus_system(
                         state.entities_to_reset.push(entity);
                     }
                 }
-            } else if *interaction == Interaction::None {
+            } else if *interaction == Interaction::NoInteraction {
                 *interaction = Interaction::Hovered;
             }
         }
@@ -137,8 +137,8 @@ pub fn ui_focus_system(
     // reset lower nodes to None
     for (_entity, _focus_policy, interaction, _) in moused_over_z_sorted_nodes {
         if let Some(mut interaction) = interaction {
-            if *interaction != Interaction::None {
-                *interaction = Interaction::None;
+            if *interaction != Interaction::NoInteraction {
+                *interaction = Interaction::NoInteraction;
             }
         }
     }

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -87,7 +87,7 @@ fn menu(
             Interaction::Hovered => {
                 *material = button_materials.hovered.clone();
             }
-            Interaction::None => {
+            Interaction::NoInteraction => {
                 *material = button_materials.normal.clone();
             }
         }

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -46,7 +46,7 @@ fn button_system(
                 text.sections[0].value = "Hover".to_string();
                 *material = button_materials.hovered.clone();
             }
-            Interaction::None => {
+            Interaction::NoInteraction => {
                 text.sections[0].value = "Button".to_string();
                 *material = button_materials.normal.clone();
             }


### PR DESCRIPTION
The `bevy::ui::Interaction` interaction enum has an unidiomatic `Interaction::None` value. E.g. earlier I wanted to optionally query for interactions to a button entity, however matching `Query<Option<&Interaction>, With<Button>` would never reach the `None` arm.