### PR TITLE
Discrete timer and stopwatch

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -15,7 +15,8 @@ pub use time::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        DefaultTaskPoolOptions, DiscreteTimer, EntityLabels, Labels, Name, Time, Timer,
+        DefaultTaskPoolOptions, DiscreteTimer, DurationTimer, EntityLabels, Labels, Name, Time,
+        Timer,
     };
 }
 
@@ -57,7 +58,7 @@ impl Plugin for CorePlugin {
             .register_type::<Name>()
             .register_type::<Labels>()
             .register_type::<Range<f32>>()
-            .register_type::<Timer>()
+            .register_type::<DurationTimer>()
             // time system is added as an "exclusive system" to ensure it runs before other systems
             // in CoreStage::First
             .add_system_to_stage(

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -14,7 +14,9 @@ pub use time::*;
 
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{DefaultTaskPoolOptions, EntityLabels, Labels, Name, Time, Timer};
+    pub use crate::{
+        DefaultTaskPoolOptions, DiscreteTimer, EntityLabels, Labels, Name, Time, Timer,
+    };
 }
 
 use bevy_app::prelude::*;

--- a/crates/bevy_core/src/time/stopwatch.rs
+++ b/crates/bevy_core/src/time/stopwatch.rs
@@ -14,7 +14,7 @@ pub trait Stopwatch: Default {
     /// # Examples
     /// ```
     /// # use bevy_core::*;
-    /// let stopwatch = Stopwatch::new();
+    /// let stopwatch = DurationStopwatch::new();
     /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
     /// assert_eq!(stopwatch.paused(), false);
     /// ```
@@ -29,7 +29,7 @@ pub trait Stopwatch: Default {
     /// ```
     /// # use bevy_core::*;
     /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
+    /// let mut stopwatch = DurationStopwatch::new();
     /// stopwatch.tick(Duration::from_secs(1));
     /// assert_eq!(stopwatch.elapsed(), Duration::from_secs(1));
     /// ```
@@ -41,7 +41,7 @@ pub trait Stopwatch: Default {
     /// ```
     /// # use bevy_core::*;
     /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
+    /// let mut stopwatch = DurationStopwatch::new();
     /// stopwatch.set_elapsed(Duration::from_secs_f32(1.0));
     /// assert_eq!(stopwatch.elapsed_secs(), 1.0);
     /// ```
@@ -55,7 +55,7 @@ pub trait Stopwatch: Default {
     /// ```
     /// # use bevy_core::*;
     /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
+    /// let mut stopwatch = DurationStopwatch::new();
     /// stopwatch.tick(Duration::from_secs_f32(1.5));
     /// assert_eq!(stopwatch.elapsed_secs(), 1.5);
     /// ```
@@ -73,7 +73,7 @@ pub trait Stopwatch: Default {
     /// ```
     /// # use bevy_core::*;
     /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
+    /// let mut stopwatch = DurationStopwatch::new();
     /// stopwatch.pause();
     /// stopwatch.tick(Duration::from_secs_f32(1.5));
     /// assert!(stopwatch.paused());
@@ -87,7 +87,7 @@ pub trait Stopwatch: Default {
     /// ```
     /// # use bevy_core::*;
     /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
+    /// let mut stopwatch = DurationStopwatch::new();
     /// stopwatch.pause();
     /// stopwatch.tick(Duration::from_secs_f32(1.0));
     /// stopwatch.unpause();
@@ -102,7 +102,7 @@ pub trait Stopwatch: Default {
     /// # Examples
     /// ```
     /// # use bevy_core::*;
-    /// let mut stopwatch = Stopwatch::new();
+    /// let mut stopwatch = DurationStopwatch::new();
     /// assert!(!stopwatch.paused());
     /// stopwatch.pause();
     /// assert!(stopwatch.paused());
@@ -117,7 +117,7 @@ pub trait Stopwatch: Default {
     /// ```
     /// # use bevy_core::*;
     /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
+    /// let mut stopwatch = DurationStopwatch::new();
     /// stopwatch.tick(Duration::from_secs_f32(1.5));
     /// stopwatch.reset();
     /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
@@ -128,14 +128,14 @@ pub trait Stopwatch: Default {
     }
 }
 
-/// A Stopwatch is a struct that track elapsed time when started.
+/// A Stopwatch is a struct that tracks elapsed time when started.
 ///
 /// # Examples
 ///
 /// ```
 /// # use bevy_core::*;
 /// use std::time::Duration;
-/// let mut stopwatch = Stopwatch::new();
+/// let mut stopwatch = DurationStopwatch::new();
 /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
 ///
 /// stopwatch.tick(Duration::from_secs_f32(1.0)); // tick one second

--- a/crates/bevy_core/src/time/stopwatch.rs
+++ b/crates/bevy_core/src/time/stopwatch.rs
@@ -169,3 +169,160 @@ impl Stopwatch {
         self.elapsed = Default::default();
     }
 }
+
+/// A DiscreteStopwatch is a struct that tracks the number of times it has been incremented when started.
+///
+/// # Examples
+///
+/// ```
+/// # use bevy_core::*;
+/// let mut stopwatch = DiscreteStopwatch::new();
+/// assert_eq!(stopwatch.elapsed(), 0);
+///
+/// stopwatch.tick(1); // tick once
+/// assert_eq!(stopwatch.elapsed(), 1);
+///
+/// stopwatch.pause();
+/// stopwatch.tick(1); // paused stopwatches don't tick
+/// assert_eq!(stopwatch.elapsed(), 1);
+///
+/// stopwatch.reset(); // reset the stopwatch
+/// assert!(stopwatch.paused());
+/// assert_eq!(stopwatch.elapsed(), 0);
+/// ```
+#[derive(Clone, Debug, Default, Reflect)]
+#[reflect(Component)]
+pub struct DiscreteStopwatch {
+    elapsed: u64,
+    paused: bool,
+}
+
+impl DiscreteStopwatch {
+    /// Create a new unpaused `Stopwatch` with no elapsed increments.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let stopwatch = DiscreteStopwatch::new();
+    /// assert_eq!(stopwatch.elapsed(), 0);
+    /// assert_eq!(stopwatch.paused(), false);
+    /// ```
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Returns the elapsed increments since the last [`reset`](DiscreteStopwatch::reset)
+    /// of the stopwatch.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// use std::time::Duration;
+    /// let mut stopwatch = DiscreteStopwatch::new();
+    /// stopwatch.tick(1);
+    /// assert_eq!(stopwatch.elapsed(), 1);
+    /// ```
+    #[inline]
+    pub fn elapsed(&self) -> u64 {
+        self.elapsed
+    }
+
+    /// Sets the elapsed time of the stopwatch.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut stopwatch = DiscreteStopwatch::new();
+    /// stopwatch.set_elapsed(1);
+    /// assert_eq!(stopwatch.elapsed(), 1);
+    /// ```
+    #[inline]
+    pub fn set_elapsed(&mut self, time: u64) {
+        self.elapsed = time;
+    }
+
+    /// Advance the stopwatch by `delta` increments.
+    /// If the stopwatch is paused, ticking will not have any effect
+    /// on elapsed time.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut stopwatch = DiscreteStopwatch::new();
+    /// stopwatch.tick(3);
+    /// assert_eq!(stopwatch.elapsed(), 3);
+    /// ```
+    pub fn tick(&mut self, delta: u64) -> &Self {
+        if !self.paused() {
+            self.elapsed += delta;
+        }
+        self
+    }
+
+    /// Pauses the stopwatch. Any call to [`tick`](Stopwatch::tick) while
+    /// paused will not have any effect on the elapsed time.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut stopwatch = DiscreteStopwatch::new();
+    /// stopwatch.pause();
+    /// stopwatch.tick(2);
+    /// assert!(stopwatch.paused());
+    /// assert_eq!(stopwatch.elapsed(), 0);
+    /// ```
+    #[inline]
+    pub fn pause(&mut self) {
+        self.paused = true;
+    }
+
+    /// Unpauses the stopwatch. Resume the effect of ticking on elapsed time.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut stopwatch = DiscreteStopwatch::new();
+    /// stopwatch.pause();
+    /// stopwatch.tick(1);
+    /// stopwatch.unpause();
+    /// stopwatch.tick(1);
+    /// assert!(!stopwatch.paused());
+    /// assert_eq!(stopwatch.elapsed(), 1);
+    /// ```
+    #[inline]
+    pub fn unpause(&mut self) {
+        self.paused = false;
+    }
+
+    /// Returns `true` if the stopwatch is paused.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut stopwatch = DiscreteStopwatch::new();
+    /// assert!(!stopwatch.paused());
+    /// stopwatch.pause();
+    /// assert!(stopwatch.paused());
+    /// stopwatch.unpause();
+    /// assert!(!stopwatch.paused());
+    /// ```
+    #[inline]
+    pub fn paused(&self) -> bool {
+        self.paused
+    }
+
+    /// Resets the stopwatch.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut stopwatch = DiscreteStopwatch::new();
+    /// stopwatch.tick(3);
+    /// stopwatch.reset();
+    /// assert_eq!(stopwatch.elapsed(), 0);
+    /// ```
+    #[inline]
+    pub fn reset(&mut self) {
+        self.elapsed = 0;
+    }
+}

--- a/crates/bevy_core/src/time/stopwatch.rs
+++ b/crates/bevy_core/src/time/stopwatch.rs
@@ -1,6 +1,132 @@
+use std::ops::Add;
+
 use bevy_ecs::reflect::ReflectComponent;
 use bevy_reflect::Reflect;
 use bevy_utils::Duration;
+
+/// The `Stopwatch` trait enables counting-up behavior to track the passage of time.
+pub trait Stopwatch: Default {
+    /// The unit by which elapsed time is measured
+    type TimeUnit: Default + Add<Output = Self::TimeUnit>;
+
+    /// Create a new unpaused `Stopwatch` object with no elapsed time.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let stopwatch = Stopwatch::new();
+    /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
+    /// assert_eq!(stopwatch.paused(), false);
+    /// ```
+    fn new() -> Self {
+        Default::default()
+    }
+
+    /// Returns the elapsed time since the last [`reset`](Stopwatch::reset)
+    /// of the stopwatch.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// use std::time::Duration;
+    /// let mut stopwatch = Stopwatch::new();
+    /// stopwatch.tick(Duration::from_secs(1));
+    /// assert_eq!(stopwatch.elapsed(), Duration::from_secs(1));
+    /// ```
+    fn elapsed(&self) -> Self::TimeUnit;
+
+    /// Sets the elapsed time of the stopwatch.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// use std::time::Duration;
+    /// let mut stopwatch = Stopwatch::new();
+    /// stopwatch.set_elapsed(Duration::from_secs_f32(1.0));
+    /// assert_eq!(stopwatch.elapsed_secs(), 1.0);
+    /// ```
+    fn set_elapsed(&mut self, time: Self::TimeUnit);
+
+    /// Advance the stopwatch by `delta` units.
+    /// If the stopwatch is paused, ticking will not have any effect
+    /// on elapsed time.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// use std::time::Duration;
+    /// let mut stopwatch = Stopwatch::new();
+    /// stopwatch.tick(Duration::from_secs_f32(1.5));
+    /// assert_eq!(stopwatch.elapsed_secs(), 1.5);
+    /// ```
+    fn tick(&mut self, delta: Self::TimeUnit) -> &Self {
+        if !self.paused() {
+            self.set_elapsed(self.elapsed() + delta);
+        }
+        self
+    }
+
+    /// Pauses the stopwatch. Any call to [`tick`](Stopwatch::tick) while
+    /// paused will not have any effect on the elapsed time.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// use std::time::Duration;
+    /// let mut stopwatch = Stopwatch::new();
+    /// stopwatch.pause();
+    /// stopwatch.tick(Duration::from_secs_f32(1.5));
+    /// assert!(stopwatch.paused());
+    /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
+    /// ```
+    fn pause(&mut self);
+
+    /// Unpauses the stopwatch. Resume the effect of ticking on elapsed time.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// use std::time::Duration;
+    /// let mut stopwatch = Stopwatch::new();
+    /// stopwatch.pause();
+    /// stopwatch.tick(Duration::from_secs_f32(1.0));
+    /// stopwatch.unpause();
+    /// stopwatch.tick(Duration::from_secs_f32(1.0));
+    /// assert!(!stopwatch.paused());
+    /// assert_eq!(stopwatch.elapsed_secs(), 1.0);
+    /// ```
+    fn unpause(&mut self);
+
+    /// Returns `true` if the stopwatch is paused.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut stopwatch = Stopwatch::new();
+    /// assert!(!stopwatch.paused());
+    /// stopwatch.pause();
+    /// assert!(stopwatch.paused());
+    /// stopwatch.unpause();
+    /// assert!(!stopwatch.paused());
+    /// ```
+    fn paused(&self) -> bool;
+
+    /// Resets the stopwatch.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// use std::time::Duration;
+    /// let mut stopwatch = Stopwatch::new();
+    /// stopwatch.tick(Duration::from_secs_f32(1.5));
+    /// stopwatch.reset();
+    /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
+    /// ```
+    #[inline]
+    fn reset(&mut self) {
+        self.set_elapsed(Self::TimeUnit::default());
+    }
+}
 
 /// A Stopwatch is a struct that track elapsed time when started.
 ///
@@ -25,148 +151,44 @@ use bevy_utils::Duration;
 /// ```
 #[derive(Clone, Debug, Default, Reflect)]
 #[reflect(Component)]
-pub struct Stopwatch {
+pub struct DurationStopwatch {
     elapsed: Duration,
     paused: bool,
 }
 
-impl Stopwatch {
-    /// Create a new unpaused `Stopwatch` with no elapsed time.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let stopwatch = Stopwatch::new();
-    /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
-    /// assert_eq!(stopwatch.paused(), false);
-    /// ```
-    pub fn new() -> Self {
-        Default::default()
-    }
+impl Stopwatch for DurationStopwatch {
+    type TimeUnit = Duration;
 
-    /// Returns the elapsed time since the last [`reset`](Stopwatch::reset)
-    /// of the stopwatch.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
-    /// stopwatch.tick(Duration::from_secs(1));
-    /// assert_eq!(stopwatch.elapsed(), Duration::from_secs(1));
-    /// ```
     #[inline]
-    pub fn elapsed(&self) -> Duration {
+    fn elapsed(&self) -> Self::TimeUnit {
         self.elapsed
     }
 
     #[inline]
-    pub fn elapsed_secs(&self) -> f32 {
-        self.elapsed().as_secs_f32()
-    }
-
-    /// Sets the elapsed time of the stopwatch.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
-    /// stopwatch.set_elapsed(Duration::from_secs_f32(1.0));
-    /// assert_eq!(stopwatch.elapsed_secs(), 1.0);
-    /// ```
-    #[inline]
-    pub fn set_elapsed(&mut self, time: Duration) {
+    fn set_elapsed(&mut self, time: Self::TimeUnit) {
         self.elapsed = time;
     }
 
-    /// Advance the stopwatch by `delta` seconds.
-    /// If the stopwatch is paused, ticking will not have any effect
-    /// on elapsed time.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
-    /// stopwatch.tick(Duration::from_secs_f32(1.5));
-    /// assert_eq!(stopwatch.elapsed_secs(), 1.5);
-    /// ```
-    pub fn tick(&mut self, delta: Duration) -> &Self {
-        if !self.paused() {
-            self.elapsed += delta;
-        }
-        self
-    }
-
-    /// Pauses the stopwatch. Any call to [`tick`](Stopwatch::tick) while
-    /// paused will not have any effect on the elapsed time.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
-    /// stopwatch.pause();
-    /// stopwatch.tick(Duration::from_secs_f32(1.5));
-    /// assert!(stopwatch.paused());
-    /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
-    /// ```
     #[inline]
-    pub fn pause(&mut self) {
+    fn pause(&mut self) {
         self.paused = true;
     }
 
-    /// Unpauses the stopwatch. Resume the effect of ticking on elapsed time.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
-    /// stopwatch.pause();
-    /// stopwatch.tick(Duration::from_secs_f32(1.0));
-    /// stopwatch.unpause();
-    /// stopwatch.tick(Duration::from_secs_f32(1.0));
-    /// assert!(!stopwatch.paused());
-    /// assert_eq!(stopwatch.elapsed_secs(), 1.0);
-    /// ```
     #[inline]
-    pub fn unpause(&mut self) {
+    fn unpause(&mut self) {
         self.paused = false;
     }
 
-    /// Returns `true` if the stopwatch is paused.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut stopwatch = Stopwatch::new();
-    /// assert!(!stopwatch.paused());
-    /// stopwatch.pause();
-    /// assert!(stopwatch.paused());
-    /// stopwatch.unpause();
-    /// assert!(!stopwatch.paused());
-    /// ```
     #[inline]
-    pub fn paused(&self) -> bool {
+    fn paused(&self) -> bool {
         self.paused
     }
+}
 
-    /// Resets the stopwatch.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
-    /// stopwatch.tick(Duration::from_secs_f32(1.5));
-    /// stopwatch.reset();
-    /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
-    /// ```
+impl DurationStopwatch {
     #[inline]
-    pub fn reset(&mut self) {
-        self.elapsed = Default::default();
+    pub fn elapsed_secs(&self) -> f32 {
+        self.elapsed().as_secs_f32()
     }
 }
 
@@ -197,132 +219,31 @@ pub struct DiscreteStopwatch {
     paused: bool,
 }
 
-impl DiscreteStopwatch {
-    /// Create a new unpaused `Stopwatch` with no elapsed increments.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let stopwatch = DiscreteStopwatch::new();
-    /// assert_eq!(stopwatch.elapsed(), 0);
-    /// assert_eq!(stopwatch.paused(), false);
-    /// ```
-    pub fn new() -> Self {
-        Default::default()
-    }
+impl Stopwatch for DiscreteStopwatch {
+    type TimeUnit = u64;
 
-    /// Returns the elapsed increments since the last [`reset`](DiscreteStopwatch::reset)
-    /// of the stopwatch.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// use std::time::Duration;
-    /// let mut stopwatch = DiscreteStopwatch::new();
-    /// stopwatch.tick(1);
-    /// assert_eq!(stopwatch.elapsed(), 1);
-    /// ```
     #[inline]
-    pub fn elapsed(&self) -> u64 {
+    fn elapsed(&self) -> Self::TimeUnit {
         self.elapsed
     }
 
-    /// Sets the elapsed time of the stopwatch.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut stopwatch = DiscreteStopwatch::new();
-    /// stopwatch.set_elapsed(1);
-    /// assert_eq!(stopwatch.elapsed(), 1);
-    /// ```
     #[inline]
-    pub fn set_elapsed(&mut self, time: u64) {
+    fn set_elapsed(&mut self, time: Self::TimeUnit) {
         self.elapsed = time;
     }
 
-    /// Advance the stopwatch by `delta` increments.
-    /// If the stopwatch is paused, ticking will not have any effect
-    /// on elapsed time.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut stopwatch = DiscreteStopwatch::new();
-    /// stopwatch.tick(3);
-    /// assert_eq!(stopwatch.elapsed(), 3);
-    /// ```
-    pub fn tick(&mut self, delta: u64) -> &Self {
-        if !self.paused() {
-            self.elapsed += delta;
-        }
-        self
-    }
-
-    /// Pauses the stopwatch. Any call to [`tick`](Stopwatch::tick) while
-    /// paused will not have any effect on the elapsed time.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut stopwatch = DiscreteStopwatch::new();
-    /// stopwatch.pause();
-    /// stopwatch.tick(2);
-    /// assert!(stopwatch.paused());
-    /// assert_eq!(stopwatch.elapsed(), 0);
-    /// ```
     #[inline]
-    pub fn pause(&mut self) {
+    fn pause(&mut self) {
         self.paused = true;
     }
 
-    /// Unpauses the stopwatch. Resume the effect of ticking on elapsed time.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut stopwatch = DiscreteStopwatch::new();
-    /// stopwatch.pause();
-    /// stopwatch.tick(1);
-    /// stopwatch.unpause();
-    /// stopwatch.tick(1);
-    /// assert!(!stopwatch.paused());
-    /// assert_eq!(stopwatch.elapsed(), 1);
-    /// ```
     #[inline]
-    pub fn unpause(&mut self) {
+    fn unpause(&mut self) {
         self.paused = false;
     }
 
-    /// Returns `true` if the stopwatch is paused.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut stopwatch = DiscreteStopwatch::new();
-    /// assert!(!stopwatch.paused());
-    /// stopwatch.pause();
-    /// assert!(stopwatch.paused());
-    /// stopwatch.unpause();
-    /// assert!(!stopwatch.paused());
-    /// ```
     #[inline]
-    pub fn paused(&self) -> bool {
+    fn paused(&self) -> bool {
         self.paused
-    }
-
-    /// Resets the stopwatch.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut stopwatch = DiscreteStopwatch::new();
-    /// stopwatch.tick(3);
-    /// stopwatch.reset();
-    /// assert_eq!(stopwatch.elapsed(), 0);
-    /// ```
-    #[inline]
-    pub fn reset(&mut self) {
-        self.elapsed = 0;
     }
 }

--- a/crates/bevy_core/src/time/timer.rs
+++ b/crates/bevy_core/src/time/timer.rs
@@ -1,10 +1,12 @@
+use std::ops::Add;
+
 use crate::time::Stopwatch;
 use crate::{DiscreteStopwatch, DurationStopwatch};
 use bevy_ecs::reflect::ReflectComponent;
 use bevy_reflect::Reflect;
 use bevy_utils::Duration;
 
-/// Tracks elapsed time. Enters the finished state once `duration` is reached.
+/// Tracks elapsed time. Enters the finished state once its duration is reached.
 ///
 /// This type is useful for measuring wall-clock time, and can be used to track cooldowns, countdowns and recurring triggers.
 /// Consider using ['DiscreteTimer'] for gameplay events whose interval should decrease in the case of frame-rate drops.
@@ -14,42 +16,13 @@ use bevy_utils::Duration;
 /// exceeded, and can still be reset at any given point.
 ///
 /// Paused timers will not have elapsed time increased.
-#[derive(Clone, Debug, Default, Reflect)]
-#[reflect(Component)]
-pub struct Timer {
-    stopwatch: DurationStopwatch,
-    duration: Duration,
-    repeating: bool,
-    finished: bool,
-    times_finished: u32,
-}
+pub trait Timer {
+    /// The unit by which elapsed time is measured
+    type TimeUnit: Default + Add<Output = Self::TimeUnit> + PartialOrd;
+    type EmbeddedStopwatch: Stopwatch<TimeUnit = Self::TimeUnit>;
 
-impl Timer {
     /// Creates a new timer with a given duration.
-    ///
-    /// See also [`Timer::from_seconds`](Timer::from_seconds).
-    pub fn new(duration: Duration, repeating: bool) -> Self {
-        Self {
-            duration,
-            repeating,
-            ..Default::default()
-        }
-    }
-
-    /// Creates a new timer with a given duration in seconds.
-    ///
-    /// # Example
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = Timer::from_seconds(1.0, false);
-    /// ```
-    pub fn from_seconds(duration: f32, repeating: bool) -> Self {
-        Self {
-            duration: Duration::from_secs_f32(duration),
-            repeating,
-            ..Default::default()
-        }
-    }
+    fn new(duration: Self::TimeUnit, repeating: bool) -> Self;
 
     /// Returns `true` if the timer has reached its duration.
     ///
@@ -57,16 +30,13 @@ impl Timer {
     /// ```
     /// # use bevy_core::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
+    /// let mut timer = DurationTimer::from_seconds(1.0, false);
     /// timer.tick(Duration::from_secs_f32(1.5));
     /// assert!(timer.finished());
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert!(timer.finished());
     /// ```
-    #[inline]
-    pub fn finished(&self) -> bool {
-        self.finished
-    }
+    fn finished(&self) -> bool;
 
     /// Returns `true` only on the tick the timer reached its duration.
     ///
@@ -74,15 +44,15 @@ impl Timer {
     /// ```
     /// # use bevy_core::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
+    /// let mut timer = DurationTimer::from_seconds(1.0, false);
     /// timer.tick(Duration::from_secs_f32(1.5));
     /// assert!(timer.just_finished());
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert!(!timer.just_finished());
     /// ```
     #[inline]
-    pub fn just_finished(&self) -> bool {
-        self.times_finished > 0
+    fn just_finished(&self) -> bool {
+        self.times_finished() > 0
     }
 
     /// Returns the time elapsed on the timer. Guaranteed to be between 0.0 and `duration`.
@@ -94,20 +64,13 @@ impl Timer {
     /// ```
     /// # use bevy_core::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
+    /// let mut timer = DurationTimer::from_seconds(1.0, false);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert_eq!(timer.elapsed(), Duration::from_secs_f32(0.5));
     /// ```
     #[inline]
-    pub fn elapsed(&self) -> Duration {
-        self.stopwatch.elapsed()
-    }
-
-    /// Returns the time elapsed on the timer as a `f32`.
-    /// See also [`Timer::elapsed`](Timer::elapsed).
-    #[inline]
-    pub fn elapsed_secs(&self) -> f32 {
-        self.stopwatch.elapsed_secs()
+    fn elapsed(&self) -> Self::TimeUnit {
+        self.stopwatch().elapsed()
     }
 
     /// Sets the elapsed time of the timer without any other considerations.
@@ -118,15 +81,15 @@ impl Timer {
     /// ```
     /// # use bevy_core::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
-    /// timer.set_elapsed(Duration::from_secs(2.0));
-    /// assert_eq!(timer.elapsed(), Duration::from_secs(2.0));
+    /// let mut timer = DurationTimer::from_seconds(1.0, false);
+    /// timer.set_elapsed(Duration::from_secs(2));
+    /// assert_eq!(timer.elapsed(), Duration::from_secs(2));
     /// // the timer is not finished even if the elapsed time is greater than the duration.
     /// assert!(!timer.finished());
     /// ```
     #[inline]
-    pub fn set_elapsed(&mut self, time: Duration) {
-        self.stopwatch.set_elapsed(time);
+    fn set_elapsed(&mut self, time: Self::TimeUnit) {
+        self.stopwatch_mut().set_elapsed(time);
     }
 
     /// Returns the duration of the timer.
@@ -135,13 +98,10 @@ impl Timer {
     /// ```
     /// # use bevy_core::*;
     /// use std::time::Duration;
-    /// let timer = Timer::new(Duration::from_secs(1), false);
+    /// let timer = DurationTimer::new(Duration::from_secs(1), false);
     /// assert_eq!(timer.duration(), Duration::from_secs(1));
     /// ```
-    #[inline]
-    pub fn duration(&self) -> Duration {
-        self.duration
-    }
+    fn duration(&self) -> Self::TimeUnit;
 
     /// Sets the duration of the timer.
     ///
@@ -149,45 +109,32 @@ impl Timer {
     /// ```
     /// # use bevy_core::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.5, false);
+    /// let mut timer = DurationTimer::from_seconds(1.5, false);
     /// timer.set_duration(Duration::from_secs(1));
     /// assert_eq!(timer.duration(), Duration::from_secs(1));
     /// ```
-    #[inline]
-    pub fn set_duration(&mut self, duration: Duration) {
-        self.duration = duration;
-    }
+    fn set_duration(&mut self, duration: Self::TimeUnit);
 
     /// Returns `true` if the timer is repeating.
     ///
     /// # Examples
     /// ```
     /// # use bevy_core::*;
-    /// let mut timer = Timer::from_seconds(1.0, true);
+    /// let mut timer = DurationTimer::from_seconds(1.0, true);
     /// assert!(timer.repeating());
     /// ```
-    #[inline]
-    pub fn repeating(&self) -> bool {
-        self.repeating
-    }
+    fn repeating(&self) -> bool;
 
     /// Sets whether the timer is repeating or not.
     ///
     /// # Examples
     /// ```
     /// # use bevy_core::*;
-    /// let mut timer = Timer::from_seconds(1.0, true);
+    /// let mut timer = DurationTimer::from_seconds(1.0, true);
     /// timer.set_repeating(false);
     /// assert!(!timer.repeating());
     /// ```
-    #[inline]
-    pub fn set_repeating(&mut self, repeating: bool) {
-        if !self.repeating && repeating && self.finished {
-            self.stopwatch.reset();
-            self.finished = self.just_finished();
-        }
-        self.repeating = repeating
-    }
+    fn set_repeating(&mut self, repeating: bool);
 
     /// Advance the timer by `delta` seconds.
     /// Non repeating timer will clamp at duration.
@@ -199,14 +146,221 @@ impl Timer {
     /// ```
     /// # use bevy_core::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
-    /// let mut repeating = Timer::from_seconds(1.0, true);
+    /// let mut timer = DurationTimer::from_seconds(1.0, false);
+    /// let mut repeating = DurationTimer::from_seconds(1.0, true);
     /// timer.tick(Duration::from_secs_f32(1.5));
     /// repeating.tick(Duration::from_secs_f32(1.5));
     /// assert_eq!(timer.elapsed_secs(), 1.0);
     /// assert_eq!(repeating.elapsed_secs(), 0.5);
     /// ```
-    pub fn tick(&mut self, delta: Duration) -> &Self {
+    fn tick(&mut self, delta: Self::TimeUnit) -> &Self;
+
+    /// Pauses the Timer. Disables the ticking of the timer.
+    ///
+    /// See also [`Stopwatch::pause`](Stopwatch::pause).
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// use std::time::Duration;
+    /// let mut timer = DurationTimer::from_seconds(1.0, false);
+    /// timer.pause();
+    /// timer.tick(Duration::from_secs_f32(0.5));
+    /// assert_eq!(timer.elapsed_secs(), 0.0);
+    /// ```
+    fn pause(&mut self) {
+        self.stopwatch_mut().pause();
+    }
+
+    /// Unpauses the Timer. Resumes the ticking of the timer.
+    ///
+    /// See also [`Stopwatch::unpause()`](Stopwatch::unpause).
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// use std::time::Duration;
+    /// let mut timer = DurationTimer::from_seconds(1.0, false);
+    /// timer.pause();
+    /// timer.tick(Duration::from_secs_f32(0.5));
+    /// timer.unpause();
+    /// timer.tick(Duration::from_secs_f32(0.5));
+    /// assert_eq!(timer.elapsed_secs(), 0.5);
+    /// ```
+    #[inline]
+    fn unpause(&mut self) {
+        self.stopwatch_mut().unpause();
+    }
+
+    /// Returns `true` if the timer is paused.
+    ///
+    /// See also [`Stopwatch::paused`](Stopwatch::paused).
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut timer = DurationTimer::from_seconds(1.0, false);
+    /// assert!(!timer.paused());
+    /// timer.pause();
+    /// assert!(timer.paused());
+    /// timer.unpause();
+    /// assert!(!timer.paused());
+    /// ```
+    #[inline]
+    fn paused(&self) -> bool {
+        self.stopwatch().paused()
+    }
+
+    /// Resets the timer. the reset doesn't affect the `paused` state of the timer.
+    ///
+    /// See also [`Stopwatch::reset`](Stopwatch::reset).
+    ///
+    /// Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// use std::time::Duration;
+    /// let mut timer = DurationTimer::from_seconds(1.0, false);
+    /// timer.tick(Duration::from_secs_f32(1.5));
+    /// timer.reset();
+    /// assert!(!timer.finished());
+    /// assert!(!timer.just_finished());
+    /// assert_eq!(timer.elapsed_secs(), 0.0);
+    /// ```
+    fn reset(&mut self);
+
+    /// Returns the percentage of the timer elapsed time (goes from 0.0 to 1.0).
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// use std::time::Duration;
+    /// let mut timer = DurationTimer::from_seconds(2.0, false);
+    /// timer.tick(Duration::from_secs_f32(0.5));
+    /// assert_eq!(timer.percent(), 0.25);
+    /// ```
+    fn percent(&self) -> f32;
+
+    /// Returns the percentage of the timer remaining time (goes from 0.0 to 1.0).
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// use std::time::Duration;
+    /// let mut timer = DurationTimer::from_seconds(2.0, false);
+    /// timer.tick(Duration::from_secs_f32(0.5));
+    /// assert_eq!(timer.percent_left(), 0.75);
+    /// ```
+    #[inline]
+    fn percent_left(&self) -> f32 {
+        1.0 - self.percent()
+    }
+
+    /// Returns the number of times a repeating timer
+    /// finished during the last [`tick`](Timer<T>::tick) call.
+    ///
+    /// For non repeating-timers, this method will only ever
+    /// return 0 or 1.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// use std::time::Duration;
+    /// let mut timer = DurationTimer::from_seconds(1.0, true);
+    /// timer.tick(Duration::from_secs_f32(6.0));
+    /// assert_eq!(timer.times_finished(), 6);
+    /// timer.tick(Duration::from_secs_f32(2.0));
+    /// assert_eq!(timer.times_finished(), 2);
+    /// timer.tick(Duration::from_secs_f32(0.5));
+    /// assert_eq!(timer.times_finished(), 0);
+    /// ```
+    fn times_finished(&self) -> u32;
+
+    /// Returns a reference to the `EmbeddedStopwatch`
+    /// stored within the struct that implements this trait
+    fn stopwatch(&self) -> &Self::EmbeddedStopwatch;
+
+    /// Returns a mutable reference to the `EmbeddedStopwatch`
+    /// stored within the struct that implements this trait
+    fn stopwatch_mut(&mut self) -> &mut Self::EmbeddedStopwatch;
+}
+
+/// Tracks elapsed time. Enters the finished state once `duration` is reached.
+///
+/// This [`Timer`] measures wall-clock time, and can be used to track cooldowns, countdowns and recurring triggers.
+/// Consider using ['DiscreteTimer'] for gameplay events whose interval should decrease in the case of frame-rate drops.
+///
+/// Non-repeating timers will stop tracking and stay in the finished state until reset.
+/// Repeating timers will only be in the finished state on each tick `duration` is reached or
+/// exceeded, and can still be reset at any given point.
+///
+/// Paused timers will not have elapsed time increased.
+#[derive(Clone, Debug, Default, Reflect)]
+#[reflect(Component)]
+pub struct DurationTimer {
+    stopwatch: DurationStopwatch,
+    duration: Duration,
+    repeating: bool,
+    finished: bool,
+    times_finished: u32,
+}
+
+impl DurationTimer {
+    /// Creates a new timer with a given duration in seconds.
+    ///
+    /// # Example
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut timer = DurationTimer::from_seconds(1.0, false);
+    /// ```
+    pub fn from_seconds(duration: f32, repeating: bool) -> Self {
+        Self {
+            duration: Duration::from_secs_f32(duration),
+            repeating,
+            ..Default::default()
+        }
+    }
+
+    /// Returns the time elapsed on the timer as a `f32`.
+    /// See also [`Timer::elapsed`](Timer::elapsed).
+    #[inline]
+    pub fn elapsed_secs(&self) -> f32 {
+        self.stopwatch.elapsed_secs()
+    }
+}
+
+impl Timer for DurationTimer {
+    type TimeUnit = Duration;
+    type EmbeddedStopwatch = DurationStopwatch;
+
+    fn new(duration: Self::TimeUnit, repeating: bool) -> Self {
+        Self {
+            duration,
+            repeating,
+            ..Default::default()
+        }
+    }
+
+    fn finished(&self) -> bool {
+        self.finished
+    }
+
+    fn duration(&self) -> Self::TimeUnit {
+        self.duration
+    }
+
+    fn set_duration(&mut self, duration: Self::TimeUnit) {
+        self.duration = duration;
+    }
+
+    fn repeating(&self) -> bool {
+        self.repeating
+    }
+
+    fn set_repeating(&mut self, repeating: bool) {
+        self.repeating = repeating
+    }
+
+    fn tick(&mut self, delta: Self::TimeUnit) -> &Self {
         if self.paused() {
             return self;
         }
@@ -236,148 +390,31 @@ impl Timer {
         self
     }
 
-    /// Pauses the Timer. Disables the ticking of the timer.
-    ///
-    /// See also [`Stopwatch::pause`](Stopwatch::pause).
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
-    /// timer.pause();
-    /// timer.tick(Duration::from_secs_f32(0.5));
-    /// assert_eq!(timer.elapsed_secs(), 0.0);
-    /// ```
-    #[inline]
-    pub fn pause(&mut self) {
-        self.stopwatch.pause();
-    }
-
-    /// Unpauses the Timer. Resumes the ticking of the timer.
-    ///
-    /// See also [`Stopwatch::unpause()`](Stopwatch::unpause).
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
-    /// timer.pause();
-    /// timer.tick(Duration::from_secs_f32(0.5));
-    /// timer.unpause();
-    /// timer.tick(Duration::from_secs_f32(0.5));
-    /// assert_eq!(timer.elapsed_secs(), 0.5);
-    /// ```
-    #[inline]
-    pub fn unpause(&mut self) {
-        self.stopwatch.unpause();
-    }
-
-    /// Returns `true` if the timer is paused.
-    ///
-    /// See also [`Stopwatch::paused`](Stopwatch::paused).
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = Timer::from_seconds(1.0, false);
-    /// assert!(!timer.paused());
-    /// timer.pause();
-    /// assert!(timer.paused());
-    /// timer.unpause();
-    /// assert!(!timer.paused());
-    /// ```
-    #[inline]
-    pub fn paused(&self) -> bool {
-        self.stopwatch.paused()
-    }
-
-    /// Resets the timer. the reset doesn't affect the `paused` state of the timer.
-    ///
-    /// See also [`Stopwatch::reset`](Stopwatch::reset).
-    ///
-    /// Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
-    /// timer.tick(Duration::from_secs_f32(1.5));
-    /// timer.reset();
-    /// assert!(!timer.finished());
-    /// assert!(!timer.just_finished());
-    /// assert_eq!(timer.elapsed_secs(), 0.0);
-    /// ```
-    pub fn reset(&mut self) {
+    fn reset(&mut self) {
         self.stopwatch.reset();
         self.finished = false;
         self.times_finished = 0;
     }
 
-    /// Returns the percentage of the timer elapsed time (goes from 0.0 to 1.0).
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(2.0, false);
-    /// timer.tick(Duration::from_secs_f32(0.5));
-    /// assert_eq!(timer.percent(), 0.25);
-    /// ```
-    #[inline]
-    pub fn percent(&self) -> f32 {
+    fn percent(&self) -> f32 {
         self.elapsed().as_secs_f32() / self.duration().as_secs_f32()
     }
 
-    /// Returns the percentage of the timer remaining time (goes from 0.0 to 1.0).
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(2.0, false);
-    /// timer.tick(Duration::from_secs_f32(0.5));
-    /// assert_eq!(timer.percent_left(), 0.75);
-    /// ```
-    #[inline]
-    pub fn percent_left(&self) -> f32 {
-        1.0 - self.percent()
+    fn times_finished(&self) -> u32 {
+        self.times_finished
     }
 
-    /// Returns the number of times a repeating timer
-    /// finished during the last [`tick`](Timer<T>::tick) call.
-    ///
-    /// For non repeating-timers, this method will only ever
-    /// return 0 or 1.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, true);
-    /// timer.tick(Duration::from_secs_f32(6.0));
-    /// assert_eq!(timer.times_finished(), 6);
-    /// timer.tick(Duration::from_secs_f32(2.0));
-    /// assert_eq!(timer.times_finished(), 2);
-    /// timer.tick(Duration::from_secs_f32(0.5));
-    /// assert_eq!(timer.times_finished(), 0);
-    /// ```
-    #[inline]
-    pub fn times_finished(&self) -> u32 {
-        self.times_finished
+    fn stopwatch(&self) -> &Self::EmbeddedStopwatch {
+        &self.stopwatch
+    }
+
+    fn stopwatch_mut(&mut self) -> &mut Self::EmbeddedStopwatch {
+        &mut self.stopwatch
     }
 }
 
-/// Tracks elapsed increments. Enters the finished state once `duration` is reached.
-///
-/// This type is useful for accurately counting frames, ticks or occurences between gameplay events.
-/// Use ['Timer'] if you care about wall-clock time.
-///
-/// Non-repeating timers will stop tracking and stay in the finished state until reset.
-/// Repeating timers will only be in the finished state on each tick `duration` is reached or
-/// exceeded, and can still be reset at any given point.
-///
-/// Paused timers will not have elapsed time increased.
+/// This ['Timer'] is useful for accurately counting frames, ticks or occurences between gameplay events.
+/// Use ['DurationTimer'] if you care about wall-clock time.
 #[derive(Clone, Debug, Default, Reflect)]
 #[reflect(Component)]
 pub struct DiscreteTimer {
@@ -388,9 +425,11 @@ pub struct DiscreteTimer {
     times_finished: u32,
 }
 
-impl DiscreteTimer {
-    /// Creates a new timer with a given duration.
-    pub fn new(duration: u64, repeating: bool) -> Self {
+impl Timer for DiscreteTimer {
+    type TimeUnit = u64;
+    type EmbeddedStopwatch = DiscreteStopwatch;
+
+    fn new(duration: Self::TimeUnit, repeating: bool) -> Self {
         Self {
             duration,
             repeating,
@@ -398,148 +437,27 @@ impl DiscreteTimer {
         }
     }
 
-    /// Returns `true` if the timer has reached its duration.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = DiscreteTimer::new(3, false);
-    /// timer.tick(3);
-    /// assert!(timer.finished());
-    /// timer.tick(1);
-    /// assert!(timer.finished());
-    /// ```
-    #[inline]
-    pub fn finished(&self) -> bool {
+    fn finished(&self) -> bool {
         self.finished
     }
 
-    /// Returns `true` only on the tick the timer reached its duration.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = DiscreteTimer::new(2, false);
-    /// timer.tick(2);
-    /// assert!(timer.just_finished());
-    /// timer.tick(1);
-    /// assert!(!timer.just_finished());
-    /// ```
-    #[inline]
-    pub fn just_finished(&self) -> bool {
-        self.times_finished > 0
-    }
-
-    /// Returns the time elapsed on the timer. Guaranteed to be between 0 and `duration`.
-    /// Will only equal `duration` when the timer is finished and non repeating.
-    ///
-    /// See also [`DiscreteStopwatch::elapsed`](DiscreteStopwatch::elapsed).
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = DiscreteTimer::new(2, false);;
-    /// timer.tick(1);
-    /// assert_eq!(timer.elapsed(), 1);
-    /// ```
-    #[inline]
-    pub fn elapsed(&self) -> u64 {
-        self.stopwatch.elapsed()
-    }
-
-    /// Sets the elapsed time of the timer without any other considerations.
-    ///
-    /// See also [`Stopwatch::set`](Stopwatch::set).
-    ///
-    /// #
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = DiscreteTimer::new(1, false);
-    /// timer.set_elapsed(2);
-    /// assert_eq!(timer.elapsed(), 2);
-    /// // the timer is not finished even if the elapsed time is greater than the duration.
-    /// assert!(!timer.finished());
-    /// ```
-    #[inline]
-    pub fn set_elapsed(&mut self, time: u64) {
-        self.stopwatch.set_elapsed(time);
-    }
-
-    /// Returns the duration of the timer.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let timer = DiscreteTimer::new(1, false);
-    /// assert_eq!(timer.duration(), 1);
-    /// ```
-    #[inline]
-    pub fn duration(&self) -> u64 {
+    fn duration(&self) -> Self::TimeUnit {
         self.duration
     }
 
-    /// Sets the duration of the timer.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = DiscreteTimer::new(2, false);
-    /// timer.set_duration(1);
-    /// assert_eq!(timer.duration(), 1);
-    /// ```
-    #[inline]
-    pub fn set_duration(&mut self, duration: u64) {
+    fn set_duration(&mut self, duration: Self::TimeUnit) {
         self.duration = duration;
     }
 
-    /// Returns `true` if the timer is repeating.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = DiscreteTimer::new(1, true);
-    /// assert!(timer.repeating());
-    /// ```
-    #[inline]
-    pub fn repeating(&self) -> bool {
+    fn repeating(&self) -> bool {
         self.repeating
     }
 
-    /// Sets whether the timer is repeating or not.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = DiscreteTimer::new(1, true);
-    /// timer.set_repeating(false);
-    /// assert!(!timer.repeating());
-    /// ```
-    #[inline]
-    pub fn set_repeating(&mut self, repeating: bool) {
-        if !self.repeating && repeating && self.finished {
-            self.stopwatch.reset();
-            self.finished = self.just_finished();
-        }
+    fn set_repeating(&mut self, repeating: bool) {
         self.repeating = repeating
     }
 
-    /// Advance the timer by `delta` increments.
-    /// Non repeating timer will clamp at duration.
-    /// Repeating timer will wrap around.
-    ///
-    /// See also [`Stopwatch::tick`](Stopwatch::tick).
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = DiscreteTimer::new(2, false);
-    /// let mut repeating = DiscreteTimer::new(2, true);
-    /// timer.tick(3);
-    /// repeating.tick(3);
-    /// assert_eq!(timer.elapsed(), 2);
-    /// assert_eq!(repeating.elapsed(), 1);
-    /// ```
-    pub fn tick(&mut self, delta: u64) -> &Self {
+    fn tick(&mut self, delta: Self::TimeUnit) -> &Self {
         if self.paused() {
             return self;
         }
@@ -567,248 +485,25 @@ impl DiscreteTimer {
         self
     }
 
-    /// Pauses the Timer. Disables the ticking of the timer.
-    ///
-    /// See also [`Stopwatch::pause`](Stopwatch::pause).
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = DiscreteTimer::new(2, false);
-    /// timer.pause();
-    /// timer.tick(1);
-    /// assert_eq!(timer.elapsed(), 0);
-    /// ```
-    #[inline]
-    pub fn pause(&mut self) {
-        self.stopwatch.pause();
-    }
-
-    /// Unpauses the Timer. Resumes the ticking of the timer.
-    ///
-    /// See also [`Stopwatch::unpause()`](Stopwatch::unpause).
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = DiscreteTimer::new(3, false);
-    /// timer.pause();
-    /// timer.tick(1);
-    /// timer.unpause();
-    /// timer.tick(2);
-    /// assert_eq!(timer.elapsed(), 2);
-    /// ```
-    #[inline]
-    pub fn unpause(&mut self) {
-        self.stopwatch.unpause();
-    }
-
-    /// Returns `true` if the timer is paused.
-    ///
-    /// See also [`Stopwatch::paused`](Stopwatch::paused).
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = DiscreteTimer::new(1, false);;
-    /// assert!(!timer.paused());
-    /// timer.pause();
-    /// assert!(timer.paused());
-    /// timer.unpause();
-    /// assert!(!timer.paused());
-    /// ```
-    #[inline]
-    pub fn paused(&self) -> bool {
-        self.stopwatch.paused()
-    }
-
-    /// Resets the timer. the reset doesn't affect the `paused` state of the timer.
-    ///
-    /// See also [`Stopwatch::reset`](Stopwatch::reset).
-    ///
-    /// Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = DiscreteTimer::new(1, false);
-    /// timer.tick(2);
-    /// timer.reset();
-    /// assert!(!timer.finished());
-    /// assert!(!timer.just_finished());
-    /// assert_eq!(timer.elapsed(), 0);
-    /// ```
-    pub fn reset(&mut self) {
+    fn reset(&mut self) {
         self.stopwatch.reset();
         self.finished = false;
         self.times_finished = 0;
     }
 
-    /// Returns the percentage of the timer elapsed time (goes from 0.0 to 1.0).
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = DiscreteTimer::new(4, false);;
-    /// timer.tick(1);
-    /// assert_eq!(timer.percent(), 0.25);
-    /// ```
-    #[inline]
-    pub fn percent(&self) -> f32 {
+    fn percent(&self) -> f32 {
         self.elapsed() as f32 / self.duration() as f32
     }
 
-    /// Returns the percentage of the timer remaining time (goes from 0.0 to 1.0).
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = DiscreteTimer::new(4, false);;
-    /// timer.tick(1);
-    /// assert_eq!(timer.percent_left(), 0.75);
-    /// ```
-    #[inline]
-    pub fn percent_left(&self) -> f32 {
-        1.0 - self.percent()
-    }
-
-    /// Returns the number of times a repeating timer
-    /// finished during the last [`tick`](Timer<T>::tick) call.
-    ///
-    /// For non repeating-timers, this method will only ever
-    /// return 0 or 1.
-    ///
-    /// # Examples
-    /// ```
-    /// # use bevy_core::*;
-    /// let mut timer = DiscreteTimer::new(2, false);
-    /// assert_eq!(timer.times_finished(), 0);
-    /// timer.tick(6);
-    /// assert_eq!(timer.times_finished(), 1);
-
-    /// let mut timer = DiscreteTimer::new(2, true);
-    /// timer.tick(7);
-    /// assert_eq!(timer.times_finished(), 3);
-    /// ```
-    #[inline]
-    pub fn times_finished(&self) -> u32 {
+    fn times_finished(&self) -> u32 {
         self.times_finished
     }
-}
 
-#[cfg(test)]
-#[allow(clippy::float_cmp)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn non_repeating_timer() {
-        let mut t = Timer::from_seconds(10.0, false);
-        // Tick once, check all attributes
-        t.tick(Duration::from_secs_f32(0.25));
-        assert_eq!(t.elapsed_secs(), 0.25);
-        assert_eq!(t.duration(), Duration::from_secs_f32(10.0));
-        assert!(!t.finished());
-        assert!(!t.just_finished());
-        assert_eq!(t.times_finished(), 0);
-        assert!(!t.repeating());
-        assert_eq!(t.percent(), 0.025);
-        assert_eq!(t.percent_left(), 0.975);
-        // Ticking while paused changes nothing
-        t.pause();
-        t.tick(Duration::from_secs_f32(500.0));
-        assert_eq!(t.elapsed_secs(), 0.25);
-        assert_eq!(t.duration(), Duration::from_secs_f32(10.0));
-        assert!(!t.finished());
-        assert!(!t.just_finished());
-        assert_eq!(t.times_finished(), 0);
-        assert!(!t.repeating());
-        assert_eq!(t.percent(), 0.025);
-        assert_eq!(t.percent_left(), 0.975);
-        // Tick past the end and make sure elapsed doesn't go past 0.0 and other things update
-        t.unpause();
-        t.tick(Duration::from_secs_f32(500.0));
-        assert_eq!(t.elapsed_secs(), 10.0);
-        assert!(t.finished());
-        assert!(t.just_finished());
-        assert_eq!(t.times_finished(), 1);
-        assert_eq!(t.percent(), 1.0);
-        assert_eq!(t.percent_left(), 0.0);
-        // Continuing to tick when finished should only change just_finished
-        t.tick(Duration::from_secs_f32(1.0));
-        assert_eq!(t.elapsed_secs(), 10.0);
-        assert!(t.finished());
-        assert!(!t.just_finished());
-        assert_eq!(t.times_finished(), 0);
-        assert_eq!(t.percent(), 1.0);
-        assert_eq!(t.percent_left(), 0.0);
+    fn stopwatch(&self) -> &Self::EmbeddedStopwatch {
+        &self.stopwatch
     }
 
-    #[test]
-    fn repeating_timer() {
-        let mut t = Timer::from_seconds(2.0, true);
-        // Tick once, check all attributes
-        t.tick(Duration::from_secs_f32(0.75));
-        assert_eq!(t.elapsed_secs(), 0.75);
-        assert_eq!(t.duration(), Duration::from_secs_f32(2.0));
-        assert!(!t.finished());
-        assert!(!t.just_finished());
-        assert_eq!(t.times_finished(), 0);
-        assert!(t.repeating());
-        assert_eq!(t.percent(), 0.375);
-        assert_eq!(t.percent_left(), 0.625);
-        // Tick past the end and make sure elapsed wraps
-        t.tick(Duration::from_secs_f32(1.5));
-        assert_eq!(t.elapsed_secs(), 0.25);
-        assert!(t.finished());
-        assert!(t.just_finished());
-        assert_eq!(t.times_finished(), 1);
-        assert_eq!(t.percent(), 0.125);
-        assert_eq!(t.percent_left(), 0.875);
-        // Continuing to tick should turn off both finished & just_finished for repeating timers
-        t.tick(Duration::from_secs_f32(1.0));
-        assert_eq!(t.elapsed_secs(), 1.25);
-        assert!(!t.finished());
-        assert!(!t.just_finished());
-        assert_eq!(t.times_finished(), 0);
-        assert_eq!(t.percent(), 0.625);
-        assert_eq!(t.percent_left(), 0.375);
-    }
-
-    #[test]
-    fn times_finished_repeating() {
-        let mut t = Timer::from_seconds(1.0, true);
-        assert_eq!(t.times_finished(), 0);
-        t.tick(Duration::from_secs_f32(3.5));
-        assert_eq!(t.times_finished(), 3);
-        assert_eq!(t.elapsed_secs(), 0.5);
-        assert!(t.finished());
-        assert!(t.just_finished());
-        t.tick(Duration::from_secs_f32(0.2));
-        assert_eq!(t.times_finished(), 0);
-    }
-
-    #[test]
-    fn times_finished() {
-        let mut t = Timer::from_seconds(1.0, false);
-        assert_eq!(t.times_finished(), 0);
-        t.tick(Duration::from_secs_f32(1.5));
-        assert_eq!(t.times_finished(), 1);
-        t.tick(Duration::from_secs_f32(0.5));
-        assert_eq!(t.times_finished(), 0);
-    }
-
-    #[test]
-    fn times_finished_precise() {
-        let mut t = Timer::from_seconds(0.01, true);
-        let duration = Duration::from_secs_f64(1.0 / 3.0);
-
-        t.tick(duration);
-        assert_eq!(t.times_finished(), 33);
-        t.tick(duration);
-        assert_eq!(t.times_finished(), 33);
-        t.tick(duration);
-        assert_eq!(t.times_finished(), 33);
-        // It has one additional tick this time to compensate for missing 100th tick
-        t.tick(duration);
-        assert_eq!(t.times_finished(), 34);
+    fn stopwatch_mut(&mut self) -> &mut Self::EmbeddedStopwatch {
+        &mut self.stopwatch
     }
 }

--- a/crates/bevy_core/src/time/timer.rs
+++ b/crates/bevy_core/src/time/timer.rs
@@ -118,8 +118,8 @@ impl Timer {
     /// # use bevy_core::*;
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, false);
-    /// timer.set_elapsed(Duration::from_secs(2));
-    /// assert_eq!(timer.elapsed(), Duration::from_secs(2));
+    /// timer.set_elapsed(Duration::from_secs(2.0));
+    /// assert_eq!(timer.elapsed(), Duration::from_secs(2.0));
     /// // the timer is not finished even if the elapsed time is greater than the duration.
     /// assert!(!timer.finished());
     /// ```
@@ -453,10 +453,9 @@ impl DiscreteTimer {
     /// #
     /// ```
     /// # use bevy_core::*;
-    /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
-    /// timer.set_elapsed(Duration::from_secs(2));
-    /// assert_eq!(timer.elapsed(), Duration::from_secs(2));
+    /// let mut timer = DiscreteTimer::new(1, false);
+    /// timer.set_elapsed(2);
+    /// assert_eq!(timer.elapsed(), 2);
     /// // the timer is not finished even if the elapsed time is greater than the duration.
     /// assert!(!timer.finished());
     /// ```
@@ -629,13 +628,12 @@ impl DiscreteTimer {
     /// Examples
     /// ```
     /// # use bevy_core::*;
-    /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
-    /// timer.tick(Duration::from_secs_f32(1.5));
+    /// let mut timer = DiscreteTimer::new(1, false);
+    /// timer.tick(2);
     /// timer.reset();
     /// assert!(!timer.finished());
     /// assert!(!timer.just_finished());
-    /// assert_eq!(timer.elapsed_secs(), 0.0);
+    /// assert_eq!(timer.elapsed(), 0);
     /// ```
     pub fn reset(&mut self) {
         self.stopwatch.reset();

--- a/crates/bevy_core/src/time/timer.rs
+++ b/crates/bevy_core/src/time/timer.rs
@@ -1,4 +1,5 @@
-use crate::{DiscreteStopwatch, Stopwatch};
+use crate::time::Stopwatch;
+use crate::{DiscreteStopwatch, DurationStopwatch};
 use bevy_ecs::reflect::ReflectComponent;
 use bevy_reflect::Reflect;
 use bevy_utils::Duration;
@@ -16,7 +17,7 @@ use bevy_utils::Duration;
 #[derive(Clone, Debug, Default, Reflect)]
 #[reflect(Component)]
 pub struct Timer {
-    stopwatch: Stopwatch,
+    stopwatch: DurationStopwatch,
     duration: Duration,
     repeating: bool,
     finished: bool,

--- a/crates/bevy_core/src/time/timer.rs
+++ b/crates/bevy_core/src/time/timer.rs
@@ -1,11 +1,14 @@
-use crate::Stopwatch;
+use crate::{DiscreteStopwatch, Stopwatch};
 use bevy_ecs::reflect::ReflectComponent;
 use bevy_reflect::Reflect;
 use bevy_utils::Duration;
 
 /// Tracks elapsed time. Enters the finished state once `duration` is reached.
 ///
-/// Non repeating timers will stop tracking and stay in the finished state until reset.
+/// This type is useful for measuring wall-clock time, and can be used to track cooldowns, countdowns and recurring triggers.
+/// Consider using ['DiscreteTimer'] for gameplay events whose interval should decrease in the case of frame-rate drops.
+///
+/// Non-repeating timers will stop tracking and stay in the finished state until reset.
 /// Repeating timers will only be in the finished state on each tick `duration` is reached or
 /// exceeded, and can still be reset at any given point.
 ///
@@ -357,6 +360,334 @@ impl Timer {
     /// assert_eq!(timer.times_finished(), 2);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert_eq!(timer.times_finished(), 0);
+    /// ```
+    #[inline]
+    pub fn times_finished(&self) -> u32 {
+        self.times_finished
+    }
+}
+
+/// Tracks elapsed increments. Enters the finished state once `duration` is reached.
+///
+/// This type is useful for accurately counting frames, ticks or occurences between gameplay events.
+/// Use ['Timer'] if you care about wall-clock time.
+///
+/// Non-repeating timers will stop tracking and stay in the finished state until reset.
+/// Repeating timers will only be in the finished state on each tick `duration` is reached or
+/// exceeded, and can still be reset at any given point.
+///
+/// Paused timers will not have elapsed time increased.
+#[derive(Clone, Debug, Default, Reflect)]
+#[reflect(Component)]
+pub struct DiscreteTimer {
+    stopwatch: DiscreteStopwatch,
+    duration: u64,
+    repeating: bool,
+    finished: bool,
+    times_finished: u32,
+}
+
+impl DiscreteTimer {
+    /// Creates a new timer with a given duration.
+    pub fn new(duration: u64, repeating: bool) -> Self {
+        Self {
+            duration,
+            repeating,
+            ..Default::default()
+        }
+    }
+
+    /// Returns `true` if the timer has reached its duration.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut timer = DiscreteTimer::new(3, false);
+    /// timer.tick(3);
+    /// assert!(timer.finished());
+    /// timer.tick(1);
+    /// assert!(timer.finished());
+    /// ```
+    #[inline]
+    pub fn finished(&self) -> bool {
+        self.finished
+    }
+
+    /// Returns `true` only on the tick the timer reached its duration.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut timer = DiscreteTimer::new(2, false);
+    /// timer.tick(2);
+    /// assert!(timer.just_finished());
+    /// timer.tick(1);
+    /// assert!(!timer.just_finished());
+    /// ```
+    #[inline]
+    pub fn just_finished(&self) -> bool {
+        self.times_finished > 0
+    }
+
+    /// Returns the time elapsed on the timer. Guaranteed to be between 0 and `duration`.
+    /// Will only equal `duration` when the timer is finished and non repeating.
+    ///
+    /// See also [`DiscreteStopwatch::elapsed`](DiscreteStopwatch::elapsed).
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut timer = DiscreteTimer::new(2, false);;
+    /// timer.tick(1);
+    /// assert_eq!(timer.elapsed(), 1);
+    /// ```
+    #[inline]
+    pub fn elapsed(&self) -> u64 {
+        self.stopwatch.elapsed()
+    }
+
+    /// Sets the elapsed time of the timer without any other considerations.
+    ///
+    /// See also [`Stopwatch::set`](Stopwatch::set).
+    ///
+    /// #
+    /// ```
+    /// # use bevy_core::*;
+    /// use std::time::Duration;
+    /// let mut timer = Timer::from_seconds(1.0, false);
+    /// timer.set_elapsed(Duration::from_secs(2));
+    /// assert_eq!(timer.elapsed(), Duration::from_secs(2));
+    /// // the timer is not finished even if the elapsed time is greater than the duration.
+    /// assert!(!timer.finished());
+    /// ```
+    #[inline]
+    pub fn set_elapsed(&mut self, time: u64) {
+        self.stopwatch.set_elapsed(time);
+    }
+
+    /// Returns the duration of the timer.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let timer = DiscreteTimer::new(1, false);
+    /// assert_eq!(timer.duration(), 1);
+    /// ```
+    #[inline]
+    pub fn duration(&self) -> u64 {
+        self.duration
+    }
+
+    /// Sets the duration of the timer.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut timer = DiscreteTimer::new(2, false);
+    /// timer.set_duration(1);
+    /// assert_eq!(timer.duration(), 1);
+    /// ```
+    #[inline]
+    pub fn set_duration(&mut self, duration: u64) {
+        self.duration = duration;
+    }
+
+    /// Returns `true` if the timer is repeating.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut timer = DiscreteTimer::new(1, true);
+    /// assert!(timer.repeating());
+    /// ```
+    #[inline]
+    pub fn repeating(&self) -> bool {
+        self.repeating
+    }
+
+    /// Sets whether the timer is repeating or not.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut timer = DiscreteTimer::new(1, true);
+    /// timer.set_repeating(false);
+    /// assert!(!timer.repeating());
+    /// ```
+    #[inline]
+    pub fn set_repeating(&mut self, repeating: bool) {
+        if !self.repeating && repeating && self.finished {
+            self.stopwatch.reset();
+            self.finished = self.just_finished();
+        }
+        self.repeating = repeating
+    }
+
+    /// Advance the timer by `delta` increments.
+    /// Non repeating timer will clamp at duration.
+    /// Repeating timer will wrap around.
+    ///
+    /// See also [`Stopwatch::tick`](Stopwatch::tick).
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut timer = DiscreteTimer::new(2, false);
+    /// let mut repeating = DiscreteTimer::new(2, true);
+    /// timer.tick(3);
+    /// repeating.tick(3);
+    /// assert_eq!(timer.elapsed(), 2);
+    /// assert_eq!(repeating.elapsed(), 1);
+    /// ```
+    pub fn tick(&mut self, delta: u64) -> &Self {
+        if self.paused() {
+            return self;
+        }
+
+        if !self.repeating() && self.finished() {
+            self.times_finished = 0;
+            return self;
+        }
+
+        self.stopwatch.tick(delta);
+        self.finished = self.elapsed() >= self.duration();
+
+        if self.finished() {
+            if self.repeating() {
+                self.times_finished = (self.elapsed() / self.duration()) as u32;
+                self.set_elapsed(self.elapsed() % self.duration());
+            } else {
+                self.times_finished = 1;
+                self.set_elapsed(self.duration());
+            }
+        } else {
+            self.times_finished = 0;
+        }
+
+        self
+    }
+
+    /// Pauses the Timer. Disables the ticking of the timer.
+    ///
+    /// See also [`Stopwatch::pause`](Stopwatch::pause).
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut timer = DiscreteTimer::new(2, false);
+    /// timer.pause();
+    /// timer.tick(1);
+    /// assert_eq!(timer.elapsed(), 0);
+    /// ```
+    #[inline]
+    pub fn pause(&mut self) {
+        self.stopwatch.pause();
+    }
+
+    /// Unpauses the Timer. Resumes the ticking of the timer.
+    ///
+    /// See also [`Stopwatch::unpause()`](Stopwatch::unpause).
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut timer = DiscreteTimer::new(3, false);
+    /// timer.pause();
+    /// timer.tick(1);
+    /// timer.unpause();
+    /// timer.tick(2);
+    /// assert_eq!(timer.elapsed(), 2);
+    /// ```
+    #[inline]
+    pub fn unpause(&mut self) {
+        self.stopwatch.unpause();
+    }
+
+    /// Returns `true` if the timer is paused.
+    ///
+    /// See also [`Stopwatch::paused`](Stopwatch::paused).
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut timer = DiscreteTimer::new(1, false);;
+    /// assert!(!timer.paused());
+    /// timer.pause();
+    /// assert!(timer.paused());
+    /// timer.unpause();
+    /// assert!(!timer.paused());
+    /// ```
+    #[inline]
+    pub fn paused(&self) -> bool {
+        self.stopwatch.paused()
+    }
+
+    /// Resets the timer. the reset doesn't affect the `paused` state of the timer.
+    ///
+    /// See also [`Stopwatch::reset`](Stopwatch::reset).
+    ///
+    /// Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// use std::time::Duration;
+    /// let mut timer = Timer::from_seconds(1.0, false);
+    /// timer.tick(Duration::from_secs_f32(1.5));
+    /// timer.reset();
+    /// assert!(!timer.finished());
+    /// assert!(!timer.just_finished());
+    /// assert_eq!(timer.elapsed_secs(), 0.0);
+    /// ```
+    pub fn reset(&mut self) {
+        self.stopwatch.reset();
+        self.finished = false;
+        self.times_finished = 0;
+    }
+
+    /// Returns the percentage of the timer elapsed time (goes from 0.0 to 1.0).
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut timer = DiscreteTimer::new(4, false);;
+    /// timer.tick(1);
+    /// assert_eq!(timer.percent(), 0.25);
+    /// ```
+    #[inline]
+    pub fn percent(&self) -> f32 {
+        self.elapsed() as f32 / self.duration() as f32
+    }
+
+    /// Returns the percentage of the timer remaining time (goes from 0.0 to 1.0).
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut timer = DiscreteTimer::new(4, false);;
+    /// timer.tick(1);
+    /// assert_eq!(timer.percent_left(), 0.75);
+    /// ```
+    #[inline]
+    pub fn percent_left(&self) -> f32 {
+        1.0 - self.percent()
+    }
+
+    /// Returns the number of times a repeating timer
+    /// finished during the last [`tick`](Timer<T>::tick) call.
+    ///
+    /// For non repeating-timers, this method will only ever
+    /// return 0 or 1.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_core::*;
+    /// let mut timer = DiscreteTimer::new(2, false);
+    /// assert_eq!(timer.times_finished(), 0);
+    /// timer.tick(6);
+    /// assert_eq!(timer.times_finished(), 1);
+
+    /// let mut timer = DiscreteTimer::new(2, true);
+    /// timer.tick(7);
+    /// assert_eq!(timer.times_finished(), 3);
     /// ```
     #[inline]
     pub fn times_finished(&self) -> u32 {

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -1,6 +1,6 @@
 use super::{Diagnostic, DiagnosticId, Diagnostics};
 use bevy_app::prelude::*;
-use bevy_core::{Time, Timer};
+use bevy_core::{DurationTimer, Time, Timer};
 use bevy_ecs::system::{Res, ResMut};
 use bevy_log::{debug, info};
 use bevy_utils::Duration;
@@ -14,7 +14,7 @@ pub struct LogDiagnosticsPlugin {
 
 /// State used by the [LogDiagnosticsPlugin]
 struct LogDiagnosticsState {
-    timer: Timer,
+    timer: DurationTimer,
     filter: Option<Vec<DiagnosticId>>,
 }
 
@@ -31,7 +31,7 @@ impl Default for LogDiagnosticsPlugin {
 impl Plugin for LogDiagnosticsPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(LogDiagnosticsState {
-            timer: Timer::new(self.wait_duration, true),
+            timer: DurationTimer::new(self.wait_duration, true),
             filter: self.filter.clone(),
         });
 

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -108,7 +108,10 @@ fn setup(
 
     sel.order.shuffle(&mut rnd);
 
-    commands.spawn_bundle((SelectTimer, Timer::from_seconds(SHOWCASE_TIMER_SECS, true)));
+    commands.spawn_bundle((
+        SelectTimer,
+        DurationTimer::from_seconds(SHOWCASE_TIMER_SECS, true),
+    ));
 
     commands
         .spawn()
@@ -150,7 +153,7 @@ fn select_system(
     mut materials: ResMut<Assets<ColorMaterial>>,
     mut sel: ResMut<ContributorSelection>,
     mut dq: Query<&mut Text, With<ContributorDisplay>>,
-    mut tq: Query<&mut Timer, With<SelectTimer>>,
+    mut tq: Query<&mut DurationTimer, With<SelectTimer>>,
     mut q: Query<(&Contributor, &Handle<ColorMaterial>, &mut Transform)>,
     time: Res<Time>,
 ) {

--- a/examples/2d/many_sprites.rs
+++ b/examples/2d/many_sprites.rs
@@ -9,7 +9,7 @@ use rand::Rng;
 
 const CAMERA_SPEED: f32 = 1000.0;
 
-pub struct PrintTimer(Timer);
+pub struct PrintTimer(DurationTimer);
 pub struct Position(Transform);
 
 /// This example is for performance testing purposes.
@@ -47,7 +47,7 @@ fn setup(
     commands
         .spawn()
         .insert_bundle(OrthographicCameraBundle::new_2d())
-        .insert(PrintTimer(Timer::from_seconds(1.0, true)))
+        .insert(PrintTimer(DurationTimer::from_seconds(1.0, true)))
         .insert(Position(Transform::from_translation(Vec3::new(
             0.0, 0.0, 1000.0,
         ))));

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -11,7 +11,11 @@ fn main() {
 fn animate_sprite_system(
     time: Res<Time>,
     texture_atlases: Res<Assets<TextureAtlas>>,
-    mut query: Query<(&mut Timer, &mut TextureAtlasSprite, &Handle<TextureAtlas>)>,
+    mut query: Query<(
+        &mut DurationTimer,
+        &mut TextureAtlasSprite,
+        &Handle<TextureAtlas>,
+    )>,
 ) {
     for (mut timer, mut sprite, texture_atlas_handle) in query.iter_mut() {
         timer.tick(time.delta());
@@ -37,5 +41,5 @@ fn setup(
             transform: Transform::from_scale(Vec3::splat(6.0)),
             ..Default::default()
         })
-        .insert(Timer::from_seconds(0.1, true));
+        .insert(DurationTimer::from_seconds(0.1, true));
 }

--- a/examples/app/plugin.rs
+++ b/examples/app/plugin.rs
@@ -26,7 +26,7 @@ impl Plugin for PrintMessagePlugin {
     fn build(&self, app: &mut App) {
         let state = PrintMessageState {
             message: self.message.clone(),
-            timer: Timer::new(self.wait_duration, true),
+            timer: DurationTimer::new(self.wait_duration, true),
         };
         app.insert_resource(state).add_system(print_message_system);
     }
@@ -34,7 +34,7 @@ impl Plugin for PrintMessagePlugin {
 
 struct PrintMessageState {
     message: String,
-    timer: Timer,
+    timer: DurationTimer,
 }
 
 fn print_message_system(mut state: ResMut<PrintMessageState>, time: Res<Time>) {

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -17,13 +17,13 @@ struct MyEvent {
 }
 
 struct EventTriggerState {
-    event_timer: Timer,
+    event_timer: DurationTimer,
 }
 
 impl Default for EventTriggerState {
     fn default() -> Self {
         EventTriggerState {
-            event_timer: Timer::from_seconds(1.0, true),
+            event_timer: DurationTimer::from_seconds(1.0, true),
         }
     }
 }

--- a/examples/ecs/timers.rs
+++ b/examples/ecs/timers.rs
@@ -11,15 +11,15 @@ fn main() {
 }
 
 pub struct Countdown {
-    pub percent_trigger: Timer,
-    pub main_timer: Timer,
+    pub percent_trigger: DurationTimer,
+    pub main_timer: DurationTimer,
 }
 
 impl Countdown {
     pub fn new() -> Self {
         Self {
-            percent_trigger: Timer::from_seconds(4.0, true),
-            main_timer: Timer::from_seconds(20.0, false),
+            percent_trigger: DurationTimer::from_seconds(4.0, true),
+            main_timer: DurationTimer::from_seconds(20.0, false),
         }
     }
 }
@@ -32,12 +32,14 @@ impl Default for Countdown {
 
 fn setup_system(mut commands: Commands) {
     // Add an entity to the world with a timer
-    commands.spawn().insert(Timer::from_seconds(5.0, false));
+    commands
+        .spawn()
+        .insert(DurationTimer::from_seconds(5.0, false));
 }
 
 /// This system ticks all the `Timer` components on entities within the scene
 /// using bevy's `Time` resource to get the delta between each update.
-fn timer_system(time: Res<Time>, mut query: Query<&mut Timer>) {
+fn timer_system(time: Res<Time>, mut query: Query<&mut DurationTimer>) {
     for mut timer in query.iter_mut() {
         if timer.tick(time.delta()).just_finished() {
             info!("Entity timer just finished")

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -17,7 +17,7 @@ fn main() {
 struct State {
     atlas_count: u32,
     handle: Handle<Font>,
-    timer: Timer,
+    timer: DurationTimer,
 }
 
 impl Default for State {
@@ -25,7 +25,7 @@ impl Default for State {
         Self {
             atlas_count: 0,
             handle: Handle::default(),
-            timer: Timer::from_seconds(0.05, true),
+            timer: DurationTimer::from_seconds(0.05, true),
         }
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #1633.
- As expressed in the linked issue, tick timers are a fundamental tool for controlling game-logic in certain game genres (factory builders, tower defenses) where we want to slow down gameplay when frame rate drops and ensure perfect synchronization.
- Using absolute time can be too complex and too inexact for many gameplay uses.

## Solution

- Create a `DiscreteStopwatch` and `DiscreteTimer` structs to closely mirror the existing `Timer` and `Stopwatch` API.
- This allows users to trivially swap between the APIs and reduces learning and maintenance burden.