### PR TITLE
[Merged by Bors] - Update derive(DynamicPlugin) to edition 2021

### DIFF
--- a/crates/bevy_derive/src/app_plugin.rs
+++ b/crates/bevy_derive/src/app_plugin.rs
@@ -8,7 +8,7 @@ pub fn derive_dynamic_plugin(input: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
         #[no_mangle]
-        pub extern "C" fn _bevy_create_plugin() -> *mut bevy::app::Plugin {
+        pub extern "C" fn _bevy_create_plugin() -> *mut dyn bevy::app::Plugin {
             // make sure the constructor is the correct type.
             let object = #struct_name {};
             let boxed = Box::new(object);


### PR DESCRIPTION
# Objective
Edition 2021 requires `dyn Trait` and it won't compile without `dyn`.

## Solution
Added `dyn`.