### PR TITLE
[Merged by Bors] - Implement Byteable and RenderResource for [T; N]

### DIFF
--- a/crates/bevy_core/src/bytes.rs
+++ b/crates/bevy_core/src/bytes.rs
@@ -83,10 +83,8 @@ where
     T: Byteable,
 {
 }
-unsafe impl<T> Byteable for [T; 2] where T: Byteable {}
-unsafe impl<T> Byteable for [T; 3] where T: Byteable {}
-unsafe impl<T> Byteable for [T; 4] where T: Byteable {}
-unsafe impl<T> Byteable for [T; 16] where T: Byteable {}
+
+unsafe impl<T, const N: usize> Byteable for [T; N] where T: Byteable {}
 
 unsafe impl Byteable for u8 {}
 unsafe impl Byteable for u16 {}
@@ -232,5 +230,11 @@ mod tests {
     #[test]
     fn test_mat4_round_trip() {
         test_round_trip(Mat4::IDENTITY);
+    }
+
+    #[test]
+    fn test_array_round_trip() {
+        test_round_trip([-10i32; 200]);
+        test_round_trip([Vec2::ZERO, Vec2::ONE, Vec2::Y, Vec2::X]);
     }
 }

--- a/crates/bevy_render/src/renderer/render_resource/render_resource.rs
+++ b/crates/bevy_render/src/renderer/render_resource/render_resource.rs
@@ -180,6 +180,27 @@ where
     }
 }
 
+impl<T, const N: usize> RenderResource for [T; N]
+where
+    T: Sized + Byteable,
+{
+    fn resource_type(&self) -> Option<RenderResourceType> {
+        Some(RenderResourceType::Buffer)
+    }
+
+    fn write_buffer_bytes(&self, buffer: &mut [u8]) {
+        self.write_bytes(buffer);
+    }
+
+    fn buffer_byte_len(&self) -> Option<usize> {
+        Some(self.byte_len())
+    }
+
+    fn texture(&self) -> Option<&Handle<Texture>> {
+        None
+    }
+}
+
 impl RenderResource for GlobalTransform {
     fn resource_type(&self) -> Option<RenderResourceType> {
         Some(RenderResourceType::Buffer)


### PR DESCRIPTION
Implements `Byteable` and `RenderResource` for any array containing `Byteable` elements. This allows `RenderResources` to be implemented on structs with arbitrarily-sized arrays, among other things:

```rust
#[derive(RenderResources, TypeUuid)]
#[uuid = "2733ff34-8f95-459f-bf04-3274e686ac5f"]
struct Foo {
    buffer: [i32; 256],
}
```
