### PR TITLE
Add SystemGraph as a handle-based method for explicitly creating system dependency graphs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -321,6 +321,10 @@ name = "system_chaining"
 path = "examples/ecs/system_chaining.rs"
 
 [[example]]
+name = "system_graph"
+path = "examples/ecs/system_graph.rs"
+
+[[example]]
 name = "system_param"
 path = "examples/ecs/system_param.rs"
 

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -331,7 +331,7 @@ impl App {
     ///         .with_system(system_c),
     /// );
     /// ```
-    pub fn add_system_set(&mut self, system_set: SystemSet) -> &mut Self {
+    pub fn add_system_set(&mut self, system_set: impl Into<SystemSet>) -> &mut Self {
         self.add_system_set_to_stage(CoreStage::Update, system_set)
     }
 
@@ -381,7 +381,7 @@ impl App {
     pub fn add_system_set_to_stage(
         &mut self,
         stage_label: impl StageLabel,
-        system_set: SystemSet,
+        system_set: impl Into<SystemSet>,
     ) -> &mut Self {
         self.schedule
             .add_system_set_to_stage(stage_label, system_set);
@@ -491,7 +491,7 @@ impl App {
     pub fn add_startup_system_set_to_stage(
         &mut self,
         stage_label: impl StageLabel,
-        system_set: SystemSet,
+        system_set: impl Into<SystemSet>,
     ) -> &mut Self {
         self.schedule
             .stage(CoreStage::Startup, |schedule: &mut Schedule| {

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -47,9 +47,9 @@ impl Parse for AllTuples {
 #[proc_macro]
 pub fn all_tuples(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as AllTuples);
-    let len = (input.start..=input.end).count();
+    let len = (0..=input.end).count();
     let mut ident_tuples = Vec::with_capacity(len);
-    for i in input.start..=input.end {
+    for i in 0..=input.end {
         let idents = input
             .idents
             .iter()

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -47,7 +47,7 @@ impl Parse for AllTuples {
 #[proc_macro]
 pub fn all_tuples(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as AllTuples);
-    let len = (0..=input.end).count();
+    let len = input.end + 1;
     let mut ident_tuples = Vec::with_capacity(len);
     for i in 0..=input.end {
         let idents = input

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -30,7 +30,8 @@ pub mod prelude {
         schedule::{
             AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,
             RunCriteria, RunCriteriaDescriptorCoercion, RunCriteriaLabel, RunCriteriaPiping,
-            Schedule, Stage, StageLabel, State, SystemLabel, SystemSet, SystemStage,
+            Schedule, Stage, StageLabel, State, SystemGraph, SystemGraphJoinExt, SystemLabel,
+            SystemSet, SystemStage,
         },
         system::{
             Commands, ConfigurableSystem, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -30,8 +30,8 @@ pub mod prelude {
         schedule::{
             AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,
             RunCriteria, RunCriteriaDescriptorCoercion, RunCriteriaLabel, RunCriteriaPiping,
-            Schedule, Stage, StageLabel, State, SystemGraph, SystemGraphJoinExt, SystemLabel,
-            SystemSet, SystemStage,
+            Schedule, Stage, StageLabel, State, SystemGraph, SystemGraphJoinExt, SystemGroup,
+            SystemLabel, SystemSet, SystemStage,
         },
         system::{
             Commands, ConfigurableSystem, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -30,8 +30,8 @@ pub mod prelude {
         schedule::{
             AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,
             RunCriteria, RunCriteriaDescriptorCoercion, RunCriteriaLabel, RunCriteriaPiping,
-            Schedule, Stage, StageLabel, State, SystemGraph, SystemGraphJoinExt, SystemGroup,
-            SystemLabel, SystemSet, SystemStage,
+            Schedule, Stage, StageLabel, State, SystemGraph, SystemGroup, SystemJoin, SystemLabel,
+            SystemSet, SystemStage,
         },
         system::{
             Commands, ConfigurableSystem, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem,

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -247,7 +247,7 @@ impl Schedule {
     pub fn add_system_set_to_stage(
         &mut self,
         stage_label: impl StageLabel,
-        system_set: SystemSet,
+        system_set: impl Into<SystemSet>,
     ) -> &mut Self {
         self.stage(stage_label, |stage: &mut SystemStage| {
             stage.add_system_set(system_set)

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -12,6 +12,7 @@ mod stage;
 mod state;
 mod system_container;
 mod system_descriptor;
+mod system_graph;
 mod system_set;
 
 pub use executor::*;
@@ -23,6 +24,7 @@ pub use stage::*;
 pub use state::*;
 pub use system_container::*;
 pub use system_descriptor::*;
+pub use system_graph::*;
 pub use system_set::*;
 
 use std::fmt::Debug;

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -251,12 +251,13 @@ impl SystemStage {
         &self.exclusive_before_commands
     }
 
-    pub fn with_system_set(mut self, system_set: SystemSet) -> Self {
+    pub fn with_system_set(mut self, system_set: impl Into<SystemSet>) -> Self {
         self.add_system_set(system_set);
         self
     }
 
-    pub fn add_system_set(&mut self, system_set: SystemSet) -> &mut Self {
+    pub fn add_system_set(&mut self, system_set: impl Into<SystemSet>) -> &mut Self {
+        let system_set = system_set.into();
         self.systems_modified = true;
         let (run_criteria, mut systems) = system_set.bake();
         let set_run_criteria_index = run_criteria.and_then(|criteria| {

--- a/crates/bevy_ecs/src/schedule/system_graph.rs
+++ b/crates/bevy_ecs/src/schedule/system_graph.rs
@@ -1,0 +1,264 @@
+use crate::schedule::{SystemDescriptor, SystemLabel, SystemSet};
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc, Mutex,
+    },
+};
+
+static NEXT_NODE_ID: AtomicU32 = AtomicU32::new(0);
+
+/// A builder for creating graphs of dependent parallel execution within a `SystemStage`.
+///
+/// # Sequential Execution
+/// The simplest graph is a sequence of systems that need to run one after another.
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// # fn sys_a() {}
+/// # fn sys_b() {}
+/// # fn sys_c() {}
+/// let graph = SystemGraph::new();
+/// graph
+///   .root(sys_a.system())
+///   .then(sys_b.system())
+///   .then(sys_c.system());
+///
+/// // Convert into a SystemSet
+/// let system_set: SystemSet = graph.into();
+/// ```
+///
+/// # Fan Out
+/// `SystemGraphNode::then` can be called repeatedly on the same node to create multiple fan-out
+/// branches. All fanned out systems will not execute until the original has finished.
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// # fn sys_a() {}
+/// # fn sys_b() {}
+/// # fn sys_c() {}
+/// # fn sys_d() {}
+/// # fn sys_e() {}
+/// let graph = SystemGraph::new();
+///
+/// let start_a = graph.root(sys_a.system());
+///
+/// start_a.then(sys_b.system());
+/// start_a.then(sys_c.system());
+///
+/// start_a
+///     .then(sys_d.system())
+///     .then(sys_e.system());
+///
+/// // Convert into a SystemSet
+/// let system_set: SystemSet = graph.into();
+/// ```
+///
+/// # Fan In
+/// A graph node can wait on multiple systems before running.
+/// `SystemGraphJoinExt::join_into` is implemented on any type that iterates over
+/// `SystemGraphNode`.
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// # fn sys_a() {}
+/// # fn sys_b() {}
+/// # fn sys_c() {}
+/// # fn sys_d() {}
+/// # fn sys_e() {}
+/// let graph = SystemGraph::new();
+///
+/// let start_a = graph.root(sys_a.system());
+/// let start_b = graph.root(sys_b.system());
+/// let start_c = graph.root(sys_c.system());
+///
+/// vec![start_a, start_b, start_c]
+///     .join_into(sys_d.system())
+///     .then(sys_e.system());
+///
+/// // Convert into a SystemSet
+/// let system_set: SystemSet = graph.into();
+/// ```
+#[derive(Clone, Default)]
+pub struct SystemGraph(Arc<Mutex<HashMap<NodeId, SystemDescriptor>>>);
+
+impl SystemGraph {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn root(&self, system: impl Into<SystemDescriptor>) -> SystemGraphNode {
+        self.create_node(system.into())
+    }
+
+    pub fn is_same_graph(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+
+    fn create_node(&self, mut system: SystemDescriptor) -> SystemGraphNode {
+        let id = NodeId(NEXT_NODE_ID.fetch_add(1, Ordering::Relaxed));
+        match &mut system {
+            SystemDescriptor::Parallel(descriptor) => descriptor.labels.push(id.dyn_clone()),
+            SystemDescriptor::Exclusive(descriptor) => descriptor.labels.push(id.dyn_clone()),
+        }
+        self.0.lock().unwrap().insert(id, system);
+        SystemGraphNode {
+            id,
+            graph: self.clone(),
+        }
+    }
+
+    fn add_dependency(&self, src: NodeId, dst: NodeId) {
+        if let Some(system) = self.0.lock().unwrap().get_mut(&dst) {
+            match system {
+                SystemDescriptor::Parallel(descriptor) => descriptor.after.push(src.dyn_clone()),
+                SystemDescriptor::Exclusive(descriptor) => descriptor.after.push(src.dyn_clone()),
+            }
+        } else {
+            panic!(
+                "Attempted to add dependency for {:?}, which doesn't exist.",
+                dst
+            );
+        }
+    }
+}
+
+/// A draining conversion from [SystemGraph] to [SystemSet]. All other clones of the same graph
+/// will be empty afterwards.
+///
+/// [SystemGraph]: crate::schedule::SystemSet
+/// [SystemSet]: crate::schedule::SystemSet
+impl From<SystemGraph> for SystemSet {
+    fn from(graph: SystemGraph) -> Self {
+        let mut system_set = SystemSet::new();
+        for (_, system) in graph.0.lock().unwrap().drain() {
+            system_set = system_set.with_system(system);
+        }
+        system_set
+    }
+}
+
+#[derive(Clone)]
+pub struct SystemGraphNode {
+    id: NodeId,
+    graph: SystemGraph,
+}
+
+impl SystemGraphNode {
+    pub fn then(&self, next: impl Into<SystemDescriptor>) -> SystemGraphNode {
+        let node = self.graph.create_node(next.into());
+        self.add_dependent(node.id);
+        node
+    }
+
+    fn add_dependent(&self, dst: NodeId) {
+        self.graph.add_dependency(self.id, dst);
+    }
+}
+
+pub trait SystemGraphJoinExt: Sized + IntoIterator<Item = SystemGraphNode> {
+    fn join_into(self, next: impl Into<SystemDescriptor>) -> SystemGraphNode {
+        let mut nodes = self.into_iter().peekable();
+        let output = nodes
+            .peek()
+            .map(|node| {
+                let output_node = node.graph.create_node(next.into());
+                node.add_dependent(output_node.id);
+                output_node
+            })
+            .expect("Attempted to join a collection of zero nodes.");
+
+        for node in nodes {
+            assert!(
+                output.graph.is_same_graph(&node.graph),
+                "Joined graph nodes should be from the same graph."
+            );
+            node.add_dependent(output.id);
+        }
+
+        output
+    }
+}
+
+impl<T: IntoIterator<Item = SystemGraphNode>> SystemGraphJoinExt for T {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct NodeId(u32);
+
+impl SystemLabel for NodeId {
+    fn dyn_clone(&self) -> Box<dyn SystemLabel> {
+        Box::new(<NodeId>::clone(self))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::prelude::*;
+    use crate::schedule::SystemDescriptor;
+
+    fn dummy_system() {}
+
+    #[test]
+    pub fn graph_creates_accurate_system_counts() {
+        let graph = SystemGraph::new();
+        let a = graph
+            .root(dummy_system.system())
+            .then(dummy_system.system())
+            .then(dummy_system.system())
+            .then(dummy_system.system());
+        let b = graph
+            .root(dummy_system.system())
+            .then(dummy_system.system());
+        let c = graph
+            .root(dummy_system.system())
+            .then(dummy_system.system())
+            .then(dummy_system.system());
+        vec![a, b, c]
+            .join_into(dummy_system.system())
+            .then(dummy_system.system());
+        let system_set: SystemSet = graph.into();
+        let (_, systems) = system_set.bake();
+
+        assert_eq!(systems.len(), 11);
+    }
+
+    #[test]
+    pub fn all_nodes_are_labeled() {
+        let graph = SystemGraph::new();
+        let a = graph
+            .root(dummy_system.system())
+            .then(dummy_system.system())
+            .then(dummy_system.system())
+            .then(dummy_system.system());
+        let b = graph
+            .root(dummy_system.system())
+            .then(dummy_system.system());
+        let c = graph
+            .root(dummy_system.system())
+            .then(dummy_system.system())
+            .then(dummy_system.system());
+        vec![a, b, c]
+            .join_into(dummy_system.system())
+            .then(dummy_system.system());
+        let system_set: SystemSet = graph.into();
+        let (_, systems) = system_set.bake();
+
+        let mut root_count = 0;
+        for system in systems {
+            match system {
+                SystemDescriptor::Parallel(desc) => {
+                    assert!(!desc.labels.is_empty());
+                    if desc.after.is_empty() {
+                        root_count += 1;
+                    }
+                }
+                SystemDescriptor::Exclusive(desc) => {
+                    assert!(!desc.labels.is_empty());
+                    if desc.after.is_empty() {
+                        root_count += 1;
+                    }
+                }
+            }
+        }
+        assert_eq!(root_count, 3);
+    }
+}

--- a/crates/bevy_ecs/src/schedule/system_graph.rs
+++ b/crates/bevy_ecs/src/schedule/system_graph.rs
@@ -8,7 +8,7 @@ use std::{
     sync::atomic::{AtomicU32, Ordering},
 };
 
-static NEXT_NODE_ID: AtomicU32 = AtomicU32::new(0);
+static NEXT_GRAPH_ID: AtomicU32 = AtomicU32::new(0);
 
 /// A builder for creating graphs of dependent parallel execution within a `SystemStage`.
 ///
@@ -86,12 +86,18 @@ static NEXT_NODE_ID: AtomicU32 = AtomicU32::new(0);
 /// # Cloning
 /// This type is backed by a Rc, so cloning it will still point to the same logical
 /// underlying graph.
-#[derive(Clone, Default)]
-pub struct SystemGraph(Rc<RefCell<HashMap<NodeId, SystemDescriptor>>>);
+#[derive(Clone)]
+pub struct SystemGraph {
+    id: u32,
+    nodes: Rc<RefCell<HashMap<NodeId, SystemDescriptor>>>,
+}
 
 impl SystemGraph {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            id: NEXT_GRAPH_ID.fetch_add(1, Ordering::Relaxed),
+            nodes: Default::default(),
+        }
     }
 
     /// Creates a root graph node without any dependencies. A graph can have multiple distinct
@@ -102,16 +108,25 @@ impl SystemGraph {
 
     /// Checks if two graphs instances point to the same logical underlying graph.
     pub fn is_same_graph(&self, other: &Self) -> bool {
-        Rc::ptr_eq(&self.0, &other.0)
+        self.id == other.id
     }
 
     fn create_node(&self, mut system: SystemDescriptor) -> SystemGraphNode {
-        let id = NodeId(NEXT_NODE_ID.fetch_add(1, Ordering::Relaxed));
+        let mut nodes = self.nodes.borrow_mut();
+        assert!(
+            nodes.len() <= u32::MAX as usize,
+            "Cannot add more than {} systems to a SystemGraph",
+            u32::MAX
+        );
+        let id = NodeId {
+            graph_id: self.id,
+            node_id: nodes.len() as u32,
+        };
         match &mut system {
             SystemDescriptor::Parallel(descriptor) => descriptor.labels.push(id.dyn_clone()),
             SystemDescriptor::Exclusive(descriptor) => descriptor.labels.push(id.dyn_clone()),
         }
-        self.0.borrow_mut().insert(id, system);
+        nodes.insert(id, system);
         SystemGraphNode {
             id,
             graph: self.clone(),
@@ -119,7 +134,7 @@ impl SystemGraph {
     }
 
     fn add_dependency(&self, src: NodeId, dst: NodeId) {
-        if let Some(system) = self.0.borrow_mut().get_mut(&dst) {
+        if let Some(system) = self.nodes.borrow_mut().get_mut(&dst) {
             match system {
                 SystemDescriptor::Parallel(descriptor) => descriptor.after.push(src.dyn_clone()),
                 SystemDescriptor::Exclusive(descriptor) => descriptor.after.push(src.dyn_clone()),
@@ -140,7 +155,7 @@ impl SystemGraph {
 impl From<SystemGraph> for SystemSet {
     fn from(graph: SystemGraph) -> Self {
         let mut system_set = SystemSet::new();
-        for (_, system) in graph.0.borrow_mut().drain() {
+        for (_, system) in graph.nodes.borrow_mut().drain() {
             system_set = system_set.with_system(system);
         }
         system_set
@@ -233,7 +248,10 @@ pub trait SystemGraphJoinExt: Sized + IntoIterator<Item = SystemGraphNode> {
 impl<T: IntoIterator<Item = SystemGraphNode>> SystemGraphJoinExt for T {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct NodeId(u32);
+struct NodeId {
+    graph_id: u32,
+    node_id: u32,
+}
 
 impl SystemLabel for NodeId {
     fn dyn_clone(&self) -> Box<dyn SystemLabel> {

--- a/crates/bevy_ecs/src/schedule/system_graph.rs
+++ b/crates/bevy_ecs/src/schedule/system_graph.rs
@@ -43,7 +43,7 @@ static NEXT_GRAPH_ID: AtomicU32 = AtomicU32::new(0);
 /// let graph = SystemGraph::new();
 ///
 /// // Fork out from one original node.
-/// let (c, b, d) = graph.root(sys_a.system())
+/// let (c, b, d) = graph.root(sys_a)
 ///     .fork((
 ///         sys_b,
 ///         sys_c,
@@ -213,7 +213,7 @@ impl SystemGraphNode {
         self.graph.clone()
     }
 
-    /// Creates a new node in the graph and adds the current node as it's dependency.
+    /// Creates a new node in the graph and adds the current node as its dependency.
     ///
     /// This function can be called multiple times to add mulitple systems to the graph,
     /// all of which will not execute until original node's system has finished running.
@@ -297,7 +297,7 @@ macro_rules! impl_system_tuple {
                 let ($($param,)*) = self;
                 $(
                     assert!(output.graph.is_same_graph(&$param.graph),
-                            "Joined graph nodes should be from the same graph.");
+                            "Joined graph nodes must be from the same graph.");
                     output.graph.add_dependency($param.id, output.id);
                 )*
                 output

--- a/crates/bevy_ecs/src/schedule/system_graph.rs
+++ b/crates/bevy_ecs/src/schedule/system_graph.rs
@@ -183,10 +183,10 @@ impl SystemGraph {
     }
 }
 
-/// A draining conversion to [SystemSet]. All other clones of the same graph will be empty
+/// A draining conversion to [`SystemSet`]. All other clones of the same graph will be empty
 /// afterwards.
 ///
-/// [SystemSet]: crate::schedule::SystemSet
+/// [`SystemSet`]: crate::schedule::SystemSet
 impl From<SystemGraph> for SystemSet {
     fn from(graph: SystemGraph) -> Self {
         let mut system_set = SystemSet::new();

--- a/crates/bevy_ecs/src/schedule/system_graph.rs
+++ b/crates/bevy_ecs/src/schedule/system_graph.rs
@@ -82,7 +82,7 @@ static NEXT_GRAPH_ID: AtomicU32 = AtomicU32::new(0);
 /// let system_set: SystemSet = graph.into();
 /// ```
 ///
-/// # Fan In
+/// # Fan Out into Fan In
 /// The types used to implement [fork] and [join] are composable.
 /// ```
 /// # use bevy_ecs::prelude::*;
@@ -106,7 +106,7 @@ static NEXT_GRAPH_ID: AtomicU32 = AtomicU32::new(0);
 /// This type is backed by a Rc, so cloning it will still point to the same logical
 /// underlying graph.
 ///
-/// [fork]: crate::schedule::SystemGraphNode::join
+/// [fork]: crate::schedule::SystemGraphNode::fork
 /// [join]: crate::schedule::SystemJoin::join
 #[derive(Clone)]
 pub struct SystemGraph {
@@ -114,12 +114,18 @@ pub struct SystemGraph {
     nodes: Rc<RefCell<HashMap<NodeId, SystemDescriptor>>>,
 }
 
-impl SystemGraph {
-    pub fn new() -> Self {
+impl Default for SystemGraph {
+    fn default() -> Self {
         Self {
             id: NEXT_GRAPH_ID.fetch_add(1, Ordering::Relaxed),
             nodes: Default::default(),
         }
+    }
+}
+
+impl SystemGraph {
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Creates a root graph node without any dependencies. A graph can have multiple distinct

--- a/crates/bevy_ecs/src/schedule/system_set.rs
+++ b/crates/bevy_ecs/src/schedule/system_set.rs
@@ -10,8 +10,6 @@ use std::{
     sync::atomic::{AtomicU32, Ordering},
 };
 
-static NEXT_SEQUENCE_ID: AtomicU32 = AtomicU32::new(0);
-
 /// A builder for describing several systems at the same time.
 #[derive(Default)]
 pub struct SystemSet {

--- a/crates/bevy_ecs/src/schedule/system_set.rs
+++ b/crates/bevy_ecs/src/schedule/system_set.rs
@@ -21,7 +21,6 @@ pub struct SystemSet {
     pub(crate) before: Vec<BoxedSystemLabel>,
     pub(crate) after: Vec<BoxedSystemLabel>,
     pub(crate) ambiguity_sets: Vec<BoxedAmbiguitySetLabel>,
-    sequential: bool,
 }
 
 impl SystemSet {
@@ -116,12 +115,7 @@ impl SystemSet {
             before,
             after,
             ambiguity_sets,
-            sequential,
         } = self;
-
-        if sequential {
-            Self::sequentialize(&mut systems);
-        }
 
         for descriptor in &mut systems {
             match descriptor {
@@ -144,94 +138,5 @@ impl SystemSet {
             }
         }
         (run_criteria, systems)
-    }
-
-    fn sequentialize(systems: &mut Vec<SystemDescriptor>) {
-        let start = NEXT_SEQUENCE_ID.fetch_add(systems.len() as u32, Ordering::Relaxed);
-        let mut last_label: Option<SequenceId> = None;
-        for (idx, descriptor) in systems.iter_mut().enumerate() {
-            let label = SequenceId(start.wrapping_add(idx as u32));
-            match descriptor {
-                SystemDescriptor::Parallel(descriptor) => {
-                    descriptor.labels.push(label.dyn_clone());
-                    if let Some(ref after) = last_label {
-                        descriptor.after.push(after.dyn_clone());
-                    }
-                }
-                SystemDescriptor::Exclusive(descriptor) => {
-                    descriptor.labels.push(label.dyn_clone());
-                    if let Some(ref after) = last_label {
-                        descriptor.after.push(after.dyn_clone());
-                    }
-                }
-            }
-            last_label = Some(label);
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct SequenceId(u32);
-
-impl SystemLabel for SequenceId {
-    fn dyn_clone(&self) -> Box<dyn SystemLabel> {
-        Box::new(<SequenceId>::clone(self))
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use crate::prelude::*;
-
-    fn dummy_system() {}
-
-    fn labels(system: &SystemDescriptor) -> &Vec<Box<dyn SystemLabel>> {
-        match system {
-            SystemDescriptor::Parallel(descriptor) => &descriptor.labels,
-            SystemDescriptor::Exclusive(descriptor) => &descriptor.labels,
-        }
-    }
-
-    fn after(system: &SystemDescriptor) -> &Vec<Box<dyn SystemLabel>> {
-        match system {
-            SystemDescriptor::Parallel(descriptor) => &descriptor.after,
-            SystemDescriptor::Exclusive(descriptor) => &descriptor.after,
-        }
-    }
-
-    #[test]
-    pub fn sequential_adds_labels() {
-        let system_set = SystemSet::new()
-            .as_sequential()
-            .with_system(dummy_system.system())
-            .with_system(dummy_system.system())
-            .with_system(dummy_system.system());
-        let (_, systems) = system_set.bake();
-
-        assert_eq!(systems.len(), 3);
-        assert_eq!(labels(&systems[0]), &vec![SequenceId(0).dyn_clone()]);
-        assert_eq!(labels(&systems[1]), &vec![SequenceId(1).dyn_clone()]);
-        assert_eq!(labels(&systems[2]), &vec![SequenceId(2).dyn_clone()]);
-        assert_eq!(after(&systems[0]), &vec![]);
-        assert_eq!(after(&systems[1]), &vec![SequenceId(0).dyn_clone()]);
-        assert_eq!(after(&systems[2]), &vec![SequenceId(1).dyn_clone()]);
-    }
-
-    #[test]
-    pub fn non_sequential_has_no_labels_by_default() {
-        let system_set = SystemSet::new()
-            .with_system(dummy_system.system())
-            .with_system(dummy_system.system())
-            .with_system(dummy_system.system());
-        let (_, systems) = system_set.bake();
-
-        assert_eq!(systems.len(), 3);
-        assert_eq!(labels(&systems[0]), &vec![]);
-        assert_eq!(labels(&systems[1]), &vec![]);
-        assert_eq!(labels(&systems[2]), &vec![]);
-        assert_eq!(after(&systems[0]), &vec![]);
-        assert_eq!(after(&systems[1]), &vec![]);
-        assert_eq!(after(&systems[2]), &vec![]);
     }
 }

--- a/crates/bevy_ecs/src/schedule/system_set.rs
+++ b/crates/bevy_ecs/src/schedule/system_set.rs
@@ -116,7 +116,6 @@ impl SystemSet {
             after,
             ambiguity_sets,
         } = self;
-
         for descriptor in &mut systems {
             match descriptor {
                 SystemDescriptor::Parallel(descriptor) => {

--- a/crates/bevy_ecs/src/schedule/system_set.rs
+++ b/crates/bevy_ecs/src/schedule/system_set.rs
@@ -150,7 +150,7 @@ impl SystemSet {
         let start = NEXT_SEQUENCE_ID.fetch_add(systems.len() as u32, Ordering::Relaxed);
         let mut last_label: Option<SequenceId> = None;
         for (idx, descriptor) in systems.iter_mut().enumerate() {
-            let label = SequenceId(start + idx as u32);
+            let label = SequenceId(start.wrapping_add(idx as u32));
             match descriptor {
                 SystemDescriptor::Parallel(descriptor) => {
                     descriptor.labels.push(label.dyn_clone());

--- a/crates/bevy_ecs/src/schedule/system_set.rs
+++ b/crates/bevy_ecs/src/schedule/system_set.rs
@@ -4,11 +4,6 @@ use crate::schedule::{
 };
 
 use super::IntoSystemDescriptor;
-use std::{
-    fmt::Debug,
-    hash::Hash,
-    sync::atomic::{AtomicU32, Ordering},
-};
 
 /// A builder for describing several systems at the same time.
 #[derive(Default)]

--- a/crates/bevy_ecs/src/schedule/system_set.rs
+++ b/crates/bevy_ecs/src/schedule/system_set.rs
@@ -4,8 +4,11 @@ use crate::schedule::{
 };
 
 use super::IntoSystemDescriptor;
-use std::sync::atomic::{AtomicU32, Ordering};
-use std::{fmt::Debug, hash::Hash};
+use std::{
+    fmt::Debug,
+    hash::Hash,
+    sync::atomic::{AtomicU32, Ordering},
+};
 
 static NEXT_SEQUENCE_ID: AtomicU32 = AtomicU32::new(0);
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -167,6 +167,7 @@ Example | File | Description
 `removal_detection` | [`ecs/removal_detection.rs`](./ecs/removal_detection.rs) | Query for entities that had a specific component removed in a previous stage during the current frame.
 `startup_system` | [`ecs/startup_system.rs`](./ecs/startup_system.rs) | Demonstrates a startup system (one that runs once when the app starts up)
 `state` | [`ecs/state.rs`](./ecs/state.rs) | Illustrates how to use States to control transitioning from a Menu state to an InGame state
+`system_graph` | [`ecs/system_graph.rs`](./ecs/system_graph.rs) | Constructing complex dependency graphs between multiple systems without labels
 `system_chaining` | [`ecs/system_chaining.rs`](./ecs/system_chaining.rs) | Chain two systems together, specifying a return type in a system (such as `Result`)
 `system_param` | [`ecs/system_param.rs`](./ecs/system_param.rs) | Illustrates creating custom system parameters with `SystemParam`
 `system_sets` | [`ecs/system_sets.rs`](./ecs/system_sets.rs) | Shows `SystemSet` use along with run criterion

--- a/examples/ecs/system_graph.rs
+++ b/examples/ecs/system_graph.rs
@@ -1,8 +1,11 @@
 use bevy::prelude::*;
 
 fn main() {
-    // SystemGraphs can be used to specify explicit system dependencies.
-    // Labels can be used alongside SystemGraphs to help specify dependency relationships.
+    // SystemGraphs can be used to specify explicit system dependencies without specifying
+    // explicit labels for each system.
+    //
+    // Labels can be used alongside SystemGraphs to help specify dependency relationships
+    // between graphs, betwen standalone systems, or between crate boundaries.
 
     // These three systems will run sequentially one after another.
     let sequential = SystemGraph::new();

--- a/examples/ecs/system_graph.rs
+++ b/examples/ecs/system_graph.rs
@@ -1,0 +1,50 @@
+use bevy::prelude::*;
+
+fn main() {
+    // SystemGraphs can be used to specify explicit system dependencies.
+    // Labels can be used alongside SystemGraphs to help specify dependency relationships.
+
+    // These three systems will run sequentially one after another.
+    let sequential = SystemGraph::new();
+    sequential
+        .root(print_system("Sequential 1"))
+        .then(print_system("Sequential 2"))
+        .then(
+            print_system("Sequential 3")
+                .system()
+                .label("Sequential End"),
+        );
+
+    // Graphs nodes can fork into multiple dependencies.
+    let wide = SystemGraph::new();
+    let (mid_1, mid_2, mid_3) = wide
+        .root(print_system("Wide Start").system().after("Sequential End"))
+        .fork((
+            print_system("Wide 1"),
+            print_system("Wide 2"),
+            print_system("Wide 3"),
+        ));
+
+    // Graphs can have multiple root systems.
+    let side = wide.root(print_system("Wide Side"));
+
+    // Branches can be continued separately from each other.
+    mid_3.then(print_system("Wide 3 Continuation"));
+
+    // Multiple branches can be merged. This system will only run when all dependencies
+    // finish running.
+    (mid_1, mid_2, side).join(print_system("Wide 1 & Wide 2 Continuation"));
+
+    // SystemGraph implements Into<SystemSet> and can be used to add of the graph's systems to an
+    // App.
+    App::build()
+        .add_system_set(sequential)
+        .add_system_set(wide)
+        .run();
+}
+
+fn print_system(message: &'static str) -> impl Fn() {
+    move || {
+        println!("{}", message);
+    }
+}

--- a/examples/ecs/system_graph.rs
+++ b/examples/ecs/system_graph.rs
@@ -36,7 +36,7 @@ fn main() {
 
     // SystemGraph implements Into<SystemSet> and can be used to add of the graph's systems to an
     // App.
-    App::build()
+    App::new()
         .add_system_set(sequential)
         .add_system_set(wide)
         .run();

--- a/examples/ecs/system_graph.rs
+++ b/examples/ecs/system_graph.rs
@@ -12,16 +12,12 @@ fn main() {
     sequential
         .root(print_system("Sequential 1"))
         .then(print_system("Sequential 2"))
-        .then(
-            print_system("Sequential 3")
-                .system()
-                .label("Sequential End"),
-        );
+        .then(print_system("Sequential 3").label("Sequential End"));
 
     // Graphs nodes can fork into multiple dependencies.
     let wide = SystemGraph::new();
     let (mid_1, mid_2, mid_3) = wide
-        .root(print_system("Wide Start").system().after("Sequential End"))
+        .root(print_system("Wide Start").after("Sequential End"))
         .fork((
             print_system("Wide 1"),
             print_system("Wide 2"),


### PR DESCRIPTION
# Objective
This PR adds `SystemGraph` as way to create system dependency graphs without explicit labeling.

## Motivation
It is currently difficult to force a strict system dependency graph. Currently the only way is manually set `label`, `before`, and/or `after` on each system. This can lead to some particularly boilerplate/non-ergonomic builder code that is difficult to read, harder to think about, and more prone to programmer error. An example of this kind of code can be found here: https://github.com/HouraiTeahouse/FantasyCresendoBevy/blob/master/src/match/mod.rs#L248.

Natural ordering invariants in game dev are common, and this should provide a simpler way to define those requirements. One notable case is the common simple sequential execution. Deterministic simulation is much easier to reason about with a single execution order, which should make it easier to create networked games that rely on determinism.

## Solution
This PR adds `SystemGraph`. It provides a handle based API for creating dependency graphs, and can be converted into SystemSets. It enforces ordering by generating `NodeId`s, a newtype around u32, as a globally unique system label, that is then used to label and order systems relative to each other.

This should be able to be used alongside "normal" SystemLabels to allow for ordering other systems relative any system in the SystemSet.

As for the choice to use AtomicU32, unless a developer is adding >2^32 systems to a stage,  there will be no collisions. If multiple Apps are set up and recycled in the same process (i.e. headless server environments spinning up game instances), the static AtomicU32 uses wrapping adds when generating IDs, so there is no risk of crashing from an overflow.