### PR TITLE
Implement Component trait for Size and Rect

### DIFF
--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -11,3 +11,4 @@ keywords = ["bevy"]
 [dependencies]
 glam = { version = "0.18.0", features = ["serde", "bytemuck"] }
 bevy_reflect = { path = "../bevy_reflect", version = "0.5.0", features = ["bevy"] }
+bevy_ecs = { path = "../bevy_ecs", version = "0.5.0" }

--- a/crates/bevy_math/src/geometry.rs
+++ b/crates/bevy_math/src/geometry.rs
@@ -1,9 +1,10 @@
+use bevy_ecs::component::Component;
 use bevy_reflect::Reflect;
 use glam::Vec2;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
 /// A two dimensional "size" as defined by a width and height
-#[derive(Copy, Clone, PartialEq, Debug, Reflect)]
+#[derive(Component, Copy, Clone, PartialEq, Debug, Reflect)]
 #[reflect(PartialEq)]
 pub struct Size<T: Reflect + PartialEq = f32> {
     pub width: T,
@@ -26,7 +27,7 @@ impl<T: Default + Reflect + PartialEq> Default for Size<T> {
 }
 
 /// A rect, as defined by its "side" locations
-#[derive(Copy, Clone, PartialEq, Debug, Reflect)]
+#[derive(Component, Copy, Clone, PartialEq, Debug, Reflect)]
 #[reflect(PartialEq)]
 pub struct Rect<T: Reflect + PartialEq> {
     pub left: T,


### PR DESCRIPTION
Currently existing Bevy Bundles that use Size or Rect as components stopped working after 07ed1d053e7946a116ce3eef273fc93dd246f49d, so implementing the Component trait for these two structs should fix that.

# Objective

Make it so that Entities that use Size as a component can work.

## Solution

By deriving the Component trait for Size and Rect, it can be used as components for Entities.
