### PR TITLE
[Merged by Bors] - Fix custom_shader_pipelined example shader

### DIFF
--- a/assets/shaders/custom.wgsl
+++ b/assets/shaders/custom.wgsl
@@ -5,14 +5,14 @@ struct View {
     world_position: vec3<f32>;
 };
 [[group(0), binding(0)]]
-var view: View;
+var<uniform> view: View;
 
 [[block]]
 struct Mesh {
     transform: mat4x4<f32>;
 };
 [[group(2), binding(0)]]
-var mesh: Mesh;
+var<uniform> mesh: Mesh;
 
 struct Vertex {
     [[location(0)]] position: vec3<f32>;
@@ -38,7 +38,7 @@ struct CustomMaterial {
     color: vec4<f32>;
 };
 [[group(1), binding(0)]]
-var material: CustomMaterial;
+var<uniform> material: CustomMaterial;
 
 [[stage(fragment)]]
 fn fragment() -> [[location(0)]] vec4<f32> {


### PR DESCRIPTION
## Objective

Looking though the new pipelined example I stumbled on an issue with the example shader :

```
Oct 20 12:38:44.891  INFO bevy_render2::renderer: AdapterInfo { name: "Intel(R) UHD Graphics 620 (KBL GT2)", vendor: 32902, device: 22807, device_type: IntegratedGpu, backend: Vulkan }
Oct 20 12:38:44.894  INFO naga::back::spv::writer: Skip function Some("fetch_point_shadow")    
Oct 20 12:38:44.894  INFO naga::back::spv::writer: Skip function Some("fetch_directional_shadow")    
Oct 20 12:38:44.898 ERROR wgpu::backend::direct: Handling wgpu errors as fatal by default    
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_shader_module
    Global variable [1] 'view' is invalid
    Type isn't compatible with the storage class
```

## Solution

added `<uniform>` here and there.
Note : my current mastery of shaders is about 2 days old, so this still kinda look likes wizardry
