### PR TITLE
[Merged by Bors] - Fix alien_cake_addict: cake should not be at height of player's location

### DIFF
--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -323,7 +323,7 @@ fn spawn_bonus(
                 Transform {
                     translation: Vec3::new(
                         game.bonus.i as f32,
-                        game.board[game.player.j][game.player.i].height + 0.2,
+                        game.board[game.bonus.j][game.bonus.i].height + 0.2,
                         game.bonus.j as f32,
                     ),
                     ..Default::default()


### PR DESCRIPTION
Just to avoid confusion to close readers of the example, this fix ensures cake is transformed to the height at the cake's cell, rather than the height at the player's cell.

Without this, cake may be floating or buried, depending on where the player is standing at time of spawning.

Love your work!