### PR TITLE
Correctly transform normals for non-uniform scales

### DIFF
--- a/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.vert
+++ b/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.vert
@@ -24,10 +24,24 @@ layout(set = 2, binding = 0) uniform Transform {
     mat4 Model;
 };
 
+// inverts the scaling, but keeps the rotation of a mat3
+// ! assumes that m is an orthogonal matrix
+mat3 to_normal_matrix(mat3 m) {
+    vec3 fac = 1.0 / vec3(
+    	dot(m[0], m[0]),
+    	dot(m[1], m[1]),
+    	dot(m[2], m[2])
+    );
+    m[0] *= fac.x;
+    m[1] *= fac.y;
+    m[2] *= fac.z;
+    return m;
+}
+
 void main() {
     vec4 world_position = Model * vec4(Vertex_Position, 1.0);
     v_WorldPosition = world_position.xyz;
-    v_WorldNormal = mat3(Model) * Vertex_Normal;
+    v_WorldNormal = to_normal_matrix(mat3(Model)) * Vertex_Normal;
     v_Uv = Vertex_Uv;
 #ifdef STANDARDMATERIAL_NORMAL_MAP
     v_WorldTangent = vec4(mat3(Model) * Vertex_Tangent.xyz, Vertex_Tangent.w);


### PR DESCRIPTION
This changes the way normals are transformed in the vertex shader of bevy_pbr. In order to correctly transform normals, the scaling actually has to be applied inversely ([see this explanation for details](https://www.scratchapixel.com/lessons/mathematics-physics-for-computer-graphics/geometry/transforming-normals)). Otherwise non-uniform scales will produces incorrect normals.

My proposed change comes with the **assumption that the `Model` matrix is orthogonal (i.e. does not contain shearing)**. This allows for some optimization, I can explain more if needed.

Here's a pancaked version of `load_gltf` as comparison:
<details> 
  <summary>screenshot</summary>
<img src="https://user-images.githubusercontent.com/3957610/116583790-02212280-a917-11eb-9400-595e07386263.png"/>
</details>

Since this is just a minor change I didn't bother creating an issue. Feel free to close if the solution doesn't seem fit.