### PR TITLE
[Merged by Bors] - alien-cake-addict example: ensure the cake doesn't spawn on the player

### DIFF
--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -307,8 +307,15 @@ fn spawn_bonus(
             return;
         }
     }
-    game.bonus.i = rand::thread_rng().gen_range(0..BOARD_SIZE_I);
-    game.bonus.j = rand::thread_rng().gen_range(0..BOARD_SIZE_J);
+
+    // ensure bonus doesn't spawn on the player
+    loop {
+        game.bonus.i = rand::thread_rng().gen_range(0..BOARD_SIZE_I);
+        game.bonus.j = rand::thread_rng().gen_range(0..BOARD_SIZE_J);
+        if game.bonus.i != game.player.i || game.bonus.j != game.player.j {
+            break;
+        }
+    }
     game.bonus.entity = commands
         .spawn((
             Transform {


### PR DESCRIPTION
fixes #1707 

In the game, it makes sense to never spawn the cake on the player.