### PR TITLE
[Merged by Bors] - Use Explicit Names for Flex Direction

### DIFF
--- a/crates/bevy_ui/src/flex/convert.rs
+++ b/crates/bevy_ui/src/flex/convert.rs
@@ -114,8 +114,8 @@ impl From<Direction> for stretch::style::Direction {
     fn from(value: Direction) -> Self {
         match value {
             Direction::Inherit => stretch::style::Direction::Inherit,
-            Direction::Ltr => stretch::style::Direction::LTR,
-            Direction::Rtl => stretch::style::Direction::RTL,
+            Direction::LeftToRight => stretch::style::Direction::LTR,
+            Direction::RightToLeft => stretch::style::Direction::RTL,
         }
     }
 }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -155,8 +155,8 @@ impl Default for AlignContent {
 #[reflect_value(PartialEq, Serialize, Deserialize)]
 pub enum Direction {
     Inherit,
-    Ltr,
-    Rtl,
+    LeftToRight,
+    RightToLeft,
 }
 
 impl Default for Direction {


### PR DESCRIPTION
# Objective

- Clarify vague meaning of "Ltr" and "Rtl". For someone familiar with Flex Box, this is easy to understand, but being more explicit will help beginners or those unfamiliar, without the need to do research.

## Solution

- Change three letter abbreviation to fully descriptive name.
