### PR TITLE
Fixed ECS example compilation issues

### DIFF
--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -96,7 +96,7 @@ The built in "parallel stage" considers dependencies between systems and (by def
 Bevy ECS should feel very natural for those familiar with Rust syntax:
 
 ```rust
-use bevy::prelude::*;
+use bevy_ecs::prelude::*;
 
 struct Velocity {
     x: f32,

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -96,7 +96,7 @@ The built in "parallel stage" considers dependencies between systems and (by def
 Bevy ECS should feel very natural for those familiar with Rust syntax:
 
 ```rust
-use bevy_ecs::prelude::*;
+use bevy::prelude::*;
 
 struct Velocity {
     x: f32,
@@ -109,7 +109,7 @@ struct Position {
 }
 
 // This system moves each entity with a Position and Velocity component
-fn movement(query: Query<(&mut Position, &Velocity)>) {
+fn movement(mut query: Query<(&mut Position, &Velocity)>) {
     for (mut position, velocity) in query.iter_mut() {
         position.x += velocity.x;
         position.y += velocity.y;
@@ -131,7 +131,7 @@ fn main() {
     // Add a Stage to our schedule. Each Stage in a schedule runs all of its systems
     // before moving on to the next Stage
     schedule.add_stage("update", SystemStage::parallel()
-        .with_system(movement)
+        .with_system(movement.system())
     );
 
     // Run the schedule once. If your app has a "loop", you would run this once per loop


### PR DESCRIPTION
If you paste the old 'Using Bevy ECS' sample code and try to compile it you will get error messages 
 - system() is not being called for the movement system in the scheduler
 - The movement systems Query is not mutableable which the rust compiler doesn't like

Fixes compile errors so that new users don't have this issue when trying to lean from the samples.
