### PR TITLE
`attribute_multi_mut` to allow simultaneous mutable access to distinct mesh attributes

### DIFF
--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -731,7 +731,19 @@ mod test {
         // Just setting them equal to each other for the heck of it.
         normals[0] = [0.1, 0.2, 0.3];
         positions[0] = normals[0];
-        assert_eq!(normals[0], positions[0])
+
+        // Get values again not using attribute_multi_mut to make sure it was updated.
+        let position = match mesh.attribute(Mesh::ATTRIBUTE_POSITION).unwrap() {
+            VertexAttributeValues::Float32x3(p) => p[0],
+            _ => panic!("Was not Float32x3"),
+        };
+
+        let normal = match mesh.attribute(Mesh::ATTRIBUTE_NORMAL).unwrap() {
+            VertexAttributeValues::Float32x3(n) => n[0],
+            _ => panic!("Was not Float32x3"),
+        };
+
+        assert_eq!(position, normal);
     }
 
     #[test]

--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -712,16 +712,17 @@ mod test {
     fn attribute_multi_mut_works_with_positions_and_normals() {
         let mut mesh = Mesh::from(shape::Box::default());
 
-        let [positions, normals] = mesh.attribute_multi_mut([Mesh::ATTRIBUTE_POSITION, Mesh::ATTRIBUTE_NORMAL]);
+        let [positions, normals] =
+            mesh.attribute_multi_mut([Mesh::ATTRIBUTE_POSITION, Mesh::ATTRIBUTE_NORMAL]);
 
         let positions = match positions.unwrap() {
             VertexAttributeValues::Float32x3(arr) => arr,
-            _ => panic!("Positions were not [f32; 3].")
+            _ => panic!("Positions were not [f32; 3]."),
         };
 
         let normals = match normals.unwrap() {
             VertexAttributeValues::Float32x3(arr) => arr,
-            _ => panic!("Normals were not [f32; 3].")
+            _ => panic!("Normals were not [f32; 3]."),
         };
 
         // Mutating positions and normals.
@@ -737,6 +738,7 @@ mod test {
         let mut mesh = Mesh::from(shape::Box::default());
 
         // Trying to get positions twice.
-        let [_positions1, _positions2] = mesh.attribute_multi_mut([Mesh::ATTRIBUTE_POSITION, Mesh::ATTRIBUTE_POSITION]);
+        let [_positions1, _positions2] =
+            mesh.attribute_multi_mut([Mesh::ATTRIBUTE_POSITION, Mesh::ATTRIBUTE_POSITION]);
     }
 }


### PR DESCRIPTION
# Objective
Fixes #2134, allowing simultaneous mutable access to distinct mesh attributes.

## Solution
The `attribute_multi_mut` method allows the user of the API to retrieve a constant amount of mutable references to unique attributes. The method uses constant generics for a clean interface. The method uses some unsafe code to retrieve multiple mutable pointers to the given vertex attributes, then verifying that they are indeed all unique (and panics otherwise).

I've also added some docs to explain the method and some tests to ensure that it works as expected.