### PR TITLE
Close window (pipelined-rendering)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ ron = "0.6.2"
 serde = { version = "1", features = ["derive"] }
 # Needed to poll Task examples
 futures-lite = "1.11.3"
-crevice = {path = "crates/crevice"}
+crevice = { path = "crates/crevice" }
 
 [[example]]
 name = "hello_world"
@@ -513,6 +513,10 @@ path = "examples/window/clear_color_pipelined.rs"
 [[example]]
 name = "multiple_windows"
 path = "examples/window/multiple_windows.rs"
+
+[[example]]
+name = "multiple_windows_pipelined"
+path = "examples/window/multiple_windows_pipelined.rs"
 
 [[example]]
 name = "scale_factor_override"

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -18,6 +18,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.5.0" }
 bevy_app = { path = "../bevy_app", version = "0.5.0" }
 bevy_math = { path = "../bevy_math", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
+bevy_input = { path = "../bevy_input", version = "0.5.0" }
 raw-window-handle = "0.3.0"
 
 # other

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
+bevy_ecs = { path = "../bevy_ecs", version = "0.5.0" }
 bevy_app = { path = "../bevy_app", version = "0.5.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.5.0" }
 bevy_math = { path = "../bevy_math", version = "0.5.0" }

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -16,7 +16,6 @@ keywords = ["bevy"]
 # bevy
 bevy_ecs = { path = "../bevy_ecs", version = "0.5.0" }
 bevy_app = { path = "../bevy_app", version = "0.5.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.5.0" }
 bevy_math = { path = "../bevy_math", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 raw-window-handle = "0.3.0"

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -18,12 +18,6 @@ pub struct CreateWindow {
     pub descriptor: WindowDescriptor,
 }
 
-/// An event that indicates a window should be closed.
-#[derive(Debug, Clone)]
-pub struct CloseWindow {
-    pub id: WindowId,
-}
-
 /// An event that is sent whenever a new window is created.
 #[derive(Debug, Clone)]
 pub struct WindowCreated {

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -26,6 +26,9 @@ pub struct WindowCreated {
 
 /// An event that is sent whenever a close was requested for a window. For example: when the "close"
 /// button is pressed on a window.
+///
+/// By default, these events are handled by closing the corresponding [`crate::Window`].
+/// To disable this behaviour, set `close_when_requested` on the [`crate::WindowPlugin`] to `false`
 #[derive(Debug, Clone)]
 pub struct WindowCloseRequested {
     pub id: WindowId,
@@ -34,7 +37,10 @@ pub struct WindowCloseRequested {
 /// An event that is sent whenever a window is closed.
 /// This will only be sent in response to the [`Window::close`] method.
 ///
-/// [`Window::close`]: `crate::window::Window::close`
+/// By default, when no windows are open, the app will close.
+/// To disable this behaviour, set `exit_on_all_closed` on the [`crate::WindowPlugin`] to `false`
+///
+/// [`Window::close`]: `crate::Window::close`
 #[derive(Debug, Clone)]
 pub struct WindowClosed {
     pub id: WindowId,

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -31,6 +31,15 @@ pub struct WindowCloseRequested {
     pub id: WindowId,
 }
 
+/// An event that is sent whenever a window is closed.
+/// This will only be sent in response to the [`Window::close`] method.
+///
+/// [`Window::close`]: `crate::window::Window::close`
+#[derive(Debug, Clone)]
+pub struct WindowClosed {
+    pub id: WindowId,
+}
+
 #[derive(Debug, Clone)]
 pub struct CursorMoved {
     pub id: WindowId,

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -40,6 +40,7 @@ impl Plugin for WindowPlugin {
         app.add_event::<WindowResized>()
             .add_event::<CreateWindow>()
             .add_event::<WindowCreated>()
+            .add_event::<WindowClosed>()
             .add_event::<WindowCloseRequested>()
             .add_event::<CursorMoved>()
             .add_event::<CursorEntered>()

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -41,7 +41,6 @@ impl Plugin for WindowPlugin {
             .add_event::<CreateWindow>()
             .add_event::<WindowCreated>()
             .add_event::<WindowCloseRequested>()
-            .add_event::<CloseWindow>()
             .add_event::<CursorMoved>()
             .add_event::<CursorEntered>()
             .add_event::<CursorLeft>()

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -22,15 +22,20 @@ use bevy_app::{prelude::*, Events};
 use bevy_ecs::system::IntoSystem;
 
 pub struct WindowPlugin {
+    /// Whether to add a default window based on the [`WindowDescriptor`] resource
     pub add_primary_window: bool,
-    pub exit_on_close: bool,
+    /// Whether to close the app when there are no open windows
+    pub exit_on_all_closed: bool,
+    /// Whether to close windows when they are requested to be closed (i.e. when the close button is pressed)
+    pub close_when_requested: bool,
 }
 
 impl Default for WindowPlugin {
     fn default() -> Self {
         WindowPlugin {
             add_primary_window: true,
-            exit_on_close: true,
+            close_when_requested: true,
+            exit_on_all_closed: true,
         }
     }
 }
@@ -69,8 +74,11 @@ impl Plugin for WindowPlugin {
             });
         }
 
-        if self.exit_on_close {
-            app.add_system(exit_on_window_close_system.system());
+        if self.exit_on_all_closed {
+            app.add_system(exit_on_all_closed.system());
+        }
+        if self.close_when_requested {
+            app.add_system(close_when_requested.system());
         }
     }
 }

--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -1,6 +1,7 @@
-use crate::{Window, WindowCloseRequested, Windows};
+use crate::{Window, WindowCloseRequested, WindowFocused, WindowId, Windows};
 use bevy_app::{AppExit, EventReader, EventWriter};
-use bevy_ecs::prelude::{Res, ResMut};
+use bevy_ecs::prelude::*;
+use bevy_input::{keyboard::KeyCode, Input};
 
 pub fn exit_on_all_closed(mut app_exit_events: EventWriter<AppExit>, windows: Res<Windows>) {
     if windows.iter().count() == 0 {
@@ -14,5 +15,26 @@ pub fn close_when_requested(
 ) {
     for event in closed.iter() {
         windows.get_mut(event.id).map(Window::close);
+    }
+}
+
+pub fn close_on_esc(
+    mut focused: Local<Option<WindowId>>,
+    mut focused_events: EventReader<WindowFocused>,
+    mut windows: ResMut<Windows>,
+    input: Res<Input<KeyCode>>,
+) {
+    for event in focused_events.iter() {
+        if event.focused {
+            *focused = Some(event.id);
+        }
+    }
+
+    if let Some(focused) = &*focused {
+        if input.just_pressed(KeyCode::Escape) {
+            if let Some(window) = windows.get_mut(*focused) {
+                window.close();
+            }
+        }
     }
 }

--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -1,11 +1,18 @@
-use crate::WindowCloseRequested;
+use crate::{Window, WindowCloseRequested, Windows};
 use bevy_app::{AppExit, EventReader, EventWriter};
+use bevy_ecs::prelude::{Res, ResMut};
 
-pub fn exit_on_window_close_system(
-    mut app_exit_events: EventWriter<AppExit>,
-    mut window_close_requested_events: EventReader<WindowCloseRequested>,
-) {
-    if window_close_requested_events.iter().next().is_some() {
+pub fn exit_on_all_closed(mut app_exit_events: EventWriter<AppExit>, windows: Res<Windows>) {
+    if windows.iter().count() == 0 {
         app_exit_events.send(AppExit);
+    }
+}
+
+pub fn close_when_requested(
+    mut windows: ResMut<Windows>,
+    mut closed: EventReader<WindowCloseRequested>,
+) {
+    for event in closed.iter() {
+        windows.get_mut(event.id).map(Window::close);
     }
 }

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -180,6 +180,7 @@ pub enum WindowCommand {
     SetResizeConstraints {
         resize_constraints: WindowResizeConstraints,
     },
+    Close,
 }
 
 /// Defines the way a window is displayed
@@ -506,6 +507,10 @@ impl Window {
             mode,
             resolution: (self.physical_width, self.physical_height),
         });
+    }
+
+    pub fn close(&mut self) {
+        self.command_queue.push(WindowCommand::Close);
     }
 
     #[inline]

--- a/crates/bevy_window/src/windows.rs
+++ b/crates/bevy_window/src/windows.rs
@@ -34,4 +34,8 @@ impl Windows {
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Window> {
         self.windows.values_mut()
     }
+
+    pub fn remove(&mut self, id: WindowId) -> Option<Window> {
+        self.windows.remove(&id)
+    }
 }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -16,8 +16,8 @@ use bevy_math::{ivec2, Vec2};
 use bevy_utils::tracing::{error, trace, warn};
 use bevy_window::{
     CreateWindow, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, ReceivedCharacter,
-    WindowBackendScaleFactorChanged, WindowCloseRequested, WindowCreated, WindowFocused,
-    WindowMoved, WindowResized, WindowScaleFactorChanged, Windows,
+    WindowBackendScaleFactorChanged, WindowCloseRequested, WindowClosed, WindowCreated,
+    WindowFocused, WindowMoved, WindowResized, WindowScaleFactorChanged, Windows,
 };
 use winit::{
     dpi::PhysicalPosition,
@@ -170,8 +170,12 @@ fn change_window(world: &mut World) {
             }
         }
     }
-    for window in removed_windows {
-        windows.remove(window);
+    if removed_windows.len() > 0 {
+        let mut events = world.get_resource_mut::<Events<WindowClosed>>().unwrap();
+        for id in removed_windows {
+            windows.remove(id);
+            events.send(WindowClosed { id });
+        }
     }
 }
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -170,7 +170,7 @@ fn change_window(world: &mut World) {
             }
         }
     }
-    if removed_windows.len() > 0 {
+    if !removed_windows.is_empty() {
         let mut events = world.get_resource_mut::<Events<WindowClosed>>().unwrap();
         for id in removed_windows {
             windows.remove(id);
@@ -280,8 +280,8 @@ pub fn winit_runner_with(mut app: App, mut event_loop: EventLoop<()>) {
                         window_id
                     } else {
                         warn!(
-                            "Skipped event for unknown winit Window Id {:?}",
-                            winit_window_id
+                            "Skipped event for unknown winit Window Id {:?}: {:?}",
+                            winit_window_id, event
                         );
                         return;
                     };
@@ -289,7 +289,10 @@ pub fn winit_runner_with(mut app: App, mut event_loop: EventLoop<()>) {
                 let window = if let Some(window) = windows.get_mut(window_id) {
                     window
                 } else {
-                    warn!("Skipped event for unknown Window Id {:?}", winit_window_id);
+                    warn!(
+                        "Skipped event for unknown Window Id {:?}: {:?}",
+                        winit_window_id, event
+                    );
                     return;
                 };
 

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -167,6 +167,7 @@ impl WinitWindows {
         self.windows.remove(&winit_id)
     }
 }
+
 pub fn get_fitting_videomode(
     monitor: &winit::monitor::MonitorHandle,
     width: u32,

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -160,6 +160,12 @@ impl WinitWindows {
     pub fn get_window_id(&self, id: winit::window::WindowId) -> Option<WindowId> {
         self.winit_to_window_id.get(&id).cloned()
     }
+
+    pub fn remove_window(&mut self, id: WindowId) -> Option<winit::window::Window> {
+        let winit_id = self.window_id_to_winit.remove(&id)?;
+        self.winit_to_window_id.remove(&winit_id);
+        self.windows.remove(&winit_id)
+    }
 }
 pub fn get_fitting_videomode(
     monitor: &winit::monitor::MonitorHandle,

--- a/examples/README.md
+++ b/examples/README.md
@@ -259,7 +259,7 @@ Example | File | Description
 `clear_color` | [`window/clear_color.rs`](./window/clear_color.rs) | Creates a solid color window
 `clear_color_pipelined` | [`window/clear_color_pipelined.rs`](./window/clear_color_pipelined.rs) | Creates a solid color window with the pipelined renderer
 `multiple_windows` | [`window/multiple_windows.rs`](./window/multiple_windows.rs) | Creates two windows and cameras viewing the same mesh
-`multiple_windows_pipelined` | [`window/multiple_windows_pipelined.rs`](./window/multiple_windows.rs) | Creates two windows and cameras viewing the same mesh
+`multiple_windows_pipelined` | [`window/multiple_windows_pipelined.rs`](./window/multiple_windows_pipelined.rs) | Creates two windows and cameras viewing the same mesh
 `scale_factor_override` | [`window/scale_factor_override.rs`](./window/scale_factor_override.rs) | Illustrates how to customize the default window settings
 `window_settings` | [`window/window_settings.rs`](./window/window_settings.rs) | Demonstrates customizing default window settings
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -259,6 +259,7 @@ Example | File | Description
 `clear_color` | [`window/clear_color.rs`](./window/clear_color.rs) | Creates a solid color window
 `clear_color_pipelined` | [`window/clear_color_pipelined.rs`](./window/clear_color_pipelined.rs) | Creates a solid color window with the pipelined renderer
 `multiple_windows` | [`window/multiple_windows.rs`](./window/multiple_windows.rs) | Creates two windows and cameras viewing the same mesh
+`multiple_windows_pipelined` | [`window/multiple_windows_pipelined.rs`](./window/multiple_windows.rs) | Creates two windows and cameras viewing the same mesh
 `scale_factor_override` | [`window/scale_factor_override.rs`](./window/scale_factor_override.rs) | Illustrates how to customize the default window settings
 `window_settings` | [`window/window_settings.rs`](./window/window_settings.rs) | Demonstrates customizing default window settings
 

--- a/examples/window/multiple_windows_pipelined.rs
+++ b/examples/window/multiple_windows_pipelined.rs
@@ -13,7 +13,7 @@ use bevy::{
         view::ExtractedWindows,
         RenderApp, RenderStage,
     },
-    window::{CreateWindow, WindowDescriptor, WindowId},
+    window::{close_on_esc, CreateWindow, WindowDescriptor, WindowId},
     PipelinedDefaultPlugins,
 };
 
@@ -22,7 +22,8 @@ fn main() {
     let mut app = App::new();
     app.add_plugins(PipelinedDefaultPlugins)
         .add_startup_system(setup)
-        .add_startup_system(create_new_window);
+        .add_startup_system(create_new_window)
+        .add_system(close_on_esc);
 
     let render_app = app.sub_app(RenderApp);
     render_app.add_system_to_stage(RenderStage::Extract, extract_secondary_camera_phases);

--- a/examples/window/multiple_windows_pipelined.rs
+++ b/examples/window/multiple_windows_pipelined.rs
@@ -45,8 +45,8 @@ fn extract_secondary_camera_phases(mut commands: Commands, active_cameras: Res<A
     }
 }
 
-const SECONDARY_CAMERA_NAME: &'static str = "Secondary";
-const SECONDARY_PASS_DRIVER: &'static str = "secondary_pass_driver";
+const SECONDARY_CAMERA_NAME: &str = "Secondary";
+const SECONDARY_PASS_DRIVER: &str = "secondary_pass_driver";
 
 fn create_new_window(
     mut create_window_events: EventWriter<CreateWindow>,

--- a/examples/window/multiple_windows_pipelined.rs
+++ b/examples/window/multiple_windows_pipelined.rs
@@ -1,0 +1,125 @@
+use bevy::{
+    core_pipeline::{draw_3d_graph, node, Transparent3d, ViewDepthTexture},
+    ecs::prelude::*,
+    math::Vec3,
+    pbr2::PointLightBundle,
+    prelude::{App, AssetServer, SpawnSceneCommands, Transform},
+    render2::{
+        camera::{
+            ActiveCameras, Camera, ExtractedCamera, ExtractedCameraNames, PerspectiveCameraBundle,
+        },
+        render_graph::{Node, RenderGraph, SlotValue},
+        render_phase::RenderPhase,
+        view::ExtractedWindows,
+        RenderApp, RenderStage,
+    },
+    window::{CreateWindow, WindowDescriptor, WindowId},
+    PipelinedDefaultPlugins,
+};
+
+/// This example creates a second window and draws a mesh from two different cameras.
+fn main() {
+    let mut app = App::new();
+    app.add_plugins(PipelinedDefaultPlugins)
+        .add_startup_system(setup)
+        .add_startup_system(create_new_window);
+
+    let render_app = app.sub_app(RenderApp);
+    render_app.add_system_to_stage(RenderStage::Extract, extract_secondary_camera_phases);
+    let mut graph = render_app.world.get_resource_mut::<RenderGraph>().unwrap();
+    graph.add_node(SECONDARY_PASS_DRIVER, SecondaryCameraDriver);
+    graph
+        .add_node_edge(node::MAIN_PASS_DEPENDENCIES, SECONDARY_PASS_DRIVER)
+        .unwrap();
+    app.run();
+}
+
+fn extract_secondary_camera_phases(mut commands: Commands, active_cameras: Res<ActiveCameras>) {
+    if let Some(secondary) = active_cameras.get(SECONDARY_CAMERA_NAME) {
+        if let Some(entity) = secondary.entity {
+            commands
+                .get_or_spawn(entity)
+                .insert(RenderPhase::<Transparent3d>::default());
+        }
+    }
+}
+
+const SECONDARY_CAMERA_NAME: &'static str = "Secondary";
+const SECONDARY_PASS_DRIVER: &'static str = "secondary_pass_driver";
+
+fn create_new_window(
+    mut create_window_events: EventWriter<CreateWindow>,
+
+    mut commands: Commands,
+    mut active_cameras: ResMut<ActiveCameras>,
+) {
+    let window_id = WindowId::new();
+
+    // sends out a "CreateWindow" event, which will be received by the windowing backend
+    create_window_events.send(CreateWindow {
+        id: window_id,
+        descriptor: WindowDescriptor {
+            width: 800.,
+            height: 600.,
+            vsync: false,
+            title: "second window".to_string(),
+            ..Default::default()
+        },
+    });
+    // second window camera
+    commands
+        .spawn_bundle(PerspectiveCameraBundle {
+            camera: Camera {
+                window: window_id,
+                name: Some(SECONDARY_CAMERA_NAME.into()),
+                ..Default::default()
+            },
+            transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..Default::default()
+        })
+        .insert(RenderPhase::<Transparent3d>::default());
+    active_cameras.add(SECONDARY_CAMERA_NAME);
+}
+
+struct SecondaryCameraDriver;
+impl Node for SecondaryCameraDriver {
+    fn run(
+        &self,
+        graph: &mut bevy::render2::render_graph::RenderGraphContext,
+        _render_context: &mut bevy::render2::renderer::RenderContext,
+        world: &World,
+    ) -> Result<(), bevy::render2::render_graph::NodeRunError> {
+        let extracted_cameras = world.get_resource::<ExtractedCameraNames>().unwrap();
+        let extracted_windows = world.get_resource::<ExtractedWindows>().unwrap();
+        if let Some(camera_3d) = extracted_cameras.entities.get(SECONDARY_CAMERA_NAME) {
+            let extracted_camera = world.entity(*camera_3d).get::<ExtractedCamera>().unwrap();
+            let extracted_window = extracted_windows.get(&extracted_camera.window_id).unwrap();
+            let depth_texture = world.entity(*camera_3d).get::<ViewDepthTexture>().unwrap();
+            let swap_chain_texture = extracted_window.swap_chain_frame.as_ref().unwrap().clone();
+            graph.run_sub_graph(
+                draw_3d_graph::NAME,
+                vec![
+                    SlotValue::Entity(*camera_3d),
+                    SlotValue::TextureView(swap_chain_texture),
+                    SlotValue::TextureView(depth_texture.view.clone()),
+                ],
+            )?;
+        }
+        Ok(())
+    }
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    // add entities to the world
+    commands.spawn_scene(asset_server.load("models/monkey/Monkey.gltf#Scene0"));
+    // light
+    commands.spawn_bundle(PointLightBundle {
+        transform: Transform::from_xyz(4.0, 5.0, 4.0),
+        ..Default::default()
+    });
+    // main camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(0.0, 0.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
+}

--- a/examples/window/multiple_windows_pipelined.rs
+++ b/examples/window/multiple_windows_pipelined.rs
@@ -67,17 +67,16 @@ fn create_new_window(
         },
     });
     // second window camera
-    commands
-        .spawn_bundle(PerspectiveCameraBundle {
-            camera: Camera {
-                window: window_id,
-                name: Some(SECONDARY_CAMERA_NAME.into()),
-                ..Default::default()
-            },
-            transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        camera: Camera {
+            window: window_id,
+            name: Some(SECONDARY_CAMERA_NAME.into()),
             ..Default::default()
-        })
-        .insert(RenderPhase::<Transparent3d>::default());
+        },
+        transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
+
     active_cameras.add(SECONDARY_CAMERA_NAME);
 }
 

--- a/pipelined/bevy_render2/src/camera/mod.rs
+++ b/pipelined/bevy_render2/src/camera/mod.rs
@@ -67,8 +67,8 @@ fn extract_cameras(
     for camera in active_cameras.iter() {
         let name = &camera.name;
         if let Some((entity, camera, transform)) = camera.entity.and_then(|e| query.get(e).ok()) {
-            entities.insert(name.clone(), entity);
             if let Some(window) = windows.get(camera.window) {
+                entities.insert(name.clone(), entity);
                 commands.get_or_spawn(entity).insert_bundle((
                     ExtractedCamera {
                         window_id: camera.window,

--- a/pipelined/bevy_render2/src/view/window.rs
+++ b/pipelined/bevy_render2/src/view/window.rs
@@ -7,7 +7,7 @@ use crate::{
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
 use bevy_utils::{tracing::debug, HashMap};
-use bevy_window::{RawWindowHandleWrapper, WindowId, Windows};
+use bevy_window::{RawWindowHandleWrapper, WindowClosed, WindowId, Windows};
 use std::ops::{Deref, DerefMut};
 use wgpu::TextureFormat;
 
@@ -57,7 +57,11 @@ impl DerefMut for ExtractedWindows {
     }
 }
 
-fn extract_windows(mut render_world: ResMut<RenderWorld>, windows: Res<Windows>) {
+fn extract_windows(
+    mut render_world: ResMut<RenderWorld>,
+    windows: Res<Windows>,
+    mut closed_windows: EventReader<WindowClosed>,
+) {
     let mut extracted_windows = render_world.get_resource_mut::<ExtractedWindows>().unwrap();
     for window in windows.iter() {
         let (new_width, new_height) = (
@@ -94,6 +98,9 @@ fn extract_windows(mut render_world: ResMut<RenderWorld>, windows: Res<Windows>)
             extracted_window.physical_width = new_width;
             extracted_window.physical_height = new_height;
         }
+    }
+    for closed_window in closed_windows.iter() {
+        extracted_windows.remove(&closed_window.id);
     }
 }
 


### PR DESCRIPTION
# Objective

- We didn't have any way to close specific windows

## Solution

- Integrate closing windows properly

Note that this still has some issues with bevy_render - in particular, I'm unsure what to do to/about the corresponding `WindowTextureNode`/`WindowSwapChainNode` when the window is closed.

At the moment, we panic whenever a window is closed, assuming it had anything drawn to it. This is not ideal.