### PR TITLE
[Merged by Bors] - Fix the left/right movement direction in state example.

### DIFF
--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -119,10 +119,10 @@ fn movement(
     for mut transform in query.iter_mut() {
         let mut direction = Vec3::ZERO;
         if input.pressed(KeyCode::Left) {
-            direction.x += 1.0;
+            direction.x -= 1.0;
         }
         if input.pressed(KeyCode::Right) {
-            direction.x -= 1.0;
+            direction.x += 1.0;
         }
         if input.pressed(KeyCode::Up) {
             direction.y += 1.0;


### PR DESCRIPTION
Direction of movement was reversed, previously.

(i.e. Left arrow key moved sprite to the right; Right arrow key moved sprite to the left.)

This PR changes the code to now be consistent with, for example, the breakout example: https://github.com/bevyengine/bevy/blob/81b53d15d4e038261182b8d7c8f65f9a3641fd2d/examples/game/breakout.rs#L184-L190

i.e. AFAICT it's not an issue with the keycode being different/wrong.