### PR TITLE
[Merged by Bors] - Optional `.system()`, part 2

### DIFF
--- a/crates/bevy_ecs/src/schedule/system_descriptor.rs
+++ b/crates/bevy_ecs/src/schedule/system_descriptor.rs
@@ -3,7 +3,7 @@ use crate::{
         AmbiguitySetLabel, BoxedAmbiguitySetLabel, BoxedSystemLabel, IntoRunCriteria,
         RunCriteriaDescriptorOrLabel, SystemLabel,
     },
-    system::{BoxedSystem, ExclusiveSystem, ExclusiveSystemCoerced, ExclusiveSystemFn, System},
+    system::{BoxedSystem, ExclusiveSystem, ExclusiveSystemCoerced, ExclusiveSystemFn, IntoSystem},
 };
 
 /// Encapsulates a system and information on when it run in a `SystemStage`.
@@ -53,7 +53,7 @@ impl IntoSystemDescriptor<()> for ParallelSystemDescriptor {
 
 impl<Params, S> IntoSystemDescriptor<Params> for S
 where
-    S: crate::system::IntoSystem<(), (), Params>,
+    S: IntoSystem<(), (), Params>,
 {
     fn into_descriptor(self) -> SystemDescriptor {
         new_parallel_descriptor(Box::new(self.system())).into_descriptor()
@@ -105,7 +105,7 @@ fn new_parallel_descriptor(system: BoxedSystem<(), ()>) -> ParallelSystemDescrip
     }
 }
 
-pub trait ParallelSystemDescriptorCoercion {
+pub trait ParallelSystemDescriptorCoercion<Params> {
     /// Assigns a run criteria to the system. Can be a new descriptor or a label of a
     /// run criteria defined elsewhere.
     fn with_run_criteria<Marker>(
@@ -127,7 +127,7 @@ pub trait ParallelSystemDescriptorCoercion {
     fn in_ambiguity_set(self, set: impl AmbiguitySetLabel) -> ParallelSystemDescriptor;
 }
 
-impl ParallelSystemDescriptorCoercion for ParallelSystemDescriptor {
+impl ParallelSystemDescriptorCoercion<()> for ParallelSystemDescriptor {
     fn with_run_criteria<Marker>(
         mut self,
         run_criteria: impl IntoRunCriteria<Marker>,
@@ -157,35 +157,35 @@ impl ParallelSystemDescriptorCoercion for ParallelSystemDescriptor {
     }
 }
 
-impl<S> ParallelSystemDescriptorCoercion for S
+impl<S, Params> ParallelSystemDescriptorCoercion<Params> for S
 where
-    S: System<In = (), Out = ()>,
+    S: IntoSystem<(), (), Params>,
 {
     fn with_run_criteria<Marker>(
         self,
         run_criteria: impl IntoRunCriteria<Marker>,
     ) -> ParallelSystemDescriptor {
-        new_parallel_descriptor(Box::new(self)).with_run_criteria(run_criteria)
+        new_parallel_descriptor(Box::new(self.system())).with_run_criteria(run_criteria)
     }
 
     fn label(self, label: impl SystemLabel) -> ParallelSystemDescriptor {
-        new_parallel_descriptor(Box::new(self)).label(label)
+        new_parallel_descriptor(Box::new(self.system())).label(label)
     }
 
     fn before(self, label: impl SystemLabel) -> ParallelSystemDescriptor {
-        new_parallel_descriptor(Box::new(self)).before(label)
+        new_parallel_descriptor(Box::new(self.system())).before(label)
     }
 
     fn after(self, label: impl SystemLabel) -> ParallelSystemDescriptor {
-        new_parallel_descriptor(Box::new(self)).after(label)
+        new_parallel_descriptor(Box::new(self.system())).after(label)
     }
 
     fn in_ambiguity_set(self, set: impl AmbiguitySetLabel) -> ParallelSystemDescriptor {
-        new_parallel_descriptor(Box::new(self)).in_ambiguity_set(set)
+        new_parallel_descriptor(Box::new(self.system())).in_ambiguity_set(set)
     }
 }
 
-impl ParallelSystemDescriptorCoercion for BoxedSystem<(), ()> {
+impl ParallelSystemDescriptorCoercion<()> for BoxedSystem<(), ()> {
     fn with_run_criteria<Marker>(
         self,
         run_criteria: impl IntoRunCriteria<Marker>,

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -276,9 +276,9 @@ fn main() {
         .init_resource::<GameState>()
         // Startup systems run exactly once BEFORE all other systems. These are generally used for
         // app initialization code (ex: adding entities and resources)
-        .add_startup_system(startup_system.system())
+        .add_startup_system(startup_system)
         // my_system calls converts normal rust functions into ECS systems:
-        .add_system(print_message_system.system())
+        .add_system(print_message_system)
         // SYSTEM EXECUTION ORDER
         //
         // Each system belongs to a `Stage`, which controls the execution strategy and broad order
@@ -310,7 +310,7 @@ fn main() {
         // add_system(system) adds systems to the UPDATE stage by default
         // However we can manually specify the stage if we want to. The following is equivalent to
         // add_system(score_system)
-        .add_system_to_stage(CoreStage::Update, score_system.system())
+        .add_system_to_stage(CoreStage::Update, score_system)
         // We can also create new stages. Here is what our games stage order will look like:
         // "before_round": new_player_system, new_round_system
         // "update": print_message_system, score_system
@@ -325,18 +325,18 @@ fn main() {
             MyStage::AfterRound,
             SystemStage::parallel(),
         )
-        .add_system_to_stage(MyStage::BeforeRound, new_round_system.system())
-        .add_system_to_stage(MyStage::BeforeRound, new_player_system.system())
+        .add_system_to_stage(MyStage::BeforeRound, new_round_system)
+        .add_system_to_stage(MyStage::BeforeRound, new_player_system)
         // We can ensure that game_over system runs after score_check_system using explicit ordering
         // constraints First, we label the system we want to refer to using `.label`
         // Then, we use either `.before` or `.after` to describe the order we want the relationship
         .add_system_to_stage(
             MyStage::AfterRound,
-            score_check_system.system().label(MyLabels::ScoreCheck),
+            score_check_system.label(MyLabels::ScoreCheck),
         )
         .add_system_to_stage(
             MyStage::AfterRound,
-            game_over_system.system().after(MyLabels::ScoreCheck),
+            game_over_system.after(MyLabels::ScoreCheck),
         )
         // We can check our systems for execution order ambiguities by examining the output produced
         // in the console by using the `LogPlugin` and adding the following Resource to our App :)


### PR DESCRIPTION
# Objective

- Extend work done in #2398.
- Make `.system()` syntax optional when using system descriptor API.

## Solution

- Slight change to `ParallelSystemDescriptorCoercion` signature and implementors.

---

I haven't touched exclusive systems, because it looks like the only two other solutions are going back to doubling our system insertion methods, or starting to lean into stageless. The latter will invalidate the former, so I think exclusive systems should remian pariahs until stageless.

I can grep & nuke `.system()` thorughout the codebase now, which might take a while, or we can do that in subsequent PR(s).