### PR TITLE
[Merged by Bors] - allow up to 16 parameters for systems

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -45,7 +45,7 @@ impl Parse for AllTuples {
 #[proc_macro]
 pub fn all_tuples(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as AllTuples);
-    let len = input.end - input.start + 1;
+    let len = (input.start..=input.end).count();
     let mut ident_tuples = Vec::with_capacity(len);
     for i in input.start..=input.end {
         let idents = input

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -259,6 +259,10 @@ pub fn impl_query_set(_input: TokenStream) -> TokenStream {
                             .extend(&#query.archetype_component_access);
                     )*
                 }
+
+                fn default_config() -> () {
+                    ()
+                }
             }
 
             impl<'a, #(#query: WorldQuery + 'static,)* #(#filter: WorldQuery + 'static,)*> SystemParamFetch<'a> for QuerySetState<(#(QueryState<#query, #filter>,)*)>
@@ -393,6 +397,10 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
 
             fn new_archetype(&mut self, archetype: &#path::archetype::Archetype, system_state: &mut #path::system::SystemState) {
                 self.state.new_archetype(archetype, system_state)
+            }
+
+            fn default_config() -> TSystemParamState::Config {
+                TSystemParamState::default_config()
             }
         }
 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -260,9 +260,7 @@ pub fn impl_query_set(_input: TokenStream) -> TokenStream {
                     )*
                 }
 
-                fn default_config() -> () {
-                    ()
-                }
+                fn default_config() {}
             }
 
             impl<'a, #(#query: WorldQuery + 'static,)* #(#filter: WorldQuery + 'static,)*> SystemParamFetch<'a> for QuerySetState<(#(QueryState<#query, #filter>,)*)>

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -45,9 +45,9 @@ impl Parse for AllTuples {
 #[proc_macro]
 pub fn all_tuples(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as AllTuples);
-    let len = input.end - input.start;
+    let len = input.end - input.start + 1;
     let mut ident_tuples = Vec::with_capacity(len);
-    for i in input.start..input.end {
+    for i in input.start..=input.end {
         let idents = input
             .idents
             .iter()
@@ -64,7 +64,7 @@ pub fn all_tuples(input: TokenStream) -> TokenStream {
     }
 
     let macro_ident = &input.macro_ident;
-    let invocations = (input.start..input.end).map(|i| {
+    let invocations = (input.start..=input.end).map(|i| {
         let ident_tuples = &ident_tuples[0..i];
         quote! {
             #macro_ident!(#(#ident_tuples),*);

--- a/crates/bevy_ecs/src/system/into_system.rs
+++ b/crates/bevy_ecs/src/system/into_system.rs
@@ -92,7 +92,7 @@ where
         FunctionSystem {
             func: self,
             param_state: None,
-            config: Some(super::Config::default()),
+            config: Some(<Param::Fetch as SystemParamState>::default_config()),
             system_state: SystemState::new::<F>(),
             marker: PhantomData,
         }

--- a/crates/bevy_ecs/src/system/into_system.rs
+++ b/crates/bevy_ecs/src/system/into_system.rs
@@ -92,7 +92,7 @@ where
         FunctionSystem {
             func: self,
             param_state: None,
-            config: Some(Default::default()),
+            config: Some(super::Config::default()),
             system_state: SystemState::new::<F>(),
             marker: PhantomData,
         }
@@ -227,4 +227,4 @@ macro_rules! impl_system_function {
     };
 }
 
-all_tuples!(impl_system_function, 0, 12, F);
+all_tuples!(impl_system_function, 0, 16, F);

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -459,9 +459,30 @@ mod tests {
             _: Query<(&E, &F)>,
         ) {
         }
-
+        fn sys_y(
+            _: (
+                Res<A>,
+                Res<B>,
+                Res<C>,
+                Res<D>,
+                Res<E>,
+                Res<F>,
+                Query<&A>,
+                Query<&B>,
+                Query<&C>,
+                Query<&D>,
+                Query<&E>,
+                Query<&F>,
+                Query<(&A, &B)>,
+                Query<(&C, &D)>,
+                Query<(&E, &F)>,
+            ),
+        ) {
+        }
         let mut world = World::default();
         let mut x = sys_x.system();
+        let mut y = sys_y.system();
         x.initialize(&mut world);
+        y.initialize(&mut world);
     }
 }

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -38,6 +38,8 @@ mod tests {
     struct B;
     struct C;
     struct D;
+    struct E;
+    struct F;
 
     #[test]
     fn simple_system() {
@@ -434,5 +436,31 @@ mod tests {
             .unwrap();
         let d_id = world.components().get_id(TypeId::of::<D>()).unwrap();
         assert_eq!(conflicts, vec![b_id, d_id]);
+    }
+
+    #[test]
+    fn can_have_16_parameters() {
+        fn sys_x(
+            _: Res<A>,
+            _: Res<B>,
+            _: Res<C>,
+            _: Res<D>,
+            _: Res<E>,
+            _: Res<F>,
+            _: Query<&A>,
+            _: Query<&B>,
+            _: Query<&C>,
+            _: Query<&D>,
+            _: Query<&E>,
+            _: Query<&F>,
+            _: Query<(&A, &B)>,
+            _: Query<(&C, &D)>,
+            _: Query<(&E, &F)>,
+        ) {
+        }
+
+        let mut world = World::default();
+        let mut x = sys_x.system();
+        x.initialize(&mut world);
     }
 }

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -439,6 +439,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::too_many_arguments)]
     fn can_have_16_parameters() {
         fn sys_x(
             _: Res<A>,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -107,9 +107,7 @@ where
             .extend(&self.archetype_component_access);
     }
 
-    fn default_config() -> () {
-        ()
-    }
+    fn default_config() {}
 }
 
 impl<'a, Q: WorldQuery + 'static, F: WorldQuery + 'static> SystemParamFetch<'a> for QueryState<Q, F>
@@ -227,9 +225,7 @@ unsafe impl<T: Component> SystemParamState for ResState<T> {
         }
     }
 
-    fn default_config() -> () {
-        ()
-    }
+    fn default_config() {}
 }
 
 impl<'a, T: Component> SystemParamFetch<'a> for ResState<T> {
@@ -272,9 +268,7 @@ unsafe impl<T: Component> SystemParamState for OptionResState<T> {
         Self(ResState::init(world, system_state, ()))
     }
 
-    fn default_config() -> () {
-        ()
-    }
+    fn default_config() {}
 }
 
 impl<'a, T: Component> SystemParamFetch<'a> for OptionResState<T> {
@@ -381,9 +375,7 @@ unsafe impl<T: Component> SystemParamState for ResMutState<T> {
         }
     }
 
-    fn default_config() -> () {
-        ()
-    }
+    fn default_config() {}
 }
 
 impl<'a, T: Component> SystemParamFetch<'a> for ResMutState<T> {
@@ -426,9 +418,7 @@ unsafe impl<T: Component> SystemParamState for OptionResMutState<T> {
         Self(ResMutState::init(world, system_state, ()))
     }
 
-    fn default_config() -> () {
-        ()
-    }
+    fn default_config() {}
 }
 
 impl<'a, T: Component> SystemParamFetch<'a> for OptionResMutState<T> {
@@ -468,9 +458,7 @@ unsafe impl SystemParamState for CommandQueue {
         self.apply(world);
     }
 
-    fn default_config() -> () {
-        ()
-    }
+    fn default_config() {}
 }
 
 impl<'a> SystemParamFetch<'a> for CommandQueue {
@@ -571,9 +559,7 @@ unsafe impl<T: Component> SystemParamState for RemovedComponentsState<T> {
         }
     }
 
-    fn default_config() -> () {
-        ()
-    }
+    fn default_config() {}
 }
 
 impl<'a, T: Component> SystemParamFetch<'a> for RemovedComponentsState<T> {
@@ -664,9 +650,7 @@ unsafe impl<T: 'static> SystemParamState for NonSendState<T> {
         }
     }
 
-    fn default_config() -> () {
-        ()
-    }
+    fn default_config() {}
 }
 
 impl<'a, T: 'static> SystemParamFetch<'a> for NonSendState<T> {
@@ -786,9 +770,7 @@ unsafe impl<T: 'static> SystemParamState for NonSendMutState<T> {
         }
     }
 
-    fn default_config() -> () {
-        ()
-    }
+    fn default_config() {}
 }
 
 impl<'a, T: 'static> SystemParamFetch<'a> for NonSendMutState<T> {
@@ -835,9 +817,7 @@ unsafe impl SystemParamState for ArchetypesState {
         Self
     }
 
-    fn default_config() -> () {
-        ()
-    }
+    fn default_config() {}
 }
 
 impl<'a> SystemParamFetch<'a> for ArchetypesState {
@@ -868,9 +848,7 @@ unsafe impl SystemParamState for ComponentsState {
         Self
     }
 
-    fn default_config() -> () {
-        ()
-    }
+    fn default_config() {}
 }
 
 impl<'a> SystemParamFetch<'a> for ComponentsState {
@@ -901,9 +879,7 @@ unsafe impl SystemParamState for EntitiesState {
         Self
     }
 
-    fn default_config() -> () {
-        ()
-    }
+    fn default_config() {}
 }
 
 impl<'a> SystemParamFetch<'a> for EntitiesState {
@@ -934,9 +910,7 @@ unsafe impl SystemParamState for BundlesState {
         Self
     }
 
-    fn default_config() -> () {
-        ()
-    }
+    fn default_config() {}
 }
 
 impl<'a> SystemParamFetch<'a> for BundlesState {
@@ -972,9 +946,7 @@ unsafe impl SystemParamState for SystemChangeTickState {
         Self {}
     }
 
-    fn default_config() -> () {
-        ()
-    }
+    fn default_config() {}
 }
 
 impl<'a> SystemParamFetch<'a> for SystemChangeTickState {


### PR DESCRIPTION
fixes #1772 

1st commit: the limit was at 11 as the macro was not using a range including the upper end. I changed that as it feels the purpose of the macro is clearer that way.

2nd commit: as suggested in the `// TODO`, I added a `Config` trait to go to 16 elements tuples. This means that if someone has a custom system parameter with a config that is not a tuple or an `Option`, they will have to implement `Config` for it instead of the standard `Default`.