### PR TITLE
[Merged by Bors] - add get_history function to Diagnostic

### DIFF
--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -120,8 +120,12 @@ impl Diagnostic {
         self.max_history_length
     }
 
-    pub fn get_history(&self) -> Vec<f64> {
-        self.history.iter().map(|x|x.value).collect()
+    pub fn values(&self) -> impl Iterator<Item=&f64> {
+        self.history.iter().map(|x|&x.value)
+    }
+
+    pub fn measurements(&self) -> impl Iterator<Item=&DiagnosticMeasurement> {
+        self.history.iter()
     }
 }
 

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -119,6 +119,10 @@ impl Diagnostic {
     pub fn get_max_history_length(&self) -> usize {
         self.max_history_length
     }
+
+    pub fn get_history(&self) -> Vec<f64> {
+        self.history.iter().map(|x|x.value).collect()
+    }
 }
 
 /// A collection of [Diagnostic]s

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -120,11 +120,11 @@ impl Diagnostic {
         self.max_history_length
     }
 
-    pub fn values(&self) -> impl Iterator<Item=&f64> {
-        self.history.iter().map(|x|&x.value)
+    pub fn values(&self) -> impl Iterator<Item = &f64> {
+        self.history.iter().map(|x| &x.value)
     }
 
-    pub fn measurements(&self) -> impl Iterator<Item=&DiagnosticMeasurement> {
+    pub fn measurements(&self) -> impl Iterator<Item = &DiagnosticMeasurement> {
         self.history.iter()
     }
 }


### PR DESCRIPTION
# Objective

- Allow access to diagnostic history value.
- Fixes #2771.

## Solution

- Add Diagnostic::get_history function.
