### PR TITLE
[Merged by Bors] - Add "ci" job to the bors.toml

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -12,6 +12,7 @@ status = [
     "check-doc",
     "check-missing-examples-in-docs",
     "check-unused-dependencies",
+    "ci",
 ]
 
 use_squash_merge = true


### PR DESCRIPTION
# Objective

- #2551 revamped our CI setup which included running clippy and rustfmt in another Job.
- This new Job wasn't added to the bors.toml, which means that PRs would be accepted that didn't run them.

## Solution

- Add the "ci" job to the bors.toml
