### PR TITLE
Add AssetEventUntyped

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -103,6 +103,7 @@ impl Plugin for AssetPlugin {
             AssetStage::AssetEvents,
             SystemStage::parallel(),
         )
+        .add_event::<AssetEventUntyped>()
         .register_type::<HandleId>()
         .add_system_to_stage(
             bevy_app::CoreStage::PreUpdate,

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -14,7 +14,9 @@ mod path;
 
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{AddAsset, AssetEvent, AssetServer, Assets, Handle, HandleUntyped};
+    pub use crate::{
+        AddAsset, AssetEvent, AssetEventUntyped, AssetServer, Assets, Handle, HandleUntyped,
+    };
 }
 
 pub use asset_server::*;


### PR DESCRIPTION
Single event type that tracks all assets regardless of type.

Provides `HandleUntyped`s.

Fixes #2457