### PR TITLE
[Merged by Bors] - Derive thiserror::Error for HexColorError

### DIFF
--- a/crates/bevy_render/src/color.rs
+++ b/crates/bevy_render/src/color.rs
@@ -10,6 +10,7 @@ use bevy_math::{Vec3, Vec4};
 use bevy_reflect::{Reflect, ReflectDeserialize};
 use serde::{Deserialize, Serialize};
 use std::ops::{Add, AddAssign, Mul, MulAssign};
+use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect)]
 #[reflect(PartialEq, Serialize, Deserialize)]
@@ -1070,10 +1071,12 @@ impl Bytes for Color {
 
 impl_render_resource_bytes!(Color);
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum HexColorError {
+    #[error("Unexpected length of hex string")]
     Length,
-    Hex(hex::FromHexError),
+    #[error("Error parsing hex value")]
+    Hex(#[from] hex::FromHexError),
 }
 
 fn decode_rgb(data: &[u8]) -> Result<Color, HexColorError> {


### PR DESCRIPTION
# Objective

- Make it easy to use HexColorError with `thiserror`, i.e. converting it into other error types.

Makes this possible:

```rust
#[derive(Debug, thiserror::Error)]
pub enum LdtkError {
    #[error("An error occured while deserializing")]
    Json(#[from] serde_json::Error),
    #[error("An error occured while parsing a color")]
    HexColor(#[from] bevy::render::color::HexColorError),
}
```

## Solution

- Derive thiserror::Error the same way we do elsewhere (see query.rs for instance)