### PR TITLE
[Merged by Bors] - fix `clippy` warning failing on CI

### DIFF
--- a/crates/bevy_core/src/time/timer.rs
+++ b/crates/bevy_core/src/time/timer.rs
@@ -375,10 +375,10 @@ mod tests {
         t.tick(Duration::from_secs_f32(0.25));
         assert_eq!(t.elapsed_secs(), 0.25);
         assert_eq!(t.duration(), Duration::from_secs_f32(10.0));
-        assert_eq!(t.finished(), false);
-        assert_eq!(t.just_finished(), false);
+        assert!(!t.finished());
+        assert!(!t.just_finished());
         assert_eq!(t.times_finished(), 0);
-        assert_eq!(t.repeating(), false);
+        assert!(!t.repeating());
         assert_eq!(t.percent(), 0.025);
         assert_eq!(t.percent_left(), 0.975);
         // Ticking while paused changes nothing
@@ -386,26 +386,26 @@ mod tests {
         t.tick(Duration::from_secs_f32(500.0));
         assert_eq!(t.elapsed_secs(), 0.25);
         assert_eq!(t.duration(), Duration::from_secs_f32(10.0));
-        assert_eq!(t.finished(), false);
-        assert_eq!(t.just_finished(), false);
+        assert!(!t.finished());
+        assert!(!t.just_finished());
         assert_eq!(t.times_finished(), 0);
-        assert_eq!(t.repeating(), false);
+        assert!(!t.repeating());
         assert_eq!(t.percent(), 0.025);
         assert_eq!(t.percent_left(), 0.975);
         // Tick past the end and make sure elapsed doesn't go past 0.0 and other things update
         t.unpause();
         t.tick(Duration::from_secs_f32(500.0));
         assert_eq!(t.elapsed_secs(), 10.0);
-        assert_eq!(t.finished(), true);
-        assert_eq!(t.just_finished(), true);
+        assert!(t.finished());
+        assert!(t.just_finished());
         assert_eq!(t.times_finished(), 1);
         assert_eq!(t.percent(), 1.0);
         assert_eq!(t.percent_left(), 0.0);
         // Continuing to tick when finished should only change just_finished
         t.tick(Duration::from_secs_f32(1.0));
         assert_eq!(t.elapsed_secs(), 10.0);
-        assert_eq!(t.finished(), true);
-        assert_eq!(t.just_finished(), false);
+        assert!(t.finished());
+        assert!(!t.just_finished());
         assert_eq!(t.times_finished(), 0);
         assert_eq!(t.percent(), 1.0);
         assert_eq!(t.percent_left(), 0.0);
@@ -418,25 +418,25 @@ mod tests {
         t.tick(Duration::from_secs_f32(0.75));
         assert_eq!(t.elapsed_secs(), 0.75);
         assert_eq!(t.duration(), Duration::from_secs_f32(2.0));
-        assert_eq!(t.finished(), false);
-        assert_eq!(t.just_finished(), false);
+        assert!(!t.finished());
+        assert!(!t.just_finished());
         assert_eq!(t.times_finished(), 0);
-        assert_eq!(t.repeating(), true);
+        assert!(t.repeating());
         assert_eq!(t.percent(), 0.375);
         assert_eq!(t.percent_left(), 0.625);
         // Tick past the end and make sure elapsed wraps
         t.tick(Duration::from_secs_f32(1.5));
         assert_eq!(t.elapsed_secs(), 0.25);
-        assert_eq!(t.finished(), true);
-        assert_eq!(t.just_finished(), true);
+        assert!(t.finished());
+        assert!(t.just_finished());
         assert_eq!(t.times_finished(), 1);
         assert_eq!(t.percent(), 0.125);
         assert_eq!(t.percent_left(), 0.875);
         // Continuing to tick should turn off both finished & just_finished for repeating timers
         t.tick(Duration::from_secs_f32(1.0));
         assert_eq!(t.elapsed_secs(), 1.25);
-        assert_eq!(t.finished(), false);
-        assert_eq!(t.just_finished(), false);
+        assert!(!t.finished());
+        assert!(!t.just_finished());
         assert_eq!(t.times_finished(), 0);
         assert_eq!(t.percent(), 0.625);
         assert_eq!(t.percent_left(), 0.375);

--- a/crates/bevy_dylib/src/lib.rs
+++ b/crates/bevy_dylib/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::single_component_path_imports)]
+
 //! Forces dynamic linking of Bevy.
 //!
 //! Dynamically linking Bevy makes the "link" step much faster. This can be achieved by adding
@@ -8,5 +10,4 @@
 
 // Force linking of the main bevy crate
 #[allow(unused_imports)]
-#[allow(clippy::single_component_path_imports)]
 use bevy_internal;

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -324,7 +324,7 @@ mod tests {
         run_system(&mut world, sys.system());
 
         // ensure the system actually ran
-        assert_eq!(*world.get_resource::<bool>().unwrap(), true);
+        assert!(*world.get_resource::<bool>().unwrap());
     }
 
     #[test]
@@ -353,7 +353,7 @@ mod tests {
         }
 
         run_system(&mut world, validate_removed.system());
-        assert_eq!(*world.get_resource::<bool>().unwrap(), true, "system ran");
+        assert!(*world.get_resource::<bool>().unwrap(), "system ran");
     }
 
     #[test]
@@ -371,7 +371,7 @@ mod tests {
         );
 
         // ensure the system actually ran
-        assert_eq!(*world.get_resource::<bool>().unwrap(), true);
+        assert!(*world.get_resource::<bool>().unwrap());
     }
     #[test]
     fn world_collections_system() {
@@ -414,7 +414,7 @@ mod tests {
         run_system(&mut world, sys.system());
 
         // ensure the system actually ran
-        assert_eq!(*world.get_resource::<bool>().unwrap(), true);
+        assert!(*world.get_resource::<bool>().unwrap());
     }
 
     #[test]

--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -167,14 +167,12 @@ mod rendering_mask_tests {
             "default masks match each other"
         );
 
-        assert_eq!(
-            RenderLayers::layer(0).intersects(&RenderLayers::layer(1)),
-            false,
+        assert!(
+            !RenderLayers::layer(0).intersects(&RenderLayers::layer(1)),
             "masks with differing layers do not match"
         );
-        assert_eq!(
-            RenderLayers(0).intersects(&RenderLayers(0)),
-            false,
+        assert!(
+            !RenderLayers(0).intersects(&RenderLayers(0)),
             "empty masks don't match"
         );
         assert_eq!(

--- a/crates/bevy_tasks/src/countdown_event.rs
+++ b/crates/bevy_tasks/src/countdown_event.rs
@@ -125,10 +125,7 @@ mod tests {
         let listener3 = event.listen();
 
         // Verify that we are still blocked
-        assert_eq!(
-            false,
-            listener2.wait_timeout(instant::Duration::from_millis(10))
-        );
+        assert!(!listener2.wait_timeout(instant::Duration::from_millis(10)));
 
         // Notify all and verify the remaining listener is notified
         event.notify(std::usize::MAX);

--- a/crates/bevy_transform/src/hierarchy/hierarchy.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy.rs
@@ -123,9 +123,8 @@ mod tests {
 
         {
             let children = world.get::<Children>(grandparent_entity).unwrap();
-            assert_eq!(
-                children.iter().any(|&i| i == parent_entity),
-                false,
+            assert!(
+                !children.iter().any(|&i| i == parent_entity),
                 "grandparent should no longer know about its child which has been removed"
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::single_component_path_imports)]
+
 //! [![](https://bevyengine.org/assets/bevy_logo_docs.svg)](https://bevyengine.org)
 //!
 //! Bevy is an open-source modular game engine built in Rust, with a focus on developer productivity
@@ -45,5 +47,4 @@ pub use bevy_internal::*;
 
 #[cfg(feature = "dynamic")]
 #[allow(unused_imports)]
-#[allow(clippy::single_component_path_imports)]
 use bevy_dylib;


### PR DESCRIPTION
# Objective

- CI jobs are starting to fail due to `clippy::bool-assert-comparison` and `clippy::single_component_path_imports` being triggered.

## Solution

- Fix all uses where `asset_eq!(<condition>, <bool>)` could be replace by `assert!`
- Move the `#[allow()]` for `single_component_path_imports` to `#![allow()]` at the start of the files.
