### PR TITLE
[Merged by Bors] - update `cargo-manifest`

### DIFF
--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -9,5 +9,5 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [dependencies]
-cargo-manifest = "0.2.3"
+cargo-manifest = "0.2.6"
 syn = "1.0"


### PR DESCRIPTION
On older versions, people with `edition = 2021` would get this error:

![grafik](https://user-images.githubusercontent.com/22177966/134387678-28ece4d4-8af6-48de-beb8-973356c3b9f0.png)
