### PR TITLE
[Merged by Bors] - remove Box from ExclusiveSystemFn

### DIFF
--- a/crates/bevy_ecs/src/schedule/system_descriptor.rs
+++ b/crates/bevy_ecs/src/schedule/system_descriptor.rs
@@ -78,7 +78,10 @@ impl IntoSystemDescriptor<()> for ExclusiveSystemDescriptor {
     }
 }
 
-impl IntoSystemDescriptor<()> for ExclusiveSystemFn {
+impl<F> IntoSystemDescriptor<()> for ExclusiveSystemFn<F>
+where
+    F: FnMut(&mut crate::prelude::World) + Send + Sync + 'static,
+{
     fn into_descriptor(self) -> SystemDescriptor {
         new_exclusive_descriptor(Box::new(self)).into_descriptor()
     }

--- a/crates/bevy_ecs/src/system/exclusive_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system.rs
@@ -15,10 +15,7 @@ pub trait ExclusiveSystem: Send + Sync + 'static {
     fn check_change_tick(&mut self, change_tick: u32);
 }
 
-pub struct ExclusiveSystemFn<F>
-where
-    F: FnMut(&mut World) + Send + Sync + 'static,
-{
+pub struct ExclusiveSystemFn<F> {
     func: F,
     name: Cow<'static, str>,
     last_change_tick: u32,

--- a/crates/bevy_ecs/src/system/exclusive_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system.rs
@@ -15,13 +15,19 @@ pub trait ExclusiveSystem: Send + Sync + 'static {
     fn check_change_tick(&mut self, change_tick: u32);
 }
 
-pub struct ExclusiveSystemFn {
-    func: Box<dyn FnMut(&mut World) + Send + Sync + 'static>,
+pub struct ExclusiveSystemFn<F>
+where
+    F: FnMut(&mut World) + Send + Sync + 'static,
+{
+    func: F,
     name: Cow<'static, str>,
     last_change_tick: u32,
 }
 
-impl ExclusiveSystem for ExclusiveSystemFn {
+impl<F> ExclusiveSystem for ExclusiveSystemFn<F>
+where
+    F: FnMut(&mut World) + Send + Sync + 'static,
+{
     fn name(&self) -> Cow<'static, str> {
         self.name.clone()
     }
@@ -52,13 +58,13 @@ pub trait IntoExclusiveSystem<Params, SystemType> {
     fn exclusive_system(self) -> SystemType;
 }
 
-impl<F> IntoExclusiveSystem<&mut World, ExclusiveSystemFn> for F
+impl<F> IntoExclusiveSystem<&mut World, ExclusiveSystemFn<F>> for F
 where
     F: FnMut(&mut World) + Send + Sync + 'static,
 {
-    fn exclusive_system(self) -> ExclusiveSystemFn {
+    fn exclusive_system(self) -> ExclusiveSystemFn<F> {
         ExclusiveSystemFn {
-            func: Box::new(self),
+            func: self,
             name: core::any::type_name::<F>().into(),
             last_change_tick: 0,
         }


### PR DESCRIPTION
Minor refactor to remove the boxing of the function pointer stored in ExclusiveSystemFn.