### PR TITLE
[Merged by Bors] - use correct size of pixel instead of 4

### DIFF
--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -168,10 +168,11 @@ impl TextureAtlasBuilder {
                 &contains_smallest_box,
             ) {
                 Ok(rect_placements) => {
-                    atlas_texture = Texture::new_fill(
-                        Extent3d::new(current_width, current_height, 1),
+                    let size = Extent3d::new(current_width, current_height, 1);
+                    atlas_texture = Texture::new(
+                        size,
                         TextureDimension::D2,
-                        &[0, 0, 0, 0],
+                        vec![0; self.format.pixel_size() * size.volume()],
                         self.format,
                     );
                     Some(rect_placements)

--- a/pipelined/bevy_sprite2/src/texture_atlas_builder.rs
+++ b/pipelined/bevy_sprite2/src/texture_atlas_builder.rs
@@ -176,14 +176,17 @@ impl TextureAtlasBuilder {
                 &contains_smallest_box,
             ) {
                 Ok(rect_placements) => {
-                    atlas_texture = Image::new_fill(
+                    atlas_texture = Image::new(
                         Extent3d {
                             width: current_width,
                             height: current_height,
                             depth_or_array_layers: 1,
                         },
                         TextureDimension::D2,
-                        &[0, 0, 0, 0],
+                        vec![
+                            0;
+                            self.format.pixel_size() * (current_width * current_height) as usize
+                        ],
                         self.format,
                     );
                     Some(rect_placements)


### PR DESCRIPTION
# Objective

- Fixes #2919 
- Initial pixel was hard coded and not dependent on texture format
- Replace #2920 as I noticed this needed to be done also on pipeline rendering branch

## Solution

- Replace the hard coded pixel with one using the texture pixel size
