### PR TITLE
Changed serializable enums to use snake_case

### DIFF
--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -8,7 +8,11 @@ use bevy_utils::HashMap;
 pub struct Gamepad(pub usize);
 
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(
+	feature = "serialize",
+	derive(serde::Serialize, serde::Deserialize),
+	serde(rename_all = "snake_case")
+)]
 pub enum GamepadEventType {
     Connected,
     Disconnected,
@@ -25,7 +29,11 @@ pub struct GamepadEvent(pub Gamepad, pub GamepadEventType);
 pub struct GamepadEventRaw(pub Gamepad, pub GamepadEventType);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(
+	feature = "serialize",
+	derive(serde::Serialize, serde::Deserialize),
+	serde(rename_all = "snake_case")
+)]
 pub enum GamepadButtonType {
     South,
     East,
@@ -53,7 +61,11 @@ pub enum GamepadButtonType {
 pub struct GamepadButton(pub Gamepad, pub GamepadButtonType);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(
+	feature = "serialize",
+	derive(serde::Serialize, serde::Deserialize),
+	serde(rename_all = "snake_case")
+)]
 pub enum GamepadAxisType {
     LeftStickX,
     LeftStickY,

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -9,9 +9,9 @@ pub struct Gamepad(pub usize);
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(
-	feature = "serialize",
-	derive(serde::Serialize, serde::Deserialize),
-	serde(rename_all = "snake_case")
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
 )]
 pub enum GamepadEventType {
     Connected,
@@ -30,9 +30,9 @@ pub struct GamepadEventRaw(pub Gamepad, pub GamepadEventType);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(
-	feature = "serialize",
-	derive(serde::Serialize, serde::Deserialize),
-	serde(rename_all = "snake_case")
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
 )]
 pub enum GamepadButtonType {
     South,
@@ -62,9 +62,9 @@ pub struct GamepadButton(pub Gamepad, pub GamepadButtonType);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(
-	feature = "serialize",
-	derive(serde::Serialize, serde::Deserialize),
-	serde(rename_all = "snake_case")
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
 )]
 pub enum GamepadAxisType {
     LeftStickX,

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -8,7 +8,7 @@ use bevy_utils::HashMap;
 pub struct Gamepad(pub usize);
 
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub enum GamepadEventType {
     Connected,
     Disconnected,
@@ -25,7 +25,7 @@ pub struct GamepadEvent(pub Gamepad, pub GamepadEventType);
 pub struct GamepadEventRaw(pub Gamepad, pub GamepadEventType);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub enum GamepadButtonType {
     South,
     East,
@@ -53,7 +53,7 @@ pub enum GamepadButtonType {
 pub struct GamepadButton(pub Gamepad, pub GamepadButtonType);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub enum GamepadAxisType {
     LeftStickX,
     LeftStickY,

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -33,7 +33,11 @@ pub fn keyboard_input_system(
 
 /// The key code of a keyboard input.
 #[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(
+	feature = "serialize",
+	derive(serde::Serialize, serde::Deserialize),
+	serde(rename_all = "snake_case")
+)]
 #[repr(u32)]
 pub enum KeyCode {
     /// The '1' key over the letters.

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -34,9 +34,9 @@ pub fn keyboard_input_system(
 /// The key code of a keyboard input.
 #[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(
-	feature = "serialize",
-	derive(serde::Serialize, serde::Deserialize),
-	serde(rename_all = "snake_case")
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
 )]
 #[repr(u32)]
 pub enum KeyCode {

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -33,7 +33,7 @@ pub fn keyboard_input_system(
 
 /// The key code of a keyboard input.
 #[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[repr(u32)]
 pub enum KeyCode {
     /// The '1' key over the letters.

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -83,7 +83,11 @@ impl Plugin for InputPlugin {
 
 /// The current "press" state of an element
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(
+	feature = "serialize",
+	derive(serde::Serialize, serde::Deserialize),
+	serde(rename_all = "snake_case")
+)]
 pub enum ElementState {
     Pressed,
     Released,

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -84,9 +84,9 @@ impl Plugin for InputPlugin {
 /// The current "press" state of an element
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(
-	feature = "serialize",
-	derive(serde::Serialize, serde::Deserialize),
-	serde(rename_all = "snake_case")
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
 )]
 pub enum ElementState {
     Pressed,

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -83,7 +83,7 @@ impl Plugin for InputPlugin {
 
 /// The current "press" state of an element
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub enum ElementState {
     Pressed,
     Released,

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -11,7 +11,11 @@ pub struct MouseButtonInput {
 
 /// A button on a mouse device
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(
+	feature = "serialize",
+	derive(serde::Serialize, serde::Deserialize),
+	serde(rename_all = "snake_case")
+)]
 pub enum MouseButton {
     Left,
     Right,

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -12,9 +12,9 @@ pub struct MouseButtonInput {
 /// A button on a mouse device
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(
-	feature = "serialize",
-	derive(serde::Serialize, serde::Deserialize),
-	serde(rename_all = "snake_case")
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
 )]
 pub enum MouseButton {
     Left,

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -11,7 +11,7 @@ pub struct MouseButtonInput {
 
 /// A button on a mouse device
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub enum MouseButton {
     Left,
     Right,

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -70,9 +70,9 @@ pub enum ForceTouch {
 /// Describes touch-screen input state.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(
-	feature = "serialize",
-	derive(serde::Serialize, serde::Deserialize),
-	serde(rename_all = "snake_case")
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
 )]
 pub enum TouchPhase {
     Started,

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -69,7 +69,11 @@ pub enum ForceTouch {
 
 /// Describes touch-screen input state.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(
+	feature = "serialize",
+	derive(serde::Serialize, serde::Deserialize),
+	serde(rename_all = "snake_case")
+)]
 pub enum TouchPhase {
     Started,
     Moved,

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -69,7 +69,7 @@ pub enum ForceTouch {
 
 /// Describes touch-screen input state.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub enum TouchPhase {
     Started,
     Moved,


### PR DESCRIPTION
# Objective

Fixes #3074 

## Solution

It was less work than I thought, there were only 5 files with serializable enums. The other serializable types were tuples, so snake_case would be pointless to add to them. I just added `serde(rename_all = "snake_case")` to the `#[cfg_attr]` on these enums.
