### PR TITLE
[Merged by Bors] - support assets of any size

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -477,7 +477,7 @@ impl AssetServer {
                         }
                     }
 
-                    let _ = assets.set(result.id, result.asset);
+                    let _ = assets.set(result.id, *result.asset);
                 }
                 Ok(AssetLifecycleEvent::Free(handle_id)) => {
                     if let HandleId::AssetPathId(id) = handle_id {

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -139,7 +139,7 @@ impl<'a> LoadContext<'a> {
 /// The result of loading an asset of type `T`
 #[derive(Debug)]
 pub struct AssetResult<T: Component> {
-    pub asset: T,
+    pub asset: Box<T>,
     pub id: HandleId,
     pub version: usize,
 }
@@ -168,7 +168,7 @@ impl<T: AssetDynamic> AssetLifecycle for AssetLifecycleChannel<T> {
             self.sender
                 .send(AssetLifecycleEvent::Create(AssetResult {
                     id,
-                    asset: *asset,
+                    asset,
                     version,
                 }))
                 .unwrap()


### PR DESCRIPTION
Fixes #1892 

The following code is a cut down version of the issue, and crashes the same way:
```rust
enum AssetLifecycleEvent <T> {
    Create(T),
    Free
}

fn main() {
    let (sender, _receiver) = crossbeam_channel::unbounded();
    sender.send(AssetLifecycleEvent::<[u32; 32000]>::Free).unwrap();
}
```

- We're creating a channel that need to be able to hold `AssetLifecycleEvent::Create(T)` which has the size of our type `T`
- The two variants of the enums have a very different size

By keeping `T` boxed while sending through the channel, it doesn't crash