### PR TITLE
Make Time update_with_instant pub

### DIFF
--- a/crates/bevy_core/src/time/time.rs
+++ b/crates/bevy_core/src/time/time.rs
@@ -31,7 +31,7 @@ impl Time {
         self.update_with_instant(now);
     }
 
-    pub(crate) fn update_with_instant(&mut self, instant: Instant) {
+    pub fn update_with_instant(&mut self, instant: Instant) {
         if let Some(last_update) = self.last_update {
             self.delta = instant - last_update;
             self.delta_seconds_f64 = self.delta.as_secs_f64();

--- a/crates/bevy_core/src/time/time.rs
+++ b/crates/bevy_core/src/time/time.rs
@@ -31,6 +31,7 @@ impl Time {
         self.update_with_instant(now);
     }
 
+    /// Update time with a specified [`Instant`], for use in tests. Should never be called on the default Time resource.
     pub fn update_with_instant(&mut self, instant: Instant) {
         if let Some(last_update) = self.last_update {
             self.delta = instant - last_update;


### PR DESCRIPTION
# Objective

A lot of systems depend on Time to implement frame-independent logic. 
To be able to write tests for these systems, one needs to be able to mock Time. By mocking time, it's possible to write tests that confirm systems are frame-independent. 

## Solution

To mock Time, one needs to be able to manually update the Time resource with an Instant defined by the developer. 
There is a function for this, but it's currently only public within the crate. I propose this function is exposed to the developer, to make it easy to write tests for systems utilizing the Time resource. 
