### PR TITLE
[pbr] Create a DirectionalLightBundle

### DIFF
--- a/crates/bevy_pbr/src/entity.rs
+++ b/crates/bevy_pbr/src/entity.rs
@@ -1,4 +1,8 @@
-use crate::{light::PointLight, material::StandardMaterial, render_graph::PBR_PIPELINE_HANDLE};
+use crate::{
+    light::{DirectionalLight, PointLight},
+    material::StandardMaterial,
+    render_graph::PBR_PIPELINE_HANDLE,
+};
 use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
 use bevy_render::{
@@ -40,10 +44,18 @@ impl Default for PbrBundle {
     }
 }
 
-/// A component bundle for "light" entities
+/// A component bundle for "point light" entities
 #[derive(Debug, Bundle, Default)]
 pub struct PointLightBundle {
     pub point_light: PointLight,
+    pub transform: Transform,
+    pub global_transform: GlobalTransform,
+}
+
+/// A component bundle for "directional light" entities
+#[derive(Debug, Bundle, Default)]
+pub struct DirectionalLightBundle {
+    pub directional_light: DirectionalLight,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
 }

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -32,6 +32,7 @@ impl Plugin for PbrPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_asset::<StandardMaterial>()
             .register_type::<PointLight>()
+            .register_type::<DirectionalLight>()
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 shader::asset_shader_defs_system::<StandardMaterial>.system(),

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -109,7 +109,7 @@ impl Default for DirectionalLight {
     fn default() -> Self {
         DirectionalLight {
             color: Color::rgb(1.0, 1.0, 1.0),
-            illuminance: 100000.0,
+            illuminance: 100_000.0,
             direction: Vec3::new(0.0, -1.0, 0.0),
         }
     }

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -30,7 +30,7 @@ fn setup(
     // light
     let transform = Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y);
     let mut directional_light = DirectionalLight::default();
-    directional_light.illuminance = 10000.0;
+    directional_light.illuminance = 10_000.0;
     directional_light.set_direction(transform.forward());
 
     commands.spawn_bundle(DirectionalLightBundle {

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -28,8 +28,14 @@ fn setup(
         ..Default::default()
     });
     // light
-    commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+    let transform = Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y);
+    let mut directional_light = DirectionalLight::default();
+    directional_light.illuminance = 10000.0;
+    directional_light.set_direction(transform.forward());
+
+    commands.spawn_bundle(DirectionalLightBundle {
+        transform,
+        directional_light,
         ..Default::default()
     });
     // camera

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -29,13 +29,11 @@ fn setup(
     });
     // light
     let transform = Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y);
-    let mut directional_light = DirectionalLight::default();
-    directional_light.illuminance = 10_000.0;
-    directional_light.set_direction(transform.forward());
+    let directional_light = DirectionalLight::new(Color::WHITE, 10_000.0, transform.forward());
 
     commands.spawn_bundle(DirectionalLightBundle {
-        transform,
         directional_light,
+        transform,
         ..Default::default()
     });
     // camera


### PR DESCRIPTION
# Objective

- Fixes #2184

## Solution

- Created a `DirectionalLightBundle` in `bevy_pbr` with `Transform` and `GlobalTransform` components
- Added the `DirectionalLight` component to the `PbrPlugin`'s registered types
- Updated the `3d_scene` example by replacing the `PointLightBundle` with the `DirectionalLightBundle`*

\*I tried to keep the appearance of the lighting pretty close to the original scene, so the only real difference should be that the new light doesn't have any fall-off. But I could create a new example instead if that would be preferred.