### PR TITLE
[Merged by Bors] - Remove the Clippy "-A clippy::manual-strip" override

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -485,7 +485,9 @@ async fn load_buffers(
             gltf::buffer::Source::Uri(uri) => {
                 if uri.starts_with("data:") {
                     if uri.starts_with(OCTET_STREAM_URI) {
-                        buffer_data.push(base64::decode(&uri[OCTET_STREAM_URI.len()..])?);
+                        buffer_data.push(base64::decode(
+                            &uri.strip_prefix(OCTET_STREAM_URI).unwrap(),
+                        )?);
                     } else {
                         return Err(GltfError::BufferFormatUnsupported);
                     }

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -484,13 +484,10 @@ async fn load_buffers(
         match buffer.source() {
             gltf::buffer::Source::Uri(uri) => {
                 if uri.starts_with("data:") {
-                    if uri.starts_with(OCTET_STREAM_URI) {
-                        buffer_data.push(base64::decode(
-                            &uri.strip_prefix(OCTET_STREAM_URI).unwrap(),
-                        )?);
-                    } else {
-                        return Err(GltfError::BufferFormatUnsupported);
-                    }
+                    buffer_data.push(base64::decode(
+                        uri.strip_prefix(OCTET_STREAM_URI)
+                            .ok_or(GltfError::BufferFormatUnsupported)?,
+                    )?);
                 } else {
                     // TODO: Remove this and add dep
                     let buffer_path = asset_path.parent().unwrap().join(uri);

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -18,7 +18,6 @@ cargo clippy --all-targets --all-features -- -D warnings -A clippy::type_complex
 
 * `-D warnings`: No warnings are allowed in the codebase.
 * `-A clippy::type_complexity`: type complexity must be ignored because we use huge templates for queries.
-* `-A clippy::manual-strip`: strip_prefix support was added in 1.45. We want to support earlier rust versions.
 
 ## [super-linter](https://github.com/github/super-linter)
 

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -13,8 +13,7 @@ fn main() {
 
     // See if clippy has any complaints.
     // - Type complexity must be ignored because we use huge templates for queries
-    // - `-A clippy::manual-strip` strip_prefix support was added in 1.45
-    cmd!("cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::type_complexity -A clippy::manual-strip")
+    cmd!("cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::type_complexity")
     .run()
     .expect("Please fix clippy errors in output above.");
 }


### PR DESCRIPTION
That override was added to support pre 1.45 Versions of Rust, but Bevy requires currently the latest stable rust release.
This means that the reason for the override doesn't apply anymore.