### PR TITLE
[Merged by Bors] - run some examples on CI using swiftshader

### DIFF
--- a/.github/example-run/alien_cake_addict.ron
+++ b/.github/example-run/alien_cake_addict.ron
@@ -1,0 +1,3 @@
+(
+    exit_after: Some(300)
+)

--- a/.github/example-run/breakout.ron
+++ b/.github/example-run/breakout.ron
@@ -1,0 +1,3 @@
+(
+    exit_after: Some(1800)
+)

--- a/.github/example-run/contributors.ron
+++ b/.github/example-run/contributors.ron
@@ -1,0 +1,3 @@
+(
+    exit_after: Some(1800)
+)

--- a/.github/example-run/load_gltf.ron
+++ b/.github/example-run/load_gltf.ron
@@ -1,0 +1,3 @@
+(
+    exit_after: Some(300)
+)

--- a/.github/example-run/scene.ron
+++ b/.github/example-run/scene.ron
@@ -1,0 +1,3 @@
+(
+    exit_after: Some(1800)
+)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,7 @@ jobs:
         run: |
           sudo apt-get update;
           DEBIAN_FRONTEND=noninteractive sudo apt-get install --no-install-recommends -yq \
-            jq \
-            libasound2-dev \
-            libudev-dev \
-            wget \
-            unzip \
-            xvfb;
+            libasound2-dev libudev-dev wget unzip xvfb;
 
       - uses: actions/checkout@v2
 
@@ -123,13 +118,13 @@ jobs:
 
       - name: Build bevy
         run: |
-          cargo build --no-default-features --features "bevy_dynamic_plugin,bevy_gilrs,bevy_gltf,bevy_wgpu,bevy_winit,render,png,hdr,x11,bevy_debug"
+          cargo build --no-default-features --features "bevy_dynamic_plugin,bevy_gilrs,bevy_gltf,bevy_wgpu,bevy_winit,render,png,hdr,x11,bevy_ci_testing"
 
       - name: Run examples
         run: |
           for example in .github/example-run/*.ron; do
             example_name=`basename $example .ron`
             echo "running $example_name - "`date`
-            time DEBUG_CONFIG=$example VK_ICD_FILENAMES=$(pwd)/vk_swiftshader_icd.json DRI_PRIME=0 xvfb-run cargo run --example $example_name --no-default-features --features "bevy_dynamic_plugin,bevy_gilrs,bevy_gltf,bevy_wgpu,bevy_winit,render,png,hdr,x11,bevy_debug"
+            time DEBUG_CONFIG=$example VK_ICD_FILENAMES=$(pwd)/vk_swiftshader_icd.json DRI_PRIME=0 xvfb-run cargo run --example $example_name --no-default-features --features "bevy_dynamic_plugin,bevy_gilrs,bevy_gltf,bevy_wgpu,bevy_winit,render,png,hdr,x11,bevy_ci_testing"
             sleep 10
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,6 @@ jobs:
           for example in .github/example-run/*.ron; do
             example_name=`basename $example .ron`
             echo "running $example_name - "`date`
-            time DEBUG_CONFIG=$example VK_ICD_FILENAMES=$(pwd)/vk_swiftshader_icd.json DRI_PRIME=0 xvfb-run cargo run --example $example_name --no-default-features --features "bevy_dynamic_plugin,bevy_gilrs,bevy_gltf,bevy_wgpu,bevy_winit,render,png,hdr,x11,bevy_ci_testing"
+            time CI_TESTING_CONFIG=$example VK_ICD_FILENAMES=$(pwd)/vk_swiftshader_icd.json DRI_PRIME=0 xvfb-run cargo run --example $example_name --no-default-features --features "bevy_dynamic_plugin,bevy_gilrs,bevy_gltf,bevy_wgpu,bevy_winit,render,png,hdr,x11,bevy_ci_testing"
             sleep 10
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    # branches: [main, staging, trying]
+    branches: [main, staging, trying]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main, staging, trying]
+    # branches: [main, staging, trying]
 
 env:
   CARGO_TERM_COLOR: always
@@ -92,3 +92,44 @@ jobs:
           DEFAULT_BRANCH: master
           # Not needed here as only one Linter is used.
           #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  run-examples:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update;
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install --no-install-recommends -yq \
+            jq \
+            libasound2-dev \
+            libudev-dev \
+            wget \
+            unzip \
+            xvfb;
+
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Setup swiftshader
+        run: |
+          wget https://github.com/qarmin/gtk_library_store/releases/download/3.24.0/swiftshader.zip;
+          unzip swiftshader.zip;
+          curr="$(pwd)/libvk_swiftshader.so";
+          sed -i "s|PATH_TO_CHANGE|$curr|" vk_swiftshader_icd.json;
+
+      - name: Build bevy
+        run: |
+          cargo build --no-default-features --features "bevy_dynamic_plugin,bevy_gilrs,bevy_gltf,bevy_wgpu,bevy_winit,render,png,hdr,x11,bevy_debug"
+
+      - name: Run examples
+        run: |
+          for example in .github/example-run/*.ron; do
+            example_name=`basename $example .ron`
+            echo "running $example_name - "`date`
+            time DEBUG_CONFIG=$example VK_ICD_FILENAMES=$(pwd)/vk_swiftshader_icd.json DRI_PRIME=0 xvfb-run cargo run --example $example_name --no-default-features --features "bevy_dynamic_plugin,bevy_gilrs,bevy_gltf,bevy_wgpu,bevy_winit,render,png,hdr,x11,bevy_debug"
+            sleep 10
+          done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,8 @@ x11 = ["bevy_internal/x11"]
 # enable rendering of font glyphs using subpixel accuracy
 subpixel_glyph_atlas = ["bevy_internal/subpixel_glyph_atlas"]
 
-# enable debug systems, for Bevy development
-bevy_debug = ["bevy_internal/bevy_debug"]
+# enable systems that allow for automated testing on CI
+bevy_ci_testing = ["bevy_internal/bevy_ci_testing"]
 
 [dependencies]
 bevy_dylib = {path = "crates/bevy_dylib", version = "0.5.0", default-features = false, optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ x11 = ["bevy_internal/x11"]
 # enable rendering of font glyphs using subpixel accuracy
 subpixel_glyph_atlas = ["bevy_internal/subpixel_glyph_atlas"]
 
+# enable debug systems, for Bevy development
+bevy_debug = ["bevy_internal/bevy_debug"]
+
 [dependencies]
 bevy_dylib = {path = "crates/bevy_dylib", version = "0.5.0", default-features = false, optional = true}
 bevy_internal = {path = "crates/bevy_internal", version = "0.5.0", default-features = false}

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["bevy"]
 
 [features]
 trace = []
-bevy_debug = ["ron"]
+bevy_ci_testing = ["ron"]
 default = ["bevy_reflect"]
 
 [dependencies]

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["bevy"]
 
 [features]
 trace = []
+bevy_debug = ["ron"]
 default = ["bevy_reflect"]
 
 [dependencies]
@@ -25,6 +26,8 @@ bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 
 # other
 serde = { version = "1.0", features = ["derive"] }
+ron = { version = "0.6.2", optional = true }
+
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/crates/bevy_app/src/app_builder.rs
+++ b/crates/bevy_app/src/app_builder.rs
@@ -15,17 +15,6 @@ use bevy_ecs::{
 use bevy_utils::tracing::debug;
 use std::{fmt::Debug, hash::Hash};
 
-#[cfg(feature = "bevy_debug")]
-use serde::Deserialize;
-
-#[cfg(feature = "bevy_debug")]
-/// Debug configuration, to help with Bevy development
-#[derive(Deserialize)]
-pub struct DebugConfig {
-    /// Number of frames after wich Bevy should exit
-    pub exit_after: Option<u32>,
-}
-
 /// Configure [App]s using the builder pattern
 pub struct AppBuilder {
     pub app: App,
@@ -45,17 +34,9 @@ impl Default for AppBuilder {
             .add_event::<AppExit>()
             .add_system_to_stage(CoreStage::Last, World::clear_trackers.exclusive_system());
 
-        #[cfg(feature = "bevy_debug")]
+        #[cfg(feature = "bevy_ci_testing")]
         {
-            let filename =
-                std::env::var("DEBUG_CONFIG").unwrap_or_else(|_| "debug_config.ron".to_string());
-            let config: DebugConfig = ron::from_str(
-                &std::fs::read_to_string(filename).expect("error reading debug configuration file"),
-            )
-            .expect("error deserializing debug configuration file");
-            app_builder
-                .insert_resource(config)
-                .add_system(debug_exit_after.system());
+            crate::ci_testing::setup_app(&mut app_builder);
         }
         app_builder
     }
@@ -354,18 +335,4 @@ impl AppBuilder {
         }
         self
     }
-}
-
-#[cfg(feature = "bevy_debug")]
-fn debug_exit_after(
-    mut current_frame: bevy_ecs::prelude::Local<u32>,
-    debug_config: bevy_ecs::prelude::Res<DebugConfig>,
-    mut app_exit_events: crate::EventWriter<AppExit>,
-) {
-    if let Some(exit_after) = debug_config.exit_after {
-        if *current_frame > exit_after {
-            app_exit_events.send(AppExit);
-        }
-    }
-    *current_frame += 1;
 }

--- a/crates/bevy_app/src/ci_testing.rs
+++ b/crates/bevy_app/src/ci_testing.rs
@@ -10,7 +10,7 @@ pub struct CiTestingConfig {
     pub exit_after: Option<u32>,
 }
 
-fn debug_exit_after(
+fn ci_testing_exit_after(
     mut current_frame: bevy_ecs::prelude::Local<u32>,
     debug_config: bevy_ecs::prelude::Res<CiTestingConfig>,
     mut app_exit_events: crate::EventWriter<AppExit>,
@@ -32,7 +32,7 @@ pub(crate) fn setup_app(app_builder: &mut AppBuilder) -> &mut AppBuilder {
     .expect("error deserializing CI testing configuration file");
     app_builder
         .insert_resource(config)
-        .add_system(debug_exit_after.system());
+        .add_system(ci_testing_exit_after.system());
 
     app_builder
 }

--- a/crates/bevy_app/src/ci_testing.rs
+++ b/crates/bevy_app/src/ci_testing.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use crate::{app::AppExit, AppBuilder};
 use bevy_ecs::system::IntoSystem;
 
-/// Debug configuration, to help with Bevy development
+/// Configuration for automated testing on CI
 #[derive(Deserialize)]
 pub struct CiTestingConfig {
     /// Number of frames after wich Bevy should exit

--- a/crates/bevy_app/src/ci_testing.rs
+++ b/crates/bevy_app/src/ci_testing.rs
@@ -12,10 +12,10 @@ pub struct CiTestingConfig {
 
 fn ci_testing_exit_after(
     mut current_frame: bevy_ecs::prelude::Local<u32>,
-    debug_config: bevy_ecs::prelude::Res<CiTestingConfig>,
+    ci_testing_config: bevy_ecs::prelude::Res<CiTestingConfig>,
     mut app_exit_events: crate::EventWriter<AppExit>,
 ) {
-    if let Some(exit_after) = debug_config.exit_after {
+    if let Some(exit_after) = ci_testing_config.exit_after {
         if *current_frame > exit_after {
             app_exit_events.send(AppExit);
         }
@@ -25,7 +25,7 @@ fn ci_testing_exit_after(
 
 pub(crate) fn setup_app(app_builder: &mut AppBuilder) -> &mut AppBuilder {
     let filename =
-        std::env::var("DEBUG_CONFIG").unwrap_or_else(|_| "ci_testing_config.ron".to_string());
+        std::env::var("CI_TESTING_CONFIG").unwrap_or_else(|_| "ci_testing_config.ron".to_string());
     let config: CiTestingConfig = ron::from_str(
         &std::fs::read_to_string(filename).expect("error reading CI testing configuration file"),
     )

--- a/crates/bevy_app/src/ci_testing.rs
+++ b/crates/bevy_app/src/ci_testing.rs
@@ -5,14 +5,14 @@ use bevy_ecs::system::IntoSystem;
 
 /// Debug configuration, to help with Bevy development
 #[derive(Deserialize)]
-pub struct DebugConfig {
+pub struct CiTestingConfig {
     /// Number of frames after wich Bevy should exit
     pub exit_after: Option<u32>,
 }
 
 fn debug_exit_after(
     mut current_frame: bevy_ecs::prelude::Local<u32>,
-    debug_config: bevy_ecs::prelude::Res<DebugConfig>,
+    debug_config: bevy_ecs::prelude::Res<CiTestingConfig>,
     mut app_exit_events: crate::EventWriter<AppExit>,
 ) {
     if let Some(exit_after) = debug_config.exit_after {
@@ -26,7 +26,7 @@ fn debug_exit_after(
 pub(crate) fn setup_app(app_builder: &mut AppBuilder) -> &mut AppBuilder {
     let filename =
         std::env::var("DEBUG_CONFIG").unwrap_or_else(|_| "ci_testing_config.ron".to_string());
-    let config: DebugConfig = ron::from_str(
+    let config: CiTestingConfig = ron::from_str(
         &std::fs::read_to_string(filename).expect("error reading CI testing configuration file"),
     )
     .expect("error deserializing CI testing configuration file");

--- a/crates/bevy_app/src/ci_testing.rs
+++ b/crates/bevy_app/src/ci_testing.rs
@@ -1,0 +1,38 @@
+use serde::Deserialize;
+
+use crate::{app::AppExit, AppBuilder};
+use bevy_ecs::system::IntoSystem;
+
+/// Debug configuration, to help with Bevy development
+#[derive(Deserialize)]
+pub struct DebugConfig {
+    /// Number of frames after wich Bevy should exit
+    pub exit_after: Option<u32>,
+}
+
+fn debug_exit_after(
+    mut current_frame: bevy_ecs::prelude::Local<u32>,
+    debug_config: bevy_ecs::prelude::Res<DebugConfig>,
+    mut app_exit_events: crate::EventWriter<AppExit>,
+) {
+    if let Some(exit_after) = debug_config.exit_after {
+        if *current_frame > exit_after {
+            app_exit_events.send(AppExit);
+        }
+    }
+    *current_frame += 1;
+}
+
+pub(crate) fn setup_app(app_builder: &mut AppBuilder) -> &mut AppBuilder {
+    let filename =
+        std::env::var("DEBUG_CONFIG").unwrap_or_else(|_| "ci_testing_config.ron".to_string());
+    let config: DebugConfig = ron::from_str(
+        &std::fs::read_to_string(filename).expect("error reading CI testing configuration file"),
+    )
+    .expect("error deserializing CI testing configuration file");
+    app_builder
+        .insert_resource(config)
+        .add_system(debug_exit_after.system());
+
+    app_builder
+}

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -4,6 +4,9 @@ mod plugin;
 mod plugin_group;
 mod schedule_runner;
 
+#[cfg(feature = "bevy_ci_testing")]
+mod ci_testing;
+
 pub use app::*;
 pub use app_builder::*;
 pub use bevy_derive::DynamicPlugin;

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -41,8 +41,8 @@ x11 = ["bevy_winit/x11"]
 # enable rendering of font glyphs using subpixel accuracy
 subpixel_glyph_atlas = ["bevy_text/subpixel_glyph_atlas"]
 
-# enable debug systems, for Bevy development
-bevy_debug = ["bevy_app/bevy_debug"]
+# enable systems that allow for automated testing on CI
+bevy_ci_testing = ["bevy_app/bevy_ci_testing"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -41,6 +41,9 @@ x11 = ["bevy_winit/x11"]
 # enable rendering of font glyphs using subpixel accuracy
 subpixel_glyph_atlas = ["bevy_text/subpixel_glyph_atlas"]
 
+# enable debug systems, for Bevy development
+bevy_debug = ["bevy_app/bevy_debug"]
+
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.5.0" }


### PR DESCRIPTION
From suggestion from Godot workflows: https://github.com/bevyengine/bevy/issues/1730#issuecomment-810321110

* Add a feature `bevy_debug` that will make Bevy read a debug config file to setup some debug systems
  * Currently, only one that will exit after x frames
  * Could add option to dump screen to image file once that's possible
* Add a job in CI workflow that will run a few examples using [`swiftshader`](https://github.com/google/swiftshader)
  * This job takes around 13 minutes, so doesn't add to global CI duration

|example|number of frames|duration|
|-|-|-|
|`alien_cake_addict`|300|1:50|
|`breakout`|1800|0:44|
|`contributors`|1800|0:43|
|`load_gltf`|300|2:37|
|`scene`|1800|0:44|