### PR TITLE
[Merged by Bors] - Expose set_changed() on ResMut and Mut

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -370,11 +370,11 @@ impl<'w, T: Component> ResMut<'w, T> {
             .is_changed(self.last_change_tick, self.change_tick)
     }
 
-    /// Flags this resource as having been changed.
+    /// Manually flags this resource as having been changed. This normally isn't
+    /// required because accessing this pointer mutably automatically flags this
+    /// resource as "changed".
     ///
-    /// **Note**: this operation is irreversible.
-    /// You should generally prefer to use [`ResMut::as_mut`], as this returns
-    /// the contained value _and_ sets this resource as changed.
+    /// **Note**: This operation is irreversible.
     #[inline]
     pub fn set_changed(&mut self) {
         self.ticks.set_changed(self.change_tick);

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -369,6 +369,16 @@ impl<'w, T: Component> ResMut<'w, T> {
         self.ticks
             .is_changed(self.last_change_tick, self.change_tick)
     }
+
+    /// Flags this resource as having been changed.
+    ///
+    /// **Note**: this operation is irreversible.
+    /// You should generally prefer to use [`ResMut::as_mut`], as this returns
+    /// the contained value _and_ sets this resource as changed.
+    #[inline]
+    pub fn set_changed(&mut self) {
+        self.ticks.set_changed(self.change_tick);
+    }
 }
 
 impl<'w, T: Component> Deref for ResMut<'w, T> {
@@ -381,7 +391,7 @@ impl<'w, T: Component> Deref for ResMut<'w, T> {
 
 impl<'w, T: Component> DerefMut for ResMut<'w, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.ticks.set_changed(self.change_tick);
+        self.set_changed();
         self.value
     }
 }

--- a/crates/bevy_ecs/src/world/pointer.rs
+++ b/crates/bevy_ecs/src/world/pointer.rs
@@ -17,7 +17,7 @@ impl<'a, T> Mut<'a, T> {
 
     /// Manually flags this value as having been changed. This normally isn't
     /// required because accessing this pointer mutably automatically flags this
-    /// resource as "changed".
+    /// value as "changed".
     ///
     /// **Note**: This operation is irreversible.
     #[inline]

--- a/crates/bevy_ecs/src/world/pointer.rs
+++ b/crates/bevy_ecs/src/world/pointer.rs
@@ -15,11 +15,11 @@ impl<'a, T> Mut<'a, T> {
         self.value
     }
 
-    /// Flags this component as having been changed.
+    /// Manually flags this value as having been changed. This normally isn't
+    /// required because accessing this pointer mutably automatically flags this
+    /// resource as "changed".
     ///
-    /// **Note**: this operation is irreversible.
-    /// You should generally prefer to use [`Mut::as_mut`], as this returns
-    /// the component _and_ sets it as changed.
+    /// **Note**: This operation is irreversible.
     #[inline]
     pub fn set_changed(&mut self) {
         self.component_ticks.set_changed(self.change_tick);

--- a/crates/bevy_ecs/src/world/pointer.rs
+++ b/crates/bevy_ecs/src/world/pointer.rs
@@ -14,6 +14,16 @@ impl<'a, T> Mut<'a, T> {
         self.component_ticks.set_changed(self.change_tick);
         self.value
     }
+
+    /// Flags this component as having been changed.
+    ///
+    /// **Note**: this operation is irreversible.
+    /// You should generally prefer to use [`Mut::as_mut`], as this returns
+    /// the component _and_ sets it as changed.
+    #[inline]
+    pub fn set_changed(&mut self) {
+        self.component_ticks.set_changed(self.change_tick);
+    }
 }
 
 impl<'a, T> Deref for Mut<'a, T> {
@@ -28,7 +38,7 @@ impl<'a, T> Deref for Mut<'a, T> {
 impl<'a, T> DerefMut for Mut<'a, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
-        self.component_ticks.set_changed(self.change_tick);
+        self.set_changed();
         self.value
     }
 }


### PR DESCRIPTION
This new api stems from this [discord conversation](https://discord.com/channels/691052431525675048/742569353878437978/844057268172357663).

This exposes a public facing `set_changed` method on `ResMut` and `Mut`.

As a side note: `ResMut` and `Mut` have a lot of duplicated code, I have a PR I may put up later that refactors these commonalities into a trait.