### PR TITLE
[Merged by Bors] - update for rectangle-pack 0.2.1 (fix CI)

### DIFF
--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -163,7 +163,7 @@ impl TextureAtlasBuilder {
             target_bins.insert(0, TargetBin::new(current_width, current_height, 1));
             rect_placements = match pack_rects(
                 &self.rects_to_place,
-                target_bins,
+                &mut target_bins,
                 &volume_heuristic,
                 &contains_smallest_box,
             ) {


### PR DESCRIPTION
crate `rectangle-pack` just published version 0.2.1 with a breaking change: https://github.com/chinedufn/rectangle-pack/commit/c9ecd58f7a68f65a77ebabad36e3e3269f260c65

I also opened an issue on their repo so that they are aware of it: https://github.com/chinedufn/rectangle-pack/issues/3