### PR TITLE
Added visibility inheritance

### DIFF
--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -356,7 +356,7 @@ mod test {
         let mut world = World::default();
         let mut update_stage = SystemStage::parallel();
         update_stage.add_system(parent_update_system.system());
-        update_stage.add_system(visible_entities_system.system());
+        update_stage.add_system(visible_effective_system.system());
 
         let mut schedule = Schedule::default();
         schedule.add_stage("update", update_stage);

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -10,6 +10,9 @@ use bevy_ecs::{
 use bevy_reflect::Reflect;
 use bevy_transform::prelude::{Children, GlobalTransform, Parent};
 
+// This struct reflects Visible and is used to store the effective value.
+// The only one reason why it's not stored in the original struct is the `is_transparent` field.
+// Having both that field and the effective value in Visible complicates creation of that struct.
 #[derive(Default, Debug, Reflect)]
 #[reflect(Component)]
 pub struct VisibleEffective {
@@ -211,6 +214,13 @@ mod rendering_mask_tests {
     }
 }
 
+//Computes effective visibility for entities.
+//
+//In hirerarchies the actual visiblity of an entity isn't only the current value,
+//but also depends on ancestors of the entity./ To avoid traversing each hierarchy
+//and determine the effective visibility for each entity, this system listens to
+//visiblity and hierarchy changes and only then computes a value to be cached and
+//used by other systems.
 pub fn visible_effective_system(
     children_query: Query<&Children>,
     changes_query: Query<

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -44,7 +44,7 @@ use bevy_asset::{AddAsset, AssetStage};
 use bevy_ecs::schedule::{StageLabel, SystemLabel};
 use camera::{
     ActiveCameras, Camera, DepthCalculation, OrthographicProjection, PerspectiveProjection,
-    RenderLayers, ScalingMode, VisibleEntities, WindowOrigin,
+    RenderLayers, ScalingMode, VisibleEffective, VisibleEntities, WindowOrigin,
 };
 use pipeline::{
     IndexFormat, PipelineCompiler, PipelineDescriptor, PipelineSpecialization, PrimitiveTopology,
@@ -140,6 +140,7 @@ impl Plugin for RenderPlugin {
         .register_type::<DepthCalculation>()
         .register_type::<Draw>()
         .register_type::<Visible>()
+        .register_type::<VisibleEffective>()
         .register_type::<OutsideFrustum>()
         .register_type::<RenderPipelines>()
         .register_type::<OrthographicProjection>()
@@ -180,6 +181,12 @@ impl Plugin for RenderPlugin {
         .add_system_to_stage(
             CoreStage::PostUpdate,
             camera::camera_system::<PerspectiveProjection>
+                .system()
+                .before(RenderSystem::VisibleEntities),
+        )
+        .add_system_to_stage(
+            CoreStage::PostUpdate,
+            camera::visible_effective_system
                 .system()
                 .before(RenderSystem::VisibleEntities),
         )


### PR DESCRIPTION
Fixes #838.

I'm not very happy that there's a new type called `VisibleEffective`, but currently it's much better way than making a new public field in `Visible` to keep an effective value and doesn't cause unnecessary breaking changes. Ideally, I would like to move `is_transparent` to materials as one comment says and make `Visible` non default and with constructors, but it's another story.