### PR TITLE
Change bevy_internal to be a 'thinner facade'

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -752,13 +752,7 @@ impl App {
     /// ## Example
     /// ```
     /// # use bevy_app::{prelude::*, PluginGroupBuilder};
-    /// #
-    /// # // Dummy created to avoid using bevy_internal, which pulls in to many dependencies.
-    /// # struct MinimalPlugins;
-    /// # impl PluginGroup for MinimalPlugins {
-    /// #     fn build(&mut self, group: &mut PluginGroupBuilder){;}
-    /// # }
-    /// #
+    /// # use bevy_app::NoopPluginGroup as MinimalPlugins;
     /// App::new()
     ///     .add_plugins(MinimalPlugins);
     /// ```
@@ -779,22 +773,18 @@ impl App {
     /// ## Example
     /// ```
     /// # use bevy_app::{prelude::*, PluginGroupBuilder};
-    /// #
-    /// # // Dummies created to avoid using bevy_internal which pulls in to many dependencies.
-    /// # struct DefaultPlugins;
-    /// # impl PluginGroup for DefaultPlugins {
-    /// #     fn build(&mut self, group: &mut PluginGroupBuilder){
-    /// #         group.add(bevy_log::LogPlugin::default());
-    /// #     }
-    /// # }
-    /// #
+    /// # use bevy_app::NoopPluginGroup as DefaultPlugins;
+    ///
     /// # struct MyOwnPlugin;
     /// # impl Plugin for MyOwnPlugin {
-    /// #     fn build(&self, app: &mut App){;}
+    /// #     fn build(&self, app: &mut App){}
     /// # }
     /// #
     /// App::new()
     ///      .add_plugins_with(DefaultPlugins, |group| {
+    /// #           // This is hidden since it would be included in DefaultPlugins if we used
+    /// #           // the default version
+    /// #           group.add(bevy_log::LogPlugin::default());
     ///             group.add_before::<bevy_log::LogPlugin, _>(MyOwnPlugin)
     ///         });
     /// ```

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -107,3 +107,18 @@ impl PluginGroupBuilder {
         }
     }
 }
+
+/// A plugin group which doesn't do anything. Useful for examples:
+/// ```rust
+/// # use bevy_app::prelude::*;
+/// use bevy_app::NoopPluginGroup as MinimalPlugins;
+///
+/// fn main(){
+///     App::new().add_plugins(MinimalPlugins).run();
+/// }
+/// ```
+pub struct NoopPluginGroup;
+
+impl PluginGroup for NoopPluginGroup {
+    fn build(&mut self, _: &mut PluginGroupBuilder) {}
+}

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -1,143 +1,71 @@
-/// `use bevy::prelude::*;` to import common components, bundles, and plugins.
-pub mod prelude;
-
 mod default_plugins;
+#[doc(hidden)]
 pub use default_plugins::*;
 
-pub mod app {
-    //! Build bevy apps, create plugins, and read events.
-    pub use bevy_app::*;
-}
-
-pub mod asset {
-    //! Load and store assets and resources for Apps.
-    pub use bevy_asset::*;
-}
-
-pub mod core {
-    //! Contains core plugins and utilities for time.
-    pub use bevy_core::*;
-}
-
-pub mod diagnostic {
-    //! Useful diagnostic plugins and types for bevy apps.
-    pub use bevy_diagnostic::*;
-}
-
-pub mod ecs {
-    //! Bevy's entity-component-system.
-    pub use bevy_ecs::*;
-}
-
-pub mod input {
-    //! Resources and events for inputs, e.g. mouse/keyboard, touch, gamepads, etc.
-    pub use bevy_input::*;
-}
-
-pub mod log {
-    //! Logging capabilities
-    pub use bevy_log::*;
-}
-
-pub mod math {
-    //! Math types (Vec3, Mat4, Quat, etc) and helpers.
-    pub use bevy_math::*;
-}
-
-pub mod reflect {
-    // TODO: remove these renames once TypeRegistryArc is no longer required
-    //! Type reflection used for dynamically interacting with rust types.
-    pub use bevy_reflect::{
-        TypeRegistry as TypeRegistryInternal, TypeRegistryArc as TypeRegistry, *,
-    };
-}
-
-pub mod scene {
-    //! Save/load collections of entities and components to/from file.
-    pub use bevy_scene::*;
-}
-
-pub mod tasks {
-    //! Pools for async, IO, and compute tasks.
-    pub use bevy_tasks::*;
-}
-
-pub mod transform {
-    //! Local and global transforms (e.g. translation, scale, rotation).
-    pub use bevy_transform::*;
-}
-
-pub mod utils {
-    pub use bevy_utils::*;
-}
-
-pub mod window {
-    //! Configuration, creation, and management of one or more windows.
-    pub use bevy_window::*;
-}
-
+#[doc(hidden)]
+pub use bevy_app;
+#[doc(hidden)]
+pub use bevy_asset;
 #[cfg(feature = "bevy_audio")]
-pub mod audio {
-    //! Provides types and plugins for audio playback.
-    pub use bevy_audio::*;
-}
-
-#[cfg(feature = "bevy_gilrs")]
-pub mod gilrs {
-    pub use bevy_gilrs::*;
-}
-
-#[cfg(feature = "bevy_gltf")]
-pub mod gltf {
-    //! Support for GLTF file loading.
-    pub use bevy_gltf::*;
-}
-
-#[cfg(feature = "bevy_pbr")]
-pub mod pbr {
-    //! Physically based rendering.
-    pub use bevy_pbr::*;
-}
-
-#[cfg(feature = "bevy_render")]
-pub mod render {
-    //! Cameras, meshes, textures, shaders, and pipelines.
-    pub use bevy_render::*;
-}
-
-#[cfg(feature = "bevy_sprite")]
-pub mod sprite {
-    //! Items for sprites, rects, texture atlases, etc.
-    pub use bevy_sprite::*;
-}
-
-#[cfg(feature = "bevy_text")]
-pub mod text {
-    //! Text drawing, styling, and font assets.
-    pub use bevy_text::*;
-}
-
-#[cfg(feature = "bevy_ui")]
-pub mod ui {
-    //! User interface components and widgets.
-    pub use bevy_ui::*;
-}
-
-#[cfg(feature = "bevy_winit")]
-pub mod winit {
-    pub use bevy_winit::*;
-}
-
-#[cfg(feature = "bevy_wgpu")]
-pub mod wgpu {
-    //! A render backend utilizing [wgpu](https://wgpu.rs/).
-    pub use bevy_wgpu::*;
-}
-
+#[doc(hidden)]
+pub use bevy_audio;
+#[doc(hidden)]
+pub use bevy_core;
+#[doc(hidden)]
+pub use bevy_derive;
+#[doc(hidden)]
+pub use bevy_diagnostic;
 #[cfg(feature = "bevy_dynamic_plugin")]
-pub mod dynamic_plugin {
-    pub use bevy_dynamic_plugin::*;
-}
+#[doc(hidden)]
+pub use bevy_dynamic_plugin;
+#[doc(hidden)]
+pub use bevy_ecs;
+#[cfg(feature = "bevy_gilrs")]
+#[doc(hidden)]
+pub use bevy_gilrs;
+#[cfg(feature = "bevy_gltf")]
+#[doc(hidden)]
+pub use bevy_gltf;
+#[doc(hidden)]
+pub use bevy_input;
+#[doc(hidden)]
+pub use bevy_log;
+#[doc(hidden)]
+pub use bevy_math;
+#[cfg(feature = "bevy_pbr")]
+#[doc(hidden)]
+pub use bevy_pbr;
+#[doc(hidden)]
+pub use bevy_reflect;
+#[cfg(feature = "bevy_render")]
+#[doc(hidden)]
+pub use bevy_render;
+#[doc(hidden)]
+pub use bevy_scene;
+#[cfg(feature = "bevy_sprite")]
+#[doc(hidden)]
+pub use bevy_sprite;
+#[doc(hidden)]
+pub use bevy_tasks;
+#[cfg(feature = "bevy_text")]
+#[doc(hidden)]
+pub use bevy_text;
+#[doc(hidden)]
+pub use bevy_transform;
+#[cfg(feature = "bevy_ui")]
+#[doc(hidden)]
+pub use bevy_ui;
+#[doc(hidden)]
+pub use bevy_utils;
+#[cfg(feature = "bevy_wgpu")]
+#[doc(hidden)]
+pub use bevy_wgpu;
+#[doc(hidden)]
+pub use bevy_window;
+#[cfg(feature = "bevy_winit")]
+#[doc(hidden)]
+pub use bevy_winit;
 
 #[cfg(target_os = "android")]
+#[doc(hidden)]
 pub use ndk_glue;

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["bevy"]
 bevy_app = { path = "../bevy_app", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 
-tracing-subscriber = {version = "0.2.22", features = ["registry"]}
+tracing-subscriber = { version = "0.2.22", features = ["registry"] }
 tracing-chrome = { version = "0.3.1", optional = true }
 tracing-tracy = { version = "0.7.0", optional = true }
 
@@ -24,5 +24,5 @@ android_log-sys = "0.2.0"
 console_error_panic_hook = "0.1.6"
 tracing-wasm = "0.2"
 
-[dev-dependencies]
-bevy_internal = { path = "../bevy_internal", version = "0.5.0" }
+# [dev-dependencies]
+# bevy_internal = { path = "../bevy_internal", version = "0.5.0" }

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -23,6 +23,3 @@ android_log-sys = "0.2.0"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.6"
 tracing-wasm = "0.2"
-
-# [dev-dependencies]
-# bevy_internal = { path = "../bevy_internal", version = "0.5.0" }

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -49,7 +49,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// If you want to setup your own tracing collector, you should disable this
 /// plugin from `DefaultPlugins` with [`App::add_plugins_with`]:
 /// ```no_run
-/// # // Dummies created to avoid using bevy_internal which pulls in to many dependencies.
+/// # // Dummies created to avoid using bevy_internal which pulls in too many dependencies.
 /// # // Note that we can't use NoopPluginGroup here, since we need to add LogPlugin, and
 /// # // keep the group on the same line
 /// # use bevy_app::{PluginGroup, PluginGroupBuilder};

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -28,7 +28,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 ///
 /// You can configure this plugin using the resource [`LogSettings`].
 /// ```no_run
-/// # use bevy_internal::DefaultPlugins;
+/// # use bevy_app::NoopPluginGroup as DefaultPlugins;
 /// # use bevy_app::App;
 /// # use bevy_log::LogSettings;
 /// # use bevy_utils::tracing::Level;
@@ -49,7 +49,16 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// If you want to setup your own tracing collector, you should disable this
 /// plugin from `DefaultPlugins` with [`App::add_plugins_with`]:
 /// ```no_run
-/// # use bevy_internal::DefaultPlugins;
+/// # // Dummies created to avoid using bevy_internal which pulls in to many dependencies.
+/// # // Note that we can't use NoopPluginGroup here, since we need to add LogPlugin, and
+/// # // keep the group on the same line
+/// # use bevy_app::{PluginGroup, PluginGroupBuilder};
+/// # struct DefaultPlugins;
+/// # impl PluginGroup for DefaultPlugins {
+/// #     fn build(&mut self, group: &mut PluginGroupBuilder){
+/// #         group.add(bevy_log::LogPlugin::default());
+/// #     }
+/// # }
 /// # use bevy_app::App;
 /// # use bevy_log::LogPlugin;
 /// fn main() {

--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -25,15 +25,19 @@ impl Default for BevyManifest {
 impl BevyManifest {
     pub fn get_path(&self, name: &str) -> syn::Path {
         const BEVY: &str = "bevy";
-        const BEVY_INTERNAL: &str = "bevy_internal";
+
+        let is_bevy = self
+            .manifest
+            .package
+            .as_ref()
+            .map(|it| it.name == BEVY)
+            .unwrap_or(false);
 
         let find_in_deps = |deps: &DepsSet| -> Option<syn::Path> {
-            let package = if let Some(dep) = deps.get(BEVY) {
-                dep.package().unwrap_or(BEVY)
-            } else if let Some(dep) = deps.get(BEVY_INTERNAL) {
-                dep.package().unwrap_or(BEVY_INTERNAL)
+            let package = if is_bevy {
+                BEVY
             } else {
-                return None;
+                deps.get(BEVY)?.package().unwrap_or(BEVY)
             };
 
             let mut path = get_path(package);
@@ -42,7 +46,6 @@ impl BevyManifest {
             }
             Some(path)
         };
-
         let deps = self.manifest.dependencies.as_ref();
         let deps_dev = self.manifest.dev_dependencies.as_ref();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,149 @@
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
 
-pub use bevy_internal::*;
+/// `use bevy::prelude::*;` to import common components, bundles, and plugins.
+pub mod prelude;
+
+#[doc(inline)]
+pub use bevy_internal::{DefaultPlugins, MinimalPlugins};
+
+#[doc(inline)]
+pub use bevy_internal::bevy_derive;
+
+pub mod app {
+    //! Build bevy apps, create plugins, and read events.
+    pub use bevy_internal::bevy_app::*;
+}
+
+pub mod asset {
+    //! Load and store assets and resources for Apps.
+    pub use bevy_internal::bevy_asset::*;
+}
+
+pub mod core {
+    //! Contains core plugins and utilities for time.
+    pub use bevy_internal::bevy_core::*;
+}
+
+pub mod diagnostic {
+    //! Useful diagnostic plugins and types for bevy apps.
+    pub use bevy_internal::bevy_diagnostic::*;
+}
+
+pub mod ecs {
+    //! Bevy's entity-component-system.
+    pub use bevy_internal::bevy_ecs::*;
+}
+
+pub mod input {
+    //! Resources and events for inputs, e.g. mouse/keyboard, touch, gamepads, etc.
+    pub use bevy_internal::bevy_input::*;
+}
+
+pub mod log {
+    //! Logging capabilities
+    pub use bevy_internal::bevy_log::*;
+}
+
+pub mod math {
+    //! Math types (Vec3, Mat4, Quat, etc) and helpers.
+    pub use bevy_internal::bevy_math::*;
+}
+
+pub mod reflect {
+    // TODO: remove these renames once TypeRegistryArc is no longer required
+    //! Type reflection used for dynamically interacting with rust types.
+    pub use bevy_internal::bevy_reflect::{
+        TypeRegistry as TypeRegistryInternal, TypeRegistryArc as TypeRegistry, *,
+    };
+}
+
+pub mod scene {
+    //! Save/load collections of entities and components to/from file.
+    pub use bevy_internal::bevy_scene::*;
+}
+
+pub mod tasks {
+    //! Pools for async, IO, and compute tasks.
+    pub use bevy_internal::bevy_tasks::*;
+}
+
+pub mod transform {
+    //! Local and global transforms (e.g. translation, scale, rotation).
+    pub use bevy_internal::bevy_transform::*;
+}
+
+pub mod utils {
+    pub use bevy_internal::bevy_utils::*;
+}
+
+pub mod window {
+    //! Configuration, creation, and management of one or more windows.
+    pub use bevy_internal::bevy_window::*;
+}
+
+#[cfg(feature = "bevy_audio")]
+pub mod audio {
+    //! Provides types and plugins for audio playback.
+    pub use bevy_internal::bevy_audio::*;
+}
+
+#[cfg(feature = "bevy_gilrs")]
+pub mod gilrs {
+    pub use bevy_internal::bevy_gilrs::*;
+}
+
+#[cfg(feature = "bevy_gltf")]
+pub mod gltf {
+    //! Support for GLTF file loading.
+    pub use bevy_internal::bevy_gltf::*;
+}
+
+#[cfg(feature = "render")]
+pub mod pbr {
+    //! Physically based rendering.
+    pub use bevy_internal::bevy_pbr::*;
+}
+
+#[cfg(feature = "render")]
+pub mod render {
+    //! Cameras, meshes, textures, shaders, and pipelines.
+    pub use bevy_internal::bevy_render::*;
+}
+
+#[cfg(feature = "render")]
+pub mod sprite {
+    //! Items for sprites, rects, texture atlases, etc.
+    pub use bevy_internal::bevy_sprite::*;
+}
+
+#[cfg(feature = "render")]
+pub mod text {
+    //! Text drawing, styling, and font assets.
+    pub use bevy_internal::bevy_text::*;
+}
+
+#[cfg(feature = "render")]
+pub mod ui {
+    //! User interface components and widgets.
+    pub use bevy_internal::bevy_ui::*;
+}
+
+#[cfg(feature = "bevy_winit")]
+pub mod winit {
+    pub use bevy_internal::bevy_winit::*;
+}
+
+#[cfg(feature = "bevy_wgpu")]
+pub mod wgpu {
+    //! A render backend utilizing [wgpu](https://wgpu.rs/).
+    pub use bevy_internal::bevy_wgpu::*;
+}
+
+#[cfg(feature = "bevy_dynamic_plugin")]
+pub mod dynamic_plugin {
+    pub use bevy_internal::bevy_dynamic_plugin::*;
+}
 
 #[cfg(feature = "dynamic")]
 #[allow(unused_imports)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,9 @@ pub mod dynamic_plugin {
     pub use bevy_internal::bevy_dynamic_plugin::*;
 }
 
+#[cfg(target_os = "android")]
+pub use bevy_internal::ndk_glue;
+
 #[cfg(feature = "dynamic")]
 #[allow(unused_imports)]
 use bevy_dylib;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,30 +5,30 @@ pub use crate::{
     transform::prelude::*, window::prelude::*, DefaultPlugins, MinimalPlugins,
 };
 
-pub use bevy_derive::bevy_main;
+pub use crate::bevy_derive::bevy_main;
 
 #[doc(hidden)]
 #[cfg(feature = "bevy_audio")]
 pub use crate::audio::prelude::*;
 
 #[doc(hidden)]
-#[cfg(feature = "bevy_pbr")]
+#[cfg(feature = "render")]
 pub use crate::pbr::prelude::*;
 
 #[doc(hidden)]
-#[cfg(feature = "bevy_render")]
+#[cfg(feature = "render")]
 pub use crate::render::prelude::*;
 
 #[doc(hidden)]
-#[cfg(feature = "bevy_sprite")]
+#[cfg(feature = "render")]
 pub use crate::sprite::prelude::*;
 
 #[doc(hidden)]
-#[cfg(feature = "bevy_text")]
+#[cfg(feature = "render")]
 pub use crate::text::prelude::*;
 
 #[doc(hidden)]
-#[cfg(feature = "bevy_ui")]
+#[cfg(feature = "render")]
 pub use crate::ui::prelude::*;
 
 #[doc(hidden)]


### PR DESCRIPTION
This change should (hopefully) fix the `[src]` links for the bevy crates on `docs.rs`

# Objective

- The src links on docs.rs are currently broken - see e.g. [`bevy::app::App`](https://docs.rs/bevy/0.5.0/bevy/app/struct.App.html), which doesn't have a `[src]` link
- Compare this to [`bevy_internal::app::App`](https://docs.rs/bevy_internal/0.5.0/bevy_internal/app/struct.App.html), which does have a `[src]` link

## Solution

- Move the modules with working `[src]` links into the `bevy` crate, as well as the prelude.
- Note that the prelude move is only for conceptual reasons -  `bevy` is the user facing crate.
- I think `bevy_internal` still needs to exist for dynamic linking reasons - in particular so that `Default/MinimalPlugins` still get dynamically linked.
- Although I think it would also be possible for us to remove `bevy_internal` entirely, and depend on the crates directly in `bevy_dylib`
