### PR TITLE
[Merged by Bors] - Expose wgpu's StencilOperation with bevy 

### DIFF
--- a/pipelined/bevy_render2/src/render_resource/mod.rs
+++ b/pipelined/bevy_render2/src/render_resource/mod.rs
@@ -26,8 +26,8 @@ pub use wgpu::{
     PipelineLayoutDescriptor, PolygonMode, PrimitiveState, PrimitiveTopology,
     RenderPassColorAttachment, RenderPassDepthStencilAttachment, RenderPassDescriptor,
     RenderPipelineDescriptor, SamplerDescriptor, ShaderFlags, ShaderModule, ShaderModuleDescriptor,
-    ShaderSource, ShaderStage, StencilFaceState, StencilState, StorageTextureAccess, TextureAspect,
-    TextureDescriptor, TextureDimension, TextureFormat, TextureSampleType, TextureUsage,
-    TextureViewDescriptor, TextureViewDimension, VertexAttribute, VertexBufferLayout, VertexFormat,
-    VertexState,
+    ShaderSource, ShaderStage, StencilFaceState, StencilOperation, StencilState,
+    StorageTextureAccess, TextureAspect, TextureDescriptor, TextureDimension, TextureFormat,
+    TextureSampleType, TextureUsage, TextureViewDescriptor, TextureViewDimension, VertexAttribute,
+    VertexBufferLayout, VertexFormat, VertexState,
 };


### PR DESCRIPTION
# Objective

Bevy should expose all wgpu types needed for building rendering pipelines.
Closes #2818

## Solution

Add wgpu's StencilOperation to bevy_render2::render_resource's export.