### PR TITLE
[Merged by Bors] - Remove bevy_dynamic_plugin as a default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ members = ["crates/*", "examples/ios", "tools/ci"]
 [features]
 default = [
   "bevy_audio",
-  "bevy_dynamic_plugin",
   "bevy_gilrs",
   "bevy_gltf",
   "bevy_wgpu",
@@ -38,7 +37,13 @@ default = [
 dynamic = ["bevy_dylib"]
 
 # Rendering support (Also needs the bevy_wgpu feature or a third-party rendering backend)
-render = ["bevy_internal/bevy_pbr", "bevy_internal/bevy_render", "bevy_internal/bevy_sprite", "bevy_internal/bevy_text", "bevy_internal/bevy_ui"]
+render = [
+  "bevy_internal/bevy_pbr",
+  "bevy_internal/bevy_render",
+  "bevy_internal/bevy_sprite",
+  "bevy_internal/bevy_text",
+  "bevy_internal/bevy_ui",
+]
 
 # Optional bevy crates
 bevy_audio = ["bevy_internal/bevy_audio"]
@@ -82,14 +87,14 @@ subpixel_glyph_atlas = ["bevy_internal/subpixel_glyph_atlas"]
 bevy_ci_testing = ["bevy_internal/bevy_ci_testing"]
 
 [dependencies]
-bevy_dylib = {path = "crates/bevy_dylib", version = "0.5.0", default-features = false, optional = true}
-bevy_internal = {path = "crates/bevy_internal", version = "0.5.0", default-features = false}
+bevy_dylib = { path = "crates/bevy_dylib", version = "0.5.0", default-features = false, optional = true }
+bevy_internal = { path = "crates/bevy_internal", version = "0.5.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.4"
 rand = "0.8.0"
 ron = "0.6.2"
-serde = {version = "1", features = ["derive"]}
+serde = { version = "1", features = ["derive"] }
 # Needed to poll Task examples
 futures-lite = "1.11.3"
 

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -5,7 +5,6 @@
 |feature name|description|
 |-|-|
 |bevy_audio|Audio support. Support for all audio formats depends on this.|
-|bevy_dynamic_plugin|Plugin for dynamic loading (libloading).|
 |bevy_gilrs|Adds gamepad support.|
 |bevy_gltf|[glTF](https://www.khronos.org/gltf/) support.|
 |bevy_winit|GUI support.|
@@ -20,6 +19,7 @@
 
 |feature name|description|
 |-|-|
+|bevy_dynamic_plugin|Plugin for dynamic loading (using [libloading](https://crates.io/crates/libloading)).|
 |dynamic|Forces bevy to be dynamically linked, which improves iterative compile times.|
 |trace|Enables system tracing (useful in tandem with a feature like trace_chrome).|
 |trace_chrome|Enables [tracing-chrome](https://github.com/thoren-d/tracing-chrome) as bevy_log output. This allows you to visualize system execution.|


### PR DESCRIPTION
It doesn't compile on wasm, and it's full of footguns

# Objective

- If bevy is used with default features on wasm, there's more of a chance it will compile
- Note that I haven't done a full audit - it's possible that there are other problematic crates

## Solution

- `bevy_dynamic_plugin` is no longer a default plugin
- I've also done an accidental drive by reformatting of the root `Cargo.toml`, as I have [Even Better Toml](https://github.com/tamasfe/taplo) installed.
- (Please, rustfmt do this for us)
