### PR TITLE
[Merged by Bors] - Freeing memory held by visible entities vector

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1551,6 +1551,22 @@ pub fn check_light_mesh_visibility(
         (Without<NotShadowCaster>, Without<DirectionalLight>),
     >,
 ) {
+    fn shrink_entities(visible_entities: &mut VisibleEntities) {
+        // Check that visible entities capacity() is no more than two times greater than len()
+        let capacity = visible_entities.entities.capacity();
+        let reserved = capacity
+            .checked_div(visible_entities.entities.len())
+            .map_or(0, |reserve| {
+                if reserve > 2 {
+                    capacity / (reserve / 2)
+                } else {
+                    capacity
+                }
+            });
+
+        visible_entities.entities.shrink_to(reserved);
+    }
+
     // Directional lights
     for (
         directional_light,
@@ -1592,8 +1608,7 @@ pub fn check_light_mesh_visibility(
             visible_entities.entities.push(entity);
         }
 
-        // TODO: check for big changes in visible entities len() vs capacity() (ex: 2x) and resize
-        // to prevent holding unneeded memory
+        shrink_entities(&mut visible_entities);
     }
 
     for visible_lights in &visible_point_lights {
@@ -1664,11 +1679,12 @@ pub fn check_light_mesh_visibility(
                     }
                 }
 
-                // TODO: check for big changes in visible entities len() vs capacity() (ex: 2x) and resize
-                // to prevent holding unneeded memory
+                for visible_entities in cubemap_visible_entities.iter_mut() {
+                    shrink_entities(visible_entities);
+                }
             }
 
-            // spot lights
+            // Spot lights
             if let Ok((point_light, transform, frustum, mut visible_entities, maybe_view_mask)) =
                 spot_lights.get_mut(light_entity)
             {
@@ -1720,8 +1736,7 @@ pub fn check_light_mesh_visibility(
                     }
                 }
 
-                // TODO: check for big changes in visible entities len() vs capacity() (ex: 2x) and resize
-                // to prevent holding unneeded memory
+                shrink_entities(&mut visible_entities);
             }
         }
     }


### PR DESCRIPTION
- Freeing unused memory held by visible entities
- Fixed comment style

# Objective

With Rust 1.56 it's possible to shrink vectors to a specified capacity. Visibility system had a comment before asking for that feature to free unused memory by a vector if its capacity is two times larger than the length.

## Solution

Shrinking the vector of visible entities to the nearest power of 2 elements next to `len()`, if capacity exceeds it more than two times.