### PR TITLE
Improved pen tablet support (specifically for X11)

### DIFF
--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -195,11 +195,9 @@ impl Touches {
             }
             TouchPhase::Moved => {
                 #[cfg(target_os = "linux")]
-                let raw_force = event.force.map(|e| {
-                    match e {
-                        ForceTouch::Calibrated { force, .. } => force,
-                        ForceTouch::Normalized(force) => force,
-                    }
+                let raw_force = event.force.map(|e| match e {
+                    ForceTouch::Calibrated { force, .. } => force,
+                    ForceTouch::Normalized(force) => force,
                 });
                 if let Some(mut new_touch) = self.pressed.get(&event.id).cloned() {
                     #[cfg(target_os = "linux")]

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -204,6 +204,7 @@ impl Touches {
                     if raw_force.unwrap_or(f64::MAX) == 0.0 {
                         self.just_released.insert(event.id, event.into());
                         self.pressed.remove_entry(&event.id);
+                        return;
                     }
                     new_touch.previous_position = new_touch.position;
                     new_touch.previous_force = new_touch.force;

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -194,6 +194,7 @@ impl Touches {
                 self.just_pressed.insert(event.id, event.into());
             }
             TouchPhase::Moved => {
+                #[cfg(target_os = "linux")]
                 let raw_force = event.force.map(|e| {
                     match e {
                         ForceTouch::Calibrated { force, .. } => force,
@@ -201,6 +202,7 @@ impl Touches {
                     }
                 });
                 if let Some(mut new_touch) = self.pressed.get(&event.id).cloned() {
+                    #[cfg(target_os = "linux")]
                     if raw_force.unwrap_or(f64::MAX) == 0.0 {
                         self.just_released.insert(event.id, event.into());
                         self.pressed.remove_entry(&event.id);
@@ -211,11 +213,12 @@ impl Touches {
                     new_touch.position = event.position;
                     new_touch.force = event.force;
                     self.pressed.insert(event.id, new_touch);
-                } else {
-                    if raw_force.unwrap_or(f64::MIN) > 0.0 {
-                        self.pressed.insert(event.id, event.into());
-                        self.just_pressed.insert(event.id, event.into());
-                    }
+                    return;
+                }
+                #[cfg(target_os = "linux")]
+                if raw_force.unwrap_or(f64::MIN) > 0.0 {
+                    self.pressed.insert(event.id, event.into());
+                    self.just_pressed.insert(event.id, event.into());
                 }
             }
             TouchPhase::Ended => {


### PR DESCRIPTION
Currently, `winit` does not have proper support for Linux graphics tablet input, but some forks exist ([here](https://github.com/DorianRudolph/winit/tree/stylus) and [here](https://github.com/tasgon/winit/tree/pen_tablet_linux)) that add the functionality. However, information on the touch phase isn't provided. So, for example, in my fork, I map them all to `TouchPhase::Moved`. However, currently, `TouchInput` events with `TouchPhase::Moved` that doesn't have an associated entry in `self.pressed` are just silently ignored:

https://github.com/bevyengine/bevy/blob/1e42de64af9560fe1de3c19473fecb241c8534af/crates/bevy_input/src/touch.rs#L196-L204

This adds some extra logic for handling input like this.