### PR TITLE
API for handling AssetServer errors

### DIFF
--- a/crates/bevy_asset/src/info.rs
+++ b/crates/bevy_asset/src/info.rs
@@ -1,7 +1,7 @@
-use crate::{path::AssetPath, LabelId};
+use crate::{path::AssetPath, AssetServerError, LabelId};
 use bevy_utils::{HashMap, HashSet, Uuid};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SourceMeta {
@@ -39,10 +39,11 @@ impl SourceInfo {
 }
 
 /// The load state of an asset
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug)]
 pub enum LoadState {
     NotLoaded,
     Loading,
     Loaded,
-    Failed,
+    Failed(Arc<AssetServerError>),
+    Removing,
 }


### PR DESCRIPTION
The `AssetServer` only communicates asset loading errors via a `warn!()`. 
This introduces a `AssetServerErrorEvent` which users can optionally retrieve using `EventReader`s.

However there are some considerations to take into account:
1) The current implementation only allows for 1 error to per stores per `HandleId`. E.g. if a user calls `asset_server.load("path.ext");` multiple times, should we store an error per call to `load` or simply per `HandleId`?
2) If an assets successfully loads after having already failed once, the error does not get removed from the internal `errors` map. Should the error be removed, or should it still be reported?