### PR TITLE
[Merged by Bors] - Implement Sub-App Labels

### DIFF
--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -23,6 +23,7 @@ bevy_derive = { path = "../bevy_derive", version = "0.5.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.5.0" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.5.0", optional = true }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
+bevy_app_macros = { path = "./macros", version = "0.5.0" }
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/bevy_app/macros/Cargo.toml
+++ b/crates/bevy_app/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "bevy_ecs_macros"
+name = "bevy_app_macros"
 version = "0.5.0"
-description = "Bevy ECS Macros"
+description = "Bevy App Macros"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 

--- a/crates/bevy_app/macros/src/lib.rs
+++ b/crates/bevy_app/macros/src/lib.rs
@@ -1,0 +1,19 @@
+extern crate proc_macro;
+
+use bevy_macro_utils::{derive_label, BevyManifest};
+use proc_macro::TokenStream;
+use quote::format_ident;
+
+#[proc_macro_derive(SubAppLabel)]
+pub fn derive_sub_app_label(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    let mut trait_path = bevy_app_path();
+    trait_path
+        .segments
+        .push(format_ident!("SubAppLabel").into());
+    derive_label(input, trait_path)
+}
+
+fn bevy_app_path() -> syn::Path {
+    BevyManifest::default().get_path("bevy_app")
+}

--- a/crates/bevy_ecs/src/schedule/label.rs
+++ b/crates/bevy_ecs/src/schedule/label.rs
@@ -1,115 +1,15 @@
 pub use bevy_ecs_macros::{AmbiguitySetLabel, RunCriteriaLabel, StageLabel, SystemLabel};
 
-use std::{
-    any::Any,
-    borrow::Cow,
-    fmt::Debug,
-    hash::{Hash, Hasher},
-};
+use bevy_utils::define_label;
 
-pub trait DynEq: Any {
-    fn as_any(&self) -> &dyn Any;
-
-    fn dyn_eq(&self, other: &dyn DynEq) -> bool;
-}
-
-impl<T> DynEq for T
-where
-    T: Any + Eq,
-{
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn dyn_eq(&self, other: &dyn DynEq) -> bool {
-        if let Some(other) = other.as_any().downcast_ref::<T>() {
-            return self == other;
-        }
-        false
-    }
-}
-
-pub trait DynHash: DynEq {
-    fn as_dyn_eq(&self) -> &dyn DynEq;
-
-    fn dyn_hash(&self, state: &mut dyn Hasher);
-}
-
-impl<T> DynHash for T
-where
-    T: DynEq + Hash,
-{
-    fn as_dyn_eq(&self) -> &dyn DynEq {
-        self
-    }
-
-    fn dyn_hash(&self, mut state: &mut dyn Hasher) {
-        T::hash(self, &mut state);
-        self.type_id().hash(&mut state);
-    }
-}
-
-pub trait StageLabel: DynHash + Debug + Send + Sync + 'static {
-    #[doc(hidden)]
-    fn dyn_clone(&self) -> Box<dyn StageLabel>;
-}
+define_label!(StageLabel);
 pub(crate) type BoxedStageLabel = Box<dyn StageLabel>;
 
-pub trait SystemLabel: DynHash + Debug + Send + Sync + 'static {
-    #[doc(hidden)]
-    fn dyn_clone(&self) -> Box<dyn SystemLabel>;
-}
+define_label!(SystemLabel);
 pub(crate) type BoxedSystemLabel = Box<dyn SystemLabel>;
 
-pub trait AmbiguitySetLabel: DynHash + Debug + Send + Sync + 'static {
-    #[doc(hidden)]
-    fn dyn_clone(&self) -> Box<dyn AmbiguitySetLabel>;
-}
+define_label!(AmbiguitySetLabel);
 pub(crate) type BoxedAmbiguitySetLabel = Box<dyn AmbiguitySetLabel>;
 
-pub trait RunCriteriaLabel: DynHash + Debug + Send + Sync + 'static {
-    #[doc(hidden)]
-    fn dyn_clone(&self) -> Box<dyn RunCriteriaLabel>;
-}
+define_label!(RunCriteriaLabel);
 pub(crate) type BoxedRunCriteriaLabel = Box<dyn RunCriteriaLabel>;
-
-macro_rules! impl_label {
-    ($trait_name:ident) => {
-        impl PartialEq for dyn $trait_name {
-            fn eq(&self, other: &Self) -> bool {
-                self.dyn_eq(other.as_dyn_eq())
-            }
-        }
-
-        impl Eq for dyn $trait_name {}
-
-        impl Hash for dyn $trait_name {
-            fn hash<H: Hasher>(&self, state: &mut H) {
-                self.dyn_hash(state);
-            }
-        }
-
-        impl Clone for Box<dyn $trait_name> {
-            fn clone(&self) -> Self {
-                self.dyn_clone()
-            }
-        }
-
-        impl $trait_name for Cow<'static, str> {
-            fn dyn_clone(&self) -> Box<dyn $trait_name> {
-                Box::new(self.clone())
-            }
-        }
-
-        impl $trait_name for &'static str {
-            fn dyn_clone(&self) -> Box<dyn $trait_name> {
-                Box::new(<&str>::clone(self))
-            }
-        }
-    };
-}
-
-impl_label!(StageLabel);
-impl_label!(SystemLabel);
-impl_label!(AmbiguitySetLabel);
-impl_label!(RunCriteriaLabel);

--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -15,3 +15,4 @@ keywords = ["bevy"]
 [dependencies]
 cargo-manifest = "0.2.3"
 syn = "1.0"
+quote = "1.0"

--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -2,6 +2,7 @@ extern crate proc_macro;
 
 use cargo_manifest::{DepsSet, Manifest};
 use proc_macro::TokenStream;
+use quote::quote;
 use std::{env, path::PathBuf};
 
 pub struct BevyManifest {
@@ -58,4 +59,30 @@ fn get_path(path: &str) -> syn::Path {
 
 fn parse_str<T: syn::parse::Parse>(path: &str) -> T {
     syn::parse(path.parse::<TokenStream>().unwrap()).unwrap()
+}
+
+/// Derive a label trait
+///
+/// # Args
+///
+/// - `input`: The [`syn::DeriveInput`] for struct that is deriving the label trait
+/// - `trait_path`: The path [`syn::Path`] to the label trait
+pub fn derive_label(input: syn::DeriveInput, trait_path: syn::Path) -> TokenStream {
+    let ident = input.ident;
+
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let mut where_clause = where_clause.cloned().unwrap_or_else(|| syn::WhereClause {
+        where_token: Default::default(),
+        predicates: Default::default(),
+    });
+    where_clause.predicates.push(syn::parse2(quote! { Self: Eq + ::std::fmt::Debug + ::std::hash::Hash + Clone + Send + Sync + 'static }).unwrap());
+
+    (quote! {
+        impl #impl_generics #trait_path for #ident #ty_generics #where_clause {
+            fn dyn_clone(&self) -> Box<dyn #trait_path> {
+                Box::new(Clone::clone(self))
+            }
+        }
+    })
+    .into()
 }

--- a/crates/bevy_utils/src/label.rs
+++ b/crates/bevy_utils/src/label.rs
@@ -1,0 +1,98 @@
+//! Traits used by label implementations
+
+use std::{
+    any::Any,
+    hash::{Hash, Hasher},
+};
+
+pub trait DynEq: Any {
+    fn as_any(&self) -> &dyn Any;
+
+    fn dyn_eq(&self, other: &dyn DynEq) -> bool;
+}
+
+impl<T> DynEq for T
+where
+    T: Any + Eq,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn dyn_eq(&self, other: &dyn DynEq) -> bool {
+        if let Some(other) = other.as_any().downcast_ref::<T>() {
+            return self == other;
+        }
+        false
+    }
+}
+
+pub trait DynHash: DynEq {
+    fn as_dyn_eq(&self) -> &dyn DynEq;
+
+    fn dyn_hash(&self, state: &mut dyn Hasher);
+}
+
+impl<T> DynHash for T
+where
+    T: DynEq + Hash,
+{
+    fn as_dyn_eq(&self) -> &dyn DynEq {
+        self
+    }
+
+    fn dyn_hash(&self, mut state: &mut dyn Hasher) {
+        T::hash(self, &mut state);
+        self.type_id().hash(&mut state);
+    }
+}
+
+/// Macro to define a new label trait
+/// 
+/// # Example
+/// 
+/// ```
+/// # use bevy_utils::define_label;
+/// define_label!(MyNewLabelTrait);
+/// ```
+#[macro_export]
+macro_rules! define_label {
+    ($label_trait_name:ident) => {
+        pub trait $label_trait_name: ::bevy_utils::label::DynHash + ::std::fmt::Debug + Send + Sync + 'static {
+            #[doc(hidden)]
+            fn dyn_clone(&self) -> Box<dyn $label_trait_name>;
+        }
+
+        impl PartialEq for dyn $label_trait_name {
+            fn eq(&self, other: &Self) -> bool {
+                self.dyn_eq(other.as_dyn_eq())
+            }
+        }
+
+        impl Eq for dyn $label_trait_name {}
+
+        impl ::std::hash::Hash for dyn $label_trait_name {
+            fn hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
+                self.dyn_hash(state);
+            }
+        }
+
+        impl Clone for Box<dyn $label_trait_name> {
+            fn clone(&self) -> Self {
+                self.dyn_clone()
+            }
+        }
+
+        impl $label_trait_name for ::std::borrow::Cow<'static, str> {
+            fn dyn_clone(&self) -> Box<dyn $label_trait_name> {
+                Box::new(self.clone())
+            }
+        }
+
+        impl $label_trait_name for &'static str {
+            fn dyn_clone(&self) -> Box<dyn $label_trait_name> {
+                Box::new(<&str>::clone(self))
+            }
+        }
+    };
+}

--- a/crates/bevy_utils/src/label.rs
+++ b/crates/bevy_utils/src/label.rs
@@ -48,9 +48,9 @@ where
 }
 
 /// Macro to define a new label trait
-/// 
+///
 /// # Example
-/// 
+///
 /// ```
 /// # use bevy_utils::define_label;
 /// define_label!(MyNewLabelTrait);
@@ -58,7 +58,9 @@ where
 #[macro_export]
 macro_rules! define_label {
     ($label_trait_name:ident) => {
-        pub trait $label_trait_name: ::bevy_utils::label::DynHash + ::std::fmt::Debug + Send + Sync + 'static {
+        pub trait $label_trait_name:
+            ::bevy_utils::label::DynHash + ::std::fmt::Debug + Send + Sync + 'static
+        {
             #[doc(hidden)]
             fn dyn_clone(&self) -> Box<dyn $label_trait_name>;
         }

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -1,5 +1,6 @@
 mod enum_variant_meta;
 pub mod slab;
+pub mod label;
 
 pub use ahash::AHasher;
 pub use enum_variant_meta::*;

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -1,6 +1,6 @@
 mod enum_variant_meta;
-pub mod slab;
 pub mod label;
+pub mod slab;
 
 pub use ahash::AHasher;
 pub use enum_variant_meta::*;

--- a/pipelined/bevy_core_pipeline/src/lib.rs
+++ b/pipelined/bevy_core_pipeline/src/lib.rs
@@ -20,7 +20,7 @@ use bevy_render2::{
     renderer::RenderDevice,
     texture::TextureCache,
     view::{ExtractedView, ViewPlugin},
-    RenderStage, RenderWorld,
+    RenderStage, RenderSubApp, RenderWorld,
 };
 
 /// Resource that configures the clear color
@@ -74,7 +74,7 @@ impl Plugin for CorePipelinePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ClearColor>();
 
-        let render_app = app.sub_app_mut(0);
+        let render_app = app.sub_app_mut(RenderSubApp).unwrap();
         render_app
             .add_system_to_stage(RenderStage::Extract, extract_clear_color)
             .add_system_to_stage(RenderStage::Extract, extract_core_pipeline_camera_phases)

--- a/pipelined/bevy_pbr2/src/lib.rs
+++ b/pipelined/bevy_pbr2/src/lib.rs
@@ -13,7 +13,7 @@ use bevy_ecs::prelude::*;
 use bevy_render2::{
     render_graph::RenderGraph,
     render_phase::{sort_phase_system, DrawFunctions},
-    RenderStage,
+    RenderStage, RenderSubApp,
 };
 
 pub mod draw_3d_graph {
@@ -30,7 +30,7 @@ impl Plugin for PbrPlugin {
         app.add_plugin(StandardMaterialPlugin)
             .init_resource::<AmbientLight>();
 
-        let render_app = app.sub_app_mut(0);
+        let render_app = app.sub_app_mut(RenderSubApp).unwrap();
         render_app
             .add_system_to_stage(RenderStage::Extract, render::extract_meshes)
             .add_system_to_stage(RenderStage::Extract, render::extract_lights)

--- a/pipelined/bevy_render2/src/camera/mod.rs
+++ b/pipelined/bevy_render2/src/camera/mod.rs
@@ -12,7 +12,7 @@ pub use bundle::*;
 pub use camera::*;
 pub use projection::*;
 
-use crate::{view::ExtractedView, RenderStage};
+use crate::{view::ExtractedView, RenderStage, RenderSubApp};
 use bevy_app::{App, CoreStage, Plugin};
 use bevy_ecs::prelude::*;
 
@@ -40,7 +40,7 @@ impl Plugin for CameraPlugin {
                 CoreStage::PostUpdate,
                 crate::camera::camera_system::<PerspectiveProjection>,
             );
-        let render_app = app.sub_app_mut(0);
+        let render_app = app.sub_app_mut(RenderSubApp).unwrap();
         render_app
             .init_resource::<ExtractedCameraNames>()
             .add_system_to_stage(RenderStage::Extract, extract_cameras);

--- a/pipelined/bevy_render2/src/lib.rs
+++ b/pipelined/bevy_render2/src/lib.rs
@@ -24,7 +24,7 @@ use crate::{
     texture::ImagePlugin,
     view::{ViewPlugin, WindowRenderPlugin},
 };
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Plugin, SubAppLabel};
 use bevy_ecs::prelude::*;
 
 #[derive(Default)]
@@ -73,6 +73,10 @@ impl DerefMut for RenderWorld {
     }
 }
 
+/// Label for the rendering sub-app
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, SubAppLabel)]
+pub struct RenderSubApp;
+
 /// A "scratch" world used to avoid allocating new worlds every frame when
 // swapping out the Render World.
 #[derive(Default)]
@@ -114,7 +118,7 @@ impl Plugin for RenderPlugin {
             .init_resource::<RenderGraph>()
             .init_resource::<DrawFunctions>();
 
-        app.add_sub_app(render_app, move |app_world, render_app| {
+        app.add_sub_app(RenderSubApp, render_app, move |app_world, render_app| {
             // reserve all existing app entities for use in render_app
             // they can only be spawned using `get_or_spawn()`
             let meta_len = app_world.entities().meta.len();

--- a/pipelined/bevy_render2/src/render_asset.rs
+++ b/pipelined/bevy_render2/src/render_asset.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::{
     renderer::{RenderDevice, RenderQueue},
-    RenderStage,
+    RenderStage, RenderSubApp,
 };
 use bevy_app::{App, Plugin};
 use bevy_asset::{Asset, AssetEvent, Assets, Handle};
@@ -31,7 +31,7 @@ impl<A: RenderAsset> Default for RenderAssetPlugin<A> {
 
 impl<A: RenderAsset> Plugin for RenderAssetPlugin<A> {
     fn build(&self, app: &mut App) {
-        let render_app = app.sub_app_mut(0);
+        let render_app = app.sub_app_mut(RenderSubApp).unwrap();
         render_app
             .init_resource::<ExtractedAssets<A>>()
             .init_resource::<RenderAssets<A>>()

--- a/pipelined/bevy_render2/src/texture/mod.rs
+++ b/pipelined/bevy_render2/src/texture/mod.rs
@@ -13,7 +13,7 @@ pub use hdr_texture_loader::*;
 pub use image_texture_loader::*;
 pub use texture_cache::*;
 
-use crate::{render_asset::RenderAssetPlugin, RenderStage};
+use crate::{render_asset::RenderAssetPlugin, RenderStage, RenderSubApp};
 use bevy_app::{App, Plugin};
 use bevy_asset::AddAsset;
 
@@ -30,7 +30,7 @@ impl Plugin for ImagePlugin {
         app.add_plugin(RenderAssetPlugin::<Image>::default())
             .add_asset::<Image>();
 
-        let render_app = app.sub_app_mut(0);
+        let render_app = app.sub_app_mut(RenderSubApp).unwrap();
         render_app
             .init_resource::<TextureCache>()
             .add_system_to_stage(RenderStage::Cleanup, update_texture_cache_system);

--- a/pipelined/bevy_render2/src/view/mod.rs
+++ b/pipelined/bevy_render2/src/view/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     render_graph::{Node, NodeRunError, RenderGraph, RenderGraphContext},
     render_resource::DynamicUniformVec,
     renderer::{RenderContext, RenderDevice},
-    RenderStage,
+    RenderStage, RenderSubApp,
 };
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
@@ -22,7 +22,7 @@ impl ViewPlugin {
 
 impl Plugin for ViewPlugin {
     fn build(&self, app: &mut App) {
-        let render_app = app.sub_app_mut(0);
+        let render_app = app.sub_app_mut(RenderSubApp).unwrap();
         render_app
             .init_resource::<ViewMeta>()
             .add_system_to_stage(RenderStage::Prepare, prepare_views);

--- a/pipelined/bevy_render2/src/view/window.rs
+++ b/pipelined/bevy_render2/src/view/window.rs
@@ -2,7 +2,7 @@ use crate::{
     render_resource::TextureView,
     renderer::{RenderDevice, RenderInstance},
     texture::BevyDefault,
-    RenderStage,
+    RenderStage, RenderSubApp,
 };
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
@@ -19,7 +19,7 @@ pub struct WindowRenderPlugin;
 
 impl Plugin for WindowRenderPlugin {
     fn build(&self, app: &mut App) {
-        let render_app = app.sub_app_mut(0);
+        let render_app = app.sub_app_mut(RenderSubApp).unwrap();
         render_app
             .init_resource::<WindowSurfaces>()
             .init_resource::<NonSendMarker>()

--- a/pipelined/bevy_sprite2/src/lib.rs
+++ b/pipelined/bevy_sprite2/src/lib.rs
@@ -16,7 +16,9 @@ pub use texture_atlas::*;
 pub use texture_atlas_builder::*;
 
 use bevy_app::prelude::*;
-use bevy_render2::{render_graph::RenderGraph, render_phase::DrawFunctions, RenderStage};
+use bevy_render2::{
+    render_graph::RenderGraph, render_phase::DrawFunctions, RenderStage, RenderSubApp,
+};
 
 #[derive(Default)]
 pub struct SpritePlugin;
@@ -26,7 +28,7 @@ impl Plugin for SpritePlugin {
         app.add_asset::<TextureAtlas>()
             .register_type::<Sprite>()
             .add_system_to_stage(CoreStage::PostUpdate, sprite_auto_resize_system);
-        let render_app = app.sub_app_mut(0);
+        let render_app = app.sub_app_mut(RenderSubApp).unwrap();
         render_app
             .init_resource::<ExtractedSprites>()
             .add_system_to_stage(RenderStage::Extract, render::extract_atlases)
@@ -42,7 +44,7 @@ impl Plugin for SpritePlugin {
             .unwrap()
             .write()
             .add(draw_sprite);
-        let render_world = app.sub_app_mut(0).world.cell();
+        let render_world = app.sub_app_mut(RenderSubApp).unwrap().world.cell();
         let mut graph = render_world.get_resource_mut::<RenderGraph>().unwrap();
         graph.add_node("sprite", SpriteNode);
         graph

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -7,6 +7,7 @@ crates=(
     bevy_tasks
     bevy_ecs/macros
     bevy_ecs
+    bevy_app/macros
     bevy_app
     bevy_log
     bevy_dynamic_plugin


### PR DESCRIPTION
This is a rather simple but wide change, and it involves adding a new `bevy_app_macros` crate. Let me know if there is a better way to do any of this!

---

# Objective

- Allow adding and accessing sub-apps by using a label instead of an index

## Solution

- Migrate the bevy label implementation and derive code to the `bevy_utils` and `bevy_macro_utils` crates and then add a new `SubAppLabel` trait to the `bevy_app` crate that is used when adding or getting a sub-app from an app.
