### PR TITLE
Added a resource for cursor positions

### DIFF
--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
-use super::{WindowDescriptor, WindowId};
+use super::{CursorPosition, WindowDescriptor, WindowId};
+use bevy_app::EventReader;
+use bevy_ecs::system::ResMut;
 use bevy_math::{IVec2, Vec2};
 
 /// A window event that is sent whenever a window has been resized.
@@ -95,4 +97,24 @@ pub enum FileDragAndDrop {
 pub struct WindowMoved {
     pub id: WindowId,
     pub position: IVec2,
+}
+
+/// Updates the CursorPosition resource with the latest CursorMoved events
+pub fn cursor_movement_res_system(
+    mut cursor_position: ResMut<CursorPosition>,
+    mut cursor_position_events: EventReader<CursorMoved>,
+    mut window_close_events: EventReader<WindowCloseRequested>,
+    mut cursor_left_events: EventReader<CursorLeft>,
+) {
+    for event in cursor_position_events.iter() {
+        cursor_position.positions.insert(event.id, event.position);
+    }
+
+    for event in window_close_events.iter() {
+        cursor_position.positions.remove(&event.id);
+    }
+
+    for event in cursor_left_events.iter() {
+        cursor_position.positions.remove(&event.id);
+    }
 }

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -4,6 +4,8 @@ mod window;
 mod windows;
 
 use bevy_ecs::system::IntoSystem;
+use bevy_math::Vec2;
+use bevy_utils::HashMap;
 pub use event::*;
 pub use system::*;
 pub use window::*;
@@ -12,8 +14,8 @@ pub use windows::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, ReceivedCharacter, Window,
-        WindowDescriptor, WindowMoved, Windows,
+        CursorEntered, CursorLeft, CursorMoved, CursorPosition, FileDragAndDrop, ReceivedCharacter,
+        Window, WindowDescriptor, WindowMoved, Windows,
     };
 }
 
@@ -33,6 +35,11 @@ impl Default for WindowPlugin {
     }
 }
 
+#[derive(Default, Debug, Clone)]
+pub struct CursorPosition {
+    pub positions: HashMap<WindowId, Vec2>,
+}
+
 impl Plugin for WindowPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_event::<WindowResized>()
@@ -41,6 +48,8 @@ impl Plugin for WindowPlugin {
             .add_event::<WindowCloseRequested>()
             .add_event::<CloseWindow>()
             .add_event::<CursorMoved>()
+            .init_resource::<CursorPosition>()
+            .add_system_to_stage(CoreStage::PreUpdate, cursor_movement_res_system.system())
             .add_event::<CursorEntered>()
             .add_event::<CursorLeft>()
             .add_event::<ReceivedCharacter>()


### PR DESCRIPTION
- Adds a cursor position to a global CursorPosition resource on
CursorMoved events. Identified by its window id.
- They get cleared upon window close events, otherwise it saves the last
event