### PR TITLE
[Merged by Bors] - Add keyboard modifier example (#1656)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,6 +303,10 @@ name = "keyboard_input"
 path = "examples/input/keyboard_input.rs"
 
 [[example]]
+name = "keyboard_modifiers"
+path = "examples/input/keyboard_modifiers.rs"
+
+[[example]]
 name = "keyboard_input_events"
 path = "examples/input/keyboard_input_events.rs"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -163,6 +163,7 @@ Example | File | Description
 `gamepad_input_events` | [`input/gamepad_input_events.rs`](./input/gamepad_input_events.rs) | Iterates and prints gamepad input and connection events
 `keyboard_input` | [`input/keyboard_input.rs`](./input/keyboard_input.rs) | Demonstrates handling a key press/release
 `keyboard_input_events` | [`input/keyboard_input_events.rs`](./input/keyboard_input_events.rs) | Prints out all keyboard events
+`keyboard_modifiers` | [`input/keyboard_modifiers.rs`](./input/keyboard_modifiers.rs) | Demonstrates using key modifiers (ctrl, shift)
 `mouse_input` | [`input/mouse_input.rs`](./input/mouse_input.rs) | Demonstrates handling a mouse button press/release
 `mouse_input_events` | [`input/mouse_input_events.rs`](./input/mouse_input_events.rs) | Prints out all mouse events (buttons, movement, etc.)
 `touch_input` | [`input/touch_input.rs`](./input/touch_input.rs) | Displays touch presses, releases, and cancels

--- a/examples/input/keyboard_modifiers.rs
+++ b/examples/input/keyboard_modifiers.rs
@@ -1,0 +1,21 @@
+use bevy::{
+    input::{keyboard::KeyCode, Input},
+    prelude::*,
+};
+
+fn main() {
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_system(keyboard_input_system.system())
+        .run();
+}
+
+/// This system prints when Ctrl + Shift + A is pressed
+fn keyboard_input_system(input: Res<Input<KeyCode>>) {
+    let shift = input.pressed(KeyCode::LShift) || input.pressed(KeyCode::RShift);
+    let ctrl = input.pressed(KeyCode::LControl) || input.pressed(KeyCode::RControl);
+
+    if ctrl && shift && input.just_pressed(KeyCode::A) {
+        println!("Just pressed Ctrl + Shift + A!");
+    }
+}


### PR DESCRIPTION
This PR adds a small example that shows how to use Keyboard modifiers, as shown in [this](https://github.com/bevyengine/bevy/issues/1654#issuecomment-798966921) snippet.

Fixes #1656.