### PR TITLE
[Merged by Bors] - SystemParam Derive fixes

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1253,3 +1253,27 @@ pub mod lifetimeless {
     pub type SResMut<T> = super::ResMut<'static, T>;
     pub type SCommands = crate::system::Commands<'static, 'static>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SystemParam;
+    use crate::{
+        self as bevy_ecs, // Neccessary for the `SystemParam` Derive when used inside `bevy_ecs`.
+        query::{FilterFetch, WorldQuery},
+        system::Query,
+    };
+
+    // Compile test for #2838
+    #[derive(SystemParam)]
+    pub struct SpecialQuery<
+        'w,
+        's,
+        Q: WorldQuery + Send + Sync + 'static,
+        F: WorldQuery + Send + Sync + 'static = (),
+    >
+    where
+        F::Fetch: FilterFetch,
+    {
+        _query: Query<'w, 's, Q, F>,
+    }
+}

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1258,7 +1258,7 @@ pub mod lifetimeless {
 mod tests {
     use super::SystemParam;
     use crate::{
-        self as bevy_ecs, // Neccessary for the `SystemParam` Derive when used inside `bevy_ecs`.
+        self as bevy_ecs, // Necessary for the `SystemParam` Derive when used inside `bevy_ecs`.
         query::{FilterFetch, WorldQuery},
         system::Query,
     };


### PR DESCRIPTION
# Objective

A user on Discord couldn't derive SystemParam for this Struct:

```rs
#[derive(SystemParam)]
pub struct SpatialQuery<'w, 's, Q: WorldQuery + Send + Sync + 'static, F: WorldQuery + Send + Sync + 'static = ()>
where
    F::Fetch: FilterFetch,
{
    query: Query<'w, 's, (C, &'static Transform), F>,
}
```

## Solution

1. The `where`-clause is now also copied to the `SystemParamFetch` impl Block.
2. The `SystemParamState` impl Block no longer gets any defaults for generics
