### PR TITLE
[Merged by Bors] - Implement Clone for Fetches

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -137,16 +137,9 @@ impl WorldQuery for Entity {
 }
 
 /// The [`Fetch`] of [`Entity`].
+#[derive(Clone)]
 pub struct EntityFetch {
     entities: *const Entity,
-}
-
-impl Clone for EntityFetch {
-    fn clone(&self) -> Self {
-        Self {
-            entities: self.entities,
-        }
-    }
 }
 
 /// SAFETY: access is read only
@@ -586,6 +579,15 @@ pub struct OptionFetch<T> {
     matches: bool,
 }
 
+impl<T: Clone> Clone for OptionFetch<T> {
+    fn clone(&self) -> Self {
+        Self {
+            fetch: self.fetch.clone(),
+            matches: self.matches
+        }
+    }
+}
+
 /// SAFETY: OptionFetch is read only because T is read only
 unsafe impl<T: ReadOnlyFetch> ReadOnlyFetch for OptionFetch<T> {}
 
@@ -804,6 +806,7 @@ unsafe impl<T: Component> FetchState for ChangeTrackersState<T> {
 }
 
 /// The [`Fetch`] of [`ChangeTrackers`].
+#[derive(Clone)]
 pub struct ChangeTrackersFetch<T> {
     storage_type: StorageType,
     table_ticks: *const ComponentTicks,

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -798,7 +798,6 @@ unsafe impl<T: Component> FetchState for ChangeTrackersState<T> {
 }
 
 /// The [`Fetch`] of [`ChangeTrackers`].
-#[derive(Clone)]
 pub struct ChangeTrackersFetch<T> {
     storage_type: StorageType,
     table_ticks: *const ComponentTicks,
@@ -808,6 +807,21 @@ pub struct ChangeTrackersFetch<T> {
     marker: PhantomData<T>,
     last_change_tick: u32,
     change_tick: u32,
+}
+
+impl<T> Clone for ChangeTrackersFetch<T> {
+    fn clone(&self) -> Self {
+        Self {
+            storage_type: self.storage_type,
+            table_ticks: self.table_ticks,
+            entity_table_rows: self.entity_table_rows,
+            entities: self.entities,
+            sparse_set: self.sparse_set,
+            marker: self.marker,
+            last_change_tick: self.last_change_tick,
+            change_tick: self.change_tick,
+        }
+    }
 }
 
 /// SAFETY: access is read only

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -141,6 +141,14 @@ pub struct EntityFetch {
     entities: *const Entity,
 }
 
+impl Clone for EntityFetch {
+    fn clone(&self) -> Self {
+        Self {
+            entities: self.entities,
+        }
+    }
+}
+
 /// SAFETY: access is read only
 unsafe impl ReadOnlyFetch for EntityFetch {}
 

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -574,18 +574,10 @@ impl<T: WorldQuery> WorldQuery for Option<T> {
 }
 
 /// The [`Fetch`] of `Option<T>`.
+#[derive(Clone)]
 pub struct OptionFetch<T> {
     fetch: T,
     matches: bool,
-}
-
-impl<T: Clone> Clone for OptionFetch<T> {
-    fn clone(&self) -> Self {
-        Self {
-            fetch: self.fetch.clone(),
-            matches: self.matches
-        }
-    }
 }
 
 /// SAFETY: OptionFetch is read only because T is read only


### PR DESCRIPTION
# Objective

This:

```rust
use bevy::prelude::*;

fn main() {
    App::new()
    .add_system(test)
    .run();
}

fn test(entities: Query<Entity>) {
    let mut combinations = entities.iter_combinations_mut();
    while let Some([e1, e2]) = combinations.fetch_next() {    
        dbg!(e1);
    }
}
```

fails with the message "the trait bound `bevy::ecs::query::EntityFetch: std::clone::Clone` is not satisfied". 


## Solution

It works after adding the naive clone implementation to EntityFetch. I'm not super familiar with ECS internals, so I'd appreciate input on this.