### PR TITLE
Add the ability to pass Vec<VecX> directly to mesh.set_attribute + simple example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,6 +223,10 @@ path = "examples/3d/wireframe.rs"
 name = "z_sort_debug"
 path = "examples/3d/z_sort_debug.rs"
 
+[[example]]
+name = "custom_mesh"
+path = "examples/3d/custom_mesh.rs"
+
 # Application
 [[example]]
 name = "custom_loop"

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -38,6 +38,7 @@ anyhow = "1.0.4"
 hex = "0.4.2"
 hexasphere = "4.0.0"
 parking_lot = "0.11.0"
+bytemuck = { version = "1.7.2", features = ["extern_crate_alloc"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 spirv-reflect = "0.2.3"

--- a/crates/bevy_render/src/mesh/mesh/conversions.rs
+++ b/crates/bevy_render/src/mesh/mesh/conversions.rs
@@ -26,10 +26,10 @@
 //! ```
 
 use crate::mesh::VertexAttributeValues;
+use bevy_math::{Vec2, Vec3, Vec4};
 use bevy_utils::EnumVariantMeta;
 use std::convert::TryFrom;
 use thiserror::Error;
-use bevy_math::{Vec3, Vec2, Vec4};
 #[derive(Debug, Clone, Error)]
 #[error("cannot convert VertexAttributeValues::{variant} to {into}")]
 pub struct FromVertexAttributeError {
@@ -128,19 +128,19 @@ impl From<Vec<[u8; 4]>> for VertexAttributeValues {
 
 impl From<Vec<Vec4>> for VertexAttributeValues {
     fn from(vec: Vec<Vec4>) -> Self {
-        VertexAttributeValues::Float32x4(bytemuck::allocation::cast_vec(vec) )
+        VertexAttributeValues::Float32x4(bytemuck::allocation::cast_vec(vec))
     }
 }
 
 impl From<Vec<Vec3>> for VertexAttributeValues {
     fn from(vec: Vec<Vec3>) -> Self {
-        VertexAttributeValues::Float32x3(bytemuck::allocation::cast_vec(vec) )
+        VertexAttributeValues::Float32x3(bytemuck::allocation::cast_vec(vec))
     }
 }
 
 impl From<Vec<Vec2>> for VertexAttributeValues {
     fn from(vec: Vec<Vec2>) -> Self {
-        VertexAttributeValues::Float32x2(bytemuck::allocation::cast_vec(vec) )
+        VertexAttributeValues::Float32x2(bytemuck::allocation::cast_vec(vec))
     }
 }
 

--- a/crates/bevy_render/src/mesh/mesh/conversions.rs
+++ b/crates/bevy_render/src/mesh/mesh/conversions.rs
@@ -29,7 +29,7 @@ use crate::mesh::VertexAttributeValues;
 use bevy_utils::EnumVariantMeta;
 use std::convert::TryFrom;
 use thiserror::Error;
-
+use bevy_math::{Vec3, Vec2, Vec4};
 #[derive(Debug, Clone, Error)]
 #[error("cannot convert VertexAttributeValues::{variant} to {into}")]
 pub struct FromVertexAttributeError {
@@ -123,6 +123,24 @@ impl From<Vec<[u32; 4]>> for VertexAttributeValues {
 impl From<Vec<[u8; 4]>> for VertexAttributeValues {
     fn from(vec: Vec<[u8; 4]>) -> Self {
         VertexAttributeValues::Unorm8x4(vec)
+    }
+}
+
+impl From<Vec<Vec4>> for VertexAttributeValues {
+    fn from(vec: Vec<Vec4>) -> Self {
+        VertexAttributeValues::Float32x4(bytemuck::allocation::cast_vec(vec) )
+    }
+}
+
+impl From<Vec<Vec3>> for VertexAttributeValues {
+    fn from(vec: Vec<Vec3>) -> Self {
+        VertexAttributeValues::Float32x3(bytemuck::allocation::cast_vec(vec) )
+    }
+}
+
+impl From<Vec<Vec2>> for VertexAttributeValues {
+    fn from(vec: Vec<Vec2>) -> Self {
+        VertexAttributeValues::Float32x2(bytemuck::allocation::cast_vec(vec) )
     }
 }
 

--- a/examples/3d/custom_mesh.rs
+++ b/examples/3d/custom_mesh.rs
@@ -1,5 +1,5 @@
-use bevy::render::mesh::Indices;
 use bevy::prelude::*;
+use bevy::render::mesh::Indices;
 use bevy::render::pipeline::PrimitiveTopology;
 
 fn main() {
@@ -20,26 +20,16 @@ fn setup(
     let right = Vec3::new(1.0, 0.0, 0.0);
     let up = Vec3::new(0.0, 1.0, 0.0);
 
-    let positions = vec![
-        origin + up,
-        origin + up + right,
-        origin,
-        origin + right,
-    ];
+    let positions = vec![origin + up, origin + up + right, origin, origin + right];
 
     let origin = Vec2::new(0.0, 0.0);
     let right = Vec2::new(1.0, 0.0);
     let up = Vec2::new(0.0, 1.0);
 
-    let uvs = vec![
-        origin + up,
-        origin + up + right,
-        origin,
-        origin + right,
-    ];
+    let uvs = vec![origin + up, origin + up + right, origin, origin + right];
 
-    let normals = vec![ [0.0, 0.0, 1.0]; 4 ];
-    let indices = Indices::U32(vec![0,1,2,3,2,1]);
+    let normals = vec![[0.0, 0.0, 1.0]; 4];
+    let indices = Indices::U32(vec![0, 1, 2, 3, 2, 1]);
 
     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
     mesh.set_indices(Some(indices));
@@ -53,7 +43,7 @@ fn setup(
         material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
         ..Default::default()
     });
-    
+
     // light
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(4.0, 8.0, 4.0),

--- a/examples/3d/custom_mesh.rs
+++ b/examples/3d/custom_mesh.rs
@@ -1,0 +1,67 @@
+use bevy::render::mesh::Indices;
+use bevy::prelude::*;
+use bevy::render::pipeline::PrimitiveTopology;
+
+fn main() {
+    App::new()
+        .insert_resource(Msaa { samples: 4 })
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(setup)
+        .run();
+}
+
+/// set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let origin = Vec3::new(0.0, 0.0, 0.0);
+    let right = Vec3::new(1.0, 0.0, 0.0);
+    let up = Vec3::new(0.0, 1.0, 0.0);
+
+    let positions = vec![
+        origin + up,
+        origin + up + right,
+        origin,
+        origin + right,
+    ];
+
+    let origin = Vec2::new(0.0, 0.0);
+    let right = Vec2::new(1.0, 0.0);
+    let up = Vec2::new(0.0, 1.0);
+
+    let uvs = vec![
+        origin + up,
+        origin + up + right,
+        origin,
+        origin + right,
+    ];
+
+    let normals = vec![ [0.0, 0.0, 1.0]; 4 ];
+    let indices = Indices::U32(vec![0,1,2,3,2,1]);
+
+    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+    mesh.set_indices(Some(indices));
+    mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, positions);
+    mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+    mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+
+    // plane
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(mesh),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        ..Default::default()
+    });
+    
+    // light
+    commands.spawn_bundle(PointLightBundle {
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..Default::default()
+    });
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(0.0, 5.0, -8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
+}

--- a/examples/3d/custom_mesh.rs
+++ b/examples/3d/custom_mesh.rs
@@ -20,13 +20,25 @@ fn setup(
     let right = Vec3::new(1.0, 0.0, 0.0);
     let up = Vec3::new(0.0, 1.0, 0.0);
 
-    let positions = vec![origin + up, origin + up + right, origin, origin + right];
+    #[rustfmt::skip]
+    let positions = vec![
+        origin + up, 
+        origin + up + right, 
+        origin, 
+        origin + right
+        ];
 
     let origin = Vec2::new(0.0, 0.0);
     let right = Vec2::new(1.0, 0.0);
     let up = Vec2::new(0.0, 1.0);
 
-    let uvs = vec![origin + up, origin + up + right, origin, origin + right];
+    #[rustfmt::skip]
+    let uvs = vec![
+        origin + up, 
+        origin + up + right, 
+        origin, 
+        origin + right
+        ];
 
     let normals = vec![[0.0, 0.0, 1.0]; 4];
     let indices = Indices::U32(vec![0, 1, 2, 3, 2, 1]);

--- a/examples/README.md
+++ b/examples/README.md
@@ -114,6 +114,7 @@ Example | File | Description
 `update_gltf_scene` | [`3d/update_gltf_scene.rs`](./3d/update_gltf_scene.rs) | Update a scene from a gltf file, either by spawning the scene as a child of another entity, or by accessing the entities of the scene
 `wireframe` | [`3d/wireframe.rs`](./3d/wireframe.rs) | Showcases wireframe rendering
 `z_sort_debug` | [`3d/z_sort_debug.rs`](./3d/z_sort_debug.rs) | Visualizes camera Z-ordering
+`custom_mesh` | [`3d/custom_mesh.rs`](./3d/custom_mesh.rs) | Simple example showing how to manually create a custom mesh.
 
 ## Application
 


### PR DESCRIPTION
# Objective

With this pr we can pass `Vec<VecX>` directly to `mesh.set_attribute`. When working with custom meshes, particularly with procedural generation, I find it extremely helpful to work directly with `Vec<VecX>` to represent my mesh points/uvs/colors/etc.

## Solution

Using bytemuck we can perform a conversion from `Vec<VecX>` to `Vec<[f32;X]>` when it gets passed to the mesh. Then we can use `Vec<Vec3>` directly to represent mesh points for example:

```    
    let origin = Vec3::new(0.0, 0.0, 0.0);
    let right = Vec3::new(1.0, 0.0, 0.0);
    let up = Vec3::new(0.0, 1.0, 0.0);

    let positions = vec![
        origin + up,
        origin + up + right,
        origin,
        origin + right,
    ];

    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
    mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, positions);
```