### PR TITLE
[Merged by Bors] - Added example of entity sorting by components

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -447,7 +447,7 @@ impl World {
     ///
     /// To iterate over entities in a deterministic order,
     /// sort the results of the query using the desired component as a key.
-    /// Note that it requires fetching the whole result set from the query
+    /// Note that this requires fetching the whole result set from the query
     /// and allocation of a [Vec] to store it.
     ///
     /// ```

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -447,6 +447,8 @@ impl World {
     ///
     /// To iterate over entities in a deterministic order,
     /// sort the results of the query using the desired component as a key.
+    /// Note that it requires fetching the whole result set from the query
+    /// and allocation of a [Vec] to store it.
     ///
     /// ```
     /// use bevy_ecs::{entity::Entity, world::World};

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -449,7 +449,7 @@ impl World {
     /// sort the results of the query using the desired component as a key.
     ///
     /// ```
-    /// use bevy_ecs{entity::Entity, world::World};
+    /// use bevy_ecs::{entity::Entity, world::World};
     /// let mut world = World::new();
     /// let a = world.spawn().insert_bundle((2, "abc")).id();
     /// let b = world.spawn().insert_bundle((3, "xyz")).id();

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -444,6 +444,25 @@ impl World {
     /// assert_eq!(world.get::<Position>(entities[0]).unwrap(), &Position { x: 1.0, y: 0.0 });
     /// assert_eq!(world.get::<Position>(entities[1]).unwrap(), &Position { x: 0.0, y: 1.0 });
     /// ```
+    ///
+    /// To iterate over entities in a deterministic order sort results using the required component as a key.
+    ///
+    /// ```
+    /// use bevy_ecs::world::World;
+    /// let mut world = World::new();
+    /// let a = world.spawn((2, "abc"));
+    /// let b = world.spawn((3, "xyz"));
+    /// let c = world.spawn((1, "def"));
+    /// let mut entities = world.query::<(Entity, &i32, &str)>()
+    ///     .map(|(e, &i &s)| (e, i, &s)) // Copy out of the world
+    ///     .collect::<Vec<_>>();
+    /// // Sort by `i32` component
+    /// entities.sort_by(|x, y| x.1.cmp(&y.1));
+    /// assert_eq!(entities.len(), 3);
+    /// assert!(entities[0] == (c, 1, "def"));
+    /// assert!(entities[1] == (a, 2, "abc"));
+    /// assert!(entities[2] == (b, 3, "xyz"));
+    /// ```
     #[inline]
     pub fn query<Q: WorldQuery>(&mut self) -> QueryState<Q, ()> {
         QueryState::new(self)

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -449,11 +449,11 @@ impl World {
     /// sort the results of the query using the desired component as a key.
     ///
     /// ```
-    /// use bevy_ecs::world::World;
+    /// use bevy_ecs{entity::Entity, world::World};
     /// let mut world = World::new();
-    /// let a = world.spawn((2, "abc"));
-    /// let b = world.spawn((3, "xyz"));
-    /// let c = world.spawn((1, "def"));
+    /// let a = world.spawn().insert_bundle((2, "abc")).id();
+    /// let b = world.spawn().insert_bundle((3, "xyz")).id();
+    /// let c = world.spawn().insert_bundle((1, "def")).id();
     /// let mut entities = world.query::<(Entity, &i32, &str)>()
     ///     .map(|(e, &i &s)| (e, i, &s)) // Copy out of the world
     ///     .collect::<Vec<_>>();

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -456,19 +456,13 @@ impl World {
     /// let a = world.spawn().insert_bundle((2, 4.0)).id();
     /// let b = world.spawn().insert_bundle((3, 5.0)).id();
     /// let c = world.spawn().insert_bundle((1, 6.0)).id();
-    /// let mut entities = world.query::<(Entity, &i32, &f32)>()
+    /// let mut entities = world.query::<(Entity, &i32, &f64)>()
     ///     .iter(&world)
     ///     .collect::<Vec<_>>();
-    /// // Sort by `i32` component
-    /// entities.sort_by(|x, y| x.1.cmp(&y.1));
-    /// for (index, entity) in entities.iter().enumerate() {
-    ///     match index {
-    ///         0 => assert_eq!(entity, &(c, &1, &6.0)),
-    ///         1 => assert_eq!(entity, &(a, &2, &4.0)),
-    ///         2 => assert_eq!(entity, &(b, &3, &5.0)),
-    ///         _ => panic!("not expected"),
-    ///     }
-    /// }
+    /// // Sort the query results by their `i32` component before comparing
+    /// // to expected results. Query iteration order should not be relied on.
+    /// entities.sort_by_key(|e| e.1);
+    /// assert_eq!(entities, vec![(c, &1, &6.0), (a, &2, &4.0), (b, &3, &5.0)]);
     /// ```
     #[inline]
     pub fn query<Q: WorldQuery>(&mut self) -> QueryState<Q, ()> {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -445,7 +445,8 @@ impl World {
     /// assert_eq!(world.get::<Position>(entities[1]).unwrap(), &Position { x: 0.0, y: 1.0 });
     /// ```
     ///
-    /// To iterate over entities in a deterministic order sort results using the required component as a key.
+    /// To iterate over entities in a deterministic order,
+    /// sort the results of the query using the desired component as a key.
     ///
     /// ```
     /// use bevy_ecs::world::World;

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -459,10 +459,13 @@ impl World {
     ///     .collect::<Vec<_>>();
     /// // Sort by `i32` component
     /// entities.sort_by(|x, y| x.1.cmp(&y.1));
-    /// assert_eq!(entities.len(), 3);
-    /// assert!(entities[0] == (c, 1, "def"));
-    /// assert!(entities[1] == (a, 2, "abc"));
-    /// assert!(entities[2] == (b, 3, "xyz"));
+    /// for (index, entity) in entities.iter().enumerate() {
+    ///     match index {
+    ///         0 => assert!(entity == (c, 1, "def")),
+    ///         1 => assert!(entity == (a, 2, "abc")),
+    ///         2 => assert!(entity == (b, 3, "xyz")),
+    ///     }
+    /// }
     /// ```
     #[inline]
     pub fn query<Q: WorldQuery>(&mut self) -> QueryState<Q, ()> {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -451,19 +451,20 @@ impl World {
     /// ```
     /// use bevy_ecs::{entity::Entity, world::World};
     /// let mut world = World::new();
-    /// let a = world.spawn().insert_bundle((2, "abc")).id();
-    /// let b = world.spawn().insert_bundle((3, "xyz")).id();
-    /// let c = world.spawn().insert_bundle((1, "def")).id();
-    /// let mut entities = world.query::<(Entity, &i32, &str)>()
-    ///     .map(|(e, &i &s)| (e, i, &s)) // Copy out of the world
+    /// let a = world.spawn().insert_bundle((2, 4.0)).id();
+    /// let b = world.spawn().insert_bundle((3, 5.0)).id();
+    /// let c = world.spawn().insert_bundle((1, 6.0)).id();
+    /// let mut entities = world.query::<(Entity, &i32, &f32)>()
+    ///     .iter(&world)
     ///     .collect::<Vec<_>>();
     /// // Sort by `i32` component
     /// entities.sort_by(|x, y| x.1.cmp(&y.1));
     /// for (index, entity) in entities.iter().enumerate() {
     ///     match index {
-    ///         0 => assert!(entity == (c, 1, "def")),
-    ///         1 => assert!(entity == (a, 2, "abc")),
-    ///         2 => assert!(entity == (b, 3, "xyz")),
+    ///         0 => assert_eq!(entity, &(c, &1, &6.0)),
+    ///         1 => assert_eq!(entity, &(a, &2, &4.0)),
+    ///         2 => assert_eq!(entity, &(b, &3, &5.0)),
+    ///         _ => panic!("not expected"),
     ///     }
     /// }
     /// ```


### PR DESCRIPTION
We discussed with @alice-i-cecile privately on iterators and agreed that making a custom ordered iterator over query makes no sense since materialization is required anyway and it's better to reuse existing components or code. Therefore, just adding an example to the documentation as requested.

Fixes #1470.