### PR TITLE
[Merged by Bors] - Fail CI on cargo doc warnings

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -8,6 +8,7 @@ status = [
     "build-android",
     "markdownlint",
     "run-examples",
+    "check-doc",
 ]
 
 use_squash_merge = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
             sleep 10
           done
 
-  deadlinks:
+  check-doc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -138,6 +138,8 @@ jobs:
         if: runner.os == 'linux'
       - name: Installs cargo-deadlinks
         run: cargo install cargo-deadlinks
-      - name: Checks dead doc links
-        run: cargo doc --all-features --no-deps && cargo deadlinks --dir target/doc/bevy
+      - name: Build and check doc
+        run: RUSTDOCFLAGS='-D warnings' cargo doc --all-features --no-deps
+      - name: Checks dead links
+        run: cargo deadlinks --dir target/doc/bevy
         continue-on-error: true


### PR DESCRIPTION
* makes CI fails on cargo doc warnings
* adds this check in bors

doc warnings are listed here: https://doc.rust-lang.org/rustdoc/lints.html

Currently the warnings emitted are:
* broken_intra_doc_links
* private_intra_doc_links
* invalid_codeblock_attributes
