### PR TITLE
[ecs] add `filter` mod for re-exported query filters

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -12,6 +12,10 @@ pub mod storage;
 pub mod system;
 pub mod world;
 
+pub mod filter {
+    pub use crate::query::{Added, Changed, Or, With, WithBundle, Without};
+}
+
 pub mod prelude {
     #[doc(hidden)]
     #[cfg(feature = "bevy_reflect")]
@@ -22,6 +26,7 @@ pub mod prelude {
         change_detection::DetectChanges,
         entity::Entity,
         event::{EventReader, EventWriter},
+        filter,
         query::{Added, ChangeTrackers, Changed, Or, QueryState, With, WithBundle, Without},
         schedule::{
             AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,


### PR DESCRIPTION
# Objective

- Fixes: #2328
- The filter types for queries are be difficult to find as they are globbed together with other `ecs` exports.
- Make it easier for users (especially those using IDEs) to find filter types by exporting a `filter` module. 

## Solution

- Inside `bevy_ecs` re-export the filter types within their own `filter` module
