### PR TITLE
[Merged by Bors] - Replace derive(Default) with impl in AssetCountDiagnosticsPlugin

### DIFF
--- a/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
+++ b/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
@@ -10,7 +10,7 @@ pub struct AssetCountDiagnosticsPlugin<T: Asset> {
 
 impl<T: Asset> Default for AssetCountDiagnosticsPlugin<T> {
     fn default() -> Self {
-        Self { 
+        Self {
             marker: std::marker::PhantomData,
         }
     }

--- a/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
+++ b/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
@@ -4,9 +4,16 @@ use bevy_diagnostic::{Diagnostic, DiagnosticId, Diagnostics};
 use bevy_ecs::system::{IntoSystem, Res, ResMut};
 
 /// Adds "asset count" diagnostic to an App
-#[derive(Default)]
 pub struct AssetCountDiagnosticsPlugin<T: Asset> {
     marker: std::marker::PhantomData<T>,
+}
+
+impl<T: Asset> Default for AssetCountDiagnosticsPlugin<T> {
+    fn default() -> Self {
+        Self { 
+            marker: std::marker::PhantomData,
+        }
+    }
 }
 
 impl<T: Asset> Plugin for AssetCountDiagnosticsPlugin<T> {


### PR DESCRIPTION
Hi, ran into this problem with the derive macro.

It fails trying to derive the Default trait when the asset does not implements it also. This is unnecessary because this plugin does not need that from the asset type, just needs to create the phantom data.