### PR TITLE
`bevy_scene` API Docs

### DIFF
--- a/crates/bevy_scene/src/command.rs
+++ b/crates/bevy_scene/src/command.rs
@@ -19,7 +19,12 @@ impl Command for SpawnScene {
     }
 }
 
+// Written in "one line" to insert it into the module overview.
+#[doc = "[`Commands`] extension: <ul>\
+<li><code>.[spawn_scene](SpawnSceneCommands::spawn_scene)(scene: [Handle]<[Scene]>)</code></li>\
+</ul>"]
 pub trait SpawnSceneCommands {
+    /// Adds a new [`SpawnScene`] instance to this command list.
     fn spawn_scene(&mut self, scene: Handle<Scene>);
 }
 
@@ -41,7 +46,12 @@ impl Command for SpawnSceneAsChild {
     }
 }
 
+// Written in "one line" to insert it into the module overview.
+#[doc = "[`ChildBuilder`] extension: <ul>\
+<li><code>.[spawn_scene](SpawnSceneAsChildCommands::spawn_scene)(scene: [Handle]<[Scene]>)</code></li>\
+</ul>"]
 pub trait SpawnSceneAsChildCommands {
+    /// Adds a new [`SpawnSceneAsChild`] instance to this command list.
     fn spawn_scene(&mut self, scene: Handle<Scene>) -> &mut Self;
 }
 

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -26,11 +26,11 @@ use bevy_ecs::{schedule::ExclusiveSystemDescriptorCoercion, system::IntoExclusiv
 ///
 /// # Contents
 ///
-/// - Assets
+/// - Asset Types
 ///
 ///   [`DynamicScene`], [`Scene`]
 ///
-/// - AssetLoaders
+/// - Asset Loaders
 ///
 ///   [`SceneLoader`]
 ///

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -22,11 +22,32 @@ use bevy_app::prelude::*;
 use bevy_asset::AddAsset;
 use bevy_ecs::{schedule::ExclusiveSystemDescriptorCoercion, system::IntoExclusiveSystem};
 
+/// Bevy scene saving/loading [`Plugin`].
+///
+/// # Contents
+///
+/// - Assets
+///
+///   [`DynamicScene`], [`Scene`]
+///
+/// - AssetLoaders
+///
+///   [`SceneLoader`]
+///
+/// - Resources
+///
+///   [`SceneSpawner`]
+///
+/// - Systems
+///
+///   - [`CoreStage::PreUpdate`]
+///     - <code>[scene_spawner_system].[exclusive_system](IntoExclusiveSystem::exclusive_system)().[at_end](ExclusiveSystemDescriptorCoercion::at_end)()</code>
 #[derive(Default)]
 pub struct ScenePlugin;
 
 impl Plugin for ScenePlugin {
     fn build(&self, app: &mut AppBuilder) {
+        // Please update the `ScenePlugin` docs when changing this.
         app.add_asset::<DynamicScene>()
             .add_asset::<Scene>()
             .init_asset_loader::<SceneLoader>()

--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -6,6 +6,10 @@ use bevy_reflect::TypeRegistryArc;
 use bevy_utils::BoxedFuture;
 use serde::de::DeserializeSeed;
 
+// Written in "one line" to insert it into the module overview.
+#[doc = "[`AssetLoader`]: <ul>\
+<li>`.scn`, `.scn.ron` -> [`DynamicScene`](`crate::dynamic_scene::DynamicScene`)</li>\
+</ul>"]
 #[derive(Debug)]
 pub struct SceneLoader {
     type_registry: TypeRegistryArc,


### PR DESCRIPTION
As mentioned in https://github.com/bevyengine/bevy/discussions/2336, I'd like to try to contribute API docs as I learn about the engine. I'm aware the API is in flux and don't mind if my contributions are deleted when they become obsolete.

# Objectives

- Making Bevy more accessible by adding API Docs with helpful cross-references.
- Finding the right style and voice for the API Docs at this stage of the project.
- Avoiding docs that are "too cohesive" and break too easily on code changes.

## Solution

- `bevy_scene` appears to be a fairly small feature that is reasonably easy for me to understand.

  I assume it's one of the APIs more likely to change, but that shouldn't be an issue for using it as documentation playground here, and it appears to be a good place for me to learn about Bevy's general high-level structure.

- I'm making this a draft pull-request in order to collect early feedback.

  Since there isn't much existing API documentation, I'm starting with a style I might use for my own projects if they had an API like this. Please let me know if you'd like to see anything changed! I don't have a strict opinion on the "right" style of documentation and tend to go a bit overboard with tricking it out if left alone. (I'll try to keep myself in check regarding that last point 😅)

  I'll add further comments where I think a change warrants more explanation or where I'd like to have some specific feedback.