### PR TITLE
[Merged by Bors] - fix attempt to modify emissive uniform

### DIFF
--- a/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.frag
+++ b/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.frag
@@ -326,6 +326,7 @@ void main() {
 #    endif
 
 #    ifdef STANDARDMATERIAL_EMISSIVE_TEXTURE
+    vec4 emissive = emissive;
     // TODO use .a for exposure compensation in HDR
     emissive.rgb *= texture(sampler2D(StandardMaterial_emissive_texture, StandardMaterial_emissive_texture_sampler), v_Uv).rgb;
 #    endif


### PR DESCRIPTION
Previously loading the boom box gltf file panic'd with `ERROR: 0:335: 'assign' :  l-value required "anon@7" (can't modify a uniform)`