### PR TITLE
Add non-overwriting variants of component/resource insertion functions

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -3,7 +3,7 @@ pub use bevy_ecs_macros::Bundle;
 use crate::{
     archetype::ComponentStatus,
     component::{
-        Component, ComponentCollision, ComponentId, ComponentTicks, Components, StorageType,
+        CollisionBehaviour, Component, ComponentId, ComponentTicks, Components, StorageType,
         TypeInfo,
     },
     entity::Entity,
@@ -138,7 +138,7 @@ impl BundleInfo {
         bundle_status: &[ComponentStatus],
         bundle: T,
         change_tick: u32,
-        overwrite_existing: ComponentCollision,
+        overwrite_existing: CollisionBehaviour,
     ) {
         // NOTE: get_components calls this closure on each component in "bundle order".
         // bundle_info.component_ids are also in "bundle order"
@@ -151,7 +151,7 @@ impl BundleInfo {
                 StorageType::Table => {
                     if !matches!(
                         (component_status, overwrite_existing),
-                        (ComponentStatus::Mutated, ComponentCollision::Skip),
+                        (ComponentStatus::Mutated, CollisionBehaviour::Skip),
                     ) {
                         let column = table.get_column(component_id).unwrap();
                         column.set_unchecked(table_row, component_ptr);
@@ -168,7 +168,7 @@ impl BundleInfo {
                 }
                 StorageType::SparseSet => {
                     if matches!(component_status, ComponentStatus::Added)
-                        || matches!(overwrite_existing, ComponentCollision::Overwrite)
+                        || matches!(overwrite_existing, CollisionBehaviour::Overwrite)
                     {
                         let sparse_set = sparse_sets.get_mut(component_id).unwrap();
                         sparse_set.insert(entity, component_ptr, change_tick);

--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -375,7 +375,7 @@ fn check_tick(last_change_tick: &mut u32, change_tick: u32) {
 /// and [World::write_components](crate::world::World::insert_resource_with_id()) to control
 /// how collisions between newly inserted and existing component types should be handled.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum ComponentCollision {
+pub enum CollisionBehaviour {
     /// Overwrite existing component/resource of the same type.
     Overwrite,
     /// Skip and do not write the new component if it already exists.

--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -370,3 +370,14 @@ fn check_tick(last_change_tick: &mut u32, change_tick: u32) {
         *last_change_tick = change_tick.wrapping_sub(MAX_DELTA);
     }
 }
+
+/// Used by [BundleInfo::write_components](crate::bundle::BundleInfo::write_components())
+/// and [World::write_components](crate::world::World::insert_resource_with_id()) to control
+/// how collisions between newly inserted and existing component types should be handled.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum ComponentCollision {
+    /// Overwrite existing component/resource of the same type.
+    Overwrite,
+    /// Skip and do not write the new component if it already exists.
+    Skip,
+}

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -942,6 +942,27 @@ mod tests {
     }
 
     #[test]
+    fn try_insert_resource_no_collision() {
+        let mut world = World::default();
+        world.try_insert_resource(64u64);
+        assert_eq!(
+            *world.get_resource::<u64>().expect("Resource exists"),
+            64u64
+        );
+    }
+
+    #[test]
+    fn try_insert_resource_collision() {
+        let mut world = World::default();
+        world.insert_resource(32u64);
+        world.try_insert_resource(64u64);
+        assert_eq!(
+            *world.get_resource::<u64>().expect("Resource exists"),
+            32u64
+        );
+    }
+
+    #[test]
     fn remove_intersection() {
         let mut world = World::default();
         let e1 = world.spawn().insert_bundle((1, 1.0, "a")).id();

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -867,20 +867,26 @@ mod tests {
             .get_archetype_component_id(resource_id)
             .unwrap();
 
-        assert_eq!(*world.get_resource::<i32>().expect("resource exists"), 123);
+        assert_eq!(
+            *world.get_resource::<i32>().expect("Resource not found"),
+            123
+        );
         assert!(world.contains_resource::<i32>());
 
         world.insert_resource(456u64);
         assert_eq!(
-            *world.get_resource::<u64>().expect("resource exists"),
+            *world.get_resource::<u64>().expect("Resource not found"),
             456u64
         );
 
         world.insert_resource(789u64);
-        assert_eq!(*world.get_resource::<u64>().expect("resource exists"), 789);
+        assert_eq!(
+            *world.get_resource::<u64>().expect("Resource not found"),
+            789
+        );
 
         {
-            let mut value = world.get_resource_mut::<u64>().expect("resource exists");
+            let mut value = world.get_resource_mut::<u64>().expect("Resource not found");
             assert_eq!(*value, 789);
             *value = 10;
         }
@@ -946,7 +952,7 @@ mod tests {
         let mut world = World::default();
         world.try_insert_resource(64u64);
         assert_eq!(
-            *world.get_resource::<u64>().expect("Resource exists"),
+            *world.get_resource::<u64>().expect("Resource not found"),
             64u64
         );
     }
@@ -957,7 +963,7 @@ mod tests {
         world.insert_resource(32u64);
         world.try_insert_resource(64u64);
         assert_eq!(
-            *world.get_resource::<u64>().expect("Resource exists"),
+            *world.get_resource::<u64>().expect("Resource not found"),
             32u64
         );
     }

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -198,6 +198,10 @@ impl<'a, 'b> EntityCommands<'a, 'b> {
     }
 
     /// Adds a [`Bundle`] of components to the current entity.
+    ///
+    /// If any of the components in the [`Bundle`] are already present on the entity,
+    /// those components will be overwritten. To add only the components in the Bundle which
+    /// are not already present on the entity, see [try_insert_bundle](Self::try_insert_bundle()).
     pub fn insert_bundle(&mut self, bundle: impl Bundle) -> &mut Self {
         self.commands.add(InsertBundle {
             entity: self.entity,
@@ -206,7 +210,11 @@ impl<'a, 'b> EntityCommands<'a, 'b> {
         self
     }
 
-    /// Adds a bundle of components to the current entity, skipping ones that already exist.
+    /// Adds a [`Bundle`] of components to the current entity.
+    ///
+    /// If any of the components in the [`Bundle`] are already present on the entity,
+    /// those components will be silenty skipped. To overwrite components already present
+    /// on the entity with the value in the Bundle, see [insert_bundle](Self::insert_bundle()).
     pub fn try_insert_bundle(&mut self, bundle: impl Bundle) -> &mut Self {
         self.commands.add(TryInsertBundle {
             entity: self.entity,
@@ -217,6 +225,8 @@ impl<'a, 'b> EntityCommands<'a, 'b> {
 
     /// Adds a single [`Component`] to the current entity.
     ///
+    /// If an instance of the Component is already present on the entity, that component will be overwritten.
+    /// For adding a [`Component`] to an entity only when an instance is not already present, see [try_insert](Self::try_insert()).
     ///
     /// # Warning
     ///
@@ -255,7 +265,17 @@ impl<'a, 'b> EntityCommands<'a, 'b> {
         self
     }
 
-    /// Like insert, but does not overwrite components which already exist on the entity
+    /// Adds a single [`Component`] to the current entity.
+    ///
+    /// If an instance of the Component is already present on the entity, `try_insert` will silently return without changing it.
+    /// For adding a [`Component`] to an entity and overwriting the existing instance, see [insert](Self::insert()).
+    ///
+    /// # Warning
+    ///
+    /// It's possible to call this with a bundle, but this is likely not intended and
+    /// [`Self::try_insert_bundle`] should be used instead. If `try_insert` is called with a bundle, the
+    /// bundle itself will be added as a component instead of the bundles' inner components each
+    /// being added.
     pub fn try_insert(&mut self, component: impl Component) -> &mut Self {
         self.commands.add(TryInsert {
             entity: self.entity,

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -519,7 +519,46 @@ mod tests {
     }
 
     #[test]
-    fn try_insert_components_not_present() {
+    fn try_insert_component_not_present() {
+        let mut world = World::default();
+        let mut command_queue = CommandQueue::default();
+        let _ = Commands::new(&mut command_queue, &world)
+            .spawn()
+            .try_insert(2u32)
+            .id();
+
+        command_queue.apply(&mut world);
+        assert!(world.entities().len() == 1);
+        let results = world
+            .query::<&u32>()
+            .iter(&world)
+            .copied()
+            .collect::<Vec<_>>();
+        assert_eq!(results, vec![2u32]);
+    }
+
+    #[test]
+    fn try_insert_component_present() {
+        let mut world = World::default();
+        let mut command_queue = CommandQueue::default();
+        let _ = Commands::new(&mut command_queue, &world)
+            .spawn()
+            .insert(1u32)
+            .try_insert(2u32)
+            .id();
+
+        command_queue.apply(&mut world);
+        assert!(world.entities().len() == 1);
+        let results = world
+            .query::<&u32>()
+            .iter(&world)
+            .copied()
+            .collect::<Vec<_>>();
+        assert_eq!(results, vec![1u32]);
+    }
+
+    #[test]
+    fn try_insert_bundle_components_not_present() {
         let mut world = World::default();
         let mut command_queue = CommandQueue::default();
         let _ = Commands::new(&mut command_queue, &world)
@@ -538,7 +577,7 @@ mod tests {
     }
 
     #[test]
-    fn try_insert_components_present() {
+    fn try_insert_bundle_components_all_present() {
         let mut world = World::default();
         let mut command_queue = CommandQueue::default();
         let _ = Commands::new(&mut command_queue, &world)
@@ -557,7 +596,7 @@ mod tests {
     }
 
     #[test]
-    fn try_insert_components_some_present() {
+    fn try_insert_bundle_components_some_present() {
         let mut world = World::default();
         let mut command_queue = CommandQueue::default();
         let _ = Commands::new(&mut command_queue, &world)

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -231,7 +231,7 @@ impl<'w> EntityMut<'w> {
         let archetypes = &mut self.world.archetypes;
         let components = &mut self.world.components;
         let storages = &mut self.world.storages;
-        
+
         let bundle_info = self.world.bundles.init_info::<T>(components);
         let current_location = self.location;
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1,7 +1,9 @@
 use crate::{
     archetype::{Archetype, ArchetypeId, Archetypes, ComponentStatus},
     bundle::{Bundle, BundleInfo},
-    component::{Component, ComponentId, ComponentTicks, Components, StorageType},
+    component::{
+        Component, ComponentCollision, ComponentId, ComponentTicks, Components, StorageType,
+    },
     entity::{Entities, Entity, EntityLocation},
     storage::{SparseSet, Storages},
     world::{Mut, World},
@@ -219,6 +221,7 @@ impl<'w> EntityMut<'w> {
                 bundle_status,
                 bundle,
                 change_tick,
+                ComponentCollision::Overwrite,
             )
         };
         self
@@ -252,7 +255,7 @@ impl<'w> EntityMut<'w> {
         let table_row = archetype.entity_table_row(new_location.index);
         // SAFE: table row is valid
         unsafe {
-            bundle_info.write_additional_components(
+            bundle_info.write_components(
                 &mut storages.sparse_sets,
                 entity,
                 table,
@@ -260,6 +263,7 @@ impl<'w> EntityMut<'w> {
                 bundle_status,
                 bundle,
                 change_tick,
+                ComponentCollision::Skip,
             )
         };
         self

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -194,76 +194,8 @@ impl<'w> EntityMut<'w> {
         let bundle_info = self.world.bundles.init_info::<T>(components);
         let current_location = self.location;
 
-        // Use a non-generic function to cut down on monomorphization
-        unsafe fn get_insert_bundle_info<'a>(
-            entities: &mut Entities,
-            archetypes: &'a mut Archetypes,
-            components: &mut Components,
-            storages: &mut Storages,
-            bundle_info: &BundleInfo,
-            current_location: EntityLocation,
-            entity: Entity,
-        ) -> (&'a Archetype, &'a Vec<ComponentStatus>, EntityLocation) {
-            // SAFE: component ids in `bundle_info` and self.location are valid
-            let new_archetype_id = add_bundle_to_archetype(
-                archetypes,
-                storages,
-                components,
-                current_location.archetype_id,
-                bundle_info,
-            );
-            if new_archetype_id == current_location.archetype_id {
-                let archetype = &archetypes[current_location.archetype_id];
-                let edge = archetype.edges().get_add_bundle(bundle_info.id).unwrap();
-                (archetype, &edge.bundle_status, current_location)
-            } else {
-                let (old_table_row, old_table_id) = {
-                    let old_archetype = &mut archetypes[current_location.archetype_id];
-                    let result = old_archetype.swap_remove(current_location.index);
-                    if let Some(swapped_entity) = result.swapped_entity {
-                        entities.meta[swapped_entity.id as usize].location = current_location;
-                    }
-                    (result.table_row, old_archetype.table_id())
-                };
-
-                let new_table_id = archetypes[new_archetype_id].table_id();
-
-                let new_location = if old_table_id == new_table_id {
-                    archetypes[new_archetype_id].allocate(entity, old_table_row)
-                } else {
-                    let (old_table, new_table) =
-                        storages.tables.get_2_mut(old_table_id, new_table_id);
-                    // PERF: store "non bundle" components in edge, then just move those to avoid
-                    // redundant copies
-                    let move_result =
-                        old_table.move_to_superset_unchecked(old_table_row, new_table);
-
-                    let new_location =
-                        archetypes[new_archetype_id].allocate(entity, move_result.new_row);
-                    // if an entity was moved into this entity's table spot, update its table row
-                    if let Some(swapped_entity) = move_result.swapped_entity {
-                        let swapped_location = entities.get(swapped_entity).unwrap();
-                        archetypes[swapped_location.archetype_id]
-                            .set_entity_table_row(swapped_location.index, old_table_row);
-                    }
-                    new_location
-                };
-
-                entities.meta[entity.id as usize].location = new_location;
-                let (old_archetype, new_archetype) =
-                    archetypes.get_2_mut(current_location.archetype_id, new_archetype_id);
-                let edge = old_archetype
-                    .edges()
-                    .get_add_bundle(bundle_info.id)
-                    .unwrap();
-                (&*new_archetype, &edge.bundle_status, new_location)
-
-                // Sparse set components are intentionally ignored here. They don't need to move
-            }
-        }
-
         let (archetype, bundle_status, new_location) = unsafe {
-            get_insert_bundle_info(
+            Self::get_insert_bundle_info(
                 entities,
                 archetypes,
                 components,
@@ -290,6 +222,113 @@ impl<'w> EntityMut<'w> {
             )
         };
         self
+    }
+
+    pub fn try_insert_bundle<T: Bundle>(&mut self, bundle: T) -> &mut Self {
+        let entity = self.entity;
+        let change_tick = self.world.change_tick();
+        let entities = &mut self.world.entities;
+        let archetypes = &mut self.world.archetypes;
+        let components = &mut self.world.components;
+        let storages = &mut self.world.storages;
+        
+        let bundle_info = self.world.bundles.init_info::<T>(components);
+        let current_location = self.location;
+
+        let (archetype, bundle_status, new_location) = unsafe {
+            Self::get_insert_bundle_info(
+                entities,
+                archetypes,
+                components,
+                storages,
+                bundle_info,
+                current_location,
+                entity,
+            )
+        };
+        self.location = new_location;
+
+        let table = &storages.tables[archetype.table_id()];
+        let table_row = archetype.entity_table_row(new_location.index);
+        // SAFE: table row is valid
+        unsafe {
+            bundle_info.write_additional_components(
+                &mut storages.sparse_sets,
+                entity,
+                table,
+                table_row,
+                bundle_status,
+                bundle,
+                change_tick,
+            )
+        };
+        self
+    }
+
+    // Use a non-generic function to cut down on monomorphization
+    unsafe fn get_insert_bundle_info<'a>(
+        entities: &mut Entities,
+        archetypes: &'a mut Archetypes,
+        components: &mut Components,
+        storages: &mut Storages,
+        bundle_info: &BundleInfo,
+        current_location: EntityLocation,
+        entity: Entity,
+    ) -> (&'a Archetype, &'a Vec<ComponentStatus>, EntityLocation) {
+        // SAFE: component ids in `bundle_info` and self.location are valid
+        let new_archetype_id = add_bundle_to_archetype(
+            archetypes,
+            storages,
+            components,
+            current_location.archetype_id,
+            bundle_info,
+        );
+        if new_archetype_id == current_location.archetype_id {
+            let archetype = &archetypes[current_location.archetype_id];
+            let edge = archetype.edges().get_add_bundle(bundle_info.id).unwrap();
+            (archetype, &edge.bundle_status, current_location)
+        } else {
+            let (old_table_row, old_table_id) = {
+                let old_archetype = &mut archetypes[current_location.archetype_id];
+                let result = old_archetype.swap_remove(current_location.index);
+                if let Some(swapped_entity) = result.swapped_entity {
+                    entities.meta[swapped_entity.id as usize].location = current_location;
+                }
+                (result.table_row, old_archetype.table_id())
+            };
+
+            let new_table_id = archetypes[new_archetype_id].table_id();
+
+            let new_location = if old_table_id == new_table_id {
+                archetypes[new_archetype_id].allocate(entity, old_table_row)
+            } else {
+                let (old_table, new_table) = storages.tables.get_2_mut(old_table_id, new_table_id);
+                // PERF: store "non bundle" components in edge, then just move those to avoid
+                // redundant copies
+                let move_result = old_table.move_to_superset_unchecked(old_table_row, new_table);
+
+                let new_location =
+                    archetypes[new_archetype_id].allocate(entity, move_result.new_row);
+                // if an entity was moved into this entity's table spot, update its table row
+                if let Some(swapped_entity) = move_result.swapped_entity {
+                    let swapped_location = entities.get(swapped_entity).unwrap();
+                    archetypes[swapped_location.archetype_id]
+                        .set_entity_table_row(swapped_location.index, old_table_row);
+                }
+                new_location
+            };
+
+            entities.meta[entity.id as usize].location = new_location;
+            let (old_archetype, new_archetype) =
+                archetypes.get_2_mut(current_location.archetype_id, new_archetype_id);
+            let edge = old_archetype
+                .edges()
+                .get_add_bundle(bundle_info.id)
+                .unwrap();
+            (&*new_archetype, &edge.bundle_status, new_location)
+
+            // Sparse set components are intentionally ignored here. They don't need to move
+        }
     }
 
     pub fn remove_bundle<T: Bundle>(&mut self) -> Option<T> {
@@ -459,6 +498,10 @@ impl<'w> EntityMut<'w> {
 
     pub fn insert<T: Component>(&mut self, value: T) -> &mut Self {
         self.insert_bundle((value,))
+    }
+
+    pub fn try_insert<T: Component>(&mut self, value: T) -> &mut Self {
+        self.try_insert_bundle((value,))
     }
 
     pub fn remove<T: Component>(&mut self) -> Option<T> {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2,7 +2,7 @@ use crate::{
     archetype::{Archetype, ArchetypeId, Archetypes, ComponentStatus},
     bundle::{Bundle, BundleInfo},
     component::{
-        Component, ComponentCollision, ComponentId, ComponentTicks, Components, StorageType,
+        CollisionBehaviour, Component, ComponentId, ComponentTicks, Components, StorageType,
     },
     entity::{Entities, Entity, EntityLocation},
     storage::{SparseSet, Storages},
@@ -221,7 +221,7 @@ impl<'w> EntityMut<'w> {
                 bundle_status,
                 bundle,
                 change_tick,
-                ComponentCollision::Overwrite,
+                CollisionBehaviour::Overwrite,
             )
         };
         self
@@ -263,7 +263,7 @@ impl<'w> EntityMut<'w> {
                 bundle_status,
                 bundle,
                 change_tick,
-                ComponentCollision::Skip,
+                CollisionBehaviour::Skip,
             )
         };
         self

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -518,7 +518,7 @@ impl World {
     }
 
     /// Inserts a new resource with the given `value`,
-    /// overwriting an existing resource of type T.
+    /// overwriting any existing resource of type T.
     /// Resources are "unique" data of a given type.
     #[inline]
     pub fn insert_resource<T: Component>(&mut self, value: T) {
@@ -529,7 +529,6 @@ impl World {
 
     /// Inserts a new resource with the given `value`.
     /// If a resource of type T already exists, the new resource is not inserted.
-    /// Resources are "unique" data of a given type.
     #[inline]
     pub fn try_insert_resource<T: Component>(&mut self, value: T) {
         let component_id = self.components.get_or_insert_resource_id::<T>();

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     archetype::{ArchetypeComponentId, ArchetypeComponentInfo, ArchetypeId, Archetypes},
     bundle::{Bundle, Bundles},
     component::{
-        Component, ComponentCollision, ComponentDescriptor, ComponentId, ComponentTicks,
+        CollisionBehaviour, Component, ComponentDescriptor, ComponentId, ComponentTicks,
         Components, ComponentsError, StorageType,
     },
     entity::{Entities, Entity},
@@ -524,7 +524,7 @@ impl World {
     pub fn insert_resource<T: Component>(&mut self, value: T) {
         let component_id = self.components.get_or_insert_resource_id::<T>();
         // SAFE: component_id just initialized and corresponds to resource of type T
-        unsafe { self.insert_resource_with_id(component_id, value, ComponentCollision::Overwrite) };
+        unsafe { self.insert_resource_with_id(component_id, value, CollisionBehaviour::Overwrite) };
     }
 
     /// Inserts a new resource with the given `value`.
@@ -533,7 +533,7 @@ impl World {
     pub fn try_insert_resource<T: Component>(&mut self, value: T) {
         let component_id = self.components.get_or_insert_resource_id::<T>();
         // SAFE: component_id just initialized and corresponds to resource of type T
-        unsafe { self.insert_resource_with_id(component_id, value, ComponentCollision::Skip) };
+        unsafe { self.insert_resource_with_id(component_id, value, CollisionBehaviour::Skip) };
     }
 
     /// Inserts a new non-send resource with the given `value`.
@@ -543,7 +543,7 @@ impl World {
         self.validate_non_send_access::<T>();
         let component_id = self.components.get_or_insert_non_send_resource_id::<T>();
         // SAFE: component_id just initialized and corresponds to resource of type T
-        unsafe { self.insert_resource_with_id(component_id, value, ComponentCollision::Overwrite) };
+        unsafe { self.insert_resource_with_id(component_id, value, CollisionBehaviour::Overwrite) };
     }
 
     /// Removes the resource of a given type and returns it, if it exists. Otherwise returns [None].
@@ -795,7 +795,7 @@ impl World {
         &mut self,
         component_id: ComponentId,
         mut value: T,
-        overwrite_existing: ComponentCollision,
+        overwrite_existing: CollisionBehaviour,
     ) {
         let change_tick = self.change_tick();
         let column = self.initialize_resource_internal(component_id);
@@ -809,7 +809,7 @@ impl World {
             std::mem::forget(value);
             // SAFE: index was just allocated above
             *column.get_ticks_unchecked_mut(row) = ComponentTicks::new(change_tick);
-        } else if matches!(overwrite_existing, ComponentCollision::Overwrite) {
+        } else if matches!(overwrite_existing, CollisionBehaviour::Overwrite) {
             // SAFE: column is of type T and has already been allocated
             *column.get_unchecked(0).cast::<T>() = value;
             column.get_ticks_unchecked_mut(0).set_changed(change_tick);

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -12,8 +12,8 @@ use crate::{
     archetype::{ArchetypeComponentId, ArchetypeComponentInfo, ArchetypeId, Archetypes},
     bundle::{Bundle, Bundles},
     component::{
-        Component, ComponentDescriptor, ComponentId, ComponentTicks, Components, ComponentsError,
-        StorageType,
+        Component, ComponentCollision, ComponentDescriptor, ComponentId, ComponentTicks,
+        Components, ComponentsError, StorageType,
     },
     entity::{Entities, Entity},
     query::{FilterFetch, QueryState, WorldQuery},
@@ -524,7 +524,7 @@ impl World {
     pub fn insert_resource<T: Component>(&mut self, value: T) {
         let component_id = self.components.get_or_insert_resource_id::<T>();
         // SAFE: component_id just initialized and corresponds to resource of type T
-        unsafe { self.insert_resource_with_id(component_id, value, true) };
+        unsafe { self.insert_resource_with_id(component_id, value, ComponentCollision::Overwrite) };
     }
 
     /// Inserts a new resource with the given `value`.
@@ -533,7 +533,7 @@ impl World {
     pub fn try_insert_resource<T: Component>(&mut self, value: T) {
         let component_id = self.components.get_or_insert_resource_id::<T>();
         // SAFE: component_id just initialized and corresponds to resource of type T
-        unsafe { self.insert_resource_with_id(component_id, value, false) };
+        unsafe { self.insert_resource_with_id(component_id, value, ComponentCollision::Skip) };
     }
 
     /// Inserts a new non-send resource with the given `value`.
@@ -543,7 +543,7 @@ impl World {
         self.validate_non_send_access::<T>();
         let component_id = self.components.get_or_insert_non_send_resource_id::<T>();
         // SAFE: component_id just initialized and corresponds to resource of type T
-        unsafe { self.insert_resource_with_id(component_id, value, true) };
+        unsafe { self.insert_resource_with_id(component_id, value, ComponentCollision::Overwrite) };
     }
 
     /// Removes the resource of a given type and returns it, if it exists. Otherwise returns [None].
@@ -795,7 +795,7 @@ impl World {
         &mut self,
         component_id: ComponentId,
         mut value: T,
-        overwrite_existing: bool,
+        overwrite_existing: ComponentCollision,
     ) {
         let change_tick = self.change_tick();
         let column = self.initialize_resource_internal(component_id);
@@ -809,7 +809,7 @@ impl World {
             std::mem::forget(value);
             // SAFE: index was just allocated above
             *column.get_ticks_unchecked_mut(row) = ComponentTicks::new(change_tick);
-        } else if overwrite_existing {
+        } else if matches!(overwrite_existing, ComponentCollision::Overwrite) {
             // SAFE: column is of type T and has already been allocated
             *column.get_unchecked(0).cast::<T>() = value;
             column.get_ticks_unchecked_mut(0).set_changed(change_tick);

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -1,7 +1,7 @@
 use crate::{
     archetype::{Archetype, ArchetypeId, ComponentStatus},
     bundle::{Bundle, BundleInfo},
-    component::ComponentCollision,
+    component::CollisionBehaviour,
     entity::{Entities, Entity},
     storage::{SparseSets, Table},
     world::{add_bundle_to_archetype, World},
@@ -105,7 +105,7 @@ where
                 self.bundle_status,
                 bundle,
                 self.change_tick,
-                ComponentCollision::Overwrite,
+                CollisionBehaviour::Overwrite,
             );
             self.entities.meta[entity.id as usize].location = location;
         }

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -1,6 +1,7 @@
 use crate::{
     archetype::{Archetype, ArchetypeId, ComponentStatus},
     bundle::{Bundle, BundleInfo},
+    component::ComponentCollision,
     entity::{Entities, Entity},
     storage::{SparseSets, Table},
     world::{add_bundle_to_archetype, World},
@@ -104,6 +105,7 @@ where
                 self.bundle_status,
                 bundle,
                 self.change_tick,
+                ComponentCollision::Overwrite,
             );
             self.entities.meta[entity.id as usize].location = location;
         }


### PR DESCRIPTION
As detailed in #2054, this PR adds `try_insert`,  `try_insert_bundle`, and  `try_insert_resource` functions. These functions act in the same manner as the original functions but instead of overwriting an existing component/resource, silently skip those which already exist.

This is my first bevy contribution and my first contribution to a large open-source rust project, so I appreciate any and all forms of feedback. I'm not completely confident in my decision to make the collision with an existing compoent/resource fail silently, but I couldn't decide how a return value could fit neatly into the command pattern. Additionally, I'm not sure about the usage of a boolean parameter to control the flow of `insert_resource_with_id`. I'd appreciate f some more experienced members of the team could enlighten me as to how this could be done better/idiomatically. 

I thought about the names quite a bit but didn't arrive at any that I was happy enough with to use instead of the `try` prefix suggested in the original issue by @alice-i-cecile. One alternative I considered was `unifying_insert` to borrow some language from set theory, but that doesn't really apply to inserting single components or resources. The other was `ensure_inserted` to communicate that the function doesn't care about the value of the component, just its prescence, but I'm not sure if the meaning of that one is immediately obvious to people other than me.