### PR TITLE
[Merged by Bors] - feat: remove_component for ReflectComponent

### DIFF
--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -10,6 +10,7 @@ use bevy_reflect::{impl_reflect_value, FromType, Reflect, ReflectDeserialize};
 pub struct ReflectComponent {
     add_component: fn(&mut World, Entity, &dyn Reflect),
     apply_component: fn(&mut World, Entity, &dyn Reflect),
+    remove_component: fn(&mut World, Entity),
     reflect_component: fn(&World, Entity) -> Option<&dyn Reflect>,
     reflect_component_mut: unsafe fn(&World, Entity) -> Option<ReflectMut>,
     copy_component: fn(&World, &mut World, Entity, Entity),
@@ -22,6 +23,10 @@ impl ReflectComponent {
 
     pub fn apply_component(&self, world: &mut World, entity: Entity, component: &dyn Reflect) {
         (self.apply_component)(world, entity, component);
+    }
+
+    pub fn remove_component(&self, world: &mut World, entity: Entity) {
+        (self.remove_component)(world, entity);
     }
 
     pub fn reflect_component<'a>(
@@ -82,6 +87,9 @@ impl<C: Component + Reflect + FromWorld> FromType<C> for ReflectComponent {
             apply_component: |world, entity, reflected_component| {
                 let mut component = world.get_mut::<C>(entity).unwrap();
                 component.apply(reflected_component);
+            },
+            remove_component: |world, entity| {
+                world.entity_mut(entity).remove::<C>();
             },
             copy_component: |source_world, destination_world, source_entity, destination_entity| {
                 let source_component = source_world.get::<C>(source_entity).unwrap();


### PR DESCRIPTION
# Objective

While implementing a plugin for my rollback networking library, I needed to load/save parts of the world. For this, I made a WorldSnapshot that works quite like the current DynamicScene. Using a TypeRegistry to register component types I want to save/load and then using ReflectComponents methods to add or apply components of the given types. 

However, I noticed there is no method to remove components from entities through the ReflectComponent.

## Solution

I added a `remove_component` field to the `ReflectComponent` struct, as well as a `pub fn remove_component(&self, world: &mut World, entity: Entity)` to call that function in `remove_component`. This follows exactly the same pattern all other methods/fields in this struct look like.

This is an example how it could be used (at least how I would use it):
https://github.com/gschup/bevy_ggrs/blob/6c003f86f1993bcbb21c180fab2e8ef664b7f7c9/src/world_snapshot.rs#L133
