### PR TITLE
Change HandleUntyped::typed to not panic

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -229,8 +229,11 @@ impl AssetServer {
     /// [`AssetServerSettings`](crate::AssetServerSettings) resource. The default name is
     /// `"assets"`.
     #[must_use = "not using the returned strong handle may result in the unexpected release of the asset"]
-    pub fn load<'a, T: Asset, P: Into<AssetPath<'a>>>(&self, path: P) -> Handle<T> {
-        self.load_untyped(path).typed()
+    pub fn load<'a, T: Asset, P: Into<AssetPath<'a>>>(&self, path: P) -> Result<Handle<T>, AssetServerError> {
+        match self.load_untyped(path).typed() {
+            Ok(handle) => Ok(handle),
+            Err(_) => Err(AssetServerError::IncorrectHandleType)
+        }
     }
 
     async fn load_async(

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -275,10 +275,10 @@ impl HandleUntyped {
         matches!(self.handle_type, HandleType::Strong(_))
     }
 
-    pub fn typed<T: Asset>(mut self) -> Handle<T> {
+    pub fn typed<T: Asset>(mut self) -> Result<Handle<T>, HandleUntyped> {
         if let HandleId::Id(type_uuid, _) = self.id {
             if T::TYPE_UUID != type_uuid {
-                panic!("Attempted to convert handle to invalid type.");
+                return Err(self)
             }
         }
         let handle_type = match &self.handle_type {
@@ -287,11 +287,11 @@ impl HandleUntyped {
         };
         // ensure we don't send the RefChange event when "self" is dropped
         self.handle_type = HandleType::Weak;
-        Handle {
+        Ok(Handle {
             handle_type,
             id: self.id,
             marker: PhantomData::default(),
-        }
+        })
     }
 }
 

--- a/crates/bevy_pbr/src/entity.rs
+++ b/crates/bevy_pbr/src/entity.rs
@@ -27,7 +27,7 @@ impl Default for PbrBundle {
     fn default() -> Self {
         Self {
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
-                PBR_PIPELINE_HANDLE.typed(),
+                PBR_PIPELINE_HANDLE.typed().unwrap(),
             )]),
             mesh: Default::default(),
             visible: Default::default(),

--- a/crates/bevy_pbr/src/render_graph/pbr_pipeline/mod.rs
+++ b/crates/bevy_pbr/src/render_graph/pbr_pipeline/mod.rs
@@ -10,6 +10,7 @@ use bevy_render::{
     texture::TextureFormat,
 };
 
+// FIXME: Naughty pipeline handle should be typed
 pub const PBR_PIPELINE_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 13148362314012771389);
 

--- a/crates/bevy_render/src/wireframe/mod.rs
+++ b/crates/bevy_render/src/wireframe/mod.rs
@@ -18,6 +18,7 @@ use bevy_utils::HashSet;
 
 mod pipeline;
 
+// FIXME: Naughty pipeline handle should be typed
 pub const WIREFRAME_PIPELINE_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 0x137c75ab7e9ad7f5);
 
@@ -84,7 +85,7 @@ pub fn draw_wireframes_system(
         };
 
         let mut render_pipeline = RenderPipeline::specialized(
-            WIREFRAME_PIPELINE_HANDLE.typed(),
+            WIREFRAME_PIPELINE_HANDLE.typed().unwrap(),
             PipelineSpecialization {
                 sample_count: msaa.samples,
                 strip_index_format: None,

--- a/crates/bevy_sprite/src/entity.rs
+++ b/crates/bevy_sprite/src/entity.rs
@@ -28,9 +28,9 @@ pub struct SpriteBundle {
 impl Default for SpriteBundle {
     fn default() -> Self {
         Self {
-            mesh: QUAD_HANDLE.typed(),
+            mesh: QUAD_HANDLE.typed().unwrap(),
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
-                SPRITE_PIPELINE_HANDLE.typed(),
+                SPRITE_PIPELINE_HANDLE.typed().unwrap(),
             )]),
             visible: Visible {
                 is_transparent: true,
@@ -68,14 +68,14 @@ impl Default for SpriteSheetBundle {
     fn default() -> Self {
         Self {
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
-                SPRITE_SHEET_PIPELINE_HANDLE.typed(),
+                SPRITE_SHEET_PIPELINE_HANDLE.typed().unwrap(),
             )]),
             visible: Visible {
                 is_transparent: true,
                 ..Default::default()
             },
             main_pass: MainPass,
-            mesh: QUAD_HANDLE.typed(),
+            mesh: QUAD_HANDLE.typed().unwrap(),
             draw: Default::default(),
             sprite: Default::default(),
             texture_atlas: Default::default(),

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -63,6 +63,7 @@ impl Default for SpriteSettings {
 #[derive(Default)]
 pub struct SpritePlugin;
 
+// FIXME: Naughty pipeline handle should be typed
 pub const QUAD_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Mesh::TYPE_UUID, 14240461981130137526);
 

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -12,9 +12,11 @@ use bevy_render::{
     texture::TextureFormat,
 };
 
+// FIXME: Naughty pipeline handle should be typed
 pub const SPRITE_PIPELINE_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 2785347840338765446);
 
+// FIXME: Naughty pipeline handle should be typed
 pub const SPRITE_SHEET_PIPELINE_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 9016885805180281612);
 

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -28,7 +28,7 @@ impl<'a> Drawable for DrawableText<'a> {
     fn draw(&mut self, draw: &mut Draw, context: &mut DrawContext) -> Result<(), DrawError> {
         context.set_pipeline(
             draw,
-            &bevy_sprite::SPRITE_SHEET_PIPELINE_HANDLE.typed(),
+            &bevy_sprite::SPRITE_SHEET_PIPELINE_HANDLE.typed().unwrap(),
             &PipelineSpecialization {
                 sample_count: self.msaa.samples,
                 vertex_buffer_layout: self.font_quad_vertex_layout.clone(),
@@ -40,7 +40,7 @@ impl<'a> Drawable for DrawableText<'a> {
 
         if let Some(RenderResourceId::Buffer(vertex_attribute_buffer_id)) = render_resource_context
             .get_asset_resource(
-                &bevy_sprite::QUAD_HANDLE.typed::<Mesh>(),
+                &bevy_sprite::QUAD_HANDLE.typed::<Mesh>().unwrap(),
                 mesh::VERTEX_ATTRIBUTE_BUFFER_ID,
             )
         {
@@ -52,7 +52,7 @@ impl<'a> Drawable for DrawableText<'a> {
         let mut indices = 0..0;
         if let Some(RenderResourceId::Buffer(quad_index_buffer)) = render_resource_context
             .get_asset_resource(
-                &bevy_sprite::QUAD_HANDLE.typed::<Mesh>(),
+                &bevy_sprite::QUAD_HANDLE.typed::<Mesh>().unwrap(),
                 mesh::INDEX_BUFFER_ASSET_INDEX,
             )
         {

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -33,9 +33,9 @@ pub struct NodeBundle {
 impl Default for NodeBundle {
     fn default() -> Self {
         NodeBundle {
-            mesh: QUAD_HANDLE.typed(),
+            mesh: QUAD_HANDLE.typed().unwrap(),
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
-                UI_PIPELINE_HANDLE.typed(),
+                UI_PIPELINE_HANDLE.typed().unwrap(),
             )]),
             visible: Visible {
                 is_transparent: true,
@@ -69,9 +69,9 @@ pub struct ImageBundle {
 impl Default for ImageBundle {
     fn default() -> Self {
         ImageBundle {
-            mesh: QUAD_HANDLE.typed(),
+            mesh: QUAD_HANDLE.typed().unwrap(),
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
-                UI_PIPELINE_HANDLE.typed(),
+                UI_PIPELINE_HANDLE.typed().unwrap(),
             )]),
             node: Default::default(),
             image: Default::default(),
@@ -143,9 +143,9 @@ impl Default for ButtonBundle {
     fn default() -> Self {
         ButtonBundle {
             button: Button,
-            mesh: QUAD_HANDLE.typed(),
+            mesh: QUAD_HANDLE.typed().unwrap(),
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
-                UI_PIPELINE_HANDLE.typed(),
+                UI_PIPELINE_HANDLE.typed().unwrap(),
             )]),
             interaction: Default::default(),
             focus_policy: Default::default(),

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -17,6 +17,7 @@ use bevy_render::{
     texture::TextureFormat,
 };
 
+// FIXME: Naughty pipeline handle should be typed
 pub const UI_PIPELINE_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 3234320022263993878);
 


### PR DESCRIPTION
# Objective

Fixes #2534

## Solution

Changed the signature and implementation of `HandleUntyped::typed` to return a `Result` instead of panicking.

Adjusted a bunch of engine crate code that uses that function, but I sense a code smell. All usages are creating `HandleUntyped`s statically, and converting to `Handle<T>` on use. This could be avoided by just creating a `Handle<T>` in the first place.

I'll open another PR with that change.