### PR TITLE
[Merged by Bors] - Optional `.system()`, part 3

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -29,8 +29,8 @@ pub mod prelude {
             Schedule, Stage, StageLabel, State, SystemLabel, SystemSet, SystemStage,
         },
         system::{
-            Commands, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend,
-            NonSendMut, Query, QuerySet, RemovedComponents, Res, ResMut, System,
+            Commands, ConfigurableSystem, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem,
+            Local, NonSend, NonSendMut, Query, QuerySet, RemovedComponents, Res, ResMut, System,
         },
         world::{FromWorld, Mut, World},
     };

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -264,9 +264,11 @@ impl<In, Out, Param: SystemParam, Marker, F> FunctionSystem<In, Out, Param, Mark
     }
 }
 
+/// Provides `my_system.config(...)` API.
 pub trait ConfigurableSystem<In, Out, Param: SystemParam, Marker>:
     IntoSystem<In, Out, (IsFunctionSystem, Param, Marker)>
 {
+    /// See [`FunctionSystem::config()`](crate::system::FunctionSystem::config).
     fn config(
         self,
         f: impl FnOnce(&mut <Param::Fetch as SystemParamState>::Config),

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -27,8 +27,8 @@ mod tests {
         query::{Added, Changed, Or, With, Without},
         schedule::{Schedule, Stage, SystemStage},
         system::{
-            IntoExclusiveSystem, IntoSystem, Local, Query, QuerySet, RemovedComponents, Res,
-            ResMut, System, SystemState,
+            ConfigurableSystem, IntoExclusiveSystem, IntoSystem, Local, Query, QuerySet,
+            RemovedComponents, Res, ResMut, System, SystemState,
         },
         world::{FromWorld, World},
     };
@@ -372,7 +372,13 @@ mod tests {
 
         // ensure the system actually ran
         assert!(*world.get_resource::<bool>().unwrap());
+
+        // Now do the same with omitted `.system()`.
+        world.insert_resource(false);
+        run_system(&mut world, sys.config(|config| config.0 = Some(42)));
+        assert!(*world.get_resource::<bool>().unwrap());
     }
+
     #[test]
     fn world_collections_system() {
         let mut world = World::default();


### PR DESCRIPTION
# Objective

- Continue work of #2398 and #2403.
- Make `.system()` syntax optional when using `.config()` API.

## Solution

- Introduce new prelude trait, `ConfigurableSystem`, that shorthands `my_system.system().config(...)` as `my_system.config(...)`.
- Expand `configure_system_local` test to also cover the new syntax.
