### PR TITLE
Debug Draw

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ bevy_winit = ["bevy_internal/bevy_winit"]
 trace_chrome = ["bevy_internal/trace_chrome"]
 trace = ["bevy_internal/trace"]
 wgpu_trace = ["bevy_internal/wgpu_trace"]
+debug_draw = ["bevy_internal/debug_draw"]
 
 # Image format support for texture loading (PNG and HDR are enabled by default)
 hdr = ["bevy_internal/hdr"]
@@ -122,6 +123,7 @@ path = "examples/3d/3d_scene.rs"
 [[example]]
 name = "debug_draw_3d"
 path = "examples/3d/debug_draw_3d.rs"
+required-features = ["debug_draw"]
 
 [[example]]
 name = "load_gltf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,10 @@ name = "3d_scene"
 path = "examples/3d/3d_scene.rs"
 
 [[example]]
+name = "debug_draw_3d"
+path = "examples/3d/debug_draw_3d.rs"
+
+[[example]]
 name = "load_gltf"
 path = "examples/3d/load_gltf.rs"
 

--- a/crates/bevy_debug_draw/Cargo.toml
+++ b/crates/bevy_debug_draw/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "bevy_debug_draw"
+version = "0.4.0"
+edition = "2018"
+authors = [
+    "Bevy Contributors <bevyengine@gmail.com>",
+    "Fabian Krauser <The5_1@outlook.com>",
+]
+description = "Provides immediate mode debug drawing for the Bevy Engine"
+homepage = "https://bevyengine.org"
+repository = "https://github.com/bevyengine/bevy"
+license = "MIT"
+keywords = ["bevy"]
+
+
+[dependencies]
+# bevy
+bevy_render = { path = "../bevy_render", version = "0.4.0" }
+bevy_app = { path = "../bevy_app", version = "0.4.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.4.0" }
+bevy_core = { path = "../bevy_core", version = "0.4.0" }
+bevy_log = { path = "../bevy_log", version = "0.4.0" }
+bevy_derive = { path = "../bevy_derive", version = "0.4.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.4.0" }
+bevy_math = { path = "../bevy_math", version = "0.4.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.4.0", features = ["bevy"] }
+bevy_transform = { path = "../bevy_transform", version = "0.4.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.4.0" }

--- a/crates/bevy_debug_draw/src/debug_draw_3d.rs
+++ b/crates/bevy_debug_draw/src/debug_draw_3d.rs
@@ -1,0 +1,196 @@
+use bevy_app::{AppBuilder, CoreStage, Plugin};
+use bevy_asset::{AddAsset, Assets, Handle};
+use bevy_ecs::{
+    prelude::{Commands, Query, ResMut},
+    schedule::*,
+    system::*,
+};
+use bevy_log::info;
+use bevy_math::*;
+use bevy_reflect::TypeUuid;
+
+use bevy_render::{
+    mesh::*,
+    pipeline::{CullMode, PipelineDescriptor, PrimitiveTopology, RenderPipeline},
+    prelude::{Color, MeshBundle, RenderPipelines},
+    render_graph::{base, AssetRenderResourcesNode, RenderGraph},
+    renderer::RenderResources,
+    shader::{Shader, ShaderStage, ShaderStages},
+};
+use bevy_transform::{
+    components::{GlobalTransform, Transform},
+    TransformSystem,
+};
+/// Bevy immediate mode debug drawing:
+/// This crate introduces a DebugDraw3D resource which provides functions such as `draw_line(start, end, color)`
+/// Whenever such a draw_line function is called, a set of vertices is added to the DebugDraw3D objects data.
+/// At the end of the frame the internal data is copied into a mesh entity for drawing and then cleared from the DebugDraw3D object.
+/// With this, no persistent line drawing is possible and lines have to be added every frame (hence immediate mode).
+/// For convenience a system called `debug_draw_all_gizmos` is provided that draws a coordinate gizmo for any `GlobalTransform`.
+///
+/// ToDo:
+/// * Add more convenience functions such as `draw_arrow(start, end, head_size, color)`, `draw_circle(origin, radius, axis, color)`, `draw_aabb(min,max,color)`.
+/// * Modify the shader and access the depth buffer and perform hidden-line rendering rather than a binary depth test for better line visualization.
+/// * Add the `debug_draw_all_gizmos` system to the plugin, using a parameter to turn it on or off.
+/// * Add transparent triangle drawing (useful to visually project a line down on a plane) and matching utility functions.
+/// * Add timed or persistent drawing: This requires storing `Line` structs containing a lifetime rather than directly pushing to an array.
+/// * Even though this is a debug feature, there current approach may likely not be the most performant solution and optimizations/refactoring should be applied.
+
+pub struct DebugDrawPlugin;
+impl Plugin for DebugDrawPlugin {
+    fn build(&self, app: &mut AppBuilder) {
+        app.add_asset::<DebugDraw3DMaterial>()
+            .init_resource::<DebugDraw3D>()
+            .add_startup_system(setup_debug_draw_3d.system())
+            .add_system_to_stage(
+                CoreStage::PostUpdate,
+                update_debug_draw_3d
+                    .system()
+                    .after(TransformSystem::TransformPropagate),
+            );
+    }
+}
+
+/// DebugDraw3D Resource providing functions for immediate mode drawing
+pub struct DebugDraw3D {
+    // The mesh data is held as plain arrays here
+    // If we wish to extend to more than just lines we may need multiple pairs that will later be ass, e.g. vertices_line and vertices_triangle
+    vertices: Vec<[f32; 3]>,
+    colors: Vec<[f32; 4]>,
+    dirty: bool,
+    clear: bool,
+}
+
+impl Default for DebugDraw3D {
+    fn default() -> Self {
+        DebugDraw3D {
+            vertices: Default::default(),
+            colors: Default::default(),
+            dirty: true,
+            clear: true,
+        }
+    }
+}
+
+impl DebugDraw3D {
+    pub fn draw_line(&mut self, start: Vec3, end: Vec3, color: Color) {
+        self.vertices.push(start.into());
+        self.vertices.push(end.into());
+        self.colors.push(color.into());
+        self.colors.push(color.into());
+        self.set_dirty();
+    }
+
+    pub fn set_dirty(&mut self) {
+        self.dirty = true;
+    }
+
+    pub fn reset(&mut self) {
+        if self.clear {
+            self.vertices.clear();
+            self.colors.clear();
+        }
+        self.dirty = false;
+    }
+
+    pub fn set_clear(&mut self, clear: bool) {
+        self.clear = clear;
+    }
+}
+/// This component marks the internal entity that does the mesh drawing.
+#[derive(Default)]
+struct DebugDraw3DComponent;
+
+/// The Material holding the shader for debug drawing
+#[derive(RenderResources, Default, TypeUuid)]
+#[uuid = "188f0f97-60b2-476a-a749-7a0103adeeba"]
+pub struct DebugDraw3DMaterial;
+
+///This system sets up the entity holding the actual mesh for drawing as well as the render pipeline step for the shader.
+fn setup_debug_draw_3d(
+    mut commands: Commands,
+    mut shaders: ResMut<Assets<Shader>>,
+    mut materials: ResMut<Assets<DebugDraw3DMaterial>>,
+    mut render_graph: ResMut<RenderGraph>,
+) {
+    // Crate a shader Pipeline
+    let mut p = PipelineDescriptor::default_config(ShaderStages {
+        vertex: shaders.add(Shader::from_glsl(
+            ShaderStage::Vertex,
+            include_str!("shaders/debugDrawLine.vert"),
+        )),
+        fragment: Some(shaders.add(Shader::from_glsl(
+            ShaderStage::Fragment,
+            include_str!("shaders/debugDrawLine.frag"),
+        ))),
+    });
+    p.primitive.topology = PrimitiveTopology::LineList;
+    p.primitive.cull_mode = CullMode::None;
+
+    // add the material to the pipeline
+    render_graph.add_system_node(
+        "debug_draw_3d",
+        AssetRenderResourcesNode::<DebugDraw3DMaterial>::new(false),
+    );
+    // connect that node stage the MAIN_PASS node
+    render_graph
+        .add_node_edge("debug_draw_3d", base::node::MAIN_PASS)
+        .unwrap();
+
+    let material_instance = materials.add(DebugDraw3DMaterial {});
+
+    // Spawn a entity that will do the debug drawing with its mesh
+    commands
+        .spawn(MeshBundle::default())
+        .with(material_instance)
+        .with(DebugDraw3DComponent::default())
+        .current_entity()
+        .unwrap();
+
+    info!("Loaded debug lines plugin.");
+}
+
+/// This system updates the debug draw Entity with the data from
+fn update_debug_draw_3d(
+    mut debug_draw: ResMut<DebugDraw3D>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    query: Query<(&DebugDraw3DComponent, &Handle<Mesh>)>,
+) {
+    if !debug_draw.dirty {
+        return;
+    } else {
+        for (_, mesh) in query.iter() {
+            if let Some(mesh) = meshes.get_mut(mesh) {
+                mesh.set_attribute(
+                    Mesh::ATTRIBUTE_POSITION,
+                    VertexAttributeValues::Float3(debug_draw.vertices.clone()),
+                );
+                mesh.set_attribute(
+                    "Vertex_Color",
+                    VertexAttributeValues::Float4(debug_draw.colors.clone()),
+                );
+            }
+        }
+    }
+    debug_draw.reset();
+}
+
+pub fn debug_draw_all_gizmos(mut debug_draw: ResMut<DebugDraw3D>, query: Query<&GlobalTransform>) {
+    for transform in query.iter() {
+        debug_draw.draw_line(
+            transform.translation,
+            transform.translation + transform.local_x(),
+            Color::RED,
+        );
+        debug_draw.draw_line(
+            transform.translation,
+            transform.translation + transform.local_y(),
+            Color::GREEN,
+        );
+        debug_draw.draw_line(
+            transform.translation,
+            transform.translation + transform.local_z(),
+            Color::BLUE,
+        );
+    }
+}

--- a/crates/bevy_debug_draw/src/debug_draw_3d.rs
+++ b/crates/bevy_debug_draw/src/debug_draw_3d.rs
@@ -8,19 +8,15 @@ use bevy_ecs::{
 use bevy_log::info;
 use bevy_math::*;
 use bevy_reflect::TypeUuid;
-
 use bevy_render::{
     mesh::*,
-    pipeline::{CullMode, PipelineDescriptor, PrimitiveTopology, RenderPipeline},
-    prelude::{Color, MeshBundle, RenderPipelines},
+    pipeline::{CullMode, PipelineDescriptor, PrimitiveTopology},
+    prelude::{Color, MeshBundle},
     render_graph::{base, AssetRenderResourcesNode, RenderGraph},
     renderer::RenderResources,
     shader::{Shader, ShaderStage, ShaderStages},
 };
-use bevy_transform::{
-    components::{GlobalTransform, Transform},
-    TransformSystem,
-};
+use bevy_transform::{components::GlobalTransform, TransformSystem};
 /// Bevy immediate mode debug drawing:
 /// This crate introduces a DebugDraw3D resource which provides functions such as `draw_line(start, end, color)`
 /// Whenever such a draw_line function is called, a set of vertices is added to the DebugDraw3D objects data.

--- a/crates/bevy_debug_draw/src/debug_draw_3d.rs
+++ b/crates/bevy_debug_draw/src/debug_draw_3d.rs
@@ -139,9 +139,7 @@ fn setup_debug_draw_3d(
     commands
         .spawn(MeshBundle::default())
         .with(material_instance)
-        .with(DebugDraw3DComponent::default())
-        .current_entity()
-        .unwrap();
+        .with(DebugDraw3DComponent::default());
 
     info!("Loaded debug lines plugin.");
 }

--- a/crates/bevy_debug_draw/src/debug_draw_3d.rs
+++ b/crates/bevy_debug_draw/src/debug_draw_3d.rs
@@ -148,12 +148,12 @@ fn setup_debug_draw_3d(
 fn update_debug_draw_3d(
     mut debug_draw: ResMut<DebugDraw3D>,
     mut meshes: ResMut<Assets<Mesh>>,
-    query: Query<(&DebugDraw3DComponent, &Handle<Mesh>)>,
+    query: Query<&Handle<Mesh>, With<DebugDraw3DComponent>>,
 ) {
     if !debug_draw.dirty {
         return;
     } else {
-        for (_, mesh) in query.iter() {
+        for mesh in query.iter() {
             if let Some(mesh) = meshes.get_mut(mesh) {
                 mesh.set_attribute(
                     Mesh::ATTRIBUTE_POSITION,

--- a/crates/bevy_debug_draw/src/gizmo.rs
+++ b/crates/bevy_debug_draw/src/gizmo.rs
@@ -11,13 +11,13 @@ impl CoordinateGizmo {
 }
 
 impl Default for CoordinateGizmo {
-    fn default() -> Self {
+    pub fn default() -> Self {
         CoordinateGizmo { size: 1.0 }
     }
 }
 
 impl From<CoordinateGizmo> for Mesh {
-    fn from(shape: CoordinateGizmo) -> Self {
+    pub fn from(shape: CoordinateGizmo) -> Self {
         let mut mesh = Mesh::new(PrimitiveTopology::LineList);
         let vertices = vec![
             [0.0, 0.0, 0.0],

--- a/crates/bevy_debug_draw/src/gizmo.rs
+++ b/crates/bevy_debug_draw/src/gizmo.rs
@@ -1,0 +1,45 @@
+use bevy_render::{mesh::*, pipeline::PrimitiveTopology};
+
+pub struct CoordinateGizmo {
+    pub size: f32,
+}
+
+impl CoordinateGizmo {
+    pub fn new(size: f32) -> CoordinateGizmo {
+        CoordinateGizmo { size }
+    }
+}
+
+impl Default for CoordinateGizmo {
+    fn default() -> Self {
+        CoordinateGizmo { size: 1.0 }
+    }
+}
+
+impl From<CoordinateGizmo> for Mesh {
+    fn from(shape: CoordinateGizmo) -> Self {
+        let mut mesh = Mesh::new(PrimitiveTopology::LineList);
+        let vertices = vec![
+            [0.0, 0.0, 0.0],
+            [shape.size, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, shape.size, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, shape.size],
+        ];
+        mesh.set_attribute(
+            Mesh::ATTRIBUTE_POSITION,
+            VertexAttributeValues::Float3(vertices),
+        );
+        let colors = vec![
+            [1.0, 0.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0, 1.0],
+            [0.0, 0.0, 1.0, 1.0],
+            [0.0, 0.0, 1.0, 1.0],
+        ];
+        mesh.set_attribute("Vertex_Color", VertexAttributeValues::Float4(colors));
+        mesh
+    }
+}

--- a/crates/bevy_debug_draw/src/lib.rs
+++ b/crates/bevy_debug_draw/src/lib.rs
@@ -1,2 +1,2 @@
-mod debug_draw_3d;
-mod gizmo;
+pub mod debug_draw_3d;
+pub mod gizmo;

--- a/crates/bevy_debug_draw/src/lib.rs
+++ b/crates/bevy_debug_draw/src/lib.rs
@@ -1,0 +1,2 @@
+mod debug_draw_3d;
+mod gizmo;

--- a/crates/bevy_debug_draw/src/shaders/debugDrawLine.frag
+++ b/crates/bevy_debug_draw/src/shaders/debugDrawLine.frag
@@ -1,0 +1,6 @@
+#version 450
+layout(location = 0) in vec4 vColor;
+layout(location = 0) out vec4 o_Target;
+void main() {
+    o_Target = vColor;
+}

--- a/crates/bevy_debug_draw/src/shaders/debugDrawLine.vert
+++ b/crates/bevy_debug_draw/src/shaders/debugDrawLine.vert
@@ -1,0 +1,15 @@
+#version 450
+layout(location = 0) in vec3 Vertex_Position;
+layout(location = 1) in vec4 Vertex_Color;
+layout(location = 0) out vec4 vColor;
+
+layout(set = 0, binding = 0) uniform Camera {
+    mat4 ViewProj;
+};
+layout(set = 1, binding = 0) uniform Transform {
+    mat4 Model;
+};
+void main() {
+    vColor = Vertex_Color;
+    gl_Position = ViewProj * Model * vec4(Vertex_Position, 1.0);
+}

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -63,6 +63,7 @@ bevy_audio = { path = "../bevy_audio", optional = true, version = "0.4.0" }
 bevy_gltf = { path = "../bevy_gltf", optional = true, version = "0.4.0" }
 bevy_pbr = { path = "../bevy_pbr", optional = true, version = "0.4.0" }
 bevy_render = { path = "../bevy_render", optional = true, version = "0.4.0" }
+bevy_debug_draw = { path = "../bevy_debug_draw", optional = true, version = "0.4.0" }
 bevy_dynamic_plugin = { path = "../bevy_dynamic_plugin", optional = true, version = "0.4.0" }
 bevy_sprite = { path = "../bevy_sprite", optional = true, version = "0.4.0" }
 bevy_text = { path = "../bevy_text", optional = true, version = "0.4.0" }

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -106,6 +106,12 @@ pub mod render {
     pub use bevy_render::*;
 }
 
+#[cfg(feature = "bevy_debug_draw")]
+pub mod debug_draw {
+    //! Immediate mode debug drawing, like a visual println.
+    pub use bevy_debug_draw::*;
+}
+
 #[cfg(feature = "bevy_sprite")]
 pub mod sprite {
     //! Items for sprites, rects, texture atlases, etc.

--- a/examples/3d/debug_draw_3d.rs
+++ b/examples/3d/debug_draw_3d.rs
@@ -4,41 +4,98 @@ fn main() {
     App::build()
         .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
+        //Add the plugin for DebugDraw
         .add_plugin(DebugDrawPlugin)
         .add_startup_system(setup.system())
-        .add_system(debug_draw_all_gizmos.system()) //add the system to draw a coordinate gizmo for all Objects
+        .add_system(rotator_system.system())
+        .add_system(deubg_draw_sample_system.system())
+        //uncomment this prebuilt system to draw a coordinate gizmo for any entity with a `GlobalTransform`
+        // .add_system(debug_draw_all_gizmos.system())
         .run();
 }
 
-/// set up a simple 3D scene
+/// This system takes any entities with GlobalTransform and Rotator
+/// and draws a line from it to the origin of the world.
+fn deubg_draw_sample_system(
+    mut debug_draw: ResMut<DebugDraw3D>,
+    query: Query<&GlobalTransform, With<Rotator>>,
+) {
+    for transform in query.iter() {
+        debug_draw.draw_line(Vec3::ZERO, transform.translation, Color::RED);
+    }
+    let bl = Vec3::new(-2.0, 0.0, -2.0);
+    let br = Vec3::new(2.0, 0.0, -2.0);
+    let tr = Vec3::new(2.0, 0.0, 2.0);
+    let tl = Vec3::new(-2.0, 0.0, 2.0);
+    //Draw a square
+    debug_draw.draw_line(bl, br, Color::BLUE);
+    debug_draw.draw_line(br, tr, Color::BLUE);
+    debug_draw.draw_line(tr, tl, Color::BLUE);
+    debug_draw.draw_line(tl, bl, Color::BLUE);
+}
+
+/// this component indicates what entities should rotate
+struct Rotator;
+
+/// rotates the parent, which will result in the child also rotating
+fn rotator_system(time: Res<Time>, mut query: Query<&mut Transform, With<Rotator>>) {
+    for mut transform in query.iter_mut() {
+        transform.rotation *=
+            Quat::from_axis_angle(Vec3::ONE.normalize_or_zero(), 2.0 * time.delta_seconds());
+    }
+}
+
+/// set up a 3D scene for testing
 fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    // add entities to the world
+    let cube_handle = meshes.add(Mesh::from(shape::Cube { size: 0.5 }));
+
     commands
-        // plane
+        // parent cube
         .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
-            material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+            mesh: cube_handle.clone(),
+            material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
+            transform: Transform::from_xyz(0.0, 0.0, 0.0),
             ..Default::default()
         })
-        // cube
-        .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-            transform: Transform::from_xyz(0.0, 0.5, 0.0),
-            ..Default::default()
+        .with(Rotator)
+        .with_children(|parent| {
+            // child cubes
+            parent
+                .spawn(PbrBundle {
+                    mesh: cube_handle.clone(),
+                    material: materials.add(Color::rgb(1.0, 0.5, 0.5).into()),
+                    transform: Transform::from_xyz(4.0, 0.0, 0.0),
+                    ..Default::default()
+                })
+                .with(Rotator)
+                .spawn(PbrBundle {
+                    mesh: cube_handle.clone(),
+                    material: materials.add(Color::rgb(0.5, 1.0, 0.5).into()),
+                    transform: Transform::from_xyz(0.0, 4.0, 0.0),
+                    ..Default::default()
+                })
+                .with(Rotator)
+                .spawn(PbrBundle {
+                    mesh: cube_handle.clone(),
+                    material: materials.add(Color::rgb(0.5, 0.5, 1.0).into()),
+                    transform: Transform::from_xyz(0.0, 0.0, 4.0),
+                    ..Default::default()
+                })
+                .with(Rotator);
         })
         // light
         .spawn(LightBundle {
-            transform: Transform::from_xyz(4.0, 8.0, 4.0),
+            transform: Transform::from_xyz(5.0, 2.0, -1.0),
             ..Default::default()
         })
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(-7.0, 6.0, 4.0)
+                .looking_at(Vec3::new(0.0, 1.0, 0.0), Vec3::Y),
             ..Default::default()
         });
 }

--- a/examples/3d/debug_draw_3d.rs
+++ b/examples/3d/debug_draw_3d.rs
@@ -1,0 +1,42 @@
+use bevy::prelude::*;
+
+fn main() {
+    App::build()
+        .insert_resource(Msaa { samples: 4 })
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(setup.system())
+        .run();
+}
+
+/// set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // add entities to the world
+    commands
+        // plane
+        .spawn(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
+            material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+            ..Default::default()
+        })
+        // cube
+        .spawn(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+            transform: Transform::from_xyz(0.0, 0.5, 0.0),
+            ..Default::default()
+        })
+        // light
+        .spawn(LightBundle {
+            transform: Transform::from_xyz(4.0, 8.0, 4.0),
+            ..Default::default()
+        })
+        // camera
+        .spawn(PerspectiveCameraBundle {
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::default(), Vec3::Y),
+            ..Default::default()
+        });
+}

--- a/examples/3d/debug_draw_3d.rs
+++ b/examples/3d/debug_draw_3d.rs
@@ -1,10 +1,12 @@
 use bevy::prelude::*;
+use bevy::debug_draw::*;
 
 fn main() {
     App::build()
         .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
+        .add_system(debug_draw_all_gizmos.system()) //add the system to draw a coordinate gizmo for all Objects
         .run();
 }
 

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -18,6 +18,7 @@ crates=(
     bevy_transform
     bevy_window
     bevy_render
+    bevy_debug_draw
     bevy_input
     bevy_gilrs
     bevy_pbr


### PR DESCRIPTION
As suggested by @TheRawMeatball on discord, this PR is to coordinate efforts for a Debug Draw crate.

Primitive shapes for drawing should ideally be supplied by #1621.

The Idea is to have a convenient way to quickly visualize something in the viewport.
Ideally on par with the ease of calling `println!` but in order to draw visual cues.
The drawing happens in "immediate mode", meaning the lines are removed after a frame.

This requires some discussion on how a robust API should look like.

The current approach is only intended for visual debugging.
Once we establish a crate for a more general drawing solution like the ones from @lassade 's or @Toqozz 's here
* https://github.com/lassade/bevy_gizmos
* https://github.com/Toqozz/bevy_debug_lines
we could rework this immediate mode debug draw crate to actually use the proper drawing supplied by such a crate.

Minimal Example: 
```rust
fn deubg_draw_sample_system(
    mut debug_draw: ResMut<DebugDraw3D>,
) {
    debug_draw.draw_line(Vec3::ZERO, Vec3::new(5.0,2.0,1.0), Color::RED);
}
```` 

Working Example:
run with `cargo run --package bevy --example debug_draw_3d --features="debug_draw"`

The code in question can be seen here.
https://github.com/bevyengine/bevy/pull/1625/files#diff-c501be256b1a5d25b2ea56f6813ba342eef03e471d38e12aab026015f3365bebR17-R35

![](https://cdn.discordapp.com/attachments/809550962850660405/820008383749816320/bevyWIP_debug_draw_contribution01.gif)

---
Some walktrough of the current implementation:

A Resource provides functions to draw lines.
Calling these functions pushes vertices into the resource.
At the end of the frame this vertex data is copied over into a entity's Mesh component while the data on the resource is cleared.
The entity then draws the mesh as per usual.
The Line simply uses the line primitive type rather than drawing nice, anti-aliased lines. 
This is most likely sufficient for debugging purposes and keeps the implementation really simple.
Since the data is cleared every frame the lines do not persist (immediate mode debug draw).
I feel this plays quite well with most systems updating every frame anyways.
For other use cases lines with a certain lifetime or persistent ones may be implemented (e.g. using Line structs with a lifetime field).
It should be easy enough to extend the system for these cases and to accept triangles or other primitives as well.

I am not quite sure if my general approach of querying a singular entity to update its mesh is sound.