### PR TITLE
[Question/PR] Should We Increase the Max Query Set Size?

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -183,7 +183,7 @@ fn get_lifetimes(fmt_string: fn(usize) -> String, count: usize) -> Vec<Lifetime>
 #[proc_macro]
 pub fn impl_query_set(_input: TokenStream) -> TokenStream {
     let mut tokens = TokenStream::new();
-    let max_queries = 4;
+    let max_queries = 8;
     let queries = get_idents(|i| format!("Q{}", i), max_queries);
     let filters = get_idents(|i| format!("F{}", i), max_queries);
     let lifetimes = get_lifetimes(|i| format!("'q{}", i), max_queries);


### PR DESCRIPTION
Consider this a question with PR just because it was a one character change. :slightly_smiling_face: 

I just ran into a situation where I needed all four slots in a `QuerySet` because of conflicting queries and I could easily see there being a situation where I needed more, is there any reason not to push this up to allow more queries in a `QuerySet`?

Here's the query set I have:

```rust
mut queries: QuerySet<(
        // Query needed to propagate world positions ( think bevy transform propagation, but for 2D )
        Query<'a, (Entity, &'static mut Position, &'static mut WorldPosition)>,
        // The player read query. This is needed to loop through the players for detecting collisions
        Query<
            (
                &Handle<Image>,
                &Sprite,
                &Handle<SpriteSheet>,
                &WorldPosition,
            ),
            With<Player>,
        >,
        // The radish read query. This is needed to loop through radishes that the player needs
        // to detect collisions with
        Query<(Entity, &Handle<Image>, &Sprite, &WorldPosition), Without<Player>>,
        // The radish mutation query. This is needed to modify the image of any radishes the player
        // has collided with.
        Query<(Entity, &mut Handle<Image>), Without<Player>>,
    )>
```

All of these queries will conflict with each-other due to, at least, the borrow of `WorldPosition`. While I could split these different steps into a system chain to keep the borrows from conflicting, it is much less verbose just to use a `QuerySet`, and while I didn't run out of queries this time, it just feels like it's cutting it a little close to limit to 4 queries in a set.

I'm not super sold on the need to push it up, but it seems like it might help in some situations and it's no trouble to change as far as code goes.

Here's the entire system if you need more context:

<details>

```rust
fn collision_detection(
    // We will need to read and write to the radish entities at different stages of the collision
    // detection so we create a query set to enforce that don't borrow the reading and writing
    // queries at the same time.
    mut queries: QuerySet<(
        Query<'a, (Entity, &'static mut Position, &'static mut WorldPosition)>,
        // The player read query
        Query<
            (
                &Handle<Image>,
                &Sprite,
                &Handle<SpriteSheet>,
                &WorldPosition,
            ),
            With<Player>,
        >,
        // The radish read query
        Query<(Entity, &Handle<Image>, &Sprite, &WorldPosition), Without<Player>>,
        // The radish mutation query
        Query<(Entity, &mut Handle<Image>), Without<Player>>,
    )>,
    mut scene_graph: ResMut<SceneGraph>,
    image_assets: Res<Assets<Image>>,
    sprite_sheet_assets: Res<Assets<SpriteSheet>>,
    radish_images: Res<RadishImages>,
) {
    // Make sure collision positions are synchronized
    queries.q0_mut().sync_world_positions(&mut scene_graph);

    // Create list of colliding radishes
    let mut colliding_radishes = HashSet::default();

    // Loop over the players
    for (player_image, player_sprite, player_sprite_sheet, player_pos) in queries.q1().iter() {
        // Get the collision image for the player
        let player_image = if let Some(col) = image_assets.get(player_image) {
            col
        } else {
            continue;
        };
        let player_sprite_sheet = if let Some(col) = sprite_sheet_assets.get(player_sprite_sheet) {
            col
        } else {
            continue;
        };

        for (other_radish, other_radish_image, other_radish_sprite, other_radish_pos) in
            queries.q2().iter()
        {
            // Get collision image for the other radish
            let other_radish_image = if let Some(col) = image_assets.get(other_radish_image) {
                col
            } else {
                continue;
            };

            // If they are colliding
            if pixels_collide_with(
                PixelColliderInfo {
                    image: player_image,
                    sprite: player_sprite,
                    position: player_pos,
                    sprite_sheet: Some(player_sprite_sheet),
                },
                PixelColliderInfo {
                    image: other_radish_image,
                    sprite: other_radish_sprite,
                    position: other_radish_pos,
                    sprite_sheet: None,
                },
            ) {
                // Add it to the colliding radish list
                colliding_radishes.insert(other_radish);
            }
        }
    }

    // Make all colliding radishes red and non-colliding radishes blue
    for (radish, mut image) in queries.q3_mut().iter_mut() {
        if colliding_radishes.contains(&radish) {
            *image = radish_images.collided.clone();
        } else {
            *image = radish_images.uncollided.clone();
        }
    }
}

```

</details>