### PR TITLE
[Merged by Bors] - Update glam (0.15.1) and hexasphere (3.4)

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -214,7 +214,7 @@ async fn load_gltf<'a, 'b>(
                         scale,
                     } => Transform {
                         translation: bevy_math::Vec3::from(translation),
-                        rotation: bevy_math::Quat::from(rotation),
+                        rotation: bevy_math::Quat::from_vec4(rotation.into()),
                         scale: bevy_math::Vec3::from(scale),
                     },
                 },

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -13,5 +13,5 @@ license = "MIT"
 keywords = ["bevy"]
 
 [dependencies]
-glam = { version = "0.14.0", features = ["serde", "bytemuck"] }
+glam = { version = "0.15.1", features = ["serde", "bytemuck"] }
 bevy_reflect = { path = "../bevy_reflect", version = "0.5.0", features = ["bevy"] }

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -28,7 +28,7 @@ parking_lot = "0.11.0"
 thiserror = "1.0"
 serde = "1"
 smallvec = { version = "1.6", features = ["serde", "union", "const_generics"], optional = true }
-glam = { version = "0.14.0", features = ["serde"], optional = true }
+glam = { version = "0.15.1", features = ["serde"], optional = true }
 
 [dev-dependencies]
 ron = "0.6.2"

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -37,7 +37,7 @@ downcast-rs = "1.2.0"
 thiserror = "1.0"
 anyhow = "1.0"
 hex = "0.4.2"
-hexasphere = "3.3"
+hexasphere = "3.4"
 parking_lot = "0.11.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -207,7 +207,7 @@ impl GlobalTransform {
         let forward = Vec3::normalize(self.translation - target);
         let right = up.cross(forward).normalize();
         let up = forward.cross(right);
-        self.rotation = Quat::from_rotation_mat3(&Mat3::from_cols(right, up, forward));
+        self.rotation = Quat::from_mat3(&Mat3::from_cols(right, up, forward));
     }
 }
 

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -221,7 +221,7 @@ impl Transform {
         let forward = Vec3::normalize(self.translation - target);
         let right = up.cross(forward).normalize();
         let up = forward.cross(right);
-        self.rotation = Quat::from_rotation_mat3(&Mat3::from_cols(right, up, forward));
+        self.rotation = Quat::from_mat3(&Mat3::from_cols(right, up, forward));
     }
 }
 


### PR DESCRIPTION
This is a version of #2195 which addresses the `glam` breaking changes.
Also update hexasphere to ensure versions of `glam` are matching