### PR TITLE
[Merged by Bors] - Replace `default` method calls from Glam types with explicit const

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -211,7 +211,7 @@ async fn load_gltf<'a, 'b>(
         let mut world = World::default();
         world
             .spawn()
-            .insert_bundle((Transform::default(), GlobalTransform::default()))
+            .insert_bundle((Transform::identity(), GlobalTransform::identity()))
             .with_children(|parent| {
                 for node in scene.nodes() {
                     let result = load_node(&node, parent, load_context, &buffer_data);
@@ -297,7 +297,7 @@ fn load_node(
     let mut gltf_error = None;
     let node = world_builder.spawn((
         Transform::from_matrix(Mat4::from_cols_array_2d(&transform.matrix())),
-        GlobalTransform::default(),
+        GlobalTransform::identity(),
     ));
 
     if let Some(name) = gltf_node.name() {
@@ -564,7 +564,7 @@ mod test {
             GltfNode {
                 children: vec![],
                 mesh: None,
-                transform: bevy_transform::prelude::Transform::default(),
+                transform: bevy_transform::prelude::Transform::identity(),
             }
         }
     }

--- a/crates/bevy_render/src/mesh/shape/capsule.rs
+++ b/crates/bevy_render/src/mesh/shape/capsule.rs
@@ -89,9 +89,9 @@ impl From<Capsule> for Mesh {
         // Initialize arrays.
         let vert_len = vert_offset_south_cap + longitudes;
 
-        let mut vs: Vec<Vec3> = vec![Vec3::default(); vert_len];
-        let mut vts: Vec<Vec2> = vec![Vec2::default(); vert_len];
-        let mut vns: Vec<Vec3> = vec![Vec3::default(); vert_len];
+        let mut vs: Vec<Vec3> = vec![Vec3::ZERO; vert_len];
+        let mut vts: Vec<Vec2> = vec![Vec2::ZERO; vert_len];
+        let mut vns: Vec<Vec3> = vec![Vec3::ZERO; vert_len];
 
         let to_theta = 2.0 * std::f32::consts::PI / longitudes as f32;
         let to_phi = std::f32::consts::PI / latitudes as f32;
@@ -106,8 +106,8 @@ impl From<Capsule> for Mesh {
         let vt_aspect_north = 1.0 - vt_aspect_ratio;
         let vt_aspect_south = vt_aspect_ratio;
 
-        let mut theta_cartesian: Vec<Vec2> = vec![Vec2::default(); longitudes];
-        let mut rho_theta_cartesian: Vec<Vec2> = vec![Vec2::default(); longitudes];
+        let mut theta_cartesian: Vec<Vec2> = vec![Vec2::ZERO; longitudes];
+        let mut rho_theta_cartesian: Vec<Vec2> = vec![Vec2::ZERO; longitudes];
         let mut s_texture_cache: Vec<f32> = vec![0.0; lonsp1];
 
         for j in 0..longitudes {

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -20,7 +20,7 @@ impl GlobalTransform {
     }
 
     #[inline]
-    pub fn identity() -> Self {
+    pub const fn identity() -> Self {
         GlobalTransform {
             translation: Vec3::ZERO,
             rotation: Quat::IDENTITY,

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -20,7 +20,7 @@ impl Transform {
     }
 
     #[inline]
-    pub fn identity() -> Self {
+    pub const fn identity() -> Self {
         Transform {
             translation: Vec3::ZERO,
             rotation: Quat::IDENTITY,

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -64,7 +64,7 @@ mod tests {
     use super::{ui_z_system, UI_Z_STEP};
 
     fn node_with_transform(name: &str) -> (String, Node, Transform) {
-        (name.to_owned(), Node::default(), Transform::default())
+        (name.to_owned(), Node::default(), Transform::identity())
     }
 
     fn node_without_transform(name: &str) -> (String, Node) {

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -36,7 +36,7 @@ fn setup(
         })
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 }

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -33,7 +33,7 @@ fn setup(
         })
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(-3.0, 3.0, 5.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(-3.0, 3.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 }

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -58,7 +58,7 @@ fn setup(
         })
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(5.0, 10.0, 10.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(5.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 }

--- a/examples/3d/spawner.rs
+++ b/examples/3d/spawner.rs
@@ -45,7 +45,7 @@ fn setup(
         })
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(0.0, 15.0, 150.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(0.0, 15.0, 150.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -96,7 +96,7 @@ fn setup(
         })
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(3.0, 5.0, 8.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(3.0, 5.0, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 }

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -40,7 +40,7 @@ fn setup(
     commands
         .spawn((
             Transform::from_xyz(0.0, 0.0, -1.0),
-            GlobalTransform::default(),
+            GlobalTransform::identity(),
         ))
         .with_children(|parent| {
             parent.spawn_scene(asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0"));

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -52,7 +52,7 @@ fn setup(
         })
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 }

--- a/examples/3d/z_sort_debug.rs
+++ b/examples/3d/z_sort_debug.rs
@@ -84,7 +84,7 @@ fn setup(
         })
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(5.0, 10.0, 10.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(5.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 }

--- a/examples/android/android.rs
+++ b/examples/android/android.rs
@@ -38,7 +38,7 @@ fn setup(
         })
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 }

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -73,7 +73,7 @@ fn setup(
         })
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(0.0, 3.0, 10.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(0.0, 3.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 }

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -31,7 +31,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         })
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(2.0, 2.0, 6.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(2.0, 2.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 }

--- a/examples/ecs/change_detection.rs
+++ b/examples/ecs/change_detection.rs
@@ -17,7 +17,7 @@ struct MyComponent(f64);
 
 fn setup(mut commands: Commands) {
     commands.spawn((MyComponent(0.),));
-    commands.spawn((Transform::default(),));
+    commands.spawn((Transform::identity(),));
 }
 
 fn change_component(time: Res<Time>, mut query: Query<(Entity, &mut MyComponent)>) {

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -120,7 +120,7 @@ fn movement(
     mut query: Query<&mut Transform, With<Sprite>>,
 ) {
     for mut transform in query.iter_mut() {
-        let mut direction = Vec3::default();
+        let mut direction = Vec3::ZERO;
         if input.pressed(KeyCode::Left) {
             direction.x += 1.0;
         }
@@ -134,7 +134,7 @@ fn movement(
             direction.y -= 1.0;
         }
 
-        if direction != Vec3::default() {
+        if direction != Vec3::ZERO {
             transform.translation += direction.normalize() * SPEED * time.delta_seconds();
         }
     }

--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -137,7 +137,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
                     commands
                         .spawn((
                             Transform::from_xyz(i as f32, height - 0.2, j as f32),
-                            GlobalTransform::default(),
+                            GlobalTransform::identity(),
                         ))
                         .with_children(|cell| {
                             cell.spawn_scene(cell_scene.clone());
@@ -160,7 +160,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
                 rotation: Quat::from_rotation_y(-std::f32::consts::FRAC_PI_2),
                 ..Default::default()
             },
-            GlobalTransform::default(),
+            GlobalTransform::identity(),
         ))
         .with_children(|cell| {
             cell.spawn_scene(asset_server.load("models/AlienCake/alien.glb#Scene0"));
@@ -336,7 +336,7 @@ fn spawn_bonus(
                 ),
                 ..Default::default()
             },
-            GlobalTransform::default(),
+            GlobalTransform::identity(),
         ))
         .with_children(|cell| {
             cell.spawn_scene(game.bonus.handle.clone());

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -53,7 +53,7 @@ fn setup(
         })
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 }

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -83,7 +83,7 @@ fn save_scene_system(world: &mut World) {
     scene_world.spawn().insert_bundle((
         component_b,
         ComponentA { x: 1.0, y: 2.0 },
-        Transform::default(),
+        Transform::identity(),
     ));
     scene_world
         .spawn()

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -112,7 +112,7 @@ fn setup(
         .unwrap();
 
     commands.spawn(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(2.0, 2.0, 2.0).looking_at(Vec3::default(), Vec3::Y),
+        transform: Transform::from_xyz(2.0, 2.0, 2.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..Default::default()
     });
 }

--- a/examples/shader/hot_shader_reloading.rs
+++ b/examples/shader/hot_shader_reloading.rs
@@ -75,7 +75,7 @@ fn setup(
         .with(material)
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 }

--- a/examples/shader/mesh_custom_attribute.rs
+++ b/examples/shader/mesh_custom_attribute.rs
@@ -141,7 +141,7 @@ fn setup(
         .with(material)
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 }

--- a/examples/shader/shader_custom_material.rs
+++ b/examples/shader/shader_custom_material.rs
@@ -97,7 +97,7 @@ fn setup(
         .with(material)
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 }

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -128,7 +128,7 @@ fn setup(
         .with(blue_material)
         // camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 }

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -190,7 +190,7 @@ fn setup_pipeline(
         })
         // main camera
         .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(0.0, 0.0, 6.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(0.0, 0.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         })
         // second window camera
@@ -200,7 +200,7 @@ fn setup_pipeline(
                 window: window_id,
                 ..Default::default()
             },
-            transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..Default::default()
         });
 }


### PR DESCRIPTION
it's a followup of #1550 

I think calling explicit methods/values instead of default makes the code easier to read: "what is `Quat::default()`" vs "Oh, it's `Quat::IDENTITY`"

`Transform::identity()` and `GlobalTransform::identity()` can also be consts and I replaced the calls to their `default()` impl with `identity()`