### PR TITLE
[assets] Conditional `AssetServer::load_folder` for specific files

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -391,18 +391,21 @@ impl AssetServer {
         }
 
         let mut handles = Vec::new();
-        for child_path in self.server.asset_io.read_directory(path.as_ref())? {
-            if predicate(child_path.as_path()) {
-                if self.server.asset_io.is_directory(&child_path) {
-                    handles.extend(self.load_folder(&child_path)?);
-                } else {
-                    if self.get_path_asset_loader(&child_path).is_err() {
-                        continue;
-                    }
-                    let handle = self
-                        .load_untyped(child_path.to_str().expect("Path should be a valid string."));
-                    handles.push(handle);
+        for child_path in self
+            .server
+            .asset_io
+            .read_directory(path.as_ref())?
+            .filter(|p| predicate(p.as_path()))
+        {
+            if self.server.asset_io.is_directory(&child_path) {
+                handles.extend(self.load_folder(&child_path)?);
+            } else {
+                if self.get_path_asset_loader(&child_path).is_err() {
+                    continue;
                 }
+                let handle =
+                    self.load_untyped(child_path.to_str().expect("Path should be a valid string."));
+                handles.push(handle);
             }
         }
 


### PR DESCRIPTION
Fixes: #2291 

## Objective
- Currently `AssetServer::load_folder` will load the entire folder, as there is no configuration possible.
- It is possible for a user to only want to load a subset of these assets based on a specific `Path` quailty (e.g. the extension type)

## Solution
- This exposes an `load_folder_if` function that takes a `f` predicate as a second parameter, that when evaluates to `true` will load the asset, otherwise, if it evaluates to `false` the asset will not be loaded. 