### PR TITLE
Fix task pool hanging with nested future::block_on calls

### DIFF
--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -185,8 +185,6 @@ impl TaskPool {
 
             if scope.spawned.is_empty() {
                 Vec::default()
-            } else if scope.spawned.len() == 1 {
-                vec![future::block_on(&mut scope.spawned[0])]
             } else {
                 let fut = async move {
                     let mut results = Vec::with_capacity(scope.spawned.len());


### PR DESCRIPTION
A previous instance of TaskPool::scope tried to optimize the case of a single task by immediately calling
future::block_on. However, @willcrichton observed an issue where a scope created within an async task
(that was already being executed via future::block_on) would hang on the inner task when recursively
calling future::block_on. Therefore this feature is disabled until someone decides it's needed and
comes up with a fix.