### PR TITLE
[Merged by Bors] - Fix pbr shader compiliation error, `#version` has to be in the first line

### DIFF
--- a/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.frag
+++ b/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.frag
@@ -1,3 +1,5 @@
+#version 450
+
 // From the Filament design doc
 // https://google.github.io/filament/Filament.html#table_symbols
 // Symbol Definition
@@ -31,8 +33,6 @@
 // f_m is the microfacet BRDF and differs between specular and diffuse components
 //
 // The above integration needs to be approximated.
-
-#version 450
 
 const int MAX_LIGHTS = 10;
 


### PR DESCRIPTION
I've had problems with compiling and running the pbr example:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Compilation("glslang_shader_preprocess:\nInfo log:\nERROR: 0:40: \'#version\' : must occur first in shader \nERROR: 0:40: \'#version\' : bad profile name; use es, core, or compatibility \nERROR: 0:40: \'#version\' : bad tokens following profile -- expected newline \nERROR: 3 compilation errors.  No code generated.\n\n\nDebug log:\n\n")', crates/bevy_render/src/pipeline/pipeline_compiler.rs:161:22
```

I've checked each shader, and only one shader hasn't had `#version` in the first line.

This change fixed my issue.