### PR TITLE
[Merged by Bors] - remove minor and patch version from superlinter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Markdown Lint
-        uses: github/super-linter@v3.17
+        uses: github/super-linter@v3
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_MARKDOWN: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Markdown Lint
-        uses: github/super-linter@v3.17.0
+        uses: github/super-linter@v3.17
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_MARKDOWN: true


### PR DESCRIPTION
Removes the superlinter patch version to prevent large amounts of dependabot pull request noise.