### PR TITLE
[Merged by Bors] - fix typo in events test assert message

### DIFF
--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -508,7 +508,7 @@ mod tests {
         assert_eq!(
             get_events(&events, &mut reader_missed),
             vec![event_2],
-            "reader_missed missed events unread after to update() calls"
+            "reader_missed missed events unread after two update() calls"
         );
     }
 


### PR DESCRIPTION
Fixing a 1-character typo in the failure message of an `assert_eq!` in the events tests.