### PR TITLE
[Merged by Bors] - Re-implement Automatic Sprite Sizing

### DIFF
--- a/examples/2d/pipelined_texture_atlas.rs
+++ b/examples/2d/pipelined_texture_atlas.rs
@@ -1,14 +1,14 @@
 use bevy::{
     asset::LoadState,
-    math::{Vec2, Vec3},
+    math::Vec3,
     prelude::{
         App, AssetServer, Assets, Commands, HandleUntyped, IntoSystem, Res, ResMut, State,
         SystemSet, Transform,
     },
     render2::{camera::OrthographicCameraBundle, texture::Image},
     sprite2::{
-        PipelinedSpriteBundle, PipelinedSpriteSheetBundle, Sprite, TextureAtlas,
-        TextureAtlasBuilder, TextureAtlasSprite,
+        PipelinedSpriteBundle, PipelinedSpriteSheetBundle, TextureAtlas, TextureAtlasBuilder,
+        TextureAtlasSprite,
     },
     PipelinedDefaultPlugins,
 };
@@ -87,10 +87,6 @@ fn setup(
     });
     // draw the atlas itself
     commands.spawn_bundle(PipelinedSpriteBundle {
-        sprite: Sprite {
-            size: Vec2::new(512.0, 512.0),
-            ..Default::default()
-        },
         texture: texture_atlas_texture,
         transform: Transform::from_xyz(-300.0, 0.0, 0.0),
         ..Default::default()

--- a/pipelined/bevy_sprite2/src/lib.rs
+++ b/pipelined/bevy_sprite2/src/lib.rs
@@ -23,7 +23,9 @@ pub struct SpritePlugin;
 
 impl Plugin for SpritePlugin {
     fn build(&self, app: &mut App) {
-        app.add_asset::<TextureAtlas>().register_type::<Sprite>();
+        app.add_asset::<TextureAtlas>()
+            .register_type::<Sprite>()
+            .add_system_to_stage(CoreStage::PostUpdate, sprite_auto_resize_system);
         let render_app = app.sub_app_mut(0);
         render_app
             .init_resource::<ExtractedSprites>()

--- a/pipelined/bevy_sprite2/src/sprite.rs
+++ b/pipelined/bevy_sprite2/src/sprite.rs
@@ -1,5 +1,8 @@
+use bevy_asset::{Assets, Handle};
+use bevy_ecs::prelude::{Query, Res};
 use bevy_math::Vec2;
 use bevy_reflect::{Reflect, ReflectDeserialize, TypeUuid};
+use bevy_render2::texture::Image;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Clone, TypeUuid, Reflect)]
@@ -34,6 +37,29 @@ impl Sprite {
             resize_mode: SpriteResizeMode::Manual,
             flip_x: false,
             flip_y: false,
+        }
+    }
+}
+
+/// System that resizes sprites that have their resize mode set to automatic
+pub fn sprite_auto_resize_system(
+    textures: Res<Assets<Image>>,
+    mut query: Query<(&mut Sprite, &Handle<Image>)>,
+) {
+    for (mut sprite, image_handle) in query.iter_mut() {
+        match sprite.resize_mode {
+            SpriteResizeMode::Manual => continue,
+            SpriteResizeMode::Automatic => {
+                if let Some(image) = textures.get(image_handle) {
+                    let extent = image.texture_descriptor.size;
+                    let texture_size = Vec2::new(extent.width as f32, extent.height as f32);
+                    // only set sprite size if it has changed (this check prevents change
+                    // detection from triggering)
+                    if sprite.size != texture_size {
+                        sprite.size = texture_size;
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# Objective

- Prevent the need to specify a sprite size when using the pipelined sprite renderer

## Solution

- Re-introduce the sprite auto resize system from the old renderer
