### PR TITLE
Add FullscreenPassNode for postprocessing

### DIFF
--- a/crates/bevy_pbr/src/render_graph/pbr_pipeline/mod.rs
+++ b/crates/bevy_pbr/src/render_graph/pbr_pipeline/mod.rs
@@ -32,7 +32,7 @@ pub(crate) fn build_pbr_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescri
             clamp_depth: false,
         }),
         color_target_states: vec![ColorTargetState {
-            format: TextureFormat::default(),
+            format: TextureFormat::Bgra8Unorm,
             color_blend: BlendState {
                 src_factor: BlendFactor::SrcAlpha,
                 dst_factor: BlendFactor::OneMinusSrcAlpha,

--- a/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.frag
+++ b/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.frag
@@ -240,41 +240,6 @@ float perceptualRoughnessToRoughness(float perceptualRoughness) {
     return clampedPerceptualRoughness * clampedPerceptualRoughness;
 }
 
-// from https://64.github.io/tonemapping/
-// reinhard on RGB oversaturates colors
-vec3 reinhard(vec3 color) {
-    return color / (1.0 + color);
-}
-
-vec3 reinhard_extended(vec3 color, float max_white) {
-    vec3 numerator = color * (1.0f + (color / vec3(max_white * max_white)));
-    return numerator / (1.0 + color);
-}
-
-// luminance coefficients from Rec. 709.
-// https://en.wikipedia.org/wiki/Rec._709
-float luminance(vec3 v) {
-    return dot(v, vec3(0.2126, 0.7152, 0.0722));
-}
-
-vec3 change_luminance(vec3 c_in, float l_out) {
-    float l_in = luminance(c_in);
-    return c_in * (l_out / l_in);
-}
-
-vec3 reinhard_luminance(vec3 color) {
-    float l_old = luminance(color);
-    float l_new = l_old / (1.0f + l_old);
-    return change_luminance(color, l_new);
-}
-
-vec3 reinhard_extended_luminance(vec3 color, float max_white_l) {
-    float l_old = luminance(color);
-    float numerator = l_old * (1.0f + (l_old / (max_white_l * max_white_l)));
-    float l_new = numerator / (1.0f + l_old);
-    return change_luminance(color, l_new);
-}
-
 #endif
 
 void main() {
@@ -400,12 +365,6 @@ void main() {
     output_color.rgb = light_accum;
     output_color.rgb += (diffuse_ambient + specular_ambient) * AmbientColor.xyz * occlusion;
     output_color.rgb += emissive.rgb * output_color.a;
-
-    // tone_mapping
-    output_color.rgb = reinhard_luminance(output_color.rgb);
-    // Gamma correction.
-    // Not needed with sRGB buffer
-    // output_color.rgb = pow(output_color.rgb, vec3(1.0 / 2.2));
 #endif
 
     o_Target = output_color;

--- a/crates/bevy_render/src/render_graph/base.rs
+++ b/crates/bevy_render/src/render_graph/base.rs
@@ -128,6 +128,8 @@ pub(crate) fn add_base_graph(config: &BaseRenderGraphConfig, world: &mut World) 
                                                           * bit depth for better performance */
                     usage: TextureUsage::OUTPUT_ATTACHMENT,
                 },
+                None,
+                None,
             ),
         );
     }
@@ -222,6 +224,8 @@ pub(crate) fn add_base_graph(config: &BaseRenderGraphConfig, world: &mut World) 
                     format: TextureFormat::default(),
                     usage: TextureUsage::OUTPUT_ATTACHMENT,
                 },
+                None,
+                None,
             ),
         );
 

--- a/crates/bevy_render/src/render_graph/base.rs
+++ b/crates/bevy_render/src/render_graph/base.rs
@@ -108,19 +108,7 @@ impl Default for BaseRenderGraphConfig {
     }
 }
 
-/// The "base render graph" provides a core set of render graph nodes which can be used to build any
-/// graph. By itself this graph doesn't do much, but it allows Render plugins to interop with each
-/// other by having a common set of nodes. It can be customized using `BaseRenderGraphConfig`.
-pub(crate) fn add_base_graph(config: &BaseRenderGraphConfig, world: &mut World) {
-    let world = world.cell();
-    let mut graph = world.get_resource_mut::<RenderGraph>().unwrap();
-    let msaa = world.get_resource::<Msaa>().unwrap();
-
-    // post pass requires main pass
-    debug_assert!(!config.add_post_pass || config.add_main_pass);
-    // debug_assert!(!config.add_resolve_pass || msaa.samples > 1);
-
-    // Set up various nodes
+fn setup_utility_nodes(config: &BaseRenderGraphConfig, graph: &mut RenderGraph) {
     graph.add_node(node::TEXTURE_COPY, TextureCopyNode::default());
     if config.add_3d_camera {
         graph.add_system_node(node::CAMERA_3D, CameraNode::new(camera::CAMERA_3D));
@@ -131,9 +119,9 @@ pub(crate) fn add_base_graph(config: &BaseRenderGraphConfig, world: &mut World) 
     }
 
     graph.add_node(node::SHARED_BUFFERS, SharedBuffersNode::default());
+}
 
-    // Set up textures
-
+fn setup_textures(config: &BaseRenderGraphConfig, msaa: &Msaa, graph: &mut RenderGraph) {
     // Always create main swap chain
     graph.add_node(
         node::PRIMARY_SWAP_CHAIN,
@@ -147,7 +135,7 @@ pub(crate) fn add_base_graph(config: &BaseRenderGraphConfig, world: &mut World) 
             TextureDescriptor {
                 size: Extent3d::new(1, 1, 1),
                 mip_level_count: 1,
-                sample_count: msaa.samples,
+                sample_count: 1,
                 dimension: TextureDimension::D2,
                 format: TextureFormat::Bgra8Unorm,
                 usage: TextureUsage::OUTPUT_ATTACHMENT | TextureUsage::SAMPLED,
@@ -157,22 +145,6 @@ pub(crate) fn add_base_graph(config: &BaseRenderGraphConfig, world: &mut World) 
         );
 
         graph.add_node(node::MAIN_RENDER_TEXTURE, main_render_texture_node);
-
-        let main_depth_texture_node = WindowTextureNode::new(
-            WindowId::primary(),
-            TextureDescriptor {
-                size: Extent3d::new(1, 1, 1),
-                mip_level_count: 1,
-                sample_count: 1,
-                dimension: TextureDimension::D2,
-                format: TextureFormat::Depth32Float,
-                usage: TextureUsage::OUTPUT_ATTACHMENT | TextureUsage::SAMPLED,
-            },
-            Some(SamplerDescriptor::default()),
-            None,
-        );
-
-        graph.add_node(node::MAIN_DEPTH_TEXTURE, main_depth_texture_node);
     } else {
         // No post pass
         if config.add_main_depth_texture {
@@ -214,7 +186,7 @@ pub(crate) fn add_base_graph(config: &BaseRenderGraphConfig, world: &mut World) 
                     mip_level_count: 1,
                     sample_count: msaa.samples,
                     dimension: TextureDimension::D2,
-                    format: TextureFormat::Bgra8UnormSrgb,
+                    format: TextureFormat::Bgra8Unorm,
                     usage: TextureUsage::OUTPUT_ATTACHMENT | TextureUsage::SAMPLED,
                 },
                 None,
@@ -235,140 +207,322 @@ pub(crate) fn add_base_graph(config: &BaseRenderGraphConfig, world: &mut World) 
                     mip_level_count: 1,
                     sample_count: msaa.samples,
                     dimension: TextureDimension::D2,
-                    format: TextureFormat::Depth32Float,
-                    usage: TextureUsage::OUTPUT_ATTACHMENT | TextureUsage::SAMPLED,
+                    format: TextureFormat::Depth32Float, /* PERF: vulkan docs recommend using 24
+                                                          * bit depth for better performance */
+                    usage: TextureUsage::OUTPUT_ATTACHMENT,
                 },
                 None,
                 None,
             ),
         );
     }
+}
 
-    // Set up passes
-
-    if config.add_main_pass {
-        let color_attachments = if config.add_resolve_pass && msaa.samples > 1 {
-            // Resolve happens during separate pass
-            vec![RenderPassColorAttachmentDescriptor {
-                attachment: TextureAttachment::Input("color_attachment".to_string()),
-                resolve_target: None,
-                ops: Operations {
-                    load: LoadOp::Clear(Color::rgb(0.1, 0.2, 0.3)),
-                    store: true,
-                },
-            }]
-        } else {
-            vec![msaa.color_attachment_descriptor(
-                TextureAttachment::Input("color_attachment".to_string()),
-                TextureAttachment::Input("color_resolve_target".to_string()),
-                Operations {
-                    load: LoadOp::Clear(Color::rgb(0.1, 0.1, 0.1)),
-                    store: true,
-                },
-            )]
-        };
-
-        let depth_stencil_attachment = Some(RenderPassDepthStencilAttachmentDescriptor {
-            attachment: TextureAttachment::Input("depth".to_string()),
-            depth_ops: Some(Operations {
-                load: LoadOp::Clear(1.0),
+fn setup_main_pass(config: &BaseRenderGraphConfig, msaa: &Msaa, graph: &mut RenderGraph) {
+    let color_attachments = if config.add_resolve_pass && msaa.samples > 1 {
+        // Resolve happens during separate pass
+        vec![RenderPassColorAttachmentDescriptor {
+            attachment: TextureAttachment::Input("color_attachment".to_string()),
+            resolve_target: None,
+            ops: Operations {
+                load: LoadOp::Clear(Color::rgb(0.1, 0.2, 0.3)),
                 store: true,
-            }),
-            stencil_ops: None,
-        });
+            },
+        }]
+    } else {
+        vec![msaa.color_attachment_descriptor(
+            TextureAttachment::Input("color_attachment".to_string()),
+            TextureAttachment::Input("color_resolve_target".to_string()),
+            Operations {
+                load: LoadOp::Clear(Color::rgb(0.1, 0.1, 0.1)),
+                store: true,
+            },
+        )]
+    };
 
-        let mut main_pass_node = PassNode::<&MainPass>::new(PassDescriptor {
-            color_attachments,
-            depth_stencil_attachment,
-            sample_count: msaa.samples,
-        });
+    let depth_stencil_attachment = Some(RenderPassDepthStencilAttachmentDescriptor {
+        attachment: TextureAttachment::Input("depth".to_string()),
+        depth_ops: Some(Operations {
+            load: LoadOp::Clear(1.0),
+            store: true,
+        }),
+        stencil_ops: None,
+    });
 
-        main_pass_node.use_default_clear_color(0);
+    let mut main_pass_node = PassNode::<&MainPass>::new(PassDescriptor {
+        color_attachments,
+        depth_stencil_attachment,
+        sample_count: msaa.samples,
+    });
 
-        if config.add_3d_camera {
-            main_pass_node.add_camera(camera::CAMERA_3D);
-        }
+    main_pass_node.use_default_clear_color(0);
 
-        if config.add_2d_camera {
-            main_pass_node.add_camera(camera::CAMERA_2D);
-        }
-
-        graph.add_node(node::MAIN_PASS, main_pass_node);
-
-        graph
-            .add_node_edge(node::TEXTURE_COPY, node::MAIN_PASS)
-            .unwrap();
-        graph
-            .add_node_edge(node::SHARED_BUFFERS, node::MAIN_PASS)
-            .unwrap();
-
-        if config.add_3d_camera {
-            graph
-                .add_node_edge(node::CAMERA_3D, node::MAIN_PASS)
-                .unwrap();
-        }
-
-        if config.add_2d_camera {
-            graph
-                .add_node_edge(node::CAMERA_2D, node::MAIN_PASS)
-                .unwrap();
-        }
+    if config.add_3d_camera {
+        main_pass_node.add_camera(camera::CAMERA_3D);
     }
 
-    if config.add_resolve_pass && msaa.samples > 1 {
-        let resolve_pass_node = PassNode::<()>::new(PassDescriptor {
-            color_attachments: vec![RenderPassColorAttachmentDescriptor {
-                attachment: TextureAttachment::Input("color_attachment".to_string()),
-                resolve_target: Some(TextureAttachment::Input("color_resolve_target".to_string())),
-                ops: Operations {
-                    load: LoadOp::Clear(Color::rgb(0.1, 0.2, 0.3)),
-                    store: true,
-                },
-            }],
-            depth_stencil_attachment: Some(RenderPassDepthStencilAttachmentDescriptor {
-                attachment: TextureAttachment::Input("depth".to_string()),
-                depth_ops: Some(Operations {
-                    load: LoadOp::Clear(1.0),
-                    store: true,
-                }),
-                stencil_ops: None,
-            }),
-            sample_count: msaa.samples,
-        });
+    if config.add_2d_camera {
+        main_pass_node.add_camera(camera::CAMERA_2D);
+    }
 
-        graph.add_node(node::MAIN_RESOLVE_PASS, resolve_pass_node);
+    graph.add_node(node::MAIN_PASS, main_pass_node);
 
+    graph
+        .add_node_edge(node::TEXTURE_COPY, node::MAIN_PASS)
+        .unwrap();
+    graph
+        .add_node_edge(node::SHARED_BUFFERS, node::MAIN_PASS)
+        .unwrap();
+
+    if config.add_3d_camera {
         graph
-            .add_node_edge(node::MAIN_PASS, node::MAIN_RESOLVE_PASS)
+            .add_node_edge(node::CAMERA_3D, node::MAIN_PASS)
             .unwrap();
-        graph
-            .add_slot_edge(
-                node::MAIN_SAMPLED_COLOR_ATTACHMENT,
-                WindowTextureNode::OUT_TEXTURE,
-                node::MAIN_RESOLVE_PASS,
-                "color_attachment",
-            )
-            .unwrap();
+    }
 
-        if config.add_post_pass {
+    if config.add_2d_camera {
+        graph
+            .add_node_edge(node::CAMERA_2D, node::MAIN_PASS)
+            .unwrap();
+    }
+
+    if config.add_post_pass || config.add_resolve_pass {
+        if msaa.samples > 1 {
+            graph
+                .add_slot_edge(
+                    node::MAIN_SAMPLED_COLOR_ATTACHMENT,
+                    WindowTextureNode::OUT_TEXTURE,
+                    node::MAIN_PASS,
+                    "color_attachment",
+                )
+                .unwrap();
+            graph
+                .add_slot_edge(
+                    node::MAIN_SAMPLED_DEPTH_STENCIL_ATTACHMENT,
+                    WindowTextureNode::OUT_TEXTURE,
+                    node::MAIN_PASS,
+                    "depth",
+                )
+                .unwrap();
+        } else {
             graph
                 .add_slot_edge(
                     node::MAIN_RENDER_TEXTURE,
                     WindowTextureNode::OUT_TEXTURE,
-                    node::MAIN_RESOLVE_PASS,
-                    "color_resolve_target",
+                    node::MAIN_PASS,
+                    "color_attachment",
                 )
                 .unwrap();
-        } else {
+            graph
+                .add_slot_edge(
+                    node::MAIN_DEPTH_TEXTURE,
+                    WindowTextureNode::OUT_TEXTURE,
+                    node::MAIN_PASS,
+                    "depth",
+                )
+                .unwrap();
+        }
+    } else {
+        if config.connect_main_pass_to_swapchain {
             graph
                 .add_slot_edge(
                     node::PRIMARY_SWAP_CHAIN,
                     WindowSwapChainNode::OUT_TEXTURE,
-                    node::MAIN_RESOLVE_PASS,
-                    "color_attachment",
+                    node::MAIN_PASS,
+                    if msaa.samples > 1 {
+                        "color_resolve_target"
+                    } else {
+                        "color_attachment"
+                    },
                 )
                 .unwrap();
         }
+        if config.connect_main_pass_to_main_depth_texture {
+            graph
+                .add_slot_edge(
+                    node::MAIN_DEPTH_TEXTURE,
+                    WindowTextureNode::OUT_TEXTURE,
+                    node::MAIN_PASS,
+                    "depth",
+                )
+                .unwrap();
+        }
+    }
+}
+
+fn setup_resolve_pass(config: &BaseRenderGraphConfig, msaa: &Msaa, graph: &mut RenderGraph) {
+    let resolve_pass_node = PassNode::<()>::new(PassDescriptor {
+        color_attachments: vec![RenderPassColorAttachmentDescriptor {
+            attachment: TextureAttachment::Input("color_attachment".to_string()),
+            resolve_target: Some(TextureAttachment::Input("color_resolve_target".to_string())),
+            ops: Operations {
+                load: LoadOp::Load,
+                store: true,
+            },
+        }],
+        depth_stencil_attachment: None,
+        sample_count: msaa.samples,
+    });
+
+    graph.add_node(node::MAIN_RESOLVE_PASS, resolve_pass_node);
+
+    graph
+        .add_node_edge(node::MAIN_PASS, node::MAIN_RESOLVE_PASS)
+        .unwrap();
+    graph
+        .add_slot_edge(
+            node::MAIN_SAMPLED_COLOR_ATTACHMENT,
+            WindowTextureNode::OUT_TEXTURE,
+            node::MAIN_RESOLVE_PASS,
+            "color_attachment",
+        )
+        .unwrap();
+
+    if config.add_post_pass {
+        // output to render texture
+        graph
+            .add_slot_edge(
+                node::MAIN_RENDER_TEXTURE,
+                WindowTextureNode::OUT_TEXTURE,
+                node::MAIN_RESOLVE_PASS,
+                "color_resolve_target",
+            )
+            .unwrap();
+    } else {
+        // output directly to swap chain
+        graph
+            .add_slot_edge(
+                node::PRIMARY_SWAP_CHAIN,
+                WindowSwapChainNode::OUT_TEXTURE,
+                node::MAIN_RESOLVE_PASS,
+                "color_attachment",
+            )
+            .unwrap();
+    }
+}
+
+fn setup_post_pass(
+    config: &BaseRenderGraphConfig,
+    msaa: &Msaa,
+    shaders: &mut Assets<Shader>,
+    pipelines: &mut Assets<PipelineDescriptor>,
+    graph: &mut RenderGraph,
+) {
+    let pipeline_descriptor = PipelineDescriptor {
+        depth_stencil: None,
+        color_target_states: vec![ColorTargetState {
+            format: TextureFormat::Bgra8UnormSrgb,
+            color_blend: BlendState {
+                src_factor: BlendFactor::SrcAlpha,
+                dst_factor: BlendFactor::OneMinusSrcAlpha,
+                operation: BlendOperation::Add,
+            },
+            alpha_blend: BlendState {
+                src_factor: BlendFactor::One,
+                dst_factor: BlendFactor::One,
+                operation: BlendOperation::Add,
+            },
+            write_mask: ColorWrite::ALL,
+        }],
+        ..PipelineDescriptor::new(ShaderStages {
+            vertex: shaders.add(Shader::from_glsl(
+                ShaderStage::Vertex,
+                fullscreen_pass_node::shaders::VERTEX_SHADER,
+            )),
+            fragment: Some(shaders.add(Shader::from_glsl(
+                ShaderStage::Fragment,
+                fullscreen_pass_node::shaders::REINHARD_FRAGMENT_SHADER,
+            ))),
+        })
+    };
+
+    let pipeline_handle = pipelines.add(pipeline_descriptor);
+
+    let pass_descriptor = PassDescriptor {
+        color_attachments: vec![RenderPassColorAttachmentDescriptor {
+            attachment: TextureAttachment::Input("color_attachment".to_string()),
+            resolve_target: None,
+            ops: Operations {
+                load: LoadOp::Clear(Color::rgb(0.1, 0.2, 0.3)),
+                store: true,
+            },
+        }],
+        depth_stencil_attachment: None,
+        sample_count: 1,
+    };
+
+    let post_pass_node = FullscreenPassNode::new(
+        pass_descriptor,
+        pipeline_handle,
+        vec!["color_texture".into()],
+    );
+
+    graph.add_node(node::POST_PASS, post_pass_node);
+
+    graph
+        .add_node_edge(node::MAIN_PASS, node::POST_PASS)
+        .unwrap();
+
+    if config.add_resolve_pass && msaa.samples > 1 {
+        graph
+            .add_node_edge(node::MAIN_RESOLVE_PASS, node::POST_PASS)
+            .unwrap();
+    }
+
+    graph
+        .add_slot_edge(
+            node::PRIMARY_SWAP_CHAIN,
+            WindowSwapChainNode::OUT_TEXTURE,
+            node::POST_PASS,
+            "color_attachment",
+        )
+        .unwrap();
+
+    graph
+        .add_slot_edge(
+            node::MAIN_RENDER_TEXTURE,
+            WindowTextureNode::OUT_TEXTURE,
+            node::POST_PASS,
+            "color_texture",
+        )
+        .unwrap();
+
+    graph
+        .add_slot_edge(
+            node::MAIN_RENDER_TEXTURE,
+            WindowTextureNode::OUT_SAMPLER,
+            node::POST_PASS,
+            "color_texture_sampler",
+        )
+        .unwrap();
+}
+
+/// The "base render graph" provides a core set of render graph nodes which can be used to build any
+/// graph. By itself this graph doesn't do much, but it allows Render plugins to interop with each
+/// other by having a common set of nodes. It can be customized using `BaseRenderGraphConfig`.
+pub(crate) fn add_base_graph(config: &BaseRenderGraphConfig, world: &mut World) {
+    let world = world.cell();
+    let mut graph = world.get_resource_mut::<RenderGraph>().unwrap();
+    let msaa = world.get_resource::<Msaa>().unwrap();
+
+    // post pass requires main pass
+    debug_assert!(!config.add_post_pass || config.add_main_pass);
+    // debug_assert!(!config.add_resolve_pass || msaa.samples > 1);
+
+    // Set up various nodes
+    setup_utility_nodes(config, &mut *graph);
+
+    // Set up textures
+    setup_textures(config, &*msaa, &mut graph);
+
+    // Set up passes
+
+    if config.add_main_pass {
+        setup_main_pass(config, &*msaa, &mut graph);
+    }
+
+    if config.add_resolve_pass && msaa.samples > 1 {
+        setup_resolve_pass(config, &*msaa, &mut graph);
     }
 
     if config.add_post_pass {
@@ -377,145 +531,6 @@ pub(crate) fn add_base_graph(config: &BaseRenderGraphConfig, world: &mut World) 
             .get_resource_mut::<Assets<PipelineDescriptor>>()
             .unwrap();
 
-        let pipeline_descriptor = PipelineDescriptor {
-            depth_stencil: None,
-            color_target_states: vec![ColorTargetState {
-                format: TextureFormat::Bgra8UnormSrgb,
-                color_blend: BlendState {
-                    src_factor: BlendFactor::SrcAlpha,
-                    dst_factor: BlendFactor::OneMinusSrcAlpha,
-                    operation: BlendOperation::Add,
-                },
-                alpha_blend: BlendState {
-                    src_factor: BlendFactor::One,
-                    dst_factor: BlendFactor::One,
-                    operation: BlendOperation::Add,
-                },
-                write_mask: ColorWrite::ALL,
-            }],
-            ..PipelineDescriptor::new(ShaderStages {
-                vertex: shaders.add(Shader::from_glsl(
-                    ShaderStage::Vertex,
-                    fullscreen_pass_node::shaders::VERTEX_SHADER,
-                )),
-                fragment: Some(shaders.add(Shader::from_glsl(
-                    ShaderStage::Fragment,
-                    fullscreen_pass_node::shaders::REINHARD_FRAGMENT_SHADER,
-                ))),
-            })
-        };
-
-        let pipeline_handle = pipelines.add(pipeline_descriptor);
-
-        let pass_descriptor = PassDescriptor {
-            color_attachments: vec![RenderPassColorAttachmentDescriptor {
-                attachment: TextureAttachment::Input("color_attachment".to_string()),
-                resolve_target: None,
-                ops: Operations {
-                    load: LoadOp::Clear(Color::rgb(0.1, 0.2, 0.3)),
-                    store: true,
-                },
-            }],
-            depth_stencil_attachment: None,
-            sample_count: msaa.samples,
-        };
-
-        let post_pass_node = FullscreenPassNode::new(
-            pass_descriptor,
-            pipeline_handle,
-            vec!["color_texture".into()],
-        );
-
-        graph.add_node(node::POST_PASS, post_pass_node);
-
-        graph
-            .add_node_edge(node::MAIN_PASS, node::POST_PASS)
-            .unwrap();
-
-        if config.add_resolve_pass && msaa.samples > 1 {
-            graph
-                .add_node_edge(node::MAIN_RESOLVE_PASS, node::POST_PASS)
-                .unwrap();
-        }
-
-        graph
-            .add_slot_edge(
-                node::MAIN_RENDER_TEXTURE,
-                WindowTextureNode::OUT_TEXTURE,
-                node::MAIN_PASS,
-                "color_attachment",
-            )
-            .unwrap();
-
-        graph
-            .add_slot_edge(
-                node::PRIMARY_SWAP_CHAIN,
-                WindowSwapChainNode::OUT_TEXTURE,
-                node::POST_PASS,
-                "color_attachment",
-            )
-            .unwrap();
-
-        graph
-            .add_slot_edge(
-                node::MAIN_RENDER_TEXTURE,
-                WindowTextureNode::OUT_TEXTURE,
-                node::POST_PASS,
-                "color_texture",
-            )
-            .unwrap();
-
-        graph
-            .add_slot_edge(
-                node::MAIN_RENDER_TEXTURE,
-                WindowTextureNode::OUT_SAMPLER,
-                node::POST_PASS,
-                "color_texture_sampler",
-            )
-            .unwrap();
-    } else if config.connect_main_pass_to_swapchain {
-        graph
-            .add_slot_edge(
-                node::PRIMARY_SWAP_CHAIN,
-                WindowSwapChainNode::OUT_TEXTURE,
-                node::MAIN_PASS,
-                if msaa.samples > 1 {
-                    "color_resolve_target"
-                } else {
-                    "color_attachment"
-                },
-            )
-            .unwrap();
-    }
-
-    if config.add_resolve_pass && msaa.samples > 1 {
-        graph
-            .add_slot_edge(
-                node::MAIN_SAMPLED_DEPTH_STENCIL_ATTACHMENT,
-                WindowTextureNode::OUT_TEXTURE,
-                node::MAIN_PASS,
-                "depth",
-            )
-            .unwrap();
-    } else if config.connect_main_pass_to_main_depth_texture {
-        graph
-            .add_slot_edge(
-                node::MAIN_DEPTH_TEXTURE,
-                WindowTextureNode::OUT_TEXTURE,
-                node::MAIN_PASS,
-                "depth",
-            )
-            .unwrap();
-
-        if msaa.samples > 1 {
-            graph
-                .add_slot_edge(
-                    node::MAIN_RENDER_TEXTURE,
-                    WindowTextureNode::OUT_TEXTURE,
-                    node::MAIN_PASS,
-                    "color_resolve_target",
-                )
-                .unwrap();
-        }
+        setup_post_pass(config, &*msaa, &mut *shaders, &mut *pipelines, &mut graph);
     }
 }

--- a/crates/bevy_render/src/render_graph/base.rs
+++ b/crates/bevy_render/src/render_graph/base.rs
@@ -1,18 +1,29 @@
 use super::{
-    CameraNode, PassNode, RenderGraph, SharedBuffersNode, TextureCopyNode, WindowSwapChainNode,
-    WindowTextureNode,
+    fullscreen_pass_node, CameraNode, FullscreenPassNode, PassNode, RenderGraph, SharedBuffersNode,
+    TextureCopyNode, TextureNode, WindowSwapChainNode, WindowTextureNode,
 };
 use crate::{
     pass::{
         LoadOp, Operations, PassDescriptor, RenderPassColorAttachmentDescriptor,
         RenderPassDepthStencilAttachmentDescriptor, TextureAttachment,
     },
-    texture::{Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsage},
+    pipeline::{
+        BlendFactor, BlendOperation, BlendState, ColorTargetState, ColorWrite, CompareFunction,
+        DepthBiasState, DepthStencilState, PipelineDescriptor, StencilFaceState, StencilState,
+    },
+    render_graph::Node,
+    renderer::RenderResourceBindings,
+    shader::{Shader, ShaderStage, ShaderStages},
+    texture::{
+        Extent3d, SamplerDescriptor, TextureDescriptor, TextureDimension, TextureFormat,
+        TextureUsage,
+    },
     Color,
 };
+use bevy_asset::Assets;
 use bevy_ecs::{reflect::ReflectComponent, world::World};
 use bevy_reflect::Reflect;
-use bevy_window::WindowId;
+use bevy_window::{WindowId, Windows};
 
 /// A component that indicates that an entity should be drawn in the "main pass"
 #[derive(Clone, Debug, Default, Reflect)]
@@ -61,6 +72,7 @@ pub struct BaseRenderGraphConfig {
     pub add_main_pass: bool,
     pub connect_main_pass_to_swapchain: bool,
     pub connect_main_pass_to_main_depth_texture: bool,
+    pub add_post_pass: bool,
 }
 
 pub mod node {
@@ -69,14 +81,26 @@ pub mod node {
     pub const CAMERA_2D: &str = "camera_2d";
     pub const TEXTURE_COPY: &str = "texture_copy";
     pub const MAIN_DEPTH_TEXTURE: &str = "main_pass_depth_texture";
+    pub const MAIN_RENDER_TEXTURE: &str = "main_pass_render_texture";
     pub const MAIN_SAMPLED_COLOR_ATTACHMENT: &str = "main_pass_sampled_color_attachment";
     pub const MAIN_PASS: &str = "main_pass";
     pub const SHARED_BUFFERS: &str = "shared_buffers";
+    pub const POST_PASS: &str = "post_pass";
 }
-
 pub mod camera {
     pub const CAMERA_3D: &str = "Camera3d";
     pub const CAMERA_2D: &str = "Camera2d";
+}
+
+pub mod texture {
+    use crate::Texture;
+    use bevy_asset::HandleUntyped;
+    use bevy_reflect::TypeUuid;
+
+    pub const MAIN_RENDER_TEXTURE_HANDLE: HandleUntyped =
+        HandleUntyped::weak_from_u64(Texture::TYPE_UUID, 13378939762009864029);
+    pub const MAIN_DEPTH_TEXTURE_HANDLE: HandleUntyped =
+        HandleUntyped::weak_from_u64(Texture::TYPE_UUID, 13378939762009864027);
 }
 
 impl Default for BaseRenderGraphConfig {
@@ -88,6 +112,7 @@ impl Default for BaseRenderGraphConfig {
             add_main_depth_texture: true,
             connect_main_pass_to_swapchain: true,
             connect_main_pass_to_main_depth_texture: true,
+            add_post_pass: true,
         }
     }
 }
@@ -110,7 +135,8 @@ pub(crate) fn add_base_graph(config: &BaseRenderGraphConfig, world: &mut World) 
     }
 
     graph.add_node(node::SHARED_BUFFERS, SharedBuffersNode::default());
-    if config.add_main_depth_texture {
+
+    if config.add_main_depth_texture && !config.add_post_pass {
         graph.add_node(
             node::MAIN_DEPTH_TEXTURE,
             WindowTextureNode::new(
@@ -135,15 +161,28 @@ pub(crate) fn add_base_graph(config: &BaseRenderGraphConfig, world: &mut World) 
     }
 
     if config.add_main_pass {
-        let mut main_pass_node = PassNode::<&MainPass>::new(PassDescriptor {
-            color_attachments: vec![msaa.color_attachment_descriptor(
+        let color_attachments = if config.add_post_pass {
+            vec![RenderPassColorAttachmentDescriptor {
+                attachment: TextureAttachment::Input("color_attachment".to_string()),
+                resolve_target: None,
+                ops: Operations {
+                    load: LoadOp::Clear(Color::rgb(0.1, 0.2, 0.3)),
+                    store: true,
+                },
+            }]
+        } else {
+            vec![msaa.color_attachment_descriptor(
                 TextureAttachment::Input("color_attachment".to_string()),
                 TextureAttachment::Input("color_resolve_target".to_string()),
                 Operations {
                     load: LoadOp::Clear(Color::rgb(0.1, 0.1, 0.1)),
                     store: true,
                 },
-            )],
+            )]
+        };
+
+        let mut main_pass_node = PassNode::<&MainPass>::new(PassDescriptor {
+            color_attachments,
             depth_stencil_attachment: Some(RenderPassDepthStencilAttachmentDescriptor {
                 attachment: TextureAttachment::Input("depth".to_string()),
                 depth_ops: Some(Operations {
@@ -187,12 +226,129 @@ pub(crate) fn add_base_graph(config: &BaseRenderGraphConfig, world: &mut World) 
         }
     }
 
+    if config.add_post_pass {
+        let main_render_texture_node = TextureNode::new(
+            TextureDescriptor {
+                size: Extent3d::new(2560, 1440, 1),
+                mip_level_count: 1,
+                sample_count: msaa.samples,
+                dimension: TextureDimension::D2,
+                format: TextureFormat::Bgra8Unorm,
+                usage: TextureUsage::OUTPUT_ATTACHMENT | TextureUsage::SAMPLED,
+            },
+            Some(SamplerDescriptor::default()),
+            Some(texture::MAIN_RENDER_TEXTURE_HANDLE),
+        );
+
+        graph.add_node(node::MAIN_RENDER_TEXTURE, main_render_texture_node);
+
+        let main_depth_texture_node = TextureNode::new(
+            TextureDescriptor {
+                size: Extent3d::new(2560, 1440, 1),
+                mip_level_count: 1,
+                sample_count: msaa.samples,
+                dimension: TextureDimension::D2,
+                format: TextureFormat::Depth32Float,
+                usage: TextureUsage::OUTPUT_ATTACHMENT | TextureUsage::SAMPLED,
+            },
+            Some(SamplerDescriptor::default()),
+            Some(texture::MAIN_DEPTH_TEXTURE_HANDLE),
+        );
+
+        graph.add_node(node::MAIN_DEPTH_TEXTURE, main_depth_texture_node);
+
+        let mut shaders = world.get_resource_mut::<Assets<Shader>>().unwrap();
+        let mut pipelines = world
+            .get_resource_mut::<Assets<PipelineDescriptor>>()
+            .unwrap();
+
+        let pipeline_descriptor = PipelineDescriptor {
+            depth_stencil: None,
+            color_target_states: vec![ColorTargetState {
+                format: TextureFormat::Bgra8UnormSrgb,
+                color_blend: BlendState {
+                    src_factor: BlendFactor::SrcAlpha,
+                    dst_factor: BlendFactor::OneMinusSrcAlpha,
+                    operation: BlendOperation::Add,
+                },
+                alpha_blend: BlendState {
+                    src_factor: BlendFactor::One,
+                    dst_factor: BlendFactor::One,
+                    operation: BlendOperation::Add,
+                },
+                write_mask: ColorWrite::ALL,
+            }],
+            ..PipelineDescriptor::new(ShaderStages {
+                vertex: shaders.add(Shader::from_glsl(
+                    ShaderStage::Vertex,
+                    fullscreen_pass_node::shaders::VERTEX_SHADER,
+                )),
+                fragment: Some(shaders.add(Shader::from_glsl(
+                    ShaderStage::Fragment,
+                    fullscreen_pass_node::shaders::REINHARD_FRAGMENT_SHADER,
+                ))),
+            })
+        };
+
+        let pipeline_handle = pipelines.add(pipeline_descriptor);
+
+        let pass_descriptor = PassDescriptor {
+            color_attachments: vec![msaa.color_attachment_descriptor(
+                TextureAttachment::Input("color_attachment".to_string()),
+                TextureAttachment::Input("color_resolve_target".to_string()),
+                Operations {
+                    load: LoadOp::Load,
+                    store: true,
+                },
+            )],
+            depth_stencil_attachment: None,
+            sample_count: msaa.samples,
+        };
+
+        let post_pass_node = FullscreenPassNode::new(
+            pass_descriptor,
+            pipeline_handle,
+            vec![fullscreen_pass_node::node::NamedTextureInput::new(
+                "color".into(),
+                texture::MAIN_RENDER_TEXTURE_HANDLE.typed(),
+            )],
+        );
+
+        graph.add_node(node::POST_PASS, post_pass_node);
+
+        graph
+            .add_node_edge(node::MAIN_PASS, node::POST_PASS)
+            .unwrap();
+    }
+
     graph.add_node(
         node::PRIMARY_SWAP_CHAIN,
         WindowSwapChainNode::new(WindowId::primary()),
     );
 
-    if config.connect_main_pass_to_swapchain {
+    if config.add_post_pass {
+        graph
+            .add_slot_edge(
+                node::MAIN_RENDER_TEXTURE,
+                TextureNode::TEXTURE,
+                node::MAIN_PASS,
+                "color_attachment",
+            )
+            .unwrap();
+
+        graph
+            .add_slot_edge(
+                node::PRIMARY_SWAP_CHAIN,
+                WindowSwapChainNode::OUT_TEXTURE,
+                node::POST_PASS,
+                if msaa.samples > 1 {
+                    "color_resolve_target"
+                } else {
+                    "color_attachment"
+                },
+            )
+            .unwrap();
+    } else if config.connect_main_pass_to_swapchain {
         graph
             .add_slot_edge(
                 node::PRIMARY_SWAP_CHAIN,
@@ -210,36 +366,55 @@ pub(crate) fn add_base_graph(config: &BaseRenderGraphConfig, world: &mut World) 
     if msaa.samples > 1 {
         graph.add_node(
             node::MAIN_SAMPLED_COLOR_ATTACHMENT,
-            WindowTextureNode::new(
-                WindowId::primary(),
+            TextureNode::new(
                 TextureDescriptor {
                     size: Extent3d {
                         depth: 1,
-                        width: 1,
-                        height: 1,
+                        width: 2560,
+                        height: 1440,
                     },
                     mip_level_count: 1,
                     sample_count: msaa.samples,
                     dimension: TextureDimension::D2,
-                    format: TextureFormat::default(),
-                    usage: TextureUsage::OUTPUT_ATTACHMENT,
+                    format: TextureFormat::Bgra8UnormSrgb,
+                    usage: TextureUsage::OUTPUT_ATTACHMENT | TextureUsage::SAMPLED,
                 },
-                None,
-                None,
+                Some(SamplerDescriptor::default()),
+                Some(texture::MAIN_RENDER_TEXTURE_HANDLE),
             ),
         );
 
-        graph
-            .add_slot_edge(
-                node::MAIN_SAMPLED_COLOR_ATTACHMENT,
-                WindowSwapChainNode::OUT_TEXTURE,
-                node::MAIN_PASS,
-                "color_attachment",
-            )
-            .unwrap();
+        if config.add_post_pass {
+            graph
+                .add_slot_edge(
+                    node::MAIN_SAMPLED_COLOR_ATTACHMENT,
+                    TextureNode::TEXTURE,
+                    node::POST_PASS,
+                    "color_attachment",
+                )
+                .unwrap();
+        } else if config.connect_main_pass_to_swapchain {
+            graph
+                .add_slot_edge(
+                    node::MAIN_SAMPLED_COLOR_ATTACHMENT,
+                    WindowSwapChainNode::OUT_TEXTURE,
+                    node::MAIN_PASS,
+                    "color_attachment",
+                )
+                .unwrap();
+        }
     }
 
-    if config.connect_main_pass_to_main_depth_texture {
+    if config.add_post_pass {
+        graph
+            .add_slot_edge(
+                node::MAIN_DEPTH_TEXTURE,
+                TextureNode::TEXTURE,
+                node::MAIN_PASS,
+                "depth",
+            )
+            .unwrap();
+    } else if config.connect_main_pass_to_main_depth_texture {
         graph
             .add_slot_edge(
                 node::MAIN_DEPTH_TEXTURE,

--- a/crates/bevy_render/src/render_graph/base.rs
+++ b/crates/bevy_render/src/render_graph/base.rs
@@ -322,7 +322,18 @@ fn setup_main_pass(config: &BaseRenderGraphConfig, msaa: &Msaa, graph: &mut Rend
                 )
                 .unwrap();
         }
-    } else {
+    } else if config.add_main_pass {
+        if msaa.samples > 1 {
+            graph
+                .add_slot_edge(
+                    node::MAIN_SAMPLED_COLOR_ATTACHMENT,
+                    WindowTextureNode::OUT_TEXTURE,
+                    node::MAIN_PASS,
+                    "color_attachment",
+                )
+                .unwrap();
+        }
+
         if config.connect_main_pass_to_swapchain {
             graph
                 .add_slot_edge(
@@ -337,7 +348,7 @@ fn setup_main_pass(config: &BaseRenderGraphConfig, msaa: &Msaa, graph: &mut Rend
                 )
                 .unwrap();
         }
-        if config.connect_main_pass_to_main_depth_texture {
+        if config.add_main_depth_texture && config.connect_main_pass_to_main_depth_texture {
             graph
                 .add_slot_edge(
                     node::MAIN_DEPTH_TEXTURE,
@@ -395,7 +406,7 @@ fn setup_resolve_pass(config: &BaseRenderGraphConfig, msaa: &Msaa, graph: &mut R
                 node::PRIMARY_SWAP_CHAIN,
                 WindowSwapChainNode::OUT_TEXTURE,
                 node::MAIN_RESOLVE_PASS,
-                "color_attachment",
+                "color_resolve_target",
             )
             .unwrap();
     }

--- a/crates/bevy_render/src/render_graph/base.rs
+++ b/crates/bevy_render/src/render_graph/base.rs
@@ -8,11 +8,8 @@ use crate::{
         RenderPassDepthStencilAttachmentDescriptor, TextureAttachment,
     },
     pipeline::{
-        BlendFactor, BlendOperation, BlendState, ColorTargetState, ColorWrite, CompareFunction,
-        DepthBiasState, DepthStencilState, PipelineDescriptor, StencilFaceState, StencilState,
+        BlendFactor, BlendOperation, BlendState, ColorTargetState, ColorWrite, PipelineDescriptor,
     },
-    render_graph::Node,
-    renderer::RenderResourceBindings,
     shader::{Shader, ShaderStage, ShaderStages},
     texture::{
         Extent3d, SamplerDescriptor, TextureDescriptor, TextureDimension, TextureFormat,
@@ -23,7 +20,7 @@ use crate::{
 use bevy_asset::Assets;
 use bevy_ecs::{reflect::ReflectComponent, world::World};
 use bevy_reflect::Reflect;
-use bevy_window::{WindowId, Windows};
+use bevy_window::WindowId;
 
 /// A component that indicates that an entity should be drawn in the "main pass"
 #[derive(Clone, Debug, Default, Reflect)]
@@ -310,16 +307,30 @@ pub(crate) fn add_base_graph(config: &BaseRenderGraphConfig, world: &mut World) 
         let post_pass_node = FullscreenPassNode::new(
             pass_descriptor,
             pipeline_handle,
-            vec![fullscreen_pass_node::node::NamedTextureInput::new(
-                "color".into(),
-                texture::MAIN_RENDER_TEXTURE_HANDLE.typed(),
-            )],
+            vec!["color_texture".into()],
         );
 
         graph.add_node(node::POST_PASS, post_pass_node);
 
         graph
             .add_node_edge(node::MAIN_PASS, node::POST_PASS)
+            .unwrap();
+
+        graph
+            .add_slot_edge(
+                node::MAIN_RENDER_TEXTURE,
+                WindowTextureNode::OUT_TEXTURE,
+                node::POST_PASS,
+                "color_texture",
+            )
+            .unwrap();
+        graph
+            .add_slot_edge(
+                node::MAIN_RENDER_TEXTURE,
+                WindowTextureNode::OUT_SAMPLER,
+                node::POST_PASS,
+                "color_texture_sampler",
+            )
             .unwrap();
     }
 

--- a/crates/bevy_render/src/render_graph/node_slot.rs
+++ b/crates/bevy_render/src/render_graph/node_slot.rs
@@ -49,9 +49,14 @@ impl ResourceSlots {
         slot.resource = Some(resource);
     }
 
-    pub fn get(&self, label: impl Into<SlotLabel>) -> Option<RenderResourceId> {
+    pub fn get(&self, label: impl Into<SlotLabel>) -> &Option<RenderResourceId> {
         let slot = self.get_slot(label).unwrap();
-        slot.resource.clone()
+        &slot.resource
+    }
+
+    pub fn get_mut(&mut self, label: impl Into<SlotLabel>) -> &mut Option<RenderResourceId> {
+        let slot = self.get_slot_mut(label).unwrap();
+        &mut slot.resource
     }
 
     pub fn get_slot(&self, label: impl Into<SlotLabel>) -> Result<&ResourceSlot, RenderGraphError> {

--- a/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/fullscreen.vert
+++ b/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/fullscreen.vert
@@ -1,0 +1,11 @@
+#version 450
+
+layout(location=0) out vec2 v_Uv;
+
+void main() {
+    float x = float(((uint(gl_VertexIndex) + 2u) / 3u)%2u);
+    float y = float(((uint(gl_VertexIndex) + 1u) / 3u)%2u);
+
+    gl_Position = vec4(-1.0f + x*2.0f, -1.0f+y*2.0f, 0.0f, 1.0f);
+    v_Uv = vec2(x, 1.0-y);
+}

--- a/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/fullscreen.vert
+++ b/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/fullscreen.vert
@@ -3,9 +3,9 @@
 layout(location=0) out vec2 v_Uv;
 
 void main() {
-    float x = float(((uint(gl_VertexIndex) + 2u) / 3u)%2u);
-    float y = float(((uint(gl_VertexIndex) + 1u) / 3u)%2u);
-
-    gl_Position = vec4(-1.0f + x*2.0f, -1.0f+y*2.0f, 0.0f, 1.0f);
-    v_Uv = vec2(x, 1.0-y);
+    // Setup a single triangle
+    float x = float((gl_VertexIndex & 1) << 2);
+    float y = float((gl_VertexIndex & 2) << 1);
+    v_Uv = vec2(x * 0.5, 1.0-y * 0.5);
+    gl_Position = vec4(x - 1.0, y - 1.0, 0, 1);
 }

--- a/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/mod.rs
+++ b/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/mod.rs
@@ -1,0 +1,7 @@
+pub mod node;
+
+pub mod shaders {
+    pub const VERTEX_SHADER: &str = include_str!("fullscreen.vert");
+    pub const NOOP_SHADER: &str = include_str!("noop.frag");
+    pub const REINHARD_FRAGMENT_SHADER: &str = include_str!("reinhard.frag");
+}

--- a/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/node.rs
@@ -98,7 +98,6 @@ impl FullscreenPassNode {
             .unwrap();
 
         if self.specialized_pipeline_handle.is_none() {
-            let msaa = world.get_resource::<Msaa>().unwrap();
             let mut pipeline_compiler = world.get_resource_mut::<PipelineCompiler>().unwrap();
             let mut shaders = world.get_resource_mut::<Assets<Shader>>().unwrap();
             let render_resource_context = world
@@ -111,7 +110,7 @@ impl FullscreenPassNode {
                 .clone();
 
             let pipeline_specialization = PipelineSpecialization {
-                sample_count: msaa.samples,
+                sample_count: 1,
                 ..Default::default()
             };
 

--- a/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/node.rs
@@ -291,7 +291,9 @@ impl Node for FullscreenPassNode {
                     },
                 );
 
-                render_pass.draw(0..6, 0..1);
+                // Draw a single triangle without the need for buffers
+                // see fullscreen.vert
+                render_pass.draw(0..3, 0..1);
             },
         );
     }

--- a/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/node.rs
@@ -165,9 +165,7 @@ impl Node for FullscreenPassNode {
 
         self.setup_specialized_pipeline(&mut world);
 
-        let mut pipeline_descriptors = world
-            .get_resource_mut::<Assets<PipelineDescriptor>>()
-            .unwrap();
+        let pipeline_descriptors = world.get_resource::<Assets<PipelineDescriptor>>().unwrap();
 
         let render_resource_context = world
             .get_resource::<Box<dyn RenderResourceContext>>()
@@ -245,12 +243,23 @@ impl Node for FullscreenPassNode {
             .enumerate()
         {
             if let Some(input_index) = self.color_attachment_input_indices[i] {
-                color_attachment.attachment =
-                    TextureAttachment::Id(input.get(input_index).unwrap().get_texture().unwrap());
+                color_attachment.attachment = TextureAttachment::Id(
+                    input
+                        .get(input_index)
+                        .as_ref()
+                        .unwrap()
+                        .get_texture()
+                        .unwrap(),
+                );
             }
             if let Some(input_index) = self.color_resolve_target_indices[i] {
                 color_attachment.resolve_target = Some(TextureAttachment::Id(
-                    input.get(input_index).unwrap().get_texture().unwrap(),
+                    input
+                        .get(input_index)
+                        .as_ref()
+                        .unwrap()
+                        .get_texture()
+                        .unwrap(),
                 ));
             }
         }

--- a/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/node.rs
@@ -1,0 +1,298 @@
+use std::{any::TypeId, borrow::Cow, sync::Arc};
+
+use bevy_asset::{Assets, Handle};
+use bevy_core::Name;
+use bevy_ecs::{prelude::World, world::WorldCell};
+
+use crate::{
+    pass::{
+        LoadOp, Operations, PassDescriptor, RenderPassDepthStencilAttachmentDescriptor,
+        TextureAttachment,
+    },
+    pipeline::{
+        BlendFactor, BlendOperation, BlendState, ColorTargetState, ColorWrite, CompareFunction,
+        DepthBiasState, DepthStencilState, PipelineCompiler, PipelineDescriptor, PipelineLayout,
+        PipelineSpecialization, StencilFaceState, StencilState,
+    },
+    prelude::{Msaa, Texture},
+    render_graph::{
+        base::{node::MAIN_RENDER_TEXTURE, texture::MAIN_RENDER_TEXTURE_HANDLE},
+        Node, ResourceSlotInfo,
+    },
+    renderer::{
+        BindGroupId, RenderResourceBinding, RenderResourceBindings, RenderResourceContext,
+        RenderResourceType,
+    },
+    shader::{Shader, ShaderStage, ShaderStages},
+    texture::{self, TextureFormat},
+};
+
+pub struct NamedTextureInput {
+    name: Cow<'static, str>,
+    handle: Handle<Texture>,
+}
+
+impl NamedTextureInput {
+    pub fn new(name: Cow<'static, str>, handle: Handle<Texture>) -> Self {
+        Self { name, handle }
+    }
+}
+
+pub struct FullscreenPassNode {
+    pass_descriptor: PassDescriptor,
+    pipeline_handle: Handle<PipelineDescriptor>,
+    inputs: Vec<ResourceSlotInfo>,
+    color_attachment_input_indices: Vec<Option<usize>>,
+    color_resolve_target_indices: Vec<Option<usize>>,
+    default_clear_color_inputs: Vec<usize>,
+    specialized_pipeline_handle: Option<Handle<PipelineDescriptor>>,
+    bind_groups: Vec<(u32, BindGroupId, Option<Arc<[u32]>>)>,
+    render_resource_bindings: RenderResourceBindings,
+    texture_inputs: Vec<NamedTextureInput>,
+}
+
+impl FullscreenPassNode {
+    pub fn new(
+        pass_descriptor: PassDescriptor,
+        pipeline_handle: Handle<PipelineDescriptor>,
+        // texture_inputs: Vec<Cow<'static, str>>,
+        texture_inputs: Vec<NamedTextureInput>,
+    ) -> Self {
+        let mut inputs = Vec::new();
+        let mut color_attachment_input_indices = Vec::new();
+        let mut color_resolve_target_indices = Vec::new();
+        for color_attachment in pass_descriptor.color_attachments.iter() {
+            if let TextureAttachment::Input(ref name) = color_attachment.attachment {
+                color_attachment_input_indices.push(Some(inputs.len()));
+                inputs.push(ResourceSlotInfo::new(
+                    name.to_string(),
+                    RenderResourceType::Texture,
+                ));
+            } else {
+                color_attachment_input_indices.push(None);
+            }
+
+            if let Some(TextureAttachment::Input(ref name)) = color_attachment.resolve_target {
+                color_resolve_target_indices.push(Some(inputs.len()));
+                inputs.push(ResourceSlotInfo::new(
+                    name.to_string(),
+                    RenderResourceType::Texture,
+                ));
+            } else {
+                color_resolve_target_indices.push(None);
+            }
+        }
+
+        // for texture_name in texture_inputs {
+        //     inputs.push(ResourceSlotInfo::new(
+        //         texture_name,
+        //         RenderResourceType::Texture,
+        //     ));
+        // }
+
+        Self {
+            pass_descriptor,
+            pipeline_handle,
+            inputs,
+            color_attachment_input_indices,
+            color_resolve_target_indices,
+            default_clear_color_inputs: Vec::new(),
+            specialized_pipeline_handle: None,
+            bind_groups: Vec::new(),
+            render_resource_bindings: RenderResourceBindings::default(),
+            texture_inputs,
+        }
+    }
+}
+
+impl FullscreenPassNode {
+    fn setup_specialized_pipeline(&mut self, world: &mut WorldCell) {
+        let mut pipeline_descriptors = world
+            .get_resource_mut::<Assets<PipelineDescriptor>>()
+            .unwrap();
+
+        if self.specialized_pipeline_handle.is_none() {
+            let msaa = world.get_resource::<Msaa>().unwrap();
+            let mut pipeline_compiler = world.get_resource_mut::<PipelineCompiler>().unwrap();
+            let mut shaders = world.get_resource_mut::<Assets<Shader>>().unwrap();
+            let render_resource_context = world
+                .get_resource::<Box<dyn RenderResourceContext>>()
+                .unwrap();
+
+            let pipeline_descriptor = pipeline_descriptors
+                .get(&self.pipeline_handle)
+                .unwrap()
+                .clone();
+
+            let pipeline_specialization = PipelineSpecialization {
+                sample_count: msaa.samples,
+                ..Default::default()
+            };
+
+            let specialized_pipeline = if let Some(specialized_pipeline) = pipeline_compiler
+                .get_specialized_pipeline(&self.pipeline_handle, &pipeline_specialization)
+            {
+                specialized_pipeline
+            } else {
+                pipeline_compiler.compile_pipeline(
+                    &**render_resource_context,
+                    &mut pipeline_descriptors,
+                    &mut shaders,
+                    &self.pipeline_handle,
+                    &pipeline_specialization,
+                )
+            };
+
+            self.specialized_pipeline_handle
+                .replace(specialized_pipeline.clone());
+
+            render_resource_context.create_render_pipeline(
+                specialized_pipeline,
+                &pipeline_descriptor,
+                &*shaders,
+            )
+        }
+    }
+}
+
+impl Node for FullscreenPassNode {
+    fn input(&self) -> &[ResourceSlotInfo] {
+        &self.inputs
+    }
+
+    fn prepare(&mut self, world: &mut World) {
+        let mut world = world.cell();
+
+        self.setup_specialized_pipeline(&mut world);
+
+        let mut pipeline_descriptors = world
+            .get_resource_mut::<Assets<PipelineDescriptor>>()
+            .unwrap();
+
+        let render_resource_context = world
+            .get_resource::<Box<dyn RenderResourceContext>>()
+            .unwrap();
+
+        let pipeline_descriptor = pipeline_descriptors
+            .get(self.specialized_pipeline_handle.as_ref().unwrap())
+            .unwrap();
+
+        // let mut render_resource_bindings =
+        //     world.get_resource_mut::<RenderResourceBindings>().unwrap();
+
+        for input in &self.texture_inputs {
+            let texture_handle = &input.handle;
+
+            // asset_resource only set after TextureNode has updated once
+            if let Some(texture_resource) = render_resource_context
+                .get_asset_resource(texture_handle, texture::TEXTURE_ASSET_INDEX)
+            {
+                let sampler_resource = render_resource_context
+                    .get_asset_resource(texture_handle, texture::SAMPLER_ASSET_INDEX)
+                    .unwrap();
+
+                let render_resource_name = format!("{}_texture", input.name);
+                let sampler_name = format!("{}_sampler", render_resource_name);
+                // dbg!(&render_resource_name);
+
+                self.render_resource_bindings.set(
+                    &render_resource_name,
+                    RenderResourceBinding::Texture(texture_resource.get_texture().unwrap()),
+                );
+                self.render_resource_bindings.set(
+                    &sampler_name,
+                    RenderResourceBinding::Sampler(sampler_resource.get_sampler().unwrap()),
+                );
+            }
+        }
+
+        // dbg!(pipeline_descriptor);
+
+        self.bind_groups.clear();
+        pipeline_descriptor
+            .layout
+            .as_ref()
+            .unwrap()
+            .bind_groups
+            .iter()
+            .for_each(|bind_group_descriptor| {
+                // dbg!(&bind_group_descriptor);
+                if let Some(bind_group) = self
+                    .render_resource_bindings
+                    .update_bind_group(bind_group_descriptor, render_resource_context.as_ref())
+                {
+                    // dbg!(&bind_group);
+                    self.bind_groups.push((
+                        bind_group_descriptor.index,
+                        bind_group.id,
+                        bind_group.dynamic_uniform_indices.clone(),
+                    ));
+                }
+            });
+    }
+
+    fn update(
+        &mut self,
+        world: &bevy_ecs::prelude::World,
+        render_context: &mut dyn crate::renderer::RenderContext,
+        input: &crate::render_graph::ResourceSlots,
+        _output: &mut crate::render_graph::ResourceSlots,
+    ) {
+        for (i, color_attachment) in self
+            .pass_descriptor
+            .color_attachments
+            .iter_mut()
+            .enumerate()
+        {
+            if let Some(input_index) = self.color_attachment_input_indices[i] {
+                color_attachment.attachment =
+                    TextureAttachment::Id(input.get(input_index).unwrap().get_texture().unwrap());
+            }
+            if let Some(input_index) = self.color_resolve_target_indices[i] {
+                color_attachment.resolve_target = Some(TextureAttachment::Id(
+                    input.get(input_index).unwrap().get_texture().unwrap(),
+                ));
+            }
+        }
+
+        let render_resource_bindings = world.get_resource::<RenderResourceBindings>().unwrap();
+        let pipeline_descriptors = world.get_resource::<Assets<PipelineDescriptor>>().unwrap();
+        let pipeline_descriptor = pipeline_descriptors
+            .get(self.specialized_pipeline_handle.as_ref().unwrap())
+            .unwrap();
+
+        // TODO fix better
+        if self.bind_groups.len() != self.texture_inputs.len() {
+            return;
+        }
+
+        render_context.begin_pass(
+            &self.pass_descriptor,
+            &render_resource_bindings,
+            &mut |render_pass| {
+                render_pass.set_pipeline(self.specialized_pipeline_handle.as_ref().unwrap());
+
+                self.bind_groups.iter().for_each(
+                    |(index, bind_group_id, dynamic_uniform_indices)| {
+                        // dbg!();
+                        let bind_group_descriptor = pipeline_descriptor
+                            .layout
+                            .as_ref()
+                            .unwrap()
+                            .get_bind_group(*index)
+                            .unwrap();
+
+                        render_pass.set_bind_group(
+                            *index,
+                            bind_group_descriptor.id,
+                            *bind_group_id,
+                            dynamic_uniform_indices.as_deref(),
+                        );
+                    },
+                );
+
+                render_pass.draw(0..6, 0..1);
+            },
+        );
+    }
+}

--- a/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/noop.frag
+++ b/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/noop.frag
@@ -1,0 +1,12 @@
+#version 450
+
+layout(location=0) in vec2 v_Uv;
+
+layout(set = 0, binding = 0) uniform texture2D color_texture;
+layout(set = 0, binding = 1) uniform sampler color_texture_sampler;
+
+layout(location=0) out vec4 o_Target;
+
+void main() {
+    o_Target = texture(sampler2D(color_texture, color_texture_sampler), v_Uv);
+}

--- a/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/reinhard.frag
+++ b/crates/bevy_render/src/render_graph/nodes/fullscreen_pass_node/reinhard.frag
@@ -1,0 +1,50 @@
+#version 450
+
+layout(location=0) in vec2 v_Uv;
+
+layout(set = 0, binding = 0) uniform texture2D color_texture;
+layout(set = 0, binding = 1) uniform sampler color_texture_sampler;
+
+layout(location=0) out vec4 o_Target;
+
+// from https://64.github.io/tonemapping/
+// reinhard on RGB oversaturates colors
+vec3 reinhard(vec3 color) {
+    return color / (1.0 + color);
+}
+
+vec3 reinhard_extended(vec3 color, float max_white) {
+    vec3 numerator = color * (1.0f + (color / vec3(max_white * max_white)));
+    return numerator / (1.0 + color);
+}
+
+// luminance coefficients from Rec. 709.
+// https://en.wikipedia.org/wiki/Rec._709
+float luminance(vec3 v) {
+    return dot(v, vec3(0.2126, 0.7152, 0.0722));
+}
+
+vec3 change_luminance(vec3 c_in, float l_out) {
+    float l_in = luminance(c_in);
+    return c_in * (l_out / l_in);
+}
+
+vec3 reinhard_luminance(vec3 color) {
+    float l_old = luminance(color);
+    float l_new = l_old / (1.0f + l_old);
+    return change_luminance(color, l_new);
+}
+
+vec3 reinhard_extended_luminance(vec3 color, float max_white_l) {
+    float l_old = luminance(color);
+    float numerator = l_old * (1.0f + (l_old / (max_white_l * max_white_l)));
+    float l_new = numerator / (1.0f + l_old);
+    return change_luminance(color, l_new);
+}
+
+void main() {
+    vec4 output_color = texture(sampler2D(color_texture, color_texture_sampler), v_Uv);
+    output_color.rgb = reinhard_luminance(output_color.rgb);
+
+    o_Target = output_color;
+}

--- a/crates/bevy_render/src/render_graph/nodes/mod.rs
+++ b/crates/bevy_render/src/render_graph/nodes/mod.rs
@@ -1,4 +1,5 @@
 mod camera_node;
+pub mod fullscreen_pass_node;
 mod pass_node;
 mod render_resources_node;
 mod shared_buffers_node;
@@ -8,6 +9,7 @@ mod window_swapchain_node;
 mod window_texture_node;
 
 pub use camera_node::*;
+pub use fullscreen_pass_node::node::*;
 pub use pass_node::*;
 pub use render_resources_node::*;
 pub use shared_buffers_node::*;

--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -217,12 +217,23 @@ where
                 }
             }
             if let Some(input_index) = self.color_attachment_input_indices[i] {
-                color_attachment.attachment =
-                    TextureAttachment::Id(input.get(input_index).unwrap().get_texture().unwrap());
+                color_attachment.attachment = TextureAttachment::Id(
+                    input
+                        .get(input_index)
+                        .as_ref()
+                        .unwrap()
+                        .get_texture()
+                        .unwrap(),
+                );
             }
             if let Some(input_index) = self.color_resolve_target_indices[i] {
                 color_attachment.resolve_target = Some(TextureAttachment::Id(
-                    input.get(input_index).unwrap().get_texture().unwrap(),
+                    input
+                        .get(input_index)
+                        .as_ref()
+                        .unwrap()
+                        .get_texture()
+                        .unwrap(),
                 ));
             }
         }
@@ -232,8 +243,14 @@ where
                 .depth_stencil_attachment
                 .as_mut()
                 .unwrap()
-                .attachment =
-                TextureAttachment::Id(input.get(input_index).unwrap().get_texture().unwrap());
+                .attachment = TextureAttachment::Id(
+                input
+                    .get(input_index)
+                    .as_ref()
+                    .unwrap()
+                    .get_texture()
+                    .unwrap(),
+            );
         }
 
         let render_resource_bindings = world.get_resource::<RenderResourceBindings>().unwrap();

--- a/crates/bevy_render/src/render_graph/nodes/texture_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/texture_node.rs
@@ -3,18 +3,21 @@ use bevy_ecs::world::World;
 use std::borrow::Cow;
 
 use crate::{
+    prelude::Texture,
     render_graph::{Node, ResourceSlotInfo, ResourceSlots},
     renderer::{RenderContext, RenderResourceId, RenderResourceType},
     texture::{SamplerDescriptor, TextureDescriptor, SAMPLER_ASSET_INDEX, TEXTURE_ASSET_INDEX},
 };
 pub struct TextureNode {
-    pub texture_descriptor: TextureDescriptor,
-    pub sampler_descriptor: Option<SamplerDescriptor>,
-    pub handle: Option<HandleUntyped>,
+    texture_descriptor: TextureDescriptor,
+    sampler_descriptor: Option<SamplerDescriptor>,
+    handle: Option<HandleUntyped>,
+    has_changed: bool,
 }
 
 impl TextureNode {
-    pub const TEXTURE: &'static str = "texture";
+    pub const OUT_TEXTURE: &'static str = "texture";
+    pub const OUT_SAMPLER: &'static str = "sampler";
 
     pub fn new(
         texture_descriptor: TextureDescriptor,
@@ -25,17 +28,57 @@ impl TextureNode {
             texture_descriptor,
             sampler_descriptor,
             handle,
+            has_changed: true,
         }
+    }
+}
+
+impl TextureNode {
+    pub fn texture_descriptor(&self) -> &TextureDescriptor {
+        &self.texture_descriptor
+    }
+
+    pub fn texture_descriptor_mut(&mut self) -> &mut TextureDescriptor {
+        self.set_changed();
+        &mut self.texture_descriptor
+    }
+
+    pub fn sampler_descriptor(&self) -> &Option<SamplerDescriptor> {
+        &self.sampler_descriptor
+    }
+
+    pub fn sampler_descriptor_mut(&mut self) -> &mut Option<SamplerDescriptor> {
+        self.set_changed();
+        &mut self.sampler_descriptor
+    }
+
+    pub fn set_changed(&mut self) {
+        self.has_changed = true;
     }
 }
 
 impl Node for TextureNode {
     fn output(&self) -> &[ResourceSlotInfo] {
-        static OUTPUT: &[ResourceSlotInfo] = &[ResourceSlotInfo {
-            name: Cow::Borrowed(TextureNode::TEXTURE),
+        static WITHOUT_SAMPLER: &[ResourceSlotInfo] = &[ResourceSlotInfo {
+            name: Cow::Borrowed(TextureNode::OUT_TEXTURE),
             resource_type: RenderResourceType::Texture,
         }];
-        OUTPUT
+        static WITH_SAMPLER: &[ResourceSlotInfo] = &[
+            ResourceSlotInfo {
+                name: Cow::Borrowed(TextureNode::OUT_TEXTURE),
+                resource_type: RenderResourceType::Texture,
+            },
+            ResourceSlotInfo {
+                name: Cow::Borrowed(TextureNode::OUT_SAMPLER),
+                resource_type: RenderResourceType::Sampler,
+            },
+        ];
+
+        if self.sampler_descriptor.is_none() {
+            WITHOUT_SAMPLER
+        } else {
+            WITH_SAMPLER
+        }
     }
 
     fn update(
@@ -45,15 +88,30 @@ impl Node for TextureNode {
         _input: &ResourceSlots,
         output: &mut ResourceSlots,
     ) {
-        if output.get(0).is_none() {
+        // Need to update
+        if self.has_changed {
             let render_resource_context = render_context.resources_mut();
+
+            // First create new texture
             let texture_id = render_resource_context.create_texture(self.texture_descriptor);
+
+            // And update handle and output
             if let Some(handle) = &self.handle {
+                // For the texture itself
                 render_resource_context.set_asset_resource_untyped(
                     handle.clone(),
                     RenderResourceId::Texture(texture_id),
                     TEXTURE_ASSET_INDEX,
                 );
+
+                // And remove the old resource
+                if let Some(old_texture) =
+                    output.get(0).replace(RenderResourceId::Texture(texture_id))
+                {
+                    render_resource_context.remove_texture(old_texture.get_texture().unwrap());
+                }
+
+                // And if needed for the sampler
                 if let Some(sampler_descriptor) = self.sampler_descriptor {
                     let sampler_id = render_resource_context.create_sampler(&sampler_descriptor);
                     render_resource_context.set_asset_resource_untyped(
@@ -61,9 +119,18 @@ impl Node for TextureNode {
                         RenderResourceId::Sampler(sampler_id),
                         SAMPLER_ASSET_INDEX,
                     );
+
+                    // And remove the old resource
+                    if let Some(old_sampler) =
+                        output.get(1).replace(RenderResourceId::Sampler(sampler_id))
+                    {
+                        render_resource_context.remove_sampler(old_sampler.get_sampler().unwrap());
+                    }
                 }
             }
-            output.set(0, RenderResourceId::Texture(texture_id));
+
+            // Remove changed flag
+            self.has_changed = false;
         }
     }
 }

--- a/crates/bevy_render/src/render_graph/nodes/texture_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/texture_node.rs
@@ -3,7 +3,6 @@ use bevy_ecs::world::World;
 use std::borrow::Cow;
 
 use crate::{
-    prelude::Texture,
     render_graph::{Node, ResourceSlotInfo, ResourceSlots},
     renderer::{RenderContext, RenderResourceId, RenderResourceType},
     texture::{SamplerDescriptor, TextureDescriptor, SAMPLER_ASSET_INDEX, TEXTURE_ASSET_INDEX},

--- a/crates/bevy_render/src/render_graph/nodes/texture_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/texture_node.rs
@@ -95,37 +95,43 @@ impl Node for TextureNode {
             // First create new texture
             let texture_id = render_resource_context.create_texture(self.texture_descriptor);
 
+            // And remove the old texture
+            if let Some(old_texture) = output
+                .get_mut(Self::OUT_TEXTURE)
+                .replace(RenderResourceId::Texture(texture_id))
+            {
+                render_resource_context.remove_texture(old_texture.get_texture().unwrap());
+            }
+
             // And update handle and output
             if let Some(handle) = &self.handle {
-                // For the texture itself
                 render_resource_context.set_asset_resource_untyped(
                     handle.clone(),
                     RenderResourceId::Texture(texture_id),
                     TEXTURE_ASSET_INDEX,
                 );
+            }
 
-                // And remove the old resource
-                if let Some(old_texture) =
-                    output.get(0).replace(RenderResourceId::Texture(texture_id))
+            // If a sampler is specified
+            if let Some(sampler_descriptor) = self.sampler_descriptor {
+                // Create the sampler
+                let sampler_id = render_resource_context.create_sampler(&sampler_descriptor);
+
+                // And remove the old sampler
+                if let Some(old_sampler) = output
+                    .get_mut(Self::OUT_SAMPLER)
+                    .replace(RenderResourceId::Sampler(sampler_id))
                 {
-                    render_resource_context.remove_texture(old_texture.get_texture().unwrap());
+                    render_resource_context.remove_sampler(old_sampler.get_sampler().unwrap());
                 }
 
-                // And if needed for the sampler
-                if let Some(sampler_descriptor) = self.sampler_descriptor {
-                    let sampler_id = render_resource_context.create_sampler(&sampler_descriptor);
+                // And update handle and output
+                if let Some(handle) = &self.handle {
                     render_resource_context.set_asset_resource_untyped(
                         handle.clone(),
                         RenderResourceId::Sampler(sampler_id),
                         SAMPLER_ASSET_INDEX,
                     );
-
-                    // And remove the old resource
-                    if let Some(old_sampler) =
-                        output.get(1).replace(RenderResourceId::Sampler(sampler_id))
-                    {
-                        render_resource_context.remove_sampler(old_sampler.get_sampler().unwrap());
-                    }
                 }
             }
 

--- a/crates/bevy_render/src/render_graph/nodes/window_texture_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/window_texture_node.rs
@@ -1,27 +1,35 @@
 use crate::{
     render_graph::{Node, ResourceSlotInfo, ResourceSlots},
     renderer::{RenderContext, RenderResourceId, RenderResourceType},
-    texture::TextureDescriptor,
+    texture::{SamplerDescriptor, TextureDescriptor},
 };
 use bevy_app::{Events, ManualEventReader};
+use bevy_asset::HandleUntyped;
 use bevy_ecs::world::World;
 use bevy_window::{WindowCreated, WindowId, WindowResized, Windows};
 use std::borrow::Cow;
 
+use super::TextureNode;
+
 pub struct WindowTextureNode {
+    inner: TextureNode,
     window_id: WindowId,
-    descriptor: TextureDescriptor,
     window_created_event_reader: ManualEventReader<WindowCreated>,
     window_resized_event_reader: ManualEventReader<WindowResized>,
 }
 
 impl WindowTextureNode {
-    pub const OUT_TEXTURE: &'static str = "texture";
+    pub const OUT_TEXTURE: &'static str = TextureNode::OUT_TEXTURE;
 
-    pub fn new(window_id: WindowId, descriptor: TextureDescriptor) -> Self {
+    pub fn new(
+        window_id: WindowId,
+        texture_descriptor: TextureDescriptor,
+        sampler_descriptor: Option<SamplerDescriptor>,
+        handle: Option<HandleUntyped>,
+    ) -> Self {
         WindowTextureNode {
+            inner: TextureNode::new(texture_descriptor, sampler_descriptor, handle),
             window_id,
-            descriptor,
             window_created_event_reader: Default::default(),
             window_resized_event_reader: Default::default(),
         }
@@ -41,7 +49,7 @@ impl Node for WindowTextureNode {
         &mut self,
         world: &World,
         render_context: &mut dyn RenderContext,
-        _input: &ResourceSlots,
+        input: &ResourceSlots,
         output: &mut ResourceSlots,
     ) {
         const WINDOW_TEXTURE: usize = 0;
@@ -67,10 +75,10 @@ impl Node for WindowTextureNode {
                 render_resource_context.remove_texture(old_texture);
             }
 
-            self.descriptor.size.width = window.physical_width();
-            self.descriptor.size.height = window.physical_height();
-            let texture_resource = render_resource_context.create_texture(self.descriptor);
-            output.set(WINDOW_TEXTURE, RenderResourceId::Texture(texture_resource));
+            self.inner.texture_descriptor_mut().size.width = window.physical_width();
+            self.inner.texture_descriptor_mut().size.height = window.physical_height();
+
+            self.inner.update(world, render_context, input, output);
         }
     }
 }

--- a/crates/bevy_render/src/render_graph/nodes/window_texture_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/window_texture_node.rs
@@ -19,6 +19,7 @@ pub struct WindowTextureNode {
 
 impl WindowTextureNode {
     pub const OUT_TEXTURE: &'static str = TextureNode::OUT_TEXTURE;
+    pub const OUT_SAMPLER: &'static str = TextureNode::OUT_SAMPLER;
 
     pub fn new(
         window_id: WindowId,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -185,7 +185,7 @@ pub(crate) fn add_ui_graph(world: &mut World) {
 
         graph
             .add_slot_edge(
-                base::node::MAIN_DEPTH_TEXTURE,
+                base::node::MAIN_SAMPLED_DEPTH_STENCIL_ATTACHMENT,
                 WindowTextureNode::OUT_TEXTURE,
                 node::UI_PASS,
                 "depth",

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -5,8 +5,8 @@ use bevy_reflect::TypeUuid;
 use bevy_render::{
     camera::ActiveCameras,
     pass::{
-        LoadOp, Operations, PassDescriptor, RenderPassDepthStencilAttachmentDescriptor,
-        TextureAttachment,
+        LoadOp, Operations, PassDescriptor, RenderPassColorAttachmentDescriptor,
+        RenderPassDepthStencilAttachmentDescriptor, TextureAttachment,
     },
     pipeline::*,
     prelude::Msaa,
@@ -15,8 +15,10 @@ use bevy_render::{
         WindowTextureNode,
     },
     shader::{Shader, ShaderStage, ShaderStages},
-    texture::TextureFormat,
+    texture::{Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsage},
 };
+use bevy_window::WindowId;
+use node::UI_PASS;
 
 pub const UI_PIPELINE_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 3234320022263993878);
@@ -71,6 +73,7 @@ pub mod node {
     pub const CAMERA_UI: &str = "camera_ui";
     pub const NODE: &str = "node";
     pub const UI_PASS: &str = "ui_pass";
+    pub const UI_DEPTH_TEXTURE: &str = "ui_depth";
 }
 
 pub mod camera {
@@ -89,15 +92,30 @@ pub(crate) fn add_ui_graph(world: &mut World) {
 
     pipelines.set_untracked(UI_PIPELINE_HANDLE, build_ui_pipeline(&mut shaders));
 
-    let mut ui_pass_node = PassNode::<&Node>::new(PassDescriptor {
-        color_attachments: vec![msaa.color_attachment_descriptor(
+    let color_attachments = if graph.get_node_id(base::node::MAIN_RESOLVE_PASS).is_ok()
+        || graph.get_node_id(base::node::POST_PASS).is_ok()
+    {
+        vec![RenderPassColorAttachmentDescriptor {
+            attachment: TextureAttachment::Input("color_attachment".to_string()),
+            resolve_target: None,
+            ops: Operations {
+                load: LoadOp::Load,
+                store: true,
+            },
+        }]
+    } else {
+        vec![msaa.color_attachment_descriptor(
             TextureAttachment::Input("color_attachment".to_string()),
             TextureAttachment::Input("color_resolve_target".to_string()),
             Operations {
                 load: LoadOp::Load,
                 store: true,
             },
-        )],
+        )]
+    };
+
+    let mut ui_pass_node = PassNode::<&Node>::new(PassDescriptor {
+        color_attachments,
         depth_stencil_attachment: Some(RenderPassDepthStencilAttachmentDescriptor {
             attachment: TextureAttachment::Input("depth".to_string()),
             depth_ops: Some(Operations {
@@ -112,43 +130,84 @@ pub(crate) fn add_ui_graph(world: &mut World) {
     ui_pass_node.add_camera(camera::CAMERA_UI);
     graph.add_node(node::UI_PASS, ui_pass_node);
 
-    graph
-        .add_slot_edge(
-            base::node::PRIMARY_SWAP_CHAIN,
-            WindowSwapChainNode::OUT_TEXTURE,
-            node::UI_PASS,
-            if msaa.samples > 1 {
-                "color_resolve_target"
-            } else {
-                "color_attachment"
-            },
-        )
-        .unwrap();
-
-    graph
-        .add_slot_edge(
-            base::node::MAIN_DEPTH_TEXTURE,
-            WindowTextureNode::OUT_TEXTURE,
-            node::UI_PASS,
-            "depth",
-        )
-        .unwrap();
-
-    if msaa.samples > 1 {
+    if let Ok(previous_node) = graph
+        .get_node_id(base::node::POST_PASS)
+        .or_else(|_| graph.get_node_id(base::node::MAIN_RESOLVE_PASS))
+    {
         graph
             .add_slot_edge(
-                base::node::MAIN_SAMPLED_COLOR_ATTACHMENT,
+                base::node::PRIMARY_SWAP_CHAIN,
                 WindowSwapChainNode::OUT_TEXTURE,
                 node::UI_PASS,
                 "color_attachment",
             )
             .unwrap();
-    }
 
-    // ensure ui pass runs after main pass
-    graph
-        .add_node_edge(base::node::MAIN_PASS, node::UI_PASS)
-        .unwrap();
+        // create own depth texture
+        let ui_depth_texture_node = WindowTextureNode::new(
+            WindowId::primary(),
+            TextureDescriptor {
+                size: Extent3d::new(1, 1, 1),
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: TextureDimension::D2,
+                format: TextureFormat::Depth32Float,
+                usage: TextureUsage::OUTPUT_ATTACHMENT,
+            },
+            None,
+            None,
+        );
+        graph.add_node(node::UI_DEPTH_TEXTURE, ui_depth_texture_node);
+
+        graph
+            .add_slot_edge(
+                node::UI_DEPTH_TEXTURE,
+                WindowTextureNode::OUT_TEXTURE,
+                UI_PASS,
+                "depth",
+            )
+            .unwrap();
+
+        graph.add_node_edge(previous_node, node::UI_PASS).unwrap();
+    } else {
+        graph
+            .add_slot_edge(
+                base::node::PRIMARY_SWAP_CHAIN,
+                WindowSwapChainNode::OUT_TEXTURE,
+                node::UI_PASS,
+                if msaa.samples > 1 {
+                    "color_resolve_target"
+                } else {
+                    "color_attachment"
+                },
+            )
+            .unwrap();
+
+        graph
+            .add_slot_edge(
+                base::node::MAIN_DEPTH_TEXTURE,
+                WindowTextureNode::OUT_TEXTURE,
+                node::UI_PASS,
+                "depth",
+            )
+            .unwrap();
+
+        if msaa.samples > 1 {
+            graph
+                .add_slot_edge(
+                    base::node::MAIN_SAMPLED_COLOR_ATTACHMENT,
+                    WindowSwapChainNode::OUT_TEXTURE,
+                    node::UI_PASS,
+                    "color_attachment",
+                )
+                .unwrap();
+        }
+
+        // ensure ui pass runs after main pass
+        graph
+            .add_node_edge(base::node::MAIN_PASS, node::UI_PASS)
+            .unwrap();
+    }
 
     // setup ui camera
     graph.add_system_node(node::CAMERA_UI, CameraNode::new(camera::CAMERA_UI));

--- a/crates/bevy_wgpu/src/renderer/wgpu_render_graph_executor.rs
+++ b/crates/bevy_wgpu/src/renderer/wgpu_render_graph_executor.rs
@@ -65,9 +65,11 @@ impl WgpuRenderGraphExecutor {
                                     panic!("Node inputs not set.")
                                 };
 
-                                let output_resource =
-                                    outputs.get(*output_index).expect("Output should be set.");
-                                input_slot.resource = Some(output_resource);
+                                let output_resource = outputs
+                                    .get(*output_index)
+                                    .as_ref()
+                                    .expect("Output should be set.");
+                                input_slot.resource = Some(output_resource.clone());
                             } else {
                                 panic!("No edge connected to input.")
                             }

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -92,7 +92,7 @@ fn add_render_to_texture_graph(graph: &mut RenderGraph, size: Extent3d) {
     graph
         .add_slot_edge(
             TEXTURE_NODE,
-            TextureNode::TEXTURE,
+            TextureNode::OUT_TEXTURE,
             FIRST_PASS,
             "color_attachment",
         )
@@ -100,7 +100,7 @@ fn add_render_to_texture_graph(graph: &mut RenderGraph, size: Extent3d) {
     graph
         .add_slot_edge(
             DEPTH_TEXTURE_NODE,
-            TextureNode::TEXTURE,
+            TextureNode::OUT_TEXTURE,
             FIRST_PASS,
             "depth",
         )

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -94,6 +94,8 @@ fn setup_pipeline(
                 sample_count: msaa.samples,
                 ..Default::default()
             },
+            None,
+            None,
         ),
     );
 
@@ -169,6 +171,8 @@ fn setup_pipeline(
                     format: TextureFormat::default(),
                     usage: TextureUsage::OUTPUT_ATTACHMENT,
                 },
+                None,
+                None,
             ),
         );
 


### PR DESCRIPTION
I've just committed a first (mostly) working version of a FullscreenPassNode that can be used to do postprocessing.

I've also done some work to (optionally) integrate it into the base rendergraph. Because of how bevy_render, bevy_pbr and bevy_ui create the render graph, there's still some issues there:
* I can't currently set up the fullscreen pass only for pbr pipelines. This means there's still some work to at least disable tonemapping for non-pbr pipelines;
* add_post_pass cannot be enabled only for bevy_pbr without referencing that feature within bevy_render, which seems bad;
* UiPass doesn't currently run after the standard fullscreen pass like it should, because bevy_ui can not access the `add_post_pass` config to determine whether it should create an edge from that instead of from MainPass. Similarly, this cannot be set up in bevy_render, because it can't know if there is a UiPass. This could be solved by having plugin config live in `Resources`, but that would create these weird dependencies between plugins;
* ~~There's an ordering problem where `TextureNode` creates the textures in `update()`, but `FullscreenPassNode` needs the textures in `prepare()` that causes a full frame delay before FullscreenPassNode has access to the textures.~~

Other things I'm working on:
* Doesn't currently work with MSAA, this should be relatively minor to fix;
* ~~Checks whether all bind groups are bound in a pretty bad way;~~
* Setting bind_groups from `Res<RenderResourceBindings>`;
* ~~Properly handling window resolution;~~
* ~~Draw a single triangle instead of a quad;~~

While I'm iterating on this, I'd love to get some feedback on the general approach. Some open questions:
* How do we want pluggable functionality like other fullscreen passes to work? Currently I foresee something like creating the rendergraph node with the right inputs and setting a node_edge to force it to run before the final gamma correction and msaa resolve pass. But it's going to be very hard to get the correct *ordering* of fullscreen passes from plugins with this method;
* ~~How should FullscreenPassNode take textures? Currently you pass it a Vec of textures + names to pass to a shader. Alternatively these could all go through `Res<RenderResourceBindings>`;~~ RenderGraph textures+samplers are connected as slot_edges to FullscreenPassNode. Other textures or resources should go through `Res<RenderResourceBindings>`.

Depends on #1998. Rebase with `git rebase --onto main <last commit of #1998>`.