### PR TITLE
[Merged by Bors] - Change definition of `ScheduleRunnerPlugin`

### DIFF
--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -48,7 +48,7 @@ impl ScheduleRunnerSettings {
 /// Configures an App to run its [Schedule](bevy_ecs::schedule::Schedule) according to a given
 /// [RunMode]
 #[derive(Default)]
-pub struct ScheduleRunnerPlugin {}
+pub struct ScheduleRunnerPlugin;
 
 impl Plugin for ScheduleRunnerPlugin {
     fn build(&self, app: &mut App) {


### PR DESCRIPTION
# Objective

- Allow `ScheduleRunnerPlugin` to be instantiated without curly braces. Other plugins in the library already use the semicolon syntax.
- Currently, you have to do the following:
```rust
App::build()
    .add_plugin(bevy::core::CorePlugin)
    .add_plugin(bevy::app::ScheduleRunnerPlugin {})
```
- With the proposed change you can do this:
```rust
App::build()
    .add_plugin(bevy::core::CorePlugin)
    .add_plugin(bevy::app::ScheduleRunnerPlugin)
```

## Solution

- Change the `ScheduleRunnerPlugin` definition to use a semicolon instead of curly braces.

