### PR TITLE
[Merged by Bors] - fix memory size for PointLightBundle

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -28,7 +28,7 @@ impl Default for PointLight {
 pub(crate) struct PointLightUniform {
     pub pos: [f32; 4],
     pub color: [f32; 4],
-    pub inverse_range_squared: f32,
+    pub inverse_range_squared: [f32; 4],
 }
 
 unsafe impl Byteable for PointLightUniform {}
@@ -43,7 +43,7 @@ impl PointLightUniform {
         PointLightUniform {
             pos: [x, y, z, 1.0],
             color,
-            inverse_range_squared: 1.0 / (light.range * light.range),
+            inverse_range_squared: [1.0 / (light.range * light.range), 0., 0., 0.],
         }
     }
 }

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -28,6 +28,7 @@ impl Default for PointLight {
 pub(crate) struct PointLightUniform {
     pub pos: [f32; 4],
     pub color: [f32; 4],
+    // storing as a `[f32; 4]` for memory alignement
     pub inverse_range_squared: [f32; 4],
 }
 

--- a/crates/bevy_pbr/src/render_graph/lights_node.rs
+++ b/crates/bevy_pbr/src/render_graph/lights_node.rs
@@ -47,6 +47,7 @@ impl Node for LightsNode {
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 struct LightCount {
+    // storing as a `[u32; 4]` for memory alignement
     pub num_lights: [u32; 4],
 }
 


### PR DESCRIPTION
Introduced in #1778, not fixed by #1931 

The size of `Lights` buffer currently is : 
```rust
    16 // (color, `[f32; 4]`)
    + 16 // (number of lights, `f32` encoded as a `[f32; 4]`)
    + 10 // (maximum number of lights)
        * ( 16 // (light position, `[f32; 4]`
          + 16 // (color, `[16; 4]`)
          + 4 // (inverse_range_squared, `f32`)
          )

-> 392
```

This makes the pbr shader crash when running with Xcode debugger or with the WebGL2 backend. They both expect a buffer sized 512. This can also be seen on desktop by adding a second light to a scene with a color, it's position and color will be wrong.

adding a second light to example `load_gltf`:
```rust
    commands
        .spawn_bundle(PointLightBundle {
            transform: Transform::from_xyz(-3.0, 5.0, -3.0),
            point_light: PointLight {
                color: Color::BLUE,
                ..Default::default()
            },
            ..Default::default()
        })
        .insert(Rotates);
```

before fix:
<img width="1392" alt="Screenshot 2021-04-16 at 19 14 59" src="https://user-images.githubusercontent.com/8672791/115060744-866fb080-9ee8-11eb-8915-f87cc872ad48.png">

after fix:
<img width="1392" alt="Screenshot 2021-04-16 at 19 16 44" src="https://user-images.githubusercontent.com/8672791/115060759-8cfe2800-9ee8-11eb-92c2-d79f39c7b36b.png">




This PR changes `inverse_range_squared` to be a `[f32; 4]` instead of a `f32` to have the expected alignement