### PR TITLE
[Merged by Bors] - remove commented code and TODO as it's not actually possible

### DIFF
--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -10,17 +10,6 @@ use crate::{
 use bevy_ecs_macros::all_tuples;
 use std::{cell::UnsafeCell, marker::PhantomData, ptr};
 
-// TODO: uncomment this and use as shorthand (remove where F::Fetch: FilterFetch everywhere) when
-// this bug is fixed in Rust 1.51: https://github.com/rust-lang/rust/pull/81671
-// pub trait QueryFilter: WorldQuery
-// where
-//     Self::Fetch: FilterFetch,
-// {
-// }
-
-// impl<T: WorldQuery> QueryFilter for T where T::Fetch: FilterFetch {
-// }
-
 /// Extension trait for [`Fetch`] containing methods used by query filters.
 /// This trait exists to allow "short circuit" behaviors for relevant query filter fetches.
 pub trait FilterFetch: for<'a> Fetch<'a> {


### PR DESCRIPTION
Fixing it was tried in #2069 and deemed not possible (https://github.com/bevyengine/bevy/pull/2069#issuecomment-841775844)

Other possibility would be to change the TODO to note the dependency on chalk integration.