### PR TITLE
Pin notify version to 5.0.0-pre.2 in bevy_asset

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -32,7 +32,7 @@ crossbeam-channel = "0.5.0"
 anyhow = "1.0.4"
 thiserror = "1.0"
 downcast-rs = "1.2.0"
-notify = { version = "5.0.0-pre.2", optional = true }
+notify = { version = "=5.0.0-pre.2", optional = true }
 parking_lot = "0.11.0"
 rand = "0.8.0"
 


### PR DESCRIPTION
# Objective

- Looks like about an hour ago a new version of notify 5.0 pre-release (5.0.0-pre.11) was pushed to crates.io which breaks the build.

## Solution

- Pin notify version to 5.0.0-pre.2
