### PR TITLE
[Merged by Bors] -  Override size_hint for all Iterators and add ExactSizeIterator where applicable

### DIFF
--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -151,15 +151,8 @@ impl<'a> Iterator for ListIter<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let mut index = 0;
-
-        loop {
-            if self.list.get(index).is_some() {
-                index += 1;
-            } else {
-                return (index, Some(index));
-            }
-        }
+        let size = self.list.len();
+        (size, Some(size))
     }
 }
 

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -149,7 +149,21 @@ impl<'a> Iterator for ListIter<'a> {
         self.index += 1;
         value
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let mut index = 0;
+
+        loop {
+            if self.list.get(index).is_some() {
+                index += 1;
+            } else {
+                return (index, Some(index));
+            }
+        }
+    }
 }
+
+impl<'a> ExactSizeIterator for ListIter<'a> {}
 
 #[inline]
 pub fn list_apply<L: List>(a: &mut L, b: &dyn Reflect) {

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -169,15 +169,8 @@ impl<'a> Iterator for MapIter<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let mut index = 0;
-
-        loop {
-            if self.map.get_at(index).is_some() {
-                index += 1;
-            } else {
-                return (index, Some(index));
-            }
-        }
+        let size = self.map.len();
+        (size, Some(size))
     }
 }
 

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -167,7 +167,21 @@ impl<'a> Iterator for MapIter<'a> {
         self.index += 1;
         value
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let mut index = 0;
+
+        loop {
+            if self.map.get_at(index).is_some() {
+                index += 1;
+            } else {
+                return (index, Some(index));
+            }
+        }
+    }
 }
+
+impl<'a> ExactSizeIterator for MapIter<'a> {}
 
 #[inline]
 pub fn map_partial_eq<M: Map>(a: &M, b: &dyn Reflect) -> Option<bool> {

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -37,7 +37,21 @@ impl<'a> Iterator for FieldIter<'a> {
         self.index += 1;
         value
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let mut index = 0;
+
+        loop {
+            if self.struct_val.field_at(index).is_some() {
+                index += 1;
+            } else {
+                return (index, Some(index));
+            }
+        }
+    }
 }
+
+impl<'a> ExactSizeIterator for FieldIter<'a> {}
 
 pub trait GetField {
     fn get_field<T: Reflect>(&self, name: &str) -> Option<&T>;

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -39,15 +39,8 @@ impl<'a> Iterator for FieldIter<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let mut index = 0;
-
-        loop {
-            if self.struct_val.field_at(index).is_some() {
-                index += 1;
-            } else {
-                return (index, Some(index));
-            }
-        }
+        let size = self.struct_val.field_len();
+        (size, Some(size))
     }
 }
 

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -32,7 +32,21 @@ impl<'a> Iterator for TupleFieldIter<'a> {
         self.index += 1;
         value
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let mut index = 0;
+
+        loop {
+            if self.tuple.field(index).is_some() {
+                index += 1;
+            } else {
+                return (index, Some(index));
+            }
+        }
+    }
 }
+
+impl<'a> ExactSizeIterator for TupleFieldIter<'a> {}
 
 pub trait GetTupleField {
     fn get_field<T: Reflect>(&self, index: usize) -> Option<&T>;

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -34,15 +34,8 @@ impl<'a> Iterator for TupleFieldIter<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let mut index = 0;
-
-        loop {
-            if self.tuple.field(index).is_some() {
-                index += 1;
-            } else {
-                return (index, Some(index));
-            }
-        }
+        let size = self.tuple.field_len();
+        (size, Some(size))
     }
 }
 

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -32,7 +32,21 @@ impl<'a> Iterator for TupleStructFieldIter<'a> {
         self.index += 1;
         value
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let mut index = 0;
+
+        loop {
+            if self.tuple_struct.field(index).is_some() {
+                index += 1;
+            } else {
+                return (index, Some(index));
+            }
+        }
+    }
 }
+
+impl<'a> ExactSizeIterator for TupleStructFieldIter<'a> {}
 
 pub trait GetTupleStructField {
     fn get_field<T: Reflect>(&self, index: usize) -> Option<&T>;

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -34,15 +34,8 @@ impl<'a> Iterator for TupleStructFieldIter<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let mut index = 0;
-
-        loop {
-            if self.tuple_struct.field(index).is_some() {
-                index += 1;
-            } else {
-                return (index, Some(index));
-            }
-        }
+        let size = self.tuple_struct.field_len();
+        (size, Some(size))
     }
 }
 

--- a/crates/bevy_render/src/renderer/render_resource/render_resource.rs
+++ b/crates/bevy_render/src/renderer/render_resource/render_resource.rs
@@ -118,7 +118,14 @@ impl<'a> Iterator for RenderResourceIterator<'a> {
             Some(render_resource)
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = self.render_resources.render_resources_len();
+        (size, Some(size))
+    }
 }
+
+impl<'a> ExactSizeIterator for RenderResourceIterator<'a> {}
 
 #[macro_export]
 macro_rules! impl_render_resource_bytes {

--- a/crates/bevy_render/src/shader/shader.rs
+++ b/crates/bevy_render/src/shader/shader.rs
@@ -228,6 +228,10 @@ impl<'a> Iterator for ShaderStagesIterator<'a> {
         self.state += 1;
         ret
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (1, Some(2))
+    }
 }
 
 impl ShaderStages {

--- a/crates/bevy_render/src/shader/shader.rs
+++ b/crates/bevy_render/src/shader/shader.rs
@@ -230,9 +230,14 @@ impl<'a> Iterator for ShaderStagesIterator<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (1, Some(2))
+        if self.shader_stages.fragment.is_some() {
+            return (2, Some(2));
+        }
+        (1, Some(1))
     }
 }
+
+impl<'a> ExactSizeIterator for ShaderStagesIterator<'a> {}
 
 impl ShaderStages {
     pub fn new(vertex_shader: Handle<Shader>) -> Self {

--- a/crates/bevy_render/src/shader/shader_defs.rs
+++ b/crates/bevy_render/src/shader/shader_defs.rs
@@ -46,7 +46,27 @@ impl<'a> Iterator for ShaderDefIterator<'a> {
             }
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let mut index = 0;
+        let mut size = 0;
+
+        loop {
+            if index == self.shader_defs.shader_defs_len() {
+                break;
+            }
+
+            if self.shader_defs.get_shader_def(index).is_some() {
+                size += 1;
+            }
+            index += 1;
+        }
+
+        (size, Some(size))
+    }
 }
+
+impl<'a> ExactSizeIterator for ShaderDefIterator<'a> {}
 
 impl ShaderDef for bool {
     fn is_defined(&self) -> bool {

--- a/crates/bevy_render/src/shader/shader_defs.rs
+++ b/crates/bevy_render/src/shader/shader_defs.rs
@@ -53,7 +53,7 @@ impl<'a> Iterator for ShaderDefIterator<'a> {
 
         loop {
             if index == self.shader_defs.shader_defs_len() {
-                break;
+                return (size, Some(size));
             }
 
             if self.shader_defs.get_shader_def(index).is_some() {
@@ -61,8 +61,6 @@ impl<'a> Iterator for ShaderDefIterator<'a> {
             }
             index += 1;
         }
-
-        (size, Some(size))
     }
 }
 

--- a/crates/bevy_render/src/shader/shader_defs.rs
+++ b/crates/bevy_render/src/shader/shader_defs.rs
@@ -48,23 +48,9 @@ impl<'a> Iterator for ShaderDefIterator<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let mut index = 0;
-        let mut size = 0;
-
-        loop {
-            if index == self.shader_defs.shader_defs_len() {
-                return (size, Some(size));
-            }
-
-            if self.shader_defs.get_shader_def(index).is_some() {
-                size += 1;
-            }
-            index += 1;
-        }
+        (0, Some(self.shader_defs.shader_defs_len()))
     }
 }
-
-impl<'a> ExactSizeIterator for ShaderDefIterator<'a> {}
 
 impl ShaderDef for bool {
     fn is_defined(&self) -> bool {


### PR DESCRIPTION
After #1697 I looked at all other Iterators from Bevy and added overrides for `size_hint` where it wasn't done.
Also implemented `ExactSizeIterator` where applicable.