### PR TITLE
[Merged by Bors] - remove branch constraints in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main, staging, trying]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -6,7 +6,6 @@ on:
       - '**/Cargo.toml'
       - 'deny.toml'
   push:
-    branches: [main, staging, trying]
     paths:
       - '**/Cargo.toml'
       - 'deny.toml'


### PR DESCRIPTION
Remove branch constraints from CI

This will let CI run on:
- fork branches before a PR is opened
- this repo branches if we start using them (😉 relations 😉 )