### PR TITLE
Remove the Stage trait

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -565,6 +565,7 @@ impl App {
 }
 
 fn run_once(mut app: App) {
+    app.startup_schedule.run(&mut app.world);
     app.update();
 }
 

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -58,6 +58,7 @@ impl Plugin for ScheduleRunnerPlugin {
             .to_owned();
         app.set_runner(move |mut app: App| {
             let mut app_exit_event_reader = ManualEventReader::<AppExit>::default();
+            app.startup_schedule.run(&mut app.world);
             match settings.run_mode {
                 RunMode::Once => {
                     app.update();

--- a/crates/bevy_core/src/label.rs
+++ b/crates/bevy_core/src/label.rs
@@ -122,7 +122,7 @@ pub(crate) fn entity_labels_system(
 #[cfg(test)]
 mod tests {
     use bevy_ecs::{
-        schedule::{Schedule, Stage, SystemStage},
+        schedule::{Schedule, SystemStage},
         world::World,
     };
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -26,7 +26,7 @@ pub mod prelude {
         schedule::{
             AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,
             RunCriteria, RunCriteriaDescriptorCoercion, RunCriteriaLabel, RunCriteriaPiping,
-            Schedule, Stage, StageLabel, State, SystemLabel, SystemSet, SystemStage,
+            Schedule, StageLabel, State, SystemLabel, SystemSet, SystemStage,
         },
         system::{
             Commands, ConfigurableSystem, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem,

--- a/crates/bevy_ecs/src/schedule/executor_parallel.rs
+++ b/crates/bevy_ecs/src/schedule/executor_parallel.rs
@@ -315,7 +315,7 @@ enum SchedulingEvent {
 mod tests {
     use super::SchedulingEvent::{self, *};
     use crate::{
-        schedule::{SingleThreadedExecutor, Stage, SystemStage},
+        schedule::{SingleThreadedExecutor, SystemStage},
         system::{NonSend, Query, Res, ResMut},
         world::World,
     };

--- a/crates/bevy_ecs/src/system/exclusive_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system.rs
@@ -127,7 +127,7 @@ mod tests {
     use crate::{
         entity::Entity,
         query::With,
-        schedule::{Stage, SystemStage},
+        schedule::SystemStage,
         system::{Commands, IntoExclusiveSystem, Query, ResMut},
         world::World,
     };

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -25,7 +25,7 @@ mod tests {
         component::Components,
         entity::{Entities, Entity},
         query::{Added, Changed, Or, QueryState, With, Without},
-        schedule::{Schedule, Stage, SystemStage},
+        schedule::{Schedule, SystemStage},
         system::{
             ConfigurableSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend, NonSendMut, Query,
             QuerySet, RemovedComponents, Res, ResMut, System, SystemState,

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -45,9 +45,7 @@ impl RenderGraph {
         T: SystemNode + 'static,
     {
         let schedule = self.system_node_schedule.as_mut().unwrap();
-        let stage = schedule
-            .get_stage_mut::<SystemStage>(&RenderGraphUpdate)
-            .unwrap();
+        let stage = schedule.get_stage_mut(&RenderGraphUpdate).unwrap();
         stage.add_system(node.get_system());
         self.add_node(name, node)
     }

--- a/crates/bevy_render/src/render_graph/system.rs
+++ b/crates/bevy_render/src/render_graph/system.rs
@@ -1,5 +1,5 @@
 use super::RenderGraph;
-use bevy_ecs::{schedule::Stage, world::World};
+use bevy_ecs::world::World;
 
 pub fn render_graph_schedule_executor_system(world: &mut World) {
     // run render graph systems

--- a/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
@@ -74,7 +74,7 @@ pub fn parent_update_system(
 #[cfg(test)]
 mod test {
     use bevy_ecs::{
-        schedule::{Schedule, Stage, SystemStage},
+        schedule::{Schedule, SystemStage},
         system::CommandQueue,
         world::World,
     };

--- a/crates/bevy_transform/src/transform_propagate_system.rs
+++ b/crates/bevy_transform/src/transform_propagate_system.rs
@@ -76,7 +76,7 @@ fn propagate_recursive(
 #[cfg(test)]
 mod test {
     use bevy_ecs::{
-        schedule::{Schedule, Stage, SystemStage},
+        schedule::{Schedule, SystemStage},
         system::{CommandQueue, Commands},
         world::World,
     };

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -53,7 +53,7 @@ fn update_hierarchy(
 #[cfg(test)]
 mod tests {
     use bevy_ecs::{
-        schedule::{Schedule, Stage, SystemStage},
+        schedule::{Schedule, SystemStage},
         system::{CommandQueue, Commands},
         world::World,
     };

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -222,6 +222,7 @@ pub fn winit_runner_any_thread(app: App) {
 }
 
 pub fn winit_runner_with(mut app: App, mut event_loop: EventLoop<()>) {
+    app.startup_schedule.run(&mut app.world);
     let mut create_window_event_reader = ManualEventReader::<CreateWindow>::default();
     let mut app_exit_event_reader = ManualEventReader::<AppExit>::default();
     app.world.insert_non_send(event_loop.create_proxy());

--- a/examples/app/custom_loop.rs
+++ b/examples/app/custom_loop.rs
@@ -7,6 +7,7 @@ struct Input(String);
 /// lines from stdin and prints them from within the ecs.
 fn my_runner(mut app: App) {
     println!("Type stuff into the console");
+    app.startup_schedule.run(&mut app.world);
     for line in io::stdin().lock().lines() {
         {
             let mut input = app.world.get_resource_mut::<Input>().unwrap();


### PR DESCRIPTION
Remove the Stage trait to simplify internals, and make further work on #1375 and adjacent tasks easier. Startup schedules, which were the only place where the api was used have been moved to a separate field in App.