### PR TITLE
[Merged by Bors] - Fix panic on is_resource_* calls (#2828)

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -886,6 +886,8 @@ mod tests {
         let mut world = World::default();
         assert!(world.get_resource::<i32>().is_none());
         assert!(!world.contains_resource::<i32>());
+        assert!(!world.is_resource_added::<i32>());
+        assert!(!world.is_resource_changed::<i32>());
 
         world.insert_resource(123);
         let resource_id = world
@@ -900,6 +902,8 @@ mod tests {
 
         assert_eq!(*world.get_resource::<i32>().expect("resource exists"), 123);
         assert!(world.contains_resource::<i32>());
+        assert!(world.is_resource_added::<i32>());
+        assert!(world.is_resource_changed::<i32>());
 
         world.insert_resource(456u64);
         assert_eq!(

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -664,16 +664,34 @@ impl World {
     }
 
     pub fn is_resource_added<T: Component>(&self) -> bool {
-        let component_id = self.components.get_resource_id(TypeId::of::<T>()).unwrap();
-        let column = self.get_populated_resource_column(component_id).unwrap();
+        let component_id =
+            if let Some(component_id) = self.components.get_resource_id(TypeId::of::<T>()) {
+                component_id
+            } else {
+                return false;
+            };
+        let column = if let Some(column) = self.get_populated_resource_column(component_id) {
+            column
+        } else {
+            return false;
+        };
         // SAFE: resources table always have row 0
         let ticks = unsafe { column.get_ticks_unchecked(0) };
         ticks.is_added(self.last_change_tick(), self.read_change_tick())
     }
 
     pub fn is_resource_changed<T: Component>(&self) -> bool {
-        let component_id = self.components.get_resource_id(TypeId::of::<T>()).unwrap();
-        let column = self.get_populated_resource_column(component_id).unwrap();
+        let component_id =
+            if let Some(component_id) = self.components.get_resource_id(TypeId::of::<T>()) {
+                component_id
+            } else {
+                return false;
+            };
+        let column = if let Some(column) = self.get_populated_resource_column(component_id) {
+            column
+        } else {
+            return false;
+        };
         // SAFE: resources table always have row 0
         let ticks = unsafe { column.get_ticks_unchecked(0) };
         ticks.is_changed(self.last_change_tick(), self.read_change_tick())


### PR DESCRIPTION
Changed out unwraps to use if let syntax instead. Returning false when None.

Also modified an existing test to encompass these methods

This PR fixes #2828
