### PR TITLE
Feature/issue 1031 window icon

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -259,7 +259,7 @@ fn window_icon_changed(
     mut map: Local<HashMap<WindowId, Handle<Texture>>>,
     textures: Res<Assets<Texture>>,
     mut windows: ResMut<Windows>,
-    asset_server: ResMut<AssetServer>,
+    asset_server: Res<AssetServer>,
 ) {
     for window in windows.iter_mut() {
         /* Insert new icon changed */

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -270,8 +270,9 @@ fn window_icon_changed(
                         map.insert(window.id(), asset_server.load(path.clone()));
                     }
                 }
+            } else {
+                map.insert(window.id(), asset_server.load(path.clone()));
             }
-            map.insert(window.id(), asset_server.load(path.clone()));
         }
 
         /* Poll load state of handle and set the icon */

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -279,15 +279,17 @@ fn window_icon_changed(
         if let Some(handle) = map.get(&window.id()) {
             match asset_server.get_load_state(handle) {
                 LoadState::Loaded => {
-                    let texture = textures.get(handle).unwrap();
-                    let window_icon = WindowIcon::from(WindowIconBytes {
-                        bytes: texture.data.clone(),
-                        width: texture.size.width,
-                        height: texture.size.height,
-                    });
-                    window.set_icon(window_icon);
+                    if let Some(texture) = textures.get(handle) {
+                        /* TODO: Why can I not just unwrap here? */
+                        let window_icon = WindowIcon::from(WindowIconBytes {
+                            bytes: texture.data.clone(),
+                            width: texture.size.width,
+                            height: texture.size.height,
+                        });
+                        window.set_icon(window_icon);
 
-                    map.remove_entry(&window.id());
+                        map.remove_entry(&window.id());
+                    }
                 }
                 LoadState::Failed => {
                     map.remove_entry(&window.id());

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -264,14 +264,14 @@ fn window_icon_changed(
     for window in windows.iter_mut() {
         /* Insert new icon changed */
         if let Some(WindowIcon::Path(path)) = window.icon() {
-            if let Some(handle) = map.get(&window.id()) {
-                if let Some(handle_path) = asset_server.get_handle_path(handle) {
-                    if handle_path.path() != path {
-                        map.insert(window.id(), asset_server.load(path.clone()));
+            match map.entry(window.id()) {
+                Entry::Occupied(mut o) => {
+                    let handle_path = asset_server.get_handle_path(o.get()).unwrap();
+                    if handle_path != path {
+                        o.insert(asset_server.load(path.clone());
                     }
                 }
-            } else {
-                map.insert(window.id(), asset_server.load(path.clone()));
+                Entry::Vacant(v) => v.insert(asset_server.load(path.clone()),
             }
         }
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -288,28 +288,28 @@ fn window_icon_changed(
             let handle = o.get();
             match asset_server.get_load_state(handle) {
                 LoadState::Loaded => {
-                    if let Some(texture) = textures.get(handle) {
-                        /* TODO: Not actually sure if we need to check the error here
-                        Whatever Texture gives us might be fine */
-                        let window_icon_bytes = WindowIconBytes::new(
-                            texture.data.clone(),
-                            texture.size.width,
-                            texture.size.height,
-                        );
+                    let texture = textures.get(handle).unwrap(); /* Safe to unwrap here, because loadstate==loaded is checked */
 
-                        match window_icon_bytes {
-                            Ok(window_icon_bytes) => {
-                                let window_icon = WindowIcon::from(window_icon_bytes);
-                                window.set_icon(window_icon);
-                            }
-                            Err(e) => error!(
-                                "For handle {:?} the following error was produced: {}",
-                                handle, e
-                            ),
+                    /* TODO: Not actually sure if we need to check the error here
+                    Whatever Texture gives us might be fine */
+                    let window_icon_bytes = WindowIconBytes::new(
+                        texture.data.clone(),
+                        texture.size.width,
+                        texture.size.height,
+                    );
+
+                    match window_icon_bytes {
+                        Ok(window_icon_bytes) => {
+                            let window_icon = WindowIcon::from(window_icon_bytes);
+                            window.set_icon(window_icon);
                         }
-
-                        o.remove();
+                        Err(e) => error!(
+                            "For handle {:?} the following error was produced: {}",
+                            handle, e
+                        ),
                     }
+
+                    o.remove();
                 }
                 LoadState::Failed => {
                     o.remove();

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -209,10 +209,7 @@ impl Plugin for RenderPlugin {
                 .label(RenderSystem::VisibleEntities)
                 .after(TransformSystem::TransformPropagate),
         )
-        .add_system_to_stage(
-            CoreStage::PostUpdate,
-            window_icon_changed.system(), /* TODO: label? */
-        )
+        .add_system_to_stage(CoreStage::PostUpdate, window_icon_changed.system())
         .add_system_to_stage(
             RenderStage::RenderResource,
             shader::shader_update_system.system(),
@@ -274,8 +271,8 @@ fn window_icon_changed(
                     if let Some(handle_path) = asset_server.get_handle_path(o.get()) {
                         if handle_path.path() != path {
                             o.insert(asset_server.load(path.clone()));
-                        }
-                    }
+                        } /* else we are still attempting to load the initial asset */
+                    } /* else the path from the asset is not available yet */
                 }
                 Entry::Vacant(v) => {
                     v.insert(asset_server.load(path.clone()));
@@ -290,9 +287,7 @@ fn window_icon_changed(
                 LoadState::Loaded => {
                     let texture = textures.get(handle).unwrap(); /* Safe to unwrap here, because loadstate==loaded is checked */
 
-                    /* TODO: Not actually sure if we need to check the error here
-                    Whatever Texture gives us might be fine */
-                    let window_icon_bytes = WindowIconBytes::new(
+                    let window_icon_bytes = WindowIconBytes::from_rgba(
                         texture.data.clone(),
                         texture.size.width,
                         texture.size.height,

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -18,6 +18,7 @@ bevy_app = { path = "../bevy_app", version = "0.5.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.5.0" }
 bevy_math = { path = "../bevy_math", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.5.0" }
 
 # other
 

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -18,7 +18,6 @@ bevy_app = { path = "../bevy_app", version = "0.5.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.5.0" }
 bevy_math = { path = "../bevy_math", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.5.0" }
 
 # other
 

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -21,6 +21,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 bevy_asset = { path = "../bevy_asset", version = "0.5.0" }
 
 # other
+thiserror = "1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = "0.3"

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -19,7 +19,6 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.5.0" }
 bevy_math = { path = "../bevy_math", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 bevy_asset = { path = "../bevy_asset", version = "0.5.0" }
-# bevy_render = { path = "../bevy_render", version = "0.5.0" }
 
 # other
 

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -18,6 +18,8 @@ bevy_app = { path = "../bevy_app", version = "0.5.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.5.0" }
 bevy_math = { path = "../bevy_math", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.5.0" }
+# bevy_render = { path = "../bevy_render", version = "0.5.0" }
 
 # other
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -91,6 +91,10 @@ impl WindowResizeConstraints {
     }
 }
 
+/// Generic icon buffer for a window.
+/// Replicates the struct from winit.
+///
+/// Only allows rgba images.
 #[derive(Debug, Clone)]
 pub struct WindowIconBytes {
     bytes: Vec<u8>,
@@ -98,6 +102,7 @@ pub struct WindowIconBytes {
     height: u32,
 }
 
+/// Errors that occur while constructing window icons.
 #[derive(Error, Debug)]
 pub enum WindowIconBytesError {
     #[error("32bpp RGBA image buffer expected, but {bytes_length} is not divisible by 4")]
@@ -109,6 +114,10 @@ pub enum WindowIconBytesError {
     },
 }
 
+/// The icon on a window.
+/// The path buffer in the `Path` variant will be passed to the asset server and will be automatically passed to the window backend.
+///
+/// Make sure that the source image is reasonably sized. Refer to winit's `set_window_icon` function.
 #[derive(Debug, Clone)]
 pub enum WindowIcon {
     Path(PathBuf),
@@ -131,7 +140,14 @@ impl From<WindowIconBytes> for WindowIcon {
 }
 
 impl WindowIconBytes {
-    pub fn new(bytes: Vec<u8>, width: u32, height: u32) -> Result<Self, WindowIconBytesError> {
+    /// Create a window icon from a rgba image.
+    ///
+    /// Returns a `WindowIconBytesError` if `bytes` do not add up to a rgba image or the size does not match the specified width and height.
+    pub fn from_rgba(
+        bytes: Vec<u8>,
+        width: u32,
+        height: u32,
+    ) -> Result<Self, WindowIconBytesError> {
         let pixel_count = (width * height) as usize;
         let pixel_bytes_length = pixel_count * 4;
         let bytes_length = bytes.len();
@@ -152,14 +168,17 @@ impl WindowIconBytes {
         }
     }
 
+    /// Bytes of the rgba icon.
     pub fn bytes(&self) -> &[u8] {
         &self.bytes
     }
 
+    /// Width of the icon.
     pub fn width(&self) -> u32 {
         self.width
     }
 
+    /// Height of the icon.
     pub fn height(&self) -> u32 {
         self.height
     }
@@ -200,9 +219,9 @@ pub struct Window {
     cursor_position: Option<Vec2>,
     focused: bool,
     mode: WindowMode,
+    icon: Option<WindowIcon>,
     #[cfg(target_arch = "wasm32")]
     pub canvas: Option<String>,
-    icon: Option<WindowIcon>,
     command_queue: Vec<WindowCommand>,
 }
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -554,8 +554,7 @@ impl Window {
     pub fn set_icon(&mut self, icon: WindowIcon) {
         self.icon = Some(icon.clone());
 
-        self.command_queue
-            .push(WindowCommand::SetIcon { icon });
+        self.command_queue.push(WindowCommand::SetIcon { icon });
     }
 
     pub fn clear_icon(&mut self) {

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,4 +1,6 @@
+use bevy_asset::Handle;
 use bevy_math::{IVec2, Vec2};
+use bevy_render::texture::Texture;
 use bevy_utils::{tracing::warn, Uuid};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -524,17 +526,14 @@ impl Window {
 
     pub fn set_icon(&mut self, icon: Option<WindowIcon>) {
         self.icon = icon.clone();
-        self.command_queue.push(WindowCommand::SetWindowIcon {
-            icon: icon.clone(),
-        });
+        self.command_queue
+            .push(WindowCommand::SetWindowIcon { icon: icon.clone() });
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct WindowIcon {
-    pub rgba: Vec<u8>,
-    pub width: u32,
-    pub height: u32,
+    pub handle: Handle<Texture>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -18,10 +18,7 @@ impl WindowId {
     }
 }
 
-use std::{
-    fmt,
-    path::{Path, PathBuf},
-};
+use std::{fmt, path::PathBuf};
 
 impl fmt::Display for WindowId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -108,10 +105,10 @@ pub enum WindowIcon {
 
 impl<T> From<T> for WindowIcon
 where
-    T: AsRef<Path>,
+    T: Into<PathBuf>,
 {
     fn from(path: T) -> Self {
-        WindowIcon::Path(path.as_ref().to_path_buf())
+        WindowIcon::Path(path.into())
     }
 }
 
@@ -559,10 +556,11 @@ impl Window {
         self.icon.as_ref()
     }
 
-    pub fn set_icon(&mut self, icon: WindowIcon) {
-        self.icon = Some(icon.clone());
+    pub fn set_icon(&mut self, icon: impl Into<WindowIcon> + Clone) {
+        self.icon = Some(icon.clone().into());
 
-        self.command_queue.push(WindowCommand::SetIcon { icon });
+        self.command_queue
+            .push(WindowCommand::SetIcon { icon: icon.into() });
     }
 
     pub fn clear_icon(&mut self) {

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,6 +1,5 @@
 use bevy_math::{IVec2, Vec2};
 use bevy_utils::{tracing::warn, Uuid};
-use bevy_asset::Handle;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct WindowId(Uuid);
@@ -225,7 +224,7 @@ impl Window {
             mode: window_descriptor.mode,
             #[cfg(target_arch = "wasm32")]
             canvas: window_descriptor.canvas.clone(),
-            icon: window_descriptor.icon,
+            icon: window_descriptor.icon.clone(),
             command_queue: Vec::new(),
         }
     }
@@ -520,20 +519,22 @@ impl Window {
 
     #[inline]
     pub fn icon(&self) -> Option<WindowIcon> {
-        self.icon
+        self.icon.clone()
     }
 
     pub fn set_icon(&mut self, icon: Option<WindowIcon>) {
-        self.icon = icon;
+        self.icon = icon.clone();
         self.command_queue.push(WindowCommand::SetWindowIcon {
-            icon,
+            icon: icon.clone(),
         });
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct WindowIcon {
-    /* icon: Handle<Texture>, */
+    pub rgba: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -520,14 +520,14 @@ impl Window {
     }
 
     #[inline]
-    pub fn icon(&self) -> Option<WindowIcon> {
-        self.icon.clone()
+    pub fn icon(&self) -> Option<&WindowIcon> {
+        self.icon.as_ref()
     }
 
     pub fn set_icon(&mut self, icon: Option<WindowIcon>) {
         self.icon = icon.clone();
         self.command_queue
-            .push(WindowCommand::SetWindowIcon { icon: icon.clone() });
+            .push(WindowCommand::SetWindowIcon { icon });
     }
 }
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -206,7 +206,7 @@ pub enum WindowCommand {
         resize_constraints: WindowResizeConstraints,
     },
     SetIcon {
-        icon: WindowIcon,
+        window_icon_bytes: WindowIconBytes,
     },
     ClearIcon,
 }
@@ -554,8 +554,10 @@ impl Window {
     pub fn set_icon(&mut self, icon: impl Into<WindowIcon> + Clone) {
         self.icon = Some(icon.clone().into());
 
-        self.command_queue
-            .push(WindowCommand::SetIcon { icon: icon.into() });
+        if let WindowIcon::Bytes(window_icon_bytes) = icon.into() {
+            self.command_queue
+                .push(WindowCommand::SetIcon { window_icon_bytes });
+        }
     }
 
     pub fn clear_icon(&mut self) {

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -542,11 +542,6 @@ impl Window {
     }
 
     #[inline]
-    pub fn command_queue(&self) -> &[WindowCommand] {
-        &self.command_queue
-    }
-
-    #[inline]
     pub fn is_focused(&self) -> bool {
         self.focused
     }

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,5 +1,6 @@
 use bevy_math::{IVec2, Vec2};
 use bevy_utils::{tracing::warn, Uuid};
+use bevy_asset::Handle;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct WindowId(Uuid);
@@ -127,6 +128,7 @@ pub struct Window {
     mode: WindowMode,
     #[cfg(target_arch = "wasm32")]
     pub canvas: Option<String>,
+    icon: Option<WindowIcon>,
     command_queue: Vec<WindowCommand>,
 }
 
@@ -176,6 +178,9 @@ pub enum WindowCommand {
     SetResizeConstraints {
         resize_constraints: WindowResizeConstraints,
     },
+    SetWindowIcon {
+        icon: Option<WindowIcon>,
+    },
 }
 
 /// Defines the way a window is displayed
@@ -220,6 +225,7 @@ impl Window {
             mode: window_descriptor.mode,
             #[cfg(target_arch = "wasm32")]
             canvas: window_descriptor.canvas.clone(),
+            icon: window_descriptor.icon,
             command_queue: Vec::new(),
         }
     }
@@ -511,6 +517,23 @@ impl Window {
     pub fn is_focused(&self) -> bool {
         self.focused
     }
+
+    #[inline]
+    pub fn icon(&self) -> Option<WindowIcon> {
+        self.icon
+    }
+
+    pub fn set_icon(&mut self, icon: Option<WindowIcon>) {
+        self.icon = icon;
+        self.command_queue.push(WindowCommand::SetWindowIcon {
+            icon,
+        });
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct WindowIcon {
+    /* icon: Handle<Texture>, */
 }
 
 #[derive(Debug, Clone)]
@@ -528,6 +551,7 @@ pub struct WindowDescriptor {
     pub mode: WindowMode,
     #[cfg(target_arch = "wasm32")]
     pub canvas: Option<String>,
+    pub icon: Option<WindowIcon>,
 }
 
 impl Default for WindowDescriptor {
@@ -546,6 +570,7 @@ impl Default for WindowDescriptor {
             mode: WindowMode::Windowed,
             #[cfg(target_arch = "wasm32")]
             canvas: None,
+            icon: None,
         }
     }
 }

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -25,8 +25,6 @@ bevy_log = { path = "../bevy_log", version = "0.5.0" }
 bevy_math = { path = "../bevy_math", version = "0.5.0" }
 bevy_window = { path = "../bevy_window", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.5.0" }
-bevy_render = { path = "../bevy_render", version = "0.5.0" }
 
 # other
 winit = { version = "0.25.0", default-features = false }

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -26,7 +26,7 @@ bevy_math = { path = "../bevy_math", version = "0.5.0" }
 bevy_window = { path = "../bevy_window", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 bevy_asset = { path = "../bevy_asset", version = "0.5.0" }
-# bevy_render = { path = "../bevy_render", version = "0.5.0" }
+bevy_render = { path = "../bevy_render", version = "0.5.0" }
 
 # other
 winit = { version = "0.25.0", default-features = false }

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -25,6 +25,8 @@ bevy_log = { path = "../bevy_log", version = "0.5.0" }
 bevy_math = { path = "../bevy_math", version = "0.5.0" }
 bevy_window = { path = "../bevy_window", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.5.0" }
+# bevy_render = { path = "../bevy_render", version = "0.5.0" }
 
 # other
 winit = { version = "0.25.0", default-features = false }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -14,15 +14,12 @@ use bevy_app::{App, AppBuilder, AppExit, CoreStage, Events, ManualEventReader, P
 use bevy_ecs::{system::IntoExclusiveSystem, world::World};
 use bevy_math::{ivec2, Vec2};
 use bevy_utils::tracing::{error, trace, warn};
-use bevy_window::{
-    CreateWindow, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, ReceivedCharacter,
-    WindowBackendScaleFactorChanged, WindowCloseRequested, WindowCreated, WindowFocused,
-    WindowMoved, WindowResized, WindowScaleFactorChanged, Windows,
-};
+use bevy_window::{CreateWindow, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, ReceivedCharacter, WindowBackendScaleFactorChanged, WindowCloseRequested, WindowCommand, WindowCreated, WindowFocused, WindowMoved, WindowResized, WindowScaleFactorChanged, Windows};
 use winit::{
     dpi::PhysicalPosition,
     event::{self, DeviceEvent, Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
+    window::Icon,
 };
 
 use winit::dpi::LogicalSize;
@@ -157,6 +154,13 @@ fn change_window(world: &mut World) {
                     if constraints.max_width.is_finite() && constraints.max_height.is_finite() {
                         window.set_max_inner_size(Some(max_inner_size));
                     }
+                }
+                bevy_window::WindowCommand::SetWindowIcon { icon } => {
+                    let window = winit_windows.get_window(id).unwrap();
+                    //let winit_icon = Icon::default;
+                    let winit_icon = None;
+
+                    window.set_window_icon(winit_icon);
                 }
             }
         }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -163,17 +163,15 @@ fn change_window(world: &mut World) {
                 bevy_window::WindowCommand::SetIcon { window_icon_bytes } => {
                     let window = winit_windows.get_window(id).unwrap();
 
-                    match Icon::from_rgba(
-                        window_icon_bytes.bytes,
-                        window_icon_bytes.width,
-                        window_icon_bytes.height,
-                    ) {
-                        Ok(winit_icon) => window.set_window_icon(Some(winit_icon)),
-                        Err(e) => {
-                            error!("Unable to create window icon: {}", e);
-                            return;
-                        }
-                    }
+                    /* Failures should already be covered in WindowIconBytes constructor */
+                    window.set_window_icon(
+                        Icon::from_rgba(
+                            window_icon_bytes.bytes().to_vec(),
+                            window_icon_bytes.width(),
+                            window_icon_bytes.height(),
+                        )
+                        .ok(),
+                    );
                 }
                 bevy_window::WindowCommand::ClearIcon => {
                     let window = winit_windows.get_window(id).unwrap();

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -163,7 +163,7 @@ fn change_window(world: &mut World) {
                 bevy_window::WindowCommand::SetIcon { window_icon_bytes } => {
                     let window = winit_windows.get_window(id).unwrap();
 
-                    /* Failures should already be covered in WindowIconBytes constructor */
+                    /* Winit errors are replicated in the WindowIconBytes constructor, so it is safe to ignore here */
                     window.set_window_icon(
                         Icon::from_rgba(
                             window_icon_bytes.bytes().to_vec(),

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -17,7 +17,7 @@ use bevy_utils::tracing::{error, trace, warn};
 use bevy_window::{
     CreateWindow, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, ReceivedCharacter,
     WindowBackendScaleFactorChanged, WindowCloseRequested, WindowCreated, WindowFocused,
-    WindowMoved, WindowResized, WindowScaleFactorChanged, Windows,
+    WindowIcon, WindowMoved, WindowResized, WindowScaleFactorChanged, Windows,
 };
 
 use winit::{
@@ -160,18 +160,24 @@ fn change_window(world: &mut World) {
                         window.set_max_inner_size(Some(max_inner_size));
                     }
                 }
-                bevy_window::WindowCommand::SetIconPath { path } => {
-                    let _ = path;
-                }
                 bevy_window::WindowCommand::SetIcon { icon } => {
-                    let window = winit_windows.get_window(id).unwrap();
+                    match icon {
+                        WindowIcon::Bytes(window_icon_bytes) => {
+                            let window = winit_windows.get_window(id).unwrap();
 
-                    match Icon::from_rgba(icon.bytes, icon.width, icon.height) {
-                        Ok(icon) => window.set_window_icon(Some(icon)),
-                        Err(e) => {
-                            error!("Unable to create window icon: {}", e);
-                            return;
+                            match Icon::from_rgba(
+                                window_icon_bytes.bytes,
+                                window_icon_bytes.width,
+                                window_icon_bytes.height,
+                            ) {
+                                Ok(winit_icon) => window.set_window_icon(Some(winit_icon)),
+                                Err(e) => {
+                                    error!("Unable to create window icon: {}", e);
+                                    return;
+                                }
+                            }
                         }
+                        WindowIcon::Path(_) => { /* Do Nothing */ }
                     }
                 }
                 bevy_window::WindowCommand::ClearIcon => {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -14,13 +14,8 @@ use bevy_app::{App, AppBuilder, AppExit, CoreStage, Events, ManualEventReader, P
 use bevy_ecs::{system::IntoExclusiveSystem, world::World};
 use bevy_math::{ivec2, Vec2};
 use bevy_utils::tracing::{error, trace, warn};
-use bevy_window::{CreateWindow, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, ReceivedCharacter, WindowBackendScaleFactorChanged, WindowCloseRequested, WindowCommand, WindowCreated, WindowFocused, WindowMoved, WindowResized, WindowScaleFactorChanged, Windows};
-use winit::{
-    dpi::PhysicalPosition,
-    event::{self, DeviceEvent, Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
-    window::Icon,
-};
+use bevy_window::{CreateWindow, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, ReceivedCharacter, WindowBackendScaleFactorChanged, WindowCloseRequested, WindowCreated, WindowFocused, WindowMoved, WindowResized, WindowScaleFactorChanged, Windows};
+use winit::{dpi::PhysicalPosition, event::{self, DeviceEvent, Event, WindowEvent}, event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget}, window::Icon};
 
 use winit::dpi::LogicalSize;
 #[cfg(any(
@@ -157,8 +152,16 @@ fn change_window(world: &mut World) {
                 }
                 bevy_window::WindowCommand::SetWindowIcon { icon } => {
                     let window = winit_windows.get_window(id).unwrap();
-                    //let winit_icon = Icon::default;
-                    let winit_icon = None;
+                    
+                    let winit_icon = match icon {
+                        Some(icon) => {
+                            match Icon::from_rgba(icon.rgba, icon.width, icon.height) {
+                                Ok(res) => Some(res),
+                                _ => /* TODO */ None,
+                            }
+                        },
+                        _ => None,
+                    };
 
                     window.set_window_icon(winit_icon);
                 }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -17,7 +17,7 @@ use bevy_utils::tracing::{error, trace, warn};
 use bevy_window::{
     CreateWindow, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, ReceivedCharacter,
     WindowBackendScaleFactorChanged, WindowCloseRequested, WindowCreated, WindowFocused,
-    WindowIcon, WindowMoved, WindowResized, WindowScaleFactorChanged, Windows,
+    WindowMoved, WindowResized, WindowScaleFactorChanged, Windows,
 };
 
 use winit::{
@@ -160,24 +160,19 @@ fn change_window(world: &mut World) {
                         window.set_max_inner_size(Some(max_inner_size));
                     }
                 }
-                bevy_window::WindowCommand::SetIcon { icon } => {
-                    match icon {
-                        WindowIcon::Bytes(window_icon_bytes) => {
-                            let window = winit_windows.get_window(id).unwrap();
+                bevy_window::WindowCommand::SetIcon { window_icon_bytes } => {
+                    let window = winit_windows.get_window(id).unwrap();
 
-                            match Icon::from_rgba(
-                                window_icon_bytes.bytes,
-                                window_icon_bytes.width,
-                                window_icon_bytes.height,
-                            ) {
-                                Ok(winit_icon) => window.set_window_icon(Some(winit_icon)),
-                                Err(e) => {
-                                    error!("Unable to create window icon: {}", e);
-                                    return;
-                                }
-                            }
+                    match Icon::from_rgba(
+                        window_icon_bytes.bytes,
+                        window_icon_bytes.width,
+                        window_icon_bytes.height,
+                    ) {
+                        Ok(winit_icon) => window.set_window_icon(Some(winit_icon)),
+                        Err(e) => {
+                            error!("Unable to create window icon: {}", e);
+                            return;
                         }
-                        WindowIcon::Path(_) => { /* Do Nothing */ }
                     }
                 }
                 bevy_window::WindowCommand::ClearIcon => {

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -139,7 +139,7 @@ impl WinitWindows {
         let scale_factor = winit_window.scale_factor();
         self.windows.insert(winit_window.id(), winit_window);
 
-        let window = Window::new(
+        let mut window = Window::new(
             window_id,
             &window_descriptor,
             inner_size.width,
@@ -149,7 +149,9 @@ impl WinitWindows {
         );
 
         /* TODO: How would we even provide a Handle at this point? */
-        window.set_icon(window_descriptor.icon); /* This will queue up SetWindowIcon until the asset has loaded */
+        if let Some(icon_path) = &window_descriptor.icon_path {
+            window.set_icon_path(icon_path); /* This will queue up SetWindowIcon until the asset has loaded */
+        }
 
         window
     }

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -1,6 +1,6 @@
 use bevy_math::IVec2;
 use bevy_utils::HashMap;
-use bevy_window::{Window, WindowDescriptor, WindowIcon, WindowId, WindowMode};
+use bevy_window::{Window, WindowDescriptor, WindowId, WindowMode};
 use winit::dpi::LogicalSize;
 
 #[derive(Debug, Default)]
@@ -149,7 +149,7 @@ impl WinitWindows {
         );
 
         if let Some(icon_path) = &window_descriptor.icon_path {
-            window.set_icon(WindowIcon::from(icon_path)); /* This will queue up SetWindowIcon until the asset has loaded */
+            window.set_icon(icon_path); /* This will queue up SetWindowIcon until the asset has loaded */
         }
 
         window

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -149,7 +149,7 @@ impl WinitWindows {
         );
 
         if let Some(icon_path) = &window_descriptor.icon_path {
-            window.set_icon(icon_path); /* This will queue up SetWindowIcon until the asset has loaded */
+            window.set_icon(icon_path); /* This will queue up loading the asset and subsequently set the window icon */
         }
 
         window

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -1,6 +1,6 @@
 use bevy_math::IVec2;
 use bevy_utils::HashMap;
-use bevy_window::{Window, WindowDescriptor, WindowId, WindowMode};
+use bevy_window::{Window, WindowDescriptor, WindowIcon, WindowId, WindowMode};
 use winit::dpi::LogicalSize;
 
 #[derive(Debug, Default)]
@@ -148,9 +148,8 @@ impl WinitWindows {
             position,
         );
 
-        /* TODO: How would we even provide a Handle at this point? */
         if let Some(icon_path) = &window_descriptor.icon_path {
-            window.set_icon_path(icon_path); /* This will queue up SetWindowIcon until the asset has loaded */
+            window.set_icon(WindowIcon::from(icon_path)); /* This will queue up SetWindowIcon until the asset has loaded */
         }
 
         window

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -138,14 +138,20 @@ impl WinitWindows {
         let inner_size = winit_window.inner_size();
         let scale_factor = winit_window.scale_factor();
         self.windows.insert(winit_window.id(), winit_window);
-        Window::new(
+
+        let window = Window::new(
             window_id,
             &window_descriptor,
             inner_size.width,
             inner_size.height,
             scale_factor,
             position,
-        )
+        );
+
+        /* TODO: How would we even provide a Handle at this point? */
+        window.set_icon(window_descriptor.icon); /* This will queue up SetWindowIcon until the asset has loaded */
+
+        window
     }
 
     pub fn get_window(&self, id: WindowId) -> Option<&winit::window::Window> {

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use bevy::{prelude::*, window::WindowIcon};
 
 /// This example illustrates how to customize the default window settings
@@ -8,6 +10,7 @@ fn main() {
             width: 500.,
             height: 300.,
             vsync: true,
+            icon_path: Some(PathBuf::from("android-res/mipmap-mdpi/ic_launcher.png")),
             ..Default::default()
         })
         .insert_resource(IconResource::default())

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -54,9 +54,12 @@ fn toggle_icon(input: Res<Input<KeyCode>>, mut windows: ResMut<Windows>, texture
     let window = windows.get_primary_mut().unwrap();
     let icon = textures.get(icon_resource.handle.clone());
     if input.just_pressed(KeyCode::I) {
-        match window.icon() {
-            None => window.set_icon(None /* TODO */),
-            _ => window.set_icon(None),
+        match icon {
+            None => (),
+            Some(texture) =>         match window.icon() {
+                None => window.set_icon(Some( bevy::window::WindowIcon { rgba: texture.data.clone(), width: texture.size.width, height: texture.size.height }) ),
+                _ => window.set_icon(None),
+            },
         }
     }
 }

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -10,7 +10,7 @@ fn main() {
             vsync: true,
             ..Default::default()
         })
-        .insert_resource(IconResource::default())
+        .insert_resource(IconResource)
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
         .add_system(change_title.system())
@@ -26,7 +26,7 @@ struct IconResource {
 
 fn setup(asset_server: Res<AssetServer>, mut icon_resource: ResMut<IconResource>) {
     let icon = asset_server.load("android-res/mipmap-mdpi/ic_launcher.png");
-    (*icon_resource).handle = icon;
+    icon_resource.handle = icon;
 }
 
 /// This system will then change the title during execution

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -24,11 +24,8 @@ struct IconResource {
     handle: Handle<Texture>,
 }
 
-fn setup(
-    asset_server: Res<AssetServer>,
-    mut icon_resource: ResMut<IconResource>,
-) {
-    let icon: /* TODO */ Handle<Texture> = asset_server.load("android-res/mipmap-mdpi/ic_launcher.png");
+fn setup(asset_server: Res<AssetServer>, mut icon_resource: ResMut<IconResource>) {
+    let icon = asset_server.load("android-res/mipmap-mdpi/ic_launcher.png");
     (*icon_resource).handle = icon;
 }
 
@@ -50,16 +47,16 @@ fn toggle_cursor(input: Res<Input<KeyCode>>, mut windows: ResMut<Windows>) {
     }
 }
 
-fn toggle_icon(input: Res<Input<KeyCode>>, mut windows: ResMut<Windows>, textures: Res<Assets<Texture>>, icon_resource: Res<IconResource>) {
+fn toggle_icon(
+    input: Res<Input<KeyCode>>,
+    mut windows: ResMut<Windows>,
+    icon_resource: Res<IconResource>,
+) {
     let window = windows.get_primary_mut().unwrap();
-    let icon = textures.get(icon_resource.handle.clone());
     if input.just_pressed(KeyCode::I) {
-        match icon {
-            None => (),
-            Some(texture) =>         match window.icon() {
-                None => window.set_icon(Some( bevy::window::WindowIcon { rgba: texture.data.clone(), width: texture.size.width, height: texture.size.height }) ),
-                _ => window.set_icon(None),
-            },
+        match window.icon() {
+            None => window.set_icon(Some(icon_resource.handle.clone())),
+            _ => window.set_icon(None),
         }
     }
 }

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
 
-use bevy::{prelude::*, window::WindowIcon};
+use bevy::{
+    prelude::*,
+    window::{WindowIcon, WindowIconBytes},
+};
 
 /// This example illustrates how to customize the default window settings
 fn main() {
@@ -61,11 +64,11 @@ fn toggle_icon(
         match window.icon() {
             None => {
                 if let Some(texture) = textures.get(&icon_resource.handle) {
-                    let window_icon = WindowIcon {
+                    let window_icon = WindowIcon::from(WindowIconBytes {
                         bytes: texture.data.clone(),
                         width: texture.size.width,
                         height: texture.size.height,
-                    };
+                    });
 
                     window.set_icon(window_icon);
                 }

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, window::WindowIcon};
 
 /// This example illustrates how to customize the default window settings
 fn main() {
@@ -10,7 +10,7 @@ fn main() {
             vsync: true,
             ..Default::default()
         })
-        .insert_resource(IconResource)
+        .insert_resource(IconResource::default())
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
         .add_system(change_title.system())
@@ -51,12 +51,23 @@ fn toggle_icon(
     input: Res<Input<KeyCode>>,
     mut windows: ResMut<Windows>,
     icon_resource: Res<IconResource>,
+    textures: Res<Assets<Texture>>,
 ) {
     let window = windows.get_primary_mut().unwrap();
     if input.just_pressed(KeyCode::I) {
         match window.icon() {
-            None => window.set_icon(Some(icon_resource.handle.clone())),
-            _ => window.set_icon(None),
+            None => {
+                if let Some(texture) = textures.get(&icon_resource.handle) {
+                    let window_icon = WindowIcon {
+                        bytes: texture.data.clone(),
+                        width: texture.size.width,
+                        height: texture.size.height,
+                    };
+
+                    window.set_icon(window_icon);
+                }
+            }
+            _ => window.clear_icon(),
         }
     }
 }

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -36,11 +36,13 @@ fn toggle_cursor(input: Res<Input<KeyCode>>, mut windows: ResMut<Windows>) {
     }
 }
 
+/// This system toggles the windows' icon (on/off) when I is pressed
 fn toggle_icon(input: Res<Input<KeyCode>>, mut windows: ResMut<Windows>) {
     let window = windows.get_primary_mut().unwrap();
     if input.just_pressed(KeyCode::I) {
         match window.icon() {
             None => {
+                /* Alternatively you can construct a "buffer-based" WindowIcon and bypass the asset server */
                 window.set_icon("android-res/mipmap-mdpi/ic_launcher.png");
             }
             _ => window.clear_icon(),

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -10,10 +10,26 @@ fn main() {
             vsync: true,
             ..Default::default()
         })
+        .insert_resource(IconResource::default())
         .add_plugins(DefaultPlugins)
+        .add_startup_system(setup.system())
         .add_system(change_title.system())
         .add_system(toggle_cursor.system())
+        .add_system(toggle_icon.system())
         .run();
+}
+
+#[derive(Debug, Clone, Default)]
+struct IconResource {
+    handle: Handle<Texture>,
+}
+
+fn setup(
+    asset_server: Res<AssetServer>,
+    mut icon_resource: ResMut<IconResource>,
+) {
+    let icon: /* TODO */ Handle<Texture> = asset_server.load("android-res/mipmap-mdpi/ic_launcher.png");
+    (*icon_resource).handle = icon;
 }
 
 /// This system will then change the title during execution
@@ -31,5 +47,16 @@ fn toggle_cursor(input: Res<Input<KeyCode>>, mut windows: ResMut<Windows>) {
     if input.just_pressed(KeyCode::Space) {
         window.set_cursor_lock_mode(!window.cursor_locked());
         window.set_cursor_visibility(!window.cursor_visible());
+    }
+}
+
+fn toggle_icon(input: Res<Input<KeyCode>>, mut windows: ResMut<Windows>, textures: Res<Assets<Texture>>, icon_resource: Res<IconResource>) {
+    let window = windows.get_primary_mut().unwrap();
+    let icon = textures.get(icon_resource.handle.clone());
+    if input.just_pressed(KeyCode::I) {
+        match window.icon() {
+            None => window.set_icon(None /* TODO */),
+            _ => window.set_icon(None),
+        }
     }
 }

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -1,9 +1,4 @@
-use std::path::PathBuf;
-
-use bevy::{
-    prelude::*,
-    window::{WindowIcon, WindowIconBytes},
-};
+use bevy::prelude::*;
 
 /// This example illustrates how to customize the default window settings
 fn main() {
@@ -13,26 +8,14 @@ fn main() {
             width: 500.,
             height: 300.,
             vsync: true,
-            icon_path: Some(PathBuf::from("android-res/mipmap-mdpi/ic_launcher.png")),
+            icon_path: Some("android-res/mipmap-mdpi/ic_launcher.png".into()),
             ..Default::default()
         })
-        .insert_resource(IconResource::default())
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup.system())
         .add_system(change_title.system())
         .add_system(toggle_cursor.system())
         .add_system(toggle_icon.system())
         .run();
-}
-
-#[derive(Debug, Clone, Default)]
-struct IconResource {
-    handle: Handle<Texture>,
-}
-
-fn setup(asset_server: Res<AssetServer>, mut icon_resource: ResMut<IconResource>) {
-    let icon = asset_server.load("android-res/mipmap-mdpi/ic_launcher.png");
-    icon_resource.handle = icon;
 }
 
 /// This system will then change the title during execution
@@ -53,25 +36,12 @@ fn toggle_cursor(input: Res<Input<KeyCode>>, mut windows: ResMut<Windows>) {
     }
 }
 
-fn toggle_icon(
-    input: Res<Input<KeyCode>>,
-    mut windows: ResMut<Windows>,
-    icon_resource: Res<IconResource>,
-    textures: Res<Assets<Texture>>,
-) {
+fn toggle_icon(input: Res<Input<KeyCode>>, mut windows: ResMut<Windows>) {
     let window = windows.get_primary_mut().unwrap();
     if input.just_pressed(KeyCode::I) {
         match window.icon() {
             None => {
-                if let Some(texture) = textures.get(&icon_resource.handle) {
-                    let window_icon = WindowIcon::from(WindowIconBytes {
-                        bytes: texture.data.clone(),
-                        width: texture.size.width,
-                        height: texture.size.height,
-                    });
-
-                    window.set_icon(window_icon);
-                }
+                window.set_icon("android-res/mipmap-mdpi/ic_launcher.png");
             }
             _ => window.clear_icon(),
         }


### PR DESCRIPTION
Adds the ability to set the window icon at runtime.
resolves #1031
based on feedback from this PR: #1163

https://user-images.githubusercontent.com/8339817/120373742-0034ef80-c319-11eb-98e0-178b7fa98de7.mp4

Notes: since there was some confusion, winit does support changing the window icon at runtime.

Outstanding work:
- [x] Feature Gating for non X11/Wayland/Windows? It is already feature gated on winit size, so I think it is fine to keep it like this on bevy side.
- [ ] Document how to work with window icons; especially Wayland