### PR TITLE
add helping log when trying to access an entity that does not exist

### DIFF
--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -153,7 +153,7 @@ where
         let location = world
             .entities
             .get(entity)
-            .ok_or(QueryEntityError::NoSuchEntity)?;
+            .map_err(|_| QueryEntityError::NoSuchEntity)?;
         if !self
             .matched_archetypes
             .contains(location.archetype_id.index())


### PR DESCRIPTION
Noticed in #1707 

This adds a warn log when accessing an entity that doesn't exist, and the reason (doesn't exist yet or already despawned)