### PR TITLE
Add register_components API for ergonomics

### DIFF
--- a/crates/bevy_app/src/app_builder.rs
+++ b/crates/bevy_app/src/app_builder.rs
@@ -319,6 +319,16 @@ impl AppBuilder {
         self
     }
 
+    /// Registers multiple new components using the given [ComponentDescriptor]s.
+    /// See [World::register_components].
+    pub fn register_components<I>(&mut self, descriptors: I) -> &mut Self
+    where
+        I: IntoIterator<Item = ComponentDescriptor>,
+    {
+        self.world_mut().register_components(descriptors).unwrap();
+        self
+    }
+
     #[cfg(feature = "bevy_reflect")]
     pub fn register_type<T: bevy_reflect::GetTypeRegistration>(&mut self) -> &mut Self {
         {

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1116,4 +1116,29 @@ mod tests {
         });
         assert_eq!(*world.get_resource::<i32>().unwrap(), 1);
     }
+
+    #[test]
+    fn register_components() {
+        let mut world = World::new();
+
+        fn cd<T: Component>() -> ComponentDescriptor {
+            ComponentDescriptor::new::<T>(StorageType::SparseSet)
+        }
+
+        let ents = world
+            .register_components(vec![cd::<i32>(), cd::<u32>()])
+            .unwrap();
+        assert_eq!(ents.len(), 2);
+        assert_ne!(ents[0], ents[1]);
+
+        let e = world.spawn().insert_bundle(("abc", 123i32)).id();
+        let f = world.spawn().insert_bundle(("def", 456u32)).id();
+        assert_eq!(*world.get::<i32>(e).unwrap(), 123);
+        assert_eq!(*world.get::<u32>(f).unwrap(), 456);
+
+        // Can't add i32 twice
+        world
+            .register_components(vec![cd::<f32>(), cd::<i32>()])
+            .unwrap_err();
+    }
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -194,13 +194,10 @@ impl World {
     where
         I: IntoIterator<Item = ComponentDescriptor>,
     {
-        let mut ids = vec![];
-
-        for descriptor in descriptors {
-            ids.push(self.register_component(descriptor)?);
-        }
-
-        Ok(ids)
+        descriptors
+            .into_iter()
+            .map(|descriptor| self.register_component(descriptor))
+            .collect()
     }
 
     /// Retrieves an [EntityRef] that exposes read-only operations for the given `entity`.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -164,6 +164,45 @@ impl World {
         Ok(component_id)
     }
 
+    /// Registers multiple components using the given [ComponentDescriptor]s.
+    /// See [register_component](World::register_component).
+    ///
+    /// ```
+    /// use bevy_ecs::{component::{Component, ComponentDescriptor, StorageType}, world::World};
+    ///
+    /// struct Position {
+    ///   x: f32,
+    ///   y: f32,
+    /// }
+    ///
+    /// struct Velocity(f32);
+    /// struct Hostility(f32);
+    ///
+    /// // Local helper for getting a sparse set descriptor
+    /// fn cd<T: Component>() -> ComponentDescriptor {
+    ///     ComponentDescriptor::new::<T>(StorageType::SparseSet)
+    /// }
+    ///
+    /// let mut world = World::new();
+    /// let descriptors = vec![cd::<Position>(), cd::<Velocity>(), cd::<Hostility>()];
+    /// world.register_components(descriptors).unwrap();
+    /// ```
+    pub fn register_components<I>(
+        &mut self,
+        descriptors: I,
+    ) -> Result<Vec<ComponentId>, ComponentsError>
+    where
+        I: IntoIterator<Item = ComponentDescriptor>,
+    {
+        let mut ids = vec![];
+
+        for descriptor in descriptors {
+            ids.push(self.register_component(descriptor)?);
+        }
+
+        Ok(ids)
+    }
+
     /// Retrieves an [EntityRef] that exposes read-only operations for the given `entity`.
     /// This will panic if the `entity` does not exist. Use [World::get_entity] if you want
     /// to check for entity existence instead of implicitly panic-ing.


### PR DESCRIPTION
A suggestion for #1794.
If accepted, fixes #1794.

The linked issue original code was as follows:

```rust
world
    .register_component(ComponentDescriptor::new::<CombatState<Peaceful>>(
        StorageType::SparseSet,
    ))
    .unwrap();
world
    .register_component(ComponentDescriptor::new::<CombatState<Chasing>>(
        StorageType::SparseSet,
    ))
    .unwrap();
world
    .register_component(ComponentDescriptor::new::<CombatState<Searching>>(
        StorageType::SparseSet,
    ))
    .unwrap();
```

With the new API, this is now:

```rust
world
    .register_components(vec![
        ComponentDescriptor::new::<CombatState<Peaceful>>(StorageType::SparseSet)),
        ComponentDescriptor::new::<CombatState<Chasing>>(StorageType::SparseSet)),
        ComponentDescriptor::new::<CombatState<Searching>>(StorageType::SparseSet)),
    ]).unwrap();
```

Or perhaps simpler as done in the added docs+test:

```rust
fn cd<T: Component>() -> ComponentDescriptor {
    ComponentDescriptor::new::<T>(StorageType::SparseSet)
 }

let descriptors = vec![
    cd::<CombatState<Peaceful>>(),
    cd::<CombatState<Chasing>>(),
    cd::<CombatState<Searching>>(),
];
world.register_components(descriptors).unwrap();
```