### PR TITLE
[Merged by Bors] - [assets] remove unnecessary temporary strong handles

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -328,8 +328,7 @@ impl AssetServer {
             let type_uuid = loaded_asset.value.as_ref().unwrap().type_uuid();
             source_info.asset_types.insert(label_id, type_uuid);
             for dependency in loaded_asset.dependencies.iter() {
-                // another handle already exists created from the asset path
-                let _ = self.load_untyped(dependency.clone());
+                self.load_untracked(dependency.clone(), false);
             }
         }
 

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -493,7 +493,7 @@ impl AssetServer {
                         }
                     }
 
-                    let _ = assets.set(result.id, *result.asset);
+                    assets.set_untracked(result.id, *result.asset);
                 }
                 Ok(AssetLifecycleEvent::Free(handle_id)) => {
                     if let HandleId::AssetPathId(id) = handle_id {


### PR DESCRIPTION
# Objective

- When creating an asset, the `update_asset_storage` function was unnecessarily creating an extraneous `Handle` to the created asset via calling `set`. This has some overhead as the `RefChange::Increment/Decrement` event was being sent.  
- A similar exteraneous handle is also created in `load_async` when loading dependencies. 

## Solution

- Have the implementation use `Assets::set_untracked` and `AssetServer::load_untracked` so no intermediate handle is created.
