### PR TITLE
[Merged by Bors] - Derive PartialEq for WindowMode

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -183,7 +183,7 @@ pub enum WindowCommand {
 /// defines whether a videomode is chosen that best fits the width and height
 /// in the Window structure, or if these are ignored.
 /// E.g. when use_size is set to false the best video mode possible is chosen.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum WindowMode {
     Windowed,
     BorderlessFullscreen,


### PR DESCRIPTION
Many a game will provide some sort of video settings where a window mode option is a common inclusion. I ran into problems, however, with [egui's](https://github.com/emilk/egui) `combo_box` that imposes a `PartialEq` necessity. Deriving the trait would fix this problem, and as this does not break any existing API it should be a non-controversial change.