### PR TITLE
[Merged by Bors] - Fixes potential panic when unwrapping touch event on Moved phase

### DIFF
--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -194,12 +194,13 @@ impl Touches {
                 self.just_pressed.insert(event.id, event.into());
             }
             TouchPhase::Moved => {
-                let mut new_touch = self.pressed.get(&event.id).cloned().unwrap();
-                new_touch.previous_position = new_touch.position;
-                new_touch.previous_force = new_touch.force;
-                new_touch.position = event.position;
-                new_touch.force = event.force;
-                self.pressed.insert(event.id, new_touch);
+                if let Some(mut new_touch) = self.pressed.get(&event.id).cloned() {
+                    new_touch.previous_position = new_touch.position;
+                    new_touch.previous_force = new_touch.force;
+                    new_touch.position = event.position;
+                    new_touch.force = event.force;
+                    self.pressed.insert(event.id, new_touch);
+                }
             }
             TouchPhase::Ended => {
                 self.just_released.insert(event.id, event.into());


### PR DESCRIPTION
Should fix https://github.com/bevyengine/bevy/issues/1516.

I don't have any devices available to test this tbh but I feel like this was the only spot that could be causing a panic.

@ptircylinder since you posted this issue, could you please try to run the example on this branch and check if you get the same behavior while using your device? Thank you!