### PR TITLE
`Local` with required config as a type parameter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,6 +284,10 @@ name = "iter_combinations"
 path = "examples/ecs/iter_combinations.rs"
 
 [[example]]
+name = "local_parameter"
+path = "examples/ecs/local_parameter.rs"
+
+[[example]]
 name = "parallel_query"
 path = "examples/ecs/parallel_query.rs"
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -31,8 +31,9 @@ pub mod prelude {
             Schedule, Stage, StageLabel, State, SystemLabel, SystemSet, SystemStage,
         },
         system::{
-            Commands, ConfigurableSystem, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem,
-            Local, NonSend, NonSendMut, Query, QuerySet, RemovedComponents, Res, ResMut, System,
+            local_value, Commands, ConfigurableSystem, In, IntoChainSystem, IntoExclusiveSystem,
+            IntoSystem, Local, NonSend, NonSendMut, Query, QuerySet, RemovedComponents, Res,
+            ResMut, System,
         },
         world::{FromWorld, Mut, World},
     };

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -95,7 +95,7 @@ mod tests {
         query::{Added, Changed, Or, QueryState, With, Without},
         schedule::{Schedule, Stage, SystemStage},
         system::{
-            ConfigurableSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend, NonSendMut, Query,
+            local_value, ConfigurableSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend, NonSendMut, Query,
             QuerySet, RemovedComponents, Res, ResMut, System, SystemState,
         },
         world::{FromWorld, World},
@@ -396,7 +396,7 @@ mod tests {
             }
         }
 
-        fn sys(local: Local<Foo>, mut modified: ResMut<bool>) {
+        fn sys(local: Local<Foo, local_value::FromWorld>, mut modified: ResMut<bool>) {
             assert_eq!(local.value, 2);
             *modified = true;
         }

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -95,8 +95,8 @@ mod tests {
         query::{Added, Changed, Or, QueryState, With, Without},
         schedule::{Schedule, Stage, SystemStage},
         system::{
-            local_value, ConfigurableSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend, NonSendMut, Query,
-            QuerySet, RemovedComponents, Res, ResMut, System, SystemState,
+            local_value, ConfigurableSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend,
+            NonSendMut, Query, QuerySet, RemovedComponents, Res, ResMut, System, SystemState,
         },
         world::{FromWorld, World},
     };

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -716,7 +716,7 @@ unsafe impl<T: Resource + Default> SystemParamState for LocalState<T, local_valu
 
     fn init(_world: &mut World, _system_meta: &mut SystemMeta, config: Self::Config) -> Self {
         Self {
-            value: config.unwrap_or_else(T::default),
+            value: config.unwrap_or_default(),
             value_from: Default::default(),
         }
     }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -716,7 +716,7 @@ unsafe impl<T: Resource + Default> SystemParamState for LocalState<T, local_valu
 
     fn init(_world: &mut World, _system_meta: &mut SystemMeta, config: Self::Config) -> Self {
         Self {
-            value: config.unwrap_or_else(|| T::default()),
+            value: config.unwrap_or_else(T::default),
             value_from: Default::default(),
         }
     }

--- a/examples/README.md
+++ b/examples/README.md
@@ -161,6 +161,7 @@ Example | File | Description
 `fixed_timestep` | [`ecs/fixed_timestep.rs`](./ecs/fixed_timestep.rs) | Shows how to create systems that run every fixed timestep, rather than every tick
 `hierarchy` | [`ecs/hierarchy.rs`](./ecs/hierarchy.rs) | Creates a hierarchy of parents and children entities
 `iter_combinations` | [`ecs/iter_combinations.rs`](./ecs/iter_combinations.rs) | Shows how to iterate over combinations of query results.
+`local_parameter` | [`ecs/local_parameter.rs`](./ecs/local_parameter.rs) | How to use `Local` parameter and the different way to initialize one.
 `parallel_query` | [`ecs/parallel_query.rs`](./ecs/parallel_query.rs) | Illustrates parallel queries with `ParallelIterator`
 `removal_detection` | [`ecs/removal_detection.rs`](./ecs/removal_detection.rs) | Query for entities that had a specific component removed in a previous stage during the current frame.
 `startup_system` | [`ecs/startup_system.rs`](./ecs/startup_system.rs) | Demonstrates a startup system (one that runs once when the app starts up)

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -225,28 +225,8 @@ fn thread_local_system(world: &mut World) {
     }
 }
 
-// Sometimes systems need their own unique "local" state. Bevy's ECS provides Local<T> resources for
-// this case. Local<T> resources are unique to their system and are automatically initialized on
-// your behalf (if they don't already exist). If you have a system's id, you can also access local
-// resources directly in the Resources collection using `Resources::get_local()`. In general you
-// should only need this feature in the following cases:  1. You have multiple instances of the same
-// system and they each need their own unique state  2. You already have a global version of a
-// resource that you don't want to overwrite for your current system  3. You are too lazy to
-// register the system's resource as a global resource
-
-#[derive(Default)]
 struct State {
-    counter: usize,
-}
-
-// NOTE: this doesn't do anything relevant to our game, it is just here for illustrative purposes
-#[allow(dead_code)]
-fn local_state_system(mut state: Local<State>, query: Query<(&Player, &Score)>) {
-    for (player, score) in query.iter() {
-        println!("processed: {} {}", player.name, score.value);
-    }
-    println!("this system ran {} times", state.counter);
-    state.counter += 1;
+    _counter: usize,
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
@@ -266,7 +246,7 @@ fn main() {
     // resources, and plugins to our app
     App::new()
         // Resources can be added to our app like this
-        .insert_resource(State { counter: 0 })
+        .insert_resource(State { _counter: 0 })
         // Some systems are configured by adding their settings as a resource
         .insert_resource(ScheduleRunnerSettings::run_loop(Duration::from_secs(5)))
         // Plugins are just a grouped set of app builder calls (just like we're doing here).

--- a/examples/ecs/local_parameter.rs
+++ b/examples/ecs/local_parameter.rs
@@ -1,0 +1,72 @@
+use std::time::Instant;
+
+use bevy::{prelude::*, utils::Duration};
+
+// Sometimes systems need their own unique "local" state. Bevy's ECS provides Local<T> resources
+// for this case. Local<T> resources are unique to their system and can be initialized either
+// automatically (with a `FromWorld` or `Default` implementation) or manually (by calling `config`
+// on the system).
+// This can be useful when:
+// - You won't need access to the value from other systems
+// - You have multiple instances of the same system and they each need their own unique state
+// - You already have a global version of a resource that you don't want to overwrite for your
+// current system
+
+#[derive(Default)]
+struct RoundCount(u32);
+
+struct TimeSinceLastReset(Instant);
+impl FromWorld for TimeSinceLastReset {
+    fn from_world(world: &mut World) -> Self {
+        let time = world.get_resource::<Time>().unwrap();
+        Self(time.startup())
+    }
+}
+
+struct SpawnEntities {
+    count: u32,
+}
+
+// This local parameter will be initialized from the `Default` impl of `RoundCount`.
+// It is equivalent to `Local<RoundCount, local_value::Default>`.
+fn default_local(mut round_count: Local<RoundCount>) {
+    info!("current round: {}", round_count.0);
+    round_count.0 += 1;
+}
+
+// This local parameter will be initialized from the `FromWorld` impl of `TimeSinceLastReset`.
+fn from_world_local(
+    mut since_last_reset: Local<TimeSinceLastReset, local_value::FromWorld>,
+    query: Query<Entity>,
+    mut commands: Commands,
+) {
+    let now = Instant::now();
+    if now.duration_since(since_last_reset.0) > Duration::from_secs(1) {
+        since_last_reset.0 = now;
+        info!("-- Despawning {} entities", query.iter().len());
+        for entity in query.iter() {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+// This local parameter will be initialized by calling `config` on the system. If `config` is not
+// called, running the system will panic.
+fn need_config_local(
+    to_spawn: Local<SpawnEntities, local_value::NeedConfig>,
+    mut commands: Commands,
+) {
+    info!("Spawning {} entities", to_spawn.count);
+    for _ in 0..to_spawn.count {
+        commands.spawn();
+    }
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_system(default_local)
+        .add_system(from_world_local)
+        .add_system(need_config_local.config(|config| config.0 = Some(SpawnEntities { count: 3 })))
+        .run();
+}


### PR DESCRIPTION
# Objective

- Alternative to #2463 and #2440
- As suggested in https://github.com/bevyengine/bevy/pull/2463#issuecomment-879722072, using unit structs

## Solution

- Added three unit struct to configure a `Local`: `Default`, `FromWorld` and `NeedConfig`
- By default, it is using the `Default` configuration. This is a breaking change but it's what is making the most sense
- If the `Local` is initialised by `Default`, nothing change
- For the other, need to add an extra type parameter to local, either `local_value::FromWorld` or `local_value::NeedConfig`
