### PR TITLE
[Merged by Bors] - Don't update when suspended to avoid GPU use on iOS.

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -233,6 +233,8 @@ pub fn winit_runner_with(mut app: App, mut event_loop: EventLoop<()>) {
         .get_resource::<WinitConfig>()
         .map_or(false, |config| config.return_from_run);
 
+    let mut active = true;
+
     let event_handler = move |event: Event<()>,
                               event_loop: &EventLoopWindowTarget<()>,
                               control_flow: &mut ControlFlow| {
@@ -475,13 +477,21 @@ pub fn winit_runner_with(mut app: App, mut event_loop: EventLoop<()>) {
                     delta: Vec2::new(delta.0 as f32, delta.1 as f32),
                 });
             }
+            event::Event::Suspended => {
+                active = false;
+            },
+            event::Event::Resumed => {
+                active = true;
+            },
             event::Event::MainEventsCleared => {
                 handle_create_window_events(
                     &mut app.world,
                     event_loop,
                     &mut create_window_event_reader,
                 );
-                app.update();
+                if active {
+                    app.update();
+                }
             }
             _ => (),
         }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -479,10 +479,10 @@ pub fn winit_runner_with(mut app: App, mut event_loop: EventLoop<()>) {
             }
             event::Event::Suspended => {
                 active = false;
-            },
+            }
             event::Event::Resumed => {
                 active = true;
-            },
+            }
             event::Event::MainEventsCleared => {
                 handle_create_window_events(
                     &mut app.world,


### PR DESCRIPTION
# Objective

This fixes a crash caused by iOS preventing GPU access when not focused: #2296

## Solution

This skips `app.update()` in `winit_runner` when `winit` sends the `Suspended` event, until `Resumed`.

I've tested that this works for me on my iOS app.
