### PR TITLE
[Merged by Bors] - Update hexasphere to 4.0.0.

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -37,7 +37,7 @@ downcast-rs = "1.2.0"
 thiserror = "1.0"
 anyhow = "1.0"
 hex = "0.4.2"
-hexasphere = "3.4"
+hexasphere = "4.0.0"
 parking_lot = "0.11.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -40,11 +40,6 @@ allow = ["MPL-2.0"]
 name = "wgpu"
 version = "0.8"
 
-[[licenses.exceptions]]
-allow = ["MPL-2.0"]
-name = "hexasphere"
-version = "3.4"
-
 [[licenses.clarify]]
 name = "stretch"
 expression = "MIT"


### PR DESCRIPTION
# Objective

- Update `hexasphere` to 4.0.0, which is now licensed with dual MIT/Apache-2.0.
