### PR TITLE
[Merged by Bors] - Add set_stencil_reference to TrackedRenderPass

### DIFF
--- a/pipelined/bevy_render2/src/render_phase/draw_state.rs
+++ b/pipelined/bevy_render2/src/render_phase/draw_state.rs
@@ -194,4 +194,10 @@ impl<'a> TrackedRenderPass<'a> {
         );
         self.pass.draw_indexed(indices, base_vertex, instances);
     }
+
+    pub fn set_stencil_reference(&mut self, reference: u32) {
+        debug!("set stencil reference: {}", reference);
+
+        self.pass.set_stencil_reference(reference);
+    }
 }


### PR DESCRIPTION
`TrackedRenderPass` is a wrapper around wgpu's `RenderPass` and should expose needed methods such as `set_stencil_reference`.