### PR TITLE
texture atlas builder: use correct pixel size instead of 4

### DIFF
--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -171,7 +171,7 @@ impl TextureAtlasBuilder {
                     atlas_texture = Texture::new_fill(
                         Extent3d::new(current_width, current_height, 1),
                         TextureDimension::D2,
-                        &[0, 0, 0, 0],
+                        &vec![0; self.format.pixel_size()],
                         self.format,
                     );
                     Some(rect_placements)


### PR DESCRIPTION
# Objective

- Fixes #2919 
- initial pixel was hard coded and not dependent on texture format

## Solution

- Replace the hard coded pixel with one using the texture pixel size
