### PR TITLE
[Merged by Bors] - Update EntityMut's location in push_children() and insert_children()

### DIFF
--- a/crates/bevy_transform/src/hierarchy/child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/child_builder.rs
@@ -475,4 +475,11 @@ mod tests {
             PreviousParent(parent)
         );
     }
+
+    #[test]
+    fn regression_push_children() {
+        let mut world = World::new();
+        let child = world.spawn().id();
+        world.spawn().push_children(&[child]);
+    }
 }

--- a/crates/bevy_transform/src/hierarchy/child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/child_builder.rs
@@ -219,7 +219,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
     fn push_children(&mut self, children: &[Entity]) -> &mut Self {
         let parent = self.id();
         {
-            // SAFE: parent entity is not modified
+            // SAFE: parent entity is not modified and its location is updated manually
             let world = unsafe { self.world_mut() };
             for child in children.iter() {
                 world
@@ -227,6 +227,8 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
                     // FIXME: don't erase the previous parent (see #1545)
                     .insert_bundle((Parent(parent), PreviousParent(parent)));
             }
+            // Inserting a bundle in the children entities may change the parent entity's location
+            self.update_location();
         }
         if let Some(mut children_component) = self.get_mut::<Children>() {
             children_component.0.extend(children.iter().cloned());
@@ -239,7 +241,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
     fn insert_children(&mut self, index: usize, children: &[Entity]) -> &mut Self {
         let parent = self.id();
         {
-            // SAFE: parent entity is not modified
+            // SAFE: parent entity is not modified and its location is updated manually
             let world = unsafe { self.world_mut() };
             for child in children.iter() {
                 world
@@ -247,6 +249,8 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
                     // FIXME: don't erase the previous parent (see #1545)
                     .insert_bundle((Parent(parent), PreviousParent(parent)));
             }
+            // Inserting a bundle in the children entities may change the parent entity's location
+            self.update_location();
         }
 
         if let Some(mut children_component) = self.get_mut::<Children>() {

--- a/crates/bevy_transform/src/hierarchy/child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/child_builder.rs
@@ -227,7 +227,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
                     // FIXME: don't erase the previous parent (see #1545)
                     .insert_bundle((Parent(parent), PreviousParent(parent)));
             }
-            // Inserting a bundle in the children entities may change the parent entity's location
+            // Inserting a bundle in the children entities may change the parent entity's location if they were of the same archetype
             self.update_location();
         }
         if let Some(mut children_component) = self.get_mut::<Children>() {
@@ -249,7 +249,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
                     // FIXME: don't erase the previous parent (see #1545)
                     .insert_bundle((Parent(parent), PreviousParent(parent)));
             }
-            // Inserting a bundle in the children entities may change the parent entity's location
+            // Inserting a bundle in the children entities may change the parent entity's location if they were of the same archetype
             self.update_location();
         }
 
@@ -477,7 +477,7 @@ mod tests {
     }
 
     #[test]
-    fn regression_push_children() {
+    fn regression_push_children_same_archetype() {
         let mut world = World::new();
         let child = world.spawn().id();
         world.spawn().push_children(&[child]);


### PR DESCRIPTION
## Objective

This code would result in a crash:
```rust
use bevy::prelude::*;

fn main() {
    let mut world = World::new();
    let child = world.spawn().id();
    world.spawn().push_children(&[child]);
}
```

## Solution

Update the `EntityMut`'s location after inserting a component on the children entities, as it may have changed.
