### PR TITLE
[Merged by Bors] - enable cargo deny

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,54 @@
+name: Dependencies
+
+on:
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - 'deny.toml'
+  push:
+    branches: [main, staging, trying]
+    paths:
+      - '**/Cargo.toml'
+      - 'deny.toml'
+  schedule:
+    - cron: "0 0 * * 0"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-advisories:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install cargo-deny
+        run: cargo install cargo-deny
+      - name: Check for security advisories and unmaintained crates
+        run: cargo deny check advisories
+
+  check-bans:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install cargo-deny
+        run: cargo install cargo-deny
+      - name: Check for banned and duplicated dependencies
+        run: cargo deny check bans
+
+  check-licenses:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install cargo-deny
+        run: cargo install cargo-deny
+      - name: Check for unauthorized licenses
+        run: cargo deny check licenses
+
+  check-sources:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install cargo-deny
+        run: cargo install cargo-deny
+      - name: Checked for unauthorized crate sources
+        run: cargo deny check sources

--- a/deny.toml
+++ b/deny.toml
@@ -17,11 +17,11 @@ notice = "deny"
 ignore = [
     "RUSTSEC-2020-0016", # net2 deprecated - https://github.com/deprecrated/net2-rs/commit/3350e3819adf151709047e93f25583a5df681091
     "RUSTSEC-2020-0056", # stdwab unmaintained - https://github.com/koute/stdweb/issues/403
-    # "RUSTSEC-2021-0047", # security issue - https://github.com/gnzlbg/slice_deque/issues/90
+    "RUSTSEC-2021-0047", # security issue - https://github.com/gnzlbg/slice_deque/issues/90
 ]
 
 [licenses]
-# unlicensed = "allow"
+unlicensed = "allow"
 copyleft = "allow"
 allow = [
     "MIT",
@@ -42,7 +42,7 @@ wildcards = "deny"
 highlight = "all"
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    # { name = "ahash", version = "=0.4.7" },
+    { name = "ahash", version = "=0.4.7" },
     { name = "android_log-sys", version = "=0.1.2" },
     { name = "cfg-if", version = "=0.1.10" },             # https://github.com/rustwasm/console_error_panic_hook/pull/18
     { name = "core-foundation", version = "=0.6.4" },

--- a/deny.toml
+++ b/deny.toml
@@ -13,7 +13,7 @@ ignore = [
 
 [licenses]
 unlicensed = "allow"
-copyleft = "allow"
+copyleft = "deny"
 allow = [
     "MIT",
     "Apache-2.0",
@@ -23,6 +23,7 @@ allow = [
     "0BSD",
     "BSD-2-Clause",
     "CC0-1.0",
+    "MPL-2.0",
 ]
 default = "deny"
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,70 @@
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "deny"
+ignore = [
+    "RUSTSEC-2020-0016", # net2 deprecated - https://github.com/deprecrated/net2-rs/commit/3350e3819adf151709047e93f25583a5df681091
+    "RUSTSEC-2020-0056", # stdwab unmaintained - https://github.com/koute/stdweb/issues/403
+    # "RUSTSEC-2021-0047", # security issue - https://github.com/gnzlbg/slice_deque/issues/90
+]
+
+[licenses]
+# unlicensed = "allow"
+copyleft = "allow"
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "0BSD",
+    "BSD-2-Clause",
+    "CC0-1.0",
+]
+default = "deny"
+
+
+[bans]
+multiple-versions = "deny"
+wildcards = "deny"
+highlight = "all"
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    # { name = "ahash", version = "=0.4.7" },
+    { name = "android_log-sys", version = "=0.1.2" },
+    { name = "cfg-if", version = "=0.1.10" },             # https://github.com/rustwasm/console_error_panic_hook/pull/18
+    { name = "core-foundation", version = "=0.6.4" },
+    { name = "core-foundation", version = "=0.7.0" },
+    { name = "core-foundation-sys", version = "=0.6.2" },
+    { name = "core-foundation-sys", version = "=0.7.0" },
+    { name = "core-graphics", version = "=0.19.2" },
+    { name = "fixedbitset", version = "=0.2.0" },
+    { name = "libm", version = "=0.1.4" },
+    { name = "mach", version = "=0.2.3" },
+    { name = "mio", version = "=0.6.23" },
+    { name = "miow", version = "=0.2.2" },
+    { name = "ndk", version = "=0.2.1" },
+    { name = "ndk-glue", version = "=0.2.1" },
+    { name = "num_enum", version = "=0.4.3" },
+    { name = "num_enum_derive", version = "=0.4.3" },
+    { name = "stdweb", version = "=0.1.3" },
+    { name = "winapi", version = "=0.2.8" },
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/deny.toml
+++ b/deny.toml
@@ -1,12 +1,3 @@
-# Note that all fields that take a lint level have these possible values:
-# * deny - An error will be produced and the check will fail
-# * warn - A warning will be produced, but the check will not fail
-# * allow - No warning or error will be produced, though in some cases a note
-# will be
-
-# This section is considered when running `cargo deny check advisories`
-# More documentation for the advisories section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
@@ -16,7 +7,7 @@ yanked = "deny"
 notice = "deny"
 ignore = [
     "RUSTSEC-2020-0016", # net2 deprecated - https://github.com/deprecrated/net2-rs/commit/3350e3819adf151709047e93f25583a5df681091
-    "RUSTSEC-2020-0056", # stdwab unmaintained - https://github.com/koute/stdweb/issues/403
+    "RUSTSEC-2020-0056", # stdweb unmaintained - https://github.com/koute/stdweb/issues/403
     "RUSTSEC-2021-0047", # security issue - https://github.com/gnzlbg/slice_deque/issues/90
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -38,25 +38,25 @@ wildcards = "deny"
 highlight = "all"
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    { name = "ahash", version = "=0.4.7" },
-    { name = "android_log-sys", version = "=0.1.2" },
-    { name = "cfg-if", version = "=0.1.10" },             # https://github.com/rustwasm/console_error_panic_hook/pull/18
-    { name = "core-foundation", version = "=0.6.4" },
-    { name = "core-foundation", version = "=0.7.0" },
-    { name = "core-foundation-sys", version = "=0.6.2" },
-    { name = "core-foundation-sys", version = "=0.7.0" },
-    { name = "core-graphics", version = "=0.19.2" },
-    { name = "fixedbitset", version = "=0.2.0" },
-    { name = "libm", version = "=0.1.4" },
-    { name = "mach", version = "=0.2.3" },
-    { name = "mio", version = "=0.6.23" },
-    { name = "miow", version = "=0.2.2" },
-    { name = "ndk", version = "=0.2.1" },
-    { name = "ndk-glue", version = "=0.2.1" },
-    { name = "num_enum", version = "=0.4.3" },
-    { name = "num_enum_derive", version = "=0.4.3" },
-    { name = "stdweb", version = "=0.1.3" },
-    { name = "winapi", version = "=0.2.8" },
+    { name = "ahash", version = "0.4" },
+    { name = "android_log-sys", version = "0.1" },
+    { name = "cfg-if", version = "0.1" },             # https://github.com/rustwasm/console_error_panic_hook/pull/18
+    { name = "core-foundation", version = "0.6" },
+    { name = "core-foundation", version = "0.7" },
+    { name = "core-foundation-sys", version = "0.6" },
+    { name = "core-foundation-sys", version = "0.7" },
+    { name = "core-graphics", version = "0.19" },
+    { name = "fixedbitset", version = "0.2" },
+    { name = "libm", version = "0.1" },
+    { name = "mach", version = "0.2" },
+    { name = "mio", version = "0.6" },
+    { name = "miow", version = "0.2" },
+    { name = "ndk", version = "0.2" },
+    { name = "ndk-glue", version = "0.2" },
+    { name = "num_enum", version = "0.4" },
+    { name = "num_enum_derive", version = "0.4" },
+    { name = "stdweb", version = "0.1" },
+    { name = "winapi", version = "0.2" },
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -12,7 +12,7 @@ ignore = [
 ]
 
 [licenses]
-unlicensed = "allow"
+unlicensed = "deny"
 copyleft = "deny"
 allow = [
     "MIT",
@@ -27,6 +27,10 @@ allow = [
 ]
 default = "deny"
 
+[[licenses.clarify]]
+name = "stretch"
+expression = "MIT"
+license-files = []
 
 [bans]
 multiple-versions = "deny"


### PR DESCRIPTION
https://github.com/EmbarkStudios/cargo-deny
cargo-deny is a tool that can issue errors for dependency issues, among other:
* security issues in a crate
* duplicated dependencies with different versions
* unauthorised license

Added cargo-deny with an opinionated configuration:
* No middle ground with warnings, either allow or deny
* Not added to Bors, we probably don't want to block a PR on something that may happen from outside
* Different github workflow than CI to run only when Cargo.toml files are changed, or on a schedule
* Each check in its own job to help readability
* Initial config makes Bevy pass all check

Pushing a first commit with commented config to show errors