### PR TITLE
[Merged by Bors] - Add a readme to bevy_ecs

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -32,3 +32,19 @@ downcast-rs = "1.2"
 parking_lot = "0.11"
 rand = "0.8"
 serde = "1"
+
+[[example]]
+name = "events"
+path = "examples/events.rs"
+
+[[example]]
+name = "component_storage"
+path = "examples/component_storage.rs"
+
+[[example]]
+name = "resources"
+path = "examples/resources.rs"
+
+[[example]]
+name = "change_detection"
+path = "examples/change_detection.rs"

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -53,7 +53,7 @@ let velocity = entity_ref.get::<Velocity>().unwrap();
 
 ### Systems
 
-System are normal Rust functions. Thanks to the Rust type system, Bevy ECS can use function parameter types to determine what data needs to be sent to the system. It also uses this "data access" information to determine what Systems can run in parallel with each other.
+Systems are normal Rust functions. Thanks to the Rust type system, Bevy ECS can use function parameter types to determine what data needs to be sent to the system. It also uses this "data access" information to determine what Systems can run in parallel with each other.
 
 ```rust
 fn print_position(query: Query<(Entity, &Position)>) {
@@ -77,7 +77,7 @@ world.insert_resource(Time::default());
 
 let time = world.get_resource::<Time>().unwrap();
 
-// you can also access resources from Systems
+// You can also access resources from Systems
 fn print_time(time: Res<Time>) {
     println!("{}", time.seconds);
 }
@@ -174,7 +174,7 @@ fn system(query: Query<&Position, Added<Velocity>>) {
 Resources also expose change state:
 
 ```rust
-// Gets the Position component of all Entities whose Velocity has changed since the last run of the System
+// Prints "time changed!" if the Time resource has changed since the last run of the System
 fn system(time: Res<Time>) {
     if time.is_changed() {
         println!("time changed!");
@@ -193,7 +193,7 @@ Components can be stored in:
 * **Tables**: Fast and cache friendly iteration, but slower adding and removing of components. This is the default storage type.
 * **Sparse Sets**: Fast adding and removing of components, but slower iteration.
 
-Component storage types are configurable and they default to table storage if the storage is not manually defined. The [`component_storage.rs`](examples/component_storage.rs) example shows how to configure the storage type for a component.
+Component storage types are configurable, and they default to table storage if the storage is not manually defined. The [`component_storage.rs`](examples/component_storage.rs) example shows how to configure the storage type for a component.
 
 ```rust
 // store Position components in Sparse Sets
@@ -212,6 +212,7 @@ struct PlayerBundle {
     velocity: Velocity,
 }
 
+// Spawn a new entity and insert the default PlayerBundle
 world.spawn().insert_bundle(PlayerBundle::default());
 
 // Bundles play well with Rust's struct update syntax

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -27,13 +27,12 @@ Bevy ECS uses Rust's type safety to represent systems as "normal" functions and 
 ### Component storage
 
 A unique feature of Bevy ECS is the support for multiple component storage types.
+
 * Tables: fast and cache friendly iteration, slower adding and removing of components
 * Sparse Sets: fast add/remove, slower iteration
 
 ### Resources
 
 A common pattern when working with ECS is the creation of global singleton components. Bevy ECS makes this pattern a first class citizen with `Resource`s. Resources live in `World` and are a special kind of components that do not belong to any entity.
-
-
 
 [bevy]: https://bevyengine.org/

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -59,20 +59,24 @@ A unique feature of Bevy ECS is the support for multiple component storage types
 * Tables: fast and cache friendly iteration, but slower adding and removing of components
 * Sparse Sets: fast adding and removing of components, but slower iteration
 
-The used storage type can be configured per component and defaults to table storage. [`examples/component_storage.rs`](examples/component_storage.rs) shows how to configure the storage type for a component.
+The used storage type can be configured per component and defaults to table storage. The example [`component_storage.rs`](examples/component_storage.rs) shows how to configure the storage type for a component.
 
 ### Resources
 
 A common pattern when working with ECS is the creation of global singleton components. Bevy ECS makes this pattern a first class citizen. `Resource`s are a special kind of component that do not belong to any entity. Bevy itself makes heavy use of Resources as a way to configure systems.
 
-[`examples/resources.rs`] uses a resource to keep a counter that can be increased by a system and read from other systems.
+The example [`resources.rs`](examples/resources.rs) uses a resource to keep a counter that can be increased by a system and read from other systems.
 
 ### Events
 
-Events offer a short-lived communication channel between one to many systems. Events can be sent using `EventWriter` and received with `EventReader`. Very little boilerplate is required to register a struct as an event. To see a minimal set up to use events, take a look at [`example/events.rs`](examples/events.rs).
+Events offer a short-lived communication channel between one to many systems. Events can be sent using `EventWriter` and received with `EventReader`. Very little boilerplate is required to register a struct as an event.
+
+A minimal set up to use events can be seen in [`events.rs`](examples/events.rs).
 
 ### Change detection
 
-Bevy ECS includes a simple way of detecting change in resources and entities. Resources have `is_changed` and `is_added` functions and entities can be queried based on changed or added components (see [`examples/change_detection`](examples/change_detection.rs)).
+Bevy ECS includes a simple way of detecting change in resources and entities. Resources have `is_changed` and `is_added` functions and entities can be queried based on changed or added components.
+
+The example [`change_detection.rs`](examples/change_detection.rs) shows how to query only for updated entities and react on changes in resources.
 
 [bevy]: https://bevyengine.org/

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -1,12 +1,12 @@
 # Bevy ECS
 
 [![Crates.io](https://img.shields.io/crates/v/bevy_ecs.svg)](https://crates.io/crates/bevy_ecs)
-[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/bevyengine/bevy/blob/HEAD/LICENSE)
 [![Discord](https://img.shields.io/discord/691052431525675048.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/gMUk5Ph)
 
 ## What is Bevy ECS?
 
-This crate contains the Entity Component System (ECS) implementation used in and developed for the game engine [Bevy][bevy]. Even though it was created as part of the game engine, Bevy ECS can be used standalone and in combination with other projects or game engines.
+Bevy ECS is the Entity Component System used in and developed for the game engine [Bevy][bevy]. Even though it was created as part of the game engine, Bevy ECS can be used standalone and in combination with other projects or game engines.
 
 ## About
 
@@ -14,11 +14,11 @@ Entity component system is an architectural pattern using composition to provide
 
 ### Main concepts
 
-* Entities are identifiers
+* Entities are identifiers for collections of components
 * Components are data structures that can be attached to entities
-* Systems encode a certain behaviour of sets of entities selected based on their components
+* Systems encode a certain behaviour of the world
 
-Entities and components are kept in a `World`. Constructing a `Schedule` with systems allows you to simulate a tick of the world, which results in systems manipulating entities and their components.
+Entities and components are kept in a `World`. Constructing a `Schedule` with systems allows you to simulate a tick of the world. The schedule will consider dependencies between systems and run as many of them in parallel as possible. This maximises performance, while keeping the system execution safe. You can make dependencies explicit by requesting certain execution orders using `SystemLabel`s.
 
 ## Features
 
@@ -28,13 +28,56 @@ Bevy ECS uses Rust's type safety to represent systems as "normal" functions and 
 
 A unique feature of Bevy ECS is the support for multiple component storage types.
 
-* Tables: fast and cache friendly iteration, slower adding and removing of components
-* Sparse Sets: fast add/remove, slower iteration
+* Tables: fast and cache friendly iteration, but slower adding and removing of components
+* Sparse Sets: fast adding and removing of components, but slower iteration
 
 The used storage type can be configured per component and defaults to table storage.
 
 ### Resources
 
-A common pattern when working with ECS is the creation of global singleton components. Bevy ECS makes this pattern a first class citizen. Resources are a special kind of component that do not belong to any entity.
+A common pattern when working with ECS is the creation of global singleton components. Bevy ECS makes this pattern a first class citizen. `Resource`s are a special kind of component that do not belong to any entity. Bevy makes heavy use of Resources as a way to configure systems.
+
+### Events
+
+Events offer a short-lived communication channel between one to many systems.
+
+To prepare a world for events of type `MyEvent`, the event needs to be registered as a resource. A system managing the event can then be added to your schedule:
+
+```rust
+// this is our event
+struct MyEvent {
+    pub message: String,
+}
+
+// Create a world and add the event as a resource
+let mut world = World::new();
+world.insert_resource(Events::<MyEvent>::default());
+
+// Create a schedule and a stage
+let mut schedule = Schedule::default();
+let mut update = SystemStage::parallel();
+
+// Add the event managing system to the stage and register the stage in with the schedule
+update.add_system(Events::<MyEvent>::update_system.system());
+schedule.add_stage("update", update);
+```
+
+After preparing your world like above, you can send and receive events in other systems like so:
+
+```rust
+fn sending_system(
+    mut event_writer: EventWriter<MyEvent>,
+) {
+    event_writer.send(MyEvent {
+        message: "MyEvent just happened!".to_string(),
+    });
+}
+
+fn recieving_system(mut event_reader: EventReader<MyEvent>) {
+    for my_event in event_reader.iter() {
+        println!("{}", my_event.message);
+    }
+}
+```
 
 [bevy]: https://bevyengine.org/

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -31,8 +31,10 @@ A unique feature of Bevy ECS is the support for multiple component storage types
 * Tables: fast and cache friendly iteration, slower adding and removing of components
 * Sparse Sets: fast add/remove, slower iteration
 
+The used storage type can be configured per component and defaults to table storage.
+
 ### Resources
 
-A common pattern when working with ECS is the creation of global singleton components. Bevy ECS makes this pattern a first class citizen with `Resource`s. Resources live in `World` and are a special kind of components that do not belong to any entity.
+A common pattern when working with ECS is the creation of global singleton components. Bevy ECS makes this pattern a first class citizen. Resources are a special kind of component that do not belong to any entity.
 
 [bevy]: https://bevyengine.org/

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -85,7 +85,6 @@ fn print_time(time: Res<Time>) {
 
 The [`resources.rs`](examples/resources.rs) example illustrates how to read and write a Counter resource from Systems.
 
-
 ### Schedules
 
 Schedules consist of zero or more Stages, which run a set of Systems according to some execution strategy. Bevy ECS provides a few built in Stage implementations (ex: parallel, serial), but you can also implement your own! Schedules run Stages one-by-one in an order defined by the user.
@@ -182,7 +181,6 @@ fn system(time: Res<Time>) {
     }
 }
 ```
-
 
 The [`change_detection.rs`](examples/change_detection.rs) example shows how to query only for updated entities and react on changes in resources.
 

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -1,0 +1,39 @@
+# Bevy ECS
+
+[![Crates.io](https://img.shields.io/crates/v/bevy_ecs.svg)](https://crates.io/crates/bevy_ecs)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
+[![Discord](https://img.shields.io/discord/691052431525675048.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/gMUk5Ph)
+
+## What is Bevy ECS?
+
+This crate contains the Entity Component System (ECS) implementation used in and developed for the game engine [Bevy][bevy]. Even though it was created as part of the game engine, Bevy ECS can be used standalone and in combination with other projects or game engines.
+
+## About
+
+Entity component system is an architectural pattern using composition to provide greater flexibility.
+
+### Main concepts
+
+* Entities are identifiers
+* Components are data structures that can be attached to entities
+* Systems encode a certain behaviour of sets of entities selected based on their components
+
+Entities and components are kept in a `World`. Constructing a `Schedule` with systems allows you to simulate a tick of the world, which results in systems manipulating entities and their components.
+
+## Features
+
+Bevy ECS uses Rust's type safety to represent systems as "normal" functions and components as structs. In most cases this does not require any additional effort by the user.
+
+### Component storage
+
+A unique feature of Bevy ECS is the support for multiple component storage types.
+* Tables: fast and cache friendly iteration, slower adding and removing of components
+* Sparse Sets: fast add/remove, slower iteration
+
+### Resources
+
+A common pattern when working with ECS is the creation of global singleton components. Bevy ECS makes this pattern a first class citizen with `Resource`s. Resources live in `World` and are a special kind of components that do not belong to any entity.
+
+
+
+[bevy]: https://bevyengine.org/

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -6,85 +6,244 @@
 
 ## What is Bevy ECS?
 
-Bevy ECS is the Entity Component System used in and developed for the game engine [Bevy][bevy]. Even though it was created as part of the game engine, Bevy ECS can be used standalone and in combination with other projects or game engines.
+Bevy ECS is an Entity Component System custom-built for the [Bevy][bevy] game engine. It aims to be simple to use, ergonomic, fast, massively parallel, opinionated, and featureful. It was created specifically for Bevy's needs, but it can easily be used as a standalone crate in other projects.
 
-## About
+## ECS
 
-Entity Component System is an architectural pattern using composition to provide greater flexibility. Using an ECS can provide a clean architecture by separating data and functionality. At the same time this separation can enable more cache friendly storage and thus allow for better performance.
+All app logic in Bevy uses the Entity Component System paradigm, which is often shortened to ECS. ECS is a software pattern that involves breaking your program up into Entities, Components, and Systems. Entities are unique "things" that are assigned groups of Components, which are then processed using Systems.
 
-### Main concepts
+For example, one entity might have a `Position` and `Velocity` component, whereas another entity might have a `Position` and `UI` component. You might have a movement system that runs on all entities with a Position and Velocity component.
 
-* Entities are identifiers for collections of components
-* Components are data structures that can be attached to entities
-* Systems encode a certain behaviour of the world
+The ECS pattern encourages clean, decoupled designs by forcing you to break up your app data and logic into its core components. It also helps make your code faster by optimizing memory access patterns and making parallelism easier.
 
-Entities and components are kept in a `World`. Constructing a `Schedule` with systems allows you to simulate a tick of the world. The schedule will consider dependencies between systems and (by default) run as many of them in parallel as possible. This maximises performance, while keeping the system execution safe. You can make dependencies explicit by requesting certain execution orders using `SystemLabel`.
+## Concepts
 
-## Features
+Bevy ECS is Bevy's implementation of the ECS pattern. Unlike other Rust ECS implementations, which often require complex lifetimes, traits, builder patterns, or macros, Bevy ECS uses normal Rust data types for all of these concepts:
 
-Bevy ECS uses Rust's type safety to represent systems as "normal" functions and components as structs. In most cases this does not require any additional effort by the user.
+### Components
 
-In a minimal example we can create a world and simulate 10 ticks with a schedule containing a single system:
+Components are normal Rust structs. They are data stored in a `World` and specific instances of Components correlate to Entities.
+
+```rust
+struct Position { x: f32, y: f32 }
+```
+
+### Worlds
+
+Entities, Components, and Resources are stored in a `World`. Worlds, much like Rust std collections like HashSet and Vec, expose operations to insert, read, write, and remove the data they store.
+
+```rust
+let world = World::default();
+```
+
+### Entities
+
+Entities are unique identifiers that correlate to zero or more Components.
+
+```rust
+let entity = world.spawn()
+    .insert(Position { x: 0.0, y: 0.0 })
+    .insert(Velocity { x: 1.0, y: 0.0 })
+    .id();
+
+let entity_ref = world.entity(entity);
+let position = entity_ref.get::<Position>().unwrap();
+let velocity = entity_ref.get::<Velocity>().unwrap();
+```
+
+### Systems
+
+System are normal Rust functions. Thanks to the Rust type system, Bevy ECS can use function parameter types to determine what data needs to be sent to the system. It also uses this "data access" information to determine what Systems can run in parallel with each other.
+
+```rust
+fn print_position(query: Query<(Entity, &Position)>) {
+    for (entity, position) in query.iter() {
+        println!("Entity {:?} is at position: x {}, y {}", entity, position.x, position.y);
+    }
+}
+```
+
+### Resources
+
+Apps often require unique resources, such as asset collections, renderers, audio servers, time, etc. Bevy ECS makes this pattern a first class citizen. `Resource` is a special kind of component that does not belong to any entity. Instead, it is identified uniquely by its type:
+
+```rust
+#[derive(Default)]
+struct Time {
+    seconds: f32,
+}
+
+world.insert_resource(Time::default());
+
+let time = world.get_resource::<Time>().unwrap();
+
+// you can also access resources from Systems
+fn print_time(time: Res<Time>) {
+    println!("{}", time.seconds);
+}
+```
+
+The [`resources.rs`](examples/resources.rs) example illustrates how to read and write a Counter resource from Systems.
+
+
+### Schedules
+
+Schedules consist of zero or more Stages, which run a set of Systems according to some execution strategy. Bevy ECS provides a few built in Stage implementations (ex: parallel, serial), but you can also implement your own! Schedules run Stages one-by-one in an order defined by the user.
+
+The built in "parallel stage" considers dependencies between systems and (by default) run as many of them in parallel as possible. This maximizes performance, while keeping the system execution safe. You can also define explicit dependencies between systems.
+
+## Using Bevy ECS
+
+Bevy ECS should feel very natural for those familiar with Rust syntax:
 
 ```rust
 use bevy_ecs::prelude::*;
 
-fn main() {
-    // Create a world
-    let mut world = World::new();
+struct Velocity {
+    x: f32,
+    y: f32,
+}
 
-    // Create a schedule and a stage
-    let mut schedule = Schedule::default();
-    let mut update = SystemStage::parallel();
+struct Position {
+    x: f32,
+    y: f32,
+}
 
-    // Add a system to the stage
-    update.add_system(print_a_message.system());
-
-    // Add the prepared stage to the schedule
-    schedule.add_stage("update", update);
-
-    // We will simulate 10 frames
-    for iteration in 1..=10 {
-        println!("Simulating frame {}/10", iteration);
-        schedule.run_once(&mut world);
+// This system moves each entity with a Position and Velocity component
+fn movement(query: Query<(&mut Position, &Velocity)>) {
+    for (mut position, velocity) in query.iter_mut() {
+        position.x += velocity.x;
+        position.y += velocity.y;
     }
 }
 
-// This function serves as a system
-fn print_a_message() {
-    println!("System is running");
+fn main() {
+    // Create a new empty World to hold our Entities and Components
+    let mut world = World::new();
+
+    // Spawn an entity with Position and Velocity components
+    world.spawn()
+        .insert(Position { x: 0.0, y: 0.0 })
+        .insert(Velocity { x: 1.0, y: 0.0 });
+
+    // Create a new Schedule, which defines an execution strategy for Systems
+    let mut schedule = Schedule::default();
+
+    // Add a Stage to our schedule. Each Stage in a schedule runs all of its systems
+    // before moving on to the next Stage
+    schedule.add_stage("update", SystemStage::parallel()
+        .with_system(movement.system())
+    );
+
+    // Run the schedule once. If your app has a "loop", you would run this once per loop
+    schedule.run(&mut world);
 }
 ```
 
-The output of this trivial example are two console logs for each tick.
+## Features
 
-### Component storage
+### Query Filters
 
-A unique feature of Bevy ECS is the support for multiple component storage types.
+```rust
+// Gets the Position component of all Entities with Player component and without the RedTeam component
+fn system(query: Query<&Position, (With<Player>, Without<RedTeam>)>) {
+    for position in query.iter() {
+    }
+}
+```
+
+### Change Detection
+
+Bevy ECS tracks _all_ changes to Components and Resources.
+
+Queries can filter for changed Components:
+
+```rust
+// Gets the Position component of all Entities whose Velocity has changed since the last run of the System
+fn system(query: Query<&Position, Changed<Velocity>>) {
+    for position in query.iter() {
+    }
+}
+
+// Gets the Position component of all Entities that had a Velocity component added since the last run of the System
+fn system(query: Query<&Position, Added<Velocity>>) {
+    for position in query.iter() {
+    }
+}
+```
+
+Resources also expose change state:
+
+```rust
+// Gets the Position component of all Entities whose Velocity has changed since the last run of the System
+fn system(time: Res<Time>) {
+    if time.is_changed() {
+        println!("time changed!");
+    }
+}
+```
+
+
+The [`change_detection.rs`](examples/change_detection.rs) example shows how to query only for updated entities and react on changes in resources.
+
+### Component Storage
+
+Bevy ECS supports multiple component storage types.
 
 Components can be stored in:
 
-* Tables: fast and cache friendly iteration, but slower adding and removing of components
-* Sparse Sets: fast adding and removing of components, but slower iteration
+* **Tables**: Fast and cache friendly iteration, but slower adding and removing of components. This is the default storage type.
+* **Sparse Sets**: Fast adding and removing of components, but slower iteration.
 
-The used storage type can be configured per component and defaults to table storage. The example [`component_storage.rs`](examples/component_storage.rs) shows how to configure the storage type for a component.
+Component storage types are configurable and they default to table storage if the storage is not manually defined. The [`component_storage.rs`](examples/component_storage.rs) example shows how to configure the storage type for a component.
 
-### Resources
+```rust
+// store Position components in Sparse Sets
+world.register_component(ComponentDescriptor::new::<Position>(StorageType::SparseSet));
+```
 
-A common pattern when working with ECS is the creation of global singleton components. Bevy ECS makes this pattern a first class citizen. `Resource` is a special kind of component that does not belong to any entity. Bevy itself makes heavy use of resources as a way to configure systems.
+### Component Bundles
 
-The example [`resources.rs`](examples/resources.rs) uses a resource to keep a counter that can be increased by a system and read from other systems.
+Define sets of Components that should be added together.
+
+```rust
+#[derive(Bundle, Default)]
+struct PlayerBundle {
+    player: Player,
+    position: Position,
+    velocity: Velocity,
+}
+
+world.spawn().insert_bundle(PlayerBundle::default());
+
+// Bundles play well with Rust's struct update syntax
+world.spawn().insert_bundle(PlayerBundle {
+    position: Position { x: 1.0, y: 1.0 },
+    ..Default::default()
+});
+```
 
 ### Events
 
-Events offer a short-lived communication channel between one to many systems. Events can be sent using the system parameter `EventWriter` and received with `EventReader`. Very little boilerplate is required to register a struct as an event.
+Events offer a communication channel between one or more systems. Events can be sent using the system parameter `EventWriter` and received with `EventReader`.
+
+```rust
+struct MyEvent {
+    message: String,
+}
+
+fn writer(mut writer: EventWriter<MyEvent>) {
+    writer.send(MyEvent {
+        message: "hello!".to_string(),
+    });
+}
+
+fn reader(mut reader: EventReader<MyEvent>) {
+    for event in reader.iter() {
+    }
+}
+```
 
 A minimal set up using events can be seen in [`events.rs`](examples/events.rs).
-
-### Change detection
-
-Bevy ECS includes a simple way of detecting change in resources and entities. Resources have `is_changed` and `is_added` functions and entities can be queried based on changed or added components.
-
-The example [`change_detection.rs`](examples/change_detection.rs) shows how to query only for updated entities and react on changes in resources.
 
 [bevy]: https://bevyengine.org/

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -10,7 +10,7 @@ Bevy ECS is the Entity Component System used in and developed for the game engin
 
 ## About
 
-Entity Component System is an architectural pattern using composition to provide greater flexibility.
+Entity Component System is an architectural pattern using composition to provide greater flexibility. Using an ECS can provide a clean architecture by separating data and functionality. At the same time this separation can enable more cache friendly storage and thus allow for better performance.
 
 ### Main concepts
 
@@ -18,13 +18,17 @@ Entity Component System is an architectural pattern using composition to provide
 * Components are data structures that can be attached to entities
 * Systems encode a certain behaviour of the world
 
-Entities and components are kept in a `World`. Constructing a `Schedule` with systems allows you to simulate a tick of the world. The schedule will consider dependencies between systems and run as many of them in parallel as possible. This maximises performance, while keeping the system execution safe. You can make dependencies explicit by requesting certain execution orders using `SystemLabel`s.
+Entities and components are kept in a `World`. Constructing a `Schedule` with systems allows you to simulate a tick of the world. The schedule will consider dependencies between systems and (by default) run as many of them in parallel as possible. This maximises performance, while keeping the system execution safe. You can make dependencies explicit by requesting certain execution orders using `SystemLabel`.
 
 ## Features
 
 Bevy ECS uses Rust's type safety to represent systems as "normal" functions and components as structs. In most cases this does not require any additional effort by the user.
 
+In a minimal example we can create a world and simulate 10 ticks with a schedule containing a single system:
+
 ```rust
+use bevy_ecs::prelude::*;
+
 fn main() {
     // Create a world
     let mut world = World::new();
@@ -35,7 +39,7 @@ fn main() {
 
     // Add a system to the stage
     update.add_system(print_a_message.system());
-    
+
     // Add the prepared stage to the schedule
     schedule.add_stage("update", update);
 
@@ -48,13 +52,17 @@ fn main() {
 
 // This function serves as a system
 fn print_a_message() {
-    println!("System is running", my_event);
+    println!("System is running");
 }
 ```
+
+The output of this trivial example are two console logs for each tick.
 
 ### Component storage
 
 A unique feature of Bevy ECS is the support for multiple component storage types.
+
+Components can be stored in:
 
 * Tables: fast and cache friendly iteration, but slower adding and removing of components
 * Sparse Sets: fast adding and removing of components, but slower iteration
@@ -63,15 +71,15 @@ The used storage type can be configured per component and defaults to table stor
 
 ### Resources
 
-A common pattern when working with ECS is the creation of global singleton components. Bevy ECS makes this pattern a first class citizen. `Resource`s are a special kind of component that do not belong to any entity. Bevy itself makes heavy use of Resources as a way to configure systems.
+A common pattern when working with ECS is the creation of global singleton components. Bevy ECS makes this pattern a first class citizen. `Resource` is a special kind of component that does not belong to any entity. Bevy itself makes heavy use of resources as a way to configure systems.
 
 The example [`resources.rs`](examples/resources.rs) uses a resource to keep a counter that can be increased by a system and read from other systems.
 
 ### Events
 
-Events offer a short-lived communication channel between one to many systems. Events can be sent using `EventWriter` and received with `EventReader`. Very little boilerplate is required to register a struct as an event.
+Events offer a short-lived communication channel between one to many systems. Events can be sent using the system parameter `EventWriter` and received with `EventReader`. Very little boilerplate is required to register a struct as an event.
 
-A minimal set up to use events can be seen in [`events.rs`](examples/events.rs).
+A minimal set up using events can be seen in [`events.rs`](examples/events.rs).
 
 ### Change detection
 

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -1,0 +1,73 @@
+use bevy_ecs::prelude::*;
+use std::ops::Deref;
+
+#[derive(Debug)]
+struct Counter {
+    pub value: i32,
+}
+
+fn main() {
+    // Create a world
+    let mut world = World::new();
+
+    // Add the counter resource
+    world.insert_resource(Counter { value: 0 });
+
+    // Create a schedule and a stage
+    let mut schedule = Schedule::default();
+    let mut update = SystemStage::parallel();
+
+    // Add systems sending and receiving events
+    update.add_system(increase_counter.system().label("increase"));
+    update.add_system(print_counter_when_changed.system().after("increase"));
+    update.add_system(manipulate_entities.system().label("mutate"));
+    update.add_system(print_changed_entities.system().after("mutate"));
+    schedule.add_stage("update", update);
+
+    for iteration in 1..=10 {
+        println!("Simulating frame {}/10", iteration);
+        schedule.run_once(&mut world);
+    }
+}
+
+fn manipulate_entities(
+    mut commands: Commands,
+    last_spawned_entity: Query<Entity, Without<i32>>,
+    mut entities: Query<&mut i32>,
+) {
+    if rand::random::<f32>() > 0.5 {
+        commands.spawn();
+    }
+    for mut value in entities.iter_mut() {
+        *value += 1;
+    }
+    for entity in last_spawned_entity.iter() {
+        commands.entity(entity).insert(0);
+    }
+}
+
+fn print_changed_entities(
+    entity_with_added_component: Query<Entity, Added<i32>>,
+    entity_with_mutated_component: Query<&i32, Changed<i32>>,
+) {
+    for entity in entity_with_added_component.iter() {
+        println!("    i32 component was just added to '{:?}'", entity);
+    }
+    for value in entity_with_mutated_component.iter() {
+        println!("    component was mutated to {:?}", value);
+    }
+}
+
+fn increase_counter(mut counter: ResMut<Counter>) {
+    let random_value: f32 = rand::random();
+    if random_value > 0.5 {
+        counter.value += 1;
+        println!("    Increased counter value");
+    }
+}
+
+fn print_counter_when_changed(counter: Res<Counter>) {
+    if counter.is_changed() && !counter.is_added() {
+        println!("    Changed to {:?}", counter.deref());
+    }
+}

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -45,9 +45,8 @@ struct Age {
 
 fn spawn_entities(mut commands: Commands, mut entity_counter: ResMut<EntityCounter>) {
     if rand::thread_rng().gen_bool(0.6) {
-        let mut entity = commands.spawn();
-        entity.insert(Age::default());
-        println!("    spawning {:?}", entity.id());
+        let entity_id = commands.spawn().insert(Age::default()).id();
+        println!("    spawning {:?}", entity_id);
         entity_counter.value += 1;
     }
 }

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -24,11 +24,15 @@ fn main() {
 
     // Add systems to the Stage that execute behaviour
     // We can label our systems to force a specific run-order between some of them
-    update.add_system(spawn_entities.system().label("spawn"));
-    update.add_system(print_counter_when_changed.system().after("spawn"));
-    update.add_system(age_all_entities.system().label("age"));
-    update.add_system(remove_old_entities.system().after("age"));
-    update.add_system(print_changed_entities.system().after("age"));
+    update.add_system(spawn_entities.system().label(SimulationSystem::Spawn));
+    update.add_system(
+        print_counter_when_changed
+            .system()
+            .after(SimulationSystem::Spawn),
+    );
+    update.add_system(age_all_entities.system().label(SimulationSystem::Age));
+    update.add_system(remove_old_entities.system().after(SimulationSystem::Age));
+    update.add_system(print_changed_entities.system().after(SimulationSystem::Age));
     // Add the Stage with our systems to the Schedule
     schedule.add_stage("update", update);
 
@@ -49,6 +53,12 @@ struct EntityCounter {
 #[derive(Default, Debug)]
 struct Age {
     frames: i32,
+}
+
+#[derive(SystemLabel, Debug, Clone, PartialEq, Eq, Hash)]
+enum SimulationSystem {
+    Spawn,
+    Age,
 }
 
 // This system randomly spawns a new entity in 60% of all frames

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -2,47 +2,58 @@ use bevy_ecs::prelude::*;
 use rand::Rng;
 use std::ops::Deref;
 
-#[derive(Debug)]
-struct EntityCounter {
-    pub value: i32,
-}
-
 // In this example we will simulate a population of entities. In every tick we will:
 // 1. spawn a new entity with a certain possibility
 // 2. age all entities
 // 3. despawn entities with age > 2
 //
-// To demonstrate change detection, there are some console outputs based on changes in the EntityCounter resource and updated Age components
+// To demonstrate change detection, there are some console outputs based on changes in
+// the EntityCounter resource and updated Age components
 fn main() {
-    // Create a world
+    // Create a new empty World to hold our Entities, Components and Resources
     let mut world = World::new();
 
     // Add the counter resource to remember how many entities where spawned
     world.insert_resource(EntityCounter { value: 0 });
 
-    // Create a schedule and a stage
+    // Create a new Schedule, which defines an execution strategy for Systems
     let mut schedule = Schedule::default();
+    // Create a Stage to add to our Schedule. Each Stage in a schedule runs all of its systems
+    // before moving on to the next Stage
     let mut update = SystemStage::parallel();
 
-    // Add systems sending and receiving events
+    // Add systems to the Stage that execute behaviour
+    // We can label our systems to force a specific run-order between some of them
     update.add_system(spawn_entities.system().label("spawn"));
     update.add_system(print_counter_when_changed.system().after("spawn"));
     update.add_system(age_all_entities.system().label("age"));
     update.add_system(remove_old_entities.system().after("age"));
     update.add_system(print_changed_entities.system().after("age"));
+    // Add the Stage with our systems to the Schedule
     schedule.add_stage("update", update);
 
+    // Simulate 10 frames in our world
     for iteration in 1..=10 {
         println!("Simulating frame {}/10", iteration);
         schedule.run(&mut world);
     }
 }
 
-#[derive(Default, Debug)]
-struct Age {
-    ticks: i32,
+// This struct will be used as a Resource keeping track of the total amount of spawned entities
+#[derive(Debug)]
+struct EntityCounter {
+    pub value: i32,
 }
 
+// This struct represents a Component and holds the age in frames of the entity it gets assigned to
+#[derive(Default, Debug)]
+struct Age {
+    frames: i32,
+}
+
+// This system randomly spawns a new entity in 60% of all frames
+// The entity will start with an age of 0 frames
+// If an entity gets spawned, we increase the counter in the EntityCounter resource
 fn spawn_entities(mut commands: Commands, mut entity_counter: ResMut<EntityCounter>) {
     if rand::thread_rng().gen_bool(0.6) {
         let entity_id = commands.spawn().insert(Age::default()).id();
@@ -51,21 +62,12 @@ fn spawn_entities(mut commands: Commands, mut entity_counter: ResMut<EntityCount
     }
 }
 
-fn remove_old_entities(mut commands: Commands, entities: Query<(Entity, &Age)>) {
-    for (entity, age) in entities.iter() {
-        if age.ticks > 2 {
-            println!("    despawning {:?} due to age > 2", entity);
-            commands.entity(entity).despawn();
-        }
-    }
-}
-
-fn age_all_entities(mut entities: Query<&mut Age>) {
-    for mut age in entities.iter_mut() {
-        age.ticks += 1;
-    }
-}
-
+// This system prints out changes in our entity collection
+// For every entity that just got the Age component added we will print that it's the
+// entities first birthday. These entities where spawned in the previous frame.
+// For every entity with a changed Age component we will print the new value.
+// In this example the Age component is changed in every frame, so we don't actually
+// need the `Changed` here, but it is still used for the purpose of demonstration.
 fn print_changed_entities(
     entity_with_added_component: Query<Entity, Added<Age>>,
     entity_with_mutated_component: Query<(Entity, &Age), Changed<Age>>,
@@ -74,10 +76,29 @@ fn print_changed_entities(
         println!("    {:?} has it's first birthday!", entity);
     }
     for (entity, value) in entity_with_mutated_component.iter() {
-        println!("    {:?} now has {:?}", entity, value);
+        println!("    {:?} is now {:?} frames old", entity, value);
     }
 }
 
+// This system iterates over all entities and increases their age in every frame
+fn age_all_entities(mut entities: Query<&mut Age>) {
+    for mut age in entities.iter_mut() {
+        age.frames += 1;
+    }
+}
+
+// This system iterates over all entities in every frame and despawns entities older than 2 frames
+fn remove_old_entities(mut commands: Commands, entities: Query<(Entity, &Age)>) {
+    for (entity, age) in entities.iter() {
+        if age.frames > 2 {
+            println!("    despawning {:?} due to age > 2", entity);
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+// This system will print the new counter value everytime it was changed since
+// the last execution of the system.
 fn print_counter_when_changed(entity_counter: Res<EntityCounter>) {
     if entity_counter.is_changed() {
         println!(

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -22,7 +22,7 @@ fn main() {
     // before moving on to the next Stage
     let mut update = SystemStage::parallel();
 
-    // Add systems to the Stage that execute behaviour
+    // Add systems to the Stage to execute our app logic
     // We can label our systems to force a specific run-order between some of them
     update.add_system(spawn_entities.system().label(SimulationSystem::Spawn));
     update.add_system(

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -55,6 +55,7 @@ struct Age {
     frames: i32,
 }
 
+// System labels to enforce a run order of our systems
 #[derive(SystemLabel, Debug, Clone, PartialEq, Eq, Hash)]
 enum SimulationSystem {
     Spawn,

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -1,28 +1,35 @@
 use bevy_ecs::prelude::*;
-use std::ops::Deref;
 use rand::Rng;
+use std::ops::Deref;
 
 #[derive(Debug)]
-struct Counter {
+struct EntityCounter {
     pub value: i32,
 }
 
+// In this example we will simulate a population of entities. In every tick we will:
+// 1. spawn a new entity with a certain possibility
+// 2. age all entities
+// 3. despawn entities with age > 2
+//
+// To demonstrate change detection, there are some console outputs based on changes in the EntityCounter resource and updated Age components
 fn main() {
     // Create a world
     let mut world = World::new();
 
-    // Add the counter resource
-    world.insert_resource(Counter { value: 0 });
+    // Add the counter resource to remember how many entities where spawned
+    world.insert_resource(EntityCounter { value: 0 });
 
     // Create a schedule and a stage
     let mut schedule = Schedule::default();
     let mut update = SystemStage::parallel();
 
     // Add systems sending and receiving events
-    update.add_system(increase_counter.system().label("increase"));
-    update.add_system(print_counter_when_changed.system().after("increase"));
-    update.add_system(manipulate_entities.system().label("mutate"));
-    update.add_system(print_changed_entities.system().after("mutate"));
+    update.add_system(spawn_entities.system().label("spawn"));
+    update.add_system(print_counter_when_changed.system().after("spawn"));
+    update.add_system(age_all_entities.system().label("age"));
+    update.add_system(remove_old_entities.system().after("age"));
+    update.add_system(print_changed_entities.system().after("age"));
     schedule.add_stage("update", update);
 
     for iteration in 1..=10 {
@@ -31,41 +38,52 @@ fn main() {
     }
 }
 
-fn manipulate_entities(
-    mut commands: Commands,
-    mut entities: Query<&mut i32>,
-) {
-    if rand::thread_rng().gen_bool(0.5) {
+#[derive(Default, Debug)]
+struct Age {
+    ticks: i32,
+}
+
+fn spawn_entities(mut commands: Commands, mut entity_counter: ResMut<EntityCounter>) {
+    if rand::thread_rng().gen_bool(0.6) {
         let mut entity = commands.spawn();
-        entity.insert(0);
-        println!("    spawned {:?}", entity.id())
+        entity.insert(Age::default());
+        println!("    spawning {:?}", entity.id());
+        entity_counter.value += 1;
     }
-    for mut value in entities.iter_mut() {
-        *value += 1;
+}
+
+fn remove_old_entities(mut commands: Commands, entities: Query<(Entity, &Age)>) {
+    for (entity, age) in entities.iter() {
+        if age.ticks > 2 {
+            println!("    despawning {:?} due to age > 2", entity);
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+fn age_all_entities(mut entities: Query<&mut Age>) {
+    for mut age in entities.iter_mut() {
+        age.ticks += 1;
     }
 }
 
 fn print_changed_entities(
-    entity_with_added_component: Query<Entity, Added<i32>>,
-    entity_with_mutated_component: Query<&i32, Changed<i32>>,
+    entity_with_added_component: Query<Entity, Added<Age>>,
+    entity_with_mutated_component: Query<(Entity, &Age), Changed<Age>>,
 ) {
     for entity in entity_with_added_component.iter() {
-        println!("    i32 component was just added to '{:?}'", entity);
+        println!("    {:?} has it's first birthday!", entity);
     }
-    for value in entity_with_mutated_component.iter() {
-        println!("    component was mutated to {:?}", value);
-    }
-}
-
-fn increase_counter(mut counter: ResMut<Counter>) {
-    if rand::thread_rng().gen_bool(0.5) {
-        counter.value += 1;
-        println!("    Increased counter value");
+    for (entity, value) in entity_with_mutated_component.iter() {
+        println!("    {:?} now has {:?}", entity, value);
     }
 }
 
-fn print_counter_when_changed(counter: Res<Counter>) {
-    if counter.is_changed() && !counter.is_added() {
-        println!("    Changed {:?}", counter.deref());
+fn print_counter_when_changed(entity_counter: Res<EntityCounter>) {
+    if entity_counter.is_changed() {
+        println!(
+            "    total number of entities spawned: {}",
+            entity_counter.deref().value
+        );
     }
 }

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -1,5 +1,6 @@
 use bevy_ecs::prelude::*;
 use std::ops::Deref;
+use rand::Rng;
 
 #[derive(Debug)]
 struct Counter {
@@ -32,17 +33,15 @@ fn main() {
 
 fn manipulate_entities(
     mut commands: Commands,
-    last_spawned_entity: Query<Entity, Without<i32>>,
     mut entities: Query<&mut i32>,
 ) {
-    if rand::random::<f32>() > 0.5 {
-        commands.spawn();
+    if rand::thread_rng().gen_bool(0.5) {
+        let mut entity = commands.spawn();
+        entity.insert(0);
+        println!("    spawned {:?}", entity.id())
     }
     for mut value in entities.iter_mut() {
         *value += 1;
-    }
-    for entity in last_spawned_entity.iter() {
-        commands.entity(entity).insert(0);
     }
 }
 
@@ -59,8 +58,7 @@ fn print_changed_entities(
 }
 
 fn increase_counter(mut counter: ResMut<Counter>) {
-    let random_value: f32 = rand::random();
-    if random_value > 0.5 {
+    if rand::thread_rng().gen_bool(0.5) {
         counter.value += 1;
         println!("    Increased counter value");
     }
@@ -68,6 +66,6 @@ fn increase_counter(mut counter: ResMut<Counter>) {
 
 fn print_counter_when_changed(counter: Res<Counter>) {
     if counter.is_changed() && !counter.is_added() {
-        println!("    Changed to {:?}", counter.deref());
+        println!("    Changed {:?}", counter.deref());
     }
 }

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -34,7 +34,7 @@ fn main() {
 
     for iteration in 1..=10 {
         println!("Simulating frame {}/10", iteration);
-        schedule.run_once(&mut world);
+        schedule.run(&mut world);
     }
 }
 

--- a/crates/bevy_ecs/examples/component_storage.rs
+++ b/crates/bevy_ecs/examples/component_storage.rs
@@ -1,4 +1,7 @@
-use bevy_ecs::{prelude::*, component::{ComponentDescriptor, StorageType}};
+use bevy_ecs::{
+    component::{ComponentDescriptor, StorageType},
+    prelude::*,
+};
 
 fn main() {
     let mut world = World::new();

--- a/crates/bevy_ecs/examples/component_storage.rs
+++ b/crates/bevy_ecs/examples/component_storage.rs
@@ -7,13 +7,13 @@ fn main() {
     // Store components of type `i32` in a Sparse set
     world
         .register_component(ComponentDescriptor::new::<i32>(StorageType::SparseSet))
-        .expect("The component of type i32 was already previously used by `World`");
+        .expect("The component of type i32 is already in use");
 
     // Components of type i32 will have the above configured Sparse set storage,
     // while f64 components will have the default table storage
-    world.spawn().insert(1).insert(1.);
+    world.spawn().insert(1).insert(0.1);
     world.spawn().insert(2);
-    world.spawn().insert(2.);
+    world.spawn().insert(0.2);
 
     // Setup a schedule and stage to add a system querying for the just spawned entities
     let mut schedule = Schedule::default();
@@ -24,7 +24,7 @@ fn main() {
     schedule.run_once(&mut world);
 }
 
-// The storage type does not matter at all for how to query in systems
+// The storage type does not matter for how to query in systems
 fn query_entities(entities_with_i32: Query<&i32>, entities_with_f64: Query<&f64>) {
     for value in entities_with_i32.iter() {
         println!("Got entity with i32: {}", value);

--- a/crates/bevy_ecs/examples/component_storage.rs
+++ b/crates/bevy_ecs/examples/component_storage.rs
@@ -1,5 +1,4 @@
-use bevy_ecs::component::{ComponentDescriptor, StorageType};
-use bevy_ecs::prelude::*;
+use bevy_ecs::{prelude::*, component::{ComponentDescriptor, StorageType}};
 
 fn main() {
     let mut world = World::new();

--- a/crates/bevy_ecs/examples/component_storage.rs
+++ b/crates/bevy_ecs/examples/component_storage.rs
@@ -3,6 +3,8 @@ use bevy_ecs::{
     prelude::*,
 };
 
+// This example shows how to configure the storage of Components.
+// A system demonstrates that querying for components is independent of their storage type.
 fn main() {
     let mut world = World::new();
 

--- a/crates/bevy_ecs/examples/component_storage.rs
+++ b/crates/bevy_ecs/examples/component_storage.rs
@@ -23,7 +23,7 @@ fn main() {
     update.add_system(query_entities.system());
     schedule.add_stage("update", update);
 
-    schedule.run_once(&mut world);
+    schedule.run(&mut world);
 }
 
 // The storage type does not matter for how to query in systems

--- a/crates/bevy_ecs/examples/component_storage.rs
+++ b/crates/bevy_ecs/examples/component_storage.rs
@@ -1,0 +1,35 @@
+use bevy_ecs::component::{ComponentDescriptor, StorageType};
+use bevy_ecs::prelude::*;
+
+fn main() {
+    let mut world = World::new();
+
+    // Store components of type `i32` in a Sparse set
+    world
+        .register_component(ComponentDescriptor::new::<i32>(StorageType::SparseSet))
+        .expect("The component of type i32 was already previously used by `World`");
+
+    // Components of type i32 will have the above configured Sparse set storage,
+    // while f64 components will have the default table storage
+    world.spawn().insert(1).insert(1.);
+    world.spawn().insert(2);
+    world.spawn().insert(2.);
+
+    // Setup a schedule and stage to add a system querying for the just spawned entities
+    let mut schedule = Schedule::default();
+    let mut update = SystemStage::parallel();
+    update.add_system(query_entities.system());
+    schedule.add_stage("update", update);
+
+    schedule.run_once(&mut world);
+}
+
+// The storage type does not matter at all for how to query in systems
+fn query_entities(entities_with_i32: Query<&i32>, entities_with_f64: Query<&f64>) {
+    for value in entities_with_i32.iter() {
+        println!("Got entity with i32: {}", value);
+    }
+    for value in entities_with_f64.iter() {
+        println!("Got entity with f64: {}", value);
+    }
+}

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -27,7 +27,7 @@ fn main() {
 
     for iteration in 1..=10 {
         println!("Simulating frame {}/10", iteration);
-        schedule.run_once(&mut world);
+        schedule.run(&mut world);
     }
 }
 

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -1,0 +1,48 @@
+use bevy_ecs::event::Events;
+use bevy_ecs::prelude::*;
+
+// this is our event
+#[derive(Debug)]
+struct MyEvent {
+    pub message: String,
+    pub random_value: f32,
+}
+
+fn main() {
+    // Create a world and add the event as a resource
+    let mut world = World::new();
+    world.insert_resource(Events::<MyEvent>::default());
+
+    // Create a schedule and a stage
+    let mut schedule = Schedule::default();
+    let mut update = SystemStage::parallel();
+
+    // Add the event managing system to the stage and register the stage in with the schedule
+    update.add_system(Events::<MyEvent>::update_system.system());
+
+    // Add systems sending and receiving events
+    update.add_system(sending_system.system());
+    update.add_system(receiving_system.system());
+    schedule.add_stage("update", update);
+
+    for iteration in 1..=10 {
+        println!("Simulating frame {}/10", iteration);
+        schedule.run_once(&mut world);
+    }
+}
+
+fn sending_system(mut event_writer: EventWriter<MyEvent>) {
+    let random_value: f32 = rand::random();
+    if random_value > 0.5 {
+        event_writer.send(MyEvent {
+            message: "A random event with value > 0.5".to_string(),
+            random_value,
+        });
+    }
+}
+
+fn receiving_system(mut event_reader: EventReader<MyEvent>) {
+    for my_event in event_reader.iter() {
+        println!("    Received: {:?}", *my_event);
+    }
+}

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -1,7 +1,4 @@
-use bevy_ecs::{
-    event::Events,
-    prelude::*,
-};
+use bevy_ecs::{event::Events, prelude::*};
 
 // This is our event
 #[derive(Debug)]

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -1,5 +1,4 @@
-use bevy_ecs::event::Events;
-use bevy_ecs::prelude::*;
+use bevy_ecs::{prelude::*, component::{ComponentDescriptor, StorageType}};
 
 // This is our event
 #[derive(Debug)]

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -1,36 +1,49 @@
 use bevy_ecs::{event::Events, prelude::*};
 
-// This is our event
-#[derive(Debug)]
-struct MyEvent {
-    pub message: String,
-    pub random_value: f32,
-}
-
 fn main() {
-    // Create a world and add the event as a resource
+    // Create a new empty world and add the event as a resource
     let mut world = World::new();
     world.insert_resource(Events::<MyEvent>::default());
 
     // Create a schedule and a stage
     let mut schedule = Schedule::default();
-    let mut update = SystemStage::parallel();
 
-    // Add the event managing system to the stage
-    update.add_system(Events::<MyEvent>::update_system.system());
+    // Events need to be updated in every frame. This update should happen before we use
+    // the events. To guarantee this, we can let the update run in an earlier stage than our logic.
+    // Here we will use a stage called "first" that will always run it's systems before the Stage
+    // called "second". In "first" we update the events and in "second" we run our systems using the events.
+    let mut first = SystemStage::parallel();
+    first.add_system(Events::<MyEvent>::update_system.system());
+    schedule.add_stage("first", first);
 
-    // Add systems sending and receiving events
-    update.add_system(sending_system.system());
-    update.add_system(receiving_system.system());
+    // Add systems sending and receiving events to a "second" Stage
+    let mut second = SystemStage::parallel();
+    second.add_system(sending_system.system().label(EventSystem::Sending));
+    second.add_system(receiving_system.system().after(EventSystem::Sending));
 
-    schedule.add_stage("update", update);
+    // Run the "second" Stage after the "first" Stage, so our Events always get updated before we use them
+    schedule.add_stage_after("first", "second", second);
 
+    // Simulate 10 frames of our world
     for iteration in 1..=10 {
         println!("Simulating frame {}/10", iteration);
         schedule.run(&mut world);
     }
 }
 
+#[derive(SystemLabel, Debug, Clone, PartialEq, Eq, Hash)]
+enum EventSystem {
+    Sending,
+}
+
+// This is our event that we will send and receive in systems
+#[derive(Debug)]
+struct MyEvent {
+    pub message: String,
+    pub random_value: f32,
+}
+
+// In every frame we will send an event with a 50/50 chance
 fn sending_system(mut event_writer: EventWriter<MyEvent>) {
     let random_value: f32 = rand::random();
     if random_value > 0.5 {
@@ -41,6 +54,8 @@ fn sending_system(mut event_writer: EventWriter<MyEvent>) {
     }
 }
 
+// This system listens for events of the type MyEvent
+// If an event is received it will be printed to the console
 fn receiving_system(mut event_reader: EventReader<MyEvent>) {
     for my_event in event_reader.iter() {
         println!("    Received: {:?}", *my_event);

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -31,6 +31,7 @@ fn main() {
     }
 }
 
+// System label to enforce a run order of our systems
 #[derive(SystemLabel, Debug, Clone, PartialEq, Eq, Hash)]
 enum EventSystem {
     Sending,

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -1,4 +1,7 @@
-use bevy_ecs::{prelude::*, component::{ComponentDescriptor, StorageType}};
+use bevy_ecs::{
+    event::Events,
+    prelude::*,
+};
 
 // This is our event
 #[derive(Debug)]

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -1,5 +1,7 @@
 use bevy_ecs::{event::Events, prelude::*};
 
+// In this example a system sends a custom event with a 50/50 chance during any frame.
+// If an event was send, it will be printed by the console in a receiving system.
 fn main() {
     // Create a new empty world and add the event as a resource
     let mut world = World::new();
@@ -11,7 +13,8 @@ fn main() {
     // Events need to be updated in every frame. This update should happen before we use
     // the events. To guarantee this, we can let the update run in an earlier stage than our logic.
     // Here we will use a stage called "first" that will always run it's systems before the Stage
-    // called "second". In "first" we update the events and in "second" we run our systems using the events.
+    // called "second". In "first" we update the events and in "second" we run our systems
+    // sending and receiving events.
     let mut first = SystemStage::parallel();
     first.add_system(Events::<MyEvent>::update_system.system());
     schedule.add_stage("first", first);

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -1,7 +1,7 @@
 use bevy_ecs::event::Events;
 use bevy_ecs::prelude::*;
 
-// this is our event
+// This is our event
 #[derive(Debug)]
 struct MyEvent {
     pub message: String,
@@ -17,12 +17,13 @@ fn main() {
     let mut schedule = Schedule::default();
     let mut update = SystemStage::parallel();
 
-    // Add the event managing system to the stage and register the stage in with the schedule
+    // Add the event managing system to the stage
     update.add_system(Events::<MyEvent>::update_system.system());
 
     // Add systems sending and receiving events
     update.add_system(sending_system.system());
     update.add_system(receiving_system.system());
+
     schedule.add_stage("update", update);
 
     for iteration in 1..=10 {

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::prelude::*;
-use std::ops::Deref;
 use rand::Rng;
+use std::ops::Deref;
 
 // This is our resource
 #[derive(Debug)]

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -30,6 +30,7 @@ fn main() {
     }
 }
 
+// System label to enforce a run order of our systems
 #[derive(SystemLabel, Debug, Clone, PartialEq, Eq, Hash)]
 enum CounterSystem {
     Increase,

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -1,5 +1,6 @@
 use bevy_ecs::prelude::*;
 use std::ops::Deref;
+use rand::Rng;
 
 // This is our resource
 #[derive(Debug)]
@@ -18,7 +19,7 @@ fn main() {
     let mut schedule = Schedule::default();
     let mut update = SystemStage::parallel();
 
-    // Add systems sending and receiving events
+    // Add systems to increase the counter and to print out the current value
     update.add_system(increase_counter.system().label("increase"));
     update.add_system(print_counter.system().after("increase"));
     schedule.add_stage("update", update);
@@ -30,8 +31,7 @@ fn main() {
 }
 
 fn increase_counter(mut counter: ResMut<Counter>) {
-    let random_value: f32 = rand::random();
-    if random_value > 0.5 {
+    if rand::thread_rng().gen_bool(0.5) {
         counter.value += 1;
         println!("    Increased counter value");
     }

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -2,12 +2,8 @@ use bevy_ecs::prelude::*;
 use rand::Rng;
 use std::ops::Deref;
 
-// This is our resource
-#[derive(Debug)]
-struct Counter {
-    pub value: i32,
-}
-
+// In this example we add a counter resource and increase it's value in one system,
+// while a different system prints the current count to the console.
 fn main() {
     // Create a world
     let mut world = World::new();
@@ -28,6 +24,12 @@ fn main() {
         println!("Simulating frame {}/10", iteration);
         schedule.run(&mut world);
     }
+}
+
+// Counter resource to be increased and read by systems
+#[derive(Debug)]
+struct Counter {
+    pub value: i32,
 }
 
 // System label to enforce a run order of our systems

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -26,7 +26,7 @@ fn main() {
 
     for iteration in 1..=10 {
         println!("Simulating frame {}/10", iteration);
-        schedule.run_once(&mut world);
+        schedule.run(&mut world);
     }
 }
 

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -20,14 +20,19 @@ fn main() {
     let mut update = SystemStage::parallel();
 
     // Add systems to increase the counter and to print out the current value
-    update.add_system(increase_counter.system().label("increase"));
-    update.add_system(print_counter.system().after("increase"));
+    update.add_system(increase_counter.system().label(CounterSystem::Increase));
+    update.add_system(print_counter.system().after(CounterSystem::Increase));
     schedule.add_stage("update", update);
 
     for iteration in 1..=10 {
         println!("Simulating frame {}/10", iteration);
         schedule.run(&mut world);
     }
+}
+
+#[derive(SystemLabel, Debug, Clone, PartialEq, Eq, Hash)]
+enum CounterSystem {
+    Increase,
 }
 
 fn increase_counter(mut counter: ResMut<Counter>) {

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -1,5 +1,4 @@
 use bevy_ecs::prelude::*;
-use bevy_ecs::system::Command;
 use std::ops::Deref;
 
 // This is our resource

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -1,0 +1,43 @@
+use bevy_ecs::prelude::*;
+use bevy_ecs::system::Command;
+use std::ops::Deref;
+
+// This is our resource
+#[derive(Debug)]
+struct Counter {
+    pub value: i32,
+}
+
+fn main() {
+    // Create a world
+    let mut world = World::new();
+
+    // Add the counter resource
+    world.insert_resource(Counter { value: 0 });
+
+    // Create a schedule and a stage
+    let mut schedule = Schedule::default();
+    let mut update = SystemStage::parallel();
+
+    // Add systems sending and receiving events
+    update.add_system(increase_counter.system().label("increase"));
+    update.add_system(print_counter.system().after("increase"));
+    schedule.add_stage("update", update);
+
+    for iteration in 1..=10 {
+        println!("Simulating frame {}/10", iteration);
+        schedule.run_once(&mut world);
+    }
+}
+
+fn increase_counter(mut counter: ResMut<Counter>) {
+    let random_value: f32 = rand::random();
+    if random_value > 0.5 {
+        counter.value += 1;
+        println!("    Increased counter value");
+    }
+}
+
+fn print_counter(counter: Res<Counter>) {
+    println!("    {:?}", counter.deref());
+}


### PR DESCRIPTION
[RENDERED](https://github.com/NiklasEi/bevy/blob/ecs_readme/crates/bevy_ecs/README.md)

Since I am trying to learn more about Bevy ECS at the moment, I thought this issue is a perfect fit.

This PR adds a readme to the `bevy_ecs` crate containing a minimal running example of stand alone `bevy_ecs`. Unique features like customizable component storage, Resources or change detection are introduced. For each of these features the readme links to an example in a newly created examples directory inside the `bevy_esc` crate.

Resolves #2008 