### PR TITLE
[Merged by Bors] - Better error message for unsupported shader features Fixes #869

### DIFF
--- a/crates/bevy_render/src/shader/shader_reflect.rs
+++ b/crates/bevy_render/src/shader/shader_reflect.rs
@@ -151,7 +151,19 @@ fn reflect_binding(
                 filtering: false,
             },
         ),
-        _ => panic!("Unsupported bind type {:?}.", binding.descriptor_type),
+        _ => {
+            let ReflectDescriptorBinding {
+                descriptor_type,
+                name,
+                set,
+                binding,
+                ..
+            } = binding;
+            panic!(
+                "Unsupported shader bind type {:?} (name '{}', set {}, binding {})",
+                descriptor_type, name, set, binding
+            );
+        }
     };
 
     let shader_stage = match shader_stage {


### PR DESCRIPTION
# Objective

- Provides more useful error messages when using unsupported shader features.

## Solution Fixes #869

- Provided a error message as follows (adding name, set and binding): 
```
Unsupported shader bind type CombinedImageSampler (name noiseVol0, set 0, binding 9)
```
