### PR TITLE
Implement Events::extend with Vec::extend 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,6 +260,10 @@ name = "event"
 path = "examples/ecs/event.rs"
 
 [[example]]
+name = "event_consumer"
+path = "examples/ecs/event_consumer.rs"
+
+[[example]]
 name = "fixed_timestep"
 path = "examples/ecs/fixed_timestep.rs"
 

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -446,6 +446,29 @@ mod tests {
     }
 
     #[test]
+    fn write_eat_repeat() {
+        struct E;
+        let mut events = Events::<E>::default();
+        let mut reader = events.get_reader();
+
+        assert!(reader.iter(&events).next().is_none());
+
+        // Send an event
+        events.send(E);
+        assert!(reader.iter(&events).next().is_some());
+        assert!(reader.iter(&events).next().is_none());
+
+        // Eat all events
+        let _ = events.drain();
+        assert!(reader.iter(&events).next().is_none());
+
+        // Try again
+        events.send(E);
+        assert!(reader.iter(&events).next().is_some());
+        assert!(reader.iter(&events).next().is_none());
+    }
+
+    #[test]
     fn test_events() {
         let mut events = Events::<TestEvent>::default();
         let event_0 = TestEvent { i: 0 };

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -306,19 +306,12 @@ fn internal_event_reader<'a, T>(
     }
 }
 /// Sends events of type `T`.
+#[derive(SystemParam)]
 pub struct EventWriter<'a, T: Component> {
-    events: &'a mut Events<T>,
-}
-
-impl<'a, T: Component> SystemParam for EventWriter<'a, T> {
-    type Fetch = ResMutState<Events<T>>;
+    events: ResMut<'a, Events<T>>,
 }
 
 impl<'a, T: Component> EventWriter<'a, T> {
-    pub fn new(events: &'a mut Events<T>) -> Self {
-        EventWriter::<'a, T> { events }
-    }
-
     pub fn send(&mut self, event: T) {
         self.events.send(event);
     }
@@ -329,13 +322,10 @@ impl<'a, T: Component> EventWriter<'a, T> {
 }
 
 /// Reads events of type `T` in order and tracks which events have already been read.
+#[derive(SystemParam)]
 pub struct EventReader<'a, T: Component> {
     last_event_count: Local<'a, (usize, PhantomData<T>)>,
-    events: &'a Events<T>,
-}
-
-impl<'a, T: Component> SystemParam for EventReader<'a, T> {
-    type Fetch = ResState<Events<T>>;
+    events: Res<'a, Events<T>>,
 }
 
 impl<'a, T: Component> EventReader<'a, T> {
@@ -361,22 +351,19 @@ impl<'a, T: Component> EventReader<'a, T> {
 /// allowing events to accumulate on your components or resources until consumed.
 /// Note: due to the draining nature of this reader, you probably only want one
 /// EventConsumer per event storage location + event type combination.
+#[derive(SystemParam)]
 pub struct EventConsumer<'a, T: Component> {
-    events: &'a mut Events<T>,
-}
-
-impl<'a, T: Component> SystemParam for EventConsumer<'a, T> {
-    type Fetch = ResMutState<Events<T>>;
+    events: ResMut<'a, Events<T>>,
 }
 
 impl<'a, T: Component> EventConsumer<'a, T> {
     /// Drains all available events this EventConsumer has access to into an iterator
-    pub fn drain(self) -> impl DoubleEndedIterator<Item = T> + 'a {
+    pub fn drain(self) -> impl DoubleEndedIterator<Item = T> {
         self.events.drain()
     }
 
     /// Drains all available events this EventConsumer has access to into an iterator and returns the id
-    pub fn drain_with_id(self) -> impl DoubleEndedIterator<Item = (T, EventId<T>)> + 'a {
+    pub fn drain_with_id(self) -> impl DoubleEndedIterator<Item = (T, EventId<T>)> {
         self.events.drain_with_id()
     }
 }

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -207,20 +207,21 @@ impl<T: Component> Events<T> {
     }
 
     /// Creates a draining iterator that removes all events.
-    pub fn drain(&mut self) -> impl Iterator<Item = T> + '_ {
-        let map = |i: EventInstance<T>| i.event;
-        match self.state {
-            State::A => self
-                .events_b
-                .drain(..)
-                .map(map)
-                .chain(self.events_a.drain(..).map(map)),
-            State::B => self
-                .events_a
-                .drain(..)
-                .map(map)
-                .chain(self.events_b.drain(..).map(map)),
-        }
+    pub fn drain(&mut self) -> impl DoubleEndedIterator<Item = T> + '_ {
+        self.drain_with_id().map(|(e, _)| e)
+    }
+
+    /// Creates a draining iterator that returns both events and their ids
+    pub fn drain_with_id(&mut self) -> impl DoubleEndedIterator<Item = (T, EventId<T>)> + '_ {
+        let event_instances = match self.state {
+            BufferState::A => self.events_b.drain(..).chain(self.events_a.drain(..)),
+            BufferState::B => self.events_a.drain(..).chain(self.events_b.drain(..)),
+        };
+
+        event_instances.map(|ei| {
+            trace!("Events::drain_with_id -> {}", ei.event_id);
+            (ei.event, ei.event_id)
+        })
     }
 
     pub fn extend<I>(&mut self, events: I)
@@ -351,6 +352,32 @@ impl<'a, T: Component> EventReader<'a, T> {
             trace!("EventReader::iter() -> {}", id);
             (event, id)
         })
+    }
+}
+
+/// Reads and consumes all events of type T
+///
+/// Useful for manual event cleanup when [AppBuilder::add_event::<T>] is omitted,
+/// allowing events to accumulate on your components or resources until consumed.
+/// Note: due to the draining nature of this reader, you probably only want one
+/// EventConsumer per event storage location + event type combination.
+pub struct EventConsumer<'a, T: Component> {
+    events: &'a mut Events<T>,
+}
+
+impl<'a, T: Component> SystemParam for EventConsumer<'a, T> {
+    type Fetch = ResMutState<Events<T>>;
+}
+
+impl<'a, T: Component> EventConsumer<'a, T> {
+    /// Drains all available events this EventConsumer has access to into an iterator
+    pub fn drain(self) -> impl DoubleEndedIterator<Item = T> + 'a {
+        self.events.drain()
+    }
+
+    /// Drains all available events this EventConsumer has access to into an iterator and returns the id
+    pub fn drain_with_id(self) -> impl DoubleEndedIterator<Item = (T, EventId<T>)> + 'a {
+        self.events.drain_with_id()
     }
 }
 

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -218,6 +218,13 @@ impl<T: Component> Events<T> {
             BufferState::B => self.events_a.drain(..).chain(self.events_b.drain(..)),
         };
 
+        // We must reset these values to 0 as all events have been drained
+        self.a_start_event_count = 0;
+        self.b_start_event_count = 0;
+        self.event_count = 0;
+        // Reset to A for consistency with Self::default()
+        self.state = BufferState::A;
+
         event_instances.map(|instance| {
             trace!("Events::drain_with_id -> {}", instance.event_id);
             (instance.event, instance.event_id)

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -247,10 +247,12 @@ impl<T: Component> Events<T> {
     }
 }
 
+// Used in internal_event_reader instead of a closure to ensure stable type
 fn map_instance_event_with_id<T>(event_instance: &EventInstance<T>) -> (&T, EventId<T>) {
     (&event_instance.event, event_instance.event_id)
 }
 
+// Used in internal_event_reader instead of a closure to ensure stable type
 fn map_instance_event<T>(event_instance: &EventInstance<T>) -> &T {
     &event_instance.event
 }

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -51,7 +51,7 @@ struct EventInstance<T> {
 }
 
 #[derive(Debug)]
-enum State {
+enum BufferState {
     A,
     B,
 }
@@ -125,7 +125,7 @@ pub struct Events<T> {
     a_start_event_count: usize,
     b_start_event_count: usize,
     event_count: usize,
-    state: State,
+    state: BufferState,
 }
 
 impl<T> Default for Events<T> {
@@ -136,7 +136,7 @@ impl<T> Default for Events<T> {
             event_count: 0,
             events_a: Vec::new(),
             events_b: Vec::new(),
-            state: State::A,
+            state: BufferState::A,
         }
     }
 }
@@ -154,8 +154,8 @@ impl<T: Component> Events<T> {
         let event_instance = EventInstance { event_id, event };
 
         match self.state {
-            State::A => self.events_a.push(event_instance),
-            State::B => self.events_b.push(event_instance),
+            BufferState::A => self.events_a.push(event_instance),
+            BufferState::B => self.events_b.push(event_instance),
         }
 
         self.event_count += 1;
@@ -182,14 +182,14 @@ impl<T: Component> Events<T> {
     /// called once per frame/update.
     pub fn update(&mut self) {
         match self.state {
-            State::A => {
+            BufferState::A => {
                 self.events_b = Vec::new();
-                self.state = State::B;
+                self.state = BufferState::B;
                 self.b_start_event_count = self.event_count;
             }
-            State::B => {
+            BufferState::B => {
                 self.events_a = Vec::new();
-                self.state = State::A;
+                self.state = BufferState::A;
                 self.a_start_event_count = self.event_count;
             }
         }
@@ -241,8 +241,8 @@ impl<T: Component> Events<T> {
     /// happen after this call and before the next `update()` call will be dropped.
     pub fn iter_current_update_events(&self) -> impl DoubleEndedIterator<Item = &T> {
         match self.state {
-            State::A => self.events_a.iter().map(map_instance_event),
-            State::B => self.events_b.iter().map(map_instance_event),
+            BufferState::A => self.events_a.iter().map(map_instance_event),
+            BufferState::B => self.events_b.iter().map(map_instance_event),
         }
     }
 }
@@ -275,7 +275,7 @@ fn internal_event_reader<'a, T>(
     };
     *last_event_count = events.event_count;
     match events.state {
-        State::A => events
+        BufferState::A => events
             .events_b
             .get(b_index..)
             .unwrap_or_else(|| &[])
@@ -289,7 +289,7 @@ fn internal_event_reader<'a, T>(
                     .iter()
                     .map(map_instance_event_with_id),
             ),
-        State::B => events
+        BufferState::B => events
             .events_a
             .get(a_index..)
             .unwrap_or_else(|| &[])

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -218,9 +218,9 @@ impl<T: Component> Events<T> {
             BufferState::B => self.events_a.drain(..).chain(self.events_b.drain(..)),
         };
 
-        event_instances.map(|ei| {
-            trace!("Events::drain_with_id -> {}", ei.event_id);
-            (ei.event, ei.event_id)
+        event_instances.map(|instance| {
+            trace!("Events::drain_with_id -> {}", instance.event_id);
+            (instance.event, instance.event_id)
         })
     }
 

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -402,10 +402,43 @@ impl<T> ManualEventReader<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::schedule::{Stage, SystemStage};
+    use crate::system::IntoSystem;
+    use crate::world::World;
 
     #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     struct TestEvent {
         i: usize,
+    }
+
+    #[test]
+    fn event_system_params() {
+        let world = World::default();
+        struct E;
+        fn writes(ew: EventWriter<E>) {
+            ew.send(E)
+        }
+        fn reads(er: EventReader<E>) {
+            er.iter();
+        }
+        fn consumes(ec: EventConsumer<E>) {
+            ec.drain();
+        }
+
+        let mut stage1 = SystemStage::parallel();
+        stage1.add_system(writes.system());
+        stage1.add_system(reads.system());
+
+        stage1.run(&mut World::default());
+        let current_events = world.get_resource::<Events<E>>().unwrap();
+        assert!(current_events.events_a.len() == 1);
+
+        let mut stage2 = SystemStage::parallel();
+        stage2.add_system(consumes.system());
+
+        stage2.run(&mut World::default());
+        let current_events = world.get_resource::<Events<E>>().unwrap();
+        assert!(current_events.events_a.len() == 0);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -442,7 +442,7 @@ mod tests {
 
         stage2.run(&mut world);
         let current_events = world.get_resource::<Events<E>>().unwrap();
-        assert!(current_events.events_a.len() == 0);
+        assert!(current_events.events_a.is_empty());
     }
 
     #[test]

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -347,7 +347,7 @@ impl<'a, T: Component> EventReader<'a, T> {
     }
 }
 
-/// Reads and consumes all events of type T
+/// Reads and consumes all events of type T when .drain or .drain_with_id are called
 ///
 /// Useful for manual event cleanup when [AppBuilder::add_event::<T>] is omitted,
 /// allowing events to accumulate on your components or resources until consumed.

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -358,13 +358,15 @@ pub struct EventConsumer<'a, T: Component> {
 
 impl<'a, T: Component> EventConsumer<'a, T> {
     /// Drains all available events this EventConsumer has access to into an iterator
-    pub fn drain(self) -> impl DoubleEndedIterator<Item = T> {
-        self.events.drain()
+    pub fn drain(self) -> impl DoubleEndedIterator<Item = T> + 'a {
+        // into_inner is needed to ensure the lifetime is not bound to the implicit .deref_mut() call
+        self.events.into_inner().drain()
     }
 
     /// Drains all available events this EventConsumer has access to into an iterator and returns the id
-    pub fn drain_with_id(self) -> impl DoubleEndedIterator<Item = (T, EventId<T>)> {
-        self.events.drain_with_id()
+    pub fn drain_with_id(self) -> impl DoubleEndedIterator<Item = (T, EventId<T>)> + 'a {
+        // into_inner is needed to ensure the lifetime is not bound to the implicit .deref_mut() call
+        self.events.into_inner().drain_with_id()
     }
 }
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -19,7 +19,7 @@ pub mod prelude {
     pub use crate::{
         bundle::Bundle,
         entity::Entity,
-        event::{EventReader, EventWriter},
+        event::{EventConsumer, EventReader, EventWriter},
         query::{Added, ChangeTrackers, Changed, Or, QueryState, With, WithBundle, Without},
         schedule::{
             AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -367,6 +367,13 @@ impl<'w, T: Component> DerefMut for ResMut<'w, T> {
     }
 }
 
+impl<'a, T: Component> ResMut<'a, T> {
+    pub fn into_inner(self) -> &'a mut T {
+        self.ticks.set_changed(self.change_tick);
+        self.value
+    }
+}
+
 /// The [`SystemParamState`] of [`ResMut`].
 pub struct ResMutState<T> {
     component_id: ComponentId,

--- a/examples/README.md
+++ b/examples/README.md
@@ -151,6 +151,7 @@ Example | File | Description
 `ecs_guide` | [`ecs/ecs_guide.rs`](./ecs/ecs_guide.rs) | Full guide to Bevy's ECS
 `change_detection` | [`ecs/change_detection.rs`](./ecs/change_detection.rs) | Change detection on components
 `event` | [`ecs/event.rs`](./ecs/event.rs) | Illustrates event creation, activation, and reception
+`event_consumer` | [`ecs/event_consumer.rs`](./ecs/event_consumer.rs) | Shows how to consume events and avoid automatic event cleanup when skipping systems
 `fixed_timestep` | [`ecs/fixed_timestep.rs`](./ecs/fixed_timestep.rs) | Shows how to create systems that run every fixed timestep, rather than every tick
 `hierarchy` | [`ecs/hierarchy.rs`](./ecs/hierarchy.rs) | Creates a hierarchy of parents and children entities
 `parallel_query` | [`ecs/parallel_query.rs`](./ecs/parallel_query.rs) | Illustrates parallel queries with `ParallelIterator`

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -1,3 +1,4 @@
+use bevy::core::FixedTimestep;
 use bevy::prelude::*;
 
 /// This example creates a new event, a system that triggers the event once per second,
@@ -6,8 +7,11 @@ fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .add_event::<MyEvent>()
-        .init_resource::<EventTriggerState>()
-        .add_system(event_trigger_system.system())
+        .add_system(
+            event_trigger_system
+                .system()
+                .with_run_criteria(FixedTimestep::step(1.0)),
+        )
         .add_system(event_listener_system.system())
         .run();
 }
@@ -16,29 +20,11 @@ struct MyEvent {
     pub message: String,
 }
 
-struct EventTriggerState {
-    event_timer: Timer,
-}
-
-impl Default for EventTriggerState {
-    fn default() -> Self {
-        EventTriggerState {
-            event_timer: Timer::from_seconds(1.0, true),
-        }
-    }
-}
-
 // sends MyEvent every second
-fn event_trigger_system(
-    time: Res<Time>,
-    mut state: ResMut<EventTriggerState>,
-    mut my_events: EventWriter<MyEvent>,
-) {
-    if state.event_timer.tick(time.delta()).finished() {
-        my_events.send(MyEvent {
-            message: "MyEvent just happened!".to_string(),
-        });
-    }
+fn event_trigger_system(mut my_events: EventWriter<MyEvent>) {
+    my_events.send(MyEvent {
+        message: "MyEvent just happened!".to_string(),
+    });
 }
 
 // prints events as they come in

--- a/examples/ecs/event_consumer.rs
+++ b/examples/ecs/event_consumer.rs
@@ -1,0 +1,65 @@
+use bevy::core::FixedTimestep;
+use bevy::prelude::*;
+
+/// Events are automatically cleaned up after two frames when intialized via `.add_event`.
+/// To bypass this, you can simply add the Events::<T> resource manually.
+/// This is critical when working with systems that read events but do not run every tick,
+/// such as those that operate with a FixedTimeStep run criteria.
+///
+/// When you do so though, you need to be careful to clean up these events eventually,
+/// otherwise the size of your vector of events will grow in an unbounded fashion.
+///
+/// `EventConsumer::<T>` provides a simple interface to do so, clearing all events that it reads
+/// by draining them into a new vector.
+/// You can combine it with other `EventReader`s as long as they read events before ,
+/// but only one `EventConsumer` system should be used per event type in most cases
+/// as they will compete for events.
+fn main() {
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_event::<MyEvent>()
+        .add_system(
+            event_trigger_system
+                .system()
+                .with_run_criteria(FixedTimestep::step(1.0)),
+        )
+        .add_system(event_listener_system.system().label("listening"))
+        .add_system(
+            event_devourer_system
+                .system()
+                // Must occur after event_listener_system or some events may be missed
+                .after("listening")
+                .with_run_criteria(FixedTimestep::step(5.0)),
+        )
+        .run();
+}
+
+struct MyEvent {
+    pub message: String,
+}
+
+// sends MyEvent every second
+fn event_trigger_system(time: Res<Time>, mut my_events: EventWriter<MyEvent>) {
+    my_events.send(MyEvent {
+        message: format!(
+            "This event was sent at {}",
+            time.time_since_startup().as_millis()
+        )
+        .to_string(),
+    });
+}
+
+// reads events as soon as they come in
+fn event_listener_system(mut events: EventReader<MyEvent>) {
+    for _ in events.iter() {
+        info!("I heard an event!");
+    }
+}
+
+// reports events once every 5 seconds
+fn event_devourer_system(events: EventConsumer<MyEvent>) {
+    // Events are only consumed when .drain() is called
+    for my_event in events.drain() {
+        info!("{}", my_event.message);
+    }
+}

--- a/examples/ecs/event_consumer.rs
+++ b/examples/ecs/event_consumer.rs
@@ -11,7 +11,7 @@ use bevy::{app::Events, core::FixedTimestep};
 ///
 /// `EventConsumer::<T>` provides a simple interface to do so, clearing all events that it reads
 /// by draining them into a new vector.
-/// You can combine it with other `EventReader`s as long as they read events before ,
+/// You can combine it with other `EventReader`s as long as they read events before,
 /// but only one `EventConsumer` system should be used per event type in most cases
 /// as they will compete for events.
 fn main() {

--- a/examples/ecs/event_consumer.rs
+++ b/examples/ecs/event_consumer.rs
@@ -1,5 +1,5 @@
-use bevy::core::FixedTimestep;
 use bevy::prelude::*;
+use bevy::{app::Events, core::FixedTimestep};
 
 /// Events are automatically cleaned up after two frames when intialized via `.add_event`.
 /// To bypass this, you can simply add the Events::<T> resource manually.
@@ -17,7 +17,8 @@ use bevy::prelude::*;
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_event::<MyEvent>()
+        // We can't use .add_event or our events will be cleaned up too soon
+        .init_resource::<Events<MyEvent>>()
         .add_system(
             event_trigger_system
                 .system()
@@ -42,7 +43,7 @@ struct MyEvent {
 fn event_trigger_system(time: Res<Time>, mut my_events: EventWriter<MyEvent>) {
     my_events.send(MyEvent {
         message: format!(
-            "This event was sent at {}",
+            "This event was sent at {} milliseconds",
             time.time_since_startup().as_millis()
         )
         .to_string(),
@@ -50,6 +51,7 @@ fn event_trigger_system(time: Res<Time>, mut my_events: EventWriter<MyEvent>) {
 }
 
 // reads events as soon as they come in
+// FIXME: stops responding after the first time events are consumed
 fn event_listener_system(mut events: EventReader<MyEvent>) {
     for _ in events.iter() {
         info!("I heard an event!");

--- a/examples/ecs/event_consumer.rs
+++ b/examples/ecs/event_consumer.rs
@@ -46,7 +46,6 @@ fn event_trigger_system(time: Res<Time>, mut my_events: EventWriter<MyEvent>) {
             "This event was sent at {} milliseconds",
             time.time_since_startup().as_millis()
         )
-        .to_string(),
     });
 }
 

--- a/examples/ecs/event_consumer.rs
+++ b/examples/ecs/event_consumer.rs
@@ -51,7 +51,6 @@ fn event_trigger_system(time: Res<Time>, mut my_events: EventWriter<MyEvent>) {
 }
 
 // reads events as soon as they come in
-// FIXME: stops responding after the first time events are consumed
 fn event_listener_system(mut events: EventReader<MyEvent>) {
     for _ in events.iter() {
         info!("I heard an event!");

--- a/examples/ecs/event_consumer.rs
+++ b/examples/ecs/event_consumer.rs
@@ -45,7 +45,7 @@ fn event_trigger_system(time: Res<Time>, mut my_events: EventWriter<MyEvent>) {
         message: format!(
             "This event was sent at {} milliseconds",
             time.time_since_startup().as_millis()
-        )
+        ),
     });
 }
 


### PR DESCRIPTION
Problem:
- Events::extend manually called Vec::push for each element of the
  provided iterator.
- This can potentially be an expensive.

Solution:
- Use Vec::extend over a Vec::push for loop.

Fixes: #2146

Blocked by: #2145