### PR TITLE
[Merged by Bors] - Add docstring comment to Style to reference CSS

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -61,6 +61,8 @@ impl AddAssign<f32> for Val {
 /// 
 /// The UI layout system follows the CSS layout model specification (see
 /// [this section](https://www.w3.org/TR/CSS2/visuren.html) in particular).
+///
+/// You may find [this flexbox guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) helpful.
 #[derive(Component, Clone, PartialEq, Debug, Reflect)]
 #[reflect(Component, PartialEq)]
 pub struct Style {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -58,7 +58,7 @@ impl AddAssign<f32> for Val {
 }
 
 /// UI node style.
-/// 
+///
 /// The UI layout system follows the CSS layout model specification (see
 /// [this section](https://www.w3.org/TR/CSS2/visuren.html) in particular).
 ///

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -61,6 +61,8 @@ impl AddAssign<f32> for Val {
 ///
 /// The UI layout system follows the CSS layout model specification (see
 /// [this section](https://www.w3.org/TR/CSS2/visuren.html) in particular).
+/// One notable difference however is that the vertical axis is inverted,
+/// with the Y axis pointing up in Bevy (origin in bottom left corner).
 ///
 /// You may find [this flexbox guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) helpful.
 #[derive(Component, Clone, PartialEq, Debug, Reflect)]

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -57,6 +57,10 @@ impl AddAssign<f32> for Val {
     }
 }
 
+/// UI node style.
+/// 
+/// The UI layout system follows the CSS layout model specification (see
+/// [this section](https://www.w3.org/TR/CSS2/visuren.html) in particular).
 #[derive(Component, Clone, PartialEq, Debug, Reflect)]
 #[reflect(Component, PartialEq)]
 pub struct Style {


### PR DESCRIPTION
Mention the fact that the UI layout system is based on the CSS layout
model through a docstring comment on the `Style` type.

# Objective

Explain to new users that the Bevy UI uses the CSS layout model, to lower the barrier to entry given the fact documentation (book and code) is fairly limited on the topic.

## Solution

Fix as discussed with @alice-i-cecile on #2918.
