### PR TITLE
[Merged by Bors] - Simplify sending empty events

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -915,5 +915,5 @@ fn run_once(mut app: App) {
 }
 
 /// An event that indicates the app should exit. This will fully exit the app process.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct AppExit;

--- a/crates/bevy_input/src/system.rs
+++ b/crates/bevy_input/src/system.rs
@@ -13,7 +13,7 @@ pub fn exit_on_esc_system(
     for event in keyboard_input_events.iter() {
         if let Some(key_code) = event.key_code {
             if event.state == ElementState::Pressed && key_code == KeyCode::Escape {
-                app_exit_events.send(AppExit);
+                app_exit_events.send_default();
             }
         }
     }

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -6,15 +6,20 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_event::<MyEvent>()
+        .add_event::<PlaySound>()
         .init_resource::<EventTriggerState>()
-        .add_system(event_trigger_system)
-        .add_system(event_listener_system)
+        .add_system(event_trigger)
+        .add_system(event_listener)
+        .add_system(sound_player)
         .run();
 }
 
 struct MyEvent {
     pub message: String,
 }
+
+#[derive(Default)]
+struct PlaySound;
 
 struct EventTriggerState {
     event_timer: Timer,
@@ -28,22 +33,32 @@ impl Default for EventTriggerState {
     }
 }
 
-// sends MyEvent every second
-fn event_trigger_system(
+// sends MyEvent and PlaySound every second
+fn event_trigger(
     time: Res<Time>,
     mut state: ResMut<EventTriggerState>,
     mut my_events: EventWriter<MyEvent>,
+    mut play_sound_events: EventWriter<PlaySound>,
 ) {
     if state.event_timer.tick(time.delta()).finished() {
         my_events.send(MyEvent {
             message: "MyEvent just happened!".to_string(),
         });
+        // When sending an event which implements `Default` you can use `fire()` to send the default
+        // value.
+        play_sound_events.send_default();
     }
 }
 
 // prints events as they come in
-fn event_listener_system(mut events: EventReader<MyEvent>) {
+fn event_listener(mut events: EventReader<MyEvent>) {
     for my_event in events.iter() {
         info!("{}", my_event.message);
+    }
+}
+
+fn sound_player(mut play_sound_events: EventReader<PlaySound>) {
+    for _ in play_sound_events.iter() {
+        info!("Playing a sound");
     }
 }

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -44,8 +44,6 @@ fn event_trigger(
         my_events.send(MyEvent {
             message: "MyEvent just happened!".to_string(),
         });
-        // When sending an event which implements `Default` you can use `fire()` to send the default
-        // value.
         play_sound_events.send_default();
     }
 }


### PR DESCRIPTION
# Objective

When using empty events, it can feel redundant to have to specify the type of the event when sending it.

## Solution

Add a new `fire()` function that sends the default value of the event. This requires that the event derives Default.
