### PR TITLE
[Merged by Bors] - Fix Events::<drain/clear> bug

### DIFF
--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -329,23 +329,22 @@ impl<T: Component> Events<T> {
     }
 
     #[inline]
-    fn increment_start_event_count(&mut self) {
-        let count = self.event_count + 1;
-        self.a_start_event_count = count;
-        self.b_start_event_count = count;
+    fn reset_start_event_count(&mut self) {
+        self.a_start_event_count = self.event_count;
+        self.b_start_event_count = self.event_count;
     }
 
     /// Removes all events.
     #[inline]
     pub fn clear(&mut self) {
-        self.increment_start_event_count();
+        self.reset_start_event_count();
         self.events_a.clear();
         self.events_b.clear();
     }
 
     /// Creates a draining iterator that removes all events.
     pub fn drain(&mut self) -> impl Iterator<Item = T> + '_ {
-        self.increment_start_event_count();
+        self.reset_start_event_count();
 
         let map = |i: EventInstance<T>| i.event;
         match self.state {

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -328,14 +328,25 @@ impl<T: Component> Events<T> {
         events.update();
     }
 
+    #[inline]
+    fn increment_start_event_count(&mut self) {
+        let count = self.event_count + 1;
+        self.a_start_event_count = count;
+        self.b_start_event_count = count;
+    }
+
     /// Removes all events.
+    #[inline]
     pub fn clear(&mut self) {
+        self.increment_start_event_count();
         self.events_a.clear();
         self.events_b.clear();
     }
 
     /// Creates a draining iterator that removes all events.
     pub fn drain(&mut self) -> impl Iterator<Item = T> + '_ {
+        self.increment_start_event_count();
+
         let map = |i: EventInstance<T>| i.event;
         match self.state {
             State::A => self
@@ -479,5 +490,41 @@ mod tests {
         reader: &mut ManualEventReader<TestEvent>,
     ) -> Vec<TestEvent> {
         reader.iter(events).cloned().collect::<Vec<TestEvent>>()
+    }
+
+    #[derive(PartialEq, Eq, Debug)]
+    struct E(usize);
+
+    fn events_clear_and_read_impl(clear_func: impl FnOnce(&mut Events<E>)) {
+        let mut events = Events::<E>::default();
+        let mut reader = events.get_reader();
+
+        assert!(reader.iter(&events).next().is_none());
+
+        events.send(E(0));
+        assert_eq!(*reader.iter(&events).next().unwrap(), E(0));
+        assert_eq!(reader.iter(&events).next(), None);
+
+        events.send(E(1));
+        clear_func(&mut events);
+        assert!(reader.iter(&events).next().is_none());
+
+        events.send(E(2));
+        events.update();
+        events.send(E(3));
+
+        assert!(reader.iter(&events).eq([E(2), E(3)].iter()));
+    }
+
+    #[test]
+    fn test_events_clear_and_read() {
+        events_clear_and_read_impl(|events| events.clear());
+    }
+
+    #[test]
+    fn test_events_drain_and_read() {
+        events_clear_and_read_impl(|events| {
+            assert!(events.drain().eq(vec![E(0), E(1)].into_iter()));
+        });
     }
 }


### PR DESCRIPTION
Taken from #2145

On draining and clearing, dangling `EventReaders` would not read into the correct event offset.