### PR TITLE
Add vertex buffer layout to `Mesh`

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -18,7 +18,7 @@ use bevy_render::{
     mesh::{Indices, Mesh, VertexAttributeValues},
     primitives::{Aabb, Frustum},
     render_resource::{
-        AddressMode, FilterMode, PrimitiveTopology, SamplerDescriptor, TextureFormat,
+        AddressMode, FilterMode, PrimitiveTopology, SamplerDescriptor, TextureFormat, VertexFormat,
     },
     texture::{Image, ImageType, TextureError},
     view::VisibleEntities,
@@ -138,6 +138,8 @@ async fn load_gltf<'a, 'b>(
                 .read_tangents()
                 .map(|v| VertexAttributeValues::Float32x4(v.collect()))
             {
+                mesh.vertex_layout_mut()
+                    .push(Mesh::ATTRIBUTE_TANGENT, VertexFormat::Float32x4);
                 mesh.set_attribute(Mesh::ATTRIBUTE_TANGENT, vertex_attribute);
             }
 

--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -159,22 +159,14 @@ impl VertexBufferLayout {
     ///
     /// The shader location is determined based on insertion order.
     pub fn push(&mut self, name: &str, format: VertexFormat) {
-        let shader_location = if let Some(attribute) = self.attributes.last() {
-            attribute.shader_location + 1
-        } else {
-            0
-        };
+        let shader_location = self.attributes.last().map_or(0, |attr| attr.shader_location + 1);
 
         self.push_location(name, format, shader_location)
     }
 
     /// Push a vertex attribute descriptor to the end of the list with an exact shader location.
     pub fn push_location(&mut self, name: &str, format: VertexFormat, shader_location: u32) {
-        let offset = if let Some(attribute) = self.attributes.last() {
-            attribute.offset + attribute.format.size()
-        } else {
-            0
-        };
+        let offset = self.attributes.last().map_or(0, |attr| attr.offset + attr.format.size());
 
         self.array_stride += format.size();
         self.attribute_names

--- a/crates/bevy_render/src/render_resource/pipeline_specializer.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_specializer.rs
@@ -22,7 +22,7 @@ impl<S: SpecializedPipeline> SpecializedPipelines<S> {
         key: S::Key,
     ) -> CachedPipelineId {
         *self.cache.entry(key.clone()).or_insert_with(|| {
-            let descriptor = specialize_pipeline.specialize(key);
+            let descriptor = specialize_pipeline.specialize(cache, key);
             cache.queue(descriptor)
         })
     }
@@ -30,5 +30,5 @@ impl<S: SpecializedPipeline> SpecializedPipelines<S> {
 
 pub trait SpecializedPipeline {
     type Key: Clone + Hash + PartialEq + Eq;
-    fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor;
+    fn specialize(&self, cache: &RenderPipelineCache, key: Self::Key) -> RenderPipelineDescriptor;
 }


### PR DESCRIPTION
Discussion: https://discord.com/channels/691052431525675048/743663924229963868/908484759833960489

# Objective

Vertex buffer attributes for the `Mesh` shader are particularly problematic because the buffer is created by iterating a `BTreeMap` without regard to the vertex attribute locations defined in the shader.

I propose a method of describing vertex buffer layouts that are configurable at runtime. This (or something like it) will be necessary for extending render pipelines with additional vertex attributes.

This PR solves two problems:

1. Replaces the hardcoded vertex buffer layout with one that can easily be adjusted at runtime on each individual `Mesh`.
2. Replaces the original vertex buffer sorting (alphabetically by name) on `Mesh` with the order provided by the vertex buffer layout on the `Mesh` itself.

This will allow us to move forward with implementing skeletal animations (#95).

## Solution

- Replace the hardcoded `VertexBufferLayout` in `SpecializedPipeline` implementations with layouts that can be configured at runtime on `Mesh`.
- Vertex buffer layouts are owned by `Mesh` for the PBR renderer, and are cached by the `RenderAsset` implementation for `Mesh`. The `SpritePipeline` caches its own vertex buffer layouts for the 2D renderer.
  - The choice for `Mesh` as the owner was made to accommodate the fact that it is responsible for building its own vertex buffer; it makes sense that it also owns the layout because it already knows which attributes it owns. It is easy to update through public `Mesh` methods.
- `SpecializedPipeline` has a new cache reference accepted by the `specialize` method. This was the easiest way I found to gain access to the vertex buffer layout cache in the specialization compiler. 

## TODO

- [x] Use the pipeline cache for specialization