### PR TITLE
[Merged by Bors] - Derive Clone for Time

### DIFF
--- a/crates/bevy_core/src/time/time.rs
+++ b/crates/bevy_core/src/time/time.rs
@@ -2,7 +2,7 @@ use bevy_ecs::system::ResMut;
 use bevy_utils::{Duration, Instant};
 
 /// Tracks elapsed time since the last update and since the App has started
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Time {
     delta: Duration,
     last_update: Option<Instant>,


### PR DESCRIPTION
# Objective

- Make it so that `Time` can be cloned
- Makes it so I can clone the entire current `Time` and easily pass it to the user in [Rusty Engine](https://github.com/CleanCut/rusty_engine) instead of [doing this](https://github.com/CleanCut/rusty_engine/blob/8302dc3914d5b14b730e994cca452ce8d252fec2/src/game.rs#L147-L150)

## Solution

- Derive the `Clone` trait on `Time`
