### PR TITLE
[Merged by Bors] - disable bors check on android

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -5,7 +5,6 @@ status = [
     "build (nightly, ubuntu-latest)",
     "build-wasm (stable, ubuntu-latest)",
     "build-wasm (nightly, ubuntu-latest)",
-    "build-android",
     "markdownlint",
     "check-markdown-links",
     "run-examples",


### PR DESCRIPTION
# Objective

- CI is failing because of an android issue
- This is blocking bors

## Solution

- Bors can ignore android failures
- Keep android job in CI to check its status

I'm not android enough to debug this one, this is a temp fix until someone knows how to fix it or it get fixed by itself with updates?
