### PR TITLE
Fixed sprite transparency artifacts

### DIFF
--- a/crates/bevy_sprite/src/render/sprite.frag
+++ b/crates/bevy_sprite/src/render/sprite.frag
@@ -20,5 +20,7 @@ void main() {
         sampler2D(ColorMaterial_texture, ColorMaterial_texture_sampler),
         v_Uv);
 # endif
+    if(color.a < 0.5) discard;
+
     o_Target = color;
 }

--- a/crates/bevy_sprite/src/render/sprite_sheet.frag
+++ b/crates/bevy_sprite/src/render/sprite_sheet.frag
@@ -9,7 +9,11 @@ layout(set = 1, binding = 2) uniform texture2D TextureAtlas_texture;
 layout(set = 1, binding = 3) uniform sampler TextureAtlas_texture_sampler;
 
 void main() {
-    o_Target = v_Color * texture(
+    vec4 color = v_Color * texture(
         sampler2D(TextureAtlas_texture, TextureAtlas_texture_sampler),
         v_Uv);
+    
+    if(color.a < 0.5) discard;
+
+    o_Target = color;
 }


### PR DESCRIPTION
# Objective

- This fixes transparency artifacts when using transparent sprites
- Fixes #1422

## Solution

- Fragments with an alpha value below 0.5 are now discarded (transparent cutout).
