### PR TITLE
[Merged by Bors] - update super-linter to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Markdown Lint
-        uses: github/super-linter@v4
+        uses: docker://ghcr.io/github/super-linter:slim-v4
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_MARKDOWN: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Markdown Lint
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_MARKDOWN: true


### PR DESCRIPTION
replaces #2285 

* bump to major release v4 instead of specifying patch
* use slim image (https://github.com/github/super-linter#slim-image) - doesn't have rust linters but we don't use them anyway
