### PR TITLE
[Merged by Bors] - Fix CI for android

### DIFF
--- a/crates/bevy_render/src/shader/shader.rs
+++ b/crates/bevy_render/src/shader/shader.rs
@@ -106,9 +106,9 @@ pub fn glsl_to_spirv(
 impl Into<shaderc::ShaderKind> for ShaderStage {
     fn into(self) -> shaderc::ShaderKind {
         match self {
-            ShaderStages::VERTEX => shaderc::ShaderKind::Vertex,
-            ShaderStages::FRAGMENT => shaderc::ShaderKind::Fragment,
-            ShaderStages::COMPUTE => shaderc::ShaderKind::Compute,
+            ShaderStage::Vertex => shaderc::ShaderKind::Vertex,
+            ShaderStage::Fragment => shaderc::ShaderKind::Fragment,
+            ShaderStage::Compute => shaderc::ShaderKind::Compute,
         }
     }
 }


### PR DESCRIPTION
# Objective

The update to wgpu 0.11 broke CI for android. This was due to a confusion between `bevy::render::ShaderStage` and `wgpu::ShaderStage`.


## Solution

Revert the incorrect change
