### PR TITLE
[Merged by Bors] - Label PRs for all target branches

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,8 +1,6 @@
 name: PR-Labeler
-on: 
+on:
   pull_request_target:
-    branches:
-      - main
     types:
       - opened
 
@@ -15,4 +13,3 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/label-config.yml
-        sync-labels: true


### PR DESCRIPTION
# Objective

- All new PRs should get the "S-Needs-Triage" label. But at the moment we for example are getting quite a few PRs to the new renderer branch that do not get the label.

## Solution

- Remove the required target "main" from the workflow
- Also removed configuration for not needed functionality of the labeler action (see [docs](https://github.com/actions/labeler#inputs))