### PR TITLE
Fix bevy_ecs::schedule::executor_parallel::system span management

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor_parallel.rs
+++ b/crates/bevy_ecs/src/schedule/executor_parallel.rs
@@ -182,14 +182,13 @@ impl ParallelExecutor {
                 let start_receiver = system_data.start_receiver.clone();
                 let finish_sender = self.finish_sender.clone();
                 let system = unsafe { systems[index].system_mut_unsafe() };
+                #[cfg(feature = "trace")] // NB: outside the task to get the TLS current span
+                let system_span = bevy_utils::tracing::info_span!("system", name = &*system.name());
                 let task = async move {
                     start_receiver
                         .recv()
                         .await
                         .unwrap_or_else(|error| unreachable!(error));
-                    #[cfg(feature = "trace")]
-                    let system_span =
-                        bevy_utils::tracing::info_span!("system", name = &*system.name());
                     #[cfg(feature = "trace")]
                     let system_guard = system_span.enter();
                     unsafe { system.run_unsafe((), world) };


### PR DESCRIPTION
# Objective

- Fixes #2904 (see for context)

## Solution

- Simply hoist span creation out of the threaded task
- Confirmed to solve the issue locally

Now all events have the full span parent tree up through `bevy_ecs::schedule::stage` all the way to `bevy_app::app::bevy_app` (and its parents in bevy-consumer code, if any).
