### PR TITLE
[Merged by Bors] - Dedupe move logic in remove_bundle and remove_bundle_intersection

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -340,6 +340,34 @@ impl<'w> EntityMut<'w> {
             })
         };
 
+        unsafe {
+            Self::move_entity_from_remove::<false>(
+                entity,
+                &mut self.location,
+                old_location.archetype_id,
+                old_location,
+                entities,
+                archetypes,
+                storages,
+                new_archetype_id,
+            );
+        }
+
+        Some(result)
+    }
+
+    /// if DROP is true we will drop removed components, if its false we will forget them
+    unsafe fn move_entity_from_remove<const DROP: bool>(
+        entity: Entity,
+        self_location: &mut EntityLocation,
+        old_archetype_id: ArchetypeId,
+        old_location: EntityLocation,
+        entities: &mut Entities,
+        archetypes: &mut Archetypes,
+        storages: &mut Storages,
+        new_archetype_id: ArchetypeId,
+    ) {
+        let old_archetype = &mut archetypes[old_archetype_id];
         let remove_result = old_archetype.swap_remove(old_location.index);
         if let Some(swapped_entity) = remove_result.swapped_entity {
             entities.meta[swapped_entity.id as usize].location = old_location;
@@ -355,10 +383,11 @@ impl<'w> EntityMut<'w> {
                 .tables
                 .get_2_mut(old_table_id, new_archetype.table_id());
 
-            // SAFE: table_row exists. All "missing" components have been extracted into the bundle
-            // above and the caller takes ownership
-            let move_result =
-                unsafe { old_table.move_to_and_forget_missing_unchecked(old_table_row, new_table) };
+            // SAFE: table_row exists. All "missing" components have been extracted into the bundle above and the caller takes ownership
+            let move_result = match DROP {
+                true => old_table.move_to_and_drop_missing_unchecked(old_table_row, new_table),
+                false => old_table.move_to_and_forget_missing_unchecked(old_table_row, new_table),
+            };
 
             // SAFE: new_table_row is a valid position in new_archetype's table
             let new_location = unsafe { new_archetype.allocate(entity, move_result.new_row) };
@@ -366,17 +395,15 @@ impl<'w> EntityMut<'w> {
             // if an entity was moved into this entity's table spot, update its table row
             if let Some(swapped_entity) = move_result.swapped_entity {
                 let swapped_location = entities.get(swapped_entity).unwrap();
-                let archetype = &mut archetypes[swapped_location.archetype_id];
-                archetype.set_entity_table_row(swapped_location.index, old_table_row);
+                archetypes[swapped_location.archetype_id]
+                    .set_entity_table_row(swapped_location.index, old_table_row);
             }
 
             new_location
         };
 
-        self.location = new_location;
-        entities.meta[self.entity.id as usize].location = new_location;
-
-        Some(result)
+        *self_location = new_location;
+        entities.meta[entity.id as usize].location = new_location;
     }
 
     /// Remove any components in the bundle that the entity has.
@@ -425,40 +452,18 @@ impl<'w> EntityMut<'w> {
             }
         }
 
-        let remove_result = old_archetype.swap_remove(old_location.index);
-        if let Some(swapped_entity) = remove_result.swapped_entity {
-            entities.meta[swapped_entity.id as usize].location = old_location;
+        unsafe {
+            Self::move_entity_from_remove::<true>(
+                entity,
+                &mut self.location,
+                old_location.archetype_id,
+                old_location,
+                entities,
+                archetypes,
+                storages,
+                new_archetype_id,
+            )
         }
-        let old_table_row = remove_result.table_row;
-        let old_table_id = old_archetype.table_id();
-        let new_archetype = &mut archetypes[new_archetype_id];
-
-        let new_location = if old_table_id == new_archetype.table_id() {
-            unsafe { new_archetype.allocate(entity, old_table_row) }
-        } else {
-            let (old_table, new_table) = storages
-                .tables
-                .get_2_mut(old_table_id, new_archetype.table_id());
-
-            // SAFE: table_row exists
-            let move_result =
-                unsafe { old_table.move_to_and_drop_missing_unchecked(old_table_row, new_table) };
-
-            // SAFE: new_table_row is a valid position in new_archetype's table
-            let new_location = unsafe { new_archetype.allocate(entity, move_result.new_row) };
-
-            // if an entity was moved into this entity's table spot, update its table row
-            if let Some(swapped_entity) = move_result.swapped_entity {
-                let swapped_location = entities.get(swapped_entity).unwrap();
-                archetypes[swapped_location.archetype_id]
-                    .set_entity_table_row(swapped_location.index, old_table_row);
-            }
-
-            new_location
-        };
-
-        self.location = new_location;
-        entities.meta[self.entity.id as usize].location = new_location;
     }
 
     pub fn insert<T: Component>(&mut self, value: T) -> &mut Self {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -367,6 +367,7 @@ impl<'w> EntityMut<'w> {
         storages: &mut Storages,
         new_archetype_id: ArchetypeId,
     ) {
+        #![allow(unused_unsafe)]
         let old_archetype = &mut archetypes[old_archetype_id];
         let remove_result = old_archetype.swap_remove(old_location.index);
         if let Some(swapped_entity) = remove_result.swapped_entity {
@@ -383,7 +384,7 @@ impl<'w> EntityMut<'w> {
                 .tables
                 .get_2_mut(old_table_id, new_archetype.table_id());
 
-            // SAFE: table_row exists. All "missing" components have been extracted into the bundle above and the caller takes ownership
+            // SAFE: table_row exists
             let move_result = match DROP {
                 true => old_table.move_to_and_drop_missing_unchecked(old_table_row, new_table),
                 false => old_table.move_to_and_forget_missing_unchecked(old_table_row, new_table),

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -357,6 +357,8 @@ impl<'w> EntityMut<'w> {
     }
 
     /// if DROP is true we will drop removed components, if its false we will forget them
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::match_bool)]
     unsafe fn move_entity_from_remove<const DROP: bool>(
         entity: Entity,
         self_location: &mut EntityLocation,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -365,7 +365,6 @@ impl<'w> EntityMut<'w> {
     // We use a const generic here so that we are less reliant on
     // inlining for rustc to optimize out the `match DROP`
     #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::match_bool)]
     unsafe fn move_entity_from_remove<const DROP: bool>(
         entity: Entity,
         self_location: &mut EntityLocation,
@@ -393,9 +392,10 @@ impl<'w> EntityMut<'w> {
                 .get_2_mut(old_table_id, new_archetype.table_id());
 
             // SAFE: old_table_row exists
-            let move_result = match DROP {
-                true => old_table.move_to_and_drop_missing_unchecked(old_table_row, new_table),
-                false => old_table.move_to_and_forget_missing_unchecked(old_table_row, new_table),
+            let move_result = if DROP {
+                old_table.move_to_and_drop_missing_unchecked(old_table_row, new_table)
+            } else {
+                old_table.move_to_and_forget_missing_unchecked(old_table_row, new_table)
             };
 
             // SAFE: move_result.new_row is a valid position in new_archetype's table

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -356,7 +356,7 @@ impl<'w> EntityMut<'w> {
         Some(result)
     }
 
-    /// if DROP is true we will drop removed components, if its false we will forget them
+    /// when DROP is true removed components will be dropped otherwise they will be forgotten
     #[allow(clippy::too_many_arguments)]
     #[allow(clippy::match_bool)]
     unsafe fn move_entity_from_remove<const DROP: bool>(


### PR DESCRIPTION
This logic was in both `remove_bundle` and ` remove_bundle_intersection` but only differed by whether we call `.._forget_missing_..` or `.._drop_missing_..`