### PR TITLE
[Merged by Bors] - limit number of lights

### DIFF
--- a/crates/bevy_pbr/src/render_graph/lights_node.rs
+++ b/crates/bevy_pbr/src/render_graph/lights_node.rs
@@ -91,7 +91,7 @@ pub fn lights_node_system(
     let ambient_light: [f32; 4] =
         (ambient_light_resource.color * ambient_light_resource.brightness).into();
     let ambient_light_size = std::mem::size_of::<[f32; 4]>();
-    let point_light_count = query.iter().count();
+    let point_light_count = query.iter().count().min(state.max_point_lights);
     let size = std::mem::size_of::<PointLightUniform>();
     let light_count_size = ambient_light_size + std::mem::size_of::<LightCount>();
     let point_light_array_size = size * point_light_count;

--- a/crates/bevy_pbr/src/render_graph/lights_node.rs
+++ b/crates/bevy_pbr/src/render_graph/lights_node.rs
@@ -91,7 +91,7 @@ pub fn lights_node_system(
     let ambient_light: [f32; 4] =
         (ambient_light_resource.color * ambient_light_resource.brightness).into();
     let ambient_light_size = std::mem::size_of::<[f32; 4]>();
-    let point_light_count = query.iter().count().min(state.max_point_lights);
+    let point_light_count = query.iter().len().min(state.max_point_lights);
     let size = std::mem::size_of::<PointLightUniform>();
     let light_count_size = ambient_light_size + std::mem::size_of::<LightCount>();
     let point_light_array_size = size * point_light_count;


### PR DESCRIPTION
Fixes #1921 

Buffer was growing with the actual number of lights instead of being limited to the max number of lights.

As it's a query that can be exactly sized, I also switched `count()` to `len()`