### PR TITLE
Use crevice to write LightsUniform

### DIFF
--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -13,5 +13,12 @@ license = "MIT"
 keywords = ["bevy"]
 
 [dependencies]
-glam = { version = "0.13.0", features = ["serde"] }
-bevy_reflect = { path = "../bevy_reflect", version = "0.5.0", features = ["bevy"] }
+glam = { version = "0.14.0", features = ["serde"], path = "../../../glam-rs" }
+crevice = { version = "0.6", optional = true, path = "../../../crevice" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.5.0", features = [
+    "bevy"
+] }
+
+[features]
+default = ["crevice_traits"]
+crevice_traits = ["crevice", "glam/crevice_traits"]

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -13,8 +13,10 @@ license = "MIT"
 keywords = ["bevy"]
 
 [dependencies]
-glam = { version = "0.14.0", features = ["serde"], path = "../../../glam-rs" }
-crevice = { version = "0.6", optional = true, path = "../../../crevice" }
+glam = { version = "0.14.0", features = [
+    "serde"
+], git = "https://github.com/mtsr/glam-rs.git", branch = "implement-crevice-asstd140" }
+crevice = { version = "0.6", optional = true, git = "https://github.com/mtsr/crevice.git", branch = "develop" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.5.0", features = [
     "bevy"
 ] }

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -27,5 +27,5 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.5.0", features = [
 bevy_render = { path = "../bevy_render", version = "0.5.0" }
 bevy_transform = { path = "../bevy_transform", version = "0.5.0" }
 bevy_window = { path = "../bevy_window", version = "0.5.0" }
-crevice = { version = "0.6.0", path = "../../../crevice" }
+crevice = { version = "0.6.0", git = "https://github.com/mtsr/crevice.git", branch = "develop" }
 arrayvec = "0.7.0"

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -18,8 +18,14 @@ bevy_asset = { path = "../bevy_asset", version = "0.5.0" }
 bevy_core = { path = "../bevy_core", version = "0.5.0" }
 bevy_derive = { path = "../bevy_derive", version = "0.5.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.5.0" }
-bevy_math = { path = "../bevy_math", version = "0.5.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.5.0", features = ["bevy"] }
+bevy_math = { path = "../bevy_math", version = "0.5.0", features = [
+    "crevice_traits"
+] }
+bevy_reflect = { path = "../bevy_reflect", version = "0.5.0", features = [
+    "bevy"
+] }
 bevy_render = { path = "../bevy_render", version = "0.5.0" }
 bevy_transform = { path = "../bevy_transform", version = "0.5.0" }
 bevy_window = { path = "../bevy_window", version = "0.5.0" }
+crevice = { version = "0.6.0", path = "../../../crevice" }
+arrayvec = "0.7.0"

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1,8 +1,10 @@
-use bevy_core::Byteable;
 use bevy_ecs::reflect::ReflectComponent;
+use bevy_math::Vec3;
 use bevy_reflect::Reflect;
 use bevy_render::color::Color;
 use bevy_transform::components::GlobalTransform;
+
+use crevice::std140::AsStd140;
 
 /// A point light
 #[derive(Debug, Reflect)]
@@ -23,26 +25,27 @@ impl Default for PointLight {
     }
 }
 
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, AsStd140)]
 pub(crate) struct PointLightUniform {
-    pub pos: [f32; 4],
-    pub color: [f32; 4],
+    pub pos: Vec3,
     pub inverse_range_squared: f32,
+    pub color: Vec3,
 }
 
-unsafe impl Byteable for PointLightUniform {}
-
 impl PointLightUniform {
+    pub fn from_tuple(tuple: (&PointLight, &GlobalTransform)) -> PointLightUniform {
+        Self::from(tuple.0, tuple.1)
+    }
+
     pub fn from(light: &PointLight, global_transform: &GlobalTransform) -> PointLightUniform {
         let (x, y, z) = global_transform.translation.into();
 
         // premultiply color by intensity
         // we don't use the alpha at all, so no reason to multiply only [0..3]
-        let color: [f32; 4] = (light.color * light.intensity).into();
+        let [r, g, b, _]: [f32; 4] = (light.color * light.intensity).into();
         PointLightUniform {
-            pos: [x, y, z, 1.0],
-            color,
+            pos: Vec3::new(x, y, z),
+            color: Vec3::new(r, g, b),
             inverse_range_squared: 1.0 / (light.range * light.range),
         }
     }
@@ -61,6 +64,20 @@ impl Default for AmbientLight {
         Self {
             color: Color::rgb(1.0, 1.0, 1.0),
             brightness: 0.05,
+        }
+    }
+}
+
+// custom implementation that premultiplies brightness and only passes 3 components
+impl AsStd140 for AmbientLight {
+    type Std140Type = crevice::std140::Vec3;
+
+    fn as_std140(&self) -> Self::Std140Type {
+        let precomputed: Color = self.color * self.brightness;
+        crevice::std140::Vec3 {
+            x: precomputed.r(),
+            y: precomputed.g(),
+            z: precomputed.b(),
         }
     }
 }

--- a/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.frag
+++ b/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.frag
@@ -37,9 +37,9 @@
 const int MAX_LIGHTS = 10;
 
 struct PointLight {
-    vec4 pos;
-    vec4 color;
+    vec3 pos;
     float inverseRangeSquared;
+    vec3 color;
 };
 
 layout(location = 0) in vec3 v_WorldPosition;
@@ -59,9 +59,9 @@ layout(std140, set = 0, binding = 1) uniform CameraPosition {
     vec4 CameraPos;
 };
 
-layout(std140, set = 1, binding = 0) uniform Lights {
-    vec4 AmbientColor;
-    uvec4 NumLights;
+layout(std140, set = 1, binding = 0, std140) uniform Lights {
+    vec3 AmbientColor;
+    int NumLights;
     PointLight PointLights[MAX_LIGHTS];
 };
 
@@ -341,7 +341,7 @@ void main() {
 
     // accumulate color
     vec3 light_accum = vec3(0.0);
-    for (int i = 0; i < int(NumLights.x) && i < MAX_LIGHTS; ++i) {
+    for (int i = 0; i < NumLights && i < MAX_LIGHTS; ++i) {
         PointLight light = PointLights[i];
 
         vec3 light_to_frag = light.pos.xyz - v_WorldPosition.xyz;

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -29,7 +29,7 @@ serde = "1"
 smallvec = { version = "1.4", features = ["serde"], optional = true }
 glam = { version = "0.14.0", features = [
     "serde"
-], optional = true, path = "../../../glam-rs" }
+], optional = true, git = "https://github.com/mtsr/glam-rs.git", branch = "implement-crevice-asstd140" }
 
 [dev-dependencies]
 ron = "0.6.2"

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -20,7 +20,6 @@ bevy = ["glam", "smallvec"]
 # bevy
 bevy_reflect_derive = { path = "bevy_reflect_derive", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
-
 # other
 erased-serde = "0.3"
 downcast-rs = "1.2"
@@ -28,7 +27,9 @@ parking_lot = "0.11.0"
 thiserror = "1.0"
 serde = "1"
 smallvec = { version = "1.4", features = ["serde"], optional = true }
-glam = { version = "0.13.0", features = ["serde"], optional = true }
+glam = { version = "0.14.0", features = [
+    "serde"
+], optional = true, path = "../../../glam-rs" }
 
 [dev-dependencies]
 ron = "0.6.2"


### PR DESCRIPTION
This is a draft of what usage of crevice for writing Std140 layout looks like, see #1779.

Note that `WriteStd140` is fairly low overhead, it converts glam types into `Std140` primitives before serializing). `AsStd140`, which can be derived in many cases, potentially has more overhead, since it converts the entire struct into a version with padding and `Std140` primitives.

Dynamic sizing of `WriteStd140` is also not without cost, since it serializes the type to `io::Sink()` and uses `writer.len()` to calculate the size.

This draft currently depends on an upcoming PR on crevice that adds the `StaticStd140Size` trait, so that the maximum size of `LightsUniform` can be calculated.

Additionally there's draft PR to glam to implement crevice traits. This is probably the most problematic part of crevice right now. Because of the orphan rule it's impossible to implement crevice traits without newtype wrappers on foreign types. There might be an upcoming solution, Lucien has been very welcoming in discussing improvements.