### PR TITLE
[Merged by Bors] - Document FromType trait

### DIFF
--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -219,8 +219,10 @@ where
     }
 }
 
-// TODO: Dead code
-// This trait seems to be unused apart from in implementations of this trait
+/// Trait used to generate `TypeData` for trait reflection.
+///
+/// This is used by the `#[derive(Reflect)]` macro to generate an implementation of [TypeData]
+/// to pass to [TypeRegistration::insert].
 pub trait FromType<T> {
     fn from_type() -> Self;
 }


### PR DESCRIPTION
# Objective

Prevent future unnecessary mental effort spent figuring out why this trait exists and how to resolve the `TODO`.

## Solution

I happened to notice this trait being used when expanding the `#[derive(Reflect)]` macro in my own crate to figure out how it worked, and noticed that there was a `TODO` comment on it because it is only used in the derive macro and thus appeared to be unused.

I figured I should document my findings to prevent someone else from finding them out the hard way in the future :laughing: 