### PR TITLE
[Merged by Bors] - Add minimum sizes to textures to prevent crash

### DIFF
--- a/crates/bevy_render/src/render_graph/nodes/window_texture_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/window_texture_node.rs
@@ -67,8 +67,8 @@ impl Node for WindowTextureNode {
                 render_resource_context.remove_texture(old_texture);
             }
 
-            self.descriptor.size.width = window.physical_width();
-            self.descriptor.size.height = window.physical_height();
+            self.descriptor.size.width = window.physical_width().max(1);
+            self.descriptor.size.height = window.physical_height().max(1);
             let texture_resource = render_resource_context.create_texture(self.descriptor);
             output.set(WINDOW_TEXTURE, RenderResourceId::Texture(texture_resource));
         }

--- a/crates/bevy_wgpu/src/wgpu_type_converter.rs
+++ b/crates/bevy_wgpu/src/wgpu_type_converter.rs
@@ -645,8 +645,8 @@ impl WgpuFrom<&Window> for wgpu::SwapChainDescriptor {
         wgpu::SwapChainDescriptor {
             usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
             format: TextureFormat::default().wgpu_into(),
-            width: window.physical_width(),
-            height: window.physical_height(),
+            width: window.physical_width().max(1),
+            height: window.physical_height().max(1),
             present_mode: if window.vsync() {
                 wgpu::PresentMode::Fifo
             } else {


### PR DESCRIPTION
# Objective
- Fixes #2299

## Solution
- Ensures that textures are never requested with 0 height/width.
