### PR TITLE
Formatting cleanup

### DIFF
--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -173,18 +173,21 @@ impl SystemStage {
     pub fn parallel_systems(&self) -> &[impl SystemContainer] {
         &self.parallel
     }
+
     /// Topologically sorted exclusive systems that want to be run at the start of the stage.
     ///
     /// Note that systems won't be fully-formed until the stage has been run at least once.
     pub fn exclusive_at_start_systems(&self) -> &[impl SystemContainer] {
         &self.exclusive_at_start
     }
+
     /// Topologically sorted exclusive systems that want to be run at the end of the stage.
     ///
     /// Note that systems won't be fully-formed until the stage has been run at least once.
     pub fn exclusive_at_end_systems(&self) -> &[impl SystemContainer] {
         &self.exclusive_at_end
     }
+
     /// Topologically sorted exclusive systems that want to be run after parallel systems but
     /// before the application of their command buffers.
     ///

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -188,7 +188,8 @@ impl<T: Component + Clone + Eq> State<T> {
 
     /// Creates a driver set for the State.
     ///
-    /// Important note: this set must be inserted **before** all other state-dependant sets to work properly!
+    /// Important note: this set must be inserted **before** all other state-dependant sets to work
+    /// properly!
     pub fn make_driver() -> SystemSet {
         SystemSet::default().with_run_criteria(state_cleaner::<T>.system())
     }
@@ -203,7 +204,8 @@ impl<T: Component + Clone + Eq> State<T> {
     }
 
     /// Schedule a state change that replaces the full stack with the given state.
-    /// This will fail if there is a scheduled operation, or if the given `state` matches the current state
+    /// This will fail if there is a scheduled operation, or if the given `state` matches the
+    /// current state
     pub fn set_next(&mut self, state: T) -> Result<(), StateError> {
         if self.stack.last().unwrap() == &state {
             return Err(StateError::AlreadyInState);
@@ -217,7 +219,8 @@ impl<T: Component + Clone + Eq> State<T> {
         Ok(())
     }
 
-    /// Same as [Self::set_next], but if there is already a next state, it will be overwritten instead of failing
+    /// Same as [Self::set_next], but if there is already a next state, it will be overwritten
+    /// instead of failing
     pub fn overwrite_next(&mut self, state: T) -> Result<(), StateError> {
         if self.stack.last().unwrap() == &state {
             return Err(StateError::AlreadyInState);
@@ -241,7 +244,8 @@ impl<T: Component + Clone + Eq> State<T> {
         Ok(())
     }
 
-    /// Same as [Self::set_push], but if there is already a next state, it will be overwritten instead of failing
+    /// Same as [Self::set_push], but if there is already a next state, it will be overwritten
+    /// instead of failing
     pub fn overwrite_push(&mut self, state: T) -> Result<(), StateError> {
         if self.stack.last().unwrap() == &state {
             return Err(StateError::AlreadyInState);
@@ -265,7 +269,8 @@ impl<T: Component + Clone + Eq> State<T> {
         Ok(())
     }
 
-    /// Same as [Self::set_pop], but if there is already a next state, it will be overwritten instead of failing
+    /// Same as [Self::set_pop], but if there is already a next state, it will be overwritten
+    /// instead of failing
     pub fn overwrite_pop(&mut self) -> Result<(), StateError> {
         if self.stack.len() == 1 {
             return Err(StateError::StackEmpty);

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -220,7 +220,7 @@ impl<T: Component + Clone + Eq> State<T> {
     }
 
     /// Same as [Self::set_next], but if there is already a next state, it will be overwritten
-    /// instead of failing
+    /// instead of failing.
     pub fn overwrite_next(&mut self, state: T) -> Result<(), StateError> {
         if self.stack.last().unwrap() == &state {
             return Err(StateError::AlreadyInState);

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -270,7 +270,7 @@ impl<T: Component + Clone + Eq> State<T> {
     }
 
     /// Same as [Self::set_pop], but if there is already a next state, it will be overwritten
-    /// instead of failing
+    /// instead of failing.
     pub fn overwrite_pop(&mut self) -> Result<(), StateError> {
         if self.stack.len() == 1 {
             return Err(StateError::StackEmpty);

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -205,7 +205,7 @@ impl<T: Component + Clone + Eq> State<T> {
 
     /// Schedule a state change that replaces the full stack with the given state.
     /// This will fail if there is a scheduled operation, or if the given `state` matches the
-    /// current state
+    /// current state.
     pub fn set_next(&mut self, state: T) -> Result<(), StateError> {
         if self.stack.last().unwrap() == &state {
             return Err(StateError::AlreadyInState);

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -245,7 +245,7 @@ impl<T: Component + Clone + Eq> State<T> {
     }
 
     /// Same as [Self::set_push], but if there is already a next state, it will be overwritten
-    /// instead of failing
+    /// instead of failing.
     pub fn overwrite_push(&mut self, state: T) -> Result<(), StateError> {
         if self.stack.last().unwrap() == &state {
             return Err(StateError::AlreadyInState);

--- a/crates/bevy_render/src/texture/texture_descriptor.rs
+++ b/crates/bevy_render/src/texture/texture_descriptor.rs
@@ -58,7 +58,8 @@ pub enum StorageTextureAccess {
     /// ```
     WriteOnly,
     /// The texture can be both read and written in the shader.
-    /// `wgpu::Features::STORAGE_TEXTURE_ACCESS_READ_WRITE` must be enabled to use this access mode.
+    /// `wgpu::Features::STORAGE_TEXTURE_ACCESS_READ_WRITE` must be enabled to use this access
+    /// mode.
     ///
     /// Example GLSL syntax:
     /// ```cpp,ignore


### PR DESCRIPTION
Fixes trivial (but noisy) formatting changes; caused by running unstable `cargo fmt` features from rustfmt.toml.