### PR TITLE
Run system from `&mut World`

### DIFF
--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -221,10 +221,10 @@ impl<In, Out, Sys: System<In = In, Out = Out>> IntoSystem<In, Out, AlreadyWasSys
 pub struct In<In>(pub In);
 pub struct InputMarker;
 
-/// The [`System`] counter part of an ordinary function.
+/// The [`System`] counterpart of an ordinary function.
 ///
 /// You get this by calling [`IntoSystem::system`]  on a function that only accepts
-/// [`SystemParam`]s. The output of the system becomes the functions return type, while the input
+/// [`SystemParam`]s. The output of the system becomes the function's return type, while the input
 /// becomes the functions [`In`] tagged parameter or `()` if no such paramater exists.
 pub struct FunctionSystem<In, Out, Param, Marker, F>
 where

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -927,22 +927,37 @@ impl World {
     /// The `system` parameter here can be any function
     /// that could be added as a system to a standard `App`.
     ///
-    /// This system cannot have an input or output;
-    /// use [World::run_system_chainable] instead
-    /// if this behavior is desired.
-    ///
     /// #Examples
     ///
     /// ```rust
+    /// use bevy_ecs::prelude::*;
+    ///
     /// struct Counter(u8);
     /// let mut world = World::new();
     ///
     /// fn count_up(mut counter: ResMut<Counter>){
-    ///    counter.0 += 1;
+    ///     counter.0 += 1;
     /// }
     ///
     /// world.insert_resource::<Counter>(Counter(0));
     /// world.run_system(count_up);
+    /// let counter = world.get_resource::<Counter>().unwrap();
+    /// assert_eq!(counter.0, 1);
+    /// ```
+    ///
+    /// ```rust
+    /// use bevy_ecs::prelude::*;
+    ///
+    /// struct Counter(u8);
+    /// let mut world = World::new();
+    ///
+    /// fn count_up_exclusive(world: &mut World){
+    ///     let mut counter = world.get_resource_mut::<Counter>().unwrap();
+    ///     counter.0 += 1;
+    /// }
+    ///
+    /// world.insert_resource::<Counter>(Counter(0));
+    /// world.run_system(count_up_exclusive.exclusive_system());
     /// let counter = world.get_resource::<Counter>().unwrap();
     /// assert_eq!(counter.0, 1);
     /// ```
@@ -1011,40 +1026,5 @@ impl Default for MainThreadValidator {
         Self {
             main_thread: std::thread::current().id(),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::prelude::*;
-
-    struct Counter(u8);
-
-    fn count_up(mut counter: ResMut<Counter>) {
-        counter.0 += 1;
-    }
-
-    fn count_up_exclusive(world: &mut World) {
-        let mut counter = world.get_resource_mut::<Counter>().unwrap();
-        counter.0 += 1;
-    }
-
-    #[test]
-    fn run_parallel_system_from_world() {
-        let mut world = World::new();
-        world.insert_resource::<Counter>(Counter(0));
-        world.run_system(count_up.system());
-        let counter = world.get_resource::<Counter>().unwrap();
-        assert_eq!(counter.0, 1);
-    }
-
-    #[test]
-    fn run_exclusive_system_from_world() {
-        let mut world = World::new();
-        world.insert_resource::<Counter>(Counter(0));
-        world.run_system(count_up_exclusive.exclusive_system());
-        let counter = world.get_resource::<Counter>().unwrap();
-        assert_eq!(counter.0, 1);
     }
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -919,7 +919,7 @@ impl World {
         }
     }
 
-    /// Runs a system in a sequential, blocking fashion on the `World`
+    /// Runs a system in a blocking fashion on the `World`
     ///
     /// Use [System::run_unsafe] directly for manual unsafe execution
     /// of simultaneous systems in parallel.
@@ -927,8 +927,9 @@ impl World {
     /// The `system` parameter here can be any function
     /// that could be added as a system to a standard `App`.
     ///
-    /// #Examples
-    ///
+    /// # Examples
+    ///  
+    /// Here's an example of how to directly run an ordinary parallel system.
     /// ```rust
     /// use bevy_ecs::prelude::*;
     ///
@@ -944,7 +945,7 @@ impl World {
     /// let counter = world.get_resource::<Counter>().unwrap();
     /// assert_eq!(counter.0, 1);
     /// ```
-    ///
+    /// And here's how you directly run an exclusive system.
     /// ```rust
     /// use bevy_ecs::prelude::*;
     ///

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     },
     entity::{Entities, Entity},
     query::{FilterFetch, QueryState, WorldQuery},
+    schedule::SystemDescriptor,
     storage::{Column, SparseSet, Storages},
 };
 use std::{
@@ -915,6 +916,49 @@ impl World {
         let resource_archetype = self.archetypes.resource_mut();
         for column in resource_archetype.unique_components.values_mut() {
             column.check_change_ticks(change_tick);
+        }
+    }
+
+    /// Runs a system in a sequential, blocking fashion on the `World`
+    ///
+    /// Use [System::run_unsafe] directly for manual unsafe execution
+    /// of simultaneous systems in parallel.
+    ///
+    /// The `system` parameter here can be any function
+    /// that could be added as a system to a standard `App`.
+    ///
+    /// This system cannot have an input or output;
+    /// use [World::run_system_chainable] instead
+    /// if this behavior is desired.
+    ///
+    /// #Examples
+    ///
+    /// ```rust
+    /// #[derive(Default)]
+    /// struct Counter(u8);
+    /// let mut world = World::new();
+    ///
+    /// fn count_up(mut counter: ResMut<Counter>){
+    ///    counter += 1;
+    /// }
+    ///
+    /// world.insert_resource::<Counter>(Counter(0));
+    /// world.run_system(count_up);
+    /// let counter = world.get_resource::<Counter>().unwrap();
+    /// assert_eq!(counter.0, 1);
+    /// ```
+    pub fn run_system(&mut self, system: impl Into<SystemDescriptor>) {
+        let system_descriptor: SystemDescriptor = system.into();
+
+        match system_descriptor {
+            SystemDescriptor::Parallel(par_system_descriptor) => {
+                let mut boxed_system = par_system_descriptor.system;
+                boxed_system.run((), self);
+            }
+            SystemDescriptor::Exclusive(exc_system_descriptor) => {
+                let mut boxed_system = exc_system_descriptor.system;
+                boxed_system.run(self);
+            }
         }
     }
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     entity::{Entities, Entity},
     query::{FilterFetch, QueryState, WorldQuery},
-    schedule::SystemDescriptor,
+    schedule::{IntoSystemDescriptor, SystemDescriptor},
     storage::{Column, SparseSet, Storages},
 };
 use std::{
@@ -946,8 +946,8 @@ impl World {
     /// let counter = world.get_resource::<Counter>().unwrap();
     /// assert_eq!(counter.0, 1);
     /// ```
-    pub fn run_system(&mut self, system: impl Into<SystemDescriptor>) {
-        let system_descriptor: SystemDescriptor = system.into();
+    pub fn run_system<Params>(&mut self, system: impl IntoSystemDescriptor<Params>) {
+        let system_descriptor: SystemDescriptor = system.into_descriptor();
 
         match system_descriptor {
             SystemDescriptor::Parallel(par_system_descriptor) => {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -952,7 +952,10 @@ impl World {
         match system_descriptor {
             SystemDescriptor::Parallel(par_system_descriptor) => {
                 let mut boxed_system = par_system_descriptor.system;
+                boxed_system.initialize(self);
                 boxed_system.run((), self);
+                // Immediately flushes any Commands or similar buffers created
+                boxed_system.apply_buffers(self);
             }
             SystemDescriptor::Exclusive(exc_system_descriptor) => {
                 let mut boxed_system = exc_system_descriptor.system;

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -959,6 +959,7 @@ impl World {
             }
             SystemDescriptor::Exclusive(exc_system_descriptor) => {
                 let mut boxed_system = exc_system_descriptor.system;
+                boxed_system.initialize(self);
                 boxed_system.run(self);
             }
         }


### PR DESCRIPTION
# Objective

Systems are an ergonomic and expressive API for performing well-encapsulated complex logic.
However, you could not easily use them while working directly with `&mut World` for custom commands, exclusive systems, writing tests or bare-bones `bevy_ecs` usage.

## Solution

Adds a `World::run_system` method, which immediately executes a single system in sequence and then flushes any Commands (or similar system parameters).

This is also very useful for users who may want to construct their own game loop in part or whole, sacrificing parallelism for simplicity and control. 

## Notes

Closely related to #2234, and borrows aggressively from the implementation there. Thanks @mockersf for pointing me in the right direction <3