### PR TITLE
[Merged by Bors] - Fix window size change panic

### DIFF
--- a/pipelined/bevy_render2/src/camera/mod.rs
+++ b/pipelined/bevy_render2/src/camera/mod.rs
@@ -77,8 +77,8 @@ fn extract_cameras(
                     ExtractedView {
                         projection: camera.projection_matrix,
                         transform: *transform,
-                        width: window.physical_width(),
-                        height: window.physical_height(),
+                        width: window.physical_width().max(1),
+                        height: window.physical_height().max(1),
                     },
                 ));
             }


### PR DESCRIPTION
# Objective

Using fullscreen or trying to resize a window caused a panic. Fix that.

## Solution

- Don't wholesale overwrite the ExtractedWindows resource when extracting windows
  - This could cause an accumulation of unused windows that are holding onto swap chain frames?
- Check the if width and/or height changed since the last frame
- If the size changed, recreate the swap chain
- Ensure dimensions are >= 1 to avoid panics due to any dimension being 0