### PR TITLE
AssetServer#get_group_load_state: Convert the iterator to borrowed version

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -194,7 +194,7 @@ impl AssetServer {
         }
     }
 
-    pub fn get_group_load_state(&self, handles: impl IntoIterator<Item = HandleId>) -> LoadState {
+    pub fn get_group_load_state(&self, handles: impl Iterator<Item = HandleId>) -> LoadState {
         let mut load_state = LoadState::Loaded;
         for handle_id in handles {
             match handle_id {


### PR DESCRIPTION
Currently, `AssetServer#get_group_load_state()` takes an `IntoIterator<_>` for the collection of handle ids.

This requires the client system to clone the collection, since it's owned by the `Res<_>` wrapper, and the typical `Vec` collection doesn't support copy:

```rust
struct AssetsLoading(Vec<HandleId>);

fn check_assets_ready(server: Res<AssetServer>, loading: Res<AssetsLoading>) {
    let group_load_state = server.get_group_load_state(loading.0.clone());
}
```

since downstream (in `get_load_state()`) the handle ids are converted to owned via into() anyway, a borrowing iterator (Iterator<_>) can do; this makes the API a bit more ergonomic, and avoids an unnecessary clone().