### PR TITLE
[Merged by Bors] - add position to WindowDescriptor

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -525,6 +525,7 @@ impl Window {
 pub struct WindowDescriptor {
     pub width: f32,
     pub height: f32,
+    pub position: Option<Vec2>,
     pub resize_constraints: WindowResizeConstraints,
     pub scale_factor_override: Option<f64>,
     pub title: String,
@@ -544,6 +545,7 @@ impl Default for WindowDescriptor {
             title: "bevy".to_string(),
             width: 1280.,
             height: 720.,
+            position: None,
             resize_constraints: WindowResizeConstraints::default(),
             scale_factor_override: None,
             vsync: true,

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -52,12 +52,18 @@ impl WinitWindows {
                 if let Some(position) = position {
                     if let Some(sf) = scale_factor_override {
                         winit_window_builder = winit_window_builder.with_position(
-                            winit::dpi::LogicalPosition::new(position[0] as f64, position[1] as f64).to_physical::<f64>(*sf),
+                            winit::dpi::LogicalPosition::new(
+                                position[0] as f64,
+                                position[1] as f64,
+                            )
+                            .to_physical::<f64>(*sf),
                         );
                     } else {
-                        winit_window_builder = winit_window_builder.with_position(
-                            winit::dpi::LogicalPosition::new(position[0] as f64, position[1] as f64),
-                        );
+                        winit_window_builder =
+                            winit_window_builder.with_position(winit::dpi::LogicalPosition::new(
+                                position[0] as f64,
+                                position[1] as f64,
+                            ));
                     }
                 }
                 if let Some(sf) = scale_factor_override {

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -44,9 +44,22 @@ impl WinitWindows {
                 let WindowDescriptor {
                     width,
                     height,
+                    position,
                     scale_factor_override,
                     ..
                 } = window_descriptor;
+
+                if let Some(position) = position {
+                    if let Some(sf) = scale_factor_override {
+                        winit_window_builder = winit_window_builder.with_position(
+                            winit::dpi::LogicalPosition::new(position[0] as f64, position[1] as f64).to_physical::<f64>(*sf),
+                        );
+                    } else {
+                        winit_window_builder = winit_window_builder.with_position(
+                            winit::dpi::LogicalPosition::new(position[0] as f64, position[1] as f64),
+                        );
+                    }
+                }
                 if let Some(sf) = scale_factor_override {
                     winit_window_builder.with_inner_size(
                         winit::dpi::LogicalSize::new(*width, *height).to_physical::<f64>(*sf),


### PR DESCRIPTION
# Objective

Set initial position of the window, so I can start it at the left side of the view automatically, used with `cargo watch`

## Solution

add window position to WindowDescriptor 