### PR TITLE
[Merged by Bors] - fix `Default` implementation of `Image` so that size and data match

### DIFF
--- a/pipelined/bevy_render2/src/texture/image.rs
+++ b/pipelined/bevy_render2/src/texture/image.rs
@@ -3,6 +3,7 @@ use crate::{
     render_asset::RenderAsset,
     render_resource::{Sampler, Texture, TextureView},
     renderer::{RenderDevice, RenderQueue},
+    texture::BevyDefault,
 };
 use bevy_reflect::TypeUuid;
 use thiserror::Error;
@@ -25,7 +26,7 @@ pub struct Image {
 
 impl Default for Image {
     fn default() -> Self {
-        let format = wgpu::TextureFormat::Rgba8UnormSrgb;
+        let format = wgpu::TextureFormat::bevy_default();
         let data = vec![1; format.pixel_size() as usize];
         Image {
             data,

--- a/pipelined/bevy_render2/src/texture/image.rs
+++ b/pipelined/bevy_render2/src/texture/image.rs
@@ -25,15 +25,17 @@ pub struct Image {
 
 impl Default for Image {
     fn default() -> Self {
+        let format = wgpu::TextureFormat::Rgba8UnormSrgb;
+        let data = vec![1; format.pixel_size() as usize];
         Image {
-            data: Default::default(),
+            data,
             texture_descriptor: wgpu::TextureDescriptor {
                 size: wgpu::Extent3d {
                     width: 1,
                     height: 1,
                     depth_or_array_layers: 1,
                 },
-                format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                format,
                 dimension: wgpu::TextureDimension::D2,
                 label: None,
                 mip_level_count: 1,


### PR DESCRIPTION
Before using this image resulted in an `Error in Queue::write_texture: copy of 0..4 would end up overrunning the bounds of the Source buffer of size 0` 