### PR TITLE
[Merged by Bors] - Relicense bors checks

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -15,3 +15,4 @@ status = [
 ]
 
 use_squash_merge = true
+block_labels = ["S-Pre-Relicense"]

--- a/.github/label-config.yml
+++ b/.github/label-config.yml
@@ -1,2 +1,8 @@
+# Config for the label workflow
+# Schema: https://github.com/actions/labeler#create-githublabeleryml
+
 S-Needs-Triage:
+- "**"
+
+S-Pre-Relicense:
 - "**"


### PR DESCRIPTION
# Objective

Currently we can sometimes allow PRs by people who haven't agreed to the relicense to get merged into main.

E.g. https://github.com/bevyengine/bevy/pull/2445

## Solution

This adds a check to ensure that this doesn't happen, by ensuring that bors doesn't relicense said PRs.

As a bonus, it also adds config to automatically label new PRs as needing checking, to ensure that we do the verification until we merge the new license.
