### PR TITLE
Atomic counter for render resource ids and Render to Gpu rename

### DIFF
--- a/crates/bevy_derive/src/id.rs
+++ b/crates/bevy_derive/src/id.rs
@@ -1,0 +1,26 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+pub fn derive_id(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+
+    let struct_name = &ast.ident;
+    let error_message = format!("The system ran out of unique `{}`s.", struct_name);
+    let (_impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
+
+    TokenStream::from(quote! {
+        impl #struct_name #type_generics #where_clause {
+            pub fn new() -> Self {
+                use std::sync::atomic::{AtomicU64, Ordering};
+                static COUNTER: AtomicU64 = AtomicU64::new(0);
+                COUNTER
+                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
+                        val.checked_add(1)
+                    })
+                    .map(Self)
+                    .expect(#error_message)
+            }
+        }
+    })
+}

--- a/crates/bevy_derive/src/lib.rs
+++ b/crates/bevy_derive/src/lib.rs
@@ -4,6 +4,7 @@ mod app_plugin;
 mod bevy_main;
 mod bytes;
 mod enum_variant_meta;
+mod id;
 mod modules;
 mod render_resource;
 mod render_resources;
@@ -69,4 +70,9 @@ pub fn derive_app_label(input: TokenStream) -> TokenStream {
     let mut trait_path = BevyManifest::default().get_path("bevy_app");
     trait_path.segments.push(format_ident!("AppLabel").into());
     derive_label(input, trait_path)
+}
+
+#[proc_macro_derive(Id)]
+pub fn derive_id(input: TokenStream) -> TokenStream {
+    id::derive_id(input)
 }

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -1,4 +1,4 @@
-use bevy_utils::tracing::warn;
+use bevy_utils::{tracing::warn, Id, IdType};
 
 use crate::{
     archetype::{Archetype, ArchetypeComponentId},
@@ -9,16 +9,8 @@ use crate::{
 use std::borrow::Cow;
 
 /// A [`System`] identifier.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub struct SystemId(pub usize);
-
-impl SystemId {
-    /// Creates a new random `SystemId`.
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        SystemId(rand::random::<usize>())
-    }
-}
+#[derive(Id, Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct SystemId(IdType);
 
 /// An ECS system that can be added to a [Schedule](crate::schedule::Schedule)
 ///

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -19,18 +19,19 @@ use crate::{
     query::{FilterFetch, QueryState, WorldQuery},
     storage::{Column, SparseSet, Storages},
 };
+use bevy_utils::{Id, IdType};
 use std::{
     any::TypeId,
     fmt,
     sync::atomic::{AtomicU32, Ordering},
 };
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct WorldId(u64);
+#[derive(Id, Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct WorldId(IdType);
 
 impl Default for WorldId {
     fn default() -> Self {
-        WorldId(rand::random())
+        WorldId::new()
     }
 }
 

--- a/crates/bevy_utils/src/id.rs
+++ b/crates/bevy_utils/src/id.rs
@@ -1,0 +1,2 @@
+pub use bevy_derive::Id;
+pub type IdType = u64;

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -1,9 +1,11 @@
 mod enum_variant_meta;
+mod id;
 pub mod label;
 pub mod slab;
 
 pub use ahash::AHasher;
 pub use enum_variant_meta::*;
+pub use id::*;
 pub use instant::{Duration, Instant};
 pub use tracing;
 pub use uuid::Uuid;

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,17 +1,13 @@
 use bevy_math::{IVec2, Vec2};
-use bevy_utils::{tracing::warn, Uuid};
+use bevy_utils::{tracing::warn, Id, IdType};
 use raw_window_handle::RawWindowHandle;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct WindowId(Uuid);
+#[derive(Id, Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct WindowId(pub IdType);
 
 impl WindowId {
-    pub fn new() -> Self {
-        WindowId(Uuid::new_v4())
-    }
-
     pub fn primary() -> Self {
-        WindowId(Uuid::from_u128(0))
+        WindowId(0)
     }
 
     pub fn is_primary(&self) -> bool {
@@ -25,7 +21,7 @@ use crate::raw_window_handle::RawWindowHandleWrapper;
 
 impl fmt::Display for WindowId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.to_simple().fmt(f)
+        self.0.fmt(f)
     }
 }
 

--- a/examples/shader/custom_shader_pipelined.rs
+++ b/examples/shader/custom_shader_pipelined.rs
@@ -19,7 +19,7 @@ use bevy::{
             AddRenderCommand, DrawFunctions, RenderCommand, RenderPhase, TrackedRenderPass,
         },
         render_resource::*,
-        renderer::RenderDevice,
+        renderer::GpuDevice,
         shader::Shader,
         texture::BevyDefault,
         view::ExtractedView,
@@ -44,7 +44,7 @@ pub struct GpuCustomMaterial {
 impl RenderAsset for CustomMaterial {
     type ExtractedAsset = CustomMaterial;
     type PreparedAsset = GpuCustomMaterial;
-    type Param = (SRes<RenderDevice>, SRes<CustomPipeline>);
+    type Param = (SRes<GpuDevice>, SRes<CustomPipeline>);
     fn extract_asset(&self) -> Self::ExtractedAsset {
         self.clone()
     }
@@ -129,11 +129,11 @@ pub struct CustomPipeline {
 // TODO: this pattern for initializing the shaders / pipeline isn't ideal. this should be handled by the asset system
 impl FromWorld for CustomPipeline {
     fn from_world(world: &mut World) -> Self {
-        let render_device = world.get_resource::<RenderDevice>().unwrap();
+        let gpu_device = world.get_resource::<GpuDevice>().unwrap();
         let shader = Shader::from_wgsl(include_str!("../../assets/shaders/custom.wgsl"));
-        let shader_module = render_device.create_shader_module(&shader);
+        let shader_module = gpu_device.create_shader_module(&shader);
 
-        let material_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+        let material_layout = gpu_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
             entries: &[BindGroupLayoutEntry {
                 binding: 0,
                 visibility: ShaderStage::FRAGMENT,
@@ -148,7 +148,7 @@ impl FromWorld for CustomPipeline {
         });
         let pbr_pipeline = world.get_resource::<PbrShaders>().unwrap();
 
-        let pipeline_layout = render_device.create_pipeline_layout(&PipelineLayoutDescriptor {
+        let pipeline_layout = gpu_device.create_pipeline_layout(&PipelineLayoutDescriptor {
             label: None,
             push_constant_ranges: &[],
             bind_group_layouts: &[
@@ -158,7 +158,7 @@ impl FromWorld for CustomPipeline {
             ],
         });
 
-        let pipeline = render_device.create_render_pipeline(&RenderPipelineDescriptor {
+        let pipeline = gpu_device.create_render_pipeline(&RenderPipelineDescriptor {
             label: None,
             vertex: VertexState {
                 buffers: &[VertexBufferLayout {

--- a/examples/shader/custom_shader_pipelined.rs
+++ b/examples/shader/custom_shader_pipelined.rs
@@ -238,8 +238,8 @@ impl FromWorld for CustomPipeline {
         });
 
         CustomPipeline {
-            pipeline,
             material_layout,
+            pipeline,
         }
     }
 }

--- a/pipelined/bevy_core_pipeline/src/lib.rs
+++ b/pipelined/bevy_core_pipeline/src/lib.rs
@@ -16,7 +16,7 @@ use bevy_render2::{
     render_graph::{EmptyNode, RenderGraph, SlotInfo, SlotType},
     render_phase::{sort_phase_system, DrawFunctionId, DrawFunctions, PhaseItem, RenderPhase},
     render_resource::*,
-    renderer::RenderDevice,
+    renderer::GpuDevice,
     texture::{Image, TextureCache},
     view::ExtractedView,
     RenderApp, RenderStage, RenderWorld,
@@ -228,12 +228,12 @@ pub fn extract_core_pipeline_camera_phases(
 pub fn prepare_core_views_system(
     mut commands: Commands,
     mut texture_cache: ResMut<TextureCache>,
-    render_device: Res<RenderDevice>,
+    gpu_device: Res<GpuDevice>,
     views: Query<(Entity, &ExtractedView), With<RenderPhase<Transparent3d>>>,
 ) {
     for (entity, view) in views.iter() {
         let cached_texture = texture_cache.get(
-            &render_device,
+            &gpu_device,
             TextureDescriptor {
                 label: None,
                 size: Extent3d {

--- a/pipelined/bevy_core_pipeline/src/main_pass_2d.rs
+++ b/pipelined/bevy_core_pipeline/src/main_pass_2d.rs
@@ -4,7 +4,7 @@ use bevy_render2::{
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
     render_phase::{DrawFunctions, RenderPhase, TrackedRenderPass},
     render_resource::{LoadOp, Operations, RenderPassColorAttachment, RenderPassDescriptor},
-    renderer::RenderContext,
+    renderer::GpuContext,
     view::ExtractedView,
 };
 
@@ -38,7 +38,7 @@ impl Node for MainPass2dNode {
     fn run(
         &self,
         graph: &mut RenderGraphContext,
-        render_context: &mut RenderContext,
+        gpu_context: &mut GpuContext,
         world: &World,
     ) -> Result<(), NodeRunError> {
         let color_attachment_texture = graph.get_input_texture(Self::IN_COLOR_ATTACHMENT)?;
@@ -66,7 +66,7 @@ impl Node for MainPass2dNode {
             .get_manual(world, view_entity)
             .expect("view entity should exist");
 
-        let render_pass = render_context
+        let render_pass = gpu_context
             .command_encoder
             .begin_render_pass(&pass_descriptor);
 

--- a/pipelined/bevy_core_pipeline/src/main_pass_3d.rs
+++ b/pipelined/bevy_core_pipeline/src/main_pass_3d.rs
@@ -7,7 +7,7 @@ use bevy_render2::{
         LoadOp, Operations, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
         RenderPassDescriptor,
     },
-    renderer::RenderContext,
+    renderer::GpuContext,
     view::ExtractedView,
 };
 
@@ -43,7 +43,7 @@ impl Node for MainPass3dNode {
     fn run(
         &self,
         graph: &mut RenderGraphContext,
-        render_context: &mut RenderContext,
+        gpu_context: &mut GpuContext,
         world: &World,
     ) -> Result<(), NodeRunError> {
         let color_attachment_texture = graph.get_input_texture(Self::IN_COLOR_ATTACHMENT)?;
@@ -79,7 +79,7 @@ impl Node for MainPass3dNode {
             .get_manual(world, view_entity)
             .expect("view entity should exist");
 
-        let render_pass = render_context
+        let render_pass = gpu_context
             .command_encoder
             .begin_render_pass(&pass_descriptor);
         let mut draw_functions = draw_functions.write();

--- a/pipelined/bevy_core_pipeline/src/main_pass_driver.rs
+++ b/pipelined/bevy_core_pipeline/src/main_pass_driver.rs
@@ -3,7 +3,7 @@ use bevy_ecs::world::World;
 use bevy_render2::{
     camera::{CameraPlugin, ExtractedCamera, ExtractedCameraNames},
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotValue},
-    renderer::RenderContext,
+    renderer::GpuContext,
     view::ExtractedWindows,
 };
 
@@ -13,7 +13,7 @@ impl Node for MainPassDriverNode {
     fn run(
         &self,
         graph: &mut RenderGraphContext,
-        _render_context: &mut RenderContext,
+        _gpu_context: &mut GpuContext,
         world: &World,
     ) -> Result<(), NodeRunError> {
         let extracted_cameras = world.get_resource::<ExtractedCameraNames>().unwrap();

--- a/pipelined/bevy_pbr2/src/material.rs
+++ b/pipelined/bevy_pbr2/src/material.rs
@@ -7,7 +7,7 @@ use bevy_render2::{
     color::Color,
     render_asset::{PrepareAssetError, RenderAsset, RenderAssetPlugin, RenderAssets},
     render_resource::{BindGroup, Buffer, BufferInitDescriptor, BufferUsage, Sampler, TextureView},
-    renderer::RenderDevice,
+    renderer::GpuDevice,
     texture::Image,
 };
 use crevice::std140::{AsStd140, Std140};
@@ -144,11 +144,7 @@ pub struct GpuStandardMaterial {
 impl RenderAsset for StandardMaterial {
     type ExtractedAsset = StandardMaterial;
     type PreparedAsset = GpuStandardMaterial;
-    type Param = (
-        SRes<RenderDevice>,
-        SRes<PbrShaders>,
-        SRes<RenderAssets<Image>>,
-    );
+    type Param = (SRes<GpuDevice>, SRes<PbrShaders>, SRes<RenderAssets<Image>>);
 
     fn extract_asset(&self) -> Self::ExtractedAsset {
         self.clone()

--- a/pipelined/bevy_render2/src/mesh/mesh/mod.rs
+++ b/pipelined/bevy_render2/src/mesh/mesh/mod.rs
@@ -3,7 +3,7 @@ mod conversions;
 use crate::{
     render_asset::{PrepareAssetError, RenderAsset},
     render_resource::Buffer,
-    renderer::RenderDevice,
+    renderer::GpuDevice,
 };
 use bevy_core::cast_slice;
 use bevy_ecs::system::{lifetimeless::SRes, SystemParamItem};
@@ -541,7 +541,7 @@ pub struct GpuIndexInfo {
 impl RenderAsset for Mesh {
     type ExtractedAsset = Mesh;
     type PreparedAsset = GpuMesh;
-    type Param = SRes<RenderDevice>;
+    type Param = SRes<GpuDevice>;
 
     fn extract_asset(&self) -> Self::ExtractedAsset {
         self.clone()

--- a/pipelined/bevy_render2/src/render_component.rs
+++ b/pipelined/bevy_render2/src/render_component.rs
@@ -1,6 +1,6 @@
 use crate::{
     render_resource::DynamicUniformVec,
-    renderer::{RenderDevice, RenderQueue},
+    renderer::{GpuDevice, GpuQueue},
     RenderApp, RenderStage,
 };
 use bevy_app::{App, Plugin};
@@ -85,8 +85,8 @@ impl<C: Component + AsStd140> Default for ComponentUniforms<C> {
 
 fn prepare_uniform_components<C: Component>(
     mut commands: Commands,
-    render_device: Res<RenderDevice>,
-    render_queue: Res<RenderQueue>,
+    gpu_device: Res<GpuDevice>,
+    gpu_queue: Res<GpuQueue>,
     mut component_uniforms: ResMut<ComponentUniforms<C>>,
     components: Query<(Entity, &C)>,
 ) where
@@ -95,7 +95,7 @@ fn prepare_uniform_components<C: Component>(
     let len = components.iter().len();
     component_uniforms
         .uniforms
-        .reserve_and_clear(len, &render_device);
+        .reserve_and_clear(len, &gpu_device);
     for (entity, component) in components.iter() {
         commands
             .get_or_spawn(entity)
@@ -105,7 +105,7 @@ fn prepare_uniform_components<C: Component>(
             });
     }
 
-    component_uniforms.uniforms.write_buffer(&render_queue);
+    component_uniforms.uniforms.write_buffer(&gpu_queue);
 }
 
 pub struct ExtractComponentPlugin<C, F = ()>(PhantomData<fn() -> (C, F)>);

--- a/pipelined/bevy_render2/src/render_graph/graph.rs
+++ b/pipelined/bevy_render2/src/render_graph/graph.rs
@@ -3,7 +3,7 @@ use crate::{
         Edge, Node, NodeId, NodeLabel, NodeRunError, NodeState, RenderGraphContext,
         RenderGraphError, SlotInfo, SlotLabel,
     },
-    renderer::RenderContext,
+    renderer::GpuContext,
 };
 use bevy_ecs::prelude::World;
 use bevy_utils::HashMap;
@@ -342,7 +342,7 @@ impl Node for GraphInputNode {
     fn run(
         &self,
         graph: &mut RenderGraphContext,
-        _render_context: &mut RenderContext,
+        _gpu_context: &mut GpuContext,
         _world: &World,
     ) -> Result<(), NodeRunError> {
         for i in 0..graph.inputs().len() {
@@ -360,7 +360,7 @@ mod tests {
             Edge, Node, NodeId, NodeRunError, RenderGraph, RenderGraphContext, RenderGraphError,
             SlotInfo, SlotType,
         },
-        renderer::RenderContext,
+        renderer::GpuContext,
     };
     use bevy_ecs::world::World;
     use bevy_utils::HashSet;
@@ -397,7 +397,7 @@ mod tests {
         fn run(
             &self,
             _: &mut RenderGraphContext,
-            _: &mut RenderContext,
+            _: &mut GpuContext,
             _: &World,
         ) -> Result<(), NodeRunError> {
             Ok(())
@@ -470,7 +470,7 @@ mod tests {
             fn run(
                 &self,
                 _: &mut RenderGraphContext,
-                _: &mut RenderContext,
+                _: &mut GpuContext,
                 _: &World,
             ) -> Result<(), NodeRunError> {
                 Ok(())

--- a/pipelined/bevy_render2/src/render_graph/node.rs
+++ b/pipelined/bevy_render2/src/render_graph/node.rs
@@ -6,24 +6,13 @@ use crate::{
     renderer::GpuContext,
 };
 use bevy_ecs::world::World;
-use bevy_utils::Uuid;
+use bevy_utils::{Id, IdType};
 use downcast_rs::{impl_downcast, Downcast};
 use std::{borrow::Cow, fmt::Debug};
 use thiserror::Error;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct NodeId(Uuid);
-
-impl NodeId {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        NodeId(Uuid::new_v4())
-    }
-
-    pub fn uuid(&self) -> &Uuid {
-        &self.0
-    }
-}
+#[derive(Id, Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct NodeId(IdType);
 
 pub trait Node: Downcast + Send + Sync + 'static {
     fn input(&self) -> Vec<SlotInfo> {

--- a/pipelined/bevy_render2/src/render_graph/node.rs
+++ b/pipelined/bevy_render2/src/render_graph/node.rs
@@ -3,7 +3,7 @@ use crate::{
         Edge, InputSlotError, OutputSlotError, RenderGraphContext, RenderGraphError,
         RunSubGraphError, SlotInfo, SlotInfos,
     },
-    renderer::RenderContext,
+    renderer::GpuContext,
 };
 use bevy_ecs::world::World;
 use bevy_utils::Uuid;
@@ -41,7 +41,7 @@ pub trait Node: Downcast + Send + Sync + 'static {
     fn run(
         &self,
         graph: &mut RenderGraphContext,
-        render_context: &mut RenderContext,
+        gpu_context: &mut GpuContext,
         world: &World,
     ) -> Result<(), NodeRunError>;
 }
@@ -229,7 +229,7 @@ impl Node for EmptyNode {
     fn run(
         &self,
         _graph: &mut RenderGraphContext,
-        _render_context: &mut RenderContext,
+        _gpu_context: &mut GpuContext,
         _world: &World,
     ) -> Result<(), NodeRunError> {
         Ok(())

--- a/pipelined/bevy_render2/src/render_resource/bind_group.rs
+++ b/pipelined/bevy_render2/src/render_resource/bind_group.rs
@@ -1,17 +1,8 @@
-use crate::render_resource::{next_id, Counter, Id};
+use bevy_utils::{Id, IdType};
 use std::sync::Arc;
 
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct BindGroupId(Id);
-
-impl BindGroupId {
-    /// Creates a new, unique [`BindGroupId`].
-    /// Returns [`None`] if the supply of unique ids has been exhausted.
-    fn new() -> Option<Self> {
-        static COUNTER: Counter = Counter::new(0);
-        next_id(&COUNTER).map(Self)
-    }
-}
+#[derive(Id, Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct BindGroupId(IdType);
 
 #[derive(Clone, Debug)]
 pub struct BindGroup {
@@ -34,7 +25,7 @@ impl BindGroup {
 impl From<wgpu::BindGroup> for BindGroup {
     fn from(value: wgpu::BindGroup) -> Self {
         BindGroup {
-            id: BindGroupId::new().expect("The system ran out of unique `BindGroupId`s."),
+            id: BindGroupId::new(),
             value: Arc::new(value),
         }
     }

--- a/pipelined/bevy_render2/src/render_resource/bind_group.rs
+++ b/pipelined/bevy_render2/src/render_resource/bind_group.rs
@@ -1,13 +1,14 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-static MAX_BIND_GROUP_ID: AtomicU64 = AtomicU64::new(0);
+static MAX_BIND_GROUP_ID: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct BindGroupId(u64);
+pub struct BindGroupId(usize);
 
 impl BindGroupId {
     /// Creates a new id by incrementing the atomic id counter.
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self(MAX_BIND_GROUP_ID.fetch_add(1, Ordering::Relaxed))
     }

--- a/pipelined/bevy_render2/src/render_resource/bind_group.rs
+++ b/pipelined/bevy_render2/src/render_resource/bind_group.rs
@@ -1,8 +1,17 @@
-use bevy_reflect::Uuid;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+static MAX_BIND_GROUP_ID: AtomicU64 = AtomicU64::new(0);
+
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct BindGroupId(Uuid);
+pub struct BindGroupId(u64);
+
+impl BindGroupId {
+    /// Creates a new id by incrementing the atomic id counter.
+    pub fn new() -> Self {
+        Self(MAX_BIND_GROUP_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct BindGroup {
@@ -25,7 +34,7 @@ impl BindGroup {
 impl From<wgpu::BindGroup> for BindGroup {
     fn from(value: wgpu::BindGroup) -> Self {
         BindGroup {
-            id: BindGroupId(Uuid::new_v4()),
+            id: BindGroupId::new(),
             value: Arc::new(value),
         }
     }

--- a/pipelined/bevy_render2/src/render_resource/buffer.rs
+++ b/pipelined/bevy_render2/src/render_resource/buffer.rs
@@ -1,16 +1,17 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{
     ops::{Bound, Deref, RangeBounds},
     sync::Arc,
 };
 
-static MAX_BUFFER_ID: AtomicU64 = AtomicU64::new(0);
+static MAX_BUFFER_ID: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct BufferId(u64);
+pub struct BufferId(usize);
 
 impl BufferId {
     /// Creates a new id by incrementing the atomic id counter.
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self(MAX_BUFFER_ID.fetch_add(1, Ordering::Relaxed))
     }

--- a/pipelined/bevy_render2/src/render_resource/buffer.rs
+++ b/pipelined/bevy_render2/src/render_resource/buffer.rs
@@ -1,20 +1,11 @@
-use crate::render_resource::{next_id, Counter, Id};
+use bevy_utils::{Id, IdType};
 use std::{
     ops::{Bound, Deref, RangeBounds},
     sync::Arc,
 };
 
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct BufferId(Id);
-
-impl BufferId {
-    /// Creates a new, unique [`BufferId`].
-    /// Returns [`None`] if the supply of unique ids has been exhausted.
-    fn new() -> Option<Self> {
-        static COUNTER: Counter = Counter::new(0);
-        next_id(&COUNTER).map(Self)
-    }
-}
+#[derive(Id, Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct BufferId(IdType);
 
 #[derive(Clone, Debug)]
 pub struct Buffer {
@@ -50,7 +41,7 @@ impl Buffer {
 impl From<wgpu::Buffer> for Buffer {
     fn from(value: wgpu::Buffer) -> Self {
         Buffer {
-            id: BufferId::new().expect("The system ran out of unique `BufferId`s."),
+            id: BufferId::new(),
             value: Arc::new(value),
         }
     }

--- a/pipelined/bevy_render2/src/render_resource/buffer.rs
+++ b/pipelined/bevy_render2/src/render_resource/buffer.rs
@@ -1,11 +1,20 @@
-use bevy_utils::Uuid;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
     ops::{Bound, Deref, RangeBounds},
     sync::Arc,
 };
 
+static MAX_BUFFER_ID: AtomicU64 = AtomicU64::new(0);
+
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct BufferId(Uuid);
+pub struct BufferId(u64);
+
+impl BufferId {
+    /// Creates a new id by incrementing the atomic id counter.
+    pub fn new() -> Self {
+        Self(MAX_BUFFER_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct Buffer {
@@ -41,7 +50,7 @@ impl Buffer {
 impl From<wgpu::Buffer> for Buffer {
     fn from(value: wgpu::Buffer) -> Self {
         Buffer {
-            id: BufferId(Uuid::new_v4()),
+            id: BufferId::new(),
             value: Arc::new(value),
         }
     }

--- a/pipelined/bevy_render2/src/render_resource/mod.rs
+++ b/pipelined/bevy_render2/src/render_resource/mod.rs
@@ -14,7 +14,6 @@ pub use render_resource_id::*;
 pub use texture::*;
 pub use uniform_vec::*;
 
-use std::sync::atomic::{AtomicU64, Ordering};
 // TODO: decide where re-exports should go
 pub use wgpu::{
     util::BufferInitDescriptor, AddressMode, BindGroupDescriptor, BindGroupEntry, BindGroupLayout,
@@ -31,18 +30,3 @@ pub use wgpu::{
     TextureSampleType, TextureUsage, TextureViewDescriptor, TextureViewDimension, VertexAttribute,
     VertexBufferLayout, VertexFormat, VertexState,
 };
-
-// Change this to AtomicU32, if AtomicU64 is not supported on your platform.
-type Id = u64;
-type Counter = AtomicU64;
-
-/// Increments the `counter` and returns the previous id.
-/// Returns [`None`] if the supply of unique ids has been exhausted.
-#[inline]
-fn next_id(counter: &Counter) -> Option<Id> {
-    counter
-        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
-            val.checked_add(1)
-        })
-        .ok()
-}

--- a/pipelined/bevy_render2/src/render_resource/mod.rs
+++ b/pipelined/bevy_render2/src/render_resource/mod.rs
@@ -14,6 +14,7 @@ pub use render_resource_id::*;
 pub use texture::*;
 pub use uniform_vec::*;
 
+use std::sync::atomic::{AtomicU64, Ordering};
 // TODO: decide where re-exports should go
 pub use wgpu::{
     util::BufferInitDescriptor, AddressMode, BindGroupDescriptor, BindGroupEntry, BindGroupLayout,
@@ -30,3 +31,18 @@ pub use wgpu::{
     TextureSampleType, TextureUsage, TextureViewDescriptor, TextureViewDimension, VertexAttribute,
     VertexBufferLayout, VertexFormat, VertexState,
 };
+
+// Change this to AtomicU32, if AtomicU64 is not supported on your platform.
+type Id = u64;
+type Counter = AtomicU64;
+
+/// Increments the `counter` and returns the previous id.
+/// Returns [`None`] if the supply of unique ids has been exhausted.
+#[inline]
+fn next_id(counter: &Counter) -> Option<Id> {
+    counter
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
+            val.checked_add(1)
+        })
+        .ok()
+}

--- a/pipelined/bevy_render2/src/render_resource/pipeline.rs
+++ b/pipelined/bevy_render2/src/render_resource/pipeline.rs
@@ -1,8 +1,30 @@
-use bevy_reflect::Uuid;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{ops::Deref, sync::Arc};
 
+static MAX_RENDER_PIPELINE_ID: AtomicUsize = AtomicUsize::new(0);
+static MAX_COMPUTE_PIPELINE_ID: AtomicUsize = AtomicUsize::new(0);
+
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct RenderPipelineId(Uuid);
+pub struct RenderPipelineId(usize);
+
+impl RenderPipelineId {
+    /// Creates a new id by incrementing the atomic id counter.
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self(MAX_RENDER_PIPELINE_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct ComputePipelineId(usize);
+
+impl ComputePipelineId {
+    /// Creates a new id by incrementing the atomic id counter.
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self(MAX_COMPUTE_PIPELINE_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct RenderPipeline {
@@ -20,7 +42,7 @@ impl RenderPipeline {
 impl From<wgpu::RenderPipeline> for RenderPipeline {
     fn from(value: wgpu::RenderPipeline) -> Self {
         RenderPipeline {
-            id: RenderPipelineId(Uuid::new_v4()),
+            id: RenderPipelineId::new(),
             value: Arc::new(value),
         }
     }
@@ -34,9 +56,6 @@ impl Deref for RenderPipeline {
         &self.value
     }
 }
-
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct ComputePipelineId(Uuid);
 
 #[derive(Clone, Debug)]
 pub struct ComputePipeline {
@@ -54,7 +73,7 @@ impl ComputePipeline {
 impl From<wgpu::ComputePipeline> for ComputePipeline {
     fn from(value: wgpu::ComputePipeline) -> Self {
         ComputePipeline {
-            id: ComputePipelineId(Uuid::new_v4()),
+            id: ComputePipelineId::new(),
             value: Arc::new(value),
         }
     }

--- a/pipelined/bevy_render2/src/render_resource/pipeline.rs
+++ b/pipelined/bevy_render2/src/render_resource/pipeline.rs
@@ -1,17 +1,8 @@
-use crate::render_resource::{next_id, Counter, Id};
+use bevy_utils::{Id, IdType};
 use std::{ops::Deref, sync::Arc};
 
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct RenderPipelineId(Id);
-
-impl RenderPipelineId {
-    /// Creates a new, unique [`RenderPipelineId`].
-    /// Returns [`None`] if the supply of unique ids has been exhausted.
-    fn new() -> Option<Self> {
-        static COUNTER: Counter = Counter::new(0);
-        next_id(&COUNTER).map(Self)
-    }
-}
+#[derive(Id, Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct RenderPipelineId(IdType);
 
 #[derive(Clone, Debug)]
 pub struct RenderPipeline {
@@ -29,7 +20,7 @@ impl RenderPipeline {
 impl From<wgpu::RenderPipeline> for RenderPipeline {
     fn from(value: wgpu::RenderPipeline) -> Self {
         RenderPipeline {
-            id: RenderPipelineId::new().expect("The system ran out of unique `RenderPipelineId`s."),
+            id: RenderPipelineId::new(),
             value: Arc::new(value),
         }
     }
@@ -44,18 +35,8 @@ impl Deref for RenderPipeline {
     }
 }
 
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct ComputePipelineId(Id);
-
-impl ComputePipelineId {
-    /// Creates a new, unique [`ComputePipelineId`].
-    /// Returns [`None`] if the supply of unique ids has been exhausted.
-    #[allow(clippy::new_without_default)]
-    fn new() -> Option<Self> {
-        static COUNTER: Counter = Counter::new(0);
-        next_id(&COUNTER).map(Self)
-    }
-}
+#[derive(Id, Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct ComputePipelineId(IdType);
 
 #[derive(Clone, Debug)]
 pub struct ComputePipeline {
@@ -73,8 +54,7 @@ impl ComputePipeline {
 impl From<wgpu::ComputePipeline> for ComputePipeline {
     fn from(value: wgpu::ComputePipeline) -> Self {
         ComputePipeline {
-            id: ComputePipelineId::new()
-                .expect("The system ran out of unique `ComputePipelineId`s."),
+            id: ComputePipelineId::new(),
             value: Arc::new(value),
         }
     }

--- a/pipelined/bevy_render2/src/render_resource/texture.rs
+++ b/pipelined/bevy_render2/src/render_resource/texture.rs
@@ -1,17 +1,8 @@
-use crate::render_resource::{next_id, Counter, Id};
+use bevy_utils::{Id, IdType};
 use std::{ops::Deref, sync::Arc};
 
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct TextureId(Id);
-
-impl TextureId {
-    /// Creates a new, unique [`TextureId`].
-    /// Returns [`None`] if the supply of unique ids has been exhausted.
-    fn new() -> Option<Self> {
-        static COUNTER: Counter = Counter::new(0);
-        next_id(&COUNTER).map(Self)
-    }
-}
+#[derive(Id, Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct TextureId(IdType);
 
 #[derive(Clone, Debug)]
 pub struct Texture {
@@ -33,7 +24,7 @@ impl Texture {
 impl From<wgpu::Texture> for Texture {
     fn from(value: wgpu::Texture) -> Self {
         Texture {
-            id: TextureId::new().expect("The system ran out of unique `TextureId`s."),
+            id: TextureId::new(),
             value: Arc::new(value),
         }
     }
@@ -48,17 +39,8 @@ impl Deref for Texture {
     }
 }
 
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct TextureViewId(Id);
-
-impl TextureViewId {
-    /// Creates a new, unique [`TextureViewId`].
-    /// Returns [`None`] if the supply of unique ids has been exhausted.
-    fn new() -> Option<Self> {
-        static COUNTER: Counter = Counter::new(0);
-        next_id(&COUNTER).map(Self)
-    }
-}
+#[derive(Id, Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct TextureViewId(IdType);
 
 #[derive(Clone, Debug)]
 pub enum TextureViewValue {
@@ -82,7 +64,7 @@ impl TextureView {
 impl From<wgpu::TextureView> for TextureView {
     fn from(value: wgpu::TextureView) -> Self {
         TextureView {
-            id: TextureViewId::new().expect("The system ran out of unique `TextureViewId`s."),
+            id: TextureViewId::new(),
             value: TextureViewValue::TextureView(Arc::new(value)),
         }
     }
@@ -91,7 +73,7 @@ impl From<wgpu::TextureView> for TextureView {
 impl From<wgpu::SwapChainFrame> for TextureView {
     fn from(value: wgpu::SwapChainFrame) -> Self {
         TextureView {
-            id: TextureViewId::new().expect("The system ran out of unique `TextureViewId`s."),
+            id: TextureViewId::new(),
             value: TextureViewValue::SwapChainFrame(Arc::new(value)),
         }
     }
@@ -109,17 +91,8 @@ impl Deref for TextureView {
     }
 }
 
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct SamplerId(Id);
-
-impl SamplerId {
-    /// Creates a new, unique [`SamplerId`].
-    /// Returns [`None`] if the supply of unique ids has been exhausted.
-    fn new() -> Option<Self> {
-        static COUNTER: Counter = Counter::new(0);
-        next_id(&COUNTER).map(Self)
-    }
-}
+#[derive(Id, Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct SamplerId(IdType);
 
 #[derive(Clone, Debug)]
 pub struct Sampler {
@@ -137,7 +110,7 @@ impl Sampler {
 impl From<wgpu::Sampler> for Sampler {
     fn from(value: wgpu::Sampler) -> Self {
         Sampler {
-            id: SamplerId::new().expect("The system ran out of unique `SamplerId`s."),
+            id: SamplerId::new(),
             value: Arc::new(value),
         }
     }
@@ -168,7 +141,7 @@ impl SwapChainFrame {
 impl From<wgpu::SwapChainFrame> for SwapChainFrame {
     fn from(value: wgpu::SwapChainFrame) -> Self {
         Self {
-            id: TextureViewId::new().expect("The system ran out of unique `TextureViewId`s."),
+            id: TextureViewId::new(),
             value: Arc::new(value),
         }
     }

--- a/pipelined/bevy_render2/src/render_resource/texture.rs
+++ b/pipelined/bevy_render2/src/render_resource/texture.rs
@@ -1,8 +1,39 @@
-use bevy_utils::Uuid;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{ops::Deref, sync::Arc};
 
+static MAX_TEXTURE_ID: AtomicU64 = AtomicU64::new(0);
+static MAX_TEXTURE_VIEW_ID: AtomicU64 = AtomicU64::new(0);
+static MAX_SAMPLER_ID: AtomicU64 = AtomicU64::new(0);
+
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct TextureId(Uuid);
+pub struct TextureId(u64);
+
+impl TextureId {
+    /// Creates a new id by incrementing the atomic id counter.
+    pub fn new() -> Self {
+        Self(MAX_TEXTURE_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct TextureViewId(u64);
+
+impl TextureViewId {
+    /// Creates a new id by incrementing the atomic id counter.
+    pub fn new() -> Self {
+        Self(MAX_TEXTURE_VIEW_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct SamplerId(u64);
+
+impl SamplerId {
+    /// Creates a new id by incrementing the atomic id counter.
+    pub fn new() -> Self {
+        Self(MAX_SAMPLER_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct Texture {
@@ -24,7 +55,7 @@ impl Texture {
 impl From<wgpu::Texture> for Texture {
     fn from(value: wgpu::Texture) -> Self {
         Texture {
-            id: TextureId(Uuid::new_v4()),
+            id: TextureId::new(),
             value: Arc::new(value),
         }
     }
@@ -38,9 +69,6 @@ impl Deref for Texture {
         &self.value
     }
 }
-
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct TextureViewId(Uuid);
 
 #[derive(Clone, Debug)]
 pub enum TextureViewValue {
@@ -64,7 +92,7 @@ impl TextureView {
 impl From<wgpu::TextureView> for TextureView {
     fn from(value: wgpu::TextureView) -> Self {
         TextureView {
-            id: TextureViewId(Uuid::new_v4()),
+            id: TextureViewId::new(),
             value: TextureViewValue::TextureView(Arc::new(value)),
         }
     }
@@ -73,7 +101,7 @@ impl From<wgpu::TextureView> for TextureView {
 impl From<wgpu::SwapChainFrame> for TextureView {
     fn from(value: wgpu::SwapChainFrame) -> Self {
         TextureView {
-            id: TextureViewId(Uuid::new_v4()),
+            id: TextureViewId::new(),
             value: TextureViewValue::SwapChainFrame(Arc::new(value)),
         }
     }
@@ -91,9 +119,6 @@ impl Deref for TextureView {
     }
 }
 
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct SamplerId(Uuid);
-
 #[derive(Clone, Debug)]
 pub struct Sampler {
     id: SamplerId,
@@ -110,7 +135,7 @@ impl Sampler {
 impl From<wgpu::Sampler> for Sampler {
     fn from(value: wgpu::Sampler) -> Self {
         Sampler {
-            id: SamplerId(Uuid::new_v4()),
+            id: SamplerId::new(),
             value: Arc::new(value),
         }
     }
@@ -141,7 +166,7 @@ impl SwapChainFrame {
 impl From<wgpu::SwapChainFrame> for SwapChainFrame {
     fn from(value: wgpu::SwapChainFrame) -> Self {
         Self {
-            id: TextureViewId(Uuid::new_v4()),
+            id: TextureViewId::new(),
             value: Arc::new(value),
         }
     }

--- a/pipelined/bevy_render2/src/render_resource/texture.rs
+++ b/pipelined/bevy_render2/src/render_resource/texture.rs
@@ -1,35 +1,38 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{ops::Deref, sync::Arc};
 
-static MAX_TEXTURE_ID: AtomicU64 = AtomicU64::new(0);
-static MAX_TEXTURE_VIEW_ID: AtomicU64 = AtomicU64::new(0);
-static MAX_SAMPLER_ID: AtomicU64 = AtomicU64::new(0);
+static MAX_TEXTURE_ID: AtomicUsize = AtomicUsize::new(0);
+static MAX_TEXTURE_VIEW_ID: AtomicUsize = AtomicUsize::new(0);
+static MAX_SAMPLER_ID: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct TextureId(u64);
+pub struct TextureId(usize);
 
 impl TextureId {
     /// Creates a new id by incrementing the atomic id counter.
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self(MAX_TEXTURE_ID.fetch_add(1, Ordering::Relaxed))
     }
 }
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct TextureViewId(u64);
+pub struct TextureViewId(usize);
 
 impl TextureViewId {
     /// Creates a new id by incrementing the atomic id counter.
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self(MAX_TEXTURE_VIEW_ID.fetch_add(1, Ordering::Relaxed))
     }
 }
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct SamplerId(u64);
+pub struct SamplerId(usize);
 
 impl SamplerId {
     /// Creates a new id by incrementing the atomic id counter.
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self(MAX_SAMPLER_ID.fetch_add(1, Ordering::Relaxed))
     }

--- a/pipelined/bevy_render2/src/render_resource/uniform_vec.rs
+++ b/pipelined/bevy_render2/src/render_resource/uniform_vec.rs
@@ -1,6 +1,6 @@
 use crate::{
     render_resource::Buffer,
-    renderer::{RenderDevice, RenderQueue},
+    renderer::{GpuDevice, GpuQueue},
 };
 use crevice::std140::{self, AsStd140, DynamicUniform, Std140};
 use std::num::NonZeroU64;
@@ -70,12 +70,12 @@ impl<T: AsStd140> UniformVec<T> {
         }
     }
 
-    pub fn reserve(&mut self, capacity: usize, device: &RenderDevice) {
+    pub fn reserve(&mut self, capacity: usize, gpu_device: &GpuDevice) {
         if capacity > self.capacity {
             self.capacity = capacity;
             let size = self.item_size * capacity;
             self.scratch.resize(size, 0);
-            self.uniform_buffer = Some(device.create_buffer(&BufferDescriptor {
+            self.uniform_buffer = Some(gpu_device.create_buffer(&BufferDescriptor {
                 label: None,
                 size: size as wgpu::BufferAddress,
                 usage: BufferUsage::COPY_DST | BufferUsage::UNIFORM,
@@ -84,12 +84,12 @@ impl<T: AsStd140> UniformVec<T> {
         }
     }
 
-    pub fn reserve_and_clear(&mut self, capacity: usize, device: &RenderDevice) {
+    pub fn reserve_and_clear(&mut self, capacity: usize, gpu_device: &GpuDevice) {
         self.clear();
-        self.reserve(capacity, device);
+        self.reserve(capacity, gpu_device);
     }
 
-    pub fn write_buffer(&mut self, queue: &RenderQueue) {
+    pub fn write_buffer(&mut self, queue: &GpuQueue) {
         if let Some(uniform_buffer) = &self.uniform_buffer {
             let range = 0..self.item_size * self.values.len();
             let mut writer = std140::Writer::new(&mut self.scratch[range.clone()]);
@@ -147,17 +147,17 @@ impl<T: AsStd140> DynamicUniformVec<T> {
     }
 
     #[inline]
-    pub fn reserve(&mut self, capacity: usize, device: &RenderDevice) {
-        self.uniform_vec.reserve(capacity, device);
+    pub fn reserve(&mut self, capacity: usize, gpu_device: &GpuDevice) {
+        self.uniform_vec.reserve(capacity, gpu_device);
     }
 
     #[inline]
-    pub fn reserve_and_clear(&mut self, capacity: usize, device: &RenderDevice) {
-        self.uniform_vec.reserve_and_clear(capacity, device);
+    pub fn reserve_and_clear(&mut self, capacity: usize, gpu_device: &GpuDevice) {
+        self.uniform_vec.reserve_and_clear(capacity, gpu_device);
     }
 
     #[inline]
-    pub fn write_buffer(&mut self, queue: &RenderQueue) {
+    pub fn write_buffer(&mut self, queue: &GpuQueue) {
         self.uniform_vec.write_buffer(queue);
     }
 

--- a/pipelined/bevy_render2/src/renderer/gpu_device.rs
+++ b/pipelined/bevy_render2/src/renderer/gpu_device.rs
@@ -7,17 +7,17 @@ use crate::render_resource::{
 use std::sync::Arc;
 
 #[derive(Clone)]
-pub struct RenderDevice {
+pub struct GpuDevice {
     device: Arc<wgpu::Device>,
 }
 
-impl From<Arc<wgpu::Device>> for RenderDevice {
+impl From<Arc<wgpu::Device>> for GpuDevice {
     fn from(device: Arc<wgpu::Device>) -> Self {
         Self { device }
     }
 }
 
-impl RenderDevice {
+impl GpuDevice {
     /// List all features that may be used with this device.
     ///
     /// Functions may panic if you use unsupported features.

--- a/pipelined/bevy_render2/src/shader/shader.rs
+++ b/pipelined/bevy_render2/src/shader/shader.rs
@@ -1,20 +1,13 @@
 use bevy_asset::{AssetLoader, LoadContext, LoadedAsset};
-use bevy_reflect::{TypeUuid, Uuid};
-use bevy_utils::{tracing::error, BoxedFuture};
+use bevy_reflect::TypeUuid;
+use bevy_utils::{tracing::error, BoxedFuture, Id, IdType};
 use naga::{valid::ModuleInfo, Module, ShaderStage};
 use std::{borrow::Cow, collections::HashMap, marker::Copy};
 use thiserror::Error;
 use wgpu::{ShaderFlags, ShaderModuleDescriptor, ShaderSource};
 
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct ShaderId(Uuid);
-
-impl ShaderId {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        ShaderId(Uuid::new_v4())
-    }
-}
+#[derive(Id, Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct ShaderId(IdType);
 
 #[derive(Error, Debug)]
 pub enum ShaderReflectError {

--- a/pipelined/bevy_render2/src/texture/image.rs
+++ b/pipelined/bevy_render2/src/texture/image.rs
@@ -2,7 +2,7 @@ use super::image_texture_conversion::image_to_texture;
 use crate::{
     render_asset::{PrepareAssetError, RenderAsset},
     render_resource::{Sampler, Texture, TextureView},
-    renderer::{RenderDevice, RenderQueue},
+    renderer::{GpuDevice, GpuQueue},
     texture::BevyDefault,
 };
 use bevy_ecs::system::{lifetimeless::SRes, SystemParamItem};
@@ -350,7 +350,7 @@ pub struct GpuImage {
 impl RenderAsset for Image {
     type ExtractedAsset = Image;
     type PreparedAsset = GpuImage;
-    type Param = (SRes<RenderDevice>, SRes<RenderQueue>);
+    type Param = (SRes<GpuDevice>, SRes<GpuQueue>);
 
     fn extract_asset(&self) -> Self::ExtractedAsset {
         self.clone()

--- a/pipelined/bevy_render2/src/texture/texture_cache.rs
+++ b/pipelined/bevy_render2/src/texture/texture_cache.rs
@@ -1,6 +1,6 @@
 use crate::{
     render_resource::{Texture, TextureView},
-    renderer::RenderDevice,
+    renderer::GpuDevice,
 };
 use bevy_ecs::prelude::ResMut;
 use bevy_utils::HashMap;
@@ -26,7 +26,7 @@ pub struct TextureCache {
 impl TextureCache {
     pub fn get(
         &mut self,
-        render_device: &RenderDevice,
+        gpu_device: &GpuDevice,
         descriptor: TextureDescriptor<'static>,
     ) -> CachedTexture {
         match self.textures.entry(descriptor) {
@@ -42,7 +42,7 @@ impl TextureCache {
                     }
                 }
 
-                let texture = render_device.create_texture(&entry.key().clone());
+                let texture = gpu_device.create_texture(&entry.key().clone());
                 let default_view = texture.create_view(&TextureViewDescriptor::default());
                 entry.get_mut().push(CachedTextureMeta {
                     texture: texture.clone(),
@@ -56,7 +56,7 @@ impl TextureCache {
                 }
             }
             std::collections::hash_map::Entry::Vacant(entry) => {
-                let texture = render_device.create_texture(entry.key());
+                let texture = gpu_device.create_texture(entry.key());
                 let default_view = texture.create_view(&TextureViewDescriptor::default());
                 entry.insert(vec![CachedTextureMeta {
                     texture: texture.clone(),

--- a/pipelined/bevy_render2/src/view/mod.rs
+++ b/pipelined/bevy_render2/src/view/mod.rs
@@ -4,7 +4,7 @@ pub use window::*;
 
 use crate::{
     render_resource::DynamicUniformVec,
-    renderer::{RenderDevice, RenderQueue},
+    renderer::{GpuDevice, GpuQueue},
     RenderApp, RenderStage,
 };
 use bevy_app::{App, Plugin};
@@ -48,14 +48,14 @@ pub struct ViewUniformOffset {
 
 fn prepare_views(
     mut commands: Commands,
-    render_device: Res<RenderDevice>,
-    render_queue: Res<RenderQueue>,
+    gpu_device: Res<GpuDevice>,
+    gpu_queue: Res<GpuQueue>,
     mut view_uniforms: ResMut<ViewUniforms>,
     mut extracted_views: Query<(Entity, &ExtractedView)>,
 ) {
     view_uniforms
         .uniforms
-        .reserve_and_clear(extracted_views.iter_mut().len(), &render_device);
+        .reserve_and_clear(extracted_views.iter_mut().len(), &gpu_device);
     for (entity, camera) in extracted_views.iter() {
         let projection = camera.projection;
         let view_uniforms = ViewUniformOffset {
@@ -69,5 +69,5 @@ fn prepare_views(
         commands.entity(entity).insert(view_uniforms);
     }
 
-    view_uniforms.uniforms.write_buffer(&render_queue);
+    view_uniforms.uniforms.write_buffer(&gpu_queue);
 }


### PR DESCRIPTION
# Objective
- check of the following two points of the list of #2535
- Consider RenderDevice + RenderQueue -> GpuDevice + GpuQueue
- Consider using atomic counter instead of UUID for render resource ids

## Solution

- renamed RenderDevice, RenderQueue, RenderInstance, RenderContext to GpuDevice, GpuQueue, GpuInstance, GpuContext
- replaced the UUIDs in the render resource ids with an atomic u64 counter for better performance and no chance of collision
    - might be replaced by the ids of wgpu if they expose them directly
