### PR TITLE
[Merged by Bors] - fix version of notify to 5.0.0-pre.10

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -32,7 +32,7 @@ crossbeam-channel = "0.5.0"
 anyhow = "1.0.4"
 thiserror = "1.0"
 downcast-rs = "1.2.0"
-notify = { version = "=5.0.0-pre.2", optional = true }
+notify = { version = "=5.0.0-pre.10", optional = true }
 parking_lot = "0.11.0"
 rand = "0.8.0"
 

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -32,7 +32,7 @@ crossbeam-channel = "0.5.0"
 anyhow = "1.0.4"
 thiserror = "1.0"
 downcast-rs = "1.2.0"
-notify = { version = "5.0.0-pre.2", optional = true }
+notify = { version = "=5.0.0-pre.2", optional = true }
 parking_lot = "0.11.0"
 rand = "0.8.0"
 


### PR DESCRIPTION
# Objective

- https://github.com/notify-rs/notify changed their api in the latest pre-release of 0.5.0
- This breaks current main AND v0.5.0

## Solution

- Fix the dependency to the known working version

before : https://docs.rs/notify/5.0.0-pre.2/notify/trait.Watcher.html
after : https://docs.rs/notify/5.0.0-pre.11/notify/trait.Watcher.html