### PR TITLE
deserialize a ron file to an asset in AssetServer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,10 @@ path = "examples/app/thread_pool_resources.rs"
 
 # Assets
 [[example]]
+name = "asset_deserialization"
+path = "examples/asset/asset_deserialization.rs"
+
+[[example]]
 name = "asset_loading"
 path = "examples/asset/asset_loading.rs"
 

--- a/assets/data/character.ron
+++ b/assets/data/character.ron
@@ -1,0 +1,4 @@
+(
+    name: "Captain Blackbeard",
+    hit_points: 25
+)

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -11,9 +11,12 @@ mod info;
 mod io;
 mod loader;
 mod path;
+mod ron_asset;
 
 pub mod prelude {
-    pub use crate::{AddAsset, AssetEvent, AssetServer, Assets, Handle, HandleUntyped};
+    pub use crate::{
+        AddAsset, AssetEvent, AssetServer, Assets, Handle, HandleUntyped, RonAssetDeserializer,
+    };
 }
 
 pub use asset_server::*;
@@ -24,6 +27,7 @@ pub use info::*;
 pub use io::*;
 pub use loader::*;
 pub use path::*;
+pub use ron_asset::*;
 
 use bevy_app::{prelude::Plugin, AppBuilder};
 use bevy_ecs::{
@@ -107,6 +111,9 @@ impl Plugin for AssetPlugin {
             bevy_app::CoreStage::PreUpdate,
             asset_server::free_unused_assets_system.system(),
         );
+
+        app.add_asset::<RonAsset>()
+            .init_asset_loader::<RonAssetLoader>();
 
         #[cfg(all(
             feature = "filesystem_watcher",

--- a/crates/bevy_asset/src/ron_asset.rs
+++ b/crates/bevy_asset/src/ron_asset.rs
@@ -1,0 +1,49 @@
+use crate::{Asset, AssetLoader, AssetServer, BoxedFuture, Handle, LoadContext, LoadedAsset};
+use bevy_log::warn;
+use bevy_reflect::TypeUuid;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, TypeUuid)]
+#[uuid = "2150da22-9881-41e6-89db-62777c6dcbee"]
+pub struct RonAsset(ron::Value);
+
+#[derive(Default)]
+pub struct RonAssetLoader;
+
+impl AssetLoader for RonAssetLoader {
+    fn load<'a>(
+        &'a self,
+        bytes: &'a [u8],
+        load_context: &'a mut LoadContext,
+    ) -> BoxedFuture<'a, Result<(), anyhow::Error>> {
+        Box::pin(async move {
+            let ron_value = ron::de::from_bytes::<ron::Value>(bytes)?;
+            load_context.set_default_asset(LoadedAsset::new(RonAsset(ron_value)));
+            Ok(())
+        })
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["ron"]
+    }
+}
+
+pub trait RonAssetDeserializer {
+    fn deserialize<T: for<'de> Deserialize<'de> + Asset>(&self, path: &str) -> Handle<T>;
+}
+
+impl RonAssetDeserializer for AssetServer {
+    fn deserialize<T: for<'de> Deserialize<'de> + Asset>(&self, path: &str) -> Handle<T> {
+        let ron_handle: Handle<RonAsset> = self.load(path);
+        let path = path.to_string();
+        self.create_from(ron_handle, move |ron| {
+            match ron.0.clone().into_rust::<T>() {
+                Ok(deserialized) => Some(deserialized),
+                Err(e) => {
+                    warn!("error deserializing \"{}\": {}", path, e);
+                    None
+                }
+            }
+        })
+    }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -112,6 +112,7 @@ Example | File | Description
 
 Example | File | Description
 --- | --- | ---
+`asset_deserialization` | [`asset/asset_deserialization.rs`](./asset/asset_deserialization.rs) | Deserialize a ron file to a struct as an asset
 `asset_loading` | [`asset/asset_loading.rs`](./asset/asset_loading.rs) | Demonstrates various methods to load assets
 `custom_asset` | [`asset/custom_asset.rs`](./asset/custom_asset.rs) | Implements a custom asset loader
 `custom_asset_io` | [`asset/custom_asset_io.rs`](./asset/custom_asset_io.rs) | Implements a custom asset io loader

--- a/examples/asset/asset_deserialization.rs
+++ b/examples/asset/asset_deserialization.rs
@@ -1,0 +1,41 @@
+use bevy::{prelude::*, reflect::TypeUuid};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, TypeUuid)]
+#[uuid = "abfa1180-abfa-41fa-80a1-2af49dd778fd"]
+pub struct Character {
+    name: String,
+    hit_points: u32,
+}
+
+fn main() {
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_asset::<Character>()
+        .add_startup_system(setup.system())
+        .add_system(character_asset_event.system())
+        .run();
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    let character: Handle<Character> = asset_server.deserialize("data/character.ron");
+
+    // attach the handle to an entity so that it won't be cleaned
+    commands.spawn((character,));
+}
+
+pub fn character_asset_event(
+    mut events: EventReader<AssetEvent<Character>>,
+    assets: Res<Assets<Character>>,
+) {
+    for event in events.iter() {
+        let handle = match event {
+            AssetEvent::Created { handle }
+            | AssetEvent::Removed { handle }
+            | AssetEvent::Modified { handle } => handle,
+        };
+        if let Some(character) = assets.get(handle) {
+            info!("{:?}", character);
+        }
+    }
+}


### PR DESCRIPTION
this PR makes it very easy to deserialise any struct as an asset from a ron file:

1. declare your asset
```rust
#[derive(Debug, Deserialize, TypeUuid)]
#[uuid = "abfa1180-abfa-41fa-80a1-2af49dd778fd"]
pub struct Character {
    name: String,
    hit_points: u32,
}
```

2. register it
```rust
app.add_asset::<Character>();
```

3. load it 🎉 
```rust
let character: Handle<Character> = asset_server.deserialize("data/character.ron");
```

It depends on #1665 to work, and won't build without.
