### PR TITLE
[Merged by Bors] - Add module level documentation for collide_aabb

### DIFF
--- a/crates/bevy_sprite/src/collide_aabb.rs
+++ b/crates/bevy_sprite/src/collide_aabb.rs
@@ -1,3 +1,5 @@
+//! Utilities for detecting if and on which side two axis-aligned bounding boxes (AABB) collide.
+
 use bevy_math::{Vec2, Vec3};
 
 #[derive(Debug)]


### PR DESCRIPTION
Related to #2105.

Doc comments are present on the `collide` function, but not on the module level.