### PR TITLE
[Merged by Bors] - Fix cargo doc warnings

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -13,7 +13,9 @@ use std::{
 
 /// Lightweight unique ID of an entity
 ///
-/// Obtained from [World::spawn](crate::world::World::spawn), typically via [Commands::spawn](crate::system::Commands::spawn). Can be stored to refer to an entity in the future.
+/// Obtained from [World::spawn](crate::world::World::spawn), typically via
+/// [Commands::spawn](crate::system::Commands::spawn). Can be stored to refer to an entity in the
+/// future.
 ///
 /// `Entity` can be a part of a query, e.g. `Query<(Entity, &MyComponent)>`.
 /// Components of a specific entity can be accessed using

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -18,7 +18,7 @@ impl SystemId {
 
 /// An ECS system that can be added to a [Schedule](crate::schedule::Schedule)
 ///
-/// Systems are functions with all arguments implementing [SystemParam].
+/// Systems are functions with all arguments implementing [SystemParam](crate::system::SystemParam).
 ///
 /// Systems are added to an application using `AppBuilder::add_system(my_system.system())`
 /// or similar methods, and will generally run once per pass of the main loop.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -351,7 +351,8 @@ impl World {
 
     /// Despawns the given `entity`, if it exists. This will also remove all of the entity's
     /// [Component]s. Returns `true` if the `entity` is successfully despawned and `false` if
-    /// the `entity` does not exist. ```
+    /// the `entity` does not exist.
+    /// ```
     /// use bevy_ecs::world::World;
     ///
     /// struct Position {
@@ -366,6 +367,7 @@ impl World {
     /// assert!(world.despawn(entity));
     /// assert!(world.get_entity(entity).is_none());
     /// assert!(world.get::<Position>(entity).is_none());
+    /// ```
     #[inline]
     pub fn despawn(&mut self, entity: Entity) -> bool {
         self.get_entity_mut(entity)
@@ -596,7 +598,8 @@ impl World {
 
     /// Temporarily removes the requested resource from this [World], then re-adds it before
     /// returning. This enables safe mutable access to a resource while still providing mutable
-    /// world access ```
+    /// world access
+    /// ```
     /// use bevy_ecs::world::{World, Mut};
     /// struct A(u32);
     /// struct B(u32);

--- a/crates/bevy_render/src/texture/texture_descriptor.rs
+++ b/crates/bevy_render/src/texture/texture_descriptor.rs
@@ -58,7 +58,7 @@ pub enum StorageTextureAccess {
     /// ```
     WriteOnly,
     /// The texture can be both read and written in the shader.
-    /// [`Features::STORAGE_TEXTURE_ACCESS_READ_WRITE`] must be enabled to use this access mode.
+    /// `wgpu::Features::STORAGE_TEXTURE_ACCESS_READ_WRITE` must be enabled to use this access mode.
     ///
     /// Example GLSL syntax:
     /// ```cpp,ignore

--- a/examples/3d/spawner.rs
+++ b/examples/3d/spawner.rs
@@ -6,8 +6,11 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 
 /// This example spawns a large number of cubes, each with its own changing position and material
 /// This is intended to be a stress test of bevy's ability to render many objects with different
-/// properties For the best results, run it in release mode: ```cargo run --example spawner
-/// --release NOTE: Bevy still has a number of optimizations to do in this area. Expect the
+/// properties For the best results, run it in release mode:
+/// ```
+/// cargo run --example spawner --release
+/// ```
+/// NOTE: Bevy still has a number of optimizations to do in this area. Expect the
 /// performance here to go way up in the future
 fn main() {
     App::build()


### PR DESCRIPTION
Fixes all warnings from `cargo doc --all`.
Those related to code blocks were introduced in #1612, but re-formatting using the experimental features in `rustfmt.toml` doesn't seem to reintroduce them.