### PR TITLE
static assert that bundles do not have duplicate types

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -142,19 +142,11 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let struct_name = &ast.ident;
 
-    let static_assert_bundle_func = syn::Ident::new(
-        &format!(
-            "static_assert_{}_does_not_have_duplicate_types",
-            struct_name.to_string()
-        ),
-        struct_name.span(),
+    let static_assert_bundle_func = format_ident!(
+        "static_assert_{}_does_not_have_duplicate_types",
+        struct_name
     );
-
-    let static_assert_trait = syn::Ident::new(
-        &format!("AssertDistinctComponents{}", struct_name.to_string()),
-        struct_name.span(),
-    );
-
+    let static_assert_trait = format_ident!("AssertDistinctComponentsFor{}", struct_name);
     let field_types = field_data.iter().map(|(_, ty, _)| ty);
 
     TokenStream::from(quote! {

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -150,6 +150,11 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
         struct_name.span(),
     );
 
+    let static_assert_trait = syn::Ident::new(
+        &format!("AssertDistinctComponents{}", struct_name.to_string()),
+        struct_name.span(),
+    );
+
     let field_types = field_data.iter().map(|(_, ty, _)| ty);
 
     TokenStream::from(quote! {
@@ -176,15 +181,8 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
 
         #[allow(dead_code, non_snake_case)]
         fn #static_assert_bundle_func() {
-            macro_rules! assert_all_bundle_types_ne {
-                ($($y:ty),+ $(,)?) => {
-                    $(impl #ecs_path::PartOfBundle<#struct_name> for $y {})+
-                };
-            }
-
-            #(impl #ecs_path::bundle::PartOfBundle<#struct_name> for #field_types {})*
-
-            #(impl<T: #ecs_path::bundle::PartOfBundle<#nested_bundle_types>> #ecs_path::bundle::PartOfBundle<#struct_name> for T {})*
+            trait #static_assert_trait {}
+            #(impl #static_assert_trait for #field_types {})*
         }
     })
 }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -179,7 +179,6 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
             }
         }
 
-        #[cfg(test)]
         #[allow(dead_code, non_snake_case)]
         fn #static_assert_bundle_func() {
             macro_rules! assert_all_bundle_types_ne {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -39,20 +39,16 @@ use std::{any::TypeId, collections::HashMap};
 ///
 /// ## Note
 /// Bundles do not support duplicate types.
+/// Currently there is static checking for duplicate types, however, it
+/// does not check nested bundles via `#[bundle]`.
 ///
 /// ```compile_fail
 /// # use bevy_ecs::bundle::Bundle;
 ///
 /// #[derive(Bundle)]
-/// struct Nested {
-///     a: usize,
-/// }
-///
-/// #[derive(Bundle)]
 /// struct HasDuplicateType {
-///     #[bundle]
-///     nested: Nested,
-///     b: usize, // `Nested` already contains a `usize` so this will fail to compile.
+///     a: usize,
+///     b: usize, // `a` is already a `usize` so this won't compile.
 /// }
 /// ```
 ///
@@ -80,9 +76,6 @@ pub unsafe trait Bundle: Send + Sync + 'static {
     /// that is desirable.
     fn get_components(self, func: impl FnMut(*mut u8));
 }
-
-/// DOCS: todo
-pub trait PartOfBundle<T> {}
 
 macro_rules! tuple_impl {
     ($($name: ident),*) => {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -37,6 +37,19 @@ use std::{any::TypeId, collections::HashMap};
 /// }
 /// ```
 ///
+/// ## Note
+/// Bundles do not support duplicate types.
+///
+/// ```compile_fail
+/// # use bevy_ecs::bundle::Bundle;
+///
+/// #[derive(Bundle)]
+/// struct HasDuplicateType {
+///     a: usize,
+///     b: usize, // `b` is also a `usize` so this will fail to compile
+/// }
+/// ```
+///
 /// # Safety
 /// [Bundle::type_info] must return the TypeInfo for each component type in the bundle, in the
 /// _exact_ order that [Bundle::get_components] is called.

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -44,9 +44,15 @@ use std::{any::TypeId, collections::HashMap};
 /// # use bevy_ecs::bundle::Bundle;
 ///
 /// #[derive(Bundle)]
-/// struct HasDuplicateType {
+/// struct Nested {
 ///     a: usize,
-///     b: usize, // `b` is also a `usize` so this will fail to compile
+/// }
+///
+/// #[derive(Bundle)]
+/// struct HasDuplicateType {
+///     #[bundle]
+///     nested: Nested,
+///     b: usize, // `Nested` already contains a `usize` so this will fail to compile.
 /// }
 /// ```
 ///
@@ -74,6 +80,9 @@ pub unsafe trait Bundle: Send + Sync + 'static {
     /// that is desirable.
     fn get_components(self, func: impl FnMut(*mut u8));
 }
+
+/// DOCS: todo
+pub trait PartOfBundle<T> {}
 
 macro_rules! tuple_impl {
     ($($name: ident),*) => {


### PR DESCRIPTION
# Objective

- Currently it is possible for a user to define a bundle that contains duplicate types. However, this is incorrect and can lead to various bugs.
- Partially addresses #2387

## Solution

- Implement a static check for Bundles that when using `#[derive(Bundle)]` will fail to compile if any of the inner types are duplicates. 
