### PR TITLE
Plugin - setup resource

### DIFF
--- a/crates/bevy_asset/src/debug_asset_server.rs
+++ b/crates/bevy_asset/src/debug_asset_server.rs
@@ -76,7 +76,7 @@ impl Plugin for DebugAssetServerPlugin {
         });
         let mut debug_asset_app = App::new();
         debug_asset_app
-            .insert_resource(AssetServerSettings {
+            .insert_setup_resource(AssetServerSettings {
                 asset_folder: "crates".to_string(),
                 watch_for_changes: true,
             })

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -70,6 +70,7 @@ pub struct AssetPlugin;
 ///
 /// This resource must be added before the [`AssetPlugin`] or `DefaultPlugins` to take effect.
 #[derive(Resource)]
+#[resource(setup)]
 pub struct AssetServerSettings {
     /// The base folder where assets are loaded from, relative to the executable.
     pub asset_folder: String,
@@ -93,8 +94,8 @@ impl Default for AssetServerSettings {
 /// delegate to the default `AssetIo` for the platform.
 pub fn create_platform_default_asset_io(app: &mut App) -> Box<dyn AssetIo> {
     let settings = app
-        .world
-        .get_resource_or_insert_with(AssetServerSettings::default);
+        .consume_setup_resource::<AssetServerSettings>()
+        .unwrap_or_default();
 
     #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
     let source = FileAssetIo::new(&settings.asset_folder, settings.watch_for_changes);

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -29,9 +29,7 @@ pub struct CorePlugin;
 impl Plugin for CorePlugin {
     fn build(&self, app: &mut App) {
         // Setup the default bevy task pools
-        app.world
-            .get_resource::<DefaultTaskPoolOptions>()
-            .cloned()
+        app.consume_setup_resource::<DefaultTaskPoolOptions>()
             .unwrap_or_default()
             .create_default_pools();
 

--- a/crates/bevy_core/src/task_pool_options.rs
+++ b/crates/bevy_core/src/task_pool_options.rs
@@ -35,6 +35,7 @@ impl TaskPoolThreadAssignmentPolicy {
 /// insert the default task pools into the resource map manually. If the pools are already inserted,
 /// this helper will do nothing.
 #[derive(Clone, Resource)]
+#[resource(setup)]
 pub struct DefaultTaskPoolOptions {
     /// If the number of physical cores is less than min_total_threads, force using
     /// min_total_threads

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -4,24 +4,6 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
 use syn::{parse_macro_input, parse_quote, DeriveInput, Error, Ident, Path, Result};
 
-pub fn derive_resource(input: TokenStream) -> TokenStream {
-    let mut ast = parse_macro_input!(input as DeriveInput);
-    let bevy_ecs_path: Path = crate::bevy_ecs_path();
-
-    ast.generics
-        .make_where_clause()
-        .predicates
-        .push(parse_quote! { Self: Send + Sync + 'static });
-
-    let struct_name = &ast.ident;
-    let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
-
-    TokenStream::from(quote! {
-        impl #impl_generics #bevy_ecs_path::system::Resource for #struct_name #type_generics #where_clause {
-        }
-    })
-}
-
 pub fn derive_component(input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as DeriveInput);
     let bevy_ecs_path: Path = crate::bevy_ecs_path();

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -2,6 +2,7 @@ extern crate proc_macro;
 
 mod component;
 mod fetch;
+mod resource;
 
 use crate::fetch::derive_world_query_impl;
 use bevy_macro_utils::{derive_label, get_named_struct_fields, BevyManifest};
@@ -454,9 +455,9 @@ pub(crate) fn bevy_ecs_path() -> syn::Path {
     BevyManifest::default().get_path("bevy_ecs")
 }
 
-#[proc_macro_derive(Resource)]
+#[proc_macro_derive(Resource, attributes(resource))]
 pub fn derive_resource(input: TokenStream) -> TokenStream {
-    component::derive_resource(input)
+    resource::derive_resource(input)
 }
 
 #[proc_macro_derive(Component, attributes(component))]

--- a/crates/bevy_ecs/macros/src/resource.rs
+++ b/crates/bevy_ecs/macros/src/resource.rs
@@ -1,0 +1,73 @@
+use bevy_macro_utils::Symbol;
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::{quote, ToTokens};
+use syn::{parse_macro_input, parse_quote, DeriveInput, Error, Ident, Path, Result};
+
+pub fn derive_resource(input: TokenStream) -> TokenStream {
+    let mut ast = parse_macro_input!(input as DeriveInput);
+    let bevy_ecs_path: Path = crate::bevy_ecs_path();
+
+    let attrs = match parse_resource_attr(&ast) {
+        Ok(attrs) => attrs,
+        Err(e) => return e.into_compile_error().into(),
+    };
+
+    let is_setup_resource = Ident::new(&format!("{}", attrs.is_setup_resource), Span::call_site());
+
+    ast.generics
+        .make_where_clause()
+        .predicates
+        .push(parse_quote! { Self: Send + Sync + 'static });
+
+    let struct_name = &ast.ident;
+    let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
+
+    TokenStream::from(quote! {
+        impl #impl_generics #bevy_ecs_path::system::Resource for #struct_name #type_generics #where_clause {
+            const IS_SETUP_RESOURCE: bool = #is_setup_resource;
+        }
+    })
+}
+
+pub const RESOURCE: Symbol = Symbol("resource");
+pub const SETUP_RESOURCE: Symbol = Symbol("setup");
+
+struct Attrs {
+    is_setup_resource: bool,
+}
+
+fn parse_resource_attr(ast: &DeriveInput) -> Result<Attrs> {
+    let meta_items = bevy_macro_utils::parse_attrs(ast, RESOURCE)?;
+
+    let mut attrs = Attrs {
+        is_setup_resource: false,
+    };
+
+    for meta in meta_items {
+        use syn::{
+            Meta::Path,
+            NestedMeta::{Lit, Meta},
+        };
+        match meta {
+            Meta(Path(m)) if m == SETUP_RESOURCE => attrs.is_setup_resource = true,
+            Meta(meta_item) => {
+                return Err(Error::new_spanned(
+                    meta_item.path(),
+                    format!(
+                        "unknown component attribute `{}`",
+                        meta_item.path().into_token_stream()
+                    ),
+                ));
+            }
+            Lit(lit) => {
+                return Err(Error::new_spanned(
+                    lit,
+                    "unexpected literal in component attribute",
+                ))
+            }
+        }
+    }
+
+    Ok(attrs)
+}

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -439,9 +439,13 @@ impl<'w, 's> Commands<'w, 's> {
     /// # bevy_ecs::system::assert_is_system(initialise_scoreboard);
     /// ```
     pub fn init_resource<R: Resource + FromWorld>(&mut self) {
-        self.queue.push(InitResource::<R> {
-            _phantom: PhantomData::<R>::default(),
-        });
+        if !R::IS_SETUP_RESOURCE {
+            self.queue.push(InitResource::<R> {
+                _phantom: PhantomData::<R>::default(),
+            });
+        } else {
+            error!("Initializing resource {} during execution has no effect. It should be added during setup using `insert_setup_resource`.", std::any::type_name::<R>());
+        }
     }
 
     /// Pushes a [`Command`] to the queue for inserting a [`Resource`] in the [`World`] with a specific value.
@@ -470,7 +474,11 @@ impl<'w, 's> Commands<'w, 's> {
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
     pub fn insert_resource<R: Resource>(&mut self, resource: R) {
-        self.queue.push(InsertResource { resource });
+        if !R::IS_SETUP_RESOURCE {
+            self.queue.push(InsertResource { resource });
+        } else {
+            error!("Inserting resource {} during execution has no effect. It should be added during setup using `insert_setup_resource`.", std::any::type_name::<R>());
+        }
     }
 
     /// Pushes a [`Command`] to the queue for removing a [`Resource`] from the [`World`].

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -258,7 +258,9 @@ impl_param_set!();
 /// # schedule.add_system_to_stage("update", write_resource_system.after("first"));
 /// # schedule.run_once(&mut world);
 /// ```
-pub trait Resource: Send + Sync + 'static {}
+pub trait Resource: Send + Sync + 'static {
+    const IS_SETUP_RESOURCE: bool = false;
+}
 
 /// Shared borrow of a [`Resource`].
 ///

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -47,14 +47,14 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// * Using [`tracing-wasm`](https://crates.io/crates/tracing-wasm) in WASM, logging
 /// to the browser console.
 ///
-/// You can configure this plugin using the resource [`LogSettings`].
+/// You can configure this plugin using the setup resource [`LogSettings`].
 /// ```no_run
 /// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins};
 /// # use bevy_log::LogSettings;
 /// # use bevy_utils::tracing::Level;
 /// fn main() {
 ///     App::new()
-///         .insert_resource(LogSettings {
+///         .insert_setup_resource(LogSettings {
 ///             level: Level::DEBUG,
 ///             filter: "wgpu=error,bevy_render=info,bevy_ecs=trace".to_string(),
 ///         })
@@ -92,6 +92,7 @@ pub struct LogPlugin;
 
 /// `LogPlugin` settings
 #[derive(Resource)]
+#[resource(setup)]
 pub struct LogSettings {
     /// Filters logs using the [`EnvFilter`] format
     pub filter: String,
@@ -122,7 +123,9 @@ impl Plugin for LogPlugin {
         }
 
         let default_filter = {
-            let settings = app.world.get_resource_or_insert_with(LogSettings::default);
+            let settings = app
+                .consume_setup_resource::<LogSettings>()
+                .unwrap_or_default();
             format!("{},{}", settings.level, settings.filter)
         };
         LogTracer::init().unwrap();

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -160,8 +160,9 @@ impl ImageSampler {
 
 /// Global resource for [`Image`] settings.
 ///
-/// Can be set via `insert_resource` during app initialization to change the default settings.
+/// Can be set via `insert_setup_resource` during app initialization to change the default settings.
 #[derive(Resource)]
+#[resource(setup)]
 pub struct ImageSettings {
     /// The default image sampler to use when [`ImageSampler`] is set to `Default`.
     pub default_sampler: wgpu::SamplerDescriptor<'static>,

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -67,10 +67,9 @@ impl Plugin for ImagePlugin {
             .set_untracked(DEFAULT_IMAGE_HANDLE, Image::default());
 
         let default_sampler = app
-            .world
-            .get_resource_or_insert_with(ImageSettings::default)
-            .default_sampler
-            .clone();
+            .consume_setup_resource::<ImageSettings>()
+            .unwrap_or_default()
+            .default_sampler;
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             let default_sampler = {
                 let device = render_app.world.resource::<RenderDevice>();

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -99,9 +99,7 @@ impl Plugin for WindowPlugin {
 
         if settings.add_primary_window {
             let window_descriptor = app
-                .world
-                .get_resource::<WindowDescriptor>()
-                .cloned()
+                .consume_setup_resource::<WindowDescriptor>()
                 .unwrap_or_default();
             let mut create_window_event = app.world.resource_mut::<Events<CreateWindow>>();
             create_window_event.send(CreateWindow {

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -859,6 +859,7 @@ pub enum MonitorSelection {
 /// [`examples/window/window_settings.rs`]: https://github.com/bevyengine/bevy/blob/latest/examples/window/window_settings.rs
 #[derive(Resource, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[resource(setup)]
 pub struct WindowDescriptor {
     /// The requested logical width of the window's client area.
     ///

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ImageSettings::default_nearest()) // prevents blurry sprites
+        .insert_setup_resource(ImageSettings::default_nearest()) // prevents blurry sprites
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(animate_sprite)

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -6,7 +6,7 @@ use bevy::{asset::LoadState, prelude::*};
 fn main() {
     App::new()
         .init_resource::<RpgSpriteHandles>()
-        .insert_resource(ImageSettings::default_nearest()) // prevents blurry sprites
+        .insert_setup_resource(ImageSettings::default_nearest()) // prevents blurry sprites
         .add_plugins(DefaultPlugins)
         .add_state(AppState::Setup)
         .add_system_set(SystemSet::on_enter(AppState::Setup).with_system(load_textures))

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -10,7 +10,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .insert_resource(ImageSettings::default_nearest())
+        .insert_setup_resource(ImageSettings::default_nearest())
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(rotate)

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         // Uncomment this to override the default log settings:
-        // .insert_resource(bevy::log::LogSettings {
+        // .insert_setup_resource(bevy::log::LogSettings {
         //     level: bevy::log::Level::TRACE,
         //     filter: "wgpu=warn,bevy_ecs=info".to_string(),
         // })
@@ -24,7 +24,7 @@ fn log_system() {
     error!("something failed");
 
     // by default, trace and debug logs are ignored because they are "noisy"
-    // you can control what level is logged by adding the LogSettings resource
+    // you can control what level is logged by adding the LogSettings setup resource
     // alternatively you can set the log level via the RUST_LOG=LEVEL environment variable
     // ex: RUST_LOG=trace, RUST_LOG=info,bevy_ecs=warn
     // the format used here is super flexible. check out this documentation for more info:

--- a/examples/app/thread_pool_resources.rs
+++ b/examples/app/thread_pool_resources.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(DefaultTaskPoolOptions::with_num_threads(4))
+        .insert_setup_resource(DefaultTaskPoolOptions::with_num_threads(4))
         .add_plugins(DefaultPlugins)
         .run();
 }

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -7,7 +7,7 @@ use bevy::{asset::AssetServerSettings, prelude::*};
 fn main() {
     App::new()
         // Tell the asset server to watch for asset changes on disk:
-        .insert_resource(AssetServerSettings {
+        .insert_setup_resource(AssetServerSettings {
             watch_for_changes: true,
             ..default()
         })

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -4,7 +4,7 @@ use bevy::{input::touch::TouchPhase, prelude::*, window::WindowMode};
 #[bevy_main]
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
+        .insert_setup_resource(WindowDescriptor {
             resizable: false,
             mode: WindowMode::BorderlessFullscreen,
             ..default()

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -22,7 +22,7 @@ const WORKGROUP_SIZE: u32 = 8;
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
-        .insert_resource(WindowDescriptor {
+        .insert_setup_resource(WindowDescriptor {
             // uncomment for unthrottled FPS
             // present_mode: bevy::window::PresentMode::AutoNoVsync,
             ..default()

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -29,7 +29,7 @@ struct Bird {
 
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
+        .insert_setup_resource(WindowDescriptor {
             title: "BevyMark".to_string(),
             width: 800.,
             height: 600.,

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -11,7 +11,7 @@ const FONT_SIZE: f32 = 7.0;
 /// This example shows what happens when there is a lot of buttons on screen.
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
+        .insert_setup_resource(WindowDescriptor {
             present_mode: PresentMode::Immediate,
             ..default()
         })

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -21,7 +21,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
+        .insert_setup_resource(WindowDescriptor {
             present_mode: PresentMode::AutoNoVsync,
             ..default()
         })

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -18,7 +18,7 @@ struct Foxes {
 
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
+        .insert_setup_resource(WindowDescriptor {
             title: "🦊🦊🦊 Many Foxes! 🦊🦊🦊".to_string(),
             present_mode: PresentMode::AutoNoVsync,
             ..default()

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -15,7 +15,7 @@ use rand::{thread_rng, Rng};
 
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
+        .insert_setup_resource(WindowDescriptor {
             width: 1024.0,
             height: 768.0,
             title: "many_lights".to_string(),

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -24,7 +24,7 @@ struct ColorTint(bool);
 
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
+        .insert_setup_resource(WindowDescriptor {
             present_mode: PresentMode::AutoNoVsync,
             ..default()
         })

--- a/examples/tools/scene_viewer.rs
+++ b/examples/tools/scene_viewer.rs
@@ -45,11 +45,11 @@ Controls:
         color: Color::WHITE,
         brightness: 1.0 / 5.0f32,
     })
-    .insert_resource(AssetServerSettings {
+    .insert_setup_resource(AssetServerSettings {
         asset_folder: std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string()),
         watch_for_changes: true,
     })
-    .insert_resource(WindowDescriptor {
+    .insert_setup_resource(WindowDescriptor {
         title: "bevy scene viewer".to_string(),
         ..default()
     })

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -8,7 +8,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
+        .insert_setup_resource(WindowDescriptor {
             present_mode: PresentMode::AutoNoVsync,
             ..default()
         })

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -25,7 +25,7 @@ fn main() {
             ..default()
         })
         // Turn off vsync to maximize CPU/GPU usage
-        .insert_resource(WindowDescriptor {
+        .insert_setup_resource(WindowDescriptor {
             present_mode: PresentMode::AutoNoVsync,
             ..default()
         })

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
+        .insert_setup_resource(WindowDescriptor {
             width: 500.,
             height: 300.,
             ..default()

--- a/examples/window/transparent_window.rs
+++ b/examples/window/transparent_window.rs
@@ -10,7 +10,7 @@ fn main() {
     App::new()
         // ClearColor must have 0 alpha, otherwise some color will bleed through
         .insert_resource(ClearColor(Color::NONE))
-        .insert_resource(WindowDescriptor {
+        .insert_setup_resource(WindowDescriptor {
             // Setting `transparent` allows the `ClearColor`'s alpha value to take effect
             transparent: true,
             // Disabling window decorations to make it feel more like a widget than a window

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -9,7 +9,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
+        .insert_setup_resource(WindowDescriptor {
             title: "I am a window!".to_string(),
             width: 500.,
             height: 300.,

--- a/tests/window/minimising.rs
+++ b/tests/window/minimising.rs
@@ -6,7 +6,7 @@ fn main() {
     // TODO: Combine this with `resizing` once multiple_windows is simpler than
     // it is currently.
     App::new()
-        .insert_resource(WindowDescriptor {
+        .insert_setup_resource(WindowDescriptor {
             title: "Minimising".into(),
             ..Default::default()
         })

--- a/tests/window/resizing.rs
+++ b/tests/window/resizing.rs
@@ -19,7 +19,7 @@ struct Dimensions {
 
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
+        .insert_setup_resource(WindowDescriptor {
             width: MAX_WIDTH.try_into().unwrap(),
             height: MAX_HEIGHT.try_into().unwrap(),
             scale_factor_override: Some(1.),


### PR DESCRIPTION
# Objective

- add more checks on plugin and app startup

## Solution

- ~~allow the same plugin to be added only once to an application (can be changed by the plugin author)~~ moved to #3988
- add the concept of a setup resource
  - setup resources are consumed once the plugin that needs them has been initialized
  - if there are still setup resources once the app starts, it means the user expected to do something but made an error, so panic
  - if adding a setup resource as a non setup resource, an error will be logged
- move `LogSettings`, `WindowDescriptor`, `AssetServerSettings`, `DefaultTaskPoolOptions`, `ImageSettings` to setup resources 

fixes #2879 and replace #2886

## Changelog

* Resources `LogSettings`, `WindowDescriptor`, `AssetServerSettings`, `DefaultTaskPoolOptions`, `ImageSettings` are now setup resources, and need to be added with `insert_setup_resource`.

