### PR TITLE
[Merged by Bors] - Resolve (most) internal system ambiguities

### DIFF
--- a/crates/bevy_app/src/app_builder.rs
+++ b/crates/bevy_app/src/app_builder.rs
@@ -211,21 +211,19 @@ impl AppBuilder {
     }
 
     pub fn add_default_stages(&mut self) -> &mut Self {
-        self.add_stage(
-            CoreStage::Startup,
-            Schedule::default()
-                .with_run_criteria(RunOnce::default())
-                .with_stage(StartupStage::PreStartup, SystemStage::parallel())
-                .with_stage(StartupStage::Startup, SystemStage::parallel())
-                .with_stage(StartupStage::PostStartup, SystemStage::parallel()),
-        )
-        .add_stage(CoreStage::First, SystemStage::parallel())
-        .add_stage(CoreStage::PreEvent, SystemStage::parallel())
-        .add_stage(CoreStage::Event, SystemStage::parallel())
-        .add_stage(CoreStage::PreUpdate, SystemStage::parallel())
-        .add_stage(CoreStage::Update, SystemStage::parallel())
-        .add_stage(CoreStage::PostUpdate, SystemStage::parallel())
-        .add_stage(CoreStage::Last, SystemStage::parallel())
+        self.add_stage(CoreStage::First, SystemStage::parallel())
+            .add_stage(
+                CoreStage::Startup,
+                Schedule::default()
+                    .with_run_criteria(RunOnce::default())
+                    .with_stage(StartupStage::PreStartup, SystemStage::parallel())
+                    .with_stage(StartupStage::Startup, SystemStage::parallel())
+                    .with_stage(StartupStage::PostStartup, SystemStage::parallel()),
+            )
+            .add_stage(CoreStage::PreUpdate, SystemStage::parallel())
+            .add_stage(CoreStage::Update, SystemStage::parallel())
+            .add_stage(CoreStage::PostUpdate, SystemStage::parallel())
+            .add_stage(CoreStage::Last, SystemStage::parallel())
     }
 
     pub fn add_event<T>(&mut self) -> &mut Self
@@ -233,7 +231,7 @@ impl AppBuilder {
         T: Component,
     {
         self.insert_resource(Events::<T>::default())
-            .add_system_to_stage(CoreStage::Event, Events::<T>::update_system.system())
+            .add_system_to_stage(CoreStage::First, Events::<T>::update_system.system())
     }
 
     /// Inserts a resource to the current [App] and overwrites any resource previously added of the same type.

--- a/crates/bevy_app/src/event.rs
+++ b/crates/bevy_app/src/event.rs
@@ -3,7 +3,11 @@ use bevy_ecs::{
     system::{Local, Res, ResMut, SystemParam},
 };
 use bevy_utils::tracing::trace;
-use std::{fmt, marker::PhantomData};
+use std::{
+    fmt::{self},
+    hash::Hash,
+    marker::PhantomData,
+};
 
 /// An `EventId` uniquely identifies an event.
 ///

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -31,10 +31,6 @@ pub enum CoreStage {
     Startup,
     /// Name of app stage that runs before all other app stages
     First,
-    /// Name of app stage that runs before EVENT
-    PreEvent,
-    /// Name of app stage that updates events. Runs before UPDATE
-    Event,
     /// Name of app stage responsible for performing setup before an update. Runs before UPDATE.
     PreUpdate,
     /// Name of app stage responsible for doing most app logic. Systems should be registered here by default.

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -17,7 +17,7 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
-use bevy_ecs::{entity::Entity, system::IntoSystem};
+use bevy_ecs::{entity::Entity, prelude::IntoExclusiveSystem, system::IntoSystem};
 use bevy_utils::HashSet;
 use std::ops::Range;
 
@@ -44,7 +44,9 @@ impl Plugin for CorePlugin {
             .register_type::<Labels>()
             .register_type::<Range<f32>>()
             .register_type::<Timer>()
-            .add_system_to_stage(CoreStage::First, time_system.system())
+            // time system is added as an "exclusive system" to ensure it runs before other systems in CoreStage::First
+            // this also ensures that it runs before other exclusive systems added after CorePlugin
+            .add_system_to_stage(CoreStage::First, time_system.exclusive_system())
             .add_startup_system_to_stage(StartupStage::PostStartup, entity_labels_system.system())
             .add_system_to_stage(CoreStage::PostUpdate, entity_labels_system.system());
 

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -17,13 +17,23 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
-use bevy_ecs::{entity::Entity, prelude::IntoExclusiveSystem, system::IntoSystem};
+use bevy_ecs::{
+    entity::Entity,
+    schedule::{ExclusiveSystemDescriptorCoercion, SystemLabel},
+    system::{IntoExclusiveSystem, IntoSystem},
+};
 use bevy_utils::HashSet;
 use std::ops::Range;
 
 /// Adds core functionality to Apps.
 #[derive(Default)]
 pub struct CorePlugin;
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, SystemLabel)]
+pub enum CoreSystem {
+    /// Updates the elapsed time. Any system that interacts with [Time] component should run after this.
+    Time,
+}
 
 impl Plugin for CorePlugin {
     fn build(&self, app: &mut AppBuilder) {
@@ -45,8 +55,10 @@ impl Plugin for CorePlugin {
             .register_type::<Range<f32>>()
             .register_type::<Timer>()
             // time system is added as an "exclusive system" to ensure it runs before other systems in CoreStage::First
-            // this also ensures that it runs before other exclusive systems added after CorePlugin
-            .add_system_to_stage(CoreStage::First, time_system.exclusive_system())
+            .add_system_to_stage(
+                CoreStage::First,
+                time_system.exclusive_system().label(CoreSystem::Time),
+            )
             .add_startup_system_to_stage(StartupStage::PostStartup, entity_labels_system.system())
             .add_system_to_stage(CoreStage::PostUpdate, entity_labels_system.system());
 

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -198,3 +198,35 @@ impl<T: SparseSetIndex> Default for FilteredAccessSet<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::query::Access;
+
+    #[test]
+    fn access_get_conflicts() {
+        let mut access_a = Access::<usize>::default();
+        access_a.add_read(0);
+        access_a.add_read(1);
+
+        let mut access_b = Access::<usize>::default();
+        access_b.add_read(0);
+        access_b.add_write(1);
+
+        assert_eq!(access_a.get_conflicts(&access_b), vec![1]);
+
+        let mut access_c = Access::<usize>::default();
+        access_c.add_write(0);
+        access_c.add_write(1);
+
+        assert_eq!(access_a.get_conflicts(&access_c), vec![0, 1]);
+        assert_eq!(access_b.get_conflicts(&access_c), vec![0, 1]);
+
+        let mut access_d = Access::<usize>::default();
+        access_d.add_read(0);
+
+        assert_eq!(access_d.get_conflicts(&access_a), vec![]);
+        assert_eq!(access_d.get_conflicts(&access_b), vec![]);
+        assert_eq!(access_d.get_conflicts(&access_c), vec![0]);
+    }
+}

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -1,4 +1,5 @@
 use crate::{
+    component::ComponentId,
     schedule::{
         BoxedSystemLabel, ExclusiveSystemContainer, InsertionPoint, ParallelExecutor,
         ParallelSystemContainer, ParallelSystemExecutor, RunCriteria, ShouldRun,
@@ -263,15 +264,16 @@ impl SystemStage {
     }
 
     /// Logs execution order ambiguities between systems. System orders must be fresh.
-    fn report_ambiguities(&self) {
+    fn report_ambiguities(&self, world: &World) {
         debug_assert!(!self.systems_modified);
         use std::fmt::Write;
         fn write_display_names_of_pairs(
             string: &mut String,
             systems: &[impl SystemContainer],
-            mut ambiguities: Vec<(usize, usize)>,
+            mut ambiguities: Vec<(usize, usize, Vec<ComponentId>)>,
+            world: &World,
         ) {
-            for (index_a, index_b) in ambiguities.drain(..) {
+            for (index_a, index_b, conflicts) in ambiguities.drain(..) {
                 writeln!(
                     string,
                     " -- {:?} and {:?}",
@@ -279,6 +281,13 @@ impl SystemStage {
                     systems[index_b].name()
                 )
                 .unwrap();
+                if !conflicts.is_empty() {
+                    let names = conflicts
+                        .iter()
+                        .map(|id| world.components().get_info(*id).unwrap().name())
+                        .collect::<Vec<_>>();
+                    writeln!(string, "    conflicts: {:?}", names).unwrap();
+                }
             }
         }
         let parallel = find_ambiguities(&self.parallel);
@@ -295,11 +304,16 @@ impl SystemStage {
                 .to_owned();
             if !parallel.is_empty() {
                 writeln!(string, " * Parallel systems:").unwrap();
-                write_display_names_of_pairs(&mut string, &self.parallel, parallel);
+                write_display_names_of_pairs(&mut string, &self.parallel, parallel, world);
             }
             if !at_start.is_empty() {
                 writeln!(string, " * Exclusive systems at start of stage:").unwrap();
-                write_display_names_of_pairs(&mut string, &self.exclusive_at_start, at_start);
+                write_display_names_of_pairs(
+                    &mut string,
+                    &self.exclusive_at_start,
+                    at_start,
+                    world,
+                );
             }
             if !before_commands.is_empty() {
                 writeln!(string, " * Exclusive systems before commands of stage:").unwrap();
@@ -307,11 +321,12 @@ impl SystemStage {
                     &mut string,
                     &self.exclusive_before_commands,
                     before_commands,
+                    world,
                 );
             }
             if !at_end.is_empty() {
                 writeln!(string, " * Exclusive systems at end of stage:").unwrap();
-                write_display_names_of_pairs(&mut string, &self.exclusive_at_end, at_end);
+                write_display_names_of_pairs(&mut string, &self.exclusive_at_end, at_end, world);
             }
             info!("{}", string);
         }
@@ -456,7 +471,7 @@ fn topological_order(
 
 /// Returns vector containing all pairs of indices of systems with ambiguous execution order.
 /// Systems must be topologically sorted beforehand.
-fn find_ambiguities(systems: &[impl SystemContainer]) -> Vec<(usize, usize)> {
+fn find_ambiguities(systems: &[impl SystemContainer]) -> Vec<(usize, usize, Vec<ComponentId>)> {
     let mut ambiguity_set_labels = HashMap::default();
     for set in systems.iter().flat_map(|c| c.ambiguity_sets()) {
         let len = ambiguity_set_labels.len();
@@ -511,9 +526,17 @@ fn find_ambiguities(systems: &[impl SystemContainer]) -> Vec<(usize, usize)> {
         {
             if !processed.contains(index_b)
                 && all_ambiguity_sets[index_a].is_disjoint(&all_ambiguity_sets[index_b])
-                && !systems[index_a].is_compatible(&systems[index_b])
             {
-                ambiguities.push((index_a, index_b));
+                let a_access = systems[index_a].component_access();
+                let b_access = systems[index_b].component_access();
+                if let (Some(a), Some(b)) = (a_access, b_access) {
+                    let conflicts = a.get_conflicts(b);
+                    if !conflicts.is_empty() {
+                        ambiguities.push((index_a, index_b, conflicts))
+                    }
+                } else {
+                    ambiguities.push((index_a, index_b, Vec::new()));
+                }
             }
         }
         processed.insert(index_a);
@@ -549,7 +572,7 @@ impl Stage for SystemStage {
             self.executor.rebuild_cached_data(&self.parallel);
             self.executor_modified = false;
             if world.contains_resource::<ReportExecutionOrderAmbiguities>() {
-                self.report_ambiguities();
+                self.report_ambiguities(world);
             }
         } else if self.executor_modified {
             self.executor.rebuild_cached_data(&self.parallel);
@@ -1184,7 +1207,7 @@ mod tests {
         ) -> Vec<(BoxedSystemLabel, BoxedSystemLabel)> {
             find_ambiguities(systems)
                 .drain(..)
-                .map(|(index_a, index_b)| {
+                .map(|(index_a, index_b, _conflicts)| {
                     (
                         systems[index_a].labels()[0].clone(),
                         systems[index_b].labels()[0].clone(),

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -469,7 +469,8 @@ fn topological_order(
     Ok(sorted)
 }
 
-/// Returns vector containing all pairs of indices of systems with ambiguous execution order.
+/// Returns vector containing all pairs of indices of systems with ambiguous execution order,
+/// along with specific components that have triggered the warning.
 /// Systems must be topologically sorted beforehand.
 fn find_ambiguities(systems: &[impl SystemContainer]) -> Vec<(usize, usize, Vec<ComponentId>)> {
     let mut ambiguity_set_labels = HashMap::default();

--- a/crates/bevy_ecs/src/schedule/system_container.rs
+++ b/crates/bevy_ecs/src/schedule/system_container.rs
@@ -1,4 +1,6 @@
 use crate::{
+    component::ComponentId,
+    query::Access,
     schedule::{
         BoxedAmbiguitySetLabel, BoxedSystemLabel, ExclusiveSystemDescriptor,
         ParallelSystemDescriptor,
@@ -16,7 +18,7 @@ pub(super) trait SystemContainer {
     fn before(&self) -> &[BoxedSystemLabel];
     fn after(&self) -> &[BoxedSystemLabel];
     fn ambiguity_sets(&self) -> &[BoxedAmbiguitySetLabel];
-    fn is_compatible(&self, other: &Self) -> bool;
+    fn component_access(&self) -> Option<&Access<ComponentId>>;
 }
 
 pub(super) struct ExclusiveSystemContainer {
@@ -81,8 +83,8 @@ impl SystemContainer for ExclusiveSystemContainer {
         &self.ambiguity_sets
     }
 
-    fn is_compatible(&self, _: &Self) -> bool {
-        false
+    fn component_access(&self) -> Option<&Access<ComponentId>> {
+        None
     }
 }
 
@@ -178,9 +180,7 @@ impl SystemContainer for ParallelSystemContainer {
         &self.ambiguity_sets
     }
 
-    fn is_compatible(&self, other: &Self) -> bool {
-        self.system()
-            .component_access()
-            .is_compatible(other.system().component_access())
+    fn component_access(&self) -> Option<&Access<ComponentId>> {
+        Some(self.system().component_access())
     }
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -248,6 +248,7 @@ impl<'a, T: Component> SystemParam for Option<Res<'a, T>> {
 
 unsafe impl<T: Component> SystemParamState for OptionResState<T> {
     type Config = ();
+
     fn init(world: &mut World, system_state: &mut SystemState, _config: Self::Config) -> Self {
         Self(ResState::init(world, system_state, ()))
     }
@@ -383,6 +384,7 @@ impl<'a, T: Component> SystemParam for Option<ResMut<'a, T>> {
 
 unsafe impl<T: Component> SystemParamState for OptionResMutState<T> {
     type Config = ();
+
     fn init(world: &mut World, system_state: &mut SystemState, _config: Self::Config) -> Self {
         Self(ResMutState::init(world, system_state, ()))
     }

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -24,7 +24,7 @@ impl Plugin for GilrsPlugin {
                         gilrs_event_startup_system.exclusive_system(),
                     )
                     .add_system_to_stage(
-                        CoreStage::PreEvent,
+                        CoreStage::PreUpdate,
                         gilrs_event_system.exclusive_system(),
                     );
             }

--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -233,13 +233,10 @@ pub struct Mesh {
 impl Mesh {
     /// Per vertex coloring. Use in conjunction with [`Mesh::set_attribute`]
     pub const ATTRIBUTE_COLOR: &'static str = "Vertex_Color";
-
     /// The direction the vertex normal is facing in. Use in conjunction with [`Mesh::set_attribute`]
     pub const ATTRIBUTE_NORMAL: &'static str = "Vertex_Normal";
-
     /// Where the vertex is located in space. Use in conjunction with [`Mesh::set_attribute`]
     pub const ATTRIBUTE_POSITION: &'static str = "Vertex_Position";
-
     /// Texture coordinates for the vertex. Use in conjunction with [`Mesh::set_attribute`]
     pub const ATTRIBUTE_UV_0: &'static str = "Vertex_Uv";
 

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -19,18 +19,10 @@ pub mod prelude {
 
 use bevy_app::prelude::*;
 use bevy_asset::AddAsset;
-use bevy_ecs::{
-    schedule::{StageLabel, SystemStage},
-    system::IntoExclusiveSystem,
-};
+use bevy_ecs::{schedule::ExclusiveSystemDescriptorCoercion, system::IntoExclusiveSystem};
 
 #[derive(Default)]
 pub struct ScenePlugin;
-
-#[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
-enum SceneStage {
-    SceneStage,
-}
 
 impl Plugin for ScenePlugin {
     fn build(&self, app: &mut AppBuilder) {
@@ -38,14 +30,9 @@ impl Plugin for ScenePlugin {
             .add_asset::<Scene>()
             .init_asset_loader::<SceneLoader>()
             .init_resource::<SceneSpawner>()
-            .add_stage_after(
-                CoreStage::Event,
-                SceneStage::SceneStage,
-                SystemStage::parallel(),
-            )
             .add_system_to_stage(
-                SceneStage::SceneStage,
-                scene_spawner_system.exclusive_system(),
+                CoreStage::PreUpdate,
+                scene_spawner_system.exclusive_system().at_end(),
             );
     }
 }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -102,6 +102,6 @@ impl Default for TextStyle {
 }
 
 #[derive(Default, Copy, Clone, Debug)]
-pub struct CalculatedSize {
+pub struct Text2dSize {
     pub size: Size,
 }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -18,9 +18,7 @@ use bevy_transform::prelude::{GlobalTransform, Transform};
 use bevy_window::Windows;
 use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
 
-use crate::{
-    CalculatedSize, DefaultTextPipeline, DrawableText, Font, FontAtlasSet, Text, TextError,
-};
+use crate::{DefaultTextPipeline, DrawableText, Font, FontAtlasSet, Text, Text2dSize, TextError};
 
 /// The bundle of components needed to draw text in a 2D scene via the Camera2dBundle.
 #[derive(Bundle, Clone, Debug)]
@@ -31,7 +29,7 @@ pub struct Text2dBundle {
     pub transform: Transform,
     pub global_transform: GlobalTransform,
     pub main_pass: MainPass,
-    pub calculated_size: CalculatedSize,
+    pub text_2d_size: Text2dSize,
 }
 
 impl Default for Text2dBundle {
@@ -48,7 +46,7 @@ impl Default for Text2dBundle {
             transform: Default::default(),
             global_transform: Default::default(),
             main_pass: MainPass {},
-            calculated_size: CalculatedSize {
+            text_2d_size: Text2dSize {
                 size: Size::default(),
             },
         }
@@ -72,7 +70,7 @@ pub fn draw_text2d_system(
             &Visible,
             &Text,
             &GlobalTransform,
-            &CalculatedSize,
+            &Text2dSize,
         ),
         With<MainPass>,
     >,
@@ -138,7 +136,7 @@ pub fn text2d_system(
     mut text_pipeline: ResMut<DefaultTextPipeline>,
     mut text_queries: QuerySet<(
         Query<Entity, (With<MainPass>, Changed<Text>)>,
-        Query<(&Text, &mut CalculatedSize), With<MainPass>>,
+        Query<(&Text, &mut Text2dSize), With<MainPass>>,
     )>,
 ) {
     // Adds all entities where the text or the style has changed to the local queue

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -2,7 +2,7 @@ use super::Node;
 use crate::{
     render::UI_PIPELINE_HANDLE,
     widget::{Button, Image},
-    FocusPolicy, Interaction, Style,
+    CalculatedSize, FocusPolicy, Interaction, Style,
 };
 use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
@@ -14,7 +14,7 @@ use bevy_render::{
     prelude::Visible,
 };
 use bevy_sprite::{ColorMaterial, QUAD_HANDLE};
-use bevy_text::{CalculatedSize, Text};
+use bevy_text::Text;
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
 #[derive(Bundle, Clone, Debug)]

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -1,16 +1,15 @@
 mod anchors;
-pub mod entity;
 mod flex;
 mod focus;
 mod margins;
 mod render;
 mod ui_node;
+
+pub mod entity;
 pub mod update;
 pub mod widget;
 
 pub use anchors::*;
-use bevy_math::{Rect, Size};
-use bevy_render::RenderStage;
 pub use flex::*;
 pub use focus::*;
 pub use margins::*;
@@ -23,26 +22,22 @@ pub mod prelude {
 
 use bevy_app::prelude::*;
 use bevy_ecs::{
-    schedule::{ParallelSystemDescriptorCoercion, StageLabel, SystemLabel, SystemStage},
+    schedule::{ParallelSystemDescriptorCoercion, SystemLabel},
     system::IntoSystem,
 };
+use bevy_input::InputSystem;
+use bevy_math::{Rect, Size};
+use bevy_render::RenderStage;
+use bevy_transform::TransformSystem;
 use update::ui_z_system;
 
 #[derive(Default)]
 pub struct UiPlugin;
 
-#[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
-pub enum UiStage {
-    Ui,
-}
-
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
 pub enum UiSystem {
+    /// After this label, the ui flex state has been updated
     Flex,
-}
-
-pub mod system {
-    pub const FLEX: &str = "flex";
 }
 
 impl Plugin for UiPlugin {
@@ -63,19 +58,33 @@ impl Plugin for UiPlugin {
             .register_type::<Rect<Val>>()
             .register_type::<Style>()
             .register_type::<Val>()
-            .add_stage_before(CoreStage::PostUpdate, UiStage::Ui, SystemStage::parallel())
-            .add_system_to_stage(CoreStage::PreUpdate, ui_focus_system.system())
+            .add_system_to_stage(
+                CoreStage::PreUpdate,
+                ui_focus_system.system().after(InputSystem),
+            )
             // add these stages to front because these must run before transform update systems
             .add_system_to_stage(
-                UiStage::Ui,
+                CoreStage::PostUpdate,
                 widget::text_system.system().before(UiSystem::Flex),
             )
             .add_system_to_stage(
-                UiStage::Ui,
+                CoreStage::PostUpdate,
                 widget::image_node_system.system().before(UiSystem::Flex),
             )
-            .add_system_to_stage(UiStage::Ui, flex_node_system.system().label(UiSystem::Flex))
-            .add_system_to_stage(UiStage::Ui, ui_z_system.system())
+            .add_system_to_stage(
+                CoreStage::PostUpdate,
+                flex_node_system
+                    .system()
+                    .label(UiSystem::Flex)
+                    .before(TransformSystem::TransformPropagate),
+            )
+            .add_system_to_stage(
+                CoreStage::PostUpdate,
+                ui_z_system
+                    .system()
+                    .after(UiSystem::Flex)
+                    .before(TransformSystem::TransformPropagate),
+            )
             .add_system_to_stage(RenderStage::Draw, widget::draw_text_system.system());
 
         crate::render::add_ui_graph(app.world_mut());

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -250,3 +250,8 @@ impl Default for FlexWrap {
         FlexWrap::NoWrap
     }
 }
+
+#[derive(Default, Copy, Clone, Debug)]
+pub struct CalculatedSize {
+    pub size: Size,
+}

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,3 +1,4 @@
+use crate::CalculatedSize;
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::{
     query::With,
@@ -6,7 +7,6 @@ use bevy_ecs::{
 use bevy_math::Size;
 use bevy_render::texture::Texture;
 use bevy_sprite::ColorMaterial;
-use bevy_text::CalculatedSize;
 
 #[derive(Debug, Clone)]
 pub enum Image {

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,4 +1,4 @@
-use crate::{Node, Style, Val};
+use crate::{CalculatedSize, Node, Style, Val};
 use bevy_asset::Assets;
 use bevy_ecs::{
     entity::Entity,
@@ -14,9 +14,7 @@ use bevy_render::{
     texture::Texture,
 };
 use bevy_sprite::{TextureAtlas, QUAD_HANDLE};
-use bevy_text::{
-    CalculatedSize, DefaultTextPipeline, DrawableText, Font, FontAtlasSet, Text, TextError,
-};
+use bevy_text::{DefaultTextPipeline, DrawableText, Font, FontAtlasSet, Text, TextError};
 use bevy_transform::prelude::GlobalTransform;
 use bevy_window::Windows;
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -10,7 +10,7 @@ use bevy_input::{
 pub use winit_config::*;
 pub use winit_windows::*;
 
-use bevy_app::{App, AppBuilder, AppExit, Events, ManualEventReader, Plugin};
+use bevy_app::{App, AppBuilder, AppExit, CoreStage, Events, ManualEventReader, Plugin};
 use bevy_ecs::{system::IntoExclusiveSystem, world::World};
 use bevy_math::{ivec2, Vec2};
 use bevy_utils::tracing::{error, trace, warn};
@@ -42,7 +42,7 @@ impl Plugin for WinitPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.init_resource::<WinitWindows>()
             .set_runner(winit_runner)
-            .add_system(change_window.exclusive_system());
+            .add_system_to_stage(CoreStage::PostUpdate, change_window.exclusive_system());
     }
 }
 


### PR DESCRIPTION
* Adds labels and orderings to systems that need them (uses the new many-to-many labels for InputSystem)
* Removes the Event, PreEvent, Scene, and Ui stages in favor of First, PreUpdate, and PostUpdate (there is more collapsing potential, such as the Asset stages and _maybe_ removing First, but those have more nuance so they should be handled separately)
* Ambiguity detection now prints component conflicts
* Removed broken change filters from flex calculation (which implicitly relied on the z-update system always modifying translation.z). This will require more work to make it behave as expected so i just removed it (and it was already doing this work every frame).