### PR TITLE
[Merged by Bors] - Add file metadata to AssetIo

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -555,10 +555,6 @@ impl AssetServer {
             }
         }
     }
-
-    pub fn asset_io(&self) -> &dyn AssetIo {
-        &*self.server.asset_io
-    }
 }
 
 fn free_unused_assets_system_impl(asset_server: &AssetServer) {

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -410,7 +410,7 @@ impl AssetServer {
         path: P,
     ) -> Result<Vec<HandleUntyped>, AssetServerError> {
         let path = path.as_ref();
-        if !self.server.asset_io.is_directory(path) {
+        if !self.server.asset_io.is_dir(path) {
             return Err(AssetServerError::AssetFolderNotADirectory(
                 path.to_str().unwrap().to_string(),
             ));
@@ -418,7 +418,7 @@ impl AssetServer {
 
         let mut handles = Vec::new();
         for child_path in self.server.asset_io.read_directory(path.as_ref())? {
-            if self.server.asset_io.is_directory(&child_path) {
+            if self.server.asset_io.is_dir(&child_path) {
                 handles.extend(self.load_folder(&child_path)?);
             } else {
                 if self.get_path_asset_loader(&child_path).is_err() {

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -556,6 +556,10 @@ impl AssetServer {
             }
         }
     }
+
+    pub fn asset_io(&self) -> &dyn AssetIo {
+        &*self.server.asset_io
+    }
 }
 
 fn free_unused_assets_system_impl(asset_server: &AssetServer) {

--- a/crates/bevy_asset/src/io/android_asset_io.rs
+++ b/crates/bevy_asset/src/io/android_asset_io.rs
@@ -1,4 +1,4 @@
-use crate::{AssetIo, AssetIoError};
+use crate::{AssetIo, AssetIoError, Metadata};
 use anyhow::Result;
 use bevy_utils::BoxedFuture;
 use std::{
@@ -48,15 +48,12 @@ impl AssetIo for AndroidAssetIo {
 
     fn get_metadata(&self, path: &Path) -> Result<Metadata, AssetIoError> {
         let full_path = self.root_path.join(path);
-        full_path
-            .metadata()
-            .map(|metadata| metadata.into())
-            .map_err(|e| {
-                if e.kind() == std::io::ErrorKind::NotFound {
-                    AssetIoError::NotFound(full_path)
-                } else {
-                    e.into()
-                }
-            })
+        full_path.metadata().map(Metadata::from).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                AssetIoError::NotFound(full_path)
+            } else {
+                e.into()
+            }
+        })
     }
 }

--- a/crates/bevy_asset/src/io/android_asset_io.rs
+++ b/crates/bevy_asset/src/io/android_asset_io.rs
@@ -46,7 +46,17 @@ impl AssetIo for AndroidAssetIo {
         Ok(())
     }
 
-    fn is_directory(&self, path: &Path) -> bool {
-        self.root_path.join(path).is_dir()
+    fn get_metadata(&self, path: &Path) -> Result<Metadata, AssetIoError> {
+        let full_path = self.root_path.join(path);
+        full_path
+            .metadata()
+            .map(|metadata| metadata.into())
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    AssetIoError::NotFound(full_path)
+                } else {
+                    e.into()
+                }
+            })
     }
 }

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -130,16 +130,13 @@ impl AssetIo for FileAssetIo {
 
     fn get_metadata(&self, path: &Path) -> Result<Metadata, AssetIoError> {
         let full_path = self.root_path.join(path);
-        full_path
-            .metadata()
-            .map(|metadata| metadata.into())
-            .map_err(|e| {
-                if e.kind() == std::io::ErrorKind::NotFound {
-                    AssetIoError::NotFound(full_path)
-                } else {
-                    e.into()
-                }
-            })
+        full_path.metadata().map(Metadata::from).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                AssetIoError::NotFound(full_path)
+            } else {
+                e.into()
+            }
+        })
     }
 }
 

--- a/crates/bevy_asset/src/io/metadata.rs
+++ b/crates/bevy_asset/src/io/metadata.rs
@@ -42,10 +42,19 @@ impl TryFrom<std::fs::FileType> for FileType {
 /// This structure is returned from the [`AssetIo::get_metadata`] method.
 #[derive(Debug, Clone)]
 pub struct Metadata {
-    pub file_type: FileType,
+    file_type: FileType,
 }
 
 impl Metadata {
+    pub fn new(file_type: FileType) -> Self {
+        Self { file_type }
+    }
+
+    #[inline]
+    pub const fn file_type(&self) -> FileType {
+        self.file_type
+    }
+
     #[inline]
     pub const fn is_dir(&self) -> bool {
         self.file_type.is_dir()

--- a/crates/bevy_asset/src/io/metadata.rs
+++ b/crates/bevy_asset/src/io/metadata.rs
@@ -39,7 +39,7 @@ impl TryFrom<std::fs::FileType> for FileType {
 
 /// Metadata information about a file.
 ///
-/// This structure is returned from the [`AssetIo::get_metadata`] method.
+/// This structure is returned from the [`AssetIo::get_metadata`](crate::AssetIo) method.
 #[derive(Debug, Clone)]
 pub struct Metadata {
     file_type: FileType,

--- a/crates/bevy_asset/src/io/metadata.rs
+++ b/crates/bevy_asset/src/io/metadata.rs
@@ -9,10 +9,12 @@ pub enum FileType {
 }
 
 impl FileType {
+    #[inline]
     pub const fn is_dir(&self) -> bool {
         matches!(self, Self::Directory)
     }
 
+    #[inline]
     pub const fn is_file(&self) -> bool {
         matches!(self, Self::File)
     }
@@ -44,10 +46,12 @@ pub struct Metadata {
 }
 
 impl Metadata {
+    #[inline]
     pub const fn is_dir(&self) -> bool {
         self.file_type.is_dir()
     }
 
+    #[inline]
     pub const fn is_file(&self) -> bool {
         self.file_type.is_file()
     }

--- a/crates/bevy_asset/src/io/metadata.rs
+++ b/crates/bevy_asset/src/io/metadata.rs
@@ -1,5 +1,5 @@
 /// A enum representing a type of file.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum FileType {
     Directory,
     File,
@@ -8,12 +8,12 @@ pub enum FileType {
 }
 
 impl FileType {
-    pub fn is_directory(&self) -> bool {
-        *self == Self::Directory
+    pub const fn is_dir(&self) -> bool {
+        (*self as isize) == (Self::Directory as isize)
     }
 
-    pub fn is_file(&self) -> bool {
-        *self == Self::File
+    pub const fn is_file(&self) -> bool {
+        (*self as isize) == (Self::File as isize)
     }
 }
 
@@ -34,17 +34,17 @@ impl From<std::fs::FileType> for FileType {
 /// Metadata information about a file.
 ///
 /// This structure is returned from the [`AssetIo::get_metadata`] method.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Metadata {
     pub file_type: FileType,
 }
 
 impl Metadata {
-    pub fn is_directory(&self) -> bool {
-        self.file_type.is_directory()
+    pub const fn is_dir(&self) -> bool {
+        self.file_type.is_dir()
     }
 
-    pub fn is_file(&self) -> bool {
+    pub const fn is_file(&self) -> bool {
         self.file_type.is_file()
     }
 }

--- a/crates/bevy_asset/src/io/metadata.rs
+++ b/crates/bevy_asset/src/io/metadata.rs
@@ -1,0 +1,58 @@
+/// A enum representing a type of file.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum FileType {
+    Directory,
+    File,
+    // To be compatible with [`std::fs::FileType`].
+    Symlink,
+}
+
+impl FileType {
+    pub fn is_directory(&self) -> bool {
+        *self == Self::Directory
+    }
+
+    pub fn is_file(&self) -> bool {
+        *self == Self::File
+    }
+}
+
+impl From<std::fs::FileType> for FileType {
+    fn from(file_type: std::fs::FileType) -> Self {
+        if file_type.is_dir() {
+            Self::Directory
+        } else if file_type.is_file() {
+            Self::File
+        } else if file_type.is_symlink() {
+            Self::Symlink
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+/// Metadata information about a file.
+///
+/// This structure is returned from the [`AssetIo::get_metadata`] method.
+#[derive(Debug)]
+pub struct Metadata {
+    pub file_type: FileType,
+}
+
+impl Metadata {
+    pub fn is_directory(&self) -> bool {
+        self.file_type.is_directory()
+    }
+
+    pub fn is_file(&self) -> bool {
+        self.file_type.is_file()
+    }
+}
+
+impl From<std::fs::Metadata> for Metadata {
+    fn from(metadata: std::fs::Metadata) -> Self {
+        Self {
+            file_type: metadata.file_type().into(),
+        }
+    }
+}

--- a/crates/bevy_asset/src/io/metadata.rs
+++ b/crates/bevy_asset/src/io/metadata.rs
@@ -10,11 +10,11 @@ pub enum FileType {
 
 impl FileType {
     pub const fn is_dir(&self) -> bool {
-        (*self as isize) == (Self::Directory as isize)
+        matches!(self, Self::Directory)
     }
 
     pub const fn is_file(&self) -> bool {
-        (*self as isize) == (Self::File as isize)
+        matches!(self, Self::File)
     }
 }
 

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -47,15 +47,17 @@ pub trait AssetIo: Downcast + Send + Sync + 'static {
     fn watch_path_for_changes(&self, path: &Path) -> Result<(), AssetIoError>;
     fn watch_for_changes(&self) -> Result<(), AssetIoError>;
 
-    fn is_directory(&self, path: &Path) -> bool {
+    fn is_dir(&self, path: &Path) -> bool {
         self.get_metadata(path)
-            .map(|metadata| metadata.is_directory())
+            .as_ref()
+            .map(Metadata::is_dir)
             .unwrap_or(false)
     }
 
     fn is_file(&self, path: &Path) -> bool {
         self.get_metadata(path)
-            .map(|metadata| metadata.is_file())
+            .as_ref()
+            .map(Metadata::is_file)
             .unwrap_or(false)
     }
 }

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -5,12 +5,16 @@ mod file_asset_io;
 #[cfg(target_arch = "wasm32")]
 mod wasm_asset_io;
 
+mod metadata;
+
 #[cfg(target_os = "android")]
 pub use android_asset_io::*;
 #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
 pub use file_asset_io::*;
 #[cfg(target_arch = "wasm32")]
 pub use wasm_asset_io::*;
+
+pub use metadata::*;
 
 use anyhow::Result;
 use bevy_utils::BoxedFuture;
@@ -39,9 +43,21 @@ pub trait AssetIo: Downcast + Send + Sync + 'static {
         &self,
         path: &Path,
     ) -> Result<Box<dyn Iterator<Item = PathBuf>>, AssetIoError>;
-    fn is_directory(&self, path: &Path) -> bool;
+    fn get_metadata(&self, path: &Path) -> Result<Metadata, AssetIoError>;
     fn watch_path_for_changes(&self, path: &Path) -> Result<(), AssetIoError>;
     fn watch_for_changes(&self) -> Result<(), AssetIoError>;
+
+    fn is_directory(&self, path: &Path) -> bool {
+        self.get_metadata(path)
+            .map(|metadata| metadata.is_directory())
+            .unwrap_or(false)
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        self.get_metadata(path)
+            .map(|metadata| metadata.is_file())
+            .unwrap_or(false)
+    }
 }
 
 impl_downcast!(AssetIo);

--- a/crates/bevy_asset/src/io/wasm_asset_io.rs
+++ b/crates/bevy_asset/src/io/wasm_asset_io.rs
@@ -1,4 +1,4 @@
-use crate::{AssetIo, AssetIoError};
+use crate::{AssetIo, AssetIoError, Metadata};
 use anyhow::Result;
 use bevy_utils::BoxedFuture;
 use js_sys::Uint8Array;
@@ -49,18 +49,15 @@ impl AssetIo for WasmAssetIo {
         bevy_log::warn!("Watching for changes is not supported in WASM");
         Ok(())
     }
-    
+
     fn get_metadata(&self, path: &Path) -> Result<Metadata, AssetIoError> {
         let full_path = self.root_path.join(path);
-        full_path
-            .metadata()
-            .map(|metadata| metadata.into())
-            .map_err(|e| {
-                if e.kind() == std::io::ErrorKind::NotFound {
-                    AssetIoError::NotFound(full_path)
-                } else {
-                    e.into()
-                }
-            })
+        full_path.metadata().map(Metadata::from).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                AssetIoError::NotFound(full_path)
+            } else {
+                e.into()
+            }
+        })
     }
 }

--- a/crates/bevy_asset/src/io/wasm_asset_io.rs
+++ b/crates/bevy_asset/src/io/wasm_asset_io.rs
@@ -49,8 +49,18 @@ impl AssetIo for WasmAssetIo {
         bevy_log::warn!("Watching for changes is not supported in WASM");
         Ok(())
     }
-
-    fn is_directory(&self, path: &Path) -> bool {
-        self.root_path.join(path).is_dir()
+    
+    fn get_metadata(&self, path: &Path) -> Result<Metadata, AssetIoError> {
+        let full_path = self.root_path.join(path);
+        full_path
+            .metadata()
+            .map(|metadata| metadata.into())
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    AssetIoError::NotFound(full_path)
+                } else {
+                    e.into()
+                }
+            })
     }
 }

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -147,6 +147,10 @@ impl<'a> LoadContext<'a> {
     pub fn task_pool(&self) -> &TaskPool {
         self.task_pool
     }
+
+    pub fn asset_io(&self) -> &dyn AssetIo {
+        self.asset_io
+    }
 }
 
 /// The result of loading an asset of type `T`

--- a/examples/asset/custom_asset_io.rs
+++ b/examples/asset/custom_asset_io.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    asset::{AssetIo, AssetIoError},
+    asset::{AssetIo, AssetIoError, Metadata},
     prelude::*,
     utils::BoxedFuture,
 };
@@ -26,11 +26,6 @@ impl AssetIo for CustomAssetIo {
         self.0.read_directory(path)
     }
 
-    fn is_directory(&self, path: &Path) -> bool {
-        info!("is_directory({:?})", path);
-        self.0.is_directory(path)
-    }
-
     fn watch_path_for_changes(&self, path: &Path) -> Result<(), AssetIoError> {
         info!("watch_path_for_changes({:?})", path);
         self.0.watch_path_for_changes(path)
@@ -39,6 +34,11 @@ impl AssetIo for CustomAssetIo {
     fn watch_for_changes(&self) -> Result<(), AssetIoError> {
         info!("watch_for_changes()");
         self.0.watch_for_changes()
+    }
+
+    fn get_metadata(&self, path: &Path) -> Result<Metadata, AssetIoError> {
+        info!("get_metadata({:?})", path);
+        self.0.get_metadata(path)
     }
 }
 


### PR DESCRIPTION
This is a replacement for #2106

This adds a `Metadata` struct which contains metadata information about a file, at the moment only the file type.
It also adds a `get_metadata` to `AssetIo` trait and an `asset_io` accessor method to `AssetServer` and `LoadContext`

I am not sure about the changes in `AndroidAssetIo ` and `WasmAssetIo`.