### PR TITLE
[Merged by Bors] - expose stages and system containers

### DIFF
--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -201,6 +201,13 @@ impl Schedule {
             stage.run(world);
         }
     }
+
+    /// All the schedule stages in insertion order
+    pub fn iter_stages(&self) -> impl Iterator<Item = (&dyn StageLabel, &dyn Stage)> {
+        self.stage_order
+            .iter()
+            .map(move |label| (&**label, &*self.stages[label]))
+    }
 }
 
 impl Stage for Schedule {

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -202,7 +202,7 @@ impl Schedule {
         }
     }
 
-    /// All the schedule stages in insertion order
+    /// Iterates over all of schedule's stages and their labels, in execution order.
     pub fn iter_stages(&self) -> impl Iterator<Item = (&dyn StageLabel, &dyn Stage)> {
         self.stage_order
             .iter()

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -59,12 +59,12 @@ pub struct SystemStage {
     executor: Box<dyn ParallelSystemExecutor>,
     /// Groups of systems; each set has its own run criterion.
     system_sets: Vec<VirtualSystemSet>,
-    /// Topologically sorted exclusive systems that want to be ran at the start of the stage.
+    /// Topologically sorted exclusive systems that want to be run at the start of the stage.
     exclusive_at_start: Vec<ExclusiveSystemContainer>,
-    /// Topologically sorted exclusive systems that want to be ran after parallel systems but
+    /// Topologically sorted exclusive systems that want to be run after parallel systems but
     /// before the application of their command buffers.
     exclusive_before_commands: Vec<ExclusiveSystemContainer>,
-    /// Topologically sorted exclusive systems that want to be ran at the end of the stage.
+    /// Topologically sorted exclusive systems that want to be run at the end of the stage.
     exclusive_at_end: Vec<ExclusiveSystemContainer>,
     /// Topologically sorted parallel systems.
     parallel: Vec<ParallelSystemContainer>,
@@ -171,15 +171,15 @@ impl SystemStage {
     pub fn parallel_systems(&self) -> &[impl SystemContainer] {
         &self.parallel
     }
-    /// Topologically sorted exclusive systems that want to be ran at the start of the stage.
+    /// Topologically sorted exclusive systems that want to be run at the start of the stage.
     pub fn exclusive_at_start_systems(&self) -> &[impl SystemContainer] {
         &self.exclusive_at_start
     }
-    /// Topologically sorted exclusive systems that want to be ran at the end of the stage.
+    /// Topologically sorted exclusive systems that want to be run at the end of the stage.
     pub fn exclusive_at_end_systems(&self) -> &[impl SystemContainer] {
         &self.exclusive_at_end
     }
-    /// Topologically sorted exclusive systems that want to be ran after parallel systems but
+    /// Topologically sorted exclusive systems that want to be run after parallel systems but
     /// before the application of their command buffers.
     pub fn exclusive_before_commands_systems(&self) -> &[impl SystemContainer] {
         &self.exclusive_before_commands

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -168,6 +168,8 @@ impl SystemStage {
     }
 
     /// Topologically sorted parallel systems.
+    ///
+    /// Note that this method won't output fully-formed data until the stage has been ran at least once.
     pub fn parallel_systems(&self) -> &[impl SystemContainer] {
         &self.parallel
     }

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -59,12 +59,12 @@ pub struct SystemStage {
     executor: Box<dyn ParallelSystemExecutor>,
     /// Groups of systems; each set has its own run criterion.
     system_sets: Vec<VirtualSystemSet>,
-    /// Topologically sorted exclusive systems that want to be ran at the start of the stage.
+    /// Topologically sorted exclusive systems that want to be run at the start of the stage.
     exclusive_at_start: Vec<ExclusiveSystemContainer>,
-    /// Topologically sorted exclusive systems that want to be ran after parallel systems but
+    /// Topologically sorted exclusive systems that want to be run after parallel systems but
     /// before the application of their command buffers.
     exclusive_before_commands: Vec<ExclusiveSystemContainer>,
-    /// Topologically sorted exclusive systems that want to be ran at the end of the stage.
+    /// Topologically sorted exclusive systems that want to be run at the end of the stage.
     exclusive_at_end: Vec<ExclusiveSystemContainer>,
     /// Topologically sorted parallel systems.
     parallel: Vec<ParallelSystemContainer>,
@@ -169,26 +169,26 @@ impl SystemStage {
 
     /// Topologically sorted parallel systems.
     ///
-    /// Note that systems won't be fully-formed until the stage has been ran at least once.
+    /// Note that systems won't be fully-formed until the stage has been run at least once.
     pub fn parallel_systems(&self) -> &[impl SystemContainer] {
         &self.parallel
     }
-    /// Topologically sorted exclusive systems that want to be ran at the start of the stage.
+    /// Topologically sorted exclusive systems that want to be run at the start of the stage.
     ///
-    /// Note that systems won't be fully-formed until the stage has been ran at least once.
+    /// Note that systems won't be fully-formed until the stage has been run at least once.
     pub fn exclusive_at_start_systems(&self) -> &[impl SystemContainer] {
         &self.exclusive_at_start
     }
-    /// Topologically sorted exclusive systems that want to be ran at the end of the stage.
+    /// Topologically sorted exclusive systems that want to be run at the end of the stage.
     ///
-    /// Note that systems won't be fully-formed until the stage has been ran at least once.
+    /// Note that systems won't be fully-formed until the stage has been run at least once.
     pub fn exclusive_at_end_systems(&self) -> &[impl SystemContainer] {
         &self.exclusive_at_end
     }
-    /// Topologically sorted exclusive systems that want to be ran after parallel systems but
+    /// Topologically sorted exclusive systems that want to be run after parallel systems but
     /// before the application of their command buffers.
     ///
-    /// Note that systems won't be fully-formed until the stage has been ran at least once.
+    /// Note that systems won't be fully-formed until the stage has been run at least once.
     pub fn exclusive_before_commands_systems(&self) -> &[impl SystemContainer] {
         &self.exclusive_before_commands
     }

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -59,12 +59,12 @@ pub struct SystemStage {
     executor: Box<dyn ParallelSystemExecutor>,
     /// Groups of systems; each set has its own run criterion.
     system_sets: Vec<VirtualSystemSet>,
-    /// Topologically sorted exclusive systems that want to be run at the start of the stage.
+    /// Topologically sorted exclusive systems that want to be ran at the start of the stage.
     exclusive_at_start: Vec<ExclusiveSystemContainer>,
-    /// Topologically sorted exclusive systems that want to be run after parallel systems but
+    /// Topologically sorted exclusive systems that want to be ran after parallel systems but
     /// before the application of their command buffers.
     exclusive_before_commands: Vec<ExclusiveSystemContainer>,
-    /// Topologically sorted exclusive systems that want to be run at the end of the stage.
+    /// Topologically sorted exclusive systems that want to be ran at the end of the stage.
     exclusive_at_end: Vec<ExclusiveSystemContainer>,
     /// Topologically sorted parallel systems.
     parallel: Vec<ParallelSystemContainer>,
@@ -171,15 +171,15 @@ impl SystemStage {
     pub fn parallel_systems(&self) -> &[impl SystemContainer] {
         &self.parallel
     }
-    /// Topologically sorted exclusive systems that want to be run at the start of the stage.
+    /// Topologically sorted exclusive systems that want to be ran at the start of the stage.
     pub fn exclusive_at_start_systems(&self) -> &[impl SystemContainer] {
         &self.exclusive_at_start
     }
-    /// Topologically sorted exclusive systems that want to be run at the end of the stage.
+    /// Topologically sorted exclusive systems that want to be ran at the end of the stage.
     pub fn exclusive_at_end_systems(&self) -> &[impl SystemContainer] {
         &self.exclusive_at_end
     }
-    /// Topologically sorted exclusive systems that want to be run after parallel systems but
+    /// Topologically sorted exclusive systems that want to be ran after parallel systems but
     /// before the application of their command buffers.
     pub fn exclusive_before_commands_systems(&self) -> &[impl SystemContainer] {
         &self.exclusive_before_commands

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -169,20 +169,26 @@ impl SystemStage {
 
     /// Topologically sorted parallel systems.
     ///
-    /// Note that this method won't output fully-formed data until the stage has been ran at least once.
+    /// Note that systems won't be fully-formed until the stage has been ran at least once.
     pub fn parallel_systems(&self) -> &[impl SystemContainer] {
         &self.parallel
     }
     /// Topologically sorted exclusive systems that want to be ran at the start of the stage.
+    ///
+    /// Note that systems won't be fully-formed until the stage has been ran at least once.
     pub fn exclusive_at_start_systems(&self) -> &[impl SystemContainer] {
         &self.exclusive_at_start
     }
     /// Topologically sorted exclusive systems that want to be ran at the end of the stage.
+    ///
+    /// Note that systems won't be fully-formed until the stage has been ran at least once.
     pub fn exclusive_at_end_systems(&self) -> &[impl SystemContainer] {
         &self.exclusive_at_end
     }
     /// Topologically sorted exclusive systems that want to be ran after parallel systems but
     /// before the application of their command buffers.
+    ///
+    /// Note that systems won't be fully-formed until the stage has been ran at least once.
     pub fn exclusive_before_commands_systems(&self) -> &[impl SystemContainer] {
         &self.exclusive_before_commands
     }

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -167,6 +167,24 @@ impl SystemStage {
         self.add_system_to_set(system, 0)
     }
 
+    /// Topologically sorted parallel systems.
+    pub fn parallel_systems(&self) -> &[impl SystemContainer] {
+        &self.parallel
+    }
+    /// Topologically sorted exclusive systems that want to be ran at the start of the stage.
+    pub fn exclusive_at_start_systems(&self) -> &[impl SystemContainer] {
+        &self.exclusive_at_start
+    }
+    /// Topologically sorted exclusive systems that want to be ran at the end of the stage.
+    pub fn exclusive_at_end_systems(&self) -> &[impl SystemContainer] {
+        &self.exclusive_at_end
+    }
+    /// Topologically sorted exclusive systems that want to be ran after parallel systems but
+    /// before the application of their command buffers.
+    pub fn exclusive_before_commands_systems(&self) -> &[impl SystemContainer] {
+        &self.exclusive_before_commands
+    }
+
     // TODO: consider exposing
     fn add_system_to_set(&mut self, system: impl Into<SystemDescriptor>, set: usize) -> &mut Self {
         self.systems_modified = true;

--- a/crates/bevy_ecs/src/schedule/system_container.rs
+++ b/crates/bevy_ecs/src/schedule/system_container.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use std::{borrow::Cow, ptr::NonNull};
 
-pub(super) trait SystemContainer {
+pub trait SystemContainer {
     fn name(&self) -> Cow<'static, str>;
     fn dependencies(&self) -> &[usize];
     fn set_dependencies(&mut self, dependencies: impl IntoIterator<Item = usize>);

--- a/crates/bevy_ecs/src/schedule/system_container.rs
+++ b/crates/bevy_ecs/src/schedule/system_container.rs
@@ -12,7 +12,9 @@ use std::{borrow::Cow, ptr::NonNull};
 /// System metadata like its name, labels, order requirements and component access.
 pub trait SystemContainer {
     fn name(&self) -> Cow<'static, str>;
+    #[doc(hidden)]
     fn dependencies(&self) -> &[usize];
+    #[doc(hidden)]
     fn set_dependencies(&mut self, dependencies: impl IntoIterator<Item = usize>);
     fn system_set(&self) -> usize;
     fn labels(&self) -> &[BoxedSystemLabel];

--- a/crates/bevy_ecs/src/schedule/system_container.rs
+++ b/crates/bevy_ecs/src/schedule/system_container.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use std::{borrow::Cow, ptr::NonNull};
 
+/// System metadata like its name, labels, order requirements and component access.
 pub trait SystemContainer {
     fn name(&self) -> Cow<'static, str>;
     fn dependencies(&self) -> &[usize];


### PR DESCRIPTION
This allows third-party plugins to analyze the schedule, e.g. `bevy_mod_picking` can [display a schedule graph](https://github.com/jakobhellermann/bevy_mod_debugdump/tree/schedule-graph#schedule-graph):

![schedule graph](https://raw.githubusercontent.com/jakobhellermann/bevy_mod_debugdump/schedule-graph/docs/schedule_graph.svg)