### PR TITLE
Make `#[derive(Bundle)]` work on tuple structs 

### DIFF
--- a/crates/bevy_derive/src/lib.rs
+++ b/crates/bevy_derive/src/lib.rs
@@ -37,7 +37,7 @@ pub fn derive_shader_defs(input: TokenStream) -> TokenStream {
     shader_defs::derive_shader_defs(input)
 }
 
-/// Generates a dynamic plugin entry point function for the given `Plugin` type.  
+/// Generates a dynamic plugin entry point function for the given `Plugin` type.
 #[proc_macro_derive(DynamicPlugin)]
 pub fn derive_dynamic_plugin(input: TokenStream) -> TokenStream {
     app_plugin::derive_dynamic_plugin(input)

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -75,6 +75,23 @@ pub fn all_tuples(input: TokenStream) -> TokenStream {
 
 static BUNDLE_ATTRIBUTE_NAME: &str = "bundle";
 
+/// Derives the Bundle trait for a struct.
+/// The #[bundle] attribute may be used on a field of the struct to flatten the field's fields into this bundle.
+///
+/// ```ignore
+/// #[derive(Bundle)]
+/// struct A {
+///     x: i32,
+///     y: u64,
+/// }
+///
+/// #[derive(Bundle)]
+/// struct B {
+///     #[bundle]
+///     a: A,
+///     z: String,
+/// }
+/// ```
 #[proc_macro_derive(Bundle, attributes(bundle))]
 pub fn derive_bundle(input: TokenStream) -> TokenStream {
     let DeriveInput {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -258,21 +258,15 @@ mod tests {
     use crate as bevy_ecs;
 
     #[derive(Bundle)]
-    struct Unit;
+    struct Simple(u32);
 
     #[derive(Bundle)]
-    struct EmptyTuple();
-
-    #[derive(Bundle)]
-    struct Tuple(#[bundle] EmptyTuple, u32);
-
-    #[derive(Bundle)]
-    struct EmptyRecord {}
+    struct Tuple(#[bundle] Simple, u32);
 
     #[derive(Bundle)]
     struct Record {
         #[bundle]
-        field0: EmptyRecord,
+        field0: Simple,
         field1: u32,
     }
 }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -249,3 +249,30 @@ unsafe fn initialize_bundle(
         storage_types,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Derive compilation tests
+    use bevy_ecs_macros::Bundle;
+
+    use crate as bevy_ecs;
+
+    #[derive(Bundle)]
+    struct Unit;
+
+    #[derive(Bundle)]
+    struct EmptyTuple();
+
+    #[derive(Bundle)]
+    struct Tuple(#[bundle] EmptyTuple, u32);
+
+    #[derive(Bundle)]
+    struct EmptyRecord {}
+
+    #[derive(Bundle)]
+    struct Record {
+        #[bundle]
+        field0: EmptyRecord,
+        field1: u32,
+    }
+}


### PR DESCRIPTION
# Objective

- This change allows one to derive the `Bundle` trait on all kinds of structs that is Record, Tuple and Unit(not that useful by itself, but for completioness sake) structs instead of just record structs.

