### PR TITLE
Handle Serialization and Deserialization

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -11,6 +11,7 @@ mod info;
 mod io;
 mod loader;
 mod path;
+mod ser;
 
 pub mod prelude {
     #[doc(hidden)]
@@ -25,6 +26,7 @@ pub use info::*;
 pub use io::*;
 pub use loader::*;
 pub use path::*;
+pub use ser::*;
 
 use bevy_app::{prelude::Plugin, AppBuilder};
 use bevy_ecs::{

--- a/crates/bevy_asset/src/ser.rs
+++ b/crates/bevy_asset/src/ser.rs
@@ -75,31 +75,14 @@ impl<'de, T: Asset> Deserialize<'de> for Handle<T> {
 }
 
 impl AssetServer {
-    pub fn serialize_with_asset_refs<S, T>(
-        &self,
-        serializer: S,
-        value: &T,
-    ) -> Result<S::Ok, S::Error>
+    /// Enables asset references to be serialized or deserialized
+    pub fn with_asset_refs_serialization<F, T>(&self, f: F) -> T
     where
-        S: Serializer,
-        T: Serialize,
+        F: FnOnce() -> T,
     {
         ASSET_SERVER.with(|key| {
             key.replace(Some(self.clone()));
-            let result = value.serialize(serializer);
-            key.replace(None);
-            result
-        })
-    }
-
-    pub fn deserialize_with_asset_refs<'de, D, T>(&self, deserializer: D) -> Result<T, D::Error>
-    where
-        D: Deserializer<'de>,
-        T: Deserialize<'de>,
-    {
-        ASSET_SERVER.with(|key| {
-            key.replace(Some(self.clone()));
-            let result = T::deserialize(deserializer);
+            let result = (f)();
             key.replace(None);
             result
         })

--- a/crates/bevy_asset/src/ser.rs
+++ b/crates/bevy_asset/src/ser.rs
@@ -1,8 +1,9 @@
 use std::cell::Cell;
 
+use bevy_reflect::Uuid;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::{Asset, AssetServer, Handle};
+use crate::{Asset, AssetServer, Handle, HandleId, HandleUntyped};
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -10,27 +11,44 @@ thread_local! {
     static ASSET_SERVER: Cell<Option<AssetServer>> = Cell::new(None);
 }
 
+#[derive(Serialize, Deserialize)]
+enum AssetRef {
+    Default,
+    /// Used for static handles like the `PBR_PIPELINE_HANDLE` or a embedded assets
+    Local(Uuid, u64),
+    /// Loads form a file
+    External(String),
+}
+
 impl<T: Asset> Serialize for Handle<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let path = ASSET_SERVER.with(|cell| {
-            let server = cell.replace(None);
-            let path = server.as_ref().and_then(|server| {
-                // TODO: `get_handle_path` does absolutely nothing issue #1290
-                server.get_handle_path(self).map(|asset_path| {
-                    let mut path = asset_path.path().to_string_lossy().to_string();
-                    if let Some(label) = asset_path.label() {
-                        path.push('#');
-                        path.push_str(label);
-                    }
-                    path
-                })
+        let path = ASSET_SERVER
+            .with(|cell| {
+                let server = cell.replace(None);
+                let path = server.as_ref().and_then(|server| {
+                    // TODO: `get_handle_path` does absolutely nothing issue #1290
+                    server
+                        .get_handle_path(self)
+                        .map(|asset_path| {
+                            let mut path = asset_path.path().to_string_lossy().to_string();
+                            if let Some(label) = asset_path.label() {
+                                path.push('#');
+                                path.push_str(label);
+                            }
+                            path
+                        })
+                        .and_then(|path| Some(AssetRef::External(path)))
+                });
+                cell.replace(server);
+                path
+            })
+            .unwrap_or_else(|| match &self.id {
+                HandleId::Id(type_uuid, id) => AssetRef::Local(*type_uuid, *id),
+                HandleId::AssetPathId(_) => AssetRef::Default,
             });
-            cell.replace(server);
-            path
-        });
 
         path.serialize(serializer)
     }
@@ -41,16 +59,21 @@ impl<'de, T: Asset> Deserialize<'de> for Handle<T> {
     where
         D: Deserializer<'de>,
     {
-        Ok(Option::<String>::deserialize(deserializer)?
-            .and_then(|path| {
-                ASSET_SERVER.with(|cell| {
-                    let server = cell.replace(None);
-                    let handle = server.as_ref().map(|server| server.load(path.as_str()));
-                    cell.replace(server);
-                    handle
-                })
-            })
-            .unwrap_or_default())
+        match AssetRef::deserialize(deserializer)? {
+            AssetRef::Default => Ok(Handle::default()),
+            AssetRef::Local(type_uuid, id) => {
+                Ok(HandleUntyped::weak_from_u64(type_uuid, id).typed())
+            }
+            AssetRef::External(path) => ASSET_SERVER.with(|cell| {
+                let server = cell.replace(None);
+                let handle = server
+                    .as_ref()
+                    .map(|server| server.load(path.as_str()))
+                    .unwrap_or_default();
+                cell.replace(server);
+                Ok(handle)
+            }),
+        }
     }
 }
 

--- a/crates/bevy_asset/src/ser.rs
+++ b/crates/bevy_asset/src/ser.rs
@@ -1,0 +1,91 @@
+use std::{cell::Cell, ptr::NonNull};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::{Asset, AssetServer, Handle};
+
+///////////////////////////////////////////////////////////////////////////////
+
+thread_local! {
+    static ASSET_SERVER: Cell<Option<NonNull<AssetServer>>> = Cell::new(None);
+}
+
+impl<T: Asset> Serialize for Handle<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let path = ASSET_SERVER.with(|server| {
+            server.get().and_then(|ptr| {
+                // SAFETY: The thread local [`ASSET_SERVER`] can only
+                // be set by a valid [`AssetServer`] instance that will
+                // also make sure to set it back to [`None`] once it's no longer is valid
+                let server = unsafe { ptr.as_ref() };
+                //  TODO: `get_handle_path` does absolutely nothing issue #1290
+                server.get_handle_path(self).map(|asset_path| {
+                    let mut path = asset_path.path().to_string_lossy().to_string();
+                    if let Some(label) = asset_path.label() {
+                        path.push('#');
+                        path.push_str(label);
+                    }
+                    path
+                })
+            })
+        });
+
+        path.serialize(serializer)
+    }
+}
+
+impl<'de, T: Asset> Deserialize<'de> for Handle<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Option::<String>::deserialize(deserializer)?
+            .and_then(|path| {
+                ASSET_SERVER.with(|server| {
+                    server.get().map(|ptr| {
+                        // SAFETY: The thread local [`ASSET_SERVER`] can only
+                        // be set by a valid [`AssetServer`] instance that will
+                        // also make sure to set it to back [`None`] once it's no longer is valid
+                        let server = unsafe { ptr.as_ref() };
+                        server.load(path.as_str())
+                    })
+                })
+            })
+            .unwrap_or_default())
+    }
+}
+
+impl AssetServer {
+    pub fn serialize_with_asset_refs<S, T>(
+        &self,
+        serializer: S,
+        value: &T,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: Serialize,
+    {
+        ASSET_SERVER.with(|key| {
+            key.replace(NonNull::new(self as *const _ as *mut _));
+            let result = value.serialize(serializer);
+            key.replace(None);
+            result
+        })
+    }
+
+    pub fn deserialize_with_asset_refs<'de, D, T>(&self, deserializer: D) -> Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: Deserialize<'de>,
+    {
+        ASSET_SERVER.with(|key| {
+            key.replace(NonNull::new(self as *const _ as *mut _));
+            let result = T::deserialize(deserializer);
+            key.replace(None);
+            result
+        })
+    }
+}

--- a/crates/bevy_asset/src/ser.rs
+++ b/crates/bevy_asset/src/ser.rs
@@ -16,7 +16,7 @@ enum AssetRef {
     Default,
     /// Used for static handles like the `PBR_PIPELINE_HANDLE` or a embedded assets
     Local(Uuid, u64),
-    /// Loads form a file
+    /// Loads from a file
     External(String),
 }
 

--- a/crates/bevy_asset/src/ser.rs
+++ b/crates/bevy_asset/src/ser.rs
@@ -30,17 +30,14 @@ impl<T: Asset> Serialize for Handle<T> {
                 let server = cell.replace(None);
                 let path = server.as_ref().and_then(|server| {
                     // TODO: `get_handle_path` does absolutely nothing issue #1290
-                    server
-                        .get_handle_path(self)
-                        .map(|asset_path| {
-                            let mut path = asset_path.path().to_string_lossy().to_string();
-                            if let Some(label) = asset_path.label() {
-                                path.push('#');
-                                path.push_str(label);
-                            }
-                            path
-                        })
-                        .and_then(|path| Some(AssetRef::External(path)))
+                    server.get_handle_path(self).map(|asset_path| {
+                        let mut path = asset_path.path().to_string_lossy().to_string();
+                        if let Some(label) = asset_path.label() {
+                            path.push('#');
+                            path.push_str(label);
+                        }
+                        AssetRef::External(path)
+                    })
                 });
                 cell.replace(server);
                 path


### PR DESCRIPTION
# Objective

Add serialization for `Handle` this will allows every type of bevy to implement `Serialize` and `Deserialize` this will also allows for scene and others data to also load all the dependencies with ease;

# Usage
```rust
struct MyDataType {
    mesh_asset: Handle<Mesh>,
}

let data = asset_server.with_asset_refs_serialization(|| MyDataType::deserialize(&mut de));

asset_server.with_asset_refs_serialization(|| data.serialize(&mut ser));

```
will result in:
```rust
r#"MyDataType(mesh: External("path/to/mesh.glb#Mesh2"))"#
// or when the asset wasn't loaded from a file
r#"MyDataType(mesh: Local("8ecbac0f-f545-4473-ad43-e1f4243af51e", 12031280123816238))"#
```
# Requiriments
- [ ] #1290

# Solves
Allow #2216 to be merged