### PR TITLE
[Merged by Bors] - Increment last event count on next instead of iter

### DIFF
--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -188,28 +188,25 @@ impl<T> Default for ManualEventReader<T> {
 
 impl<T> ManualEventReader<T> {
     /// See [`EventReader::iter`]
-    pub fn iter<'a: 'r, 'loc: 'r, 'r>(
-        &'loc mut self,
-        events: &'a Events<T>,
-    ) -> impl DoubleEndedIterator<Item = &'a T> + 'r {
+    pub fn iter<'a>(&'a mut self, events: &'a Events<T>) -> impl DoubleEndedIterator<Item = &'a T> {
         internal_event_reader(&mut self.last_event_count, events).map(|(e, _)| e)
     }
 
     /// See [`EventReader::iter_with_id`]
-    pub fn iter_with_id<'a: 'r, 'loc: 'r, 'r>(
-        &'loc mut self,
+    pub fn iter_with_id<'a>(
+        &'a mut self,
         events: &'a Events<T>,
-    ) -> impl DoubleEndedIterator<Item = (&'a T, EventId<T>)> + 'r {
+    ) -> impl DoubleEndedIterator<Item = (&'a T, EventId<T>)> {
         internal_event_reader(&mut self.last_event_count, events)
     }
 }
 
 /// Like [`iter_with_id`](EventReader::iter_with_id) except not emitting any traces for read
 /// messages.
-fn internal_event_reader<'a: 'r, 'loc: 'r, 'r, T>(
-    last_event_count: &'loc mut usize,
+fn internal_event_reader<'a, T>(
+    last_event_count: &'a mut usize,
     events: &'a Events<T>,
-) -> impl DoubleEndedIterator<Item = (&'a T, EventId<T>)> + 'r {
+) -> impl DoubleEndedIterator<Item = (&'a T, EventId<T>)> {
     // if the reader has seen some of the events in a buffer, find the proper index offset.
     // otherwise read all events in the buffer
     let a_index = if *last_event_count > events.a_start_event_count {

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -232,7 +232,7 @@ fn internal_event_reader<'a: 'r, 'loc: 'r, 'r, T>(
     };
     iterator
         .map(map_instance_event_with_id)
-        .inspect(move |(_, id)| *last_event_count = id.id.max(*last_event_count))
+        .inspect(move |(_, id)| *last_event_count = (id.id + 1).max(*last_event_count))
 }
 
 impl<'a, T: Component> EventReader<'a, T> {

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -188,25 +188,28 @@ impl<T> Default for ManualEventReader<T> {
 
 impl<T> ManualEventReader<T> {
     /// See [`EventReader::iter`]
-    pub fn iter<'a>(&'a mut self, events: &'a Events<T>) -> impl DoubleEndedIterator<Item = &'a T> {
+    pub fn iter<'a: 'r, 'loc: 'r, 'r>(
+        &'loc mut self,
+        events: &'a Events<T>,
+    ) -> impl DoubleEndedIterator<Item = &'a T> + 'r {
         internal_event_reader(&mut self.last_event_count, events).map(|(e, _)| e)
     }
 
     /// See [`EventReader::iter_with_id`]
-    pub fn iter_with_id<'a>(
-        &'a mut self,
+    pub fn iter_with_id<'a: 'r, 'loc: 'r, 'r>(
+        &'loc mut self,
         events: &'a Events<T>,
-    ) -> impl DoubleEndedIterator<Item = (&'a T, EventId<T>)> {
+    ) -> impl DoubleEndedIterator<Item = (&'a T, EventId<T>)> + 'r {
         internal_event_reader(&mut self.last_event_count, events)
     }
 }
 
 /// Like [`iter_with_id`](EventReader::iter_with_id) except not emitting any traces for read
 /// messages.
-fn internal_event_reader<'a, T>(
-    last_event_count: &'a mut usize,
+fn internal_event_reader<'a: 'r, 'loc: 'r, 'r, T>(
+    last_event_count: &'loc mut usize,
     events: &'a Events<T>,
-) -> impl DoubleEndedIterator<Item = (&'a T, EventId<T>)> + 'a {
+) -> impl DoubleEndedIterator<Item = (&'a T, EventId<T>)> + 'r {
     // if the reader has seen some of the events in a buffer, find the proper index offset.
     // otherwise read all events in the buffer
     let a_index = if *last_event_count > events.a_start_event_count {

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -232,7 +232,7 @@ fn internal_event_reader<'a: 'r, 'loc: 'r, 'r, T>(
     };
     iterator
         .map(map_instance_event_with_id)
-        .inspect(move |_| *last_event_count += 1)
+        .inspect(move |(_, id)| *last_event_count = id.id.max(*last_event_count))
 }
 
 impl<'a, T: Component> EventReader<'a, T> {

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -303,6 +303,7 @@ pub fn scene_spawner_system(world: &mut World) {
             .unwrap();
 
         let mut updated_spawned_scenes = Vec::new();
+        let scene_spawner = &mut *scene_spawner;
         for event in scene_spawner
             .scene_asset_event_reader
             .iter(&scene_asset_events)


### PR DESCRIPTION
# Objective

Currently, simply calling `iter` on an event reader will mark all of it's events as read, even if the returned iterator is never used

## Solution

With this, the cursor will simply move to the last unread, but available event when iter is called, and incremented by one per `next` call.
