### PR TITLE
[Merged by Bors] - fix dead intra links in doc on `Input` and `Reflect`

### DIFF
--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -18,7 +18,7 @@ use bevy_ecs::schedule::State;
 /// but only one should react, for example in the case of triggering
 /// [`State`] change, you should consider clearing the input state, either by:
 ///
-/// * Using [`Input::just_pressed_and_clear`] or [`Input::just_released_and_clear`] instead.
+/// * Using [`Input::clear_just_pressed`] or [`Inut::clear_just_released`] instead.
 /// * Calling [`Input::clear`] or [`Input::reset`] immediately after the state change.
 ///
 /// ## Notes when adding this resource for a new input type

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -18,7 +18,7 @@ use bevy_ecs::schedule::State;
 /// but only one should react, for example in the case of triggering
 /// [`State`] change, you should consider clearing the input state, either by:
 ///
-/// * Using [`Input::clear_just_pressed`] or [`Inut::clear_just_released`] instead.
+/// * Using [`Input::clear_just_pressed`] or [`Input::clear_just_released`] instead.
 /// * Calling [`Input::clear`] or [`Input::reset`] immediately after the state change.
 ///
 /// ## Notes when adding this resource for a new input type

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -24,9 +24,9 @@ pub enum ReflectMut<'a> {
 /// A reflected rust type.
 ///
 /// # Safety
-/// Implementors _must_ ensure that [Reflect::any] and [Reflect::any_mut] both return the `self`
-/// value passed in If this is not done, [Reflect::downcast] will be UB (and also just logically
-/// broken).
+/// Implementors _must_ ensure that [`Reflect::any`] and [`Reflect::any_mut`] both return the `self`
+/// value passed in If this is not done, [`Reflect::downcast`](trait.Reflect.html#method.downcast)
+/// will be UB (and also just logically broken).
 pub unsafe trait Reflect: Any + Send + Sync {
     fn type_name(&self) -> &str;
     fn any(&self) -> &dyn Any;


### PR DESCRIPTION
fix a few dead links

* Links in `Input` missed a refactor
* `Reflect::downcast` can't use the intra doc link format, as it's not a link to a trait function, but to a function implemented on `dyn Reflect`

noticed in https://github.com/bevyengine/bevy/pull/1781#discussion_r619777879