### PR TITLE
Clamp `light_count` to `max_lights` and remove `&&`

### DIFF
--- a/crates/bevy_pbr/src/render_graph/lights_node.rs
+++ b/crates/bevy_pbr/src/render_graph/lights_node.rs
@@ -92,6 +92,7 @@ pub fn lights_node_system(
     let ambient_light: [f32; 4] =
         (ambient_light_resource.color * ambient_light_resource.brightness).into();
     let ambient_light_size = std::mem::size_of::<[f32; 4]>();
+    // make sure to never pass a light_count higher than max_lights to GPU
     let point_light_count = query.iter().len().min(state.max_point_lights);
     let size = std::mem::size_of::<PointLightUniform>();
     let light_count_size = ambient_light_size + std::mem::size_of::<LightCount>();

--- a/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.frag
+++ b/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.frag
@@ -343,7 +343,8 @@ void main() {
 
     // accumulate color
     vec3 light_accum = vec3(0.0);
-    for (int i = 0; i < int(NumLights.x) && i < MAX_LIGHTS; ++i) {
+    // No need to check against MAX_LIGHTS as NumLights will not exceed it
+    for (int i = 0; i < int(NumLights.x); ++i) {
         PointLight light = PointLights[i];
         vec3 light_to_frag = light.pos.xyz - v_WorldPosition.xyz;
         float distance_square = dot(light_to_frag, light_to_frag);


### PR DESCRIPTION
This clamps the light_count passed to shaders to max_lights, so shaders don't have to check against MAX_LIGHTS. This allows removing the `&&` that causes #1812.

Fixes: #1812 