### PR TITLE
[Merged by Bors] - Fix Option<NonSend<T>> and Option<NonSendMut<T>>

### DIFF
--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -27,8 +27,8 @@ mod tests {
         query::{Added, Changed, Or, QueryState, With, Without},
         schedule::{Schedule, Stage, SystemStage},
         system::{
-            ConfigurableSystem, IntoExclusiveSystem, IntoSystem, Local, Query, QuerySet,
-            RemovedComponents, Res, ResMut, System, SystemState, NonSend, NonSendMut
+            ConfigurableSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend, NonSendMut, Query,
+            QuerySet, RemovedComponents, Res, ResMut, System, SystemState,
         },
         world::{FromWorld, World},
     };
@@ -334,16 +334,16 @@ mod tests {
     #[test]
     fn non_send_option_system() {
         let mut world = World::default();
-        
+
         world.insert_resource(false);
         struct NotSend1(std::rc::Rc<i32>);
         struct NotSend2(std::rc::Rc<i32>);
         world.insert_non_send(NotSend1(std::rc::Rc::new(0)));
 
         fn sys(
-                op: Option<NonSend<NotSend1>>, 
+            op: Option<NonSend<NotSend1>>,
             mut _op2: Option<NonSendMut<NotSend2>>,
-            mut run: ResMut<bool>
+            mut run: ResMut<bool>,
         ) {
             op.expect("NonSend should exist");
             *run = true;
@@ -357,26 +357,21 @@ mod tests {
     #[test]
     fn non_send_system() {
         let mut world = World::default();
-        
+
         world.insert_resource(false);
         struct NotSend1(std::rc::Rc<i32>);
         struct NotSend2(std::rc::Rc<i32>);
-        
+
         world.insert_non_send(NotSend1(std::rc::Rc::new(1)));
         world.insert_non_send(NotSend2(std::rc::Rc::new(2)));
 
-        fn sys(
-                _op: NonSend<NotSend1>, 
-            mut _op2: NonSendMut<NotSend2>,
-            mut run: ResMut<bool>
-        ) {
+        fn sys(_op: NonSend<NotSend1>, mut _op2: NonSendMut<NotSend2>, mut run: ResMut<bool>) {
             *run = true;
         }
 
         run_system(&mut world, sys);
         assert!(*world.get_resource::<bool>().unwrap());
     }
-
 
     #[test]
     fn remove_tracking() {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -329,6 +329,7 @@ impl<'w, 's, T: Component> SystemParamFetch<'w, 's> for ResState<T> {
 }
 
 /// The [`SystemParamState`] of [`Option<Res<T>>`].
+/// See: [`Res<T>`]
 pub struct OptionResState<T>(ResState<T>);
 
 impl<'a, T: Component> SystemParam for Option<Res<'a, T>> {
@@ -445,6 +446,7 @@ impl<'w, 's, T: Component> SystemParamFetch<'w, 's> for ResMutState<T> {
 }
 
 /// The [`SystemParamState`] of [`Option<ResMut<T>>`].
+/// See: [`ResMut<T>`]
 pub struct OptionResMutState<T>(ResMutState<T>);
 
 impl<'a, T: Component> SystemParam for Option<ResMut<'a, T>> {
@@ -815,6 +817,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendState<T> {
 }
 
 /// The [`SystemParamState`] of [`Option<NonSend<T>>`].
+/// See: [`NonSend<T>`]
 pub struct OptionNonSendState<T>(NonSendState<T>);
 
 impl<'w, T: Component> SystemParam for Option<NonSend<'w, T>> {
@@ -935,6 +938,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendMutState<T> {
 }
 
 /// The [`SystemParamState`] of [`Option<NonSendMut<T>>`].
+/// See: [`NonSendMut<T>`]
 pub struct OptionNonSendMutState<T>(NonSendMutState<T>);
 
 impl<'a, T: 'static> SystemParam for Option<NonSendMut<'a, T>> {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -903,8 +903,6 @@ unsafe impl<T: 'static> SystemParamState for NonSendMutState<T> {
         }
     }
 
-    
-
     fn default_config() {}
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -19,8 +19,6 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use super::SystemId;
-
 /// A parameter that can be used in a [`System`](super::System).
 ///
 /// # Derive
@@ -1156,39 +1154,6 @@ impl<'w, 's> SystemParamFetch<'w, 's> for SystemChangeTickState {
             last_change_tick: system_meta.last_change_tick,
             change_tick,
         }
-    }
-}
-
-/// The [`SystemParamState`] of [`SystemIdState`].
-pub struct SystemIdState;
-
-// SAFE: Only reads internal system state
-unsafe impl ReadOnlySystemParamFetch for SystemIdState {}
-
-impl SystemParam for SystemId {
-    type Fetch = SystemIdState;
-}
-
-unsafe impl SystemParamState for SystemIdState {
-    type Config = ();
-
-    fn init(_world: &mut World, _system_meta: &mut SystemMeta, _config: Self::Config) -> Self {
-        Self {}
-    }
-
-    fn default_config() {}
-}
-
-impl<'w, 's> SystemParamFetch<'w, 's> for SystemIdState {
-    type Item = SystemId;
-
-    unsafe fn get_param(
-        _state: &'s mut Self,
-        system_meta: &SystemMeta,
-        _world: &'w World,
-        _change_tick: u32,
-    ) -> Self::Item {
-        system_meta.id
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -444,8 +444,7 @@ impl<'w, 's, T: Component> SystemParamFetch<'w, 's> for ResMutState<T> {
     }
 }
 
-/// The [`SystemParamState`] of [`Option<ResMut<T>>`].
-/// See: [`ResMut<T>`]
+/// The [`SystemParamState`] of `Option<ResMut<T>>`.
 pub struct OptionResMutState<T>(ResMutState<T>);
 
 impl<'a, T: Component> SystemParam for Option<ResMut<'a, T>> {
@@ -815,8 +814,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendState<T> {
     }
 }
 
-/// The [`SystemParamState`] of [`Option<NonSend<T>>`].
-/// See: [`NonSend<T>`]
+/// The [`SystemParamState`] of `Option<NonSend<T>>`.
 pub struct OptionNonSendState<T>(NonSendState<T>);
 
 impl<'w, T: 'static> SystemParam for Option<NonSend<'w, T>> {
@@ -936,8 +934,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendMutState<T> {
     }
 }
 
-/// The [`SystemParamState`] of [`Option<NonSendMut<T>>`].
-/// See: [`NonSendMut<T>`]
+/// The [`SystemParamState`] of `Option<NonSendMut<T>>`.
 pub struct OptionNonSendMutState<T>(NonSendMutState<T>);
 
 impl<'a, T: 'static> SystemParam for Option<NonSendMut<'a, T>> {
@@ -1131,7 +1128,7 @@ impl SystemParam for SystemChangeTick {
     type Fetch = SystemChangeTickState;
 }
 
-/// The [`SystemParamState`] of [`SystemChangeTick`].
+/// The [`SystemParamState`] of [`SystemChangeTickState`].
 pub struct SystemChangeTickState {}
 
 unsafe impl SystemParamState for SystemChangeTickState {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -877,7 +877,7 @@ unsafe impl<T: 'static> SystemParamState for NonSendMutState<T> {
     fn init(world: &mut World, system_meta: &mut SystemMeta, _config: Self::Config) -> Self {
         system_meta.set_non_send();
 
-        let component_id = world.components.get_or_insert_non_send_resource_id::<T>();
+        let component_id = world.initialize_non_send_resource::<T>();
         let combined_access = system_meta.component_access_set.combined_access_mut();
         if combined_access.has_write(component_id) {
             panic!(
@@ -902,6 +902,8 @@ unsafe impl<T: 'static> SystemParamState for NonSendMutState<T> {
             marker: PhantomData,
         }
     }
+
+    
 
     fn default_config() {}
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -19,6 +19,8 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+use super::SystemId;
+
 /// A parameter that can be used in a [`System`](super::System).
 ///
 /// # Derive
@@ -1154,6 +1156,39 @@ impl<'w, 's> SystemParamFetch<'w, 's> for SystemChangeTickState {
             last_change_tick: system_meta.last_change_tick,
             change_tick,
         }
+    }
+}
+
+/// The [`SystemParamState`] of [`SystemIdState`].
+pub struct SystemIdState;
+
+// SAFE: Only reads internal system state
+unsafe impl ReadOnlySystemParamFetch for SystemIdState {}
+
+impl SystemParam for SystemId {
+    type Fetch = SystemIdState;
+}
+
+unsafe impl SystemParamState for SystemIdState {
+    type Config = ();
+
+    fn init(_world: &mut World, _system_meta: &mut SystemMeta, _config: Self::Config) -> Self {
+        Self {}
+    }
+
+    fn default_config() {}
+}
+
+impl<'w, 's> SystemParamFetch<'w, 's> for SystemIdState {
+    type Item = SystemId;
+
+    unsafe fn get_param(
+        _state: &'s mut Self,
+        system_meta: &SystemMeta,
+        _world: &'w World,
+        _change_tick: u32,
+    ) -> Self::Item {
+        system_meta.id
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -259,7 +259,7 @@ impl<'w, T: Component> AsRef<T> for Res<'w, T> {
     }
 }
 
-/// The [`SystemParamState`] of [`Res<T>`].
+/// The [`SystemParamState`] of [`Res`].
 pub struct ResState<T> {
     component_id: ComponentId,
     marker: PhantomData<T>,
@@ -328,8 +328,7 @@ impl<'w, 's, T: Component> SystemParamFetch<'w, 's> for ResState<T> {
     }
 }
 
-/// The [`SystemParamState`] of [`Option<Res<T>>`].
-/// See: [`Res<T>`]
+/// The [`SystemParamState`] of `Option<Res<T>>`.
 pub struct OptionResState<T>(ResState<T>);
 
 impl<'a, T: Component> SystemParam for Option<Res<'a, T>> {
@@ -370,7 +369,7 @@ impl<'w, 's, T: Component> SystemParamFetch<'w, 's> for OptionResState<T> {
     }
 }
 
-/// The [`SystemParamState`] of [`ResMut<T>`].
+/// The [`SystemParamState`] of [`ResMut`].
 pub struct ResMutState<T> {
     component_id: ComponentId,
     marker: PhantomData<T>,
@@ -578,7 +577,7 @@ impl<'a, T: Component> DerefMut for Local<'a, T> {
     }
 }
 
-/// The [`SystemParamState`] of [`Local<T>`].
+/// The [`SystemParamState`] of [`Local`].
 pub struct LocalState<T: Component>(T);
 
 impl<'a, T: Component + FromWorld> SystemParam for Local<'a, T> {
@@ -646,7 +645,7 @@ impl<'a, T> RemovedComponents<'a, T> {
 // SAFE: Only reads World components
 unsafe impl<T: Component> ReadOnlySystemParamFetch for RemovedComponentsState<T> {}
 
-/// The [`SystemParamState`] of [`RemovedComponents<T>`].
+/// The [`SystemParamState`] of [`RemovedComponents`].
 pub struct RemovedComponentsState<T> {
     component_id: ComponentId,
     marker: PhantomData<T>,
@@ -743,7 +742,7 @@ impl<'w, T: 'static> Deref for NonSend<'w, T> {
     }
 }
 
-/// The [`SystemParamState`] of [`NonSend<T>`].
+/// The [`SystemParamState`] of [`NonSend`].
 pub struct NonSendState<T> {
     component_id: ComponentId,
     marker: PhantomData<fn() -> T>,
@@ -859,7 +858,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for OptionNonSendState<T> {
     }
 }
 
-/// The [`SystemParamState`] of [`NonSendMut<T>`].
+/// The [`SystemParamState`] of [`NonSendMut`].
 pub struct NonSendMutState<T> {
     component_id: ComponentId,
     marker: PhantomData<fn() -> T>,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -820,7 +820,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendState<T> {
 /// See: [`NonSend<T>`]
 pub struct OptionNonSendState<T>(NonSendState<T>);
 
-impl<'w, T: Component> SystemParam for Option<NonSend<'w, T>> {
+impl<'w, T: 'static> SystemParam for Option<NonSend<'w, T>> {
     type Fetch = OptionNonSendState<T>;
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -444,7 +444,7 @@ impl<'w, 's, T: Component> SystemParamFetch<'w, 's> for ResMutState<T> {
     }
 }
 
-/// The [`SystemParamState`] of `Option<ResMut<T>>`.
+/// The [`SystemParamState`] of [`Option<ResMut<T>>`].
 pub struct OptionResMutState<T>(ResMutState<T>);
 
 impl<'a, T: Component> SystemParam for Option<ResMut<'a, T>> {
@@ -814,7 +814,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendState<T> {
     }
 }
 
-/// The [`SystemParamState`] of `Option<NonSend<T>>`.
+/// The [`SystemParamState`] of [`Option<NonSend<T>>`].
 pub struct OptionNonSendState<T>(NonSendState<T>);
 
 impl<'w, T: Component> SystemParam for Option<NonSend<'w, T>> {
@@ -934,7 +934,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendMutState<T> {
     }
 }
 
-/// The [`SystemParamState`] of `Option<NonSendMut<T>>`.
+/// The [`SystemParamState`] of [`Option<NonSendMut<T>>`].
 pub struct OptionNonSendMutState<T>(NonSendMutState<T>);
 
 impl<'a, T: 'static> SystemParam for Option<NonSendMut<'a, T>> {
@@ -1128,7 +1128,7 @@ impl SystemParam for SystemChangeTick {
     type Fetch = SystemChangeTickState;
 }
 
-/// The [`SystemParamState`] of [`SystemChangeTickState`].
+/// The [`SystemParamState`] of [`SystemChangeTick`].
 pub struct SystemChangeTickState {}
 
 unsafe impl SystemParamState for SystemChangeTickState {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -259,7 +259,7 @@ impl<'w, T: Component> AsRef<T> for Res<'w, T> {
     }
 }
 
-/// The [`SystemParamState`] of [`Res`].
+/// The [`SystemParamState`] of [`Res<T>`].
 pub struct ResState<T> {
     component_id: ComponentId,
     marker: PhantomData<T>,
@@ -328,7 +328,7 @@ impl<'w, 's, T: Component> SystemParamFetch<'w, 's> for ResState<T> {
     }
 }
 
-/// The [`SystemParamState`] of `Option<Res<T>>`.
+/// The [`SystemParamState`] of [`Option<Res<T>>`].
 pub struct OptionResState<T>(ResState<T>);
 
 impl<'a, T: Component> SystemParam for Option<Res<'a, T>> {
@@ -369,7 +369,7 @@ impl<'w, 's, T: Component> SystemParamFetch<'w, 's> for OptionResState<T> {
     }
 }
 
-/// The [`SystemParamState`] of [`ResMut`].
+/// The [`SystemParamState`] of [`ResMut<T>`].
 pub struct ResMutState<T> {
     component_id: ComponentId,
     marker: PhantomData<T>,
@@ -576,7 +576,7 @@ impl<'a, T: Component> DerefMut for Local<'a, T> {
     }
 }
 
-/// The [`SystemParamState`] of [`Local`].
+/// The [`SystemParamState`] of [`Local<T>`].
 pub struct LocalState<T: Component>(T);
 
 impl<'a, T: Component + FromWorld> SystemParam for Local<'a, T> {
@@ -644,7 +644,7 @@ impl<'a, T> RemovedComponents<'a, T> {
 // SAFE: Only reads World components
 unsafe impl<T: Component> ReadOnlySystemParamFetch for RemovedComponentsState<T> {}
 
-/// The [`SystemParamState`] of [`RemovedComponents`].
+/// The [`SystemParamState`] of [`RemovedComponents<T>`].
 pub struct RemovedComponentsState<T> {
     component_id: ComponentId,
     marker: PhantomData<T>,
@@ -741,7 +741,7 @@ impl<'w, T: 'static> Deref for NonSend<'w, T> {
     }
 }
 
-/// The [`SystemParamState`] of [`NonSend`].
+/// The [`SystemParamState`] of [`NonSend<T>`].
 pub struct NonSendState<T> {
     component_id: ComponentId,
     marker: PhantomData<fn() -> T>,
@@ -856,7 +856,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for OptionNonSendState<T> {
     }
 }
 
-/// The [`SystemParamState`] of [`NonSendMut`].
+/// The [`SystemParamState`] of [`NonSendMut<T>`].
 pub struct NonSendMutState<T> {
     component_id: ComponentId,
     marker: PhantomData<fn() -> T>,


### PR DESCRIPTION
# Objective
Fix `Option<NonSend<T>>` to work when T isn't `Send`
Fix `Option<NonSendMut<T>>` to work when T isnt in the world.

## Solution
Simple two row fix, properly initialize T in `OptionNonSendState` and remove `T: Component` bound for `Option<NonSendMut<T>>`
also added a rudimentary test
