### PR TITLE
[Merged by Bors] - Removed redundant visibility check

### DIFF
--- a/crates/bevy_render/src/render_graph/nodes/pass_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/pass_node.rs
@@ -3,7 +3,6 @@ use crate::{
     draw::{Draw, RenderCommand},
     pass::{ClearColor, LoadOp, PassDescriptor, TextureAttachment},
     pipeline::{IndexFormat, PipelineDescriptor},
-    prelude::Visible,
     render_graph::{Node, ResourceSlotInfo, ResourceSlots},
     renderer::{
         BindGroupId, BufferId, RenderContext, RenderResourceBindings, RenderResourceContext,
@@ -160,11 +159,6 @@ where
                         continue;
                     };
 
-                    if let Some(visible) = world.get::<Visible>(visible_entity.entity) {
-                        if !visible.is_visible {
-                            continue;
-                        }
-                    }
                     for render_command in draw.render_commands.iter() {
                         commands.push(render_command.clone());
                         // whenever a new pipeline is set, ensure the relevant camera bind groups


### PR DESCRIPTION
Since `visible_entities_system` already checks `Visiblie::is_visible` for each entity and requires it to be `true`, there's no reason to verify visibility in `PassNode::prepare` which consumes entities produced by the system.