### PR TITLE
[Merged by Bors] - Document setting "CARGO_MANIFEST_DIR" for asset root

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -216,9 +216,9 @@ impl AssetServer {
     ///
     /// The absolute Path to the asset is "ROOT/ASSET_FOLDER_NAME/path".
     ///
-    /// By default the ROOT is the directory of the Application, but this can be overriden by
+    /// By default the ROOT is the directory of the Application, but this can be overridden by
     /// setting the `"CARGO_MANIFEST_DIR"` environment variable to another directory.
-    /// When you run your application through Cargo, then is `"CARGO_MANIFEST_DIR"` automatically
+    /// When you run your application through Cargo, then `"CARGO_MANIFEST_DIR"` is automatically
     /// set to the root folder of your crate.
     ///
     /// The name of the asset folder is set inside the

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -212,6 +212,18 @@ impl AssetServer {
         load_state
     }
 
+    /// Loads an Asset at the provided relative path.
+    ///
+    /// The absolute Path to the asset is "ROOT/ASSET_FOLDER_NAME/path".
+    ///
+    /// By default the ROOT is the directory of the Application, but this can be overriden by
+    /// setting the `"CARGO_MANIFEST_DIR"` environment variable to another directory.
+    /// When you run your application through Cargo, then is `"CARGO_MANIFEST_DIR"` automatically
+    /// set to the root folder of your crate.
+    ///
+    /// The name of the asset folder is set inside the
+    /// [`AssetServerSettings`](crate::AssetServerSettings) resource. The default name is
+    /// `"assets"`.
     pub fn load<'a, T: Asset, P: Into<AssetPath<'a>>>(&self, path: P) -> Handle<T> {
         self.load_untyped(path).typed()
     }

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -217,9 +217,9 @@ impl AssetServer {
     /// The absolute Path to the asset is "ROOT/ASSET_FOLDER_NAME/path".
     ///
     /// By default the ROOT is the directory of the Application, but this can be overridden by
-    /// setting the `"CARGO_MANIFEST_DIR"` environment variable to another directory.
-    /// When you run your application through Cargo, then `"CARGO_MANIFEST_DIR"` is automatically
-    /// set to the root folder of your crate.
+    /// setting the `"CARGO_MANIFEST_DIR"` environment variable (see https://doc.rust-lang.org/cargo/reference/environment-variables.html)
+    /// to another directory. When the application  is run through Cargo, then
+    /// `"CARGO_MANIFEST_DIR"` is automatically set to the root folder of your crate (workspace).
     ///
     /// The name of the asset folder is set inside the
     /// [`AssetServerSettings`](crate::AssetServerSettings) resource. The default name is

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -15,12 +15,13 @@ fn setup(
     meshes: Res<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    // By default AssetServer will load assets from inside the "assets" folder
-    // For example, the next line will load "ROOT/assets/models/cube/cube.gltf#Mesh0/Primitive0"
-    // Where "ROOT" is the directory of the Application.
-    // This can be overridden by setting the "CARGO_MANIFEST_DIR" environment variable.
-    // When the Application is run through Cargo, "CARGO_MANIFEST_DIR" is automatically set to your
-    // crate root directory.
+    // By default AssetServer will load assets from inside the "assets" folder.
+    // For example, the next line will load "ROOT/assets/models/cube/cube.gltf#Mesh0/Primitive0",
+    // where "ROOT" is the directory of the Application.
+    //
+    // This can be overridden by setting the "CARGO_MANIFEST_DIR" environment variable (see https://doc.rust-lang.org/cargo/reference/environment-variables.html)
+    // to another directory. When the Application is run through Cargo, "CARGO_MANIFEST_DIR" is
+    // automatically set to your crate (workspace) root directory.
     let cube_handle = asset_server.load("models/cube/cube.gltf#Mesh0/Primitive0");
     let sphere_handle = asset_server.load("models/sphere/sphere.gltf#Mesh0/Primitive0");
 

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -16,7 +16,8 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // By default AssetServer will load assets from inside the "assets" folder
-    // For example, the next line will load "assets/models/cube/cube.gltf#Mesh0/Primitive0"
+    // For example, the next line will load "./assets/models/cube/cube.gltf#Mesh0/Primitive0"
+    // You can set the Root by setting the enviroment variable "CARGO_MANIFEST_DIR" to the new root
     let cube_handle = asset_server.load("models/cube/cube.gltf#Mesh0/Primitive0");
     let sphere_handle = asset_server.load("models/sphere/sphere.gltf#Mesh0/Primitive0");
 

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -19,7 +19,8 @@ fn setup(
     // For example, the next line will load "ROOT/assets/models/cube/cube.gltf#Mesh0/Primitive0",
     // where "ROOT" is the directory of the Application.
     //
-    // This can be overridden by setting the "CARGO_MANIFEST_DIR" environment variable (see https://doc.rust-lang.org/cargo/reference/environment-variables.html)
+    // This can be overridden by setting the "CARGO_MANIFEST_DIR" environment variable (see
+    // https://doc.rust-lang.org/cargo/reference/environment-variables.html)
     // to another directory. When the Application is run through Cargo, "CARGO_MANIFEST_DIR" is
     // automatically set to your crate (workspace) root directory.
     let cube_handle = asset_server.load("models/cube/cube.gltf#Mesh0/Primitive0");

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -18,7 +18,7 @@ fn setup(
     // By default AssetServer will load assets from inside the "assets" folder
     // For example, the next line will load "ROOT/assets/models/cube/cube.gltf#Mesh0/Primitive0"
     // Where "ROOT" is the directory of the Application.
-    // This can be overriden by setting the "CARGO_MANIFEST_DIR" enviroment variable.
+    // This can be overridden by setting the "CARGO_MANIFEST_DIR" environment variable.
     // When the Application is run through Cargo, "CARGO_MANIFEST_DIR" is automatically set to your
     // crate root directory.
     let cube_handle = asset_server.load("models/cube/cube.gltf#Mesh0/Primitive0");

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -16,8 +16,11 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // By default AssetServer will load assets from inside the "assets" folder
-    // For example, the next line will load "./assets/models/cube/cube.gltf#Mesh0/Primitive0"
-    // You can set the Root by setting the enviroment variable "CARGO_MANIFEST_DIR" to the new root
+    // For example, the next line will load "ROOT/assets/models/cube/cube.gltf#Mesh0/Primitive0"
+    // Where "ROOT" is the directory of the Application.
+    // This can be overriden by setting the "CARGO_MANIFEST_DIR" enviroment variable.
+    // When the Application is run through Cargo, "CARGO_MANIFEST_DIR" is automatically set to your
+    // crate root directory.
     let cube_handle = asset_server.load("models/cube/cube.gltf#Mesh0/Primitive0");
     let sphere_handle = asset_server.load("models/sphere/sphere.gltf#Mesh0/Primitive0");
 


### PR DESCRIPTION
This was nowhere documented inside Bevy.
Should I also mention the use case of debugging a project?

Closes #810