### PR TITLE
[Merged by Bors] - [ecs] implement is_empty for queries

### DIFF
--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -84,7 +84,6 @@ where
                             None => return true,
                         };
                         let table = &self.tables[*table_id];
-                        self.fetch.set_table(&self.query_state.fetch_state, table);
                         self.filter.set_table(&self.query_state.filter_state, table);
                         self.current_len = table.len();
                         self.current_index = 0;
@@ -106,11 +105,6 @@ where
                             None => return true,
                         };
                         let archetype = &self.archetypes[*archetype_id];
-                        self.fetch.set_archetype(
-                            &self.query_state.fetch_state,
-                            archetype,
-                            self.tables,
-                        );
                         self.filter.set_archetype(
                             &self.query_state.filter_state,
                             archetype,

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -72,7 +72,6 @@ where
 
     /// Consumes `self` and returns true if there were any elements remaining in this iterator.
     #[inline(always)]
-    #[allow(clippy::wrong_self_convention)]
     pub(crate) fn any_remaining(mut self) -> bool {
         // NOTE: this mimics the behavior of `QueryIter::next()`, expect that it
         // never gets a `Self::Item`.

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -69,6 +69,67 @@ where
             current_index: 0,
         }
     }
+
+    #[inline(always)]
+    #[allow(clippy::wrong_self_convention)]
+    pub(crate) fn is_empty(mut self) -> bool {
+        // NOTE: this mimics the behavior of `QueryIter::next()`
+        unsafe {
+            if self.is_dense {
+                loop {
+                    if self.current_index == self.current_len {
+                        let table_id = match self.table_id_iter.next() {
+                            Some(table_id) => table_id,
+                            None => return true,
+                        };
+                        let table = &self.tables[*table_id];
+                        self.fetch.set_table(&self.query_state.fetch_state, table);
+                        self.filter.set_table(&self.query_state.filter_state, table);
+                        self.current_len = table.len();
+                        self.current_index = 0;
+                        continue;
+                    }
+
+                    if !self.filter.table_filter_fetch(self.current_index) {
+                        self.current_index += 1;
+                        continue;
+                    }
+
+                    return false;
+                }
+            } else {
+                loop {
+                    if self.current_index == self.current_len {
+                        let archetype_id = match self.archetype_id_iter.next() {
+                            Some(archetype_id) => archetype_id,
+                            None => return true,
+                        };
+                        let archetype = &self.archetypes[*archetype_id];
+                        self.fetch.set_archetype(
+                            &self.query_state.fetch_state,
+                            archetype,
+                            self.tables,
+                        );
+                        self.filter.set_archetype(
+                            &self.query_state.filter_state,
+                            archetype,
+                            self.tables,
+                        );
+                        self.current_len = archetype.len();
+                        self.current_index = 0;
+                        continue;
+                    }
+
+                    if !self.filter.archetype_filter_fetch(self.current_index) {
+                        self.current_index += 1;
+                        continue;
+                    }
+
+                    return false;
+                }
+            }
+        }
+    }
 }
 
 impl<'w, 's, Q: WorldQuery, F: WorldQuery> Iterator for QueryIter<'w, 's, Q, F>

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -70,9 +70,10 @@ where
         }
     }
 
+    /// Consumes `self` and returns true is there were any elements left to yield.
     #[inline(always)]
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn is_empty(mut self) -> bool {
+    pub(crate) fn any_remaining(mut self) -> bool {
         // NOTE: this mimics the behavior of `QueryIter::next()`, expect that it
         // never gets a `Self::Item`.
         unsafe {

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -73,7 +73,8 @@ where
     #[inline(always)]
     #[allow(clippy::wrong_self_convention)]
     pub(crate) fn is_empty(mut self) -> bool {
-        // NOTE: this mimics the behavior of `QueryIter::next()`
+        // NOTE: this mimics the behavior of `QueryIter::next()`, expect that it
+        // never gets a `Self::Item`.
         unsafe {
             if self.is_dense {
                 loop {

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -73,7 +73,7 @@ where
     /// Consumes `self` and returns true if there were any elements remaining in this iterator.
     #[inline(always)]
     pub(crate) fn any_remaining(mut self) -> bool {
-        // NOTE: this mimics the behavior of `QueryIter::next()`, expect that it
+        // NOTE: this mimics the behavior of `QueryIter::next()`, except that it
         // never gets a `Self::Item`.
         unsafe {
             if self.is_dense {

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -70,9 +70,9 @@ where
         }
     }
 
-    /// Consumes `self` and returns true if there were any elements remaining in this iterator.
+    /// Consumes `self` and returns true if there were no elements remaining in this iterator.
     #[inline(always)]
-    pub(crate) fn any_remaining(mut self) -> bool {
+    pub(crate) fn none_remaining(mut self) -> bool {
         // NOTE: this mimics the behavior of `QueryIter::next()`, except that it
         // never gets a `Self::Item`.
         unsafe {

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -70,7 +70,7 @@ where
         }
     }
 
-    /// Consumes `self` and returns true is there were any elements left to yield.
+    /// Consumes `self` and returns true if there were any elements remaining in this iterator.
     #[inline(always)]
     #[allow(clippy::wrong_self_convention)]
     pub(crate) fn any_remaining(mut self) -> bool {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -70,8 +70,8 @@ where
 
     #[inline]
     pub fn is_empty(&self, world: &World, last_change_tick: u32, change_tick: u32) -> bool {
-        // SAFE: the iterator is instantly consumed via `is_empty` and the implementation of
-        // `QueryIter::is_empty` never creates any references (mutable or immutable) to the `Item`.
+        // SAFE: the iterator is instantly consumed via `any_remaining` and the implementation of
+        // `QueryIter::any_remaining` never creates any references to the `<Q::Fetch as Fetch<'w>>::Item`.
         unsafe {
             self.iter_unchecked_manual(world, last_change_tick, change_tick)
                 .any_remaining()

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -68,6 +68,12 @@ where
         state
     }
 
+    #[inline]
+    pub fn is_empty(&self, world: &World, last_change_tick: u32, change_tick: u32) -> bool {
+        let iter = unsafe { self.iter_unchecked_manual(world, last_change_tick, change_tick) };
+        iter.is_empty()
+    }
+
     pub fn validate_world_and_update_archetypes(&mut self, world: &World) {
         if world.id() != self.world_id {
             panic!("Attempted to use {} with a mismatched World. QueryStates can only be used with the World they were created from.",

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -74,7 +74,7 @@ where
         // `QueryIter::is_empty` never creates any references (mutable or immutable) to the `Item`.
         unsafe {
             self.iter_unchecked_manual(world, last_change_tick, change_tick)
-                .is_empty()
+                .any_remaining()
         }
     }
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -70,8 +70,12 @@ where
 
     #[inline]
     pub fn is_empty(&self, world: &World, last_change_tick: u32, change_tick: u32) -> bool {
-        let iter = unsafe { self.iter_unchecked_manual(world, last_change_tick, change_tick) };
-        iter.is_empty()
+        // SAFE: the iterator is instantly consumed via `is_empty` and the implementation of
+        // `QueryIter::is_empty` never creates any references (mutable or immutable) to the `Item`.
+        unsafe {
+            self.iter_unchecked_manual(world, last_change_tick, change_tick)
+                .is_empty()
+        }
     }
 
     pub fn validate_world_and_update_archetypes(&mut self, world: &World) {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -70,11 +70,11 @@ where
 
     #[inline]
     pub fn is_empty(&self, world: &World, last_change_tick: u32, change_tick: u32) -> bool {
-        // SAFE: the iterator is instantly consumed via `any_remaining` and the implementation of
-        // `QueryIter::any_remaining` never creates any references to the `<Q::Fetch as Fetch<'w>>::Item`.
+        // SAFE: the iterator is instantly consumed via `none_remaining` and the implementation of
+        // `QueryIter::none_remaining` never creates any references to the `<Q::Fetch as Fetch<'w>>::Item`.
         unsafe {
             self.iter_unchecked_manual(world, last_change_tick, change_tick)
-                .any_remaining()
+                .none_remaining()
         }
     }
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -440,11 +440,14 @@ mod tests {
 
     #[test]
     fn query_is_empty() {
-        fn sys(query: Query<&A>) {
-            assert!(query.is_empty());
+        fn sys(empty: Query<&A>, not_empty: Query<&B>) {
+            assert!(empty.is_empty());
+            assert!(!not_empty.is_empty());
         }
 
         let mut world = World::default();
+        world.spawn().insert(B);
+
         let mut sys = sys.system();
         sys.initialize(&mut world);
         sys.run((), &mut world);

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -439,6 +439,18 @@ mod tests {
     }
 
     #[test]
+    fn query_is_empty() {
+        fn sys(query: Query<&A>) {
+            assert!(query.is_empty());
+        }
+
+        let mut world = World::default();
+        let mut sys = sys.system();
+        sys.initialize(&mut world);
+        sys.run((), &mut world);
+    }
+
+    #[test]
     #[allow(clippy::too_many_arguments)]
     fn can_have_16_parameters() {
         fn sys_x(

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -440,17 +440,26 @@ mod tests {
 
     #[test]
     fn query_is_empty() {
-        fn sys(empty: Query<&A>, not_empty: Query<&B>) {
-            assert!(empty.is_empty());
+        fn without_filter(not_empty: Query<&A>, empty: Query<&B>) {
             assert!(!not_empty.is_empty());
+            assert!(empty.is_empty());
+        }
+
+        fn with_filter(not_empty: Query<&A, With<C>>, empty: Query<&A, With<D>>) {
+            assert!(!not_empty.is_empty());
+            assert!(empty.is_empty());
         }
 
         let mut world = World::default();
-        world.spawn().insert(B);
+        world.spawn().insert(A).insert(C);
 
-        let mut sys = sys.system();
-        sys.initialize(&mut world);
-        sys.run((), &mut world);
+        let mut without_filter = without_filter.system();
+        without_filter.initialize(&mut world);
+        without_filter.run((), &mut world);
+
+        let mut with_filter = with_filter.system();
+        with_filter.initialize(&mut world);
+        with_filter.run((), &mut world);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -547,6 +547,8 @@ where
     /// Returns true if this query contains no elements.
     #[inline]
     pub fn is_empty(&self) -> bool {
+        // TODO: This code can be replaced with `self.iter().next().is_none()` if/when
+        // we sort out how to convert "write" queries to "read" queries.
         self.state
             .is_empty(self.world, self.last_change_tick, self.change_tick)
     }

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -543,6 +543,17 @@ where
             >())),
         }
     }
+
+    /// Returns true if this query contains no elements.
+    pub fn is_empty(&self) -> bool {
+        // SAFE: system runs without conflicts with other systems.
+        // same-system queries have runtime borrow checks when they conflict
+        let iter = unsafe {
+            self.state
+                .iter_unchecked_manual(self.world, self.last_change_tick, self.change_tick)
+        };
+        iter.peekable().peek().is_none()
+    }
 }
 
 /// An error that occurs when retrieving a specific [`Entity`]'s component from a [`Query`]

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -547,13 +547,8 @@ where
     /// Returns true if this query contains no elements.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        // SAFE: system runs without conflicts with other systems.
-        // same-system queries have runtime borrow checks when they conflict
-        let mut iter = unsafe {
-            self.state
-                .iter_unchecked_manual(self.world, self.last_change_tick, self.change_tick)
-        };
-        iter.next().is_none()
+        self.state
+            .is_empty(self.world, self.last_change_tick, self.change_tick)
     }
 }
 

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -545,6 +545,7 @@ where
     }
 
     /// Returns true if this query contains no elements.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         // SAFE: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -548,11 +548,11 @@ where
     pub fn is_empty(&self) -> bool {
         // SAFE: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict
-        let iter = unsafe {
+        let mut iter = unsafe {
             self.state
                 .iter_unchecked_manual(self.world, self.last_change_tick, self.change_tick)
         };
-        iter.peekable().peek().is_none()
+        iter.next().is_none()
     }
 }
 


### PR DESCRIPTION
## Problem
- The `Query` struct does not provide an easy way to check if it is empty. 
- Specifically, users have to use `.iter().peekable()` or `.iter().next().is_none()` which is not very ergonomic. 
- Fixes: #2270 

## Solution
- Implement an `is_empty` function for queries to more easily check if the query is empty.