### PR TITLE
[Merged by Bors] - Document what `Config` is and how to use it.

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -49,6 +49,18 @@ pub trait SystemParam: Sized {
 /// Additionally, it is the implementor's responsibility to ensure there is no
 /// conflicting access across all SystemParams.
 pub unsafe trait SystemParamState: Send + Sync + 'static {
+    /// Values of this type can be used to adjust the behavior of the
+    /// system parameter.  For instance, this can be used to pass
+    /// values from a `Plugin` to a `System`, or to control the
+    /// behavior of the `System`.
+    ///
+    /// The default configuration of the parameter is set by
+    /// [`SystemParamState::default_config`]. To change it, invoke
+    /// [`FunctionSystem::config`](super::FunctionSystem::config) when
+    /// creating the system.
+    ///
+    /// See [`FunctionSystem::config`](super::FunctionSystem::config)
+    /// for more information and examples.
     type Config: Send + Sync;
     fn init(world: &mut World, system_state: &mut SystemState, config: Self::Config) -> Self;
     #[inline]

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -50,7 +50,7 @@ pub trait SystemParam: Sized {
 /// conflicting access across all SystemParams.
 pub unsafe trait SystemParamState: Send + Sync + 'static {
     /// Values of this type can be used to adjust the behavior of the
-    /// system parameter.  For instance, this can be used to pass
+    /// system parameter. For instance, this can be used to pass
     /// values from a `Plugin` to a `System`, or to control the
     /// behavior of the `System`.
     ///


### PR DESCRIPTION
While trying to figure out how to implement a `SystemParam`, I spent a
long time looking for a feature that would do exactly what `Config`
does.  I ignored it at first because all the examples I could find used
`()` and I couldn't see a way to modify it.

This is documented in other places, but `Config` is a logical place to
include some breadcrumbs.  I've added some text that gives a brief
overview of what `Config` is for, and links to the existing docs on
`FunctionSystem::config` for more details.

This would have saved me from embarrassing myself by filing https://github.com/bevyengine/bevy/issues/2178.