### PR TITLE
[Merged by Bors] - Fix bad bounds for NonSend SystemParams

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -683,7 +683,7 @@ impl<'a, T: Component> SystemParamFetch<'a> for RemovedComponentsState<T> {
 /// # Panics
 ///
 /// Panics when used as a `SystemParameter` if the resource does not exist.
-pub struct NonSend<'w, T> {
+pub struct NonSend<'w, T: 'static> {
     pub(crate) value: &'w T,
     ticks: ComponentTicks,
     last_change_tick: u32,
@@ -702,7 +702,7 @@ where
     }
 }
 
-impl<'w, T: Component> NonSend<'w, T> {
+impl<'w, T: 'static> NonSend<'w, T> {
     /// Returns true if (and only if) this resource been added since the last execution of this
     /// system.
     pub fn is_added(&self) -> bool {
@@ -815,7 +815,7 @@ pub struct NonSendMut<'a, T: 'static> {
     change_tick: u32,
 }
 
-impl<'w, T: Component> NonSendMut<'w, T> {
+impl<'w, T: 'static> NonSendMut<'w, T> {
     /// Returns true if (and only if) this resource been added since the last execution of this
     /// system.
     pub fn is_added(&self) -> bool {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -815,7 +815,7 @@ pub struct NonSendMut<'a, T: 'static> {
     change_tick: u32,
 }
 
-impl<'w, T: 'static> NonSendMut<'w, T> {
+impl<'w, T: Component> NonSendMut<'w, T> {
     /// Returns true if (and only if) this resource been added since the last execution of this
     /// system.
     pub fn is_added(&self) -> bool {


### PR DESCRIPTION
# Objective

Currently, you can't call `is_added` or `is_changed` on a `NonSend` SystemParam, unless the Resource is a Component (implements `Send` and `Sync`). 
This defeats the purpose of providing change detection for NonSend Resources.
While fixing this, I also noticed that `NonSend` does not have a bound at all on its struct.

## Solution

Change the bounds of `T` to always be `'static`.
