### PR TITLE
Improve code quality of Breakout game example

### DIFF
--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -23,6 +23,7 @@ mod config {
     pub const PADDLE_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
     pub const PADDLE_SPEED: f32 = 500.0;
     pub const PADDLE_SIZE: Vec2 = const_vec2!([120.0, 30.0]);
+    pub const PADDLE_BOUND: f32 = 380.0;
 
     pub const BALL_COLOR: Color = Color::rgb(1.0, 0.5, 0.5);
     // Our ball is actually a square. Shhh...
@@ -338,14 +339,13 @@ fn paddle_input(keyboard_input: Res<Input<KeyCode>>, mut query: Query<(&Paddle, 
 
 /// Ensures our paddle never goes out of bounds
 fn bound_paddle(mut query: Query<(&mut Transform, &mut Velocity), With<Paddle>>) {
-    const BOUND: f32 = 380.0;
     let (mut paddle_transform, mut paddle_velocity) = query.single_mut().unwrap();
 
-    if paddle_transform.translation.x >= BOUND {
-        paddle_transform.translation.x = BOUND;
+    if paddle_transform.translation.x >= PADDLE_BOUND {
+        paddle_transform.translation.x = PADDLE_BOUND;
         paddle_velocity.x = 0.0;
-    } else if paddle_transform.translation.x <= -BOUND {
-        paddle_transform.translation.x = -BOUND;
+    } else if paddle_transform.translation.x <= -PADDLE_BOUND {
+        paddle_transform.translation.x = -PADDLE_BOUND;
         paddle_velocity.x = 0.0;
     }
 }

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -13,6 +13,7 @@ mod config {
     use bevy::math::Vec2;
     use bevy::transform::components::Transform;
     use bevy::render::color::Color;
+    use bevy::ui::Val;
 
     pub const TIME_STEP: f64 = 1.0 / 60.0;
     pub const BACKGROUND_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);
@@ -35,6 +36,8 @@ mod config {
 
     pub const SCOREBOARD_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
     pub const SCORE_COLOR: Color = Color::rgb(1.0, 0.5, 0.5);
+    pub const SCORE_FONT_SIZE: f32 = 40.0;
+    pub const SCORE_PADDING: Val = Val::Px(5.0);
 }
 
 /// A simple implementation of the classic game "Breakout"
@@ -224,7 +227,7 @@ fn add_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
                     value: "Score: ".to_string(),
                     style: TextStyle {
                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                        font_size: 40.0,
+                        font_size: config::SCORE_FONT_SIZE,
                         color: config::SCOREBOARD_COLOR,
                     },
                 },
@@ -232,7 +235,7 @@ fn add_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
                     value: "".to_string(),
                     style: TextStyle {
                         font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                        font_size: 40.0,
+                        font_size: config::SCORE_FONT_SIZE,
                         color: config::SCORE_COLOR,
                     },
                 },
@@ -242,8 +245,8 @@ fn add_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
         style: Style {
             position_type: PositionType::Absolute,
             position: Rect {
-                top: Val::Px(5.0),
-                left: Val::Px(5.0),
+                top: config::SCORE_PADDING,
+                left: config::SCORE_PADDING,
                 ..Default::default()
             },
             ..Default::default()

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -56,11 +56,11 @@ fn main() {
         // This adds the Score resource with its default values: 0
         .init_resource::<Score>()
         // These systems run only once, before all other systems
-        .add_startup_system(add_cameras.system())
-        .add_startup_system(add_paddle.system())
-        .add_startup_system(add_ball.system())
-        .add_startup_system(add_walls.system())
-        .add_startup_system(add_scoreboard.system())
+        .add_startup_system(spawn_cameras.system())
+        .add_startup_system(spawn_paddle.system())
+        .add_startup_system(spawn_ball.system())
+        .add_startup_system(spawn_walls.system())
+        .add_startup_system(spawn_scoreboard.system())
         // These systems run repeatedly, whnever the FixedTimeStep's duration has elapsed
         .add_system_set(
             SystemSet::new()
@@ -100,12 +100,12 @@ mod components {
     }
 }
 
-fn add_cameras(mut commands: Commands) {
+fn spawn_cameras(mut commands: Commands) {
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
     commands.spawn_bundle(UiCameraBundle::default());
 }
 
-fn add_paddle(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
+fn spawn_paddle(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(config::PADDLE_COLOR.into()),
@@ -120,7 +120,7 @@ fn add_paddle(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial
         .insert(Velocity::default());
 }
 
-fn add_ball(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
+fn spawn_ball(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(config::BALL_COLOR.into()),
@@ -188,7 +188,7 @@ impl WallBundle {
     }
 }
 
-fn add_walls(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
+fn spawn_walls(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
     let material_handle = materials.add(config::WALL_COLOR.into());
 
     commands.spawn_bundle(WallBundle::new(Side::Top, material_handle));
@@ -233,7 +233,7 @@ fn add_bricks(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial
     }
 }
 
-fn add_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn spawn_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(TextBundle {
         text: Text {
             sections: vec![

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -11,7 +11,8 @@ use resources::*;
 
 /// Constants that can be used to fine-tune the behavior of our game
 mod config {
-    // TODO: add various Transforms to this config module for clarity and consistency
+    // FIXME: add various Transforms to this config module for clarity and consistency
+    // Blocked on https://github.com/bevyengine/bevy/issues/2097
     use bevy::math::{const_vec2, Vec2};
     use bevy::render::color::Color;
     use bevy::ui::Val;
@@ -134,6 +135,7 @@ fn spawn_ball(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial
     let ball_starting_location: Transform = Transform::from_xyz(0.0, -50.0, 1.0);
 
     // .normalize is not a const fn, so we have to perform this operation at runtime
+    // FIXME: Blocked on https://github.com/bitshifter/glam-rs/issues/76
     let normalized_direction = BALL_STARTING_DIRECTION.normalize();
     let ball_starting_velocity: Velocity = Velocity {
         x: normalized_direction.x * BALL_STARTING_SPEED,

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -55,7 +55,7 @@ fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .insert_resource(ClearColor(BACKGROUND_COLOR))
-        // This adds the Score resource with its default values: 0
+        // This adds the Score resource with its default value of 0
         .init_resource::<Score>()
         // These systems run only once, before all other systems
         .add_startup_system(spawn_cameras.system())
@@ -260,6 +260,8 @@ fn spawn_bricks(mut commands: Commands, mut materials: ResMut<Assets<ColorMateri
                 brick_material.clone(),
             )
         });
+    // spawn_batch is slightly more efficient than repeatedly calling .spawn_bundle due to memory pre-allocation
+    // This approach is overkill for the small number of entities here, but serves to demonstrate how the function is used
     commands.spawn_batch(brick_iterator);
 
     /* Equivalently, you could spawn one brick at a time using for loops instead, at a small cost to performance
@@ -416,5 +418,7 @@ fn ball_collision(
 /// Updates the Scoreboard entity's Text based on the value of the Score resource
 fn update_scoreboard(score: Res<Score>, mut query: Query<&mut Text, With<Scoreboard>>) {
     let mut scoreboard_text = query.single_mut().unwrap();
+    // We need to access the second section, so we need to access the sections field at the [1] index
+    // (Rust is 0-indexed: https://medium.com/analytics-vidhya/array-indexing-0-based-or-1-based-dd89d631d11c)
     scoreboard_text.sections[1].value = format!("{}", score.0);
 }

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -6,7 +6,7 @@ use bevy::{
 };
 
 use components::*;
-use config::{BRICK_HEIGHT, BRICK_WIDTH};
+use config::*;
 use resources::*;
 
 /// Constants that can be used to fine-tune the behavior of our game

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -143,7 +143,7 @@ enum Side {
 }
 
 impl Side {
-    fn wall_coord(self, bounds: Vec2) -> Transform {
+    fn wall_coord(&self, bounds: Vec2) -> Transform {
         let (x, y) = match self {
             Side::Top => (0.0, bounds.y / 2.0),
             Side::Bottom => (0.0, -bounds.y / 2.0),
@@ -154,7 +154,7 @@ impl Side {
         Transform::from_xyz(x, y, 0.0)
     }
 
-    fn wall_size(self, bounds: Vec2, thickness: f32) -> Vec2 {
+    fn wall_size(&self, bounds: Vec2, thickness: f32) -> Vec2 {
         match self {
             Side::Top => Vec2::new(thickness, bounds.y + thickness),
             Side::Bottom => Vec2::new(thickness, bounds.y + thickness),
@@ -173,7 +173,7 @@ struct WallBundle {
 }
 
 impl WallBundle {
-    fn new(side: Side, material_handle: Handle<ColorMaterial>) -> Self {
+    fn new(side: Side, material_handle: &Handle<ColorMaterial>) -> Self {
         let bounds = config::ARENA_BOUNDS;
         let thickness = config::WALL_THICKNESS;
 
@@ -192,10 +192,10 @@ impl WallBundle {
 fn spawn_walls(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
     let material_handle = materials.add(config::WALL_COLOR.into());
 
-    commands.spawn_bundle(WallBundle::new(Side::Top, material_handle));
-    commands.spawn_bundle(WallBundle::new(Side::Bottom, material_handle));
-    commands.spawn_bundle(WallBundle::new(Side::Left, material_handle));
-    commands.spawn_bundle(WallBundle::new(Side::Right, material_handle));
+    commands.spawn_bundle(WallBundle::new(Side::Top, &material_handle));
+    commands.spawn_bundle(WallBundle::new(Side::Bottom, &material_handle));
+    commands.spawn_bundle(WallBundle::new(Side::Left, &material_handle));
+    commands.spawn_bundle(WallBundle::new(Side::Right, &material_handle));
 }
 
 fn add_bricks(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
@@ -272,7 +272,7 @@ fn spawn_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 /// Moves everything with both a Transform and a Velovity accordingly
 fn kinematics(mut query: Query<(&mut Transform, &Velocity)>) {
-    for (transform, velocity) in query.iter_mut() {
+    for (mut transform, velocity) in query.iter_mut() {
         transform.translation.x += velocity.x * config::TIME_STEP;
         transform.translation.y += velocity.y * config::TIME_STEP;
     }

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -218,10 +218,11 @@ impl WallBundle {
 fn spawn_walls(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
     let material_handle = materials.add(WALL_COLOR.into());
 
+    // Each material handle must be uniquely owned as handles are ref-counted
     commands.spawn_bundle(WallBundle::new(Side::Top, material_handle.clone()));
     commands.spawn_bundle(WallBundle::new(Side::Bottom, material_handle.clone()));
     commands.spawn_bundle(WallBundle::new(Side::Left, material_handle.clone()));
-    commands.spawn_bundle(WallBundle::new(Side::Right, material_handle.clone()));
+    commands.spawn_bundle(WallBundle::new(Side::Right, material_handle));
 }
 
 #[derive(Bundle)]

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -11,10 +11,9 @@ use resources::*;
 
 /// Constants that can be used to fine-tune the behavior of our game
 mod config {
-    // FIXME: add various Transforms to this config module for clarity and consistency
-    // Blocked on https://github.com/bevyengine/bevy/issues/2097
-    use bevy::math::{const_vec2, Vec2};
+    use bevy::math::{const_quat, const_vec2, const_vec3, Vec2};
     use bevy::render::color::Color;
+    use bevy::transform::components::Transform;
     use bevy::ui::Val;
 
     pub const TIME_STEP: f32 = 1.0 / 60.0;
@@ -24,12 +23,25 @@ mod config {
     pub const PADDLE_SPEED: f32 = 500.0;
     pub const PADDLE_SIZE: Vec2 = const_vec2!([120.0, 30.0]);
     pub const PADDLE_BOUND: f32 = 380.0;
+    pub const PADDLE_STARTING_TRANSFORM: Transform = Transform {
+        translation: const_vec3!([0.0, -215.0, 0.0]),
+        // We don't want any rotation
+        rotation: const_quat!([0.0, 0.0, 0.0, 0.0]),
+        // We want the scale to be 1 in all directions
+        scale: const_vec3!([1.0, 1.0, 1.0]),
+    };
 
     pub const BALL_COLOR: Color = Color::rgb(1.0, 0.5, 0.5);
     // Our ball is actually a square. Shhh...
     pub const BALL_SIZE: Vec2 = const_vec2!([30.0, 30.0]);
     pub const BALL_STARTING_DIRECTION: Vec2 = const_vec2!([0.5, -0.5]);
     pub const BALL_STARTING_SPEED: f32 = 400.0;
+    // We set the z-value to one to ensure it appears on top of our other objects in case of overlap
+    pub const BALL_STARTING_TRANSFORM: Transform = Transform {
+        translation: const_vec3!([0.0, -50.0, 1.0]),
+        rotation: const_quat!([0.0, 0.0, 0.0, 0.0]),
+        scale: const_vec3!([1.0, 1.0, 1.0]),
+    };
 
     pub const ARENA_BOUNDS: Vec2 = const_vec2!([900.0, 600.0]);
     pub const WALL_THICKNESS: f32 = 10.0;
@@ -115,12 +127,10 @@ fn spawn_cameras(mut commands: Commands) {
 }
 
 fn spawn_paddle(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
-    let paddle_starting_location: Transform = Transform::from_xyz(0.0, -215.0, 0.0);
-
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(PADDLE_COLOR.into()),
-            transform: paddle_starting_location,
+            transform: PADDLE_STARTING_TRANSFORM,
             sprite: Sprite::new(PADDLE_SIZE),
             ..Default::default()
         })
@@ -132,9 +142,6 @@ fn spawn_paddle(mut commands: Commands, mut materials: ResMut<Assets<ColorMateri
 }
 
 fn spawn_ball(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
-    // We set the z-value to one to ensure it appears on top of our other objects in case of overlap
-    let ball_starting_location: Transform = Transform::from_xyz(0.0, -50.0, 1.0);
-
     // .normalize is not a const fn, so we have to perform this operation at runtime
     // FIXME: Blocked on https://github.com/bitshifter/glam-rs/issues/76
     let normalized_direction = BALL_STARTING_DIRECTION.normalize();
@@ -146,7 +153,7 @@ fn spawn_ball(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(BALL_COLOR.into()),
-            transform: ball_starting_location,
+            transform: BALL_STARTING_TRANSFORM,
             sprite: Sprite::new(BALL_SIZE),
             ..Default::default()
         })

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -20,7 +20,8 @@ mod config {
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .insert_resource(Scoreboard { score: 0 })
+        // This adds the Scoreboard resource with its default values: 0
+        .init_resource::<Scoreboard>()
         .insert_resource(config::BACKGROUND_COLOR)
         .add_startup_system(setup.system())
         .add_system_set(
@@ -35,6 +36,7 @@ fn main() {
 }
 
 mod resources {
+    #[derive(Default)]
     pub struct Scoreboard {
         score: usize,
     }

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -70,9 +70,7 @@ fn main() {
 
 mod resources {
     #[derive(Default)]
-    pub struct Score {
-        score: usize,
-    }
+    pub struct Score(pub usize);
 }
 
 mod components {
@@ -295,11 +293,6 @@ fn bound_paddle_system(mut query: Query<&mut Transform, With<Paddle>>) {
     paddle_transform.translation.x = paddle_transform.translation.x.min(380.0).max(-380.0);
 }
 
-fn scoreboard_system(scoreboard: Res<Scoreboard>, mut query: Query<&mut Text>) {
-    let mut text = query.single_mut().unwrap();
-    text.sections[0].value = format!("Score: {}", scoreboard.score);
-}
-
 fn ball_collision_system(
     mut commands: Commands,
     mut scoreboard: ResMut<Scoreboard>,
@@ -356,4 +349,10 @@ fn ball_collision_system(
             }
         }
     }
+}
+
+/// Updates the Scoreboard entity based on the Score resource
+fn scoreboard_system(score: Res<Score>, mut query: Query<&mut Text, With<Scoreboard>>) {
+    let mut scoreboard_text = query.single_mut().unwrap();
+    scoreboard_text.sections[0].value = format!("Score: {}", score.0);
 }

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -19,6 +19,8 @@ mod config {
     pub const ARENA_BOUNDS: Vec2 = Vec2::new(900.0, 600.0);
     pub const WALL_THICKNESS: f32 = 10.0;
     pub const WALL_COLOR: Color = Color::rgb(0.8, 0.8, 0.8);
+
+    pub const BRICK_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
 }
 
 /// A simple implementation of the classic game "Breakout"
@@ -165,24 +167,28 @@ fn add_walls(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>
 }
 
 fn add_bricks(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
-    // Add bricks
-    let brick_rows = 4;
-    let brick_columns = 5;
-    let brick_spacing = 20.0;
-    let brick_size = Vec2::new(150.0, 30.0);
-    let bricks_width = brick_columns as f32 * (brick_size.x + brick_spacing) - brick_spacing;
-    // center the bricks and move them up a bit
-    let bricks_offset = Vec3::new(-(bricks_width - brick_size.x) / 2.0, 100.0, 0.0);
-    let brick_material = materials.add(Color::rgb(0.5, 0.5, 1.0).into());
+    let brick_material = materials.add(config::BRICK_COLOR.into());
+   
+    // Brick layout constants
+    const brick_rows: i8 = 4;
+    const brick_columns: i8 = 5;
+    const brick_spacing: f32 = 20.0;
+    const brick_size: Vec2 = Vec2::new(150.0, 30.0);
+
+    // Compute the total width that all of the bricks take
+    let total_width = brick_columns as f32 * (brick_size.x + brick_spacing) - brick_spacing;
+    // Center the bricks and move them up a bit
+    let bricks_offset = Vec3::new(-(total_width - brick_size.x) / 2.0, 100.0, 0.0);
+    
+    // Add the bricks
     for row in 0..brick_rows {
-        let y_position = row as f32 * (brick_size.y + brick_spacing);
         for column in 0..brick_columns {
             let brick_position = Vec3::new(
                 column as f32 * (brick_size.x + brick_spacing),
-                y_position,
+                row as f32 * (brick_size.y + brick_spacing),
                 0.0,
             ) + bricks_offset;
-            // brick
+            // Adding one brick at a time
             commands
                 .spawn_bundle(SpriteBundle {
                     material: brick_material.clone(),

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -190,7 +190,7 @@ struct WallBundle {
 }
 
 impl WallBundle {
-    fn new(side: Side, material_handle: &Handle<ColorMaterial>) -> Self {
+    fn new(side: Side, material_handle: Handle<ColorMaterial>) -> Self {
         let arena_bounds: Vec2 = Vec2::new(900.0, 600.0);
 
         let bounds = arena_bounds;
@@ -198,7 +198,7 @@ impl WallBundle {
 
         WallBundle {
             sprite_bundle: SpriteBundle {
-                material: material_handle.clone(),
+                material: material_handle,
                 transform: side.wall_coord(bounds),
                 sprite: Sprite::new(side.wall_size(bounds, thickness)),
                 ..Default::default()
@@ -211,10 +211,10 @@ impl WallBundle {
 fn spawn_walls(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
     let material_handle = materials.add(WALL_COLOR.into());
 
-    commands.spawn_bundle(WallBundle::new(Side::Top, &material_handle));
-    commands.spawn_bundle(WallBundle::new(Side::Bottom, &material_handle));
-    commands.spawn_bundle(WallBundle::new(Side::Left, &material_handle));
-    commands.spawn_bundle(WallBundle::new(Side::Right, &material_handle));
+    commands.spawn_bundle(WallBundle::new(Side::Top, material_handle.clone()));
+    commands.spawn_bundle(WallBundle::new(Side::Bottom, material_handle.clone()));
+    commands.spawn_bundle(WallBundle::new(Side::Left, material_handle.clone()));
+    commands.spawn_bundle(WallBundle::new(Side::Right, material_handle.clone()));
 }
 #[derive(Bundle)]
 struct BrickBundle {
@@ -225,10 +225,10 @@ struct BrickBundle {
 }
 
 impl BrickBundle {
-    fn new(x: f32, y: f32, material_handle: &Handle<ColorMaterial>) -> Self {
+    fn new(x: f32, y: f32, material_handle: Handle<ColorMaterial>) -> Self {
         BrickBundle {
             sprite_bundle: SpriteBundle {
-                material: material_handle.clone(),
+                material: material_handle,
                 transform: Transform::from_xyz(x, y, 0.0),
                 sprite: Sprite::new(Vec2::new(BRICK_WIDTH, BRICK_HEIGHT)),
                 ..Default::default()
@@ -250,9 +250,20 @@ fn spawn_bricks(mut commands: Commands, mut materials: ResMut<Assets<ColorMateri
     const OFFSET_Y: f32 = 100.0;
 
     // Add the bricks
+    let brick_iterator = (0..BRICK_ROWS)
+        .flat_map(|row| (0..BRICK_COLUMNS).map(move |col| (row, col)))
+        .map(move |(row, column)| {
+            BrickBundle::new(
+                column as f32 * (BRICK_WIDTH + BRICK_SPACING) + OFFSET_X,
+                row as f32 * (BRICK_HEIGHT + BRICK_SPACING) + OFFSET_Y,
+                brick_material.clone(),
+            )
+        });
+    commands.spawn_batch(brick_iterator);
+
+    /* Equivalently, you could spawn one brick at a time using for loops instead, at a small cost to performance
     for row in 0..BRICK_ROWS {
         for column in 0..BRICK_COLUMNS {
-            // Adding one brick at a time
             commands.spawn_bundle(BrickBundle::new(
                 column as f32 * (BRICK_WIDTH + BRICK_SPACING) + OFFSET_X,
                 row as f32 * (BRICK_HEIGHT + BRICK_SPACING) + OFFSET_Y,
@@ -260,6 +271,7 @@ fn spawn_bricks(mut commands: Commands, mut materials: ResMut<Assets<ColorMateri
             ));
         }
     }
+    */
 }
 
 fn spawn_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -10,6 +10,7 @@ use resources::*;
 
 /// Constants that can be used to fine-tune the behavior of our game
 mod config {
+    use super::Velocity;
     use bevy::math::Vec2;
     use bevy::render::color::Color;
     use bevy::transform::components::Transform;
@@ -28,6 +29,12 @@ mod config {
     pub const BALL_STARTING_LOCATION: Transform = Transform::from_xyz(0.0, -50.0, 1.0);
     // Our ball is actually a square. Shhh...
     pub const BALL_SIZE: Vec2 = Vec2::new(30.0, 30.0);
+    const BALL_STARTING_DIRECTION: Vec2 = Vec2::new(0.5, -0.5).normalize();
+    const BALL_STARTING_SPEED: f32 = 400.0;
+    pub const BALL_STARTING_VELOCITY: Velocity = Velocity {
+        x: BALL_STARTING_DIRECTION.x * BALL_STARTING_SPEED,
+        y: BALL_STARTING_DIRECTION.y * BALL_STARTING_SPEED,
+    };
 
     pub const ARENA_BOUNDS: Vec2 = Vec2::new(900.0, 600.0);
     pub const WALL_THICKNESS: f32 = 10.0;
@@ -121,7 +128,9 @@ fn add_ball(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>
             sprite: Sprite::new(config::BALL_SIZE),
             ..Default::default()
         })
-        .insert(Ball);
+        .insert(Ball)
+        // Adds a `Velocity` component with the value defined in the `config` module
+        .insert(config::BALL_STARTING_VELOCITY);
 }
 
 /// Defines which side of the arena a wall is part of

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -30,18 +30,23 @@ mod config {
     pub const BRICK_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
     pub const BRICK_WIDTH: f32 = 150.0;
     pub const BRICK_HEIGHT: f32 = 30.0;
+    pub const BRICK_ROWS: i8 = 4;
+    pub const BRICK_COLUMNS: i8 = 5;
+    pub const BRICK_SPACING: f32 = 20.0;
 
     pub const SCOREBOARD_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
     pub const SCORE_COLOR: Color = Color::rgb(1.0, 0.5, 0.5);
     pub const SCORE_FONT_SIZE: f32 = 40.0;
     pub const SCORE_PADDING: Val = Val::Px(5.0);
+    pub const SCOREBOARD_FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+    pub const SCORE_FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
 }
 
 /// A simple implementation of the classic game "Breakout"
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .insert_resource(ClearColor(config::BACKGROUND_COLOR))
+        .insert_resource(ClearColor(BACKGROUND_COLOR))
         // This adds the Score resource with its default values: 0
         .init_resource::<Score>()
         // These systems run only once, before all other systems
@@ -54,7 +59,7 @@ fn main() {
         // These systems run repeatedly, whnever the FixedTimeStep's duration has elapsed
         .add_system_set(
             SystemSet::new()
-                .with_run_criteria(FixedTimestep::step(config::TIME_STEP as f64))
+                .with_run_criteria(FixedTimestep::step(TIME_STEP as f64))
                 .with_system(kinematics.system().label("kinematics"))
                 .with_system(ball_collision.system().before("kinematics")),
         )
@@ -107,13 +112,13 @@ fn spawn_paddle(mut commands: Commands, mut materials: ResMut<Assets<ColorMateri
 
     commands
         .spawn_bundle(SpriteBundle {
-            material: materials.add(config::PADDLE_COLOR.into()),
+            material: materials.add(PADDLE_COLOR.into()),
             transform: paddle_starting_location,
             sprite: Sprite::new(paddle_size),
             ..Default::default()
         })
         .insert(Paddle {
-            speed: config::PADDLE_SPEED,
+            speed: PADDLE_SPEED,
         })
         .insert(Collides)
         .insert(Velocity::default());
@@ -134,7 +139,7 @@ fn spawn_ball(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial
 
     commands
         .spawn_bundle(SpriteBundle {
-            material: materials.add(config::BALL_COLOR.into()),
+            material: materials.add(BALL_COLOR.into()),
             transform: ball_starting_location,
             sprite: Sprite::new(ball_size),
             ..Default::default()
@@ -189,7 +194,7 @@ impl WallBundle {
         let arena_bounds: Vec2 = Vec2::new(900.0, 600.0);
 
         let bounds = arena_bounds;
-        let thickness = config::WALL_THICKNESS;
+        let thickness = WALL_THICKNESS;
 
         WallBundle {
             sprite_bundle: SpriteBundle {
@@ -204,7 +209,7 @@ impl WallBundle {
 }
 
 fn spawn_walls(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
-    let material_handle = materials.add(config::WALL_COLOR.into());
+    let material_handle = materials.add(WALL_COLOR.into());
 
     commands.spawn_bundle(WallBundle::new(Side::Top, &material_handle));
     commands.spawn_bundle(WallBundle::new(Side::Bottom, &material_handle));
@@ -235,12 +240,7 @@ impl BrickBundle {
 }
 
 fn spawn_bricks(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
-    let brick_material = materials.add(config::BRICK_COLOR.into());
-
-    // Brick layout constants
-    const BRICK_ROWS: i8 = 4;
-    const BRICK_COLUMNS: i8 = 5;
-    const BRICK_SPACING: f32 = 20.0;
+    let brick_material = materials.add(BRICK_COLOR.into());
 
     // Compute the total width that all of the bricks take
     const TOTAL_WIDTH: f32 = BRICK_COLUMNS as f32 * (BRICK_WIDTH + BRICK_SPACING) - BRICK_SPACING;
@@ -270,17 +270,17 @@ fn spawn_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
                     TextSection {
                         value: "Score: ".to_string(),
                         style: TextStyle {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                            font_size: config::SCORE_FONT_SIZE,
-                            color: config::SCOREBOARD_COLOR,
+                            font: asset_server.load(SCOREBOARD_FONT_PATH),
+                            font_size: SCORE_FONT_SIZE,
+                            color: SCOREBOARD_COLOR,
                         },
                     },
                     TextSection {
                         value: "".to_string(),
                         style: TextStyle {
-                            font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                            font_size: config::SCORE_FONT_SIZE,
-                            color: config::SCORE_COLOR,
+                            font: asset_server.load(SCORE_FONT_PATH),
+                            font_size: SCORE_FONT_SIZE,
+                            color: SCORE_COLOR,
                         },
                     },
                 ],
@@ -289,8 +289,8 @@ fn spawn_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
             style: Style {
                 position_type: PositionType::Absolute,
                 position: Rect {
-                    top: config::SCORE_PADDING,
-                    left: config::SCORE_PADDING,
+                    top: SCORE_PADDING,
+                    left: SCORE_PADDING,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -303,8 +303,8 @@ fn spawn_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
 /// Moves everything with both a Transform and a Velocity accordingly
 fn kinematics(mut query: Query<(&mut Transform, &Velocity)>) {
     query.for_each_mut(|(mut transform, velocity)| {
-        transform.translation.x += velocity.x * config::TIME_STEP;
-        transform.translation.y += velocity.y * config::TIME_STEP;
+        transform.translation.x += velocity.x * TIME_STEP;
+        transform.translation.y += velocity.y * TIME_STEP;
     });
 }
 

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -1,5 +1,6 @@
 use bevy::{
     core::FixedTimestep,
+    input::system::exit_on_esc_system,
     prelude::*,
     render::pass::ClearColor,
     sprite::collide_aabb::{collide, Collision},
@@ -81,26 +82,34 @@ fn main() {
             SystemSet::new()
                 .with_run_criteria(FixedTimestep::step(TIME_STEP as f64))
                 .with_system(kinematics.system().label("kinematics"))
-                // We need to check for collisions before handling movement 
+                // We need to check for collisions before handling movement
                 // to reduce the risk of the ball passing through objects
                 .with_system(ball_collision.system().before("kinematics")),
         )
         // Ordinary systems run every frame
-        // We need to handle input before we move our paddle, 
+        // We need to handle input before we move our paddle,
         // to ensure that we're responding to the most recent frame's events,
         // avoiding input lag
-        // See https://github.com/bevyengine/bevy/blob/latest/examples/ecs/ecs_guide.rs 
+        // See https://github.com/bevyengine/bevy/blob/latest/examples/ecs/ecs_guide.rs
         // for more information on system ordering
-        .add_system(paddle_input.system().before("bound_paddle").before("kinematics"))
+        .add_system(
+            paddle_input
+                .system()
+                .before("bound_paddle")
+                .before("kinematics"),
+        )
         .add_system(
             bound_paddle
                 .system()
                 .label("bound_paddle")
                 // This system must run after kinematics, or the velocity will be set to 0
-                // before the paddle moves, causing it to be stuck to the wall 
+                // before the paddle moves, causing it to be stuck to the wall
                 .after("kinematics"),
         )
         .add_system(update_scoreboard.system())
+        // Exits the game when `KeyCode::Esc` is pressed
+        // This is a simple built-in system
+        .add_system(exit_on_esc_system.system())
         .run();
 }
 

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -158,10 +158,10 @@ impl Side {
 
     fn wall_size(&self, bounds: Vec2, thickness: f32) -> Vec2 {
         match self {
-            Side::Top => Vec2::new(thickness, bounds.y + thickness),
-            Side::Bottom => Vec2::new(thickness, bounds.y + thickness),
-            Side::Left => Vec2::new(bounds.x + thickness, thickness),
-            Side::Right => Vec2::new(bounds.x + thickness, thickness),
+            Side::Top => Vec2::new(bounds.x + thickness, thickness),
+            Side::Bottom => Vec2::new(bounds.x + thickness, thickness),
+            Side::Left => Vec2::new(thickness, bounds.y + thickness),
+            Side::Right => Vec2::new(thickness, bounds.y + thickness),
         }
     }
 }

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -16,11 +16,18 @@ mod config {
     pub const TIME_STEP: f64 = 1.0 / 60.0;
     pub const BACKGROUND_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);
 
+    pub const PADDLE_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
+    
+    pub const BALL_COLOR: Color = Color::rgb(1.0, 0.5, 0.5);
+
     pub const ARENA_BOUNDS: Vec2 = Vec2::new(900.0, 600.0);
     pub const WALL_THICKNESS: f32 = 10.0;
     pub const WALL_COLOR: Color = Color::rgb(0.8, 0.8, 0.8);
 
     pub const BRICK_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
+
+    pub const SCOREBOARD_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
+    pub const SCORE_COLOR: Color = Color::rgb(1.0, 0.5, 0.5);
 }
 
 /// A simple implementation of the classic game "Breakout"
@@ -81,7 +88,7 @@ fn add_cameras(mut commands: Commands) {
 fn add_paddle(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
     commands
         .spawn_bundle(SpriteBundle {
-            material: materials.add(Color::rgb(0.5, 0.5, 1.0).into()),
+            material: materials.add(config::PADDLE_COLOR.into()),
             transform: Transform::from_xyz(0.0, -215.0, 0.0),
             sprite: Sprite::new(Vec2::new(120.0, 30.0)),
             ..Default::default()
@@ -94,7 +101,7 @@ fn add_paddle(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial
 fn add_ball(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
     commands
         .spawn_bundle(SpriteBundle {
-            material: materials.add(Color::rgb(1.0, 0.5, 0.5).into()),
+            material: materials.add(config::BALL_COLOR.into()),
             transform: Transform::from_xyz(0.0, -50.0, 1.0),
             sprite: Sprite::new(Vec2::new(30.0, 30.0)),
             ..Default::default()
@@ -211,7 +218,7 @@ fn add_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: TextStyle {
                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                         font_size: 40.0,
-                        color: Color::rgb(0.5, 0.5, 1.0),
+                        color: config::SCOREBOARD_COLOR,
                     },
                 },
                 TextSection {
@@ -219,7 +226,7 @@ fn add_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: TextStyle {
                         font: asset_server.load("fonts/FiraMono-Medium.ttf"),
                         font_size: 40.0,
-                        color: Color::rgb(1.0, 0.5, 0.5),
+                        color: config::SCORE_COLOR,
                     },
                 },
             ],

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -240,39 +240,41 @@ fn spawn_bricks(mut commands: Commands, mut materials: ResMut<Assets<ColorMateri
 }
 
 fn spawn_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn_bundle(TextBundle {
-        text: Text {
-            sections: vec![
-                TextSection {
-                    value: "Score: ".to_string(),
-                    style: TextStyle {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                        font_size: config::SCORE_FONT_SIZE,
-                        color: config::SCOREBOARD_COLOR,
+    commands
+        .spawn_bundle(TextBundle {
+            text: Text {
+                sections: vec![
+                    TextSection {
+                        value: "Score: ".to_string(),
+                        style: TextStyle {
+                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                            font_size: config::SCORE_FONT_SIZE,
+                            color: config::SCOREBOARD_COLOR,
+                        },
                     },
-                },
-                TextSection {
-                    value: "".to_string(),
-                    style: TextStyle {
-                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                        font_size: config::SCORE_FONT_SIZE,
-                        color: config::SCORE_COLOR,
+                    TextSection {
+                        value: "".to_string(),
+                        style: TextStyle {
+                            font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                            font_size: config::SCORE_FONT_SIZE,
+                            color: config::SCORE_COLOR,
+                        },
                     },
+                ],
+                ..Default::default()
+            },
+            style: Style {
+                position_type: PositionType::Absolute,
+                position: Rect {
+                    top: config::SCORE_PADDING,
+                    left: config::SCORE_PADDING,
+                    ..Default::default()
                 },
-            ],
-            ..Default::default()
-        },
-        style: Style {
-            position_type: PositionType::Absolute,
-            position: Rect {
-                top: config::SCORE_PADDING,
-                left: config::SCORE_PADDING,
                 ..Default::default()
             },
             ..Default::default()
-        },
-        ..Default::default()
-    });
+        })
+        .insert(Scoreboard);
 }
 
 /// Moves everything with both a Transform and a Velovity accordingly

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -56,8 +56,13 @@ fn main() {
                 .with_system(ball_collision.system().before("kinematics")),
         )
         // Ordinary systems run every frame
-        .add_system(bound_paddle.system().label("bound_paddle"))
-        .add_system(paddle_input.system().after("bound_paddle"))
+        .add_system(paddle_input.system().before("bound_paddle"))
+        .add_system(
+            bound_paddle
+                .system()
+                .label("bound_paddle")
+                .after("kinematics"),
+        )
         .add_system(update_scoreboard.system())
         .run();
 }

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -169,6 +169,7 @@ impl Side {
 // By creating our own bundles, we can avoid duplicating code
 #[derive(Bundle)]
 struct WallBundle {
+    // Use #[bundle] like this to nest bundles correctly
     #[bundle]
     sprite_bundle: SpriteBundle,
     collides: Collides,
@@ -307,6 +308,7 @@ fn bound_paddle(mut query: Query<&mut Transform, With<Paddle>>) {
     paddle_transform.translation.x = paddle_transform.translation.x.min(380.0).max(-380.0);
 }
 
+/// Detects and handles ball collisions
 fn ball_collision(
     mut ball_query: Query<(&Transform, &mut Velocity, &Sprite), With<Ball>>,
     // Option<&C> returns Some(c: C) if the component exists on the entity, and None if it does not
@@ -368,7 +370,7 @@ fn ball_collision(
     }
 }
 
-/// Updates the Scoreboard entity based on the Score resource
+/// Updates the Scoreboard entity's Text based on the value of the Score resource
 fn update_scoreboard(score: Res<Score>, mut query: Query<&mut Text, With<Scoreboard>>) {
     let mut scoreboard_text = query.single_mut().unwrap();
     scoreboard_text.sections[0].value = format!("Score: {}", score.0);

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -71,6 +71,7 @@ mod components {
     pub struct Paddle {
         pub speed: f32,
     }
+
     // These are data-less marker components
     // which let us query for the correct entities
     // and specialize behavior

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -13,7 +13,7 @@ mod config {
     use bevy::render::color::Color;
     use bevy::ui::Val;
     // TODO: add various Vec2's and Transforms to this config module for clarity and consistency
-    // Blocked on https://github.com/bitshifter/glam-rs/issues/173
+    // Blocked on https://github.com/bitshifter/glam-rs/issues/76
 
     pub const TIME_STEP: f32 = 1.0 / 60.0;
     pub const BACKGROUND_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);
@@ -210,7 +210,7 @@ fn spawn_bricks(mut commands: Commands, mut materials: ResMut<Assets<ColorMateri
     const BRICK_ROWS: i8 = 4;
     const BRICK_COLUMNS: i8 = 5;
     const BRICK_SPACING: f32 = 20.0;
-    // TODO: change to const when https://github.com/bitshifter/glam-rs/issues/173 is fixed
+    // TODO: change to const when https://github.com/bitshifter/glam-rs/issues/76 is fixed
     let brick_size: Vec2 = Vec2::new(150.0, 30.0);
 
     // Compute the total width that all of the bricks take

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -381,5 +381,5 @@ fn ball_collision(
 /// Updates the Scoreboard entity's Text based on the value of the Score resource
 fn update_scoreboard(score: Res<Score>, mut query: Query<&mut Text, With<Scoreboard>>) {
     let mut scoreboard_text = query.single_mut().unwrap();
-    scoreboard_text.sections[0].value = format!("Score: {}", score.0);
+    scoreboard_text.sections[1].value = format!("{}", score.0);
 }

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -65,13 +65,13 @@ fn main() {
         .add_system_set(
             SystemSet::new()
                 .with_run_criteria(FixedTimestep::step(config::TIME_STEP as f64))
-                .with_system(kinematics_system.system())
-                .with_system(paddle_input_system.system())
-                .with_system(ball_collision_system.system()),
+                .with_system(kinematics.system())
+                .with_system(paddle_input.system())
+                .with_system(ball_collision.system()),
         )
         // Ordinary systems run every frame
-        .add_system(bound_paddle_system.system())
-        .add_system(scoreboard_system.system())
+        .add_system(bound_paddle.system())
+        .add_system(update_scoreboard.system())
         .run();
 }
 
@@ -270,7 +270,7 @@ fn spawn_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
 }
 
 /// Moves everything with both a Transform and a Velovity accordingly
-fn kinematics_system(mut query: Query<(&mut Transform, &Velocity)>) {
+fn kinematics(mut query: Query<(&mut Transform, &Velocity)>) {
     for (transform, velocity) in query.iter_mut() {
         transform.translation.x += velocity.x * config::TIME_STEP;
         transform.translation.y += velocity.y * config::TIME_STEP;
@@ -278,10 +278,7 @@ fn kinematics_system(mut query: Query<(&mut Transform, &Velocity)>) {
 }
 
 /// Turns left and right arrow key inputs to set paddle velocity
-fn paddle_input_system(
-    keyboard_input: Res<Input<KeyCode>>,
-    mut query: Query<(&Paddle, &mut Velocity)>,
-) {
+fn paddle_input(keyboard_input: Res<Input<KeyCode>>, mut query: Query<(&Paddle, &mut Velocity)>) {
     let (paddle, mut velocity) = query.single_mut().unwrap();
 
     let mut direction = 0.0;
@@ -297,12 +294,12 @@ fn paddle_input_system(
 }
 
 /// Ensures our paddle never goes out of bounds
-fn bound_paddle_system(mut query: Query<&mut Transform, With<Paddle>>) {
+fn bound_paddle(mut query: Query<&mut Transform, With<Paddle>>) {
     let mut paddle_transform = query.single_mut().unwrap();
     paddle_transform.translation.x = paddle_transform.translation.x.min(380.0).max(-380.0);
 }
 
-fn ball_collision_system(
+fn ball_collision(
     mut commands: Commands,
     mut scoreboard: ResMut<Scoreboard>,
     mut ball_query: Query<(&mut Ball, &Transform, &Sprite)>,
@@ -361,7 +358,7 @@ fn ball_collision_system(
 }
 
 /// Updates the Scoreboard entity based on the Score resource
-fn scoreboard_system(score: Res<Score>, mut query: Query<&mut Text, With<Scoreboard>>) {
+fn update_scoreboard(score: Res<Score>, mut query: Query<&mut Text, With<Scoreboard>>) {
     let mut scoreboard_text = query.single_mut().unwrap();
     scoreboard_text.sections[0].value = format!("Score: {}", score.0);
 }

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -1,7 +1,6 @@
 use bevy::{
     core::FixedTimestep,
     prelude::*,
-    render::pass::ClearColor,
     sprite::collide_aabb::{collide, Collision},
 };
 
@@ -10,7 +9,11 @@ use resources::*;
 
 /// Constants that can be used to fine-tune the behavior of our game
 mod config {
-    const TIME_STEP: f64 = 1.0 / 60.0;
+    use bevy::render::color::Color;
+    use bevy::render::pass::ClearColor;
+
+    pub const TIME_STEP: f64 = 1.0 / 60.0;
+    pub const BACKGROUND_COLOR: ClearColor = ClearColor(Color::rgb(0.9, 0.9, 0.9));
 }
 
 /// A simple implementation of the classic game "Breakout"
@@ -18,7 +21,7 @@ fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .insert_resource(Scoreboard { score: 0 })
-        .insert_resource(ClearColor(Color::rgb(0.9, 0.9, 0.9)))
+        .insert_resource(config::BACKGROUND_COLOR)
         .add_startup_system(setup.system())
         .add_system_set(
             SystemSet::new()

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -279,7 +279,7 @@ fn spawn_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
         .insert(Scoreboard);
 }
 
-/// Moves everything with both a Transform and a Velovity accordingly
+/// Moves everything with both a Transform and a Velocity accordingly
 fn kinematics(mut query: Query<(&mut Transform, &Velocity)>) {
     for (mut transform, velocity) in query.iter_mut() {
         transform.translation.x += velocity.x * config::TIME_STEP;

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -5,12 +5,15 @@ use bevy::{
     sprite::collide_aabb::{collide, Collision},
 };
 
+use components::*;
+use resources::*;
+
 /// Constants that can be used to fine-tune the behavior of our game
 mod config {
     const TIME_STEP: f64 = 1.0 / 60.0;
 }
 
-/// An implementation of the classic game "Breakout"
+/// A simple implementation of the classic game "Breakout"
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
@@ -28,22 +31,26 @@ fn main() {
         .run();
 }
 
-struct Paddle {
-    speed: f32,
+mod resources {
+    pub struct Scoreboard {
+        score: usize,
+    }
 }
 
-struct Ball {
-    velocity: Vec3,
-}
+mod components {
+    pub struct Paddle;
+    pub struct Ball;
 
-struct Scoreboard {
-    score: usize,
-}
+    pub struct Velocity {
+        x: f32,
+        y: f32,
+    }
 
-enum Collider {
-    Solid,
-    Scorable,
-    Paddle,
+    pub enum Collider {
+        Solid,
+        Scorable,
+        Paddle,
+    }
 }
 
 fn setup(

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -5,8 +5,12 @@ use bevy::{
     sprite::collide_aabb::{collide, Collision},
 };
 
+/// Constants that can be used to fine-tune the behavior of our game
+mod config {
+    const TIME_STEP: f64 = 1.0 / 60.0;
+}
+
 /// An implementation of the classic game "Breakout"
-const TIME_STEP: f32 = 1.0 / 60.0;
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
@@ -15,7 +19,7 @@ fn main() {
         .add_startup_system(setup.system())
         .add_system_set(
             SystemSet::new()
-                .with_run_criteria(FixedTimestep::step(TIME_STEP as f64))
+                .with_run_criteria(FixedTimestep::step(config::TIME_STEP))
                 .with_system(paddle_movement_system.system())
                 .with_system(ball_collision_system.system())
                 .with_system(ball_movement_system.system()),
@@ -196,7 +200,8 @@ fn paddle_movement_system(
 
         let translation = &mut transform.translation;
         // move the paddle horizontally
-        translation.x += direction * paddle.speed * TIME_STEP;
+        // FIXME: this should use delta_time
+        translation.x += direction * paddle.speed * config::TIME_STEP;
         // bound the paddle within the walls
         translation.x = translation.x.min(380.0).max(-380.0);
     }
@@ -204,7 +209,8 @@ fn paddle_movement_system(
 
 fn ball_movement_system(mut ball_query: Query<(&Ball, &mut Transform)>) {
     if let Ok((ball, mut transform)) = ball_query.single_mut() {
-        transform.translation += ball.velocity * TIME_STEP;
+        // FIXME: this should use delta_time
+        transform.translation += ball.velocity * config::TIME_STEP;
     }
 }
 

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -11,14 +11,21 @@ use resources::*;
 /// Constants that can be used to fine-tune the behavior of our game
 mod config {
     use bevy::math::Vec2;
+    use bevy::transform::components::Transform;
     use bevy::render::color::Color;
 
     pub const TIME_STEP: f64 = 1.0 / 60.0;
     pub const BACKGROUND_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);
 
     pub const PADDLE_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
+    pub const PADDLE_STARTING_LOCATION: Transform = Transform::from_xyz(0.0, -215.0, 0.0);
+    pub const PADDLE_SIZE: Vec2 = Vec2::new(120.0, 30.0);
     
     pub const BALL_COLOR: Color = Color::rgb(1.0, 0.5, 0.5);
+    // We set the z-value to one to ensure it appears on top of our other objects in case of overlap
+    pub const BALL_STARTING_LOCATION: Transform = Transform::from_xyz(0.0, -50.0, 1.0);
+    // Our ball is actually a square. Shhh...
+    pub const BALL_SIZE: Vec2 = Vec2::new(30.0, 30.0);
 
     pub const ARENA_BOUNDS: Vec2 = Vec2::new(900.0, 600.0);
     pub const WALL_THICKNESS: f32 = 10.0;
@@ -89,8 +96,8 @@ fn add_paddle(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(config::PADDLE_COLOR.into()),
-            transform: Transform::from_xyz(0.0, -215.0, 0.0),
-            sprite: Sprite::new(Vec2::new(120.0, 30.0)),
+            transform: config::PADDLE_STARTING_LOCATION,
+            sprite: Sprite::new(config::PADDLE_SIZE),
             ..Default::default()
         })
         .insert(Paddle)
@@ -102,8 +109,8 @@ fn add_ball(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(config::BALL_COLOR.into()),
-            transform: Transform::from_xyz(0.0, -50.0, 1.0),
-            sprite: Sprite::new(Vec2::new(30.0, 30.0)),
+            transform: config::BALL_STARTING_LOCATION,
+            sprite: Sprite::new(config::BALL_SIZE),
             ..Default::default()
         })
         .insert(Ball);

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -304,8 +304,9 @@ fn paddle_input(keyboard_input: Res<Input<KeyCode>>, mut query: Query<(&Paddle, 
 
 /// Ensures our paddle never goes out of bounds
 fn bound_paddle(mut query: Query<&mut Transform, With<Paddle>>) {
+    const BOUND: f32 = 380.0;
     let mut paddle_transform = query.single_mut().unwrap();
-    paddle_transform.translation.x = paddle_transform.translation.x.min(380.0).max(-380.0);
+    paddle_transform.translation.x = paddle_transform.translation.x.min(BOUND).max(-BOUND);
 }
 
 /// Detects and handles ball collisions

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -20,8 +20,8 @@ mod config {
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        // This adds the Scoreboard resource with its default values: 0
-        .init_resource::<Scoreboard>()
+        // This adds the Score resource with its default values: 0
+        .init_resource::<Score>()
         .insert_resource(config::BACKGROUND_COLOR)
         // These systems run only once, before all other systems
         .add_startup_system(add_cameras.system())
@@ -43,14 +43,18 @@ fn main() {
 
 mod resources {
     #[derive(Default)]
-    pub struct Scoreboard {
+    pub struct Score {
         score: usize,
     }
 }
 
 mod components {
+    // These are data-less marker components
+    // Which let us query for the correct entities
     pub struct Paddle;
     pub struct Ball;
+    pub struct Brick;
+    pub struct Scoreboard;
 
     pub struct Velocity {
         x: f32,
@@ -77,7 +81,7 @@ fn add_paddle(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial
             sprite: Sprite::new(Vec2::new(120.0, 30.0)),
             ..Default::default()
         })
-        .insert(Paddle { speed: 500.0 })
+        .insert(Paddle)
         .insert(Collider::Paddle);
 }
 

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -81,14 +81,23 @@ fn main() {
             SystemSet::new()
                 .with_run_criteria(FixedTimestep::step(TIME_STEP as f64))
                 .with_system(kinematics.system().label("kinematics"))
+                // We need to check for collisions before handling movement 
+                // to reduce the risk of the ball passing through objects
                 .with_system(ball_collision.system().before("kinematics")),
         )
         // Ordinary systems run every frame
-        .add_system(paddle_input.system().before("bound_paddle"))
+        // We need to handle input before we move our paddle, 
+        // to ensure that we're responding to the most recent frame's events,
+        // avoiding input lag
+        // See https://github.com/bevyengine/bevy/blob/latest/examples/ecs/ecs_guide.rs 
+        // for more information on system ordering
+        .add_system(paddle_input.system().before("bound_paddle").before("kinematics"))
         .add_system(
             bound_paddle
                 .system()
                 .label("bound_paddle")
+                // This system must run after kinematics, or the velocity will be set to 0
+                // before the paddle moves, causing it to be stuck to the wall 
                 .after("kinematics"),
         )
         .add_system(update_scoreboard.system())

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -29,7 +29,7 @@ fn main() {
         .add_startup_system(add_ball.system())
         .add_startup_system(add_walls.system())
         .add_startup_system(add_scoreboard.system())
-        // These systems run repeatedly, whnever the FixedTimeStep has elapsed
+        // These systems run repeatedly, whnever the FixedTimeStep's duration has elapsed
         .add_system_set(
             SystemSet::new()
                 .with_run_criteria(FixedTimestep::step(config::TIME_STEP))

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -52,8 +52,8 @@ fn main() {
         .add_system_set(
             SystemSet::new()
                 .with_run_criteria(FixedTimestep::step(config::TIME_STEP as f64))
-                .with_system(kinematics.system())
-                .with_system(ball_collision.system()),
+                .with_system(kinematics.system().label("kinematics"))
+                .with_system(ball_collision.system().before("kinematics")),
         )
         // Ordinary systems run every frame
         .add_system(bound_paddle.system().label("bound_paddle"))

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -21,7 +21,7 @@ mod config {
     pub const BACKGROUND_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);
 
     pub const PADDLE_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
-    pub const PADDLE_SPEED: f32 = 500.0;
+    pub const PADDLE_SPEED: f32 = 20000.0;
     pub const PADDLE_SIZE: Vec2 = const_vec2!([120.0, 30.0]);
     pub const PADDLE_BOUND: f32 = 380.0;
     pub const PADDLE_STARTING_TRANSFORM: Transform = Transform {
@@ -350,7 +350,11 @@ fn kinematics(mut query: Query<(&mut Transform, &Velocity)>) {
 }
 
 /// Turns left and right arrow key inputs to set paddle velocity
-fn paddle_input(keyboard_input: Res<Input<KeyCode>>, mut query: Query<(&Paddle, &mut Velocity)>) {
+fn paddle_input(
+    keyboard_input: Res<Input<KeyCode>>,
+    mut query: Query<(&Paddle, &mut Velocity)>,
+    time: Res<Time>,
+) {
     let (paddle, mut velocity) = query.single_mut().unwrap();
 
     let mut direction = 0.0;
@@ -362,7 +366,7 @@ fn paddle_input(keyboard_input: Res<Input<KeyCode>>, mut query: Query<(&Paddle, 
         direction += 1.0;
     }
 
-    velocity.x = direction * paddle.speed;
+    velocity.x = direction * paddle.speed * time.delta_seconds();
 }
 
 /// Ensures our paddle never goes out of bounds

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -23,7 +23,13 @@ fn main() {
         // This adds the Scoreboard resource with its default values: 0
         .init_resource::<Scoreboard>()
         .insert_resource(config::BACKGROUND_COLOR)
-        .add_startup_system(setup.system())
+        // These systems run only once, before all other systems
+        .add_startup_system(add_cameras.system())
+        .add_startup_system(add_paddle.system())
+        .add_startup_system(add_ball.system())
+        .add_startup_system(add_walls.system())
+        .add_startup_system(add_scoreboard.system())
+        // These systems run repeatedly, whnever the FixedTimeStep has elapsed
         .add_system_set(
             SystemSet::new()
                 .with_run_criteria(FixedTimestep::step(config::TIME_STEP))
@@ -58,17 +64,12 @@ mod components {
     }
 }
 
-fn setup(
-    mut commands: Commands,
-    mut materials: ResMut<Assets<ColorMaterial>>,
-    asset_server: Res<AssetServer>,
-) {
-    // Add the game's entities to our world
-
-    // cameras
+fn add_cameras(mut commands: Commands) {
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
     commands.spawn_bundle(UiCameraBundle::default());
-    // paddle
+}
+
+fn add_paddle(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(0.5, 0.5, 1.0).into()),
@@ -78,7 +79,9 @@ fn setup(
         })
         .insert(Paddle { speed: 500.0 })
         .insert(Collider::Paddle);
-    // ball
+}
+
+fn add_ball(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(1.0, 0.5, 0.5).into()),
@@ -89,41 +92,9 @@ fn setup(
         .insert(Ball {
             velocity: 400.0 * Vec3::new(0.5, -0.5, 0.0).normalize(),
         });
-    // scoreboard
-    commands.spawn_bundle(TextBundle {
-        text: Text {
-            sections: vec![
-                TextSection {
-                    value: "Score: ".to_string(),
-                    style: TextStyle {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                        font_size: 40.0,
-                        color: Color::rgb(0.5, 0.5, 1.0),
-                    },
-                },
-                TextSection {
-                    value: "".to_string(),
-                    style: TextStyle {
-                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                        font_size: 40.0,
-                        color: Color::rgb(1.0, 0.5, 0.5),
-                    },
-                },
-            ],
-            ..Default::default()
-        },
-        style: Style {
-            position_type: PositionType::Absolute,
-            position: Rect {
-                top: Val::Px(5.0),
-                left: Val::Px(5.0),
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        ..Default::default()
-    });
+}
 
+fn add_walls(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
     // Add walls
     let wall_material = materials.add(Color::rgb(0.8, 0.8, 0.8).into());
     let wall_thickness = 10.0;
@@ -165,7 +136,9 @@ fn setup(
             ..Default::default()
         })
         .insert(Collider::Solid);
+}
 
+fn add_bricks(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
     // Add bricks
     let brick_rows = 4;
     let brick_columns = 5;
@@ -194,6 +167,42 @@ fn setup(
                 .insert(Collider::Scorable);
         }
     }
+}
+
+fn add_scoreboard(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn_bundle(TextBundle {
+        text: Text {
+            sections: vec![
+                TextSection {
+                    value: "Score: ".to_string(),
+                    style: TextStyle {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font_size: 40.0,
+                        color: Color::rgb(0.5, 0.5, 1.0),
+                    },
+                },
+                TextSection {
+                    value: "".to_string(),
+                    style: TextStyle {
+                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                        font_size: 40.0,
+                        color: Color::rgb(1.0, 0.5, 0.5),
+                    },
+                },
+            ],
+            ..Default::default()
+        },
+        style: Style {
+            position_type: PositionType::Absolute,
+            position: Rect {
+                top: Val::Px(5.0),
+                left: Val::Px(5.0),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    });
 }
 
 fn paddle_movement_system(


### PR DESCRIPTION
Functionality should be nearly an exact match to the old feature. @rhulha, take a look :) This PR was inspired by https://github.com/bevyengine/bevy-website/pull/102, and should make this example much more suitable as a tutorial, whether that's part of the Bevy book or not.

Main improvements:

1. Better comments
2. Better practices for magic numbers, which are *mostly* contained to a config module to allow for easier twiddling and better comprehensibility.
3. Smaller, more comprehensible systems
4. Idiomatic use of marker components to make the example easier to extend
5. A single `kinematics` system that operates on everything with a velocity
6. Always use the fixed time step const, rather than sometimes using delta_time
7. Removed confusing early break in collision system
8. Demonstrates nested bundles
9. Much less confusing wall spawning logic by breaking it down into simple parts
10. Removed redundant `add_system(my_system.system())` system naming convention in favor of more descriptive names ;) (Cart feel free to revert this but it will still make me sad)