### PR TITLE
[Merged by Bors] - don't panic when no RenderResourceContext can be found

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -17,6 +17,7 @@ use bevy_ecs::{
     system::{IntoExclusiveSystem, IntoSystem, Res},
 };
 use bevy_transform::TransformSystem;
+use bevy_utils::tracing::warn;
 use draw::{OutsideFrustum, Visible};
 
 pub use once_cell;
@@ -229,8 +230,8 @@ impl Plugin for RenderPlugin {
 
 fn check_for_render_resource_context(context: Option<Res<Box<dyn RenderResourceContext>>>) {
     if context.is_none() {
-        panic!(
+        warn!(
             "bevy_render couldn't find a render backend. Perhaps try adding the bevy_wgpu feature/plugin!"
-        )
+        );
     }
 }


### PR DESCRIPTION
In bevy_webgl2, the `RenderResourceContext` is created after startup as it needs to first wait for an event from js side:
https://github.com/mrk-its/bevy_webgl2/blob/f31e5d49def7de6bfe58a47587e7ab3ca349da05/src/lib.rs#L117

remove `panic` introduced in #1965 and log as a `warn` instead