### PR TITLE
[Merged by Bors] - Add Deref implementation for ComputePipeline

### DIFF
--- a/pipelined/bevy_render2/src/render_resource/pipeline.rs
+++ b/pipelined/bevy_render2/src/render_resource/pipeline.rs
@@ -59,3 +59,12 @@ impl From<wgpu::ComputePipeline> for ComputePipeline {
         }
     }
 }
+
+impl Deref for ComputePipeline {
+    type Target = wgpu::ComputePipeline;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}


### PR DESCRIPTION
# Objective

Fixes a usability problem where the user is unable to use their reference to a ComputePipeline in their compute pass.

## Solution

Implements Deref, allowing the user to obtain the reference to the underlying wgpu::ComputePipeline
