### PR TITLE
Update to Rust 1.56 and 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 categories = ["game-engines", "graphics", "gui", "rendering"]
 description = "A refreshingly simple data-driven game engine and app framework"
 exclude = ["assets/**/*", "tools/**/*", ".github/**/*", "crates/**/*"]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "benches"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_app"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides core App functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_asset"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides asset functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_audio"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides audio functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_core"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides core functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_derive/Cargo.toml
+++ b/crates/bevy_derive/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_derive"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides derive implementations for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_derive/src/enum_variant_meta.rs
+++ b/crates/bevy_derive/src/enum_variant_meta.rs
@@ -21,7 +21,7 @@ pub fn derive_enum_variant_meta(input: TokenStream) -> TokenStream {
     let indices = 0..names.len();
 
     TokenStream::from(quote! {
-        impl #impl_generics #bevy_util_path::EnumVariantMeta for #struct_name#ty_generics #where_clause {
+        impl #impl_generics #bevy_util_path::EnumVariantMeta for # struct_name # ty_generics # where_clause {
             fn enum_variant_index(&self) -> usize {
                 match self {
                     #(#struct_name::#idents {..} => #indices,)*

--- a/crates/bevy_derive/src/shader_defs.rs
+++ b/crates/bevy_derive/src/shader_defs.rs
@@ -40,7 +40,7 @@ pub fn derive_shader_defs(input: TokenStream) -> TokenStream {
     let (impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
 
     TokenStream::from(quote! {
-        impl #impl_generics #bevy_render_path::shader::ShaderDefs for #struct_name#ty_generics {
+        impl #impl_generics #bevy_render_path::shader::ShaderDefs for # struct_name # ty_generics {
             fn shader_defs_len(&self) -> usize {
                 #shader_defs_len
             }

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_diagnostic"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides diagnostic functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_dylib/Cargo.toml
+++ b/crates/bevy_dylib/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_dylib"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Force the Bevy Engine to be dynamically linked for faster linking"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_dynamic_plugin/Cargo.toml
+++ b/crates/bevy_dynamic_plugin/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_dynamic_plugin"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides dynamic plugin loading capabilities for non-wasm platforms"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_ecs"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Bevy Engine's entity component system"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_gilrs/Cargo.toml
+++ b/crates/bevy_gilrs/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_gilrs"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Gamepad system made using Gilrs for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_gltf"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Bevy Engine GLTF loading"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_input"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides input functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_internal"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "An internal Bevy crate used to facilitate optional dynamic linking via the 'dynamic' feature"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_log"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides logging for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_macro_utils"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "A collection of utils for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_math"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides math functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_pbr"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Adds PBR rendering to Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_reflect"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Dynamically interact with rust types"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
+++ b/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_reflect_derive"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Derive implementations for bevy_reflect"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -206,7 +206,7 @@ fn impl_struct(
     TokenStream::from(quote! {
         #get_type_registration_impl
 
-        impl #impl_generics #bevy_reflect_path::Struct for #struct_name#ty_generics #where_clause {
+        impl #impl_generics #bevy_reflect_path::Struct for # struct_name # ty_generics #where_clause {
             fn field(&self, name: &str) -> Option<&dyn #bevy_reflect_path::Reflect> {
                 match name {
                     #(#field_names => Some(&self.#field_idents),)*
@@ -259,7 +259,7 @@ fn impl_struct(
         }
 
         // SAFE: any and any_mut both return self
-        unsafe impl #impl_generics #bevy_reflect_path::Reflect for #struct_name#ty_generics #where_clause {
+        unsafe impl #impl_generics #bevy_reflect_path::Reflect for # struct_name # ty_generics #where_clause {
             #[inline]
             fn type_name(&self) -> &str {
                 std::any::type_name::<Self>()
@@ -349,7 +349,7 @@ fn impl_tuple_struct(
     TokenStream::from(quote! {
         #get_type_registration_impl
 
-        impl #impl_generics #bevy_reflect_path::TupleStruct for #struct_name#ty_generics {
+        impl #impl_generics #bevy_reflect_path::TupleStruct for # struct_name # ty_generics {
             fn field(&self, index: usize) -> Option<&dyn #bevy_reflect_path::Reflect> {
                 match index {
                     #(#field_indices => Some(&self.#field_idents),)*
@@ -381,7 +381,7 @@ fn impl_tuple_struct(
         }
 
         // SAFE: any and any_mut both return self
-        unsafe impl #impl_generics #bevy_reflect_path::Reflect for #struct_name#ty_generics {
+        unsafe impl #impl_generics #bevy_reflect_path::Reflect for # struct_name # ty_generics {
             #[inline]
             fn type_name(&self) -> &str {
                 std::any::type_name::<Self>()
@@ -457,7 +457,7 @@ fn impl_value(
         #get_type_registration_impl
 
         // SAFE: any and any_mut both return self
-        unsafe impl #impl_generics #bevy_reflect_path::Reflect for #type_name#ty_generics #where_clause  {
+        unsafe impl #impl_generics #bevy_reflect_path::Reflect for # type_name # ty_generics #where_clause  {
             #[inline]
             fn type_name(&self) -> &str {
                 std::any::type_name::<Self>()
@@ -715,10 +715,10 @@ fn impl_get_type_registration(
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     quote! {
         #[allow(unused_mut)]
-        impl #impl_generics #bevy_reflect_path::GetTypeRegistration for #type_name#ty_generics #where_clause {
+        impl #impl_generics #bevy_reflect_path::GetTypeRegistration for # type_name # ty_generics #where_clause {
             fn get_type_registration() -> #bevy_reflect_path::TypeRegistration {
-                let mut registration = #bevy_reflect_path::TypeRegistration::of::<#type_name#ty_generics>();
-                #(registration.insert::<#registration_data>(#bevy_reflect_path::FromType::<#type_name#ty_generics>::from_type());)*
+                let mut registration = #bevy_reflect_path::TypeRegistration::of::<# type_name # ty_generics>();
+                #(registration.insert::<#registration_data>(#bevy_reflect_path::FromType::<# type_name # ty_generics>::from_type());)*
                 registration
             }
         }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_render"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides rendering functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_scene"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides scene functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_sprite"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides sprite functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_tasks"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "A task executor for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_text"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides text functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_transform"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides hierarchy and transform functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_ui"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "A custom ECS-driven UI framework built specifically for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_utils"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "A collection of utils for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_wgpu/Cargo.toml
+++ b/crates/bevy_wgpu/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_wgpu"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "A wgpu render backend for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_window"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "Provides windowing functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bevy_winit"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 description = "A winit window and input backend for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"

--- a/tools/ci/Cargo.toml
+++ b/tools/ci/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "ci"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
# Objective

Add  'rust-version' to all crates and update to latest edition.

Fixes issue #2998 

## Solution

Added 'rust-version = "1.56"' to all crates and
changed edition from 2018 to 2021.

This required adding whitespace to some rs files
containing macros, because prefix identifiers are
 reserved as of 1.56.