### PR TITLE
[Merged by Bors] - add_texture returns index to texture

### DIFF
--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -158,13 +158,15 @@ impl TextureAtlas {
     }
 
     /// Add a sprite to the list of textures in the `TextureAtlas`
+    /// returns an index to the texture which can be used with `TextureAtlasSprite`
     ///
     /// # Arguments
     ///
     /// * `rect` - The section of the atlas that contains the texture to be added,
     /// from the top-left corner of the texture to the bottom-right corner
-    pub fn add_texture(&mut self, rect: Rect) {
+    pub fn add_texture(&mut self, rect: Rect) -> u32 {
         self.textures.push(rect);
+        (self.textures.len() - 1) as u32
     }
 
     /// How many textures are in the `TextureAtlas`


### PR DESCRIPTION
If you need to build a texture atlas from an already created texture that is not match a grid, you need to use new_empty and add_texture to create it.  However it is not straight forward to get the index to be used with TextureAtlasSprite. add_texture should be changed to return the index to the texture.

Currently you can do something like this:

```rs
let texture = asset_server.load::<Texture>::("texture.png");
let texture_atlas = TextureAtlas::new_empty(texture, Vec2::new(40.0, 40.0));

texture_atlas.add_texture(Rect { 
  min: Vec2::new(20.0, 20.0),
  max: Vec2::new(40.0, 40.0),
});
let index = (texture_atlas.len() - 1) as u32;

let texture_atlas_sprite = TextureAtlasSprite {
  index,
  Default::default()
};
```

But this is more clear
```rs
let index = texture_atlas.add_texture(Rect { 
  min: Vec2::new(20.0, 20.0),
  max: Vec2::new(40.0, 40.0),
});
```