### PR TITLE
Fix `Changed` docs with advantages and drawbacks

### DIFF
--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -621,7 +621,7 @@ impl_tick_filter!(
     /// All components internally remember the last tick they were added at, and the last tick they
     /// were mutated at. The mutation detection is powered by `DerefMut`, such that any dereferencing
     /// will mark the component as changed. Note that there is no deep value inspection on the actual
-    /// data of the component, which would be prohibilively expensive. This means false positives can
+    /// data of the component, which would be prohibitively expensive. This means false positives can
     /// occur if dereferencing via `DerefMut` but not changing any component data.
     ///
     /// This filter is useful for synchronizing components. It can also be used as a performance

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -619,10 +619,11 @@ impl_tick_filter!(
     /// Filter that retrieves components of type `T` that have been changed since the last tick.
     ///
     /// All components internally remember the last tick they were added at, and the last tick they
-    /// were mutated at. The mutation detection is powered by `DerefMut`, such that any dereferencing
+    /// were mutated at. The mutation detection is powered by [`DerefMut`](std::ops::DerefMut), such that any mutable dereferencing
     /// will mark the component as changed. Note that there is no deep value inspection on the actual
     /// data of the component, which would be prohibitively expensive. This means false positives can
-    /// occur if dereferencing via `DerefMut` but not changing any component data.
+    /// occur if dereferencing via [`DerefMut`](std::ops::DerefMut) but not changing any component data.
+    /// Just reading the value of a component will not mark it as changed, as [`Deref`](std::ops::Deref) will be used instead.
     ///
     /// This filter is useful for synchronizing components. It can also be used as a performance
     /// optimization in case of expensive operations, by filtering unchanged components out and

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -630,7 +630,7 @@ impl_tick_filter!(
     /// filterings, applying this filtering has a small cost, which must be balanced against the
     /// cost of the operation on the changed components.
     ///
-    /// Because by default the ordering of systems can change, and this filter is only effective
+    /// Because by default the ordering of systems within the same stage is nondeterministic, and this filter is only effective
     /// on changes detected before the query executes, to avoid frame delays you need to use
     /// explicit dependency ordering or ordered stages to ensure the detecting system where the
     /// query is used runs after the system(s) which mutate the component.


### PR DESCRIPTION
# Objective

Fix the documentation of the `Changed` filter to detail its mutating
detection functioning, and explain the advantages and drawbacks of using
it.

Fixes #3082

## Solution

Discussed on #3082, integrate remarks from @cart and clarify drawbacks.
