### PR TITLE
[Merged by Bors] - load zeroed UVs as fallback in gltf loader

### DIFF
--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -24,6 +24,7 @@ bevy_render = { path = "../bevy_render", version = "0.5.0" }
 bevy_transform = { path = "../bevy_transform", version = "0.5.0" }
 bevy_math = { path = "../bevy_math", version = "0.5.0" }
 bevy_scene = { path = "../bevy_scene", version = "0.5.0" }
+bevy_log = { path = "../bevy_log", version = "0.5.0" }
 
 # other
 gltf = { version = "0.15.2", default-features = false, features = ["utils", "names", "KHR_materials_unlit"] }

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -143,6 +143,7 @@ async fn load_gltf<'a, 'b>(
             } else {
                 let len = mesh.count_vertices();
                 let uvs = vec![[0.0, 0.0]; len];
+                bevy_log::warn!("missing `TEXCOORD_0` vertex attribute, loading zeroed out UVs");
                 mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
             }
 

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -140,6 +140,10 @@ async fn load_gltf<'a, 'b>(
                 .map(|v| VertexAttributeValues::Float2(v.into_f32().collect()))
             {
                 mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, vertex_attribute);
+            } else {
+                let len = mesh.count_vertices();
+                let uvs = vec![[0.0, 0.0]; len];
+                mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
             }
 
             if let Some(vertex_attribute) = reader

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -143,7 +143,7 @@ async fn load_gltf<'a, 'b>(
             } else {
                 let len = mesh.count_vertices();
                 let uvs = vec![[0.0, 0.0]; len];
-                bevy_log::warn!("missing `TEXCOORD_0` vertex attribute, loading zeroed out UVs");
+                bevy_log::debug!("missing `TEXCOORD_0` vertex attribute, loading zeroed out UVs");
                 mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
             }
 


### PR DESCRIPTION
fixes a lot of gltf loading failures (see https://github.com/bevyengine/bevy/issues/1802)