### PR TITLE
Reexport crevice in bevy_utils

### DIFF
--- a/pipelined/bevy_render2/src/lib.rs
+++ b/pipelined/bevy_render2/src/lib.rs
@@ -11,6 +11,7 @@ pub mod renderer;
 pub mod texture;
 pub mod view;
 
+pub use crevice;
 pub use once_cell;
 
 use crate::{


### PR DESCRIPTION
# Objective

Let's reexport bevy's version of crevice to be able to use it in apps.
