### PR TITLE
[Merged by Bors] - Replace `.insert_resource(T::default())` calls with `init_resource::<T>()`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -334,7 +334,7 @@ impl App {
     where
         T: Component,
     {
-        self.insert_resource(Events::<T>::default())
+        self.init_resource::<Events<T>>()
             .add_system_to_stage(CoreStage::First, Events::<T>::update_system)
     }
 

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -42,7 +42,7 @@ impl Plugin for TextPlugin {
         app.add_asset::<Font>()
             .add_asset::<FontAtlasSet>()
             .init_asset_loader::<FontLoader>()
-            .insert_resource(DefaultTextPipeline::default())
+            .init_resource::<DefaultTextPipeline>()
             .add_system_to_stage(CoreStage::PostUpdate, text2d_system)
             .add_system_to_stage(RenderStage::Draw, text2d::draw_text2d_system);
     }

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -4,7 +4,7 @@ fn main() {
     App::new()
         .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
-        .insert_resource(SceneInstance::default())
+        .init_resource::<SceneInstance>()
         .add_startup_system(setup)
         .add_system(scene_update)
         .add_system(move_scene_entities)

--- a/examples/ecs/timers.rs
+++ b/examples/ecs/timers.rs
@@ -3,7 +3,7 @@ use bevy::{log::info, prelude::*};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_resource(Countdown::default())
+        .init_resource::<Countdown>()
         .add_startup_system(setup_system)
         .add_system(countdown_system)
         .add_system(timer_system)


### PR DESCRIPTION
# Objective

I added the [INSERT_RESOURCE_WITH_DEFAULT](https://minersebas.github.io/bevy_lint/bevy_lint/static.INSERT_RESOURCE_WITH_DEFAULT.html) Lint to [bevy_lint](https://github.com/MinerSebas/bevy_lint) and while Testing it on bevy itself, I found several places where the Lint correctly triggered.



## Solution

Replace `.insert_resource(T::default())` calls with `init_resource::<T>()`
