### PR TITLE
[tasks] Handle TaskPool panicking threads

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -25,6 +25,7 @@ use bevy_ecs::{
 };
 use bevy_utils::HashSet;
 use std::ops::Range;
+
 /// Adds core functionality to Apps.
 #[derive(Default)]
 pub struct CorePlugin;

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -23,8 +23,10 @@ use bevy_ecs::{
     schedule::{ExclusiveSystemDescriptorCoercion, SystemLabel},
     system::{IntoExclusiveSystem, IntoSystem},
 };
+use bevy_tasks::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool};
 use bevy_utils::HashSet;
 use std::ops::Range;
+use task_pool_options::handle_task_pool_panicking_threads_system;
 
 /// Adds core functionality to Apps.
 #[derive(Default)]
@@ -45,6 +47,10 @@ impl Plugin for CorePlugin {
             .cloned()
             .unwrap_or_else(DefaultTaskPoolOptions::default)
             .create_default_pools(app.world_mut());
+
+        app.add_system(handle_task_pool_panicking_threads_system::<IoTaskPool>.system())
+            .add_system(handle_task_pool_panicking_threads_system::<ComputeTaskPool>.system())
+            .add_system(handle_task_pool_panicking_threads_system::<AsyncComputeTaskPool>.system());
 
         app.init_resource::<Time>()
             .init_resource::<EntityLabels>()

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -48,6 +48,7 @@ impl Plugin for CorePlugin {
             .unwrap_or_else(DefaultTaskPoolOptions::default)
             .create_default_pools(app.world_mut());
 
+        #[cfg(not(target_arch = "wasm32"))]
         app.add_system(handle_task_pool_panicking_threads_system::<IoTaskPool>.system())
             .add_system(handle_task_pool_panicking_threads_system::<ComputeTaskPool>.system())
             .add_system(handle_task_pool_panicking_threads_system::<AsyncComputeTaskPool>.system());

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -23,11 +23,8 @@ use bevy_ecs::{
     schedule::{ExclusiveSystemDescriptorCoercion, SystemLabel},
     system::{IntoExclusiveSystem, IntoSystem},
 };
-use bevy_tasks::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool};
 use bevy_utils::HashSet;
 use std::ops::Range;
-use task_pool_options::handle_task_pool_panicking_threads_system;
-
 /// Adds core functionality to Apps.
 #[derive(Default)]
 pub struct CorePlugin;
@@ -49,9 +46,22 @@ impl Plugin for CorePlugin {
             .create_default_pools(app.world_mut());
 
         #[cfg(not(target_arch = "wasm32"))]
-        app.add_system(handle_task_pool_panicking_threads_system::<IoTaskPool>.system())
-            .add_system(handle_task_pool_panicking_threads_system::<ComputeTaskPool>.system())
-            .add_system(handle_task_pool_panicking_threads_system::<AsyncComputeTaskPool>.system());
+        app.add_system(
+            task_pool_options::handle_task_pool_panicking_threads_system::<bevy_tasks::IoTaskPool>
+                .system(),
+        )
+        .add_system(
+            task_pool_options::handle_task_pool_panicking_threads_system::<
+                bevy_tasks::ComputeTaskPool,
+            >
+                .system(),
+        )
+        .add_system(
+            task_pool_options::handle_task_pool_panicking_threads_system::<
+                bevy_tasks::AsyncComputeTaskPool,
+            >
+                .system(),
+        );
 
         app.init_resource::<Time>()
             .init_resource::<EntityLabels>()

--- a/crates/bevy_core/src/task_pool_options.rs
+++ b/crates/bevy_core/src/task_pool_options.rs
@@ -178,7 +178,6 @@ impl DefaultTaskPoolOptions {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn handle_task_pool_panicking_threads_system<
     T: TaskPoolTrait + Send + Sync + 'static,
 >(

--- a/crates/bevy_core/src/task_pool_options.rs
+++ b/crates/bevy_core/src/task_pool_options.rs
@@ -1,7 +1,7 @@
 use bevy_ecs::{system::Res, world::World};
 use bevy_tasks::{
-    AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool, TaskPoolBuilder, TaskPoolTrait,
-    ThreadPanicPolicy,
+    AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool, TaskPoolBuilder, TaskPoolThreadPanicPolicy,
+    TaskPoolTrait,
 };
 use bevy_utils::tracing::trace;
 
@@ -11,7 +11,7 @@ pub struct TaskPoolPolicies {
     /// Used to determine number of threads to allocate
     pub assignment_policy: TaskPoolThreadAssignmentPolicy,
     /// Used to determine the panic policy of the task pool
-    pub panic_policy: ThreadPanicPolicy,
+    pub panic_policy: TaskPoolThreadPanicPolicy,
 }
 
 /// Defines a simple way to determine how many threads to use given the number of remaining cores
@@ -76,7 +76,7 @@ impl Default for DefaultTaskPoolOptions {
                     max_threads: 4,
                     percent: 0.25,
                 },
-                panic_policy: ThreadPanicPolicy::Restart,
+                panic_policy: TaskPoolThreadPanicPolicy::Restart,
             },
 
             // Use 25% of cores for async compute, at least 1, no more than 4
@@ -86,7 +86,7 @@ impl Default for DefaultTaskPoolOptions {
                     max_threads: 4,
                     percent: 0.25,
                 },
-                panic_policy: ThreadPanicPolicy::Restart,
+                panic_policy: TaskPoolThreadPanicPolicy::Restart,
             },
 
             // Use all remaining cores for compute (at least 1)
@@ -96,7 +96,7 @@ impl Default for DefaultTaskPoolOptions {
                     max_threads: std::usize::MAX,
                     percent: 1.0, // This 1.0 here means "whatever is left over"
                 },
-                panic_policy: ThreadPanicPolicy::Restart,
+                panic_policy: TaskPoolThreadPanicPolicy::Restart,
             },
         }
     }

--- a/crates/bevy_core/src/task_pool_options.rs
+++ b/crates/bevy_core/src/task_pool_options.rs
@@ -2,8 +2,8 @@
 use bevy_ecs::system::Res;
 use bevy_ecs::world::World;
 use bevy_tasks::{
-    AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool, TaskPoolBuilder, TaskPoolThreadPanicPolicy,
-    TaskPoolTrait,
+    AsyncComputeTaskPool, ComputeTaskPool, DerefTaskPool, IoTaskPool, TaskPoolBuilder,
+    TaskPoolThreadPanicPolicy,
 };
 use bevy_utils::tracing::trace;
 
@@ -182,7 +182,7 @@ impl DefaultTaskPoolOptions {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn handle_task_pool_panicking_threads_system<
-    T: TaskPoolTrait + Send + Sync + 'static,
+    T: DerefTaskPool + Send + Sync + 'static,
 >(
     task_pool: Res<T>,
 ) {

--- a/crates/bevy_core/src/task_pool_options.rs
+++ b/crates/bevy_core/src/task_pool_options.rs
@@ -7,7 +7,7 @@ use bevy_tasks::{
 };
 use bevy_utils::tracing::trace;
 
-/// DOCS: todo
+/// The set of policies describing how the according task pool behaves
 #[derive(Clone, Debug)]
 pub struct TaskPoolPolicies {
     /// Used to determine number of threads to allocate

--- a/crates/bevy_core/src/task_pool_options.rs
+++ b/crates/bevy_core/src/task_pool_options.rs
@@ -1,4 +1,6 @@
-use bevy_ecs::{system::Res, world::World};
+#[cfg(not(target_arch = "wasm32"))]
+use bevy_ecs::system::Res;
+use bevy_ecs::world::World;
 use bevy_tasks::{
     AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool, TaskPoolBuilder, TaskPoolThreadPanicPolicy,
     TaskPoolTrait,
@@ -178,6 +180,7 @@ impl DefaultTaskPoolOptions {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn handle_task_pool_panicking_threads_system<
     T: TaskPoolTrait + Send + Sync + 'static,
 >(

--- a/crates/bevy_core/src/task_pool_options.rs
+++ b/crates/bevy_core/src/task_pool_options.rs
@@ -178,6 +178,7 @@ impl DefaultTaskPoolOptions {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn handle_task_pool_panicking_threads_system<
     T: TaskPoolTrait + Send + Sync + 'static,
 >(

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["bevy"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_utils = { path = "../bevy_utils" }
+bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 parking_lot = "0.11.0"
 futures-lite = "1.4.0"
 event-listener = "2.4.0"

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -16,6 +16,8 @@ keywords = ["bevy"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tracing = { version = "0.1", features = ["release_max_level_info"] }
+parking_lot = "0.11.0"
 futures-lite = "1.4.0"
 event-listener = "2.4.0"
 async-executor = "1.3.0"

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["bevy"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tracing = { version = "0.1", features = ["release_max_level_info"] }
+bevy_utils = { path = "../bevy_utils" }
 parking_lot = "0.11.0"
 futures-lite = "1.4.0"
 event-listener = "2.4.0"

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -4,12 +4,13 @@ pub use slice::{ParallelSlice, ParallelSliceMut};
 mod task;
 pub use task::Task;
 
+mod task_pool_common;
+pub use task_pool_common::ThreadPanicPolicy;
+
 #[cfg(not(target_arch = "wasm32"))]
 mod task_pool;
 #[cfg(not(target_arch = "wasm32"))]
-pub use task_pool::{
-    handle_task_pool_panicking_threads, Scope, TaskPool, TaskPoolBuilder, ThreadPanicPolicy,
-};
+pub use task_pool::{handle_task_pool_panicking_threads, Scope, TaskPool, TaskPoolBuilder};
 
 #[cfg(target_arch = "wasm32")]
 mod single_threaded_task_pool;

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -7,7 +7,7 @@ pub use task::Task;
 #[cfg(not(target_arch = "wasm32"))]
 mod task_pool;
 #[cfg(not(target_arch = "wasm32"))]
-pub use task_pool::{Scope, TaskPool, TaskPoolBuilder};
+pub use task_pool::{Scope, TaskPool, TaskPoolBuilder, ThreadPanicPolicy};
 
 #[cfg(target_arch = "wasm32")]
 mod single_threaded_task_pool;
@@ -15,7 +15,10 @@ mod single_threaded_task_pool;
 pub use single_threaded_task_pool::{Scope, TaskPool, TaskPoolBuilder};
 
 mod usages;
-pub use usages::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool};
+pub use usages::{
+    handle_task_pool_panicking_threads, AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool,
+    TaskPoolTrait,
+};
 
 mod countdown_event;
 pub use countdown_event::CountdownEvent;

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -7,7 +7,9 @@ pub use task::Task;
 #[cfg(not(target_arch = "wasm32"))]
 mod task_pool;
 #[cfg(not(target_arch = "wasm32"))]
-pub use task_pool::{Scope, TaskPool, TaskPoolBuilder, ThreadPanicPolicy};
+pub use task_pool::{
+    handle_task_pool_panicking_threads, Scope, TaskPool, TaskPoolBuilder, ThreadPanicPolicy,
+};
 
 #[cfg(target_arch = "wasm32")]
 mod single_threaded_task_pool;
@@ -15,10 +17,7 @@ mod single_threaded_task_pool;
 pub use single_threaded_task_pool::{Scope, TaskPool, TaskPoolBuilder};
 
 mod usages;
-pub use usages::{
-    handle_task_pool_panicking_threads, AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool,
-    TaskPoolTrait,
-};
+pub use usages::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool, TaskPoolTrait};
 
 mod countdown_event;
 pub use countdown_event::CountdownEvent;

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -5,7 +5,7 @@ mod task;
 pub use task::Task;
 
 mod task_pool_common;
-pub use task_pool_common::ThreadPanicPolicy;
+pub use task_pool_common::TaskPoolThreadPanicPolicy;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod task_pool;

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -18,7 +18,7 @@ mod single_threaded_task_pool;
 pub use single_threaded_task_pool::{Scope, TaskPool, TaskPoolBuilder};
 
 mod usages;
-pub use usages::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool, TaskPoolTrait};
+pub use usages::{AsyncComputeTaskPool, ComputeTaskPool, DerefTaskPool, IoTaskPool};
 
 mod countdown_event;
 pub use countdown_event::CountdownEvent;

--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -1,9 +1,9 @@
+use crate::TaskPoolThreadPanicPolicy;
 use std::{
     future::Future,
     mem,
     sync::{Arc, Mutex},
 };
-use crate::TaskPoolThreadPanicPolicy;
 
 /// Used to create a TaskPool
 #[derive(Debug, Default, Clone)]

--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -3,6 +3,7 @@ use std::{
     mem,
     sync::{Arc, Mutex},
 };
+use crate::ThreadPanicPolicy;
 
 /// Used to create a TaskPool
 #[derive(Debug, Default, Clone)]
@@ -23,6 +24,10 @@ impl TaskPoolBuilder {
     }
 
     pub fn thread_name(self, _thread_name: String) -> Self {
+        self
+    }
+
+    pub fn panic_policy(self, _policy: ThreadPanicPolicy) -> Self {
         self
     }
 

--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -3,7 +3,7 @@ use std::{
     mem,
     sync::{Arc, Mutex},
 };
-use crate::ThreadPanicPolicy;
+use crate::TaskPoolThreadPanicPolicy;
 
 /// Used to create a TaskPool
 #[derive(Debug, Default, Clone)]
@@ -27,7 +27,7 @@ impl TaskPoolBuilder {
         self
     }
 
-    pub fn panic_policy(self, _policy: ThreadPanicPolicy) -> Self {
+    pub fn panic_policy(self, _policy: TaskPoolThreadPanicPolicy) -> Self {
         self
     }
 

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -1,4 +1,5 @@
 use crate::{Task, TaskPoolThreadPanicPolicy};
+use bevy_utils::tracing::warn;
 use futures_lite::{future, pin};
 use parking_lot::RwLock;
 use std::{
@@ -11,7 +12,6 @@ use std::{
     },
     thread::{self, JoinHandle},
 };
-use tracing::warn;
 
 /// Used to create a TaskPool
 #[derive(Debug, Default, Clone)]

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -194,14 +194,13 @@ impl TaskPool {
                             ),
                         );
 
-                        // join the panicked thread handle
-                        let panic_error = old_state.handle.join().unwrap_err();
-
                         warn!(
-                            "TaskPool's inner thread '{:?}' panicked with error: {:?}",
-                            state.thread(),
-                            panic_error
+                            "TaskPool's inner thread '{:?}' panicked!",
+                            old_state.thread()
                         );
+
+                        // join the panicked thread handle
+                        old_state.handle.join().unwrap_err();
                     }
                 }
             }

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -159,9 +159,9 @@ impl TaskPool {
     }
 
     pub(crate) fn handle_panicking_threads(&self) {
-        match self.panic_policy {
-            TaskPoolThreadPanicPolicy::Propagate => {
-                if self.any_panicking_threads() {
+        if self.any_panicking_threads() {
+            match self.panic_policy {
+                TaskPoolThreadPanicPolicy::Propagate => {
                     for state in self.inner.write().threads.drain(..) {
                         let thread = state.thread().clone();
                         if let Err(err) = state.handle.join() {
@@ -172,9 +172,7 @@ impl TaskPool {
                         }
                     }
                 }
-            }
-            TaskPoolThreadPanicPolicy::Restart => {
-                if self.any_panicking_threads() {
+                TaskPoolThreadPanicPolicy::Restart => {
                     for (idx, state) in self
                         .inner
                         .write()

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -394,6 +394,11 @@ impl Default for TaskPool {
     }
 }
 
+#[doc(hidden)]
+pub fn handle_task_pool_panicking_threads(task_pool: &TaskPool) {
+    task_pool.handle_panicking_threads();
+}
+
 #[derive(Debug)]
 pub struct Scope<'scope, T> {
     executor: &'scope async_executor::Executor<'scope>,

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -176,8 +176,8 @@ impl TaskPool {
                         .write()
                         .threads
                         .iter_mut()
-                        .filter(|state| state.panicking())
                         .enumerate()
+                        .filter(|(_, state)| state.panicking())
                     {
                         let thread_name = match state.thread().name() {
                             Some(name) => name.to_owned(),

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -1,3 +1,4 @@
+use crate::{Task, ThreadPanicPolicy};
 use futures_lite::{future, pin};
 use parking_lot::RwLock;
 use std::{
@@ -11,19 +12,6 @@ use std::{
     thread::{self, JoinHandle},
 };
 use tracing::warn;
-
-use crate::Task;
-
-/// The policy used when a [`TaskPool`]'s thread panics
-#[derive(Copy, Clone, Debug)]
-pub enum ThreadPanicPolicy {
-    /// Propagate the panic to the main thread, causing the main
-    /// thread to panic as well.
-    Propagate,
-    /// Restart the thread by joining the panicked thread and
-    /// spawning another one in it's place.
-    Restart,
-}
 
 /// Used to create a TaskPool
 #[derive(Debug, Default, Clone)]

--- a/crates/bevy_tasks/src/task_pool_common.rs
+++ b/crates/bevy_tasks/src/task_pool_common.rs
@@ -1,6 +1,6 @@
 /// The policy used when a task pool's internal thread panics
 #[derive(Copy, Clone, Debug)]
-pub enum ThreadPanicPolicy {
+pub enum TaskPoolThreadPanicPolicy {
     /// Propagate the panic to the main thread, causing the main
     /// thread to panic as well.
     Propagate,

--- a/crates/bevy_tasks/src/task_pool_common.rs
+++ b/crates/bevy_tasks/src/task_pool_common.rs
@@ -1,0 +1,10 @@
+/// The policy used when a task pool's internal thread panics
+#[derive(Copy, Clone, Debug)]
+pub enum ThreadPanicPolicy {
+    /// Propagate the panic to the main thread, causing the main
+    /// thread to panic as well.
+    Propagate,
+    /// Restart the thread by joining the panicked thread and
+    /// spawning another one in it's place.
+    Restart,
+}

--- a/crates/bevy_tasks/src/usages.rs
+++ b/crates/bevy_tasks/src/usages.rs
@@ -50,3 +50,13 @@ impl Deref for IoTaskPool {
         &self.0
     }
 }
+
+/// TODO: RENAME
+pub trait TaskPoolTrait: Deref<Target = TaskPool> {}
+
+impl<T> TaskPoolTrait for T where T: Deref<Target = TaskPool> {}
+
+#[doc(hidden)]
+pub fn handle_task_pool_panicking_threads(task_pool: &TaskPool) {
+    task_pool.handle_panicking_threads();
+}

--- a/crates/bevy_tasks/src/usages.rs
+++ b/crates/bevy_tasks/src/usages.rs
@@ -51,7 +51,6 @@ impl Deref for IoTaskPool {
     }
 }
 
-/// TODO: RENAME
-pub trait TaskPoolTrait: Deref<Target = TaskPool> {}
+pub trait DerefTaskPool: Deref<Target = TaskPool> {}
 
-impl<T> TaskPoolTrait for T where T: Deref<Target = TaskPool> {}
+impl<T> DerefTaskPool for T where T: Deref<Target = TaskPool> {}

--- a/crates/bevy_tasks/src/usages.rs
+++ b/crates/bevy_tasks/src/usages.rs
@@ -55,8 +55,3 @@ impl Deref for IoTaskPool {
 pub trait TaskPoolTrait: Deref<Target = TaskPool> {}
 
 impl<T> TaskPoolTrait for T where T: Deref<Target = TaskPool> {}
-
-#[doc(hidden)]
-pub fn handle_task_pool_panicking_threads(task_pool: &TaskPool) {
-    task_pool.handle_panicking_threads();
-}


### PR DESCRIPTION
# Objective

- Fixes: #2302 
- Currently, when a `TaskPool`'s inner threads panic, there is no way to act on the errors. 
- The main threads continues executing while now having one fewer thread in one of it's task pools.

## Solution

- Implement a `TaskPoolThreadPanicPolicy` which implements two different behaviors
  - `Restart` (default) -> this will join the panicked thread and then spawn a new thread in it's place.
  - `Propagate` -> this will propagate the panic from the inner thread to the spawning thread (usually the main thread)


### TODO
- [x] Testing
- [x] Some more docs
- [ ] An example