### PR TITLE
Add Joinable trait allowing filtering the results of one query with another

### DIFF
--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -512,8 +512,8 @@ where
     }
 }
 
-pub trait WithQueryExt {
-    fn with_query<'world, 'state, Q, F>(
+pub trait Joinable {
+    fn join_with<'world, 'state, Q, F>(
         self,
         query: &'world Query<'world, 'state, Q, F>,
     ) -> WithQuery<'world, 'state, Self, Q, F>
@@ -521,15 +521,16 @@ pub trait WithQueryExt {
         Self: Sized,
         Q: WorldQuery,
         F: WorldQuery;
-    fn with_query_mut<Q, F, CB>(self, query: &mut Query<Q, F>, cb: CB)
+
+    fn join_with_mut<Q, F, CB>(self, query: &mut Query<Q, F>, cb: CB)
     where
         Q: WorldQuery,
         F: WorldQuery,
         CB: FnMut(QueryItem<Q>);
 }
 
-impl<I: Iterator<Item = Entity>> WithQueryExt for I {
-    fn with_query<'w, 's, Q, F>(
+impl<I: Iterator<Item = Entity>> Joinable for I {
+    fn join_with<'w, 's, Q, F>(
         self,
         query: &'w Query<'w, 's, Q, F>,
     ) -> WithQuery<'w, 's, Self, Q, F>
@@ -540,7 +541,7 @@ impl<I: Iterator<Item = Entity>> WithQueryExt for I {
         WithQuery { iter: self, query }
     }
 
-    fn with_query_mut<Q, F, CB>(self, query: &mut Query<Q, F>, mut cb: CB)
+    fn join_with_mut<Q, F, CB>(self, query: &mut Query<Q, F>, mut cb: CB)
     where
         Q: WorldQuery,
         F: WorldQuery,

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -100,7 +100,7 @@ mod tests {
         bundle::Bundles,
         component::{Component, Components},
         entity::{Entities, Entity},
-        query::{Added, Changed, Or, With, Joinable, Without},
+        query::{Added, Changed, Joinable, Or, With, Without},
         schedule::{Schedule, Stage, SystemStage},
         system::{
             Commands, IntoExclusiveSystem, IntoSystem, Local, NonSend, NonSendMut, ParamSet, Query,

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -100,7 +100,7 @@ mod tests {
         bundle::Bundles,
         component::{Component, Components},
         entity::{Entities, Entity},
-        query::{Added, Changed, Or, With, WithQueryExt, Without},
+        query::{Added, Changed, Or, With, Joinable, Without},
         schedule::{Schedule, Stage, SystemStage},
         system::{
             Commands, IntoExclusiveSystem, IntoSystem, Local, NonSend, NonSendMut, ParamSet, Query,
@@ -929,7 +929,7 @@ mod tests {
     #[test]
     fn join_with_query() {
         fn sys(has_a: Query<Entity, With<A>>, has_a_and_b: Query<(&A, &B)>) {
-            assert_eq!(has_a.iter().with_query(&has_a_and_b).count(), 2);
+            assert_eq!(has_a.iter().join_with(&has_a_and_b).count(), 2);
         }
 
         let mut system = IntoSystem::into_system(sys);
@@ -946,7 +946,7 @@ mod tests {
     #[test]
     fn join_with_query_mut() {
         fn sys(has_a: Query<Entity, With<A>>, mut has_w: Query<&mut W<u64>>) {
-            has_a.iter().with_query_mut(&mut has_w, |mut w| {
+            has_a.iter().join_with_mut(&mut has_w, |mut w| {
                 w.0 = 999;
             });
         }


### PR DESCRIPTION
# Objective

There's a bit of boilerplate when using the entities from `Children` to join against a second query.

## Solution

Add a method on `Children` that takes a second query and calls `.get` on it in a loop, skipping entities that have no results in the subquery.

An alternative might be a more general `join` type of function that will subquery anything that is an `Iterator<Item=Entity>` and put that directly on `Query` maybe? Another option might be to add a `Join` at the type level.
