### PR TITLE
(WinitPlugin) Allow control of game tick

### DIFF
--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -15,6 +15,7 @@ x11 = ["winit/x11"]
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.5.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.5.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.5.0" }
 bevy_input = { path = "../bevy_input", version = "0.5.0" }
 bevy_math = { path = "../bevy_math", version = "0.5.0" }
@@ -24,6 +25,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 # other
 winit = { version = "0.25.0", default-features = false }
 approx = { version = "0.5.0", default-features = false }
+parking_lot = "0.11.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 winit = { version = "0.25.0", features = ["web-sys"], default-features = false }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -58,6 +58,9 @@ impl AssetNotify for WinitNotify {
 #[cfg(target_arch = "wasm32")]
 unsafe impl Send for WinitNotify {}
 
+#[cfg(target_arch = "wasm32")]
+unsafe impl Sync for WinitNotify {}
+
 #[derive(Default)]
 pub struct WinitPlugin;
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -54,6 +54,10 @@ impl AssetNotify for WinitNotify {
     }
 }
 
+// SAFETY: We clone the EventLoopProxy in exclusive system, and never destroy it.
+#[cfg(target_arch = "wasm32")]
+unsafe impl Send for WinitNotify {}
+
 #[derive(Default)]
 pub struct WinitPlugin;
 

--- a/crates/bevy_winit/src/winit_tick.rs
+++ b/crates/bevy_winit/src/winit_tick.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
+/// A resource for dynamically control of game tick.
 pub struct WinitTick {
     default_poll_tick: bool,
     should_poll_tick: AtomicBool,
@@ -12,6 +13,11 @@ impl Default for WinitTick {
 }
 
 impl WinitTick {
+    /// Create a `WinitTick` resource with the specified `default_poll_tick`.
+    /// `false` is recommended for GUI applications, animation systems can call
+    /// `poll_tick` with `WinitTick` resource to poll game tick for the next frame.
+    ///
+    /// Default value of `default_poll_tick` parameter is `true`.
     pub fn new(default_poll_tick: bool) -> Self {
         Self {
             default_poll_tick,

--- a/crates/bevy_winit/src/winit_tick.rs
+++ b/crates/bevy_winit/src/winit_tick.rs
@@ -1,0 +1,30 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub struct WinitTick {
+    default_poll_tick: bool,
+    should_poll_tick: AtomicBool,
+}
+
+impl Default for WinitTick {
+    fn default() -> Self {
+        Self::new(true)
+    }
+}
+
+impl WinitTick {
+    pub fn new(default_poll_tick: bool) -> Self {
+        Self {
+            default_poll_tick,
+            should_poll_tick: AtomicBool::new(default_poll_tick),
+        }
+    }
+
+    pub fn poll_tick(&self) {
+        self.should_poll_tick.store(true, Ordering::Relaxed);
+    }
+
+    pub fn finish(&self) -> bool {
+        self.should_poll_tick
+            .swap(self.default_poll_tick, Ordering::Relaxed)
+    }
+}

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -1,9 +1,11 @@
 use bevy::prelude::*;
+use bevy::winit::WinitTick;
 
 /// This example illustrates the various features of Bevy UI.
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
+        .insert_resource(WinitTick::new(false))
         .add_startup_system(setup)
         .run();
 }


### PR DESCRIPTION
# Objective

Related to #1343, this PR allow dynamic control of game tick, and benefit power savings for GUI applications. 

<img width="1173" alt="image" src="https://user-images.githubusercontent.com/11287532/134813884-f5e51afd-c5b1-41c1-bc5c-f93cc8332b2b.png">


## Solution

To disable the default poll game tick, insert `WinitTick::new(false)` resource into the world, animation systems can call `poll_tick` with `WinitTick` resource to poll game tick for the next frame.

The default `default_poll_tick` parameter value of `WinitTick` is `true` to prevent break changes.

## Todo

- [x] When `Asset` is loaded asynchronously, we should send a tick event to `EventLoop`.