### PR TITLE
[Merged by Bors] - fix parenting of scenes

### DIFF
--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -4,10 +4,11 @@ use bevy_asset::{AssetEvent, Assets, Handle};
 use bevy_ecs::{
     entity::{Entity, EntityMap},
     reflect::{ReflectComponent, ReflectMapEntities},
+    system::Command,
     world::{Mut, World},
 };
 use bevy_reflect::TypeRegistryArc;
-use bevy_transform::{components::Children, prelude::Parent};
+use bevy_transform::{hierarchy::AddChild, prelude::Parent};
 use bevy_utils::{tracing::error, HashMap};
 use thiserror::Error;
 use uuid::Uuid;
@@ -268,23 +269,22 @@ impl SceneSpawner {
         for (instance_id, parent) in scenes_with_parent {
             if let Some(instance) = self.spawned_instances.get(&instance_id) {
                 for entity in instance.entity_map.values() {
-                    // Add the `Parent` component to the scene root
-                    if let Some(mut entity_mut) = world.get_entity_mut(entity) {
+                    // Add the `Parent` component to the scene root, and update the `Children` component of
+                    // the scene parent
+                    if !world
+                        .get_entity(entity)
                         // This will filter only the scene root entity, as all other from the
                         // scene have a parent
-                        if !entity_mut.contains::<Parent>() {
-                            entity_mut.insert(Parent(parent));
-                            if let Some(mut parent_entity) = world.get_entity_mut(parent) {
-                                if let Some(children) = parent_entity.get_mut::<Children>() {
-                                    let children = &**children;
-                                    let mut children = children.to_vec();
-                                    children.push(entity);
-                                    parent_entity.insert(Children::with(&children));
-                                } else {
-                                    parent_entity.insert(Children::with(&[entity]));
-                                }
-                            }
+                        .map(|entity| entity.contains::<Parent>())
+                        // Default is true so that it won't run on an entity that wouldn't exist anymore
+                        // this case shouldn't happen anyway
+                        .unwrap_or(true)
+                    {
+                        AddChild {
+                            parent,
+                            child: entity,
                         }
+                        .write(world);
                     }
                 }
             } else {

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -274,17 +274,16 @@ impl SceneSpawner {
                         // scene have a parent
                         if !entity_mut.contains::<Parent>() {
                             entity_mut.insert(Parent(parent));
-                        }
-                    }
-                    // Add the scene root to the `Children` component on the parent
-                    if let Some(mut parent_entity) = world.get_entity_mut(parent) {
-                        if let Some(children) = parent_entity.get_mut::<Children>() {
-                            let children = &**children;
-                            let mut children = children.to_vec();
-                            children.push(entity);
-                            parent_entity.insert(Children::with(&children));
-                        } else {
-                            parent_entity.insert(Children::with(&[entity]));
+                            if let Some(mut parent_entity) = world.get_entity_mut(parent) {
+                                if let Some(children) = parent_entity.get_mut::<Children>() {
+                                    let children = &**children;
+                                    let mut children = children.to_vec();
+                                    children.push(entity);
+                                    parent_entity.insert(Children::with(&children));
+                                } else {
+                                    parent_entity.insert(Children::with(&[entity]));
+                                }
+                            }
                         }
                     }
                 }

--- a/crates/bevy_transform/src/hierarchy/child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/child_builder.rs
@@ -8,6 +8,28 @@ use bevy_ecs::{
 use smallvec::SmallVec;
 
 #[derive(Debug)]
+pub struct AddChild {
+    pub parent: Entity,
+    pub child: Entity,
+}
+
+impl Command for AddChild {
+    fn write(self, world: &mut World) {
+        world
+            .entity_mut(self.child)
+            // FIXME: don't erase the previous parent (see #1545)
+            .insert_bundle((Parent(self.parent), PreviousParent(self.parent)));
+        if let Some(mut children) = world.get_mut::<Children>(self.parent) {
+            children.0.push(self.child);
+        } else {
+            world
+                .entity_mut(self.parent)
+                .insert(Children(smallvec::smallvec![self.child]));
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct InsertChildren {
     parent: Entity,
     children: SmallVec<[Entity; 8]>,

--- a/crates/bevy_transform/src/hierarchy/child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/child_builder.rs
@@ -156,6 +156,7 @@ pub trait BuildChildren {
     fn push_children(&mut self, children: &[Entity]) -> &mut Self;
     fn insert_children(&mut self, index: usize, children: &[Entity]) -> &mut Self;
     fn remove_children(&mut self, children: &[Entity]) -> &mut Self;
+    fn add_child(&mut self, child: Entity) -> &mut Self;
 }
 
 impl<'w, 's, 'a> BuildChildren for EntityCommands<'w, 's, 'a> {
@@ -202,6 +203,12 @@ impl<'w, 's, 'a> BuildChildren for EntityCommands<'w, 's, 'a> {
             children: SmallVec::from(children),
             parent,
         });
+        self
+    }
+
+    fn add_child(&mut self, child: Entity) -> &mut Self {
+        let parent = self.id();
+        self.commands().add(AddChild { child, parent });
         self
     }
 }

--- a/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
@@ -49,6 +49,7 @@ pub fn parent_update_system(
         // `children_additions`).
         if let Ok(mut new_parent_children) = children_query.get_mut(parent.0) {
             // This is the parent
+            // PERF: Ideally we shouldn't need to check for duplicates
             if !(*new_parent_children).0.contains(&entity) {
                 (*new_parent_children).0.push(entity);
             }

--- a/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
@@ -49,11 +49,9 @@ pub fn parent_update_system(
         // `children_additions`).
         if let Ok(mut new_parent_children) = children_query.get_mut(parent.0) {
             // This is the parent
-            debug_assert!(
-                !(*new_parent_children).0.contains(&entity),
-                "children already added"
-            );
-            (*new_parent_children).0.push(entity);
+            if !(*new_parent_children).0.contains(&entity) {
+                (*new_parent_children).0.push(entity);
+            }
         } else {
             // The parent doesn't have a children entity, lets add it
             children_additions


### PR DESCRIPTION
# Objective

Fix #2406 

Scene parenting was not done completely, leaving the hierarchy maintenance to the standard system. As scene spawning happens in stage `PreUpdate` and hierarchy maintenance in stage `PostUpdate`, this left the scene in an invalid state parent wise for part of a frame

## Solution

Also add/update the `Children` component when spawning the scene.

I kept the `Children` component as a `SmallVec`, it could be moved to an `HashSet` to guarantee uniqueness
