### PR TITLE
[reflection] cleanup `derive_reflect`

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -17,11 +17,6 @@ use syn::{
     NestedMeta, Path,
 };
 
-#[derive(Default)]
-struct PropAttributeArgs {
-    pub ignore: Option<bool>,
-}
-
 #[derive(Clone)]
 enum TraitImpl {
     NotImplemented,

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -45,7 +45,7 @@ fn active_fields(punctuated: &Punctuated<Field, Comma>) -> impl Iterator<Item = 
         field
             .attrs
             .iter()
-            .find(|attr| *attr.path.get_ident().as_ref().unwrap() == REFLECT_ATTRIBUTE_NAME)
+            .find(|attr| attr.path.get_ident().unwrap() == REFLECT_ATTRIBUTE_NAME)
             .map(|attr| {
                 syn::custom_keyword!(ignore);
                 attr.parse_args::<Option<ignore>>()


### PR DESCRIPTION
# Objective

- The current `derive_reflect` implementation is a large function with difficult to follow code paths.
- When determining the "active fields" (e.g. those that don't use `#[reflect(ignore)]`) the logic is unnecessarily complex.

## Solution

- Refactor `derive_reflect` by breaking into into smaller functions, and simplifying the logic for obtaining the "active fields".
