### PR TITLE
[Merged by Bors] - Fix scale_factor_override in the winit backend

### DIFF
--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -3,11 +3,13 @@ use std::path::PathBuf;
 use super::{WindowDescriptor, WindowId};
 use bevy_math::{IVec2, Vec2};
 
-/// A window event that is sent whenever a window has been resized.
+/// A window event that is sent whenever a windows logical size has changed
 #[derive(Debug, Clone)]
 pub struct WindowResized {
     pub id: WindowId,
+    /// The new logical width of the window
     pub width: f32,
+    /// The new logical height of the window
     pub height: f32,
 }
 

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -23,6 +23,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 
 # other
 winit = { version = "0.25.0", default-features = false }
+approx = { version = "0.5.0", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 winit = { version = "0.25.0", features = ["web-sys"], default-features = false }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -402,7 +402,7 @@ pub fn winit_runner_with(mut app: App, mut event_loop: EventLoop<()>) {
                             )
                             .to_physical::<u32>(old_factor);
                         } else {
-                            if window.scale_factor() != scale_factor {
+                            if (window.scale_factor() - scale_factor).abs() > f64::EPSILON {
                                 let mut scale_factor_change_events = world
                                     .get_resource_mut::<Events<WindowScaleFactorChanged>>()
                                     .unwrap();

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -395,35 +395,41 @@ pub fn winit_runner_with(mut app: App, mut event_loop: EventLoop<()>) {
                             id: window_id,
                             scale_factor,
                         });
-                        #[allow(clippy::float_cmp)]
-                        if window.scale_factor() != scale_factor {
-                            let mut scale_factor_change_events = world
-                                .get_resource_mut::<Events<WindowScaleFactorChanged>>()
-                                .unwrap();
+                        if let Some(old_factor) = window.scale_factor_override() {
+                            *new_inner_size = winit::dpi::LogicalSize::new(
+                                window.requested_width(),
+                                window.requested_height(),
+                            )
+                            .to_physical::<u32>(old_factor);
+                        } else {
+                            if window.scale_factor() != scale_factor {
+                                let mut scale_factor_change_events = world
+                                    .get_resource_mut::<Events<WindowScaleFactorChanged>>()
+                                    .unwrap();
 
-                            scale_factor_change_events.send(WindowScaleFactorChanged {
-                                id: window_id,
-                                scale_factor,
-                            });
+                                scale_factor_change_events.send(WindowScaleFactorChanged {
+                                    id: window_id,
+                                    scale_factor,
+                                });
+                            }
+                            window.update_scale_factor_from_backend(scale_factor);
+
+                            if window.physical_width() != new_inner_size.width
+                                || window.physical_height() != new_inner_size.height
+                            {
+                                let mut resize_events =
+                                    world.get_resource_mut::<Events<WindowResized>>().unwrap();
+                                resize_events.send(WindowResized {
+                                    id: window_id,
+                                    width: window.width(),
+                                    height: window.height(),
+                                });
+                            }
+                            window.update_actual_size_from_backend(
+                                new_inner_size.width,
+                                new_inner_size.height,
+                            );
                         }
-
-                        window.update_scale_factor_from_backend(scale_factor);
-
-                        if window.physical_width() != new_inner_size.width
-                            || window.physical_height() != new_inner_size.height
-                        {
-                            let mut resize_events =
-                                world.get_resource_mut::<Events<WindowResized>>().unwrap();
-                            resize_events.send(WindowResized {
-                                id: window_id,
-                                width: window.width(),
-                                height: window.height(),
-                            });
-                        }
-                        window.update_actual_size_from_backend(
-                            new_inner_size.width,
-                            new_inner_size.height,
-                        );
                     }
                     WindowEvent::Focused(focused) => {
                         window.update_focused_status_from_backend(focused);


### PR DESCRIPTION
# Objective

- Fixes #2751

## Solution

- Avoid changing the window size if there is a scale factor override
- Can be tested with the `scale_factor_override` example - use <kbd>⏎</kbd> to active overriding the scale factor
