### PR TITLE
[Merged by Bors] - Impl AsRef+AsMut for Res, ResMut, and Mut

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -207,6 +207,13 @@ impl<'w, T: Component> Deref for Res<'w, T> {
     }
 }
 
+impl<'w, T: Component> AsRef<T> for Res<'w, T> {
+    #[inline]
+    fn as_ref(&self) -> &T {
+        self.deref()
+    }
+}
+
 /// The [`SystemParamState`] of [`Res`].
 pub struct ResState<T> {
     component_id: ComponentId,
@@ -364,6 +371,20 @@ impl<'w, T: Component> DerefMut for ResMut<'w, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.ticks.set_changed(self.change_tick);
         self.value
+    }
+}
+
+impl<'w, T: Component> AsRef<T> for ResMut<'w, T> {
+    #[inline]
+    fn as_ref(&self) -> &T {
+        self.deref()
+    }
+}
+
+impl<'w, T: Component> AsMut<T> for ResMut<'w, T> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut T {
+        self.deref_mut()
     }
 }
 

--- a/crates/bevy_ecs/src/world/pointer.rs
+++ b/crates/bevy_ecs/src/world/pointer.rs
@@ -39,6 +39,20 @@ impl<'a, T: core::fmt::Debug> core::fmt::Debug for Mut<'a, T> {
     }
 }
 
+impl<'w, T> AsRef<T> for Mut<'w, T> {
+    #[inline]
+    fn as_ref(&self) -> &T {
+        self.deref()
+    }
+}
+
+impl<'w, T> AsMut<T> for Mut<'w, T> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut T {
+        self.deref_mut()
+    }
+}
+
 impl<'w, T> Mut<'w, T> {
     /// Returns true if (and only if) this component been added since the last execution of this
     /// system.


### PR DESCRIPTION
This can save users from having to type `&*X` all the time at the cost of some complexity in the type signature. For instance, this allows me to accommodate @jakobhellermann's suggestion in #1799 without requiring users to type `&*windows` 99% of the time.