### PR TITLE
[Merged by Bors] - Small improvement of code quality of Assets::set* methods

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -465,7 +465,7 @@ impl AssetServer {
                         }
                     }
 
-                    assets.set(result.id, result.asset);
+                    let _ = assets.set(result.id, result.asset);
                 }
                 Ok(AssetLifecycleEvent::Free(handle_id)) => {
                     if let HandleId::AssetPathId(id) = handle_id {

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -72,18 +72,10 @@ impl<T: Asset> Assets<T> {
         self.get_handle(id)
     }
 
+    #[must_use = "not using the returned strong handle may result in the unexpected release of the asset"]
     pub fn set<H: Into<HandleId>>(&mut self, handle: H, asset: T) -> Handle<T> {
         let id: HandleId = handle.into();
-        if self.assets.insert(id, asset).is_some() {
-            self.events.send(AssetEvent::Modified {
-                handle: Handle::weak(id),
-            });
-        } else {
-            self.events.send(AssetEvent::Created {
-                handle: Handle::weak(id),
-            });
-        }
-
+        self.set_untracked(id, asset);
         self.get_handle(id)
     }
 


### PR DESCRIPTION
As mentioned in #1609.

I'm not sure if this is desirable, but on top of factoring the `set` and `set_untracked` methods I added a warning when the return value of `set` isn't used to mitigate similar issues.

I silenced it for the only occurence where it's currently done  https://github.com/bevyengine/bevy/blob/68606934e32ab45828c628e1cefd3873273f8708/crates/bevy_asset/src/asset_server.rs#L468