### PR TITLE
[Merged by Bors] - fix automated pr labeling

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     types:
-      - created
+      - opened
 
 jobs:
   label:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -3,6 +3,8 @@ on:
   pull_request_target:
     branches:
       - main
+    types:
+      - created
 
 jobs:
   label:


### PR DESCRIPTION
# Objective

- the PR labeler workflow will always add the `needs-traige` label to every pull request event

## Solution

- Limit this workflow to only be on the `opened` event
