### PR TITLE
Asset Path Fallback to Working Directory

### DIFF
--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -30,7 +30,7 @@ impl FileAssetIo {
         if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
             PathBuf::from(manifest_dir)
         } else {
-            env::current_exe()
+            env::current_dir()
                 .map(|path| {
                     path.parent()
                         .map(|exe_parent_path| exe_parent_path.to_owned())


### PR DESCRIPTION
Changes the root path used for the asset server to the current workspace, not the exe directory. This gives significantly more flexibility when testing without changing the cargo_manifest_dir environment variable.

I'd be interested to hear pros/cons of this change from the community.