### PR TITLE
RFC: Create an RFC Process

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,3 +2,7 @@
 
 Please see the [Contributing Code](https://bevyengine.org/learn/book/contributing/code/) section of
 [The Book](https://bevyengine.org/learn/book/introduction/).
+
+## RFCs
+
+See the [RFC Repo]() to learn the how and the why of Bevy RFCs.

--- a/docs/rfcs/0000-template.md
+++ b/docs/rfcs/0000-template.md
@@ -1,0 +1,95 @@
+- Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Explain the proposal as if it was already included in the language and you were teaching it to another Rust programmer. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how Rust programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
+- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
+
+For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
+
+- For language, library, cargo, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
+- For community proposals: Is this done by some other community and what were their experiences with it?
+- For other teams: What lessons can we learn from what other communities have done here?
+- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+
+This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
+If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
+
+Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
+Please also take into consideration that rust sometimes intentionally diverges from common language features.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+Think about what the natural extension and evolution of your proposal would
+be and how it would affect the language and project as a whole in a holistic
+way. Try to use this section as a tool to more fully consider all possible
+interactions with the project and language in your proposal.
+Also consider how this all fits into the roadmap for the project
+and of the relevant sub-team.
+
+This is also a good place to "dump ideas", if they are out of scope for the
+RFC you are writing but otherwise related.
+
+If you have tried and cannot think of any future possibilities,
+you may simply state that you cannot think of anything.
+
+Note that having something written down in the future-possibilities section
+is not a reason to accept the current or a future RFC; such notes should be
+in the section on motivation or rationale in this or subsequent RFCs.
+The section merely provides additional information.

--- a/docs/rfcs/0000-template.md
+++ b/docs/rfcs/0000-template.md
@@ -1,7 +1,5 @@
 - Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
-- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 
 # Summary
 [summary]: #summary
@@ -11,20 +9,18 @@ One paragraph explanation of the feature.
 # Motivation
 [motivation]: #motivation
 
-Why are we doing this? What use cases does it support? What is the expected outcome?
+Why are we doing this? What use cases does it support?
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-Explain the proposal as if it was already included in the language and you were teaching it to another Rust programmer. That generally means:
+Explain the proposal as if it was already included in the language and you were teaching it to another Bevy user. That generally means:
 
 - Introducing new named concepts.
-- Explaining the feature largely in terms of examples.
-- Explaining how Rust programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
+- Explaining the feature, largely in terms of examples grounded in simple and common game constructs.
+- Explaining how Bevy users should *think* about the feature, and how it should impact the way they use Bevy. It should explain the impact as concretely as possible.
 - If applicable, provide sample error messages, deprecation warnings, or migration guidance.
-- If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
 
-For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -70,7 +66,7 @@ Please also take into consideration that rust sometimes intentionally diverges f
 [unresolved-questions]: #unresolved-questions
 
 - What parts of the design do you expect to resolve through the RFC process before this gets merged?
-- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What parts of the design do you expect to resolve through the implementation of this feature before the feature PR is merged?
 - What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
 
 # Future possibilities

--- a/docs/rfcs/0000-template.md
+++ b/docs/rfcs/0000-template.md
@@ -20,6 +20,7 @@ Explain the proposal as if it was already included in the engine and you were te
 - Explaining the feature, ideally through simple examples of solutions to concrete problems.
 - Explaining how Bevy users should *think* about the feature, and how it should impact the way they use Bevy. It should explain the impact as concretely as possible.
 - If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, explain how this feature compares to similar existing features, and in what situations the user would use each one.
 
 
 # Reference-level explanation
@@ -44,6 +45,7 @@ Why should we *not* do this?
 - Why is this design the best in the space of possible designs?
 - What other designs have been considered and what is the rationale for not choosing them?
 - What is the impact of not doing this?
+- Why must this be a feature of Bevy itself, rather than an ecosystem crate?
 
 # Prior art
 [prior-art]: #prior-art

--- a/docs/rfcs/0000-template.md
+++ b/docs/rfcs/0000-template.md
@@ -1,17 +1,14 @@
-- Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
+# Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
 
-# Summary
-[summary]: #summary
+## Summary
 
 One paragraph explanation of the feature.
 
-# Motivation
-[motivation]: #motivation
+## Motivation
 
 Why are we doing this? What use cases does it support?
 
-# Guide-level explanation
-[guide-level-explanation]: #guide-level-explanation
+## Guide-level explanation
 
 Explain the proposal as if it was already included in the engine and you were teaching it to another Bevy user. That generally means:
 
@@ -21,8 +18,7 @@ Explain the proposal as if it was already included in the engine and you were te
 - If applicable, provide sample error messages, deprecation warnings, or migration guidance.
 - If applicable, explain how this feature compares to similar existing features, and in what situations the user would use each one.
 
-# Reference-level explanation
-[reference-level-explanation]: #reference-level-explanation
+## Reference-level explanation
 
 This is the technical portion of the RFC. Explain the design in sufficient detail that:
 
@@ -32,21 +28,18 @@ This is the technical portion of the RFC. Explain the design in sufficient detai
 
 The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
 
-# Drawbacks
-[drawbacks]: #drawbacks
+## Drawbacks
 
 Why should we *not* do this?
 
-# Rationale and alternatives
-[rationale-and-alternatives]: #rationale-and-alternatives
+## Rationale and alternatives
 
 - Why is this design the best in the space of possible designs?
 - What other designs have been considered and what is the rationale for not choosing them?
 - What is the impact of not doing this?
 - Why is this important to implement as a feature of Bevy itself, rather than an ecosystem crate?
 
-# [Optional] Prior art
-[prior-art]: #prior-art
+## \[Optional\] Prior art
 
 Discuss prior art, both the good and the bad, in relation to this proposal.
 This can include:
@@ -58,15 +51,13 @@ This section is intended to encourage you as an author to think about the lesson
 
 Note that while precedent set by other engines is some motivation, it does not on its own motivate an RFC.
 
-# Unresolved questions
-[unresolved-questions]: #unresolved-questions
+## Unresolved questions
 
 - What parts of the design do you expect to resolve through the RFC process before this gets merged?
 - What parts of the design do you expect to resolve through the implementation of this feature before the feature PR is merged?
 - What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
 
-# [Optional] Future possibilities
-[future-possibilities]: #future-possibilities
+## \[Optional\] Future possibilities
 
 Think about what the natural extension and evolution of your proposal would
 be and how it would affect Bevy as a whole in a holistic way.

--- a/docs/rfcs/0000-template.md
+++ b/docs/rfcs/0000-template.md
@@ -1,5 +1,4 @@
 - Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
-- Start Date: (fill me in with today's date, YYYY-MM-DD)
 
 # Summary
 [summary]: #summary
@@ -80,8 +79,6 @@ Also consider how this all fits into the roadmap for the project.
 This is also a good place to "dump ideas", if they are out of scope for the
 RFC you are writing but otherwise related.
 
-If you have tried and cannot think of any future possibilities,
-you may simply state that you cannot think of anything.
 
 Note that having something written down in the future-possibilities section
 is not a reason to accept the current or a future RFC; such notes should be

--- a/docs/rfcs/0000-template.md
+++ b/docs/rfcs/0000-template.md
@@ -44,9 +44,9 @@ Why should we *not* do this?
 - Why is this design the best in the space of possible designs?
 - What other designs have been considered and what is the rationale for not choosing them?
 - What is the impact of not doing this?
-- Why must this be a feature of Bevy itself, rather than an ecosystem crate?
+- Why is this important to implement as a feature of Bevy itself, rather than an ecosystem crate?
 
-# Prior art
+# [Optional] Prior art
 [prior-art]: #prior-art
 
 Discuss prior art, both the good and the bad, in relation to this proposal.
@@ -67,14 +67,13 @@ Note that while precedent set by other engines is some motivation, it does not o
 - What parts of the design do you expect to resolve through the implementation of this feature before the feature PR is merged?
 - What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
 
-# Future possibilities
+# [Optional] Future possibilities
 [future-possibilities]: #future-possibilities
 
 Think about what the natural extension and evolution of your proposal would
-be and how it would affect Bevy as a whole in a holistic
-way. Try to use this section as a tool to more fully consider all possible
+be and how it would affect Bevy as a whole in a holistic way.
+Try to use this section as a tool to more fully consider other possible
 interactions with the engine in your proposal.
-Also consider how this all fits into the roadmap for the project.
 
 This is also a good place to "dump ideas", if they are out of scope for the
 RFC you are writing but otherwise related.

--- a/docs/rfcs/0000-template.md
+++ b/docs/rfcs/0000-template.md
@@ -14,10 +14,10 @@ Why are we doing this? What use cases does it support?
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-Explain the proposal as if it was already included in the language and you were teaching it to another Bevy user. That generally means:
+Explain the proposal as if it was already included in the engine and you were teaching it to another Bevy user. That generally means:
 
 - Introducing new named concepts.
-- Explaining the feature, largely in terms of examples grounded in simple and common game constructs.
+- Explaining the feature, ideally through simple examples of solutions to concrete problems.
 - Explaining how Bevy users should *think* about the feature, and how it should impact the way they use Bevy. It should explain the impact as concretely as possible.
 - If applicable, provide sample error messages, deprecation warnings, or migration guidance.
 
@@ -51,16 +51,13 @@ Why should we *not* do this?
 Discuss prior art, both the good and the bad, in relation to this proposal.
 A few examples of what this can include are:
 
-- For language, library, cargo, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
-- For community proposals: Is this done by some other community and what were their experiences with it?
-- For other teams: What lessons can we learn from what other communities have done here?
+- Does this feature exist in other libraries and what experiences have their community had?
 - Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
 
 This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
 If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
 
-Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
-Please also take into consideration that rust sometimes intentionally diverges from common language features.
+Note that while precedent set by other engines is some motivation, it does not on its own motivate an RFC.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
@@ -73,11 +70,10 @@ Please also take into consideration that rust sometimes intentionally diverges f
 [future-possibilities]: #future-possibilities
 
 Think about what the natural extension and evolution of your proposal would
-be and how it would affect the language and project as a whole in a holistic
+be and how it would affect Bevy as a whole in a holistic
 way. Try to use this section as a tool to more fully consider all possible
-interactions with the project and language in your proposal.
-Also consider how this all fits into the roadmap for the project
-and of the relevant sub-team.
+interactions with the engine in your proposal.
+Also consider how this all fits into the roadmap for the project.
 
 This is also a good place to "dump ideas", if they are out of scope for the
 RFC you are writing but otherwise related.

--- a/docs/rfcs/0000-template.md
+++ b/docs/rfcs/0000-template.md
@@ -21,7 +21,6 @@ Explain the proposal as if it was already included in the engine and you were te
 - If applicable, provide sample error messages, deprecation warnings, or migration guidance.
 - If applicable, explain how this feature compares to similar existing features, and in what situations the user would use each one.
 
-
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
@@ -50,13 +49,12 @@ Why should we *not* do this?
 [prior-art]: #prior-art
 
 Discuss prior art, both the good and the bad, in relation to this proposal.
-A few examples of what this can include are:
+This can include:
 
 - Does this feature exist in other libraries and what experiences have their community had?
-- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+- Papers: Are there any published papers or great posts that discuss this?
 
-This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
-If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
+This section is intended to encourage you as an author to think about the lessons from other tools and provide readers of your RFC with a fuller picture.
 
 Note that while precedent set by other engines is some motivation, it does not on its own motivate an RFC.
 
@@ -78,8 +76,7 @@ interactions with the engine in your proposal.
 This is also a good place to "dump ideas", if they are out of scope for the
 RFC you are writing but otherwise related.
 
-
 Note that having something written down in the future-possibilities section
 is not a reason to accept the current or a future RFC; such notes should be
 in the section on motivation or rationale in this or subsequent RFCs.
-The section merely provides additional information.
+If a feature or change has no direct value on its own, expand your RFC to include the first valuable feature that would build on it.


### PR DESCRIPTION
Large PRs that are either complex or out of scope of current "focus area" efforts can often sit around, gated by feedback from cart. Creating an RFC process would give the community a useful tool to discuss complex proposals, especially if the proposed PR has implications for features that will get built on top.

 A standard format would make it more likely that all the information needed to make a decision is accounted for and in a predictable format for cart and the broader community to digest. The intent here is not to create burden for contributors, but give the community a way of making headway on big decisions without PRs rotting in the queue.

I'd like to collaborate on a template, and discuss this meta-RFC here! We can make this RFC into the first RFC as a way of testing out the process. I've copied the Rust RFC template, per @alice-i-cecile's recommendation, as a starting point.

Edit 2021-04-01:

# Current Status

## Summary

We have consensus on:

- Supporting an implementation-first process that has minimal overhead for contributors
- Supporting a design-first process if community members want to collect information before implementing anything
- Hosting the RFCs in a separate repo

## Next Steps

1. Create a new RFC repo in the bevy org
2. Add the RFC template to the RFC repo
3. Add the [welcome message](https://github.com/bevyengine/bevy/pull/1662#issuecomment-801260699) to the RFC repo README
4. Remove the template and RFC folder from this PR
5. Add info about RFCs to the bevy CONTRIBUTING.md as part of this PR