### PR TITLE
Re-export winit monitor types

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -19,13 +19,15 @@ use bevy_window::{
     WindowBackendScaleFactorChanged, WindowCloseRequested, WindowCreated, WindowFocused,
     WindowMoved, WindowResized, WindowScaleFactorChanged, Windows,
 };
+
+pub use winit::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Pixel};
+pub use winit::monitor::{MonitorHandle, VideoMode};
+
 use winit::{
-    dpi::PhysicalPosition,
     event::{self, DeviceEvent, Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
 };
 
-use winit::dpi::LogicalSize;
 #[cfg(any(
     target_os = "linux",
     target_os = "dragonfly",


### PR DESCRIPTION
This simply re-exports a few `winit` convenience types so Bevy users can now acquire monitor information from the engine itself. Common uses cases would be requesting which video modes the monitor supports or determining the current native resolution.