### PR TITLE
Add error that arises from adding DefaultPlugin twice.

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -126,7 +126,7 @@ impl Plugin for LogPlugin {
             let subscriber = subscriber.with(tracy_layer);
 
             bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
+                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins. Also, check that you're not accidentally adding DefaultPlugins twice.");
         }
 
         #[cfg(target_arch = "wasm32")]
@@ -136,14 +136,14 @@ impl Plugin for LogPlugin {
                 tracing_wasm::WASMLayerConfig::default(),
             ));
             bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
+                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins. Also, check that you're not accidentally adding DefaultPlugins twice.");
         }
 
         #[cfg(target_os = "android")]
         {
             let subscriber = subscriber.with(android_tracing::AndroidLayer::default());
             bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
+                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins. Also, check that you're not accidentally adding DefaultPlugins twice.");
         }
     }
 }

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -126,7 +126,7 @@ impl Plugin for LogPlugin {
             let subscriber = subscriber.with(tracy_layer);
 
             bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins. Also, check that you're not accidentally adding DefaultPlugins twice.");
+                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins. Also, check that you're not accidentally adding DefaultPlugins more than once.");
         }
 
         #[cfg(target_arch = "wasm32")]
@@ -136,14 +136,14 @@ impl Plugin for LogPlugin {
                 tracing_wasm::WASMLayerConfig::default(),
             ));
             bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins. Also, check that you're not accidentally adding DefaultPlugins twice.");
+                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins. Also, check that you're not accidentally adding DefaultPlugins more than once.");
         }
 
         #[cfg(target_os = "android")]
         {
             let subscriber = subscriber.with(android_tracing::AndroidLayer::default());
             bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins. Also, check that you're not accidentally adding DefaultPlugins twice.");
+                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins. Also, check that you're not accidentally adding DefaultPlugins more than once.");
         }
     }
 }


### PR DESCRIPTION
# Objective

I was copy and pasting some code between projects and accidentally had `.add_plugins(DefaultPlugins)` twice. This resulted in `thread 'main' panicked at 'Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins: SetGlobalDefaultError { _no_construct: () }', /Users/mirkorainer/.cargo/registry/src/github.com-1ecc6299db9ec823/bevy_log-0.5.0/src/lib.rs:85:22
note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace`.

I understand this error to a degree, but I imagine importing Defaults could be a common mistake for beginners or people cobbling together examples found on blogs, etc. so wanted to add to the error message.

## Solution

Added an extra sentence to the error message.