### PR TITLE
[Merged by Bors] - use discord vanity link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Crates.io](https://img.shields.io/crates/d/bevy.svg)](https://crates.io/crates/bevy)
 [![Rust](https://github.com/bevyengine/bevy/workflows/CI/badge.svg)](https://github.com/bevyengine/bevy/actions)
 ![iOS cron CI](https://github.com/bevyengine/bevy/workflows/iOS%20cron%20CI/badge.svg)
-[![Discord](https://img.shields.io/discord/691052431525675048.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/gMUk5Ph)
+[![Discord](https://img.shields.io/discord/691052431525675048.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/bevy)
 
 ## What is Bevy?
 
@@ -41,7 +41,7 @@ Bevy is still in the _very_ early stages of development. APIs can and will chang
 Before contributing or participating in discussions with the community, you should familiarize yourself with our **[Code of Conduct](./CODE_OF_CONDUCT.md)** and
 **[How to Contribute](https://bevyengine.org/learn/book/contributing/code/)**
 
-* **[Discord](https://discord.gg/gMUk5Ph):** Bevy's official discord server.
+* **[Discord](https://discord.gg/bevy):** Bevy's official discord server.
 * **[Reddit](https://reddit.com/r/bevy):** Bevy's official subreddit.
 * **[Stack Overflow](https://stackoverflow.com/questions/tagged/bevy):** Questions tagged Bevy on Stack Overflow.
 * **[Awesome Bevy](https://github.com/bevyengine/awesome-bevy):** A collection of awesome Bevy projects.

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/bevy_ecs.svg)](https://crates.io/crates/bevy_ecs)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/bevyengine/bevy/blob/HEAD/LICENSE)
-[![Discord](https://img.shields.io/discord/691052431525675048.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/gMUk5Ph)
+[![Discord](https://img.shields.io/discord/691052431525675048.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/bevy)
 
 ## What is Bevy ECS?
 

--- a/docs/plugins_guidelines.md
+++ b/docs/plugins_guidelines.md
@@ -26,7 +26,7 @@ You are free to use a `bevy_xxx` name for your plugin, but please be reasonable.
 You can promote your plugin in Bevy's [communities](https://github.com/bevyengine/bevy#community):
 
 * Add it to [Awesome Bevy](https://github.com/bevyengine/awesome-bevy).
-* Announce it on [Discord](https://discord.gg/gMUk5Ph), in the `#showcase` channel.
+* Announce it on [Discord](https://discord.gg/bevy), in the `#showcase` channel.
 * Announce it on [Reddit](https://reddit.com/r/bevy).
 
 ## Bevy Version Supported


### PR DESCRIPTION
# Objective

I wanted to send the Bevy discord link to someone but couldn't find a pretty link to copy paste 

## Solution

Use the vanity link we have for discord
