### PR TITLE
[Merged by Bors] - docs: add hint that texture atlas padding is between tiles

### DIFF
--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -112,7 +112,8 @@ impl TextureAtlas {
 
     /// Generate a `TextureAtlas` by splitting a texture into a grid where each
     /// cell of the grid of `tile_size` is one of the textures in the atlas and is separated by
-    /// some `padding` in the texture
+    /// some `padding` in the texture. The padding is assumed to be only between tiles
+    /// and not at the borders of the texture.
     pub fn from_grid_with_padding(
         texture: Handle<Texture>,
         tile_size: Vec2,


### PR DESCRIPTION
I struggled with some sprite sheet animation which was like drifting from right to left.
This PR documents the current behaviour that the padding which is used on slicing a texture into a texture atlas, is assumed to be only between tiles. In my case I had some padding also on the right side of the texture.