### PR TITLE
[Merged by Bors] - change how to select bevy-glsl-to-spirv or shaderc

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -44,10 +44,10 @@ parking_lot = "0.11.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 spirv-reflect = "0.2.3"
 
-[target.'cfg(any(all(target_arch="x86_64", target_os="linux", target_env="gnu"), all(target_arch="x86_64", target_os="macos"), all(target_arch="aarch64", target_os="android"), all(target_arch="armv7", target_os="androidabi"), all(target_arch="x86_64", target_os="windows", target_env="msvc"), all(target_arch="x86", target_os="windows", target_env="msvc"), all(target_arch="x86_64", target_os="windows", target_env="gnu"), all(target_arch="x86", target_os="windows", target_env="gnu")))'.dependencies]
+[target.'cfg(any(all(target_arch="x86_64", target_os="linux", target_env="gnu"), all(target_arch="x86_64", target_os="macos"), all(target_arch="aarch64", target_os="android"), all(target_arch="armv7", target_os="androidabi"), all(target_arch="x86_64", target_os="windows", target_env="msvc")))'.dependencies]
 bevy-glsl-to-spirv = "0.2.0"
 
-[target.'cfg(not(any(target_arch = "wasm32", all(target_arch="x86_64", target_os="linux", target_env="gnu"), all(target_arch="x86_64", target_os="macos"), all(target_arch="aarch64", target_os="android"), all(target_arch="armv7", target_os="androidabi"), all(target_arch="x86_64", target_os="windows", target_env="msvc"), all(target_arch="x86", target_os="windows", target_env="msvc"), all(target_arch="x86_64", target_os="windows", target_env="gnu"), all(target_arch="x86", target_os="windows", target_env="gnu"))))'.dependencies]
+[target.'cfg(not(any(target_arch = "wasm32", all(target_arch="x86_64", target_os="linux", target_env="gnu"), all(target_arch="x86_64", target_os="macos"), all(target_arch="aarch64", target_os="android"), all(target_arch="armv7", target_os="androidabi"), all(target_arch="x86_64", target_os="windows", target_env="msvc"))))'.dependencies]
 shaderc = "0.7.0"
 
 [features]

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -44,10 +44,10 @@ parking_lot = "0.11.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 spirv-reflect = "0.2.3"
 
-[target.'cfg(all(not(target_os = "ios"), not(target_arch = "wasm32"), not(all(target_arch = "aarch64", target_os = "macos"))))'.dependencies]
+[target.'cfg(any(all(target_arch="x86_64", target_os="linux", target_env="gnu"), all(target_arch="x86_64", target_os="macos"), all(target_arch="aarch64", target_os="android"), all(target_arch="armv7", target_os="android"), all(target_arch="x86_64", target_os="windows", target_env="msvc"), all(target_arch="x86", target_os="windows", target_env="msvc"), all(target_arch="x86_64", target_os="windows", target_env="gnu"), all(target_arch="x86", target_os="windows", target_env="gnu")))'.dependencies]
 bevy-glsl-to-spirv = "0.2.0"
 
-[target.'cfg(any(target_os = "ios", all(target_arch = "aarch64", target_os = "macos")))'.dependencies]
+[target.'cfg(not(any(target_arch = "wasm32", all(target_arch="x86_64", target_os="linux", target_env="gnu"), all(target_arch="x86_64", target_os="macos"), all(target_arch="aarch64", target_os="android"), all(target_arch="armv7", target_os="android"), all(target_arch="x86_64", target_os="windows", target_env="msvc"), all(target_arch="x86", target_os="windows", target_env="msvc"), all(target_arch="x86_64", target_os="windows", target_env="gnu"), all(target_arch="x86", target_os="windows", target_env="gnu"))))'.dependencies]
 shaderc = "0.7.0"
 
 [features]

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -44,10 +44,10 @@ parking_lot = "0.11.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 spirv-reflect = "0.2.3"
 
-[target.'cfg(any(all(target_arch="x86_64", target_os="linux", target_env="gnu"), all(target_arch="x86_64", target_os="macos"), all(target_arch="aarch64", target_os="android"), all(target_arch="armv7", target_os="android"), all(target_arch="x86_64", target_os="windows", target_env="msvc"), all(target_arch="x86", target_os="windows", target_env="msvc"), all(target_arch="x86_64", target_os="windows", target_env="gnu"), all(target_arch="x86", target_os="windows", target_env="gnu")))'.dependencies]
+[target.'cfg(any(all(target_arch="x86_64", target_os="linux", target_env="gnu"), all(target_arch="x86_64", target_os="macos"), all(target_arch="aarch64", target_os="android"), all(target_arch="armv7", target_os="androidabi"), all(target_arch="x86_64", target_os="windows", target_env="msvc"), all(target_arch="x86", target_os="windows", target_env="msvc"), all(target_arch="x86_64", target_os="windows", target_env="gnu"), all(target_arch="x86", target_os="windows", target_env="gnu")))'.dependencies]
 bevy-glsl-to-spirv = "0.2.0"
 
-[target.'cfg(not(any(target_arch = "wasm32", all(target_arch="x86_64", target_os="linux", target_env="gnu"), all(target_arch="x86_64", target_os="macos"), all(target_arch="aarch64", target_os="android"), all(target_arch="armv7", target_os="android"), all(target_arch="x86_64", target_os="windows", target_env="msvc"), all(target_arch="x86", target_os="windows", target_env="msvc"), all(target_arch="x86_64", target_os="windows", target_env="gnu"), all(target_arch="x86", target_os="windows", target_env="gnu"))))'.dependencies]
+[target.'cfg(not(any(target_arch = "wasm32", all(target_arch="x86_64", target_os="linux", target_env="gnu"), all(target_arch="x86_64", target_os="macos"), all(target_arch="aarch64", target_os="android"), all(target_arch="armv7", target_os="androidabi"), all(target_arch="x86_64", target_os="windows", target_env="msvc"), all(target_arch="x86", target_os="windows", target_env="msvc"), all(target_arch="x86_64", target_os="windows", target_env="gnu"), all(target_arch="x86", target_os="windows", target_env="gnu"))))'.dependencies]
 shaderc = "0.7.0"
 
 [features]

--- a/crates/bevy_render/src/shader/shader.rs
+++ b/crates/bevy_render/src/shader/shader.rs
@@ -32,7 +32,7 @@ pub enum ShaderError {
         all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
         all(target_arch = "x86_64", target_os = "macos"),
         all(target_arch = "aarch64", target_os = "android"),
-        all(target_arch = "armv7", target_os = "android"),
+        all(target_arch = "armv7", target_os = "androidabi"),
         all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
     )))]
     /// shaderc error.
@@ -44,7 +44,7 @@ pub enum ShaderError {
         all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
         all(target_arch = "x86_64", target_os = "macos"),
         all(target_arch = "aarch64", target_os = "android"),
-        all(target_arch = "armv7", target_os = "android"),
+        all(target_arch = "armv7", target_os = "androidabi"),
         all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
     )))]
     #[error("Error initializing shaderc Compiler")]
@@ -55,7 +55,7 @@ pub enum ShaderError {
         all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
         all(target_arch = "x86_64", target_os = "macos"),
         all(target_arch = "aarch64", target_os = "android"),
-        all(target_arch = "armv7", target_os = "android"),
+        all(target_arch = "armv7", target_os = "androidabi"),
         all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
     )))]
     #[error("Error initializing shaderc CompileOptions")]
@@ -66,7 +66,7 @@ pub enum ShaderError {
     all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
     all(target_arch = "x86_64", target_os = "macos"),
     all(target_arch = "aarch64", target_os = "android"),
-    all(target_arch = "armv7", target_os = "android"),
+    all(target_arch = "armv7", target_os = "androidabi"),
     all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
 ))]
 impl From<ShaderStage> for bevy_glsl_to_spirv::ShaderType {
@@ -83,7 +83,7 @@ impl From<ShaderStage> for bevy_glsl_to_spirv::ShaderType {
     all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
     all(target_arch = "x86_64", target_os = "macos"),
     all(target_arch = "aarch64", target_os = "android"),
-    all(target_arch = "armv7", target_os = "android"),
+    all(target_arch = "armv7", target_os = "androidabi"),
     all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
 ))]
 pub fn glsl_to_spirv(
@@ -100,7 +100,7 @@ pub fn glsl_to_spirv(
     all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
     all(target_arch = "x86_64", target_os = "macos"),
     all(target_arch = "aarch64", target_os = "android"),
-    all(target_arch = "armv7", target_os = "android"),
+    all(target_arch = "armv7", target_os = "androidabi"),
     all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
 )))]
 impl Into<shaderc::ShaderKind> for ShaderStage {
@@ -118,7 +118,7 @@ impl Into<shaderc::ShaderKind> for ShaderStage {
     all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
     all(target_arch = "x86_64", target_os = "macos"),
     all(target_arch = "aarch64", target_os = "android"),
-    all(target_arch = "armv7", target_os = "android"),
+    all(target_arch = "armv7", target_os = "androidabi"),
     all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
 )))]
 pub fn glsl_to_spirv(

--- a/crates/bevy_render/src/shader/shader.rs
+++ b/crates/bevy_render/src/shader/shader.rs
@@ -27,24 +27,59 @@ pub enum ShaderError {
     #[error("Shader compilation error:\n{0}")]
     Compilation(String),
 
-    #[cfg(any(target_os = "ios", all(target_arch = "aarch64", target_os = "macos")))]
+    #[cfg(not(any(
+        target_arch = "wasm32",
+        all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
+        all(target_arch = "x86_64", target_os = "macos"),
+        all(target_arch = "aarch64", target_os = "android"),
+        all(target_arch = "armv7", target_os = "android"),
+        all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
+        all(target_arch = "x86", target_os = "windows", target_env = "msvc"),
+        all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"),
+        all(target_arch = "x86", target_os = "windows", target_env = "gnu")
+    )))]
     /// shaderc error.
     #[error("shaderc error: {0}")]
     ShaderC(#[from] shaderc::Error),
 
-    #[cfg(any(target_os = "ios", all(target_arch = "aarch64", target_os = "macos")))]
+    #[cfg(not(any(
+        target_arch = "wasm32",
+        all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
+        all(target_arch = "x86_64", target_os = "macos"),
+        all(target_arch = "aarch64", target_os = "android"),
+        all(target_arch = "armv7", target_os = "android"),
+        all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
+        all(target_arch = "x86", target_os = "windows", target_env = "msvc"),
+        all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"),
+        all(target_arch = "x86", target_os = "windows", target_env = "gnu")
+    )))]
     #[error("Error initializing shaderc Compiler")]
     ErrorInitializingShadercCompiler,
 
-    #[cfg(any(target_os = "ios", all(target_arch = "aarch64", target_os = "macos")))]
+    #[cfg(not(any(
+        target_arch = "wasm32",
+        all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
+        all(target_arch = "x86_64", target_os = "macos"),
+        all(target_arch = "aarch64", target_os = "android"),
+        all(target_arch = "armv7", target_os = "android"),
+        all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
+        all(target_arch = "x86", target_os = "windows", target_env = "msvc"),
+        all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"),
+        all(target_arch = "x86", target_os = "windows", target_env = "gnu")
+    )))]
     #[error("Error initializing shaderc CompileOptions")]
     ErrorInitializingShadercCompileOptions,
 }
 
-#[cfg(all(
-    not(target_os = "ios"),
-    not(target_arch = "wasm32"),
-    not(all(target_arch = "aarch64", target_os = "macos"))
+#[cfg(any(
+    all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
+    all(target_arch = "x86_64", target_os = "macos"),
+    all(target_arch = "aarch64", target_os = "android"),
+    all(target_arch = "armv7", target_os = "android"),
+    all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
+    all(target_arch = "x86", target_os = "windows", target_env = "msvc"),
+    all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"),
+    all(target_arch = "x86", target_os = "windows", target_env = "gnu")
 ))]
 impl From<ShaderStage> for bevy_glsl_to_spirv::ShaderType {
     fn from(s: ShaderStage) -> bevy_glsl_to_spirv::ShaderType {
@@ -56,10 +91,15 @@ impl From<ShaderStage> for bevy_glsl_to_spirv::ShaderType {
     }
 }
 
-#[cfg(all(
-    not(target_os = "ios"),
-    not(target_arch = "wasm32"),
-    not(all(target_arch = "aarch64", target_os = "macos"))
+#[cfg(any(
+    all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
+    all(target_arch = "x86_64", target_os = "macos"),
+    all(target_arch = "aarch64", target_os = "android"),
+    all(target_arch = "armv7", target_os = "android"),
+    all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
+    all(target_arch = "x86", target_os = "windows", target_env = "msvc"),
+    all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"),
+    all(target_arch = "x86", target_os = "windows", target_env = "gnu")
 ))]
 pub fn glsl_to_spirv(
     glsl_source: &str,
@@ -70,7 +110,17 @@ pub fn glsl_to_spirv(
         .map_err(ShaderError::Compilation)
 }
 
-#[cfg(any(target_os = "ios", all(target_arch = "aarch64", target_os = "macos")))]
+#[cfg(not(any(
+    target_arch = "wasm32",
+    all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
+    all(target_arch = "x86_64", target_os = "macos"),
+    all(target_arch = "aarch64", target_os = "android"),
+    all(target_arch = "armv7", target_os = "android"),
+    all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
+    all(target_arch = "x86", target_os = "windows", target_env = "msvc"),
+    all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"),
+    all(target_arch = "x86", target_os = "windows", target_env = "gnu")
+)))]
 impl Into<shaderc::ShaderKind> for ShaderStage {
     fn into(self) -> shaderc::ShaderKind {
         match self {
@@ -81,7 +131,17 @@ impl Into<shaderc::ShaderKind> for ShaderStage {
     }
 }
 
-#[cfg(any(target_os = "ios", all(target_arch = "aarch64", target_os = "macos")))]
+#[cfg(not(any(
+    target_arch = "wasm32",
+    all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
+    all(target_arch = "x86_64", target_os = "macos"),
+    all(target_arch = "aarch64", target_os = "android"),
+    all(target_arch = "armv7", target_os = "android"),
+    all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
+    all(target_arch = "x86", target_os = "windows", target_env = "msvc"),
+    all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"),
+    all(target_arch = "x86", target_os = "windows", target_env = "gnu")
+)))]
 pub fn glsl_to_spirv(
     glsl_source: &str,
     stage: ShaderStage,

--- a/crates/bevy_render/src/shader/shader.rs
+++ b/crates/bevy_render/src/shader/shader.rs
@@ -34,9 +34,6 @@ pub enum ShaderError {
         all(target_arch = "aarch64", target_os = "android"),
         all(target_arch = "armv7", target_os = "android"),
         all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
-        all(target_arch = "x86", target_os = "windows", target_env = "msvc"),
-        all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"),
-        all(target_arch = "x86", target_os = "windows", target_env = "gnu")
     )))]
     /// shaderc error.
     #[error("shaderc error: {0}")]
@@ -49,9 +46,6 @@ pub enum ShaderError {
         all(target_arch = "aarch64", target_os = "android"),
         all(target_arch = "armv7", target_os = "android"),
         all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
-        all(target_arch = "x86", target_os = "windows", target_env = "msvc"),
-        all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"),
-        all(target_arch = "x86", target_os = "windows", target_env = "gnu")
     )))]
     #[error("Error initializing shaderc Compiler")]
     ErrorInitializingShadercCompiler,
@@ -63,9 +57,6 @@ pub enum ShaderError {
         all(target_arch = "aarch64", target_os = "android"),
         all(target_arch = "armv7", target_os = "android"),
         all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
-        all(target_arch = "x86", target_os = "windows", target_env = "msvc"),
-        all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"),
-        all(target_arch = "x86", target_os = "windows", target_env = "gnu")
     )))]
     #[error("Error initializing shaderc CompileOptions")]
     ErrorInitializingShadercCompileOptions,
@@ -77,9 +68,6 @@ pub enum ShaderError {
     all(target_arch = "aarch64", target_os = "android"),
     all(target_arch = "armv7", target_os = "android"),
     all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
-    all(target_arch = "x86", target_os = "windows", target_env = "msvc"),
-    all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"),
-    all(target_arch = "x86", target_os = "windows", target_env = "gnu")
 ))]
 impl From<ShaderStage> for bevy_glsl_to_spirv::ShaderType {
     fn from(s: ShaderStage) -> bevy_glsl_to_spirv::ShaderType {
@@ -97,9 +85,6 @@ impl From<ShaderStage> for bevy_glsl_to_spirv::ShaderType {
     all(target_arch = "aarch64", target_os = "android"),
     all(target_arch = "armv7", target_os = "android"),
     all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
-    all(target_arch = "x86", target_os = "windows", target_env = "msvc"),
-    all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"),
-    all(target_arch = "x86", target_os = "windows", target_env = "gnu")
 ))]
 pub fn glsl_to_spirv(
     glsl_source: &str,
@@ -117,9 +102,6 @@ pub fn glsl_to_spirv(
     all(target_arch = "aarch64", target_os = "android"),
     all(target_arch = "armv7", target_os = "android"),
     all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
-    all(target_arch = "x86", target_os = "windows", target_env = "msvc"),
-    all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"),
-    all(target_arch = "x86", target_os = "windows", target_env = "gnu")
 )))]
 impl Into<shaderc::ShaderKind> for ShaderStage {
     fn into(self) -> shaderc::ShaderKind {
@@ -138,9 +120,6 @@ impl Into<shaderc::ShaderKind> for ShaderStage {
     all(target_arch = "aarch64", target_os = "android"),
     all(target_arch = "armv7", target_os = "android"),
     all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"),
-    all(target_arch = "x86", target_os = "windows", target_env = "msvc"),
-    all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"),
-    all(target_arch = "x86", target_os = "windows", target_env = "gnu")
 )))]
 pub fn glsl_to_spirv(
     glsl_source: &str,


### PR DESCRIPTION
`cfg` for `bevy-glsl-to-spirv` use now mimics https://github.com/cart/glsl-to-spirv/blob/master/Cargo.toml

fixes #898 
fixes #1348 
fixes #1942 
fixes #1078 