### PR TITLE
[Merged by Bors] - Add synonyms for transform relative vectors

### DIFF
--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -147,7 +147,7 @@ impl GlobalTransform {
     pub fn down(&self) -> Vec3 {
         -self.local_y()
     }
-  
+
     /// Get the unit vector in the local z direction
     #[inline]
     pub fn local_z(&self) -> Vec3 {
@@ -165,7 +165,7 @@ impl GlobalTransform {
     pub fn back(&self) -> Vec3 {
         self.local_z()
     }
-  
+
     #[doc(hidden)]
     #[inline]
     pub fn rotate(&mut self, rotation: Quat) {

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -83,15 +83,51 @@ impl GlobalTransform {
     }
 
     #[inline]
+    /// Equivalent to -local_x()
+    pub fn left(&self) -> Vec3 {
+        -self.local_x()
+    }
+
+    #[inline]
+    /// Equivalent to local_x()
+    pub fn right(&self) -> Vec3 {
+        self.local_x()
+    }
+
+    #[inline]
     /// Get the unit vector in the local y direction
     pub fn local_y(&self) -> Vec3 {
         self.rotation * Vec3::Y
     }
 
     #[inline]
+    /// Equivalent to local_y()
+    pub fn up(&self) -> Vec3 {
+        self.local_y()
+    }
+
+    #[inline]
+    /// Equivalent to -local_y()
+    pub fn down(&self) -> Vec3 {
+        -self.local_y()
+    }
+
+    #[inline]
     /// Get the unit vector in the local z direction
     pub fn local_z(&self) -> Vec3 {
         self.rotation * Vec3::Z
+    }
+
+    #[inline]
+    /// Equivalent to -local_z()
+    pub fn forward(&self) -> Vec3 {
+        -self.local_z()
+    }
+
+    #[inline]
+    /// Equivalent to local_z()
+    pub fn back(&self) -> Vec3 {
+        self.local_z()
     }
 
     #[inline]

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -83,15 +83,51 @@ impl Transform {
     }
 
     #[inline]
+    /// Equivalent to -local_x()
+    pub fn left(&self) -> Vec3 {
+        -self.local_x()
+    }
+
+    #[inline]
+    /// Equivalent to local_x()
+    pub fn right(&self) -> Vec3 {
+        self.local_x()
+    }
+
+    #[inline]
     /// Get the unit vector in the local y direction
     pub fn local_y(&self) -> Vec3 {
         self.rotation * Vec3::Y
     }
 
     #[inline]
+    /// Equivalent to local_y()
+    pub fn up(&self) -> Vec3 {
+        self.local_y()
+    }
+
+    #[inline]
+    /// Equivalent to -local_y()
+    pub fn down(&self) -> Vec3 {
+        -self.local_y()
+    }
+
+    #[inline]
     /// Get the unit vector in the local z direction
     pub fn local_z(&self) -> Vec3 {
         self.rotation * Vec3::Z
+    }
+
+    #[inline]
+    /// Equivalent to -local_z()
+    pub fn forward(&self) -> Vec3 {
+        -self.local_z()
+    }
+
+    #[inline]
+    /// Equivalent to local_z()
+    pub fn back(&self) -> Vec3 {
+        self.local_z()
     }
 
     #[inline]

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -154,7 +154,6 @@ impl Transform {
         self.local_y()
     }
 
-    
     /// Equivalent to -local_y()
     #[inline]
     pub fn down(&self) -> Vec3 {


### PR DESCRIPTION
Fixes #1663.

I think the directions are correct (same as [here](https://docs.godotengine.org/en/stable/classes/class_vector3.html?highlight=forward#constants)), but please double check because I might have mixed them up.