### PR TITLE
[Merged by Bors] - [assets] Fix `AssetServer::get_handle_path`

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -831,4 +831,25 @@ mod test {
         assert_eq!(LoadState::Loaded, get_load_state(&handle, &world));
         assert!(get_asset(&handle, &world).is_some());
     }
+
+    #[test]
+    fn test_get_handle_path() {
+        const PATH: &str = "path/file.png";
+
+        // valid handle
+        let server = setup(".");
+        let handle = server.load_untyped(PATH);
+        let handle_path = server.get_handle_path(&handle).unwrap();
+
+        assert_eq!(handle_path.path(), Path::new(PATH));
+        assert!(handle_path.label().is_none());
+
+        let handle_id: HandleId = handle.into();
+        let path_id: HandleId = handle_path.get_id().into();
+        assert_eq!(handle_id, path_id);
+
+        // invalid handle
+        let invalid = HandleId::new(Uuid::new_v4(), 42);
+        assert!(server.get_handle_path(invalid).is_none());
+    }
 }

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -368,14 +368,11 @@ impl AssetServer {
             .detach();
 
         let handle_id = asset_path.get_id().into();
-
-        // check if the `handle_id` exists first to avoid unnecessary `write()` calls.
-        if !self.server.handle_to_path.read().contains_key(&handle_id) {
-            self.server
-                .handle_to_path
-                .write()
-                .insert(handle_id, asset_path.to_owned());
-        }
+        self.server
+            .handle_to_path
+            .write()
+            .entry(handle_id)
+            .or_insert_with(|| asset_path.to_owned());
 
         asset_path.into()
     }

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -848,8 +848,17 @@ mod test {
         let path_id: HandleId = handle_path.get_id().into();
         assert_eq!(handle_id, path_id);
 
-        // invalid handle
-        let invalid = HandleId::new(Uuid::new_v4(), 42);
-        assert!(server.get_handle_path(invalid).is_none());
+        // invalid handle (not loaded through server)
+        let mut assets = server.register_asset_type::<PngAsset>();
+        let handle = assets.add(PngAsset);
+        assert!(server.get_handle_path(&handle).is_none());
+
+        // invalid HandleId
+        let invalid_id = HandleId::new(Uuid::new_v4(), 42);
+        assert!(server.get_handle_path(invalid_id).is_none());
+
+        // invalid AssetPath
+        let invalid_path = AssetPath::new("some/path.ext".into(), None);
+        assert!(server.get_handle_path(invalid_path).is_none());
     }
 }

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -233,7 +233,7 @@ impl AssetServer {
 
     async fn load_async(
         &self,
-        asset_path: AssetPath<'_>,
+        asset_path: AssetPath<'static>,
         force: bool,
     ) -> Result<AssetPathId, AssetServerError> {
         let asset_loader = self.get_path_asset_loader(asset_path.path())?;
@@ -264,6 +264,13 @@ impl AssetServer {
             {
                 return Ok(asset_path_id);
             }
+
+            // add the asset to internal HashMap<HandleId, AssetPath>
+            let handle_id: HandleId = asset_path.get_id().into();
+            self.server
+                .handle_to_path
+                .write()
+                .insert(handle_id, asset_path.clone());
 
             source_info.load_state = LoadState::Loading;
             source_info.committed_assets.clear();

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -368,6 +368,8 @@ impl AssetServer {
             .detach();
 
         let handle_id = asset_path.get_id().into();
+
+        // check if the `handle_id` exists first to avoid unnecessary `write()` calls.
         if !self.server.handle_to_path.read().contains_key(&handle_id) {
             self.server
                 .handle_to_path

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -266,7 +266,7 @@ impl AssetServer {
             }
 
             // add the asset to internal HashMap<HandleId, AssetPath>
-            let handle_id: HandleId = asset_path.get_id().into();
+            let handle_id = asset_path.get_id().into();
             self.server
                 .handle_to_path
                 .write()

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -233,7 +233,7 @@ impl AssetServer {
 
     async fn load_async(
         &self,
-        asset_path: AssetPath<'static>,
+        asset_path: AssetPath<'_>,
         force: bool,
     ) -> Result<AssetPathId, AssetServerError> {
         let asset_loader = self.get_path_asset_loader(asset_path.path())?;
@@ -264,13 +264,6 @@ impl AssetServer {
             {
                 return Ok(asset_path_id);
             }
-
-            // add the asset to internal HashMap<HandleId, AssetPath>
-            let handle_id = asset_path.get_id().into();
-            self.server
-                .handle_to_path
-                .write()
-                .insert(handle_id, asset_path.clone());
 
             source_info.load_state = LoadState::Loading;
             source_info.committed_assets.clear();
@@ -373,6 +366,15 @@ impl AssetServer {
                 }
             })
             .detach();
+
+        let handle_id = asset_path.get_id().into();
+        if !self.server.handle_to_path.read().contains_key(&handle_id) {
+            self.server
+                .handle_to_path
+                .write()
+                .insert(handle_id, asset_path.to_owned());
+        }
+
         asset_path.into()
     }
 


### PR DESCRIPTION
# Objective

- Currently `AssetServer::get_handle_path` always returns `None` since the inner hash map is never written to.

## Solution

- Inside the `load_untracked` function, insert the asset path into the map.

This is similar to #1290 (thanks @TheRawMeatball)