### PR TITLE
[Merged by Bors] - Implement RenderResource for Box<T>

### DIFF
--- a/crates/bevy_render/src/renderer/render_resource/render_resource.rs
+++ b/crates/bevy_render/src/renderer/render_resource/render_resource.rs
@@ -159,6 +159,27 @@ impl_render_resource_bytes!(i64);
 impl_render_resource_bytes!(f32);
 impl_render_resource_bytes!(f64);
 
+impl<T> RenderResource for Box<T>
+where
+    T: RenderResource,
+{
+    fn resource_type(&self) -> Option<RenderResourceType> {
+        self.as_ref().resource_type()
+    }
+
+    fn write_buffer_bytes(&self, buffer: &mut [u8]) {
+        self.as_ref().write_buffer_bytes(buffer);
+    }
+
+    fn buffer_byte_len(&self) -> Option<usize> {
+        self.as_ref().buffer_byte_len()
+    }
+
+    fn texture(&self) -> Option<&Handle<Texture>> {
+        self.as_ref().texture()
+    }
+}
+
 impl<T> RenderResource for Vec<T>
 where
     T: Sized + Byteable,


### PR DESCRIPTION
Allows render resources to move data to the heap by boxing them. I did this as a workaround to #1892, but it seems like it'd be useful regardless. If not, feel free to close this PR.