### PR TITLE
Add bevy_entropy plugin and include it in the default set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ bevy_internal = { path = "crates/bevy_internal", version = "0.8.0-dev", default-
 
 [dev-dependencies]
 anyhow = "1.0.4"
-rand = "0.8.0"
+rand = { version = "0.8.0", features = ["small_rng"] }
 ron = "0.7.0"
 serde = { version = "1", features = ["derive"] }
 bytemuck = "1.7"
@@ -562,6 +562,10 @@ name = "Plugin Group"
 description = "Demonstrates the creation and registration of a custom plugin group"
 category = "Application"
 wasm = true
+
+[[example]]
+name = "random"
+path = "examples/app/random.rs"
 
 [[example]]
 name = "return_after_run"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -569,7 +569,7 @@ path = "examples/app/random.rs"
 
 [package.metadata.example.random]
 name = "Random"
-description = "Demonstrates how to use entropy to control randomness in bevy."
+description = "Demonstrates how to use entropy to control randomness in Bevy."
 category = "Application"
 wasm = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -567,6 +567,12 @@ wasm = true
 name = "random"
 path = "examples/app/random.rs"
 
+[package.metadata.example.random]
+name = "Random"
+description = "Demonstrates how to use entropy to control randomness in bevy."
+category = "Application"
+wasm = true
+
 [[example]]
 name = "return_after_run"
 path = "examples/app/return_after_run.rs"

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -28,7 +28,8 @@ downcast-rs = "1.2"
 serde = "1"
 
 [dev-dependencies]
-rand = "0.8"
+bevy_entropy = { path = "../bevy_entropy", version = "0.8.0-dev" }
+rand = { version = "0.8", features = ["small_rng"] }
 
 [[example]]
 name = "events"

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -15,7 +15,7 @@ fn main() {
     let mut world = World::new();
 
     // Add the entropy resource for future random number generators to use.
-    // This makes execution deterministic.
+    // This makes random number generation deterministic.
     let world_seed = [1; 32];
     world.insert_resource(Entropy::from(world_seed));
 

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -1,5 +1,6 @@
 use bevy_ecs::prelude::*;
-use rand::Rng;
+use bevy_entropy::Entropy;
+use rand::{prelude::SmallRng, Rng, SeedableRng};
 use std::ops::Deref;
 
 // In this example we add a counter resource and increase it's value in one system,
@@ -7,6 +8,10 @@ use std::ops::Deref;
 fn main() {
     // Create a world
     let mut world = World::new();
+
+    // Add the entropy resource
+    let world_seed = [1; 32];
+    world.insert_resource(Entropy::from(world_seed));
 
     // Add the counter resource
     world.insert_resource(Counter { value: 0 });
@@ -32,8 +37,11 @@ struct Counter {
     pub value: i32,
 }
 
-fn increase_counter(mut counter: ResMut<Counter>) {
-    if rand::thread_rng().gen_bool(0.5) {
+fn increase_counter(mut counter: ResMut<Counter>, mut entropy: ResMut<Entropy>) {
+    // Note that in a real system it would be better to create this once
+    // as a resource.
+    let mut rng = SmallRng::from_seed(entropy.get());
+    if rng.gen_bool(0.5) {
         counter.value += 1;
         println!("    Increased counter value");
     }

--- a/crates/bevy_entropy/Cargo.toml
+++ b/crates/bevy_entropy/Cargo.toml
@@ -17,7 +17,8 @@ keywords = ["bevy", "random", "entropy"]
 bevy_app = { path = "../bevy_app", version = "0.8.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 # other
-rand = { version = "0.8", features = ["std_rng"] }
+rand_core = { version = "0.6.3" }
+rand_chacha = { version = "0.3.1" }
 
 [dev-dependencies]
 bevy_internal = { path = "../bevy_internal", version = "0.8.0-dev" }

--- a/crates/bevy_entropy/Cargo.toml
+++ b/crates/bevy_entropy/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["bevy", "random", "entropy"]
 bevy_app = { path = "../bevy_app", version = "0.8.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 # other
-rand_core = { version = "0.6.3" }
+rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand_chacha = { version = "0.3.1" }
 
 [dev-dependencies]

--- a/crates/bevy_entropy/Cargo.toml
+++ b/crates/bevy_entropy/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 description = "Provides entropy functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
-license = "MIT"
+license = "MIT OR Apache-2.0"
 keywords = ["bevy", "random", "entropy"]
 
 [dependencies]

--- a/crates/bevy_entropy/Cargo.toml
+++ b/crates/bevy_entropy/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "bevy_entropy"
+version = "0.8.0-dev"
+edition = "2018"
+authors = [
+    "Bevy Contributors <bevyengine@gmail.com>",
+    "Christian Legnitto <christian@legnitto.com>",
+]
+description = "Provides entropy functionality for Bevy Engine"
+homepage = "https://bevyengine.org"
+repository = "https://github.com/bevyengine/bevy"
+license = "MIT"
+keywords = ["bevy", "random", "entropy"]
+
+[dependencies]
+# bevy 
+bevy_app = { path = "../bevy_app", version = "0.8.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
+# other
+rand = { version = "0.8", features = ["std_rng"] }
+
+[dev-dependencies]
+bevy_internal = { path = "../bevy_internal", version = "0.8.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.8.0-dev" }
+rand = { version = "0.8", features = ["std_rng", "small_rng"] }

--- a/crates/bevy_entropy/src/lib.rs
+++ b/crates/bevy_entropy/src/lib.rs
@@ -50,7 +50,7 @@ impl Entropy {
 
     /// Fill `dest` with entropy data. For an allocating alternative, see [`Entropy::get`].
     pub fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.0.fill_bytes(dest)
+        self.0.fill_bytes(dest);
     }
 
     /// Allocate and return entropy data. For a non-allocating alternative, see [`Entropy::fill_bytes`].

--- a/crates/bevy_entropy/src/lib.rs
+++ b/crates/bevy_entropy/src/lib.rs
@@ -122,7 +122,7 @@ mod test {
                         result_channel.0.send(thing.0).expect("result to send");
                     }
                 }
-                app_exit_events.send(AppExit)
+                app_exit_events.send(AppExit);
             }
 
             // The result of running the app.

--- a/crates/bevy_entropy/src/lib.rs
+++ b/crates/bevy_entropy/src/lib.rs
@@ -10,8 +10,8 @@ pub mod prelude {
 /// Provides a source of entropy.
 /// This enables deterministic random number generation.
 ///
-// See <https://github.com/bevyengine/bevy/discussions/2480> for issues
-// to be mindful of if you desire complete determinism.
+/// See <https://github.com/bevyengine/bevy/discussions/2480> for issues
+/// to be mindful of if you desire complete determinism.
 #[derive(Default)]
 pub struct EntropyPlugin;
 

--- a/crates/bevy_entropy/src/lib.rs
+++ b/crates/bevy_entropy/src/lib.rs
@@ -1,0 +1,139 @@
+use bevy_app::{App, Plugin};
+use bevy_utils::tracing::{debug, trace};
+use rand::{rngs::StdRng, RngCore, SeedableRng};
+
+pub mod prelude {
+    #[doc(hidden)]
+    pub use crate::Entropy;
+}
+
+/// Provides a source of entropy.
+/// This enables deterministic random number generation.
+///
+// See <https://github.com/bevyengine/bevy/discussions/2480> for issues
+// to be mindful of if you desire complete determinism.
+#[derive(Default)]
+pub struct EntropyPlugin;
+
+impl Plugin for EntropyPlugin {
+    fn build(&self, app: &mut App) {
+        if !app.world.contains_resource::<Entropy>() {
+            trace!("Creating entropy");
+            app.init_resource::<Entropy>();
+        }
+    }
+}
+
+/// A resource that provides entropy.
+pub struct Entropy(StdRng);
+
+impl Default for Entropy {
+    /// The default entropy source is non-deterministic and seeded from the operating system.
+    /// For a deterministic source, use [`Entropy::from`].
+    fn default() -> Self {
+        debug!("Entropy created via the operating system");
+        let rng = StdRng::from_entropy();
+        Entropy(rng)
+    }
+}
+
+impl Entropy {
+    /// Create a deterministic source of entropy. All random number generators
+    /// later seeded from an [`Entropy`] created this way will be deterministic.
+    /// If determinism is not required, use [`Entropy::default`].
+    pub fn from(seed: [u8; 32]) -> Self {
+        debug!("Entropy created via seed: {:?} ", seed);
+        let rng = StdRng::from_seed(seed);
+        Entropy(rng)
+    }
+
+    /// Fill `dest` with entropy data. For an allocating alternative, see [`Entropy::get`].
+    pub fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest)
+    }
+
+    /// Allocate and return entropy data. For a non-allocating alternative, see [`Entropy::fill_bytes`].
+    pub fn get(&mut self) -> [u8; 32] {
+        let mut dest = [0; 32];
+        self.0.fill_bytes(&mut dest);
+        dest
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use bevy_app::AppExit;
+    use bevy_ecs::prelude::*;
+    use bevy_internal::prelude::*;
+    use rand::{rngs::SmallRng, seq::IteratorRandom, SeedableRng};
+    use std::sync::mpsc;
+    use std::sync::mpsc::{Receiver, SyncSender};
+
+    #[test]
+    fn is_deterministic() {
+        const APP_RUN_COUNT: u8 = 10;
+        const CHOOSE_COUNT: u8 = 5;
+        const THING_COUNT: u8 = 100;
+
+        #[derive(Component)]
+        struct Thing(u8);
+        struct ResultChannel(SyncSender<u8>);
+
+        // The result of the app we will check to make sure it is always the same.
+        let mut expected_result: Option<Vec<u8>> = None;
+
+        // The seed we will use for the random number generator in all app runs.
+        let world_seed: [u8; 32] = [1; 32];
+
+        // Run the app multiple times.
+        for runs in 0..APP_RUN_COUNT {
+            let (tx, rx): (SyncSender<u8>, Receiver<u8>) = mpsc::sync_channel(CHOOSE_COUNT.into());
+
+            App::new()
+                .insert_resource(Entropy::from(world_seed))
+                .insert_resource(ResultChannel(tx))
+                .add_plugins_with(MinimalPlugins, |group| group.add(super::EntropyPlugin))
+                .add_startup_system(spawn_things)
+                .add_system(choose_things)
+                .run();
+
+            fn spawn_things(mut commands: Commands) {
+                for x in 1..THING_COUNT {
+                    commands.spawn().insert(Thing(x));
+                }
+            }
+
+            fn choose_things(
+                query: Query<&Thing>,
+                mut entropy: ResMut<Entropy>,
+                result_channel: Res<ResultChannel>,
+                mut app_exit_events: EventWriter<AppExit>,
+            ) {
+                // Create RNG from global entropy.
+                let seed = entropy.get();
+                let mut rng = SmallRng::from_seed(seed);
+
+                // Choose some random things.
+                for _ in 0..CHOOSE_COUNT {
+                    if let Some(thing) = query.iter().choose(&mut rng) {
+                        // Send the chosen thing out of the app so it can be inspected
+                        // after the app exits.
+                        result_channel.0.send(thing.0).expect("result to send");
+                    }
+                }
+                app_exit_events.send(AppExit)
+            }
+
+            // The result of running the app.
+            let run_result: Vec<u8> = rx.iter().collect();
+
+            // If it is the first run, treat the current result as the expected
+            // result we will check future runs against.
+            if runs == 0 {
+                expected_result = Some(run_result.clone());
+            }
+
+            assert_eq!(expected_result, Some(run_result));
+        }
+    }
+}

--- a/crates/bevy_entropy/src/lib.rs
+++ b/crates/bevy_entropy/src/lib.rs
@@ -1,6 +1,7 @@
 use bevy_app::{App, Plugin};
 use bevy_utils::tracing::{debug, trace};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand_chacha::ChaCha12Rng;
+use rand_core::{RngCore, SeedableRng};
 
 pub mod prelude {
     #[doc(hidden)]
@@ -25,14 +26,14 @@ impl Plugin for EntropyPlugin {
 }
 
 /// A resource that provides entropy.
-pub struct Entropy(StdRng);
+pub struct Entropy(ChaCha12Rng);
 
 impl Default for Entropy {
     /// The default entropy source is non-deterministic and seeded from the operating system.
     /// For a deterministic source, use [`Entropy::from`].
     fn default() -> Self {
         debug!("Entropy created via the operating system");
-        let rng = StdRng::from_entropy();
+        let rng = ChaCha12Rng::from_entropy();
         Entropy(rng)
     }
 }
@@ -43,7 +44,7 @@ impl Entropy {
     /// If determinism is not required, use [`Entropy::default`].
     pub fn from(seed: [u8; 32]) -> Self {
         debug!("Entropy created via seed: {:?} ", seed);
-        let rng = StdRng::from_seed(seed);
+        let rng = ChaCha12Rng::from_seed(seed);
         Entropy(rng)
     }
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -71,6 +71,7 @@ bevy_core = { path = "../bevy_core", version = "0.8.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.8.0-dev" }
 bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.8.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.8.0-dev" }
+bevy_entropy = { path = "../bevy_entropy", version = "0.8.0-dev" }
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.8.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.8.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.8.0-dev" }

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -38,6 +38,7 @@ impl PluginGroup for DefaultPlugins {
         #[cfg(feature = "debug_asset_server")]
         group.add(bevy_asset::debug_asset_server::DebugAssetServerPlugin::default());
         group.add(bevy_scene::ScenePlugin::default());
+        group.add(bevy_entropy::EntropyPlugin::default());
 
         #[cfg(feature = "bevy_winit")]
         group.add(bevy_winit::WinitPlugin::default());

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -32,6 +32,11 @@ pub mod ecs {
     pub use bevy_ecs::*;
 }
 
+pub mod entropy {
+    //! Resources for entropy.
+    pub use bevy_entropy::*;
+}
+
 pub mod input {
     //! Resources and events for inputs, e.g. mouse/keyboard, touch, gamepads, etc.
     pub use bevy_input::*;

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -1,6 +1,6 @@
 #[doc(hidden)]
 pub use crate::{
-    app::prelude::*, asset::prelude::*, core::prelude::*, ecs::prelude::*, hierarchy::prelude::*,
+    app::prelude::*, asset::prelude::*, core::prelude::*, ecs::prelude::*, entropy::prelude::*, hierarchy::prelude::*,
     input::prelude::*, log::prelude::*, math::prelude::*, reflect::prelude::*, scene::prelude::*,
     time::prelude::*, transform::prelude::*, utils::prelude::*, window::prelude::*, DefaultPlugins,
     MinimalPlugins,

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -1,9 +1,9 @@
 #[doc(hidden)]
 pub use crate::{
-    app::prelude::*, asset::prelude::*, core::prelude::*, ecs::prelude::*, entropy::prelude::*, hierarchy::prelude::*,
-    input::prelude::*, log::prelude::*, math::prelude::*, reflect::prelude::*, scene::prelude::*,
-    time::prelude::*, transform::prelude::*, utils::prelude::*, window::prelude::*, DefaultPlugins,
-    MinimalPlugins,
+    app::prelude::*, asset::prelude::*, core::prelude::*, ecs::prelude::*, entropy::prelude::*,
+    hierarchy::prelude::*, input::prelude::*, log::prelude::*, math::prelude::*,
+    reflect::prelude::*, scene::prelude::*, time::prelude::*, transform::prelude::*,
+    utils::prelude::*, window::prelude::*, DefaultPlugins, MinimalPlugins,
 };
 
 pub use bevy_derive::{bevy_main, Deref, DerefMut};

--- a/examples/README.md
+++ b/examples/README.md
@@ -146,7 +146,7 @@ Example | Description
 [Logs](../examples/app/logs.rs) | Illustrate how to use generate log output
 [Plugin](../examples/app/plugin.rs) | Demonstrates the creation and registration of a custom plugin
 [Plugin Group](../examples/app/plugin_group.rs) | Demonstrates the creation and registration of a custom plugin group
-[Random](../examples/app/random.rs) | Show how to use a central source of entropy for random number generation.
+[Random](../examples/app/random.rs) | Demonstrates how to use entropy to control randomness in Bevy.
 [Return after Run](../examples/app/return_after_run.rs) | Show how to return to main after the Bevy app has exited
 [Thread Pool Resources](../examples/app/thread_pool_resources.rs) | Creates and customizes the internal thread pool
 [Without Winit](../examples/app/without_winit.rs) | Create an application without winit (runs single time, no event loop)

--- a/examples/README.md
+++ b/examples/README.md
@@ -146,6 +146,7 @@ Example | Description
 [Logs](../examples/app/logs.rs) | Illustrate how to use generate log output
 [Plugin](../examples/app/plugin.rs) | Demonstrates the creation and registration of a custom plugin
 [Plugin Group](../examples/app/plugin_group.rs) | Demonstrates the creation and registration of a custom plugin group
+[Random](../examples/app/random.rs) | Show how to use a central source of entropy for random number generation.
 [Return after Run](../examples/app/return_after_run.rs) | Show how to return to main after the Bevy app has exited
 [Thread Pool Resources](../examples/app/thread_pool_resources.rs) | Creates and customizes the internal thread pool
 [Without Winit](../examples/app/without_winit.rs) | Create an application without winit (runs single time, no event loop)

--- a/examples/app/random.rs
+++ b/examples/app/random.rs
@@ -1,0 +1,121 @@
+use bevy::prelude::*;
+use rand::{prelude::IteratorRandom, rngs::SmallRng, Rng, SeedableRng};
+
+// This example illustrates how to use entropy to control randomness in bevy.
+// We randomly choose a coin to toss (which is itself random) and record the result.
+//
+// Because all the random number generators are seeded from the same "world seed",
+// the chosen coin and results of the coin tosses are deterministic across runs.
+//
+// There are many different random number generators with different tradeoffs.
+// We use a `SmallRng`, which is an insecure random number generator designed to
+// be fast, simple, require little memory, and have good output quality.
+// This would be an inappropriate choice for cryptographic randomness.
+//
+// See <https://docs.rs/rand/0.8.4/rand/rngs/index.html> for more details
+
+#[derive(Component)]
+struct Coin;
+
+impl Coin {
+    // Toss the coin and return the `Face` that lands up.
+    // Coin tosses are independent so each toss needs its own
+    // random number generator.
+    fn toss(&self, seed: [u8; 32]) -> Face {
+        let mut rng = SmallRng::from_seed(seed);
+        if rng.gen_bool(0.5) {
+            Face::Heads
+        } else {
+            Face::Tails
+        }
+    }
+}
+
+struct CoinChooser(SmallRng);
+
+#[derive(Component, Debug, PartialEq)]
+enum Face {
+    Heads,
+    Tails,
+}
+
+fn main() {
+    // We create a random seed for the world. Random number generators created with
+    // or derived from this seed will appear random during execution but will be
+    // deterministic across multiple executions.
+    // See <https://en.wikipedia.org/wiki/Random_seed> and
+    // <https://blog.unity.com/technology/a-primer-on-repeatable-random-numbers>
+    // for more details.
+    //
+    // The seed you choose may have security implications or influence the
+    // distribution of the random numbers generated.
+    // See <https://rust-random.github.io/book/guide-seeding.html> for more details
+    // about how to pick a "good" random seed for your needs.
+    //
+    // Normally you would do one of the following:
+    //   1. Get a good random seed out-of-band and hardcode it in the source.
+    //   2. Dynamically call to the OS and print the seed so the user can rerun
+    //      deterministically.
+    //   3. Dynamically call to the OS and share the seed with a server so the
+    //      client and server deterministically execute together.
+    //   4. Load the seed from a server so the client and server deterministically
+    //      execute together.
+    let world_seed: [u8; 32] = [1; 32];
+
+    // Create a source of entropy for the world using the random seed.
+    let mut world_entropy = Entropy::from(world_seed);
+
+    // Create a coin chooser, seeded from the world's entropy.
+    // We do this at the start of the world so the random number generator backing
+    // the coin chooser is not influenced by coin tosses.
+    let seed = world_entropy.get();
+    let coin_chooser = CoinChooser(SmallRng::from_seed(seed));
+
+    App::new()
+        // Delete the following line to use the default OS-provided entropy source.
+        // Note that doing so introduces non-determinism.
+        .insert_resource(world_entropy)
+        .insert_resource(coin_chooser)
+        .add_plugins_with(MinimalPlugins, |group| {
+            group.add(bevy::entropy::EntropyPlugin);
+            group.add(bevy::log::LogPlugin)
+        })
+        .add_startup_system(spawn_coins)
+        .add_system(toss_coin)
+        .run();
+}
+
+// System to spawn coins into the world.
+fn spawn_coins(mut commands: Commands) {
+    for _ in 1..100 {
+        commands.spawn().insert(Coin).insert(Face::Heads);
+    }
+    info!("Spawned coins")
+}
+
+// System to toss a random coin.
+fn toss_coin(
+    mut query: Query<(Entity, &Coin, &mut Face), With<Coin>>,
+    coin_chooser: ResMut<CoinChooser>,
+    mut entropy: ResMut<Entropy>,
+) {
+    // Pick a random coin.
+    if let Some((ent, coin, mut face)) = query.iter_mut().choose(&mut coin_chooser.into_inner().0) {
+        // Toss it to determine the resulting [Face].
+        // Tosses are seeded from the world's entropy and are deterministic.
+        let seed = entropy.get();
+        let new_face = coin.toss(seed);
+
+        info!(
+            "Tossed entity {:?} - old: {:?} new: {:?}",
+            ent, *face, new_face
+        );
+
+        // If the face has changed, update it.
+        if *face != new_face {
+            info!("    - Updating face for entity {:?} to {:?}", ent, new_face);
+            let f = face.as_mut();
+            *f = new_face;
+        }
+    }
+}

--- a/examples/app/random.rs
+++ b/examples/app/random.rs
@@ -33,7 +33,7 @@ impl Coin {
 
 struct CoinChooser(SmallRng);
 
-#[derive(Component, Debug, PartialEq)]
+#[derive(Component, Debug, Eq, PartialEq)]
 enum Face {
     Heads,
     Tails,
@@ -90,7 +90,7 @@ fn spawn_coins(mut commands: Commands) {
     for _ in 1..100 {
         commands.spawn().insert(Coin).insert(Face::Heads);
     }
-    info!("Spawned coins")
+    info!("Spawned coins");
 }
 
 // System to toss a random coin.

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -1,7 +1,7 @@
 //! Shows how to iterate over combinations of query results.
 
 use bevy::{pbr::AmbientLight, prelude::*, render::camera::Camera, time::FixedTimestep};
-use rand::{thread_rng, Rng};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
 struct FixedUpdateStage;
@@ -9,7 +9,10 @@ struct FixedUpdateStage;
 const DELTA_TIME: f64 = 0.01;
 
 fn main() {
+    let world_seed = [1; 32];
+
     App::new()
+        .insert_resource(Entropy::from(world_seed))
         .add_plugins(DefaultPlugins)
         .insert_resource(AmbientLight {
             brightness: 0.03,
@@ -52,6 +55,7 @@ struct BodyBundle {
 
 fn generate_bodies(
     mut commands: Commands,
+    mut entropy: ResMut<Entropy>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
@@ -63,7 +67,7 @@ fn generate_bodies(
     let color_range = 0.5..1.0;
     let vel_range = -0.5..0.5;
 
-    let mut rng = thread_rng();
+    let mut rng = SmallRng::from_seed(entropy.get());
     for _ in 0..NUM_BODIES {
         let radius: f32 = rng.gen_range(0.1..0.7);
         let mass_value = radius.powi(3) * 10.;


### PR DESCRIPTION
# Objective

- Bevy games / applications often need to use random number generators, but they make execution non-deterministic. Currently there is no official way to introduce determinism in a bevy-supported way.

## Solution

- Include a source of entropy to (optionally) enable deterministic random number generators. The plugin can be completely disabled if no source of entropy is required, the default entropy from the OS can be used if randomness is needed but deterministic execution is not, or a world seed can be specified for deterministic random number generation.

Note that I put up a [PR previously to add default rngs](https://github.com/bevyengine/bevy/pull/2355). While most other engines (godot, unity, etc) provide built-in rngs, this is a lower-level (and more general?) building block we likely want to start with first.

## Open items
- [x] Is the naming ok? `Entropy` or `EntropySource`? `get()`? _Naming is ok_
- [x] Should this be a plugin or in core? One can make the argument that entropy is as core as time and thus should always be there. _Plugin is better and [time might move out of core](https://github.com/bevyengine/bevy/pull/4187)._
- [x] Tests
- [ ] Docs (did I miss these in the repo?)
- [ ] Changelog item