### PR TITLE
Directly run system given world

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -29,8 +29,9 @@ pub mod prelude {
             Schedule, Stage, StageLabel, State, SystemLabel, SystemSet, SystemStage,
         },
         system::{
-            Commands, ConfigurableSystem, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem,
-            Local, NonSend, NonSendMut, Query, QuerySet, RemovedComponents, Res, ResMut, System,
+            Commands, ConfigurableSystem, ExclusiveSystem, In, IntoChainSystem,
+            IntoExclusiveSystem, IntoSystem, Local, NonSend, NonSendMut, Query, QuerySet,
+            RemovedComponents, Res, ResMut, System,
         },
         world::{FromWorld, Mut, World},
     };

--- a/crates/bevy_ecs/src/system/exclusive_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system.rs
@@ -32,7 +32,7 @@ pub trait ExclusiveSystem: Send + Sync + 'static {
     /// }
     ///
     /// world.insert_resource::<Counter>(Counter(0));
-    /// count_up.exclusive_system().run_direct(world);
+    /// count_up.exclusive_system().run_direct(&mut world);
     /// let counter = world.get_resource::<Counter>().unwrap();
     /// assert_eq!(counter.0, 1);
     ///```
@@ -76,6 +76,11 @@ impl ExclusiveSystem for ExclusiveSystemFn {
         *change_tick += 1;
 
         world.last_change_tick = saved_last_tick;
+    }
+
+    fn run_direct(&mut self, world: &mut World) {
+        self.initialize(world);
+        self.run(world);
     }
 
     fn initialize(&mut self, _: &mut World) {}

--- a/crates/bevy_ecs/src/system/exclusive_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system.rs
@@ -10,8 +10,18 @@ pub trait ExclusiveSystem: Send + Sync + 'static {
 
     fn id(&self) -> SystemId;
 
+    /// Runs the exclusive system in the world.
+    ///
+    /// Use [`run_direct`] instead if you are manually running a system outside of a schedule
     fn run(&mut self, world: &mut World);
 
+    /// Runs the exclusive system directly on the world, initializing the world correctly
+    fn run_direct(&mut self, world: &mut World) {
+        self.initialize(world);
+        self.run(world);
+    }
+
+    /// Initialize the World, so that the system can safely run
     fn initialize(&mut self, world: &mut World);
 
     fn check_change_tick(&mut self, change_tick: u32);

--- a/crates/bevy_ecs/src/system/exclusive_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system.rs
@@ -13,9 +13,29 @@ pub trait ExclusiveSystem: Send + Sync + 'static {
     /// Runs the exclusive system in the world.
     ///
     /// Use [`run_direct`] instead if you are manually running a system outside of a schedule
+
     fn run(&mut self, world: &mut World);
 
     /// Runs the exclusive system directly on the world, initializing the world correctly
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bevy_ecs::prelude::*;
+    ///
+    /// struct Counter(u8);
+    /// let mut world = World::new();
+    ///
+    /// fn count_up(world: &mut World){
+    ///     let mut counter = world.get_resource_mut::<Counter>().unwrap();
+    ///     counter.0 += 1;
+    /// }
+    ///
+    /// world.insert_resource::<Counter>(Counter(0));
+    /// count_up.exclusive_system().run_direct(world);
+    /// let counter = world.get_resource::<Counter>().unwrap();
+    /// assert_eq!(counter.0, 1);
+    ///```
     fn run_direct(&mut self, world: &mut World) {
         self.initialize(world);
         self.run(world);

--- a/crates/bevy_ecs/src/system/exclusive_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system.rs
@@ -16,7 +16,7 @@ pub trait ExclusiveSystem: Send + Sync + 'static {
 
     fn run(&mut self, world: &mut World);
 
-    /// Runs the exclusive system directly on the world, initializing the world correctly
+    /// Runs the exclusive system directly on the world, correctly initializing its state first
     ///
     /// # Example
     ///

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -221,10 +221,10 @@ impl<In, Out, Sys: System<In = In, Out = Out>> IntoSystem<In, Out, AlreadyWasSys
 pub struct In<In>(pub In);
 pub struct InputMarker;
 
-/// The [`System`] counter part of an ordinary function.
+/// The [`System`] counterpart of an ordinary function.
 ///
 /// You get this by calling [`IntoSystem::system`]  on a function that only accepts
-/// [`SystemParam`]s. The output of the system becomes the functions return type, while the input
+/// [`SystemParam`]s. The output of the system becomes the function's return type, while the input
 /// becomes the functions [`In`] tagged parameter or `()` if no such paramater exists.
 pub struct FunctionSystem<In, Out, Param, Marker, F>
 where

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -100,7 +100,7 @@ pub trait System: Send + Sync + 'static {
     }
     /// Applies any buffers (such as `Commands`) created by this system's parameters to the world
     fn apply_buffers(&mut self, world: &mut World);
-    /// Initialize the World, so that the system can safely run
+    /// Initializes the system from the world, so that it may be run successfully
     fn initialize(&mut self, _world: &mut World);
     fn check_change_tick(&mut self, change_tick: u32);
 }

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -96,7 +96,7 @@ pub trait System: Send + Sync + 'static {
         self.initialize(world);
         let output = self.run(input, world);
         self.apply_buffers(world);
-        return output;
+        output
     }
     /// Applies any buffers (such as `Commands`) created by this system's parameters to the world
     fn apply_buffers(&mut self, world: &mut World);

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -71,6 +71,23 @@ pub trait System: Send + Sync + 'static {
     /// immediately applying buffers (such as `Commands`) modified by its system parameters
     ///
     /// Use () as the `input` parameter for systems which do not take any chained input
+    ///
+    /// # Examples
+    /// ```rust
+    /// use bevy_ecs::prelude::*;
+    ///
+    /// struct Counter(u8);
+    /// let mut world = World::new();
+    ///
+    /// fn count_up(mut counter: ResMut<Counter>){
+    ///     counter.0 += 1;
+    /// }
+    ///
+    /// world.insert_resource::<Counter>(Counter(0));
+    /// count_up.run_direct((), world);
+    /// let counter = world.get_resource::<Counter>().unwrap();
+    /// assert_eq!(counter.0, 1);
+    /// ```
     fn run_direct(&mut self, input: Self::In, world: &mut World) -> Self::Out {
         self.initialize(world);
         let output = self.run(input, world);

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -65,8 +65,9 @@ pub trait System: Send + Sync + 'static {
         // SAFE: world and resources are exclusively borrowed
         unsafe { self.run_unsafe(input, world) }
     }
+    /// Applies any buffers (such as `Commands`) created by this system's parameters to the world
     fn apply_buffers(&mut self, world: &mut World);
-    /// Initialize the system.
+    /// Initialize the World, so that the system can safely run
     fn initialize(&mut self, _world: &mut World);
     fn check_change_tick(&mut self, change_tick: u32);
 }

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -88,7 +88,7 @@ pub trait System: Send + Sync + 'static {
     /// }
     ///
     /// world.insert_resource::<Counter>(Counter(0));
-    /// count_up.system().run_direct((), &mut world);
+    /// count_up.run_direct((), &mut world);
     /// let counter = world.get_resource::<Counter>().unwrap();
     /// assert_eq!(counter.0, 1);
     /// ```

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -88,7 +88,7 @@ pub trait System: Send + Sync + 'static {
     /// }
     ///
     /// world.insert_resource::<Counter>(Counter(0));
-    /// count_up.run_direct((), world);
+    /// count_up.system().run_direct((), &mut world);
     /// let counter = world.get_resource::<Counter>().unwrap();
     /// assert_eq!(counter.0, 1);
     /// ```

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -70,7 +70,11 @@ pub trait System: Send + Sync + 'static {
     /// Runs the system directly on the world, initializing the world correctly;
     /// immediately applying buffers (such as `Commands`) modified by its system parameters
     ///
-    /// Use () as the `input` parameter for systems which do not take any chained input
+    /// Use () as the `input` parameter for systems which do not take any chained input.
+    ///
+    /// Only one system will run at a time when executed in this way;
+    /// use a [`Schedule`] (or a custom abstraction created with [`run_unsafe`])
+    /// when system parallelism is desired.
     ///
     /// # Examples
     /// ```rust

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -958,6 +958,7 @@ impl World {
             }
             SystemDescriptor::Exclusive(exc_system_descriptor) => {
                 let mut boxed_system = exc_system_descriptor.system;
+                boxed_system.initialize(self);
                 boxed_system.run(self);
             }
         }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -926,22 +926,37 @@ impl World {
     /// The `system` parameter here can be any function
     /// that could be added as a system to a standard `App`.
     ///
-    /// This system cannot have an input or output;
-    /// use [World::run_system_chainable] instead
-    /// if this behavior is desired.
-    ///
     /// #Examples
     ///
     /// ```rust
+    /// use bevy_ecs::prelude::*;
+    ///
     /// struct Counter(u8);
     /// let mut world = World::new();
     ///
     /// fn count_up(mut counter: ResMut<Counter>){
-    ///    counter.0 += 1;
+    ///     counter.0 += 1;
     /// }
     ///
     /// world.insert_resource::<Counter>(Counter(0));
     /// world.run_system(count_up);
+    /// let counter = world.get_resource::<Counter>().unwrap();
+    /// assert_eq!(counter.0, 1);
+    /// ```
+    ///
+    /// ```rust
+    /// use bevy_ecs::prelude::*;
+    ///
+    /// struct Counter(u8);
+    /// let mut world = World::new();
+    ///
+    /// fn count_up_exclusive(world: &mut World){
+    ///     let mut counter = world.get_resource_mut::<Counter>().unwrap();
+    ///     counter.0 += 1;
+    /// }
+    ///
+    /// world.insert_resource::<Counter>(Counter(0));
+    /// world.run_system(count_up_exclusive.exclusive_system());
     /// let counter = world.get_resource::<Counter>().unwrap();
     /// assert_eq!(counter.0, 1);
     /// ```
@@ -1010,40 +1025,5 @@ impl Default for MainThreadValidator {
         Self {
             main_thread: std::thread::current().id(),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::prelude::*;
-
-    struct Counter(u8);
-
-    fn count_up(mut counter: ResMut<Counter>) {
-        counter.0 += 1;
-    }
-
-    fn count_up_exclusive(world: &mut World) {
-        let mut counter = world.get_resource_mut::<Counter>().unwrap();
-        counter.0 += 1;
-    }
-
-    #[test]
-    fn run_parallel_system_from_world() {
-        let mut world = World::new();
-        world.insert_resource::<Counter>(Counter(0));
-        world.run_system(count_up.system());
-        let counter = world.get_resource::<Counter>().unwrap();
-        assert_eq!(counter.0, 1);
-    }
-
-    #[test]
-    fn run_exclusive_system_from_world() {
-        let mut world = World::new();
-        world.insert_resource::<Counter>(Counter(0));
-        world.run_system(count_up_exclusive.exclusive_system());
-        let counter = world.get_resource::<Counter>().unwrap();
-        assert_eq!(counter.0, 1);
     }
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -17,7 +17,6 @@ use crate::{
     },
     entity::{Entities, Entity},
     query::{FilterFetch, QueryState, WorldQuery},
-    schedule::{IntoSystemDescriptor, SystemDescriptor},
     storage::{Column, SparseSet, Storages},
 };
 use std::{

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -917,68 +917,6 @@ impl World {
             column.check_change_ticks(change_tick);
         }
     }
-
-    /// Runs a system in a blocking fashion on the `World`
-    ///
-    /// Use [System::run_unsafe] directly for manual unsafe execution
-    /// of simultaneous systems in parallel.
-    ///
-    /// The `system` parameter here can be any function
-    /// that could be added as a system to a standard `App`.
-    ///
-    /// # Examples
-    ///  
-    /// Here's an example of how to directly run an ordinary parallel system.
-    /// ```rust
-    /// use bevy_ecs::prelude::*;
-    ///
-    /// struct Counter(u8);
-    /// let mut world = World::new();
-    ///
-    /// fn count_up(mut counter: ResMut<Counter>){
-    ///     counter.0 += 1;
-    /// }
-    ///
-    /// world.insert_resource::<Counter>(Counter(0));
-    /// world.run_system(count_up);
-    /// let counter = world.get_resource::<Counter>().unwrap();
-    /// assert_eq!(counter.0, 1);
-    /// ```
-    /// And here's how you directly run an exclusive system.
-    /// ```rust
-    /// use bevy_ecs::prelude::*;
-    ///
-    /// struct Counter(u8);
-    /// let mut world = World::new();
-    ///
-    /// fn count_up_exclusive(world: &mut World){
-    ///     let mut counter = world.get_resource_mut::<Counter>().unwrap();
-    ///     counter.0 += 1;
-    /// }
-    ///
-    /// world.insert_resource::<Counter>(Counter(0));
-    /// world.run_system(count_up_exclusive.exclusive_system());
-    /// let counter = world.get_resource::<Counter>().unwrap();
-    /// assert_eq!(counter.0, 1);
-    /// ```
-    pub fn run_system<Params>(&mut self, system: impl IntoSystemDescriptor<Params>) {
-        let system_descriptor: SystemDescriptor = system.into_descriptor();
-
-        match system_descriptor {
-            SystemDescriptor::Parallel(par_system_descriptor) => {
-                let mut boxed_system = par_system_descriptor.system;
-                boxed_system.initialize(self);
-                boxed_system.run((), self);
-                // Immediately flushes any Commands or similar buffers created
-                boxed_system.apply_buffers(self);
-            }
-            SystemDescriptor::Exclusive(exc_system_descriptor) => {
-                let mut boxed_system = exc_system_descriptor.system;
-                boxed_system.initialize(self);
-                boxed_system.run(self);
-            }
-        }
-    }
 }
 
 impl fmt::Debug for World {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -951,7 +951,10 @@ impl World {
         match system_descriptor {
             SystemDescriptor::Parallel(par_system_descriptor) => {
                 let mut boxed_system = par_system_descriptor.system;
+                boxed_system.initialize(self);
                 boxed_system.run((), self);
+                // Immediately flushes any Commands or similar buffers created
+                boxed_system.apply_buffers(self);
             }
             SystemDescriptor::Exclusive(exc_system_descriptor) => {
                 let mut boxed_system = exc_system_descriptor.system;

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -918,7 +918,7 @@ impl World {
         }
     }
 
-    /// Runs a system in a sequential, blocking fashion on the `World`
+    /// Runs a system in a blocking fashion on the `World`
     ///
     /// Use [System::run_unsafe] directly for manual unsafe execution
     /// of simultaneous systems in parallel.
@@ -926,8 +926,9 @@ impl World {
     /// The `system` parameter here can be any function
     /// that could be added as a system to a standard `App`.
     ///
-    /// #Examples
-    ///
+    /// # Examples
+    ///  
+    /// Here's an example of how to directly run an ordinary parallel system.
     /// ```rust
     /// use bevy_ecs::prelude::*;
     ///
@@ -943,7 +944,7 @@ impl World {
     /// let counter = world.get_resource::<Counter>().unwrap();
     /// assert_eq!(counter.0, 1);
     /// ```
-    ///
+    /// And here's how you directly run an exclusive system.
     /// ```rust
     /// use bevy_ecs::prelude::*;
     ///

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -933,12 +933,11 @@ impl World {
     /// #Examples
     ///
     /// ```rust
-    /// #[derive(Default)]
     /// struct Counter(u8);
     /// let mut world = World::new();
     ///
     /// fn count_up(mut counter: ResMut<Counter>){
-    ///    counter += 1;
+    ///    counter.0 += 1;
     /// }
     ///
     /// world.insert_resource::<Counter>(Counter(0));
@@ -1007,5 +1006,40 @@ impl Default for MainThreadValidator {
         Self {
             main_thread: std::thread::current().id(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prelude::*;
+
+    struct Counter(u8);
+
+    fn count_up(mut counter: ResMut<Counter>) {
+        counter.0 += 1;
+    }
+
+    fn count_up_exclusive(world: &mut World) {
+        let mut counter = world.get_resource_mut::<Counter>().unwrap();
+        counter.0 += 1;
+    }
+
+    #[test]
+    fn run_parallel_system_from_world() {
+        let mut world = World::new();
+        world.insert_resource::<Counter>(Counter(0));
+        world.run_system(count_up.system());
+        let counter = world.get_resource::<Counter>().unwrap();
+        assert_eq!(counter.0, 1);
+    }
+
+    #[test]
+    fn run_exclusive_system_from_world() {
+        let mut world = World::new();
+        world.insert_resource::<Counter>(Counter(0));
+        world.run_system(count_up_exclusive.exclusive_system());
+        let counter = world.get_resource::<Counter>().unwrap();
+        assert_eq!(counter.0, 1);
     }
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     entity::{Entities, Entity},
     query::{FilterFetch, QueryState, WorldQuery},
-    schedule::SystemDescriptor,
+    schedule::{IntoSystemDescriptor, SystemDescriptor},
     storage::{Column, SparseSet, Storages},
 };
 use std::{
@@ -945,8 +945,8 @@ impl World {
     /// let counter = world.get_resource::<Counter>().unwrap();
     /// assert_eq!(counter.0, 1);
     /// ```
-    pub fn run_system(&mut self, system: impl Into<SystemDescriptor>) {
-        let system_descriptor: SystemDescriptor = system.into();
+    pub fn run_system<Params>(&mut self, system: impl IntoSystemDescriptor<Params>) {
+        let system_descriptor: SystemDescriptor = system.into_descriptor();
 
         match system_descriptor {
             SystemDescriptor::Parallel(par_system_descriptor) => {


### PR DESCRIPTION
## Objective
Systems are an ergonomic and expressive API for performing well-encapsulated complex logic.
However, you could not easily use them while working directly with &mut World for custom commands, exclusive systems, writing tests or bare-bones bevy_ecs usage.

## Solution
Adds a System::run_direct method, which immediately executes a single system on a particular world and then flushes any Commands (or similar system parameters).

The equivalent run_direct method is also created for exclusive systems.

This is also very useful for users who may want to construct their own game loop in part or whole, sacrificing parallelism for simplicity and control.

## Notes
Successor to #2417; exposing an API that dodges the ownership issues created there. Closely related to #2234. 