### PR TITLE
[Merged by Bors] - Fix PBR regression for unlit materials 

### DIFF
--- a/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.frag
+++ b/crates/bevy_pbr/src/render_graph/pbr_pipeline/pbr.frag
@@ -283,8 +283,6 @@ vec3 reinhard_extended_luminance(vec3 color, float max_white_l) {
     return change_luminance(color, l_new);
 }
 
-#endif
-
 vec3 point_light(PointLight light, float roughness, float NdotV, vec3 N, vec3 V, vec3 R, vec3 F0, vec3 diffuseColor) {
     vec3 light_to_frag = light.pos.xyz - v_WorldPosition.xyz;
     float distance_square = dot(light_to_frag, light_to_frag);
@@ -348,6 +346,8 @@ vec3 dir_light(DirectionalLight light, float roughness, float NdotV, vec3 normal
 
     return (specular + diffuse) * light.color.rgb * NoL;
 }
+
+#endif
 
 void main() {
     vec4 output_color = base_color;

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -33,20 +33,44 @@ fn setup(
                     roughness: x01,
                     ..Default::default()
                 }),
-                transform: Transform::from_xyz(x as f32, y as f32, 0.0),
+                transform: Transform::from_xyz(x as f32, y as f32 + 0.5, 0.0),
                 ..Default::default()
             });
         }
     }
+    // unlit sphere
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Icosphere {
+            radius: 0.45,
+            subdivisions: 32,
+        })),
+        material: materials.add(StandardMaterial {
+            base_color: Color::hex("ffd891").unwrap(),
+            // vary key PBR parameters on a grid of spheres to show the effect
+            unlit: true,
+            ..Default::default()
+        }),
+        transform: Transform::from_xyz(-5.0, -2.5, 0.0),
+        ..Default::default()
+    });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, 5.0, 5.0)),
+        transform: Transform::from_translation(Vec3::new(50.0, 50.0, 50.0)),
+        point_light: PointLight {
+            intensity: 50000.,
+            range: 100.,
+            ..Default::default()
+        },
         ..Default::default()
     });
     // camera
-    commands.spawn_bundle(PerspectiveCameraBundle {
+    commands.spawn_bundle(OrthographicCameraBundle {
         transform: Transform::from_translation(Vec3::new(0.0, 0.0, 8.0))
             .looking_at(Vec3::default(), Vec3::Y),
-        ..Default::default()
+        orthographic_projection: bevy::render::camera::OrthographicProjection {
+            scale: 0.01,
+            ..Default::default()
+        },
+        ..OrthographicCameraBundle::new_3d()
     });
 }


### PR DESCRIPTION
Fixes the frag shader for unlit materials by correcting the scope of the `#ifndef` to include the light functions. Closes #2190, introduced in #2112.

Tested by changing materials in the the `3d_scene` example to be unlit. Unsure how to prevent future regressions without creating a test case scene that will catch these runtime panics.