### PR TITLE
[Merged by Bors] - Add g++ to the Ubuntu dependencies

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -7,17 +7,13 @@ If you don't see your distro present in the list, feel free to add the instructi
 ## Ubuntu 20.04
 
 ```bash
-sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev
+sudo apt-get install g++ pkg-config libx11-dev libasound2-dev libudev-dev
 ```
 
 Depending on your graphics card, you may have to install one of the following:
 `vulkan-radeon`, `vulkan-intel`, or `mesa-vulkan-drivers`
 
-If you want to enable fast compiles
-
-```bash
-sudo apt-get install clang
-```
+Compiling with clang is also possible - replace the `g++` package with `clang`.
 
 ### Windows Subsystem for Linux (WSL 2)
 


### PR DESCRIPTION
The g++ package may not be preinstalled.

Also, replaced the mention of "fast" compiles, with generic instructions about how to install clang; this is because on my test system, clang didn't make any difference, and it's likely not to do any in general, as it is a relatively small part of the build.

Closes #1294.