### PR TITLE
`Command` error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,6 +263,10 @@ name = "change_detection"
 path = "examples/ecs/change_detection.rs"
 
 [[example]]
+name = "command_error_handling"
+path = "examples/ecs/command_error_handling.rs"
+
+[[example]]
 name = "event"
 path = "examples/ecs/event.rs"
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -29,8 +29,9 @@ pub mod prelude {
             Schedule, Stage, StageLabel, State, SystemLabel, SystemSet, SystemStage,
         },
         system::{
-            Commands, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend,
-            NonSendMut, Query, QuerySet, RemovedComponents, Res, ResMut, System,
+            CommandErrorHandler, Commands, FallibleCommand, In, IntoChainSystem,
+            IntoExclusiveSystem, IntoSystem, Local, NonSend, NonSendMut, Query, QuerySet,
+            RemovedComponents, Res, ResMut, System,
         },
         world::{FromWorld, Mut, World},
     };

--- a/crates/bevy_ecs/src/system/commands/config.rs
+++ b/crates/bevy_ecs/src/system/commands/config.rs
@@ -1,0 +1,201 @@
+use crate::{
+    prelude::{FallibleCommand, World},
+    system::Command,
+};
+use bevy_utils::tracing::error;
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
+
+#[doc(hidden)]
+pub trait AddCommand {
+    fn add_command(&mut self, command: impl Command);
+}
+
+/// Provides configuration mechanisms in case a command errors.
+/// You can specify a custom handler via [`FallibleCommandConfig::on_failure`] or
+/// use one of the provided implementations.
+///
+/// ## Note
+/// The default error handler logs the error (via [`error!`]), but does not panic.
+pub struct FallibleCommandConfig<'a, C, T>
+where
+    C: FallibleCommand,
+    T: AddCommand,
+{
+    command: Option<C>,
+    inner: &'a mut T,
+}
+
+impl<'a, C, T> Deref for FallibleCommandConfig<'a, C, T>
+where
+    C: FallibleCommand,
+    T: AddCommand,
+{
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.inner
+    }
+}
+
+impl<'a, C, T> DerefMut for FallibleCommandConfig<'a, C, T>
+where
+    C: FallibleCommand,
+    T: AddCommand,
+{
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner
+    }
+}
+
+/// Builtin command error handlers.
+pub struct CommandErrorHandler;
+
+impl CommandErrorHandler {
+    /// If the command failed, log the error.
+    ///
+    /// ## Note
+    /// This is the default behavior if no error handler is specified.
+    pub fn log<E: Debug>(error: E, _ctx: CommandContext) {
+        error!("Commands failed with error: {:?}", error)
+    }
+
+    /// If the command failed, [`panic!`] with the error.
+    pub fn panic<E: Debug>(error: E, _ctx: CommandContext) {
+        panic!("Commands failed with error: {:?}", error)
+    }
+
+    /// If the command failed, ignore the error and silently succeed.
+    pub fn ignore<E>(_error: E, _ctx: CommandContext) {}
+}
+
+pub(crate) struct HandledErrorCommand<C, F>
+where
+    C: FallibleCommand,
+    F: FnOnce(C::Error, CommandContext) + Send + Sync + 'static,
+{
+    pub(crate) command: C,
+    pub(crate) error_handler: F,
+}
+
+impl<C, F> Command for HandledErrorCommand<C, F>
+where
+    C: FallibleCommand,
+    F: FnOnce(C::Error, CommandContext) + Send + Sync + 'static,
+{
+    fn write(self: Box<Self>, world: &mut World) {
+        let HandledErrorCommand {
+            command,
+            error_handler,
+        } = *self;
+
+        if let Err(error) = command.try_write(world) {
+            error_handler(error, CommandContext { world });
+        }
+    }
+}
+
+#[non_exhaustive]
+pub struct CommandContext<'a> {
+    pub world: &'a mut World,
+}
+
+/// Similar to [`FallibleCommandConfig`] however does not
+/// implement [`DerefMut`] nor return `&mut T` of the underlying
+/// Commands type.
+pub struct FinalFallibleCommandConfig<'a, C, T>
+where
+    C: FallibleCommand,
+    T: AddCommand,
+{
+    command: Option<C>,
+    inner: &'a mut T,
+}
+
+macro_rules! impl_fallible_commands {
+    ($name:ident, $returnty:ty, $returnfunc:ident) => {
+        impl<'a, C, T> $name<'a, C, T>
+        where
+            C: FallibleCommand,
+            C::Error: Debug,
+            T: AddCommand,
+        {
+            #[inline]
+            pub(crate) fn new(command: C, inner: &'a mut T) -> Self {
+                Self {
+                    command: Some(command),
+                    inner,
+                }
+            }
+
+            #[inline]
+            #[allow(dead_code)]
+            fn return_inner(&mut self) -> &mut T {
+                self.inner
+            }
+
+            #[inline]
+            #[allow(dead_code)]
+            fn return_unit(&self) {}
+        }
+
+        impl<'a, C, T> $name<'a, C, T>
+        where
+            C: FallibleCommand,
+            C::Error: Debug,
+            T: AddCommand,
+        {
+            /// If the command failed, run the provided `error_handler`.
+            ///
+            /// ## Note
+            /// This is normally used in conjunction with [`CommandErrorHandler`].
+            /// However, this can also be used with custom error handlers (e.g. closures).
+            ///
+            /// # Examples
+            /// ```
+            /// use bevy_ecs::prelude::*;
+            ///
+            /// fn system(mut commands: Commands) {
+            ///     // built-in error handler
+            ///     commands.spawn().insert(42).on_err(CommandErrorHandler::ignore);
+            ///
+            ///     // custom error handler
+            ///     commands.spawn().insert(42).on_err(|error, ctx| {});
+            /// }
+            /// ```
+            pub fn on_err(
+                &mut self,
+                error_handler: impl FnOnce(C::Error, CommandContext) + Send + Sync + 'static,
+            ) -> $returnty {
+                let command = self
+                    .command
+                    .take()
+                    .expect("Cannot call `on_err` multiple times for a command error handler.");
+                self.inner.add_command(HandledErrorCommand {
+                    command,
+                    error_handler,
+                });
+                self.$returnfunc()
+            }
+        }
+
+        impl<'a, C, T> Drop for $name<'a, C, T>
+        where
+            C: FallibleCommand,
+            T: AddCommand,
+        {
+            fn drop(&mut self) {
+                if self.command.is_some() {
+                    self.on_err(CommandErrorHandler::log);
+                }
+            }
+        }
+    };
+}
+
+impl_fallible_commands!(FinalFallibleCommandConfig, (), return_unit);
+impl_fallible_commands!(FallibleCommandConfig, &mut T, return_inner);

--- a/examples/README.md
+++ b/examples/README.md
@@ -157,6 +157,7 @@ Example | File | Description
 --- | --- | ---
 `ecs_guide` | [`ecs/ecs_guide.rs`](./ecs/ecs_guide.rs) | Full guide to Bevy's ECS
 `change_detection` | [`ecs/change_detection.rs`](./ecs/change_detection.rs) | Change detection on components
+`command_error_handling` | [`ecs/command_error_handling.rs`](./ecs/command_error_handling.rs) | Error handling fallible commands
 `event` | [`ecs/event.rs`](./ecs/event.rs) | Illustrates event creation, activation, and reception
 `fixed_timestep` | [`ecs/fixed_timestep.rs`](./ecs/fixed_timestep.rs) | Shows how to create systems that run every fixed timestep, rather than every tick
 `hierarchy` | [`ecs/hierarchy.rs`](./ecs/hierarchy.rs) | Creates a hierarchy of parents and children entities

--- a/examples/ecs/command_error_handling.rs
+++ b/examples/ecs/command_error_handling.rs
@@ -1,0 +1,77 @@
+use bevy::{core::FixedTimestep, prelude::*};
+
+fn main() {
+    App::build()
+        .insert_resource(FailedDespawnAttempts(0))
+        .add_startup_system(setup.system())
+        .add_system(
+            remove_components
+                .system()
+                .with_run_criteria(FixedTimestep::step(0.5)),
+        )
+        .add_system_set(
+            SystemSet::new()
+                .with_run_criteria(FixedTimestep::step(2.0))
+                .with_system(despawn_all_entities.system())
+                .with_system(log_failed_despawn_attempts.system()),
+        )
+        .run();
+}
+
+struct A(usize);
+
+#[derive(Bundle, Default)]
+struct B {
+    value: usize,
+}
+
+struct FailedDespawnAttempts(usize);
+
+fn setup(mut commands: Commands) {
+    for i in 0..3 {
+        // Note that `insert` and `insert_bundle` are fallible functions.
+        // If no error handler is specified, the default behavior is to log the error, and continue.
+        // However, these calls to `insert` and `insert_bundle` will not fail, since the entity is valid.
+        commands.spawn().insert(A(i)).insert_bundle(B::default());
+    }
+}
+
+fn log_failed_despawn_attempts(attempts: Res<FailedDespawnAttempts>) {
+    info!("There have been {} failed despawn attempts!", attempts.0);
+}
+
+fn despawn_all_entities(mut commands: Commands, query: Query<Entity>) {
+    for e in query.iter() {
+        // `on_err` also allows you to provide a custom error handler!
+        commands.entity(e).despawn().on_err(|error, ctx| {
+            // You'll notice that the `error` will also give you back the entity
+            // you tried to despawn.
+            let entity = error.entity;
+
+            warn!("Sadly our entity '{:?}' didn't despawn :(", entity);
+
+            // error handlers have mutable access to `World`
+            if let Some(mut failed_despawns) = ctx.world.get_resource_mut::<FailedDespawnAttempts>()
+            {
+                failed_despawns.0 += 1;
+            }
+        });
+    }
+}
+
+fn remove_components(mut commands: Commands, query: Query<Entity>) {
+    for e in query.iter() {
+        // Some nice things:
+        // - You can still chain commands!
+        // - There are a slew of built-in error handlers
+        commands
+            .entity(e)
+            .remove::<A>()
+            // `CommandErrorHandler::ignore` will neither log nor panic the error
+            .on_err(CommandErrorHandler::ignore)
+            .remove_bundle::<B>()
+            // `CommandErrorHandler::log` is the default behavior, and will log the error.
+            // `CommandErrorHandler::panic` is another alternative which will panic on the error.
+            .on_err(CommandErrorHandler::log);
+    }
+}


### PR DESCRIPTION
Fixes: #2004

Some new traits were introducted:
- `FallibleCommand`
  - this is for command that can potentially fail, and allow people to provide error handlers if an error occurs 
- `CommandErrorHandling`
  - this is for function like types that can handle command errors.

If a command is _fallible_, then new return type is a `Config` type. 
The `Config` type allows a user to optionally provide an error handler via `on_err_do`.
However, I added some builtin handlers (via `CommandErrorHandler`) like `ignore()` `panic()` and `log()` for some typical use cases of what someone might want to do with an error.
**note**: the default behavior is `log()`. None of the commands will `panic!` but will instead log the error via `error!`.

EXAMPLES:
```rust
fn system(mut commands: Commands) {
    commands.entity(e)
        .insert(32)
        .on_err_do(|error| { /*..*/ });

    command
        .remove_resource::<f32>()
        .on_err(CommandErrorHandler::ignore);

    commands
        .entity(e)
        .despawn()
        .on_err(CommandErrorHandler::panic);

    commands
        .entity(e)
        .insert(32)
        .insert(3.14); // you can also ignore the error handling and just chain regular commands
}
```