### PR TITLE
Add commands() method to ChildBuilder

### DIFF
--- a/crates/bevy_transform/src/hierarchy/child_builder.rs
+++ b/crates/bevy_transform/src/hierarchy/child_builder.rs
@@ -92,6 +92,11 @@ impl<'w, 's, 'a> ChildBuilder<'w, 's, 'a> {
         self.commands.add(command);
         self
     }
+
+    /// Returns the underlying [`Commands`].
+    pub fn commands(&mut self) -> &mut Commands<'w, 's> {
+        self.commands
+    }
 }
 
 pub trait BuildChildren {


### PR DESCRIPTION
# Objective

- Have access to the `Commands` structure while constructing child entities

## Solution

- Expose the underlying `Commands` through a `commands` method on `ChuildBuilder` in a similar fashion to `EntityCommands`
