### PR TITLE
[Merged by Bors] - iOS: replace cargo-lipo, and update for new macOS 

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -322,9 +322,14 @@ Example | File | Description
 
 ### Setup
 
+You need to install the correct rust targets:
+
+* `aarch64-apple-ios`: iOS devices
+* `x86_64-apple-ios`: iOS simulator on x86 processors
+* `aarch64-apple-ios-sim`: iOS simulator on Apple processors
+
 ```sh
-rustup target add aarch64-apple-ios x86_64-apple-ios
-cargo install cargo-lipo
+rustup target add aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
 ```
 
 ### Build & Run
@@ -352,15 +357,6 @@ open bevy_ios_example.xcodeproj/
 
 which will open xcode. You then must push the zoom zoom play button and wait
 for the magic.
-
-The Xcode build GUI will by default build the rust library for both
-`x86_64-apple-ios`, and `aarch64-apple-ios` which may take a while. If you'd
-like speed this up, you update the `IOS_TARGETS` User-Defined environment
-variable in the "`cargo_ios` target" to be either `x86_64-apple-ios` or
-`aarch64-apple-ios` depending on your goal.
-
-Note: if you update this variable in Xcode, it will also change the default
-used for the `Makefile`.
 
 Example | File | Description
 --- | --- | ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -324,9 +324,9 @@ Example | File | Description
 
 You need to install the correct rust targets:
 
-* `aarch64-apple-ios`: iOS devices
-* `x86_64-apple-ios`: iOS simulator on x86 processors
-* `aarch64-apple-ios-sim`: iOS simulator on Apple processors
+- `aarch64-apple-ios`: iOS devices
+- `x86_64-apple-ios`: iOS simulator on x86 processors
+- `aarch64-apple-ios-sim`: iOS simulator on Apple processors
 
 ```sh
 rustup target add aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim

--- a/examples/ios/Cargo.toml
+++ b/examples/ios/Cargo.toml
@@ -11,4 +11,19 @@ name = "bevy_ios_example"
 crate-type = ["staticlib"]
 
 [dependencies]
-bevy = { path = "../../", features = [ "bevy_gilrs", "bevy_gltf", "bevy_wgpu", "bevy_winit", "render", "png", "hdr", "bevy_audio", "mp3"], default-features = false}
+bevy = { path = "../../", features = [ 
+  "bevy_audio",
+  "bevy_core_pipeline",
+  "bevy_gltf2",
+  "bevy_wgpu",
+  "bevy_sprite2",
+  "bevy_render2",
+  "bevy_pbr2",
+  "bevy_winit",
+  "render",
+  "png",
+  "hdr",
+  "mp3",
+  "x11",
+  "filesystem_watcher"
+], default-features = false}

--- a/examples/ios/Makefile
+++ b/examples/ios/Makefile
@@ -14,12 +14,6 @@ boot-sim:
 install: xcodebuild-simulator boot-sim
 	 xcrun simctl install $(DEVICE) build/Build/Products/Debug-iphonesimulator/bevy_ios_example.app
 
-xcodebuild-simulator:
-	IOS_TARGETS=x86_64-apple-ios xcodebuild -scheme bevy_ios_example -configuration Debug -derivedDataPath build -destination "id=$(DEVICE)"
-
-xcodebuild-iphone:
-	IOS_TARGETS=aarch64-apple-ios xcodebuild -scheme bevy_ios_example -configuration Debug -derivedDataPath build -arch arm64
-
 clean:
 	rm -r build
 	cargo clean

--- a/examples/ios/Makefile
+++ b/examples/ios/Makefile
@@ -14,6 +14,12 @@ boot-sim:
 install: xcodebuild-simulator boot-sim
 	 xcrun simctl install $(DEVICE) build/Build/Products/Debug-iphonesimulator/bevy_ios_example.app
 
+xcodebuild-simulator:
+ 	IOS_TARGETS=x86_64-apple-ios xcodebuild -scheme bevy_ios_example -configuration Debug -derivedDataPath build -destination "id=$(DEVICE)"
+
+xcodebuild-iphone:
+ 	IOS_TARGETS=aarch64-apple-ios xcodebuild -scheme bevy_ios_example -configuration Debug -derivedDataPath build -arch arm64
+
 clean:
 	rm -r build
 	cargo clean

--- a/examples/ios/bevy_ios_example.xcodeproj/project.pbxproj
+++ b/examples/ios/bevy_ios_example.xcodeproj/project.pbxproj
@@ -354,7 +354,6 @@
 		8265913A25816D964A847F1B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				IOS_TARGETS = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -410,7 +409,6 @@
 		FEA9B18D9236F9F6DC6DF799 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				IOS_TARGETS = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/examples/ios/bevy_ios_example.xcodeproj/project.pbxproj
+++ b/examples/ios/bevy_ios_example.xcodeproj/project.pbxproj
@@ -276,9 +276,17 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = (
+				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*][arch=arm64]" = (
 					"$(inherited)",
-					../../target/universal/release,
+					"../../target/aarch64-apple-ios/release",
+				);
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=arm64]" = (
+					"$(inherited)",
+					"../../target/aarch64-apple-ios-sim/release",
+				);
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=x86_64]" = (
+					"$(inherited)",
+					"../../target/x86_64-apple-ios/release",
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -376,9 +384,17 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = (
+				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*][arch=arm64]" = (
 					"$(inherited)",
-					../../target/universal/debug,
+					"../../target/aarch64-apple-ios/debug",
+				);
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=arm64]" = (
+					"$(inherited)",
+					"../../target/aarch64-apple-ios-sim/debug",
+				);
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=x86_64]" = (
+					"$(inherited)",
+					"../../target/x86_64-apple-ios/debug",
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/examples/ios/build_rust_deps.sh
+++ b/examples/ios/build_rust_deps.sh
@@ -1,12 +1,43 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -e
+# based on https://github.com/mozilla/glean/blob/main/build-scripts/xc-universal-binary.sh
+
+set -eux
 
 PATH=$PATH:$HOME/.cargo/bin
 
-# If you want your build to run faster, add a "--targets x86_64-apple-ios" for just using the ios simulator.
-if [ -n ${IOS_TARGETS} ]; then
-    cargo lipo --targets ${IOS_TARGETS}
-else
-    cargo lipo
+RELFLAG=
+if [[ "$CONFIGURATION" != "Debug" ]]; then
+    RELFLAG=--release
 fi
+
+set -euvx
+
+IS_SIMULATOR=0
+if [ "${LLVM_TARGET_TRIPLE_SUFFIX-}" = "-simulator" ]; then
+  IS_SIMULATOR=1
+fi
+
+for arch in $ARCHS; do
+  case "$arch" in
+    x86_64)
+      if [ $IS_SIMULATOR -eq 0 ]; then
+        echo "Building for x86_64, but not a simulator build. What's going on?" >&2
+        exit 2
+      fi
+
+      # Intel iOS simulator
+      export CFLAGS_x86_64_apple_ios="-target x86_64-apple-ios"
+      cargo build --lib $RELFLAG --target x86_64-apple-ios
+      ;;
+
+    arm64)
+      if [ $IS_SIMULATOR -eq 0 ]; then
+        # Hardware iOS targets
+        cargo build --lib $RELFLAG --target aarch64-apple-ios
+      else
+        # M1 iOS simulator -- currently in Nightly only and requires to build `libstd`
+        cargo build --lib $RELFLAG --target aarch64-apple-ios-sim
+      fi
+  esac
+done

--- a/examples/ios/build_rust_deps.sh
+++ b/examples/ios/build_rust_deps.sh
@@ -13,6 +13,21 @@ fi
 
 set -euvx
 
+# add path to the system SDK, needed since macOS 11
+if [ -z ${var+x} ]; then
+    export LIBRARY_PATH="$(xcrun --show-sdk-path)/usr/lib"
+else
+    export LIBRARY_PATH="$LIBRARY_PATH:$(xcrun --show-sdk-path)/usr/lib"
+fi
+
+# add path to cmake, needed on apple arm processors as it's not available by default
+if ! cmake --version; then
+    # use the one installed from homebrew
+    if /opt/homebrew/bin/cmake --version; then
+        export PATH="$PATH:/opt/homebrew/bin"
+    fi
+fi
+
 IS_SIMULATOR=0
 if [ "${LLVM_TARGET_TRIPLE_SUFFIX-}" = "-simulator" ]; then
   IS_SIMULATOR=1

--- a/examples/ios/build_rust_deps.sh
+++ b/examples/ios/build_rust_deps.sh
@@ -20,13 +20,9 @@ else
     export LIBRARY_PATH="$LIBRARY_PATH:$(xcrun --show-sdk-path)/usr/lib"
 fi
 
-# add path to cmake, needed on apple arm processors as it's not available by default
-if ! cmake --version; then
-    # use the one installed from homebrew
-    if /opt/homebrew/bin/cmake --version; then
-        export PATH="$PATH:/opt/homebrew/bin"
-    fi
-fi
+# add homebrew bin path, as it's the most commonly used package manager on macOS
+# this is needed for cmake on apple arm processors as it's not available by default
+export PATH="$PATH:/opt/homebrew/bin"
 
 IS_SIMULATOR=0
 if [ "${LLVM_TARGET_TRIPLE_SUFFIX-}" = "-simulator" ]; then

--- a/examples/ios/build_rust_deps.sh
+++ b/examples/ios/build_rust_deps.sh
@@ -14,7 +14,7 @@ fi
 set -euvx
 
 # add path to the system SDK, needed since macOS 11
-if [ -z ${var+x} ]; then
+if [ -z ${LIBRARY_PATH+x} ]; then
     export LIBRARY_PATH="$(xcrun --show-sdk-path)/usr/lib"
 else
     export LIBRARY_PATH="$LIBRARY_PATH:$(xcrun --show-sdk-path)/usr/lib"

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -1,4 +1,21 @@
-use bevy::{prelude::*, window::WindowMode};
+use bevy::{
+    audio::{Audio, AudioPlugin},
+    input::touch::TouchPhase,
+    math::{Vec2, Vec3},
+    pbr2::{PbrBundle, PointLight, PointLightBundle, StandardMaterial},
+    prelude::{
+        bevy_main, App, AssetServer, Assets, Commands, EventReader, Local, Query, Res, ResMut,
+        TouchInput, Transform, With,
+    },
+    render2::{
+        camera::{Camera, PerspectiveCameraBundle},
+        color::Color,
+        mesh::{shape, Mesh},
+        view::Msaa,
+    },
+    window::{WindowDescriptor, WindowMode, Windows},
+    PipelinedDefaultPlugins,
+};
 
 // the `bevy_main` proc_macro generates the required ios boilerplate
 #[bevy_main]
@@ -11,7 +28,8 @@ fn main() {
             ..Default::default()
         })
         .insert_resource(Msaa { samples: 4 })
-        .add_plugins(DefaultPlugins)
+        .add_plugins(PipelinedDefaultPlugins)
+        .add_plugin(AudioPlugin)
         .add_startup_system(setup_scene)
         .add_startup_system(setup_music)
         .run();
@@ -48,6 +66,11 @@ fn setup_scene(
     // light
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        point_light: PointLight {
+            intensity: 5000.0,
+            shadows_enabled: true,
+            ..Default::default()
+        },
         ..Default::default()
     });
     // camera

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -32,8 +32,37 @@ fn main() {
         .add_plugin(AudioPlugin)
         .add_startup_system(setup_scene)
         .add_startup_system(setup_music)
+        .add_system(touch_camera)
         .run();
 }
+
+fn touch_camera(
+    windows: ResMut<Windows>,
+    mut touches: EventReader<TouchInput>,
+    mut camera: Query<&mut Transform, With<Camera>>,
+    mut last_position: Local<Option<Vec2>>,
+) {
+    for touch in touches.iter() {
+        match touch.phase {
+            TouchPhase::Started => *last_position = None,
+            _ => (),
+        }
+        if let Some(last_position) = *last_position {
+            let window = windows.get_primary().unwrap();
+            let mut transform = camera.single_mut();
+            *transform = Transform::from_xyz(
+                transform.translation.x
+                    + (touch.position.x - last_position.x) / window.width() * 5.0,
+                transform.translation.y,
+                transform.translation.z
+                    + (touch.position.y - last_position.y) / window.height() * 5.0,
+            )
+            .looking_at(Vec3::ZERO, Vec3::Y);
+        }
+        *last_position = Some(touch.position);
+    }
+}
+
 /// set up a simple 3D scene
 fn setup_scene(
     mut commands: Commands,

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -43,9 +43,8 @@ fn touch_camera(
     mut last_position: Local<Option<Vec2>>,
 ) {
     for touch in touches.iter() {
-        match touch.phase {
-            TouchPhase::Started => *last_position = None,
-            _ => (),
+        if touch.phase == TouchPhase::Started {
+            *last_position = None;
         }
         if let Some(last_position) = *last_position {
             let window = windows.get_primary().unwrap();


### PR DESCRIPTION
# Objective

- Remove `cargo-lipo` as [it's deprecated](https://github.com/TimNN/cargo-lipo#maintenance-status) and doesn't work on new Apple processors
- Fix CI that will fail as soon as GitHub update the worker used by Bevy to macOS 11

## Solution

- Replace `cargo-lipo` with building with the correct target
- Setup the correct path to libraries by using `xcrun --show-sdk-path`
- Also try and fix path to cmake in case it's not found but available through homebrew

