### PR TITLE
Add example for modifying textures on the CPU

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,6 +224,10 @@ name = "asset_loading"
 path = "examples/asset/asset_loading.rs"
 
 [[example]]
+name = "cpu_texture"
+path = "examples/asset/cpu_texture.rs"
+
+[[example]]
 name = "custom_asset"
 path = "examples/asset/custom_asset.rs"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -127,6 +127,7 @@ Example | File | Description
 Example | File | Description
 --- | --- | ---
 `asset_loading` | [`asset/asset_loading.rs`](./asset/asset_loading.rs) | Demonstrates various methods to load assets
+`cpu_texture` | [`asset/cpu_texture.rs`](./asset/cpu_texture.rs) | Illustrates how to mutate a texture on the CPU
 `custom_asset` | [`asset/custom_asset.rs`](./asset/custom_asset.rs) | Implements a custom asset loader
 `custom_asset_io` | [`asset/custom_asset_io.rs`](./asset/custom_asset_io.rs) | Implements a custom asset io loader
 `hot_asset_reloading` | [`asset/hot_asset_reloading.rs`](./asset/hot_asset_reloading.rs) | Demonstrates automatic reloading of assets when modified on disk

--- a/examples/asset/cpu_texture.rs
+++ b/examples/asset/cpu_texture.rs
@@ -1,0 +1,76 @@
+use bevy::{
+    prelude::*,
+    render::texture::{Extent3d, TextureDimension, TextureFormat},
+    utils::Duration,
+};
+use std::num::Wrapping;
+
+/// This example illustrates how to mutate a texture on the CPU.
+fn main() {
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(setup.system())
+        .add_startup_system(setup_timer.system())
+        .add_system(timer_tick.system())
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut textures: ResMut<Assets<Texture>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    // Create a texture with varying shades of red.
+    let texture = Texture::new_fill(
+        Extent3d {
+            width: 16,
+            height: 16,
+            depth: 1,
+        },
+        TextureDimension::D2,
+        &(0..(256))
+            .flat_map(|i| vec![255, i as u8, 0, 255])
+            .collect::<Vec<u8>>(),
+        TextureFormat::Rgba8UnormSrgb,
+    );
+
+    let texture_handle = textures.add(texture);
+
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+
+    commands.spawn_bundle(SpriteBundle {
+        material: materials.add(texture_handle.clone().into()),
+        transform: Transform::from_scale(Vec3::splat(30.0)),
+        ..Default::default()
+    });
+    commands.insert_resource(texture_handle);
+}
+
+struct TickTrack {
+    count: Wrapping<u8>,
+    timer: Timer,
+}
+
+fn setup_timer(mut commands: Commands) {
+    commands.insert_resource(TickTrack {
+        count: Wrapping(0),
+        timer: Timer::new(Duration::from_secs(1), true),
+    });
+}
+
+fn timer_tick(
+    time: Res<Time>,
+    mut timer: ResMut<TickTrack>,
+    mut textures: ResMut<Assets<Texture>>,
+    pic: Res<Handle<Texture>>,
+) {
+    timer.timer.tick(time.delta());
+    if timer.timer.finished() {
+        timer.count += Wrapping(1);
+
+        let texture = textures.get_mut(&*pic).unwrap();
+        let idx = (timer.count.0 as usize) * 4 % texture.size.volume();
+        // Each timer interval, one pixel turns black.
+        texture.data[idx..(idx + 3)].iter_mut().for_each(|i| *i = 0);
+    }
+}


### PR DESCRIPTION
The example shows how to modify images using the CPU and then display them.

It binds into the render pipeline by AssetRenderResourcesNode, so I placed it in `shaders/`.