### PR TITLE
Keep a reference to wgpu::Queue in WgpuRenderContext

### DIFF
--- a/crates/bevy_wgpu/src/renderer/wgpu_render_context.rs
+++ b/crates/bevy_wgpu/src/renderer/wgpu_render_context.rs
@@ -53,14 +53,20 @@ impl LazyCommandEncoder {
 #[derive(Debug)]
 pub struct WgpuRenderContext {
     pub device: Arc<wgpu::Device>,
+    pub queue: Arc<wgpu::Queue>,
     pub command_encoder: LazyCommandEncoder,
     pub render_resource_context: WgpuRenderResourceContext,
 }
 
 impl WgpuRenderContext {
-    pub fn new(device: Arc<wgpu::Device>, resources: WgpuRenderResourceContext) -> Self {
+    pub fn new(
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        resources: WgpuRenderResourceContext,
+    ) -> Self {
         WgpuRenderContext {
             device,
+            queue,
             render_resource_context: resources,
             command_encoder: LazyCommandEncoder::default(),
         }

--- a/crates/bevy_wgpu/src/renderer/wgpu_render_graph_executor.rs
+++ b/crates/bevy_wgpu/src/renderer/wgpu_render_graph_executor.rs
@@ -18,7 +18,7 @@ impl WgpuRenderGraphExecutor {
         &self,
         world: &World,
         device: Arc<wgpu::Device>,
-        queue: &mut wgpu::Queue,
+        queue: Arc<wgpu::Queue>,
         stages: &mut [StageBorrow],
     ) {
         let render_resource_context = {
@@ -47,7 +47,8 @@ impl WgpuRenderGraphExecutor {
                 let render_resource_context = render_resource_context.clone();
                 let node_outputs = node_outputs.clone();
                 // s.spawn(move |_| {
-                let mut render_context = WgpuRenderContext::new(device, render_resource_context);
+                let mut render_context =
+                    WgpuRenderContext::new(device, queue.clone(), render_resource_context);
                 for job in jobs_chunk.iter_mut() {
                     for node_state in job.node_states.iter_mut() {
                         // bind inputs from connected node outputs

--- a/crates/bevy_wgpu/src/wgpu_renderer.rs
+++ b/crates/bevy_wgpu/src/wgpu_renderer.rs
@@ -15,7 +15,7 @@ use std::{ops::Deref, sync::Arc};
 pub struct WgpuRenderer {
     pub instance: wgpu::Instance,
     pub device: Arc<wgpu::Device>,
-    pub queue: wgpu::Queue,
+    pub queue: Arc<wgpu::Queue>,
     pub window_resized_event_reader: ManualEventReader<WindowResized>,
     pub window_created_event_reader: ManualEventReader<WindowCreated>,
     pub initialized: bool,
@@ -68,6 +68,7 @@ impl WgpuRenderer {
             .await
             .unwrap();
         let device = Arc::new(device);
+        let queue = Arc::new(queue);
         WgpuRenderer {
             instance,
             device,
@@ -118,7 +119,12 @@ impl WgpuRenderer {
             let graph_executor = WgpuRenderGraphExecutor {
                 max_thread_count: 2,
             };
-            graph_executor.execute(world, self.device.clone(), &mut self.queue, &mut borrowed);
+            graph_executor.execute(
+                world,
+                self.device.clone(),
+                self.queue.clone(),
+                &mut borrowed,
+            );
         })
     }
 


### PR DESCRIPTION
Builds on #2240. Many wgpu libraries likely need direct access to the wgpu::Queue, so this patch exposes it to render nodes. Any render commands which operate on inputs from other bevy render nodes would still need to record onto the designated command_encoder, but Queue::{write_texture, write_buffer} would be directly accessible and unrelated command buffers can also be written directly to the queue. 