### PR TITLE
[Merged by Bors] - EntityRenderCommand and PhaseItemRenderCommand

### DIFF
--- a/assets/shaders/custom.wgsl
+++ b/assets/shaders/custom.wgsl
@@ -11,7 +11,7 @@ var<uniform> view: View;
 struct Mesh {
     transform: mat4x4<f32>;
 };
-[[group(2), binding(0)]]
+[[group(1), binding(0)]]
 var<uniform> mesh: Mesh;
 
 struct Vertex {
@@ -37,7 +37,7 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 struct CustomMaterial {
     color: vec4<f32>;
 };
-[[group(1), binding(0)]]
+[[group(2), binding(0)]]
 var<uniform> material: CustomMaterial;
 
 [[stage(fragment)]]

--- a/pipelined/bevy_core_pipeline/src/lib.rs
+++ b/pipelined/bevy_core_pipeline/src/lib.rs
@@ -8,17 +8,14 @@ pub use main_pass_driver::*;
 
 use bevy_app::{App, Plugin};
 use bevy_core::FloatOrd;
-use bevy_ecs::{
-    prelude::*,
-    system::{lifetimeless::SRes, SystemParamItem},
-};
+use bevy_ecs::prelude::*;
 use bevy_render2::{
     camera::{ActiveCameras, CameraPlugin},
     color::Color,
     render_graph::{EmptyNode, RenderGraph, SlotInfo, SlotType},
     render_phase::{
-        sort_phase_system, DrawFunctionId, DrawFunctions, PhaseItem, RenderCommand, RenderPhase,
-        TrackedRenderPass,
+        sort_phase_system, CachedPipelinePhaseItem, DrawFunctionId, DrawFunctions, EntityPhaseItem,
+        PhaseItem, RenderPhase,
     },
     render_resource::*,
     renderer::RenderDevice,
@@ -171,38 +168,17 @@ impl PhaseItem for Transparent3d {
     }
 }
 
-pub struct SetItemPipeline;
-impl RenderCommand<Transparent3d> for SetItemPipeline {
-    type Param = SRes<RenderPipelineCache>;
+impl EntityPhaseItem for Transparent3d {
     #[inline]
-    fn render<'w>(
-        _view: Entity,
-        item: &Transparent3d,
-        pipeline_cache: SystemParamItem<'w, '_, Self::Param>,
-        pass: &mut TrackedRenderPass<'w>,
-    ) {
-        let pipeline = pipeline_cache
-            .into_inner()
-            .get_state(item.pipeline)
-            .unwrap();
-        pass.set_render_pipeline(pipeline);
+    fn entity(&self) -> Entity {
+        self.entity
     }
 }
 
-impl RenderCommand<Transparent2d> for SetItemPipeline {
-    type Param = SRes<RenderPipelineCache>;
+impl CachedPipelinePhaseItem for Transparent3d {
     #[inline]
-    fn render<'w>(
-        _view: Entity,
-        item: &Transparent2d,
-        pipeline_cache: SystemParamItem<'w, '_, Self::Param>,
-        pass: &mut TrackedRenderPass<'w>,
-    ) {
-        let pipeline = pipeline_cache
-            .into_inner()
-            .get_state(item.pipeline)
-            .unwrap();
-        pass.set_render_pipeline(pipeline);
+    fn cached_pipeline(&self) -> CachedPipelineId {
+        self.pipeline
     }
 }
 

--- a/pipelined/bevy_pbr2/src/lib.rs
+++ b/pipelined/bevy_pbr2/src/lib.rs
@@ -108,15 +108,10 @@ impl Plugin for PbrPlugin {
             .init_resource::<SpecializedPipelines<PbrPipeline>>()
             .init_resource::<SpecializedPipelines<ShadowPipeline>>();
 
-        let draw_shadow_mesh = DrawShadowMesh::new(&mut render_app.world);
         let shadow_pass_node = ShadowPassNode::new(&mut render_app.world);
         render_app.add_render_command::<Transparent3d, DrawPbr>();
-        let render_world = render_app.world.cell();
-        let draw_functions = render_world
-            .get_resource::<DrawFunctions<Shadow>>()
-            .unwrap();
-        draw_functions.write().add(draw_shadow_mesh);
-        let mut graph = render_world.get_resource_mut::<RenderGraph>().unwrap();
+        render_app.add_render_command::<Shadow, DrawShadowMesh>();
+        let mut graph = render_app.world.get_resource_mut::<RenderGraph>().unwrap();
         let draw_3d_graph = graph
             .get_sub_graph_mut(bevy_core_pipeline::draw_3d_graph::NAME)
             .unwrap();


### PR DESCRIPTION
Adds new `EntityRenderCommand`, `EntityPhaseItem`, and `CachedPipelinePhaseItem` traits to make it possible to reuse RenderCommands across phases. This should be helpful for features like #3072 . It also makes the trait impls slightly less generic-ey in the common cases.

This also fixes the custom shader examples to account for the recent Frustum Culling and MSAA changes (the UX for these things will be improved later).