### PR TITLE
[Merged by Bors] - Schedule gilrs system before input systems

### DIFF
--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -2,6 +2,8 @@ mod converter;
 mod gilrs_system;
 
 use bevy_app::{App, CoreStage, Plugin, StartupStage};
+use bevy_ecs::schedule::ParallelSystemDescriptorCoercion;
+use bevy_input::InputSystem;
 use bevy_utils::tracing::error;
 use gilrs::GilrsBuilder;
 use gilrs_system::{gilrs_event_startup_system, gilrs_event_system};
@@ -22,7 +24,10 @@ impl Plugin for GilrsPlugin {
                         StartupStage::PreStartup,
                         gilrs_event_startup_system,
                     )
-                    .add_system_to_stage(CoreStage::PreUpdate, gilrs_event_system);
+                    .add_system_to_stage(
+                        CoreStage::PreUpdate,
+                        gilrs_event_system.before(InputSystem),
+                    );
             }
             Err(err) => error!("Failed to start Gilrs. {}", err),
         }


### PR DESCRIPTION
# Objective

Previously, the gilrs system had no explicit relationship to the input
systems. This could potentially cause it to be scheduled after the
input systems, leading to a one-frame lag in gamepad inputs.

This was a regression introduced in #1606 which removed the `PreEvent` stage

## Solution

This adds an explicit `before` relationship to the gilrs plugin,
ensuring that raw gamepad events will be processed on the same frame
that they are generated.
