### PR TITLE
Specified toolchains for all jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - uses: actions/cache@v2
         with:
           path: |
@@ -255,6 +258,9 @@ jobs:
     if: always()
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
         if: runner.os == 'linux'


### PR DESCRIPTION
# Objective

During work on #3009 I've found that not all jobs use `actions-rs`, and therefore, an previous version of Rust is used for them. So while compilation and other stuff can pass, checking markup and Android build may fail with compilation errors.

## Solution

This PR takes changes made in #3009 (adds `action-rs` where needed) since it requires more work and time.