### PR TITLE
[Merged by Bors] - bevy_pbr2: Add support for configurable shadow map sizes

### DIFF
--- a/pipelined/bevy_pbr2/src/lib.rs
+++ b/pipelined/bevy_pbr2/src/lib.rs
@@ -28,7 +28,9 @@ pub struct PbrPlugin;
 impl Plugin for PbrPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugin(StandardMaterialPlugin)
-            .init_resource::<AmbientLight>();
+            .init_resource::<AmbientLight>()
+            .init_resource::<DirectionalLightShadowMap>()
+            .init_resource::<PointLightShadowMap>();
 
         let render_app = app.sub_app(RenderApp);
         render_app

--- a/pipelined/bevy_pbr2/src/light.rs
+++ b/pipelined/bevy_pbr2/src/light.rs
@@ -49,6 +49,17 @@ impl PointLight {
     pub const DEFAULT_SHADOW_NORMAL_BIAS: f32 = 0.5;
 }
 
+#[derive(Clone, Debug)]
+pub struct PointLightShadowMap {
+    pub size: usize,
+}
+
+impl Default for PointLightShadowMap {
+    fn default() -> Self {
+        Self { size: 1024 }
+    }
+}
+
 /// A Directional light.
 ///
 /// Directional lights don't exist in reality but they are a good
@@ -111,6 +122,17 @@ impl Default for DirectionalLight {
 impl DirectionalLight {
     pub const DEFAULT_SHADOW_DEPTH_BIAS: f32 = 0.02;
     pub const DEFAULT_SHADOW_NORMAL_BIAS: f32 = 0.6;
+}
+
+#[derive(Clone, Debug)]
+pub struct DirectionalLightShadowMap {
+    pub size: usize,
+}
+
+impl Default for DirectionalLightShadowMap {
+    fn default() -> Self {
+        Self { size: 4096 }
+    }
 }
 
 /// Ambient light.


### PR DESCRIPTION
# Objective

Add support for configurable shadow map sizes

## Solution

- Add `DirectionalLightShadowMap` and `PointLightShadowMap` resources, which just have size members, to the app world, and add `Extracted*` counterparts to the render world
- Use the configured sizes when rendering shadow maps
- Default sizes remain the same - 4096 for directional light shadow maps, 1024 for point light shadow maps (which are cube maps so 6 faces at 1024x1024 per light)
