### PR TITLE
set build opt level in bevy dev mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,11 @@ crevice = { path = "crates/crevice", version = "0.8.0", features = ["glam"] }
 [profile.dev.package."*"]
 opt-level = 3
 
+# This profile is used during test. By default it inherits the value from the dev profile, so this
+# sets it back to the default value.
+[profile.test.package."*"]
+opt-level = 0
+
 [[example]]
 name = "hello_world"
 path = "examples/hello_world.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,10 @@ serde = { version = "1", features = ["derive"] }
 futures-lite = "1.11.3"
 crevice = { path = "crates/crevice", version = "0.8.0", features = ["glam"] }
 
+
+[profile.dev.package."*"]
+opt-level = 3
+
 [[example]]
 name = "hello_world"
 path = "examples/hello_world.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,8 @@ serde = { version = "1", features = ["derive"] }
 futures-lite = "1.11.3"
 crevice = { path = "crates/crevice", version = "0.8.0", features = ["glam"] }
 
-
+# Set opt level when building Bevy not in release. This is interesting when running examples, but
+# it will make build time slower for development. It has no impact on crates depending on Bevy.
 [profile.dev.package."*"]
 opt-level = 3
 


### PR DESCRIPTION
# Objective

- Run example faster

## Solution

- Set the opt level for Bevy dependencies

This will:
* slow down build time when developing Bevy
* slow down build time when running examples
* **run examples faster when not specifying `--release`**
* **NOT** impact other project that depends on Bevy
