### PR TITLE
[Merged by Bors] - add proc-macro-crate as a known duplicate

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -52,6 +52,7 @@ skip = [
     { name = "ndk-glue", version = "0.2" },
     { name = "num_enum", version = "0.4" },
     { name = "num_enum_derive", version = "0.4" },
+    { name = "proc-macro-crate", version = "0.1" },
     { name = "stdweb", version = "0.1" },
 ]
 


### PR DESCRIPTION
# Objective

- CI is failing because of a dependency (`num_enum`) that now uses the latest version of `proc-macro-crate`

```
    = proc-macro-crate v0.1.5
      ├── ndk-macro v0.2.0
      │   ├── ndk-glue v0.2.1
      │   │   ├── bevy_asset v0.5.0
      │   │   └── bevy_internal v0.5.0 (*)
      │   └── ndk-glue v0.3.0
      │       ├── cpal v0.13.3
      │       │   └── rodio v0.14.0
      │       │       └── bevy_audio v0.5.0 (*)
      │       ├── oboe v0.4.2
      │       │   └── cpal v0.13.3 (*)
      │       └── winit v0.25.0
      │           ├── bevy_winit v0.5.0 (*)
      │           └── bevy_winit v0.5.0 (*)
      └── num_enum_derive v0.4.3
          └── num_enum v0.4.3
              └── ndk v0.2.1
                  └── ndk-glue v0.2.1 (*)

    = proc-macro-crate v1.0.0
      └── num_enum_derive v0.5.2
          └── num_enum v0.5.2
              └── ndk v0.3.0
                  ├── cpal v0.13.3
                  │   └── rodio v0.14.0
                  │       └── bevy_audio v0.5.0
                  ├── ndk-glue v0.3.0
                  │   ├── cpal v0.13.3 (*)
                  │   ├── oboe v0.4.2
                  │   │   └── cpal v0.13.3 (*)
                  │   └── winit v0.25.0
                  │       ├── bevy_winit v0.5.0 (*)
                  │       └── bevy_winit v0.5.0 (*)
                  ├── oboe v0.4.2 (*)
                  └── winit v0.25.0 (*)
```

## Solution

- Add `proc-macro-crate` as a known duplicate
