### PR TITLE
[Merged by Bors] - Automated PR labeling

### DIFF
--- a/.github/label-config.yml
+++ b/.github/label-config.yml
@@ -1,0 +1,2 @@
+needs-triage:
+- "**"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,16 @@
+name: PR-Labeler
+on: 
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/label-config.yml
+        sync-labels: true

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,6 +1,6 @@
 name: PR-Labeler
 on: 
-  pull_request:
+  pull_request_target:
     branches:
       - main
 


### PR DESCRIPTION
# Objective

- Currently only issues automatically have labels assigned to them on creation.
- The enables pull requests to have the same functionality and currently only adds the `needs-triage` label to all PRs.

## Solution

- Integrate `actions/labeler@v2` into the github workflows to automatically tag PRs.
- Add a `label-config.yml` file that specifies how PRs should be labeled.
