### PR TITLE
[Merged by Bors] - Update old docs mentioning Camera2dBundle

### DIFF
--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -20,7 +20,7 @@ use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
 
 use crate::{DefaultTextPipeline, DrawableText, Font, FontAtlasSet, Text, Text2dSize, TextError};
 
-/// The bundle of components needed to draw text in a 2D scene via the Camera2dBundle.
+/// The bundle of components needed to draw text in a 2D scene via a 2D `OrthographicCameraBundle`.
 #[derive(Bundle, Clone, Debug)]
 pub struct Text2dBundle {
     pub draw: Draw,
@@ -53,7 +53,7 @@ impl Default for Text2dBundle {
     }
 }
 
-/// System for drawing text in a 2D scene via the Camera2dBundle.  Included in the default
+/// System for drawing text in a 2D scene via a 2D `OrthographicCameraBundle`. Included in the default
 /// `TextPlugin`. Position is determined by the `Transform`'s translation, though scale and rotation
 /// are ignored.
 pub fn draw_text2d_system(


### PR DESCRIPTION
This replaces some outdated mentions of the `Camera2dBundle` that is removed now with 0.5.