### PR TITLE
[Merged by Bors] - bevy_render2: Make default near plane more sensible at 0.1

### DIFF
--- a/pipelined/bevy_render2/src/camera/projection.rs
+++ b/pipelined/bevy_render2/src/camera/projection.rs
@@ -37,7 +37,7 @@ impl Default for PerspectiveProjection {
     fn default() -> Self {
         PerspectiveProjection {
             fov: std::f32::consts::PI / 4.0,
-            near: 1.0,
+            near: 0.1,
             far: 1000.0,
             aspect_ratio: 1.0,
         }


### PR DESCRIPTION
# Objective

The default perspective projection near plane being at 1 unit feels very far away if one considers units to directly map to real world units such as metres. Not being able to see anything that is closer than 1m is unnecessarily limiting. Using a default of 0.1 makes more sense as it is difficult to even focus on things closer than 10cm in the real world.

## Solution

- Changed the default perspective projection near plane to 0.1.
