### PR TITLE
[Merged by Bors] - enable change detection for hierarchy maintenance

### DIFF
--- a/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
@@ -1,6 +1,7 @@
 use crate::components::*;
 use bevy_ecs::{
     entity::Entity,
+    prelude::Changed,
     query::Without,
     system::{Commands, Query},
 };
@@ -10,9 +11,7 @@ use smallvec::SmallVec;
 pub fn parent_update_system(
     mut commands: Commands,
     removed_parent_query: Query<(Entity, &PreviousParent), Without<Parent>>,
-    // The next query could be run with a Changed<Parent> filter. However, this would mean that
-    // modifications later in the frame are lost. See issue 891: https://github.com/bevyengine/bevy/issues/891
-    mut parent_query: Query<(Entity, &Parent, Option<&mut PreviousParent>)>,
+    mut parent_query: Query<(Entity, &Parent, Option<&mut PreviousParent>), Changed<Parent>>,
     mut children_query: Query<&mut Children>,
 ) {
     // Entities with a missing `Parent` (ie. ones that have a `PreviousParent`), remove


### PR DESCRIPTION
# Objective

Noticed a comment saying changed detection should be enabled for hierarchy maintenance once stable

Fixes #891


## Solution

Added `Changed<Parent>` filter on the query