### PR TITLE
In use-after-despawn situation, make despawning system name available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,6 +315,10 @@ path = "examples/ecs/system_sets.rs"
 name = "timers"
 path = "examples/ecs/timers.rs"
 
+[[example]]
+name = "use_after_despawn"
+path = "examples/ecs/use_after_despawn.rs"
+
 # Games
 [[example]]
 name = "alien_cake_addict"

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -740,6 +740,11 @@ fn find_ambiguities(systems: &[impl SystemContainer]) -> Vec<(usize, usize, Vec<
 
 impl Stage for SystemStage {
     fn run(&mut self, world: &mut World) {
+        if world.despawned.len() > 0 {
+            println!("despawned clear {}", world.despawned.len());
+            world.despawned.clear();
+        }
+
         if let Some(world_id) = self.world_id {
             assert!(
                 world.id() == world_id,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -519,11 +519,15 @@ impl<'w, 's> SystemParamFetch<'w, 's> for CommandQueue {
     #[inline]
     unsafe fn get_param(
         state: &'s mut Self,
-        _system_meta: &SystemMeta,
+        system_meta: &SystemMeta,
         world: &'w World,
         _change_tick: u32,
     ) -> Self::Item {
-        Commands::new(state, world)
+        let name: &'static str = match system_meta.name {
+            std::borrow::Cow::Borrowed(s) => s,
+            std::borrow::Cow::Owned(_) => "owned",
+        };
+        Commands::new(state, world).with_name(name)
     }
 }
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -411,6 +411,11 @@ impl<'w> EntityMut<'w> {
         let table_row;
         let moved_entity;
         {
+            if let Some(name) = world.system_name {
+                println!("world despawn from {}", name);
+                world.despawned.push((self.entity, name));
+            }
+
             let archetype = &mut world.archetypes[location.archetype_id];
             for component_id in archetype.components() {
                 let removed_components = world

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -478,10 +478,6 @@ impl World {
     /// ```
     #[inline]
     pub fn despawn(&mut self, entity: Entity) -> bool {
-        if let Some(name) = self.system_name {
-            println!("world despawn from {}", name);
-            self.despawned.push((entity, name));
-        }
         self.get_entity_mut(entity)
             .map(|e| {
                 e.despawn();

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -83,6 +83,8 @@ pub struct World {
     main_thread_validator: MainThreadValidator,
     pub(crate) change_tick: AtomicU32,
     pub(crate) last_change_tick: u32,
+    pub(crate) despawned: Vec<(Entity, &'static str)>,
+    pub(crate) system_name: Option<&'static str>,
 }
 
 impl Default for World {
@@ -101,6 +103,8 @@ impl Default for World {
             // are detected on first system runs and for direct world queries.
             change_tick: AtomicU32::new(1),
             last_change_tick: 0,
+            despawned: Vec::new(),
+            system_name: None,
         }
     }
 }
@@ -115,6 +119,12 @@ impl World {
     #[inline]
     pub fn new() -> World {
         World::default()
+    }
+
+    #[inline]
+    pub fn set_system_name(&mut self, name: Option<&'static str>) {
+        println!("set system name {:?}", name);
+        self.system_name = name;
     }
 
     /// Retrieves this [`World`]'s unique ID
@@ -468,6 +478,10 @@ impl World {
     /// ```
     #[inline]
     pub fn despawn(&mut self, entity: Entity) -> bool {
+        if let Some(name) = self.system_name {
+            println!("world despawn from {}", name);
+            self.despawned.push((entity, name));
+        }
         self.get_entity_mut(entity)
             .map(|e| {
                 e.despawn();

--- a/crates/bevy_transform/src/hierarchy/hierarchy.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy.rs
@@ -9,6 +9,7 @@ use bevy_utils::tracing::debug;
 #[derive(Debug)]
 pub struct DespawnRecursive {
     entity: Entity,
+    name: &'static str,
 }
 
 pub fn despawn_with_children_recursive(world: &mut World, entity: Entity) {
@@ -38,7 +39,10 @@ fn despawn_with_children_recursive_inner(world: &mut World, entity: Entity) {
 
 impl Command for DespawnRecursive {
     fn write(self, world: &mut World) {
+        println!("despawn recursive from {}", self.name);
+        world.set_system_name(Some(self.name));
         despawn_with_children_recursive(world, self.entity);
+        world.set_system_name(None);
     }
 }
 
@@ -51,7 +55,8 @@ impl<'w, 's, 'a> DespawnRecursiveExt for EntityCommands<'w, 's, 'a> {
     /// Despawns the provided entity and its children.
     fn despawn_recursive(mut self) {
         let entity = self.id();
-        self.commands().add(DespawnRecursive { entity });
+        let name = self.system_name();
+        self.commands().add(DespawnRecursive { entity, name });
     }
 }
 

--- a/examples/ecs/use_after_despawn.rs
+++ b/examples/ecs/use_after_despawn.rs
@@ -3,7 +3,23 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_startup_system(do_spawn)
+        // This system despawns the entity in the Update stage.
         .add_system(do_despawn.system().label("despawn"))
+        // This system inserts into the entity in the Update stage.
+        // It is scheduled explicitly to run after do_despawn, so its Insert command
+        // will panic because in the meantime the Despawn command despawed the entity.
+        //
+        // Here it is simple. But it could be as complicated a schedule like
+        // the inserting system is some system of a third party plugin.
+        // About this imagined system you as a user,
+        //  you don't immediately know it exists,
+        //  you don't know when it is scheduled,
+        //  you don't know if it is handling intermittent despawned entities well.
+        // But eventually the parallel schedule is run in a way where
+        // both systems, your despawner and the third party inserter, run in the same stage
+        // in an order where they clash.
+        // And when you don't know, which of my entity kinds was it? When was it despawned?
+        // How to reproduce it?
         .add_system(do_insert.system().after("despawn"))
         .run();
 }

--- a/examples/ecs/use_after_despawn.rs
+++ b/examples/ecs/use_after_despawn.rs
@@ -1,0 +1,28 @@
+use bevy::prelude::*;
+
+fn main() {
+    App::new()
+        .add_startup_system(do_spawn)
+        .add_system(do_despawn.system().label("despawn"))
+        .add_system(do_insert.system().after("despawn"))
+        .run();
+}
+
+fn do_spawn(mut cmds: Commands) {
+    let entity = cmds.spawn().insert(5u32).id();
+    println!("{:?} spawn", entity);
+}
+
+fn do_despawn(query: Query<Entity, With<u32>>, mut cmds: Commands) {
+    for entity in query.iter() {
+        println!("{:?} despawn", entity);
+        cmds.entity(entity).despawn();
+    }
+}
+
+fn do_insert(query: Query<Entity, With<u32>>, mut cmds: Commands) {
+    for entity in query.iter() {
+        println!("{:?} insert", entity);
+        cmds.entity(entity).insert("panic".to_string());
+    }
+}


### PR DESCRIPTION
This draft sketches a debugging help in a situation where a command like `Insert` acts upon an entity which was already despawned. When the command is applied it will panic with the message
```
thread 'main' panicked at 'Could not add a component (of type `alloc::string::String`) to entity 0v0 because it doesn't exist in this World.
If this command was added to a newly spawned entity, ensure that you have not despawned that entity within the same stage.
This may have occurred due to system order ambiguity, or if the spawning system has multiple command buffers
```
This tells which component (String) should have been added to which Entity (0v0) together with a hint that some system order dependency exist and is off.
To debug a situation like this one question would be "Which system was despawning this entity?" but this question might not be easy to answer.

A related issue and PR is
* #2004 and #2241 but configurable error handling does not help in debugging the issue nor can it be easily be used in the case where the panicing system is a third party system

## Solution

The panic message should contain the name of the system which despawned the entity, so when debugging I can immediately jump to this system, schedule it in a different stage or delay the despawn:
```
thread 'main' panicked at 'Could not add a component (of type `alloc::string::String`) to entity 0v0 because it doesn't exist in this World.
Entity was despawned in use_after_despawn::do_despawn.
If this command was added to a newly spawned entity, ensure that you have not despawned that entity within the same stage.
This may have occurred due to system order ambiguity, or if the spawning system has multiple command buffers'
```
In this case `use_after_despawn::do_despawn` is the fully qualified name of the system `do_despawn`.

The implementation extents `Commands` with a system name (if it is a static str).
When `Despawn` (or `DespawnRecursive`) is added to the queue the struct carries on this system name.
When `Despawn::write` is run, it is setting some crude system name state on the world.
When `EntityRef::despawn` is run, it looks up the system name from the world and adds this entity and this name to a `World::despawned` vec.
This vec is cleared at the beginning of every stage (ignoring use cases without stages).
When a panic happens due to a missing entity during a `Command::write`, you can now look up the entity in the `World::despawned` vec and put the system name in the panic message.