### PR TITLE
[Merged by Bors] - Provide better size_hint for QueryIter

### DIFF
--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -123,6 +123,20 @@ where
             }
         }
     }
+
+    // NOTE: For unfiltered Queries this should actually return a exact size hint,
+    // to fulfil the ExactSizeIterator invariant, but this isn't practical without specialization.
+    // For more information see Issue #1686.
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let max_size = self
+            .query_state
+            .matched_archetypes
+            .ones()
+            .map(|index| self.world.archetypes[ArchetypeId::new(index)].len())
+            .sum();
+
+        (0, Some(max_size))
+    }
 }
 
 // NOTE: We can cheaply implement this for unfiltered Queries because we have:


### PR DESCRIPTION
This PR overrides the default size_hint for QueryIter.
This is mainly done to provide inline documentation of Issue #1686.