### PR TITLE
[Merged by Bors] - update ndk-glue to 0.4

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -39,7 +39,7 @@ wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = { version = "0.2" }
+ndk-glue = { version = "0.4" }
 
 [dev-dependencies]
 futures-lite = "1.4.0"

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -74,4 +74,4 @@ bevy_winit = { path = "../bevy_winit", optional = true, version = "0.5.0" }
 bevy_gilrs = { path = "../bevy_gilrs", optional = true, version = "0.5.0" }
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = {version = "0.2", features = ["logger"]}
+ndk-glue = {version = "0.4", features = ["logger"]}

--- a/deny.toml
+++ b/deny.toml
@@ -37,7 +37,6 @@ highlight = "all"
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
     { name = "ahash", version = "0.4" },
-    { name = "android_log-sys", version = "0.1" },
     { name = "cfg-if", version = "0.1" },             # https://github.com/rustwasm/console_error_panic_hook/pull/18
     { name = "core-foundation", version = "0.6" },
     { name = "core-foundation", version = "0.7" },
@@ -48,10 +47,8 @@ skip = [
     { name = "hashbrown", version = "0.9" },
     { name = "libm", version = "0.1" },
     { name = "mach", version = "0.2" },
-    { name = "ndk", version = "0.2" },
-    { name = "ndk-glue", version = "0.2" },
-    { name = "num_enum", version = "0.4" },
-    { name = "num_enum_derive", version = "0.4" },
+    { name = "ndk", version = "0.3" },
+    { name = "ndk-glue", version = "0.3" },
     { name = "proc-macro-crate", version = "0.1" },
     { name = "stdweb", version = "0.1" },
 ]


### PR DESCRIPTION
# Objective

- We currently depends on ndk 0.2, 0.3, 0.4
- Only 0.2 dependencies comes from Bevy itself

## Solution

- Replace #1371 
- Update Bevy to ndk-glue 0.4
- Also fixes duplicate dependency CI issue