### PR TITLE
[ecs] `Entry` API for components and `try_insert` command

### DIFF
--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -207,6 +207,7 @@ impl<'a, 'b> EntityCommands<'a, 'b> {
     }
 
     /// Adds a single [`Component`] to the current entity.
+    /// This will overwrite an existing [`Component`] of the same type.
     ///
     ///
     /// # Warning
@@ -240,6 +241,16 @@ impl<'a, 'b> EntityCommands<'a, 'b> {
     /// ```
     pub fn insert(&mut self, component: impl Component) -> &mut Self {
         self.commands.add(Insert {
+            entity: self.entity,
+            component,
+        });
+        self
+    }
+
+    /// Adds a single [`Component`] to the current entity, if (and only if) the current entity
+    /// does not already have a [`Component`] of the same type.
+    pub fn try_insert(&mut self, component: impl Component) -> &mut Self {
+        self.commands.add(TryInsert {
             entity: self.entity,
             component,
         });
@@ -354,6 +365,21 @@ where
 {
     fn write(self: Box<Self>, world: &mut World) {
         world.entity_mut(self.entity).insert(self.component);
+    }
+}
+
+#[derive(Debug)]
+pub struct TryInsert<T> {
+    pub entity: Entity,
+    pub component: T,
+}
+
+impl<T> Command for TryInsert<T>
+where
+    T: Component,
+{
+    fn write(self: Box<Self>, world: &mut World) {
+        let _ = world.entity_mut(self.entity).try_insert(self.component);
     }
 }
 

--- a/crates/bevy_ecs/src/system/commands.rs
+++ b/crates/bevy_ecs/src/system/commands.rs
@@ -379,7 +379,10 @@ where
     T: Component,
 {
     fn write(self: Box<Self>, world: &mut World) {
-        let _ = world.entity_mut(self.entity).try_insert(self.component);
+        world
+            .entity_mut(self.entity)
+            .component::<T>()
+            .or_insert(self.component);
     }
 }
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -461,6 +461,15 @@ impl<'w> EntityMut<'w> {
         entities.meta[self.entity.id as usize].location = new_location;
     }
 
+    pub fn try_insert<T: Component>(&mut self, value: T) -> Result<(), T> {
+        if self.get::<T>().is_some() {
+            Err(value)
+        } else {
+            self.insert(value);
+            Ok(())
+        }
+    }
+
     pub fn insert<T: Component>(&mut self, value: T) -> &mut Self {
         self.insert_bundle((value,))
     }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -905,7 +905,7 @@ where
 {
     /// Gets a reference to the entity's component.
     #[inline]
-    fn get(&self) -> &T {
+    pub fn get(&self) -> &T {
         self.component.as_ref()
     }
 
@@ -914,25 +914,25 @@ where
     /// ## Note
     /// This triggers change detection.
     #[inline]
-    fn get_mut(&mut self) -> &mut T {
+    pub fn get_mut(&mut self) -> &mut T {
         self.component.as_mut()
     }
 
     /// Sets the value of the component, and returns the old component.
     #[inline]
-    fn insert(&mut self, component: T) -> T {
+    pub fn insert(&mut self, component: T) -> T {
         std::mem::replace(self.component.as_mut(), component)
     }
 
     /// Gets a [`Mut`] for the entity's component.
     #[inline]
-    fn into_mut(self) -> Mut<'w, T> {
+    pub fn into_mut(self) -> Mut<'w, T> {
         self.component
     }
 
     /// Removes the entity's component, and returns it.
     #[inline]
-    fn remove(mut self) -> T {
+    pub fn remove(mut self) -> T {
         self.entity.remove::<T>().unwrap()
     }
 }
@@ -951,7 +951,7 @@ where
     /// Inserts the component for the current entity, and returns
     /// a [`Mut`] of the component.
     #[inline]
-    fn insert(mut self, component: T) -> Mut<'w, T> {
+    pub fn insert(mut self, component: T) -> Mut<'w, T> {
         self.entity.insert(component);
         self.entity.get_mut().unwrap()
     }
@@ -980,7 +980,7 @@ impl<'e, 'w, T: Component> ComponentEntry<'e, 'w, T> {
     /// ## Note
     /// If the component exists, this triggers change detection.
     #[inline]
-    fn and_modify(self, f: impl FnOnce(&mut T)) -> Self {
+    pub fn and_modify(self, f: impl FnOnce(&mut T)) -> Self {
         match self {
             ComponentEntry::Occupied(mut o) => {
                 f(o.get_mut());
@@ -998,14 +998,14 @@ impl<'e, 'w, T: Component> ComponentEntry<'e, 'w, T> {
     ///
     /// [`or_insert_with`]: ComponentEntry::or_insert_with
     #[inline]
-    fn or_insert(self, component: T) -> Mut<'w, T> {
+    pub fn or_insert(self, component: T) -> Mut<'w, T> {
         self.or_insert_with(|| component)
     }
 
     /// Ensures a component is in the entry by inserting the result of the `default` function
     /// if empty, and returns a [`Mut`] to the component in the entry.
     #[inline]
-    fn or_insert_with(self, default: impl FnOnce() -> T) -> Mut<'w, T> {
+    pub fn or_insert_with(self, default: impl FnOnce() -> T) -> Mut<'w, T> {
         match self {
             ComponentEntry::Occupied(o) => o.component,
             ComponentEntry::Vacant(v) => v.insert(default()),
@@ -1017,7 +1017,7 @@ impl<'e, 'w, T: Component + Default> ComponentEntry<'e, 'w, T> {
     /// Ensures a component is in the entry by inserting the default value if empty, and returns
     /// a [`Mut`] to the component in the entry.
     #[inline]
-    fn or_default(self) -> Mut<'w, T> {
+    pub fn or_default(self) -> Mut<'w, T> {
         self.or_insert_with(T::default)
     }
 }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -932,7 +932,7 @@ where
 
     /// Removes the entity's component, and returns it.
     #[inline]
-    pub fn remove(mut self) -> T {
+    pub fn remove(self) -> T {
         self.entity.remove::<T>().unwrap()
     }
 }
@@ -951,7 +951,7 @@ where
     /// Inserts the component for the current entity, and returns
     /// a [`Mut`] of the component.
     #[inline]
-    pub fn insert(mut self, component: T) -> Mut<'w, T> {
+    pub fn insert(self, component: T) -> Mut<'w, T> {
         self.entity.insert(component);
         self.entity.get_mut().unwrap()
     }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -464,7 +464,7 @@ impl<'w> EntityMut<'w> {
     /// Adds a single [`Component`] to the current entity, if (and only if) the current entity
     /// does not already have a [`Component`] of the same type.
     ///
-    /// Returns `Ok(())` if the component was added, and `Err(value)` if the componet was not added.
+    /// Returns `Ok(())` if the component was inserted, and `Err(value)` if the component was not inserted.
     pub fn try_insert<T: Component>(&mut self, value: T) -> Result<(), T> {
         if self.get::<T>().is_some() {
             Err(value)

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -461,6 +461,10 @@ impl<'w> EntityMut<'w> {
         entities.meta[self.entity.id as usize].location = new_location;
     }
 
+    /// Adds a single [`Component`] to the current entity, if (and only if) the current entity
+    /// does not already have a [`Component`] of the same type.
+    ///
+    /// Returns `Ok(())` if the component was added, and `Err(value)` if the componet was not added.
     pub fn try_insert<T: Component>(&mut self, value: T) -> Result<(), T> {
         if self.get::<T>().is_some() {
             Err(value)

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -463,10 +463,10 @@ impl<'w> EntityMut<'w> {
 
     /// Gets the current entity's [`ComponentEntry`] for in-place manipulation.
     pub fn component<T: Component>(&mut self) -> ComponentEntry<'_, 'w, T> {
-        if let Some(c) = self.get_mut::<T>() {
+        if let Some(component) = self.get_mut::<T>() {
             ComponentEntry::Occupied(OccupiedComponentEntry {
                 entity: self,
-                component: c,
+                component,
             })
         } else {
             ComponentEntry::Vacant(VacantComponentEntry {


### PR DESCRIPTION
# Objective

- It can be desired to add a component to an entity, if (and only if) that entity doesn't contain the component. 
- Partially addresses #2054

## Solution

- Adds a `component` function to `EntityMut`
- Adds a `try_insert` function to `EntityCommands`. 

## TODO:
- [ ] Add examples of entry API