### PR TITLE
[Merged by Bors] - CI break: fix syn version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,9 @@ subpixel_glyph_atlas = ["bevy_internal/subpixel_glyph_atlas"]
 bevy_dylib = {path = "crates/bevy_dylib", version = "0.4.0", default-features = false, optional = true}
 bevy_internal = {path = "crates/bevy_internal", version = "0.4.0", default-features = false}
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+syn = "=1.0.65"
+
 [dev-dependencies]
 anyhow = "1.0"
 rand = "0.8.0"


### PR DESCRIPTION
This is a temporary fix for the CI (and anyone building for wasm) break until `wgpu` can update

* `syn` released a version that fixed a bug in how they parsed attributes
* `wasm_bindgen` released a version that uses that fix
* but we're stuck with old `wasm_bindgen` as `wgpu` uses a fixed version: https://github.com/gfx-rs/wgpu-rs/blob/c5ee9cd98310aee66fb49bc98f4f65590304e4aa/Cargo.toml#L118

So, to fix this, either we update everyone to latest version of `wasm_bindgen` or we keep using old version of `syn`.

On Bevy side, it should be faster to fix the version of `syn` to one that works.

More details: https://github.com/rustwasm/wasm-bindgen/pull/2510 & https://github.com/rustwasm/wasm-bindgen/issues/2508