### PR TITLE
[Merged by Bors] - Add trace_tracy feature for Tracy profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ bevy_wgpu = ["bevy_internal/bevy_wgpu"]
 bevy_winit = ["bevy_internal/bevy_winit"]
 
 trace_chrome = ["bevy_internal/trace_chrome"]
+trace_tracy = ["bevy_internal/trace_tracy"]
 trace = ["bevy_internal/trace"]
 wgpu_trace = ["bevy_internal/wgpu_trace"]
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["game-engines", "graphics", "gui", "rendering"]
 wgpu_trace = ["bevy_wgpu/trace"]
 trace = [ "bevy_app/trace", "bevy_ecs/trace" ]
 trace_chrome = [ "bevy_log/tracing-chrome" ]
+trace_tracy = [ "bevy_log/tracing-tracy" ]
 
 # Image format support for texture loading (PNG and HDR are enabled by default)
 hdr = ["bevy_render/hdr"]

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -13,8 +13,9 @@ keywords = ["bevy"]
 bevy_app = { path = "../bevy_app", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 
-tracing-subscriber = {version = "0.2.15", features = ["registry"]}
-tracing-chrome = { version = "0.3.0", optional = true }
+tracing-subscriber = {version = "0.2.22", features = ["registry"]}
+tracing-chrome = { version = "0.3.1", optional = true }
+tracing-tracy = { version = "0.7.0", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_log-sys = "0.2.0"

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -120,11 +120,9 @@ impl Plugin for LogPlugin {
             let fmt_layer = tracing_subscriber::fmt::Layer::default();
             let subscriber = subscriber.with(fmt_layer);
 
-            #[cfg(all(feature = "tracing-chrome", feature = "tracing-tracy"))]
-            let subscriber = subscriber.with(chrome_layer).with(tracy_layer);
-            #[cfg(all(feature = "tracing-chrome", not(feature = "tracing-tracy")))]
+            #[cfg(feature = "tracing-chrome")]
             let subscriber = subscriber.with(chrome_layer);
-            #[cfg(all(not(feature = "tracing-chrome"), feature = "tracing-tracy"))]
+            #[cfg(feature = "tracing-tracy")]
             let subscriber = subscriber.with(tracy_layer);
 
             bevy_utils::tracing::subscriber::set_global_default(subscriber)

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -94,10 +94,8 @@ impl Plugin for LogPlugin {
 
         #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
         {
-            let fmt_layer = tracing_subscriber::fmt::Layer::default();
-            let subscriber = subscriber.with(fmt_layer);
-            #[cfg(all(feature = "tracing-chrome", not(feature = "tracing-tracy")))]
-            {
+            #[cfg(feature = "tracing-chrome")]
+            let chrome_layer = {
                 let (chrome_layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
                     .name_fn(Box::new(|event_or_span| match event_or_span {
                         tracing_chrome::EventOrSpan::Event(event) => event.metadata().name().into(),
@@ -113,24 +111,24 @@ impl Plugin for LogPlugin {
                     }))
                     .build();
                 app.world.insert_non_send(guard);
-                let subscriber = subscriber.with(chrome_layer);
-                bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                    .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
-            }
+                chrome_layer
+            };
 
-            #[cfg(all(feature = "tracing-tracy", not(feature = "tracing-chrome")))]
-            {
-                let tracy_layer = tracing_tracy::TracyLayer::new();
-                let subscriber = subscriber.with(tracy_layer);
-                bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                    .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
-            }
+            #[cfg(feature = "tracing-tracy")]
+            let tracy_layer = tracing_tracy::TracyLayer::new();
 
-            #[cfg(all(not(feature = "tracing-chrome"), not(feature = "tracing-tracy")))]
-            {
-                bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                    .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
-            }
+            let fmt_layer = tracing_subscriber::fmt::Layer::default();
+            let subscriber = subscriber.with(fmt_layer);
+
+            #[cfg(all(feature = "tracing-chrome", feature = "tracing-tracy"))]
+            let subscriber = subscriber.with(chrome_layer).with(tracy_layer);
+            #[cfg(all(feature = "tracing-chrome", not(feature = "tracing-tracy")))]
+            let subscriber = subscriber.with(chrome_layer);
+            #[cfg(all(not(feature = "tracing-chrome"), feature = "tracing-tracy"))]
+            let subscriber = subscriber.with(tracy_layer);
+
+            bevy_utils::tracing::subscriber::set_global_default(subscriber)
+                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
         }
 
         #[cfg(target_arch = "wasm32")]

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -96,7 +96,7 @@ impl Plugin for LogPlugin {
         {
             let fmt_layer = tracing_subscriber::fmt::Layer::default();
             let subscriber = subscriber.with(fmt_layer);
-            #[cfg(feature = "tracing-chrome")]
+            #[cfg(all(feature = "tracing-chrome", not(feature = "tracing-tracy")))]
             {
                 let (chrome_layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
                     .name_fn(Box::new(|event_or_span| match event_or_span {
@@ -118,7 +118,15 @@ impl Plugin for LogPlugin {
                     .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
             }
 
-            #[cfg(not(feature = "tracing-chrome"))]
+            #[cfg(all(feature = "tracing-tracy", not(feature = "tracing-chrome")))]
+            {
+                let tracy_layer = tracing_tracy::TracyLayer::new();
+                let subscriber = subscriber.with(tracy_layer);
+                bevy_utils::tracing::subscriber::set_global_default(subscriber)
+                    .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
+            }
+
+            #[cfg(all(not(feature = "tracing-chrome"), not(feature = "tracing-tracy")))]
             {
                 bevy_utils::tracing::subscriber::set_global_default(subscriber)
                     .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -23,6 +23,7 @@
 |dynamic|Forces bevy to be dynamically linked, which improves iterative compile times.|
 |trace|Enables system tracing (useful in tandem with a feature like trace_chrome).|
 |trace_chrome|Enables [tracing-chrome](https://github.com/thoren-d/tracing-chrome) as bevy_log output. This allows you to visualize system execution.|
+|trace_tracy|Enables [Tracy](https://github.com/wolfpld/tracy) as bevy_log output. This allows `Tracy` to connect to and capture profiling data as well as visualize system execution in real-time, present statistics about system execution times, and more.|
 |wgpu_trace|For tracing wgpu.|
 |dds|DDS picture format support.|
 |tga|TGA picture format support.|


### PR DESCRIPTION
# Objective

[Tracy](https://github.com/wolfpld/tracy) is:
> A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.

With the `trace_tracy` feature enabled, you run your bevy app and either a headless server (`capture`) or a live, interactive profiler UI (`Tracy`), and connect that to your bevy application to then stream the metric data and events, and save it or inspect it live/offline.

Previously when I implemented the spans across systems and stages and I was trying out different profiling tools, Tracy was too unstable on macOS to use. But now, quite some months later, it is working stably with Tracy 0.7.8. You can see timelines, aggregate statistics of mean system/stage execution times, and much more. It's very useful!

![Screenshot_2021-09-15_at_18 07 19](https://user-images.githubusercontent.com/302146/133554920-350d3d45-fbb8-479f-91f7-7a7a4f9f5873.png)

## Solution

- Use the `tracing-tracy` crate which supports our tracing spans
- Expose via the non-default feature `trace_tracy` for consistency with other `trace*` features