### PR TITLE
add a method on `AssetServer` to create an asset from an existing one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,6 +271,10 @@ name = "asset_loading"
 path = "examples/asset/asset_loading.rs"
 
 [[example]]
+name = "asset_transformation"
+path = "examples/asset/asset_transformation.rs"
+
+[[example]]
 name = "custom_asset"
 path = "examples/asset/custom_asset.rs"
 

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -238,7 +238,7 @@ impl AssetServer {
     }
 
     /// Create a new asset from another one
-    pub fn create_new_from<FROM: Asset, TO: Asset, F>(
+    pub fn create_from<FROM: Asset, TO: Asset, F>(
         &self,
         original_handle: Handle<FROM>,
         transform: F,
@@ -569,7 +569,7 @@ impl AssetServer {
                     }
                     assets.remove(handle_id);
                 }
-                Ok(AssetLifecycleEvent::CreateNewFrom {
+                Ok(AssetLifecycleEvent::CreateFrom {
                     from,
                     to,
                     to_uuid,
@@ -582,7 +582,7 @@ impl AssetServer {
                             .unwrap()
                             .create_asset(to, new, 0);
                     } else {
-                        rerun.push(AssetLifecycleEvent::CreateNewFrom {
+                        rerun.push(AssetLifecycleEvent::CreateFrom {
                             from,
                             to,
                             to_uuid,

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -574,8 +574,8 @@ impl AssetServer {
                     transform,
                 }) => {
                     if let Some(original) = assets.get(from) {
-                        // `transform` can fail if it's result is not the expected type
-                        // this should happen as public API to reach this point is stronly typed
+                        // `transform` can fail if its result is not the expected type
+                        // this should not happen as public API to reach this point is stronly typed
                         // traits are only used in flight for communication
                         if let Ok(new) = transform(original) {
                             let _ = assets.set(to, *new);

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -575,7 +575,7 @@ impl AssetServer {
                 }) => {
                     if let Some(original) = assets.get(from) {
                         // `transform` can fail if its result is not the expected type
-                        // this should not happen as public API to reach this point is stronly typed
+                        // this should not happen as public API to reach this point is strongly typed
                         // traits are only used in flight for communication
                         if let Ok(new) = transform(original) {
                             let _ = assets.set(to, *new);

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -507,7 +507,7 @@ impl AssetServer {
             .unwrap();
 
         loop {
-            match channel.receiver.try_recv() {
+            match channel.from_asset_server.try_recv() {
                 Ok(AssetLifecycleEvent::Create(result)) => {
                     // update SourceInfo if this asset was loaded from an AssetPath
                     if let HandleId::AssetPathId(id) = result.id {

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -1,8 +1,8 @@
 use crate::{
     path::{AssetPath, AssetPathId, SourcePathId},
-    Asset, AssetIo, AssetIoError, AssetLifecycle, AssetLifecycleChannel, AssetLifecycleEvent,
-    AssetLoader, Assets, Handle, HandleId, HandleUntyped, LabelId, LoadContext, LoadState,
-    RefChange, RefChangeChannel, SourceInfo, SourceMeta,
+    Asset, AssetDynamic, AssetIo, AssetIoError, AssetLifecycle, AssetLifecycleChannel,
+    AssetLifecycleEvent, AssetLoader, Assets, Handle, HandleId, HandleUntyped, LabelId,
+    LoadContext, LoadState, RefChange, RefChangeChannel, SourceInfo, SourceMeta,
 };
 use anyhow::Result;
 use bevy_ecs::system::{Res, ResMut};
@@ -255,7 +255,7 @@ impl AssetServer {
             asset_lifecycle.create_asset_from(
                 original_handle.into(),
                 new_handle,
-                Box::new(|asset| {
+                Box::new(|asset: &dyn AssetDynamic| {
                     Box::new(transform(
                         asset
                             .downcast_ref::<T>()

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -257,7 +257,7 @@ impl AssetServer {
                 new_handle,
                 Box::new(|asset| {
                     Box::new(transform(
-                        Box::new(asset)
+                        asset
                             .downcast_ref::<T>()
                             .expect("This can't happen as asset is of type T"),
                     ))

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -264,11 +264,15 @@ impl AssetServer {
                         asset
                             .downcast_ref::<FROM>()
                             // this downcast can't fail as we know the actual types here
-                            .expect("Error converting an asset to it's type, please open an issue in Bevy GitHub repository"),
+                            .expect("Error converting an asset to its type, please open an issue in Bevy GitHub repository"),
                     ) {
                         Some(Box::new(transformed))
                     } else {
-                        warn!("Error creating a new asset from {} to {}", std::any::type_name::<FROM>(), std::any::type_name::<TO>());
+                        warn!(
+                            "Error creating a new asset from {}, attempting to convert to {}",
+                            std::any::type_name::<FROM>(),
+                            std::any::type_name::<TO>()
+                        );
                         None
                     }
                 }),

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -216,7 +216,7 @@ impl<T: AssetDynamic> AssetLifecycle for AssetLifecycleChannel<T> {
                     transform(asset)
                         .downcast::<T>()
                         // `downcast` can fail if `transform` result is not the expected type
-                        // this should not happen as public API to reach this point is stronly typed
+                        // this should not happen as public API to reach this point is strongly typed
                         // traits are only used in flight for communication
                         .map_err(|_| ())
                 }),

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -212,7 +212,14 @@ impl<T: AssetDynamic> AssetLifecycle for AssetLifecycleChannel<T> {
             .send(AssetLifecycleEvent::CreateNewFrom {
                 from,
                 to,
-                transform: Box::new(|asset: &T| transform(asset).downcast::<T>().map_err(|_| ())),
+                transform: Box::new(|asset: &T| {
+                    transform(asset)
+                        .downcast::<T>()
+                        // `downcast` can fail if `transform` result is not the expected type
+                        // this should not happen as public API to reach this point is stronly typed
+                        // traits are only used in flight for communication
+                        .map_err(|_| ())
+                }),
             })
             .unwrap();
     }

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -164,7 +164,7 @@ pub struct AssetLifecycleChannel<T> {
 
 pub enum AssetLifecycleEvent<T> {
     Create(AssetResult<T>),
-    CreateNewFrom {
+    CreateFrom {
         from: HandleId,
         to: HandleId,
         to_uuid: Uuid,
@@ -212,7 +212,7 @@ impl<T: AssetDynamic> AssetLifecycle for AssetLifecycleChannel<T> {
         transform: Box<dyn (FnOnce(&dyn AssetDynamic) -> Box<dyn AssetDynamic>) + Send>,
     ) {
         self.to_system
-            .send(AssetLifecycleEvent::CreateNewFrom {
+            .send(AssetLifecycleEvent::CreateFrom {
                 from,
                 to,
                 to_uuid,

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -205,7 +205,7 @@ impl<T: AssetDynamic> AssetLifecycle for AssetLifecycleChannel<T> {
         }
     }
 
-    /// Convert an asset from type `T` to type with `T_TO::TYPE_UUID == to_uuid`.
+    /// Convert an asset from type `T` to type with `To::TYPE_UUID == to_uuid`.
     /// It is the responsibility of the caller to ensure that input/output of `transform`
     /// matches those types
     fn create_asset_from(

--- a/examples/README.md
+++ b/examples/README.md
@@ -136,6 +136,7 @@ Example | File | Description
 Example | File | Description
 --- | --- | ---
 `asset_loading` | [`asset/asset_loading.rs`](./asset/asset_loading.rs) | Demonstrates various methods to load assets
+`asset_transformation` | [`asset/asset_transformation.rs`](./asset/asset_transformation.rs) | Create new assets from an existing one, with some transformation
 `custom_asset` | [`asset/custom_asset.rs`](./asset/custom_asset.rs) | Implements a custom asset loader
 `custom_asset_io` | [`asset/custom_asset_io.rs`](./asset/custom_asset_io.rs) | Implements a custom asset io loader
 `hot_asset_reloading` | [`asset/hot_asset_reloading.rs`](./asset/hot_asset_reloading.rs) | Demonstrates automatic reloading of assets when modified on disk

--- a/examples/asset/asset_transformation.rs
+++ b/examples/asset/asset_transformation.rs
@@ -1,0 +1,73 @@
+use bevy::prelude::*;
+
+fn main() {
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(setup.system())
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    let texture_handle = asset_server.load("branding/icon.png");
+    // new texture with one pixel every three removed
+    let texture_handle_1 =
+        asset_server.create_new_from(texture_handle.clone(), |texture: &Texture| {
+            let new_data = texture
+                .data
+                .iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    if i / texture.format.pixel_size() % 3 == 0 {
+                        0
+                    } else {
+                        *v
+                    }
+                })
+                .collect();
+            Texture {
+                data: new_data,
+                ..*texture
+            }
+        });
+    // new texture with one pixel every two removed
+    let texture_handle_2 =
+        asset_server.create_new_from(texture_handle.clone(), |texture: &Texture| {
+            let new_data = texture
+                .data
+                .iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    if i / texture.format.pixel_size() % 2 == 0 {
+                        0
+                    } else {
+                        *v
+                    }
+                })
+                .collect();
+            Texture {
+                data: new_data,
+                ..*texture
+            }
+        });
+
+    commands
+        .spawn(OrthographicCameraBundle::new_2d())
+        .spawn(SpriteBundle {
+            material: materials.add(texture_handle.into()),
+            transform: Transform::from_xyz(-300.0, 0.0, 0.0),
+            ..Default::default()
+        })
+        .spawn(SpriteBundle {
+            material: materials.add(texture_handle_1.into()),
+            ..Default::default()
+        })
+        .spawn(SpriteBundle {
+            material: materials.add(texture_handle_2.into()),
+            transform: Transform::from_xyz(300.0, 0.0, 0.0),
+            ..Default::default()
+        });
+}

--- a/examples/asset/asset_transformation.rs
+++ b/examples/asset/asset_transformation.rs
@@ -45,20 +45,20 @@ fn setup(
         })
     });
 
-    commands
-        .spawn(OrthographicCameraBundle::new_2d())
-        .spawn(SpriteBundle {
-            material: materials.add(texture_handle.into()),
-            transform: Transform::from_xyz(-300.0, 0.0, 0.0),
-            ..Default::default()
-        })
-        .spawn(SpriteBundle {
-            material: materials.add(texture_handle_1.into()),
-            ..Default::default()
-        })
-        .spawn(SpriteBundle {
-            material: materials.add(texture_handle_2.into()),
-            transform: Transform::from_xyz(300.0, 0.0, 0.0),
-            ..Default::default()
-        });
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+
+    commands.spawn_bundle(SpriteBundle {
+        material: materials.add(texture_handle.into()),
+        transform: Transform::from_xyz(-300.0, 0.0, 0.0),
+        ..Default::default()
+    });
+    commands.spawn_bundle(SpriteBundle {
+        material: materials.add(texture_handle_1.into()),
+        ..Default::default()
+    });
+    commands.spawn_bundle(SpriteBundle {
+        material: materials.add(texture_handle_2.into()),
+        transform: Transform::from_xyz(300.0, 0.0, 0.0),
+        ..Default::default()
+    });
 }

--- a/examples/asset/asset_transformation.rs
+++ b/examples/asset/asset_transformation.rs
@@ -1,19 +1,19 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, render::texture::TextureFormatPixelInfo};
 
 fn main() {
-    App::build()
+    App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();
 }
 
-fn filter_pixels(filter: usize, texture: &Texture) -> Vec<u8> {
-    texture
+fn filter_pixels(filter: usize, image: &Image) -> Vec<u8> {
+    image
         .data
         .iter()
         .enumerate()
         .map(|(i, v)| {
-            if i / texture.format.pixel_size() % filter == 0 {
+            if i / image.texture_descriptor.format.pixel_size() % filter == 0 {
                 0
             } else {
                 *v
@@ -22,42 +22,38 @@ fn filter_pixels(filter: usize, texture: &Texture) -> Vec<u8> {
         .collect()
 }
 
-fn setup(
-    mut commands: Commands,
-    asset_server: Res<AssetServer>,
-    mut materials: ResMut<Assets<ColorMaterial>>,
-) {
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let texture_handle = asset_server.load("branding/icon.png");
 
     // new texture with every third pixel removed
-    let texture_handle_1 = asset_server.create_from(texture_handle.clone(), |texture: &Texture| {
-        Some(Texture {
+    let texture_handle_1 = asset_server.create_from(texture_handle.clone(), |texture: &Image| {
+        Some(Image {
             data: filter_pixels(3, texture),
-            ..*texture
+            ..texture.clone()
         })
     });
 
     // new texture with every second pixel removed
-    let texture_handle_2 = asset_server.create_from(texture_handle.clone(), |texture: &Texture| {
-        Some(Texture {
+    let texture_handle_2 = asset_server.create_from(texture_handle.clone(), |texture: &Image| {
+        Some(Image {
             data: filter_pixels(2, texture),
-            ..*texture
+            ..texture.clone()
         })
     });
 
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
 
     commands.spawn_bundle(SpriteBundle {
-        material: materials.add(texture_handle.into()),
+        texture: texture_handle,
         transform: Transform::from_xyz(-300.0, 0.0, 0.0),
         ..Default::default()
     });
     commands.spawn_bundle(SpriteBundle {
-        material: materials.add(texture_handle_1.into()),
+        texture: texture_handle_1,
         ..Default::default()
     });
     commands.spawn_bundle(SpriteBundle {
-        material: materials.add(texture_handle_2.into()),
+        texture: texture_handle_2,
         transform: Transform::from_xyz(300.0, 0.0, 0.0),
         ..Default::default()
     });

--- a/examples/asset/asset_transformation.rs
+++ b/examples/asset/asset_transformation.rs
@@ -29,7 +29,7 @@ fn setup(
 ) {
     let texture_handle = asset_server.load("branding/icon.png");
 
-    // new texture with one pixel every three removed
+    // new texture with every third pixel removed
     let texture_handle_1 = asset_server.create_from(texture_handle.clone(), |texture: &Texture| {
         Some(Texture {
             data: filter_pixels(3, texture),
@@ -37,7 +37,7 @@ fn setup(
         })
     });
 
-    // new texture with one pixel every two removed
+    // new texture with every second pixel removed
     let texture_handle_2 = asset_server.create_from(texture_handle.clone(), |texture: &Texture| {
         Some(Texture {
             data: filter_pixels(2, texture),

--- a/examples/asset/asset_transformation.rs
+++ b/examples/asset/asset_transformation.rs
@@ -7,52 +7,43 @@ fn main() {
         .run();
 }
 
+fn filter_pixels(filter: usize, texture: &Texture) -> Vec<u8> {
+    texture
+        .data
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            if i / texture.format.pixel_size() % filter == 0 {
+                0
+            } else {
+                *v
+            }
+        })
+        .collect()
+}
+
 fn setup(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let texture_handle = asset_server.load("branding/icon.png");
+
     // new texture with one pixel every three removed
-    let texture_handle_1 =
-        asset_server.create_new_from(texture_handle.clone(), |texture: &Texture| {
-            let new_data = texture
-                .data
-                .iter()
-                .enumerate()
-                .map(|(i, v)| {
-                    if i / texture.format.pixel_size() % 3 == 0 {
-                        0
-                    } else {
-                        *v
-                    }
-                })
-                .collect();
-            Texture {
-                data: new_data,
-                ..*texture
-            }
-        });
+    let texture_handle_1 = asset_server.create_from(texture_handle.clone(), |texture: &Texture| {
+        Some(Texture {
+            data: filter_pixels(3, texture),
+            ..*texture
+        })
+    });
+
     // new texture with one pixel every two removed
-    let texture_handle_2 =
-        asset_server.create_new_from(texture_handle.clone(), |texture: &Texture| {
-            let new_data = texture
-                .data
-                .iter()
-                .enumerate()
-                .map(|(i, v)| {
-                    if i / texture.format.pixel_size() % 2 == 0 {
-                        0
-                    } else {
-                        *v
-                    }
-                })
-                .collect();
-            Texture {
-                data: new_data,
-                ..*texture
-            }
-        });
+    let texture_handle_2 = asset_server.create_from(texture_handle.clone(), |texture: &Texture| {
+        Some(Texture {
+            data: filter_pixels(2, texture),
+            ..*texture
+        })
+    });
 
     commands
         .spawn(OrthographicCameraBundle::new_2d())


### PR DESCRIPTION
Some assets loaded from disk by the asset server have extra fields that are not possible to setup on load, as the asset loader is picking the values. Changing those values is quite bothersome as it requires the user to:
* save the asset handle in a resource
* add a system that will wait for the asset to be loaded then modify it

This PR add a method on `AssetServer` to simplify that:
```rust
// load the texture from disk
let texture_handle = asset_server.load("branding/icon.png");

// new texture with one pixel every two removed
let texture_handle_1 =
    asset_server.create_from(texture_handle, |texture: &Texture| {
        let new_data = texture
            .data
            .iter()
            .enumerate()
            .map(|(i, v)| {
                if i / texture.format.pixel_size() % 2 == 0 {
                    0
                } else {
                    *v
                }
            })
            .collect();
        Some(Texture {
            data: new_data,
            ..*texture
        })
    });
```

screenshot from example
<img width="1392" alt="Screenshot 2021-03-16 at 01 11 01" src="https://user-images.githubusercontent.com/8672791/111237595-bb40cd00-85f5-11eb-933b-bd755716c60c.png">
