### PR TITLE
[Merged by Bors] - Exclude some Branches from running CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
   push:
+    branches-ignore:
+      - 'dependabot/**'
+      - staging-squash-merge.tmp
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - '**/Cargo.toml'
       - 'deny.toml'
+    branches-ignore:
+      - 'dependabot/**'
+      - staging-squash-merge.tmp
   schedule:
     - cron: "0 0 * * 0"
 


### PR DESCRIPTION
# Objective

#2230 allowed the CI to run on every Branch of this Repo.
But some Branches should not actually run the CI, which wastes the available capacity of CI runners.

### staging-squash-merge.tmp

This Branch is used by Bors when squashing a PR. 
CI shouldn't need to run here, as the actual verification happens in the staging branch

![ci](https://user-images.githubusercontent.com/66798382/122072006-82ccad00-cdf7-11eb-84c8-29356594180d.PNG)
![ci2](https://user-images.githubusercontent.com/66798382/122072030-85c79d80-cdf7-11eb-8c30-2e3088d47285.png)

### dependabot/**

Dependabot creates its branches in this Repo, which causes the CI to run twice on the same commit
![ci3](https://user-images.githubusercontent.com/66798382/122072345-c6bfb200-cdf7-11eb-8de6-3ffcbf641631.PNG)


## Solution

Exclude those branches from running CI.
