### PR TITLE
Add a few transform convenience methods

### DIFF
--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -211,6 +211,24 @@ impl GlobalTransform {
         value
     }
 
+    /// Returns the result of applying this [`GlobalTransform`] to a [`Vec3`] interpreted as a point.
+    ///
+    /// This applies rotation, scale, and translation. It's the equivalent of using w=1 in
+    /// homogeneous coordinates.
+    #[inline]
+    pub fn transform_point(&self, point: Vec3) -> Vec3 {
+        self.scale * (self.rotation * point)
+    }
+
+    /// Returns the result of applying this [`GlobalTransform`] to a [`Vec3`] interpreted as a vector.
+    ///
+    /// This applies rotation and scale, but not translation. It's the equivalent of using w=0 in
+    /// homogeneous coordinates.
+    #[inline]
+    pub fn transform_vector(&self, vector: Vec3) -> Vec3 {
+        self.scale * (self.rotation * point) + self.translation
+    }
+
     #[doc(hidden)]
     #[inline]
     pub fn apply_non_uniform_scale(&mut self, scale: Vec3) {

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -112,6 +112,22 @@ impl GlobalTransform {
         Mat4::from_scale_rotation_translation(self.scale, self.rotation, self.translation)
     }
 
+    /// Returns the inverse of this transform.
+    ///
+    /// The inverse consists of applying the inverse rotation, scale, and
+    /// translation in reverse order.
+    #[inline]
+    pub fn inverse(&self) -> Transform {
+        let rotation = self.rotation.inverse();
+        let scale = rotation * -self.scale;
+        let translation = scale * -self.translation;
+        Transform {
+            rotation,
+            scale,
+            translation,
+        }
+    }
+
     /// Get the unit vector in the local x direction
     #[inline]
     pub fn local_x(&self) -> Vec3 {

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -223,6 +223,24 @@ impl Transform {
         value
     }
 
+    /// Returns the result of applying this [`Transform`] to a [`Vec3`] interpreted as a point.
+    ///
+    /// This applies rotation, scale, and translation. It's the equivalent of using w=1 in
+    /// homogeneous coordinates.
+    #[inline]
+    pub fn transform_point(&self, point: Vec3) -> Vec3 {
+        self.scale * (self.rotation * point)
+    }
+
+    /// Returns the result of applying this [`Transform`] to a [`Vec3`] interpreted as a vector.
+    ///
+    /// This applies rotation and scale, but not translation. It's the equivalent of using w=0 in
+    /// homogeneous coordinates.
+    #[inline]
+    pub fn transform_vector(&self, vector: Vec3) -> Vec3 {
+        self.scale * (self.rotation * point) + self.translation
+    }
+
     /// Changes the `scale` of this [`Transform`], multiplying the current `scale` by
     /// `scale_factor`.
     #[inline]

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -124,6 +124,22 @@ impl Transform {
         Mat4::from_scale_rotation_translation(self.scale, self.rotation, self.translation)
     }
 
+    /// Returns the inverse of this transform.
+    ///
+    /// The inverse consists of applying the inverse rotation, scale, and
+    /// translation in reverse order.
+    #[inline]
+    pub fn inverse(&self) -> Transform {
+        let rotation = self.rotation.inverse();
+        let scale = rotation * -self.scale;
+        let translation = scale * -self.translation;
+        Transform {
+            rotation,
+            scale,
+            translation,
+        }
+    }
+
     /// Get the unit vector in the local x direction.
     #[inline]
     pub fn local_x(&self) -> Vec3 {


### PR DESCRIPTION
Converting transforms into a matrix in order to operate on vectors or compute the inverse is poor ergonomics, and these operations can be implemented easily as methods in `Transform` and `GlobalTransform`. I think the name `transform_vector` is a bit confusing, especially given `mul_vec3` exists. If anybody has a better suggestion that would be great!