### PR TITLE
[Merged by Bors] - Removed frame rate updates from fixed step example

### DIFF
--- a/examples/ecs/fixed_timestep.rs
+++ b/examples/ecs/fixed_timestep.rs
@@ -11,8 +11,6 @@ struct FixedUpdateStage;
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        // this system will run once every update (it should match your screen's refresh rate)
-        .add_system(update.system())
         // add a new stage that runs every two seconds
         .add_stage_after(
             CoreStage::Update,
@@ -27,11 +25,6 @@ fn main() {
                 .with_system(fixed_update.system()),
         )
         .run();
-}
-
-fn update(mut last_time: Local<f64>, time: Res<Time>) {
-    println!("update: {}", time.seconds_since_startup() - *last_time);
-    *last_time = time.seconds_since_startup();
 }
 
 fn fixed_update(mut last_time: Local<f64>, time: Res<Time>, fixed_timesteps: Res<FixedTimesteps>) {

--- a/examples/ecs/fixed_timestep.rs
+++ b/examples/ecs/fixed_timestep.rs
@@ -11,13 +11,15 @@ struct FixedUpdateStage;
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
+        // this system will run once every update (it should match your screen's refresh rate)
+        .add_system(frame_update.system())
         // add a new stage that runs every two seconds
         .add_stage_after(
             CoreStage::Update,
             FixedUpdateStage,
             SystemStage::parallel()
                 .with_run_criteria(
-                    FixedTimestep::step(2.0)
+                    FixedTimestep::step(0.5)
                         // labels are optional. they provide a way to access the current
                         // FixedTimestep state from within a system
                         .with_label(LABEL),
@@ -25,6 +27,11 @@ fn main() {
                 .with_system(fixed_update.system()),
         )
         .run();
+}
+
+fn frame_update(mut last_time: Local<f64>, time: Res<Time>) {
+    println!("update: {}", time.seconds_since_startup() - *last_time);
+    *last_time = time.seconds_since_startup();
 }
 
 fn fixed_update(mut last_time: Local<f64>, time: Res<Time>, fixed_timesteps: Res<FixedTimesteps>) {


### PR DESCRIPTION
Fixes #1751.

Output before:

```
...
update: 0.016478100000000495
update: 0.01955749999999945
fixed_update: 2.0052284
  overstep_percentage: 0.00946374999999966
update: 0.013902800000000326
update: 0.02283240000000042
...
```

Output after:

```
...
fixed_update: 2.0053731
  overstep_percentage: 0.0031439500000001175
fixed_update: 1.9976363
  overstep_percentage: 0.0019621000000002997
fixed_update: 2.0069121999999995
  overstep_percentage: 0.005418200000000262
...
```