### PR TITLE
If we try to write to an entity that doesn't exist, log it rather than completely crash the game.

### DIFF
--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -4,7 +4,7 @@ use crate::{
     entity::{Entities, Entity},
     world::World,
 };
-use bevy_utils::tracing::debug;
+use bevy_utils::tracing::{debug, warn};
 use std::marker::PhantomData;
 
 /// A [`World`] mutation.
@@ -353,7 +353,11 @@ where
     T: Component,
 {
     fn write(self: Box<Self>, world: &mut World) {
-        world.entity_mut(self.entity).insert(self.component);
+        if let Some(mut entity) = world.get_entity_mut(self.entity) {
+            entity.insert(self.component);
+        } else {
+            warn!("Attempt to write to entity that no longer exists");
+        }
     }
 }
 


### PR DESCRIPTION
Admittedly this should probably be fixed in the bowels of the ECS where I'm not smart enough to wander, but I've hit this again and again to the point where it's holding back feature development. Every single time I've hit this crash, it's been when writing to an entity that I removed--enemy I destroyed, an entity that no longer exists because I reset the game, etc. Who cares if the ECS tries to write hit points to a monster that was killed and removed entirely from the game? I don't--certainly not enough to bring down the entire world. :)

I don't know if this should log at a higher level--debug, maybe?

I hesitate to call this a fix for #1743 because again, there's probably a proper fix. But can we please stop crashing? Aside from occasional log messages, this works well for me and I've had no crashes since.

Sorry if I seem cranky--it'd just be nice to not bring things to a screeching halt if we can at all avoid it. :) Thanks.