### PR TITLE
Remove double Events::update in bevy-gilrs

### DIFF
--- a/crates/bevy_gilrs/src/gilrs_system.rs
+++ b/crates/bevy_gilrs/src/gilrs_system.rs
@@ -1,13 +1,13 @@
 use crate::converter::{convert_axis, convert_button, convert_gamepad_id};
 use bevy_app::Events;
-use bevy_ecs::world::World;
+use bevy_ecs::system::{NonSend, NonSendMut, ResMut};
 use bevy_input::{gamepad::GamepadEventRaw, prelude::*};
 use gilrs::{EventType, Gilrs};
 
-pub fn gilrs_event_startup_system(world: &mut World) {
-    let world = world.cell();
-    let gilrs = world.get_non_send::<Gilrs>().unwrap();
-    let mut event = world.get_resource_mut::<Events<GamepadEventRaw>>().unwrap();
+pub fn gilrs_event_startup_system(
+    gilrs: NonSend<Gilrs>,
+    mut event: ResMut<Events<GamepadEventRaw>>,
+) {
     for (id, _) in gilrs.gamepads() {
         event.send(GamepadEventRaw(
             convert_gamepad_id(id),
@@ -16,10 +16,10 @@ pub fn gilrs_event_startup_system(world: &mut World) {
     }
 }
 
-pub fn gilrs_event_system(world: &mut World) {
-    let world = world.cell();
-    let mut gilrs = world.get_non_send_mut::<Gilrs>().unwrap();
-    let mut event = world.get_resource_mut::<Events<GamepadEventRaw>>().unwrap();
+pub fn gilrs_event_system(
+    mut gilrs: NonSendMut<Gilrs>,
+    mut event: ResMut<Events<GamepadEventRaw>>,
+) {
     event.update();
     while let Some(gilrs_event) = gilrs.next_event() {
         match gilrs_event.event {

--- a/crates/bevy_gilrs/src/gilrs_system.rs
+++ b/crates/bevy_gilrs/src/gilrs_system.rs
@@ -20,7 +20,6 @@ pub fn gilrs_event_system(
     mut gilrs: NonSendMut<Gilrs>,
     mut event: ResMut<Events<GamepadEventRaw>>,
 ) {
-    event.update();
     while let Some(gilrs_event) = gilrs.next_event() {
         match gilrs_event.event {
             EventType::Connected => {

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -2,7 +2,6 @@ mod converter;
 mod gilrs_system;
 
 use bevy_app::{App, CoreStage, Plugin, StartupStage};
-use bevy_ecs::system::IntoExclusiveSystem;
 use bevy_utils::tracing::error;
 use gilrs::GilrsBuilder;
 use gilrs_system::{gilrs_event_startup_system, gilrs_event_system};
@@ -21,12 +20,9 @@ impl Plugin for GilrsPlugin {
                 app.insert_non_send_resource(gilrs)
                     .add_startup_system_to_stage(
                         StartupStage::PreStartup,
-                        gilrs_event_startup_system.exclusive_system(),
+                        gilrs_event_startup_system,
                     )
-                    .add_system_to_stage(
-                        CoreStage::PreUpdate,
-                        gilrs_event_system.exclusive_system(),
-                    );
+                    .add_system_to_stage(CoreStage::PreUpdate, gilrs_event_system);
             }
             Err(err) => error!("Failed to start Gilrs. {}", err),
         }


### PR DESCRIPTION
# Objective

- Remove duplicate `Events::update` call in `gilrs_event_system` (fixes #2893)
  - See #2893 for context
- While there, make the systems no longer exclusive, as that is not required of them

## Solution

- Do the change

r? @alice-i-cecile 
