### PR TITLE
[Merged by Bors] - gltf-loader: support data url for images

### DIFF
--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -30,3 +30,4 @@ gltf = { version = "0.15.2", default-features = false, features = ["utils", "nam
 thiserror = "1.0"
 anyhow = "1.0"
 base64 = "0.13.0"
+percent-encoding = "2.1"

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -669,10 +669,16 @@ struct DataUri<'a> {
     data: &'a str,
 }
 
+fn split_once(input: &str, delimiter: char) -> Option<(&str, &str)> {
+    let mut iter = input.splitn(2, delimiter);
+    Some((iter.next()?, iter.next()?))
+}
+
 impl<'a> DataUri<'a> {
     fn parse(uri: &'a str) -> Result<DataUri<'a>, ()> {
         let uri = uri.strip_prefix("data:").ok_or(())?;
-        let (mime_type, data) = uri.split_once(',').ok_or(())?;
+        let (mime_type, data) = split_once(uri, ',').ok_or(())?;
+
         let (mime_type, base64) = match mime_type.strip_suffix(";base64") {
             Some(mime_type) => (mime_type, true),
             None => (mime_type, false),

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -222,6 +222,10 @@ async fn load_gltf<'a, 'b>(
                 Texture::from_buffer(buffer, ImageType::MimeType(mime_type))?
             }
             gltf::image::Source::Uri { uri, mime_type } => {
+                let uri = percent_encoding::percent_decode_str(uri)
+                    .decode_utf8()
+                    .unwrap();
+                let uri = uri.as_ref();
                 let (bytes, image_type) = match DataUri::parse(uri) {
                     Ok(data_uri) => (data_uri.decode()?, ImageType::MimeType(data_uri.mime_type)),
                     Err(()) => {
@@ -584,6 +588,10 @@ async fn load_buffers(
     for buffer in gltf.buffers() {
         match buffer.source() {
             gltf::buffer::Source::Uri(uri) => {
+                let uri = percent_encoding::percent_decode_str(uri)
+                    .decode_utf8()
+                    .unwrap();
+                let uri = uri.as_ref();
                 let buffer_bytes = match DataUri::parse(uri) {
                     Ok(data_uri) if data_uri.mime_type == OCTET_STREAM_URI => data_uri.decode()?,
                     Ok(_) => return Err(GltfError::BufferFormatUnsupported),


### PR DESCRIPTION
This allows the `glTF-Embedded` variants in the [sample models](https://github.com/KhronosGroup/glTF-Sample-Models/) to be used.
The data url format is relatively small, so I didn't include a crate like [docs.rs/data-url](https://docs.rs/data-url/0.1.0/data_url/).

Also fixes the 'Box With Spaces' model as URIs are now percent-decoded.

cc #1802 