### PR TITLE
[Merged by Bors] - update duplicate dependency skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -44,22 +44,15 @@ skip = [
     { name = "core-foundation-sys", version = "0.6" },
     { name = "core-foundation-sys", version = "0.7" },
     { name = "core-graphics", version = "0.19" },
-    { name = "crossbeam-channel", version = "0.4" },
-    { name = "crossbeam-utils", version = "0.7" },
     { name = "fixedbitset", version = "0.2" },
-    { name = "getrandom", version = "0.1" },
+    { name = "hashbrown", version = "0.9" },
     { name = "libm", version = "0.1" },
     { name = "mach", version = "0.2" },
     { name = "ndk", version = "0.2" },
     { name = "ndk-glue", version = "0.2" },
     { name = "num_enum", version = "0.4" },
     { name = "num_enum_derive", version = "0.4" },
-    { name = "rand", version = "0.7" },
-    { name = "rand_chacha", version = "0.2" },
-    { name = "rand_core", version = "0.5" },
-    { name = "rand_hc", version = "0.2" },
     { name = "stdweb", version = "0.1" },
-    { name = "wasi", version = "0.9" },
 ]
 
 [sources]


### PR DESCRIPTION
# Objective

- CI is failing because of new duplicate dependency: https://github.com/bevyengine/bevy/pull/2414/checks?check_run_id=2946566180

## Solution

- update dependency duplicate skip list

updated `hashbrown` dependency comes from:
```
    │   │   ├── bevy_macro_utils v0.5.0
    │   │   │   ├── cargo-manifest v0.2.4
    │   │   │   │   └── toml v0.5.8
    │   │   │   │       ├── indexmap v1.7.0
    │   │   │   │       │   └── hashbrown v0.11.2
```