### PR TITLE
[Merged by Bors] - Implement init_resource for `Commands` and `World`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -673,11 +673,13 @@ impl App {
         self
     }
 
-    /// Initialize a resource with default values by adding it to the [`World`]
+    /// Initialize a resource with standard starting values by adding it to the [`World`]
     ///
     /// If the resource already exists, nothing happens.
     ///
-    /// The resource must implement either the `Default` or [`FromWorld`] trait.
+    /// The resource must implement the [`FromWorld`] trait.
+    /// If the `Default` trait is implemented, the `FromWorld` trait will use
+    /// the `Default::default` method to initialize the resource.
     ///
     /// ## Example
     /// ```
@@ -703,11 +705,11 @@ impl App {
         self
     }
 
-    /// Initialize a non-send resource with default values by adding it to the [`World`]
+    /// Initialize a non-send resource with standard starting values by adding it to the [`World`]
     ///
-    /// If the resource already exists, nothing happens.
-    ///
-    /// The resource must implement either the `Default` or [`FromWorld`] trait.
+    /// The resource must implement the [`FromWorld`] trait.
+    /// If the `Default` trait is implemented, the `FromWorld` trait will use
+    /// the `Default::default` method to initialize the resource.
     pub fn init_non_send_resource<R: 'static + FromWorld>(&mut self) -> &mut Self {
         self.world.init_non_send_resource::<R>();
         self

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -647,18 +647,15 @@ impl App {
     /// App::new()
     ///    .insert_resource(MyCounter { counter: 0 });
     /// ```
-    pub fn insert_resource<T>(&mut self, resource: T) -> &mut Self
-    where
-        T: Resource,
-    {
+    pub fn insert_resource<R: Resource>(&mut self, resource: R) -> &mut Self {
         self.world.insert_resource(resource);
         self
     }
 
     /// Inserts a non-send resource to the app
     ///
-    /// You usually want to use `insert_resource`, but there are some special cases when a resource must
-    /// be non-send.
+    /// You usually want to use `insert_resource`,
+    /// but there are some special cases when a resource cannot be sent across threads.
     ///
     /// ## Example
     /// ```
@@ -671,19 +668,16 @@ impl App {
     /// App::new()
     ///     .insert_non_send_resource(MyCounter { counter: 0 });
     /// ```
-    pub fn insert_non_send_resource<T>(&mut self, resource: T) -> &mut Self
-    where
-        T: 'static,
-    {
-        self.world.insert_non_send(resource);
+    pub fn insert_non_send_resource<R: 'static>(&mut self, resource: R) -> &mut Self {
+        self.world.insert_non_send_resource(resource);
         self
     }
 
-    /// Initialize a resource in the current [`App`], if it does not exist yet
+    /// Initialize a resource with default values by adding it to the [`World`]
     ///
     /// If the resource already exists, nothing happens.
     ///
-    /// Adds a resource that implements `Default` or [`FromWorld`] trait.
+    /// The resource must implement either the `Default` or [`FromWorld`] trait.
     ///
     /// ## Example
     /// ```
@@ -704,32 +698,18 @@ impl App {
     /// App::new()
     ///     .init_resource::<MyCounter>();
     /// ```
-    pub fn init_resource<R>(&mut self) -> &mut Self
-    where
-        R: FromWorld + Send + Sync + 'static,
-    {
-        // PERF: We could avoid double hashing here, since the `from_resources` call is guaranteed
-        // not to modify the map. However, we would need to be borrowing resources both
-        // mutably and immutably, so we would need to be extremely certain this is correct
-        if !self.world.contains_resource::<R>() {
-            let resource = R::from_world(&mut self.world);
-            self.insert_resource(resource);
-        }
+    pub fn init_resource<R: Resource + FromWorld>(&mut self) -> &mut Self {
+        self.world.init_resource::<R>();
         self
     }
 
-    /// Initialize a non-send resource in the current [`App`], if it does not exist yet.
+    /// Initialize a non-send resource with default values by adding it to the [`World`]
     ///
-    /// Adds a resource that implements `Default` or [`FromWorld`] trait.
-    pub fn init_non_send_resource<R>(&mut self) -> &mut Self
-    where
-        R: FromWorld + 'static,
-    {
-        // See perf comment in init_resource
-        if self.world.get_non_send_resource::<R>().is_none() {
-            let resource = R::from_world(&mut self.world);
-            self.world.insert_non_send(resource);
-        }
+    /// If the resource already exists, nothing happens.
+    ///
+    /// The resource must implement either the `Default` or [`FromWorld`] trait.
+    pub fn init_non_send_resource<R: 'static + FromWorld>(&mut self) -> &mut Self {
+        self.world.init_non_send_resource::<R>();
         self
     }
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1181,8 +1181,8 @@ mod tests {
     #[test]
     fn non_send_resource() {
         let mut world = World::default();
-        world.insert_non_send(123i32);
-        world.insert_non_send(456i64);
+        world.insert_non_send_resource(123i32);
+        world.insert_non_send_resource(456i64);
         assert_eq!(*world.get_non_send_resource::<i32>().unwrap(), 123);
         assert_eq!(*world.get_non_send_resource_mut::<i64>().unwrap(), 456);
     }
@@ -1191,7 +1191,7 @@ mod tests {
     #[should_panic]
     fn non_send_resource_panic() {
         let mut world = World::default();
-        world.insert_non_send(0i32);
+        world.insert_non_send_resource(0i32);
         std::thread::spawn(move || {
             let _ = world.get_non_send_resource_mut::<i32>();
         })

--- a/crates/bevy_ecs/src/schedule/executor_parallel.rs
+++ b/crates/bevy_ecs/src/schedule/executor_parallel.rs
@@ -476,7 +476,7 @@ mod tests {
     fn non_send_resource() {
         use std::thread;
         let mut world = World::new();
-        world.insert_non_send(thread::current().id());
+        world.insert_non_send_resource(thread::current().id());
         fn non_send(thread_id: NonSend<thread::ThreadId>) {
             assert_eq!(thread::current().id(), *thread_id);
         }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -267,6 +267,8 @@ impl<'w, 's> Commands<'w, 's> {
     /// Note that any resource with the `Default` trait automatically implements `FromWorld`,
     /// and those default values will be here instead.
     ///
+    /// See [`World::init_resource`] for more details.
+    ///
     /// # Example
     ///
     /// ```
@@ -747,8 +749,7 @@ pub struct InitResource<T: Resource + FromWorld> {
 
 impl<T: Resource + FromWorld> Command for InitResource<T> {
     fn write(self, world: &mut World) {
-        let resource: T = FromWorld::from_world(world);
-        world.insert_resource(resource);
+        world.init_resource::<T>();
     }
 }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -261,7 +261,7 @@ impl<'w, 's> Commands<'w, 's> {
         self.queue.push(InsertOrSpawnBatch { bundles_iter });
     }
 
-    /// Inserts a resource with default values to the [`World`].
+    /// Inserts a resource with standard starting values to the [`World`].
     ///
     /// If the resource already exists, nothing happens.
     ///

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -261,7 +261,9 @@ impl<'w, 's> Commands<'w, 's> {
         self.queue.push(InsertOrSpawnBatch { bundles_iter });
     }
 
-    /// Inserts a resource with default values to the [`World`], overwriting any previous value of the same type.
+    /// Inserts a resource with default values to the [`World`].
+    ///
+    /// If the resource already exists, nothing happens.
     ///
     /// The value given by the [`FromWorld::from_world`] method will be used.
     /// Note that any resource with the `Default` trait automatically implements `FromWorld`,
@@ -287,9 +289,9 @@ impl<'w, 's> Commands<'w, 's> {
     /// # }
     /// # system.system();
     /// ```
-    pub fn init_resource<T: Resource + FromWorld>(&mut self) {
-        self.queue.push(InitResource::<T> {
-            _phantom: PhantomData::<T>::default(),
+    pub fn init_resource<R: Resource + FromWorld>(&mut self) {
+        self.queue.push(InitResource::<R> {
+            _phantom: PhantomData::<R>::default(),
         })
     }
 
@@ -317,7 +319,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// # }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
-    pub fn insert_resource<T: Resource>(&mut self, resource: T) {
+    pub fn insert_resource<R: Resource>(&mut self, resource: R) {
         self.queue.push(InsertResource { resource })
     }
 
@@ -340,8 +342,8 @@ impl<'w, 's> Commands<'w, 's> {
     /// # }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
-    pub fn remove_resource<T: Resource>(&mut self) {
-        self.queue.push(RemoveResource::<T> {
+    pub fn remove_resource<R: Resource>(&mut self) {
+        self.queue.push(RemoveResource::<R> {
             phantom: PhantomData,
         });
     }
@@ -747,33 +749,33 @@ where
     }
 }
 
-pub struct InitResource<T: Resource + FromWorld> {
-    _phantom: PhantomData<T>,
+pub struct InitResource<R: Resource + FromWorld> {
+    _phantom: PhantomData<R>,
 }
 
-impl<T: Resource + FromWorld> Command for InitResource<T> {
+impl<R: Resource + FromWorld> Command for InitResource<R> {
     fn write(self, world: &mut World) {
-        world.init_resource::<T>();
+        world.init_resource::<R>();
     }
 }
 
-pub struct InsertResource<T: Resource> {
-    pub resource: T,
+pub struct InsertResource<R: Resource> {
+    pub resource: R,
 }
 
-impl<T: Resource> Command for InsertResource<T> {
+impl<R: Resource> Command for InsertResource<R> {
     fn write(self, world: &mut World) {
         world.insert_resource(self.resource);
     }
 }
 
-pub struct RemoveResource<T: Resource> {
-    pub phantom: PhantomData<T>,
+pub struct RemoveResource<R: Resource> {
+    pub phantom: PhantomData<R>,
 }
 
-impl<T: Resource> Command for RemoveResource<T> {
+impl<R: Resource> Command for RemoveResource<R> {
     fn write(self, world: &mut World) {
-        world.remove_resource::<T>();
+        world.remove_resource::<R>();
     }
 }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -268,6 +268,8 @@ impl<'w, 's> Commands<'w, 's> {
     /// and those default values will be here instead.
     ///
     /// See [`World::init_resource`] for more details.
+    /// Note that commands do not take effect immediately.
+    /// When possible, prefer the equivalent methods on `App` or `World`.
     ///
     /// # Example
     ///
@@ -294,6 +296,8 @@ impl<'w, 's> Commands<'w, 's> {
     /// Inserts a resource to the [`World`], overwriting any previous value of the same type.
     ///
     /// See [`World::insert_resource`] for more details.
+    /// Note that commands do not take effect immediately.
+    /// When possible, prefer the equivalent methods on `App` or `World`.
     ///
     /// # Example
     ///

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -422,7 +422,7 @@ mod tests {
         world.insert_resource(false);
         struct NotSend1(std::rc::Rc<i32>);
         struct NotSend2(std::rc::Rc<i32>);
-        world.insert_non_send(NotSend1(std::rc::Rc::new(0)));
+        world.insert_non_send_resource(NotSend1(std::rc::Rc::new(0)));
 
         fn sys(
             op: Option<NonSend<NotSend1>>,
@@ -446,8 +446,8 @@ mod tests {
         struct NotSend1(std::rc::Rc<i32>);
         struct NotSend2(std::rc::Rc<i32>);
 
-        world.insert_non_send(NotSend1(std::rc::Rc::new(1)));
-        world.insert_non_send(NotSend2(std::rc::Rc::new(2)));
+        world.insert_non_send_resource(NotSend1(std::rc::Rc::new(1)));
+        world.insert_non_send_resource(NotSend2(std::rc::Rc::new(2)));
 
         fn sys(_op: NonSend<NotSend1>, mut _op2: NonSendMut<NotSend2>, mut run: ResMut<bool>) {
             *run = true;

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -597,7 +597,7 @@ impl World {
     /// If the resource already exists, nothing happens.
     ///
     /// Uses the [`FromWorld`] trait to determine values,
-    /// which has a blanket impl for all `T: Default`.
+    /// which has a blanket impl for all `R: Default`.
     #[inline]
     pub fn init_resource<R: Resource + FromWorld>(&mut self) {
         // PERF: We could avoid double hashing here, since the `from_resources` call is guaranteed
@@ -612,8 +612,8 @@ impl World {
     /// Inserts a new resource with the given `value`.
     ///
     /// Resources are "unique" data of a given type.
-    /// Insert a resource of a type that already exists
-    /// will overwrite any existing data.
+    /// If you insert a resource of a type that already exists,
+    /// you will overwrite any existing data.
     #[inline]
     pub fn insert_resource<T: Resource>(&mut self, value: T) {
         let component_id = self.components.init_resource::<T>();
@@ -626,7 +626,7 @@ impl World {
     /// If the resource already exists, nothing happens.
     ///
     /// Uses the [`FromWorld`] trait to determine values,
-    /// which has a blanket impl for all `T: Default`.
+    /// which has a blanket impl for all `R: Default`.
     #[inline]
     pub fn init_non_send_resource<R: 'static + FromWorld>(&mut self) {
         // PERF: We could avoid double hashing here, since the `from_resources` call is guaranteed

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -631,7 +631,7 @@ impl World {
     /// and those default values will be here instead.
     #[inline]
     pub fn init_non_send_resource<R: 'static + FromWorld>(&mut self) {
-        // PERF: We could avoid double hashing here, since the `from_resources` call is guaranteed
+        // PERF: We could avoid double hashing here, since the `from_world` call is guaranteed
         // not to modify the map. However, we would need to be borrowing resources both
         // mutably and immutably, so we would need to be extremely certain this is correct
         if !self.contains_resource::<R>() {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -592,12 +592,13 @@ impl World {
         }
     }
 
-    /// Inserts a new resource with default values.
+    /// Inserts a new resource with standard starting values.
     ///
     /// If the resource already exists, nothing happens.
     ///
-    /// Uses the [`FromWorld`] trait to determine values,
-    /// which has a blanket impl for all `R: Default`.
+    /// The value given by the [`FromWorld::from_world`] method will be used.
+    /// Note that any resource with the `Default` trait automatically implements `FromWorld`,
+    /// and those default values will be here instead.
     #[inline]
     pub fn init_resource<R: Resource + FromWorld>(&mut self) {
         // PERF: We could avoid double hashing here, since the `from_resources` call is guaranteed
@@ -621,12 +622,13 @@ impl World {
         unsafe { self.insert_resource_with_id(component_id, value) };
     }
 
-    /// Inserts a new non-send resource with default values.
+    /// Inserts a new non-send resource with standard starting values.
     ///
     /// If the resource already exists, nothing happens.
     ///
-    /// Uses the [`FromWorld`] trait to determine values,
-    /// which has a blanket impl for all `R: Default`.
+    /// The value given by the [`FromWorld::from_world`] method will be used.
+    /// Note that any resource with the `Default` trait automatically implements `FromWorld`,
+    /// and those default values will be here instead.
     #[inline]
     pub fn init_non_send_resource<R: 'static + FromWorld>(&mut self) {
         // PERF: We could avoid double hashing here, since the `from_resources` call is guaranteed

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -601,7 +601,7 @@ impl World {
     /// and those default values will be here instead.
     #[inline]
     pub fn init_resource<R: Resource + FromWorld>(&mut self) {
-        // PERF: We could avoid double hashing here, since the `from_resources` call is guaranteed
+        // PERF: We could avoid double hashing here, since the `from_world` call is guaranteed
         // not to modify the map. However, we would need to be borrowing resources both
         // mutably and immutably, so we would need to be extremely certain this is correct
         if !self.contains_resource::<R>() {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -621,6 +621,23 @@ impl World {
         unsafe { self.insert_resource_with_id(component_id, value) };
     }
 
+    /// Inserts a new resource with default values.
+    ///
+    /// If the resource already exists, nothing happens.
+    ///
+    /// Uses the [`FromWorld`] trait to determine values,
+    /// which has a blanket impl for all `T: Default`.
+    #[inline]
+    pub fn init_non_send_resource<R: 'static + FromWorld>(&mut self) {
+        // PERF: We could avoid double hashing here, since the `from_resources` call is guaranteed
+        // not to modify the map. However, we would need to be borrowing resources both
+        // mutably and immutably, so we would need to be extremely certain this is correct
+        if !self.contains_resource::<R>() {
+            let resource = R::from_world(self);
+            self.insert_non_send_resource(resource);
+        }
+    }
+
     /// Inserts a new non-send resource with the given `value`.
     ///
     /// NonSend resources cannot be sent across threads,

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -642,7 +642,7 @@ impl World {
 
     /// Inserts a new non-send resource with the given `value`.
     ///
-    /// NonSend resources cannot be sent across threads,
+    /// `NonSend` resources cannot be sent across threads,
     /// and do not need the `Send + Sync` bounds.
     /// Systems with `NonSend` resources are always scheduled on the main thread.
     #[inline]
@@ -669,7 +669,7 @@ impl World {
 
     #[inline]
     /// # Safety
-    /// Only remove NonSend resources from the main thread
+    /// Only remove `NonSend` resources from the main thread
     /// as they cannot be sent across theads
     #[allow(unused_unsafe)]
     pub unsafe fn remove_resource_unchecked<R: 'static>(&mut self) -> Option<R> {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -592,6 +592,16 @@ impl World {
         }
     }
 
+    /// Inserts a new resource with default values.
+    ///
+    /// Uses the [`FromWorld`] trait to determine values,
+    /// which has a blanket impl for all `T: Default`.
+    #[inline]
+    pub fn init_resource<T: Resource + FromWorld>(&mut self) {
+        let resource: T = FromWorld::from_world(self);
+        self.insert_resource(resource);
+    }
+
     /// Inserts a new resource with the given `value`.
     /// Resources are "unique" data of a given type.
     #[inline]

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -621,7 +621,7 @@ impl World {
         unsafe { self.insert_resource_with_id(component_id, value) };
     }
 
-    /// Inserts a new resource with default values.
+    /// Inserts a new non-send resource with default values.
     ///
     /// If the resource already exists, nothing happens.
     ///

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -133,7 +133,7 @@ impl Plugin for LogPlugin {
                         }
                     }))
                     .build();
-                app.world.insert_non_send(guard);
+                app.world.insert_non_send_resource(guard);
                 chrome_layer
             };
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -223,7 +223,10 @@ pub fn winit_runner(app: App) {
 // }
 
 pub fn winit_runner_with(mut app: App) {
-    let mut event_loop = app.world.remove_non_send::<EventLoop<()>>().unwrap();
+    let mut event_loop = app
+        .world
+        .remove_non_send_resource::<EventLoop<()>>()
+        .unwrap();
     let mut create_window_event_reader = ManualEventReader::<CreateWindow>::default();
     let mut app_exit_event_reader = ManualEventReader::<AppExit>::default();
     app.world

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -226,7 +226,8 @@ pub fn winit_runner_with(mut app: App) {
     let mut event_loop = app.world.remove_non_send::<EventLoop<()>>().unwrap();
     let mut create_window_event_reader = ManualEventReader::<CreateWindow>::default();
     let mut app_exit_event_reader = ManualEventReader::<AppExit>::default();
-    app.world.insert_non_send(event_loop.create_proxy());
+    app.world
+        .insert_non_send_resource(event_loop.create_proxy());
 
     trace!("Entering winit event loop");
 


### PR DESCRIPTION
# Objective

- Fixes #3078
- Fixes #1397

## Solution

- Implement Commands::init_resource.
- Also implement for World, for consistency and to simplify internal structure.
- While we're here, clean up some of the docs for Command and World resource modification.