### PR TITLE
Add time scaling and simplify fixed timestep use

### DIFF
--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -42,13 +42,13 @@ impl FrameTimeDiagnosticsPlugin {
             state.frame_count as f64
         });
 
-        if time.delta_seconds_f64() == 0.0 {
+        if time.raw_delta_seconds_f64() == 0.0 {
             return;
         }
 
-        diagnostics.add_measurement(Self::FRAME_TIME, || time.delta_seconds_f64());
+        diagnostics.add_measurement(Self::FRAME_TIME, || time.raw_delta_seconds_f64());
 
-        diagnostics.add_measurement(Self::FPS, || 1.0 / time.delta_seconds_f64());
+        diagnostics.add_measurement(Self::FPS, || 1.0 / time.raw_delta_seconds_f64());
     }
 }
 

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -84,7 +84,7 @@ impl LogDiagnosticsPlugin {
         time: Res<Time>,
         diagnostics: Res<Diagnostics>,
     ) {
-        if state.timer.tick(time.delta()).finished() {
+        if state.timer.tick(time.raw_delta()).finished() {
             if let Some(ref filter) = state.filter {
                 for diagnostic in filter.iter().flat_map(|id| {
                     diagnostics
@@ -109,7 +109,7 @@ impl LogDiagnosticsPlugin {
         time: Res<Time>,
         diagnostics: Res<Diagnostics>,
     ) {
-        if state.timer.tick(time.delta()).finished() {
+        if state.timer.tick(time.raw_delta()).finished() {
             if let Some(ref filter) = state.filter {
                 for diagnostic in filter.iter().flat_map(|id| {
                     diagnostics

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -1,302 +1,401 @@
 use crate::Time;
-use bevy_ecs::{
-    archetype::ArchetypeComponentId,
-    component::ComponentId,
-    query::Access,
-    schedule::ShouldRun,
-    system::{IntoSystem, Res, ResMut, System},
-    world::World,
-};
-use bevy_utils::HashMap;
-use std::borrow::Cow;
 
-/// The internal state of each [`FixedTimestep`].
-#[derive(Debug)]
+use bevy_ecs::world::{FromWorld, World};
+use bevy_utils::{Duration, Instant};
+
+/// A [`Time`] variant that is synchronized to the main `Time` resource, but only advances
+/// in increments of a constant [`delta`](FixedTime::delta).
+#[derive(Debug, Clone)]
+pub struct FixedTime {
+    startup: Instant,
+    first_update: Option<Instant>,
+    last_update: Option<Instant>,
+    delta: Duration,
+    delta_seconds: f32,
+    delta_seconds_f64: f64,
+    elapsed_since_startup: Duration,
+    seconds_since_startup: f32,
+    seconds_since_startup_f64: f64,
+}
+
+impl FromWorld for FixedTime {
+    fn from_world(world: &mut World) -> Self {
+        let time = world.resource::<Time>();
+        Self {
+            startup: time.startup(),
+            first_update: None,
+            last_update: None,
+            delta: Self::DEFAULT_STEP_SIZE,
+            delta_seconds: Self::DEFAULT_STEP_SIZE.as_secs_f32(),
+            delta_seconds_f64: Self::DEFAULT_STEP_SIZE.as_secs_f64(),
+            elapsed_since_startup: Duration::ZERO,
+            seconds_since_startup: 0.0,
+            seconds_since_startup_f64: 0.0,
+        }
+    }
+}
+
+impl FixedTime {
+    /// The default step size.
+    // 60Hz is a popular tick rate, but it can't be expressed as an exact float.
+    // The nearby power of two, 64Hz, is more stable for numerical integration.
+    pub const DEFAULT_STEP_SIZE: Duration = Duration::from_micros(15625); // 64Hz
+
+    /// Constructs a new `FixedTime` instance with a specific step size [`Duration`] and startup [`Instant`].
+    pub fn new(step_size: Duration, startup: Instant) -> Self {
+        Self {
+            startup,
+            first_update: None,
+            last_update: None,
+            delta: step_size,
+            delta_seconds: step_size.as_secs_f32(),
+            delta_seconds_f64: step_size.as_secs_f64(),
+            elapsed_since_startup: Duration::ZERO,
+            seconds_since_startup: 0.0,
+            seconds_since_startup_f64: 0.0,
+        }
+    }
+
+    /// Updates internal time measurements.
+    pub fn update(&mut self) {
+        let now = Instant::now();
+        self.update_with_instant(now);
+    }
+
+    /// Updates time with a specified [`Instant`].
+    pub fn update_with_instant(&mut self, instant: Instant) {
+        if self.last_update.is_none() {
+            self.first_update = Some(instant);
+        }
+        self.last_update = Some(instant);
+        self.elapsed_since_startup += self.delta;
+        self.seconds_since_startup = self.elapsed_since_startup.as_secs_f32();
+        self.seconds_since_startup_f64 = self.elapsed_since_startup.as_secs_f64();
+    }
+
+    /// Returns the [`Instant`] the app was started.
+    #[inline]
+    pub fn startup(&self) -> Instant {
+        self.startup
+    }
+
+    /// Returns the [`Instant`] when [`update`](Self::update) was first called, if it exists.
+    #[inline]
+    pub fn first_update(&self) -> Option<Instant> {
+        self.first_update
+    }
+
+    /// Returns the [`Instant`] when [`update`](Self::update) was last called, if it exists.
+    #[inline]
+    pub fn last_update(&self) -> Option<Instant> {
+        self.last_update
+    }
+
+    /// Returns how much time advances with each [`update`](Self::update), as a [`Duration`].
+    #[inline]
+    pub fn delta(&self) -> Duration {
+        self.delta
+    }
+
+    /// Returns how much time advances with each [`update`](Self::update), as [`f32`] seconds.
+    #[inline]
+    pub fn delta_seconds(&self) -> f32 {
+        self.delta_seconds
+    }
+
+    /// Returns how much time advances with each [`update`](Self::update), as [`f64`] seconds.
+    #[inline]
+    pub fn delta_seconds_f64(&self) -> f64 {
+        self.delta_seconds_f64
+    }
+
+    /// Sets [`delta`](Self::delta) to the given step size ([`Duration`]).
+    ///
+    /// **Note:** Outside of startup, users should strongly prefer using [`Time::set_relative_speed`].
+    /// Changing the step size itself will likely result in unstable numerical behavior.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `step_size` is a zero-length duration.
+    pub fn set_delta(&mut self, step_size: Duration) {
+        assert!(!step_size.is_zero(), "division by zero");
+        self.delta = step_size;
+        self.delta_seconds = self.delta.as_secs_f32();
+        self.delta_seconds_f64 = self.delta.as_secs_f64();
+    }
+
+    /// Sets [`delta`](Self::delta) to the given step size ([`f32`] seconds).
+    ///
+    /// **Note:** This should only be set *once* (i.e. at startup).
+    /// Afterwards, only [`Time::set_relative_speed`] should be used to adjust simulation speed.
+    /// Changing [`delta`](Self::delta) directly will likely result in unstable numerical behavior.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `step_size` is less than or equal to zero, not finite, or overflows a `Duration`.
+    pub fn set_delta_seconds(&mut self, step_size: f32) {
+        self.set_delta(Duration::from_secs_f32(step_size));
+    }
+
+    /// Sets [`delta`](Self::delta) to the given step size ([`f64`] seconds).
+    ///
+    /// **Note:** This should only be set *once* (i.e. at startup).
+    /// Afterwards, only [`Time::set_relative_speed`] should be used to adjust simulation speed.
+    /// Changing [`delta`](Self::delta) directly will likely result in unstable numerical behavior.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `step_size` is less than or equal to zero, not finite, or overflows a `Duration`.
+    pub fn set_delta_seconds_f64(&mut self, step_size: f64) {
+        self.set_delta(Duration::from_secs_f64(step_size));
+    }
+
+    /// Returns the nominal update rate (reciprocal of [`delta`](Self::delta)) as [`f32`].
+    #[inline]
+    pub fn steps_per_second(&self) -> f32 {
+        1.0 / self.delta_seconds
+    }
+
+    /// Returns the nominal update rate (reciprocal of [`delta`](Self::delta)) as [`f64`].
+    #[inline]
+    pub fn steps_per_second_f64(&self) -> f64 {
+        1.0 / self.delta_seconds_f64
+    }
+
+    /// Sets [`delta`](Self::delta) to the reciprocal of `rate`, given as [`f32`].
+    ///
+    /// **Note:** This should only be set *once* (i.e. at startup).
+    /// Afterwards, only [`Time::set_relative_speed`] should be used to adjust simulation speed.
+    /// Changing [`delta`](Self::delta) directly will likely result in unstable numerical behavior.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `rate` is less than or equal to zero or not finite.
+    pub fn set_steps_per_second(&mut self, rate: f32) {
+        assert!(rate.is_finite(), "tried to go infinitely fast");
+        assert!(rate.is_sign_positive(), "tried to go back in time");
+        self.set_delta(Duration::from_secs_f32(1.0 / rate));
+    }
+
+    /// Sets [`delta`](Self::delta) to the reciprocal of `rate`, given as [`f64`].
+    ///
+    /// **Note:** This should only be set *once* (i.e. at startup).
+    /// Afterwards, only [`Time::set_relative_speed`] should be used to adjust simulation speed.
+    /// Changing [`delta`](Self::delta) directly will likely result in unstable numerical behavior.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `rate` is less than or equal to zero or not finite.
+    pub fn set_steps_per_second_f64(&mut self, rate: f64) {
+        assert!(rate.is_finite(), "tried to go infinitely fast");
+        assert!(rate.is_sign_positive(), "tried to go back in time");
+        self.set_delta(Duration::from_secs_f64(1.0 / rate));
+    }
+
+    /// Returns how much time has advanced since [`startup`](Self::startup), as [`Duration`].
+    #[inline]
+    pub fn elapsed_since_startup(&self) -> Duration {
+        self.elapsed_since_startup
+    }
+
+    /// Returns how much time has advanced since [`startup`](Self::startup), as [`f32`] seconds.
+    #[inline]
+    pub fn seconds_since_startup(&self) -> f32 {
+        self.seconds_since_startup
+    }
+
+    /// Returns how much time has advanced since [`startup`](Self::startup), as [`f64`] seconds.
+    #[inline]
+    pub fn seconds_since_startup_f64(&self) -> f64 {
+        self.seconds_since_startup_f64
+    }
+}
+
+/// Accumulates time and converts it into steps: one step per `timestep`.
+///
+/// Used to advance [`FixedTime`].
+#[derive(Debug, Clone)]
 pub struct FixedTimestepState {
-    step: f64,
-    accumulator: f64,
+    steps: u32,
+    overstep: Duration,
+}
+
+impl Default for FixedTimestepState {
+    fn default() -> Self {
+        Self {
+            steps: 0,
+            overstep: Duration::ZERO,
+        }
+    }
 }
 
 impl FixedTimestepState {
-    /// The amount of time each step takes.
-    pub fn step(&self) -> f64 {
-        self.step
+    /// Constructs a new `FixedTimestepState`.
+    pub fn new(steps: u32, overstep: Duration) -> Self {
+        Self { steps, overstep }
     }
 
-    /// The number of steps made in a second.
-    pub fn steps_per_second(&self) -> f64 {
-        1.0 / self.step
+    /// Returns the number of steps accumulated.
+    #[inline]
+    pub fn steps(&self) -> u32 {
+        self.steps
     }
 
-    /// The amount of time (in seconds) left over from the last step.
-    pub fn accumulator(&self) -> f64 {
-        self.accumulator
+    /// Returns the amount of time accumulated toward new steps, as a [`Duration`].
+    #[inline]
+    pub fn overstep(&self) -> Duration {
+        self.overstep
     }
 
-    /// The percentage of "step" stored inside the accumulator. Calculated as accumulator / step.
-    pub fn overstep_percentage(&self) -> f64 {
-        self.accumulator / self.step
+    /// Returns the amount of time accumulated toward new steps, as an [`f32`] fraction of `timestep`.
+    ///
+    /// Useful for interpolating data between consecutive updates.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `timestep` is a zero-length duration.
+    pub fn overstep_percentage(&self, timestep: Duration) -> f32 {
+        assert!(!timestep.is_zero(), "division by zero");
+        self.overstep.as_secs_f32() / timestep.as_secs_f32()
     }
-}
 
-/// A global resource that tracks the individual [`FixedTimestepState`]s
-/// for every labeled [`FixedTimestep`].
-#[derive(Default)]
-pub struct FixedTimesteps {
-    fixed_timesteps: HashMap<String, FixedTimestepState>,
-}
-
-impl FixedTimesteps {
-    /// Gets the [`FixedTimestepState`] for a given label.
-    pub fn get(&self, name: &str) -> Option<&FixedTimestepState> {
-        self.fixed_timesteps.get(name)
+    /// Returns the amount of time accumulated toward new steps, as an [`f64`] fraction of `timestep`.
+    ///
+    /// Useful for interpolating data between consecutive updates.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `timestep` is a zero-length duration.
+    pub fn overstep_percentage_f64(&self, timestep: Duration) -> f64 {
+        assert!(!timestep.is_zero(), "division by zero");
+        self.overstep.as_secs_f64() / timestep.as_secs_f64()
     }
-}
 
-/// A system run criteria that enables systems or stages to run at a fixed timestep between executions.
-///
-/// This does not guarantee that the time elapsed between executions is exactly the provided
-/// fixed timestep, but will guarantee that the execution will run multiple times per game tick
-/// until the number of repetitions is as expected.
-///
-/// For example, a system with a fixed timestep run criteria of 120 times per second will run
-/// two times during a ~16.667ms frame, once during a ~8.333ms frame, and once every two frames
-/// with ~4.167ms frames. However, the same criteria may not result in exactly 8.333ms passing
-/// between each execution.
-///
-/// When using this run criteria, it is advised not to rely on [`Time::delta`] or any of it's
-/// variants for game simulation, but rather use the constant time delta used to initialize the
-/// [`FixedTimestep`] instead.
-///
-/// For more fine tuned information about the execution status of a given fixed timestep,
-/// use the [`FixedTimesteps`] resource.
-pub struct FixedTimestep {
-    state: LocalFixedTimestepState,
-    internal_system: Box<dyn System<In = (), Out = ShouldRun>>,
-}
-
-impl Default for FixedTimestep {
-    fn default() -> Self {
-        Self {
-            state: LocalFixedTimestepState::default(),
-            internal_system: Box::new(IntoSystem::into_system(Self::prepare_system(
-                Default::default(),
-            ))),
-        }
-    }
-}
-
-impl FixedTimestep {
-    /// Creates a [`FixedTimestep`] that ticks once every `step` seconds.
-    pub fn step(step: f64) -> Self {
-        Self {
-            state: LocalFixedTimestepState {
-                step,
-                ..Default::default()
-            },
-            ..Default::default()
+    /// Adds `time` to the internal `overstep`, then converts the `overstep` accumulated into
+    /// as many `timestep`-sized steps as possible.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `timestep` is a zero-length duration.
+    pub fn add_time(&mut self, time: Duration, timestep: Duration) {
+        assert!(!timestep.is_zero(), "division by zero");
+        self.overstep += time;
+        while self.overstep >= timestep {
+            self.overstep -= timestep;
+            self.steps += 1;
         }
     }
 
-    /// Creates a [`FixedTimestep`] that ticks once every `rate` times per second.
-    pub fn steps_per_second(rate: f64) -> Self {
-        Self {
-            state: LocalFixedTimestepState {
-                step: 1.0 / rate,
-                ..Default::default()
-            },
-            ..Default::default()
-        }
+    /// Consumes one step and returns the number remaining. Returns `None` if there was
+    /// no step to consume.
+    pub fn sub_step(&mut self) -> Option<u32> {
+        let remaining = self.steps.checked_sub(1);
+        self.steps = self.steps.saturating_sub(1);
+        remaining
     }
 
-    /// Sets the label for the timestep. Setting a label allows a timestep
-    /// to be observed by the global [`FixedTimesteps`] resource.
-    #[must_use]
-    pub fn with_label(mut self, label: &str) -> Self {
-        self.state.label = Some(label.to_string());
-        self
-    }
-
-    fn prepare_system(
-        mut state: LocalFixedTimestepState,
-    ) -> impl FnMut(Res<Time>, ResMut<FixedTimesteps>) -> ShouldRun {
-        move |time, mut fixed_timesteps| {
-            let should_run = state.update(&time);
-            if let Some(ref label) = state.label {
-                let res_state = fixed_timesteps.fixed_timesteps.get_mut(label).unwrap();
-                res_state.step = state.step;
-                res_state.accumulator = state.accumulator;
-            }
-
-            should_run
-        }
-    }
-}
-
-#[derive(Clone)]
-struct LocalFixedTimestepState {
-    label: Option<String>, // TODO: consider making this a TypedLabel
-    step: f64,
-    accumulator: f64,
-    looping: bool,
-}
-
-impl Default for LocalFixedTimestepState {
-    fn default() -> Self {
-        Self {
-            step: 1.0 / 60.0,
-            accumulator: 0.0,
-            label: None,
-            looping: false,
-        }
-    }
-}
-
-impl LocalFixedTimestepState {
-    fn update(&mut self, time: &Time) -> ShouldRun {
-        if !self.looping {
-            self.accumulator += time.delta_seconds_f64();
-        }
-
-        if self.accumulator >= self.step {
-            self.accumulator -= self.step;
-            self.looping = true;
-            ShouldRun::YesAndCheckAgain
-        } else {
-            self.looping = false;
-            ShouldRun::No
-        }
-    }
-}
-
-impl System for FixedTimestep {
-    type In = ();
-    type Out = ShouldRun;
-
-    fn name(&self) -> Cow<'static, str> {
-        Cow::Borrowed(std::any::type_name::<FixedTimestep>())
-    }
-
-    fn archetype_component_access(&self) -> &Access<ArchetypeComponentId> {
-        self.internal_system.archetype_component_access()
-    }
-
-    fn component_access(&self) -> &Access<ComponentId> {
-        self.internal_system.component_access()
-    }
-
-    fn is_send(&self) -> bool {
-        self.internal_system.is_send()
-    }
-
-    unsafe fn run_unsafe(&mut self, _input: (), world: &World) -> ShouldRun {
-        // SAFETY: this system inherits the internal system's component access and archetype component
-        // access, which means the caller has ensured running the internal system is safe
-        self.internal_system.run_unsafe((), world)
-    }
-
-    fn apply_buffers(&mut self, world: &mut World) {
-        self.internal_system.apply_buffers(world);
-    }
-
-    fn initialize(&mut self, world: &mut World) {
-        self.internal_system = Box::new(IntoSystem::into_system(Self::prepare_system(
-            self.state.clone(),
-        )));
-        self.internal_system.initialize(world);
-        if let Some(ref label) = self.state.label {
-            let mut fixed_timesteps = world.resource_mut::<FixedTimesteps>();
-            fixed_timesteps.fixed_timesteps.insert(
-                label.clone(),
-                FixedTimestepState {
-                    accumulator: 0.0,
-                    step: self.state.step,
-                },
-            );
-        }
-    }
-
-    fn update_archetype_component_access(&mut self, world: &World) {
-        self.internal_system
-            .update_archetype_component_access(world);
-    }
-
-    fn check_change_tick(&mut self, change_tick: u32) {
-        self.internal_system.check_change_tick(change_tick);
+    /// Clears accumulated time and steps.
+    pub fn reset(&mut self) {
+        self.steps = 0;
+        self.overstep = Duration::ZERO;
     }
 }
 
 #[cfg(test)]
-mod test {
-    use super::*;
-    use bevy_ecs::prelude::*;
-    use bevy_utils::Instant;
-    use std::ops::{Add, Mul};
-    use std::time::Duration;
+mod tests {
+    use crate::{FixedTime, FixedTimestepState, Time};
+    use bevy_utils::{Duration, Instant};
+    #[test]
+    fn test_fixed_timestep_state_methods() {
+        let mut accumulator = FixedTimestepState::default();
+        assert_eq!(accumulator.steps(), 0);
+        assert_eq!(accumulator.overstep(), Duration::ZERO);
 
-    type Count = usize;
-    const LABEL: &str = "test_step";
+        accumulator.add_time(Duration::from_secs(5), Duration::from_secs(1));
+        assert_eq!(accumulator.steps(), 5);
+        assert_eq!(accumulator.overstep(), Duration::ZERO);
+
+        let steps_remaining = accumulator.sub_step();
+        assert_eq!(steps_remaining, Some(4));
+        assert_eq!(accumulator.steps(), 4);
+        assert_eq!(accumulator.overstep(), Duration::ZERO);
+
+        accumulator.reset();
+        assert_eq!(accumulator.steps(), 0);
+        assert_eq!(accumulator.overstep(), Duration::ZERO);
+
+        let steps_remaining = accumulator.sub_step();
+        assert_eq!(steps_remaining, None);
+        assert_eq!(accumulator.steps(), 0);
+        assert_eq!(accumulator.overstep(), Duration::ZERO);
+    }
 
     #[test]
-    fn test() {
-        let mut world = World::default();
-        let mut time = Time::default();
-        let instance = Instant::now();
-        time.update_with_instant(instance);
-        world.insert_resource(time);
-        world.insert_resource(FixedTimesteps::default());
-        world.insert_resource::<Count>(0);
-        let mut schedule = Schedule::default();
+    fn test_fixed_timestep() {
+        let start_instant = Instant::now();
+        let timestep = Duration::from_millis(20);
 
-        schedule.add_stage(
-            "update",
-            SystemStage::parallel()
-                .with_run_criteria(FixedTimestep::step(0.5).with_label(LABEL))
-                .with_system(fixed_update),
+        // Create a `Time`, `FixedTime`, and `FixedTimestepState` for testing.
+        let mut time = Time::new(start_instant);
+        let mut fixed_time = FixedTime::new(timestep, start_instant);
+        let mut accumulator = FixedTimestepState::default();
+
+        // Confirm that the timestep is what we set it to be.
+        assert_eq!(fixed_time.delta(), timestep);
+        assert_eq!(fixed_time.delta_seconds(), timestep.as_secs_f32());
+        assert_eq!(fixed_time.delta_seconds_f64(), timestep.as_secs_f64());
+
+        // Get the first update out of the way, so time.delta() has a nonzero value next time.
+        let first_update_instant = Instant::now();
+        time.update_with_instant(first_update_instant);
+
+        // Accumulate the time.
+        let start_delay = first_update_instant - start_instant;
+        accumulator.add_time(start_delay, fixed_time.delta());
+
+        // 10.5x the timestep elapses before the second update.
+        let ten = Duration::from_millis(200);
+        let half = Duration::from_millis(10);
+
+        let second_update_instant = first_update_instant + ten + half;
+        time.update_with_instant(second_update_instant);
+        assert_eq!(time.raw_delta(), ten + half);
+        assert_eq!(time.delta(), ten + half);
+
+        // Accumulate the time.
+        accumulator.add_time(time.delta(), fixed_time.delta());
+
+        // Confirm that 10.5 steps have accumulated.
+        assert_eq!(accumulator.steps(), 10);
+        assert_eq!(accumulator.overstep(), start_delay + half);
+
+        // Confirm that fixed time has not been updated yet.
+        assert_eq!(fixed_time.elapsed_since_startup(), Duration::ZERO);
+        assert_eq!(
+            fixed_time.seconds_since_startup(),
+            Duration::ZERO.as_secs_f32()
+        );
+        assert_eq!(
+            fixed_time.seconds_since_startup_f64(),
+            Duration::ZERO.as_secs_f64()
         );
 
-        // if time does not progress, the step does not run
-        schedule.run(&mut world);
-        schedule.run(&mut world);
-        assert_eq!(0, *world.resource::<Count>());
-        assert_eq!(0., get_accumulator_deciseconds(&world));
+        // Consume accumulated steps and advanced the fixed time clock.
+        while accumulator.sub_step().is_some() {
+            fixed_time.update();
+        }
+        // Confirm that the timestep is still the same.
+        assert_eq!(fixed_time.delta(), timestep);
+        assert_eq!(fixed_time.delta_seconds(), timestep.as_secs_f32());
+        assert_eq!(fixed_time.delta_seconds_f64(), timestep.as_secs_f64());
 
-        // let's progress less than one step
-        advance_time(&mut world, instance, 0.4);
-        schedule.run(&mut world);
-        assert_eq!(0, *world.resource::<Count>());
-        assert_eq!(4., get_accumulator_deciseconds(&world));
+        // Confirm that the fixed time clock has advanced 10 steps worth of time.
+        assert_eq!(fixed_time.elapsed_since_startup(), ten);
+        assert_eq!(fixed_time.seconds_since_startup(), ten.as_secs_f32());
+        assert_eq!(fixed_time.seconds_since_startup_f64(), ten.as_secs_f64());
 
-        // finish the first step with 0.1s above the step length
-        advance_time(&mut world, instance, 0.6);
-        schedule.run(&mut world);
-        assert_eq!(1, *world.resource::<Count>());
-        assert_eq!(1., get_accumulator_deciseconds(&world));
-
-        // runs multiple times if the delta is multiple step lengths
-        advance_time(&mut world, instance, 1.7);
-        schedule.run(&mut world);
-        assert_eq!(3, *world.resource::<Count>());
-        assert_eq!(2., get_accumulator_deciseconds(&world));
-    }
-
-    fn fixed_update(mut count: ResMut<Count>) {
-        *count += 1;
-    }
-
-    fn advance_time(world: &mut World, instance: Instant, seconds: f32) {
-        world
-            .resource_mut::<Time>()
-            .update_with_instant(instance.add(Duration::from_secs_f32(seconds)));
-    }
-
-    fn get_accumulator_deciseconds(world: &World) -> f64 {
-        world
-            .resource::<FixedTimesteps>()
-            .get(LABEL)
-            .unwrap()
-            .accumulator
-            .mul(10.)
-            .round()
+        // Confirm that the fixed clock lags behind the normal clock by the sub-step amount.
+        let diff = time.elapsed_since_startup() - fixed_time.elapsed_since_startup();
+        assert_eq!(diff, start_delay + half);
     }
 }

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -9,6 +9,7 @@ pub use stopwatch::*;
 pub use time::*;
 pub use timer::*;
 
+use bevy_ecs::schedule::ShouldRun;
 use bevy_ecs::system::{Local, Res, ResMut};
 use bevy_utils::{tracing::warn, Instant};
 use crossbeam_channel::{Receiver, Sender};
@@ -16,25 +17,29 @@ use crossbeam_channel::{Receiver, Sender};
 pub mod prelude {
     //! The Bevy Time Prelude.
     #[doc(hidden)]
-    pub use crate::{Time, Timer};
+    pub use crate::{FixedTime, FixedTimestep, FixedTimestepState, Time, Timer};
 }
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 
-/// Adds time functionality to Apps.
+/// Adds timekeeping functionality.
 #[derive(Default)]
 pub struct TimePlugin;
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, SystemLabel)]
-/// Updates the elapsed time. Any system that interacts with [Time] component should run after
-/// this.
+
+/// Measures elapsed time since previous update, advances [`Time`], and accumulates elapsed time for
+/// to advance [`FixedTime`] later.
+///
+/// Systems that interact with the [`Time`] resource should be scheduled after this.
 pub struct TimeSystem;
 
 impl Plugin for TimePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<Time>()
-            .init_resource::<FixedTimesteps>()
+            .init_resource::<FixedTime>()
+            .init_resource::<FixedTimestepState>()
             .register_type::<Timer>()
             // time system is added as an "exclusive system" to ensure it runs before other systems
             // in CoreStage::First
@@ -58,22 +63,81 @@ pub fn create_time_channels() -> (TimeSender, TimeReceiver) {
     (TimeSender(s), TimeReceiver(r))
 }
 
-/// The system used to update the [`Time`] used by app logic. If there is a render world the time is sent from
-/// there to this system through channels. Otherwise the time is updated in this system.
+/// Advances [`Time`] and accumulates the elapsed time to advance [`FixedTime`] later.
+///
+/// If the render world exists, the update [`Instant`] is received from a channel.
+/// Otherwise, the update `Instant` is measured inside this system.
 fn time_system(
     mut time: ResMut<Time>,
+    fixed_time: Option<Res<FixedTime>>,
+    accumulator: Option<ResMut<FixedTimestepState>>,
     time_recv: Option<Res<TimeReceiver>>,
     mut has_received_time: Local<bool>,
 ) {
+    let cond1 = time.first_update().is_none();
+
     if let Some(time_recv) = time_recv {
         // TODO: Figure out how to handle this when using pipelined rendering.
-        if let Ok(new_time) = time_recv.0.try_recv() {
-            time.update_with_instant(new_time);
+        if let Ok(instant) = time_recv.0.try_recv() {
+            time.update_with_instant(instant);
             *has_received_time = true;
         } else if *has_received_time {
-            warn!("time_system did not receive the time from the render world! Calculations depending on the time may be incorrect.");
+            warn!(
+                "`time_system` did not receive `Time` from the render world! \
+                Calculations depending on the time may be incorrect!"
+            );
         }
     } else {
         time.update();
+    }
+
+    let cond2 = time.first_update().is_some();
+
+    if let (Some(fixed_time), Some(mut accumulator)) = (fixed_time, accumulator) {
+        // On first update, account for the exact startup delay so that `FixedTime` is synced.
+        let mut delta = if cond1 && cond2 {
+            time.first_update().unwrap() - time.startup()
+        } else {
+            time.raw_delta()
+        };
+        // Avoid rounding errors when the relative speed is 1.
+        if time.relative_speed_f64() != 1.0 {
+            delta = delta.mul_f64(time.relative_speed_f64());
+        }
+        // Accumulate the time advanced.
+        accumulator.add_time(delta, fixed_time.delta());
+    }
+}
+
+/// A run criteria that succeeds once for every [`FixedTime::delta`] seconds that [`Time`] advances.
+///
+/// That is different from the run criteria succeeding once every `FixedTime::delta` seconds.
+/// The exact CPU time between runs depends on the frame rate and [`Time::relative_speed`].
+///
+/// For example, a [`Stage`](bevy_ecs::schedule::Stage) set to run 100 times per second (10ms timestep)
+/// will run once for every 10ms that [`Time`] advances. But unless [`Time::delta`] happens to be a
+/// constant 10ms, the actual time between runs will vary, so systems subject to this run criteria
+/// should use `FixedTime` instead of `Time` to see consistent behavior.
+pub struct FixedTimestep;
+
+impl FixedTimestep {
+    /// Returns `ShouldRun::YesAndCheckAgain` while there are accumulated steps remaining, `ShouldRun::No` otherwise.
+    ///
+    /// Also returns `ShouldRun::No` if either [`FixedTime`] or [`FixedTimestepState`] does not exist.
+    pub fn step(
+        fixed_time: Option<ResMut<FixedTime>>,
+        accumulator: Option<ResMut<FixedTimestepState>>,
+    ) -> ShouldRun {
+        match (fixed_time, accumulator) {
+            (Some(mut fixed_time), Some(mut accumulator)) => {
+                if accumulator.sub_step().is_some() {
+                    fixed_time.update();
+                    ShouldRun::YesAndCheckAgain
+                } else {
+                    ShouldRun::No
+                }
+            }
+            _ => ShouldRun::No,
+        }
     }
 }

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -2,48 +2,71 @@ use bevy_ecs::reflect::ReflectResource;
 use bevy_reflect::Reflect;
 use bevy_utils::{Duration, Instant};
 
-/// Tracks elapsed time since the last update and since the App has started
+/// Tracks how much time has advanced (and also the raw CPU time elapsed) since its previous update
+/// and since the app was started.
 #[derive(Reflect, Debug, Clone)]
 #[reflect(Resource)]
 pub struct Time {
-    delta: Duration,
-    last_update: Option<Instant>,
-    delta_seconds_f64: f64,
-    delta_seconds: f32,
-    seconds_since_startup: f64,
-    time_since_startup: Duration,
     startup: Instant,
+    first_update: Option<Instant>,
+    last_update: Option<Instant>,
+    relative_speed: f64, // using `f64` instead of `f32` to minimize drift from rounding errors
+    delta: Duration,
+    delta_seconds: f32,
+    delta_seconds_f64: f64,
+    elapsed_since_startup: Duration,
+    seconds_since_startup: f32,
+    seconds_since_startup_f64: f64,
+    raw_delta: Duration,
+    raw_delta_seconds: f32,
+    raw_delta_seconds_f64: f64,
+    raw_elapsed_since_startup: Duration,
+    raw_seconds_since_startup: f32,
+    raw_seconds_since_startup_f64: f64,
 }
 
 impl Default for Time {
-    fn default() -> Time {
-        Time {
-            delta: Duration::from_secs(0),
-            last_update: None,
+    fn default() -> Self {
+        Self {
             startup: Instant::now(),
-            delta_seconds_f64: 0.0,
-            seconds_since_startup: 0.0,
-            time_since_startup: Duration::from_secs(0),
+            first_update: None,
+            last_update: None,
+            relative_speed: 1.0,
+            delta: Duration::ZERO,
             delta_seconds: 0.0,
+            delta_seconds_f64: 0.0,
+            elapsed_since_startup: Duration::ZERO,
+            seconds_since_startup: 0.0,
+            seconds_since_startup_f64: 0.0,
+            raw_delta: Duration::ZERO,
+            raw_delta_seconds: 0.0,
+            raw_delta_seconds_f64: 0.0,
+            raw_elapsed_since_startup: Duration::ZERO,
+            raw_seconds_since_startup: 0.0,
+            raw_seconds_since_startup_f64: 0.0,
         }
     }
 }
 
 impl Time {
-    /// Updates the internal time measurements.
-    ///
-    /// Calling this method on the [`Time`] resource as part of your app will most likely result in
-    /// inaccurate timekeeping, as the resource is ordinarily managed by the
-    /// [`TimePlugin`](crate::TimePlugin).
-    pub fn update(&mut self) {
-        self.update_with_instant(Instant::now());
+    /// Constructs a new `Time` instance with a specific startup `Instant`.
+    pub fn new(startup: Instant) -> Self {
+        Self {
+            startup,
+            ..Default::default()
+        }
     }
 
-    /// Update time with a specified [`Instant`]
+    /// Updates the internal time measurements.
+    pub fn update(&mut self) {
+        let now = Instant::now();
+        self.update_with_instant(now);
+    }
+
+    /// Updates time with a specified [`Instant`].
     ///
-    /// This method is provided for use in tests. Calling this method on the [`Time`] resource as
-    /// part of your app will most likely result in inaccurate timekeeping, as the resource is
-    /// ordinarily managed by the [`TimePlugin`](crate::TimePlugin).
+    /// This method is provided for use in tests. Calling this method in a normal app will result
+    /// in inaccurate timekeeping, as the resource is ordinarily managed by the [`TimePlugin`](crate::TimePlugin).
     ///
     /// # Examples
     ///
@@ -91,57 +114,165 @@ impl Time {
     /// }
     /// ```
     pub fn update_with_instant(&mut self, instant: Instant) {
-        if let Some(last_update) = self.last_update {
-            self.delta = instant - last_update;
-            self.delta_seconds_f64 = self.delta.as_secs_f64();
+        let raw_delta = if let Some(last_update) = self.last_update {
+            instant - last_update
+        } else {
+            instant - self.startup
+        };
+
+        // Avoid rounding errors when the relative speed is 1.
+        let delta = if self.relative_speed != 1.0 {
+            raw_delta.mul_f64(self.relative_speed)
+        } else {
+            raw_delta
+        };
+
+        if self.last_update.is_some() {
+            self.delta = delta;
             self.delta_seconds = self.delta.as_secs_f32();
+            self.delta_seconds_f64 = self.delta.as_secs_f64();
+            self.raw_delta = raw_delta;
+            self.raw_delta_seconds = self.raw_delta.as_secs_f32();
+            self.raw_delta_seconds_f64 = self.raw_delta.as_secs_f64();
+        } else {
+            self.first_update = Some(instant);
         }
 
-        self.time_since_startup = instant - self.startup;
-        self.seconds_since_startup = self.time_since_startup.as_secs_f64();
+        self.elapsed_since_startup += delta;
+        self.seconds_since_startup = self.elapsed_since_startup.as_secs_f32();
+        self.seconds_since_startup_f64 = self.elapsed_since_startup.as_secs_f64();
+        self.raw_elapsed_since_startup += raw_delta;
+        self.raw_seconds_since_startup = self.raw_elapsed_since_startup.as_secs_f32();
+        self.raw_seconds_since_startup_f64 = self.raw_elapsed_since_startup.as_secs_f64();
         self.last_update = Some(instant);
     }
 
-    /// The delta between the current tick and last tick as a [`Duration`]
-    #[inline]
-    pub fn delta(&self) -> Duration {
-        self.delta
-    }
-
-    /// The delta between the current and last tick as [`f32`] seconds
-    #[inline]
-    pub fn delta_seconds(&self) -> f32 {
-        self.delta_seconds
-    }
-
-    /// The delta between the current and last tick as [`f64`] seconds
-    #[inline]
-    pub fn delta_seconds_f64(&self) -> f64 {
-        self.delta_seconds_f64
-    }
-
-    /// The time from startup to the last update in seconds
-    #[inline]
-    pub fn seconds_since_startup(&self) -> f64 {
-        self.seconds_since_startup
-    }
-
-    /// The [`Instant`] the app was started
+    /// Returns the [`Instant`] the app was started.
     #[inline]
     pub fn startup(&self) -> Instant {
         self.startup
     }
 
-    /// The [`Instant`] when [`Time::update`] was last called, if it exists
+    /// Returns the [`Instant`] when [`update`](Self::update) was first called, if it exists.
+    #[inline]
+    pub fn first_update(&self) -> Option<Instant> {
+        self.first_update
+    }
+
+    /// Returns the [`Instant`] when [`update`](Self::update) was last called, if it exists.
     #[inline]
     pub fn last_update(&self) -> Option<Instant> {
         self.last_update
     }
 
-    /// The [`Duration`] from startup to the last update
+    /// Returns the rate that time advances relative to raw CPU time, as [`f32`].
+    ///
+    /// `1.0` by default.
     #[inline]
-    pub fn time_since_startup(&self) -> Duration {
-        self.time_since_startup
+    pub fn relative_speed(&self) -> f32 {
+        self.relative_speed as f32
+    }
+
+    /// Returns the rate that time advances relative to raw CPU time, as [`f64`].
+    ///
+    /// `1.0` by default.
+    #[inline]
+    pub fn relative_speed_f64(&self) -> f64 {
+        self.relative_speed
+    }
+
+    /// Sets the rate that time advances relative to raw CPU time, given as [`f32`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ratio` is negative or not finite.
+    pub fn set_relative_speed(&mut self, ratio: f32) {
+        assert!(ratio.is_finite(), "tried to go infinitely fast");
+        assert!(ratio.is_sign_positive(), "tried to go back in time");
+        self.relative_speed = ratio as f64;
+    }
+
+    /// Sets the rate that time advances relative to raw CPU time, given as [`f64`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ratio` is negative or not finite.
+    pub fn set_relative_speed_f64(&mut self, ratio: f64) {
+        assert!(ratio.is_finite(), "tried to go infinitely fast");
+        assert!(ratio.is_sign_positive(), "tried to go back in time");
+        self.relative_speed = ratio;
+    }
+
+    /// Returns how much time has advanced since the last [`update`](Self::update), as a [`Duration`].
+    #[inline]
+    pub fn delta(&self) -> Duration {
+        self.delta
+    }
+
+    /// Returns how much time has advanced since the last [`update`](Self::update), as [`f32`] seconds.
+    #[inline]
+    pub fn delta_seconds(&self) -> f32 {
+        self.delta_seconds
+    }
+
+    /// Returns how much time has advanced since the last [`update`](Self::update), as [`f64`] seconds.
+    #[inline]
+    pub fn delta_seconds_f64(&self) -> f64 {
+        self.delta_seconds_f64
+    }
+
+    /// Returns the exact CPU time elapsed since the last [`update`](Self::update), as a [`Duration`].
+    #[inline]
+    pub fn raw_delta(&self) -> Duration {
+        self.raw_delta
+    }
+
+    /// Returns the exact CPU time elapsed since the last [`update`](Self::update), as [`f32`] seconds.
+    #[inline]
+    pub fn raw_delta_seconds(&self) -> f32 {
+        self.raw_delta_seconds
+    }
+
+    /// Returns the exact CPU time elapsed since the last [`update`](Self::update), as [`f64`] seconds.
+    #[inline]
+    pub fn raw_delta_seconds_f64(&self) -> f64 {
+        self.raw_delta_seconds_f64
+    }
+
+    /// Returns how much time has advanced since [`startup`](Self::startup), as [`Duration`].
+    #[inline]
+    pub fn elapsed_since_startup(&self) -> Duration {
+        self.elapsed_since_startup
+    }
+
+    /// Returns how much time has advanced since [`startup`](Self::startup), as [`f32`] seconds.
+    #[inline]
+    pub fn seconds_since_startup(&self) -> f32 {
+        self.seconds_since_startup
+    }
+
+    /// Returns how much time has advanced since [`startup`](Self::startup), as [`f64`] seconds.
+    #[inline]
+    pub fn seconds_since_startup_f64(&self) -> f64 {
+        self.seconds_since_startup_f64
+    }
+
+    /// Returns the exact CPU time elapsed since [`startup`](Self::startup), as [`Duration`].
+    #[inline]
+    pub fn raw_elapsed_since_startup(&self) -> Duration {
+        self.raw_elapsed_since_startup
+    }
+
+    /// Returns the exact CPU time elapsed since [`startup`](Self::startup), as [`f32`] seconds.
+    #[inline]
+    pub fn raw_seconds_since_startup(&self) -> f32 {
+        self.raw_seconds_since_startup
+    }
+
+    /// Returns the exact CPU time elapsed since [`startup`](Self::startup), as [`f64`] seconds.
+    #[inline]
+    pub fn raw_seconds_since_startup_f64(&self) -> f64 {
+        self.raw_seconds_since_startup_f64
     }
 }
 
@@ -153,61 +284,166 @@ mod tests {
 
     #[test]
     fn update_test() {
+        // Create a `Time` for testing.
         let start_instant = Instant::now();
+        let mut time = Time::new(start_instant);
 
-        // Create a `Time` for testing
-        let mut time = Time {
-            startup: start_instant,
-            ..Default::default()
-        };
-
-        // Ensure `time` was constructed correctly
-        assert_eq!(time.delta(), Duration::from_secs(0));
-        assert_eq!(time.last_update(), None);
+        // Ensure `time` was constructed correctly.
         assert_eq!(time.startup(), start_instant);
-        assert_eq!(time.delta_seconds_f64(), 0.0);
-        assert_eq!(time.seconds_since_startup(), 0.0);
-        assert_eq!(time.time_since_startup(), Duration::from_secs(0));
+        assert_eq!(time.first_update(), None);
+        assert_eq!(time.last_update(), None);
+        assert_eq!(time.relative_speed(), 1.0);
+        assert_eq!(time.delta(), Duration::ZERO);
         assert_eq!(time.delta_seconds(), 0.0);
+        assert_eq!(time.delta_seconds_f64(), 0.0);
+        assert_eq!(time.raw_delta(), Duration::ZERO);
+        assert_eq!(time.raw_delta_seconds(), 0.0);
+        assert_eq!(time.raw_delta_seconds_f64(), 0.0);
+        assert_eq!(time.elapsed_since_startup(), Duration::ZERO);
+        assert_eq!(time.seconds_since_startup(), 0.0);
+        assert_eq!(time.seconds_since_startup_f64(), 0.0);
+        assert_eq!(time.raw_elapsed_since_startup(), Duration::ZERO);
+        assert_eq!(time.raw_seconds_since_startup(), 0.0);
+        assert_eq!(time.raw_seconds_since_startup_f64(), 0.0);
 
-        // Update `time` and check results
+        // Update `time` and check results.
+        // The first update to `time` normally happens before other systems have run,
+        // so the first delta doesn't appear until the second update.
         let first_update_instant = Instant::now();
-
         time.update_with_instant(first_update_instant);
 
-        assert_eq!(time.delta(), Duration::from_secs(0));
+        assert_eq!(time.startup(), start_instant);
+        assert_eq!(time.first_update(), Some(first_update_instant));
         assert_eq!(time.last_update(), Some(first_update_instant));
-        assert_eq!(time.startup(), start_instant);
+        assert_eq!(time.relative_speed(), 1.0);
+        assert_eq!(time.delta(), Duration::ZERO);
+        assert_eq!(time.delta_seconds(), 0.0);
         assert_eq!(time.delta_seconds_f64(), 0.0);
+        assert_eq!(time.raw_delta(), Duration::ZERO);
+        assert_eq!(time.raw_delta_seconds(), 0.0);
+        assert_eq!(time.raw_delta_seconds_f64(), 0.0);
+        assert_eq!(
+            time.elapsed_since_startup(),
+            first_update_instant - start_instant,
+        );
         assert_eq!(
             time.seconds_since_startup(),
-            (first_update_instant - start_instant).as_secs_f64()
+            (first_update_instant - start_instant).as_secs_f32(),
         );
         assert_eq!(
-            time.time_since_startup(),
-            (first_update_instant - start_instant)
+            time.seconds_since_startup_f64(),
+            (first_update_instant - start_instant).as_secs_f64(),
         );
-        assert_eq!(time.delta_seconds, 0.0);
+        assert_eq!(
+            time.raw_elapsed_since_startup(),
+            first_update_instant - start_instant,
+        );
+        assert_eq!(
+            time.raw_seconds_since_startup(),
+            (first_update_instant - start_instant).as_secs_f32(),
+        );
+        assert_eq!(
+            time.raw_seconds_since_startup_f64(),
+            (first_update_instant - start_instant).as_secs_f64(),
+        );
 
-        // Update `time` again and check results
+        // Update `time` again and check results.
+        // At this point its safe to use time.delta().
         let second_update_instant = Instant::now();
-
         time.update_with_instant(second_update_instant);
-
-        assert_eq!(time.delta(), second_update_instant - first_update_instant);
-        assert_eq!(time.last_update(), Some(second_update_instant));
         assert_eq!(time.startup(), start_instant);
-        // At this point its safe to use time.delta as a valid value
-        // because it's been previously verified to be correct
-        assert_eq!(time.delta_seconds_f64(), time.delta().as_secs_f64());
+        assert_eq!(time.first_update(), Some(first_update_instant));
+        assert_eq!(time.last_update(), Some(second_update_instant));
+        assert_eq!(time.relative_speed(), 1.0);
+        assert_eq!(time.delta(), second_update_instant - first_update_instant);
+        assert_eq!(
+            time.delta_seconds(),
+            (second_update_instant - first_update_instant).as_secs_f32(),
+        );
+        assert_eq!(
+            time.delta_seconds_f64(),
+            (second_update_instant - first_update_instant).as_secs_f64(),
+        );
+        assert_eq!(
+            time.raw_delta(),
+            second_update_instant - first_update_instant,
+        );
+        assert_eq!(
+            time.raw_delta_seconds(),
+            (second_update_instant - first_update_instant).as_secs_f32(),
+        );
+        assert_eq!(
+            time.raw_delta_seconds_f64(),
+            (second_update_instant - first_update_instant).as_secs_f64(),
+        );
+        assert_eq!(
+            time.elapsed_since_startup(),
+            second_update_instant - start_instant,
+        );
         assert_eq!(
             time.seconds_since_startup(),
-            (second_update_instant - start_instant).as_secs_f64()
+            (second_update_instant - start_instant).as_secs_f32(),
         );
         assert_eq!(
-            time.time_since_startup(),
-            (second_update_instant - start_instant)
+            time.seconds_since_startup_f64(),
+            (second_update_instant - start_instant).as_secs_f64(),
         );
-        assert_eq!(time.delta_seconds(), time.delta().as_secs_f32());
+        assert_eq!(
+            time.raw_elapsed_since_startup(),
+            second_update_instant - start_instant,
+        );
+        assert_eq!(
+            time.raw_seconds_since_startup(),
+            (second_update_instant - start_instant).as_secs_f32(),
+        );
+        assert_eq!(
+            time.raw_seconds_since_startup_f64(),
+            (second_update_instant - start_instant).as_secs_f64(),
+        );
+
+        // Make app time advance at 2x the rate of the system clock.
+        time.set_relative_speed(2.0);
+
+        // Update `time` again 1 second later.
+        let elapsed = Duration::from_secs(1);
+        let third_update_instant = second_update_instant + elapsed;
+        time.update_with_instant(third_update_instant);
+
+        // Since app is advancing 2x the system clock, expect elapsed time
+        // to have advanced by twice the amount of raw CPU time.
+        assert_eq!(time.startup(), start_instant);
+        assert_eq!(time.first_update(), Some(first_update_instant));
+        assert_eq!(time.last_update(), Some(third_update_instant));
+        assert_eq!(time.relative_speed(), 2.0);
+        assert_eq!(time.delta(), elapsed.mul_f32(2.0));
+        assert_eq!(time.delta_seconds(), elapsed.mul_f32(2.0).as_secs_f32());
+        assert_eq!(time.delta_seconds_f64(), elapsed.mul_f32(2.0).as_secs_f64());
+        assert_eq!(time.raw_delta(), elapsed);
+        assert_eq!(time.raw_delta_seconds(), elapsed.as_secs_f32());
+        assert_eq!(time.raw_delta_seconds_f64(), elapsed.as_secs_f64());
+        assert_eq!(
+            time.elapsed_since_startup(),
+            second_update_instant - start_instant + elapsed.mul_f32(2.0),
+        );
+        assert_eq!(
+            time.seconds_since_startup(),
+            (second_update_instant - start_instant + elapsed.mul_f32(2.0)).as_secs_f32(),
+        );
+        assert_eq!(
+            time.seconds_since_startup_f64(),
+            (second_update_instant - start_instant + elapsed.mul_f32(2.0)).as_secs_f64(),
+        );
+        assert_eq!(
+            time.raw_elapsed_since_startup(),
+            second_update_instant - start_instant + elapsed,
+        );
+        assert_eq!(
+            time.raw_seconds_since_startup(),
+            (second_update_instant - start_instant + elapsed).as_secs_f32(),
+        );
+        assert_eq!(
+            time.raw_seconds_since_startup_f64(),
+            (second_update_instant - start_instant + elapsed).as_secs_f64(),
+        );
     }
 }

--- a/examples/3d/transparency_3d.rs
+++ b/examples/3d/transparency_3d.rs
@@ -88,7 +88,7 @@ fn setup(
 ///                when the alpha value goes back below the threshold.
 /// - `Blend`: Object fades in and out smoothly.
 pub fn fade_transparency(time: Res<Time>, mut materials: ResMut<Assets<StandardMaterial>>) {
-    let alpha = (time.time_since_startup().as_secs_f32().sin() / 2.0) + 0.5;
+    let alpha = (time.seconds_since_startup().sin() / 2.0) + 0.5;
     for (_, material) in materials.iter_mut() {
         material.base_color.set_a(alpha);
     }

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -164,9 +164,7 @@ fn setup(
 /// Animate the joint marked with [`AnimatedJoint`] component.
 fn joint_animation(time: Res<Time>, mut query: Query<&mut Transform, With<AnimatedJoint>>) {
     for mut transform in &mut query {
-        transform.rotation = Quat::from_axis_angle(
-            Vec3::Z,
-            0.5 * PI * time.time_since_startup().as_secs_f32().sin(),
-        );
+        transform.rotation =
+            Quat::from_axis_angle(Vec3::Z, 0.5 * PI * time.seconds_since_startup().sin());
     }
 }

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -66,9 +66,7 @@ fn joint_animation(
         // Get `Transform` in the second joint.
         let mut second_joint_transform = transform_query.get_mut(second_joint_entity).unwrap();
 
-        second_joint_transform.rotation = Quat::from_axis_angle(
-            Vec3::Z,
-            0.5 * PI * time.time_since_startup().as_secs_f32().sin(),
-        );
+        second_joint_transform.rotation =
+            Quat::from_axis_angle(Vec3::Z, 0.5 * PI * time.seconds_since_startup().sin());
     }
 }

--- a/examples/ecs/component_change_detection.rs
+++ b/examples/ecs/component_change_detection.rs
@@ -14,7 +14,7 @@ fn main() {
 }
 
 #[derive(Component, Debug)]
-struct MyComponent(f64);
+struct MyComponent(f32);
 
 fn setup(mut commands: Commands) {
     commands.spawn().insert(MyComponent(0.));

--- a/examples/ecs/fixed_timestep.rs
+++ b/examples/ecs/fixed_timestep.rs
@@ -1,11 +1,6 @@
 //! Shows how to create systems that run every fixed timestep, rather than every tick.
 
-use bevy::{
-    prelude::*,
-    time::{FixedTimestep, FixedTimesteps},
-};
-
-const LABEL: &str = "my_fixed_timestep";
+use bevy::prelude::*;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
 struct FixedUpdateStage;
@@ -13,40 +8,48 @@ struct FixedUpdateStage;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        // this system will run once every update (it should match your screen's refresh rate)
+        .add_startup_system(|mut fixed_time: ResMut<FixedTime>| {
+            fixed_time.set_steps_per_second(10.0);
+        })
+        // Add a system that runs once per update (which should match your screen's refresh rate).
         .add_system(frame_update)
-        // add a new stage that runs twice a second
+        // Add a new stage that runs ten times per second.
         .add_stage_after(
             CoreStage::Update,
             FixedUpdateStage,
             SystemStage::parallel()
-                .with_run_criteria(
-                    FixedTimestep::step(0.5)
-                        // labels are optional. they provide a way to access the current
-                        // FixedTimestep state from within a system
-                        .with_label(LABEL),
-                )
+                .with_run_criteria(FixedTimestep::step)
                 .with_system(fixed_update),
         )
         .run();
 }
 
-fn frame_update(mut last_time: Local<f64>, time: Res<Time>) {
-    info!("update: {}", time.seconds_since_startup() - *last_time);
+fn frame_update(mut last_time: Local<f32>, time: Res<Time>) {
+    info!(
+        "time since last frame_update: {}",
+        time.seconds_since_startup() - *last_time
+    );
     *last_time = time.seconds_since_startup();
 }
 
-fn fixed_update(mut last_time: Local<f64>, time: Res<Time>, fixed_timesteps: Res<FixedTimesteps>) {
+fn fixed_update(
+    mut last_time: Local<f32>,
+    time: Res<Time>,
+    fixed_time: Res<FixedTime>,
+    accumulator: Res<FixedTimestepState>,
+) {
     info!(
-        "fixed_update: {}",
-        time.seconds_since_startup() - *last_time,
+        "time since last fixed_update: {}\n",
+        time.seconds_since_startup() - *last_time
     );
-
-    let fixed_timestep = fixed_timesteps.get(LABEL).unwrap();
+    info!("fixed timestep: {}\n", fixed_time.delta_seconds());
     info!(
-        "  overstep_percentage: {}",
-        fixed_timestep.overstep_percentage()
+        "time accrued toward next fixed_update: {}\n",
+        accumulator.overstep().as_secs_f32()
     );
-
+    info!(
+        "time accrued toward next fixed_update (% of timestep): {}",
+        accumulator.overstep_percentage(fixed_time.delta())
+    );
     *last_time = time.seconds_since_startup();
 }

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -43,7 +43,7 @@ impl FromWorld for ComponentB {
     fn from_world(world: &mut World) -> Self {
         let time = world.resource::<Time>();
         ComponentB {
-            _time_since_startup: time.time_since_startup(),
+            _time_since_startup: time.elapsed_since_startup(),
             value: "Default Value".to_string(),
         }
     }

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -5,7 +5,6 @@
 use bevy::{
     diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    time::FixedTimestep,
     window::PresentMode,
 };
 use rand::{thread_rng, Rng};
@@ -43,6 +42,9 @@ fn main() {
             count: 0,
             color: Color::WHITE,
         })
+        .add_startup_system(|mut fixed_time: ResMut<FixedTime>| {
+            fixed_time.set_steps_per_second(5.0);
+        })
         .add_startup_system(setup)
         .add_system(mouse_handler)
         .add_system(movement_system)
@@ -50,7 +52,7 @@ fn main() {
         .add_system(counter_system)
         .add_system_set(
             SystemSet::new()
-                .with_run_criteria(FixedTimestep::step(0.2))
+                .with_run_criteria(FixedTimestep::step)
                 .with_system(scheduled_spawner),
         )
         .run();


### PR DESCRIPTION
## Objective

- Fill out `Time` API.
- Make using `FixedTimestep` less prone to user error.
- Implement time scaling.
- Improve documentation.

## Solution

- Ensure the "delta" and "elapsed" methods on `Time` all have `f32`, `f64`, and `Duration` variants.
	- The `f32` and `f64` values are cached, but derived from the `Duration` value to minimize drift from rounding errors.
- Add an explicit `FixedTime` counterpart to `Time` for people to use in their fixed timestep systems.
- Remove the `FixedTimesteps` resource (`HashMap<String, FixedTimestepState>`).
	- There's only one `FixedTimestepState` now (only need to read it when you want to interpolate something).
	- Having more than one instance was a big footgun.
- Implement time scaling.
	- Fixed time follows scaled time in fixed increments.

Setting the step rate isn't _quite_ as ergonomic as before but it's still pretty easy to do.

## Changelist

- Renamed `Time::time_since_startup` to `Time::elapsed_since_startup`.
- Added method to get the `Instant` of the first `Time` update (there's some delay after startup).
	- `Time::first_update`
- Added methods to control time scaling.
	- `Time::relative_speed`
	- `Time::set_relative_speed`
- Added methods that ignore time scaling (i.e. for diagnostics).
	- `Time::raw_delta`
	- `Time::raw_elapsed_since_startup`
- Added `FixedTime` resource with similar API.
    - `FixedTime::startup` (should give same value as `Time::startup`)
    - `FixedTime::first_update`
    - `FixedTime::last_update`
	- `FixedTime::delta`
	- `FixedTime::set_delta`
    - `FixedTime::steps_per_second`
	- `FixedTime::set_steps_per_second`
	- `FixedTime::elasped_since_startup`
- Changed `FixedTimestepState` to be step-size agnostic so it works seamlessly with time scaling.
- Removed `FixedTimesteps` resource. (explained below)
	- The builtin run criteria is now just `FixedTimestep::step`. Set the base step size/rate through `FixedTime`.

## Why only one built-in fixed timestep?

### *tl;dr* 
- `FixedTimestep` is for repeatable, deterministic behavior
- having two or more will mess up system ordering, which is non-deterministic and defeats the purpose
- no other engine has this footgun and we don't need to either
- users wanting precise time intervals need to use another thread, `FixedTimestep` won't work for that

___

A fixed timestep is "context" that wraps a block of systems and sort-of-but-not-really-decouples it from the main frame rate. (It's still *inside* the frame loop, so nothing is really decoupled.) The systems inside the block use your hardcoded `dt` value, and `FixedTimestep` just makes it so the *average* time between runs is `dt`. It'll regularly loop several times in a single frame to achieve that.

So your systems always see a constant `dt` while the actual `dt` between runs varies wildly. Great for getting consistent game physics, but useless if you wanted an actual fixed frequency (if you need that, your only option is a dedicated thread).

Anyway, `FixedTimestep` only works correctly when it wraps _a single_ system/stage/sub-schedule. You can't use a bunch of them in different places without running into some subtle side effects. 

For example, if you had two of `FixedTimestep` instances, their steps wouldn't run in a consistent order. E.g. if you had a 50ms timestep `A` and a 100ms timestep `B`, you'd probably expect them to interleave like this...

```
A AB A AB A AB...
```

...which might often be the case. However, if the app stutters even a little (e.g. one frame takes half a second), `A` and `B` would get several steps queued up, and then their order on the next frame would be completely screwed up (because of how they catch up):

```
AAAAAA BBB...
```

So a single long frame could cause very subtle bugs. 

Note: You can subdivide one timestep into longer ones by counting. For example, you can get a 1 second timestep from a 100ms timestep just by counting to 10 and having run criteria detect that. That gives variable—but still coarse—rate limiting without messing up the system order.

I still left `FixedTimestepState` `pub` so people can build their own `HashMap<Key, FixedTimestepState>` resource if they need it for something exotic.