### PR TITLE
[Merged by Bors] - Bump notify to 5.0.0-pre.11

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -32,7 +32,7 @@ crossbeam-channel = "0.5.0"
 anyhow = "1.0.4"
 thiserror = "1.0"
 downcast-rs = "1.2.0"
-notify = { version = "=5.0.0-pre.10", optional = true }
+notify = { version = "=5.0.0-pre.11", optional = true }
 parking_lot = "0.11.0"
 rand = "0.8.0"
 

--- a/crates/bevy_asset/src/filesystem_watcher.rs
+++ b/crates/bevy_asset/src/filesystem_watcher.rs
@@ -12,7 +12,7 @@ pub struct FilesystemWatcher {
 impl Default for FilesystemWatcher {
     fn default() -> Self {
         let (sender, receiver) = crossbeam_channel::unbounded();
-        let watcher: RecommendedWatcher = Watcher::new_immediate(move |res| {
+        let watcher: RecommendedWatcher = RecommendedWatcher::new(move |res| {
             sender.send(res).expect("Watch event send failure.");
         })
         .expect("Failed to create filesystem watcher.");
@@ -22,6 +22,6 @@ impl Default for FilesystemWatcher {
 
 impl FilesystemWatcher {
     pub fn watch<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
-        self.watcher.watch(path, RecursiveMode::Recursive)
+        self.watcher.watch(path.as_ref(), RecursiveMode::Recursive)
     }
 }


### PR DESCRIPTION
# Objective

notify 5.0.0-pre.11 breaks the interface again, but apparently in a way that's similar to how it used to be

## Solution

Bump `bevy_asset` dependency on notify to `5.0.0-pre.11` and fix the errors that crop up.

It looks like `pre.11` was mentioned in #2528 by @mockersf but there's no mention of why `pre.10` was chosen ultimately.
