### PR TITLE
[Merged by Bors] - Add separate brightness field to AmbientLight

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -60,12 +60,15 @@ impl LightRaw {
 #[derive(Debug)]
 pub struct AmbientLight {
     pub color: Color,
+    /// Color is premultiplied by brightness before being passed to the shader
+    pub brightness: f32,
 }
 
 impl Default for AmbientLight {
     fn default() -> Self {
         Self {
-            color: Color::rgb(0.05, 0.05, 0.05),
+            color: Color::rgb(1.0, 1.0, 1.0),
+            brightness: 0.05,
         }
     }
 }

--- a/crates/bevy_pbr/src/render_graph/lights_node.rs
+++ b/crates/bevy_pbr/src/render_graph/lights_node.rs
@@ -86,7 +86,9 @@ pub fn lights_node_system(
     let state = &mut state;
     let render_resource_context = &**render_resource_context;
 
-    let ambient_light: [f32; 4] = ambient_light_resource.color.into();
+    // premultiply ambient brightness
+    let ambient_light: [f32; 4] =
+        (ambient_light_resource.color * ambient_light_resource.brightness).into();
     let ambient_light_size = std::mem::size_of::<[f32; 4]>();
     let light_count = query.iter().count();
     let size = std::mem::size_of::<LightRaw>();


### PR DESCRIPTION
Idea being this would be easier to grasp for end-users. Problem with the logical defaults is this breaks current setups, because light will become 20 times less bright. But most folks won't have customized this resource or will not have used `..Default::default()` due to lack of other fields.