### PR TITLE
[Merged by Bors] - Fix compile_fail tests

### DIFF
--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -787,7 +787,7 @@ mod tests {
     }
 }
 
-/// ```compile_fail
+/// ```compile_fail E0499
 /// use bevy_ecs::prelude::*;
 /// #[derive(Component)]
 /// struct A(usize);
@@ -806,7 +806,7 @@ mod tests {
 #[cfg(doctest)]
 fn system_query_iter_lifetime_safety_test() {}
 
-/// ```compile_fail
+/// ```compile_fail E0499
 /// use bevy_ecs::prelude::*;
 /// #[derive(Component)]
 /// struct A(usize);
@@ -821,7 +821,7 @@ fn system_query_iter_lifetime_safety_test() {}
 #[cfg(doctest)]
 fn system_query_get_lifetime_safety_test() {}
 
-/// ```compile_fail
+/// ```compile_fail E0499
 /// use bevy_ecs::prelude::*;
 /// #[derive(Component)]
 /// struct A(usize);
@@ -842,7 +842,7 @@ fn system_query_get_lifetime_safety_test() {}
 #[cfg(doctest)]
 fn system_query_set_iter_lifetime_safety_test() {}
 
-/// ```compile_fail
+/// ```compile_fail E0499
 /// use bevy_ecs::prelude::*;
 /// #[derive(Component)]
 /// struct A(usize);
@@ -863,7 +863,7 @@ fn system_query_set_iter_lifetime_safety_test() {}
 #[cfg(doctest)]
 fn system_query_set_iter_flip_lifetime_safety_test() {}
 
-/// ```compile_fail
+/// ```compile_fail E0499
 /// use bevy_ecs::prelude::*;
 /// #[derive(Component)]
 /// struct A(usize);
@@ -882,7 +882,7 @@ fn system_query_set_iter_flip_lifetime_safety_test() {}
 #[cfg(doctest)]
 fn system_query_set_get_lifetime_safety_test() {}
 
-/// ```compile_fail
+/// ```compile_fail E0499
 /// use bevy_ecs::prelude::*;
 /// #[derive(Component)]
 /// struct A(usize);
@@ -900,7 +900,7 @@ fn system_query_set_get_lifetime_safety_test() {}
 #[cfg(doctest)]
 fn system_query_set_get_flip_lifetime_safety_test() {}
 
-/// ```compile_fail
+/// ```compile_fail E0502
 /// use bevy_ecs::prelude::*;
 /// use bevy_ecs::system::SystemState;
 /// #[derive(Component)]
@@ -929,7 +929,7 @@ fn system_query_set_get_flip_lifetime_safety_test() {}
 #[cfg(doctest)]
 fn system_state_get_lifetime_safety_test() {}
 
-/// ```compile_fail
+/// ```compile_fail E0502
 /// use bevy_ecs::prelude::*;
 /// use bevy_ecs::system::SystemState;
 /// #[derive(Component)]


### PR DESCRIPTION
# Objective

- Bevy has several `compile_fail` test
- #2254 added `#[derive(Component)]`
- Those tests now fail for a different reason.
- This was not caught as these test still "successfully" failed to compile.

## Solution

- Add `#[derive(Component)]` to the doctest
- Also changed their cfg attribute from `doc` to `doctest`, so that these tests don't appear when running `cargo doc` with `--document-private-items`