### PR TITLE
[Merged by Bors] - move bevy_core_pipeline to its own plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = ["crates/*", "pipelined/*", "examples/ios", "tools/ci"]
 [features]
 default = [
   "bevy_audio",
+  "bevy_core_pipeline",
   "bevy_dynamic_plugin",
   "bevy_gilrs",
   "bevy_gltf",
@@ -51,6 +52,7 @@ bevy_gltf = ["bevy_internal/bevy_gltf"]
 bevy_wgpu = ["bevy_internal/bevy_wgpu"]
 bevy_winit = ["bevy_internal/bevy_winit"]
 
+bevy_core_pipeline = ["bevy_internal/bevy_core_pipeline"]
 bevy_render2 = ["bevy_internal/bevy_render2"]
 bevy_sprite2 = ["bevy_internal/bevy_sprite2"]
 bevy_pbr2 = ["bevy_internal/bevy_pbr2"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -66,6 +66,7 @@ bevy_window = { path = "../bevy_window", version = "0.5.0" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.5.0" }
 # bevy (optional)
 bevy_audio = { path = "../bevy_audio", optional = true, version = "0.5.0" }
+bevy_core_pipeline = { path = "../../pipelined/bevy_core_pipeline", optional = true, version = "0.5.0" }
 bevy_gltf = { path = "../bevy_gltf", optional = true, version = "0.5.0" }
 bevy_pbr = { path = "../bevy_pbr", optional = true, version = "0.5.0" }
 bevy_pbr2 = { path = "../../pipelined/bevy_pbr2", optional = true, version = "0.5.0" }

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -121,16 +121,20 @@ impl PluginGroup for PipelinedDefaultPlugins {
         #[cfg(feature = "bevy_render2")]
         {
             group.add(bevy_render2::RenderPlugin::default());
-            group.add(bevy_render2::core_pipeline::CorePipelinePlugin::default());
+        }
+
+        #[cfg(feature = "bevy_core_pipeline")]
+        {
+            group.add(bevy_core_pipeline::CorePipelinePlugin::default());
+
+            #[cfg(feature = "bevy_sprite2")]
+            group.add(bevy_sprite2::SpritePlugin::default());
+
+            #[cfg(feature = "bevy_pbr2")]
+            group.add(bevy_pbr2::PbrPlugin::default());
         }
 
         #[cfg(feature = "bevy_winit")]
         group.add(bevy_winit::WinitPlugin::default());
-
-        #[cfg(feature = "bevy_sprite2")]
-        group.add(bevy_sprite2::SpritePlugin::default());
-
-        #[cfg(feature = "bevy_pbr2")]
-        group.add(bevy_pbr2::PbrPlugin::default());
     }
 }

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -19,11 +19,6 @@ pub mod core {
     pub use bevy_core::*;
 }
 
-pub mod core_pipeline {
-    //! Core render pipeline.
-    pub use bevy_core_pipeline::*;
-}
-
 pub mod diagnostic {
     //! Useful diagnostic plugins and types for bevy apps.
     pub use bevy_diagnostic::*;
@@ -85,6 +80,12 @@ pub mod window {
 pub mod audio {
     //! Provides types and plugins for audio playback.
     pub use bevy_audio::*;
+}
+
+#[cfg(feature = "bevy_core_pipeline")]
+pub mod core_pipeline {
+    //! Core render pipeline.
+    pub use bevy_core_pipeline::*;
 }
 
 #[cfg(feature = "bevy_gilrs")]

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -19,6 +19,11 @@ pub mod core {
     pub use bevy_core::*;
 }
 
+pub mod core_pipeline {
+    //! Core render pipeline.
+    pub use bevy_core_pipeline::*;
+}
+
 pub mod diagnostic {
     //! Useful diagnostic plugins and types for bevy apps.
     pub use bevy_diagnostic::*;

--- a/pipelined/bevy_core_pipeline/Cargo.toml
+++ b/pipelined/bevy_core_pipeline/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bevy_core_pipeline"
+version = "0.5.0"
+edition = "2018"
+authors = [
+    "Bevy Contributors <bevyengine@gmail.com>",
+    "Carter Anderson <mcanders1@gmail.com>",
+]
+description = "Provides a core render pipeline for Bevy Engine."
+homepage = "https://bevyengine.org"
+repository = "https://github.com/bevyengine/bevy"
+license = "MIT OR Apache-2.0"
+keywords = ["bevy"]
+
+[dependencies]
+# bevy
+bevy_app = { path = "../../crates/bevy_app", version = "0.5.0" }
+bevy_ecs = { path = "../../crates/bevy_ecs", version = "0.5.0" }
+bevy_render2 = { path = "../bevy_render2", version = "0.5.0" }
+

--- a/pipelined/bevy_core_pipeline/src/lib.rs
+++ b/pipelined/bevy_core_pipeline/src/lib.rs
@@ -6,19 +6,21 @@ pub use main_pass_2d::*;
 pub use main_pass_3d::*;
 pub use main_pass_driver::*;
 
-use crate::{
+use bevy_app::{App, Plugin};
+use bevy_ecs::prelude::*;
+use bevy_render2::{
     camera::{ActiveCameras, CameraPlugin},
     render_graph::{EmptyNode, RenderGraph, SlotInfo, SlotType},
     render_phase::{sort_phase_system, RenderPhase},
-    render_resource::{Texture, TextureView},
+    render_resource::{
+        Extent3d, Texture, TextureDescriptor, TextureDimension, TextureFormat, TextureUsage,
+        TextureView,
+    },
     renderer::RenderDevice,
     texture::TextureCache,
     view::{ExtractedView, ViewPlugin},
     RenderStage,
 };
-use bevy_app::{App, Plugin};
-use bevy_ecs::prelude::*;
-use wgpu::{Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsage};
 
 // Plugins that contribute to the RenderGraph should use the following label conventions:
 // 1. Graph modules should have a NAME, input module, and node module (where relevant)

--- a/pipelined/bevy_core_pipeline/src/main_pass_2d.rs
+++ b/pipelined/bevy_core_pipeline/src/main_pass_2d.rs
@@ -1,13 +1,13 @@
-use crate::{
+use crate::Transparent2dPhase;
+use bevy_ecs::prelude::*;
+use bevy_render2::{
     color::Color,
-    core_pipeline::Transparent2dPhase,
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
     render_phase::{DrawFunctions, RenderPhase, TrackedRenderPass},
+    render_resource::{LoadOp, Operations, RenderPassColorAttachment, RenderPassDescriptor},
     renderer::RenderContext,
     view::ExtractedView,
 };
-use bevy_ecs::prelude::*;
-use wgpu::{LoadOp, Operations, RenderPassColorAttachment, RenderPassDescriptor};
 
 pub struct MainPass2dNode {
     query: QueryState<&'static RenderPhase<Transparent2dPhase>, With<ExtractedView>>,

--- a/pipelined/bevy_core_pipeline/src/main_pass_3d.rs
+++ b/pipelined/bevy_core_pipeline/src/main_pass_3d.rs
@@ -1,15 +1,15 @@
-use crate::{
+use crate::Transparent3dPhase;
+use bevy_ecs::prelude::*;
+use bevy_render2::{
     color::Color,
-    core_pipeline::Transparent3dPhase,
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
     render_phase::{DrawFunctions, RenderPhase, TrackedRenderPass},
+    render_resource::{
+        LoadOp, Operations, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
+        RenderPassDescriptor,
+    },
     renderer::RenderContext,
     view::ExtractedView,
-};
-use bevy_ecs::prelude::*;
-use wgpu::{
-    LoadOp, Operations, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
-    RenderPassDescriptor,
 };
 
 pub struct MainPass3dNode {

--- a/pipelined/bevy_core_pipeline/src/main_pass_driver.rs
+++ b/pipelined/bevy_core_pipeline/src/main_pass_driver.rs
@@ -1,11 +1,11 @@
-use crate::{
+use crate::ViewDepthTexture;
+use bevy_ecs::world::World;
+use bevy_render2::{
     camera::{CameraPlugin, ExtractedCamera, ExtractedCameraNames},
-    core_pipeline::{self, ViewDepthTexture},
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotValue},
     renderer::RenderContext,
     view::ExtractedWindows,
 };
-use bevy_ecs::world::World;
 
 pub struct MainPassDriverNode;
 
@@ -24,7 +24,7 @@ impl Node for MainPassDriverNode {
             let extracted_window = extracted_windows.get(&extracted_camera.window_id).unwrap();
             let swap_chain_texture = extracted_window.swap_chain_frame.as_ref().unwrap().clone();
             graph.run_sub_graph(
-                core_pipeline::draw_2d_graph::NAME,
+                crate::draw_2d_graph::NAME,
                 vec![
                     SlotValue::Entity(*camera_2d),
                     SlotValue::TextureView(swap_chain_texture),
@@ -38,7 +38,7 @@ impl Node for MainPassDriverNode {
             let extracted_window = extracted_windows.get(&extracted_camera.window_id).unwrap();
             let swap_chain_texture = extracted_window.swap_chain_frame.as_ref().unwrap().clone();
             graph.run_sub_graph(
-                core_pipeline::draw_3d_graph::NAME,
+                crate::draw_3d_graph::NAME,
                 vec![
                     SlotValue::Entity(*camera_3d),
                     SlotValue::TextureView(swap_chain_texture),

--- a/pipelined/bevy_pbr2/Cargo.toml
+++ b/pipelined/bevy_pbr2/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["bevy"]
 bevy_app = { path = "../../crates/bevy_app", version = "0.5.0" }
 bevy_asset = { path = "../../crates/bevy_asset", version = "0.5.0" }
 bevy_core = { path = "../../crates/bevy_core", version = "0.5.0" }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.5.0" }
 bevy_ecs = { path = "../../crates/bevy_ecs", version = "0.5.0" }
 bevy_math = { path = "../../crates/bevy_math", version = "0.5.0" }
 bevy_reflect = { path = "../../crates/bevy_reflect", version = "0.5.0", features = ["bevy"] }

--- a/pipelined/bevy_pbr2/src/lib.rs
+++ b/pipelined/bevy_pbr2/src/lib.rs
@@ -11,7 +11,6 @@ pub use render::*;
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_render2::{
-    core_pipeline,
     render_graph::RenderGraph,
     render_phase::{sort_phase_system, DrawFunctions},
     RenderStage,
@@ -61,23 +60,23 @@ impl Plugin for PbrPlugin {
         let mut graph = render_world.get_resource_mut::<RenderGraph>().unwrap();
         graph.add_node("pbr", PbrNode);
         graph
-            .add_node_edge("pbr", core_pipeline::node::MAIN_PASS_DEPENDENCIES)
+            .add_node_edge("pbr", bevy_core_pipeline::node::MAIN_PASS_DEPENDENCIES)
             .unwrap();
 
         let draw_3d_graph = graph
-            .get_sub_graph_mut(core_pipeline::draw_3d_graph::NAME)
+            .get_sub_graph_mut(bevy_core_pipeline::draw_3d_graph::NAME)
             .unwrap();
         draw_3d_graph.add_node(draw_3d_graph::node::SHADOW_PASS, shadow_pass_node);
         draw_3d_graph
             .add_node_edge(
                 draw_3d_graph::node::SHADOW_PASS,
-                core_pipeline::draw_3d_graph::node::MAIN_PASS,
+                bevy_core_pipeline::draw_3d_graph::node::MAIN_PASS,
             )
             .unwrap();
         draw_3d_graph
             .add_slot_edge(
                 draw_3d_graph.input_node().unwrap().id,
-                core_pipeline::draw_3d_graph::input::VIEW_ENTITY,
+                bevy_core_pipeline::draw_3d_graph::input::VIEW_ENTITY,
                 draw_3d_graph::node::SHADOW_PASS,
                 ShadowPassNode::IN_VIEW,
             )

--- a/pipelined/bevy_pbr2/src/render/light.rs
+++ b/pipelined/bevy_pbr2/src/render/light.rs
@@ -1,10 +1,10 @@
 use crate::{AmbientLight, DirectionalLight, ExtractedMeshes, MeshMeta, PbrShaders, PointLight};
+use bevy_core_pipeline::Transparent3dPhase;
 use bevy_ecs::{prelude::*, system::SystemState};
 use bevy_math::{const_vec3, Mat4, Vec3, Vec4};
 use bevy_render2::{
     camera::CameraProjection,
     color::Color,
-    core_pipeline::Transparent3dPhase,
     mesh::Mesh,
     render_asset::RenderAssets,
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},

--- a/pipelined/bevy_pbr2/src/render/mod.rs
+++ b/pipelined/bevy_pbr2/src/render/mod.rs
@@ -1,11 +1,12 @@
 mod light;
 pub use light::*;
 
+use crate::{StandardMaterial, StandardMaterialUniformData};
 use bevy_asset::{Assets, Handle};
+use bevy_core_pipeline::Transparent3dPhase;
 use bevy_ecs::{prelude::*, system::SystemState};
 use bevy_math::Mat4;
 use bevy_render2::{
-    core_pipeline::Transparent3dPhase,
     mesh::Mesh,
     render_asset::RenderAssets,
     render_graph::{Node, NodeRunError, RenderGraphContext},
@@ -23,8 +24,6 @@ use wgpu::{
     Extent3d, ImageCopyTexture, ImageDataLayout, Origin3d, TextureDimension, TextureFormat,
     TextureViewDescriptor,
 };
-
-use crate::{StandardMaterial, StandardMaterialUniformData};
 
 pub struct PbrShaders {
     pipeline: RenderPipeline,

--- a/pipelined/bevy_render2/src/lib.rs
+++ b/pipelined/bevy_render2/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod camera;
 pub mod color;
-pub mod core_pipeline;
 pub mod mesh;
 pub mod render_asset;
 pub mod render_graph;

--- a/pipelined/bevy_sprite2/Cargo.toml
+++ b/pipelined/bevy_sprite2/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["bevy"]
 bevy_app = { path = "../../crates/bevy_app", version = "0.5.0" }
 bevy_asset = { path = "../../crates/bevy_asset", version = "0.5.0" }
 bevy_core = { path = "../../crates/bevy_core", version = "0.5.0" }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.5.0" }
 bevy_ecs = { path = "../../crates/bevy_ecs", version = "0.5.0" }
 bevy_log = { path = "../../crates/bevy_log", version = "0.5.0" }
 bevy_math = { path = "../../crates/bevy_math", version = "0.5.0" }

--- a/pipelined/bevy_sprite2/src/lib.rs
+++ b/pipelined/bevy_sprite2/src/lib.rs
@@ -9,9 +9,7 @@ pub use render::*;
 pub use sprite::*;
 
 use bevy_app::prelude::*;
-use bevy_render2::{
-    core_pipeline, render_graph::RenderGraph, render_phase::DrawFunctions, RenderStage,
-};
+use bevy_render2::{render_graph::RenderGraph, render_phase::DrawFunctions, RenderStage};
 
 #[derive(Default)]
 pub struct SpritePlugin;
@@ -37,7 +35,7 @@ impl Plugin for SpritePlugin {
         let mut graph = render_world.get_resource_mut::<RenderGraph>().unwrap();
         graph.add_node("sprite", SpriteNode);
         graph
-            .add_node_edge("sprite", core_pipeline::node::MAIN_PASS_DEPENDENCIES)
+            .add_node_edge("sprite", bevy_core_pipeline::node::MAIN_PASS_DEPENDENCIES)
             .unwrap();
     }
 }

--- a/pipelined/bevy_sprite2/src/render/mod.rs
+++ b/pipelined/bevy_sprite2/src/render/mod.rs
@@ -1,9 +1,9 @@
 use crate::Sprite;
 use bevy_asset::{Assets, Handle};
+use bevy_core_pipeline::Transparent2dPhase;
 use bevy_ecs::{prelude::*, system::SystemState};
 use bevy_math::{Mat4, Vec2, Vec3, Vec4Swizzles};
 use bevy_render2::{
-    core_pipeline::Transparent2dPhase,
     mesh::{shape::Quad, Indices, Mesh, VertexAttributeValues},
     render_asset::RenderAssets,
     render_graph::{Node, NodeRunError, RenderGraphContext},


### PR DESCRIPTION
This decouples the opinionated "core pipeline" from the new (less opinionated) bevy_render crate. The "core pipeline" is intended to be used by crates like bevy_sprites, bevy_pbr, bevy_ui, and 3rd party crates that extends core rendering functionality.