### PR TITLE
[Merged by Bors] - Improve many sprites example

### DIFF
--- a/examples/2d/many_sprites.rs
+++ b/examples/2d/many_sprites.rs
@@ -10,8 +10,6 @@ use rand::Rng;
 
 const CAMERA_SPEED: f32 = 1000.0;
 
-pub struct PrintTimer(Timer);
-
 /// This example is for performance testing purposes.
 /// See https://github.com/bevyengine/bevy/pull/1492
 fn main() {
@@ -24,7 +22,7 @@ fn main() {
         })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(tick.label("Tick"))
+        .add_system(tick_system.label("Tick"))
         .add_system(move_camera_system.after("Tick"))
         .run()
 }
@@ -47,7 +45,7 @@ fn setup(
     commands
         .spawn()
         .insert_bundle(OrthographicCameraBundle::new_2d())
-        .insert(PrintTimer(Timer::from_seconds(1.0, true)))
+        .insert(Timer::from_seconds(1.0, true))
         .insert(Transform::from_xyz(0.0, 0.0, 1000.0));
 
     for y in -half_y..half_y {
@@ -79,12 +77,12 @@ fn move_camera_system(time: Res<Time>, mut camera_query: Query<&mut Transform, W
         *camera_transform * Transform::from_translation(Vec3::X * CAMERA_SPEED * time.delta_seconds());
 }
 
-fn tick(time: Res<Time>, sprites: Query<&Sprite>, mut query: Query<&mut PrintTimer>) {
-    for mut timer in query.iter_mut() {
-        timer.0.tick(time.delta());
+// System for printing the number of sprites on every tick of the timer
+fn tick_system(time: Res<Time>, sprites_query: Query<&Sprite>, mut timer_query: Query<&mut Timer>) {
+    let mut timer = timer_query.single_mut().unwrap();
+    timer.tick(time.delta());
 
-        if timer.0.just_finished() {
-            info!("Sprites: {}", sprites.iter().count(),);
-        }
+    if timer.just_finished() {
+        info!("Sprites: {}", sprites_query.iter().count(),);
     }
 }

--- a/examples/2d/many_sprites.rs
+++ b/examples/2d/many_sprites.rs
@@ -77,8 +77,8 @@ fn setup(
 fn move_camera_system(time: Res<Time>, mut camera_query: Query<&mut Transform, With<Camera>>) {
     let mut camera_transform = camera_query.single_mut().unwrap();
     camera_transform.rotate(Quat::from_rotation_z(time.delta_seconds() * 0.5));
-    *camera_transform =
-        *camera_transform * Transform::from_translation(Vec3::X * CAMERA_SPEED * time.delta_seconds());
+    *camera_transform = *camera_transform
+        * Transform::from_translation(Vec3::X * CAMERA_SPEED * time.delta_seconds());
 }
 
 // System for printing the number of sprites on every tick of the timer

--- a/examples/2d/many_sprites.rs
+++ b/examples/2d/many_sprites.rs
@@ -42,12 +42,15 @@ fn setup(
 
     let sprite_handle = materials.add(assets.load("branding/icon.png").into());
 
+    // Spawns the camera
     commands
         .spawn()
         .insert_bundle(OrthographicCameraBundle::new_2d())
         .insert(Timer::from_seconds(1.0, true))
         .insert(Transform::from_xyz(0.0, 0.0, 1000.0));
 
+    // Builds and spawns the sprites
+    let mut sprites = vec![];
     for y in -half_y..half_y {
         for x in -half_x..half_x {
             let position = Vec2::new(x as f32, y as f32);
@@ -55,7 +58,7 @@ fn setup(
             let rotation = Quat::from_rotation_z(rng.gen::<f32>());
             let scale = Vec3::splat(rng.gen::<f32>() * 2.0);
 
-            commands.spawn().insert_bundle(SpriteBundle {
+            sprites.push(SpriteBundle {
                 material: sprite_handle.clone(),
                 transform: Transform {
                     translation,
@@ -67,6 +70,7 @@ fn setup(
             });
         }
     }
+    commands.spawn_batch(sprites);
 }
 
 // System for rotating and translating the camera


### PR DESCRIPTION
# Objective

My attempt at fixing #2075 .

This is my very first contribution to this repo. Also, I'm very new to both Rust and bevy, so any feedback is *deeply* appreciated.

## Solution
- Changed `move_camera_system` so it only targets the camera entity. My approach here differs from the one used in the [cheatbook](https://bevy-cheatbook.github.io/cookbook/cursor2world.html?highlight=maincamera#2d-games) (in which a marker component is used to track the camera), so please, let me know which of them is more idiomatic.
- `move_camera_system` does not require both `Position` and `Transform` anymore (I used `rotate` for rotating the `Transform` in place, but couldn't find an equivalent `translate` method).
- Changed `tick_system` so it only targets the timer entity.
- Sprites are now spawned via a single `spawn_batch` instead of multiple `spawn`s. 