### PR TITLE
Span parenting so that system spans are correctly linked in multithreaded executor

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -40,6 +40,8 @@ pub struct App {
     pub world: World,
     pub runner: Box<dyn Fn(App)>,
     pub schedule: Schedule,
+    #[cfg(feature = "trace")]
+    frame_count: u32,
 }
 
 impl Default for App {
@@ -71,13 +73,16 @@ impl App {
             world: Default::default(),
             schedule: Default::default(),
             runner: Box::new(run_once),
+            #[cfg(feature = "trace")]
+            frame_count: 0,
         }
     }
 
     pub fn update(&mut self) {
         #[cfg(feature = "trace")]
         {
-            let bevy_frame_update_span = info_span!("frame");
+            self.frame_count = self.frame_count.wrapping_add(1);
+            let bevy_frame_update_span = info_span!("frame", frame_count = self.frame_count);
             let _bevy_frame_update_guard = bevy_frame_update_span.enter();
             self.schedule
                 .run_in_span(&mut self.world, Some(&bevy_frame_update_span));

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -76,9 +76,13 @@ impl App {
 
     pub fn update(&mut self) {
         #[cfg(feature = "trace")]
-        let bevy_frame_update_span = info_span!("frame");
-        #[cfg(feature = "trace")]
-        let _bevy_frame_update_guard = bevy_frame_update_span.enter();
+        {
+            let bevy_frame_update_span = info_span!("frame");
+            let _bevy_frame_update_guard = bevy_frame_update_span.enter();
+            self.schedule
+                .run_in_span(&mut self.world, Some(&bevy_frame_update_span));
+        }
+        #[cfg(not(feature = "trace"))]
         self.schedule.run(&mut self.world);
     }
 


### PR DESCRIPTION
# Objective

When using a parallel executor, system spans are not correctly related to the stage/frame spans

Example logs:
```
Jul 01 18:39:40.772  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:40.853  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:40.866  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:40.881  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:40.907  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:40.928  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:40.972  INFO bevy_app:frame:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:40.997  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:41.027  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:41.064  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:41.092  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:41.108  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:41.140  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:41.176  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:41.208  INFO bevy_app:frame:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:41.237  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:41.258  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 18:39:41.288  INFO system{name="load_gltf::rotator_system"}: load_gltf: rotating light
```

Logs with `bevy_app:frame...` are when the system is executed on the main thread, the other lines are on other threads

## Solution

Correctly pass the parent span, and set it as parent when creating a new one. I also added the frame count to the frame span as this was how this issue was noticed on discord

```
Jul 01 19:05:46.288  INFO bevy_app:frame{frame_count=1}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.390  INFO bevy_app:frame{frame_count=2}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.400  INFO bevy_app:frame{frame_count=3}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.426  INFO bevy_app:frame{frame_count=4}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.460  INFO bevy_app:frame{frame_count=5}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.501  INFO bevy_app:frame{frame_count=6}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.524  INFO bevy_app:frame{frame_count=7}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.564  INFO bevy_app:frame{frame_count=8}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.596  INFO bevy_app:frame{frame_count=9}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.626  INFO bevy_app:frame{frame_count=10}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.657  INFO bevy_app:frame{frame_count=11}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.690  INFO bevy_app:frame{frame_count=12}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.725  INFO bevy_app:frame{frame_count=13}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.758  INFO bevy_app:frame{frame_count=14}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.791  INFO bevy_app:frame{frame_count=15}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.825  INFO bevy_app:frame{frame_count=16}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.858  INFO bevy_app:frame{frame_count=17}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.892  INFO bevy_app:frame{frame_count=18}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.923  INFO bevy_app:frame{frame_count=19}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
Jul 01 19:05:46.958  INFO bevy_app:frame{frame_count=20}:stage{name="Update"}:system{name="load_gltf::rotator_system"}: load_gltf: rotating light
```