### PR TITLE
Add marker components for cameras

### DIFF
--- a/crates/bevy_render/src/entity.rs
+++ b/crates/bevy_render/src/entity.rs
@@ -25,6 +25,11 @@ pub struct MeshBundle {
     pub global_transform: GlobalTransform,
 }
 
+/// Marker component used in [PerspectiveCameraBundle] and
+/// [OrthographicCameraBundle].
+#[derive(Default)]
+pub struct GameplayCamera;
+
 /// Component bundle for camera entities with perspective projection
 ///
 /// Use this for 3D rendering.
@@ -35,6 +40,7 @@ pub struct PerspectiveCameraBundle {
     pub visible_entities: VisibleEntities,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
+    pub marker: GameplayCamera,
 }
 
 impl PerspectiveCameraBundle {
@@ -52,6 +58,7 @@ impl PerspectiveCameraBundle {
             visible_entities: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),
+            marker: Default::default(),
         }
     }
 }
@@ -67,6 +74,7 @@ impl Default for PerspectiveCameraBundle {
             visible_entities: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),
+            marker: Default::default(),
         }
     }
 }
@@ -81,6 +89,7 @@ pub struct OrthographicCameraBundle {
     pub visible_entities: VisibleEntities,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
+    pub marker: GameplayCamera,
 }
 
 impl OrthographicCameraBundle {
@@ -101,6 +110,7 @@ impl OrthographicCameraBundle {
             visible_entities: Default::default(),
             transform: Transform::from_xyz(0.0, 0.0, far - 0.1),
             global_transform: Default::default(),
+            marker: Default::default(),
         }
     }
 
@@ -118,6 +128,7 @@ impl OrthographicCameraBundle {
             visible_entities: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),
+            marker: Default::default(),
         }
     }
 
@@ -131,6 +142,7 @@ impl OrthographicCameraBundle {
             visible_entities: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),
+            marker: Default::default(),
         }
     }
 }

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -163,6 +163,10 @@ impl Default for ButtonBundle {
     }
 }
 
+/// Marker component used in [UiCameraBundle].
+#[derive(Default, Debug)]
+pub struct UiCamera;
+
 #[derive(Bundle, Debug)]
 pub struct UiCameraBundle {
     pub camera: Camera,
@@ -170,6 +174,7 @@ pub struct UiCameraBundle {
     pub visible_entities: VisibleEntities,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
+    pub marker: UiCamera,
 }
 
 impl Default for UiCameraBundle {
@@ -191,6 +196,7 @@ impl Default for UiCameraBundle {
             visible_entities: Default::default(),
             transform: Transform::from_xyz(0.0, 0.0, far - 0.1),
             global_transform: Default::default(),
+            marker: Default::default(),
         }
     }
 }

--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -1,9 +1,4 @@
-use bevy::{
-    core::FixedTimestep,
-    ecs::schedule::SystemSet,
-    prelude::*,
-    render::{camera::Camera, render_graph::base::camera::CAMERA_3D},
-};
+use bevy::{core::FixedTimestep, ecs::schedule::SystemSet, prelude::*, render::camera::Camera};
 use rand::Rng;
 
 #[derive(Clone, Eq, PartialEq, Debug, Hash)]
@@ -251,7 +246,10 @@ fn move_player(
 fn focus_camera(
     time: Res<Time>,
     mut game: ResMut<Game>,
-    mut transforms: QuerySet<(Query<(&mut Transform, &Camera)>, Query<&Transform>)>,
+    mut transforms: QuerySet<(
+        Query<&mut Transform, With<GameplayCamera>>,
+        Query<&Transform>,
+    )>,
 ) {
     const SPEED: f32 = 2.0;
     // if there is both a player and a bonus, target the mid-point of them
@@ -283,11 +281,8 @@ fn focus_camera(
         game.camera_is_focus += camera_motion;
     }
     // look at that new camera's actual focus
-    for (mut transform, camera) in transforms.q0_mut().iter_mut() {
-        if camera.name == Some(CAMERA_3D.to_string()) {
-            *transform = transform.looking_at(game.camera_is_focus, Vec3::Y);
-        }
-    }
+    let mut transform = transforms.q0_mut().single_mut().unwrap();
+    *transform = transform.looking_at(game.camera_is_focus, Vec3::Y);
 }
 
 // despawn the bonus if there is one, then spawn a new one at a random location


### PR DESCRIPTION
Adds marker components for cameras, as suggested in #1854.
Fixes #1854.

Changes alien cake addict example to use the `GameplayCamera` marker in order to show use.