### PR TITLE
[Merged by Bors] - Fix breakout example scoreboard

### DIFF
--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -211,7 +211,7 @@ fn ball_movement_system(mut ball_query: Query<(&Ball, &mut Transform)>) {
 
 fn scoreboard_system(scoreboard: Res<Scoreboard>, mut query: Query<&mut Text>) {
     let mut text = query.single_mut().unwrap();
-    text.sections[0].value = format!("Score: {}", scoreboard.score);
+    text.sections[1].value = format!("{}", scoreboard.score);
 }
 
 fn ball_collision_system(


### PR DESCRIPTION
# Objective

- The breakout scoreboard was not using the correct text section to display the score integer.

## Solution

- This updates the code to use the correct text section.