### PR TITLE
[Merged by Bors] - [assets] set LoadState properly and more testing!

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -45,3 +45,7 @@ js-sys = "0.3"
 
 [target.'cfg(target_os = "android")'.dependencies]
 ndk-glue = { version = "0.2" }
+
+[dev-dependencies]
+futures-lite = "1.4.0"
+tempfile = "3.2.0"

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -536,7 +536,7 @@ pub fn free_unused_assets_system(asset_server: Res<AssetServer>) {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::loader::LoadedAsset;
+    use crate::{loader::LoadedAsset, update_asset_storage_system};
     use bevy_ecs::prelude::*;
     use bevy_reflect::TypeUuid;
     use bevy_utils::BoxedFuture;
@@ -755,25 +755,14 @@ mod test {
         world.insert_resource(asset_server);
 
         let mut tick = {
-            fn free_unused_assets(asset_server: Res<AssetServer>) {
-                free_unused_assets_system(asset_server);
-            }
-
-            fn update_asset_storage(
-                asset_server: Res<AssetServer>,
-                assets: ResMut<Assets<PngAsset>>,
-            ) {
-                asset_server.update_asset_storage(assets);
-            }
-
-            let mut free_unused_assets = free_unused_assets.system();
-            free_unused_assets.initialize(&mut world);
-            let mut update_asset_storage = update_asset_storage.system();
-            update_asset_storage.initialize(&mut world);
+            let mut free_unused_assets_system = free_unused_assets_system.system();
+            free_unused_assets_system.initialize(&mut world);
+            let mut update_asset_storage_system = update_asset_storage_system.system();
+            update_asset_storage_system.initialize(&mut world);
 
             move |world: &mut World| {
-                free_unused_assets.run((), world);
-                update_asset_storage.run((), world);
+                free_unused_assets_system.run((), world);
+                update_asset_storage_system.run((), world);
             }
         };
 

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -593,7 +593,7 @@ mod test {
     fn setup(asset_path: impl AsRef<Path>) -> AssetServer {
         use crate::FileAssetIo;
 
-        let asset_server = AssetServer {
+        AssetServer {
             server: Arc::new(AssetServerInternal {
                 loaders: Default::default(),
                 extension_to_loader_index: Default::default(),
@@ -604,16 +604,14 @@ mod test {
                 task_pool: Default::default(),
                 asset_io: Box::new(FileAssetIo::new(asset_path)),
             }),
-        };
-        asset_server.add_loader::<FakePngLoader>(FakePngLoader);
-        asset_server.add_loader::<FailingLoader>(FailingLoader);
-        asset_server.add_loader::<FakeMultipleDotLoader>(FakeMultipleDotLoader);
-        asset_server
+        }
     }
 
     #[test]
     fn extensions() {
         let asset_server = setup(".");
+        asset_server.add_loader(FakePngLoader);
+
         let t = asset_server.get_path_asset_loader("test.png");
         assert_eq!(t.unwrap().extensions()[0], "png");
     }
@@ -621,6 +619,8 @@ mod test {
     #[test]
     fn case_insensitive_extensions() {
         let asset_server = setup(".");
+        asset_server.add_loader(FakePngLoader);
+
         let t = asset_server.get_path_asset_loader("test.PNG");
         assert_eq!(t.unwrap().extensions()[0], "png");
     }
@@ -670,6 +670,8 @@ mod test {
     #[test]
     fn filename_with_dots() {
         let asset_server = setup(".");
+        asset_server.add_loader(FakePngLoader);
+
         let t = asset_server.get_path_asset_loader("test-v1.2.3.png");
         assert_eq!(t.unwrap().extensions()[0], "png");
     }
@@ -677,6 +679,8 @@ mod test {
     #[test]
     fn multiple_extensions() {
         let asset_server = setup(".");
+        asset_server.add_loader(FakeMultipleDotLoader);
+
         let t = asset_server.get_path_asset_loader("test.test.png");
         assert_eq!(t.unwrap().extensions()[0], "test.png");
     }
@@ -710,6 +714,7 @@ mod test {
     #[test]
     fn test_invalid_asset_path() {
         let asset_server = setup(".");
+        asset_server.add_loader(FakePngLoader);
 
         let path: AssetPath = "an/invalid/path.png".into();
         let handle = asset_server.get_handle_untyped(path.get_id());
@@ -725,6 +730,7 @@ mod test {
     fn test_failing_loader() {
         let dir = create_dir_and_file("fake.fail");
         let asset_server = setup(dir.path());
+        asset_server.add_loader(FailingLoader);
 
         let path: AssetPath = "fake.fail".into();
         let handle = asset_server.get_handle_untyped(path.get_id());
@@ -740,6 +746,8 @@ mod test {
     fn test_asset_lifecycle() {
         let dir = create_dir_and_file("fake.png");
         let asset_server = setup(dir.path());
+        asset_server.add_loader(FakePngLoader);
+
         let mut assets = asset_server.register_asset_type::<PngAsset>();
 
         let path: AssetPath = "fake.png".into();

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -757,7 +757,7 @@ mod test {
         let mut tick = {
             let mut free_unused_assets_system = free_unused_assets_system.system();
             free_unused_assets_system.initialize(&mut world);
-            let mut update_asset_storage_system = update_asset_storage_system.system();
+            let mut update_asset_storage_system = update_asset_storage_system::<PngAsset>.system();
             update_asset_storage_system.initialize(&mut world);
 
             move |world: &mut World| {

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -539,7 +539,6 @@ mod test {
     use crate::loader::LoadedAsset;
     use bevy_reflect::TypeUuid;
     use bevy_utils::BoxedFuture;
-    use tempfile::*;
 
     #[derive(Debug, TypeUuid)]
     #[uuid = "a5189b72-0572-4290-a2e0-96f73a491c44"]
@@ -682,8 +681,8 @@ mod test {
         assert_eq!(t.unwrap().extensions()[0], "test.png");
     }
 
-    fn create_dir_and_file(file: impl AsRef<Path>) -> TempDir {
-        let asset_dir = tempdir().unwrap();
+    fn create_dir_and_file(file: impl AsRef<Path>) -> tempfile::TempDir {
+        let asset_dir = tempfile::tempdir().unwrap();
         std::fs::write(asset_dir.path().join(file), &[]).unwrap();
         asset_dir
     }

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -777,7 +777,7 @@ mod test {
 
         // second call to tick will actually remove the asset.
         tick(&asset_server, &mut assets);
-        assert_eq!(LoadState::NotLoaded, asset_server.get_load_state(id));
+        assert_eq!(LoadState::Loaded, asset_server.get_load_state(id)); // TODO: should this now show `LoadState::NotLoaded`?
         assert!(assets.get(id).is_none());
     }
 }

--- a/crates/bevy_asset/src/info.rs
+++ b/crates/bevy_asset/src/info.rs
@@ -41,8 +41,15 @@ impl SourceInfo {
 /// The load state of an asset
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub enum LoadState {
+    /// The asset has not be loaded.
     NotLoaded,
+    /// The asset in the the process of loading.
     Loading,
+    /// The asset has loaded and is living inside an [`Assets`](crate::Assets) collection.
     Loaded,
+    /// The asset failed to load.
     Failed,
+    /// The asset was previously loaded, however all handles were dropped and
+    /// the asset was removed from the [`Assets`](crate::Assets) collection.
+    Unloaded,
 }


### PR DESCRIPTION
1) Sets `LoadState` properly on all failing cases in `AssetServer::load_async`
2) Adds more tests for sad and happy paths of asset loading

_Note_: this brings in the `tempfile` crate.