### PR TITLE
[bevy_ecs] Cleanup SparseSetIndex impls

### DIFF
--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -368,55 +368,25 @@ pub trait SparseSetIndex: Clone {
     fn get_sparse_set_index(value: usize) -> Self;
 }
 
-impl SparseSetIndex for u8 {
-    fn sparse_set_index(&self) -> usize {
-        *self as usize
-    }
+macro_rules! impl_sparse_set_index {
+    ($ty:ty) => {
+        impl SparseSetIndex for $ty {
+            fn sparse_set_index(&self) -> usize {
+                *self as usize
+            }
 
-    fn get_sparse_set_index(value: usize) -> Self {
-        value as u8
-    }
+            fn get_sparse_set_index(value: usize) -> Self {
+                value as $ty
+            }
+        }
+    };
 }
 
-impl SparseSetIndex for u16 {
-    fn sparse_set_index(&self) -> usize {
-        *self as usize
-    }
-
-    fn get_sparse_set_index(value: usize) -> Self {
-        value as u16
-    }
-}
-
-impl SparseSetIndex for u32 {
-    fn sparse_set_index(&self) -> usize {
-        *self as usize
-    }
-
-    fn get_sparse_set_index(value: usize) -> Self {
-        value as u32
-    }
-}
-
-impl SparseSetIndex for u64 {
-    fn sparse_set_index(&self) -> usize {
-        *self as usize
-    }
-
-    fn get_sparse_set_index(value: usize) -> Self {
-        value as u64
-    }
-}
-
-impl SparseSetIndex for usize {
-    fn sparse_set_index(&self) -> usize {
-        *self
-    }
-
-    fn get_sparse_set_index(value: usize) -> Self {
-        value
-    }
-}
+impl_sparse_set_index!(u8);
+impl_sparse_set_index!(u16);
+impl_sparse_set_index!(u32);
+impl_sparse_set_index!(u64);
+impl_sparse_set_index!(usize);
 
 #[derive(Default)]
 pub struct SparseSets {


### PR DESCRIPTION
Problem:
- SparseSetIndex trait implementations had a lot of duplicated code.

Solution:
- Utilize a macro to implement the trait for a generic type.