### PR TITLE
[Merged by Bors] - Remove Lutris from NixOS dependency section

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -73,8 +73,7 @@ These packages provide the dependencies required to run a bevy project. They can
 Based on your global configuration it also might be necessary to allow unfree packages:
 
 ```bash
-export NIXPKGS_ALLOW_UNFREE=1 # needed for lutris
-nix-shell -p cargo pkgconfig udev lutris alsaLib x11 xorg.libXcursor xorg.libXrandr xorg.libXi vulkan-tools vulkan-headers vulkan-loader vulkan-validation-layers
+nix-shell -p cargo pkgconfig udev alsaLib x11 xorg.libXcursor xorg.libXrandr xorg.libXi vulkan-tools vulkan-headers vulkan-loader vulkan-validation-layers
 ```
 
 Alternatively, you can define `shell.nix` containing:
@@ -87,7 +86,7 @@ with pkgs;
 mkShell {
   buildInputs = [
     cargo
-    pkgconfig udev alsaLib lutris
+    pkgconfig udev alsaLib
     x11 xorg.libXcursor xorg.libXrandr xorg.libXi
     vulkan-tools vulkan-headers vulkan-loader vulkan-validation-layers
   ];


### PR DESCRIPTION
# Objective

- Using the instructions given for NixOS results in an unnecessarily long time to evaluate the shell expression due to unnecessary dependencies pulled in by `lutris`.

## Solution

- Removed `lutris` dependency.

Lutris is a GUI tool for running games on wine, I'm assuming it was pulled in by accident as it's definitely not necessary for running bevy. A hello world example, at the least, works fine without it.
