### PR TITLE
[Merged by Bors] - Adds an alias mouse position -> cursor position

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -467,6 +467,7 @@ impl Window {
     }
 
     #[inline]
+    #[doc(alias = "mouse position")]
     pub fn cursor_position(&self) -> Option<Vec2> {
         self.cursor_position
     }


### PR DESCRIPTION
This alias is to aid people finding the cursor_position function, as the mouse
pressed / moved functionality and naming likely primes people for thinking
of "mouse" before "cursor" when searching the api documentation.