### PR TITLE
[Merged by Bors] - README/examples: better direct users to the release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ Before contributing or participating in discussions with the community, you shou
 We recommend checking out [The Bevy Book](https://bevyengine.org/learn/book/introduction) for a full tutorial.
 
 Follow the [Setup guide](https://bevyengine.org/learn/book/getting-started/setup/) to ensure your development environment is set up correctly.
-Once set up, you can quickly try out the [examples](/examples) by cloning this repo and running the following command:
+Once set up, you can quickly try out the [examples](https://github.com/bevyengine/bevy/tree/latest/examples) by cloning this repo and running the following commands:
 
 ```sh
+# Switch to the correct version (latest release, default is main development branch)
+git checkout latest
 # Runs the "breakout" example
 cargo run --example breakout
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,12 +12,19 @@ cargo run --features wayland --example hello_world
 
 **⚠️ Note: for users of releases on crates.io!**
 
-Due to changes and additions to APIs, there are often differences between the development examples and the released versions of Bevy on crates.io.
-If you are using a release version from [crates.io](https://crates.io/crates/bevy), view the examples by checking out the appropriate git tag, e.g., users of `0.4` should use the examples on [https://github.com/bevyengine/bevy/tree/v0.4.0/examples](https://github.com/bevyengine/bevy/tree/v0.4.0/examples)
+There are often large differences and incompatible API changes between the latest [crates.io](https://crates.io/crates/bevy) release and the development version of Bevy in the git main branch!
 
-If you have cloned bevy's repo locally, `git checkout` with the appropriate version tag.
+If you are using a released version of bevy, you need to make sure you are viewing the correct version of the examples!
+
+ - Latest release: [https://github.com/bevyengine/bevy/tree/latest/examples](https://github.com/bevyengine/bevy/tree/latest/examples)
+ - Specific version, such as `0.4`: [https://github.com/bevyengine/bevy/tree/v0.4.0/examples](https://github.com/bevyengine/bevy/tree/v0.4.0/examples)
+
+When you clone the repo locally to run the examples, use `git checkout` to get the correct version:
 
 ```bash
+# `latest` always points to the newest release
+git checkout latest
+# or use a specific version
 git checkout v0.4.0
 ```
 


### PR DESCRIPTION
1. The instructions in the main README used to point users to the git main version. This has likely misdirected and confused many new users. Update to direct users to the latest release instead.
2. Rewrite the notice in the examples README to make it clearer and more concise, and to show the `latest` git branch.

See also: https://github.com/bevyengine/bevy-website/pull/109 for similar changes to the website and official book.