### PR TITLE
allow using any stage as a startup stage

### DIFF
--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -7,6 +7,8 @@ mod schedule_runner;
 #[cfg(feature = "bevy_ci_testing")]
 mod ci_testing;
 
+use std::{any::Any, hash::Hash};
+
 pub use app::*;
 pub use app_builder::*;
 pub use bevy_derive::DynamicPlugin;
@@ -23,7 +25,7 @@ pub mod prelude {
     };
 }
 
-use bevy_ecs::schedule::StageLabel;
+use bevy_ecs::schedule::{DynEq, DynHash, StageLabel};
 
 /// The names of the default App stages
 #[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
@@ -42,8 +44,9 @@ pub enum CoreStage {
     /// Name of app stage that runs after all other app stages
     Last,
 }
+
 /// The names of the default App startup stages
-#[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum StartupStage {
     /// Name of app stage that runs once before the startup stage
     PreStartup,
@@ -51,4 +54,42 @@ pub enum StartupStage {
     Startup,
     /// Name of app stage that runs once after the startup stage
     PostStartup,
+}
+
+impl StageLabel for StartupStage {
+    fn dyn_clone(&self) -> Box<dyn StageLabel> {
+        Box::new(Clone::clone(self))
+    }
+}
+
+impl DynEq for StartupStage {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn dyn_eq(&self, other: &dyn DynEq) -> bool {
+        match self {
+            StartupStage::PreStartup => CoreStage::PreUpdate.dyn_eq(other),
+            StartupStage::Startup => CoreStage::Update.dyn_eq(other),
+            StartupStage::PostStartup => CoreStage::PostUpdate.dyn_eq(other),
+        }
+    }
+}
+impl DynHash for StartupStage {
+    fn as_dyn_eq(&self) -> &dyn bevy_ecs::schedule::DynEq {
+        match self {
+            StartupStage::PreStartup => &CoreStage::PreUpdate,
+            StartupStage::Startup => &CoreStage::Update,
+            StartupStage::PostStartup => &CoreStage::PostUpdate,
+        }
+    }
+
+    fn dyn_hash(&self, mut state: &mut dyn std::hash::Hasher) {
+        match self {
+            StartupStage::PreStartup => CoreStage::PreUpdate.hash(&mut state),
+            StartupStage::Startup => CoreStage::Update.hash(&mut state),
+            StartupStage::PostStartup => CoreStage::PostUpdate.hash(&mut state),
+        }
+        CoreStage::Update.type_id().hash(&mut state);
+    }
 }

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -85,6 +85,11 @@ impl Schedule {
 
     pub fn add_stage<S: Stage>(&mut self, label: impl StageLabel, stage: S) -> &mut Self {
         let label: Box<dyn StageLabel> = Box::new(label);
+        self.add_stage_boxed(label, stage)
+    }
+
+    #[doc(hidden)]
+    pub fn add_stage_boxed<S: Stage>(&mut self, label: Box<dyn StageLabel>, stage: S) -> &mut Self {
         self.stage_order.push(label.clone());
         let prev = self.stages.insert(label.clone(), Box::new(stage));
         if prev.is_some() {
@@ -101,11 +106,21 @@ impl Schedule {
     ) -> &mut Self {
         let label: Box<dyn StageLabel> = Box::new(label);
         let target = &target as &dyn StageLabel;
+        self.add_stage_after_boxed(target, label, stage)
+    }
+
+    #[doc(hidden)]
+    pub fn add_stage_after_boxed<S: Stage>(
+        &mut self,
+        target: &dyn StageLabel,
+        label: Box<dyn StageLabel>,
+        stage: S,
+    ) -> &mut Self {
         let target_index = self
             .stage_order
             .iter()
             .enumerate()
-            .find(|(_i, stage_label)| &***stage_label == target)
+            .find(|(_i, stage_label)| target == &***stage_label)
             .map(|(i, _)| i)
             .unwrap_or_else(|| panic!("Target stage does not exist: {:?}.", target));
 
@@ -125,11 +140,21 @@ impl Schedule {
     ) -> &mut Self {
         let label: Box<dyn StageLabel> = Box::new(label);
         let target = &target as &dyn StageLabel;
+        self.add_stage_before_boxed(target, label, stage)
+    }
+
+    #[doc(hidden)]
+    pub fn add_stage_before_boxed<S: Stage>(
+        &mut self,
+        target: &dyn StageLabel,
+        label: Box<dyn StageLabel>,
+        stage: S,
+    ) -> &mut Self {
         let target_index = self
             .stage_order
             .iter()
             .enumerate()
-            .find(|(_i, stage_label)| &***stage_label == target)
+            .find(|(_i, stage_label)| target == &***stage_label)
             .map(|(i, _)| i)
             .unwrap_or_else(|| panic!("Target stage does not exist: {:?}.", target));
 


### PR DESCRIPTION
Fixes #2246, #2229 

- methods `add_stage`, `add_stage_before` and `add_stage_after` also adds an empty stage with the same label to the startup schedule
- all `CoreStage` are added to the startup schedule
- `StartupStage`s now work as aliases of matching `CoreStage`s (`Startup` -> `Update`, `PreStartup` -> `PreUpdate`, `PostStartup` -> `PostUpdate`)

This means:
- for the default use case, no more surprising differences between startup and normal stages
- extra stages are added to the startup schedule, but it shouldn't impact much as they'll remain empty and only run once
- for the advanced user, nothing changed and they can still add custom stages with the explicit `StartupStage`