### PR TITLE
[Merged by Bors] - Despawn with children doesn't need to remove entities from parents children when parents are also removed

### DIFF
--- a/crates/bevy_transform/src/hierarchy/hierarchy.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy.rs
@@ -27,7 +27,7 @@ pub fn despawn_with_children_recursive(world: &mut World, entity: Entity) {
 fn despawn_with_children_recursive_inner(world: &mut World, entity: Entity) {
     if let Some(mut children) = world.get_mut::<Children>(entity) {
         for e in std::mem::take(&mut children.0) {
-            despawn_with_children_recursive(world, e);
+            despawn_with_children_recursive_inner(world, e);
         }
     }
 


### PR DESCRIPTION
Fixes #2274 

When calling `despawn_recursive`, the recursive loop doesn't need to remove the entity from the children list of its parent when the parent will also be deleted

Upside:
* Removes two entity lookup per entity being recursively despawned

Downside:
* The change detection on the `Children` component of a deleted entity in the despawned hierarchy will not be triggered