### PR TITLE
specify uniform storage class for variables in `custom.wgsl`

### DIFF
--- a/assets/shaders/custom.wgsl
+++ b/assets/shaders/custom.wgsl
@@ -5,14 +5,14 @@ struct View {
     world_position: vec3<f32>;
 };
 [[group(0), binding(0)]]
-var view: View;
+var<uniform> view: View;
 
 [[block]]
 struct Mesh {
     transform: mat4x4<f32>;
 };
 [[group(2), binding(0)]]
-var mesh: Mesh;
+var<uniform> mesh: Mesh;
 
 struct Vertex {
     [[location(0)]] position: vec3<f32>;
@@ -38,7 +38,7 @@ struct CustomMaterial {
     color: vec4<f32>;
 };
 [[group(1), binding(0)]]
-var material: CustomMaterial;
+var<uniform> material: CustomMaterial;
 
 [[stage(fragment)]]
 fn fragment() -> [[location(0)]] vec4<f32> {


### PR DESCRIPTION
WGSL as shipped with wgpu 0.11 requires explicit storage classes for uniforms.