### PR TITLE
[Merged by Bors] - revert supporting generics for deriving TypeUuid

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
@@ -1,6 +1,6 @@
 extern crate proc_macro;
 
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::{parse::*, *};
 use uuid::Uuid;
 
@@ -15,7 +15,11 @@ pub fn type_uuid_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStre
 
     // Build the trait implementation
     let name = &ast.ident;
-    let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
+
+    let (impl_generics, type_generics, _) = &ast.generics.split_for_impl();
+    if !impl_generics.to_token_stream().is_empty() || !type_generics.to_token_stream().is_empty() {
+        panic!("#[derive(TypeUuid)] is not supported for generics.");
+    }
 
     let mut uuid = None;
     for attribute in ast.attrs.iter().filter_map(|attr| attr.parse_meta().ok()) {
@@ -54,7 +58,7 @@ pub fn type_uuid_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStre
         .map(|byte_str| syn::parse_str::<LitInt>(&byte_str).unwrap());
 
     let gen = quote! {
-        impl #impl_generics #bevy_reflect_path::TypeUuid for #name #type_generics #where_clause {
+        impl #bevy_reflect_path::TypeUuid for #name {
             const TYPE_UUID: #bevy_reflect_path::Uuid = #bevy_reflect_path::Uuid::from_bytes([
                 #( #bytes ),*
             ]);

--- a/crates/bevy_reflect/src/type_uuid.rs
+++ b/crates/bevy_reflect/src/type_uuid.rs
@@ -22,25 +22,3 @@ where
         std::any::type_name::<Self>()
     }
 }
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[derive(TypeUuid)]
-    #[uuid = "af6466c2-a9f4-11eb-bcbc-0242ac130002"]
-    struct TestDeriveStruct<T>
-    where
-        T: Clone,
-    {
-        _value: T,
-    }
-
-    fn test_impl_type_uuid(_: &impl TypeUuid) {}
-
-    #[test]
-    fn test_generic_type_uuid_derive() {
-        let test_struct = TestDeriveStruct { _value: 42 };
-        test_impl_type_uuid(&test_struct);
-    }
-}


### PR DESCRIPTION
This reverts some of the changes made in #2044 as supporting generics for a `#[derive(TypeUuid)]` should not work as each generic instantiation would have the same uuid.

Stems from [this conversation](https://github.com/bevyengine/bevy/pull/2044#issuecomment-841743135)