### PR TITLE
[Merged by Bors] - Add aarch64-apple-darwin to the config_fast_builds for Apple Silicon

### DIFF
--- a/.cargo/config_fast_builds
+++ b/.cargo/config_fast_builds
@@ -12,6 +12,9 @@ rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]
 [target.x86_64-apple-darwin]
 rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Zshare-generics=y"]
 
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Zshare-generics=y"]
+
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"
 rustflags = ["-Zshare-generics=y"]


### PR DESCRIPTION
# Objective

M1 Macs / Apple Silicon / simply aarch64 needs to be specified for it to compile with zld, so users might be surprised to find that they aren't getting the benefits and see the fast compiles they might be seeing on other platforms.

## Solution

- Add it? :)