### PR TITLE
[Merged by Bors] - Make Commands and World apis consistent

### DIFF
--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -64,9 +64,9 @@ impl<'a> Commands<'a> {
     ///     // Create another empty entity, then add some component to it
     ///     commands.spawn()
     ///         // adds a new component bundle to the entity
-    ///         .insert_bundle((1usize, 2u32)) 
+    ///         .insert_bundle((1usize, 2u32))
     ///         // adds a single component to the entity
-    ///         .insert("hello world"); 
+    ///         .insert("hello world");
     /// }
     /// # example_system.system();
     /// ```
@@ -82,7 +82,7 @@ impl<'a> Commands<'a> {
     ///
     /// This returns an [EntityCommands] builder, which enables inserting more components and bundles
     /// using a "builder pattern".
-    /// 
+    ///
     /// Note that `bundle` is a [Bundle], which is a collection of components. [Bundle] is
     /// automatically implemented for tuples of components. You can also create your own bundle
     /// types by deriving [`derive@Bundle`].
@@ -112,9 +112,9 @@ impl<'a> Commands<'a> {
     ///         // Create a new entity with two components using a "tuple bundle".
     ///         .spawn_bundle((Component1, Component2))
     ///         // spawn_bundle returns a builder, so you can insert more bundles like this:
-    ///         .insert_bundle((1usize, 2u32)) 
+    ///         .insert_bundle((1usize, 2u32))
     ///         // or insert single components like this:
-    ///         .insert("hello world"); 
+    ///         .insert("hello world");
     /// }
     /// # example_system.system();
     /// ```
@@ -137,9 +137,9 @@ impl<'a> Commands<'a> {
     ///
     ///     commands.entity(entity)
     ///         // adds a new component bundle to the entity
-    ///         .insert_bundle((1usize, 2u32)) 
+    ///         .insert_bundle((1usize, 2u32))
     ///         // adds a single component to the entity
-    ///         .insert("hello world"); 
+    ///         .insert("hello world");
     /// }
     /// # example_system.system();
     /// ```
@@ -184,7 +184,7 @@ pub struct EntityCommands<'a, 'b> {
 }
 
 impl<'a, 'b> EntityCommands<'a, 'b> {
-    /// Retrieves the current entity's unique [Entity] id. 
+    /// Retrieves the current entity's unique [Entity] id.
     #[inline]
     pub fn id(&self) -> Entity {
         self.entity

--- a/crates/bevy_ecs/src/system/exclusive_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system.rs
@@ -131,7 +131,7 @@ mod tests {
         ) {
             for entity in query.iter() {
                 *counter += 1;
-                commands.remove::<f32>(entity);
+                commands.entity(entity).remove::<f32>();
             }
         }
 

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -296,18 +296,18 @@ fn load_node(
 ) -> Result<(), GltfError> {
     let transform = gltf_node.transform();
     let mut gltf_error = None;
-    let node = world_builder.spawn((
+    let mut node = world_builder.spawn_bundle((
         Transform::from_matrix(Mat4::from_cols_array_2d(&transform.matrix())),
         GlobalTransform::identity(),
     ));
 
     if let Some(name) = gltf_node.name() {
-        node.with(Name::new(name.to_string()));
+        node.insert(Name::new(name.to_string()));
     }
 
     // create camera node
     if let Some(camera) = gltf_node.camera() {
-        node.with(VisibleEntities {
+        node.insert(VisibleEntities {
             ..Default::default()
         });
 
@@ -325,12 +325,12 @@ fn load_node(
                     ..Default::default()
                 };
 
-                node.with(Camera {
+                node.insert(Camera {
                     name: Some(base::camera::CAMERA_2D.to_owned()),
                     projection_matrix: orthographic_projection.get_projection_matrix(),
                     ..Default::default()
                 });
-                node.with(orthographic_projection);
+                node.insert(orthographic_projection);
             }
             gltf::camera::Projection::Perspective(perspective) => {
                 let mut perspective_projection: PerspectiveProjection = PerspectiveProjection {
@@ -344,12 +344,12 @@ fn load_node(
                 if let Some(aspect_ratio) = perspective.aspect_ratio() {
                     perspective_projection.aspect_ratio = aspect_ratio;
                 }
-                node.with(Camera {
+                node.insert(Camera {
                     name: Some(base::camera::CAMERA_3D.to_owned()),
                     projection_matrix: perspective_projection.get_projection_matrix(),
                     ..Default::default()
                 });
-                node.with(perspective_projection);
+                node.insert(perspective_projection);
             }
         }
     }
@@ -374,7 +374,7 @@ fn load_node(
                 let material_asset_path =
                     AssetPath::new_ref(load_context.path(), Some(&material_label));
 
-                parent.spawn(PbrBundle {
+                parent.spawn_bundle(PbrBundle {
                     mesh: load_context.get_handle(mesh_asset_path),
                     material: load_context.get_handle(material_asset_path),
                     ..Default::default()

--- a/crates/bevy_scene/src/command.rs
+++ b/crates/bevy_scene/src/command.rs
@@ -20,12 +20,12 @@ impl Command for SpawnScene {
 }
 
 pub trait SpawnSceneCommands {
-    fn spawn_scene(&mut self, scene: Handle<Scene>) -> &mut Self;
+    fn spawn_scene(&mut self, scene: Handle<Scene>);
 }
 
 impl<'a> SpawnSceneCommands for Commands<'a> {
-    fn spawn_scene(&mut self, scene_handle: Handle<Scene>) -> &mut Self {
-        self.add_command(SpawnScene { scene_handle })
+    fn spawn_scene(&mut self, scene_handle: Handle<Scene>) {
+        self.add(SpawnScene { scene_handle });
     }
 }
 

--- a/crates/bevy_transform/src/hierarchy/child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/child_builder.rs
@@ -1,9 +1,8 @@
 use crate::prelude::{Children, Parent, PreviousParent};
 use bevy_ecs::{
     bundle::Bundle,
-    component::Component,
     entity::Entity,
-    system::{Command, Commands},
+    system::{Command, Commands, EntityCommands},
     world::{EntityMut, World},
 };
 use smallvec::SmallVec;
@@ -47,7 +46,7 @@ pub struct PushChildren {
 }
 
 pub struct ChildBuilder<'a, 'b> {
-    commands: &'a mut Commands<'b>,
+    commands: &'b mut Commands<'a>,
     push_children: PushChildren,
 }
 
@@ -77,124 +76,65 @@ impl Command for PushChildren {
 }
 
 impl<'a, 'b> ChildBuilder<'a, 'b> {
-    pub fn spawn(&mut self, bundle: impl Bundle) -> &mut Self {
-        self.commands.spawn(bundle);
-        self.push_children
-            .children
-            .push(self.commands.current_entity().unwrap());
-        self
+    pub fn spawn_bundle(&mut self, bundle: impl Bundle) -> EntityCommands<'a, '_> {
+        let e = self.commands.spawn_bundle(bundle);
+        self.push_children.children.push(e.id());
+        e
     }
 
-    pub fn current_entity(&self) -> Option<Entity> {
-        self.commands.current_entity()
+    pub fn spawn(&mut self) -> EntityCommands<'a, '_> {
+        let e = self.commands.spawn();
+        self.push_children.children.push(e.id());
+        e
     }
 
     pub fn parent_entity(&self) -> Entity {
         self.push_children.parent
     }
 
-    pub fn with_bundle(&mut self, bundle: impl Bundle) -> &mut Self {
-        self.commands.with_bundle(bundle);
-        self
-    }
-
-    pub fn with(&mut self, component: impl Component) -> &mut Self {
-        self.commands.with(component);
-        self
-    }
-
-    pub fn for_current_entity(&mut self, func: impl FnOnce(Entity)) -> &mut Self {
-        let current_entity = self
-            .commands
-            .current_entity()
-            .expect("The 'current entity' is not set. You should spawn an entity first.");
-        func(current_entity);
-        self
-    }
-
     pub fn add_command<C: Command + 'static>(&mut self, command: C) -> &mut Self {
-        self.commands.add_command(command);
+        self.commands.add(command);
         self
     }
 }
 
 pub trait BuildChildren {
     fn with_children(&mut self, f: impl FnOnce(&mut ChildBuilder)) -> &mut Self;
-    fn push_children(&mut self, parent: Entity, children: &[Entity]) -> &mut Self;
-    fn insert_children(&mut self, parent: Entity, index: usize, children: &[Entity]) -> &mut Self;
+    fn push_children(&mut self, children: &[Entity]) -> &mut Self;
+    fn insert_children(&mut self, index: usize, children: &[Entity]) -> &mut Self;
 }
 
-impl<'a> BuildChildren for Commands<'a> {
-    fn with_children(&mut self, parent: impl FnOnce(&mut ChildBuilder)) -> &mut Self {
-        let current_entity = self.current_entity().expect("Cannot add children because the 'current entity' is not set. You should spawn an entity first.");
-        self.clear_current_entity();
-        let push_children = {
-            let mut builder = ChildBuilder {
-                commands: self,
-                push_children: PushChildren {
-                    children: SmallVec::default(),
-                    parent: current_entity,
-                },
-            };
-            parent(&mut builder);
-            builder.push_children
-        };
-
-        self.set_current_entity(current_entity);
-        self.add_command(push_children);
-        self
-    }
-
-    fn push_children(&mut self, parent: Entity, children: &[Entity]) -> &mut Self {
-        self.add_command(PushChildren {
-            children: SmallVec::from(children),
-            parent,
-        });
-        self
-    }
-
-    fn insert_children(&mut self, parent: Entity, index: usize, children: &[Entity]) -> &mut Self {
-        self.add_command(InsertChildren {
-            children: SmallVec::from(children),
-            index,
-            parent,
-        });
-        self
-    }
-}
-
-impl<'a, 'b> BuildChildren for ChildBuilder<'a, 'b> {
+impl<'a, 'b> BuildChildren for EntityCommands<'a, 'b> {
     fn with_children(&mut self, spawn_children: impl FnOnce(&mut ChildBuilder)) -> &mut Self {
-        let current_entity = self.commands.current_entity().expect("Cannot add children because the 'current entity' is not set. You should spawn an entity first.");
-        self.commands.clear_current_entity();
+        let parent = self.id();
         let push_children = {
             let mut builder = ChildBuilder {
-                commands: self.commands,
+                commands: self.commands(),
                 push_children: PushChildren {
                     children: SmallVec::default(),
-                    parent: current_entity,
+                    parent,
                 },
             };
-
             spawn_children(&mut builder);
             builder.push_children
         };
 
-        self.commands.set_current_entity(current_entity);
-        self.commands.add_command(push_children);
+        self.commands().add(push_children);
         self
     }
 
-    fn push_children(&mut self, parent: Entity, children: &[Entity]) -> &mut Self {
-        self.commands.add_command(PushChildren {
+    fn push_children(&mut self, children: &[Entity]) -> &mut Self {
+        let parent = self.id();
+        self.commands().add(PushChildren {
             children: SmallVec::from(children),
             parent,
         });
         self
     }
 
-    fn insert_children(&mut self, parent: Entity, index: usize, children: &[Entity]) -> &mut Self {
-        self.commands.add_command(InsertChildren {
+    fn insert_children(&mut self, index: usize, children: &[Entity]) -> &mut Self {
+        let parent = self.id();
+        self.commands().add(InsertChildren {
             children: SmallVec::from(children),
             index,
             parent,
@@ -211,12 +151,8 @@ pub struct WorldChildBuilder<'w> {
 }
 
 impl<'w> WorldChildBuilder<'w> {
-    pub fn spawn(&mut self, bundle: impl Bundle + Send + Sync + 'static) -> &mut Self {
-        let parent_entity = self
-            .parent_entities
-            .last()
-            .cloned()
-            .expect("There should always be a parent at this point.");
+    pub fn spawn_bundle(&mut self, bundle: impl Bundle + Send + Sync + 'static) -> EntityMut<'_> {
+        let parent_entity = self.parent_entity();
         let entity = self
             .world
             .spawn()
@@ -231,33 +167,32 @@ impl<'w> WorldChildBuilder<'w> {
                 parent.insert(Children(smallvec::smallvec![entity]));
             }
         }
-        self
+        self.world.entity_mut(entity)
     }
 
-    pub fn with_bundle(&mut self, bundle: impl Bundle + Send + Sync + 'static) -> &mut Self {
-        self.world
-            .entity_mut(self.current_entity.unwrap())
-            .insert_bundle(bundle);
-        self
+    pub fn spawn(&mut self) -> EntityMut<'_> {
+        let parent_entity = self.parent_entity();
+        let entity = self
+            .world
+            .spawn()
+            .insert_bundle((Parent(parent_entity), PreviousParent(parent_entity)))
+            .id();
+        self.current_entity = Some(entity);
+        if let Some(mut parent) = self.world.get_entity_mut(parent_entity) {
+            if let Some(mut children) = parent.get_mut::<Children>() {
+                children.0.push(entity);
+            } else {
+                parent.insert(Children(smallvec::smallvec![entity]));
+            }
+        }
+        self.world.entity_mut(entity)
     }
 
-    pub fn with(&mut self, component: impl Component) -> &mut Self {
-        self.world
-            .entity_mut(self.current_entity.unwrap())
-            .insert(component);
-        self
-    }
-
-    pub fn current_entity(&self) -> Option<Entity> {
-        self.current_entity
-    }
-
-    pub fn for_current_entity(&mut self, func: impl FnOnce(Entity)) -> &mut Self {
-        let current_entity = self
-            .current_entity()
-            .expect("The 'current entity' is not set. You should spawn an entity first.");
-        func(current_entity);
-        self
+    pub fn parent_entity(&self) -> Entity {
+        self.parent_entities
+            .last()
+            .cloned()
+            .expect("There should always be a parent at this point.")
     }
 }
 
@@ -319,45 +254,28 @@ mod tests {
         let mut queue = CommandQueue::default();
         let mut commands = Commands::new(&mut queue, &world);
 
-        let mut parent = None;
-        let mut child1 = None;
-        let mut child2 = None;
-        let mut child3 = None;
-
-        commands
-            .spawn((1,))
-            .for_current_entity(|e| parent = Some(e))
-            .with_children(|parent| {
-                parent
-                    .spawn((2,))
-                    .for_current_entity(|e| child1 = Some(e))
-                    .spawn((3,))
-                    .for_current_entity(|e| child2 = Some(e))
-                    .spawn((4,));
-
-                child3 = parent.current_entity();
-            });
+        let mut children = Vec::new();
+        let parent = commands.spawn().insert(1).id();
+        commands.entity(parent).with_children(|parent| {
+            children.push(parent.spawn().insert(2).id());
+            children.push(parent.spawn().insert(3).id());
+            children.push(parent.spawn().insert(4).id());
+        });
 
         queue.apply(&mut world);
-        let parent = parent.expect("parent should exist");
-        let child1 = child1.expect("child1 should exist");
-        let child2 = child2.expect("child2 should exist");
-        let child3 = child3.expect("child3 should exist");
-        let expected_children: SmallVec<[Entity; 8]> = smallvec![child1, child2, child3];
-
         assert_eq!(
-            world.get::<Children>(parent).unwrap().0.clone(),
-            expected_children
+            world.get::<Children>(parent).unwrap().0.as_slice(),
+            children.as_slice(),
         );
-        assert_eq!(*world.get::<Parent>(child1).unwrap(), Parent(parent));
-        assert_eq!(*world.get::<Parent>(child2).unwrap(), Parent(parent));
+        assert_eq!(*world.get::<Parent>(children[0]).unwrap(), Parent(parent));
+        assert_eq!(*world.get::<Parent>(children[1]).unwrap(), Parent(parent));
 
         assert_eq!(
-            *world.get::<PreviousParent>(child1).unwrap(),
+            *world.get::<PreviousParent>(children[0]).unwrap(),
             PreviousParent(parent)
         );
         assert_eq!(
-            *world.get::<PreviousParent>(child2).unwrap(),
+            *world.get::<PreviousParent>(children[1]).unwrap(),
             PreviousParent(parent)
         );
     }
@@ -373,7 +291,7 @@ mod tests {
         let mut queue = CommandQueue::default();
         {
             let mut commands = Commands::new(&mut queue, &world);
-            commands.push_children(entities[0], &entities[1..3]);
+            commands.entity(entities[0]).push_children(&entities[1..3]);
         }
         queue.apply(&mut world);
 
@@ -402,7 +320,7 @@ mod tests {
 
         {
             let mut commands = Commands::new(&mut queue, &world);
-            commands.insert_children(parent, 1, &entities[3..]);
+            commands.entity(parent).insert_children(1, &entities[3..]);
         }
         queue.apply(&mut world);
 

--- a/crates/bevy_transform/src/hierarchy/hierarchy.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy.rs
@@ -1,7 +1,7 @@
 use crate::components::{Children, Parent};
 use bevy_ecs::{
     entity::Entity,
-    system::{Command, Commands},
+    system::{Command, EntityCommands},
     world::World,
 };
 use bevy_utils::tracing::debug;
@@ -44,13 +44,14 @@ impl Command for DespawnRecursive {
 
 pub trait DespawnRecursiveExt {
     /// Despawns the provided entity and its children.
-    fn despawn_recursive(&mut self, entity: Entity);
+    fn despawn_recursive(&mut self);
 }
 
-impl<'a> DespawnRecursiveExt for Commands<'a> {
+impl<'a, 'b> DespawnRecursiveExt for EntityCommands<'a, 'b> {
     /// Despawns the provided entity and its children.
-    fn despawn_recursive(&mut self, entity: Entity) {
-        self.add(DespawnRecursive { entity });
+    fn despawn_recursive(&mut self) {
+        let entity = self.id();
+        self.commands().add(DespawnRecursive { entity });
     }
 }
 
@@ -107,9 +108,9 @@ mod tests {
 
         {
             let mut commands = Commands::new(&mut queue, &world);
-            commands.despawn_recursive(parent_entity);
-            commands.despawn_recursive(parent_entity); // despawning the same entity twice should
-                                                       // not panic
+            commands.entity(parent_entity).despawn_recursive();
+            // despawning the same entity twice should not panic
+            commands.entity(parent_entity).despawn_recursive();
         }
         queue.apply(&mut world);
 

--- a/crates/bevy_transform/src/hierarchy/hierarchy.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy.rs
@@ -44,13 +44,13 @@ impl Command for DespawnRecursive {
 
 pub trait DespawnRecursiveExt {
     /// Despawns the provided entity and its children.
-    fn despawn_recursive(&mut self, entity: Entity) -> &mut Self;
+    fn despawn_recursive(&mut self, entity: Entity);
 }
 
 impl<'a> DespawnRecursiveExt for Commands<'a> {
     /// Despawns the provided entity and its children.
-    fn despawn_recursive(&mut self, entity: Entity) -> &mut Self {
-        self.add_command(DespawnRecursive { entity })
+    fn despawn_recursive(&mut self, entity: Entity) {
+        self.add(DespawnRecursive { entity });
     }
 }
 
@@ -73,31 +73,33 @@ mod tests {
             let mut commands = Commands::new(&mut queue, &world);
 
             commands
-                .spawn(("Another parent".to_owned(), 0u32))
+                .spawn_bundle(("Another parent".to_owned(), 0u32))
                 .with_children(|parent| {
-                    parent.spawn(("Another child".to_owned(), 1u32));
+                    parent.spawn_bundle(("Another child".to_owned(), 1u32));
                 });
 
             // Create a grandparent entity which will _not_ be deleted
-            commands.spawn(("Grandparent".to_owned(), 2u32));
-            grandparent_entity = commands.current_entity().unwrap();
-
-            commands.with_children(|parent| {
+            grandparent_entity = commands.spawn_bundle(("Grandparent".to_owned(), 2u32)).id();
+            commands.entity(grandparent_entity).with_children(|parent| {
                 // Add a child to the grandparent (the "parent"), which will get deleted
-                parent.spawn(("Parent, to be deleted".to_owned(), 3u32));
-                // All descendents of the "parent" should also be deleted.
-                parent.with_children(|parent| {
-                    parent
-                        .spawn(("First Child, to be deleted".to_owned(), 4u32))
-                        .with_children(|parent| {
-                            // child
-                            parent.spawn(("First grand child, to be deleted".to_owned(), 5u32));
-                        });
-                    parent.spawn(("Second child, to be deleted".to_owned(), 6u32));
-                });
+                parent
+                    .spawn_bundle(("Parent, to be deleted".to_owned(), 3u32))
+                    // All descendents of the "parent" should also be deleted.
+                    .with_children(|parent| {
+                        parent
+                            .spawn_bundle(("First Child, to be deleted".to_owned(), 4u32))
+                            .with_children(|parent| {
+                                // child
+                                parent.spawn_bundle((
+                                    "First grand child, to be deleted".to_owned(),
+                                    5u32,
+                                ));
+                            });
+                        parent.spawn_bundle(("Second child, to be deleted".to_owned(), 6u32));
+                    });
             });
 
-            commands.spawn(("An innocent bystander".to_owned(), 7u32));
+            commands.spawn_bundle(("An innocent bystander".to_owned(), 7u32));
         }
         queue.apply(&mut world);
 

--- a/crates/bevy_transform/src/transform_propagate_system.rs
+++ b/crates/bevy_transform/src/transform_propagate_system.rs
@@ -109,17 +109,22 @@ mod test {
                 GlobalTransform::identity(),
             ))
             .with_children(|parent| {
-                parent
-                    .spawn((
-                        Transform::from_xyz(0.0, 2.0, 0.),
-                        GlobalTransform::identity(),
-                    ))
-                    .for_current_entity(|entity| children.push(entity))
-                    .spawn((
-                        Transform::from_xyz(0.0, 0.0, 3.),
-                        GlobalTransform::identity(),
-                    ))
-                    .for_current_entity(|entity| children.push(entity));
+                children.push(
+                    parent
+                        .spawn_bundle((
+                            Transform::from_xyz(0.0, 2.0, 0.),
+                            GlobalTransform::identity(),
+                        ))
+                        .id(),
+                );
+                children.push(
+                    parent
+                        .spawn_bundle((
+                            Transform::from_xyz(0.0, 0.0, 3.),
+                            GlobalTransform::identity(),
+                        ))
+                        .id(),
+                );
             });
         schedule.run(&mut world);
 
@@ -150,22 +155,27 @@ mod test {
         let mut commands = Commands::new(&mut queue, &world);
         let mut children = Vec::new();
         commands
-            .spawn((
+            .spawn_bundle((
                 Transform::from_xyz(1.0, 0.0, 0.0),
                 GlobalTransform::identity(),
             ))
             .with_children(|parent| {
-                parent
-                    .spawn((
-                        Transform::from_xyz(0.0, 2.0, 0.0),
-                        GlobalTransform::identity(),
-                    ))
-                    .for_current_entity(|entity| children.push(entity))
-                    .spawn((
-                        Transform::from_xyz(0.0, 0.0, 3.0),
-                        GlobalTransform::identity(),
-                    ))
-                    .for_current_entity(|entity| children.push(entity));
+                children.push(
+                    parent
+                        .spawn_bundle((
+                            Transform::from_xyz(0.0, 2.0, 0.0),
+                            GlobalTransform::identity(),
+                        ))
+                        .id(),
+                );
+                children.push(
+                    parent
+                        .spawn_bundle((
+                            Transform::from_xyz(0.0, 0.0, 3.0),
+                            GlobalTransform::identity(),
+                        ))
+                        .id(),
+                );
             });
         queue.apply(&mut world);
         schedule.run(&mut world);

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -80,42 +80,42 @@ mod tests {
         let mut world = World::default();
         let mut queue = CommandQueue::default();
         let mut commands = Commands::new(&mut queue, &world);
-        commands.spawn(node_with_transform("0"));
+        commands.spawn_bundle(node_with_transform("0"));
 
         commands
-            .spawn(node_with_transform("1"))
+            .spawn_bundle(node_with_transform("1"))
             .with_children(|parent| {
                 parent
-                    .spawn(node_with_transform("1-0"))
+                    .spawn_bundle(node_with_transform("1-0"))
                     .with_children(|parent| {
-                        parent.spawn(node_with_transform("1-0-0"));
-                        parent.spawn(node_without_transform("1-0-1"));
-                        parent.spawn(node_with_transform("1-0-2"));
+                        parent.spawn_bundle(node_with_transform("1-0-0"));
+                        parent.spawn_bundle(node_without_transform("1-0-1"));
+                        parent.spawn_bundle(node_with_transform("1-0-2"));
                     });
-                parent.spawn(node_with_transform("1-1"));
+                parent.spawn_bundle(node_with_transform("1-1"));
                 parent
-                    .spawn(node_without_transform("1-2"))
+                    .spawn_bundle(node_without_transform("1-2"))
                     .with_children(|parent| {
-                        parent.spawn(node_with_transform("1-2-0"));
-                        parent.spawn(node_with_transform("1-2-1"));
+                        parent.spawn_bundle(node_with_transform("1-2-0"));
+                        parent.spawn_bundle(node_with_transform("1-2-1"));
                         parent
-                            .spawn(node_with_transform("1-2-2"))
+                            .spawn_bundle(node_with_transform("1-2-2"))
                             .with_children(|_| ());
-                        parent.spawn(node_with_transform("1-2-3"));
+                        parent.spawn_bundle(node_with_transform("1-2-3"));
                     });
-                parent.spawn(node_with_transform("1-3"));
+                parent.spawn_bundle(node_with_transform("1-3"));
             });
 
         commands
-            .spawn(node_without_transform("2"))
+            .spawn_bundle(node_without_transform("2"))
             .with_children(|parent| {
                 parent
-                    .spawn(node_with_transform("2-0"))
+                    .spawn_bundle(node_with_transform("2-0"))
                     .with_children(|_parent| ());
                 parent
-                    .spawn(node_with_transform("2-1"))
+                    .spawn_bundle(node_with_transform("2-1"))
                     .with_children(|parent| {
-                        parent.spawn(node_with_transform("2-1-0"));
+                        parent.spawn_bundle(node_with_transform("2-1-0"));
                     });
             });
         queue.apply(&mut world);

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -79,7 +79,8 @@ fn setup(
         let transform = Transform::from_xyz(pos.0, pos.1, 0.0);
 
         let e = commands
-            .spawn_bundle((
+            .spawn()
+            .insert_bundle((
                 Contributor { hue },
                 Velocity {
                     translation: velocity,

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -57,9 +57,8 @@ fn setup(
 
     let texture_handle = asset_server.load("branding/icon.png");
 
-    commands
-        .spawn(OrthographicCameraBundle::new_2d())
-        .spawn(UiCameraBundle::default());
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(UiCameraBundle::default());
 
     let mut sel = ContributorSelection {
         order: vec![],
@@ -79,13 +78,15 @@ fn setup(
 
         let transform = Transform::from_xyz(pos.0, pos.1, 0.0);
 
-        commands
-            .spawn((Contributor { hue },))
-            .with(Velocity {
-                translation: velocity,
-                rotation: -dir * 5.0,
-            })
-            .with_bundle(SpriteBundle {
+        let e = commands
+            .spawn_bundle((
+                Contributor { hue },
+                Velocity {
+                    translation: velocity,
+                    rotation: -dir * 5.0,
+                },
+            ))
+            .insert_bundle(SpriteBundle {
                 sprite: Sprite {
                     size: Vec2::new(1.0, 1.0) * SPRITE_SIZE,
                     resize_mode: SpriteResizeMode::Manual,
@@ -98,20 +99,20 @@ fn setup(
                 }),
                 transform,
                 ..Default::default()
-            });
-
-        let e = commands.current_entity().unwrap();
+            })
+            .id();
 
         sel.order.push((name, e));
     }
 
     sel.order.shuffle(&mut rnd);
 
-    commands.spawn((SelectTimer, Timer::from_seconds(SHOWCASE_TIMER_SECS, true)));
+    commands.spawn_bundle((SelectTimer, Timer::from_seconds(SHOWCASE_TIMER_SECS, true)));
 
     commands
-        .spawn((ContributorDisplay,))
-        .with_bundle(TextBundle {
+        .spawn()
+        .insert(ContributorDisplay)
+        .insert_bundle(TextBundle {
             style: Style {
                 align_self: AlignSelf::FlexEnd,
                 ..Default::default()

--- a/examples/2d/sprite.rs
+++ b/examples/2d/sprite.rs
@@ -13,10 +13,9 @@ fn setup(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let texture_handle = asset_server.load("branding/icon.png");
-    commands
-        .spawn(OrthographicCameraBundle::new_2d())
-        .spawn(SpriteBundle {
-            material: materials.add(texture_handle.into()),
-            ..Default::default()
-        });
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(SpriteBundle {
+        material: materials.add(texture_handle.into()),
+        ..Default::default()
+    });
 }

--- a/examples/2d/sprite_flipping.rs
+++ b/examples/2d/sprite_flipping.rs
@@ -13,17 +13,16 @@ fn setup(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let texture_handle = asset_server.load("branding/icon.png");
-    commands
-        .spawn(OrthographicCameraBundle::new_2d())
-        .spawn(SpriteBundle {
-            material: materials.add(texture_handle.into()),
-            sprite: Sprite {
-                // Flip the logo to the left
-                flip_x: true,
-                // And don't flip it upside-down ( the default )
-                flip_y: false,
-                ..Default::default()
-            },
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(SpriteBundle {
+        material: materials.add(texture_handle.into()),
+        sprite: Sprite {
+            // Flip the logo to the left
+            flip_x: true,
+            // And don't flip it upside-down ( the default )
+            flip_y: false,
             ..Default::default()
-        });
+        },
+        ..Default::default()
+    });
 }

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -30,12 +30,12 @@ fn setup(
     let texture_handle = asset_server.load("textures/rpg/chars/gabe/gabe-idle-run.png");
     let texture_atlas = TextureAtlas::from_grid(texture_handle, Vec2::new(24.0, 24.0), 7, 1);
     let texture_atlas_handle = texture_atlases.add(texture_atlas);
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
     commands
-        .spawn(OrthographicCameraBundle::new_2d())
-        .spawn(SpriteSheetBundle {
+        .spawn_bundle(SpriteSheetBundle {
             texture_atlas: texture_atlas_handle,
             transform: Transform::from_scale(Vec3::splat(6.0)),
             ..Default::default()
         })
-        .with(Timer::from_seconds(0.1, true));
+        .insert(Timer::from_seconds(0.1, true));
 }

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -9,24 +9,23 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands
-        // 2d camera
-        .spawn(OrthographicCameraBundle::new_2d())
-        .spawn(Text2dBundle {
-            text: Text::with_section(
-                "This text is in the 2D scene.",
-                TextStyle {
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                    font_size: 60.0,
-                    color: Color::WHITE,
-                },
-                TextAlignment {
-                    vertical: VerticalAlign::Center,
-                    horizontal: HorizontalAlign::Center,
-                },
-            ),
-            ..Default::default()
-        });
+    // 2d camera
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Text2dBundle {
+        text: Text::with_section(
+            "This text is in the 2D scene.",
+            TextStyle {
+                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                font_size: 60.0,
+                color: Color::WHITE,
+            },
+            TextAlignment {
+                vertical: VerticalAlign::Center,
+                horizontal: HorizontalAlign::Center,
+            },
+        ),
+        ..Default::default()
+    });
 }
 
 fn animate(time: Res<Time>, mut query: Query<&mut Transform, With<Text>>) {

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -61,23 +61,22 @@ fn setup(
     let atlas_handle = texture_atlases.add(texture_atlas);
 
     // set up a scene to display our texture atlas
-    commands
-        .spawn(OrthographicCameraBundle::new_2d())
-        // draw a sprite from the atlas
-        .spawn(SpriteSheetBundle {
-            transform: Transform {
-                translation: Vec3::new(150.0, 0.0, 0.0),
-                scale: Vec3::splat(4.0),
-                ..Default::default()
-            },
-            sprite: TextureAtlasSprite::new(vendor_index as u32),
-            texture_atlas: atlas_handle,
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    // draw a sprite from the atlas
+    commands.spawn_bundle(SpriteSheetBundle {
+        transform: Transform {
+            translation: Vec3::new(150.0, 0.0, 0.0),
+            scale: Vec3::splat(4.0),
             ..Default::default()
-        })
-        // draw the atlas itself
-        .spawn(SpriteBundle {
-            material: materials.add(texture_atlas_texture.into()),
-            transform: Transform::from_xyz(-300.0, 0.0, 0.0),
-            ..Default::default()
-        });
+        },
+        sprite: TextureAtlasSprite::new(vendor_index as u32),
+        texture_atlas: atlas_handle,
+        ..Default::default()
+    });
+    // draw the atlas itself
+    commands.spawn_bundle(SpriteBundle {
+        material: materials.add(texture_atlas_texture.into()),
+        transform: Transform::from_xyz(-300.0, 0.0, 0.0),
+        ..Default::default()
+    });
 }

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -14,29 +14,27 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    // add entities to the world
-    commands
-        // plane
-        .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
-            material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
-            ..Default::default()
-        })
-        // cube
-        .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-            transform: Transform::from_xyz(0.0, 0.5, 0.0),
-            ..Default::default()
-        })
-        // light
-        .spawn(LightBundle {
-            transform: Transform::from_xyz(4.0, 8.0, 4.0),
-            ..Default::default()
-        })
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
-        });
+    // plane
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        ..Default::default()
+    });
+    // cube
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        ..Default::default()
+    });
+    // light
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..Default::default()
+    });
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -9,15 +9,13 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands
-        .spawn_scene(asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0"))
-        .spawn(LightBundle {
-            transform: Transform::from_xyz(4.0, 5.0, 4.0),
-            ..Default::default()
-        })
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(0.7, 0.7, 1.0)
-                .looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
-            ..Default::default()
-        });
+    commands.spawn_scene(asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0"));
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_xyz(4.0, 5.0, 4.0),
+        ..Default::default()
+    });
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(0.7, 0.7, 1.0).looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -18,22 +18,20 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    // add entities to the world
-    commands
-        // cube
-        .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 2.0 })),
-            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-            ..Default::default()
-        })
-        // light
-        .spawn(LightBundle {
-            transform: Transform::from_xyz(4.0, 8.0, 4.0),
-            ..Default::default()
-        })
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(-3.0, 3.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
-        });
+    // cube
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 2.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        ..Default::default()
+    });
+    // light
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..Default::default()
+    });
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(-3.0, 3.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -19,44 +19,43 @@ fn setup(
     camera.orthographic_projection.scale = 3.0;
     camera.transform = Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y);
 
-    // add entities to the world
-    commands
-        // plane
-        .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
-            material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
-            ..Default::default()
-        })
-        // cubes
-        .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-            transform: Transform::from_xyz(1.5, 0.5, 1.5),
-            ..Default::default()
-        })
-        .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-            transform: Transform::from_xyz(1.5, 0.5, -1.5),
-            ..Default::default()
-        })
-        .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-            transform: Transform::from_xyz(-1.5, 0.5, 1.5),
-            ..Default::default()
-        })
-        .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-            transform: Transform::from_xyz(-1.5, 0.5, -1.5),
-            ..Default::default()
-        })
-        // light
-        .spawn(LightBundle {
-            transform: Transform::from_xyz(3.0, 8.0, 5.0),
-            ..Default::default()
-        })
-        // camera
-        .spawn(camera);
+    // camera
+    commands.spawn_bundle(camera);
+
+    // plane
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        ..Default::default()
+    });
+    // cubes
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        transform: Transform::from_xyz(1.5, 0.5, 1.5),
+        ..Default::default()
+    });
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        transform: Transform::from_xyz(1.5, 0.5, -1.5),
+        ..Default::default()
+    });
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        transform: Transform::from_xyz(-1.5, 0.5, 1.5),
+        ..Default::default()
+    });
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        transform: Transform::from_xyz(-1.5, 0.5, -1.5),
+        ..Default::default()
+    });
+    // light
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_xyz(3.0, 8.0, 5.0),
+        ..Default::default()
+    });
 }

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -33,32 +33,32 @@ fn setup(
         ..Default::default()
     });
 
+    // parent cube
     commands
-        // parent cube
-        .spawn(PbrBundle {
+        .spawn_bundle(PbrBundle {
             mesh: cube_handle.clone(),
             material: cube_material_handle.clone(),
             transform: Transform::from_xyz(0.0, 0.0, 1.0),
             ..Default::default()
         })
-        .with(Rotator)
+        .insert(Rotator)
         .with_children(|parent| {
             // child cube
-            parent.spawn(PbrBundle {
+            parent.spawn_bundle(PbrBundle {
                 mesh: cube_handle,
                 material: cube_material_handle,
                 transform: Transform::from_xyz(0.0, 0.0, 3.0),
                 ..Default::default()
             });
-        })
-        // light
-        .spawn(LightBundle {
-            transform: Transform::from_xyz(4.0, 5.0, -4.0),
-            ..Default::default()
-        })
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(5.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
         });
+    // light
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_xyz(4.0, 5.0, -4.0),
+        ..Default::default()
+    });
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(5.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -20,35 +20,33 @@ fn setup(
         for x in -5..=5 {
             let x01 = (x + 5) as f32 / 10.0;
             let y01 = (y + 2) as f32 / 4.0;
-            commands
-                // spheres
-                .spawn(PbrBundle {
-                    mesh: meshes.add(Mesh::from(shape::Icosphere {
-                        radius: 0.45,
-                        subdivisions: 32,
-                    })),
-                    material: materials.add(StandardMaterial {
-                        base_color: Color::hex("ffd891").unwrap(),
-                        // vary key PBR parameters on a grid of spheres to show the effect
-                        metallic: y01,
-                        roughness: x01,
-                        ..Default::default()
-                    }),
-                    transform: Transform::from_xyz(x as f32, y as f32, 0.0),
+            // sphere
+            commands.spawn_bundle(PbrBundle {
+                mesh: meshes.add(Mesh::from(shape::Icosphere {
+                    radius: 0.45,
+                    subdivisions: 32,
+                })),
+                material: materials.add(StandardMaterial {
+                    base_color: Color::hex("ffd891").unwrap(),
+                    // vary key PBR parameters on a grid of spheres to show the effect
+                    metallic: y01,
+                    roughness: x01,
                     ..Default::default()
-                });
+                }),
+                transform: Transform::from_xyz(x as f32, y as f32, 0.0),
+                ..Default::default()
+            });
         }
     }
-    commands
-        // light
-        .spawn(LightBundle {
-            transform: Transform::from_translation(Vec3::new(0.0, 5.0, 5.0)),
-            ..Default::default()
-        })
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 8.0))
-                .looking_at(Vec3::default(), Vec3::Y),
-            ..Default::default()
-        });
+    // light
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_translation(Vec3::new(0.0, 5.0, 5.0)),
+        ..Default::default()
+    });
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_translation(Vec3::new(0.0, 0.0, 8.0))
+            .looking_at(Vec3::default(), Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/3d/spawner.rs
+++ b/examples/3d/spawner.rs
@@ -40,22 +40,21 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands
-        // light
-        .spawn(LightBundle {
-            transform: Transform::from_xyz(4.0, -4.0, 5.0),
-            ..Default::default()
-        })
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(0.0, 15.0, 150.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
-        });
+    // light
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_xyz(4.0, -4.0, 5.0),
+        ..Default::default()
+    });
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(0.0, 15.0, 150.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 
     let mut rng = StdRng::from_entropy();
     let cube_handle = meshes.add(Mesh::from(shape::Cube { size: 1.0 }));
     for _ in 0..10000 {
-        commands.spawn(PbrBundle {
+        commands.spawn_bundle(PbrBundle {
             mesh: cube_handle.clone(),
             material: materials.add(StandardMaterial {
                 base_color: Color::rgb(

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -49,56 +49,54 @@ fn setup(
         ..Default::default()
     });
 
-    // add entities to the world
-    commands
-        // textured quad - normal
-        .spawn(PbrBundle {
-            mesh: quad_handle.clone(),
-            material: material_handle,
-            transform: Transform {
-                translation: Vec3::new(0.0, 0.0, 1.5),
-                rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
-                ..Default::default()
-            },
-            visible: Visible {
-                is_transparent: true,
-                ..Default::default()
-            },
+    // textured quad - normal
+    commands.spawn_bundle(PbrBundle {
+        mesh: quad_handle.clone(),
+        material: material_handle,
+        transform: Transform {
+            translation: Vec3::new(0.0, 0.0, 1.5),
+            rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
             ..Default::default()
-        })
-        // textured quad - modulated
-        .spawn(PbrBundle {
-            mesh: quad_handle.clone(),
-            material: red_material_handle,
-            transform: Transform {
-                translation: Vec3::new(0.0, 0.0, 0.0),
-                rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
-                ..Default::default()
-            },
-            visible: Visible {
-                is_transparent: true,
-                ..Default::default()
-            },
+        },
+        visible: Visible {
+            is_transparent: true,
             ..Default::default()
-        })
-        // textured quad - modulated
-        .spawn(PbrBundle {
-            mesh: quad_handle,
-            material: blue_material_handle,
-            transform: Transform {
-                translation: Vec3::new(0.0, 0.0, -1.5),
-                rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
-                ..Default::default()
-            },
-            visible: Visible {
-                is_transparent: true,
-                ..Default::default()
-            },
+        },
+        ..Default::default()
+    });
+    // textured quad - modulated
+    commands.spawn_bundle(PbrBundle {
+        mesh: quad_handle.clone(),
+        material: red_material_handle,
+        transform: Transform {
+            translation: Vec3::new(0.0, 0.0, 0.0),
+            rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
             ..Default::default()
-        })
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(3.0, 5.0, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        },
+        visible: Visible {
+            is_transparent: true,
             ..Default::default()
-        });
+        },
+        ..Default::default()
+    });
+    // textured quad - modulated
+    commands.spawn_bundle(PbrBundle {
+        mesh: quad_handle,
+        material: blue_material_handle,
+        transform: Transform {
+            translation: Vec3::new(0.0, 0.0, -1.5),
+            rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
+            ..Default::default()
+        },
+        visible: Visible {
+            is_transparent: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(3.0, 5.0, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -24,21 +24,20 @@ fn setup(
     mut scene_spawner: ResMut<SceneSpawner>,
     mut scene_instance: ResMut<SceneInstance>,
 ) {
-    commands
-        .spawn(LightBundle {
-            transform: Transform::from_xyz(4.0, 5.0, 4.0),
-            ..Default::default()
-        })
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(1.05, 0.9, 1.5)
-                .looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
-            ..Default::default()
-        });
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_xyz(4.0, 5.0, 4.0),
+        ..Default::default()
+    });
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(1.05, 0.9, 1.5)
+            .looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
+        ..Default::default()
+    });
 
     // Spawn the scene as a child of another entity. This first scene will be translated backward
     // with its parent
     commands
-        .spawn((
+        .spawn_bundle((
             Transform::from_xyz(0.0, 0.0, -1.0),
             GlobalTransform::identity(),
         ))
@@ -65,7 +64,7 @@ fn scene_update(
         if let Some(instance_id) = scene_instance.0 {
             if let Some(entity_iter) = scene_spawner.iter_instance_entities(instance_id) {
                 entity_iter.for_each(|entity| {
-                    commands.insert(entity, EntityInMyScene);
+                    commands.entity(entity).insert(EntityInMyScene);
                 });
                 *done = true;
             }

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -29,30 +29,30 @@ fn setup(
 ) {
     // To draw the wireframe on all entities, set this to 'true'
     wireframe_config.global = false;
-    // add entities to the world
+    // plane
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        ..Default::default()
+    });
+    // cube
     commands
-        // plane
-        .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
-            material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
-            ..Default::default()
-        })
-        // cube
-        .spawn(PbrBundle {
+        .spawn_bundle(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
             transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..Default::default()
         })
-        .with(Wireframe) // This enables wireframe drawing on this entity
-        // light
-        .spawn(LightBundle {
-            transform: Transform::from_xyz(4.0, 8.0, 4.0),
-            ..Default::default()
-        })
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
-        });
+        // This enables wireframe drawing on this entity
+        .insert(Wireframe);
+    // light
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..Default::default()
+    });
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/3d/z_sort_debug.rs
+++ b/examples/3d/z_sort_debug.rs
@@ -48,9 +48,9 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let cube_handle = meshes.add(Mesh::from(shape::Cube { size: 2.0 }));
+    // parent cube
     commands
-        // parent cube
-        .spawn(PbrBundle {
+        .spawn_bundle(PbrBundle {
             mesh: cube_handle.clone(),
             material: materials.add(StandardMaterial {
                 unlit: true,
@@ -59,32 +59,31 @@ fn setup(
             transform: Transform::from_xyz(0.0, 0.0, 1.0),
             ..Default::default()
         })
-        .with(Rotator)
+        .insert(Rotator)
         .with_children(|parent| {
             // child cubes
-            parent
-                .spawn(PbrBundle {
-                    mesh: cube_handle.clone(),
-                    material: materials.add(StandardMaterial {
-                        unlit: true,
-                        ..Default::default()
-                    }),
-                    transform: Transform::from_xyz(0.0, 3.0, 0.0),
+            parent.spawn_bundle(PbrBundle {
+                mesh: cube_handle.clone(),
+                material: materials.add(StandardMaterial {
+                    unlit: true,
                     ..Default::default()
-                })
-                .spawn(PbrBundle {
-                    mesh: cube_handle,
-                    material: materials.add(StandardMaterial {
-                        unlit: true,
-                        ..Default::default()
-                    }),
-                    transform: Transform::from_xyz(0.0, -3.0, 0.0),
+                }),
+                transform: Transform::from_xyz(0.0, 3.0, 0.0),
+                ..Default::default()
+            });
+            parent.spawn_bundle(PbrBundle {
+                mesh: cube_handle,
+                material: materials.add(StandardMaterial {
+                    unlit: true,
                     ..Default::default()
-                });
-        })
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(5.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
+                }),
+                transform: Transform::from_xyz(0.0, -3.0, 0.0),
+                ..Default::default()
+            });
         });
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(5.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/android/android.rs
+++ b/examples/android/android.rs
@@ -16,29 +16,27 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    // add entities to the world
-    commands
-        // plane
-        .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
-            material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
-            ..Default::default()
-        })
-        // cube
-        .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-            transform: Transform::from_xyz(0.0, 0.5, 0.0),
-            ..Default::default()
-        })
-        // light
-        .spawn(LightBundle {
-            transform: Transform::from_xyz(4.0, 8.0, 4.0),
-            ..Default::default()
-        })
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
-        });
+    // plane
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        ..Default::default()
+    });
+    // cube
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        ..Default::default()
+    });
+    // light
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..Default::default()
+    });
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -43,37 +43,35 @@ fn setup(
         ..Default::default()
     });
 
-    // Add entities to the world:
-    commands
-        // monkey
-        .spawn(PbrBundle {
-            mesh: monkey_handle,
-            material: material_handle.clone(),
-            transform: Transform::from_xyz(-3.0, 0.0, 0.0),
-            ..Default::default()
-        })
-        // cube
-        .spawn(PbrBundle {
-            mesh: cube_handle,
-            material: material_handle.clone(),
-            transform: Transform::from_xyz(0.0, 0.0, 0.0),
-            ..Default::default()
-        })
-        // sphere
-        .spawn(PbrBundle {
-            mesh: sphere_handle,
-            material: material_handle,
-            transform: Transform::from_xyz(3.0, 0.0, 0.0),
-            ..Default::default()
-        })
-        // light
-        .spawn(LightBundle {
-            transform: Transform::from_xyz(4.0, 5.0, 4.0),
-            ..Default::default()
-        })
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(0.0, 3.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
-        });
+    // monkey
+    commands.spawn_bundle(PbrBundle {
+        mesh: monkey_handle,
+        material: material_handle.clone(),
+        transform: Transform::from_xyz(-3.0, 0.0, 0.0),
+        ..Default::default()
+    });
+    // cube
+    commands.spawn_bundle(PbrBundle {
+        mesh: cube_handle,
+        material: material_handle.clone(),
+        transform: Transform::from_xyz(0.0, 0.0, 0.0),
+        ..Default::default()
+    });
+    // sphere
+    commands.spawn_bundle(PbrBundle {
+        mesh: sphere_handle,
+        material: material_handle,
+        transform: Transform::from_xyz(3.0, 0.0, 0.0),
+        ..Default::default()
+    });
+    // light
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_xyz(4.0, 5.0, 4.0),
+        ..Default::default()
+    });
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(0.0, 3.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/asset/custom_asset_io.rs
+++ b/examples/asset/custom_asset_io.rs
@@ -95,10 +95,9 @@ fn setup(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let texture_handle = asset_server.load("branding/icon.png");
-    commands
-        .spawn(OrthographicCameraBundle::new_2d())
-        .spawn(SpriteBundle {
-            material: materials.add(texture_handle.into()),
-            ..Default::default()
-        });
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(SpriteBundle {
+        material: materials.add(texture_handle.into()),
+        ..Default::default()
+    });
 }

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -20,18 +20,16 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Any changes to the mesh will be reloaded automatically! Try making a change to Monkey.gltf.
     // You should see the changes immediately show up in your app.
 
-    // Add entities to the world:
-    commands
-        // mesh
-        .spawn_scene(scene_handle)
-        // light
-        .spawn(LightBundle {
-            transform: Transform::from_xyz(4.0, 5.0, 4.0),
-            ..Default::default()
-        })
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(2.0, 2.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
-        });
+    // mesh
+    commands.spawn_scene(scene_handle);
+    // light
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_xyz(4.0, 5.0, 4.0),
+        ..Default::default()
+    });
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(2.0, 2.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/ecs/change_detection.rs
+++ b/examples/ecs/change_detection.rs
@@ -16,8 +16,8 @@ fn main() {
 struct MyComponent(f64);
 
 fn setup(mut commands: Commands) {
-    commands.spawn((MyComponent(0.),));
-    commands.spawn((Transform::identity(),));
+    commands.spawn().insert(MyComponent(0.));
+    commands.spawn().insert(Transform::identity());
 }
 
 fn change_component(time: Res<Time>, mut query: Query<(Entity, &mut MyComponent)>) {

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -184,7 +184,7 @@ fn new_player_system(
     let add_new_player = random::<bool>();
     if add_new_player && game_state.total_players < game_rules.max_players {
         game_state.total_players += 1;
-        commands.spawn((
+        commands.spawn_bundle((
             Player {
                 name: format!("Player {}", game_state.total_players),
             },

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -13,12 +13,12 @@ fn setup(
     asset_server: Res<AssetServer>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
-    commands.spawn(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
     let texture = asset_server.load("branding/icon.png");
 
     // Spawn a root entity with no parent
     let parent = commands
-        .spawn(SpriteBundle {
+        .spawn_bundle(SpriteBundle {
             transform: Transform::from_scale(Vec3::splat(0.75)),
             material: materials.add(ColorMaterial {
                 color: Color::WHITE,
@@ -29,7 +29,7 @@ fn setup(
         // With that entity as a parent, run a lambda that spawns its children
         .with_children(|parent| {
             // parent is a ChildBuilder, which has a similar API to Commands
-            parent.spawn(SpriteBundle {
+            parent.spawn_bundle(SpriteBundle {
                 transform: Transform {
                     translation: Vec3::new(250.0, 0.0, 0.0),
                     scale: Vec3::splat(0.75),
@@ -43,15 +43,14 @@ fn setup(
             });
         })
         // Store parent entity for next sections
-        .current_entity()
-        .unwrap();
+        .id();
 
     // Another way to create a hierarchy is to add a Parent component to an entity,
     // which would be added automatically to parents with other methods.
     // Similarly, adding a Parent component will automatically add a Children component to the
     // parent.
     commands
-        .spawn(SpriteBundle {
+        .spawn_bundle(SpriteBundle {
             transform: Transform {
                 translation: Vec3::new(-250.0, 0.0, 0.0),
                 scale: Vec3::splat(0.75),
@@ -64,12 +63,12 @@ fn setup(
             ..Default::default()
         })
         // Using the entity from the previous section as the parent:
-        .with(Parent(parent));
+        .insert(Parent(parent));
 
     // Another way is to use the push_children function to add children after the parent
     // entity has already been spawned.
     let child = commands
-        .spawn(SpriteBundle {
+        .spawn_bundle(SpriteBundle {
             transform: Transform {
                 translation: Vec3::new(0.0, 250.0, 0.0),
                 scale: Vec3::splat(0.75),
@@ -81,11 +80,10 @@ fn setup(
             }),
             ..Default::default()
         })
-        .current_entity()
-        .unwrap();
+        .id();
 
     // Pushing takes a slice of children to add:
-    commands.push_children(parent, &[child]);
+    commands.entity(parent).push_children(&[child]);
 }
 
 // A simple system to rotate the root entity, and rotate all its children separately
@@ -113,7 +111,7 @@ fn rotate(
         // seconds
         if time.seconds_since_startup() >= 2.0 && children.len() == 3 {
             let child = children.last().copied().unwrap();
-            commands.despawn(child);
+            commands.entity(child).despawn();
         }
 
         if time.seconds_since_startup() >= 4.0 {

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -117,7 +117,7 @@ fn rotate(
         if time.seconds_since_startup() >= 4.0 {
             // This will remove the entity from its parent's list of children, as well as despawn
             // any children the entity has.
-            commands.despawn_recursive(parent);
+            commands.entity(parent).despawn_recursive();
         }
     }
 }

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -8,17 +8,17 @@ fn spawn_system(
     asset_server: Res<AssetServer>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
-    commands.spawn(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
     let texture_handle = asset_server.load("branding/icon.png");
     let material = materials.add(texture_handle.into());
     for _ in 0..128 {
         commands
-            .spawn(SpriteBundle {
+            .spawn_bundle(SpriteBundle {
                 material: material.clone(),
                 transform: Transform::from_scale(Vec3::splat(0.1)),
                 ..Default::default()
             })
-            .with(Velocity(
+            .insert(Velocity(
                 20.0 * Vec2::new(random::<f32>() - 0.5, random::<f32>() - 0.5),
             ));
     }

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -32,13 +32,13 @@ fn setup(
 ) {
     let texture = asset_server.load("branding/icon.png");
 
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
     commands
-        .spawn(OrthographicCameraBundle::new_2d())
-        .spawn(SpriteBundle {
+        .spawn_bundle(SpriteBundle {
             material: materials.add(texture.into()),
             ..Default::default()
         })
-        .with(MyComponent); // Add the `Component`.
+        .insert(MyComponent); // Add the `Component`.
 }
 
 fn remove_component(
@@ -49,7 +49,7 @@ fn remove_component(
     // After two seconds have passed the `Component` is removed.
     if time.seconds_since_startup() > 2.0 {
         if let Some(entity) = query.iter().next() {
-            commands.remove::<MyComponent>(entity);
+            commands.entity(entity).remove::<MyComponent>();
         }
     }
 }

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -94,7 +94,7 @@ fn menu(
 }
 
 fn cleanup_menu(mut commands: Commands, menu_data: Res<MenuData>) {
-    commands.despawn_recursive(menu_data.button_entity);
+    commands.entity(menu_data.button_entity).despawn_recursive();
 }
 
 fn setup_game(

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -34,10 +34,10 @@ fn setup_menu(
     asset_server: Res<AssetServer>,
     button_materials: Res<ButtonMaterials>,
 ) {
-    commands
-        // ui camera
-        .spawn(UiCameraBundle::default())
-        .spawn(ButtonBundle {
+    // ui camera
+    commands.spawn_bundle(UiCameraBundle::default());
+    let button_entity = commands
+        .spawn_bundle(ButtonBundle {
             style: Style {
                 size: Size::new(Val::Px(150.0), Val::Px(65.0)),
                 // center button
@@ -52,7 +52,7 @@ fn setup_menu(
             ..Default::default()
         })
         .with_children(|parent| {
-            parent.spawn(TextBundle {
+            parent.spawn_bundle(TextBundle {
                 text: Text::with_section(
                     "Play",
                     TextStyle {
@@ -64,10 +64,9 @@ fn setup_menu(
                 ),
                 ..Default::default()
             });
-        });
-    commands.insert_resource(MenuData {
-        button_entity: commands.current_entity().unwrap(),
-    });
+        })
+        .id();
+    commands.insert_resource(MenuData { button_entity });
 }
 
 fn menu(
@@ -104,12 +103,11 @@ fn setup_game(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let texture_handle = asset_server.load("branding/icon.png");
-    commands
-        .spawn(OrthographicCameraBundle::new_2d())
-        .spawn(SpriteBundle {
-            material: materials.add(texture_handle.into()),
-            ..Default::default()
-        });
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(SpriteBundle {
+        material: materials.add(texture_handle.into()),
+        ..Default::default()
+    });
 }
 
 const SPEED: f32 = 100.0;

--- a/examples/ecs/system_param.rs
+++ b/examples/ecs/system_param.rs
@@ -30,9 +30,9 @@ impl<'a> PlayerCounter<'a> {
 
 /// Spawn some players to count
 fn spawn(mut commands: Commands) {
-    commands.spawn((Player,));
-    commands.spawn((Player,));
-    commands.spawn((Player,));
+    commands.spawn().insert(Player);
+    commands.spawn().insert(Player);
+    commands.spawn().insert(Player);
 }
 
 /// The SystemParam can be used directly in a system argument.

--- a/examples/ecs/timers.rs
+++ b/examples/ecs/timers.rs
@@ -32,7 +32,7 @@ impl Default for Countdown {
 
 fn setup_system(mut commands: Commands) {
     // Add an entity to the world with a timer
-    commands.spawn((Timer::from_seconds(5.0, false),));
+    commands.spawn().insert(Timer::from_seconds(5.0, false));
 }
 
 /// This system ticks all the `Timer` components on entities within the scene

--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -85,17 +85,16 @@ const RESET_FOCUS: [f32; 3] = [
 fn setup_cameras(mut commands: Commands, mut game: ResMut<Game>) {
     game.camera_should_focus = Vec3::from(RESET_FOCUS);
     game.camera_is_focus = game.camera_should_focus;
-    commands
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(
-                -(BOARD_SIZE_I as f32 / 2.0),
-                2.0 * BOARD_SIZE_J as f32 / 3.0,
-                BOARD_SIZE_J as f32 / 2.0 - 0.5,
-            )
-            .looking_at(game.camera_is_focus, Vec3::Y),
-            ..Default::default()
-        })
-        .spawn(UiCameraBundle::default());
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(
+            -(BOARD_SIZE_I as f32 / 2.0),
+            2.0 * BOARD_SIZE_J as f32 / 3.0,
+            BOARD_SIZE_J as f32 / 2.0 - 0.5,
+        )
+        .looking_at(game.camera_is_focus, Vec3::Y),
+        ..Default::default()
+    });
+    commands.spawn_bundle(UiCameraBundle::default());
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMut<Game>) {
@@ -105,7 +104,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
     game.player.i = BOARD_SIZE_I / 2;
     game.player.j = BOARD_SIZE_J / 2;
 
-    commands.spawn(LightBundle {
+    commands.spawn_bundle(LightBundle {
         transform: Transform::from_xyz(4.0, 5.0, 4.0),
         ..Default::default()
     });
@@ -118,7 +117,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
                 .map(|i| {
                     let height = rand::thread_rng().gen_range(-0.1..0.1);
                     commands
-                        .spawn((
+                        .spawn_bundle((
                             Transform::from_xyz(i as f32, height - 0.2, j as f32),
                             GlobalTransform::identity(),
                         ))
@@ -132,29 +131,31 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
         .collect();
 
     // spawn the game character
-    game.player.entity = commands
-        .spawn((
-            Transform {
-                translation: Vec3::new(
-                    game.player.i as f32,
-                    game.board[game.player.j][game.player.i].height,
-                    game.player.j as f32,
-                ),
-                rotation: Quat::from_rotation_y(-std::f32::consts::FRAC_PI_2),
-                ..Default::default()
-            },
-            GlobalTransform::identity(),
-        ))
-        .with_children(|cell| {
-            cell.spawn_scene(asset_server.load("models/AlienCake/alien.glb#Scene0"));
-        })
-        .current_entity();
+    game.player.entity = Some(
+        commands
+            .spawn_bundle((
+                Transform {
+                    translation: Vec3::new(
+                        game.player.i as f32,
+                        game.board[game.player.j][game.player.i].height,
+                        game.player.j as f32,
+                    ),
+                    rotation: Quat::from_rotation_y(-std::f32::consts::FRAC_PI_2),
+                    ..Default::default()
+                },
+                GlobalTransform::identity(),
+            ))
+            .with_children(|cell| {
+                cell.spawn_scene(asset_server.load("models/AlienCake/alien.glb#Scene0"));
+            })
+            .id(),
+    );
 
     // load the scene for the cake
     game.bonus.handle = asset_server.load("models/AlienCake/cakeBirthday.glb#Scene0");
 
     // scoreboard
-    commands.spawn(TextBundle {
+    commands.spawn_bundle(TextBundle {
         text: Text::with_section(
             "Score:",
             TextStyle {
@@ -307,7 +308,6 @@ fn spawn_bonus(
             return;
         }
     }
-
     // ensure bonus doesn't spawn on the player
     loop {
         game.bonus.i = rand::thread_rng().gen_range(0..BOARD_SIZE_I);
@@ -316,22 +316,24 @@ fn spawn_bonus(
             break;
         }
     }
-    game.bonus.entity = commands
-        .spawn((
-            Transform {
-                translation: Vec3::new(
-                    game.bonus.i as f32,
-                    game.board[game.player.j][game.player.i].height + 0.2,
-                    game.bonus.j as f32,
-                ),
-                ..Default::default()
-            },
-            GlobalTransform::identity(),
-        ))
-        .with_children(|cell| {
-            cell.spawn_scene(game.bonus.handle.clone());
-        })
-        .current_entity();
+    game.bonus.entity = Some(
+        commands
+            .spawn_bundle((
+                Transform {
+                    translation: Vec3::new(
+                        game.bonus.i as f32,
+                        game.board[game.player.j][game.player.i].height + 0.2,
+                        game.bonus.j as f32,
+                    ),
+                    ..Default::default()
+                },
+                GlobalTransform::identity(),
+            ))
+            .with_children(|cell| {
+                cell.spawn_scene(game.bonus.handle.clone());
+            })
+            .id(),
+    );
 }
 
 // let the cake turn on itself
@@ -367,7 +369,7 @@ fn display_score(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     commands
-        .spawn(NodeBundle {
+        .spawn_bundle(NodeBundle {
             style: Style {
                 margin: Rect::all(Val::Auto),
                 justify_content: JustifyContent::Center,
@@ -378,7 +380,7 @@ fn display_score(
             ..Default::default()
         })
         .with_children(|parent| {
-            parent.spawn(TextBundle {
+            parent.spawn_bundle(TextBundle {
                 text: Text::with_section(
                     format!("Cake eaten: {}", game.cake_eaten),
                     TextStyle {

--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -308,6 +308,7 @@ fn spawn_bonus(
             return;
         }
     }
+
     // ensure bonus doesn't spawn on the player
     loop {
         game.bonus.i = rand::thread_rng().gen_range(0..BOARD_SIZE_I);

--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -181,7 +181,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
 // remove all entities that are not a camera
 fn teardown(mut commands: Commands, entities: Query<Entity, Without<Camera>>) {
     for entity in entities.iter() {
-        commands.despawn_recursive(entity);
+        commands.entity(entity).despawn_recursive();
     }
 }
 
@@ -241,7 +241,7 @@ fn move_player(
         if game.player.i == game.bonus.i && game.player.j == game.bonus.j {
             game.score += 2;
             game.cake_eaten += 1;
-            commands.despawn_recursive(entity);
+            commands.entity(entity).despawn_recursive();
             game.bonus.entity = None;
         }
     }
@@ -301,7 +301,7 @@ fn spawn_bonus(
     }
     if let Some(entity) = game.bonus.entity {
         game.score -= 3;
-        commands.despawn_recursive(entity);
+        commands.entity(entity).despawn_recursive();
         game.bonus.entity = None;
         if game.score <= -5 {
             state.set_next(GameState::GameOver).unwrap();

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -42,102 +42,107 @@ fn setup(
     asset_server: Res<AssetServer>,
 ) {
     // Add the game's entities to our world
+
+    // cameras
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(UiCameraBundle::default());
+    // paddle
     commands
-        // cameras
-        .spawn(OrthographicCameraBundle::new_2d())
-        .spawn(UiCameraBundle::default())
-        // paddle
-        .spawn(SpriteBundle {
+        .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(0.5, 0.5, 1.0).into()),
             transform: Transform::from_xyz(0.0, -215.0, 0.0),
             sprite: Sprite::new(Vec2::new(120.0, 30.0)),
             ..Default::default()
         })
-        .with(Paddle { speed: 500.0 })
-        .with(Collider::Paddle)
-        // ball
-        .spawn(SpriteBundle {
+        .insert(Paddle { speed: 500.0 })
+        .insert(Collider::Paddle);
+    // ball
+    commands
+        .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(1.0, 0.5, 0.5).into()),
             transform: Transform::from_xyz(0.0, -50.0, 1.0),
             sprite: Sprite::new(Vec2::new(30.0, 30.0)),
             ..Default::default()
         })
-        .with(Ball {
+        .insert(Ball {
             velocity: 400.0 * Vec3::new(0.5, -0.5, 0.0).normalize(),
-        })
-        // scoreboard
-        .spawn(TextBundle {
-            text: Text {
-                sections: vec![
-                    TextSection {
-                        value: "Score: ".to_string(),
-                        style: TextStyle {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                            font_size: 40.0,
-                            color: Color::rgb(0.5, 0.5, 1.0),
-                        },
+        });
+    // scoreboard
+    commands.spawn_bundle(TextBundle {
+        text: Text {
+            sections: vec![
+                TextSection {
+                    value: "Score: ".to_string(),
+                    style: TextStyle {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font_size: 40.0,
+                        color: Color::rgb(0.5, 0.5, 1.0),
                     },
-                    TextSection {
-                        value: "".to_string(),
-                        style: TextStyle {
-                            font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                            font_size: 40.0,
-                            color: Color::rgb(1.0, 0.5, 0.5),
-                        },
-                    },
-                ],
-                ..Default::default()
-            },
-            style: Style {
-                position_type: PositionType::Absolute,
-                position: Rect {
-                    top: Val::Px(5.0),
-                    left: Val::Px(5.0),
-                    ..Default::default()
                 },
+                TextSection {
+                    value: "".to_string(),
+                    style: TextStyle {
+                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                        font_size: 40.0,
+                        color: Color::rgb(1.0, 0.5, 0.5),
+                    },
+                },
+            ],
+            ..Default::default()
+        },
+        style: Style {
+            position_type: PositionType::Absolute,
+            position: Rect {
+                top: Val::Px(5.0),
+                left: Val::Px(5.0),
                 ..Default::default()
             },
             ..Default::default()
-        });
+        },
+        ..Default::default()
+    });
 
     // Add walls
     let wall_material = materials.add(Color::rgb(0.8, 0.8, 0.8).into());
     let wall_thickness = 10.0;
     let bounds = Vec2::new(900.0, 600.0);
 
+    // left
     commands
-        // left
-        .spawn(SpriteBundle {
+        .spawn_bundle(SpriteBundle {
             material: wall_material.clone(),
             transform: Transform::from_xyz(-bounds.x / 2.0, 0.0, 0.0),
             sprite: Sprite::new(Vec2::new(wall_thickness, bounds.y + wall_thickness)),
             ..Default::default()
         })
-        .with(Collider::Solid)
-        // right
-        .spawn(SpriteBundle {
+        .insert(Collider::Solid);
+    // right
+    commands
+        .spawn_bundle(SpriteBundle {
             material: wall_material.clone(),
             transform: Transform::from_xyz(bounds.x / 2.0, 0.0, 0.0),
             sprite: Sprite::new(Vec2::new(wall_thickness, bounds.y + wall_thickness)),
             ..Default::default()
         })
-        .with(Collider::Solid)
-        // bottom
-        .spawn(SpriteBundle {
+        .insert(Collider::Solid);
+    // bottom
+    commands
+        .spawn_bundle(SpriteBundle {
             material: wall_material.clone(),
             transform: Transform::from_xyz(0.0, -bounds.y / 2.0, 0.0),
             sprite: Sprite::new(Vec2::new(bounds.x + wall_thickness, wall_thickness)),
             ..Default::default()
         })
-        .with(Collider::Solid)
-        // top
-        .spawn(SpriteBundle {
+        .insert(Collider::Solid);
+    // top
+    commands
+        .spawn_bundle(SpriteBundle {
             material: wall_material,
             transform: Transform::from_xyz(0.0, bounds.y / 2.0, 0.0),
             sprite: Sprite::new(Vec2::new(bounds.x + wall_thickness, wall_thickness)),
             ..Default::default()
         })
-        .with(Collider::Solid);
+        .insert(Collider::Solid);
 
     // Add bricks
     let brick_rows = 4;
@@ -156,15 +161,15 @@ fn setup(
                 y_position,
                 0.0,
             ) + bricks_offset;
+            // brick
             commands
-                // brick
-                .spawn(SpriteBundle {
+                .spawn_bundle(SpriteBundle {
                     material: brick_material.clone(),
                     sprite: Sprite::new(brick_size),
                     transform: Transform::from_translation(brick_position),
                     ..Default::default()
                 })
-                .with(Collider::Scorable);
+                .insert(Collider::Scorable);
         }
     }
 }
@@ -228,7 +233,7 @@ fn ball_collision_system(
                 // scorable colliders should be despawned and increment the scoreboard on collision
                 if let Collider::Scorable = *collider {
                     scoreboard.score += 1;
-                    commands.despawn(collider_entity);
+                    commands.entity(collider_entity).despawn();
                 }
 
                 // reflect the ball when it collides

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -21,39 +21,37 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    // add entities to the world
-    commands
-        // plane
-        .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
-            material: materials.add(Color::rgb(0.1, 0.2, 0.1).into()),
-            ..Default::default()
-        })
-        // cube
-        .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::rgb(0.5, 0.4, 0.3).into()),
-            transform: Transform::from_xyz(0.0, 0.5, 0.0),
-            ..Default::default()
-        })
-        // sphere
-        .spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Icosphere {
-                subdivisions: 4,
-                radius: 0.5,
-            })),
-            material: materials.add(Color::rgb(0.1, 0.4, 0.8).into()),
-            transform: Transform::from_xyz(1.5, 1.5, 1.5),
-            ..Default::default()
-        })
-        // light
-        .spawn(LightBundle {
-            transform: Transform::from_xyz(4.0, 8.0, 4.0),
-            ..Default::default()
-        })
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
-        });
+    // plane
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
+        material: materials.add(Color::rgb(0.1, 0.2, 0.1).into()),
+        ..Default::default()
+    });
+    // cube
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.5, 0.4, 0.3).into()),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        ..Default::default()
+    });
+    // sphere
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Icosphere {
+            subdivisions: 4,
+            radius: 0.5,
+        })),
+        material: materials.add(Color::rgb(0.1, 0.4, 0.8).into()),
+        transform: Transform::from_xyz(1.5, 1.5, 1.5),
+        ..Default::default()
+    });
+    // light
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..Default::default()
+    });
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -103,7 +103,8 @@ fn save_scene_system(world: &mut World) {
 // This is only necessary for the info message in the UI. See examples/ui/text.rs for a standalone
 // text example.
 fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(UiCameraBundle::default()).spawn(TextBundle {
+    commands.spawn_bundle(UiCameraBundle::default());
+    commands.spawn_bundle(TextBundle {
         style: Style {
             align_self: AlignSelf::FlexEnd,
             ..Default::default()

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -111,7 +111,7 @@ fn setup(
         .add_node_edge("my_array_texture", base::node::MAIN_PASS)
         .unwrap();
 
-    commands.spawn(PerspectiveCameraBundle {
+    commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(2.0, 2.0, 2.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..Default::default()
     });
@@ -143,12 +143,12 @@ fn create_array_texture(
 
     // Spawn a cube that's shaded using the array texture.
     commands
-        .spawn(MeshBundle {
+        .spawn_bundle(MeshBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 my_pipeline.0.clone(),
             )]),
             ..Default::default()
         })
-        .with(array_texture);
+        .insert(array_texture);
 }

--- a/examples/shader/hot_shader_reloading.rs
+++ b/examples/shader/hot_shader_reloading.rs
@@ -61,10 +61,9 @@ fn setup(
         color: Color::rgb(0.0, 0.8, 0.0),
     });
 
-    // Setup our world
+    // cube
     commands
-        // cube
-        .spawn(MeshBundle {
+        .spawn_bundle(MeshBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 2.0 })),
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
@@ -72,10 +71,10 @@ fn setup(
             transform: Transform::from_xyz(0.0, 0.0, 0.0),
             ..Default::default()
         })
-        .with(material)
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
-        });
+        .insert(material);
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/shader/mesh_custom_attribute.rs
+++ b/examples/shader/mesh_custom_attribute.rs
@@ -127,10 +127,9 @@ fn setup(
             [0.20, 0.27, 0.29],
         ]),
     );
-    // Setup our world
+    // cube
     commands
-        // cube
-        .spawn(MeshBundle {
+        .spawn_bundle(MeshBundle {
             mesh: meshes.add(cube_with_vertex_colors), // use our cube with vertex colors
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
@@ -138,10 +137,10 @@ fn setup(
             transform: Transform::from_xyz(0.0, 0.0, 0.0),
             ..Default::default()
         })
-        .with(material)
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
-        });
+        .insert(material);
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/shader/shader_custom_material.rs
+++ b/examples/shader/shader_custom_material.rs
@@ -83,10 +83,9 @@ fn setup(
         color: Color::rgb(0.0, 0.8, 0.0),
     });
 
-    // Setup our world
+    // cube
     commands
-        // cube
-        .spawn(MeshBundle {
+        .spawn_bundle(MeshBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 2.0 })),
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
@@ -94,10 +93,10 @@ fn setup(
             transform: Transform::from_xyz(0.0, 0.0, 0.0),
             ..Default::default()
         })
-        .with(material)
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
-        });
+        .insert(material);
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -105,9 +105,9 @@ fn setup(
     // Create a cube mesh which will use our materials
     let cube_handle = meshes.add(Mesh::from(shape::Cube { size: 2.0 }));
 
+    // cube
     commands
-        // cube
-        .spawn(MeshBundle {
+        .spawn_bundle(MeshBundle {
             mesh: cube_handle.clone(),
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle.clone(),
@@ -115,9 +115,10 @@ fn setup(
             transform: Transform::from_xyz(-2.0, 0.0, 0.0),
             ..Default::default()
         })
-        .with(green_material)
-        // cube
-        .spawn(MeshBundle {
+        .insert(green_material);
+    // cube
+    commands
+        .spawn_bundle(MeshBundle {
             mesh: cube_handle,
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
@@ -125,10 +126,10 @@ fn setup(
             transform: Transform::from_xyz(2.0, 0.0, 0.0),
             ..Default::default()
         })
-        .with(blue_material)
-        // camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
-        });
+        .insert(blue_material);
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -53,58 +53,57 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands
-        .spawn(OrthographicCameraBundle::new_2d())
-        .spawn(UiCameraBundle::default())
-        .spawn(TextBundle {
-            text: Text {
-                sections: vec![
-                    TextSection {
-                        value: "Bird Count: ".to_string(),
-                        style: TextStyle {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                            font_size: 40.0,
-                            color: Color::rgb(0.0, 1.0, 0.0),
-                        },
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(UiCameraBundle::default());
+    commands.spawn_bundle(TextBundle {
+        text: Text {
+            sections: vec![
+                TextSection {
+                    value: "Bird Count: ".to_string(),
+                    style: TextStyle {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font_size: 40.0,
+                        color: Color::rgb(0.0, 1.0, 0.0),
                     },
-                    TextSection {
-                        value: "".to_string(),
-                        style: TextStyle {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                            font_size: 40.0,
-                            color: Color::rgb(0.0, 1.0, 1.0),
-                        },
-                    },
-                    TextSection {
-                        value: "\nAverage FPS: ".to_string(),
-                        style: TextStyle {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                            font_size: 40.0,
-                            color: Color::rgb(0.0, 1.0, 0.0),
-                        },
-                    },
-                    TextSection {
-                        value: "".to_string(),
-                        style: TextStyle {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                            font_size: 40.0,
-                            color: Color::rgb(0.0, 1.0, 1.0),
-                        },
-                    },
-                ],
-                ..Default::default()
-            },
-            style: Style {
-                position_type: PositionType::Absolute,
-                position: Rect {
-                    top: Val::Px(5.0),
-                    left: Val::Px(5.0),
-                    ..Default::default()
                 },
+                TextSection {
+                    value: "".to_string(),
+                    style: TextStyle {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font_size: 40.0,
+                        color: Color::rgb(0.0, 1.0, 1.0),
+                    },
+                },
+                TextSection {
+                    value: "\nAverage FPS: ".to_string(),
+                    style: TextStyle {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font_size: 40.0,
+                        color: Color::rgb(0.0, 1.0, 0.0),
+                    },
+                },
+                TextSection {
+                    value: "".to_string(),
+                    style: TextStyle {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font_size: 40.0,
+                        color: Color::rgb(0.0, 1.0, 1.0),
+                    },
+                },
+            ],
+            ..Default::default()
+        },
+        style: Style {
+            position_type: PositionType::Absolute,
+            position: Rect {
+                top: Val::Px(5.0),
+                left: Val::Px(5.0),
                 ..Default::default()
             },
             ..Default::default()
-        });
+        },
+        ..Default::default()
+    });
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -138,7 +137,7 @@ fn mouse_handler(
         for count in 0..spawn_count {
             let bird_z = (counter.count + count) as f32 * 0.00001;
             commands
-                .spawn(SpriteBundle {
+                .spawn_bundle(SpriteBundle {
                     material: bird_material.0.clone(),
                     transform: Transform {
                         translation: Vec3::new(bird_x, bird_y, bird_z),
@@ -147,7 +146,7 @@ fn mouse_handler(
                     },
                     ..Default::default()
                 })
-                .with(Bird {
+                .insert(Bird {
                     velocity: Vec3::new(
                         rand::random::<f32>() * MAX_VELOCITY - (MAX_VELOCITY * 0.5),
                         0.,

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -60,10 +60,10 @@ fn setup(
     asset_server: Res<AssetServer>,
     button_materials: Res<ButtonMaterials>,
 ) {
+    // ui camera
+    commands.spawn_bundle(UiCameraBundle::default());
     commands
-        // ui camera
-        .spawn(UiCameraBundle::default())
-        .spawn(ButtonBundle {
+        .spawn_bundle(ButtonBundle {
             style: Style {
                 size: Size::new(Val::Px(150.0), Val::Px(65.0)),
                 // center button
@@ -78,7 +78,7 @@ fn setup(
             ..Default::default()
         })
         .with_children(|parent| {
-            parent.spawn(TextBundle {
+            parent.spawn_bundle(TextBundle {
                 text: Text::with_section(
                     "Button",
                     TextStyle {

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -47,7 +47,7 @@ fn atlas_render_system(
                 .get(&font_atlas[state.atlas_count as usize].texture_atlas)
                 .unwrap();
             state.atlas_count += 1;
-            commands.spawn(ImageBundle {
+            commands.spawn_bundle(ImageBundle {
                 material: materials.add(texture_atlas.texture.clone().into()),
                 style: Style {
                     position_type: PositionType::Absolute,
@@ -80,7 +80,8 @@ fn text_update_system(mut state: ResMut<State>, time: Res<Time>, mut query: Quer
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut state: ResMut<State>) {
     let font_handle = asset_server.load("fonts/FiraSans-Bold.ttf");
     state.handle = font_handle.clone();
-    commands.spawn(UiCameraBundle::default()).spawn(TextBundle {
+    commands.spawn_bundle(UiCameraBundle::default());
+    commands.spawn_bundle(TextBundle {
         text: Text::with_section(
             "a",
             TextStyle {

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -23,11 +23,11 @@ struct FpsText;
 struct ColorText;
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    // UI camera
+    commands.spawn_bundle(UiCameraBundle::default());
+    // Text with one section
     commands
-        // UI camera
-        .spawn(UiCameraBundle::default())
-        // Text with one section
-        .spawn(TextBundle {
+        .spawn_bundle(TextBundle {
             style: Style {
                 align_self: AlignSelf::FlexEnd,
                 position_type: PositionType::Absolute,
@@ -55,9 +55,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             ),
             ..Default::default()
         })
-        .with(ColorText)
-        // Rich text with multiple sections
-        .spawn(TextBundle {
+        .insert(ColorText);
+    // Rich text with multiple sections
+    commands
+        .spawn_bundle(TextBundle {
             style: Style {
                 align_self: AlignSelf::FlexEnd,
                 ..Default::default()
@@ -87,7 +88,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
             ..Default::default()
         })
-        .with(FpsText);
+        .insert(FpsText);
 }
 
 fn text_update_system(diagnostics: Res<Diagnostics>, mut query: Query<&mut Text, With<FpsText>>) {

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -21,8 +21,8 @@ struct TextChanges;
 
 fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
     let font = asset_server.load("fonts/FiraSans-Bold.ttf");
-    commands.spawn(UiCameraBundle::default());
-    commands.spawn(TextBundle {
+    commands.spawn_bundle(UiCameraBundle::default());
+    commands.spawn_bundle(TextBundle {
         style: Style {
             align_self: AlignSelf::FlexEnd,
             position_type: PositionType::Absolute,
@@ -44,7 +44,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         ),
         ..Default::default()
     });
-    commands.spawn(TextBundle {
+    commands.spawn_bundle(TextBundle {
         style: Style {
             align_self: AlignSelf::FlexEnd,
             position_type: PositionType::Absolute,
@@ -74,7 +74,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         ..Default::default()
     });
     commands
-        .spawn(TextBundle {
+        .spawn_bundle(TextBundle {
             style: Style {
                 align_self: AlignSelf::FlexEnd,
                 position_type: PositionType::Absolute,
@@ -140,8 +140,8 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
             ..Default::default()
         })
-        .with(TextChanges);
-    commands.spawn(TextBundle {
+        .insert(TextChanges);
+    commands.spawn_bundle(TextBundle {
         style: Style {
             align_self: AlignSelf::FlexEnd,
             position_type: PositionType::Absolute,

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -13,11 +13,11 @@ fn setup(
     asset_server: Res<AssetServer>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
+    // ui camera
+    commands.spawn_bundle(UiCameraBundle::default());
+    // root node
     commands
-        // ui camera
-        .spawn(UiCameraBundle::default())
-        // root node
-        .spawn(NodeBundle {
+        .spawn_bundle(NodeBundle {
             style: Style {
                 size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                 justify_content: JustifyContent::SpaceBetween,
@@ -27,9 +27,9 @@ fn setup(
             ..Default::default()
         })
         .with_children(|parent| {
+            // left vertical fill (border)
             parent
-                // left vertical fill (border)
-                .spawn(NodeBundle {
+                .spawn_bundle(NodeBundle {
                     style: Style {
                         size: Size::new(Val::Px(200.0), Val::Percent(100.0)),
                         border: Rect::all(Val::Px(2.0)),
@@ -39,9 +39,9 @@ fn setup(
                     ..Default::default()
                 })
                 .with_children(|parent| {
+                    // left vertical fill (content)
                     parent
-                        // left vertical fill (content)
-                        .spawn(NodeBundle {
+                        .spawn_bundle(NodeBundle {
                             style: Style {
                                 size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                                 align_items: AlignItems::FlexEnd,
@@ -52,7 +52,7 @@ fn setup(
                         })
                         .with_children(|parent| {
                             // text
-                            parent.spawn(TextBundle {
+                            parent.spawn_bundle(TextBundle {
                                 style: Style {
                                     margin: Rect::all(Val::Px(5.0)),
                                     ..Default::default()
@@ -69,18 +69,19 @@ fn setup(
                                 ..Default::default()
                             });
                         });
-                })
-                // right vertical fill
-                .spawn(NodeBundle {
-                    style: Style {
-                        size: Size::new(Val::Px(200.0), Val::Percent(100.0)),
-                        ..Default::default()
-                    },
-                    material: materials.add(Color::rgb(0.15, 0.15, 0.15).into()),
+                });
+            // right vertical fill
+            parent.spawn_bundle(NodeBundle {
+                style: Style {
+                    size: Size::new(Val::Px(200.0), Val::Percent(100.0)),
                     ..Default::default()
-                })
-                // absolute positioning
-                .spawn(NodeBundle {
+                },
+                material: materials.add(Color::rgb(0.15, 0.15, 0.15).into()),
+                ..Default::default()
+            });
+            // absolute positioning
+            parent
+                .spawn_bundle(NodeBundle {
                     style: Style {
                         size: Size::new(Val::Px(200.0), Val::Px(200.0)),
                         position_type: PositionType::Absolute,
@@ -96,7 +97,7 @@ fn setup(
                     ..Default::default()
                 })
                 .with_children(|parent| {
-                    parent.spawn(NodeBundle {
+                    parent.spawn_bundle(NodeBundle {
                         style: Style {
                             size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                             ..Default::default()
@@ -104,9 +105,10 @@ fn setup(
                         material: materials.add(Color::rgb(0.8, 0.8, 1.0).into()),
                         ..Default::default()
                     });
-                })
-                // render order test: reddest in the back, whitest in the front (flex center)
-                .spawn(NodeBundle {
+                });
+            // render order test: reddest in the back, whitest in the front (flex center)
+            parent
+                .spawn_bundle(NodeBundle {
                     style: Style {
                         size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                         position_type: PositionType::Absolute,
@@ -119,7 +121,7 @@ fn setup(
                 })
                 .with_children(|parent| {
                     parent
-                        .spawn(NodeBundle {
+                        .spawn_bundle(NodeBundle {
                             style: Style {
                                 size: Size::new(Val::Px(100.0), Val::Px(100.0)),
                                 ..Default::default()
@@ -128,68 +130,68 @@ fn setup(
                             ..Default::default()
                         })
                         .with_children(|parent| {
-                            parent
-                                .spawn(NodeBundle {
-                                    style: Style {
-                                        size: Size::new(Val::Px(100.0), Val::Px(100.0)),
-                                        position_type: PositionType::Absolute,
-                                        position: Rect {
-                                            left: Val::Px(20.0),
-                                            bottom: Val::Px(20.0),
-                                            ..Default::default()
-                                        },
+                            parent.spawn_bundle(NodeBundle {
+                                style: Style {
+                                    size: Size::new(Val::Px(100.0), Val::Px(100.0)),
+                                    position_type: PositionType::Absolute,
+                                    position: Rect {
+                                        left: Val::Px(20.0),
+                                        bottom: Val::Px(20.0),
                                         ..Default::default()
                                     },
-                                    material: materials.add(Color::rgb(1.0, 0.3, 0.3).into()),
                                     ..Default::default()
-                                })
-                                .spawn(NodeBundle {
-                                    style: Style {
-                                        size: Size::new(Val::Px(100.0), Val::Px(100.0)),
-                                        position_type: PositionType::Absolute,
-                                        position: Rect {
-                                            left: Val::Px(40.0),
-                                            bottom: Val::Px(40.0),
-                                            ..Default::default()
-                                        },
+                                },
+                                material: materials.add(Color::rgb(1.0, 0.3, 0.3).into()),
+                                ..Default::default()
+                            });
+                            parent.spawn_bundle(NodeBundle {
+                                style: Style {
+                                    size: Size::new(Val::Px(100.0), Val::Px(100.0)),
+                                    position_type: PositionType::Absolute,
+                                    position: Rect {
+                                        left: Val::Px(40.0),
+                                        bottom: Val::Px(40.0),
                                         ..Default::default()
                                     },
-                                    material: materials.add(Color::rgb(1.0, 0.5, 0.5).into()),
                                     ..Default::default()
-                                })
-                                .spawn(NodeBundle {
-                                    style: Style {
-                                        size: Size::new(Val::Px(100.0), Val::Px(100.0)),
-                                        position_type: PositionType::Absolute,
-                                        position: Rect {
-                                            left: Val::Px(60.0),
-                                            bottom: Val::Px(60.0),
-                                            ..Default::default()
-                                        },
+                                },
+                                material: materials.add(Color::rgb(1.0, 0.5, 0.5).into()),
+                                ..Default::default()
+                            });
+                            parent.spawn_bundle(NodeBundle {
+                                style: Style {
+                                    size: Size::new(Val::Px(100.0), Val::Px(100.0)),
+                                    position_type: PositionType::Absolute,
+                                    position: Rect {
+                                        left: Val::Px(60.0),
+                                        bottom: Val::Px(60.0),
                                         ..Default::default()
                                     },
-                                    material: materials.add(Color::rgb(1.0, 0.7, 0.7).into()),
                                     ..Default::default()
-                                })
-                                // alpha test
-                                .spawn(NodeBundle {
-                                    style: Style {
-                                        size: Size::new(Val::Px(100.0), Val::Px(100.0)),
-                                        position_type: PositionType::Absolute,
-                                        position: Rect {
-                                            left: Val::Px(80.0),
-                                            bottom: Val::Px(80.0),
-                                            ..Default::default()
-                                        },
+                                },
+                                material: materials.add(Color::rgb(1.0, 0.7, 0.7).into()),
+                                ..Default::default()
+                            });
+                            // alpha test
+                            parent.spawn_bundle(NodeBundle {
+                                style: Style {
+                                    size: Size::new(Val::Px(100.0), Val::Px(100.0)),
+                                    position_type: PositionType::Absolute,
+                                    position: Rect {
+                                        left: Val::Px(80.0),
+                                        bottom: Val::Px(80.0),
                                         ..Default::default()
                                     },
-                                    material: materials.add(Color::rgba(1.0, 0.9, 0.9, 0.4).into()),
                                     ..Default::default()
-                                });
+                                },
+                                material: materials.add(Color::rgba(1.0, 0.9, 0.9, 0.4).into()),
+                                ..Default::default()
+                            });
                         });
-                })
-                // bevy logo (flex center)
-                .spawn(NodeBundle {
+                });
+            // bevy logo (flex center)
+            parent
+                .spawn_bundle(NodeBundle {
                     style: Style {
                         size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                         position_type: PositionType::Absolute,
@@ -202,7 +204,7 @@ fn setup(
                 })
                 .with_children(|parent| {
                     // bevy logo (image)
-                    parent.spawn(ImageBundle {
+                    parent.spawn_bundle(ImageBundle {
                         style: Style {
                             size: Size::new(Val::Px(500.0), Val::Auto),
                             ..Default::default()

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -184,26 +184,25 @@ fn setup_pipeline(
     // SETUP SCENE
 
     // add entities to the world
-    commands
-        .spawn_scene(asset_server.load("models/monkey/Monkey.gltf#Scene0"))
-        // light
-        .spawn(LightBundle {
-            transform: Transform::from_xyz(4.0, 5.0, 4.0),
+    commands.spawn_scene(asset_server.load("models/monkey/Monkey.gltf#Scene0"));
+    // light
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_xyz(4.0, 5.0, 4.0),
+        ..Default::default()
+    });
+    // main camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(0.0, 0.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
+    // second window camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        camera: Camera {
+            name: Some("Secondary".to_string()),
+            window: window_id,
             ..Default::default()
-        })
-        // main camera
-        .spawn(PerspectiveCameraBundle {
-            transform: Transform::from_xyz(0.0, 0.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
-        })
-        // second window camera
-        .spawn(PerspectiveCameraBundle {
-            camera: Camera {
-                name: Some("Secondary".to_string()),
-                window: window_id,
-                ..Default::default()
-            },
-            transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
-        });
+        },
+        transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
 }

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -20,11 +20,11 @@ fn setup(
     asset_server: Res<AssetServer>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
+    // ui camera
+    commands.spawn_bundle(UiCameraBundle::default());
+    // root node
     commands
-        // ui camera
-        .spawn(UiCameraBundle::default())
-        // root node
-        .spawn(NodeBundle {
+        .spawn_bundle(NodeBundle {
             style: Style {
                 size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                 justify_content: JustifyContent::SpaceBetween,
@@ -34,9 +34,9 @@ fn setup(
             ..Default::default()
         })
         .with_children(|parent| {
+            // left vertical fill (border)
             parent
-                // left vertical fill (border)
-                .spawn(NodeBundle {
+                .spawn_bundle(NodeBundle {
                     style: Style {
                         size: Size::new(Val::Px(200.0), Val::Percent(100.0)),
                         border: Rect::all(Val::Px(2.0)),
@@ -46,7 +46,7 @@ fn setup(
                     ..Default::default()
                 })
                 .with_children(|parent| {
-                    parent.spawn(TextBundle {
+                    parent.spawn_bundle(TextBundle {
                         style: Style {
                             align_self: AlignSelf::FlexEnd,
                             ..Default::default()


### PR DESCRIPTION
Resolves #1253 #1562

This makes the Commands apis consistent with World apis. This moves to a "type state" pattern (like World) where the "current entity" is stored in an `EntityCommands` builder.

In general this tends to cuts down on indentation and line count. It comes at the cost of needing to type `commands` more and adding more semicolons to terminate expressions.

I also added `spawn_bundle` to Commands because this is a common enough operation that I think its worth providing a shorthand. 