### PR TITLE
[Merged by Bors] - Fix table reserve logic

### DIFF
--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -327,12 +327,17 @@ impl Table {
     pub fn reserve(&mut self, amount: usize) {
         let available_space = self.capacity - self.len();
         if available_space < amount {
-            let reserve_amount = (amount - available_space).max(self.grow_amount);
+            let min_capacity = self.len() + amount;
+            // normally we would check if min_capacity is 0 for the below calculation, but amount > available_space and
+            // available_space > 0, so min_capacity > 1
+            let new_capacity =
+                ((min_capacity + self.grow_amount - 1) / self.grow_amount) * self.grow_amount;
+            let reserve_amount = new_capacity - self.len();
             for column in self.columns.values_mut() {
                 column.reserve(reserve_amount);
             }
             self.entities.reserve(reserve_amount);
-            self.capacity += reserve_amount;
+            self.capacity = new_capacity;
         }
     }
 


### PR DESCRIPTION
Fixes #1692
Alternative to #1696

This ensures that the capacity actually grows in increments of grow_amount, and also ensures that Table capacity is always <= column and entity vec capacity.

Debug logs that describe the new logic (running the example in #1692)
[out.txt](https://github.com/bevyengine/bevy/files/6173808/out.txt)
