### PR TITLE
[Merged by Bors] - Make some asset loading functions monomorphic

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -217,12 +217,11 @@ impl AssetServer {
     }
 
     // TODO: properly set failed LoadState in all failure cases
-    async fn load_async<'a, P: Into<AssetPath<'a>>>(
+    async fn load_async(
         &self,
-        path: P,
+        asset_path: AssetPath<'_>,
         force: bool,
     ) -> Result<AssetPathId, AssetServerError> {
-        let asset_path: AssetPath = path.into();
         let asset_loader = self.get_path_asset_loader(asset_path.path())?;
         let asset_path_id: AssetPathId = asset_path.get_id();
 
@@ -326,16 +325,11 @@ impl AssetServer {
     }
 
     pub fn load_untyped<'a, P: Into<AssetPath<'a>>>(&self, path: P) -> HandleUntyped {
-        let handle_id = self.load_untracked(path, false);
+        let handle_id = self.load_untracked(path.into(), false);
         self.get_handle_untyped(handle_id)
     }
 
-    pub(crate) fn load_untracked<'a, P: Into<AssetPath<'a>>>(
-        &self,
-        path: P,
-        force: bool,
-    ) -> HandleId {
-        let asset_path: AssetPath<'a> = path.into();
+    pub(crate) fn load_untracked(&self, asset_path: AssetPath<'_>, force: bool) -> HandleId {
         let server = self.clone();
         let owned_path = asset_path.to_owned();
         self.server

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -133,7 +133,7 @@ pub fn filesystem_watcher_system(asset_server: Res<AssetServer>) {
                 for path in paths.iter() {
                     if !changed.contains(path) {
                         let relative_path = path.strip_prefix(&asset_io.root_path).unwrap();
-                        let _ = asset_server.load_untracked(relative_path, true);
+                        let _ = asset_server.load_untracked(relative_path.into(), true);
                     }
                 }
                 changed.extend(paths);


### PR DESCRIPTION
This reduces the size of executables when using bevy as dylib by
ensuring that they get codegened in bevy_assets instead of the game
itself. This by extension avoids pulling in parts of bevy_tasks and
async_task.

Before this change the breakout example was 923k big after this change
it is only 775k big for cg_clif. For cg_llvm in release mode breakout
shrinks from 356k to 316k. For cg_llvm in debug mode breakout shrinks
from 3814k to 3057k.


