### PR TITLE
Update hexasphere to 5.0.0

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -32,7 +32,7 @@ downcast-rs = "1.2.0"
 thiserror = "1.0"
 anyhow = "1.0.4"
 hex = "0.4.2"
-hexasphere = "4.0.0"
+hexasphere = "5.0.0"
 parking_lot = "0.11.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]


### PR DESCRIPTION
I made a mistake in creating the cubesphere api for other users. There should be no visible changes to the API on Bevy's end.