### PR TITLE
[Merged by Bors] - Flexible camera bindings

### DIFF
--- a/assets/shaders/hot.vert
+++ b/assets/shaders/hot.vert
@@ -2,7 +2,7 @@
 
 layout(location = 0) in vec3 Vertex_Position;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
 };
 

--- a/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.frag
+++ b/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.frag
@@ -14,7 +14,7 @@ layout(location = 2) in vec2 v_Uv;
 
 layout(location = 0) out vec4 o_Target;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
 };
 

--- a/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.vert
+++ b/crates/bevy_pbr/src/render_graph/forward_pipeline/forward.vert
@@ -8,7 +8,7 @@ layout(location = 0) out vec3 v_Position;
 layout(location = 1) out vec3 v_Normal;
 layout(location = 2) out vec2 v_Uv;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
 };
 

--- a/crates/bevy_render/src/camera/active_cameras.rs
+++ b/crates/bevy_render/src/camera/active_cameras.rs
@@ -1,3 +1,5 @@
+use crate::renderer::RenderResourceBindings;
+
 use super::Camera;
 use bevy_ecs::{
     entity::Entity,
@@ -6,21 +8,28 @@ use bevy_ecs::{
 use bevy_utils::HashMap;
 
 #[derive(Debug, Default)]
+pub struct ActiveCamera {
+    pub entity: Option<Entity>,
+    pub bindings: RenderResourceBindings,
+}
+
+#[derive(Debug, Default)]
 pub struct ActiveCameras {
-    pub cameras: HashMap<String, Option<Entity>>,
+    cameras: HashMap<String, ActiveCamera>,
 }
 
 impl ActiveCameras {
     pub fn add(&mut self, name: &str) {
-        self.cameras.insert(name.to_string(), None);
+        self.cameras
+            .insert(name.to_string(), ActiveCamera::default());
     }
 
-    pub fn set(&mut self, name: &str, entity: Entity) {
-        self.cameras.insert(name.to_string(), Some(entity));
+    pub fn get(&self, name: &str) -> Option<&ActiveCamera> {
+        self.cameras.get(name)
     }
 
-    pub fn get(&self, name: &str) -> Option<Entity> {
-        self.cameras.get(name).and_then(|e| *e)
+    pub fn get_mut(&mut self, name: &str) -> Option<&mut ActiveCamera> {
+        self.cameras.get_mut(name)
     }
 }
 
@@ -29,11 +38,11 @@ pub fn active_cameras_system(
     query: Query<(Entity, &Camera)>,
 ) {
     for (name, active_camera) in active_cameras.cameras.iter_mut() {
-        if active_camera.is_none() {
+        if active_camera.entity.is_none() {
             for (camera_entity, camera) in query.iter() {
                 if let Some(ref current_name) = camera.name {
                     if current_name == name {
-                        *active_camera = Some(camera_entity);
+                        active_camera.entity = Some(camera_entity);
                     }
                 }
             }

--- a/crates/bevy_render/src/shader/shader_reflect.rs
+++ b/crates/bevy_render/src/shader/shader_reflect.rs
@@ -153,23 +153,17 @@ fn reflect_binding(
         _ => panic!("Unsupported bind type {:?}.", binding.descriptor_type),
     };
 
-    let mut shader_stage = match shader_stage {
+    let shader_stage = match shader_stage {
         ReflectShaderStageFlags::COMPUTE => BindingShaderStage::COMPUTE,
         ReflectShaderStageFlags::VERTEX => BindingShaderStage::VERTEX,
         ReflectShaderStageFlags::FRAGMENT => BindingShaderStage::FRAGMENT,
         _ => panic!("Only one specified shader stage is supported."),
     };
 
-    let name = name.to_string();
-
-    if name == "Camera" {
-        shader_stage = BindingShaderStage::VERTEX | BindingShaderStage::FRAGMENT;
-    }
-
     BindingDescriptor {
         index: binding.binding,
         bind_type,
-        name,
+        name: name.to_string(),
         shader_stage,
     }
 }
@@ -325,7 +319,7 @@ mod tests {
             layout(location = 2) in uvec4 I_TestInstancing_Property;
 
             layout(location = 0) out vec4 v_Position;
-            layout(set = 0, binding = 0) uniform Camera {
+            layout(set = 0, binding = 0) uniform CameraViewProj {
                 mat4 ViewProj;
             };
             layout(set = 1, binding = 0) uniform texture2D Texture;
@@ -381,12 +375,12 @@ mod tests {
                         0,
                         vec![BindingDescriptor {
                             index: 0,
-                            name: "Camera".into(),
+                            name: "CameraViewProj".into(),
                             bind_type: BindType::Uniform {
                                 has_dynamic_offset: false,
                                 property: UniformProperty::Struct(vec![UniformProperty::Mat4]),
                             },
-                            shader_stage: BindingShaderStage::VERTEX | BindingShaderStage::FRAGMENT,
+                            shader_stage: BindingShaderStage::VERTEX,
                         }]
                     ),
                     BindGroupDescriptor::new(

--- a/crates/bevy_render/src/wireframe/wireframe.vert
+++ b/crates/bevy_render/src/wireframe/wireframe.vert
@@ -2,7 +2,7 @@
 
 layout(location = 0) in vec3 Vertex_Position;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
 };
 

--- a/crates/bevy_sprite/src/render/sprite.vert
+++ b/crates/bevy_sprite/src/render/sprite.vert
@@ -6,7 +6,7 @@ layout(location = 2) in vec2 Vertex_Uv;
 
 layout(location = 0) out vec2 v_Uv;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
 };
 

--- a/crates/bevy_sprite/src/render/sprite_sheet.vert
+++ b/crates/bevy_sprite/src/render/sprite_sheet.vert
@@ -7,7 +7,7 @@ layout(location = 2) in vec2 Vertex_Uv;
 layout(location = 0) out vec2 v_Uv;
 layout(location = 1) out vec4 v_Color;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
 };
 

--- a/crates/bevy_ui/src/render/ui.vert
+++ b/crates/bevy_ui/src/render/ui.vert
@@ -6,7 +6,7 @@ layout(location = 2) in vec2 Vertex_Uv;
 
 layout(location = 0) out vec2 v_Uv;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
 };
 

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -33,7 +33,7 @@ const VERTEX_SHADER: &str = r#"
 layout(location = 0) in vec3 Vertex_Position;
 layout(location = 0) out vec4 v_Position;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
 };
 layout(set = 1, binding = 0) uniform Transform {

--- a/examples/shader/mesh_custom_attribute.rs
+++ b/examples/shader/mesh_custom_attribute.rs
@@ -29,7 +29,7 @@ layout(location = 0) in vec3 Vertex_Position;
 layout(location = 1) in vec3 Vertex_Color;
 layout(location = 0) out vec3 v_color;
 
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
 };
 layout(set = 1, binding = 0) uniform Transform {

--- a/examples/shader/shader_custom_material.rs
+++ b/examples/shader/shader_custom_material.rs
@@ -29,7 +29,7 @@ struct MyMaterial {
 const VERTEX_SHADER: &str = r#"
 #version 450
 layout(location = 0) in vec3 Vertex_Position;
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
 };
 layout(set = 1, binding = 0) uniform Transform {

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -37,7 +37,7 @@ struct MyMaterial {
 const VERTEX_SHADER: &str = r#"
 #version 450
 layout(location = 0) in vec3 Vertex_Position;
-layout(set = 0, binding = 0) uniform Camera {
+layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
 };
 layout(set = 1, binding = 0) uniform Transform {


### PR DESCRIPTION
Alternative to #1203 and #1611

Camera bindings have historically been "hacked in". They were _required_ in all shaders and only supported a single Mat4. PBR (#1554) requires the CameraView matrix, but adding this using the "hacked" method forced users to either include all possible camera data in a single binding (#1203) or include all possible bindings (#1611).

This approach instead assigns each "active camera" its own RenderResourceBindings, which are populated by CameraNode. The PassNode then retrieves (and initializes) the relevant bind groups for all render pipelines used by visible entities. 

* Enables any number of camera bindings , including zero (with any set or binding number ... set 0 should still be used to avoid rebinds).
* Renames Camera binding to CameraViewProj
* Adds CameraView binding