### PR TITLE
Optimize dropping in bevy_ecs

### DIFF
--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -99,7 +99,11 @@ pub struct ComponentSparseSet {
 impl ComponentSparseSet {
     pub fn new(component_info: &ComponentInfo, capacity: usize) -> Self {
         Self {
-            dense: BlobVec::new(component_info.layout(), component_info.drop(), capacity),
+            dense: BlobVec::new(
+                component_info.layout(),
+                component_info.drop_multiple(),
+                capacity,
+            ),
             ticks: Vec::with_capacity(capacity),
             entities: Vec::with_capacity(capacity),
             sparse: Default::default(),

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -42,7 +42,11 @@ impl Column {
     pub fn with_capacity(component_info: &ComponentInfo, capacity: usize) -> Self {
         Column {
             component_id: component_info.id(),
-            data: BlobVec::new(component_info.layout(), component_info.drop(), capacity),
+            data: BlobVec::new(
+                component_info.layout(),
+                component_info.drop_multiple(),
+                capacity,
+            ),
             ticks: Vec::with_capacity(capacity),
         }
     }


### PR DESCRIPTION
Previously, the type-erased drop impl was for dropping a single element, which meant a large number of fn pointer calls and having to iterate each component even for no-op drops. This PR moves the iteration to the generic part, which should enable noop drops to get optimized much further.