### PR TITLE
add method to setup several stages with a state

### DIFF
--- a/crates/bevy_app/src/app_builder.rs
+++ b/crates/bevy_app/src/app_builder.rs
@@ -181,8 +181,8 @@ impl AppBuilder {
     /// Adds a new [State] with the given `initial` value.
     /// This inserts a new `State<T>` resource and adds a new "driver" to [CoreStage::Update].
     /// Each stage that uses `State<T>` for system run criteria needs a driver. If you need to use your state in a
-    /// different stage, consider using [Self::add_state_to_stage] or manually adding [State::get_driver] to additional stages
-    /// you need it in.
+    /// different stage, consider using [Self::add_state_to_stage], [Self::add_state_to_stages] or manually adding
+    /// [State::get_driver] to additional stages you need it in.
     pub fn add_state<T>(&mut self, initial: T) -> &mut Self
     where
         T: Component + Debug + Clone + Eq + Hash,
@@ -193,14 +193,31 @@ impl AppBuilder {
     /// Adds a new [State] with the given `initial` value.
     /// This inserts a new `State<T>` resource and adds a new "driver" to the given stage.
     /// Each stage that uses `State<T>` for system run criteria needs a driver. If you need to use your state in
-    /// more than one stage, consider manually adding [State::get_driver] to the stages
-    /// you need it in.
+    /// more than one stage, consider using [Self::add_state_to_stages] or manually adding [State::get_driver] to
+    /// the stages you need it in.
     pub fn add_state_to_stage<T>(&mut self, stage: impl StageLabel, initial: T) -> &mut Self
     where
         T: Component + Debug + Clone + Eq + Hash,
     {
-        self.insert_resource(State::new(initial))
-            .add_system_set_to_stage(stage, State::<T>::get_driver())
+        self.add_state_to_stages([stage], initial)
+    }
+
+    /// Adds a new [State] with the given `initial` value.
+    /// This inserts a new `State<T>` resource and adds a new "driver" to the given stages.
+    /// Each stage that uses `State<T>` for system run criteria needs a driver.
+    pub fn add_state_to_stages<T, const N: usize>(
+        &mut self,
+        stages: [impl StageLabel; N],
+        initial: T,
+    ) -> &mut Self
+    where
+        T: Component + Debug + Clone + Eq + Hash,
+    {
+        self.insert_resource(State::new(initial));
+        for stage in std::array::IntoIter::new(stages) {
+            self.add_system_set_to_stage(stage, State::<T>::get_driver());
+        }
+        self
     }
 
     pub fn add_default_stages(&mut self) -> &mut Self {


### PR DESCRIPTION
Related to #1746 

Add a new method to add a state (and its driver) to several stages at once

⚠️  I used new Rust features from 1.51 for a nicer api
