### PR TITLE
Add TransformBundle and use it as Sub-Bundle

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -281,7 +281,7 @@ async fn load_gltf<'a, 'b>(
         let mut world = World::default();
         world
             .spawn()
-            .insert_bundle(TransformBundle::default())
+            .insert_bundle(TransformBundle::identity())
             .with_children(|parent| {
                 for node in scene.nodes() {
                     let result = load_node(&node, parent, load_context, &buffer_data);

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -20,7 +20,8 @@ use bevy_render::{
 use bevy_scene::Scene;
 use bevy_transform::{
     hierarchy::{BuildWorldChildren, WorldChildBuilder},
-    prelude::{GlobalTransform, Transform},
+    prelude::Transform,
+    TransformBundle,
 };
 use gltf::{
     mesh::Mode,
@@ -280,7 +281,7 @@ async fn load_gltf<'a, 'b>(
         let mut world = World::default();
         world
             .spawn()
-            .insert_bundle((Transform::identity(), GlobalTransform::identity()))
+            .insert_bundle(TransformBundle::default())
             .with_children(|parent| {
                 for node in scene.nodes() {
                     let result = load_node(&node, parent, load_context, &buffer_data);
@@ -450,9 +451,8 @@ fn load_node(
 ) -> Result<(), GltfError> {
     let transform = gltf_node.transform();
     let mut gltf_error = None;
-    let mut node = world_builder.spawn_bundle((
+    let mut node = world_builder.spawn_bundle(TransformBundle::from_transform(
         Transform::from_matrix(Mat4::from_cols_array_2d(&transform.matrix())),
-        GlobalTransform::identity(),
     ));
 
     if let Some(name) = gltf_node.name() {

--- a/crates/bevy_pbr/src/entity.rs
+++ b/crates/bevy_pbr/src/entity.rs
@@ -8,7 +8,7 @@ use bevy_render::{
     prelude::Visible,
     render_graph::base::MainPass,
 };
-use bevy_transform::prelude::{GlobalTransform, Transform};
+use bevy_transform::prelude::TransformBundle;
 
 /// A component bundle for "pbr mesh" entities
 #[derive(Bundle)]
@@ -19,8 +19,8 @@ pub struct PbrBundle {
     pub draw: Draw,
     pub visible: Visible,
     pub render_pipelines: RenderPipelines,
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
+    #[bundle]
+    pub transform: TransformBundle,
 }
 
 impl Default for PbrBundle {
@@ -35,7 +35,6 @@ impl Default for PbrBundle {
             main_pass: Default::default(),
             draw: Default::default(),
             transform: Default::default(),
-            global_transform: Default::default(),
         }
     }
 }
@@ -44,6 +43,6 @@ impl Default for PbrBundle {
 #[derive(Debug, Bundle, Default)]
 pub struct PointLightBundle {
     pub point_light: PointLight,
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
+    #[bundle]
+    pub transform: TransformBundle,
 }

--- a/crates/bevy_render/src/entity.rs
+++ b/crates/bevy_render/src/entity.rs
@@ -11,7 +11,7 @@ use crate::{
 use base::MainPass;
 use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
-use bevy_transform::TransformBundle;
+use bevy_transform::{components::Transform, TransformBundle};
 
 /// A component bundle for "mesh" entities
 #[derive(Bundle, Default)]
@@ -97,7 +97,7 @@ impl OrthographicCameraBundle {
                 ..Default::default()
             },
             visible_entities: Default::default(),
-            transform: TransformBundle::from_xyz(0.0, 0.0, far - 0.1),
+            transform: Transform::from_xyz(0.0, 0.0, far - 0.1).into(),
         }
     }
 

--- a/crates/bevy_render/src/entity.rs
+++ b/crates/bevy_render/src/entity.rs
@@ -11,7 +11,7 @@ use crate::{
 use base::MainPass;
 use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
-use bevy_transform::components::{GlobalTransform, Transform};
+use bevy_transform::TransformBundle;
 
 /// A component bundle for "mesh" entities
 #[derive(Bundle, Default)]
@@ -21,8 +21,8 @@ pub struct MeshBundle {
     pub visible: Visible,
     pub render_pipelines: RenderPipelines,
     pub main_pass: MainPass,
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
+    #[bundle]
+    pub transform: TransformBundle,
 }
 
 /// Component bundle for camera entities with perspective projection
@@ -33,8 +33,8 @@ pub struct PerspectiveCameraBundle {
     pub camera: Camera,
     pub perspective_projection: PerspectiveProjection,
     pub visible_entities: VisibleEntities,
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
+    #[bundle]
+    pub transform: TransformBundle,
 }
 
 impl PerspectiveCameraBundle {
@@ -51,7 +51,6 @@ impl PerspectiveCameraBundle {
             perspective_projection: Default::default(),
             visible_entities: Default::default(),
             transform: Default::default(),
-            global_transform: Default::default(),
         }
     }
 }
@@ -66,7 +65,6 @@ impl Default for PerspectiveCameraBundle {
             perspective_projection: Default::default(),
             visible_entities: Default::default(),
             transform: Default::default(),
-            global_transform: Default::default(),
         }
     }
 }
@@ -79,8 +77,8 @@ pub struct OrthographicCameraBundle {
     pub camera: Camera,
     pub orthographic_projection: OrthographicProjection,
     pub visible_entities: VisibleEntities,
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
+    #[bundle]
+    pub transform: TransformBundle,
 }
 
 impl OrthographicCameraBundle {
@@ -99,8 +97,7 @@ impl OrthographicCameraBundle {
                 ..Default::default()
             },
             visible_entities: Default::default(),
-            transform: Transform::from_xyz(0.0, 0.0, far - 0.1),
-            global_transform: Default::default(),
+            transform: TransformBundle::from_xyz(0.0, 0.0, far - 0.1),
         }
     }
 
@@ -117,7 +114,6 @@ impl OrthographicCameraBundle {
             },
             visible_entities: Default::default(),
             transform: Default::default(),
-            global_transform: Default::default(),
         }
     }
 
@@ -130,7 +126,6 @@ impl OrthographicCameraBundle {
             orthographic_projection: Default::default(),
             visible_entities: Default::default(),
             transform: Default::default(),
-            global_transform: Default::default(),
         }
     }
 }

--- a/crates/bevy_sprite/src/entity.rs
+++ b/crates/bevy_sprite/src/entity.rs
@@ -10,7 +10,7 @@ use bevy_render::{
     prelude::{Draw, Visible},
     render_graph::base::MainPass,
 };
-use bevy_transform::prelude::{GlobalTransform, Transform};
+use bevy_transform::TransformBundle;
 
 #[derive(Bundle, Clone)]
 pub struct SpriteBundle {
@@ -21,8 +21,8 @@ pub struct SpriteBundle {
     pub draw: Draw,
     pub visible: Visible,
     pub render_pipelines: RenderPipelines,
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
+    #[bundle]
+    pub transform: TransformBundle,
 }
 
 impl Default for SpriteBundle {
@@ -41,7 +41,6 @@ impl Default for SpriteBundle {
             sprite: Default::default(),
             material: Default::default(),
             transform: Default::default(),
-            global_transform: Default::default(),
         }
     }
 }
@@ -60,8 +59,8 @@ pub struct SpriteSheetBundle {
     pub render_pipelines: RenderPipelines,
     pub main_pass: MainPass,
     pub mesh: Handle<Mesh>, // TODO: maybe abstract this out
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
+    #[bundle]
+    pub transform: TransformBundle,
 }
 
 impl Default for SpriteSheetBundle {
@@ -80,7 +79,6 @@ impl Default for SpriteSheetBundle {
             sprite: Default::default(),
             texture_atlas: Default::default(),
             transform: Default::default(),
-            global_transform: Default::default(),
         }
     }
 }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -14,7 +14,7 @@ use bevy_render::{
     renderer::RenderResourceBindings,
 };
 use bevy_sprite::{TextureAtlas, QUAD_HANDLE};
-use bevy_transform::prelude::{GlobalTransform, Transform};
+use bevy_transform::prelude::{GlobalTransform, TransformBundle};
 use bevy_window::Windows;
 use glyph_brush_layout::{HorizontalAlign, VerticalAlign};
 
@@ -27,10 +27,10 @@ pub struct Text2dBundle {
     pub draw: Draw,
     pub visible: Visible,
     pub text: Text,
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
     pub main_pass: MainPass,
     pub text_2d_size: Text2dSize,
+    #[bundle]
+    pub transform: TransformBundle,
 }
 
 impl Default for Text2dBundle {
@@ -44,12 +44,11 @@ impl Default for Text2dBundle {
                 ..Default::default()
             },
             text: Default::default(),
-            transform: Default::default(),
-            global_transform: Default::default(),
             main_pass: MainPass {},
             text_2d_size: Text2dSize {
                 size: Size::default(),
             },
+            transform: Default::default(),
         }
     }
 }

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -9,7 +9,7 @@ use std::ops::Mul;
 /// * To place or move an entity, you should set its [`Transform`].
 /// * To get the global position of an entity, you should get its [`GlobalTransform`].
 /// * To be displayed, an entity must have both a [`Transform`] and a [`GlobalTransform`].
-///   * Use the [`TransformBundle`] to guaranty this.
+///   * You may use the [`TransformBundle`] to guaranty this.
 ///
 /// ## [`Transform`] and [`GlobalTransform`]
 ///

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -9,7 +9,7 @@ use std::ops::Mul;
 /// * To place or move an entity, you should set its [`Transform`].
 /// * To get the global position of an entity, you should get its [`GlobalTransform`].
 /// * To be displayed, an entity must have both a [`Transform`] and a [`GlobalTransform`].
-///   * You may use the [`TransformBundle`] to guaranty this.
+///   * You may use the [`TransformBundle`] to guarantee this.
 ///
 /// ## [`Transform`] and [`GlobalTransform`]
 ///

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -21,16 +21,6 @@ use std::ops::Mul;
 /// [`GlobalTransform`] is updated from [`Transform`] in the system
 /// [`transform_propagate_system`](crate::transform_propagate_system::transform_propagate_system).
 ///
-/// In pseudo code:
-/// ```ignore
-/// for entity in entities_without_parent:
-///     set entity.global_transform to entity.transform
-///     recursively:
-///         set parent to current entity
-///         for child in parent.children:
-///             set child.global_transform to parent.global_transform * child.transform
-/// ```
-///
 /// This system runs in stage [`CoreStage::PostUpdate`](crate::CoreStage::PostUpdate). If you
 /// update the[`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -7,8 +7,9 @@ use std::ops::Mul;
 /// Describe the position of an entity relative to the reference frame.
 ///
 /// * To place or move an entity, you should set its [`Transform`].
-/// * To be displayed, an entity must have both a [`Transform`] and a [`GlobalTransform`].
 /// * To get the global position of an entity, you should get its [`GlobalTransform`].
+/// * To be displayed, an entity must have both a [`Transform`] and a [`GlobalTransform`].
+///   * Use the [`TransformBundle`] to guaranty this.
 ///
 /// ## [`Transform`] and [`GlobalTransform`]
 ///

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -22,16 +22,6 @@ use std::ops::Mul;
 /// [`GlobalTransform`] is updated from [`Transform`] in the system
 /// [`transform_propagate_system`](crate::transform_propagate_system::transform_propagate_system).
 ///
-/// In pseudo code:
-/// ```ignore
-/// for entity in entities_without_parent:
-///     set entity.global_transform to entity.transform
-///     recursively:
-///         set parent to current entity
-///         for child in parent.children:
-///             set child.global_transform to parent.global_transform * child.transform
-/// ```
-///
 /// This system runs in stage [`CoreStage::PostUpdate`](crate::CoreStage::PostUpdate). If you
 /// update the[`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -10,7 +10,7 @@ use std::ops::Mul;
 /// * To place or move an entity, you should set its [`Transform`].
 /// * To get the global position of an entity, you should get its [`GlobalTransform`].
 /// * To be displayed, an entity must have both a [`Transform`] and a [`GlobalTransform`].
-///   * You may use the [`TransformBundle`] to guaranty this.
+///   * You may use the [`TransformBundle`] to guarantee this.
 ///
 /// ## [`Transform`] and [`GlobalTransform`]
 ///

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -10,7 +10,7 @@ use std::ops::Mul;
 /// * To place or move an entity, you should set its [`Transform`].
 /// * To get the global position of an entity, you should get its [`GlobalTransform`].
 /// * To be displayed, an entity must have both a [`Transform`] and a [`GlobalTransform`].
-///   * Use the [`TransformBundle`] to guaranty this.
+///   * You may use the [`TransformBundle`] to guaranty this.
 ///
 /// ## [`Transform`] and [`GlobalTransform`]
 ///

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -8,8 +8,9 @@ use std::ops::Mul;
 /// to its parent position.
 ///
 /// * To place or move an entity, you should set its [`Transform`].
-/// * To be displayed, an entity must have both a [`Transform`] and a [`GlobalTransform`].
 /// * To get the global position of an entity, you should get its [`GlobalTransform`].
+/// * To be displayed, an entity must have both a [`Transform`] and a [`GlobalTransform`].
+///   * Use the [`TransformBundle`] to guaranty this.
 ///
 /// ## [`Transform`] and [`GlobalTransform`]
 ///

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -42,12 +42,6 @@ pub struct TransformBundle {
 }
 
 impl TransformBundle {
-    /// Creates a new [`TransformBundle`] from a [`Transform`] and a [`GlobalTransform`].
-    #[inline]
-    pub fn new(local: Transform, global: GlobalTransform) -> Self {
-        TransformBundle { local, global }
-    }
-
     /// Creates a new [`TransformBundle`] from a [`Transform`] and leaving [`GlobalTransform`] with
     /// no translation, rotation, and a scale of 1 on all axes.
     #[inline]

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -8,27 +8,24 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
-// Note: Neccesary because `Component` is only used in the documentation of TransformBundle.
-#[allow(unused_imports)]
 use bevy_ecs::{
     bundle::Bundle,
-    component::Component,
     schedule::{ParallelSystemDescriptorCoercion, SystemLabel},
 };
 use bevy_math::{Mat4, Quat, Vec3};
 use prelude::{parent_update_system, Children, GlobalTransform, Parent, PreviousParent, Transform};
 
-/// A [`Bundle`] of the [`Transform`] and [`GlobalTransform`] [`Component`]s, which describe the position of an entity.
+/// A [`Bundle`] of the [`Transform`] and [`GlobalTransform`] [`Component`](bevy_ecs::component::Component)s, which describe the position of an entity.
 ///
 /// * To place or move an entity, you should set its [`Transform`].
 /// * To get the global position of an entity, you should get its [`GlobalTransform`].
 /// * To be displayed, an entity must have both a [`Transform`] and a [`GlobalTransform`].
-///   * Use the [`TransformBundle`] to guaranty this.
+///   * You may use the [`TransformBundle`] to guaranty this.
 ///
 /// ## [`Transform`] and [`GlobalTransform`]
 ///
 /// [`Transform`] is the position of an entity relative to its parent position, or the reference
-/// frame if it doesn't have a [`Parent`](super::Parent).
+/// frame if it doesn't have a [`Parent`](Parent).
 ///
 /// [`GlobalTransform`] is the position of an entity relative to the reference frame.
 ///
@@ -72,6 +69,7 @@ impl TransformBundle {
     pub const fn identity() -> Self {
         TransformBundle {
             local: Transform::identity(),
+            // Note: `..Default::default()` cannot be used here, because it isn't const
             global: GlobalTransform::identity(),
         }
     }

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -53,6 +53,7 @@ pub struct TransformBundle {
 
 impl TransformBundle {
     /// Creates a new [`TransformBundle`] from a [`Transform`] and a [`GlobalTransform`].
+    #[inline]
     pub fn new(local: Transform, global: GlobalTransform) -> Self {
         TransformBundle { local, global }
     }
@@ -80,6 +81,7 @@ impl TransformBundle {
 }
 
 impl From<Transform> for TransformBundle {
+    #[inline]
     fn from(transform: Transform) -> Self {
         Self::from_transform(transform)
     }

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -32,16 +32,6 @@ use prelude::{parent_update_system, Children, GlobalTransform, Parent, PreviousP
 /// [`GlobalTransform`] is updated from [`Transform`] in the system
 /// [`transform_propagate_system`](crate::transform_propagate_system::transform_propagate_system).
 ///
-/// In pseudo code:
-/// ```ignore
-/// for entity in entities_without_parent:
-///     set entity.global_transform to entity.transform
-///     recursively:
-///         set parent to current entity
-///         for child in parent.children:
-///             set child.global_transform to parent.global_transform * child.transform
-/// ```
-///
 /// This system runs in stage [`CoreStage::PostUpdate`](crate::CoreStage::PostUpdate). If you
 /// update the[`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -20,7 +20,7 @@ use prelude::{parent_update_system, Children, GlobalTransform, Parent, PreviousP
 /// * To place or move an entity, you should set its [`Transform`].
 /// * To get the global position of an entity, you should get its [`GlobalTransform`].
 /// * To be displayed, an entity must have both a [`Transform`] and a [`GlobalTransform`].
-///   * You may use the [`TransformBundle`] to guaranty this.
+///   * You may use the [`TransformBundle`] to guarantee this.
 ///
 /// ## [`Transform`] and [`GlobalTransform`]
 ///

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -17,8 +17,8 @@ use prelude::{parent_update_system, Children, GlobalTransform, Parent, PreviousP
 
 #[derive(Default, Bundle, Clone, Debug)]
 pub struct TransformBundle {
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
+    pub local: Transform,
+    pub global: GlobalTransform,
 }
 
 impl TransformBundle {
@@ -28,7 +28,7 @@ impl TransformBundle {
     #[inline]
     pub fn from_xyz(x: f32, y: f32, z: f32) -> Self {
         TransformBundle {
-            transform: Transform::from_xyz(x, y, z),
+            local: Transform::from_xyz(x, y, z),
             ..Default::default()
         }
     }
@@ -38,8 +38,8 @@ impl TransformBundle {
     #[inline]
     pub const fn identity() -> Self {
         TransformBundle {
-            transform: Transform::identity(),
-            global_transform: GlobalTransform::identity(),
+            local: Transform::identity(),
+            global: GlobalTransform::identity(),
         }
     }
 
@@ -48,7 +48,7 @@ impl TransformBundle {
     #[inline]
     pub fn from_matrix(matrix: Mat4) -> Self {
         TransformBundle {
-            transform: Transform::from_matrix(matrix),
+            local: Transform::from_matrix(matrix),
             ..Default::default()
         }
     }
@@ -58,7 +58,7 @@ impl TransformBundle {
     #[inline]
     pub fn from_translation(translation: Vec3) -> Self {
         TransformBundle {
-            transform: Transform::from_translation(translation),
+            local: Transform::from_translation(translation),
             ..Default::default()
         }
     }
@@ -68,7 +68,7 @@ impl TransformBundle {
     #[inline]
     pub fn from_rotation(rotation: Quat) -> Self {
         TransformBundle {
-            transform: Transform::from_rotation(rotation),
+            local: Transform::from_rotation(rotation),
             ..Default::default()
         }
     }
@@ -78,7 +78,7 @@ impl TransformBundle {
     #[inline]
     pub fn from_scale(scale: Vec3) -> Self {
         TransformBundle {
-            transform: Transform::from_scale(scale),
+            local: Transform::from_scale(scale),
             ..Default::default()
         }
     }
@@ -87,7 +87,7 @@ impl TransformBundle {
 impl From<Transform> for TransformBundle {
     fn from(transform: Transform) -> Self {
         TransformBundle {
-            transform,
+            local: transform,
             ..Default::default()
         }
     }

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -4,12 +4,94 @@ pub mod transform_propagate_system;
 
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{components::*, hierarchy::*, TransformPlugin};
+    pub use crate::{components::*, hierarchy::*, TransformBundle, TransformPlugin};
 }
 
 use bevy_app::prelude::*;
-use bevy_ecs::schedule::{ParallelSystemDescriptorCoercion, SystemLabel};
+use bevy_ecs::{
+    bundle::Bundle,
+    schedule::{ParallelSystemDescriptorCoercion, SystemLabel},
+};
+use bevy_math::{Mat4, Quat, Vec3};
 use prelude::{parent_update_system, Children, GlobalTransform, Parent, PreviousParent, Transform};
+
+#[derive(Default, Bundle, Clone, Debug)]
+pub struct TransformBundle {
+    pub transform: Transform,
+    pub global_transform: GlobalTransform,
+}
+
+impl TransformBundle {
+    /// Creates a new [`TransformBundle`] at the position `(x, y, z)`. In 2d, the `z` component
+    /// is used for z-ordering elements: higher `z`-value will be in front of lower
+    /// `z`-value.
+    #[inline]
+    pub fn from_xyz(x: f32, y: f32, z: f32) -> Self {
+        TransformBundle {
+            transform: Transform::from_xyz(x, y, z),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new identity [`TransformBundle`], with no translation, rotation, and a scale of 1
+    /// on all axes.
+    #[inline]
+    pub const fn identity() -> Self {
+        TransformBundle {
+            transform: Transform::identity(),
+            global_transform: GlobalTransform::identity(),
+        }
+    }
+
+    /// Extracts the translation, rotation, and scale from `matrix`. It must be a 3d affine
+    /// transformation matrix.
+    #[inline]
+    pub fn from_matrix(matrix: Mat4) -> Self {
+        TransformBundle {
+            transform: Transform::from_matrix(matrix),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new [`TransformBundle`], with `translation`. Rotation will be 0 and scale 1 on
+    /// all axes.
+    #[inline]
+    pub fn from_translation(translation: Vec3) -> Self {
+        TransformBundle {
+            transform: Transform::from_translation(translation),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new [`TransformBundle`], with `rotation`. Translation will be 0 and scale 1 on
+    /// all axes.
+    #[inline]
+    pub fn from_rotation(rotation: Quat) -> Self {
+        TransformBundle {
+            transform: Transform::from_rotation(rotation),
+            ..Default::default()
+        }
+    }
+
+    /// Creates a new [`TransformBundle`], with `scale`. Translation will be 0 and rotation 0 on
+    /// all axes.
+    #[inline]
+    pub fn from_scale(scale: Vec3) -> Self {
+        TransformBundle {
+            transform: Transform::from_scale(scale),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<Transform> for TransformBundle {
+    fn from(transform: Transform) -> Self {
+        TransformBundle {
+            transform,
+            ..Default::default()
+        }
+    }
+}
 
 #[derive(Default)]
 pub struct TransformPlugin;

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -8,13 +8,46 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
+// Note: Neccesary because `Component` is only used in the documentation of TransformBundle.
+#[allow(unused_imports)]
 use bevy_ecs::{
     bundle::Bundle,
+    component::Component,
     schedule::{ParallelSystemDescriptorCoercion, SystemLabel},
 };
 use bevy_math::{Mat4, Quat, Vec3};
 use prelude::{parent_update_system, Children, GlobalTransform, Parent, PreviousParent, Transform};
 
+/// A [`Bundle`] of the [`Transform`] and [`GlobalTransform`] [`Component`]s, which describe the position of an entity.
+///
+/// * To place or move an entity, you should set its [`Transform`].
+/// * To get the global position of an entity, you should get its [`GlobalTransform`].
+/// * To be displayed, an entity must have both a [`Transform`] and a [`GlobalTransform`].
+///   * Use the [`TransformBundle`] to guaranty this.
+///
+/// ## [`Transform`] and [`GlobalTransform`]
+///
+/// [`Transform`] is the position of an entity relative to its parent position, or the reference
+/// frame if it doesn't have a [`Parent`](super::Parent).
+///
+/// [`GlobalTransform`] is the position of an entity relative to the reference frame.
+///
+/// [`GlobalTransform`] is updated from [`Transform`] in the system
+/// [`transform_propagate_system`](crate::transform_propagate_system::transform_propagate_system).
+///
+/// In pseudo code:
+/// ```ignore
+/// for entity in entities_without_parent:
+///     set entity.global_transform to entity.transform
+///     recursively:
+///         set parent to current entity
+///         for child in parent.children:
+///             set child.global_transform to parent.global_transform * child.transform
+/// ```
+///
+/// This system runs in stage [`CoreStage::PostUpdate`](crate::CoreStage::PostUpdate). If you
+/// update the[`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
+/// before the [`GlobalTransform`] is updated.
 #[derive(Default, Bundle, Clone, Debug)]
 pub struct TransformBundle {
     pub local: Transform,

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -12,10 +12,10 @@ use bevy_ecs::{
     bundle::Bundle,
     schedule::{ParallelSystemDescriptorCoercion, SystemLabel},
 };
-use bevy_math::{Mat4, Quat, Vec3};
 use prelude::{parent_update_system, Children, GlobalTransform, Parent, PreviousParent, Transform};
 
-/// A [`Bundle`] of the [`Transform`] and [`GlobalTransform`] [`Component`](bevy_ecs::component::Component)s, which describe the position of an entity.
+/// A [`Bundle`] of the [`Transform`] and [`GlobalTransform`]
+/// [`Component`](bevy_ecs::component::Component)s, which describe the position of an entity.
 ///
 /// * To place or move an entity, you should set its [`Transform`].
 /// * To get the global position of an entity, you should get its [`GlobalTransform`].
@@ -52,13 +52,17 @@ pub struct TransformBundle {
 }
 
 impl TransformBundle {
-    /// Creates a new [`TransformBundle`] at the position `(x, y, z)`. In 2d, the `z` component
-    /// is used for z-ordering elements: higher `z`-value will be in front of lower
-    /// `z`-value.
+    /// Creates a new [`TransformBundle`] from a [`Transform`] and a [`GlobalTransform`].
+    pub fn new(local: Transform, global: GlobalTransform) -> Self {
+        TransformBundle { local, global }
+    }
+
+    /// Creates a new [`TransformBundle`] from a [`Transform`] and leaving [`GlobalTransform`] with
+    /// no translation, rotation, and a scale of 1 on all axes.
     #[inline]
-    pub fn from_xyz(x: f32, y: f32, z: f32) -> Self {
+    pub fn from_transform(transform: Transform) -> Self {
         TransformBundle {
-            local: Transform::from_xyz(x, y, z),
+            local: transform,
             ..Default::default()
         }
     }
@@ -73,54 +77,11 @@ impl TransformBundle {
             global: GlobalTransform::identity(),
         }
     }
-
-    /// Extracts the translation, rotation, and scale from `matrix`. It must be a 3d affine
-    /// transformation matrix.
-    #[inline]
-    pub fn from_matrix(matrix: Mat4) -> Self {
-        TransformBundle {
-            local: Transform::from_matrix(matrix),
-            ..Default::default()
-        }
-    }
-
-    /// Creates a new [`TransformBundle`], with `translation`. Rotation will be 0 and scale 1 on
-    /// all axes.
-    #[inline]
-    pub fn from_translation(translation: Vec3) -> Self {
-        TransformBundle {
-            local: Transform::from_translation(translation),
-            ..Default::default()
-        }
-    }
-
-    /// Creates a new [`TransformBundle`], with `rotation`. Translation will be 0 and scale 1 on
-    /// all axes.
-    #[inline]
-    pub fn from_rotation(rotation: Quat) -> Self {
-        TransformBundle {
-            local: Transform::from_rotation(rotation),
-            ..Default::default()
-        }
-    }
-
-    /// Creates a new [`TransformBundle`], with `scale`. Translation will be 0 and rotation 0 on
-    /// all axes.
-    #[inline]
-    pub fn from_scale(scale: Vec3) -> Self {
-        TransformBundle {
-            local: Transform::from_scale(scale),
-            ..Default::default()
-        }
-    }
 }
 
 impl From<Transform> for TransformBundle {
     fn from(transform: Transform) -> Self {
-        TransformBundle {
-            local: transform,
-            ..Default::default()
-        }
+        Self::from_transform(transform)
     }
 }
 

--- a/crates/bevy_transform/src/transform_propagate_system.rs
+++ b/crates/bevy_transform/src/transform_propagate_system.rs
@@ -82,7 +82,10 @@ mod test {
     };
 
     use super::*;
-    use crate::hierarchy::{parent_update_system, BuildChildren, BuildWorldChildren};
+    use crate::{
+        hierarchy::{parent_update_system, BuildChildren, BuildWorldChildren},
+        TransformBundle,
+    };
 
     #[test]
     fn did_propagate() {
@@ -96,33 +99,31 @@ mod test {
         schedule.add_stage("update", update_stage);
 
         // Root entity
-        world.spawn().insert_bundle((
-            Transform::from_xyz(1.0, 0.0, 0.0),
-            GlobalTransform::identity(),
-        ));
+        world
+            .spawn()
+            .insert_bundle(TransformBundle::from_transform(Transform::from_xyz(
+                1.0, 0.0, 0.0,
+            )));
 
         let mut children = Vec::new();
         world
             .spawn()
-            .insert_bundle((
-                Transform::from_xyz(1.0, 0.0, 0.0),
-                GlobalTransform::identity(),
-            ))
+            .insert_bundle(TransformBundle::from_transform(Transform::from_xyz(
+                1.0, 0.0, 0.0,
+            )))
             .with_children(|parent| {
                 children.push(
                     parent
-                        .spawn_bundle((
-                            Transform::from_xyz(0.0, 2.0, 0.),
-                            GlobalTransform::identity(),
-                        ))
+                        .spawn_bundle(TransformBundle::from_transform(Transform::from_xyz(
+                            0.0, 2.0, 0.,
+                        )))
                         .id(),
                 );
                 children.push(
                     parent
-                        .spawn_bundle((
-                            Transform::from_xyz(0.0, 0.0, 3.),
-                            GlobalTransform::identity(),
-                        ))
+                        .spawn_bundle(TransformBundle::from_transform(Transform::from_xyz(
+                            0.0, 0.0, 3.,
+                        )))
                         .id(),
                 );
             });
@@ -155,25 +156,22 @@ mod test {
         let mut commands = Commands::new(&mut queue, &world);
         let mut children = Vec::new();
         commands
-            .spawn_bundle((
-                Transform::from_xyz(1.0, 0.0, 0.0),
-                GlobalTransform::identity(),
-            ))
+            .spawn_bundle(TransformBundle::from_transform(Transform::from_xyz(
+                1.0, 0.0, 0.0,
+            )))
             .with_children(|parent| {
                 children.push(
                     parent
-                        .spawn_bundle((
-                            Transform::from_xyz(0.0, 2.0, 0.0),
-                            GlobalTransform::identity(),
-                        ))
+                        .spawn_bundle(TransformBundle::from_transform(Transform::from_xyz(
+                            0.0, 2.0, 0.0,
+                        )))
                         .id(),
                 );
                 children.push(
                     parent
-                        .spawn_bundle((
-                            Transform::from_xyz(0.0, 0.0, 3.0),
-                            GlobalTransform::identity(),
-                        ))
+                        .spawn_bundle(TransformBundle::from_transform(Transform::from_xyz(
+                            0.0, 0.0, 3.0,
+                        )))
                         .id(),
                 );
             });

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -15,7 +15,7 @@ use bevy_render::{
 };
 use bevy_sprite::{ColorMaterial, QUAD_HANDLE};
 use bevy_text::Text;
-use bevy_transform::TransformBundle;
+use bevy_transform::{components::Transform, TransformBundle};
 
 #[derive(Bundle, Clone, Debug)]
 pub struct NodeBundle {
@@ -185,7 +185,7 @@ impl Default for UiCameraBundle {
                 ..Default::default()
             },
             visible_entities: Default::default(),
-            transform: TransformBundle::from_xyz(0.0, 0.0, far - 0.1),
+            transform: Transform::from_xyz(0.0, 0.0, far - 0.1).into(),
         }
     }
 }

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -15,7 +15,7 @@ use bevy_render::{
 };
 use bevy_sprite::{ColorMaterial, QUAD_HANDLE};
 use bevy_text::Text;
-use bevy_transform::prelude::{GlobalTransform, Transform};
+use bevy_transform::TransformBundle;
 
 #[derive(Bundle, Clone, Debug)]
 pub struct NodeBundle {
@@ -26,8 +26,8 @@ pub struct NodeBundle {
     pub draw: Draw,
     pub visible: Visible,
     pub render_pipelines: RenderPipelines,
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
+    #[bundle]
+    pub transform: TransformBundle,
 }
 
 impl Default for NodeBundle {
@@ -46,7 +46,6 @@ impl Default for NodeBundle {
             material: Default::default(),
             draw: Default::default(),
             transform: Default::default(),
-            global_transform: Default::default(),
         }
     }
 }
@@ -62,8 +61,8 @@ pub struct ImageBundle {
     pub draw: Draw,
     pub visible: Visible,
     pub render_pipelines: RenderPipelines,
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
+    #[bundle]
+    pub transform: TransformBundle,
 }
 
 impl Default for ImageBundle {
@@ -84,7 +83,6 @@ impl Default for ImageBundle {
                 ..Default::default()
             },
             transform: Default::default(),
-            global_transform: Default::default(),
         }
     }
 }
@@ -98,8 +96,8 @@ pub struct TextBundle {
     pub text: Text,
     pub calculated_size: CalculatedSize,
     pub focus_policy: FocusPolicy,
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
+    #[bundle]
+    pub transform: TransformBundle,
 }
 
 impl Default for TextBundle {
@@ -118,7 +116,6 @@ impl Default for TextBundle {
             calculated_size: Default::default(),
             style: Default::default(),
             transform: Default::default(),
-            global_transform: Default::default(),
         }
     }
 }
@@ -135,8 +132,8 @@ pub struct ButtonBundle {
     pub draw: Draw,
     pub visible: Visible,
     pub render_pipelines: RenderPipelines,
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
+    #[bundle]
+    pub transform: TransformBundle,
 }
 
 impl Default for ButtonBundle {
@@ -158,7 +155,6 @@ impl Default for ButtonBundle {
                 ..Default::default()
             },
             transform: Default::default(),
-            global_transform: Default::default(),
         }
     }
 }
@@ -168,8 +164,8 @@ pub struct UiCameraBundle {
     pub camera: Camera,
     pub orthographic_projection: OrthographicProjection,
     pub visible_entities: VisibleEntities,
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
+    #[bundle]
+    pub transform: TransformBundle,
 }
 
 impl Default for UiCameraBundle {
@@ -189,8 +185,7 @@ impl Default for UiCameraBundle {
                 ..Default::default()
             },
             visible_entities: Default::default(),
-            transform: Transform::from_xyz(0.0, 0.0, far - 0.1),
-            global_transform: Default::default(),
+            transform: TransformBundle::from_xyz(0.0, 0.0, far - 0.1),
         }
     }
 }

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -68,15 +68,14 @@ fn setup(
     let mut rnd = rand::thread_rng();
 
     for name in contribs {
-        let pos = (rnd.gen_range(-400.0..400.0), rnd.gen_range(0.0..400.0));
+        let transform =
+            TransformBundle::from_xyz(rnd.gen_range(-400.0..400.0), rnd.gen_range(0.0..400.0), 0.0);
         let dir = rnd.gen_range(-1.0..1.0);
         let velocity = Vec3::new(dir * 500.0, 0.0, 0.0);
         let hue = rnd.gen_range(0.0..=360.0);
 
         // some sprites should be flipped
         let flipped = rnd.gen_bool(0.5);
-
-        let transform = Transform::from_xyz(pos.0, pos.1, 0.0);
 
         let e = commands
             .spawn()

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -69,7 +69,8 @@ fn setup(
 
     for name in contribs {
         let transform =
-            TransformBundle::from_xyz(rnd.gen_range(-400.0..400.0), rnd.gen_range(0.0..400.0), 0.0);
+            Transform::from_xyz(rnd.gen_range(-400.0..400.0), rnd.gen_range(0.0..400.0), 0.0)
+                .into();
         let dir = rnd.gen_range(-1.0..1.0);
         let velocity = Vec3::new(dir * 500.0, 0.0, 0.0);
         let hue = rnd.gen_range(0.0..=360.0);

--- a/examples/2d/many_sprites.rs
+++ b/examples/2d/many_sprites.rs
@@ -65,7 +65,8 @@ fn setup(
                     translation,
                     rotation,
                     scale,
-                },
+                }
+                .into(),
                 sprite: Sprite::new(tile_size),
                 ..Default::default()
             });

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -34,7 +34,7 @@ fn setup(
     commands
         .spawn_bundle(SpriteSheetBundle {
             texture_atlas: texture_atlas_handle,
-            transform: TransformBundle::from_scale(Vec3::splat(6.0)),
+            transform: Transform::from_scale(Vec3::splat(6.0)).into(),
             ..Default::default()
         })
         .insert(Timer::from_seconds(0.1, true));

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -34,7 +34,7 @@ fn setup(
     commands
         .spawn_bundle(SpriteSheetBundle {
             texture_atlas: texture_atlas_handle,
-            transform: Transform::from_scale(Vec3::splat(6.0)),
+            transform: TransformBundle::from_scale(Vec3::splat(6.0)),
             ..Default::default()
         })
         .insert(Timer::from_seconds(0.1, true));

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -68,7 +68,8 @@ fn setup(
             translation: Vec3::new(150.0, 0.0, 0.0),
             scale: Vec3::splat(4.0),
             ..Default::default()
-        },
+        }
+        .into(),
         sprite: TextureAtlasSprite::new(vendor_index as u32),
         texture_atlas: atlas_handle,
         ..Default::default()
@@ -76,7 +77,7 @@ fn setup(
     // draw the atlas itself
     commands.spawn_bundle(SpriteBundle {
         material: materials.add(texture_atlas_texture.into()),
-        transform: Transform::from_xyz(-300.0, 0.0, 0.0),
+        transform: TransformBundle::from_xyz(-300.0, 0.0, 0.0),
         ..Default::default()
     });
 }

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -77,7 +77,7 @@ fn setup(
     // draw the atlas itself
     commands.spawn_bundle(SpriteBundle {
         material: materials.add(texture_atlas_texture.into()),
-        transform: TransformBundle::from_xyz(-300.0, 0.0, 0.0),
+        transform: Transform::from_xyz(-300.0, 0.0, 0.0).into(),
         ..Default::default()
     });
 }

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -24,12 +24,12 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-        transform: TransformBundle::from_xyz(0.0, 0.5, 0.0),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0).into(),
         ..Default::default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(4.0, 8.0, 4.0),
+        transform: Transform::from_xyz(4.0, 8.0, 4.0).into(),
         ..Default::default()
     });
     // camera

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -24,17 +24,19 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        transform: TransformBundle::from_xyz(0.0, 0.5, 0.0),
         ..Default::default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        transform: TransformBundle::from_xyz(4.0, 8.0, 4.0),
         ..Default::default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -16,12 +16,14 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_scene(asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0"));
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(0.7, 0.7, 1.0).looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
+        transform: Transform::from_xyz(0.7, 0.7, 1.0)
+            .looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y)
+            .into(),
         ..Default::default()
     });
     commands
         .spawn_bundle(PointLightBundle {
-            transform: Transform::from_xyz(3.0, 5.0, 3.0),
+            transform: TransformBundle::from_xyz(3.0, 5.0, 3.0),
             ..Default::default()
         })
         .insert(Rotates);

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -23,7 +23,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     });
     commands
         .spawn_bundle(PointLightBundle {
-            transform: TransformBundle::from_xyz(3.0, 5.0, 3.0),
+            transform: Transform::from_xyz(3.0, 5.0, 3.0).into(),
             ..Default::default()
         })
         .insert(Rotates);

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -26,7 +26,7 @@ fn setup(
     });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(4.0, 8.0, 4.0),
+        transform: Transform::from_xyz(4.0, 8.0, 4.0).into(),
         ..Default::default()
     });
     // camera

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -26,12 +26,14 @@ fn setup(
     });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        transform: TransformBundle::from_xyz(4.0, 8.0, 4.0),
         ..Default::default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(-3.0, 3.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(-3.0, 3.0, 5.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -34,30 +34,30 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-        transform: TransformBundle::from_xyz(1.5, 0.5, 1.5),
+        transform: Transform::from_xyz(1.5, 0.5, 1.5).into(),
         ..Default::default()
     });
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-        transform: TransformBundle::from_xyz(1.5, 0.5, -1.5),
+        transform: Transform::from_xyz(1.5, 0.5, -1.5).into(),
         ..Default::default()
     });
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-        transform: TransformBundle::from_xyz(-1.5, 0.5, 1.5),
+        transform: Transform::from_xyz(-1.5, 0.5, 1.5).into(),
         ..Default::default()
     });
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-        transform: TransformBundle::from_xyz(-1.5, 0.5, -1.5),
+        transform: Transform::from_xyz(-1.5, 0.5, -1.5).into(),
         ..Default::default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(3.0, 8.0, 5.0),
+        transform: Transform::from_xyz(3.0, 8.0, 5.0).into(),
         ..Default::default()
     });
 }

--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -17,7 +17,9 @@ fn setup(
     // set up the camera
     let mut camera = OrthographicCameraBundle::new_3d();
     camera.orthographic_projection.scale = 3.0;
-    camera.transform = Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y);
+    camera.transform = Transform::from_xyz(5.0, 5.0, 5.0)
+        .looking_at(Vec3::ZERO, Vec3::Y)
+        .into();
 
     // camera
     commands.spawn_bundle(camera);
@@ -32,30 +34,30 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-        transform: Transform::from_xyz(1.5, 0.5, 1.5),
+        transform: TransformBundle::from_xyz(1.5, 0.5, 1.5),
         ..Default::default()
     });
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-        transform: Transform::from_xyz(1.5, 0.5, -1.5),
+        transform: TransformBundle::from_xyz(1.5, 0.5, -1.5),
         ..Default::default()
     });
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-        transform: Transform::from_xyz(-1.5, 0.5, 1.5),
+        transform: TransformBundle::from_xyz(-1.5, 0.5, 1.5),
         ..Default::default()
     });
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-        transform: Transform::from_xyz(-1.5, 0.5, -1.5),
+        transform: TransformBundle::from_xyz(-1.5, 0.5, -1.5),
         ..Default::default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_xyz(3.0, 8.0, 5.0),
+        transform: TransformBundle::from_xyz(3.0, 8.0, 5.0),
         ..Default::default()
     });
 }

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -38,7 +38,7 @@ fn setup(
         .spawn_bundle(PbrBundle {
             mesh: cube_handle.clone(),
             material: cube_material_handle.clone(),
-            transform: Transform::from_xyz(0.0, 0.0, 1.0),
+            transform: TransformBundle::from_xyz(0.0, 0.0, 1.0),
             ..Default::default()
         })
         .insert(Rotator)
@@ -47,18 +47,20 @@ fn setup(
             parent.spawn_bundle(PbrBundle {
                 mesh: cube_handle,
                 material: cube_material_handle,
-                transform: Transform::from_xyz(0.0, 0.0, 3.0),
+                transform: TransformBundle::from_xyz(0.0, 0.0, 3.0),
                 ..Default::default()
             });
         });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_xyz(4.0, 5.0, -4.0),
+        transform: TransformBundle::from_xyz(4.0, 5.0, -4.0),
         ..Default::default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(5.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(5.0, 10.0, 10.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -38,7 +38,7 @@ fn setup(
         .spawn_bundle(PbrBundle {
             mesh: cube_handle.clone(),
             material: cube_material_handle.clone(),
-            transform: TransformBundle::from_xyz(0.0, 0.0, 1.0),
+            transform: Transform::from_xyz(0.0, 0.0, 1.0).into(),
             ..Default::default()
         })
         .insert(Rotator)
@@ -47,13 +47,13 @@ fn setup(
             parent.spawn_bundle(PbrBundle {
                 mesh: cube_handle,
                 material: cube_material_handle,
-                transform: TransformBundle::from_xyz(0.0, 0.0, 3.0),
+                transform: Transform::from_xyz(0.0, 0.0, 3.0).into(),
                 ..Default::default()
             });
         });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(4.0, 5.0, -4.0),
+        transform: Transform::from_xyz(4.0, 5.0, -4.0).into(),
         ..Default::default()
     });
     // camera

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -33,7 +33,7 @@ fn setup(
                     roughness: x01,
                     ..Default::default()
                 }),
-                transform: TransformBundle::from_xyz(x as f32, y as f32 + 0.5, 0.0),
+                transform: Transform::from_xyz(x as f32, y as f32 + 0.5, 0.0).into(),
                 ..Default::default()
             });
         }
@@ -50,12 +50,12 @@ fn setup(
             unlit: true,
             ..Default::default()
         }),
-        transform: TransformBundle::from_xyz(-5.0, -2.5, 0.0),
+        transform: Transform::from_xyz(-5.0, -2.5, 0.0).into(),
         ..Default::default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(50.0, 50.0, 50.0),
+        transform: Transform::from_xyz(50.0, 50.0, 50.0).into(),
         point_light: PointLight {
             intensity: 50000.,
             range: 100.,

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -33,7 +33,7 @@ fn setup(
                     roughness: x01,
                     ..Default::default()
                 }),
-                transform: Transform::from_xyz(x as f32, y as f32 + 0.5, 0.0),
+                transform: TransformBundle::from_xyz(x as f32, y as f32 + 0.5, 0.0),
                 ..Default::default()
             });
         }
@@ -50,12 +50,12 @@ fn setup(
             unlit: true,
             ..Default::default()
         }),
-        transform: Transform::from_xyz(-5.0, -2.5, 0.0),
+        transform: TransformBundle::from_xyz(-5.0, -2.5, 0.0),
         ..Default::default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_translation(Vec3::new(50.0, 50.0, 50.0)),
+        transform: TransformBundle::from_xyz(50.0, 50.0, 50.0),
         point_light: PointLight {
             intensity: 50000.,
             range: 100.,
@@ -65,8 +65,9 @@ fn setup(
     });
     // camera
     commands.spawn_bundle(OrthographicCameraBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, 0.0, 8.0))
-            .looking_at(Vec3::default(), Vec3::Y),
+        transform: Transform::from_xyz(0.0, 0.0, 8.0)
+            .looking_at(Vec3::default(), Vec3::Y)
+            .into(),
         orthographic_projection: bevy::render::camera::OrthographicProjection {
             scale: 0.01,
             ..Default::default()

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -61,7 +61,6 @@ fn setup(
             range: 100.,
             ..Default::default()
         },
-        ..Default::default()
     });
     // camera
     commands.spawn_bundle(OrthographicCameraBundle {

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -151,7 +151,7 @@ fn setup(
         .spawn_bundle(PbrBundle {
             mesh: cube_handle,
             material: cube_material_handle,
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 1.0)),
+            transform: TransformBundle::from_xyz(0.0, 0.0, 1.0),
             ..Default::default()
         })
         .insert(FirstPassCube)
@@ -161,7 +161,7 @@ fn setup(
     // light
     // note: currently lights are shared between passes!
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
+        transform: TransformBundle::from_xyz(0.0, 0.0, 10.0),
         ..Default::default()
     });
 
@@ -174,7 +174,8 @@ fn setup(
             ..Default::default()
         },
         transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
-            .looking_at(Vec3::default(), Vec3::Y),
+            .looking_at(Vec3::default(), Vec3::Y)
+            .into(),
         ..Default::default()
     };
     active_cameras.add(FIRST_PASS_CAMERA);
@@ -207,7 +208,8 @@ fn setup(
                 translation: Vec3::new(0.0, 0.0, 1.5),
                 rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
                 ..Default::default()
-            },
+            }
+            .into(),
             visible: Visible {
                 is_transparent: true,
                 ..Default::default()
@@ -218,7 +220,8 @@ fn setup(
 
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
-            .looking_at(Vec3::default(), Vec3::Y),
+            .looking_at(Vec3::default(), Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -151,7 +151,7 @@ fn setup(
         .spawn_bundle(PbrBundle {
             mesh: cube_handle,
             material: cube_material_handle,
-            transform: TransformBundle::from_xyz(0.0, 0.0, 1.0),
+            transform: Transform::from_xyz(0.0, 0.0, 1.0).into(),
             ..Default::default()
         })
         .insert(FirstPassCube)
@@ -161,7 +161,7 @@ fn setup(
     // light
     // note: currently lights are shared between passes!
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(0.0, 0.0, 10.0),
+        transform: Transform::from_xyz(0.0, 0.0, 10.0).into(),
         ..Default::default()
     });
 

--- a/examples/3d/spawner.rs
+++ b/examples/3d/spawner.rs
@@ -42,7 +42,7 @@ fn setup(
 ) {
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(4.0, -4.0, 5.0),
+        transform: Transform::from_xyz(4.0, -4.0, 5.0).into(),
         ..Default::default()
     });
     // camera
@@ -66,11 +66,12 @@ fn setup(
                 ),
                 ..Default::default()
             }),
-            transform: TransformBundle::from_xyz(
+            transform: Transform::from_xyz(
                 rng.gen_range(-50.0..50.0),
                 rng.gen_range(-50.0..50.0),
                 0.0,
-            ),
+            )
+            .into(),
             ..Default::default()
         });
     }

--- a/examples/3d/spawner.rs
+++ b/examples/3d/spawner.rs
@@ -42,12 +42,14 @@ fn setup(
 ) {
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_xyz(4.0, -4.0, 5.0),
+        transform: TransformBundle::from_xyz(4.0, -4.0, 5.0),
         ..Default::default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(0.0, 15.0, 150.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(0.0, 15.0, 150.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 
@@ -64,7 +66,7 @@ fn setup(
                 ),
                 ..Default::default()
             }),
-            transform: Transform::from_xyz(
+            transform: TransformBundle::from_xyz(
                 rng.gen_range(-50.0..50.0),
                 rng.gen_range(-50.0..50.0),
                 0.0,

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -57,7 +57,8 @@ fn setup(
             translation: Vec3::new(0.0, 0.0, 1.5),
             rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
             ..Default::default()
-        },
+        }
+        .into(),
         visible: Visible {
             is_transparent: true,
             ..Default::default()
@@ -72,7 +73,8 @@ fn setup(
             translation: Vec3::new(0.0, 0.0, 0.0),
             rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
             ..Default::default()
-        },
+        }
+        .into(),
         visible: Visible {
             is_transparent: true,
             ..Default::default()
@@ -87,7 +89,8 @@ fn setup(
             translation: Vec3::new(0.0, 0.0, -1.5),
             rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
             ..Default::default()
-        },
+        }
+        .into(),
         visible: Visible {
             is_transparent: true,
             ..Default::default()
@@ -96,7 +99,9 @@ fn setup(
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(3.0, 5.0, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(3.0, 5.0, 8.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -25,12 +25,13 @@ fn setup(
     mut scene_instance: ResMut<SceneInstance>,
 ) {
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_xyz(4.0, 5.0, 4.0),
+        transform: TransformBundle::from_xyz(4.0, 5.0, 4.0),
         ..Default::default()
     });
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(1.05, 0.9, 1.5)
-            .looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
+            .looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y)
+            .into(),
         ..Default::default()
     });
 

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -25,7 +25,7 @@ fn setup(
     mut scene_instance: ResMut<SceneInstance>,
 ) {
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(4.0, 5.0, 4.0),
+        transform: Transform::from_xyz(4.0, 5.0, 4.0).into(),
         ..Default::default()
     });
     commands.spawn_bundle(PerspectiveCameraBundle {
@@ -38,10 +38,9 @@ fn setup(
     // Spawn the scene as a child of another entity. This first scene will be translated backward
     // with its parent
     commands
-        .spawn_bundle((
-            Transform::from_xyz(0.0, 0.0, -1.0),
-            GlobalTransform::identity(),
-        ))
+        .spawn_bundle(TransformBundle::from_transform(Transform::from_xyz(
+            0.0, 0.0, -1.0,
+        )))
         .with_children(|parent| {
             parent.spawn_scene(asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0"));
         });

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -40,19 +40,21 @@ fn setup(
         .spawn_bundle(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-            transform: Transform::from_xyz(0.0, 0.5, 0.0),
+            transform: TransformBundle::from_xyz(0.0, 0.5, 0.0),
             ..Default::default()
         })
         // This enables wireframe drawing on this entity
         .insert(Wireframe);
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        transform: TransformBundle::from_xyz(4.0, 8.0, 4.0),
         ..Default::default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -40,14 +40,14 @@ fn setup(
         .spawn_bundle(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-            transform: TransformBundle::from_xyz(0.0, 0.5, 0.0),
+            transform: Transform::from_xyz(0.0, 0.5, 0.0).into(),
             ..Default::default()
         })
         // This enables wireframe drawing on this entity
         .insert(Wireframe);
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(4.0, 8.0, 4.0),
+        transform: Transform::from_xyz(4.0, 8.0, 4.0).into(),
         ..Default::default()
     });
     // camera

--- a/examples/3d/z_sort_debug.rs
+++ b/examples/3d/z_sort_debug.rs
@@ -56,7 +56,7 @@ fn setup(
                 unlit: true,
                 ..Default::default()
             }),
-            transform: Transform::from_xyz(0.0, 0.0, 1.0),
+            transform: TransformBundle::from_xyz(0.0, 0.0, 1.0),
             ..Default::default()
         })
         .insert(Rotator)
@@ -68,7 +68,7 @@ fn setup(
                     unlit: true,
                     ..Default::default()
                 }),
-                transform: Transform::from_xyz(0.0, 3.0, 0.0),
+                transform: TransformBundle::from_xyz(0.0, 3.0, 0.0),
                 ..Default::default()
             });
             parent.spawn_bundle(PbrBundle {
@@ -77,13 +77,15 @@ fn setup(
                     unlit: true,
                     ..Default::default()
                 }),
-                transform: Transform::from_xyz(0.0, -3.0, 0.0),
+                transform: TransformBundle::from_xyz(0.0, -3.0, 0.0),
                 ..Default::default()
             });
         });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(5.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(5.0, 10.0, 10.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/3d/z_sort_debug.rs
+++ b/examples/3d/z_sort_debug.rs
@@ -56,7 +56,7 @@ fn setup(
                 unlit: true,
                 ..Default::default()
             }),
-            transform: TransformBundle::from_xyz(0.0, 0.0, 1.0),
+            transform: Transform::from_xyz(0.0, 0.0, 1.0).into(),
             ..Default::default()
         })
         .insert(Rotator)
@@ -68,7 +68,7 @@ fn setup(
                     unlit: true,
                     ..Default::default()
                 }),
-                transform: TransformBundle::from_xyz(0.0, 3.0, 0.0),
+                transform: Transform::from_xyz(0.0, 3.0, 0.0).into(),
                 ..Default::default()
             });
             parent.spawn_bundle(PbrBundle {
@@ -77,7 +77,7 @@ fn setup(
                     unlit: true,
                     ..Default::default()
                 }),
-                transform: TransformBundle::from_xyz(0.0, -3.0, 0.0),
+                transform: Transform::from_xyz(0.0, -3.0, 0.0).into(),
                 ..Default::default()
             });
         });

--- a/examples/android/android.rs
+++ b/examples/android/android.rs
@@ -26,17 +26,19 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        transform: TransformBundle::from_xyz(0.0, 0.5, 0.0),
         ..Default::default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        transform: TransformBundle::from_xyz(4.0, 8.0, 4.0),
         ..Default::default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/android/android.rs
+++ b/examples/android/android.rs
@@ -26,12 +26,12 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-        transform: TransformBundle::from_xyz(0.0, 0.5, 0.0),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0).into(),
         ..Default::default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(4.0, 8.0, 4.0),
+        transform: Transform::from_xyz(4.0, 8.0, 4.0).into(),
         ..Default::default()
     });
     // camera

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -53,31 +53,33 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: monkey_handle,
         material: material_handle.clone(),
-        transform: Transform::from_xyz(-3.0, 0.0, 0.0),
+        transform: TransformBundle::from_xyz(-3.0, 0.0, 0.0),
         ..Default::default()
     });
     // cube
     commands.spawn_bundle(PbrBundle {
         mesh: cube_handle,
         material: material_handle.clone(),
-        transform: Transform::from_xyz(0.0, 0.0, 0.0),
+        transform: TransformBundle::from_xyz(0.0, 0.0, 0.0),
         ..Default::default()
     });
     // sphere
     commands.spawn_bundle(PbrBundle {
         mesh: sphere_handle,
         material: material_handle,
-        transform: Transform::from_xyz(3.0, 0.0, 0.0),
+        transform: TransformBundle::from_xyz(3.0, 0.0, 0.0),
         ..Default::default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_xyz(4.0, 5.0, 4.0),
+        transform: TransformBundle::from_xyz(4.0, 5.0, 4.0),
         ..Default::default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(0.0, 3.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(0.0, 3.0, 10.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -53,26 +53,26 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: monkey_handle,
         material: material_handle.clone(),
-        transform: TransformBundle::from_xyz(-3.0, 0.0, 0.0),
+        transform: Transform::from_xyz(-3.0, 0.0, 0.0).into(),
         ..Default::default()
     });
     // cube
     commands.spawn_bundle(PbrBundle {
         mesh: cube_handle,
         material: material_handle.clone(),
-        transform: TransformBundle::from_xyz(0.0, 0.0, 0.0),
+        transform: Transform::from_xyz(0.0, 0.0, 0.0).into(),
         ..Default::default()
     });
     // sphere
     commands.spawn_bundle(PbrBundle {
         mesh: sphere_handle,
         material: material_handle,
-        transform: TransformBundle::from_xyz(3.0, 0.0, 0.0),
+        transform: Transform::from_xyz(3.0, 0.0, 0.0).into(),
         ..Default::default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(4.0, 5.0, 4.0),
+        transform: Transform::from_xyz(4.0, 5.0, 4.0).into(),
         ..Default::default()
     });
     // camera

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -24,12 +24,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_scene(scene_handle);
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_xyz(4.0, 5.0, 4.0),
+        transform: TransformBundle::from_xyz(4.0, 5.0, 4.0),
         ..Default::default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(2.0, 2.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(2.0, 2.0, 6.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -24,7 +24,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_scene(scene_handle);
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(4.0, 5.0, 4.0),
+        transform: Transform::from_xyz(4.0, 5.0, 4.0).into(),
         ..Default::default()
     });
     // camera

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -107,7 +107,7 @@ fn setup_env(mut commands: Commands) {
 
     // lights
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(4.0, 12.0, 15.0),
+        transform: Transform::from_xyz(4.0, 12.0, 15.0).into(),
         ..Default::default()
     });
 

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -86,7 +86,7 @@ fn handle_tasks(
             commands.entity(entity).insert_bundle(PbrBundle {
                 mesh: box_mesh_handle.0.clone(),
                 material: box_material_handle.0.clone(),
-                transform,
+                transform: transform.into(),
                 ..Default::default()
             });
 
@@ -107,14 +107,15 @@ fn setup_env(mut commands: Commands) {
 
     // lights
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_translation(Vec3::new(4.0, 12.0, 15.0)),
+        transform: TransformBundle::from_xyz(4.0, 12.0, 15.0),
         ..Default::default()
     });
 
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_translation(Vec3::new(offset, offset, 15.0))
-            .looking_at(Vec3::new(offset, offset, 0.0), Vec3::Y),
+        transform: Transform::from_xyz(offset, offset, 15.0)
+            .looking_at(Vec3::new(offset, offset, 0.0), Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -19,7 +19,7 @@ fn setup(
     // Spawn a root entity with no parent
     let parent = commands
         .spawn_bundle(SpriteBundle {
-            transform: Transform::from_scale(Vec3::splat(0.75)),
+            transform: TransformBundle::from_scale(Vec3::splat(0.75)),
             material: materials.add(ColorMaterial {
                 color: Color::WHITE,
                 texture: Some(texture.clone()),
@@ -34,7 +34,8 @@ fn setup(
                     translation: Vec3::new(250.0, 0.0, 0.0),
                     scale: Vec3::splat(0.75),
                     ..Default::default()
-                },
+                }
+                .into(),
                 material: materials.add(ColorMaterial {
                     color: Color::BLUE,
                     texture: Some(texture.clone()),
@@ -55,7 +56,8 @@ fn setup(
                 translation: Vec3::new(-250.0, 0.0, 0.0),
                 scale: Vec3::splat(0.75),
                 ..Default::default()
-            },
+            }
+            .into(),
             material: materials.add(ColorMaterial {
                 color: Color::RED,
                 texture: Some(texture.clone()),
@@ -73,7 +75,8 @@ fn setup(
                 translation: Vec3::new(0.0, 250.0, 0.0),
                 scale: Vec3::splat(0.75),
                 ..Default::default()
-            },
+            }
+            .into(),
             material: materials.add(ColorMaterial {
                 color: Color::GREEN,
                 texture: Some(texture),

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -19,7 +19,7 @@ fn setup(
     // Spawn a root entity with no parent
     let parent = commands
         .spawn_bundle(SpriteBundle {
-            transform: TransformBundle::from_scale(Vec3::splat(0.75)),
+            transform: Transform::from_scale(Vec3::splat(0.75)).into(),
             material: materials.add(ColorMaterial {
                 color: Color::WHITE,
                 texture: Some(texture.clone()),

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -75,7 +75,8 @@ fn generate_bodies(
                     translation: position,
                     scale: Vec3::splat(mass_value_cube_root * 0.1),
                     ..Default::default()
-                },
+                }
+                .into(),
                 mesh: mesh.clone(),
                 material: materials.add(
                     Color::rgb_linear(
@@ -104,10 +105,7 @@ fn generate_bodies(
     commands
         .spawn_bundle(BodyBundle {
             pbr: PbrBundle {
-                transform: Transform {
-                    scale: Vec3::splat(0.5),
-                    ..Default::default()
-                },
+                transform: TransformBundle::from_scale(Vec3::splat(0.5)),
                 mesh: meshes.add(Mesh::from(shape::Icosphere {
                     radius: 1.0,
                     subdivisions: 5,
@@ -123,7 +121,9 @@ fn generate_bodies(
             ..Default::default()
         });
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(0.0, 10.5, -20.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(0.0, 10.5, -20.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -105,7 +105,7 @@ fn generate_bodies(
     commands
         .spawn_bundle(BodyBundle {
             pbr: PbrBundle {
-                transform: TransformBundle::from_scale(Vec3::splat(0.5)),
+                transform: Transform::from_scale(Vec3::splat(0.5)).into(),
                 mesh: meshes.add(Mesh::from(shape::Icosphere {
                     radius: 1.0,
                     subdivisions: 5,

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -15,7 +15,7 @@ fn spawn_system(
         commands
             .spawn_bundle(SpriteBundle {
                 material: material.clone(),
-                transform: TransformBundle::from_scale(Vec3::splat(0.1)),
+                transform: Transform::from_scale(Vec3::splat(0.1)).into(),
                 ..Default::default()
             })
             .insert(Velocity(

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -15,7 +15,7 @@ fn spawn_system(
         commands
             .spawn_bundle(SpriteBundle {
                 material: material.clone(),
-                transform: Transform::from_scale(Vec3::splat(0.1)),
+                transform: TransformBundle::from_scale(Vec3::splat(0.1)),
                 ..Default::default()
             })
             .insert(Velocity(

--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -88,7 +88,8 @@ fn setup_cameras(mut commands: Commands, mut game: ResMut<Game>) {
             2.0 * BOARD_SIZE_J as f32 / 3.0,
             BOARD_SIZE_J as f32 / 2.0 - 0.5,
         )
-        .looking_at(game.camera_is_focus, Vec3::Y),
+        .looking_at(game.camera_is_focus, Vec3::Y)
+        .into(),
         ..Default::default()
     });
     commands.spawn_bundle(UiCameraBundle::default());
@@ -102,7 +103,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
     game.player.j = BOARD_SIZE_J / 2;
 
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_xyz(4.0, 5.0, 4.0),
+        transform: TransformBundle::from_xyz(4.0, 5.0, 4.0),
         ..Default::default()
     });
 

--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -103,7 +103,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
     game.player.j = BOARD_SIZE_J / 2;
 
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(4.0, 5.0, 4.0),
+        transform: Transform::from_xyz(4.0, 5.0, 4.0).into(),
         ..Default::default()
     });
 
@@ -115,10 +115,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
                 .map(|i| {
                     let height = rand::thread_rng().gen_range(-0.1..0.1);
                     commands
-                        .spawn_bundle((
-                            Transform::from_xyz(i as f32, height - 0.2, j as f32),
-                            GlobalTransform::identity(),
-                        ))
+                        .spawn_bundle(TransformBundle::from_transform(Transform::from_xyz(
+                            i as f32,
+                            height - 0.2,
+                            j as f32,
+                        )))
                         .with_children(|cell| {
                             cell.spawn_scene(cell_scene.clone());
                         });
@@ -131,18 +132,15 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
     // spawn the game character
     game.player.entity = Some(
         commands
-            .spawn_bundle((
-                Transform {
-                    translation: Vec3::new(
-                        game.player.i as f32,
-                        game.board[game.player.j][game.player.i].height,
-                        game.player.j as f32,
-                    ),
-                    rotation: Quat::from_rotation_y(-std::f32::consts::FRAC_PI_2),
-                    ..Default::default()
-                },
-                GlobalTransform::identity(),
-            ))
+            .spawn_bundle(TransformBundle::from_transform(Transform {
+                translation: Vec3::new(
+                    game.player.i as f32,
+                    game.board[game.player.j][game.player.i].height,
+                    game.player.j as f32,
+                ),
+                rotation: Quat::from_rotation_y(-std::f32::consts::FRAC_PI_2),
+                ..Default::default()
+            }))
             .with_children(|cell| {
                 cell.spawn_scene(asset_server.load("models/AlienCake/alien.glb#Scene0"));
             })
@@ -321,16 +319,12 @@ fn spawn_bonus(
     }
     game.bonus.entity = Some(
         commands
-            .spawn_bundle((
-                Transform {
-                    translation: Vec3::new(
-                        game.bonus.i as f32,
-                        game.board[game.bonus.j][game.bonus.i].height + 0.2,
-                        game.bonus.j as f32,
-                    ),
-                    ..Default::default()
-                },
-                GlobalTransform::identity(),
+            .spawn_bundle(TransformBundle::from_transform(
+                Transform::from_translation(Vec3::new(
+                    game.bonus.i as f32,
+                    game.board[game.bonus.j][game.bonus.i].height + 0.2,
+                    game.bonus.j as f32,
+                )),
             ))
             .with_children(|cell| {
                 cell.spawn_scene(game.bonus.handle.clone());

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -57,7 +57,7 @@ fn setup(
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(0.5, 0.5, 1.0).into()),
-            transform: TransformBundle::from_xyz(0.0, -215.0, 0.0),
+            transform: Transform::from_xyz(0.0, -215.0, 0.0).into(),
             sprite: Sprite::new(Vec2::new(120.0, 30.0)),
             ..Default::default()
         })
@@ -67,7 +67,7 @@ fn setup(
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(1.0, 0.5, 0.5).into()),
-            transform: TransformBundle::from_xyz(0.0, -50.0, 1.0),
+            transform: Transform::from_xyz(0.0, -50.0, 1.0).into(),
             sprite: Sprite::new(Vec2::new(30.0, 30.0)),
             ..Default::default()
         })
@@ -118,7 +118,7 @@ fn setup(
     commands
         .spawn_bundle(SpriteBundle {
             material: wall_material.clone(),
-            transform: TransformBundle::from_xyz(-bounds.x / 2.0, 0.0, 0.0),
+            transform: Transform::from_xyz(-bounds.x / 2.0, 0.0, 0.0).into(),
             sprite: Sprite::new(Vec2::new(wall_thickness, bounds.y + wall_thickness)),
             ..Default::default()
         })
@@ -127,7 +127,7 @@ fn setup(
     commands
         .spawn_bundle(SpriteBundle {
             material: wall_material.clone(),
-            transform: TransformBundle::from_xyz(bounds.x / 2.0, 0.0, 0.0),
+            transform: Transform::from_xyz(bounds.x / 2.0, 0.0, 0.0).into(),
             sprite: Sprite::new(Vec2::new(wall_thickness, bounds.y + wall_thickness)),
             ..Default::default()
         })
@@ -136,7 +136,7 @@ fn setup(
     commands
         .spawn_bundle(SpriteBundle {
             material: wall_material.clone(),
-            transform: TransformBundle::from_xyz(0.0, -bounds.y / 2.0, 0.0),
+            transform: Transform::from_xyz(0.0, -bounds.y / 2.0, 0.0).into(),
             sprite: Sprite::new(Vec2::new(bounds.x + wall_thickness, wall_thickness)),
             ..Default::default()
         })
@@ -145,7 +145,7 @@ fn setup(
     commands
         .spawn_bundle(SpriteBundle {
             material: wall_material,
-            transform: TransformBundle::from_xyz(0.0, bounds.y / 2.0, 0.0),
+            transform: Transform::from_xyz(0.0, bounds.y / 2.0, 0.0).into(),
             sprite: Sprite::new(Vec2::new(bounds.x + wall_thickness, wall_thickness)),
             ..Default::default()
         })
@@ -173,7 +173,7 @@ fn setup(
                 .spawn_bundle(SpriteBundle {
                     material: brick_material.clone(),
                     sprite: Sprite::new(brick_size),
-                    transform: TransformBundle::from_translation(brick_position),
+                    transform: Transform::from_translation(brick_position).into(),
                     ..Default::default()
                 })
                 .insert(Collider::Scorable);

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -57,7 +57,7 @@ fn setup(
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(0.5, 0.5, 1.0).into()),
-            transform: Transform::from_xyz(0.0, -215.0, 0.0),
+            transform: TransformBundle::from_xyz(0.0, -215.0, 0.0),
             sprite: Sprite::new(Vec2::new(120.0, 30.0)),
             ..Default::default()
         })
@@ -67,7 +67,7 @@ fn setup(
     commands
         .spawn_bundle(SpriteBundle {
             material: materials.add(Color::rgb(1.0, 0.5, 0.5).into()),
-            transform: Transform::from_xyz(0.0, -50.0, 1.0),
+            transform: TransformBundle::from_xyz(0.0, -50.0, 1.0),
             sprite: Sprite::new(Vec2::new(30.0, 30.0)),
             ..Default::default()
         })
@@ -118,7 +118,7 @@ fn setup(
     commands
         .spawn_bundle(SpriteBundle {
             material: wall_material.clone(),
-            transform: Transform::from_xyz(-bounds.x / 2.0, 0.0, 0.0),
+            transform: TransformBundle::from_xyz(-bounds.x / 2.0, 0.0, 0.0),
             sprite: Sprite::new(Vec2::new(wall_thickness, bounds.y + wall_thickness)),
             ..Default::default()
         })
@@ -127,7 +127,7 @@ fn setup(
     commands
         .spawn_bundle(SpriteBundle {
             material: wall_material.clone(),
-            transform: Transform::from_xyz(bounds.x / 2.0, 0.0, 0.0),
+            transform: TransformBundle::from_xyz(bounds.x / 2.0, 0.0, 0.0),
             sprite: Sprite::new(Vec2::new(wall_thickness, bounds.y + wall_thickness)),
             ..Default::default()
         })
@@ -136,7 +136,7 @@ fn setup(
     commands
         .spawn_bundle(SpriteBundle {
             material: wall_material.clone(),
-            transform: Transform::from_xyz(0.0, -bounds.y / 2.0, 0.0),
+            transform: TransformBundle::from_xyz(0.0, -bounds.y / 2.0, 0.0),
             sprite: Sprite::new(Vec2::new(bounds.x + wall_thickness, wall_thickness)),
             ..Default::default()
         })
@@ -145,7 +145,7 @@ fn setup(
     commands
         .spawn_bundle(SpriteBundle {
             material: wall_material,
-            transform: Transform::from_xyz(0.0, bounds.y / 2.0, 0.0),
+            transform: TransformBundle::from_xyz(0.0, bounds.y / 2.0, 0.0),
             sprite: Sprite::new(Vec2::new(bounds.x + wall_thickness, wall_thickness)),
             ..Default::default()
         })
@@ -173,7 +173,7 @@ fn setup(
                 .spawn_bundle(SpriteBundle {
                     material: brick_material.clone(),
                     sprite: Sprite::new(brick_size),
-                    transform: Transform::from_translation(brick_position),
+                    transform: TransformBundle::from_translation(brick_position),
                     ..Default::default()
                 })
                 .insert(Collider::Scorable);

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -32,7 +32,7 @@ fn setup_scene(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.5, 0.4, 0.3).into()),
-        transform: TransformBundle::from_xyz(0.0, 0.5, 0.0),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0).into(),
         ..Default::default()
     });
     // sphere
@@ -42,12 +42,12 @@ fn setup_scene(
             radius: 0.5,
         })),
         material: materials.add(Color::rgb(0.1, 0.4, 0.8).into()),
-        transform: TransformBundle::from_xyz(1.5, 1.5, 1.5),
+        transform: Transform::from_xyz(1.5, 1.5, 1.5).into(),
         ..Default::default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(4.0, 8.0, 4.0),
+        transform: Transform::from_xyz(4.0, 8.0, 4.0).into(),
         ..Default::default()
     });
     // camera

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -32,7 +32,7 @@ fn setup_scene(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.5, 0.4, 0.3).into()),
-        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        transform: TransformBundle::from_xyz(0.0, 0.5, 0.0),
         ..Default::default()
     });
     // sphere
@@ -42,17 +42,19 @@ fn setup_scene(
             radius: 0.5,
         })),
         material: materials.add(Color::rgb(0.1, 0.4, 0.8).into()),
-        transform: Transform::from_xyz(1.5, 1.5, 1.5),
+        transform: TransformBundle::from_xyz(1.5, 1.5, 1.5),
         ..Default::default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        transform: TransformBundle::from_xyz(4.0, 8.0, 4.0),
         ..Default::default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -104,7 +104,7 @@ fn setup(
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
             )]),
-            transform: TransformBundle::from_xyz(0.0, 0.0, 0.0),
+            transform: Transform::from_xyz(0.0, 0.0, 0.0).into(),
             ..Default::default()
         })
         .insert(TimeUniform { value: 0.0 });

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -104,14 +104,16 @@ fn setup(
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
             )]),
-            transform: Transform::from_xyz(0.0, 0.0, 0.0),
+            transform: TransformBundle::from_xyz(0.0, 0.0, 0.0),
             ..Default::default()
         })
         .insert(TimeUniform { value: 0.0 });
 
     // Spawn a camera.
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(0.0, 0.0, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(0.0, 0.0, 8.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -112,7 +112,9 @@ fn setup(
         .unwrap();
 
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(2.0, 2.0, 2.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(2.0, 2.0, 2.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/shader/hot_shader_reloading.rs
+++ b/examples/shader/hot_shader_reloading.rs
@@ -68,13 +68,15 @@ fn setup(
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
             )]),
-            transform: Transform::from_xyz(0.0, 0.0, 0.0),
+            transform: TransformBundle::from_xyz(0.0, 0.0, 0.0),
             ..Default::default()
         })
         .insert(material);
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(3.0, 5.0, -8.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/shader/hot_shader_reloading.rs
+++ b/examples/shader/hot_shader_reloading.rs
@@ -68,7 +68,7 @@ fn setup(
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
             )]),
-            transform: TransformBundle::from_xyz(0.0, 0.0, 0.0),
+            transform: Transform::from_xyz(0.0, 0.0, 0.0).into(),
             ..Default::default()
         })
         .insert(material);

--- a/examples/shader/mesh_custom_attribute.rs
+++ b/examples/shader/mesh_custom_attribute.rs
@@ -104,7 +104,7 @@ fn setup(
         render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
             pipeline_handle,
         )]),
-        transform: TransformBundle::from_xyz(0.0, 0.0, 0.0),
+        transform: Transform::from_xyz(0.0, 0.0, 0.0).into(),
         ..Default::default()
     });
     // camera

--- a/examples/shader/mesh_custom_attribute.rs
+++ b/examples/shader/mesh_custom_attribute.rs
@@ -104,12 +104,14 @@ fn setup(
         render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
             pipeline_handle,
         )]),
-        transform: Transform::from_xyz(0.0, 0.0, 0.0),
+        transform: TransformBundle::from_xyz(0.0, 0.0, 0.0),
         ..Default::default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(3.0, 5.0, -8.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/shader/shader_custom_material.rs
+++ b/examples/shader/shader_custom_material.rs
@@ -90,7 +90,7 @@ fn setup(
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
             )]),
-            transform: TransformBundle::from_xyz(0.0, 0.0, 0.0),
+            transform: Transform::from_xyz(0.0, 0.0, 0.0).into(),
             ..Default::default()
         })
         .insert(material);

--- a/examples/shader/shader_custom_material.rs
+++ b/examples/shader/shader_custom_material.rs
@@ -90,13 +90,15 @@ fn setup(
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
             )]),
-            transform: Transform::from_xyz(0.0, 0.0, 0.0),
+            transform: TransformBundle::from_xyz(0.0, 0.0, 0.0),
             ..Default::default()
         })
         .insert(material);
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(3.0, 5.0, -8.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -112,7 +112,7 @@ fn setup(
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle.clone(),
             )]),
-            transform: Transform::from_xyz(-2.0, 0.0, 0.0),
+            transform: TransformBundle::from_xyz(-2.0, 0.0, 0.0),
             ..Default::default()
         })
         .insert(green_material);
@@ -123,13 +123,15 @@ fn setup(
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
             )]),
-            transform: Transform::from_xyz(2.0, 0.0, 0.0),
+            transform: TransformBundle::from_xyz(2.0, 0.0, 0.0),
             ..Default::default()
         })
         .insert(blue_material);
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(3.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(3.0, 5.0, -8.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 }

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -112,7 +112,7 @@ fn setup(
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle.clone(),
             )]),
-            transform: TransformBundle::from_xyz(-2.0, 0.0, 0.0),
+            transform: Transform::from_xyz(-2.0, 0.0, 0.0).into(),
             ..Default::default()
         })
         .insert(green_material);
@@ -123,7 +123,7 @@ fn setup(
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 pipeline_handle,
             )]),
-            transform: TransformBundle::from_xyz(2.0, 0.0, 0.0),
+            transform: Transform::from_xyz(2.0, 0.0, 0.0).into(),
             ..Default::default()
         })
         .insert(blue_material);

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -143,7 +143,8 @@ fn mouse_handler(
                         translation: Vec3::new(bird_x, bird_y, bird_z),
                         scale: Vec3::splat(BIRD_SCALE),
                         ..Default::default()
-                    },
+                    }
+                    .into(),
                     ..Default::default()
                 })
                 .insert(Bird {

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -186,12 +186,14 @@ fn setup_pipeline(
     commands.spawn_scene(asset_server.load("models/monkey/Monkey.gltf#Scene0"));
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_xyz(4.0, 5.0, 4.0),
+        transform: TransformBundle::from_xyz(4.0, 5.0, 4.0),
         ..Default::default()
     });
     // main camera
     commands.spawn_bundle(PerspectiveCameraBundle {
-        transform: Transform::from_xyz(0.0, 0.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(0.0, 0.0, 6.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
     // second window camera
@@ -201,7 +203,9 @@ fn setup_pipeline(
             window: window_id,
             ..Default::default()
         },
-        transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(6.0, 0.0, 0.0)
+            .looking_at(Vec3::ZERO, Vec3::Y)
+            .into(),
         ..Default::default()
     });
 

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -186,7 +186,7 @@ fn setup_pipeline(
     commands.spawn_scene(asset_server.load("models/monkey/Monkey.gltf#Scene0"));
     // light
     commands.spawn_bundle(PointLightBundle {
-        transform: TransformBundle::from_xyz(4.0, 5.0, 4.0),
+        transform: Transform::from_xyz(4.0, 5.0, 4.0).into(),
         ..Default::default()
     });
     // main camera


### PR DESCRIPTION
# Objective

- "Simplifies" build-in bundles
- Beginners don't realize that both the `Transform` and `GlobalTransform` Components are necessary to propagate the Transform to children, and usually, only insert `Transform`.

This was previously attempted in #1588, but that PR contained other nested bundles and didn't provide any constructors for `TransformBundle`.

## Solution

- A new `TransformBundle` that contains a `Transform` and a `GlobalTransform`.
- Implements `impl From<Transform> for TransformBundle` for easy `Transform` -> `TransformBundle` conversion.
- Replace `Transform` and `GlobalTransform` in Bundles with `TransformBundle`
  - Kept the `transform` field name for `TransformBundle` to ease migrate and avoid a long name like `transform_bundle`

## Open Questions

- Should `impl From<GlobalTransform> for TransformBundle` also be added?
- Should creating a `TransformBundle` also directly set the `GlobalTransform` or leave the default?
  - The values `GlobalTransform` of only have meaning after the `transform_propagate_system` was run.
  - The update struct syntax (using `..Default::default()`) doesn't change the `GlobalTransform` if `Transform` has a non-default value.
  - In the bundles where `Transform` did not have its default value (2D Orthographic and UI Camera), `GlobalTransform` still was assigned its default values.
- Should the field name for `TransformBundle`s remain `transform`?