### PR TITLE
[Merged by Bors] - Fix the new nightly CI errors

### DIFF
--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -62,6 +62,9 @@ fn sending_system(mut event_writer: EventWriter<MyEvent>) {
 // If an event is received it will be printed to the console
 fn receiving_system(mut event_reader: EventReader<MyEvent>) {
     for my_event in event_reader.iter() {
-        println!("    Received: {:?}", *my_event);
+        println!(
+            "    Received message {:?}, with random value of {}",
+            my_event.message, my_event.random_value
+        );
     }
 }

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -41,7 +41,6 @@ enum EventSystem {
 }
 
 // This is our event that we will send and receive in systems
-#[derive(Debug)]
 struct MyEvent {
     pub message: String,
     pub random_value: f32,


### PR DESCRIPTION
# Objective

- CI is failing again
- These failures result from https://github.com/rust-lang/rust/pull/85200

## Solution

- Fix the errors which result from this by using the given fields
- I also removed the now unused `Debug` impl.

I suspect that we shouldn't use -D warnings for nightly CI - ideally we'd get a discord webhook message into some (non-#github) dedicated channel on warnings. 

But this does not implement that.