### PR TITLE
[Merged by Bors] - Allow deriving `SystemParam` on private types

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -373,13 +373,14 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
 
     let struct_name = &ast.ident;
     let fetch_struct_name = Ident::new(&format!("{}State", struct_name), Span::call_site());
+    let fetch_struct_visibility = &ast.vis;
 
     TokenStream::from(quote! {
         impl #impl_generics #path::system::SystemParam for #struct_name#ty_generics #where_clause {
             type Fetch = #fetch_struct_name <(#(<#field_types as SystemParam>::Fetch,)*), #punctuated_generic_idents>;
         }
 
-        pub struct #fetch_struct_name<TSystemParamState, #punctuated_generic_idents> {
+        #fetch_struct_visibility struct #fetch_struct_name<TSystemParamState, #punctuated_generic_idents> {
             state: TSystemParamState,
             marker: std::marker::PhantomData<(#punctuated_generic_idents)>
         }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -25,7 +25,7 @@ use std::{
 /// use bevy_ecs::system::SystemParam;
 ///
 /// #[derive(SystemParam)]
-/// pub struct MyParam<'a> {
+/// struct MyParam<'a> {
 ///     foo: Res<'a, usize>,
 /// }
 ///

--- a/examples/ecs/system_param.rs
+++ b/examples/ecs/system_param.rs
@@ -17,7 +17,7 @@ pub struct PlayerCount(usize);
 ///
 /// In this example, it includes a query and a mutable resource.
 #[derive(SystemParam)]
-pub struct PlayerCounter<'a> {
+struct PlayerCounter<'a> {
     players: Query<'a, &'static Player>,
     count: ResMut<'a, PlayerCount>,
 }


### PR DESCRIPTION
Examples creating a public type to derive `SystemParam` on were updated
to create a private type where a public one is no longer needed.

Resolves #1869