### PR TITLE
[Merged by Bors] - derive Debug, Clone for FixedState (StableAHash)

### DIFF
--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -16,7 +16,7 @@ pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
 /// A hasher builder that will create a fixed hasher.
-#[derive(Default)]
+#[derive(Debug, Clone, Default)]
 pub struct FixedState;
 
 impl std::hash::BuildHasher for FixedState {


### PR DESCRIPTION
This matches `ahash::RandomState`, which provides both `Debug` and `Clone`.

Notably, implementing `Clone` allows the `StableHashMap`/`Set` to also implement `Clone`.

# Objective

- Allow `bevy_utils::StableHashMap` to be cloned.

## Solution

- Derive `Clone` for `bevy_utils::FixedState`.
- Also derive `Debug`, since we're touching it anyway, and this aligns `FixedState` with `ahash::RandomState`.
