### PR TITLE
`Local` with required config as a const generic parameter

### DIFF
--- a/crates/bevy_app/src/ci_testing.rs
+++ b/crates/bevy_app/src/ci_testing.rs
@@ -11,7 +11,7 @@ pub struct CiTestingConfig {
 }
 
 fn ci_testing_exit_after(
-    mut current_frame: bevy_ecs::prelude::Local<u32>,
+    mut current_frame: bevy_ecs::prelude::Local<u32, true>,
     ci_testing_config: bevy_ecs::prelude::Res<CiTestingConfig>,
     mut app_exit_events: crate::EventWriter<AppExit>,
 ) {

--- a/crates/bevy_core/src/time/fixed_timestep.rs
+++ b/crates/bevy_core/src/time/fixed_timestep.rs
@@ -89,7 +89,7 @@ impl FixedTimestep {
     }
 
     fn prepare_system(
-        mut state: Local<State>,
+        mut state: Local<State, true>,
         time: Res<Time>,
         mut fixed_timesteps: ResMut<FixedTimesteps>,
     ) -> ShouldRun {

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -152,7 +152,7 @@ fn map_instance_event<T>(event_instance: &EventInstance<T>) -> &T {
 /// Reads events of type `T` in order and tracks which events have already been read.
 #[derive(SystemParam)]
 pub struct EventReader<'a, T: Component> {
-    last_event_count: Local<'a, (usize, PhantomData<T>)>,
+    last_event_count: Local<'a, (usize, PhantomData<T>), true>,
     events: Res<'a, Events<T>>,
 }
 

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -913,7 +913,7 @@ mod tests {
         }};
     }
 
-    fn every_other_time(mut has_ran: Local<bool>) -> ShouldRun {
+    fn every_other_time(mut has_ran: Local<bool, true>) -> ShouldRun {
         *has_ran = !*has_ran;
         if *has_ran {
             ShouldRun::Yes
@@ -1456,7 +1456,7 @@ mod tests {
 
         // Piping criteria.
         world.get_resource_mut::<Vec<usize>>().unwrap().clear();
-        fn eot_piped(input: In<ShouldRun>, has_ran: Local<bool>) -> ShouldRun {
+        fn eot_piped(input: In<ShouldRun>, has_ran: Local<bool, true>) -> ShouldRun {
             if let ShouldRun::Yes | ShouldRun::YesAndCheckAgain = input.0 {
                 every_other_time(has_ran)
             } else {

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -94,7 +94,7 @@ where
     T: Component + Debug + Clone + Eq + Hash,
 {
     pub fn on_update(s: T) -> RunCriteriaDescriptor {
-        (|state: Res<State<T>>, pred: Local<Option<T>>| {
+        (|state: Res<State<T>>, pred: Local<Option<T>, true>| {
             state.stack.last().unwrap() == pred.as_ref().unwrap() && state.transition.is_none()
         })
         .system()
@@ -105,9 +105,9 @@ where
     }
 
     pub fn on_inactive_update(s: T) -> RunCriteriaDescriptor {
-        (|state: Res<State<T>>, mut is_inactive: Local<bool>, pred: Local<Option<T>>| match &state
-            .transition
-        {
+        (|state: Res<State<T>>,
+          mut is_inactive: Local<bool, true>,
+          pred: Local<Option<T>, true>| match &state.transition {
             Some(StateTransition::Pausing(ref relevant, _))
             | Some(StateTransition::Resuming(_, ref relevant)) => {
                 if relevant == pred.as_ref().unwrap() {
@@ -126,9 +126,9 @@ where
     }
 
     pub fn on_in_stack_update(s: T) -> RunCriteriaDescriptor {
-        (|state: Res<State<T>>, mut is_in_stack: Local<bool>, pred: Local<Option<T>>| match &state
-            .transition
-        {
+        (|state: Res<State<T>>,
+          mut is_in_stack: Local<bool, true>,
+          pred: Local<Option<T>, true>| match &state.transition {
             Some(StateTransition::Entering(ref relevant, _))
             | Some(StateTransition::ExitingToResume(_, ref relevant)) => {
                 if relevant == pred.as_ref().unwrap() {
@@ -159,7 +159,7 @@ where
     }
 
     pub fn on_enter(s: T) -> RunCriteriaDescriptor {
-        (|state: Res<State<T>>, pred: Local<Option<T>>| {
+        (|state: Res<State<T>>, pred: Local<Option<T>, true>| {
             state
                 .transition
                 .as_ref()
@@ -179,7 +179,7 @@ where
     }
 
     pub fn on_exit(s: T) -> RunCriteriaDescriptor {
-        (|state: Res<State<T>>, pred: Local<Option<T>>| {
+        (|state: Res<State<T>>, pred: Local<Option<T>, true>| {
             state
                 .transition
                 .as_ref()
@@ -197,7 +197,7 @@ where
     }
 
     pub fn on_pause(s: T) -> RunCriteriaDescriptor {
-        (|state: Res<State<T>>, pred: Local<Option<T>>| {
+        (|state: Res<State<T>>, pred: Local<Option<T>, true>| {
             state
                 .transition
                 .as_ref()
@@ -214,7 +214,7 @@ where
     }
 
     pub fn on_resume(s: T) -> RunCriteriaDescriptor {
-        (|state: Res<State<T>>, pred: Local<Option<T>>| {
+        (|state: Res<State<T>>, pred: Local<Option<T>, true>| {
             state
                 .transition
                 .as_ref()
@@ -410,7 +410,7 @@ fn should_run_adapter<T: Component + Clone + Eq>(
 
 fn state_cleaner<T: Component + Clone + Eq>(
     mut state: ResMut<State<T>>,
-    mut prep_exit: Local<bool>,
+    mut prep_exit: Local<bool, true>,
 ) -> ShouldRun {
     if *prep_exit {
         *prep_exit = false;

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -248,7 +248,7 @@ impl<In, Out, Param: SystemParam, Marker, F> FunctionSystem<In, Out, Param, Mark
     /// ```
     /// # use bevy_ecs::prelude::*;
     /// # let world = &mut World::default();
-    /// fn local_is_42(local: Local<usize>) {
+    /// fn local_is_42(local: Local<usize, false>) {
     ///     assert_eq!(*local, 42);
     /// }
     /// let mut system = local_is_42.system().config(|config| config.0 = Some(42));

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -295,7 +295,7 @@ mod tests {
 
     #[test]
     fn nonconflicting_system_resources() {
-        fn sys(_: Local<BufferRes>, _: ResMut<BufferRes>, _: Local<A>, _: ResMut<A>) {}
+        fn sys(_: Local<BufferRes, true>, _: ResMut<BufferRes>, _: Local<A, true>, _: ResMut<A>) {}
         test_for_conflicting_resources(sys.system())
     }
 
@@ -316,7 +316,7 @@ mod tests {
             }
         }
 
-        fn sys(local: Local<Foo>, mut modified: ResMut<bool>) {
+        fn sys(local: Local<Foo, true>, mut modified: ResMut<bool>) {
             assert_eq!(local.value, 2);
             *modified = true;
         }
@@ -360,7 +360,7 @@ mod tests {
     fn configure_system_local() {
         let mut world = World::default();
         world.insert_resource(false);
-        fn sys(local: Local<usize>, mut modified: ResMut<bool>) {
+        fn sys(local: Local<usize, true>, mut modified: ResMut<bool>) {
             assert_eq!(*local, 42);
             *modified = true;
         }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -516,10 +516,10 @@ impl<'a> SystemParamFetch<'a> for CommandQueue {
 /// ```
 /// # use bevy_ecs::prelude::*;
 /// # let world = &mut World::default();
-/// fn write_to_local(mut local: Local<usize>) {
+/// fn write_to_local(mut local: Local<usize, true>) {
 ///     *local = 42;
 /// }
-/// fn read_from_local(local: Local<usize>) -> usize {
+/// fn read_from_local(local: Local<usize, true>) -> usize {
 ///     *local
 /// }
 /// let mut write_system = write_to_local.system();

--- a/crates/bevy_pbr/src/render_graph/lights_node.rs
+++ b/crates/bevy_pbr/src/render_graph/lights_node.rs
@@ -83,7 +83,7 @@ pub struct LightsNodeSystemState {
 }
 
 pub fn lights_node_system(
-    mut state: Local<LightsNodeSystemState>,
+    mut state: Local<LightsNodeSystemState, true>,
     render_resource_context: Res<Box<dyn RenderResourceContext>>,
     ambient_light_resource: Res<AmbientLight>,
     // TODO: this write on RenderResourceBindings will prevent this system from running in parallel

--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -507,7 +507,7 @@ pub struct MeshResourceProviderState {
 
 #[allow(clippy::type_complexity)]
 pub fn mesh_resource_provider_system(
-    mut state: Local<MeshResourceProviderState>,
+    mut state: Local<MeshResourceProviderState, true>,
     render_resource_context: Res<Box<dyn RenderResourceContext>>,
     meshes: Res<Assets<Mesh>>,
     mut mesh_events: EventReader<AssetEvent<Mesh>>,

--- a/crates/bevy_render/src/render_graph/nodes/camera_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/camera_node.rs
@@ -72,7 +72,7 @@ const MATRIX_SIZE: usize = std::mem::size_of::<[[f32; 4]; 4]>();
 const VEC4_SIZE: usize = std::mem::size_of::<[f32; 4]>();
 
 pub fn camera_node_system(
-    mut state: Local<CameraNodeState>,
+    mut state: Local<CameraNodeState, true>,
     mut active_cameras: ResMut<ActiveCameras>,
     render_resource_context: Res<Box<dyn RenderResourceContext>>,
     mut query: Query<(&Camera, &GlobalTransform)>,

--- a/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
@@ -430,8 +430,8 @@ impl<I, T: RenderResources> Default for RenderResourcesNodeState<I, T> {
 
 #[allow(clippy::type_complexity)]
 fn render_resources_node_system<T: RenderResources>(
-    mut state: Local<RenderResourcesNodeState<Entity, T>>,
-    mut entities_waiting_for_textures: Local<Vec<Entity>>,
+    mut state: Local<RenderResourcesNodeState<Entity, T>, true>,
+    mut entities_waiting_for_textures: Local<Vec<Entity>, true>,
     render_resource_context: Res<Box<dyn RenderResourceContext>>,
     removed: RemovedComponents<T>,
     mut queries: QuerySet<(
@@ -613,8 +613,8 @@ impl<T: Asset> Default for AssetRenderNodeState<T> {
 
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 fn asset_render_resources_node_system<T: RenderResources + Asset>(
-    mut state: Local<RenderResourcesNodeState<HandleId, T>>,
-    mut asset_state: Local<AssetRenderNodeState<T>>,
+    mut state: Local<RenderResourcesNodeState<HandleId, T>, true>,
+    mut asset_state: Local<AssetRenderNodeState<T>, true>,
     assets: Res<Assets<T>>,
     mut asset_events: EventReader<AssetEvent<T>>,
     mut asset_render_resource_bindings: ResMut<AssetRenderResourceBindings>,

--- a/crates/bevy_sprite/src/color_material.rs
+++ b/crates/bevy_sprite/src/color_material.rs
@@ -61,12 +61,12 @@ impl From<Handle<Texture>> for ColorMaterial {
 // TODO: should be removed when pipelined rendering is done
 #[allow(clippy::type_complexity)]
 pub(crate) fn material_texture_detection_system(
-    mut texture_to_material: Local<HashMap<Handle<Texture>, HashSet<Handle<ColorMaterial>>>>,
-    mut material_to_texture: Local<HashMap<Handle<ColorMaterial>, Handle<Texture>>>,
+    mut texture_to_material: Local<HashMap<Handle<Texture>, HashSet<Handle<ColorMaterial>>>, true>,
+    mut material_to_texture: Local<HashMap<Handle<ColorMaterial>, Handle<Texture>>, true>,
     materials: Res<Assets<ColorMaterial>>,
     mut texture_events: EventReader<AssetEvent<Texture>>,
     (mut material_events_reader, mut material_events): (
-        Local<ManualEventReader<AssetEvent<ColorMaterial>>>,
+        Local<ManualEventReader<AssetEvent<ColorMaterial>>, true>,
         ResMut<Events<AssetEvent<ColorMaterial>>>,
     ),
 ) {

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -128,7 +128,7 @@ pub struct QueuedText2d {
 /// Updates the TextGlyphs with the new computed glyphs from the layout
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn text2d_system(
-    mut queued_text: Local<QueuedText2d>,
+    mut queued_text: Local<QueuedText2d, true>,
     mut textures: ResMut<Assets<Texture>>,
     fonts: Res<Assets<Font>>,
     windows: Res<Windows>,

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -41,7 +41,7 @@ pub struct State {
 
 #[allow(clippy::type_complexity)]
 pub fn ui_focus_system(
-    mut state: Local<State>,
+    mut state: Local<State, true>,
     windows: Res<Windows>,
     mouse_button_input: Res<Input<MouseButton>>,
     touches_input: Res<Touches>,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -44,8 +44,8 @@ pub fn text_constraint(min_size: Val, size: Val, max_size: Val, scale_factor: f6
 /// new computed glyphs from the layout
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn text_system(
-    mut queued_text: Local<QueuedText>,
-    mut last_scale_factor: Local<f64>,
+    mut queued_text: Local<QueuedText, true>,
+    mut last_scale_factor: Local<f64, true>,
     mut textures: ResMut<Assets<Texture>>,
     fonts: Res<Assets<Font>>,
     windows: Res<Windows>,

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -58,7 +58,7 @@ fn scene_update(
     mut commands: Commands,
     scene_spawner: Res<SceneSpawner>,
     scene_instance: Res<SceneInstance>,
-    mut done: Local<bool>,
+    mut done: Local<bool, true>,
 ) {
     if !*done {
         if let Some(instance_id) = scene_instance.0 {

--- a/examples/app/headless.rs
+++ b/examples/app/headless.rs
@@ -30,7 +30,7 @@ fn hello_world_system() {
     println!("hello world");
 }
 
-fn counter(mut state: Local<CounterState>) {
+fn counter(mut state: Local<CounterState, true>) {
     if state.count % 60 == 0 {
         println!("{}", state.count);
     }

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -239,7 +239,7 @@ struct State {
 
 // NOTE: this doesn't do anything relevant to our game, it is just here for illustrative purposes
 #[allow(dead_code)]
-fn local_state_system(mut state: Local<State>, query: Query<(&Player, &Score)>) {
+fn local_state_system(mut state: Local<State, true>, query: Query<(&Player, &Score)>) {
     for (player, score) in query.iter() {
         println!("processed: {} {}", player.name, score.value);
     }

--- a/examples/ecs/fixed_timestep.rs
+++ b/examples/ecs/fixed_timestep.rs
@@ -29,12 +29,16 @@ fn main() {
         .run();
 }
 
-fn frame_update(mut last_time: Local<f64>, time: Res<Time>) {
+fn frame_update(mut last_time: Local<f64, true>, time: Res<Time>) {
     info!("update: {}", time.seconds_since_startup() - *last_time);
     *last_time = time.seconds_since_startup();
 }
 
-fn fixed_update(mut last_time: Local<f64>, time: Res<Time>, fixed_timesteps: Res<FixedTimesteps>) {
+fn fixed_update(
+    mut last_time: Local<f64, true>,
+    time: Res<Time>,
+    fixed_timesteps: Res<FixedTimesteps>,
+) {
     info!(
         "fixed_update: {}",
         time.seconds_since_startup() - *last_time,

--- a/examples/wasm/headless_wasm.rs
+++ b/examples/wasm/headless_wasm.rs
@@ -21,7 +21,7 @@ fn hello_world_system() {
     info!("hello wasm");
 }
 
-fn counter(mut state: Local<CounterState>) {
+fn counter(mut state: Local<CounterState, true>) {
     if state.count % 60 == 0 {
         info!("counter system: {}", state.count);
     }

--- a/examples/wasm/winit_wasm.rs
+++ b/examples/wasm/winit_wasm.rs
@@ -27,7 +27,7 @@ fn hello_wasm_system() {
     info!("hello wasm");
 }
 
-fn counter(mut state: Local<CounterState>, time: Res<Time>) {
+fn counter(mut state: Local<CounterState, true>, time: Res<Time>) {
     if state.count % 60 == 0 {
         info!(
             "tick {} @ {:?} [Δ{}]",


### PR DESCRIPTION
# Objective

- Alternative to #2440, but with a const generic parameter on `Local` instead of a new type

## Solution

Either:
- parameter should use the default value or a `FromWorld` impl, use `Local<T, true>`
- parameter must be configured using `config`, use `Local<T, false>`

If the parameter is `false`, the bound for T on `FromWorld` is lifted.

```rust
#[derive(Default)]
struct DefaultableStruct(u32);

struct NotDefaultableStruct(u32);

fn my_system(a: Local<DefaultableStruct, true>, b: Local<NotDefaultableStruct, false>) {}
```

Ideally, I would want the `Local` type to be:

```rust
enum LocalType {
    FromWorld,
    NeedConfig
}

pub struct Local<'a, T: Component, const LOCAL_TYPE: LocalType = LocalType::FromWorld>(&'a mut T);
```

Then my system would be:

```rust
fn my_system(a: Local<DefaultableStruct>, b: Local<NotDefaultableStruct, LocalType::NeedConfig>) {}
```


But this is not possible in Rust for now 😞 :
* we can't have our own type as a const generic: https://blog.rust-lang.org/2021/02/26/const-generics-mvp-beta.html#const-generics-for-custom-types
* we can't have a default value for const generics: https://blog.rust-lang.org/2021/02/26/const-generics-mvp-beta.html#const-generics-and-default-arguments

Those are the two top issues in "what's next", so hopefully they should come soonish...