### PR TITLE
Removed reference to non-exsisting copyright notice

### DIFF
--- a/docs/LICENSE-MIT
+++ b/docs/LICENSE-MIT
@@ -7,8 +7,8 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+This permission notice shall be included in all copies or substantial portions
+of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,


### PR DESCRIPTION
This project has removed the copyright notice, which usually lives at the top of the MIT license. However, the license text still referred to the copyright notice. This commit removes that reference.

# Objective
Have an easily understandable license.

## Solution
Removed a reference to a copyright notice that doesn't exist.
