### PR TITLE
Add flag on the State to allow for a full search of the stack if wanted

### DIFF
--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -152,11 +152,6 @@ where
             .run_full_search
         {
             StateFullSearchState::Started | StateFullSearchState::InProgress => {
-                eprintln!(
-                    "Running full search for on_in_stack_update on {}",
-                    std::any::type_name::<T>()
-                );
-
                 let is_in_stack_search = state.stack.contains(pred.as_ref().unwrap());
                 *is_in_stack = is_in_stack_search;
 

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -117,13 +117,7 @@ where
             .run_full_search
         {
             StateFullSearchState::Started | StateFullSearchState::InProgress => {
-                // TODO: Replace with `state.inactives()` when PR #1668 is merged
-                let is_inactive_search = state
-                    .stack
-                    .split_last()
-                    .map(|(_, rest)| rest)
-                    .unwrap()
-                    .contains(pred.as_ref().unwrap());
+                let is_inactive_search = state.inactives().contains(pred.as_ref().unwrap());
                 *is_inactive = is_inactive_search;
 
                 is_inactive_search


### PR DESCRIPTION
Based on discussions in Discord @
https://discordapp.com/channels/691052431525675048/742884593551802431/829733048002150461 and https://discordapp.com/channels/691052431525675048/749335865876021248/829738449333649489.

This PR adds a flag on the State resource, which when flipped by calling its new `run_full_search()` method, makes the `on_in_stack_update` and `on_inactive_update` run criteria do a full search of the state stack for their predicate rather than relying on the cached state from when the state transitioned. This allows for relying on said run criteria even in `Stage`s where the transition didn't take place. (Or in my case, using those run criteria with the `State` in an entirely different `Schedule` than the one in `App`.)