### PR TITLE
[Merged by Bors] - Fixes Timer Precision Error Causing Panic

### DIFF
--- a/crates/bevy_core/src/time/timer.rs
+++ b/crates/bevy_core/src/time/timer.rs
@@ -217,7 +217,8 @@ impl Timer {
 
         if self.finished() {
             if self.repeating() {
-                self.times_finished = (self.elapsed().as_nanos() / self.duration().as_nanos()) as u32;
+                self.times_finished =
+                    (self.elapsed().as_nanos() / self.duration().as_nanos()) as u32;
                 // Duration does not have a modulo
                 self.set_elapsed(self.elapsed() - self.duration() * self.times_finished);
             } else {

--- a/crates/bevy_core/src/time/timer.rs
+++ b/crates/bevy_core/src/time/timer.rs
@@ -217,7 +217,7 @@ impl Timer {
 
         if self.finished() {
             if self.repeating() {
-                self.times_finished = self.percent().floor() as u32;
+                self.times_finished = (self.elapsed().as_nanos() / self.duration().as_nanos()) as u32;
                 // Duration does not have a modulo
                 self.set_elapsed(self.elapsed() - self.duration() * self.times_finished);
             } else {
@@ -463,5 +463,21 @@ mod tests {
         assert_eq!(t.times_finished(), 1);
         t.tick(Duration::from_secs_f32(0.5));
         assert_eq!(t.times_finished(), 0);
+    }
+
+    #[test]
+    fn times_finished_precise() {
+        let mut t = Timer::from_seconds(0.01, true);
+        let duration = Duration::from_secs_f64(1.0 / 3.0);
+
+        t.tick(duration);
+        assert_eq!(t.times_finished(), 33);
+        t.tick(duration);
+        assert_eq!(t.times_finished(), 33);
+        t.tick(duration);
+        assert_eq!(t.times_finished(), 33);
+        // It has one additional tick this time to compensate for missing 100th tick
+        t.tick(duration);
+        assert_eq!(t.times_finished(), 34);
     }
 }


### PR DESCRIPTION
# Objective

Fixes #2361 

## Solution

Uses integer division instead of floating-point which prevents precision errors, I think. 
