### PR TITLE
Reorder Imports in Examples

### DIFF
--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -1,5 +1,5 @@
-use bevy::prelude::*;
-use bevy_internal::{
+use bevy::{
+    prelude::*,
     render::wireframe::{Wireframe, WireframeConfig, WireframePlugin},
     wgpu::{WgpuFeature, WgpuFeatures, WgpuOptions},
 };

--- a/examples/reflection/generic_reflection.rs
+++ b/examples/reflection/generic_reflection.rs
@@ -1,7 +1,5 @@
+use bevy::{prelude::*, reflect::TypeRegistry};
 use std::any::TypeId;
-
-pub use bevy::prelude::*;
-use bevy::reflect::TypeRegistry;
 
 /// You must manually register each instance of a generic type
 fn main() {


### PR DESCRIPTION
This only affected 2 Examples:
* `generic_reflection`: For some reason, a `pub use` statement was used. This was removed, and alphabetically ordered.
* `wireframe`: This example used the `bevy_internal` crate directly. Changed to use `bevy` instead.

All other Example Imports are correct.

One potential subjective change is the `removel_detection` example. 
Unlike all other Examples, it has its (first) explanatory comment before the Imports.