### PR TITLE
add support for non-'a lifetimes when deriving SystemParam

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -363,16 +363,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
     let generics = ast.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
-    let lifetime_generics: Vec<_> = generics
-        .params
-        .iter()
-        .map(|g| match g {
-            GenericParam::Lifetime(l) => Some(l),
-            _ => None,
-        })
-        .flatten()
-        .map(|l| &l.lifetime)
-        .collect();
+    let lifetime_generics: Vec<_> = generics.lifetimes().map(|l| &l.lifetime).collect();
 
     let impl_generics_as_generics = {
         let tmp = TokenStream::from(quote!(#impl_generics));

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -385,7 +385,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                 lifetime,
             )
         }
-        [lifetime_generic] => (impl_generics_as_generics, lifetime_generic.clone()),
+        [lifetime_generic] => (impl_generics_as_generics, Lifetime::clone(lifetime_generic)),
         _ => panic!("at most one lifetime is supported for derived SystemParam"),
     };
 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -370,8 +370,8 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
         parse_macro_input!(tmp as Generics)
     };
 
-    let (lifetime_impl_generics, lifetime_generic) = match lifetime_generics.len() {
-        0 => {
+    let (lifetime_impl_generics, lifetime_generic) = match lifetime_generics.as_slice() {
+        [] => {
             let lifetime = Lifetime::new("'a", Span::mixed_site());
             (
                 Generics {
@@ -385,7 +385,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                 lifetime,
             )
         }
-        1 => (impl_generics_as_generics, lifetime_generics[0].clone()),
+        [lifetime_generic] => (impl_generics_as_generics, lifetime_generic.clone()),
         _ => panic!("at most one lifetime is supported for derived SystemParam"),
     };
 


### PR DESCRIPTION
# Objective

Fixes #2587 

## Solution

Check if the struct definition contains a lifetime. If it does, use that instead of `'a`.
