### PR TITLE
[Merged by Bors] - Make Command's public?

### DIFF
--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -284,7 +284,7 @@ impl<'a, 'b> EntityCommands<'a, 'b> {
 }
 
 #[derive(Debug)]
-pub(crate) struct Spawn<T> {
+pub struct Spawn<T> {
     bundle: T,
 }
 
@@ -297,7 +297,7 @@ where
     }
 }
 
-pub(crate) struct SpawnBatch<I>
+pub struct SpawnBatch<I>
 where
     I: IntoIterator,
     I::Item: Bundle,
@@ -316,7 +316,7 @@ where
 }
 
 #[derive(Debug)]
-pub(crate) struct Despawn {
+pub struct Despawn {
     entity: Entity,
 }
 
@@ -343,7 +343,7 @@ where
 }
 
 #[derive(Debug)]
-pub(crate) struct Insert<T> {
+pub struct Insert<T> {
     entity: Entity,
     component: T,
 }
@@ -358,7 +358,7 @@ where
 }
 
 #[derive(Debug)]
-pub(crate) struct Remove<T> {
+pub struct Remove<T> {
     entity: Entity,
     phantom: PhantomData<T>,
 }
@@ -375,7 +375,7 @@ where
 }
 
 #[derive(Debug)]
-pub(crate) struct RemoveBundle<T> {
+pub struct RemoveBundle<T> {
     entity: Entity,
     phantom: PhantomData<T>,
 }

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -285,7 +285,7 @@ impl<'a, 'b> EntityCommands<'a, 'b> {
 
 #[derive(Debug)]
 pub struct Spawn<T> {
-    bundle: T,
+    pub bundle: T,
 }
 
 impl<T> Command for Spawn<T>
@@ -302,7 +302,7 @@ where
     I: IntoIterator,
     I::Item: Bundle,
 {
-    bundles_iter: I,
+    pub bundles_iter: I,
 }
 
 impl<I> Command for SpawnBatch<I>
@@ -317,7 +317,7 @@ where
 
 #[derive(Debug)]
 pub struct Despawn {
-    entity: Entity,
+    pub entity: Entity,
 }
 
 impl Command for Despawn {
@@ -328,9 +328,9 @@ impl Command for Despawn {
     }
 }
 
-pub(crate) struct InsertBundle<T> {
-    entity: Entity,
-    bundle: T,
+pub struct InsertBundle<T> {
+    pub entity: Entity,
+    pub bundle: T,
 }
 
 impl<T> Command for InsertBundle<T>
@@ -344,8 +344,8 @@ where
 
 #[derive(Debug)]
 pub struct Insert<T> {
-    entity: Entity,
-    component: T,
+    pub entity: Entity,
+    pub component: T,
 }
 
 impl<T> Command for Insert<T>
@@ -376,8 +376,8 @@ where
 
 #[derive(Debug)]
 pub struct RemoveBundle<T> {
-    entity: Entity,
-    phantom: PhantomData<T>,
+    pub entity: Entity,
+    pub phantom: PhantomData<T>,
 }
 
 impl<T> Command for RemoveBundle<T>
@@ -393,8 +393,8 @@ where
     }
 }
 
-pub(crate) struct InsertResource<T: Component> {
-    resource: T,
+pub struct InsertResource<T: Component> {
+    pub resource: T,
 }
 
 impl<T: Component> Command for InsertResource<T> {
@@ -403,8 +403,8 @@ impl<T: Component> Command for InsertResource<T> {
     }
 }
 
-pub(crate) struct RemoveResource<T: Component> {
-    phantom: PhantomData<T>,
+pub struct RemoveResource<T: Component> {
+    pub phantom: PhantomData<T>,
 }
 
 impl<T: Component> Command for RemoveResource<T> {


### PR DESCRIPTION
I'm using Bevy ECS in a project of mine and I'd like to do world changes asynchronously. 

The current public API for creating entities, `Commands` , has a lifetime that restricts it from being sent across threads. `CommandQueue` on the other hand is a Vec of commands that can be later ran on a World. 

So far this is all public, but the commands themselves are private API. I know the intented use is with `Commands`, but that's not possible for my use case as I mentioned, and so I simply copied over the code for the commands I need and it works. Obviously, this isn't a nice solution, so I'd like to ask if it's not out of scope to make the commands public?