### PR TITLE
Fix frustum culling w/ sprite transform scaling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,10 @@ path = "examples/hello_world.rs"
 
 # 2D Rendering
 [[example]]
+name = "frustum"
+path = "examples/2d/frustum.rs"
+
+[[example]]
 name = "contributors"
 path = "examples/2d/contributors.rs"
 

--- a/crates/bevy_sprite/src/frustum_culling.rs
+++ b/crates/bevy_sprite/src/frustum_culling.rs
@@ -46,7 +46,7 @@ pub fn sprite_frustum_culling_system(
         if let Ok(camera_transform) = camera_transforms.get(active_camera_entity) {
             let camera_size = window_size * camera_transform.scale.truncate();
 
-            let rect = Rect {
+            let camera_rect = Rect {
                 position: camera_transform.translation.truncate(),
                 size: camera_size,
             };
@@ -54,10 +54,10 @@ pub fn sprite_frustum_culling_system(
             for (entity, drawable_transform, sprite) in sprites.iter() {
                 let sprite_rect = Rect {
                     position: drawable_transform.translation.truncate(),
-                    size: sprite.size,
+                    size: sprite.size * drawable_transform.scale.truncate(),
                 };
 
-                if rect.is_intersecting(sprite_rect) {
+                if camera_rect.is_intersecting(sprite_rect) {
                     if culled_sprites.get(entity).is_ok() {
                         commands.entity(entity).remove::<OutsideFrustum>();
                     }
@@ -90,7 +90,7 @@ pub fn atlas_frustum_culling_system(
         if let Ok(camera_transform) = camera_transforms.get(active_camera_entity) {
             let camera_size = window_size * camera_transform.scale.truncate();
 
-            let rect = Rect {
+            let camera_rect = Rect {
                 position: camera_transform.translation.truncate(),
                 size: camera_size,
             };
@@ -102,10 +102,10 @@ pub fn atlas_frustum_culling_system(
 
                         let sprite_rect = Rect {
                             position: drawable_transform.translation.truncate(),
-                            size,
+                            size: size * drawable_transform.scale.truncate(),
                         };
 
-                        if rect.is_intersecting(sprite_rect) {
+                        if camera_rect.is_intersecting(sprite_rect) {
                             if culled_sprites.get(entity).is_ok() {
                                 commands.entity(entity).remove::<OutsideFrustum>();
                             }

--- a/examples/2d/frustum.rs
+++ b/examples/2d/frustum.rs
@@ -1,5 +1,9 @@
-use bevy::{prelude::*, sprite::SpriteSettings};
-use bevy::render::draw::OutsideFrustum;
+use bevy::{
+    prelude::*,
+    render::draw::OutsideFrustum,
+    sprite::SpriteSettings,
+};
+use bevy::render::camera::OrthographicProjection;
 
 struct Bar;
 struct PrintTimer(Timer);
@@ -28,21 +32,32 @@ fn rotate(mut query: Query<&mut Transform, With<Bar>>, time: Res<Time>) {
     }
 }
 
+fn travel_camera(keys: Res<Input<KeyCode>>, mut query: Query<&mut Transform, With<OrthographicProjection>>, time: Res<Time>) {
+    let speed = 2f32;
+    for mut t in query.iter_mut() {
+        if keys.pressed(KeyCode::S) {
+            t.scale += time.delta_seconds() * speed;
+        }
+        if keys.pressed(KeyCode::W) {
+            t.scale -= time.delta_seconds() * speed;
+        }
+    }
+}
 
 fn travel(keys: Res<Input<KeyCode>>, mut query: Query<&mut Transform, With<Bar>>, time: Res<Time>) {
     let speed = 500f32;
     for mut t in query.iter_mut() {
         if keys.pressed(KeyCode::Right) {
-            t.translation.x += time.delta_seconds() * speed
+            t.translation.x += time.delta_seconds() * speed;
         }
         if keys.pressed(KeyCode::Left) {
-            t.translation.x -= time.delta_seconds() * speed
+            t.translation.x -= time.delta_seconds() * speed;
         }
         if keys.pressed(KeyCode::Up) {
-            t.translation.y += time.delta_seconds() * speed
+            t.translation.y += time.delta_seconds() * speed;
         }
         if keys.pressed(KeyCode::Down) {
-            t.translation.y -= time.delta_seconds() * speed
+            t.translation.y -= time.delta_seconds() * speed;
         }
     }
 }
@@ -58,7 +73,7 @@ fn info(time: Res<Time>, mut timer: ResMut<PrintTimer>, query: Query<&Bar, Witho
 }
 
 fn startup() {
-    info!("use the arrow keys to move the bar");
+    info!("use the arrow keys to move the bar, 'W' & 'S' to scale the camera");
 }
 
 fn main() {
@@ -72,6 +87,7 @@ fn main() {
         .add_startup_system(startup.system())
         .add_system(rotate.system())
         .add_system(travel.system())
+        .add_system(travel_camera.system())
         .add_system(info.system())
         .run();
 }

--- a/examples/2d/frustum.rs
+++ b/examples/2d/frustum.rs
@@ -1,0 +1,74 @@
+use bevy::{prelude::*, sprite::SpriteSettings};
+use bevy::render::draw::OutsideFrustum;
+
+struct Bar;
+struct PrintTimer(Timer);
+
+fn setup(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+
+    let mut transform = Transform::from_xyz(-800.0, 0.0, 0.0);
+    transform.scale = Vec3::new(1.0, 20.0, 1.0);
+
+    commands.spawn_bundle(SpriteBundle {
+        material: materials.add(Color::rgb(0.5, 0.5, 1.0).into()),
+        transform,
+        sprite: Sprite::new(Vec2::new(30.0, 30.0)),
+        ..Default::default()
+    }).insert(Bar);
+}
+
+fn rotate(mut query: Query<&mut Transform, With<Bar>>, time: Res<Time>) {
+    let speed = 5f32;
+    for mut t in query.iter_mut() {
+        t.rotation *= Quat::from_rotation_z(time.delta_seconds() * speed);
+    }
+}
+
+
+fn travel(keys: Res<Input<KeyCode>>, mut query: Query<&mut Transform, With<Bar>>, time: Res<Time>) {
+    let speed = 500f32;
+    for mut t in query.iter_mut() {
+        if keys.pressed(KeyCode::Right) {
+            t.translation.x += time.delta_seconds() * speed
+        }
+        if keys.pressed(KeyCode::Left) {
+            t.translation.x -= time.delta_seconds() * speed
+        }
+        if keys.pressed(KeyCode::Up) {
+            t.translation.y += time.delta_seconds() * speed
+        }
+        if keys.pressed(KeyCode::Down) {
+            t.translation.y -= time.delta_seconds() * speed
+        }
+    }
+}
+
+fn log_outside(time: Res<Time>, mut timer: ResMut<PrintTimer>, query: Query<&Bar, Without<OutsideFrustum>>) {
+    let mut count = 0;
+    for _ in query.iter() {
+        count += 1;
+    }
+    if timer.0.tick(time.delta()).just_finished() {
+        info!("{} sprites on screen", count);
+    }
+}
+
+
+fn main() {
+    info!("move the bar around with arrow keys!");
+    App::new()
+        .insert_resource(SpriteSettings {
+            frustum_culling_enabled: true,
+        })
+        .insert_resource(PrintTimer(Timer::from_seconds(1.0, true)))
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(setup.system())
+        .add_system(rotate.system())
+        .add_system(travel.system())
+        .add_system(log_outside.system())
+        .run();
+}

--- a/examples/2d/frustum.rs
+++ b/examples/2d/frustum.rs
@@ -10,7 +10,7 @@ fn setup(
 ) {
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
 
-    let mut transform = Transform::from_xyz(-800.0, 0.0, 0.0);
+    let mut transform = Transform::from_xyz(-400.0, 0.0, 0.0);
     transform.scale = Vec3::new(1.0, 20.0, 1.0);
 
     commands.spawn_bundle(SpriteBundle {
@@ -47,7 +47,7 @@ fn travel(keys: Res<Input<KeyCode>>, mut query: Query<&mut Transform, With<Bar>>
     }
 }
 
-fn log_outside(time: Res<Time>, mut timer: ResMut<PrintTimer>, query: Query<&Bar, Without<OutsideFrustum>>) {
+fn info(time: Res<Time>, mut timer: ResMut<PrintTimer>, query: Query<&Bar, Without<OutsideFrustum>>) {
     let mut count = 0;
     for _ in query.iter() {
         count += 1;
@@ -57,9 +57,11 @@ fn log_outside(time: Res<Time>, mut timer: ResMut<PrintTimer>, query: Query<&Bar
     }
 }
 
+fn startup() {
+    info!("use the arrow keys to move the bar");
+}
 
 fn main() {
-    info!("move the bar around with arrow keys!");
     App::new()
         .insert_resource(SpriteSettings {
             frustum_culling_enabled: true,
@@ -67,8 +69,9 @@ fn main() {
         .insert_resource(PrintTimer(Timer::from_seconds(1.0, true)))
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
+        .add_startup_system(startup.system())
         .add_system(rotate.system())
         .add_system(travel.system())
-        .add_system(log_outside.system())
+        .add_system(info.system())
         .run();
 }

--- a/examples/2d/frustum.rs
+++ b/examples/2d/frustum.rs
@@ -1,28 +1,23 @@
-use bevy::{
-    prelude::*,
-    render::draw::OutsideFrustum,
-    sprite::SpriteSettings,
-};
 use bevy::render::camera::OrthographicProjection;
+use bevy::{prelude::*, render::draw::OutsideFrustum, sprite::SpriteSettings};
 
 struct Bar;
 struct PrintTimer(Timer);
 
-fn setup(
-    mut commands: Commands,
-    mut materials: ResMut<Assets<ColorMaterial>>,
-) {
+fn setup(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
 
     let mut transform = Transform::from_xyz(-400.0, 0.0, 0.0);
     transform.scale = Vec3::new(1.0, 20.0, 1.0);
 
-    commands.spawn_bundle(SpriteBundle {
-        material: materials.add(Color::rgb(0.5, 0.5, 1.0).into()),
-        transform,
-        sprite: Sprite::new(Vec2::new(30.0, 30.0)),
-        ..Default::default()
-    }).insert(Bar);
+    commands
+        .spawn_bundle(SpriteBundle {
+            material: materials.add(Color::rgb(0.5, 0.5, 1.0).into()),
+            transform,
+            sprite: Sprite::new(Vec2::new(30.0, 30.0)),
+            ..Default::default()
+        })
+        .insert(Bar);
 }
 
 fn rotate(mut query: Query<&mut Transform, With<Bar>>, time: Res<Time>) {
@@ -32,7 +27,11 @@ fn rotate(mut query: Query<&mut Transform, With<Bar>>, time: Res<Time>) {
     }
 }
 
-fn travel_camera(keys: Res<Input<KeyCode>>, mut query: Query<&mut Transform, With<OrthographicProjection>>, time: Res<Time>) {
+fn travel_camera(
+    keys: Res<Input<KeyCode>>,
+    mut query: Query<&mut Transform, With<OrthographicProjection>>,
+    time: Res<Time>,
+) {
     let speed = 2f32;
     for mut t in query.iter_mut() {
         if keys.pressed(KeyCode::S) {
@@ -62,7 +61,11 @@ fn travel(keys: Res<Input<KeyCode>>, mut query: Query<&mut Transform, With<Bar>>
     }
 }
 
-fn info(time: Res<Time>, mut timer: ResMut<PrintTimer>, query: Query<&Bar, Without<OutsideFrustum>>) {
+fn info(
+    time: Res<Time>,
+    mut timer: ResMut<PrintTimer>,
+    query: Query<&Bar, Without<OutsideFrustum>>,
+) {
     let mut count = 0;
     for _ in query.iter() {
         count += 1;

--- a/examples/README.md
+++ b/examples/README.md
@@ -83,6 +83,7 @@ Example | File | Description
 Example | File | Description
 --- | --- | ---
 `contributors` | [`2d/contributors.rs`](./2d/contributors.rs) | Displays each contributor as a bouncy bevy-ball!
+`frustum` | [`2d/frustum.rs`](./2d/frustum.rs) | Tests the frustum culling system (only draws sprites on-screen)
 `many_sprites` | [`2d/many_sprites.rs`](./2d/many_sprites.rs) | Displays many sprites in a grid arragement! Used for performance testing.
 `mesh` | [`2d/mesh.rs`](./2d/mesh.rs) | Renders a custom mesh
 `sprite` | [`2d/sprite.rs`](./2d/sprite.rs) | Renders a sprite


### PR DESCRIPTION
# Objective

- Frustum culling now takes in account the Transform scale of the sprite
- Also added a demo example (from https://github.com/rparrett/bevy-test/tree/culling)

## Solution

- Take sprite's Transform.scale into account when measuring whether camera_rect & sprite_rect intersect each other
