### PR TITLE
Sprite3d

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,10 @@ name = "3d_scene_pipelined"
 path = "examples/3d/3d_scene_pipelined.rs"
 
 [[example]]
+name = "3d_sprite_pipelined"
+path = "examples/3d/3d_sprite_pipelined.rs"
+
+[[example]]
 name = "cornell_box_pipelined"
 path = "examples/3d/cornell_box_pipelined.rs"
 

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -129,7 +129,10 @@ impl PluginGroup for PipelinedDefaultPlugins {
             group.add(bevy_core_pipeline::CorePipelinePlugin::default());
 
             #[cfg(feature = "bevy_sprite2")]
-            group.add(bevy_sprite2::SpritePlugin::default());
+            group.add(bevy_sprite2::Sprite2dPlugin::default());
+
+            #[cfg(feature = "bevy_sprite2")]
+            group.add(bevy_sprite2::Sprite3dPlugin::default());
 
             #[cfg(feature = "bevy_pbr2")]
             group.add(bevy_pbr2::PbrPlugin::default());

--- a/examples/2d/pipelined_texture_atlas.rs
+++ b/examples/2d/pipelined_texture_atlas.rs
@@ -8,7 +8,7 @@ use bevy::{
     render2::{camera::OrthographicCameraBundle, texture::Image},
     sprite2::{
         PipelinedSpriteBundle, PipelinedSpriteSheetBundle, TextureAtlas, TextureAtlasBuilder,
-        TextureAtlasSprite,
+        TextureAtlasEntry,
     },
     PipelinedDefaultPlugins,
 };
@@ -81,7 +81,7 @@ fn setup(
             scale: Vec3::splat(4.0),
             ..Default::default()
         },
-        sprite: TextureAtlasSprite::new(vendor_index as u32),
+        texture_atlas_entry: TextureAtlasEntry::new(vendor_index as u32),
         texture_atlas: atlas_handle,
         ..Default::default()
     });

--- a/examples/2d/pipelined_texture_atlas.rs
+++ b/examples/2d/pipelined_texture_atlas.rs
@@ -7,8 +7,7 @@ use bevy::{
     },
     render2::{camera::OrthographicCameraBundle, texture::Image},
     sprite2::{
-        PipelinedSpriteBundle, PipelinedSpriteSheetBundle, TextureAtlas, TextureAtlasBuilder,
-        TextureAtlasEntry,
+        Sprite2dBundle, Sprite2dSheetBundle, TextureAtlas, TextureAtlasBuilder, TextureAtlasEntry,
     },
     PipelinedDefaultPlugins,
 };
@@ -75,7 +74,7 @@ fn setup(
     // set up a scene to display our texture atlas
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
     // draw a sprite from the atlas
-    commands.spawn_bundle(PipelinedSpriteSheetBundle {
+    commands.spawn_bundle(Sprite2dSheetBundle {
         transform: Transform {
             translation: Vec3::new(150.0, 0.0, 0.0),
             scale: Vec3::splat(4.0),
@@ -86,7 +85,7 @@ fn setup(
         ..Default::default()
     });
     // draw the atlas itself
-    commands.spawn_bundle(PipelinedSpriteBundle {
+    commands.spawn_bundle(Sprite2dBundle {
         texture: texture_atlas_texture,
         transform: Transform::from_xyz(-300.0, 0.0, 0.0),
         ..Default::default()

--- a/examples/3d/3d_sprite_pipelined.rs
+++ b/examples/3d/3d_sprite_pipelined.rs
@@ -1,0 +1,132 @@
+use bevy::{
+    asset::LoadState,
+    ecs::query::With,
+    math::Quat,
+    prelude::{
+        App, AssetServer, Commands, HandleUntyped, Query, Res, ResMut, State, SystemSet, Time,
+        Transform,
+    },
+    render2::{camera::PerspectiveCameraBundle, texture::Image},
+    PipelinedDefaultPlugins,
+};
+
+use bevy::prelude::*;
+use bevy::sprite2::Sprite3dBundle;
+
+fn main() {
+    App::new()
+        .init_resource::<TexHandle>()
+        .add_plugins(PipelinedDefaultPlugins)
+        .add_state(AppState::Setup)
+        .add_system_set(SystemSet::on_enter(AppState::Setup).with_system(load_textures))
+        .add_system_set(SystemSet::on_update(AppState::Setup).with_system(check_textures))
+        .add_system_set(SystemSet::on_enter(AppState::Finished).with_system(setup))
+        .add_system_set(SystemSet::on_update(AppState::Finished).with_system(rotation_system))
+        .add_system_set(SystemSet::on_update(AppState::Finished).with_system(zoom_system))
+        .run();
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum AppState {
+    Setup,
+    Finished,
+}
+
+#[derive(Default)]
+struct TexHandle {
+    handle: Option<HandleUntyped>,
+}
+
+fn load_textures(mut tex_handle: ResMut<TexHandle>, asset_server: Res<AssetServer>) {
+    tex_handle.handle = Some(
+        asset_server
+            .load::<Image, _>("branding/icon.png")
+            .clone_untyped(),
+    );
+}
+
+fn check_textures(
+    mut state: ResMut<State<AppState>>,
+    tex_handle: ResMut<TexHandle>,
+    asset_server: Res<AssetServer>,
+) {
+    if let LoadState::Loaded = asset_server.get_load_state(tex_handle.handle.as_ref().unwrap().id) {
+        state.set(AppState::Finished).unwrap();
+    }
+}
+
+fn setup(mut commands: Commands, tex_handle: Res<TexHandle>) {
+    let entity = commands
+        .spawn_bundle(Sprite3dBundle {
+            texture: tex_handle.handle.as_ref().unwrap().clone().typed(),
+            transform: Transform::from_xyz(0.0, 0.0, 0.0),
+            ..Default::default()
+        })
+        .id();
+
+    let mut camera = PerspectiveCameraBundle::new_3d();
+    camera.transform = Transform {
+        translation: Vec3::new(0.0, 0.0, 1000.0),
+        ..Default::default()
+    };
+
+    commands.spawn_bundle(camera).insert(Rotate).insert(Zoom {
+        target: entity,
+        zooming: Zooming::In,
+    });
+}
+
+struct Rotate;
+
+fn rotation_system(time: Res<Time>, mut query: Query<&mut Transform, With<Rotate>>) {
+    for mut transform in query.iter_mut() {
+        *transform = Transform::from_rotation(Quat::from_rotation_z(
+            (4.0 * std::f32::consts::PI / 30.0) * time.delta_seconds(),
+        )) * Transform::from_rotation(Quat::from_rotation_y(
+            (4.0 * std::f32::consts::PI / 20.0) * time.delta_seconds(),
+        )) * Transform::from_rotation(Quat::from_rotation_x(
+            (4.0 * std::f32::consts::PI / 16.0) * time.delta_seconds(),
+        )) * *transform;
+    }
+}
+
+struct Zoom {
+    target: Entity,
+    zooming: Zooming,
+}
+
+enum Zooming {
+    In,
+    Out,
+}
+
+fn zoom_system(
+    time: Res<Time>,
+    mut queries: QuerySet<(
+        Query<(&mut Transform, &mut Zoom)>,
+        Query<&Transform, Without<Zoom>>,
+    )>,
+) {
+    for (mut camera_transform, mut zoom) in queries.q0_mut().iter_mut() {
+        let target_transform = queries.q1().get(zoom.target).unwrap();
+
+        let diff = camera_transform.translation - target_transform.translation;
+        let distance = diff.length();
+        let dir = diff.normalize();
+
+        match zoom.zooming {
+            Zooming::In => {
+                if distance < 100.0 {
+                    zoom.zooming = Zooming::Out;
+                }
+                camera_transform.translation = dir * (distance - 1000.0 * time.delta_seconds());
+            }
+            Zooming::Out => {
+                if distance > 5000.0 {
+                    zoom.zooming = Zooming::In;
+                }
+                camera_transform.translation = dir * (distance + 1000.0 * time.delta_seconds());
+            }
+        }
+    }
+}

--- a/examples/tools/bevymark_pipelined.rs
+++ b/examples/tools/bevymark_pipelined.rs
@@ -6,7 +6,7 @@ use bevy::{
     math::Vec3,
     prelude::{App, AssetServer, Handle, MouseButton, Transform},
     render2::{camera::OrthographicCameraBundle, color::Color, texture::Image},
-    sprite2::PipelinedSpriteBundle,
+    sprite2::Sprite2dBundle,
     window::WindowDescriptor,
     PipelinedDefaultPlugins,
 };
@@ -174,7 +174,7 @@ fn spawn_birds(
     for count in 0..spawn_count {
         let bird_z = (counter.count + count) as f32 * 0.00001;
         commands
-            .spawn_bundle(PipelinedSpriteBundle {
+            .spawn_bundle(Sprite2dBundle {
                 // material: bird_material.0.clone(),
                 texture: texture.clone(),
                 transform: Transform {

--- a/pipelined/bevy_sprite2/src/bundle.rs
+++ b/pipelined/bevy_sprite2/src/bundle.rs
@@ -1,5 +1,5 @@
 use crate::{
-    texture_atlas::{TextureAtlas, TextureAtlasSprite},
+    texture_atlas::{TextureAtlas, TextureAtlasEntry},
     Sprite,
 };
 use bevy_asset::Handle;
@@ -30,8 +30,9 @@ impl Default for PipelinedSpriteBundle {
 /// to as a `TextureAtlas`)
 #[derive(Bundle, Clone)]
 pub struct PipelinedSpriteSheetBundle {
+    pub sprite: Sprite,
     /// The specific sprite from the texture atlas to be drawn
-    pub sprite: TextureAtlasSprite,
+    pub texture_atlas_entry: TextureAtlasEntry,
     /// A handle to the texture atlas that holds the sprite images
     pub texture_atlas: Handle<TextureAtlas>,
     /// Data pertaining to how the sprite is drawn on the screen
@@ -43,6 +44,7 @@ impl Default for PipelinedSpriteSheetBundle {
     fn default() -> Self {
         Self {
             sprite: Default::default(),
+            texture_atlas_entry: Default::default(),
             texture_atlas: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),

--- a/pipelined/bevy_sprite2/src/bundle.rs
+++ b/pipelined/bevy_sprite2/src/bundle.rs
@@ -1,6 +1,6 @@
 use crate::{
     texture_atlas::{TextureAtlas, TextureAtlasEntry},
-    Sprite,
+    Sprite2d, Sprite3d,
 };
 use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
@@ -8,14 +8,14 @@ use bevy_render2::texture::Image;
 use bevy_transform::components::{GlobalTransform, Transform};
 
 #[derive(Bundle, Clone)]
-pub struct PipelinedSpriteBundle {
-    pub sprite: Sprite,
+pub struct Sprite2dBundle {
+    pub sprite: Sprite2d,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
     pub texture: Handle<Image>,
 }
 
-impl Default for PipelinedSpriteBundle {
+impl Default for Sprite2dBundle {
     fn default() -> Self {
         Self {
             sprite: Default::default(),
@@ -29,8 +29,8 @@ impl Default for PipelinedSpriteBundle {
 /// A Bundle of components for drawing a single sprite from a sprite sheet (also referred
 /// to as a `TextureAtlas`)
 #[derive(Bundle, Clone)]
-pub struct PipelinedSpriteSheetBundle {
-    pub sprite: Sprite,
+pub struct Sprite2dSheetBundle {
+    pub sprite: Sprite2d,
     /// The specific sprite from the texture atlas to be drawn
     pub texture_atlas_entry: TextureAtlasEntry,
     /// A handle to the texture atlas that holds the sprite images
@@ -40,7 +40,52 @@ pub struct PipelinedSpriteSheetBundle {
     pub global_transform: GlobalTransform,
 }
 
-impl Default for PipelinedSpriteSheetBundle {
+impl Default for Sprite2dSheetBundle {
+    fn default() -> Self {
+        Self {
+            sprite: Default::default(),
+            texture_atlas_entry: Default::default(),
+            texture_atlas: Default::default(),
+            transform: Default::default(),
+            global_transform: Default::default(),
+        }
+    }
+}
+
+#[derive(Bundle, Clone)]
+pub struct Sprite3dBundle {
+    pub sprite: Sprite3d,
+    pub transform: Transform,
+    pub global_transform: GlobalTransform,
+    pub texture: Handle<Image>,
+}
+
+impl Default for Sprite3dBundle {
+    fn default() -> Self {
+        Self {
+            sprite: Default::default(),
+            transform: Default::default(),
+            global_transform: Default::default(),
+            texture: Default::default(),
+        }
+    }
+}
+
+/// A Bundle of components for drawing a single sprite from a sprite sheet (also referred
+/// to as a `TextureAtlas`)
+#[derive(Bundle, Clone)]
+pub struct Sprite3dSheetBundle {
+    pub sprite: Sprite3d,
+    /// The specific sprite from the texture atlas to be drawn
+    pub texture_atlas_entry: TextureAtlasEntry,
+    /// A handle to the texture atlas that holds the sprite images
+    pub texture_atlas: Handle<TextureAtlas>,
+    /// Data pertaining to how the sprite is drawn on the screen
+    pub transform: Transform,
+    pub global_transform: GlobalTransform,
+}
+
+impl Default for Sprite3dSheetBundle {
     fn default() -> Self {
         Self {
             sprite: Default::default(),

--- a/pipelined/bevy_sprite2/src/lib.rs
+++ b/pipelined/bevy_sprite2/src/lib.rs
@@ -16,6 +16,7 @@ pub use texture_atlas::*;
 pub use texture_atlas_builder::*;
 
 use bevy_app::prelude::*;
+use bevy_core_pipeline::{Transparent2dPhase, Transparent3dPhase};
 use bevy_render2::{
     render_graph::RenderGraph, render_phase::DrawFunctions, RenderApp, RenderStage,
 };
@@ -28,14 +29,17 @@ impl Plugin for Sprite2dPlugin {
         app.add_asset::<TextureAtlas>().register_type::<Sprite2d>();
         let render_app = app.sub_app(RenderApp);
         render_app
-            .init_resource::<ExtractedSprites2d>()
+            .init_resource::<ExtractedSprites<Sprite2d>>()
             .add_system_to_stage(RenderStage::Extract, render::extract_atlases_2d)
             .add_system_to_stage(RenderStage::Extract, render::extract_sprites_2d)
-            .add_system_to_stage(RenderStage::Prepare, render::prepare_sprites_2d)
-            .add_system_to_stage(RenderStage::Queue, render::queue_sprites_2d)
-            .init_resource::<Sprite2dShaders>()
-            .init_resource::<Sprite2dMeta>();
-        let draw_sprite_2d = DrawSprite2d::new(&mut render_app.world);
+            .add_system_to_stage(RenderStage::Prepare, render::prepare_sprites::<Sprite2d>)
+            .add_system_to_stage(
+                RenderStage::Queue,
+                render::queue_sprites::<Sprite2d, Transparent2dPhase>,
+            )
+            .init_resource::<SpriteShaders<Sprite2d>>()
+            .init_resource::<SpriteMeta<Sprite2d>>();
+        let draw_sprite_2d = DrawSprite::<Sprite2d>::new(&mut render_app.world);
         render_app
             .world
             .get_resource::<DrawFunctions>()
@@ -43,7 +47,7 @@ impl Plugin for Sprite2dPlugin {
             .write()
             .add(draw_sprite_2d);
         let mut graph = render_app.world.get_resource_mut::<RenderGraph>().unwrap();
-        graph.add_node("sprite2d", Sprite2dNode);
+        graph.add_node("sprite2d", SpriteNode::<Sprite2d>::default());
         graph
             .add_node_edge("sprite2d", bevy_core_pipeline::node::MAIN_PASS_DEPENDENCIES)
             .unwrap();
@@ -58,14 +62,17 @@ impl Plugin for Sprite3dPlugin {
         app.add_asset::<TextureAtlas>().register_type::<Sprite3d>();
         let render_app = app.sub_app(RenderApp);
         render_app
-            .init_resource::<ExtractedSprites3d>()
+            .init_resource::<ExtractedSprites<Sprite3d>>()
             .add_system_to_stage(RenderStage::Extract, render::extract_atlases_3d)
             .add_system_to_stage(RenderStage::Extract, render::extract_sprites_3d)
-            .add_system_to_stage(RenderStage::Prepare, render::prepare_sprites_3d)
-            .add_system_to_stage(RenderStage::Queue, render::queue_sprites_3d)
-            .init_resource::<Sprite3dShaders>()
-            .init_resource::<Sprite3dMeta>();
-        let draw_sprite_3d = DrawSprite3d::new(&mut render_app.world);
+            .add_system_to_stage(RenderStage::Prepare, render::prepare_sprites::<Sprite3d>)
+            .add_system_to_stage(
+                RenderStage::Queue,
+                render::queue_sprites::<Sprite3d, Transparent3dPhase>,
+            )
+            .init_resource::<SpriteShaders<Sprite3d>>()
+            .init_resource::<SpriteMeta<Sprite3d>>();
+        let draw_sprite_3d = DrawSprite::<Sprite3d>::new(&mut render_app.world);
         render_app
             .world
             .get_resource::<DrawFunctions>()
@@ -73,7 +80,7 @@ impl Plugin for Sprite3dPlugin {
             .write()
             .add(draw_sprite_3d);
         let mut graph = render_app.world.get_resource_mut::<RenderGraph>().unwrap();
-        graph.add_node("sprite3d", Sprite3dNode);
+        graph.add_node("sprite3d", SpriteNode::<Sprite3d>::default());
         graph
             .add_node_edge("sprite3d", bevy_core_pipeline::node::MAIN_PASS_DEPENDENCIES)
             .unwrap();

--- a/pipelined/bevy_sprite2/src/lib.rs
+++ b/pipelined/bevy_sprite2/src/lib.rs
@@ -21,31 +21,61 @@ use bevy_render2::{
 };
 
 #[derive(Default)]
-pub struct SpritePlugin;
+pub struct Sprite2dPlugin;
 
-impl Plugin for SpritePlugin {
+impl Plugin for Sprite2dPlugin {
     fn build(&self, app: &mut App) {
-        app.add_asset::<TextureAtlas>().register_type::<Sprite>();
+        app.add_asset::<TextureAtlas>().register_type::<Sprite2d>();
         let render_app = app.sub_app(RenderApp);
         render_app
-            .init_resource::<ExtractedSprites>()
-            .add_system_to_stage(RenderStage::Extract, render::extract_atlases)
-            .add_system_to_stage(RenderStage::Extract, render::extract_sprites)
-            .add_system_to_stage(RenderStage::Prepare, render::prepare_sprites)
-            .add_system_to_stage(RenderStage::Queue, queue_sprites)
-            .init_resource::<SpriteShaders>()
-            .init_resource::<SpriteMeta>();
-        let draw_sprite = DrawSprite::new(&mut render_app.world);
+            .init_resource::<ExtractedSprites2d>()
+            .add_system_to_stage(RenderStage::Extract, render::extract_atlases_2d)
+            .add_system_to_stage(RenderStage::Extract, render::extract_sprites_2d)
+            .add_system_to_stage(RenderStage::Prepare, render::prepare_sprites_2d)
+            .add_system_to_stage(RenderStage::Queue, render::queue_sprites_2d)
+            .init_resource::<Sprite2dShaders>()
+            .init_resource::<Sprite2dMeta>();
+        let draw_sprite_2d = DrawSprite2d::new(&mut render_app.world);
         render_app
             .world
             .get_resource::<DrawFunctions>()
             .unwrap()
             .write()
-            .add(draw_sprite);
+            .add(draw_sprite_2d);
         let mut graph = render_app.world.get_resource_mut::<RenderGraph>().unwrap();
-        graph.add_node("sprite", SpriteNode);
+        graph.add_node("sprite2d", Sprite2dNode);
         graph
-            .add_node_edge("sprite", bevy_core_pipeline::node::MAIN_PASS_DEPENDENCIES)
+            .add_node_edge("sprite2d", bevy_core_pipeline::node::MAIN_PASS_DEPENDENCIES)
+            .unwrap();
+    }
+}
+
+#[derive(Default)]
+pub struct Sprite3dPlugin;
+
+impl Plugin for Sprite3dPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_asset::<TextureAtlas>().register_type::<Sprite3d>();
+        let render_app = app.sub_app(RenderApp);
+        render_app
+            .init_resource::<ExtractedSprites3d>()
+            .add_system_to_stage(RenderStage::Extract, render::extract_atlases_3d)
+            .add_system_to_stage(RenderStage::Extract, render::extract_sprites_3d)
+            .add_system_to_stage(RenderStage::Prepare, render::prepare_sprites_3d)
+            .add_system_to_stage(RenderStage::Queue, render::queue_sprites_3d)
+            .init_resource::<Sprite3dShaders>()
+            .init_resource::<Sprite3dMeta>();
+        let draw_sprite_3d = DrawSprite3d::new(&mut render_app.world);
+        render_app
+            .world
+            .get_resource::<DrawFunctions>()
+            .unwrap()
+            .write()
+            .add(draw_sprite_3d);
+        let mut graph = render_app.world.get_resource_mut::<RenderGraph>().unwrap();
+        graph.add_node("sprite3d", Sprite3dNode);
+        graph
+            .add_node_edge("sprite3d", bevy_core_pipeline::node::MAIN_PASS_DEPENDENCIES)
             .unwrap();
     }
 }

--- a/pipelined/bevy_sprite2/src/render/mod.rs
+++ b/pipelined/bevy_sprite2/src/render/mod.rs
@@ -1,9 +1,9 @@
 use crate::{
     texture_atlas::{TextureAtlas, TextureAtlasEntry},
-    Rect, Sprite,
+    Rect, Sprite2d, Sprite3d,
 };
 use bevy_asset::{Assets, Handle};
-use bevy_core_pipeline::Transparent2dPhase;
+use bevy_core_pipeline::{Transparent2dPhase, Transparent3dPhase};
 use bevy_ecs::{prelude::*, system::SystemState};
 use bevy_math::{Mat4, Vec2, Vec3, Vec4Swizzles};
 use bevy_render2::{
@@ -22,14 +22,14 @@ use bevy_transform::components::GlobalTransform;
 use bevy_utils::slab::{FrameSlabMap, FrameSlabMapKey};
 use bytemuck::{Pod, Zeroable};
 
-pub struct SpriteShaders {
+pub struct Sprite2dShaders {
     pipeline: RenderPipeline,
     view_layout: BindGroupLayout,
     material_layout: BindGroupLayout,
 }
 
 // TODO: this pattern for initializing the shaders / pipeline isn't ideal. this should be handled by the asset system
-impl FromWorld for SpriteShaders {
+impl FromWorld for Sprite2dShaders {
     fn from_world(world: &mut World) -> Self {
         let render_device = world.get_resource::<RenderDevice>().unwrap();
         let shader = Shader::from_wgsl(include_str!("sprite.wgsl"));
@@ -138,7 +138,7 @@ impl FromWorld for SpriteShaders {
             },
         });
 
-        SpriteShaders {
+        Sprite2dShaders {
             pipeline,
             view_layout,
             material_layout,
@@ -146,7 +146,7 @@ impl FromWorld for SpriteShaders {
     }
 }
 
-struct ExtractedSprite {
+struct ExtractedSprite2d {
     transform: Mat4,
     rect: Rect,
     handle: Handle<Image>,
@@ -154,14 +154,14 @@ struct ExtractedSprite {
 }
 
 #[derive(Default)]
-pub struct ExtractedSprites {
-    sprites: Vec<ExtractedSprite>,
+pub struct ExtractedSprites2d {
+    sprites: Vec<ExtractedSprite2d>,
 }
 
-pub fn extract_atlases(
+pub fn extract_atlases_2d(
     texture_atlases: Res<Assets<TextureAtlas>>,
     atlas_query: Query<(
-        &Sprite,
+        &Sprite2d,
         &TextureAtlasEntry,
         &GlobalTransform,
         &Handle<TextureAtlas>,
@@ -176,7 +176,7 @@ pub fn extract_atlases(
 
         if let Some(texture_atlas) = texture_atlases.get(texture_atlas_handle) {
             let rect = texture_atlas.textures[texture_atlas_entry.index as usize];
-            extracted_sprites.push(ExtractedSprite {
+            extracted_sprites.push(ExtractedSprite2d {
                 atlas_size: Some(texture_atlas.size),
                 transform: transform.compute_matrix(),
                 rect,
@@ -185,14 +185,14 @@ pub fn extract_atlases(
         }
     }
 
-    if let Some(mut extracted_sprites_res) = render_world.get_resource_mut::<ExtractedSprites>() {
+    if let Some(mut extracted_sprites_res) = render_world.get_resource_mut::<ExtractedSprites2d>() {
         extracted_sprites_res.sprites.extend(extracted_sprites);
     }
 }
 
-pub fn extract_sprites(
+pub fn extract_sprites_2d(
     images: Res<Assets<Image>>,
-    sprite_query: Query<(&Sprite, &GlobalTransform, &Handle<Image>)>,
+    sprite_query: Query<(&Sprite2d, &GlobalTransform, &Handle<Image>)>,
     mut render_world: ResMut<RenderWorld>,
 ) {
     let mut extracted_sprites = Vec::new();
@@ -204,7 +204,7 @@ pub fn extract_sprites(
         };
         let size = image.texture_descriptor.size;
 
-        extracted_sprites.push(ExtractedSprite {
+        extracted_sprites.push(ExtractedSprite2d {
             atlas_size: None,
             transform: transform.compute_matrix(),
             rect: Rect {
@@ -217,20 +217,20 @@ pub fn extract_sprites(
         });
     }
 
-    if let Some(mut extracted_sprites_res) = render_world.get_resource_mut::<ExtractedSprites>() {
+    if let Some(mut extracted_sprites_res) = render_world.get_resource_mut::<ExtractedSprites2d>() {
         extracted_sprites_res.sprites.extend(extracted_sprites);
     }
 }
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
-struct SpriteVertex {
+struct Sprite2dVertex {
     pub position: [f32; 3],
     pub uv: [f32; 2],
 }
 
-pub struct SpriteMeta {
-    vertices: BufferVec<SpriteVertex>,
+pub struct Sprite2dMeta {
+    vertices: BufferVec<Sprite2dVertex>,
     indices: BufferVec<u32>,
     quad: Mesh,
     view_bind_group: Option<BindGroup>,
@@ -238,7 +238,7 @@ pub struct SpriteMeta {
     texture_bind_groups: FrameSlabMap<Handle<Image>, BindGroup>,
 }
 
-impl Default for SpriteMeta {
+impl Default for Sprite2dMeta {
     fn default() -> Self {
         Self {
             vertices: BufferVec::new(BufferUsage::VERTEX),
@@ -255,10 +255,10 @@ impl Default for SpriteMeta {
     }
 }
 
-pub fn prepare_sprites(
+pub fn prepare_sprites_2d(
     render_device: Res<RenderDevice>,
-    mut sprite_meta: ResMut<SpriteMeta>,
-    extracted_sprites: Res<ExtractedSprites>,
+    mut sprite_meta: ResMut<Sprite2dMeta>,
+    extracted_sprites: Res<ExtractedSprites2d>,
 ) {
     // dont create buffers when there are no sprites
     if extracted_sprites.sprites.is_empty() {
@@ -307,7 +307,7 @@ pub fn prepare_sprites(
             let mut final_position =
                 Vec3::from(*vertex_position) * extracted_sprite.rect.size().extend(1.0);
             final_position = (extracted_sprite.transform * final_position.extend(1.0)).xyz();
-            sprite_meta.vertices.push(SpriteVertex {
+            sprite_meta.vertices.push(Sprite2dVertex {
                 position: final_position.into(),
                 uv: (atlas_positions[index]
                     / extracted_sprite.atlas_size.unwrap_or(sprite_rect.max))
@@ -327,13 +327,13 @@ pub fn prepare_sprites(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn queue_sprites(
+pub fn queue_sprites_2d(
     draw_functions: Res<DrawFunctions>,
     render_device: Res<RenderDevice>,
-    mut sprite_meta: ResMut<SpriteMeta>,
+    mut sprite_meta: ResMut<Sprite2dMeta>,
     view_meta: Res<ViewMeta>,
-    sprite_shaders: Res<SpriteShaders>,
-    mut extracted_sprites: ResMut<ExtractedSprites>,
+    sprite_shaders: Res<Sprite2dShaders>,
+    mut extracted_sprites: ResMut<ExtractedSprites2d>,
     gpu_images: Res<RenderAssets<Image>>,
     mut views: Query<&mut RenderPhase<Transparent2dPhase>>,
 ) {
@@ -353,7 +353,7 @@ pub fn queue_sprites(
         })
     });
     let sprite_meta = &mut *sprite_meta;
-    let draw_sprite_function = draw_functions.read().get_id::<DrawSprite>().unwrap();
+    let draw_sprite_function = draw_functions.read().get_id::<DrawSprite2d>().unwrap();
     sprite_meta.texture_bind_groups.next_frame();
     sprite_meta.texture_bind_group_keys.clear();
     for mut transparent_phase in views.iter_mut() {
@@ -394,16 +394,16 @@ pub fn queue_sprites(
 }
 
 // TODO: this logic can be moved to prepare_sprites once wgpu::Queue is exposed directly
-pub struct SpriteNode;
+pub struct Sprite2dNode;
 
-impl Node for SpriteNode {
+impl Node for Sprite2dNode {
     fn run(
         &self,
         _graph: &mut RenderGraphContext,
         render_context: &mut RenderContext,
         world: &World,
     ) -> Result<(), NodeRunError> {
-        let sprite_buffers = world.get_resource::<SpriteMeta>().unwrap();
+        let sprite_buffers = world.get_resource::<Sprite2dMeta>().unwrap();
         sprite_buffers
             .vertices
             .write_to_buffer(&mut render_context.command_encoder);
@@ -414,16 +414,16 @@ impl Node for SpriteNode {
     }
 }
 
-type DrawSpriteQuery<'s, 'w> = (
-    Res<'w, SpriteShaders>,
-    Res<'w, SpriteMeta>,
+type DrawSprite2dQuery<'s, 'w> = (
+    Res<'w, Sprite2dShaders>,
+    Res<'w, Sprite2dMeta>,
     Query<'w, 's, &'w ViewUniformOffset>,
 );
-pub struct DrawSprite {
-    params: SystemState<DrawSpriteQuery<'static, 'static>>,
+pub struct DrawSprite2d {
+    params: SystemState<DrawSprite2dQuery<'static, 'static>>,
 }
 
-impl DrawSprite {
+impl DrawSprite2d {
     pub fn new(world: &mut World) -> Self {
         Self {
             params: SystemState::new(world),
@@ -431,7 +431,471 @@ impl DrawSprite {
     }
 }
 
-impl Draw for DrawSprite {
+impl Draw for DrawSprite2d {
+    fn draw<'w>(
+        &mut self,
+        world: &'w World,
+        pass: &mut TrackedRenderPass<'w>,
+        view: Entity,
+        draw_key: usize,
+        _sort_key: usize,
+    ) {
+        const INDICES: usize = 6;
+        let (sprite_shaders, sprite_meta, views) = self.params.get(world);
+        let view_uniform = views.get(view).unwrap();
+        let sprite_meta = sprite_meta.into_inner();
+        pass.set_render_pipeline(&sprite_shaders.into_inner().pipeline);
+        pass.set_vertex_buffer(0, sprite_meta.vertices.buffer().unwrap().slice(..));
+        pass.set_index_buffer(
+            sprite_meta.indices.buffer().unwrap().slice(..),
+            0,
+            IndexFormat::Uint32,
+        );
+        pass.set_bind_group(
+            0,
+            sprite_meta.view_bind_group.as_ref().unwrap(),
+            &[view_uniform.offset],
+        );
+        pass.set_bind_group(
+            1,
+            &sprite_meta.texture_bind_groups[sprite_meta.texture_bind_group_keys[draw_key]],
+            &[],
+        );
+
+        pass.draw_indexed(
+            (draw_key * INDICES) as u32..(draw_key * INDICES + INDICES) as u32,
+            0,
+            0..1,
+        );
+    }
+}
+
+pub struct Sprite3dShaders {
+    pipeline: RenderPipeline,
+    view_layout: BindGroupLayout,
+    material_layout: BindGroupLayout,
+}
+
+// TODO: this pattern for initializing the shaders / pipeline isn't ideal. this should be handled by the asset system
+impl FromWorld for Sprite3dShaders {
+    fn from_world(world: &mut World) -> Self {
+        let render_device = world.get_resource::<RenderDevice>().unwrap();
+        let shader = Shader::from_wgsl(include_str!("sprite.wgsl"));
+        let shader_module = render_device.create_shader_module(&shader);
+
+        let view_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            entries: &[BindGroupLayoutEntry {
+                binding: 0,
+                visibility: ShaderStage::VERTEX | ShaderStage::FRAGMENT,
+                ty: BindingType::Buffer {
+                    ty: BufferBindingType::Uniform,
+                    has_dynamic_offset: true,
+                    // TODO: change this to ViewUniform::std140_size_static once crevice fixes this!
+                    // Context: https://github.com/LPGhatguy/crevice/issues/29
+                    min_binding_size: BufferSize::new(144),
+                },
+                count: None,
+            }],
+            label: None,
+        });
+
+        let material_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            entries: &[
+                BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStage::FRAGMENT,
+                    ty: BindingType::Texture {
+                        multisampled: false,
+                        sample_type: TextureSampleType::Float { filterable: false },
+                        view_dimension: TextureViewDimension::D2,
+                    },
+                    count: None,
+                },
+                BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: ShaderStage::FRAGMENT,
+                    ty: BindingType::Sampler {
+                        comparison: false,
+                        filtering: true,
+                    },
+                    count: None,
+                },
+            ],
+            label: None,
+        });
+
+        let pipeline_layout = render_device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: None,
+            push_constant_ranges: &[],
+            bind_group_layouts: &[&view_layout, &material_layout],
+        });
+
+        let pipeline = render_device.create_render_pipeline(&RenderPipelineDescriptor {
+            label: None,
+            // Just taken from PBR pipeline
+            depth_stencil: Some(DepthStencilState {
+                format: TextureFormat::Depth32Float,
+                depth_write_enabled: true,
+                depth_compare: CompareFunction::Greater,
+                stencil: StencilState {
+                    front: StencilFaceState::IGNORE,
+                    back: StencilFaceState::IGNORE,
+                    read_mask: 0,
+                    write_mask: 0,
+                },
+                bias: DepthBiasState {
+                    constant: 0,
+                    slope_scale: 0.0,
+                    clamp: 0.0,
+                },
+            }),
+            vertex: VertexState {
+                buffers: &[VertexBufferLayout {
+                    array_stride: 20,
+                    step_mode: InputStepMode::Vertex,
+                    attributes: &[
+                        VertexAttribute {
+                            format: VertexFormat::Float32x3,
+                            offset: 0,
+                            shader_location: 0,
+                        },
+                        VertexAttribute {
+                            format: VertexFormat::Float32x2,
+                            offset: 12,
+                            shader_location: 1,
+                        },
+                    ],
+                }],
+                module: &shader_module,
+                entry_point: "vertex",
+            },
+            fragment: Some(FragmentState {
+                module: &shader_module,
+                entry_point: "fragment",
+                targets: &[ColorTargetState {
+                    format: TextureFormat::bevy_default(),
+                    blend: Some(BlendState {
+                        color: BlendComponent {
+                            src_factor: BlendFactor::SrcAlpha,
+                            dst_factor: BlendFactor::OneMinusSrcAlpha,
+                            operation: BlendOperation::Add,
+                        },
+                        alpha: BlendComponent {
+                            src_factor: BlendFactor::One,
+                            dst_factor: BlendFactor::One,
+                            operation: BlendOperation::Add,
+                        },
+                    }),
+                    write_mask: ColorWrite::ALL,
+                }],
+            }),
+            layout: Some(&pipeline_layout),
+            multisample: MultisampleState::default(),
+            primitive: PrimitiveState {
+                topology: PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: FrontFace::Ccw,
+                cull_mode: None,
+                polygon_mode: PolygonMode::Fill,
+                clamp_depth: false,
+                conservative: false,
+            },
+        });
+
+        Sprite3dShaders {
+            pipeline,
+            view_layout,
+            material_layout,
+        }
+    }
+}
+
+struct ExtractedSprite3d {
+    transform: Mat4,
+    rect: Rect,
+    handle: Handle<Image>,
+    atlas_size: Option<Vec2>,
+}
+
+#[derive(Default)]
+pub struct ExtractedSprites3d {
+    sprites: Vec<ExtractedSprite3d>,
+}
+
+pub fn extract_atlases_3d(
+    texture_atlases: Res<Assets<TextureAtlas>>,
+    atlas_query: Query<(
+        &Sprite3d,
+        &TextureAtlasEntry,
+        &GlobalTransform,
+        &Handle<TextureAtlas>,
+    )>,
+    mut render_world: ResMut<RenderWorld>,
+) {
+    let mut extracted_sprites = Vec::new();
+    for (_sprite, texture_atlas_entry, transform, texture_atlas_handle) in atlas_query.iter() {
+        if !texture_atlases.contains(texture_atlas_handle) {
+            continue;
+        }
+
+        if let Some(texture_atlas) = texture_atlases.get(texture_atlas_handle) {
+            let rect = texture_atlas.textures[texture_atlas_entry.index as usize];
+            extracted_sprites.push(ExtractedSprite3d {
+                atlas_size: Some(texture_atlas.size),
+                transform: transform.compute_matrix(),
+                rect,
+                handle: texture_atlas.texture.clone_weak(),
+            });
+        }
+    }
+
+    if let Some(mut extracted_sprites_res) = render_world.get_resource_mut::<ExtractedSprites3d>() {
+        extracted_sprites_res.sprites.extend(extracted_sprites);
+    }
+}
+
+pub fn extract_sprites_3d(
+    images: Res<Assets<Image>>,
+    sprite_query: Query<(&Sprite3d, &GlobalTransform, &Handle<Image>)>,
+    mut render_world: ResMut<RenderWorld>,
+) {
+    let mut extracted_sprites = Vec::new();
+    for (sprite, transform, handle) in sprite_query.iter() {
+        let image = if let Some(image) = images.get(handle) {
+            image
+        } else {
+            continue;
+        };
+        let size = image.texture_descriptor.size;
+
+        extracted_sprites.push(ExtractedSprite3d {
+            atlas_size: None,
+            transform: transform.compute_matrix(),
+            rect: Rect {
+                min: Vec2::ZERO,
+                max: sprite
+                    .custom_size
+                    .unwrap_or_else(|| Vec2::new(size.width as f32, size.height as f32)),
+            },
+            handle: handle.clone_weak(),
+        });
+    }
+
+    if let Some(mut extracted_sprites_res) = render_world.get_resource_mut::<ExtractedSprites3d>() {
+        extracted_sprites_res.sprites.extend(extracted_sprites);
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+struct Sprite3dVertex {
+    pub position: [f32; 3],
+    pub uv: [f32; 2],
+}
+
+pub struct Sprite3dMeta {
+    vertices: BufferVec<Sprite3dVertex>,
+    indices: BufferVec<u32>,
+    quad: Mesh,
+    view_bind_group: Option<BindGroup>,
+    texture_bind_group_keys: Vec<FrameSlabMapKey<Handle<Image>, BindGroup>>,
+    texture_bind_groups: FrameSlabMap<Handle<Image>, BindGroup>,
+}
+
+impl Default for Sprite3dMeta {
+    fn default() -> Self {
+        Self {
+            vertices: BufferVec::new(BufferUsage::VERTEX),
+            indices: BufferVec::new(BufferUsage::INDEX),
+            texture_bind_groups: Default::default(),
+            texture_bind_group_keys: Default::default(),
+            view_bind_group: None,
+            quad: Quad {
+                size: Vec2::new(1.0, 1.0),
+                ..Default::default()
+            }
+            .into(),
+        }
+    }
+}
+
+pub fn prepare_sprites_3d(
+    render_device: Res<RenderDevice>,
+    mut sprite_meta: ResMut<Sprite3dMeta>,
+    extracted_sprites: Res<ExtractedSprites3d>,
+) {
+    // dont create buffers when there are no sprites
+    if extracted_sprites.sprites.is_empty() {
+        return;
+    }
+
+    let quad_vertex_positions = if let VertexAttributeValues::Float32x3(vertex_positions) =
+        sprite_meta
+            .quad
+            .attribute(Mesh::ATTRIBUTE_POSITION)
+            .unwrap()
+            .clone()
+    {
+        vertex_positions
+    } else {
+        panic!("expected vec3");
+    };
+
+    let quad_indices = if let Indices::U32(indices) = sprite_meta.quad.indices().unwrap() {
+        indices.clone()
+    } else {
+        panic!("expected u32 indices");
+    };
+
+    sprite_meta.vertices.reserve_and_clear(
+        extracted_sprites.sprites.len() * quad_vertex_positions.len(),
+        &render_device,
+    );
+    sprite_meta.indices.reserve_and_clear(
+        extracted_sprites.sprites.len() * quad_indices.len(),
+        &render_device,
+    );
+
+    for (i, extracted_sprite) in extracted_sprites.sprites.iter().enumerate() {
+        let sprite_rect = extracted_sprite.rect;
+
+        // Specify the corners of the sprite
+        let bottom_left = Vec2::new(sprite_rect.min.x, sprite_rect.max.y);
+        let top_left = sprite_rect.min;
+        let top_right = Vec2::new(sprite_rect.max.x, sprite_rect.min.y);
+        let bottom_right = sprite_rect.max;
+
+        let atlas_positions: [Vec2; 4] = [bottom_left, top_left, top_right, bottom_right];
+
+        for (index, vertex_position) in quad_vertex_positions.iter().enumerate() {
+            let mut final_position =
+                Vec3::from(*vertex_position) * extracted_sprite.rect.size().extend(1.0);
+            final_position = (extracted_sprite.transform * final_position.extend(1.0)).xyz();
+            sprite_meta.vertices.push(Sprite3dVertex {
+                position: final_position.into(),
+                uv: (atlas_positions[index]
+                    / extracted_sprite.atlas_size.unwrap_or(sprite_rect.max))
+                .into(),
+            });
+        }
+
+        for index in quad_indices.iter() {
+            sprite_meta
+                .indices
+                .push((i * quad_vertex_positions.len()) as u32 + *index);
+        }
+    }
+
+    sprite_meta.vertices.write_to_staging_buffer(&render_device);
+    sprite_meta.indices.write_to_staging_buffer(&render_device);
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn queue_sprites_3d(
+    draw_functions: Res<DrawFunctions>,
+    render_device: Res<RenderDevice>,
+    mut sprite_meta: ResMut<Sprite3dMeta>,
+    view_meta: Res<ViewMeta>,
+    sprite_shaders: Res<Sprite3dShaders>,
+    mut extracted_sprites: ResMut<ExtractedSprites3d>,
+    gpu_images: Res<RenderAssets<Image>>,
+    mut views: Query<&mut RenderPhase<Transparent3dPhase>>,
+) {
+    if view_meta.uniforms.is_empty() {
+        return;
+    }
+
+    // TODO: define this without needing to check every frame
+    sprite_meta.view_bind_group.get_or_insert_with(|| {
+        render_device.create_bind_group(&BindGroupDescriptor {
+            entries: &[BindGroupEntry {
+                binding: 0,
+                resource: view_meta.uniforms.binding(),
+            }],
+            label: None,
+            layout: &sprite_shaders.view_layout,
+        })
+    });
+    let sprite_meta = &mut *sprite_meta;
+    let draw_sprite_function = draw_functions.read().get_id::<DrawSprite3d>().unwrap();
+    sprite_meta.texture_bind_groups.next_frame();
+    sprite_meta.texture_bind_group_keys.clear();
+    for mut transparent_phase in views.iter_mut() {
+        for (i, sprite) in extracted_sprites.sprites.iter().enumerate() {
+            let texture_bind_group_key = sprite_meta.texture_bind_groups.get_or_insert_with(
+                sprite.handle.clone_weak(),
+                || {
+                    let gpu_image = gpu_images.get(&sprite.handle).unwrap();
+                    render_device.create_bind_group(&BindGroupDescriptor {
+                        entries: &[
+                            BindGroupEntry {
+                                binding: 0,
+                                resource: BindingResource::TextureView(&gpu_image.texture_view),
+                            },
+                            BindGroupEntry {
+                                binding: 1,
+                                resource: BindingResource::Sampler(&gpu_image.sampler),
+                            },
+                        ],
+                        label: None,
+                        layout: &sprite_shaders.material_layout,
+                    })
+                },
+            );
+            sprite_meta
+                .texture_bind_group_keys
+                .push(texture_bind_group_key);
+
+            transparent_phase.add(Drawable {
+                draw_function: draw_sprite_function,
+                draw_key: i,
+                sort_key: texture_bind_group_key.index(),
+            });
+        }
+    }
+
+    extracted_sprites.sprites.clear();
+}
+
+// TODO: this logic can be moved to prepare_sprites once wgpu::Queue is exposed directly
+pub struct Sprite3dNode;
+
+impl Node for Sprite3dNode {
+    fn run(
+        &self,
+        _graph: &mut RenderGraphContext,
+        render_context: &mut RenderContext,
+        world: &World,
+    ) -> Result<(), NodeRunError> {
+        let sprite_buffers = world.get_resource::<Sprite3dMeta>().unwrap();
+        sprite_buffers
+            .vertices
+            .write_to_buffer(&mut render_context.command_encoder);
+        sprite_buffers
+            .indices
+            .write_to_buffer(&mut render_context.command_encoder);
+        Ok(())
+    }
+}
+
+type DrawSprite3dQuery<'s, 'w> = (
+    Res<'w, Sprite3dShaders>,
+    Res<'w, Sprite3dMeta>,
+    Query<'w, 's, &'w ViewUniformOffset>,
+);
+pub struct DrawSprite3d {
+    params: SystemState<DrawSprite3dQuery<'static, 'static>>,
+}
+
+impl DrawSprite3d {
+    pub fn new(world: &mut World) -> Self {
+        Self {
+            params: SystemState::new(world),
+        }
+    }
+}
+
+impl Draw for DrawSprite3d {
     fn draw<'w>(
         &mut self,
         world: &'w World,

--- a/pipelined/bevy_sprite2/src/render/mod.rs
+++ b/pipelined/bevy_sprite2/src/render/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    texture_atlas::{TextureAtlas, TextureAtlasSprite},
+    texture_atlas::{TextureAtlas, TextureAtlasEntry},
     Rect, Sprite,
 };
 use bevy_asset::{Assets, Handle};
@@ -160,17 +160,22 @@ pub struct ExtractedSprites {
 
 pub fn extract_atlases(
     texture_atlases: Res<Assets<TextureAtlas>>,
-    atlas_query: Query<(&TextureAtlasSprite, &GlobalTransform, &Handle<TextureAtlas>)>,
+    atlas_query: Query<(
+        &Sprite,
+        &TextureAtlasEntry,
+        &GlobalTransform,
+        &Handle<TextureAtlas>,
+    )>,
     mut render_world: ResMut<RenderWorld>,
 ) {
     let mut extracted_sprites = Vec::new();
-    for (atlas_sprite, transform, texture_atlas_handle) in atlas_query.iter() {
+    for (_sprite, texture_atlas_entry, transform, texture_atlas_handle) in atlas_query.iter() {
         if !texture_atlases.contains(texture_atlas_handle) {
             continue;
         }
 
         if let Some(texture_atlas) = texture_atlases.get(texture_atlas_handle) {
-            let rect = texture_atlas.textures[atlas_sprite.index as usize];
+            let rect = texture_atlas.textures[texture_atlas_entry.index as usize];
             extracted_sprites.push(ExtractedSprite {
                 atlas_size: Some(texture_atlas.size),
                 transform: transform.compute_matrix(),

--- a/pipelined/bevy_sprite2/src/sprite.rs
+++ b/pipelined/bevy_sprite2/src/sprite.rs
@@ -4,7 +4,20 @@ use bevy_reflect::{Reflect, TypeUuid};
 #[derive(Debug, Default, Clone, TypeUuid, Reflect)]
 #[uuid = "7233c597-ccfa-411f-bd59-9af349432ada"]
 #[repr(C)]
-pub struct Sprite {
+pub struct Sprite2d {
+    /// Flip the sprite along the X axis
+    pub flip_x: bool,
+    /// Flip the sprite along the Y axis
+    pub flip_y: bool,
+    /// An optional custom size for the sprite that will be used when rendering, instead of the size
+    /// of the sprite's image
+    pub custom_size: Option<Vec2>,
+}
+
+#[derive(Debug, Default, Clone, TypeUuid, Reflect)]
+#[uuid = "0d9324ce-a45f-44fd-9752-87d85b30dfcf"]
+#[repr(C)]
+pub struct Sprite3d {
     /// Flip the sprite along the X axis
     pub flip_x: bool,
     /// Flip the sprite along the Y axis

--- a/pipelined/bevy_sprite2/src/texture_atlas.rs
+++ b/pipelined/bevy_sprite2/src/texture_atlas.rs
@@ -2,7 +2,7 @@ use crate::Rect;
 use bevy_asset::Handle;
 use bevy_math::Vec2;
 use bevy_reflect::{Reflect, TypeUuid};
-use bevy_render2::{color::Color, texture::Image};
+use bevy_render2::texture::Image;
 use bevy_utils::HashMap;
 
 /// An atlas containing multiple textures (like a spritesheet or a tilemap).
@@ -22,30 +22,19 @@ pub struct TextureAtlas {
 
 #[derive(Debug, Clone, TypeUuid, Reflect)]
 #[uuid = "7233c597-ccfa-411f-bd59-9af349432ada"]
-pub struct TextureAtlasSprite {
-    pub color: Color,
+pub struct TextureAtlasEntry {
     pub index: u32,
-    pub flip_x: bool,
-    pub flip_y: bool,
 }
 
-impl Default for TextureAtlasSprite {
+impl Default for TextureAtlasEntry {
     fn default() -> Self {
-        Self {
-            index: 0,
-            color: Color::WHITE,
-            flip_x: false,
-            flip_y: false,
-        }
+        Self { index: 0 }
     }
 }
 
-impl TextureAtlasSprite {
-    pub fn new(index: u32) -> TextureAtlasSprite {
-        Self {
-            index,
-            ..Default::default()
-        }
+impl TextureAtlasEntry {
+    pub fn new(index: u32) -> TextureAtlasEntry {
+        Self { index }
     }
 }
 


### PR DESCRIPTION
# Objective

Make Sprites usable in 3d space.
Closes #2786.

## Solution

* Split `TextureAtlasSprite` into `Sprite` and `TextureAtlasEntry`. `Sprite`s are bundled with either Texture (`Handle<Image>`) or TextureAtlas (`Handle<TextureAtlas>`) + `TextureAtlasEntry`.
* Rename `Sprite` to `Sprite2d` and add `Sprite3d`.
* Rename `SpritePlugin` to `Sprite2dPlugin` and add `Sprite3dPlugin`.
* Make adjustments to the rendering pipeline.
* Added Example `3d_sprite_pipelined`

NOTE: I have not copied the `color` property from the removed `TextureAtlasSprite` since it wasn't used and wasn't on `Sprite` either. I think it's supposed to be on `Sprite2d` and `Sprite3d`, but that can obviously added later if needed.