### PR TITLE
[Merged by Bors] - make pbr shader std140 compatible

### DIFF
--- a/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.frag
+++ b/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.frag
@@ -38,10 +38,8 @@ const int MAX_LIGHTS = 10;
 
 struct Light {
     mat4 proj;
-    vec3 pos;
-    float inverseRadiusSquared;
-    vec3 color;
-    float unused; // unused 4th element of vec4;
+    vec4 pos;
+    vec4 color;
 };
 
 layout(location = 0) in vec3 v_WorldPosition;
@@ -57,12 +55,12 @@ layout(location = 0) out vec4 o_Target;
 layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
 };
-layout(set = 0, binding = 1) uniform CameraPosition {
-    vec3 CameraPos;
+layout(std140, set = 0, binding = 1) uniform CameraPosition {
+    vec4 CameraPos;
 };
 
-layout(set = 1, binding = 0) uniform Lights {
-    vec3 AmbientColor;
+layout(std140, set = 1, binding = 0) uniform Lights {
+    vec4 AmbientColor;
     uvec4 NumLights;
     Light SceneLights[MAX_LIGHTS];
 };
@@ -350,7 +348,7 @@ void main() {
         vec3 L = normalize(lightDir);
 
         float rangeAttenuation =
-            getDistanceAttenuation(lightDir, light.inverseRadiusSquared);
+            getDistanceAttenuation(lightDir, light.pos.w);
 
         vec3 H = normalize(L + V);
         float NoL = saturate(dot(N, L));
@@ -379,7 +377,7 @@ void main() {
     vec3 specular_ambient = EnvBRDFApprox(F0, perceptual_roughness, NdotV);
 
     output_color.rgb = light_accum;
-    output_color.rgb += (diffuse_ambient + specular_ambient) * AmbientColor * occlusion;
+    output_color.rgb += (diffuse_ambient + specular_ambient) * AmbientColor.xyz * occlusion;
     output_color.rgb += emissive.rgb * output_color.a;
 
     // tone_mapping


### PR DESCRIPTION
In shaders, `vec3` should be avoided for `std140` layout, as they take the size of a `vec4` and won't support manual padding by adding an additional `float`.

This change is needed for 3D to work in WebGL2. With it, I get PBR to render
<img width="1407" alt="Screenshot 2021-04-02 at 02 57 14" src="https://user-images.githubusercontent.com/8672791/113368551-5a3c2780-935f-11eb-8c8d-e9ba65b5ee98.png">

Without it, nothing renders... @cart Could this be considered for 0.5 release?

Also, I learned shaders 2 days ago, so don't hesitate to correct any issue or misunderstanding I may have

bevy_webgl2 PR in progress for Bevy 0.5 is here if you want to test: https://github.com/rparrett/bevy_webgl2/pull/1