### PR TITLE
[Merged by Bors] - Add entity ID to expect() message

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -187,13 +187,8 @@ impl World {
     #[inline]
     pub fn entity(&self, entity: Entity) -> EntityRef {
         // Lazily evaluate panic!() via unwrap_or_else() to avoid allocation unless failure
-        self.get_entity(entity).unwrap_or_else(|| {
-            panic!(
-                "Entity #{} does not exist (generation #{})",
-                entity.id(),
-                entity.generation()
-            )
-        })
+        self.get_entity(entity)
+            .unwrap_or_else(|| panic!("Entity {:?} does not exist", entity))
     }
 
     /// Retrieves an [EntityMut] that exposes read and write operations for the given `entity`.
@@ -219,13 +214,8 @@ impl World {
     #[inline]
     pub fn entity_mut(&mut self, entity: Entity) -> EntityMut {
         // Lazily evaluate panic!() via unwrap_or_else() to avoid allocation unless failure
-        self.get_entity_mut(entity).unwrap_or_else(|| {
-            panic!(
-                "Entity #{} does not exist (generation #{})",
-                entity.id(),
-                entity.generation()
-            )
-        })
+        self.get_entity_mut(entity)
+            .unwrap_or_else(|| panic!("Entity {:?} does not exist", entity))
     }
 
     /// Retrieves an [EntityRef] that exposes read-only operations for the given `entity`.


### PR DESCRIPTION
Add the entity ID and generation to the expect() message of two
world accessors, to make it easier to debug use-after-free issues.
Coupled with e.g. bevy-inspector-egui which also displays the entity ID,
this makes it much easier to identify what entity is being misused.

# Objective

Make it easier to identity an entity being accessed after being deleted.

## Solution

Augment the error message of some `expect()` call with the entity ID and
generation. Combined with some external tool like `bevy-inspector-egui`, which
also displays the entity ID, this increases the chances to be able to identify
the entity, and therefore find the error that led to a use-after-despawn.
