### PR TITLE
[Merged by Bors] - Remove wasm audio feature flag for 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,9 +68,6 @@ mp3 = ["bevy_internal/mp3"]
 vorbis = ["bevy_internal/vorbis"]
 wav = ["bevy_internal/wav"]
 
-# WASM support for audio (Currently only works with flac, wav and vorbis. Not with mp3)
-wasm_audio = ["bevy_internal/wasm_audio"]
-
 serialize = ["bevy_internal/serialize"]
 
 # Display server protocol support (X11 is enabled by default)

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -18,8 +18,11 @@ bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 
 # other
 anyhow = "1.0.4"
-rodio = { version = "0.14", default-features = false, features = ["wasm-bindgen"] }
+rodio = { version = "0.14", default-features = false }
 parking_lot = "0.11.0"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+rodio = { version = "0.14", default-features = false, features = ["wasm-bindgen"] }
 
 [features]
 mp3 = ["rodio/mp3"]

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -18,7 +18,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 
 # other
 anyhow = "1.0.4"
-rodio = { version = "0.14", default-features = false }
+rodio = { version = "0.14", default-features = false, features = ["wasm-bindgen"] }
 parking_lot = "0.11.0"
 
 [features]
@@ -26,4 +26,3 @@ mp3 = ["rodio/mp3"]
 flac = ["rodio/flac"]
 wav = ["rodio/wav"]
 vorbis = ["rodio/vorbis"]
-wasm_audio = ["rodio/wasm-bindgen"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -29,9 +29,6 @@ mp3 = ["bevy_audio/mp3"]
 vorbis = ["bevy_audio/vorbis"]
 wav = ["bevy_audio/wav"]
 
-# WASM support for audio
-wasm_audio = ["bevy_audio/wasm_audio"]
-
 serialize = ["bevy_input/serialize"]
 
 # Display server protocol support (X11 is enabled by default)

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -32,7 +32,6 @@
 |flac|FLAC audio format support. It's included in bevy_audio feature.|
 |wav|WAV audio format support.|
 |vorbis|Vorbis audio format support.|
-|wasm_audio|WASM audio support. (Currently only works with flac, wav and vorbis. Not with mp3)|
 |serialize|Enables serialization of `bevy_input` types.|
 |wayland|Enable this to use Wayland display server protocol other than X11.|
 |subpixel_glyph_atlas|Enable this to cache glyphs using subpixel accuracy. This increases texture memory usage as each position requires a separate sprite in the glyph atlas, but provide more accurate character spacing.|


### PR DESCRIPTION
- Requires #2997 
- Removes `wasm_audio` feature as discussed in #2397
- Closes only task in #2479 

Open questions:
Should we enable wasm audio by default or only when building for wasm using `cfg`?
Maybe there should be a global wasm feature for bevy?