### PR TITLE
Changed regexes to be lazy_static

### DIFF
--- a/pipelined/bevy_render2/Cargo.toml
+++ b/pipelined/bevy_render2/Cargo.toml
@@ -44,6 +44,7 @@ hexasphere = "6.0.0"
 parking_lot = "0.11.0"
 regex = "1.5"
 crevice = { path = "../../crates/crevice", version = "0.8.0", features = ["glam"] }
+lazy_static = "1.4.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wgpu = { version = "0.11.0", features = ["spirv", "webgl"] }


### PR DESCRIPTION
Seemed proper to store "constant" values outside of ShaderProcessor

# Objective

Before, regexes were just store in `ShaderProcessor`. It didn't seem proper to store these "constant" values in a struct, so I used lazy_static to fix that.

## Solution

Removed the fields from `ShaderProcessor` to make it a unit-like struct. Used lazy_static to create three static variables and replaced the places they were used. I put `#[derive(Default)]` on `ShaderProcessor`, since I figured `ShaderProcessor` will likely not be a unit-like struct in the future if more features are added.

This might be overkill for a struct that is used one as far as I know. But I'll let you be the judge of that.
