### PR TITLE
Changes Reflect derive for Handle<T>, so scenes with Vec<Handle<T>> can be spawned

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -59,7 +59,7 @@ impl HandleId {
 /// Handles contain a unique id that corresponds to a specific asset in the [Assets](crate::Assets)
 /// collection.
 #[derive(Reflect)]
-#[reflect(Component)]
+#[reflect_value(Component)]
 pub struct Handle<T>
 where
     T: Asset,


### PR DESCRIPTION
Simplest way of address #2215, but doesn't solve the problem completely