### PR TITLE
use `get_entity_mut` in insert commands to avoid a panic

### DIFF
--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -338,7 +338,9 @@ where
     T: Bundle + 'static,
 {
     fn write(self: Box<Self>, world: &mut World) {
-        world.entity_mut(self.entity).insert_bundle(self.bundle);
+        if let Some(mut entity_mut) = world.get_entity_mut(self.entity) {
+            entity_mut.insert_bundle(self.bundle);
+        }
     }
 }
 
@@ -353,7 +355,9 @@ where
     T: Component,
 {
     fn write(self: Box<Self>, world: &mut World) {
-        world.entity_mut(self.entity).insert(self.component);
+        if let Some(mut entity_mut) = world.get_entity_mut(self.entity) {
+            entity_mut.insert(self.component);
+        }
     }
 }
 


### PR DESCRIPTION
At the moment, the `insert` and `insert_bundle` commands issued through a `Commands` struct in a system can cause a panic when applied if the entity the command is used for no longer exists. This fixes that problem via the use of `get_entity_mut`, and brings them inline with the other commands.