### PR TITLE
[Merged by Bors] - [ecs] add `StorageType` documentation

### DIFF
--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -32,7 +32,7 @@ impl<T: Send + Sync + 'static> Component for T {}
 /// The [`StorageType`] for a component is normally configured via `World::register_component`.
 ///
 /// ```
-/// # use bevy_ecs::prelude::*;
+/// # use bevy_ecs::{prelude::*, component::ComponentDescriptor};
 ///
 /// struct A;
 ///

--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -37,7 +37,7 @@ impl<T: Send + Sync + 'static> Component for T {}
 /// struct A;
 ///
 /// let mut world = World::default();
-/// world.register_component(ComponentDescriptor::new::<A>::(StorageType::SparseSet));
+/// world.register_component(ComponentDescriptor::new::<A>(StorageType::SparseSet));
 /// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum StorageType {

--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -26,9 +26,25 @@ use thiserror::Error;
 pub trait Component: Send + Sync + 'static {}
 impl<T: Send + Sync + 'static> Component for T {}
 
+/// The storage used for a specific component type.
+///
+/// # Examples
+/// The [`StorageType`] for a component is normally configured via `World::register_component`.
+///
+/// ```
+/// # use bevy_ecs::prelude::*;
+///
+/// struct A;
+///
+/// let mut world = World::default();
+/// world.register_component(ComponentDescriptor::new::<A>::(StorageType::SparseSet));
+/// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum StorageType {
+    /// Provides fast and cache friendly iteration, but slower adding and removing of components.
+    /// This is the default storage type.
     Table,
+    /// Provides fast adding and removing of components, but slower iteration.
     SparseSet,
 }
 

--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -32,7 +32,7 @@ impl<T: Send + Sync + 'static> Component for T {}
 /// The [`StorageType`] for a component is normally configured via `World::register_component`.
 ///
 /// ```
-/// # use bevy_ecs::{prelude::*, component::ComponentDescriptor};
+/// # use bevy_ecs::{prelude::*, component::*};
 ///
 /// struct A;
 ///

--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -41,10 +41,10 @@ impl<T: Send + Sync + 'static> Component for T {}
 /// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum StorageType {
-    /// Provides fast and cache friendly iteration, but slower adding and removing of components.
+    /// Provides fast and cache-friendly iteration, but slower addition and removal of components.
     /// This is the default storage type.
     Table,
-    /// Provides fast adding and removing of components, but slower iteration.
+    /// Provides fast addition and removal of components, but slower iteration.
     SparseSet,
 }
 


### PR DESCRIPTION
# Objective

- Add inline documentation for `StorageType`.
- Currently the README in `bevy_ecs` provides docs for `StorageType`, however, adding addition inline docs makes it simpler for users who are actively reading the source code.

## Solution
- Add inline docs.
