### PR TITLE
Remove window descriptor resource once used

### DIFF
--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -56,6 +56,7 @@ impl Plugin for WindowPlugin {
                 .get_resource::<WindowDescriptor>()
                 .map(|descriptor| (*descriptor).clone())
                 .unwrap_or_else(WindowDescriptor::default);
+            app.world.remove_resource::<WindowDescriptor>();
             let mut create_window_event = app
                 .world
                 .get_resource_mut::<Events<CreateWindow>>()

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -53,10 +53,8 @@ impl Plugin for WindowPlugin {
         if self.add_primary_window {
             let window_descriptor = app
                 .world
-                .get_resource::<WindowDescriptor>()
-                .map(|descriptor| (*descriptor).clone())
+                .remove_resource::<WindowDescriptor>()
                 .unwrap_or_else(WindowDescriptor::default);
-            app.world.remove_resource::<WindowDescriptor>();
             let mut create_window_event = app
                 .world
                 .get_resource_mut::<Events<CreateWindow>>()

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -513,6 +513,10 @@ impl Window {
     }
 }
 
+/// This resource will only be used as initialization to setup the window.
+/// To change those settings during runtime, the [`Windows`](super::windows::Windows)
+/// resource should be used. See example
+/// [window_settings](https://github.com/bevyengine/bevy/blob/latest/examples/window/window_settings.rs)
 #[derive(Debug, Clone)]
 pub struct WindowDescriptor {
     pub width: f32,


### PR DESCRIPTION
# Objective

- Fixes #2879. Somewhat?

## Solution

- Remove resource `WindowDescriptor` once it's used
- Add doc explaining what to do and linking to example
