### PR TITLE
[Merged by Bors] - Added StorageTextureAccess to the exposed wgpu API

### DIFF
--- a/pipelined/bevy_render2/src/render_resource/mod.rs
+++ b/pipelined/bevy_render2/src/render_resource/mod.rs
@@ -25,8 +25,8 @@ pub use wgpu::{
     MultisampleState, Operations, PipelineLayoutDescriptor, PolygonMode, PrimitiveState,
     PrimitiveTopology, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
     RenderPassDescriptor, RenderPipelineDescriptor, SamplerDescriptor, ShaderFlags, ShaderModule,
-    ShaderModuleDescriptor, ShaderSource, ShaderStage, StencilFaceState, StencilState, StorageTextureAccess,
-    TextureAspect, TextureDescriptor, TextureDimension, TextureFormat, TextureSampleType,
-    TextureUsage, TextureViewDescriptor, TextureViewDimension, VertexAttribute, VertexBufferLayout,
-    VertexFormat, VertexState,
+    ShaderModuleDescriptor, ShaderSource, ShaderStage, StencilFaceState, StencilState,
+    StorageTextureAccess, TextureAspect, TextureDescriptor, TextureDimension, TextureFormat,
+    TextureSampleType, TextureUsage, TextureViewDescriptor, TextureViewDimension, VertexAttribute,
+    VertexBufferLayout, VertexFormat, VertexState,
 };

--- a/pipelined/bevy_render2/src/render_resource/mod.rs
+++ b/pipelined/bevy_render2/src/render_resource/mod.rs
@@ -25,7 +25,7 @@ pub use wgpu::{
     MultisampleState, Operations, PipelineLayoutDescriptor, PolygonMode, PrimitiveState,
     PrimitiveTopology, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
     RenderPassDescriptor, RenderPipelineDescriptor, SamplerDescriptor, ShaderFlags, ShaderModule,
-    ShaderModuleDescriptor, ShaderSource, ShaderStage, StencilFaceState, StencilState,
+    ShaderModuleDescriptor, ShaderSource, ShaderStage, StencilFaceState, StencilState, StorageTextureAccess,
     TextureAspect, TextureDescriptor, TextureDimension, TextureFormat, TextureSampleType,
     TextureUsage, TextureViewDescriptor, TextureViewDimension, VertexAttribute, VertexBufferLayout,
     VertexFormat, VertexState,


### PR DESCRIPTION
# Objective
This fixes not having access to StorageTextureAccess in the API, which is needed for using storage textures

## Solution
Added it to the use in render_resource module
