### PR TITLE
System Lifecycle Rework: all Systems are initialized by definition

### DIFF
--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -13,7 +13,7 @@ pub use audio_source::*;
 
 use bevy_app::prelude::*;
 use bevy_asset::AddAsset;
-use bevy_ecs::system::IntoExclusiveSystem;
+use bevy_ecs::{schedule::IntoExclusiveSystemWrapper, system::IntoExclusiveSystem};
 
 /// Adds support for audio playback to an App
 #[derive(Default)]
@@ -26,7 +26,7 @@ impl Plugin for AudioPlugin {
             .init_resource::<Audio<AudioSource>>()
             .add_system_to_stage(
                 CoreStage::PostUpdate,
-                play_queued_audio_system::<AudioSource>.exclusive_system(),
+                play_queued_audio_system::<AudioSource>.exclusive(),
             );
 
         #[cfg(any(feature = "mp3", feature = "flac", feature = "wav", feature = "vorbis"))]

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -18,11 +18,7 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
-use bevy_ecs::{
-    entity::Entity,
-    schedule::{ExclusiveSystemDescriptorCoercion, SystemLabel},
-    system::IntoExclusiveSystem,
-};
+use bevy_ecs::{entity::Entity, schedule::{ExclusiveSystemDescriptorCoercion, IntoExclusiveSystemWrapper, ParallelSystemDescriptorCoercion, SystemLabel}, system::IntoExclusiveSystem};
 use bevy_utils::HashSet;
 use std::ops::Range;
 
@@ -60,7 +56,7 @@ impl Plugin for CorePlugin {
             // in CoreStage::First
             .add_system_to_stage(
                 CoreStage::First,
-                time_system.exclusive_system().label(CoreSystem::Time),
+                time_system.exclusive().label(CoreSystem::Time),
             )
             .add_startup_system_to_stage(StartupStage::PostStartup, entity_labels_system)
             .add_system_to_stage(CoreStage::PostUpdate, entity_labels_system);

--- a/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
@@ -1,5 +1,6 @@
 use bevy_app::{App, Plugin};
 use bevy_ecs::{
+    schedule::IntoExclusiveSystemWrapper,
     system::{IntoExclusiveSystem, ResMut},
     world::World,
 };
@@ -13,7 +14,7 @@ pub struct EntityCountDiagnosticsPlugin;
 impl Plugin for EntityCountDiagnosticsPlugin {
     fn build(&self, app: &mut App) {
         app.add_startup_system(Self::setup_system)
-            .add_system(Self::diagnostic_system.exclusive_system());
+            .add_system(Self::diagnostic_system.exclusive());
     }
 }
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -29,8 +29,9 @@ pub mod prelude {
             Schedule, Stage, StageLabel, State, SystemLabel, SystemSet, SystemStage,
         },
         system::{
-            Commands, ConfigurableSystem, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem,
-            Local, NonSend, NonSendMut, Query, QuerySet, RemovedComponents, Res, ResMut, System,
+            Commands, ConfigSystemParamFunction, In, IntoChainSystem, IntoExclusiveSystem,
+            IntoSystem, Local, NonSend, NonSendMut, Query, QuerySet, RemovedComponents, Res,
+            ResMut, System,
         },
         world::{FromWorld, Mut, World},
     };

--- a/crates/bevy_ecs/src/schedule/executor_parallel.rs
+++ b/crates/bevy_ecs/src/schedule/executor_parallel.rs
@@ -311,138 +311,138 @@ enum SchedulingEvent {
     StartedSystems(usize),
 }
 
-#[cfg(test)]
-mod tests {
-    use super::SchedulingEvent::{self, *};
-    use crate::{
-        schedule::{SingleThreadedExecutor, Stage, SystemStage},
-        system::{NonSend, Query, Res, ResMut},
-        world::World,
-    };
-    use async_channel::Receiver;
+// #[cfg(test)]
+// mod tests {
+//     use super::SchedulingEvent::{self, *};
+//     use crate::{
+//         schedule::{SingleThreadedExecutor, Stage, SystemStage},
+//         system::{NonSend, Query, Res, ResMut},
+//         world::World,
+//     };
+//     use async_channel::Receiver;
 
-    fn receive_events(world: &World) -> Vec<SchedulingEvent> {
-        let mut events = Vec::new();
-        while let Ok(event) = world
-            .get_resource::<Receiver<SchedulingEvent>>()
-            .unwrap()
-            .try_recv()
-        {
-            events.push(event);
-        }
-        events
-    }
+//     fn receive_events(world: &World) -> Vec<SchedulingEvent> {
+//         let mut events = Vec::new();
+//         while let Ok(event) = world
+//             .get_resource::<Receiver<SchedulingEvent>>()
+//             .unwrap()
+//             .try_recv()
+//         {
+//             events.push(event);
+//         }
+//         events
+//     }
 
-    #[test]
-    fn trivial() {
-        let mut world = World::new();
-        fn wants_for_nothing() {}
-        let mut stage = SystemStage::parallel()
-            .with_system(wants_for_nothing)
-            .with_system(wants_for_nothing)
-            .with_system(wants_for_nothing);
-        stage.run(&mut world);
-        stage.run(&mut world);
-        assert_eq!(
-            receive_events(&world),
-            vec![StartedSystems(3), StartedSystems(3),]
-        )
-    }
+//     #[test]
+//     fn trivial() {
+//         let mut world = World::new();
+//         fn wants_for_nothing() {}
+//         let mut stage = SystemStage::parallel()
+//             .with_system(wants_for_nothing)
+//             .with_system(wants_for_nothing)
+//             .with_system(wants_for_nothing);
+//         stage.run(&mut world);
+//         stage.run(&mut world);
+//         assert_eq!(
+//             receive_events(&world),
+//             vec![StartedSystems(3), StartedSystems(3),]
+//         )
+//     }
 
-    #[test]
-    fn resources() {
-        let mut world = World::new();
-        world.insert_resource(0usize);
-        fn wants_mut(_: ResMut<usize>) {}
-        fn wants_ref(_: Res<usize>) {}
-        let mut stage = SystemStage::parallel()
-            .with_system(wants_mut)
-            .with_system(wants_mut);
-        stage.run(&mut world);
-        assert_eq!(
-            receive_events(&world),
-            vec![StartedSystems(1), StartedSystems(1),]
-        );
-        let mut stage = SystemStage::parallel()
-            .with_system(wants_mut)
-            .with_system(wants_ref);
-        stage.run(&mut world);
-        assert_eq!(
-            receive_events(&world),
-            vec![StartedSystems(1), StartedSystems(1),]
-        );
-        let mut stage = SystemStage::parallel()
-            .with_system(wants_ref)
-            .with_system(wants_ref);
-        stage.run(&mut world);
-        assert_eq!(receive_events(&world), vec![StartedSystems(2),]);
-    }
+//     #[test]
+//     fn resources() {
+//         let mut world = World::new();
+//         world.insert_resource(0usize);
+//         fn wants_mut(_: ResMut<usize>) {}
+//         fn wants_ref(_: Res<usize>) {}
+//         let mut stage = SystemStage::parallel()
+//             .with_system(wants_mut)
+//             .with_system(wants_mut);
+//         stage.run(&mut world);
+//         assert_eq!(
+//             receive_events(&world),
+//             vec![StartedSystems(1), StartedSystems(1),]
+//         );
+//         let mut stage = SystemStage::parallel()
+//             .with_system(wants_mut)
+//             .with_system(wants_ref);
+//         stage.run(&mut world);
+//         assert_eq!(
+//             receive_events(&world),
+//             vec![StartedSystems(1), StartedSystems(1),]
+//         );
+//         let mut stage = SystemStage::parallel()
+//             .with_system(wants_ref)
+//             .with_system(wants_ref);
+//         stage.run(&mut world);
+//         assert_eq!(receive_events(&world), vec![StartedSystems(2),]);
+//     }
 
-    #[test]
-    fn queries() {
-        let mut world = World::new();
-        world.spawn().insert(0usize);
-        fn wants_mut(_: Query<&mut usize>) {}
-        fn wants_ref(_: Query<&usize>) {}
-        let mut stage = SystemStage::parallel()
-            .with_system(wants_mut)
-            .with_system(wants_mut);
-        stage.run(&mut world);
-        assert_eq!(
-            receive_events(&world),
-            vec![StartedSystems(1), StartedSystems(1),]
-        );
-        let mut stage = SystemStage::parallel()
-            .with_system(wants_mut)
-            .with_system(wants_ref);
-        stage.run(&mut world);
-        assert_eq!(
-            receive_events(&world),
-            vec![StartedSystems(1), StartedSystems(1),]
-        );
-        let mut stage = SystemStage::parallel()
-            .with_system(wants_ref)
-            .with_system(wants_ref);
-        stage.run(&mut world);
-        assert_eq!(receive_events(&world), vec![StartedSystems(2),]);
-        let mut world = World::new();
-        world.spawn().insert_bundle((0usize, 0u32, 0f32));
-        fn wants_mut_usize(_: Query<(&mut usize, &f32)>) {}
-        fn wants_mut_u32(_: Query<(&mut u32, &f32)>) {}
-        let mut stage = SystemStage::parallel()
-            .with_system(wants_mut_usize)
-            .with_system(wants_mut_u32);
-        stage.run(&mut world);
-        assert_eq!(receive_events(&world), vec![StartedSystems(2),]);
-    }
+//     #[test]
+//     fn queries() {
+//         let mut world = World::new();
+//         world.spawn().insert(0usize);
+//         fn wants_mut(_: Query<&mut usize>) {}
+//         fn wants_ref(_: Query<&usize>) {}
+//         let mut stage = SystemStage::parallel()
+//             .with_system(wants_mut)
+//             .with_system(wants_mut);
+//         stage.run(&mut world);
+//         assert_eq!(
+//             receive_events(&world),
+//             vec![StartedSystems(1), StartedSystems(1),]
+//         );
+//         let mut stage = SystemStage::parallel()
+//             .with_system(wants_mut)
+//             .with_system(wants_ref);
+//         stage.run(&mut world);
+//         assert_eq!(
+//             receive_events(&world),
+//             vec![StartedSystems(1), StartedSystems(1),]
+//         );
+//         let mut stage = SystemStage::parallel()
+//             .with_system(wants_ref)
+//             .with_system(wants_ref);
+//         stage.run(&mut world);
+//         assert_eq!(receive_events(&world), vec![StartedSystems(2),]);
+//         let mut world = World::new();
+//         world.spawn().insert_bundle((0usize, 0u32, 0f32));
+//         fn wants_mut_usize(_: Query<(&mut usize, &f32)>) {}
+//         fn wants_mut_u32(_: Query<(&mut u32, &f32)>) {}
+//         let mut stage = SystemStage::parallel()
+//             .with_system(wants_mut_usize)
+//             .with_system(wants_mut_u32);
+//         stage.run(&mut world);
+//         assert_eq!(receive_events(&world), vec![StartedSystems(2),]);
+//     }
 
-    #[test]
-    fn non_send_resource() {
-        use std::thread;
-        let mut world = World::new();
-        world.insert_non_send(thread::current().id());
-        fn non_send(thread_id: NonSend<thread::ThreadId>) {
-            assert_eq!(thread::current().id(), *thread_id);
-        }
-        fn empty() {}
-        let mut stage = SystemStage::parallel()
-            .with_system(non_send)
-            .with_system(non_send)
-            .with_system(empty)
-            .with_system(empty)
-            .with_system(non_send)
-            .with_system(non_send);
-        stage.run(&mut world);
-        assert_eq!(
-            receive_events(&world),
-            vec![
-                StartedSystems(3),
-                StartedSystems(1),
-                StartedSystems(1),
-                StartedSystems(1),
-            ]
-        );
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
-        stage.run(&mut world);
-    }
-}
+//     #[test]
+//     fn non_send_resource() {
+//         use std::thread;
+//         let mut world = World::new();
+//         world.insert_non_send(thread::current().id());
+//         fn non_send(thread_id: NonSend<thread::ThreadId>) {
+//             assert_eq!(thread::current().id(), *thread_id);
+//         }
+//         fn empty() {}
+//         let mut stage = SystemStage::parallel()
+//             .with_system(non_send)
+//             .with_system(non_send)
+//             .with_system(empty)
+//             .with_system(empty)
+//             .with_system(non_send)
+//             .with_system(non_send);
+//         stage.run(&mut world);
+//         assert_eq!(
+//             receive_events(&world),
+//             vec![
+//                 StartedSystems(3),
+//                 StartedSystems(1),
+//                 StartedSystems(1),
+//                 StartedSystems(1),
+//             ]
+//         );
+//         stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+//         stage.run(&mut world);
+//     }
+// }

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -65,10 +65,11 @@ impl Schedule {
 
     pub fn with_system_in_stage<Params>(
         mut self,
+        world: &mut World,
         stage_label: impl StageLabel,
         system: impl IntoSystemDescriptor<Params>,
     ) -> Self {
-        self.add_system_to_stage(stage_label, system);
+        self.add_system_to_stage(world, stage_label, system);
         self
     }
 
@@ -140,6 +141,7 @@ impl Schedule {
 
     pub fn add_system_to_stage<Params>(
         &mut self,
+        world: &mut World,
         stage_label: impl StageLabel,
         system: impl IntoSystemDescriptor<Params>,
     ) -> &mut Self {
@@ -156,17 +158,18 @@ impl Schedule {
         let stage = self
             .get_stage_mut::<SystemStage>(&stage_label)
             .unwrap_or_else(move || stage_not_found(&stage_label));
-        stage.add_system(system);
+        stage.add_system(world, system);
         self
     }
 
     pub fn add_system_set_to_stage(
         &mut self,
+        world: &mut World,
         stage_label: impl StageLabel,
         system_set: SystemSet,
     ) -> &mut Self {
         self.stage(stage_label, |stage: &mut SystemStage| {
-            stage.add_system_set(system_set)
+            stage.add_system_set(world, system_set)
         })
     }
 

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -1,10 +1,11 @@
 use crate::{
     component::Component,
+    prelude::ConfigSystemParamFunction,
     schedule::{
         RunCriteriaDescriptor, RunCriteriaDescriptorCoercion, RunCriteriaLabel, ShouldRun,
         SystemSet,
     },
-    system::{ConfigurableSystem, In, IntoChainSystem, Local, Res, ResMut},
+    system::{In, IntoChainSystem, Local, Res, ResMut},
 };
 use std::{any::TypeId, fmt::Debug, hash::Hash};
 use thiserror::Error;
@@ -479,181 +480,181 @@ fn state_cleaner<T: Component + Clone + Eq>(
     ShouldRun::YesAndCheckAgain
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
-    use crate::prelude::*;
+// #[cfg(test)]
+// mod test {
+//     use super::*;
+//     use crate::prelude::*;
 
-    #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-    enum MyState {
-        S1,
-        S2,
-        S3,
-        S4,
-        S5,
-        S6,
-        Final,
-    }
+//     #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+//     enum MyState {
+//         S1,
+//         S2,
+//         S3,
+//         S4,
+//         S5,
+//         S6,
+//         Final,
+//     }
 
-    #[test]
-    fn state_test() {
-        let mut world = World::default();
+//     #[test]
+//     fn state_test() {
+//         let mut world = World::default();
 
-        world.insert_resource(Vec::<&'static str>::new());
-        world.insert_resource(State::new(MyState::S1));
+//         world.insert_resource(Vec::<&'static str>::new());
+//         world.insert_resource(State::new(MyState::S1));
 
-        let mut stage = SystemStage::parallel();
+//         let mut stage = SystemStage::parallel();
 
-        stage.add_system_set(State::<MyState>::get_driver());
-        stage
-            .add_system_set(
-                State::on_enter_set(MyState::S1)
-                    .with_system(|mut r: ResMut<Vec<&'static str>>| r.push("startup")),
-            )
-            .add_system_set(State::on_update_set(MyState::S1).with_system(
-                |mut r: ResMut<Vec<&'static str>>, mut s: ResMut<State<MyState>>| {
-                    r.push("update S1");
-                    s.overwrite_replace(MyState::S2).unwrap();
-                },
-            ))
-            .add_system_set(
-                State::on_enter_set(MyState::S2)
-                    .with_system(|mut r: ResMut<Vec<&'static str>>| r.push("enter S2")),
-            )
-            .add_system_set(State::on_update_set(MyState::S2).with_system(
-                |mut r: ResMut<Vec<&'static str>>, mut s: ResMut<State<MyState>>| {
-                    r.push("update S2");
-                    s.overwrite_replace(MyState::S3).unwrap();
-                },
-            ))
-            .add_system_set(
-                State::on_exit_set(MyState::S2)
-                    .with_system(|mut r: ResMut<Vec<&'static str>>| r.push("exit S2")),
-            )
-            .add_system_set(
-                State::on_enter_set(MyState::S3)
-                    .with_system(|mut r: ResMut<Vec<&'static str>>| r.push("enter S3")),
-            )
-            .add_system_set(State::on_update_set(MyState::S3).with_system(
-                |mut r: ResMut<Vec<&'static str>>, mut s: ResMut<State<MyState>>| {
-                    r.push("update S3");
-                    s.overwrite_push(MyState::S4).unwrap();
-                },
-            ))
-            .add_system_set(
-                State::on_pause_set(MyState::S3)
-                    .with_system(|mut r: ResMut<Vec<&'static str>>| r.push("pause S3")),
-            )
-            .add_system_set(State::on_update_set(MyState::S4).with_system(
-                |mut r: ResMut<Vec<&'static str>>, mut s: ResMut<State<MyState>>| {
-                    r.push("update S4");
-                    s.overwrite_push(MyState::S5).unwrap();
-                },
-            ))
-            .add_system_set(State::on_inactive_update_set(MyState::S4).with_system(
-                (|mut r: ResMut<Vec<&'static str>>| r.push("inactive S4")).label("inactive s4"),
-            ))
-            .add_system_set(
-                State::on_update_set(MyState::S5).with_system(
-                    (|mut r: ResMut<Vec<&'static str>>, mut s: ResMut<State<MyState>>| {
-                        r.push("update S5");
-                        s.overwrite_push(MyState::S6).unwrap();
-                    })
-                    .after("inactive s4"),
-                ),
-            )
-            .add_system_set(
-                State::on_inactive_update_set(MyState::S5).with_system(
-                    (|mut r: ResMut<Vec<&'static str>>| r.push("inactive S5"))
-                        .label("inactive s5")
-                        .after("inactive s4"),
-                ),
-            )
-            .add_system_set(
-                State::on_update_set(MyState::S6).with_system(
-                    (|mut r: ResMut<Vec<&'static str>>, mut s: ResMut<State<MyState>>| {
-                        r.push("update S6");
-                        s.overwrite_push(MyState::Final).unwrap();
-                    })
-                    .after("inactive s5"),
-                ),
-            )
-            .add_system_set(
-                State::on_resume_set(MyState::S4)
-                    .with_system(|mut r: ResMut<Vec<&'static str>>| r.push("resume S4")),
-            )
-            .add_system_set(
-                State::on_exit_set(MyState::S5)
-                    .with_system(|mut r: ResMut<Vec<&'static str>>| r.push("exit S4")),
-            );
+//         stage.add_system_set(State::<MyState>::get_driver());
+//         stage
+//             .add_system_set(
+//                 State::on_enter_set(MyState::S1)
+//                     .with_system(|mut r: ResMut<Vec<&'static str>>| r.push("startup")),
+//             )
+//             .add_system_set(State::on_update_set(MyState::S1).with_system(
+//                 |mut r: ResMut<Vec<&'static str>>, mut s: ResMut<State<MyState>>| {
+//                     r.push("update S1");
+//                     s.overwrite_replace(MyState::S2).unwrap();
+//                 },
+//             ))
+//             .add_system_set(
+//                 State::on_enter_set(MyState::S2)
+//                     .with_system(|mut r: ResMut<Vec<&'static str>>| r.push("enter S2")),
+//             )
+//             .add_system_set(State::on_update_set(MyState::S2).with_system(
+//                 |mut r: ResMut<Vec<&'static str>>, mut s: ResMut<State<MyState>>| {
+//                     r.push("update S2");
+//                     s.overwrite_replace(MyState::S3).unwrap();
+//                 },
+//             ))
+//             .add_system_set(
+//                 State::on_exit_set(MyState::S2)
+//                     .with_system(|mut r: ResMut<Vec<&'static str>>| r.push("exit S2")),
+//             )
+//             .add_system_set(
+//                 State::on_enter_set(MyState::S3)
+//                     .with_system(|mut r: ResMut<Vec<&'static str>>| r.push("enter S3")),
+//             )
+//             .add_system_set(State::on_update_set(MyState::S3).with_system(
+//                 |mut r: ResMut<Vec<&'static str>>, mut s: ResMut<State<MyState>>| {
+//                     r.push("update S3");
+//                     s.overwrite_push(MyState::S4).unwrap();
+//                 },
+//             ))
+//             .add_system_set(
+//                 State::on_pause_set(MyState::S3)
+//                     .with_system(|mut r: ResMut<Vec<&'static str>>| r.push("pause S3")),
+//             )
+//             .add_system_set(State::on_update_set(MyState::S4).with_system(
+//                 |mut r: ResMut<Vec<&'static str>>, mut s: ResMut<State<MyState>>| {
+//                     r.push("update S4");
+//                     s.overwrite_push(MyState::S5).unwrap();
+//                 },
+//             ))
+//             .add_system_set(State::on_inactive_update_set(MyState::S4).with_system(
+//                 (|mut r: ResMut<Vec<&'static str>>| r.push("inactive S4")).label("inactive s4"),
+//             ))
+//             .add_system_set(
+//                 State::on_update_set(MyState::S5).with_system(
+//                     (|mut r: ResMut<Vec<&'static str>>, mut s: ResMut<State<MyState>>| {
+//                         r.push("update S5");
+//                         s.overwrite_push(MyState::S6).unwrap();
+//                     })
+//                     .after("inactive s4"),
+//                 ),
+//             )
+//             .add_system_set(
+//                 State::on_inactive_update_set(MyState::S5).with_system(
+//                     (|mut r: ResMut<Vec<&'static str>>| r.push("inactive S5"))
+//                         .label("inactive s5")
+//                         .after("inactive s4"),
+//                 ),
+//             )
+//             .add_system_set(
+//                 State::on_update_set(MyState::S6).with_system(
+//                     (|mut r: ResMut<Vec<&'static str>>, mut s: ResMut<State<MyState>>| {
+//                         r.push("update S6");
+//                         s.overwrite_push(MyState::Final).unwrap();
+//                     })
+//                     .after("inactive s5"),
+//                 ),
+//             )
+//             .add_system_set(
+//                 State::on_resume_set(MyState::S4)
+//                     .with_system(|mut r: ResMut<Vec<&'static str>>| r.push("resume S4")),
+//             )
+//             .add_system_set(
+//                 State::on_exit_set(MyState::S5)
+//                     .with_system(|mut r: ResMut<Vec<&'static str>>| r.push("exit S4")),
+//             );
 
-        const EXPECTED: &[&str] = &[
-            //
-            "startup",
-            "update S1",
-            //
-            "enter S2",
-            "update S2",
-            //
-            "exit S2",
-            "enter S3",
-            "update S3",
-            //
-            "pause S3",
-            "update S4",
-            //
-            "inactive S4",
-            "update S5",
-            //
-            "inactive S4",
-            "inactive S5",
-            "update S6",
-            //
-            "inactive S4",
-            "inactive S5",
-        ];
+//         const EXPECTED: &[&str] = &[
+//             //
+//             "startup",
+//             "update S1",
+//             //
+//             "enter S2",
+//             "update S2",
+//             //
+//             "exit S2",
+//             "enter S3",
+//             "update S3",
+//             //
+//             "pause S3",
+//             "update S4",
+//             //
+//             "inactive S4",
+//             "update S5",
+//             //
+//             "inactive S4",
+//             "inactive S5",
+//             "update S6",
+//             //
+//             "inactive S4",
+//             "inactive S5",
+//         ];
 
-        stage.run(&mut world);
-        let mut collected = world.get_resource_mut::<Vec<&'static str>>().unwrap();
-        let mut count = 0;
-        for (found, expected) in collected.drain(..).zip(EXPECTED) {
-            assert_eq!(found, *expected);
-            count += 1;
-        }
-        // If not equal, some elements weren't executed
-        assert_eq!(EXPECTED.len(), count);
-        assert_eq!(
-            world.get_resource::<State<MyState>>().unwrap().current(),
-            &MyState::Final
-        );
-    }
+//         stage.run(&mut world);
+//         let mut collected = world.get_resource_mut::<Vec<&'static str>>().unwrap();
+//         let mut count = 0;
+//         for (found, expected) in collected.drain(..).zip(EXPECTED) {
+//             assert_eq!(found, *expected);
+//             count += 1;
+//         }
+//         // If not equal, some elements weren't executed
+//         assert_eq!(EXPECTED.len(), count);
+//         assert_eq!(
+//             world.get_resource::<State<MyState>>().unwrap().current(),
+//             &MyState::Final
+//         );
+//     }
 
-    #[test]
-    fn issue_1753() {
-        #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-        enum AppState {
-            Main,
-        }
+//     #[test]
+//     fn issue_1753() {
+//         #[derive(Clone, PartialEq, Eq, Debug, Hash)]
+//         enum AppState {
+//             Main,
+//         }
 
-        fn should_run_once(mut flag: ResMut<bool>, test_name: Res<&'static str>) {
-            assert!(!*flag, "{:?}", *test_name);
-            *flag = true;
-        }
+//         fn should_run_once(mut flag: ResMut<bool>, test_name: Res<&'static str>) {
+//             assert!(!*flag, "{:?}", *test_name);
+//             *flag = true;
+//         }
 
-        let mut world = World::new();
-        world.insert_resource(State::new(AppState::Main));
-        world.insert_resource(false);
-        world.insert_resource("control");
-        let mut stage = SystemStage::parallel().with_system(should_run_once);
-        stage.run(&mut world);
-        assert!(*world.get_resource::<bool>().unwrap(), "after control");
+//         let mut world = World::new();
+//         world.insert_resource(State::new(AppState::Main));
+//         world.insert_resource(false);
+//         world.insert_resource("control");
+//         let mut stage = SystemStage::parallel().with_system(should_run_once);
+//         stage.run(&mut world);
+//         assert!(*world.get_resource::<bool>().unwrap(), "after control");
 
-        world.insert_resource(false);
-        world.insert_resource("test");
-        let mut stage = SystemStage::parallel()
-            .with_system_set(State::<AppState>::get_driver())
-            .with_system(should_run_once);
-        stage.run(&mut world);
-        assert!(*world.get_resource::<bool>().unwrap(), "after test");
-    }
-}
+//         world.insert_resource(false);
+//         world.insert_resource("test");
+//         let mut stage = SystemStage::parallel()
+//             .with_system_set(State::<AppState>::get_driver())
+//             .with_system(should_run_once);
+//         stage.run(&mut world);
+//         assert!(*world.get_resource::<bool>().unwrap(), "after test");
+//     }
+// }

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -15,857 +15,851 @@ pub use system::*;
 pub use system_chaining::*;
 pub use system_param::*;
 
-#[cfg(test)]
-mod tests {
-    use std::any::TypeId;
-
-    use crate::{
-        archetype::Archetypes,
-        bundle::Bundles,
-        component::Components,
-        entity::{Entities, Entity},
-        query::{Added, Changed, Or, QueryState, With, Without},
-        schedule::{Schedule, Stage, SystemStage},
-        system::{
-            ConfigurableSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend, NonSendMut, Query,
-            QuerySet, RemovedComponents, Res, ResMut, System, SystemState,
-        },
-        world::{FromWorld, World},
-    };
-
-    #[derive(Debug, Eq, PartialEq, Default)]
-    struct A;
-    struct B;
-    struct C;
-    struct D;
-    struct E;
-    struct F;
-
-    #[test]
-    fn simple_system() {
-        fn sys(query: Query<&A>) {
-            for a in query.iter() {
-                println!("{:?}", a);
-            }
-        }
-
-        let mut system = sys.system();
-        let mut world = World::new();
-        world.spawn().insert(A);
-
-        system.initialize(&mut world);
-        for archetype in world.archetypes.iter() {
-            system.new_archetype(archetype);
-        }
-        system.run((), &mut world);
-    }
-
-    fn run_system<Param, S: IntoSystem<(), (), Param>>(world: &mut World, system: S) {
-        let mut schedule = Schedule::default();
-        let mut update = SystemStage::parallel();
-        update.add_system(system);
-        schedule.add_stage("update", update);
-        schedule.run(world);
-    }
-
-    #[test]
-    fn query_system_gets() {
-        fn query_system(
-            mut ran: ResMut<bool>,
-            entity_query: Query<Entity, With<A>>,
-            b_query: Query<&B>,
-            a_c_query: Query<(&A, &C)>,
-            d_query: Query<&D>,
-        ) {
-            let entities = entity_query.iter().collect::<Vec<Entity>>();
-            assert!(
-                b_query.get_component::<B>(entities[0]).is_err(),
-                "entity 0 should not have B"
-            );
-            assert!(
-                b_query.get_component::<B>(entities[1]).is_ok(),
-                "entity 1 should have B"
-            );
-            assert!(
-                b_query.get_component::<A>(entities[1]).is_err(),
-                "entity 1 should have A, but b_query shouldn't have access to it"
-            );
-            assert!(
-                b_query.get_component::<D>(entities[3]).is_err(),
-                "entity 3 should have D, but it shouldn't be accessible from b_query"
-            );
-            assert!(
-                b_query.get_component::<C>(entities[2]).is_err(),
-                "entity 2 has C, but it shouldn't be accessible from b_query"
-            );
-            assert!(
-                a_c_query.get_component::<C>(entities[2]).is_ok(),
-                "entity 2 has C, and it should be accessible from a_c_query"
-            );
-            assert!(
-                a_c_query.get_component::<D>(entities[3]).is_err(),
-                "entity 3 should have D, but it shouldn't be accessible from b_query"
-            );
-            assert!(
-                d_query.get_component::<D>(entities[3]).is_ok(),
-                "entity 3 should have D"
-            );
-
-            *ran = true;
-        }
-
-        let mut world = World::default();
-        world.insert_resource(false);
-        world.spawn().insert_bundle((A,));
-        world.spawn().insert_bundle((A, B));
-        world.spawn().insert_bundle((A, C));
-        world.spawn().insert_bundle((A, D));
-
-        run_system(&mut world, query_system);
-
-        assert!(*world.get_resource::<bool>().unwrap(), "system ran");
-    }
-
-    #[test]
-    fn or_query_set_system() {
-        // Regression test for issue #762
-        fn query_system(
-            mut ran: ResMut<bool>,
-            mut set: QuerySet<(
-                QueryState<(), Or<(Changed<A>, Changed<B>)>>,
-                QueryState<(), Or<(Added<A>, Added<B>)>>,
-            )>,
-        ) {
-            let changed = set.q0().iter().count();
-            let added = set.q1().iter().count();
-
-            assert_eq!(changed, 1);
-            assert_eq!(added, 1);
-
-            *ran = true;
-        }
-
-        let mut world = World::default();
-        world.insert_resource(false);
-        world.spawn().insert_bundle((A, B));
-
-        run_system(&mut world, query_system);
-
-        assert!(*world.get_resource::<bool>().unwrap(), "system ran");
-    }
-
-    #[test]
-    fn changed_resource_system() {
-        struct Added(usize);
-        struct Changed(usize);
-        fn incr_e_on_flip(
-            value: Res<bool>,
-            mut changed: ResMut<Changed>,
-            mut added: ResMut<Added>,
-        ) {
-            if value.is_added() {
-                added.0 += 1;
-            }
-
-            if value.is_changed() {
-                changed.0 += 1;
-            }
-        }
-
-        let mut world = World::default();
-        world.insert_resource(false);
-        world.insert_resource(Added(0));
-        world.insert_resource(Changed(0));
-
-        let mut schedule = Schedule::default();
-        let mut update = SystemStage::parallel();
-        update.add_system(incr_e_on_flip);
-        schedule.add_stage("update", update);
-        schedule.add_stage(
-            "clear_trackers",
-            SystemStage::single(World::clear_trackers.exclusive_system()),
-        );
-
-        schedule.run(&mut world);
-        assert_eq!(world.get_resource::<Added>().unwrap().0, 1);
-        assert_eq!(world.get_resource::<Changed>().unwrap().0, 1);
-
-        schedule.run(&mut world);
-        assert_eq!(world.get_resource::<Added>().unwrap().0, 1);
-        assert_eq!(world.get_resource::<Changed>().unwrap().0, 1);
-
-        *world.get_resource_mut::<bool>().unwrap() = true;
-        schedule.run(&mut world);
-        assert_eq!(world.get_resource::<Added>().unwrap().0, 1);
-        assert_eq!(world.get_resource::<Changed>().unwrap().0, 2);
-    }
-
-    #[test]
-    #[should_panic]
-    fn conflicting_query_mut_system() {
-        fn sys(_q1: Query<&mut A>, _q2: Query<&mut A>) {}
-
-        let mut world = World::default();
-        run_system(&mut world, sys);
-    }
-
-    #[test]
-    fn disjoint_query_mut_system() {
-        fn sys(_q1: Query<&mut A, With<B>>, _q2: Query<&mut A, Without<B>>) {}
-
-        let mut world = World::default();
-        run_system(&mut world, sys);
-    }
-
-    #[test]
-    fn disjoint_query_mut_read_component_system() {
-        fn sys(_q1: Query<(&mut A, &B)>, _q2: Query<&mut A, Without<B>>) {}
-
-        let mut world = World::default();
-        run_system(&mut world, sys);
-    }
-
-    #[test]
-    #[should_panic]
-    fn conflicting_query_immut_system() {
-        fn sys(_q1: Query<&A>, _q2: Query<&mut A>) {}
-
-        let mut world = World::default();
-        run_system(&mut world, sys);
-    }
-
-    #[test]
-    fn query_set_system() {
-        fn sys(mut _set: QuerySet<(QueryState<&mut A>, QueryState<&A>)>) {}
-        let mut world = World::default();
-        run_system(&mut world, sys);
-    }
-
-    #[test]
-    #[should_panic]
-    fn conflicting_query_with_query_set_system() {
-        fn sys(_query: Query<&mut A>, _set: QuerySet<(QueryState<&mut A>, QueryState<&B>)>) {}
-
-        let mut world = World::default();
-        run_system(&mut world, sys);
-    }
-
-    #[test]
-    #[should_panic]
-    fn conflicting_query_sets_system() {
-        fn sys(
-            _set_1: QuerySet<(QueryState<&mut A>,)>,
-            _set_2: QuerySet<(QueryState<&mut A>, QueryState<&B>)>,
-        ) {
-        }
-
-        let mut world = World::default();
-        run_system(&mut world, sys);
-    }
-
-    #[derive(Default)]
-    struct BufferRes {
-        _buffer: Vec<u8>,
-    }
-
-    fn test_for_conflicting_resources<Param, S: IntoSystem<(), (), Param>>(sys: S) {
-        let mut world = World::default();
-        world.insert_resource(BufferRes::default());
-        world.insert_resource(A);
-        world.insert_resource(B);
-        run_system(&mut world, sys);
-    }
-
-    #[test]
-    #[should_panic]
-    fn conflicting_system_resources() {
-        fn sys(_: ResMut<BufferRes>, _: Res<BufferRes>) {}
-        test_for_conflicting_resources(sys)
-    }
-
-    #[test]
-    #[should_panic]
-    fn conflicting_system_resources_reverse_order() {
-        fn sys(_: Res<BufferRes>, _: ResMut<BufferRes>) {}
-        test_for_conflicting_resources(sys)
-    }
-
-    #[test]
-    #[should_panic]
-    fn conflicting_system_resources_multiple_mutable() {
-        fn sys(_: ResMut<BufferRes>, _: ResMut<BufferRes>) {}
-        test_for_conflicting_resources(sys)
-    }
-
-    #[test]
-    fn nonconflicting_system_resources() {
-        fn sys(_: Local<BufferRes>, _: ResMut<BufferRes>, _: Local<A>, _: ResMut<A>) {}
-        test_for_conflicting_resources(sys)
-    }
-
-    #[test]
-    fn local_system() {
-        let mut world = World::default();
-        world.insert_resource(1u32);
-        world.insert_resource(false);
-        struct Foo {
-            value: u32,
-        }
-
-        impl FromWorld for Foo {
-            fn from_world(world: &mut World) -> Self {
-                Foo {
-                    value: *world.get_resource::<u32>().unwrap() + 1,
-                }
-            }
-        }
-
-        fn sys(local: Local<Foo>, mut modified: ResMut<bool>) {
-            assert_eq!(local.value, 2);
-            *modified = true;
-        }
-
-        run_system(&mut world, sys);
-
-        // ensure the system actually ran
-        assert!(*world.get_resource::<bool>().unwrap());
-    }
-
-    #[test]
-    fn non_send_option_system() {
-        let mut world = World::default();
-
-        world.insert_resource(false);
-        struct NotSend1(std::rc::Rc<i32>);
-        struct NotSend2(std::rc::Rc<i32>);
-        world.insert_non_send(NotSend1(std::rc::Rc::new(0)));
-
-        fn sys(
-            op: Option<NonSend<NotSend1>>,
-            mut _op2: Option<NonSendMut<NotSend2>>,
-            mut run: ResMut<bool>,
-        ) {
-            op.expect("NonSend should exist");
-            *run = true;
-        }
-
-        run_system(&mut world, sys);
-        // ensure the system actually ran
-        assert!(*world.get_resource::<bool>().unwrap());
-    }
-
-    #[test]
-    fn non_send_system() {
-        let mut world = World::default();
-
-        world.insert_resource(false);
-        struct NotSend1(std::rc::Rc<i32>);
-        struct NotSend2(std::rc::Rc<i32>);
-
-        world.insert_non_send(NotSend1(std::rc::Rc::new(1)));
-        world.insert_non_send(NotSend2(std::rc::Rc::new(2)));
-
-        fn sys(_op: NonSend<NotSend1>, mut _op2: NonSendMut<NotSend2>, mut run: ResMut<bool>) {
-            *run = true;
-        }
-
-        run_system(&mut world, sys);
-        assert!(*world.get_resource::<bool>().unwrap());
-    }
-
-    #[test]
-    fn remove_tracking() {
-        let mut world = World::new();
-        struct Despawned(Entity);
-        let a = world.spawn().insert_bundle(("abc", 123)).id();
-        world.spawn().insert_bundle(("abc", 123));
-        world.insert_resource(false);
-        world.insert_resource(Despawned(a));
-
-        world.entity_mut(a).despawn();
-
-        fn validate_removed(
-            removed_i32: RemovedComponents<i32>,
-            despawned: Res<Despawned>,
-            mut ran: ResMut<bool>,
-        ) {
-            assert_eq!(
-                removed_i32.iter().collect::<Vec<_>>(),
-                &[despawned.0],
-                "despawning results in 'removed component' state"
-            );
-
-            *ran = true;
-        }
-
-        run_system(&mut world, validate_removed);
-        assert!(*world.get_resource::<bool>().unwrap(), "system ran");
-    }
-
-    #[test]
-    fn configure_system_local() {
-        let mut world = World::default();
-        world.insert_resource(false);
-        fn sys(local: Local<usize>, mut modified: ResMut<bool>) {
-            assert_eq!(*local, 42);
-            *modified = true;
-        }
-
-        run_system(&mut world, sys.config(|config| config.0 = Some(42)));
-
-        // ensure the system actually ran
-        assert!(*world.get_resource::<bool>().unwrap());
-    }
-
-    #[test]
-    fn world_collections_system() {
-        let mut world = World::default();
-        world.insert_resource(false);
-        world.spawn().insert_bundle((42, true));
-        fn sys(
-            archetypes: &Archetypes,
-            components: &Components,
-            entities: &Entities,
-            bundles: &Bundles,
-            query: Query<Entity, With<i32>>,
-            mut modified: ResMut<bool>,
-        ) {
-            assert_eq!(query.iter().count(), 1, "entity exists");
-            for entity in query.iter() {
-                let location = entities.get(entity).unwrap();
-                let archetype = archetypes.get(location.archetype_id).unwrap();
-                let archetype_components = archetype.components().collect::<Vec<_>>();
-                let bundle_id = bundles
-                    .get_id(std::any::TypeId::of::<(i32, bool)>())
-                    .expect("Bundle used to spawn entity should exist");
-                let bundle_info = bundles.get(bundle_id).unwrap();
-                let mut bundle_components = bundle_info.components().to_vec();
-                bundle_components.sort();
-                for component_id in bundle_components.iter() {
-                    assert!(
-                        components.get_info(*component_id).is_some(),
-                        "every bundle component exists in Components"
-                    );
-                }
-                assert_eq!(
-                    bundle_components, archetype_components,
-                    "entity's bundle components exactly match entity's archetype components"
-                );
-            }
-            *modified = true;
-        }
-
-        run_system(&mut world, sys);
-
-        // ensure the system actually ran
-        assert!(*world.get_resource::<bool>().unwrap());
-    }
-
-    #[test]
-    fn get_system_conflicts() {
-        fn sys_x(_: Res<A>, _: Res<B>, _: Query<(&C, &D)>) {}
-
-        fn sys_y(_: Res<A>, _: ResMut<B>, _: Query<(&C, &mut D)>) {}
-
-        let mut world = World::default();
-        let mut x = sys_x.system();
-        let mut y = sys_y.system();
-        x.initialize(&mut world);
-        y.initialize(&mut world);
-
-        let conflicts = x.component_access().get_conflicts(y.component_access());
-        let b_id = world
-            .components()
-            .get_resource_id(TypeId::of::<B>())
-            .unwrap();
-        let d_id = world.components().get_id(TypeId::of::<D>()).unwrap();
-        assert_eq!(conflicts, vec![b_id, d_id]);
-    }
-
-    #[test]
-    fn query_is_empty() {
-        fn without_filter(not_empty: Query<&A>, empty: Query<&B>) {
-            assert!(!not_empty.is_empty());
-            assert!(empty.is_empty());
-        }
-
-        fn with_filter(not_empty: Query<&A, With<C>>, empty: Query<&A, With<D>>) {
-            assert!(!not_empty.is_empty());
-            assert!(empty.is_empty());
-        }
-
-        let mut world = World::default();
-        world.spawn().insert(A).insert(C);
-
-        let mut without_filter = without_filter.system();
-        without_filter.initialize(&mut world);
-        without_filter.run((), &mut world);
-
-        let mut with_filter = with_filter.system();
-        with_filter.initialize(&mut world);
-        with_filter.run((), &mut world);
-    }
-
-    #[test]
-    #[allow(clippy::too_many_arguments)]
-    fn can_have_16_parameters() {
-        fn sys_x(
-            _: Res<A>,
-            _: Res<B>,
-            _: Res<C>,
-            _: Res<D>,
-            _: Res<E>,
-            _: Res<F>,
-            _: Query<&A>,
-            _: Query<&B>,
-            _: Query<&C>,
-            _: Query<&D>,
-            _: Query<&E>,
-            _: Query<&F>,
-            _: Query<(&A, &B)>,
-            _: Query<(&C, &D)>,
-            _: Query<(&E, &F)>,
-        ) {
-        }
-        fn sys_y(
-            _: (
-                Res<A>,
-                Res<B>,
-                Res<C>,
-                Res<D>,
-                Res<E>,
-                Res<F>,
-                Query<&A>,
-                Query<&B>,
-                Query<&C>,
-                Query<&D>,
-                Query<&E>,
-                Query<&F>,
-                Query<(&A, &B)>,
-                Query<(&C, &D)>,
-                Query<(&E, &F)>,
-            ),
-        ) {
-        }
-        let mut world = World::default();
-        let mut x = sys_x.system();
-        let mut y = sys_y.system();
-        x.initialize(&mut world);
-        y.initialize(&mut world);
-    }
-
-    #[test]
-    fn read_system_state() {
-        #[derive(Eq, PartialEq, Debug)]
-        struct A(usize);
-
-        #[derive(Eq, PartialEq, Debug)]
-        struct B(usize);
-
-        let mut world = World::default();
-        world.insert_resource(A(42));
-        world.spawn().insert(B(7));
-
-        let mut system_state: SystemState<(
-            Res<A>,
-            Query<&B>,
-            QuerySet<(QueryState<&C>, QueryState<&D>)>,
-        )> = SystemState::new(&mut world);
-        let (a, query, _) = system_state.get(&world);
-        assert_eq!(*a, A(42), "returned resource matches initial value");
-        assert_eq!(
-            *query.single().unwrap(),
-            B(7),
-            "returned component matches initial value"
-        );
-    }
-
-    #[test]
-    fn write_system_state() {
-        #[derive(Eq, PartialEq, Debug)]
-        struct A(usize);
-
-        #[derive(Eq, PartialEq, Debug)]
-        struct B(usize);
-
-        let mut world = World::default();
-        world.insert_resource(A(42));
-        world.spawn().insert(B(7));
-
-        let mut system_state: SystemState<(ResMut<A>, Query<&mut B>)> =
-            SystemState::new(&mut world);
-
-        // The following line shouldn't compile because the parameters used are not ReadOnlySystemParam
-        // let (a, query) = system_state.get(&world);
-
-        let (a, mut query) = system_state.get_mut(&mut world);
-        assert_eq!(*a, A(42), "returned resource matches initial value");
-        assert_eq!(
-            *query.single_mut().unwrap(),
-            B(7),
-            "returned component matches initial value"
-        );
-    }
-
-    #[test]
-    fn system_state_change_detection() {
-        #[derive(Eq, PartialEq, Debug)]
-        struct A(usize);
-
-        let mut world = World::default();
-        let entity = world.spawn().insert(A(1)).id();
-
-        let mut system_state: SystemState<Query<&A, Changed<A>>> = SystemState::new(&mut world);
-        {
-            let query = system_state.get(&world);
-            assert_eq!(*query.single().unwrap(), A(1));
-        }
-
-        {
-            let query = system_state.get(&world);
-            assert!(query.single().is_err());
-        }
-
-        world.entity_mut(entity).get_mut::<A>().unwrap().0 = 2;
-        {
-            let query = system_state.get(&world);
-            assert_eq!(*query.single().unwrap(), A(2));
-        }
-    }
-
-    #[test]
-    #[should_panic]
-    fn system_state_invalid_world() {
-        let mut world = World::default();
-        let mut system_state = SystemState::<Query<&A>>::new(&mut world);
-        let mismatched_world = World::default();
-        system_state.get(&mismatched_world);
-    }
-
-    #[test]
-    fn system_state_archetype_update() {
-        #[derive(Eq, PartialEq, Debug)]
-        struct A(usize);
-
-        #[derive(Eq, PartialEq, Debug)]
-        struct B(usize);
-
-        let mut world = World::default();
-        world.spawn().insert(A(1));
-
-        let mut system_state = SystemState::<Query<&A>>::new(&mut world);
-        {
-            let query = system_state.get(&world);
-            assert_eq!(
-                query.iter().collect::<Vec<_>>(),
-                vec![&A(1)],
-                "exactly one component returned"
-            );
-        }
-
-        world.spawn().insert_bundle((A(2), B(2)));
-        {
-            let query = system_state.get(&world);
-            assert_eq!(
-                query.iter().collect::<Vec<_>>(),
-                vec![&A(1), &A(2)],
-                "components from both archetypes returned"
-            );
-        }
-    }
-
-    /// this test exists to show that read-only world-only queries can return data that lives as long as 'world
-    #[test]
-    #[allow(unused)]
-    fn long_life_test() {
-        struct Holder<'w> {
-            value: &'w A,
-        }
-
-        struct State {
-            state: SystemState<Res<'static, A>>,
-            state_q: SystemState<Query<'static, 'static, &'static A>>,
-        }
-
-        impl State {
-            fn hold_res<'w>(&mut self, world: &'w World) -> Holder<'w> {
-                let a = self.state.get(world);
-                Holder {
-                    value: a.into_inner(),
-                }
-            }
-            fn hold_component<'w>(&mut self, world: &'w World, entity: Entity) -> Holder<'w> {
-                let q = self.state_q.get(world);
-                let a = q.get(entity).unwrap();
-                Holder { value: a }
-            }
-            fn hold_components<'w>(&mut self, world: &'w World) -> Vec<Holder<'w>> {
-                let mut components = Vec::new();
-                let q = self.state_q.get(world);
-                for a in q.iter() {
-                    components.push(Holder { value: a });
-                }
-                components
-            }
-        }
-    }
-}
-
-/// ```compile_fail
-/// use bevy_ecs::prelude::*;
-/// struct A(usize);
-/// fn system(mut query: Query<&mut A>, e: Res<Entity>) {
-///     let mut iter = query.iter_mut();
-///     let a = &mut *iter.next().unwrap();
-///
-///     let mut iter2 = query.iter_mut();
-///     let b = &mut *iter2.next().unwrap();
-///
-///     // this should fail to compile
-///     println!("{}", a.0);
-/// }
-/// ```
-#[allow(unused)]
-#[cfg(doc)]
-fn system_query_iter_lifetime_safety_test() {}
-
-/// ```compile_fail
-/// use bevy_ecs::prelude::*;
-/// struct A(usize);
-/// fn system(mut query: Query<&mut A>, e: Res<Entity>) {
-///     let mut a1 = query.get_mut(*e).unwrap();
-///     let mut a2 = query.get_mut(*e).unwrap();
-///     // this should fail to compile
-///     println!("{} {}", a1.0, a2.0);
-/// }
-/// ```
-#[allow(unused)]
-#[cfg(doc)]
-fn system_query_get_lifetime_safety_test() {}
-
-/// ```compile_fail
-/// use bevy_ecs::prelude::*;
-/// struct A(usize);
-/// fn query_set(mut queries: QuerySet<(QueryState<&mut A>, QueryState<&A>)>, e: Res<Entity>) {
-///     let mut q2 = queries.q0();
-///     let mut iter2 = q2.iter_mut();
-///     let mut b = iter2.next().unwrap();
-///
-///     let q1 = queries.q1();
-///     let mut iter = q1.iter();
-///     let a = &*iter.next().unwrap();
-///
-///     // this should fail to compile
-///     b.0 = a.0
-/// }
-/// ```
-#[allow(unused)]
-#[cfg(doc)]
-fn system_query_set_iter_lifetime_safety_test() {}
-
-/// ```compile_fail
-/// use bevy_ecs::prelude::*;
-/// struct A(usize);
-/// fn query_set(mut queries: QuerySet<(QueryState<&mut A>, QueryState<&A>)>, e: Res<Entity>) {
-///     let q1 = queries.q1();
-///     let mut iter = q1.iter();
-///     let a = &*iter.next().unwrap();
-///
-///     let mut q2 = queries.q0();
-///     let mut iter2 = q2.iter_mut();
-///     let mut b = iter2.next().unwrap();
-///
-///     // this should fail to compile
-///     b.0 = a.0;
-/// }
-/// ```
-#[allow(unused)]
-#[cfg(doc)]
-fn system_query_set_iter_flip_lifetime_safety_test() {}
-
-/// ```compile_fail
-/// use bevy_ecs::prelude::*;
-/// struct A(usize);
-/// fn query_set(mut queries: QuerySet<(QueryState<&mut A>, QueryState<&A>)>, e: Res<Entity>) {
-///     let mut q2 = queries.q0();
-///     let mut b = q2.get_mut(*e).unwrap();
-///
-///     let q1 = queries.q1();
-///     let a = q1.get(*e).unwrap();
-///
-///     // this should fail to compile
-///     b.0 = a.0
-/// }
-/// ```
-#[allow(unused)]
-#[cfg(doc)]
-fn system_query_set_get_lifetime_safety_test() {}
-
-/// ```compile_fail
-/// use bevy_ecs::prelude::*;
-/// struct A(usize);
-/// fn query_set(mut queries: QuerySet<(QueryState<&mut A>, QueryState<&A>)>, e: Res<Entity>) {
-///     let q1 = queries.q1();
-///     let a = q1.get(*e).unwrap();
-///
-///     let mut q2 = queries.q0();
-///     let mut b = q2.get_mut(*e).unwrap();
-///     // this should fail to compile
-///     b.0 = a.0
-/// }
-/// ```
-#[allow(unused)]
-#[cfg(doc)]
-fn system_query_set_get_flip_lifetime_safety_test() {}
-
-/// ```compile_fail
-/// use bevy_ecs::prelude::*;
-/// use bevy_ecs::system::SystemState;
-/// struct A(usize);
-/// struct B(usize);
-/// struct State {
-///     state_r: SystemState<Query<'static, 'static, &'static A>>,
-///     state_w: SystemState<Query<'static, 'static, &'static mut A>>,
-/// }
-///
-/// impl State {
-///     fn get_component<'w>(&mut self, world: &'w mut World, entity: Entity) {
-///         let q1 = self.state_r.get(&world);
-///         let a1 = q1.get(entity).unwrap();
-///
-///         let mut q2 = self.state_w.get_mut(world);
-///         let a2 = q2.get_mut(entity).unwrap();
-///
-///         // this should fail to compile
-///         println!("{}", a1.0);
-///     }
-/// }
-/// ```
-#[allow(unused)]
-#[cfg(doc)]
-fn system_state_get_lifetime_safety_test() {}
-
-/// ```compile_fail
-/// use bevy_ecs::prelude::*;
-/// use bevy_ecs::system::SystemState;
-/// struct A(usize);
-/// struct B(usize);
-/// struct State {
-///     state_r: SystemState<Query<'static, 'static, &'static A>>,
-///     state_w: SystemState<Query<'static, 'static, &'static mut A>>,
-/// }
-///
-/// impl State {
-///     fn get_components<'w>(&mut self, world: &'w mut World) {
-///         let q1 = self.state_r.get(&world);
-///         let a1 = q1.iter().next().unwrap();
-///         let mut q2 = self.state_w.get_mut(world);
-///         let a2 = q2.iter_mut().next().unwrap();
-///         // this should fail to compile
-///         println!("{}", a1.0);
-///     }
-/// }
-/// ```
-#[allow(unused)]
-#[cfg(doc)]
-fn system_state_iter_lifetime_safety_test() {}
+// #[cfg(test)]
+// mod tests {
+//     use std::any::TypeId;
+
+//     use crate::{
+//         archetype::Archetypes,
+//         bundle::Bundles,
+//         component::Components,
+//         entity::{Entities, Entity},
+//         query::{Added, Changed, Or, QueryState, With, Without},
+//         schedule::{Schedule, Stage, SystemStage},
+//         system::{
+//             ConfigSystemParamFunction, IntoExclusiveSystem, IntoSystem, Local,
+//             NonSend, NonSendMut, Query, QuerySet, RemovedComponents, Res, ResMut, System,
+//             SystemState,
+//         },
+//         world::{FromWorld, World},
+//     };
+
+//     #[derive(Debug, Eq, PartialEq, Default)]
+//     struct A;
+//     struct B;
+//     struct C;
+//     struct D;
+//     struct E;
+//     struct F;
+
+//     #[test]
+//     fn simple_system() {
+//         fn sys(query: Query<&A>) {
+//             for a in query.iter() {
+//                 println!("{:?}", a);
+//             }
+//         }
+
+//         let mut world = World::new();
+//         let mut system = sys.system(&mut world);
+//         world.spawn().insert(A);
+
+//         for archetype in world.archetypes.iter() {
+//             system.new_archetype(archetype);
+//         }
+//         system.run((), &mut world);
+//     }
+
+//     fn run_system<Param, S: IntoSystem<(), (), Param>>(world: &mut World, system: S) {
+//         let mut schedule = Schedule::default();
+//         let mut update = SystemStage::parallel();
+//         update.add_system(system);
+//         schedule.add_stage("update", update);
+//         schedule.run(world);
+//     }
+
+//     #[test]
+//     fn query_system_gets() {
+//         fn query_system(
+//             mut ran: ResMut<bool>,
+//             entity_query: Query<Entity, With<A>>,
+//             b_query: Query<&B>,
+//             a_c_query: Query<(&A, &C)>,
+//             d_query: Query<&D>,
+//         ) {
+//             let entities = entity_query.iter().collect::<Vec<Entity>>();
+//             assert!(
+//                 b_query.get_component::<B>(entities[0]).is_err(),
+//                 "entity 0 should not have B"
+//             );
+//             assert!(
+//                 b_query.get_component::<B>(entities[1]).is_ok(),
+//                 "entity 1 should have B"
+//             );
+//             assert!(
+//                 b_query.get_component::<A>(entities[1]).is_err(),
+//                 "entity 1 should have A, but b_query shouldn't have access to it"
+//             );
+//             assert!(
+//                 b_query.get_component::<D>(entities[3]).is_err(),
+//                 "entity 3 should have D, but it shouldn't be accessible from b_query"
+//             );
+//             assert!(
+//                 b_query.get_component::<C>(entities[2]).is_err(),
+//                 "entity 2 has C, but it shouldn't be accessible from b_query"
+//             );
+//             assert!(
+//                 a_c_query.get_component::<C>(entities[2]).is_ok(),
+//                 "entity 2 has C, and it should be accessible from a_c_query"
+//             );
+//             assert!(
+//                 a_c_query.get_component::<D>(entities[3]).is_err(),
+//                 "entity 3 should have D, but it shouldn't be accessible from b_query"
+//             );
+//             assert!(
+//                 d_query.get_component::<D>(entities[3]).is_ok(),
+//                 "entity 3 should have D"
+//             );
+
+//             *ran = true;
+//         }
+
+//         let mut world = World::default();
+//         world.insert_resource(false);
+//         world.spawn().insert_bundle((A,));
+//         world.spawn().insert_bundle((A, B));
+//         world.spawn().insert_bundle((A, C));
+//         world.spawn().insert_bundle((A, D));
+
+//         run_system(&mut world, query_system);
+
+//         assert!(*world.get_resource::<bool>().unwrap(), "system ran");
+//     }
+
+//     #[test]
+//     fn or_query_set_system() {
+//         // Regression test for issue #762
+//         fn query_system(
+//             mut ran: ResMut<bool>,
+//             mut set: QuerySet<(
+//                 QueryState<(), Or<(Changed<A>, Changed<B>)>>,
+//                 QueryState<(), Or<(Added<A>, Added<B>)>>,
+//             )>,
+//         ) {
+//             let changed = set.q0().iter().count();
+//             let added = set.q1().iter().count();
+
+//             assert_eq!(changed, 1);
+//             assert_eq!(added, 1);
+
+//             *ran = true;
+//         }
+
+//         let mut world = World::default();
+//         world.insert_resource(false);
+//         world.spawn().insert_bundle((A, B));
+
+//         run_system(&mut world, query_system);
+
+//         assert!(*world.get_resource::<bool>().unwrap(), "system ran");
+//     }
+
+//     #[test]
+//     fn changed_resource_system() {
+//         struct Added(usize);
+//         struct Changed(usize);
+//         fn incr_e_on_flip(
+//             value: Res<bool>,
+//             mut changed: ResMut<Changed>,
+//             mut added: ResMut<Added>,
+//         ) {
+//             if value.is_added() {
+//                 added.0 += 1;
+//             }
+
+//             if value.is_changed() {
+//                 changed.0 += 1;
+//             }
+//         }
+
+//         let mut world = World::default();
+//         world.insert_resource(false);
+//         world.insert_resource(Added(0));
+//         world.insert_resource(Changed(0));
+
+//         let mut schedule = Schedule::default();
+//         let mut update = SystemStage::parallel();
+//         update.add_system(incr_e_on_flip);
+//         schedule.add_stage("update", update);
+//         schedule.add_stage(
+//             "clear_trackers",
+//             SystemStage::single(World::clear_trackers.exclusive_system(&mut world)),
+//         );
+
+//         schedule.run(&mut world);
+//         assert_eq!(world.get_resource::<Added>().unwrap().0, 1);
+//         assert_eq!(world.get_resource::<Changed>().unwrap().0, 1);
+
+//         schedule.run(&mut world);
+//         assert_eq!(world.get_resource::<Added>().unwrap().0, 1);
+//         assert_eq!(world.get_resource::<Changed>().unwrap().0, 1);
+
+//         *world.get_resource_mut::<bool>().unwrap() = true;
+//         schedule.run(&mut world);
+//         assert_eq!(world.get_resource::<Added>().unwrap().0, 1);
+//         assert_eq!(world.get_resource::<Changed>().unwrap().0, 2);
+//     }
+
+//     #[test]
+//     #[should_panic]
+//     fn conflicting_query_mut_system() {
+//         fn sys(_q1: Query<&mut A>, _q2: Query<&mut A>) {}
+
+//         let mut world = World::default();
+//         run_system(&mut world, sys);
+//     }
+
+//     #[test]
+//     fn disjoint_query_mut_system() {
+//         fn sys(_q1: Query<&mut A, With<B>>, _q2: Query<&mut A, Without<B>>) {}
+
+//         let mut world = World::default();
+//         run_system(&mut world, sys);
+//     }
+
+//     #[test]
+//     fn disjoint_query_mut_read_component_system() {
+//         fn sys(_q1: Query<(&mut A, &B)>, _q2: Query<&mut A, Without<B>>) {}
+
+//         let mut world = World::default();
+//         run_system(&mut world, sys);
+//     }
+
+//     #[test]
+//     #[should_panic]
+//     fn conflicting_query_immut_system() {
+//         fn sys(_q1: Query<&A>, _q2: Query<&mut A>) {}
+
+//         let mut world = World::default();
+//         run_system(&mut world, sys);
+//     }
+
+//     #[test]
+//     fn query_set_system() {
+//         fn sys(mut _set: QuerySet<(QueryState<&mut A>, QueryState<&A>)>) {}
+//         let mut world = World::default();
+//         run_system(&mut world, sys);
+//     }
+
+//     #[test]
+//     #[should_panic]
+//     fn conflicting_query_with_query_set_system() {
+//         fn sys(_query: Query<&mut A>, _set: QuerySet<(QueryState<&mut A>, QueryState<&B>)>) {}
+
+//         let mut world = World::default();
+//         run_system(&mut world, sys);
+//     }
+
+//     #[test]
+//     #[should_panic]
+//     fn conflicting_query_sets_system() {
+//         fn sys(
+//             _set_1: QuerySet<(QueryState<&mut A>,)>,
+//             _set_2: QuerySet<(QueryState<&mut A>, QueryState<&B>)>,
+//         ) {
+//         }
+
+//         let mut world = World::default();
+//         run_system(&mut world, sys);
+//     }
+
+//     #[derive(Default)]
+//     struct BufferRes {
+//         _buffer: Vec<u8>,
+//     }
+
+//     fn test_for_conflicting_resources<Param, S: IntoSystem<(), (), Param>>(sys: S) {
+//         let mut world = World::default();
+//         world.insert_resource(BufferRes::default());
+//         world.insert_resource(A);
+//         world.insert_resource(B);
+//         run_system(&mut world, sys);
+//     }
+
+//     #[test]
+//     #[should_panic]
+//     fn conflicting_system_resources() {
+//         fn sys(_: ResMut<BufferRes>, _: Res<BufferRes>) {}
+//         test_for_conflicting_resources(sys)
+//     }
+
+//     #[test]
+//     #[should_panic]
+//     fn conflicting_system_resources_reverse_order() {
+//         fn sys(_: Res<BufferRes>, _: ResMut<BufferRes>) {}
+//         test_for_conflicting_resources(sys)
+//     }
+
+//     #[test]
+//     #[should_panic]
+//     fn conflicting_system_resources_multiple_mutable() {
+//         fn sys(_: ResMut<BufferRes>, _: ResMut<BufferRes>) {}
+//         test_for_conflicting_resources(sys)
+//     }
+
+//     #[test]
+//     fn nonconflicting_system_resources() {
+//         fn sys(_: Local<BufferRes>, _: ResMut<BufferRes>, _: Local<A>, _: ResMut<A>) {}
+//         test_for_conflicting_resources(sys)
+//     }
+
+//     #[test]
+//     fn local_system() {
+//         let mut world = World::default();
+//         world.insert_resource(1u32);
+//         world.insert_resource(false);
+//         struct Foo {
+//             value: u32,
+//         }
+
+//         impl FromWorld for Foo {
+//             fn from_world(world: &mut World) -> Self {
+//                 Foo {
+//                     value: *world.get_resource::<u32>().unwrap() + 1,
+//                 }
+//             }
+//         }
+
+//         fn sys(local: Local<Foo>, mut modified: ResMut<bool>) {
+//             assert_eq!(local.value, 2);
+//             *modified = true;
+//         }
+
+//         run_system(&mut world, sys);
+
+//         // ensure the system actually ran
+//         assert!(*world.get_resource::<bool>().unwrap());
+//     }
+
+//     #[test]
+//     fn non_send_option_system() {
+//         let mut world = World::default();
+
+//         world.insert_resource(false);
+//         struct NotSend1(std::rc::Rc<i32>);
+//         struct NotSend2(std::rc::Rc<i32>);
+//         world.insert_non_send(NotSend1(std::rc::Rc::new(0)));
+
+//         fn sys(
+//             op: Option<NonSend<NotSend1>>,
+//             mut _op2: Option<NonSendMut<NotSend2>>,
+//             mut run: ResMut<bool>,
+//         ) {
+//             op.expect("NonSend should exist");
+//             *run = true;
+//         }
+
+//         run_system(&mut world, sys);
+//         // ensure the system actually ran
+//         assert!(*world.get_resource::<bool>().unwrap());
+//     }
+
+//     #[test]
+//     fn non_send_system() {
+//         let mut world = World::default();
+
+//         world.insert_resource(false);
+//         struct NotSend1(std::rc::Rc<i32>);
+//         struct NotSend2(std::rc::Rc<i32>);
+
+//         world.insert_non_send(NotSend1(std::rc::Rc::new(1)));
+//         world.insert_non_send(NotSend2(std::rc::Rc::new(2)));
+
+//         fn sys(_op: NonSend<NotSend1>, mut _op2: NonSendMut<NotSend2>, mut run: ResMut<bool>) {
+//             *run = true;
+//         }
+
+//         run_system(&mut world, sys);
+//         assert!(*world.get_resource::<bool>().unwrap());
+//     }
+
+//     #[test]
+//     fn remove_tracking() {
+//         let mut world = World::new();
+//         struct Despawned(Entity);
+//         let a = world.spawn().insert_bundle(("abc", 123)).id();
+//         world.spawn().insert_bundle(("abc", 123));
+//         world.insert_resource(false);
+//         world.insert_resource(Despawned(a));
+
+//         world.entity_mut(a).despawn();
+
+//         fn validate_removed(
+//             removed_i32: RemovedComponents<i32>,
+//             despawned: Res<Despawned>,
+//             mut ran: ResMut<bool>,
+//         ) {
+//             assert_eq!(
+//                 removed_i32.iter().collect::<Vec<_>>(),
+//                 &[despawned.0],
+//                 "despawning results in 'removed component' state"
+//             );
+
+//             *ran = true;
+//         }
+
+//         run_system(&mut world, validate_removed);
+//         assert!(*world.get_resource::<bool>().unwrap(), "system ran");
+//     }
+
+//     #[test]
+//     fn configure_system_local() {
+//         let mut world = World::default();
+//         world.insert_resource(false);
+//         fn sys(local: Local<usize>, mut modified: ResMut<bool>) {
+//             assert_eq!(*local, 42);
+//             *modified = true;
+//         }
+
+//         run_system(&mut world, sys.config(|config| config.0 = Some(42)));
+
+//         // ensure the system actually ran
+//         assert!(*world.get_resource::<bool>().unwrap());
+//     }
+
+//     #[test]
+//     fn world_collections_system() {
+//         let mut world = World::default();
+//         world.insert_resource(false);
+//         world.spawn().insert_bundle((42, true));
+//         fn sys(
+//             archetypes: &Archetypes,
+//             components: &Components,
+//             entities: &Entities,
+//             bundles: &Bundles,
+//             query: Query<Entity, With<i32>>,
+//             mut modified: ResMut<bool>,
+//         ) {
+//             assert_eq!(query.iter().count(), 1, "entity exists");
+//             for entity in query.iter() {
+//                 let location = entities.get(entity).unwrap();
+//                 let archetype = archetypes.get(location.archetype_id).unwrap();
+//                 let archetype_components = archetype.components().collect::<Vec<_>>();
+//                 let bundle_id = bundles
+//                     .get_id(std::any::TypeId::of::<(i32, bool)>())
+//                     .expect("Bundle used to spawn entity should exist");
+//                 let bundle_info = bundles.get(bundle_id).unwrap();
+//                 let mut bundle_components = bundle_info.components().to_vec();
+//                 bundle_components.sort();
+//                 for component_id in bundle_components.iter() {
+//                     assert!(
+//                         components.get_info(*component_id).is_some(),
+//                         "every bundle component exists in Components"
+//                     );
+//                 }
+//                 assert_eq!(
+//                     bundle_components, archetype_components,
+//                     "entity's bundle components exactly match entity's archetype components"
+//                 );
+//             }
+//             *modified = true;
+//         }
+
+//         run_system(&mut world, sys);
+
+//         // ensure the system actually ran
+//         assert!(*world.get_resource::<bool>().unwrap());
+//     }
+
+//     #[test]
+//     fn get_system_conflicts() {
+//         fn sys_x(_: Res<A>, _: Res<B>, _: Query<(&C, &D)>) {}
+
+//         fn sys_y(_: Res<A>, _: ResMut<B>, _: Query<(&C, &mut D)>) {}
+
+//         let mut world = World::default();
+//         let mut x = sys_x.system(&mut world);
+//         let mut y = sys_y.system(&mut world);
+
+//         let conflicts = x.component_access().get_conflicts(y.component_access());
+//         let b_id = world
+//             .components()
+//             .get_resource_id(TypeId::of::<B>())
+//             .unwrap();
+//         let d_id = world.components().get_id(TypeId::of::<D>()).unwrap();
+//         assert_eq!(conflicts, vec![b_id, d_id]);
+//     }
+
+//     #[test]
+//     fn query_is_empty() {
+//         fn without_filter(not_empty: Query<&A>, empty: Query<&B>) {
+//             assert!(!not_empty.is_empty());
+//             assert!(empty.is_empty());
+//         }
+
+//         fn with_filter(not_empty: Query<&A, With<C>>, empty: Query<&A, With<D>>) {
+//             assert!(!not_empty.is_empty());
+//             assert!(empty.is_empty());
+//         }
+
+//         let mut world = World::default();
+//         world.spawn().insert(A).insert(C);
+
+//         let mut without_filter = without_filter.system(&mut world);
+//         without_filter.run((), &mut world);
+
+//         let mut with_filter = with_filter.system(&mut world);
+//         with_filter.run((), &mut world);
+//     }
+
+//     #[test]
+//     #[allow(clippy::too_many_arguments)]
+//     fn can_have_16_parameters() {
+//         fn sys_x(
+//             _: Res<A>,
+//             _: Res<B>,
+//             _: Res<C>,
+//             _: Res<D>,
+//             _: Res<E>,
+//             _: Res<F>,
+//             _: Query<&A>,
+//             _: Query<&B>,
+//             _: Query<&C>,
+//             _: Query<&D>,
+//             _: Query<&E>,
+//             _: Query<&F>,
+//             _: Query<(&A, &B)>,
+//             _: Query<(&C, &D)>,
+//             _: Query<(&E, &F)>,
+//         ) {
+//         }
+//         fn sys_y(
+//             _: (
+//                 Res<A>,
+//                 Res<B>,
+//                 Res<C>,
+//                 Res<D>,
+//                 Res<E>,
+//                 Res<F>,
+//                 Query<&A>,
+//                 Query<&B>,
+//                 Query<&C>,
+//                 Query<&D>,
+//                 Query<&E>,
+//                 Query<&F>,
+//                 Query<(&A, &B)>,
+//                 Query<(&C, &D)>,
+//                 Query<(&E, &F)>,
+//             ),
+//         ) {
+//         }
+//         let mut world = World::default();
+//         let mut x = sys_x.system(&mut world);
+//         let mut y = sys_y.system(&mut world);
+//     }
+
+//     #[test]
+//     fn read_system_state() {
+//         #[derive(Eq, PartialEq, Debug)]
+//         struct A(usize);
+
+//         #[derive(Eq, PartialEq, Debug)]
+//         struct B(usize);
+
+//         let mut world = World::default();
+//         world.insert_resource(A(42));
+//         world.spawn().insert(B(7));
+
+//         let mut system_state: SystemState<(
+//             Res<A>,
+//             Query<&B>,
+//             QuerySet<(QueryState<&C>, QueryState<&D>)>,
+//         )> = SystemState::new(&mut world);
+//         let (a, query, _) = system_state.get(&world);
+//         assert_eq!(*a, A(42), "returned resource matches initial value");
+//         assert_eq!(
+//             *query.single().unwrap(),
+//             B(7),
+//             "returned component matches initial value"
+//         );
+//     }
+
+//     #[test]
+//     fn write_system_state() {
+//         #[derive(Eq, PartialEq, Debug)]
+//         struct A(usize);
+
+//         #[derive(Eq, PartialEq, Debug)]
+//         struct B(usize);
+
+//         let mut world = World::default();
+//         world.insert_resource(A(42));
+//         world.spawn().insert(B(7));
+
+//         let mut system_state: SystemState<(ResMut<A>, Query<&mut B>)> =
+//             SystemState::new(&mut world);
+
+//         // The following line shouldn't compile because the parameters used are not ReadOnlySystemParam
+//         // let (a, query) = system_state.get(&world);
+
+//         let (a, mut query) = system_state.get_mut(&mut world);
+//         assert_eq!(*a, A(42), "returned resource matches initial value");
+//         assert_eq!(
+//             *query.single_mut().unwrap(),
+//             B(7),
+//             "returned component matches initial value"
+//         );
+//     }
+
+//     #[test]
+//     fn system_state_change_detection() {
+//         #[derive(Eq, PartialEq, Debug)]
+//         struct A(usize);
+
+//         let mut world = World::default();
+//         let entity = world.spawn().insert(A(1)).id();
+
+//         let mut system_state: SystemState<Query<&A, Changed<A>>> = SystemState::new(&mut world);
+//         {
+//             let query = system_state.get(&world);
+//             assert_eq!(*query.single().unwrap(), A(1));
+//         }
+
+//         {
+//             let query = system_state.get(&world);
+//             assert!(query.single().is_err());
+//         }
+
+//         world.entity_mut(entity).get_mut::<A>().unwrap().0 = 2;
+//         {
+//             let query = system_state.get(&world);
+//             assert_eq!(*query.single().unwrap(), A(2));
+//         }
+//     }
+
+//     #[test]
+//     #[should_panic]
+//     fn system_state_invalid_world() {
+//         let mut world = World::default();
+//         let mut system_state = SystemState::<Query<&A>>::new(&mut world);
+//         let mismatched_world = World::default();
+//         system_state.get(&mismatched_world);
+//     }
+
+//     #[test]
+//     fn system_state_archetype_update() {
+//         #[derive(Eq, PartialEq, Debug)]
+//         struct A(usize);
+
+//         #[derive(Eq, PartialEq, Debug)]
+//         struct B(usize);
+
+//         let mut world = World::default();
+//         world.spawn().insert(A(1));
+
+//         let mut system_state = SystemState::<Query<&A>>::new(&mut world);
+//         {
+//             let query = system_state.get(&world);
+//             assert_eq!(
+//                 query.iter().collect::<Vec<_>>(),
+//                 vec![&A(1)],
+//                 "exactly one component returned"
+//             );
+//         }
+
+//         world.spawn().insert_bundle((A(2), B(2)));
+//         {
+//             let query = system_state.get(&world);
+//             assert_eq!(
+//                 query.iter().collect::<Vec<_>>(),
+//                 vec![&A(1), &A(2)],
+//                 "components from both archetypes returned"
+//             );
+//         }
+//     }
+
+//     /// this test exists to show that read-only world-only queries can return data that lives as long as 'world
+//     #[test]
+//     #[allow(unused)]
+//     fn long_life_test() {
+//         struct Holder<'w> {
+//             value: &'w A,
+//         }
+
+//         struct State {
+//             state: SystemState<Res<'static, A>>,
+//             state_q: SystemState<Query<'static, 'static, &'static A>>,
+//         }
+
+//         impl State {
+//             fn hold_res<'w>(&mut self, world: &'w World) -> Holder<'w> {
+//                 let a = self.state.get(world);
+//                 Holder {
+//                     value: a.into_inner(),
+//                 }
+//             }
+//             fn hold_component<'w>(&mut self, world: &'w World, entity: Entity) -> Holder<'w> {
+//                 let q = self.state_q.get(world);
+//                 let a = q.get(entity).unwrap();
+//                 Holder { value: a }
+//             }
+//             fn hold_components<'w>(&mut self, world: &'w World) -> Vec<Holder<'w>> {
+//                 let mut components = Vec::new();
+//                 let q = self.state_q.get(world);
+//                 for a in q.iter() {
+//                     components.push(Holder { value: a });
+//                 }
+//                 components
+//             }
+//         }
+//     }
+// }
+
+// /// ```compile_fail
+// /// use bevy_ecs::prelude::*;
+// /// struct A(usize);
+// /// fn system(mut query: Query<&mut A>, e: Res<Entity>) {
+// ///     let mut iter = query.iter_mut();
+// ///     let a = &mut *iter.next().unwrap();
+// ///
+// ///     let mut iter2 = query.iter_mut();
+// ///     let b = &mut *iter2.next().unwrap();
+// ///
+// ///     // this should fail to compile
+// ///     println!("{}", a.0);
+// /// }
+// /// ```
+// #[allow(unused)]
+// #[cfg(doc)]
+// fn system_query_iter_lifetime_safety_test() {}
+
+// /// ```compile_fail
+// /// use bevy_ecs::prelude::*;
+// /// struct A(usize);
+// /// fn system(mut query: Query<&mut A>, e: Res<Entity>) {
+// ///     let mut a1 = query.get_mut(*e).unwrap();
+// ///     let mut a2 = query.get_mut(*e).unwrap();
+// ///     // this should fail to compile
+// ///     println!("{} {}", a1.0, a2.0);
+// /// }
+// /// ```
+// #[allow(unused)]
+// #[cfg(doc)]
+// fn system_query_get_lifetime_safety_test() {}
+
+// /// ```compile_fail
+// /// use bevy_ecs::prelude::*;
+// /// struct A(usize);
+// /// fn query_set(mut queries: QuerySet<(QueryState<&mut A>, QueryState<&A>)>, e: Res<Entity>) {
+// ///     let mut q2 = queries.q0();
+// ///     let mut iter2 = q2.iter_mut();
+// ///     let mut b = iter2.next().unwrap();
+// ///
+// ///     let q1 = queries.q1();
+// ///     let mut iter = q1.iter();
+// ///     let a = &*iter.next().unwrap();
+// ///
+// ///     // this should fail to compile
+// ///     b.0 = a.0
+// /// }
+// /// ```
+// #[allow(unused)]
+// #[cfg(doc)]
+// fn system_query_set_iter_lifetime_safety_test() {}
+
+// /// ```compile_fail
+// /// use bevy_ecs::prelude::*;
+// /// struct A(usize);
+// /// fn query_set(mut queries: QuerySet<(QueryState<&mut A>, QueryState<&A>)>, e: Res<Entity>) {
+// ///     let q1 = queries.q1();
+// ///     let mut iter = q1.iter();
+// ///     let a = &*iter.next().unwrap();
+// ///
+// ///     let mut q2 = queries.q0();
+// ///     let mut iter2 = q2.iter_mut();
+// ///     let mut b = iter2.next().unwrap();
+// ///
+// ///     // this should fail to compile
+// ///     b.0 = a.0;
+// /// }
+// /// ```
+// #[allow(unused)]
+// #[cfg(doc)]
+// fn system_query_set_iter_flip_lifetime_safety_test() {}
+
+// /// ```compile_fail
+// /// use bevy_ecs::prelude::*;
+// /// struct A(usize);
+// /// fn query_set(mut queries: QuerySet<(QueryState<&mut A>, QueryState<&A>)>, e: Res<Entity>) {
+// ///     let mut q2 = queries.q0();
+// ///     let mut b = q2.get_mut(*e).unwrap();
+// ///
+// ///     let q1 = queries.q1();
+// ///     let a = q1.get(*e).unwrap();
+// ///
+// ///     // this should fail to compile
+// ///     b.0 = a.0
+// /// }
+// /// ```
+// #[allow(unused)]
+// #[cfg(doc)]
+// fn system_query_set_get_lifetime_safety_test() {}
+
+// /// ```compile_fail
+// /// use bevy_ecs::prelude::*;
+// /// struct A(usize);
+// /// fn query_set(mut queries: QuerySet<(QueryState<&mut A>, QueryState<&A>)>, e: Res<Entity>) {
+// ///     let q1 = queries.q1();
+// ///     let a = q1.get(*e).unwrap();
+// ///
+// ///     let mut q2 = queries.q0();
+// ///     let mut b = q2.get_mut(*e).unwrap();
+// ///     // this should fail to compile
+// ///     b.0 = a.0
+// /// }
+// /// ```
+// #[allow(unused)]
+// #[cfg(doc)]
+// fn system_query_set_get_flip_lifetime_safety_test() {}
+
+// /// ```compile_fail
+// /// use bevy_ecs::prelude::*;
+// /// use bevy_ecs::system::SystemState;
+// /// struct A(usize);
+// /// struct B(usize);
+// /// struct State {
+// ///     state_r: SystemState<Query<'static, 'static, &'static A>>,
+// ///     state_w: SystemState<Query<'static, 'static, &'static mut A>>,
+// /// }
+// ///
+// /// impl State {
+// ///     fn get_component<'w>(&mut self, world: &'w mut World, entity: Entity) {
+// ///         let q1 = self.state_r.get(&world);
+// ///         let a1 = q1.get(entity).unwrap();
+// ///
+// ///         let mut q2 = self.state_w.get_mut(world);
+// ///         let a2 = q2.get_mut(entity).unwrap();
+// ///
+// ///         // this should fail to compile
+// ///         println!("{}", a1.0);
+// ///     }
+// /// }
+// /// ```
+// #[allow(unused)]
+// #[cfg(doc)]
+// fn system_state_get_lifetime_safety_test() {}
+
+// /// ```compile_fail
+// /// use bevy_ecs::prelude::*;
+// /// use bevy_ecs::system::SystemState;
+// /// struct A(usize);
+// /// struct B(usize);
+// /// struct State {
+// ///     state_r: SystemState<Query<'static, 'static, &'static A>>,
+// ///     state_w: SystemState<Query<'static, 'static, &'static mut A>>,
+// /// }
+// ///
+// /// impl State {
+// ///     fn get_components<'w>(&mut self, world: &'w mut World) {
+// ///         let q1 = self.state_r.get(&world);
+// ///         let a1 = q1.iter().next().unwrap();
+// ///         let mut q2 = self.state_w.get_mut(world);
+// ///         let a2 = q2.iter_mut().next().unwrap();
+// ///         // this should fail to compile
+// ///         println!("{}", a1.0);
+// ///     }
+// /// }
+// /// ```
+// #[allow(unused)]
+// #[cfg(doc)]
+// fn system_state_iter_lifetime_safety_test() {}

--- a/crates/bevy_ecs/src/system/system_chaining.rs
+++ b/crates/bevy_ecs/src/system/system_chaining.rs
@@ -97,15 +97,6 @@ impl<SystemA: System, SystemB: System<In = SystemA::Out>> System for ChainSystem
         self.system_b.apply_buffers(world);
     }
 
-    fn initialize(&mut self, world: &mut World) {
-        self.system_a.initialize(world);
-        self.system_b.initialize(world);
-        self.component_access
-            .extend(self.system_a.component_access());
-        self.component_access
-            .extend(self.system_b.component_access());
-    }
-
     fn check_change_tick(&mut self, change_tick: u32) {
         self.system_a.check_change_tick(change_tick);
         self.system_b.check_change_tick(change_tick);
@@ -135,15 +126,16 @@ where
     SystemB: IntoSystem<Payload, Out, ParamB>,
 {
     fn chain(self, system: SystemB) -> ChainSystem<SystemA::System, SystemB::System> {
-        let system_a = self.system();
-        let system_b = system.system();
-        ChainSystem {
-            name: Cow::Owned(format!("Chain({}, {})", system_a.name(), system_b.name())),
-            system_a,
-            system_b,
-            archetype_component_access: Default::default(),
-            component_access: Default::default(),
-            id: SystemId::new(),
-        }
+        todo!("port this to IntoSystem")
+        // let system_a = self.system();
+        // let system_b = system.system();
+        // ChainSystem {
+        //     name: Cow::Owned(format!("Chain({}, {})", system_a.name(), system_b.name())),
+        //     system_a,
+        //     system_b,
+        //     archetype_component_access: Default::default(),
+        //     component_access: Default::default(),
+        //     id: SystemId::new(),
+        // }
     }
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -47,6 +47,8 @@ pub trait SystemParam: Sized {
     type Fetch: for<'w, 's> SystemParamFetch<'w, 's>;
 }
 
+pub type SystemParamItem<'s, 'w, P> = <<P as SystemParam>::Fetch as SystemParamFetch<'s, 'w>>::Item;
+
 /// The state of a [`SystemParam`].
 ///
 /// # Safety

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -2,7 +2,7 @@ mod converter;
 mod gilrs_system;
 
 use bevy_app::{App, CoreStage, Plugin, StartupStage};
-use bevy_ecs::system::IntoExclusiveSystem;
+use bevy_ecs::{schedule::IntoExclusiveSystemWrapper, system::IntoExclusiveSystem};
 use bevy_utils::tracing::error;
 use gilrs::GilrsBuilder;
 use gilrs_system::{gilrs_event_startup_system, gilrs_event_system};
@@ -21,11 +21,11 @@ impl Plugin for GilrsPlugin {
                 app.insert_non_send_resource(gilrs)
                     .add_startup_system_to_stage(
                         StartupStage::PreStartup,
-                        gilrs_event_startup_system.exclusive_system(),
+                        gilrs_event_startup_system.exclusive(),
                     )
                     .add_system_to_stage(
                         CoreStage::PreUpdate,
-                        gilrs_event_system.exclusive_system(),
+                        gilrs_event_system.exclusive(),
                     );
             }
             Err(err) => error!("Failed to start Gilrs. {}", err),

--- a/crates/bevy_pbr/src/render_graph/lights_node.rs
+++ b/crates/bevy_pbr/src/render_graph/lights_node.rs
@@ -6,7 +6,8 @@ use crate::{
 };
 use bevy_core::{bytes_of, Pod, Zeroable};
 use bevy_ecs::{
-    system::{BoxedSystem, ConfigurableSystem, Local, Query, Res, ResMut},
+    prelude::{ConfigSystemParamFunction, IntoSystem},
+    system::{BoxedSystem, Local, Query, Res, ResMut},
     world::World,
 };
 use bevy_render::{
@@ -58,7 +59,7 @@ struct LightCount {
 }
 
 impl SystemNode for LightsNode {
-    fn get_system(&self) -> BoxedSystem {
+    fn get_system(&self, world: &mut World) -> BoxedSystem {
         let system = lights_node_system.config(|config| {
             config.0 = Some(LightsNodeSystemState {
                 command_queue: self.command_queue.clone(),
@@ -68,7 +69,7 @@ impl SystemNode for LightsNode {
                 staging_buffer: None,
             })
         });
-        Box::new(system)
+        Box::new(system.system(world))
     }
 }
 

--- a/crates/bevy_pbr/src/render_graph/mod.rs
+++ b/crates/bevy_pbr/src/render_graph/mod.rs
@@ -1,7 +1,7 @@
 mod lights_node;
 mod pbr_pipeline;
 
-use bevy_ecs::world::World;
+use bevy_ecs::{prelude::Mut, world::World};
 pub use lights_node::*;
 pub use pbr_pipeline::*;
 
@@ -29,18 +29,20 @@ use bevy_transform::prelude::GlobalTransform;
 pub const MAX_POINT_LIGHTS: usize = 10;
 pub const MAX_DIRECTIONAL_LIGHTS: usize = 1;
 pub(crate) fn add_pbr_graph(world: &mut World) {
-    {
-        let mut graph = world.get_resource_mut::<RenderGraph>().unwrap();
+    world.resource_scope(|world, mut graph: Mut<RenderGraph>| {
         graph.add_system_node(
+            world,
             node::TRANSFORM,
             RenderResourcesNode::<GlobalTransform>::new(true),
         );
         graph.add_system_node(
+            world,
             node::STANDARD_MATERIAL,
             AssetRenderResourcesNode::<StandardMaterial>::new(true),
         );
 
         graph.add_system_node(
+            world,
             node::LIGHTS,
             LightsNode::new(MAX_POINT_LIGHTS, MAX_DIRECTIONAL_LIGHTS),
         );
@@ -55,7 +57,7 @@ pub(crate) fn add_pbr_graph(world: &mut World) {
         graph
             .add_node_edge(node::LIGHTS, base::node::MAIN_PASS)
             .unwrap();
-    }
+    });
     let pipeline = build_pbr_pipeline(&mut world.get_resource_mut::<Assets<Shader>>().unwrap());
     let mut pipelines = world
         .get_resource_mut::<Assets<PipelineDescriptor>>()

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -13,7 +13,8 @@ pub mod texture;
 pub mod wireframe;
 
 use bevy_ecs::{
-    schedule::{ParallelSystemDescriptorCoercion, SystemStage},
+    component::{ComponentDescriptor, StorageType},
+    schedule::{IntoExclusiveSystemWrapper, ParallelSystemDescriptorCoercion, SystemStage},
     system::{IntoExclusiveSystem, Res},
 };
 use bevy_transform::TransformSystem;
@@ -144,6 +145,9 @@ impl Plugin for RenderPlugin {
             SystemStage::parallel(),
         )
         .init_asset_loader::<ShaderLoader>()
+        .register_component(ComponentDescriptor::new::<OutsideFrustum>(
+            StorageType::SparseSet,
+        ))
         .add_asset::<Mesh>()
         .add_asset::<Texture>()
         .add_asset::<Shader>()
@@ -202,7 +206,7 @@ impl Plugin for RenderPlugin {
         )
         .add_system_to_stage(
             RenderStage::RenderGraphSystems,
-            render_graph::render_graph_schedule_executor_system.exclusive_system(),
+            render_graph::render_graph_schedule_executor_system.exclusive(),
         )
         .add_system_to_stage(RenderStage::Draw, pipeline::draw_render_pipelines_system)
         .add_system_to_stage(RenderStage::PostRender, shader::clear_shader_defs_system);

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -40,7 +40,7 @@ impl RenderGraph {
         id
     }
 
-    pub fn add_system_node<T>(&mut self, name: impl Into<Cow<'static, str>>, node: T) -> NodeId
+    pub fn add_system_node<T>(&mut self, world: &mut World, name: impl Into<Cow<'static, str>>, node: T) -> NodeId
     where
         T: SystemNode + 'static,
     {
@@ -48,7 +48,8 @@ impl RenderGraph {
         let stage = schedule
             .get_stage_mut::<SystemStage>(&RenderGraphUpdate)
             .unwrap();
-        stage.add_system(node.get_system());
+        let system= node.get_system(world);
+        stage.add_system(world, system);
         self.add_node(name, node)
     }
 

--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -46,7 +46,7 @@ pub trait Node: Downcast + Send + Sync + 'static {
 impl_downcast!(Node);
 
 pub trait SystemNode: Node {
-    fn get_system(&self) -> BoxedSystem;
+    fn get_system(&self, world: &mut World) -> BoxedSystem;
 }
 
 #[derive(Debug)]

--- a/crates/bevy_render/src/render_graph/nodes/camera_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/camera_node.rs
@@ -7,10 +7,7 @@ use crate::{
     },
 };
 use bevy_core::bytes_of;
-use bevy_ecs::{
-    system::{BoxedSystem, ConfigurableSystem, Local, Query, Res, ResMut},
-    world::World,
-};
+use bevy_ecs::{prelude::{ConfigSystemParamFunction, IntoSystem}, system::{BoxedSystem, Local, Query, Res, ResMut}, world::World};
 use bevy_transform::prelude::*;
 use std::borrow::Cow;
 
@@ -45,7 +42,7 @@ impl Node for CameraNode {
 }
 
 impl SystemNode for CameraNode {
-    fn get_system(&self) -> BoxedSystem {
+    fn get_system(&self, world: &mut World) -> BoxedSystem {
         let system = camera_node_system.config(|config| {
             config.0 = Some(CameraNodeState {
                 camera_name: self.camera_name.clone(),
@@ -53,7 +50,7 @@ impl SystemNode for CameraNode {
                 staging_buffer: None,
             })
         });
-        Box::new(system)
+        Box::new(system.system(world))
     }
 }
 

--- a/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
+++ b/crates/bevy_render/src/render_graph/nodes/render_resources_node.rs
@@ -13,9 +13,9 @@ use bevy_app::EventReader;
 use bevy_asset::{Asset, AssetEvent, Assets, Handle, HandleId};
 use bevy_ecs::{
     entity::Entity,
-    prelude::QueryState,
+    prelude::{ConfigSystemParamFunction, IntoSystem, QueryState},
     query::{Changed, Or, With},
-    system::{BoxedSystem, ConfigurableSystem, Local, QuerySet, RemovedComponents, Res, ResMut},
+    system::{BoxedSystem, Local, QuerySet, RemovedComponents, Res, ResMut},
     world::World,
 };
 use bevy_utils::HashMap;
@@ -400,7 +400,7 @@ impl<T> SystemNode for RenderResourcesNode<T>
 where
     T: renderer::RenderResources,
 {
-    fn get_system(&self) -> BoxedSystem {
+    fn get_system(&self, world: &mut World) -> BoxedSystem {
         let system = render_resources_node_system::<T>.config(|config| {
             config.0 = Some(RenderResourcesNodeState {
                 command_queue: self.command_queue.clone(),
@@ -409,7 +409,7 @@ where
             })
         });
 
-        Box::new(system)
+        Box::new(system.system(world))
     }
 }
 
@@ -583,7 +583,7 @@ impl<T> SystemNode for AssetRenderResourcesNode<T>
 where
     T: renderer::RenderResources + Asset,
 {
-    fn get_system(&self) -> BoxedSystem {
+    fn get_system(&self, world: &mut World) -> BoxedSystem {
         let system = asset_render_resources_node_system::<T>.config(|config| {
             config.0 = Some(RenderResourcesNodeState {
                 command_queue: self.command_queue.clone(),
@@ -592,7 +592,7 @@ where
             })
         });
 
-        Box::new(system)
+        Box::new(system.system(world))
     }
 }
 

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -20,7 +20,10 @@ pub mod prelude {
 
 use bevy_app::prelude::*;
 use bevy_asset::AddAsset;
-use bevy_ecs::{schedule::ExclusiveSystemDescriptorCoercion, system::IntoExclusiveSystem};
+use bevy_ecs::{
+    schedule::{ExclusiveSystemDescriptorCoercion, IntoExclusiveSystemWrapper},
+    system::IntoExclusiveSystem,
+};
 
 #[derive(Default)]
 pub struct ScenePlugin;
@@ -33,7 +36,7 @@ impl Plugin for ScenePlugin {
             .init_resource::<SceneSpawner>()
             .add_system_to_stage(
                 CoreStage::PreUpdate,
-                scene_spawner_system.exclusive_system().at_end(),
+                scene_spawner_system.exclusive().at_end(),
             );
     }
 }

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -90,20 +90,9 @@ impl Plugin for SpritePlugin {
                 frustum_culling::atlas_frustum_culling_system,
             );
         }
-        app.world
-            .register_component(ComponentDescriptor::new::<OutsideFrustum>(
-                StorageType::SparseSet,
-            ))
-            .unwrap();
 
+        crate::render::add_sprite_graph(&mut app.world);
         let world_cell = app.world.cell();
-        let mut render_graph = world_cell.get_resource_mut::<RenderGraph>().unwrap();
-        let mut pipelines = world_cell
-            .get_resource_mut::<Assets<PipelineDescriptor>>()
-            .unwrap();
-        let mut shaders = world_cell.get_resource_mut::<Assets<Shader>>().unwrap();
-        crate::render::add_sprite_graph(&mut render_graph, &mut pipelines, &mut shaders);
-
         let mut meshes = world_cell.get_resource_mut::<Assets<Mesh>>().unwrap();
         let mut color_materials = world_cell
             .get_resource_mut::<Assets<ColorMaterial>>()

--- a/crates/bevy_wgpu/src/lib.rs
+++ b/crates/bevy_wgpu/src/lib.rs
@@ -10,7 +10,7 @@ pub use wgpu_renderer::*;
 pub use wgpu_resources::*;
 
 use bevy_app::prelude::*;
-use bevy_ecs::{system::IntoExclusiveSystem, world::World};
+use bevy_ecs::{schedule::IntoExclusiveSystemWrapper, system::IntoExclusiveSystem, world::World};
 use bevy_render::{
     renderer::{shared_buffers_update_system, RenderResourceContext, SharedBuffers},
     RenderStage,
@@ -103,7 +103,7 @@ pub struct WgpuPlugin;
 impl Plugin for WgpuPlugin {
     fn build(&self, app: &mut App) {
         let render_system = get_wgpu_render_system(&mut app.world);
-        app.add_system_to_stage(RenderStage::Render, render_system.exclusive_system())
+        app.add_system_to_stage(RenderStage::Render, render_system.exclusive())
             .add_system_to_stage(RenderStage::PostRender, shared_buffers_update_system);
     }
 }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -11,7 +11,7 @@ pub use winit_config::*;
 pub use winit_windows::*;
 
 use bevy_app::{App, AppExit, CoreStage, Events, ManualEventReader, Plugin};
-use bevy_ecs::{system::IntoExclusiveSystem, world::World};
+use bevy_ecs::{schedule::IntoExclusiveSystemWrapper, system::IntoExclusiveSystem, world::World};
 use bevy_math::{ivec2, Vec2};
 use bevy_utils::tracing::{error, trace, warn};
 use bevy_window::{
@@ -42,7 +42,7 @@ impl Plugin for WinitPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<WinitWindows>()
             .set_runner(winit_runner)
-            .add_system_to_stage(CoreStage::PostUpdate, change_window.exclusive_system());
+            .add_system_to_stage(CoreStage::PostUpdate, change_window.exclusive());
     }
 }
 


### PR DESCRIPTION
Note: This is just very rough experimentation. I (currently) have no intention to move this forward as-is ... I just created it because people are discussing reworking system descriptors and scheduling right now and this change is something that relates / that I've been wanting to explore for awhile.
 
This does the following:

* Systems are "initialized" by definition. The "system initialization" lifecycle has been completely removed. IntoSystem takes a world reference and is responsible for initializing the system.
* FunctionSystems now use SystemState internally, unifying them as alluded to in #2283. The impl is much smaller / simpler now
* SystemDescriptors / ExclusiveSystemDescriptors now store functions that take a World and return a System.
* Adding a SystemDescriptor to a Schedule therefore requires a World reference. For Apps, this means users don't need to care because we can abstract this out. For raw Schedules / Stages, naively this means they need to accept a World reference, which significantly affects ergonomics. If we were to move forward with this, we would (1) remove all IntoSystem-related methods from Schedule and Stage in favor of accepting "boxed ready-to-go" systems. This would make them much simpler / might improve compile times (2) for direct bevy_ecs users that can't use App, add relevant StageBuilder and ScheduleBuilder types that abstract out the World requirement. alternatively we could just merge bevy_app into bevy_ecs.

The things this accomplishes:

* One less thing Systems need to do
* Simpler / smaller implementation that allows code reuse
* Systems no longer need to store their param state in an Option or unwrap it on every run
* Systems no longer need to store their Config indefinitely. It is only in memory when the app is being built.
* Things running systems and run criteria (like the parallel executor) no longer need to worry about ensuring everything is initialized, which makes the code smaller/simpler/mistake proof. 

This comes at the cost of:

1. Systems types cannot be created and stored without a World. This makes some patterns harder (ex: see the changes made to the old renderer's graph init ... this was quick and dirty. Fortunately we dont need that pattern in the new renderer).  People that really need this pattern (which honestly should be discouraged generally) can just use SystemDescriptors instead of boxed Systems.
2.  Schedules and Stages cannot add new systems without a World reference. This makes sense to me because they are the "baked and ready to go" types. In situations where a world isn't available, we could have intermediate types like StageDescriptor. But I expect App to meet basically everyone's needs in practice.