### PR TITLE
[Merged by Bors] - Make ECS benchmark more representative

### DIFF
--- a/benches/benches/bevy_ecs/world_get.rs
+++ b/benches/benches/bevy_ecs/world_get.rs
@@ -23,7 +23,7 @@ const RANGE: std::ops::Range<u32> = 5..6;
 fn setup<T: Component + Default>(entity_count: u32) -> World {
     let mut world = World::default();
     world.spawn_batch((0..entity_count).map(|_| (T::default(),)));
-    world
+    black_box(world)
 }
 
 fn world_entity(criterion: &mut Criterion) {
@@ -126,6 +126,7 @@ fn world_query_iter(criterion: &mut Criterion) {
                 for comp in query.iter(&world) {
                     black_box(comp);
                     count += 1;
+                    black_box(count);
                 }
                 assert_eq!(black_box(count), entity_count);
             });
@@ -139,6 +140,7 @@ fn world_query_iter(criterion: &mut Criterion) {
                 for comp in query.iter(&world) {
                     black_box(comp);
                     count += 1;
+                    black_box(count);
                 }
                 assert_eq!(black_box(count), entity_count);
             });
@@ -163,6 +165,7 @@ fn world_query_for_each(criterion: &mut Criterion) {
                 query.for_each(&world, |comp| {
                     black_box(comp);
                     count += 1;
+                    black_box(count);
                 });
                 assert_eq!(black_box(count), entity_count);
             });
@@ -176,6 +179,7 @@ fn world_query_for_each(criterion: &mut Criterion) {
                 query.for_each(&world, |comp| {
                     black_box(comp);
                     count += 1;
+                    black_box(count);
                 });
                 assert_eq!(black_box(count), entity_count);
             });


### PR DESCRIPTION
# Objective

- The addition was being optimised out in the `for_each` loop, but not the `for` loop
- Previously this meant that the `for_each` loop looked 3 times as fast - it's actually only 2 times as fast
- Effectively, the addition take one unit of time, the for_each takes one unit of time, and the for loop version takes two units of time. 

## Solution

- `black_box` the count in each loop

Note that this does not fix `for_each` being faster than `for`, unfortunately.
