### PR TITLE
[Merged by Bors] - Implement direct mutable dereferencing

### DIFF
--- a/crates/bevy_ecs/src/world/pointer.rs
+++ b/crates/bevy_ecs/src/world/pointer.rs
@@ -9,6 +9,13 @@ pub struct Mut<'a, T> {
     pub(crate) change_tick: u32,
 }
 
+impl<'a, T> Mut<'a, T> {
+    pub fn deref_mut(self) -> &'a mut T {
+        self.component_ticks.set_changed(self.change_tick);
+        self.value
+    }
+}
+
 impl<'a, T> Deref for Mut<'a, T> {
     type Target = T;
 

--- a/crates/bevy_ecs/src/world/pointer.rs
+++ b/crates/bevy_ecs/src/world/pointer.rs
@@ -10,7 +10,7 @@ pub struct Mut<'a, T> {
 }
 
 impl<'a, T> Mut<'a, T> {
-    pub fn deref_mut(self) -> &'a mut T {
+    pub fn into_inner(self) -> &'a mut T {
         self.component_ticks.set_changed(self.change_tick);
         self.value
     }

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -157,7 +157,7 @@ impl<'w, T> Deref for WorldBorrowMut<'w, T> {
 
 impl<'w, T> DerefMut for WorldBorrowMut<'w, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.value.deref_mut()
+        &mut *self.value
     }
 }
 


### PR DESCRIPTION
This PR adds a way to get the underlying mutable reference for it's full lifetime.

Context:
https://discord.com/channels/691052431525675048/692572690833473578/839255317287796796