### PR TITLE
[Merged by Bors] - implement DetectChanges for NonSendMut

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -150,6 +150,25 @@ change_detection_impl!(ResMut<'a, T>, T, Component);
 impl_into_inner!(ResMut<'a, T>, T, Component);
 impl_debug!(ResMut<'a, T>, Component);
 
+/// Unique borrow of a non-[`Send`] resource.
+///
+/// Only [`Send`] resources may be accessed with the [`ResMut`] [`SystemParam`]. In case that the
+/// resource does not implement `Send`, this `SystemParam` wrapper can be used. This will instruct
+/// the scheduler to instead run the system on the main thread so that it doesn't send the resource
+/// over to another thread.
+///
+/// # Panics
+///
+/// Panics when used as a `SystemParameter` if the resource does not exist.
+pub struct NonSendMut<'a, T: 'static> {
+    pub(crate) value: &'a mut T,
+    pub(crate) ticks: Ticks<'a>,
+}
+
+change_detection_impl!(NonSendMut<'a, T>, T,);
+impl_into_inner!(NonSendMut<'a, T>, T,);
+impl_debug!(NonSendMut<'a, T>,);
+
 /// Unique mutable borrow of an entity's component
 pub struct Mut<'a, T> {
     pub(crate) value: &'a mut T,


### PR DESCRIPTION
# Objective

- The `DetectChanges` trait is used for types that detect change on mutable access (such as `ResMut`, `Mut`, etc...)
- `DetectChanges` was not implemented for `NonSendMut`

## Solution

- implement `NonSendMut` in terms of `DetectChanges`
