### PR TITLE
[Merged by Bors] - Hide Derived SystemParam State Struct From Docs

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -380,6 +380,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
             type Fetch = #fetch_struct_name <(#(<#field_types as SystemParam>::Fetch,)*), #punctuated_generic_idents>;
         }
 
+        #[doc(hidden)]
         #fetch_struct_visibility struct #fetch_struct_name<TSystemParamState, #punctuated_generic_idents> {
             state: TSystemParamState,
             marker: std::marker::PhantomData<(#punctuated_generic_idents)>


### PR DESCRIPTION
This makes sure the automatically generated MyStructState type is not
shown in the rustdoc when deriving SystemParam on MyStruct.