### PR TITLE
Add ability to check for changes that originated in the same system last time it ran

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -347,11 +347,23 @@ impl ComponentTicks {
     }
 
     #[inline]
+    /// Returns true if (and only if) this data been changed since the last execution of this
+    /// system.
     pub fn is_changed(&self, last_change_tick: u32, change_tick: u32) -> bool {
         let component_delta = change_tick.wrapping_sub(self.changed);
         let system_delta = change_tick.wrapping_sub(last_change_tick);
 
         component_delta < system_delta
+    }
+
+    #[inline]
+    /// Returns true if (and only if) this data been changed since the last execution of this
+    /// system or by the system itself the last time it ran.
+    pub fn is_changed_inclusive(&self, last_change_tick: u32, change_tick: u32) -> bool {
+        let component_delta = change_tick.wrapping_sub(self.changed);
+        let system_delta = change_tick.wrapping_sub(last_change_tick);
+
+        component_delta <= system_delta
     }
 
     pub(crate) fn new(change_tick: u32) -> Self {

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -660,3 +660,36 @@ impl_tick_filter!(
     ChangedFetch,
     ComponentTicks::is_changed
 );
+
+impl_tick_filter!(
+    /// Filter that retrieves components of type `T` that have been changed since the last
+    /// execution of this system, or by the system itself last time it ran.
+    ///
+    /// [`Changed`] should be your default: this can cause your system
+    /// to continually detect changes and then alter data each time that it runs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::system::IntoSystem;
+    /// # use bevy_ecs::system::Query;
+    /// # use bevy_ecs::query::ChangedInclusive;
+    /// #
+    ///
+    /// struct Counter(u32);
+    ///
+    /// fn never_stop_counting_system(mut query: Query<&mut Counter, ChangedInclusive<Counter>>) {
+    ///     for mut counter in query.iter_mut() {
+    ///         counter.0 += 1;
+    ///     }
+    /// }
+    ///
+    /// # never_stop_counting_system.system();
+    /// ```
+    ChangedInclusive,
+    /// The [`FetchState`] of [`Changed`].
+    ChangedInclusiveState,
+    /// The [`Fetch`] of [`Changed`].
+    ChangedInclusiveFetch,
+    ComponentTicks::is_changed_inclusive
+);

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -239,6 +239,13 @@ impl<'w, T: Component> Res<'w, T> {
             .is_changed(self.last_change_tick, self.change_tick)
     }
 
+    /// Returns true if (and only if) this resource been changed since the last execution of this
+    /// system or by the system itself the last time it ran.
+    pub fn is_changed_inclusive(&self) -> bool {
+        self.ticks
+            .is_changed_inclusive(self.last_change_tick, self.change_tick)
+    }
+
     pub fn into_inner(self) -> &'w T {
         self.value
     }


### PR DESCRIPTION
# Objective

- Occasionally, users prefer to detect changes that originated in the same system last time it ran.
- This can be useful for some niche use cases, such as triggering run-away-reaction behavior.
- The existing workarounds involve creating several tightly interlocked systems in ugly and hard-to-maintain ways.

## Solution

- Created `ChangedInclusive` query filter and `is_changed_inclusive` methods for components and resources, which has the desired alternate behavior.
- This should not be the default behavior: the self-triggering nature of this check is surprising, breaking and will tend to lead to changes being responded to repeatedly when the user only intends to respond once.