### PR TITLE
[Merged by Bors] - Error message improvements for shader compilation/gltf loading

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -39,7 +39,7 @@ use crate::{Gltf, GltfNode};
 pub enum GltfError {
     #[error("unsupported primitive mode")]
     UnsupportedPrimitive { mode: Mode },
-    #[error("invalid GLTF file")]
+    #[error("invalid GLTF file: {0}")]
     Gltf(#[from] gltf::Error),
     #[error("binary blob is missing")]
     MissingBlob,
@@ -47,11 +47,11 @@ pub enum GltfError {
     Base64Decode(#[from] base64::DecodeError),
     #[error("unsupported buffer format")]
     BufferFormatUnsupported,
-    #[error("invalid image mime type")]
+    #[error("invalid image mime type: {0}")]
     InvalidImageMimeType(String),
-    #[error("failed to load an image")]
+    #[error("{0}")]
     ImageError(#[from] TextureError),
-    #[error("failed to load an asset path")]
+    #[error("failed to load an asset path: {0}")]
     AssetIoError(#[from] AssetIoError),
 }
 

--- a/crates/bevy_render/src/pipeline/pipeline_compiler.rs
+++ b/crates/bevy_render/src/pipeline/pipeline_compiler.rs
@@ -143,7 +143,7 @@ impl PipelineCompiler {
                 &specialized_descriptor.shader_stages.vertex,
                 &pipeline_specialization.shader_specialization,
             )
-            .unwrap();
+            .unwrap_or_else(|e| panic_shader_error(e));
         specialized_descriptor.shader_stages.vertex = specialized_vertex_shader.clone_weak();
         let mut specialized_fragment_shader = None;
         specialized_descriptor.shader_stages.fragment = specialized_descriptor
@@ -158,7 +158,7 @@ impl PipelineCompiler {
                         fragment,
                         &pipeline_specialization.shader_specialization,
                     )
-                    .unwrap();
+                    .unwrap_or_else(|e| panic_shader_error(e));
                 specialized_fragment_shader = Some(shader.clone_weak());
                 shader
             });
@@ -355,4 +355,11 @@ impl PipelineCompiler {
 
         Ok(())
     }
+}
+
+fn panic_shader_error(error: ShaderError) -> ! {
+    let msg = error.to_string();
+    let msg = msg.trim_end().trim_end_matches("Debug log:"); // if this matches, then there wasn't a debug log anyways
+    let msg = msg.trim_end();
+    panic!("{}\n", msg);
 }

--- a/crates/bevy_render/src/pipeline/pipeline_compiler.rs
+++ b/crates/bevy_render/src/pipeline/pipeline_compiler.rs
@@ -359,7 +359,9 @@ impl PipelineCompiler {
 
 fn panic_shader_error(error: ShaderError) -> ! {
     let msg = error.to_string();
-    let msg = msg.trim_end().trim_end_matches("Debug log:"); // if this matches, then there wasn't a debug log anyways
-    let msg = msg.trim_end();
+    let msg = msg
+        .trim_end()
+        .trim_end_matches("Debug log:") // if this matches, then there wasn't a debug log anyways
+        .trim_end();
     panic!("{}\n", msg);
 }

--- a/crates/bevy_render/src/shader/shader.rs
+++ b/crates/bevy_render/src/shader/shader.rs
@@ -24,12 +24,12 @@ pub enum ShaderStage {
 #[derive(Error, Debug)]
 pub enum ShaderError {
     /// Shader compilation error.
-    #[error("Shader compilation error: {0}")]
+    #[error("Shader compilation error:\n{0}")]
     Compilation(String),
 
     #[cfg(any(target_os = "ios", all(target_arch = "aarch64", target_os = "macos")))]
     /// shaderc error.
-    #[error("shaderc error")]
+    #[error("shaderc error: {}")]
     ShaderC(#[from] shaderc::Error),
 
     #[cfg(any(target_os = "ios", all(target_arch = "aarch64", target_os = "macos")))]

--- a/crates/bevy_render/src/texture/texture.rs
+++ b/crates/bevy_render/src/texture/texture.rs
@@ -287,7 +287,7 @@ pub enum TextureError {
     InvalidImageMimeType(String),
     #[error("invalid image extension")]
     InvalidImageExtension(String),
-    #[error("failed to load an image")]
+    #[error("failed to load an image: {0}")]
     ImageError(#[from] image::ImageError),
 }
 


### PR DESCRIPTION
- prints glsl compile error message in multiple lines instead of `thread 'main' panicked at 'called Result::unwrap() on an Err value: Compilation("glslang_shader_parse:\nInfo log:\nERROR: 0:335: \'assign\' :  l-value required \"anon@7\" (can\'t modify a uniform)\nERROR: 0:335: \'\' : compilation terminated \nERROR: 2 compilation errors.  No code generated.\n\n\nDebug log:\n\n")', crates/bevy_render/src/pipeline/pipeline_compiler.rs:161:22`
- makes gltf error messages have more context

New error:
```rust
thread 'Compute Task Pool (5)' panicked at 'Shader compilation error:
glslang_shader_parse:
Info log:
ERROR: 0:12: 'assign' :  l-value required "anon@1" (can't modify a uniform)
ERROR: 0:12: '' : compilation terminated 
ERROR: 2 compilation errors.  No code generated.
', crates/bevy_render/src/pipeline/pipeline_compiler.rs:364:5
```


These changes are a bit unrelated. I can open separate PRs if someone wants that.