### PR TITLE
Lift update necessity on hexasphere.

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -38,7 +38,7 @@ downcast-rs = "1.2.0"
 thiserror = "1.0"
 anyhow = "1.0"
 hex = "0.4.2"
-hexasphere = "3.2"
+bevy_hexasphere = "0.1.2"
 parking_lot = "0.11.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/bevy_render/src/mesh/shape/icosphere.rs
+++ b/crates/bevy_render/src/mesh/shape/icosphere.rs
@@ -1,7 +1,4 @@
-use bevy_hexasphere::{
-    shapes::IcoSphere,
-    Vec3 as V3,
-};
+use bevy_hexasphere::{shapes::IcoSphere, Vec3 as V3};
 
 use bevy_math::Vec3;
 


### PR DESCRIPTION
I rewrote `hexasphere` into a parallel library `bevy_hexasphere`, which should alleviate the necessity to update glam in `hexasphere`. It also doesn't have all the features that regular `hexasphere` has, so it should be marginally faster to compile (it was already blazingly fast to compile, but now it should be even faster).

It uses a bit of an ugly hack to get it done, since we don't define our own Vec3 and just reexport the `glam` one.