### PR TITLE
[Merged by Bors] - fix window resize after wgpu 0.11 upgrade

### DIFF
--- a/pipelined/bevy_render2/src/view/window.rs
+++ b/pipelined/bevy_render2/src/view/window.rs
@@ -136,7 +136,7 @@ pub fn prepare_windows(
         };
 
         // Do the initial surface configuration if it hasn't been configured yet
-        if window_surfaces.configured_windows.insert(window.id) {
+        if window_surfaces.configured_windows.insert(window.id) || window.size_changed {
             render_device.configure_surface(surface, &swap_chain_descriptor);
         }
 


### PR DESCRIPTION
The fix originally got introduced in [#2858](https://github.com/bevyengine/bevy/pull/2858/files#diff-0f34eeda7ac2fe1f9e9b27de92d9290e0b360ffa6f032770aff22b5fef4eaa63R137-R143) but got lost in the upgrade to wgpu 0.11 at https://github.com/bevyengine/bevy/pull/2933