### PR TITLE
Allowing the wgpu renderer to be created externally

### DIFF
--- a/pipelined/bevy_render2/src/renderer/mod.rs
+++ b/pipelined/bevy_render2/src/renderer/mod.rs
@@ -41,11 +41,17 @@ pub fn render_system(world: &mut World) {
 pub type RenderQueue = Arc<Queue>;
 pub type RenderInstance = Instance;
 
+pub struct Renderer {
+    pub instance: RenderInstance,
+    pub device: RenderDevice,
+    pub queue: RenderQueue,
+}
+
 pub async fn initialize_renderer(
     backends: Backends,
     request_adapter_options: &RequestAdapterOptions<'_>,
     device_descriptor: &DeviceDescriptor<'_>,
-) -> (RenderInstance, RenderDevice, RenderQueue) {
+) -> Renderer {
     let instance = wgpu::Instance::new(backends);
 
     let adapter = instance
@@ -72,7 +78,11 @@ pub async fn initialize_renderer(
         .unwrap();
     let device = Arc::new(device);
     let queue = Arc::new(queue);
-    (instance, RenderDevice::from(device), queue)
+    Renderer {
+        instance,
+        device: RenderDevice::from(device),
+        queue,
+    }
 }
 
 pub struct RenderContext {


### PR DESCRIPTION
# Objective

This PR makes it so that bevy_render2 will create the WGPU Renderer if and only if there isn't already one created. The motivation in my case is that this would allow me to create the WGPU instance from raw handles (https://github.com/gfx-rs/wgpu/pull/1609)

## Solution

To create the WGPU Renderer externally, the user needs to create `bevy_render2::renderer::Renderer` before initializing the `bevy_render2` plugin and insert it into the world. `bevy_render2` will try to remove the renderer from the world and use it upon initialization.
