### PR TITLE
run a system from a command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -302,6 +302,10 @@ name = "system_chaining"
 path = "examples/ecs/system_chaining.rs"
 
 [[example]]
+name = "system_command"
+path = "examples/ecs/system_command.rs"
+
+[[example]]
 name = "system_param"
 path = "examples/ecs/system_param.rs"
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -154,7 +154,7 @@ impl<'a> Commands<'a> {
         });
     }
 
-    /// Run a one off [`System`].
+    /// Run a one-off [`System`].
     pub fn run_system(&mut self, system: impl System<In = (), Out = ()>) {
         self.queue.push(RunSystem {
             system: Box::new(system),

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 use bevy_utils::tracing::debug;
 pub use command_queue::CommandQueue;
 use parking_lot::Mutex;
-use std::{cell::RefCell, marker::PhantomData};
+use std::marker::PhantomData;
 
 use super::System;
 
@@ -158,7 +158,7 @@ impl<'a> Commands<'a> {
     /// Run a one off [`System`].
     pub fn run_system(&mut self, system: impl System<In = (), Out = ()>) {
         self.queue.push(RunSystem {
-            system: Mutex::new(RefCell::new(Box::new(system))),
+            system: Mutex::new(Box::new(system)),
         });
     }
 
@@ -398,13 +398,12 @@ impl<T: Component> Command for RemoveResource<T> {
 }
 
 pub struct RunSystem {
-    pub system: Mutex<RefCell<Box<dyn System<In = (), Out = ()>>>>,
+    pub system: Mutex<Box<dyn System<In = (), Out = ()>>>,
 }
 
 impl Command for RunSystem {
     fn write(self: Box<Self>, world: &mut World) {
-        let lock = self.system.lock();
-        let mut system = lock.borrow_mut();
+        let mut system = self.system.lock();
         system.initialize(world);
         system.run((), world);
     }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -398,7 +398,7 @@ impl<T: Component> Command for RemoveResource<T> {
 }
 
 pub struct RunSystem {
-    system: Mutex<RefCell<Box<dyn System<In = (), Out = ()>>>>,
+    pub system: Mutex<RefCell<Box<dyn System<In = (), Out = ()>>>>,
 }
 
 impl Command for RunSystem {

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -10,7 +10,7 @@ use bevy_utils::tracing::debug;
 pub use command_queue::CommandQueue;
 use std::marker::PhantomData;
 
-use super::System;
+use super::{IntoSystem, System};
 
 /// A [`World`] mutation.
 pub trait Command: Send + Sync + 'static {
@@ -155,9 +155,9 @@ impl<'a> Commands<'a> {
     }
 
     /// Run a one-off [`System`].
-    pub fn run_system(&mut self, system: impl System<In = (), Out = ()>) {
+    pub fn run_system<Params>(&mut self, system: impl IntoSystem<(), (), Params>) {
         self.queue.push(RunSystem {
-            system: Box::new(system),
+            system: Box::new(system.system()),
         });
     }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -155,6 +155,23 @@ impl<'a> Commands<'a> {
     }
 
     /// Run a one-off [`System`].
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// # struct MyComponent;
+    ///
+    /// # fn my_system(_components: Query<&MyComponent>) {}
+    ///
+    /// # fn main_system(mut commands: Commands) {
+    /// // Can take a standard system function
+    /// commands.run_system(my_system);
+    /// // Can take a closure system
+    /// commands.run_system(|query: Query<&MyComponent>| {
+    ///     println!("count: {}", query.iter().len());
+    /// });
+    /// # }
+    /// # main_system.system();
+    /// ```
     pub fn run_system<Params>(&mut self, system: impl IntoSystem<(), (), Params>) {
         self.queue.push(RunSystem {
             system: Box::new(system.system()),

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -404,6 +404,7 @@ impl Command for RunSystem {
     fn write(mut self, world: &mut World) {
         self.system.initialize(world);
         self.system.run((), world);
+        self.system.apply_buffers(world);
     }
 }
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -167,6 +167,7 @@ Example | File | Description
 `startup_system` | [`ecs/startup_system.rs`](./ecs/startup_system.rs) | Demonstrates a startup system (one that runs once when the app starts up)
 `state` | [`ecs/state.rs`](./ecs/state.rs) | Illustrates how to use States to control transitioning from a Menu state to an InGame state
 `system_chaining` | [`ecs/system_chaining.rs`](./ecs/system_chaining.rs) | Chain two systems together, specifying a return type in a system (such as `Result`)
+`system_command` | [`ecs/system_command.rs`](./ecs/system_command.rs) | Run a system from a command
 `system_param` | [`ecs/system_param.rs`](./ecs/system_param.rs) | Illustrates creating custom system parameters with `SystemParam`
 `system_sets` | [`ecs/system_sets.rs`](./ecs/system_sets.rs) | Shows `SystemSet` use along with run criterion
 `timers` | [`ecs/timers.rs`](./ecs/timers.rs) | Illustrates ticking `Timer` resources inside systems and handling their state

--- a/examples/ecs/system_command.rs
+++ b/examples/ecs/system_command.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+
 /// This example triggers a system from a command
 fn main() {
     App::build()

--- a/examples/ecs/system_command.rs
+++ b/examples/ecs/system_command.rs
@@ -1,0 +1,32 @@
+use bevy::prelude::*;
+/// This example triggers a system from a command
+fn main() {
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(spawn.system())
+        .add_system(trigger_sync.system())
+        .run();
+}
+
+pub struct Player;
+
+/// Spawn some players to sync
+fn spawn(mut commands: Commands) {
+    commands.spawn().insert(Player);
+    commands.spawn().insert(Player);
+}
+
+fn trigger_sync(mut commands: Commands, mut last_sync: Local<f64>, time: Res<Time>) {
+    if time.seconds_since_startup() - *last_sync > 5.0 {
+        commands.run_system(sync_system.system());
+        *last_sync = time.seconds_since_startup();
+    }
+}
+
+/// As this system is run through a command, it will run at the end of the current stage.
+fn sync_system(players: Query<&Player>) {
+    for _player in players.iter() {
+        // do the sync
+    }
+    info!("synced: {:?} players", players.iter().len());
+}

--- a/examples/ecs/system_command.rs
+++ b/examples/ecs/system_command.rs
@@ -2,7 +2,7 @@ use bevy::{prelude::*, utils::Duration};
 
 /// This example triggers a system from a command
 fn main() {
-    App::build()
+    App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(spawn)
         .add_system(trigger_sync)

--- a/examples/ecs/system_command.rs
+++ b/examples/ecs/system_command.rs
@@ -4,8 +4,8 @@ use bevy::{prelude::*, utils::Duration};
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(spawn.system())
-        .add_system(trigger_sync.system())
+        .add_startup_system(spawn)
+        .add_system(trigger_sync)
         .run();
 }
 
@@ -19,11 +19,8 @@ fn spawn(mut commands: Commands) {
 
 fn trigger_sync(mut commands: Commands, mut last_sync: Local<f64>, time: Res<Time>) {
     if time.seconds_since_startup() - *last_sync > 5.0 {
-        commands.run_system(
-            sync_system
-                .system()
-                .config(|config| config.1 = Some(time.time_since_startup())),
-        );
+        commands
+            .run_system(sync_system.config(|config| config.1 = Some(time.time_since_startup())));
         *last_sync = time.seconds_since_startup();
     }
 }

--- a/examples/ecs/system_command.rs
+++ b/examples/ecs/system_command.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, utils::Duration};
 
 /// This example triggers a system from a command
 fn main() {
@@ -19,15 +19,23 @@ fn spawn(mut commands: Commands) {
 
 fn trigger_sync(mut commands: Commands, mut last_sync: Local<f64>, time: Res<Time>) {
     if time.seconds_since_startup() - *last_sync > 5.0 {
-        commands.run_system(sync_system.system());
+        commands.run_system(
+            sync_system
+                .system()
+                .config(|config| config.1 = Some(time.time_since_startup())),
+        );
         *last_sync = time.seconds_since_startup();
     }
 }
 
 /// As this system is run through a command, it will run at the end of the current stage.
-fn sync_system(players: Query<&Player>) {
+fn sync_system(players: Query<&Player>, since_startup: Local<Duration>) {
     for _player in players.iter() {
         // do the sync
     }
-    info!("synced: {:?} players", players.iter().len());
+    info!(
+        "synced: {} players ({:?})",
+        players.iter().len(),
+        *since_startup
+    );
 }


### PR DESCRIPTION
Fixes #2192 

Can run a system from a command.

This adds a command:
```rust
commands.run_system(sync_system.system());
```