### PR TITLE
Rounded sprite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,10 @@ name = "sprite"
 path = "examples/2d/sprite.rs"
 
 [[example]]
+name = "pipelined_sprite"
+path = "examples/2d/pipelined_sprite.rs"
+
+[[example]]
 name = "sprite_flipping"
 path = "examples/2d/sprite_flipping.rs"
 

--- a/examples/2d/pipelined_sprite.rs
+++ b/examples/2d/pipelined_sprite.rs
@@ -1,0 +1,26 @@
+use bevy::math::Vec3;
+use bevy::prelude::{App, AssetServer, Commands, Res, Transform};
+use bevy::render2::camera::OrthographicCameraBundle;
+use bevy::sprite2::{PipelinedSpriteBundle, Sprite};
+use bevy::PipelinedDefaultPlugins;
+
+fn main() {
+    App::new()
+        .add_plugins(PipelinedDefaultPlugins)
+        .add_startup_system(setup)
+        .run();
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    let texture_handle = asset_server.load("branding/banner.png");
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(PipelinedSpriteBundle {
+        sprite: Sprite {
+            border_radius: 14.0,
+            ..Default::default()
+        },
+        texture: texture_handle,
+        transform: Transform::from_scale(Vec3::new(0.5, 0.5, 1.0)),
+        ..Default::default()
+    });
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -87,6 +87,7 @@ Example | File | Description
 `mesh` | [`2d/mesh.rs`](./2d/mesh.rs) | Renders a custom mesh
 `pipelined_texture_atlas` | [`2d/pipelined_texture_atlas.rs`](./2d/pipelined_texture_atlas.rs) | Generates a texture atlas (sprite sheet) from individual sprites
 `sprite` | [`2d/sprite.rs`](./2d/sprite.rs) | Renders a sprite
+`pipelined_sprite` | [`2d/pipelined_sprite.rs`](./2d/pipelined_sprite.rs) | Renders a sprite
 `sprite_sheet` | [`2d/sprite_sheet.rs`](./2d/sprite_sheet.rs) | Renders an animated sprite
 `text2d` | [`2d/text2d.rs`](./2d/text2d.rs) | Generates text in 2d
 `sprite_flipping` | [`2d/sprite_flipping.rs`](./2d/sprite_flipping.rs) | Renders a sprite flipped along an axis

--- a/pipelined/bevy_sprite2/Cargo.toml
+++ b/pipelined/bevy_sprite2/Cargo.toml
@@ -34,3 +34,4 @@ guillotiere = "0.6.0"
 thiserror = "1.0"
 rectangle-pack = "0.4"
 serde = { version = "1", features = ["derive"] }
+crevice = { path = "../../crates/crevice", version = "0.6.0" }

--- a/pipelined/bevy_sprite2/src/render/sprite.wgsl
+++ b/pipelined/bevy_sprite2/src/render/sprite.wgsl
@@ -27,7 +27,40 @@ var sprite_texture: texture_2d<f32>;
 [[group(1), binding(1)]]
 var sprite_sampler: sampler;
 
+[[block]]
+struct SpriteUniforms {
+    size: vec2<f32>;
+    uv_min: vec2<f32>;
+    uv_max: vec2<f32>;
+    border_radius: f32;
+};
+[[group(2), binding(0)]]
+var<uniform> sprite_uniforms: SpriteUniforms;
+
+// Calculate the distance from the fragment to the border of the rounded rectangle,
+// return negative value when the fragment is inside the rounded rectangle.
+fn distance_round_border(point: vec2<f32>, size: vec2<f32>, radius: f32) -> f32 {
+    let dr = abs(point) - (size - radius);
+    let d = length(max(dr, vec2<f32>(0.0))) - radius;
+    let t = min(dr, vec2<f32>(0.0));
+    let d_extra = max(t.x, t.y);
+
+    return d + d_extra;
+}
+
 [[stage(fragment)]]
 fn fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
-    return textureSample(sprite_texture, sprite_sampler, in.uv);
+    var color = textureSample(sprite_texture, sprite_sampler, in.uv);
+
+    if (sprite_uniforms.border_radius > 0.0) {
+        let d = distance_round_border(
+            ((in.uv - sprite_uniforms.uv_min) / (sprite_uniforms.uv_max - sprite_uniforms.uv_min) - vec2<f32>(0.5)) * sprite_uniforms.size, 
+            sprite_uniforms.size * 0.5, 
+            sprite_uniforms.border_radius
+        );
+        let softness = 0.33;
+        color.a = color.a * (1.0 - smoothStep(-softness, softness, d));
+    }
+
+    return color;
 }

--- a/pipelined/bevy_sprite2/src/sprite.rs
+++ b/pipelined/bevy_sprite2/src/sprite.rs
@@ -12,4 +12,5 @@ pub struct Sprite {
     /// An optional custom size for the sprite that will be used when rendering, instead of the size
     /// of the sprite's image
     pub custom_size: Option<Vec2>,
+    pub border_radius: f32,
 }

--- a/pipelined/bevy_sprite2/src/texture_atlas.rs
+++ b/pipelined/bevy_sprite2/src/texture_atlas.rs
@@ -27,6 +27,7 @@ pub struct TextureAtlasSprite {
     pub index: u32,
     pub flip_x: bool,
     pub flip_y: bool,
+    pub border_radius: f32,
 }
 
 impl Default for TextureAtlasSprite {
@@ -36,6 +37,7 @@ impl Default for TextureAtlasSprite {
             color: Color::WHITE,
             flip_x: false,
             flip_y: false,
+            border_radius: 0.0,
         }
     }
 }


### PR DESCRIPTION
# Objective

Related: #3006 
Implement rounded sprites for the new renderer. 

The new `pipelined-sprite` example looks like:

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/11287532/138680759-9801cc2d-cc3d-46be-b36d-98ac65375cea.png">
