### PR TITLE
[Merged by Bors] - Fix pipeline initialisation of wireframe mode (fixes #1609)

### DIFF
--- a/crates/bevy_render/src/wireframe/mod.rs
+++ b/crates/bevy_render/src/wireframe/mod.rs
@@ -33,7 +33,7 @@ impl Plugin for WireframePlugin {
         let mut pipelines = world
             .get_resource_mut::<Assets<PipelineDescriptor>>()
             .unwrap();
-        pipelines.set(
+        pipelines.set_untracked(
             WIREFRAME_PIPELINE_HANDLE,
             pipeline::build_wireframe_pipeline(&mut shaders),
         );


### PR DESCRIPTION
More details are in the associated issue #1609.

While looking for the source of this issue, I've noticed that the `set` and `set_untracked` methods aren't really DRY:
https://github.com/bevyengine/bevy/blob/68606934e32ab45828c628e1cefd3873273f8708/crates/bevy_asset/src/assets.rs#L76-L85

https://github.com/bevyengine/bevy/blob/68606934e32ab45828c628e1cefd3873273f8708/crates/bevy_asset/src/assets.rs#L91-L99

Shouldn't `set` call `set_untracked`? Also, given the bug that arose from a misusage of these functions, maybe some refactoring is needed?