### PR TITLE
[Merged by Bors] - Automatic System Spans

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor.rs
+++ b/crates/bevy_ecs/src/schedule/executor.rs
@@ -31,6 +31,10 @@ impl ParallelSystemExecutor for SingleThreadedExecutor {
 
         for system in systems {
             if system.should_run() {
+                #[cfg(feature = "trace")]
+                let system_span = bevy_utils::tracing::info_span!("system", name = &*system.name());
+                #[cfg(feature = "trace")]
+                let _system_guard = system_span.enter();
                 system.system_mut().run((), world);
             }
         }

--- a/crates/bevy_ecs/src/schedule/executor_parallel.rs
+++ b/crates/bevy_ecs/src/schedule/executor_parallel.rs
@@ -201,8 +201,10 @@ impl ParallelExecutor {
                     let system_span =
                         bevy_utils::tracing::info_span!("system", name = &*system.name());
                     #[cfg(feature = "trace")]
-                    let _system_guard = system_span.enter();
+                    let system_guard = system_span.enter();
                     unsafe { system.run_unsafe((), world) };
+                    #[cfg(feature = "trace")]
+                    drop(system_guard);
                     finish_sender
                         .send(index)
                         .await

--- a/crates/bevy_ecs/src/schedule/executor_parallel.rs
+++ b/crates/bevy_ecs/src/schedule/executor_parallel.rs
@@ -197,6 +197,11 @@ impl ParallelExecutor {
                         .recv()
                         .await
                         .unwrap_or_else(|error| unreachable!(error));
+                    #[cfg(feature = "trace")]
+                    let system_span =
+                        bevy_utils::tracing::info_span!("system", name = &*system.name());
+                    #[cfg(feature = "trace")]
+                    let _system_guard = system_span.enter();
                     unsafe { system.run_unsafe((), world) };
                     finish_sender
                         .send(index)

--- a/crates/bevy_wgpu/src/wgpu_renderer.rs
+++ b/crates/bevy_wgpu/src/wgpu_renderer.rs
@@ -47,7 +47,12 @@ impl WgpuRenderer {
             .expect("Unable to find a GPU! Make sure you have installed required drivers!");
 
         #[cfg(feature = "trace")]
-        let trace_path = Some(std::path::Path::new("wgpu_trace"));
+        let trace_path = {
+            let path = std::path::Path::new("wgpu_trace");
+            // ignore potential error, wgpu will log it
+            let _ = std::fs::create_dir(path);
+            Some(path)
+        };
         #[cfg(not(feature = "trace"))]
         let trace_path = None;
 


### PR DESCRIPTION
As mentioned in https://github.com/bevyengine/bevy/issues/2025#issuecomment-827867660, systems used to have spans by default.

* add spans by default for every system executed
* create folder if missing for feature `wgpu_trace`