### PR TITLE
Add coordinate system trait and implementations for Vec3 and Vec2

### DIFF
--- a/crates/bevy_math/src/coordinate_system.rs
+++ b/crates/bevy_math/src/coordinate_system.rs
@@ -1,0 +1,33 @@
+use glam::{const_vec2, const_vec3, Vec2, Vec3};
+
+pub trait CoordSystem2D {
+    const UP: Self;
+    const DOWN: Self;
+    const RIGHT: Self;
+    const LEFT: Self;
+}
+
+pub trait CoordSystem3D {
+    const UP: Self;
+    const DOWN: Self;
+    const RIGHT: Self;
+    const LEFT: Self;
+    const FORWARD: Self;
+    const BACKWARD: Self;
+}
+
+impl CoordSystem2D for Vec2 {
+    const UP: Self = const_vec2!([0.0, 1.0]);
+    const DOWN: Self = const_vec2!([0.0, -1.0]);
+    const RIGHT: Self = const_vec2!([1.0, 0.0]);
+    const LEFT: Self = const_vec2!([-1.0, 0.0]);
+}
+
+impl CoordSystem3D for Vec3 {
+    const UP: Self = const_vec3!([0.0, 1.0, 0.0]);
+    const DOWN: Self = const_vec3!([0.0, -1.0, 0.0]);
+    const RIGHT: Self = const_vec3!([1.0, 0.0, 0.0]);
+    const LEFT: Self = const_vec3!([-1.0, 0.0, 0.0]);
+    const FORWARD: Self = const_vec3!([0.0, 0.0, -1.0]);
+    const BACKWARD: Self = const_vec3!([0.0, 0.0, 1.0]);
+}

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -1,6 +1,8 @@
+mod coordinate_system;
 mod face_toward;
 mod geometry;
 
+pub use coordinate_system::*;
 pub use face_toward::*;
 pub use geometry::*;
 pub use glam::*;
@@ -8,7 +10,7 @@ pub use glam::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        BVec2, BVec3, BVec4, FaceToward, IVec2, IVec3, IVec4, Mat3, Mat4, Quat, Rect, Size, UVec2,
-        UVec3, UVec4, Vec2, Vec3, Vec4,
+        BVec2, BVec3, BVec4, CoordSystem2D, CoordSystem3D, FaceToward, IVec2, IVec3, IVec4, Mat3,
+        Mat4, Quat, Rect, Size, UVec2, UVec3, UVec4, Vec2, Vec3, Vec4,
     };
 }

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -34,7 +34,7 @@ fn setup(
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -16,7 +16,8 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_scene(asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0"));
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(0.7, 0.7, 1.0).looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
+        transform: Transform::from_xyz(0.7, 0.7, 1.0)
+            .looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::UP),
         ..Default::default()
     });
     commands

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -31,7 +31,7 @@ fn setup(
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(-3.0, 3.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(-3.0, 3.0, 5.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -17,7 +17,7 @@ fn setup(
     // set up the camera
     let mut camera = OrthographicCameraBundle::new_3d();
     camera.orthographic_projection.scale = 3.0;
-    camera.transform = Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y);
+    camera.transform = Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::UP);
 
     // camera
     commands.spawn_bundle(camera);

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -58,7 +58,7 @@ fn setup(
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(5.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(5.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -66,7 +66,7 @@ fn setup(
     // camera
     commands.spawn_bundle(OrthographicCameraBundle {
         transform: Transform::from_translation(Vec3::new(0.0, 0.0, 8.0))
-            .looking_at(Vec3::default(), Vec3::Y),
+            .looking_at(Vec3::default(), Vec3::UP),
         orthographic_projection: bevy::render::camera::OrthographicProjection {
             scale: 0.01,
             ..Default::default()

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -174,7 +174,7 @@ fn setup(
             ..Default::default()
         },
         transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
-            .looking_at(Vec3::default(), Vec3::Y),
+            .looking_at(Vec3::default(), Vec3::UP),
         ..Default::default()
     };
     active_cameras.add(FIRST_PASS_CAMERA);
@@ -218,7 +218,7 @@ fn setup(
 
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
-            .looking_at(Vec3::default(), Vec3::Y),
+            .looking_at(Vec3::default(), Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/3d/spawner.rs
+++ b/examples/3d/spawner.rs
@@ -47,7 +47,7 @@ fn setup(
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(0.0, 15.0, 150.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(0.0, 15.0, 150.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -96,7 +96,7 @@ fn setup(
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(3.0, 5.0, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(3.0, 5.0, 8.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -30,7 +30,7 @@ fn setup(
     });
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(1.05, 0.9, 1.5)
-            .looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
+            .looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::UP),
         ..Default::default()
     });
 

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -52,7 +52,7 @@ fn setup(
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/3d/z_sort_debug.rs
+++ b/examples/3d/z_sort_debug.rs
@@ -83,7 +83,7 @@ fn setup(
         });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(5.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(5.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/android/android.rs
+++ b/examples/android/android.rs
@@ -36,7 +36,7 @@ fn setup(
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -77,7 +77,7 @@ fn setup(
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(0.0, 3.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(0.0, 3.0, 10.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -29,7 +29,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(2.0, 2.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(2.0, 2.0, 6.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -114,7 +114,7 @@ fn setup_env(mut commands: Commands) {
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_translation(Vec3::new(offset, offset, 15.0))
-            .looking_at(Vec3::new(offset, offset, 0.0), Vec3::Y),
+            .looking_at(Vec3::new(offset, offset, 0.0), Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -123,7 +123,7 @@ fn generate_bodies(
             ..Default::default()
         });
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(0.0, 10.5, -20.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(0.0, 10.5, -20.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -88,7 +88,7 @@ fn setup_cameras(mut commands: Commands, mut game: ResMut<Game>) {
             2.0 * BOARD_SIZE_J as f32 / 3.0,
             BOARD_SIZE_J as f32 / 2.0 - 0.5,
         )
-        .looking_at(game.camera_is_focus, Vec3::Y),
+        .looking_at(game.camera_is_focus, Vec3::UP),
         ..Default::default()
     });
     commands.spawn_bundle(UiCameraBundle::default());
@@ -286,7 +286,7 @@ fn focus_camera(
     // look at that new camera's actual focus
     for (mut transform, camera) in transforms.q0().iter_mut() {
         if camera.name == Some(CAMERA_3D.to_string()) {
-            *transform = transform.looking_at(game.camera_is_focus, Vec3::Y);
+            *transform = transform.looking_at(game.camera_is_focus, Vec3::UP);
         }
     }
 }

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -52,7 +52,7 @@ fn setup_scene(
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -111,7 +111,7 @@ fn setup(
 
     // Spawn a camera.
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(0.0, 0.0, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(0.0, 0.0, 8.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -112,7 +112,7 @@ fn setup(
         .unwrap();
 
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(2.0, 2.0, 2.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(2.0, 2.0, 2.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/shader/hot_shader_reloading.rs
+++ b/examples/shader/hot_shader_reloading.rs
@@ -74,7 +74,7 @@ fn setup(
         .insert(material);
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/shader/mesh_custom_attribute.rs
+++ b/examples/shader/mesh_custom_attribute.rs
@@ -109,7 +109,7 @@ fn setup(
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/shader/shader_custom_material.rs
+++ b/examples/shader/shader_custom_material.rs
@@ -96,7 +96,7 @@ fn setup(
         .insert(material);
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -129,7 +129,7 @@ fn setup(
         .insert(blue_material);
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 }

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -191,7 +191,7 @@ fn setup_pipeline(
     });
     // main camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(0.0, 0.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(0.0, 0.0, 6.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
     // second window camera
@@ -201,7 +201,7 @@ fn setup_pipeline(
             window: window_id,
             ..Default::default()
         },
-        transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::UP),
         ..Default::default()
     });
 


### PR DESCRIPTION
This is related to #1663 which proposes changing `local_y` to `local_up` and so on. Internally these methods currently rotate `Vec3::Y` for `local_y` but if they are changed to `local_up` then they can now rotate `Vec3::UP`.