### PR TITLE
[Merged by Bors] - Fix mesh with no vertex attributes causing panic

### DIFF
--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -551,18 +551,19 @@ pub fn mesh_resource_provider_system(
             }
 
             let interleaved_buffer = mesh.get_vertex_buffer_data();
-
-            render_resource_context.set_asset_resource(
-                changed_mesh_handle,
-                RenderResourceId::Buffer(render_resource_context.create_buffer_with_data(
-                    BufferInfo {
-                        buffer_usage: BufferUsage::VERTEX,
-                        ..Default::default()
-                    },
-                    &interleaved_buffer,
-                )),
-                VERTEX_ATTRIBUTE_BUFFER_ID,
-            );
+            if !interleaved_buffer.is_empty() {
+                render_resource_context.set_asset_resource(
+                    changed_mesh_handle,
+                    RenderResourceId::Buffer(render_resource_context.create_buffer_with_data(
+                        BufferInfo {
+                            buffer_usage: BufferUsage::VERTEX,
+                            ..Default::default()
+                        },
+                        &interleaved_buffer,
+                    )),
+                    VERTEX_ATTRIBUTE_BUFFER_ID,
+                );
+            }
 
             if let Some(mesh_entities) = state.mesh_entities.get_mut(changed_mesh_handle) {
                 for entity in mesh_entities.entities.iter() {


### PR DESCRIPTION
If a mesh without any vertex attributes is rendered (for example, one that only has indices), bevy will crash since the mesh still creates a vertex buffer even though it's empty. Later code assumes that there is vertex data, causing an index-out-of-bounds panic. This PR fixes the issue by adding a check that there is any vertex data before creating a vertex buffer.

I ran into this issue while rendering a tilemap without any vertex attributes (only indices).

Stack trace:
```
thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0', C:\Dev\Games\bevy\crates\bevy_render\src\render_graph\nodes\pass_node.rs:346:9
stack backtrace:
   0: std::panicking::begin_panic_handler
             at /rustc/bb491ed23937aef876622e4beb68ae95938b3bf9\/library\std\src\panicking.rs:493
   1: core::panicking::panic_fmt
             at /rustc/bb491ed23937aef876622e4beb68ae95938b3bf9\/library\core\src\panicking.rs:92
   2: core::panicking::panic_bounds_check
             at /rustc/bb491ed23937aef876622e4beb68ae95938b3bf9\/library\core\src\panicking.rs:69
   3: core::slice::index::{{impl}}::index<core::option::Option<tuple<bevy_render::renderer::render_resource::buffer::BufferId, u64>>>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\slice\index.rs:184
   4: core::slice::index::{{impl}}::index<core::option::Option<tuple<bevy_render::renderer::render_resource::buffer::BufferId, u64>>,usize>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\slice\index.rs:15
   5: alloc::vec::{{impl}}::index<core::option::Option<tuple<bevy_render::renderer::render_resource::buffer::BufferId, u64>>,usize,alloc::alloc::Global>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\alloc\src\vec\mod.rs:2386
   6: bevy_render::render_graph::nodes::pass_node::DrawState::is_vertex_buffer_set
             at C:\Dev\Games\bevy\crates\bevy_render\src\render_graph\nodes\pass_node.rs:346
   7: bevy_render::render_graph::nodes::pass_node::{{impl}}::update::{{closure}}<bevy_render::render_graph::base::MainPass*>
             at C:\Dev\Games\bevy\crates\bevy_render\src\render_graph\nodes\pass_node.rs:285
   8: bevy_wgpu::renderer::wgpu_render_context::{{impl}}::begin_pass
             at C:\Dev\Games\bevy\crates\bevy_wgpu\src\renderer\wgpu_render_context.rs:196
   9: bevy_render::render_graph::nodes::pass_node::{{impl}}::update<bevy_render::render_graph::base::MainPass*>
             at C:\Dev\Games\bevy\crates\bevy_render\src\render_graph\nodes\pass_node.rs:244
  10: bevy_wgpu::renderer::wgpu_render_graph_executor::WgpuRenderGraphExecutor::execute
             at C:\Dev\Games\bevy\crates\bevy_wgpu\src\renderer\wgpu_render_graph_executor.rs:75
  11: bevy_wgpu::wgpu_renderer::{{impl}}::run_graph::{{closure}}
             at C:\Dev\Games\bevy\crates\bevy_wgpu\src\wgpu_renderer.rs:115
  12: bevy_ecs::world::World::resource_scope<bevy_render::render_graph::graph::RenderGraph,tuple<>,closure-0>
             at C:\Dev\Games\bevy\crates\bevy_ecs\src\world\mod.rs:715
  13: bevy_wgpu::wgpu_renderer::WgpuRenderer::run_graph
             at C:\Dev\Games\bevy\crates\bevy_wgpu\src\wgpu_renderer.rs:104
  14: bevy_wgpu::wgpu_renderer::WgpuRenderer::update
             at C:\Dev\Games\bevy\crates\bevy_wgpu\src\wgpu_renderer.rs:121
  15: bevy_wgpu::get_wgpu_render_system::{{closure}}
             at C:\Dev\Games\bevy\crates\bevy_wgpu\src\lib.rs:112
  16: alloc::boxed::{{impl}}::call_mut<tuple<mut bevy_ecs::world::World*>,FnMut<tuple<mut bevy_ecs::world::World*>>,alloc::alloc::Global>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\alloc\src\boxed.rs:1553
  17: bevy_ecs::system::exclusive_system::{{impl}}::run
             at C:\Dev\Games\bevy\crates\bevy_ecs\src\system\exclusive_system.rs:41
  18: bevy_ecs::schedule::stage::{{impl}}::run
             at C:\Dev\Games\bevy\crates\bevy_ecs\src\schedule\stage.rs:812
  19: bevy_ecs::schedule::Schedule::run_once
             at C:\Dev\Games\bevy\crates\bevy_ecs\src\schedule\mod.rs:201
  20: bevy_ecs::schedule::{{impl}}::run
             at C:\Dev\Games\bevy\crates\bevy_ecs\src\schedule\mod.rs:219
  21: bevy_app::app::App::update
             at C:\Dev\Games\bevy\crates\bevy_app\src\app.rs:58
  22: bevy_winit::winit_runner_with::{{closure}}
             at C:\Dev\Games\bevy\crates\bevy_winit\src\lib.rs:485
  23: winit::platform_impl::platform::event_loop::{{impl}}::run_return::{{closure}}<tuple<>,closure-1>
             at C:\Users\tehpe\.cargo\registry\src\github.com-1ecc6299db9ec823\winit-0.24.0\src\platform_impl\windows\event_loop.rs:203
  24: alloc::boxed::{{impl}}::call_mut<tuple<winit::event::Event<tuple<>>, mut winit::event_loop::ControlFlow*>,FnMut<tuple<winit::event::Event<tuple<>>, mut winit::event_loop::ControlFlow*>>,alloc::alloc::Global>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\alloc\src\boxed.rs:1553
  25: winit::platform_impl::platform::event_loop::runner::{{impl}}::call_event_handler::{{closure}}<tuple<>>
             at C:\Users\tehpe\.cargo\registry\src\github.com-1ecc6299db9ec823\winit-0.24.0\src\platform_impl\windows\event_loop\runner.rs:245
  26: std::panic::{{impl}}::call_once<tuple<>,closure-0>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\panic.rs:344
  27: std::panicking::try::do_call<std::panic::AssertUnwindSafe<closure-0>,tuple<>>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\panicking.rs:379
  28: hashbrown::set::HashSet<mut winapi::shared::windef::HWND__*, std::collections::hash::map::RandomState, alloc::alloc::Global>::iter<mut winapi::shared::windef::HWND__*,std::collections::hash::map::RandomState,alloc::alloc::Global>
  29: std::panicking::try<tuple<>,std::panic::AssertUnwindSafe<closure-0>>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\panicking.rs:343
  30: std::panic::catch_unwind<std::panic::AssertUnwindSafe<closure-0>,tuple<>>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\panic.rs:431
  31: winit::platform_impl::platform::event_loop::runner::EventLoopRunner<tuple<>>::catch_unwind<tuple<>,tuple<>,closure-0>
             at C:\Users\tehpe\.cargo\registry\src\github.com-1ecc6299db9ec823\winit-0.24.0\src\platform_impl\windows\event_loop\runner.rs:152
  32: winit::platform_impl::platform::event_loop::runner::EventLoopRunner<tuple<>>::call_event_handler<tuple<>>
             at C:\Users\tehpe\.cargo\registry\src\github.com-1ecc6299db9ec823\winit-0.24.0\src\platform_impl\windows\event_loop\runner.rs:239
  33: winit::platform_impl::platform::event_loop::runner::EventLoopRunner<tuple<>>::move_state_to<tuple<>>
             at C:\Users\tehpe\.cargo\registry\src\github.com-1ecc6299db9ec823\winit-0.24.0\src\platform_impl\windows\event_loop\runner.rs:341
  34: winit::platform_impl::platform::event_loop::runner::EventLoopRunner<tuple<>>::main_events_cleared<tuple<>>
             at C:\Users\tehpe\.cargo\registry\src\github.com-1ecc6299db9ec823\winit-0.24.0\src\platform_impl\windows\event_loop\runner.rs:227
  35: winit::platform_impl::platform::event_loop::flush_paint_messages<tuple<>>
             at C:\Users\tehpe\.cargo\registry\src\github.com-1ecc6299db9ec823\winit-0.24.0\src\platform_impl\windows\event_loop.rs:676
  36: winit::platform_impl::platform::event_loop::thread_event_target_callback::{{closure}}<tuple<>>
             at C:\Users\tehpe\.cargo\registry\src\github.com-1ecc6299db9ec823\winit-0.24.0\src\platform_impl\windows\event_loop.rs:1967
  37: std::panic::{{impl}}::call_once<isize,closure-0>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\panic.rs:344
  38: std::panicking::try::do_call<std::panic::AssertUnwindSafe<closure-0>,isize>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\panicking.rs:379
  39: hashbrown::set::HashSet<mut winapi::shared::windef::HWND__*, std::collections::hash::map::RandomState, alloc::alloc::Global>::iter<mut winapi::shared::windef::HWND__*,std::collections::hash::map::RandomState,alloc::alloc::Global>
  40: std::panicking::try<isize,std::panic::AssertUnwindSafe<closure-0>>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\panicking.rs:343
  41: std::panic::catch_unwind<std::panic::AssertUnwindSafe<closure-0>,isize>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\panic.rs:431
  42: winit::platform_impl::platform::event_loop::runner::EventLoopRunner<tuple<>>::catch_unwind<tuple<>,isize,closure-0>
             at C:\Users\tehpe\.cargo\registry\src\github.com-1ecc6299db9ec823\winit-0.24.0\src\platform_impl\windows\event_loop\runner.rs:152
  43: winit::platform_impl::platform::event_loop::thread_event_target_callback<tuple<>>
             at C:\Users\tehpe\.cargo\registry\src\github.com-1ecc6299db9ec823\winit-0.24.0\src\platform_impl\windows\event_loop.rs:2151
  44: DefSubclassProc
  45: DefSubclassProc
  46: CallWindowProcW
  47: DispatchMessageW
  48: SendMessageTimeoutW
  49: KiUserCallbackDispatcher
  50: NtUserDispatchMessage
  51: DispatchMessageW
  52: winit::platform_impl::platform::event_loop::EventLoop<tuple<>>::run_return<tuple<>,closure-1>
             at C:\Users\tehpe\.cargo\registry\src\github.com-1ecc6299db9ec823\winit-0.24.0\src\platform_impl\windows\event_loop.rs:218
  53: winit::platform_impl::platform::event_loop::EventLoop<tuple<>>::run<tuple<>,closure-1>
             at C:\Users\tehpe\.cargo\registry\src\github.com-1ecc6299db9ec823\winit-0.24.0\src\platform_impl\windows\event_loop.rs:188
  54: winit::event_loop::EventLoop<tuple<>>::run<tuple<>,closure-1>
             at C:\Users\tehpe\.cargo\registry\src\github.com-1ecc6299db9ec823\winit-0.24.0\src\event_loop.rs:154
  55: bevy_winit::run<closure-1>
             at C:\Dev\Games\bevy\crates\bevy_winit\src\lib.rs:171
  56: bevy_winit::winit_runner_with
             at C:\Dev\Games\bevy\crates\bevy_winit\src\lib.rs:493
  57: bevy_winit::winit_runner
             at C:\Dev\Games\bevy\crates\bevy_winit\src\lib.rs:211
  58: core::ops::function::Fn::call<fn(bevy_app::app::App),tuple<bevy_app::app::App>>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ops\function.rs:70
  59: alloc::boxed::{{impl}}::call<tuple<bevy_app::app::App>,Fn<tuple<bevy_app::app::App>>,alloc::alloc::Global>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\alloc\src\boxed.rs:1560
  60: bevy_app::app::App::run
             at C:\Dev\Games\bevy\crates\bevy_app\src\app.rs:68
  61: bevy_app::app_builder::AppBuilder::run
             at C:\Dev\Games\bevy\crates\bevy_app\src\app_builder.rs:54
  62: game_main::main
             at .\crates\game_main\src\main.rs:23
  63: core::ops::function::FnOnce::call_once<fn(),tuple<>>
             at C:\Users\tehpe\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ops\function.rs:227
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
Apr 27 21:51:01.026 ERROR gpu_descriptor::allocator: `DescriptorAllocator` is dropped while some descriptor sets were not deallocated
error: process didn't exit successfully: `target/cargo\debug\game_main.exe` (exit code: 0xc000041d)
```