### PR TITLE
[Merged by Bors] - Angle bracket annotated types to support generics

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -124,7 +124,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
                 self.#field.get_components(&mut func);
             });
             field_from_components.push(quote! {
-                #field: <#field_type>::from_components(&mut func),
+                #field: <#field_type as #ecs_path::bundle::Bundle>::from_components(&mut func),
             });
         } else {
             field_type_infos.push(quote! {

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -118,7 +118,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
     {
         if *is_bundle {
             field_type_infos.push(quote! {
-                type_info.extend(<#field_type>::type_info());
+                type_info.extend(<#field_type as #ecs_path::bundle::Bundle>::type_info());
             });
             field_get_components.push(quote! {
                 self.#field.get_components(&mut func);

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -118,13 +118,13 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
     {
         if *is_bundle {
             field_type_infos.push(quote! {
-                type_info.extend(#field_type::type_info());
+                type_info.extend(<#field_type>::type_info());
             });
             field_get_components.push(quote! {
                 self.#field.get_components(&mut func);
             });
             field_from_components.push(quote! {
-                #field: #field_type::from_components(&mut func),
+                #field: <#field_type>::from_components(&mut func),
             });
         } else {
             field_type_infos.push(quote! {


### PR DESCRIPTION
Fixes #1873. Types should be enclosed in angular brackets to avoid ambiquity and to correctly resolve associated functions.