### PR TITLE
[Merged by Bors] - Fix MIME type support for glTF buffer Data URIs

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -647,7 +647,7 @@ async fn load_buffers(
     load_context: &LoadContext<'_>,
     asset_path: &Path,
 ) -> Result<Vec<Vec<u8>>, GltfError> {
-    const OCTET_STREAM_URI: &str = "application/octet-stream";
+    const VALID_MIME_TYPES: &[&str] = &["application/octet-stream", "application/gltf-buffer"];
 
     let mut buffer_data = Vec::new();
     for buffer in gltf.buffers() {
@@ -658,7 +658,9 @@ async fn load_buffers(
                     .unwrap();
                 let uri = uri.as_ref();
                 let buffer_bytes = match DataUri::parse(uri) {
-                    Ok(data_uri) if data_uri.mime_type == OCTET_STREAM_URI => data_uri.decode()?,
+                    Ok(data_uri) if VALID_MIME_TYPES.contains(&data_uri.mime_type) => {
+                        data_uri.decode()?
+                    }
                     Ok(_) => return Err(GltfError::BufferFormatUnsupported),
                     Err(()) => {
                         // TODO: Remove this and add dep


### PR DESCRIPTION
# Objective

- The glTF 2.0 spec requires that Data URIs use one of two valid MIME types. `bevy_gltf` only supports one of these.
- See:
  - https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#_media_type_registrations
  - https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#file-extensions-and-media-types
  - https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#binary-data-storage

> Buffer data **MAY** alternatively be embedded in the glTF file via `data:` URI with base64 encoding. When `data:` URI is used for buffer storage, its mediatype field **MUST** be set to `application/octet-stream` or `application/gltf-buffer`.

(Emphasis in original.)

## Solution

- Check for both MIME types.
