### PR TITLE
[bevy_ecs] Rework `spawn_batch` to return an iterator over its entities.

### DIFF
--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -158,7 +158,7 @@ impl<'a> Commands<'a> {
 
     /// Equivalent to iterating `bundles_iter` and calling [`Self::spawn`] on each bundle, but
     /// slightly more performant.
-    pub fn spawn_batch<I>(&mut self, bundles_iter: I) -> impl IntoIterator<Item = Entity>
+    pub fn spawn_batch<I>(&mut self, bundles_iter: I) -> Vec<Entity>
     where
         I: IntoIterator,
         I::IntoIter: ExactSizeIterator + Send + Sync + 'static,


### PR DESCRIPTION
Fixes: #2098

Problem:
- `Commands::spawn` returns the Entity created, however,
`Commands::spawn_batch` does not.

This PR reworks `spawn_batch` to return an iterator over the resulting entities.