### PR TITLE
[Merged by Bors] - Some cleanups

### DIFF
--- a/crates/bevy_ecs/src/schedule/graph_utils.rs
+++ b/crates/bevy_ecs/src/schedule/graph_utils.rs
@@ -6,22 +6,23 @@ pub enum DependencyGraphError<Labels> {
     GraphCycles(Vec<(usize, Labels)>),
 }
 
-pub trait GraphNode<Label> {
+pub trait GraphNode {
+    type Label;
     fn name(&self) -> Cow<'static, str>;
-    fn labels(&self) -> &[Label];
-    fn before(&self) -> &[Label];
-    fn after(&self) -> &[Label];
+    fn labels(&self) -> &[Self::Label];
+    fn before(&self) -> &[Self::Label];
+    fn after(&self) -> &[Self::Label];
 }
 
 /// Constructs a dependency graph of given nodes.
-pub fn build_dependency_graph<Node, Label>(
+pub fn build_dependency_graph<Node>(
     nodes: &[Node],
-) -> HashMap<usize, HashMap<usize, HashSet<Label>>>
+) -> HashMap<usize, HashMap<usize, HashSet<Node::Label>>>
 where
-    Node: GraphNode<Label>,
-    Label: Debug + Clone + Eq + Hash,
+    Node: GraphNode,
+    Node::Label: Debug + Clone + Eq + Hash,
 {
-    let mut labels = HashMap::<Label, FixedBitSet>::default();
+    let mut labels = HashMap::<Node::Label, FixedBitSet>::default();
     for (label, index) in nodes.iter().enumerate().flat_map(|(index, container)| {
         container
             .labels()

--- a/crates/bevy_ecs/src/schedule/run_criteria.rs
+++ b/crates/bevy_ecs/src/schedule/run_criteria.rs
@@ -124,7 +124,9 @@ impl RunCriteriaContainer {
     }
 }
 
-impl GraphNode<BoxedRunCriteriaLabel> for RunCriteriaContainer {
+impl GraphNode for RunCriteriaContainer {
+    type Label = BoxedRunCriteriaLabel;
+
     fn name(&self) -> Cow<'static, str> {
         match &self.inner {
             RunCriteriaInner::Single(system) => system.name(),

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -412,9 +412,9 @@ impl SystemStage {
                 && self.uninitialized_before_commands.is_empty()
                 && self.uninitialized_at_end.is_empty()
         );
-        fn unwrap_dependency_cycle_error<Output, Label, Labels: Debug>(
+        fn unwrap_dependency_cycle_error<Node: GraphNode, Output, Labels: Debug>(
             result: Result<Output, DependencyGraphError<Labels>>,
-            nodes: &[impl GraphNode<Label>],
+            nodes: &[Node],
             nodes_description: &'static str,
         ) -> Output {
             match result {

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -137,17 +137,13 @@ impl SystemStage {
     }
 
     pub fn add_system(&mut self, system: impl Into<SystemDescriptor>) -> &mut Self {
-        self.add_system_inner(system, None);
+        self.add_system_inner(system.into(), None);
         self
     }
 
-    fn add_system_inner(
-        &mut self,
-        system: impl Into<SystemDescriptor>,
-        default_run_criteria: Option<usize>,
-    ) {
+    fn add_system_inner(&mut self, system: SystemDescriptor, default_run_criteria: Option<usize>) {
         self.systems_modified = true;
-        match system.into() {
+        match system {
             SystemDescriptor::Exclusive(mut descriptor) => {
                 let insertion_point = descriptor.insertion_point;
                 let criteria = descriptor.run_criteria.take();

--- a/crates/bevy_ecs/src/schedule/system_container.rs
+++ b/crates/bevy_ecs/src/schedule/system_container.rs
@@ -10,7 +10,7 @@ use crate::{
 use std::{borrow::Cow, ptr::NonNull};
 
 /// System metadata like its name, labels, order requirements and component access.
-pub trait SystemContainer: GraphNode<BoxedSystemLabel> {
+pub trait SystemContainer: GraphNode<Label = BoxedSystemLabel> {
     #[doc(hidden)]
     fn dependencies(&self) -> &[usize];
     #[doc(hidden)]
@@ -54,7 +54,9 @@ impl ExclusiveSystemContainer {
     }
 }
 
-impl GraphNode<BoxedSystemLabel> for ExclusiveSystemContainer {
+impl GraphNode for ExclusiveSystemContainer {
+    type Label = BoxedSystemLabel;
+
     fn name(&self) -> Cow<'static, str> {
         self.system.name()
     }
@@ -163,7 +165,9 @@ impl ParallelSystemContainer {
     }
 }
 
-impl GraphNode<BoxedSystemLabel> for ParallelSystemContainer {
+impl GraphNode for ParallelSystemContainer {
+    type Label = BoxedSystemLabel;
+
     fn name(&self) -> Cow<'static, str> {
         self.system().name()
     }


### PR DESCRIPTION
The first commit monomorphizes `add_system_inner` which I think was intended to be monomorphized anyway. The second commit moves the type argument of `GraphNode` to an associated type.