### PR TITLE
[Merged by Bors] - Add builder methods to Transform

### DIFF
--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -105,6 +105,28 @@ impl GlobalTransform {
         self
     }
 
+    #[doc(hidden)]
+    #[inline]
+    pub fn with_translation(mut self, translation: Vec3) -> Self {
+        self.translation = translation;
+        self
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn with_rotation(mut self, rotation: Quat) -> Self {
+        self.rotation = rotation;
+        self
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn with_scale(mut self, scale: Vec3) -> Self {
+        self.scale = scale;
+        self
+    }
+
+
     /// Returns the 3d affine transformation matrix from this transforms translation,
     /// rotation, and scale.
     #[inline]

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -126,7 +126,6 @@ impl GlobalTransform {
         self
     }
 
-
     /// Returns the 3d affine transformation matrix from this transforms translation,
     /// rotation, and scale.
     #[inline]

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -117,6 +117,27 @@ impl Transform {
         self
     }
 
+    /// Returns this [`Transform`] with a new translation.
+    #[inline]
+    pub fn with_translation(mut self, translation: Vec3) -> Self {
+        self.translation = translation;
+        self
+    }
+
+    /// Returns this [`Transform`] with a new rotation.
+    #[inline]
+    pub fn with_rotation(mut self, rotation: Quat) -> Self {
+        self.rotation = rotation;
+        self
+    }
+
+    /// Returns this [`Transform`] with a new scale.
+    #[inline]
+    pub fn with_scale(mut self, scale: Vec3) -> Self {
+        self.scale = scale;
+        self
+    }
+
     /// Returns the 3d affine transformation matrix from this transforms translation,
     /// rotation, and scale.
     #[inline]


### PR DESCRIPTION
# Objective

Make it easier to construct transforms. E.g.

```rs
Transform::from_xyz(0.0, 0.0, 10.0).with_scale(Vec3::splat(2.0))
```

I found myself writing an extension method to do this so I don't have to write:

```rs
Transform {
  translation: Vec3::new(0.0, 0.0, 10.0),
  scale: Vec3::splat(2.0),
  ..Default::default()
}
```

## Solution

Add *builder style* methods to `Transform`.

Methods:

- `with_translation`
- `with_rotation`
- `with_scale`

I also added these methods to `GlobalTransform`. But they are probably less useful there.
