### PR TITLE
Add "orthographic size" option to 2d camera scaling

### DIFF
--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -64,6 +64,9 @@ pub enum ScalingMode {
     FixedVertical,
     /// Keep horizontal axis constant; resize vertical with aspect ratio.
     FixedHorizontal,
+    /// Unity style 2D camera scaling - the view is adjusted so the vertical space is always equal to 2 times the orthographic size in world units.
+    /// Horizontal size depends on aspect ratio. 
+    OrthographicSize(f32),
 }
 
 #[derive(Debug, Clone, Reflect)]
@@ -136,6 +139,24 @@ impl CameraProjection for OrthographicProjection {
                 self.right = 1.0;
                 self.top = aspect_ratio;
                 self.bottom = 0.0;
+            }
+            (ScalingMode::OrthographicSize(size), WindowOrigin::Center) => {
+                let half_vert = *size;
+                let aspect = width / height;
+                let half_hor = (size * 2.0 * aspect) / 2.0;
+                
+                self.left = -half_hor;
+                self.right = half_hor;
+                self.top = half_vert;
+                self.bottom = -half_vert;
+            }
+            (ScalingMode::OrthographicSize(size), WindowOrigin::BottomLeft) => {
+                let size = size * 2.0;
+                let aspect = width / height;
+                self.left = 0.0;
+                self.right = size * aspect;
+                self.bottom = 0.0;
+                self.top = size;
             }
             (ScalingMode::None, _) => {}
         }


### PR DESCRIPTION
# Objective

To add unity-style scaling for the 2d orthographic camera. In Unity you can specify an "Orthographic Size" and the camera will always be adjusted such that the vertical space in the view is equal to exactly "Orthographic Size * 2" in world units. With some simple calculations based on the current vertical resolution you can set this value on the fly to allow your 2D art to scale nicely to any resolution.

One big benefit of this is you don't need to think about or scale your transforms in terms of pixels, everything works in world space just like a normal 3d project. You determine your 'pixels per unit' based on  the resolution of your assets and that becomes your standard pixel height for a single world unit.

## Solution

Very minor change, I added a new option to camera scaling:

![xfVzecJmdm](https://user-images.githubusercontent.com/477520/131629753-69f7b8ee-aa2b-4103-a666-2e90e79dae59.gif)

