### PR TITLE
[Merged by Bors] - Allow Option<NonSend<T>> and Option<NonSendMut<T>> as SystemParam

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -160,6 +160,8 @@ impl_debug!(ResMut<'a, T>, Component);
 /// # Panics
 ///
 /// Panics when used as a `SystemParameter` if the resource does not exist.
+///
+/// Use `Option<NonSendMut<T>>` instead if the resource might not always exist.
 pub struct NonSendMut<'a, T: 'static> {
     pub(crate) value: &'a mut T,
     pub(crate) ticks: Ticks<'a>,


### PR DESCRIPTION
# Objective

Currently, you can add `Option<Res<T>` or `Option<ResMut<T>` as a SystemParam, if the Resource could potentially not exist, but this functionality doesn't exist for `NonSend` and `NonSendMut`

## Solution

Adds implementations to use `Option<NonSend<T>>` and Option<NonSendMut<T>> as SystemParams.