### PR TITLE
[Merged by Bors] - Adds rustfmt configs to wrap and limit comment width

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -8,3 +8,4 @@ newline_style = "Unix"
 #reorder_impl_items = true
 #wrap_comments = true
 #comment_width = 100
+#normalize_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -6,3 +6,5 @@ newline_style = "Unix"
 #unstable_features = true
 #imports_granularity = "Crate"
 #reorder_impl_items = true
+#wrap_comments = true
+#comment_width = 100


### PR DESCRIPTION
Aims to close https://github.com/bevyengine/bevy/issues/1594.

These options are unstable and depend on the following PR's:

[wrap_comments](https://rust-lang.github.io/rustfmt/?version=v1.4.36&search=#wrap_comments): https://github.com/rust-lang/rustfmt/issues/3347

[comment_width](https://rust-lang.github.io/rustfmt/?version=v1.4.36&search=#comment_width): https://github.com/rust-lang/rustfmt/issues/3349

[normalize_comments](https://rust-lang.github.io/rustfmt/?version=v1.4.36&search=#normalize_comments): https://github.com/rust-lang/rustfmt/issues/3350

@alice-i-cecile do you think this will solve the issue? When enabled, running the formatter locally should take the configurations into account to format comments. `--check` runs should also be considering them. This should be testable on the `nightly` toolchain.

~I didn't delve into normalizing `//` vs `/* */` though, should I take a look into that too? [normalize_comments](https://rust-lang.github.io/rustfmt/?version=v1.4.36&search=#normalize_comments) seems to be the solution for that but it's also unstable (tracking issue: https://github.com/rust-lang/rustfmt/issues/3350). I can also add this configuration (commented out, of course) if it's desirable.~ Added `normalize_comments` option.
