### PR TITLE
Switch to infinite_reverse_rh perspective

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -492,9 +492,6 @@ fn load_node(
                     near: perspective.znear(),
                     ..Default::default()
                 };
-                if let Some(zfar) = perspective.zfar() {
-                    perspective_projection.far = zfar;
-                }
                 if let Some(aspect_ratio) = perspective.aspect_ratio() {
                     perspective_projection.aspect_ratio = aspect_ratio;
                 }

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -16,12 +16,11 @@ pub struct PerspectiveProjection {
     pub fov: f32,
     pub aspect_ratio: f32,
     pub near: f32,
-    pub far: f32,
 }
 
 impl CameraProjection for PerspectiveProjection {
     fn get_projection_matrix(&self) -> Mat4 {
-        Mat4::perspective_rh(self.fov, self.aspect_ratio, self.near, self.far)
+        Mat4::perspective_infinite_reverse_rh(self.fov, self.aspect_ratio, self.near)
     }
 
     fn update(&mut self, width: f32, height: f32) {
@@ -38,7 +37,6 @@ impl Default for PerspectiveProjection {
         PerspectiveProjection {
             fov: std::f32::consts::PI / 4.0,
             near: 1.0,
-            far: 1000.0,
             aspect_ratio: 1.0,
         }
     }


### PR DESCRIPTION
# Objective

As with #2543, switch to infinite_reverse_rh perspective for now, before the rendering rework is merged.

Will only affect those working off `main` and will (I assume) be overwritten by the rework.

## Solution

- Changed projection matrix for `PerspectiveProjection` and removed far plane

## Alternate Solutions

- I thought about adding a 3rd projection `InverseInfiniteProjection` but we'd need to add another camera system. One system would (almost) always be redundant.
