### PR TITLE
[Merged by Bors] - Disable frustum culling and add warning

### DIFF
--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -44,13 +44,17 @@ use sprite::sprite_system;
 
 #[derive(Debug, Clone)]
 pub struct SpriteSettings {
+    /// Enable sprite frustum culling.
+    ///
+    /// # Warning
+    /// This is currently experimental. It does not work correctly in all cases.
     pub frustum_culling_enabled: bool,
 }
 
 impl Default for SpriteSettings {
     fn default() -> Self {
         Self {
-            frustum_culling_enabled: true,
+            frustum_culling_enabled: false,
         }
     }
 }


### PR DESCRIPTION
Frustum culling has some pretty major gaps right now (such as not supporting sprite transform scaling and not taking into account projections). It should be disabled by default until it provides a solid experience across all bevy use cases.