### PR TITLE
Rework of #1203: Provide the camera's view matrix to shaders

### DIFF
--- a/assets/shaders/hot.vert
+++ b/assets/shaders/hot.vert
@@ -4,6 +4,7 @@ layout(location = 0) in vec3 Vertex_Position;
 
 layout(set = 0, binding = 0) uniform Camera {
     mat4 ViewProj;
+    mat4 View;
 };
 
 layout(set = 1, binding = 0) uniform Transform {

--- a/assets/shaders/hot.vert
+++ b/assets/shaders/hot.vert
@@ -2,9 +2,8 @@
 
 layout(location = 0) in vec3 Vertex_Position;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
-    mat4 View;
 };
 
 layout(set = 1, binding = 0) uniform Transform {

--- a/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.frag
+++ b/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.frag
@@ -14,8 +14,10 @@ layout(location = 2) in vec2 v_Uv;
 
 layout(location = 0) out vec4 o_Target;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
+};
+layout(set = 0, binding = 1) uniform CameraView {
     mat4 View;
 };
 

--- a/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.frag
+++ b/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.frag
@@ -16,6 +16,7 @@ layout(location = 0) out vec4 o_Target;
 
 layout(set = 0, binding = 0) uniform Camera {
     mat4 ViewProj;
+    mat4 View;
 };
 
 layout(set = 1, binding = 0) uniform Lights {

--- a/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.vert
+++ b/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.vert
@@ -10,6 +10,7 @@ layout(location = 2) out vec2 v_Uv;
 
 layout(set = 0, binding = 0) uniform Camera {
     mat4 ViewProj;
+    mat4 View;
 };
 
 layout(set = 2, binding = 0) uniform Transform {

--- a/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.vert
+++ b/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.vert
@@ -8,8 +8,10 @@ layout(location = 0) out vec3 v_Position;
 layout(location = 1) out vec3 v_Normal;
 layout(location = 2) out vec2 v_Uv;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
+};
+layout(set = 0, binding = 1) uniform CameraView {
     mat4 View;
 };
 

--- a/crates/bevy_render/src/render_graph/nodes/camera_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/camera_node.rs
@@ -6,13 +6,14 @@ use crate::{
         RenderResourceBindings, RenderResourceContext,
     },
 };
-use bevy_core::{AsBytes, Bytes};
+use bevy_core::{AsBytes, Byteable, Bytes};
 use bevy_ecs::{
     system::{BoxedSystem, IntoSystem, Local, Query, Res, ResMut},
     world::World,
 };
 
 use bevy_transform::prelude::*;
+use bevy_utils::HashMap;
 use std::borrow::Cow;
 
 #[derive(Debug)]
@@ -51,9 +52,9 @@ impl SystemNode for CameraNode {
             config.0 = Some(CameraNodeState {
                 camera_name: self.camera_name.clone(),
                 command_queue: self.command_queue.clone(),
-                camera_buffer: None,
-                staging_buffer: None,
-            })
+                buffers: HashMap::default(),
+                // staging_buffer: None,
+            });
         });
         Box::new(system)
     }
@@ -63,8 +64,8 @@ impl SystemNode for CameraNode {
 pub struct CameraNodeState {
     command_queue: CommandQueue,
     camera_name: Cow<'static, str>,
-    camera_buffer: Option<BufferId>,
-    staging_buffer: Option<BufferId>,
+    buffers: HashMap<String, (BufferId, BufferId)>,
+    // staging_buffer: Option<BufferId>,
 }
 
 pub fn camera_node_system(
@@ -76,73 +77,85 @@ pub fn camera_node_system(
     mut render_resource_bindings: ResMut<RenderResourceBindings>,
     query: Query<(&Camera, &GlobalTransform)>,
 ) {
-    let render_resource_context = &**render_resource_context;
+    let camera_name = state.camera_name.clone();
 
-    let (camera, global_transform) = if let Some(entity) = active_cameras.get(&state.camera_name) {
+    let (camera, global_transform) = if let Some(entity) = active_cameras.get(&camera_name) {
         query.get(entity).unwrap()
     } else {
         return;
     };
 
     let view_matrix = global_transform.compute_matrix().inverse();
-    let camera_matrix = [
-        (camera.projection_matrix * view_matrix).to_cols_array(),
+    let view_proj_matrix = camera.projection_matrix * view_matrix;
+
+    make_binding(
+        &mut *state,
+        &**render_resource_context,
+        &mut *render_resource_bindings,
+        &format!("{}ViewProj", camera_name),
+        view_proj_matrix.to_cols_array(),
+    );
+
+    make_binding(
+        &mut *state,
+        &**render_resource_context,
+        &mut *render_resource_bindings,
+        &format!("{}View", camera_name),
         view_matrix.to_cols_array(),
-    ];
-    let buffer_size = camera_matrix.byte_len();
+    );
+}
 
-    let staging_buffer = if let Some(staging_buffer) = state.staging_buffer {
-        render_resource_context.map_buffer(staging_buffer, BufferMapMode::Write);
-        staging_buffer
-    } else {
-        let buffer = render_resource_context.create_buffer(BufferInfo {
-            size: buffer_size,
-            buffer_usage: BufferUsage::COPY_DST | BufferUsage::UNIFORM,
-            ..Default::default()
+fn make_binding<B>(
+    state: &mut CameraNodeState,
+    render_resource_context: &dyn RenderResourceContext,
+    render_resource_bindings: &mut RenderResourceBindings,
+    binding_name: &str,
+    bytes: B,
+) where
+    B: Bytes + Byteable,
+{
+    let buffer_size = bytes.byte_len();
+
+    let buffers_entry = state.buffers.entry(binding_name.to_owned());
+
+    let (staging_buffer, buffer) = buffers_entry
+        .and_modify(|(staging_buffer, _)| {
+            render_resource_context.map_buffer(*staging_buffer, BufferMapMode::Write);
+        })
+        .or_insert_with(|| {
+            let buffer = render_resource_context.create_buffer(BufferInfo {
+                size: buffer_size,
+                buffer_usage: BufferUsage::COPY_DST | BufferUsage::UNIFORM,
+                ..Default::default()
+            });
+
+            render_resource_bindings.set(
+                &binding_name,
+                RenderResourceBinding::Buffer {
+                    buffer,
+                    range: 0..buffer_size as u64,
+                    dynamic_index: None,
+                },
+            );
+
+            let staging_buffer = render_resource_context.create_buffer(BufferInfo {
+                size: buffer_size,
+                buffer_usage: BufferUsage::COPY_SRC | BufferUsage::MAP_WRITE,
+                mapped_at_creation: true,
+            });
+            (staging_buffer, buffer)
         });
-        render_resource_bindings.set(
-            &format!("{}ViewProj", &state.camera_name),
-            RenderResourceBinding::Buffer {
-                buffer,
-                range: 0..view_matrix.byte_len() as u64,
-                dynamic_index: None,
-            },
-        );
-        render_resource_bindings.set(
-            &format!("{}View", &state.camera_name),
-            RenderResourceBinding::Buffer {
-                buffer,
-                range: view_matrix.byte_len() as u64..buffer_size as u64,
-                dynamic_index: None,
-            },
-        );
-        state.camera_buffer = Some(buffer);
-
-        let staging_buffer = render_resource_context.create_buffer(BufferInfo {
-            size: buffer_size,
-            buffer_usage: BufferUsage::COPY_SRC | BufferUsage::MAP_WRITE,
-            mapped_at_creation: true,
-        });
-
-        state.staging_buffer = Some(staging_buffer);
-        staging_buffer
-    };
 
     render_resource_context.write_mapped_buffer(
-        staging_buffer,
+        *staging_buffer,
         0..buffer_size as u64,
         &mut |data, _renderer| {
-            data[0..buffer_size].copy_from_slice(camera_matrix.as_bytes());
+            data[0..buffer_size].copy_from_slice(bytes.as_bytes());
         },
     );
-    render_resource_context.unmap_buffer(staging_buffer);
+    render_resource_context.unmap_buffer(*staging_buffer);
 
-    let camera_buffer = state.camera_buffer.unwrap();
-    state.command_queue.copy_buffer_to_buffer(
-        staging_buffer,
-        0,
-        camera_buffer,
-        0,
-        buffer_size as u64,
-    );
+    state
+        .command_queue
+        .copy_buffer_to_buffer(*staging_buffer, 0, *buffer, 0, buffer_size as u64);
 }

--- a/crates/bevy_render/src/render_graph/nodes/camera_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/camera_node.rs
@@ -87,7 +87,7 @@ pub fn camera_node_system(
         render_resource_context.map_buffer(staging_buffer, BufferMapMode::Write);
         staging_buffer
     } else {
-        let size = std::mem::size_of::<[[f32; 4]; 4]>();
+        let size = std::mem::size_of::<[[[f32; 4]; 4]; 2]>();
         let buffer = render_resource_context.create_buffer(BufferInfo {
             size,
             buffer_usage: BufferUsage::COPY_DST | BufferUsage::UNIFORM,
@@ -113,9 +113,12 @@ pub fn camera_node_system(
         staging_buffer
     };
 
-    let matrix_size = std::mem::size_of::<[[f32; 4]; 4]>();
-    let camera_matrix: [f32; 16] =
-        (camera.projection_matrix * global_transform.compute_matrix().inverse()).to_cols_array();
+    let matrix_size = std::mem::size_of::<[[[f32; 4]; 4]; 2]>();
+    let view_matrix = global_transform.compute_matrix().inverse();
+    let camera_matrix: [[f32; 16]; 2] = [
+        (camera.projection_matrix * view_matrix).to_cols_array(),
+        view_matrix.to_cols_array()
+    ];
 
     render_resource_context.write_mapped_buffer(
         staging_buffer,

--- a/crates/bevy_render/src/render_graph/nodes/camera_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/camera_node.rs
@@ -53,7 +53,6 @@ impl SystemNode for CameraNode {
                 camera_name: self.camera_name.clone(),
                 command_queue: self.command_queue.clone(),
                 buffers: HashMap::default(),
-                // staging_buffer: None,
             });
         });
         Box::new(system)
@@ -65,7 +64,6 @@ pub struct CameraNodeState {
     command_queue: CommandQueue,
     camera_name: Cow<'static, str>,
     buffers: HashMap<String, (BufferId, BufferId)>,
-    // staging_buffer: Option<BufferId>,
 }
 
 pub fn camera_node_system(

--- a/crates/bevy_render/src/render_graph/nodes/camera_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/camera_node.rs
@@ -63,6 +63,7 @@ impl SystemNode for CameraNode {
 pub struct CameraNodeState {
     command_queue: CommandQueue,
     camera_name: Cow<'static, str>,
+    /// This mas from `binding_name` -> `(staging_buffer_id, buffer_id)`
     buffers: HashMap<String, (BufferId, BufferId)>,
 }
 

--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -208,7 +208,7 @@ where
                 TextureAttachment::Id(input.get(input_index).unwrap().get_texture().unwrap());
         }
 
-        for camera_info in self.cameras.iter_mut() {
+        'outer: for camera_info in self.cameras.iter_mut() {
             let camera_name = &camera_info.name;
 
             if render_context
@@ -217,22 +217,23 @@ where
             {
                 let mut camera_bind_group_builder = BindGroup::build();
 
-                for binding_name in self
+                for (index, binding_name) in self
                     .camera_bind_group_descriptor
                     .bindings
                     .iter()
                     .map(|binding| &binding.name)
+                    .enumerate()
                 {
                     let camera_binding = if let Some(camera_binding) = render_resource_bindings.get(
                         &format!("{}{}", &camera_name, binding_name.replace("Camera", "")),
                     ) {
                         camera_binding.clone()
                     } else {
-                        continue;
+                        continue 'outer;
                     };
 
                     camera_bind_group_builder =
-                        camera_bind_group_builder.add_binding(0, camera_binding);
+                        camera_bind_group_builder.add_binding(index as u32, camera_binding);
                 }
 
                 let camera_bind_group = camera_bind_group_builder.finish();

--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -113,7 +113,10 @@ impl<Q: WorldQuery> PassNode<Q> {
                 index: 0,
                 bind_type: BindType::Uniform {
                     has_dynamic_offset: false,
-                    property: UniformProperty::Struct(vec![UniformProperty::Mat4]),
+                    property: UniformProperty::Struct(vec![
+                        UniformProperty::Mat4,
+                        UniformProperty::Mat4,
+                    ]),
                 },
                 shader_stage: BindingShaderStage::VERTEX | BindingShaderStage::FRAGMENT,
             }],

--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -114,8 +114,8 @@ impl<Q: WorldQuery> PassNode<Q> {
                 bind_type: BindType::Uniform {
                     has_dynamic_offset: false,
                     property: UniformProperty::Struct(vec![
-                        UniformProperty::Mat4,
-                        UniformProperty::Mat4,
+                        UniformProperty::Mat4, // View Projection
+                        UniformProperty::Mat4, // View
                     ]),
                 },
                 shader_stage: BindingShaderStage::VERTEX | BindingShaderStage::FRAGMENT,

--- a/crates/bevy_render/src/shader/shader_reflect.rs
+++ b/crates/bevy_render/src/shader/shader_reflect.rs
@@ -325,7 +325,7 @@ mod tests {
             layout(location = 2) in uvec4 I_TestInstancing_Property;
 
             layout(location = 0) out vec4 v_Position;
-            layout(set = 0, binding = 0) uniform Camera {
+            layout(set = 0, binding = 0) uniform CameraViewProj {
                 mat4 ViewProj;
                 mat4 View;
             };

--- a/crates/bevy_render/src/shader/shader_reflect.rs
+++ b/crates/bevy_render/src/shader/shader_reflect.rs
@@ -162,7 +162,7 @@ fn reflect_binding(
 
     let name = name.to_string();
 
-    if name == "Camera" {
+    if let Some(0usize) = name.find("Camera") {
         shader_stage = BindingShaderStage::VERTEX | BindingShaderStage::FRAGMENT;
     }
 
@@ -327,7 +327,6 @@ mod tests {
             layout(location = 0) out vec4 v_Position;
             layout(set = 0, binding = 0) uniform CameraViewProj {
                 mat4 ViewProj;
-                mat4 View;
             };
             layout(set = 1, binding = 0) uniform texture2D Texture;
 
@@ -382,7 +381,7 @@ mod tests {
                         0,
                         vec![BindingDescriptor {
                             index: 0,
-                            name: "Camera".into(),
+                            name: "CameraViewProj".into(),
                             bind_type: BindType::Uniform {
                                 has_dynamic_offset: false,
                                 property: UniformProperty::Struct(vec![UniformProperty::Mat4]),

--- a/crates/bevy_render/src/shader/shader_reflect.rs
+++ b/crates/bevy_render/src/shader/shader_reflect.rs
@@ -327,6 +327,7 @@ mod tests {
             layout(location = 0) out vec4 v_Position;
             layout(set = 0, binding = 0) uniform Camera {
                 mat4 ViewProj;
+                mat4 View;
             };
             layout(set = 1, binding = 0) uniform texture2D Texture;
 

--- a/crates/bevy_render/src/wireframe/wireframe.vert
+++ b/crates/bevy_render/src/wireframe/wireframe.vert
@@ -2,7 +2,7 @@
 
 layout(location = 0) in vec3 Vertex_Position;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
 };
 

--- a/crates/bevy_sprite/src/render/sprite.vert
+++ b/crates/bevy_sprite/src/render/sprite.vert
@@ -6,7 +6,7 @@ layout(location = 2) in vec2 Vertex_Uv;
 
 layout(location = 0) out vec2 v_Uv;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
     mat4 View;
 };
@@ -26,7 +26,7 @@ void main() {
 
     uint x_flip_bit = 1; // The X flip bit
     uint y_flip_bit = 2; // The Y flip bit
-    
+
     // Note: Here we subtract f32::EPSILON from the flipped UV coord. This is due to reasons unknown
     // to me (@zicklag ) that causes the uv's to be slightly offset and causes over/under running of
     // the sprite UV sampling which is visible when resizing the screen.

--- a/crates/bevy_sprite/src/render/sprite.vert
+++ b/crates/bevy_sprite/src/render/sprite.vert
@@ -8,6 +8,7 @@ layout(location = 0) out vec2 v_Uv;
 
 layout(set = 0, binding = 0) uniform Camera {
     mat4 ViewProj;
+    mat4 View;
 };
 
 layout(set = 2, binding = 0) uniform Transform {

--- a/crates/bevy_sprite/src/render/sprite_sheet.vert
+++ b/crates/bevy_sprite/src/render/sprite_sheet.vert
@@ -9,6 +9,7 @@ layout(location = 1) out vec4 v_Color;
 
 layout(set = 0, binding = 0) uniform Camera {
     mat4 ViewProj;
+    mat4 View;
 };
 
 // TODO: merge dimensions into "sprites" buffer when that is supported in the Uniforms derive abstraction

--- a/crates/bevy_sprite/src/render/sprite_sheet.vert
+++ b/crates/bevy_sprite/src/render/sprite_sheet.vert
@@ -7,7 +7,7 @@ layout(location = 2) in vec2 Vertex_Uv;
 layout(location = 0) out vec2 v_Uv;
 layout(location = 1) out vec4 v_Color;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
     mat4 View;
 };
@@ -25,7 +25,6 @@ struct Rect {
 layout(set = 1, binding = 1) buffer TextureAtlas_textures {
     Rect[] Textures;
 };
-
 
 layout(set = 2, binding = 0) uniform Transform {
     mat4 SpriteTransform;
@@ -76,8 +75,7 @@ void main() {
         bottom_left,
         top_left,
         top_right,
-        bottom_right
-    );
+        bottom_right);
 
     v_Uv = (atlas_positions[gl_VertexIndex]) / AtlasSize;
 

--- a/crates/bevy_ui/src/render/ui.vert
+++ b/crates/bevy_ui/src/render/ui.vert
@@ -8,6 +8,7 @@ layout(location = 0) out vec2 v_Uv;
 
 layout(set = 0, binding = 0) uniform Camera {
     mat4 ViewProj;
+    mat4 View;
 };
 
 layout(set = 1, binding = 0) uniform Transform {

--- a/crates/bevy_ui/src/render/ui.vert
+++ b/crates/bevy_ui/src/render/ui.vert
@@ -6,7 +6,7 @@ layout(location = 2) in vec2 Vertex_Uv;
 
 layout(location = 0) out vec2 v_Uv;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
     mat4 View;
 };

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -34,6 +34,7 @@ layout(location = 0) out vec4 v_Position;
 
 layout(set = 0, binding = 0) uniform Camera {
     mat4 ViewProj;
+    mat4 View;
 };
 layout(set = 1, binding = 0) uniform Transform {
     mat4 Model;

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -32,7 +32,7 @@ const VERTEX_SHADER: &str = r#"
 layout(location = 0) in vec3 Vertex_Position;
 layout(location = 0) out vec4 v_Position;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
     mat4 View;
 };

--- a/examples/shader/mesh_custom_attribute.rs
+++ b/examples/shader/mesh_custom_attribute.rs
@@ -29,7 +29,7 @@ layout(location = 0) in vec3 Vertex_Position;
 layout(location = 1) in vec3 Vertex_Color;
 layout(location = 0) out vec3 v_color;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
     mat4 View;
 };

--- a/examples/shader/mesh_custom_attribute.rs
+++ b/examples/shader/mesh_custom_attribute.rs
@@ -31,6 +31,7 @@ layout(location = 0) out vec3 v_color;
 
 layout(set = 0, binding = 0) uniform Camera {
     mat4 ViewProj;
+    mat4 View;
 };
 layout(set = 1, binding = 0) uniform Transform {
     mat4 Model;

--- a/examples/shader/shader_custom_material.rs
+++ b/examples/shader/shader_custom_material.rs
@@ -30,6 +30,7 @@ const VERTEX_SHADER: &str = r#"
 layout(location = 0) in vec3 Vertex_Position;
 layout(set = 0, binding = 0) uniform Camera {
     mat4 ViewProj;
+    mat4 View;
 };
 layout(set = 1, binding = 0) uniform Transform {
     mat4 Model;

--- a/examples/shader/shader_custom_material.rs
+++ b/examples/shader/shader_custom_material.rs
@@ -28,7 +28,7 @@ struct MyMaterial {
 const VERTEX_SHADER: &str = r#"
 #version 450
 layout(location = 0) in vec3 Vertex_Position;
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
     mat4 View;
 };

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -38,6 +38,7 @@ const VERTEX_SHADER: &str = r#"
 layout(location = 0) in vec3 Vertex_Position;
 layout(set = 0, binding = 0) uniform Camera {
     mat4 ViewProj;
+    mat4 View;
 };
 layout(set = 1, binding = 0) uniform Transform {
     mat4 Model;

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -36,7 +36,7 @@ struct MyMaterial {
 const VERTEX_SHADER: &str = r#"
 #version 450
 layout(location = 0) in vec3 Vertex_Position;
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
     mat4 View;
 };


### PR DESCRIPTION
I reworked the code from #1203 based on [this comment](https://github.com/bevyengine/bevy/pull/1203#issuecomment-755784860) by Cart. Particularly, I've split the Camera Uniform into separate bindings and made it easy to extend with more bindings in the future. Such as the `CameraPos` needed in #1554.

@lwansbrough I hope you don't mind. I also tried doing a PR against your fork, but github won't show/autocomplete your username or repositories in any fields for me.