### PR TITLE
[Merged by Bors] - Add missing bytemuck feature

### DIFF
--- a/pipelined/bevy_sprite2/Cargo.toml
+++ b/pipelined/bevy_sprite2/Cargo.toml
@@ -29,7 +29,7 @@ bevy_transform = { path = "../../crates/bevy_transform", version = "0.5.0" }
 bevy_utils = { path = "../../crates/bevy_utils", version = "0.5.0" }
 
 # other
-bytemuck = "1.5"
+bytemuck = { version = "1.5", features = ["derive"] }
 guillotiere = "0.6.0"
 thiserror = "1.0"
 rectangle-pack = "0.4"


### PR DESCRIPTION
# Objective

- Allow you to compile Bevy with the `bevy_sprite2` feature, but without the `bevy_pbr2` feature.
  - This currently fails because the `bevy_sprite2` crate does not require the `derive` feature of the `bytemuck` crate in its `Cargo.toml`, even though it is required to compile.

## Solution

- Add the `derive` feature of `bytemuck` to the `bevy_sprite2` crate
