### PR TITLE
[Merged by Bors] - Changed Zshare-generics to `n` on Windows

### DIFF
--- a/.cargo/config_fast_builds
+++ b/.cargo/config_fast_builds
@@ -14,7 +14,7 @@ rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Zshare-generics=y"]
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"
-rustflags = ["-Zshare-generics=y"]
+rustflags = ["-Zshare-generics=n"]
 
 # Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
 # In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.


### PR DESCRIPTION
It seems like this option needs to be off on Windows: https://github.com/bevyengine/bevy-website/issues/131

This change also simplifies the instructions required for the Fast Compiles section of the book: https://github.com/bevyengine/bevy-website/pull/137