### PR TITLE
Add bevy_core as a dev dependency to bevy_ecs

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -33,6 +33,7 @@ serde = "1"
 
 [dev-dependencies]
 parking_lot = "0.11"
+bevy_core = { path = "../bevy_core", version = "0.5.0" }
 
 [[example]]
 name = "events"


### PR DESCRIPTION
# Objective

As I'm working on #2365, I'm noticing that adding dev dependencies between bevy crates could be very helpful for writing good documentation examples.

## Example

I'll use as an example the documentation I'm writing for `Query::iter_mut`.

### Without dev dependency

I have to replicate a dummy `Time` resource. In case of edits to the real `Time`, this example will fall out of sync and become potentially misleading.

```
# use bevy_ecs::prelude::*;
#
# struct Velocity { x: f32, y: f32, z: f32 }
# struct Time;
# impl Time {
#     fn delta_seconds(&self) -> f32 { 1.0 / 60.0 }
# }
#
fn gravity_system(mut query: Query<&mut Velocity>, time: Res<Time> ) {
    for mut velocity in query.iter_mut() {
        velocity.y -= 9.8 * time.delta_seconds();
    }
}
# gravity_system.system();
```

### With dev dependency

No more dummy. Test suite will raise an error if `Time` changes.

```
# use bevy_ecs::prelude::*;
# use bevy_core::prelude::*;
#
# struct Velocity { x: f32, y: f32, z: f32 }
#
fn gravity_system(mut query: Query<&mut Velocity>, time: Res<Time> ) {
    for mut velocity in query.iter_mut() {
        velocity.y -= 9.8 * time.delta_seconds();
    }
}
# gravity_system.system();
```

# Solution

- Change `Cargo.toml` file of `bevy_ecs` to include `bevy_core` to the `dev-dependencies`.
