### PR TITLE
[Merged by Bors] - Add convenience methods for checking a set of inputs

### DIFF
--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -63,6 +63,11 @@ where
         self.pressed.contains(&input)
     }
 
+    /// Check if any item in `inputs` has been pressed.
+    pub fn any_pressed(&self, inputs: impl IntoIterator<Item = T>) -> bool {
+        inputs.into_iter().any(|it| self.pressed(it))
+    }
+
     /// Register a release for input `input`.
     pub fn release(&mut self, input: T) {
         self.pressed.remove(&input);
@@ -72,6 +77,11 @@ where
     /// Check if `input` has been just pressed.
     pub fn just_pressed(&self, input: T) -> bool {
         self.just_pressed.contains(&input)
+    }
+
+    /// Check if any item in `inputs` has just been pressed.
+    pub fn any_just_pressed(&self, inputs: impl IntoIterator<Item = T>) -> bool {
+        inputs.into_iter().any(|it| self.just_pressed(it))
     }
 
     /// Clear the "just pressed" state of `input`. Future calls to [`Input::just_pressed`] for the
@@ -84,6 +94,11 @@ where
     /// Check if `input` has been just released.
     pub fn just_released(&self, input: T) -> bool {
         self.just_released.contains(&input)
+    }
+
+    /// Check if any item in `inputs` has just been released.
+    pub fn any_just_released(&self, inputs: impl IntoIterator<Item = T>) -> bool {
+        inputs.into_iter().any(|it| self.just_released(it))
     }
 
     /// Clear the "just released" state of `input`. Future calls to [`Input::just_released`] for the

--- a/examples/input/keyboard_modifiers.rs
+++ b/examples/input/keyboard_modifiers.rs
@@ -12,8 +12,8 @@ fn main() {
 
 /// This system prints when Ctrl + Shift + A is pressed
 fn keyboard_input_system(input: Res<Input<KeyCode>>) {
-    let shift = input.pressed(KeyCode::LShift) || input.pressed(KeyCode::RShift);
-    let ctrl = input.pressed(KeyCode::LControl) || input.pressed(KeyCode::RControl);
+    let shift = input.any_pressed([KeyCode::LShift, KeyCode::RShift]);
+    let ctrl = input.any_pressed([KeyCode::LControl, KeyCode::RControl]);
 
     if ctrl && shift && input.just_pressed(KeyCode::A) {
         info!("Just pressed Ctrl + Shift + A!");


### PR DESCRIPTION
# Objective

Make it easier to check if some set of inputs matches a key, such as if you want to allow all of space or up or w for jumping.

Currently, this requires:
```rust
if keyboard.pressed(KeyCode::Space)
            || keyboard.pressed(KeyCode::Up)
            || keyboard.pressed(KeyCode::W) {
    // ...
```

## Solution

Add an implementation of the helper methods, which very simply iterate through the items, used as:
```rust
if keyboard.any_pressed([KeyCode::Space, KeyCode::Up, KeyCode::W]) {
```
