### PR TITLE
[Merged by Bors] - change texture atlas sprite indexing to usize

### DIFF
--- a/examples/2d/pipelined_texture_atlas.rs
+++ b/examples/2d/pipelined_texture_atlas.rs
@@ -81,7 +81,7 @@ fn setup(
             scale: Vec3::splat(4.0),
             ..Default::default()
         },
-        sprite: TextureAtlasSprite::new(vendor_index as u32),
+        sprite: TextureAtlasSprite::new(vendor_index),
         texture_atlas: atlas_handle,
         ..Default::default()
     });

--- a/pipelined/bevy_sprite2/src/dynamic_texture_atlas_builder.rs
+++ b/pipelined/bevy_sprite2/src/dynamic_texture_atlas_builder.rs
@@ -33,8 +33,7 @@ impl DynamicTextureAtlasBuilder {
             let mut rect: Rect = allocation.rectangle.into();
             rect.max.x -= self.padding as f32;
             rect.max.y -= self.padding as f32;
-            texture_atlas.add_texture(rect);
-            Some(texture_atlas.len() - 1)
+            Some(texture_atlas.add_texture(rect))
         } else {
             None
         }

--- a/pipelined/bevy_sprite2/src/dynamic_texture_atlas_builder.rs
+++ b/pipelined/bevy_sprite2/src/dynamic_texture_atlas_builder.rs
@@ -22,7 +22,7 @@ impl DynamicTextureAtlasBuilder {
         texture_atlas: &mut TextureAtlas,
         textures: &mut Assets<Image>,
         texture: &Image,
-    ) -> Option<u32> {
+    ) -> Option<usize> {
         let allocation = self.atlas_allocator.allocate(size2(
             texture.texture_descriptor.size.width as i32 + self.padding,
             texture.texture_descriptor.size.height as i32 + self.padding,
@@ -34,7 +34,7 @@ impl DynamicTextureAtlasBuilder {
             rect.max.x -= self.padding as f32;
             rect.max.y -= self.padding as f32;
             texture_atlas.add_texture(rect);
-            Some((texture_atlas.len() - 1) as u32)
+            Some(texture_atlas.len() - 1)
         } else {
             None
         }

--- a/pipelined/bevy_sprite2/src/render/mod.rs
+++ b/pipelined/bevy_sprite2/src/render/mod.rs
@@ -166,7 +166,7 @@ pub fn extract_atlases(
     let mut sprites = Vec::new();
     for (entity, atlas_sprite, transform, texture_atlas_handle) in atlas_query.iter() {
         if let Some(texture_atlas) = texture_atlases.get(texture_atlas_handle) {
-            let rect = texture_atlas.textures[atlas_sprite.index as usize];
+            let rect = texture_atlas.textures[atlas_sprite.index];
             sprites.push((
                 entity,
                 (ExtractedSprite {

--- a/pipelined/bevy_sprite2/src/texture_atlas.rs
+++ b/pipelined/bevy_sprite2/src/texture_atlas.rs
@@ -24,7 +24,7 @@ pub struct TextureAtlas {
 #[uuid = "7233c597-ccfa-411f-bd59-9af349432ada"]
 pub struct TextureAtlasSprite {
     pub color: Color,
-    pub index: u32,
+    pub index: usize,
     pub flip_x: bool,
     pub flip_y: bool,
 }
@@ -41,7 +41,7 @@ impl Default for TextureAtlasSprite {
 }
 
 impl TextureAtlasSprite {
-    pub fn new(index: u32) -> TextureAtlasSprite {
+    pub fn new(index: usize) -> TextureAtlasSprite {
         Self {
             index,
             ..Default::default()

--- a/pipelined/bevy_sprite2/src/texture_atlas.rs
+++ b/pipelined/bevy_sprite2/src/texture_atlas.rs
@@ -119,13 +119,15 @@ impl TextureAtlas {
     }
 
     /// Add a sprite to the list of textures in the `TextureAtlas`
+    /// returns an index to the texture which can be used with `TextureAtlasSprite`
     ///
     /// # Arguments
     ///
     /// * `rect` - The section of the atlas that contains the texture to be added,
     /// from the top-left corner of the texture to the bottom-right corner
-    pub fn add_texture(&mut self, rect: Rect) {
+    pub fn add_texture(&mut self, rect: Rect) -> usize {
         self.textures.push(rect);
+        self.textures.len() - 1
     }
 
     /// How many textures are in the `TextureAtlas`


### PR DESCRIPTION
Per this comment https://github.com/bevyengine/bevy/pull/2864#discussion_r717947232,
I have done a pass at changing all the public facing indexes for `TextureAtlas` to usize.