### PR TITLE
[Merged by Bors] - Moved events to ECS

### DIFF
--- a/crates/bevy_app/src/app_builder.rs
+++ b/crates/bevy_app/src/app_builder.rs
@@ -1,11 +1,11 @@
 use crate::{
     app::{App, AppExit},
-    event::Events,
     plugin::Plugin,
     CoreStage, PluginGroup, PluginGroupBuilder, StartupStage,
 };
 use bevy_ecs::{
     component::{Component, ComponentDescriptor},
+    event::Events,
     schedule::{
         RunOnce, Schedule, Stage, StageLabel, State, SystemDescriptor, SystemSet, SystemStage,
     },

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -14,9 +14,8 @@ pub use schedule_runner::*;
 
 pub mod prelude {
     pub use crate::{
-        app::App,
-        app_builder::AppBuilder,
-        CoreStage, DynamicPlugin, Plugin, PluginGroup, StartupStage,
+        app::App, app_builder::AppBuilder, CoreStage, DynamicPlugin, Plugin, PluginGroup,
+        StartupStage,
     };
 }
 

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -1,6 +1,5 @@
 mod app;
 mod app_builder;
-mod event;
 mod plugin;
 mod plugin_group;
 mod schedule_runner;
@@ -8,7 +7,7 @@ mod schedule_runner;
 pub use app::*;
 pub use app_builder::*;
 pub use bevy_derive::DynamicPlugin;
-pub use event::*;
+pub use bevy_ecs::event::*;
 pub use plugin::*;
 pub use plugin_group::*;
 pub use schedule_runner::*;
@@ -17,7 +16,6 @@ pub mod prelude {
     pub use crate::{
         app::App,
         app_builder::AppBuilder,
-        event::{EventReader, EventWriter},
         CoreStage, DynamicPlugin, Plugin, PluginGroup, StartupStage,
     };
 }

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -1,5 +1,6 @@
 use super::{App, AppBuilder};
-use crate::{app::AppExit, event::Events, plugin::Plugin, ManualEventReader};
+use crate::{app::AppExit, plugin::Plugin, ManualEventReader};
+use bevy_ecs::event::Events;
 use bevy_utils::{Duration, Instant};
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/bevy_ecs/macros/Cargo.toml
+++ b/crates/bevy_ecs/macros/Cargo.toml
@@ -16,4 +16,4 @@ proc-macro = true
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"
-find-crate = "0.6"
+cargo-manifest = "0.2.3"

--- a/crates/bevy_ecs/macros/Cargo.toml
+++ b/crates/bevy_ecs/macros/Cargo.toml
@@ -16,4 +16,4 @@ proc-macro = true
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"
-cargo-manifest = "0.2.3"
+find-crate = "0.6"

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -1,9 +1,10 @@
 extern crate proc_macro;
 
-use find_crate::{Dependencies, Manifest};
+use cargo_manifest::{DepsSet, Manifest};
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
+use std::{env, path::PathBuf};
 use syn::{
     parse::{Parse, ParseStream},
     parse_macro_input,
@@ -465,24 +466,45 @@ fn derive_label(input: DeriveInput, label_type: Ident) -> TokenStream2 {
 }
 
 fn bevy_ecs_path() -> syn::Path {
-    fn find_in_manifest(manifest: &mut Manifest, dependencies: Dependencies) -> Option<String> {
-        manifest.dependencies = dependencies;
-        if let Some(package) = manifest.find(|name| name == "bevy") {
-            Some(format!("{}::ecs", package.name))
-        } else if let Some(package) = manifest.find(|name| name == "bevy_internal") {
-            Some(format!("{}::ecs", package.name))
-        } else if let Some(package) = manifest.find(|name| name == "bevy_ecs") {
-            Some(package.name)
+    const BEVY: &str = "bevy";
+    const BEVY_ECS: &str = "bevy_ecs";
+    const BEVY_INTERNAL: &str = "bevy_internal";
+
+    fn find_in_deps(deps: DepsSet) -> Option<String> {
+        if let Some(dep) = deps.get(BEVY) {
+            Some(format!("{}::ecs", dep.package().unwrap_or(BEVY)))
+        } else if let Some(dep) = deps.get(BEVY_INTERNAL) {
+            Some(format!("{}::ecs", dep.package().unwrap_or(BEVY_INTERNAL)))
+        } else if let Some(dep) = deps.get(BEVY_ECS) {
+            Some(dep.package().unwrap_or(BEVY_ECS).to_string())
         } else {
             None
         }
     }
 
-    let mut manifest = Manifest::new().unwrap();
-    let path_str = find_in_manifest(&mut manifest, Dependencies::Release)
-        .or_else(|| find_in_manifest(&mut manifest, Dependencies::Dev))
-        .unwrap_or_else(|| "bevy_ecs".to_string());
+    let manifest = env::var_os("CARGO_MANIFEST_DIR")
+        .map(PathBuf::from)
+        .map(
+        |mut path| {
+            path.push("Cargo.toml");
+            Manifest::from_path(path).unwrap()
+        })
+        .unwrap();
+    let deps = manifest.dependencies;
+    let deps_dev = manifest.dev_dependencies;
+    let path_stream = manifest.package
+        .and_then(|p|
+            if p.name == BEVY_ECS {
+                Some("crate".to_string())
+            } else {
+                None
+            })
+        .or_else(|| deps.and_then(find_in_deps))
+        .or_else(|| deps_dev.and_then(find_in_deps))
+        .unwrap_or_else(|| BEVY_ECS.to_string())
+        .parse::<TokenStream>()
+        .unwrap();
 
-    let path: Path = syn::parse(path_str.parse::<TokenStream>().unwrap()).unwrap();
+    let path: Path = syn::parse(path_stream).unwrap();
     path
 }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -484,21 +484,22 @@ fn bevy_ecs_path() -> syn::Path {
 
     let manifest = env::var_os("CARGO_MANIFEST_DIR")
         .map(PathBuf::from)
-        .map(
-        |mut path| {
+        .map(|mut path| {
             path.push("Cargo.toml");
             Manifest::from_path(path).unwrap()
         })
         .unwrap();
     let deps = manifest.dependencies;
     let deps_dev = manifest.dev_dependencies;
-    let path_stream = manifest.package
-        .and_then(|p|
+    let path_stream = manifest
+        .package
+        .and_then(|p| {
             if p.name == BEVY_ECS {
                 Some("crate".to_string())
             } else {
                 None
-            })
+            }
+        })
         .or_else(|| deps.and_then(find_in_deps))
         .or_else(|| deps_dev.and_then(find_in_deps))
         .unwrap_or_else(|| BEVY_ECS.to_string())

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -77,7 +77,7 @@ enum State {
 ///
 /// # Example
 /// ```
-/// use bevy_app::Events;
+/// use bevy_ecs::Events;
 ///
 /// struct MyEvent {
 ///     value: usize

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -1,4 +1,4 @@
-use bevy_ecs::{
+use crate::{
     component::Component,
     system::{Local, Res, ResMut, SystemParam},
 };

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -77,7 +77,7 @@ enum State {
 ///
 /// # Example
 /// ```
-/// use bevy_ecs::Events;
+/// use bevy_ecs::event::Events;
 ///
 /// struct MyEvent {
 ///     value: usize

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -1,3 +1,4 @@
+use crate as bevy_ecs;
 use crate::{
     component::Component,
     system::{Local, Res, ResMut, SystemParam},

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2,6 +2,7 @@ pub mod archetype;
 pub mod bundle;
 pub mod component;
 pub mod entity;
+pub mod event;
 pub mod query;
 #[cfg(feature = "bevy_reflect")]
 pub mod reflect;
@@ -16,6 +17,7 @@ pub mod prelude {
     pub use crate::{
         bundle::Bundle,
         entity::Entity,
+        event::{EventReader, EventWriter},
         query::{Added, ChangeTrackers, Changed, Or, QueryState, With, WithBundle, Without},
         schedule::{
             AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -1,5 +1,5 @@
 use crate::{ElementState, Input};
-use bevy_ecs::{system::ResMut, event::EventReader};
+use bevy_ecs::{event::EventReader, system::ResMut};
 use bevy_math::Vec2;
 
 /// A mouse button input event

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -1,6 +1,5 @@
 use crate::{ElementState, Input};
-use bevy_app::prelude::EventReader;
-use bevy_ecs::system::ResMut;
+use bevy_ecs::{system::ResMut, event::EventReader};
 use bevy_math::Vec2;
 
 /// A mouse button input event

--- a/crates/bevy_input/src/system.rs
+++ b/crates/bevy_input/src/system.rs
@@ -2,10 +2,8 @@ use crate::{
     keyboard::{KeyCode, KeyboardInput},
     ElementState,
 };
-use bevy_app::{
-    prelude::{EventReader, EventWriter},
-    AppExit,
-};
+use bevy_app::AppExit;
+use bevy_ecs::prelude::{EventReader, EventWriter};
 
 /// Sends the AppExit event whenever the "esc" key is pressed.
 pub fn exit_on_esc_system(

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -1,8 +1,8 @@
 use super::CameraProjection;
-use bevy_app::prelude::EventReader;
 use bevy_ecs::{
     component::Component,
     entity::Entity,
+    event::EventReader,
     query::Added,
     reflect::ReflectComponent,
     system::{Query, QuerySet, Res},

--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -2,11 +2,11 @@ use crate::{
     pipeline::{IndexFormat, PrimitiveTopology, RenderPipelines, VertexFormat},
     renderer::{BufferInfo, BufferUsage, RenderResourceContext, RenderResourceId},
 };
-use bevy_app::prelude::EventReader;
 use bevy_asset::{AssetEvent, Assets, Handle};
 use bevy_core::AsBytes;
 use bevy_ecs::{
     entity::Entity,
+    event::EventReader,
     query::{Changed, With},
     system::{Local, Query, QuerySet, Res},
     world::Mut,

--- a/crates/bevy_render/src/texture/texture.rs
+++ b/crates/bevy_render/src/texture/texture.rs
@@ -5,9 +5,8 @@ use super::{
 use crate::renderer::{
     RenderResource, RenderResourceContext, RenderResourceId, RenderResourceType,
 };
-use bevy_app::prelude::EventReader;
 use bevy_asset::{AssetEvent, Assets, Handle};
-use bevy_ecs::system::Res;
+use bevy_ecs::{event::EventReader, system::Res};
 use bevy_reflect::TypeUuid;
 use bevy_utils::HashSet;
 use thiserror::Error;


### PR DESCRIPTION
Fixes #1809. It makes it also possible to use `derive` for `SystemParam` inside ECS and avoid manual implementation. An alternative solution to macro changes is to use `use crate as bevy_ecs;` in `event.rs`.