### PR TITLE
detailed description for Query::par_for_each and Query::par_for_each_mut

### DIFF
--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -298,10 +298,20 @@ where
         };
     }
 
-    /// Runs `f` on each query result in parallel using the given task pool.
-    ///
+    /// Runs `f` on each query result in parallel using the given [`TaskPool`].
+    /// 
     /// This can only be called for read-only queries, see [`Self::par_for_each_mut`] for
     /// write-queries.
+    ///
+    ///# Arguments
+    ///
+    ///* `task_pool` - The [`TaskPool`] to use
+    ///* `batch_size` - The items in the query get sorted into batches. 
+    /// Internally, this function spawns a group of futures that each take on a `batch_size` sized section of the items (or less if the division is not perfect). 
+    /// You can use this value to tune between maximum multithreading ability (many small batches) and minimum parallelization overhead (few, big batches). 
+    /// Generally speaking: If the function body is (mostly) computationally expensive but there are not many items, a small batch size (=more batches) may help to even out the load. 
+    /// If the body is computationally cheap and you have many items, a large batch size (=fewer batches) avoids spawning additional futures that dont help to even out the load.
+    ///* `f` - the function to run on each item in the query
     #[inline]
     pub fn par_for_each(
         &'s self,
@@ -325,7 +335,8 @@ where
         };
     }
 
-    /// Runs `f` on each query result in parallel using the given task pool.
+    /// Runs `f` on each query result in parallel using the given [`TaskPool`].
+    /// See [`Self::par_for_each`] for more details.
     #[inline]
     pub fn par_for_each_mut<'a>(
         &'a mut self,


### PR DESCRIPTION


# Objective

- Better documentation for parallel for each methods, especially as they are an entrypoint to the complex inner workings of bevy. Batch_size is not meaningful until 

## Solution

- added documentation
