### PR TITLE
[Merged by Bors] - Fix unsetting RenderLayers bit in without fn

### DIFF
--- a/crates/bevy_render/src/camera/visible_entities.rs
+++ b/crates/bevy_render/src/camera/visible_entities.rs
@@ -110,7 +110,7 @@ impl RenderLayers {
     /// Panics when called with a layer greater than `TOTAL_LAYERS - 1`.
     pub fn without(mut self, layer: Layer) -> Self {
         assert!(usize::from(layer) < Self::TOTAL_LAYERS);
-        self.0 |= 0 << layer;
+        self.0 &= !(1 << layer);
         self
     }
 
@@ -146,6 +146,11 @@ mod rendering_mask_tests {
         assert_eq!(RenderLayers::layer(0).0, 1, "layer 0 is mask 1");
         assert_eq!(RenderLayers::layer(1).0, 2, "layer 1 is mask 2");
         assert_eq!(RenderLayers::layer(0).with(1).0, 3, "layer 0 + 1 is mask 3");
+        assert_eq!(
+            RenderLayers::layer(0).with(1).without(0).0,
+            2,
+            "layer 0 + 1 - 0 is mask 2"
+        );
         assert!(
             RenderLayers::layer(1).intersects(&RenderLayers::layer(1)),
             "layers match like layers"


### PR DESCRIPTION
# Objective

Fixes how the layer bit is unset in the RenderLayers bit mask when calling the `without` method.

## Solution

Unsets the layer bit using `&=` and the inverse of the layer bit mask.
