### PR TITLE
[Merged by Bors] - fix diagnostic length for asset count

### DIFF
--- a/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
+++ b/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
@@ -1,6 +1,6 @@
 use crate::{Asset, Assets};
 use bevy_app::prelude::*;
-use bevy_diagnostic::{Diagnostic, DiagnosticId, Diagnostics};
+use bevy_diagnostic::{Diagnostic, DiagnosticId, Diagnostics, MAX_DIAGNOSTIC_NAME_WIDTH};
 use bevy_ecs::system::{IntoSystem, Res, ResMut};
 
 /// Adds "asset count" diagnostic to an App
@@ -29,9 +29,18 @@ impl<T: Asset> AssetCountDiagnosticsPlugin<T> {
     }
 
     pub fn setup_system(mut diagnostics: ResMut<Diagnostics>) {
+        let asset_type_name = std::any::type_name::<T>();
+        let max_length = MAX_DIAGNOSTIC_NAME_WIDTH - "asset_count ".len();
         diagnostics.add(Diagnostic::new(
             Self::diagnostic_id(),
-            format!("asset_count {}", std::any::type_name::<T>()),
+            format!(
+                    "asset_count {}",
+                    if asset_type_name.len() > max_length {
+                        asset_type_name.split_at(asset_type_name.len() - max_length + 1).1
+                    } else {
+                        asset_type_name
+                    }
+                ),
             20,
         ));
     }

--- a/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
+++ b/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
@@ -34,13 +34,15 @@ impl<T: Asset> AssetCountDiagnosticsPlugin<T> {
         diagnostics.add(Diagnostic::new(
             Self::diagnostic_id(),
             format!(
-                    "asset_count {}",
-                    if asset_type_name.len() > max_length {
-                        asset_type_name.split_at(asset_type_name.len() - max_length + 1).1
-                    } else {
-                        asset_type_name
-                    }
-                ),
+                "asset_count {}",
+                if asset_type_name.len() > max_length {
+                    asset_type_name
+                        .split_at(asset_type_name.len() - max_length + 1)
+                        .1
+                } else {
+                    asset_type_name
+                }
+            ),
             20,
         ));
     }

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -2,7 +2,7 @@ use bevy_log::warn;
 use bevy_utils::{Duration, Instant, StableHashMap, Uuid};
 use std::{borrow::Cow, collections::VecDeque};
 
-use crate::log_diagnostics_plugin::MAX_LOG_NAME_WIDTH;
+use crate::MAX_DIAGNOSTIC_NAME_WIDTH;
 
 /// Unique identifier for a [Diagnostic]
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
@@ -59,12 +59,12 @@ impl Diagnostic {
         max_history_length: usize,
     ) -> Diagnostic {
         let name = name.into();
-        if name.chars().count() > MAX_LOG_NAME_WIDTH {
+        if name.chars().count() > MAX_DIAGNOSTIC_NAME_WIDTH {
             // This could be a false positive due to a unicode width being shorter
             warn!(
                 "Diagnostic {:?} has name longer than {} characters, and so might overflow in the LogDiagnosticsPlugin\
                 Consider using a shorter name.",
-                name, MAX_LOG_NAME_WIDTH
+                name, MAX_DIAGNOSTIC_NAME_WIDTH
             )
         }
         Diagnostic {

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -18,3 +18,7 @@ impl Plugin for DiagnosticsPlugin {
         app.init_resource::<Diagnostics>();
     }
 }
+
+/// The width which diagnostic names will be printed as
+/// Plugin names should not be longer than this value
+pub const MAX_DIAGNOSTIC_NAME_WIDTH: usize = 32;

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -28,10 +28,6 @@ impl Default for LogDiagnosticsPlugin {
     }
 }
 
-/// The width which diagnostic names will be printed as
-/// Plugin names should not be longer than this value
-pub(crate) const MAX_LOG_NAME_WIDTH: usize = 32;
-
 impl Plugin for LogDiagnosticsPlugin {
     fn build(&self, app: &mut bevy_app::AppBuilder) {
         app.insert_resource(LogDiagnosticsState {
@@ -71,7 +67,7 @@ impl LogDiagnosticsPlugin {
                     // Do not reserve one column for the suffix in the average
                     // The ) hugging the value is more aesthetically pleasing
                     format!("{:.6}{:}", average, diagnostic.suffix),
-                    name_width = MAX_LOG_NAME_WIDTH,
+                    name_width = crate::MAX_DIAGNOSTIC_NAME_WIDTH,
                 );
             } else {
                 info!(
@@ -79,7 +75,7 @@ impl LogDiagnosticsPlugin {
                     "{:<name_width$}: {:>}",
                     diagnostic.name,
                     format!("{:.6}{:}", value, diagnostic.suffix),
-                    name_width = MAX_LOG_NAME_WIDTH,
+                    name_width = crate::MAX_DIAGNOSTIC_NAME_WIDTH,
                 );
             }
         }


### PR DESCRIPTION
fixes #2156 
limit the diagnostic name to `MAX_DIAGNOSTIC_NAME_WIDTH` length