### PR TITLE
[Merged by Bors] - Use cfg attribute to filter supported extensions

### DIFF
--- a/crates/bevy_audio/src/audio_source.rs
+++ b/crates/bevy_audio/src/audio_source.rs
@@ -30,7 +30,16 @@ impl AssetLoader for Mp3Loader {
     }
 
     fn extensions(&self) -> &[&str] {
-        &["mp3", "flac", "wav", "ogg"]
+        &[
+            #[cfg(feature = "mp3")]
+            "mp3",
+            #[cfg(feature = "flac")]
+            "flac",
+            #[cfg(feature = "wav")]
+            "wav",
+            #[cfg(feature = "vorbis")]
+            "ogg",
+        ]
     }
 }
 

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -23,11 +23,13 @@ impl Plugin for AudioPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.init_non_send_resource::<AudioOutput<AudioSource>>()
             .add_asset::<AudioSource>()
-            .init_asset_loader::<Mp3Loader>()
             .init_resource::<Audio<AudioSource>>()
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 play_queued_audio_system::<AudioSource>.exclusive_system(),
             );
+
+        #[cfg(any(feature = "mp3", feature = "flac", feature = "wav", feature = "vorbis"))]
+        app.init_asset_loader::<Mp3Loader>();
     }
 }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -58,7 +58,13 @@ use renderer::{AssetRenderResourceBindings, RenderResourceBindings, RenderResour
 use shader::ShaderLoader;
 #[cfg(feature = "hdr")]
 use texture::HdrTextureLoader;
-#[cfg(feature = "png")]
+#[cfg(any(
+    feature = "png",
+    feature = "dds",
+    feature = "tga",
+    feature = "jpeg",
+    feature = "bmp"
+))]
 use texture::ImageTextureLoader;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
@@ -97,7 +103,13 @@ impl Default for RenderPlugin {
 
 impl Plugin for RenderPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        #[cfg(feature = "png")]
+        #[cfg(any(
+            feature = "png",
+            feature = "dds",
+            feature = "tga",
+            feature = "jpeg",
+            feature = "bmp"
+        ))]
         {
             app.init_asset_loader::<ImageTextureLoader>();
         }

--- a/crates/bevy_render/src/texture/image_texture_loader.rs
+++ b/crates/bevy_render/src/texture/image_texture_loader.rs
@@ -8,7 +8,20 @@ use thiserror::Error;
 #[derive(Clone, Default)]
 pub struct ImageTextureLoader;
 
-const FILE_EXTENSIONS: &[&str] = &["png", "dds", "tga", "jpg", "jpeg", "bmp"];
+const FILE_EXTENSIONS: &[&str] = &[
+    #[cfg(feature = "png")]
+    "png",
+    #[cfg(feature = "dds")]
+    "dds",
+    #[cfg(feature = "tga")]
+    "tga",
+    #[cfg(feature = "jpeg")]
+    "jpg",
+    #[cfg(feature = "jpeg")]
+    "jpeg",
+    #[cfg(feature = "bmp")]
+    "bmp",
+];
 
 impl AssetLoader for ImageTextureLoader {
     fn load<'a>(


### PR DESCRIPTION
When implementing `AssetLoader ` you need to specify which File extensions are supported by that loader.
Currently, Bevy always says it supports extensions that actually require activating a Feature beforehand.

This PR adds cf attributes, so Bevy only tries to load those Extensions whose Features were activated.

This prevents Bevy from Panicking and reports such a warning:
```
Jun 02 23:05:57.139  WARN bevy_asset::asset_server: no `AssetLoader` found for the following extension: ogg
```

This also fixes the Bug, that the `png Feature had to be activated even if you wanted to load a different image format.

Fixes #640