### PR TITLE
[Merged by Bors] - MSAA example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,10 @@ name = "msaa"
 path = "examples/3d/msaa.rs"
 
 [[example]]
+name = "msaa_pipelined"
+path = "examples/3d/msaa_pipelined.rs"
+
+[[example]]
 name = "orthographic"
 path = "examples/3d/orthographic.rs"
 

--- a/examples/3d/msaa_pipelined.rs
+++ b/examples/3d/msaa_pipelined.rs
@@ -23,8 +23,8 @@ fn main() {
     App::new()
         .insert_resource(Msaa { samples: 4 })
         .add_plugins(PipelinedDefaultPlugins)
-        .add_startup_system(setup.system())
-        .add_system(cycle_msaa.system())
+        .add_startup_system(setup)
+        .add_system(cycle_msaa)
         .run();
 }
 

--- a/examples/3d/msaa_pipelined.rs
+++ b/examples/3d/msaa_pipelined.rs
@@ -1,0 +1,65 @@
+use bevy::{
+    ecs::prelude::*,
+    input::Input,
+    math::Vec3,
+    pbr2::{PbrBundle, PointLightBundle, StandardMaterial},
+    prelude::{App, Assets, KeyCode, Transform},
+    render2::{
+        camera::PerspectiveCameraBundle,
+        color::Color,
+        mesh::{shape, Mesh},
+        view::Msaa,
+    },
+    PipelinedDefaultPlugins,
+};
+
+/// This example shows how to configure Multi-Sample Anti-Aliasing. Setting the sample count higher
+/// will result in smoother edges, but it will also increase the cost to render those edges. The
+/// range should generally be somewhere between 1 (no multi sampling, but cheap) to 8 (crisp but
+/// expensive)
+fn main() {
+    println!("Press 'm' to toggle MSAA");
+    println!("Using 4x MSAA");
+    App::new()
+        .insert_resource(Msaa { samples: 4 })
+        .add_plugins(PipelinedDefaultPlugins)
+        .add_startup_system(setup.system())
+        .add_system(cycle_msaa.system())
+        .run();
+}
+
+/// set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // cube
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 2.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        ..Default::default()
+    });
+    // light
+    commands.spawn_bundle(PointLightBundle {
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..Default::default()
+    });
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(-3.0, 3.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
+}
+
+fn cycle_msaa(input: Res<Input<KeyCode>>, mut msaa: ResMut<Msaa>) {
+    if input.just_pressed(KeyCode::M) {
+        msaa.samples = if msaa.samples == 4 {
+            println!("Not using MSAA");
+            1
+        } else {
+            println!("Using 4x MSAA");
+            4
+        };
+    }
+}

--- a/examples/3d/msaa_pipelined.rs
+++ b/examples/3d/msaa_pipelined.rs
@@ -54,12 +54,12 @@ fn setup(
 
 fn cycle_msaa(input: Res<Input<KeyCode>>, mut msaa: ResMut<Msaa>) {
     if input.just_pressed(KeyCode::M) {
-        msaa.samples = if msaa.samples == 4 {
+        if msaa.samples == 4 {
             println!("Not using MSAA");
-            1
+            msaa.samples = 1;
         } else {
             println!("Using 4x MSAA");
-            4
-        };
+            msaa.samples = 4;
+        }
     }
 }

--- a/examples/3d/msaa_pipelined.rs
+++ b/examples/3d/msaa_pipelined.rs
@@ -16,7 +16,10 @@ use bevy::{
 /// This example shows how to configure Multi-Sample Anti-Aliasing. Setting the sample count higher
 /// will result in smoother edges, but it will also increase the cost to render those edges. The
 /// range should generally be somewhere between 1 (no multi sampling, but cheap) to 8 (crisp but
-/// expensive)
+/// expensive).
+/// Note that WGPU currently only supports 1 or 4 samples.
+/// Ultimately we plan on supporting whatever is natively supported on a given device.
+/// Check out this issue for more info: https://github.com/gfx-rs/wgpu/issues/1832
 fn main() {
     println!("Press 'm' to toggle MSAA");
     println!("Using 4x MSAA");

--- a/examples/README.md
+++ b/examples/README.md
@@ -103,6 +103,7 @@ Example | File | Description
 `load_gltf_pipelined` | [`3d/load_gltf_pipelined.rs`](./3d/load_gltf_pipelined.rs) | Loads and renders a gltf file as a scene
 `many_cubes_pipelined` | [`3d/many_cubes_pipelined.rs`](./3d/many_cubes_pipelined.rs) | Simple benchmark to test per-entity draw overhead
 `msaa` | [`3d/msaa.rs`](./3d/msaa.rs) | Configures MSAA (Multi-Sample Anti-Aliasing) for smoother edges
+`msaa_pipelined` | [`3d/msaa_pipelined.rs`](./3d/msaa_pipelined.rs) | Configures MSAA (Multi-Sample Anti-Aliasing) for smoother edges
 `orthographic` | [`3d/orthographic.rs`](./3d/orthographic.rs) | Shows how to create a 3D orthographic view (for isometric-look games or CAD applications)
 `orthographic_pipelined` | [`3d/orthographic_pipelined.rs`](./3d/orthographic_pipelined.rs) | Shows how to create a 3D orthographic view (for isometric-look games or CAD applications)
 `parenting` | [`3d/parenting.rs`](./3d/parenting.rs) | Demonstrates parent->child relationships and relative transformations


### PR DESCRIPTION
Add an example that demonstrates the difference between no MSAA and MSAA 4x. This is also useful for testing panics when resizing the window using MSAA. This is on top of #3042 .