### PR TITLE
[Merged by Bors] - Add readme to errors crate and clean up cargo files

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -2,10 +2,13 @@
 name = "benches"
 version = "0.1.0"
 edition = "2021"
+description = "Benchmarks for Bevy engine"
+publish = false
+license = "MIT OR Apache-2.0"
 
 [dev-dependencies]
 criterion = "0.3"
-bevy = { path = "../" }
+bevy = { path = ".." }
 
 [[bench]]
 name = "system_stage"

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
-
 [dependencies]
 bevy_app = { path = "../bevy_app", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -8,8 +8,6 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 futures-lite = "1.4.0"
 event-listener = "2.4.0"

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -2,6 +2,9 @@
 name = "errors"
 version = "0.1.0"
 edition = "2021"
+description = "Bevy's error codes"
+publish = false
+license = "MIT OR Apache-2.0"
 
 [dependencies]
-bevy = { path = "../" }
+bevy = { path = ".." }

--- a/errors/README.md
+++ b/errors/README.md
@@ -2,6 +2,6 @@
 
 This crate lists and tests explanations and examples of Bevy's error codes.
 
-You can find a rendered version of the error code descriptions at [bevyengine.org/errors].
+For the latest Bevy release, you can find a rendered version of the error code descriptions at [bevyengine.org/errors].
 
 [bevyengine.org/errors]: https://bevyengine.org/errors

--- a/errors/README.md
+++ b/errors/README.md
@@ -2,7 +2,7 @@
 
 This crate lists and tests explanations and examples of Bevy's error codes.
 
-For the latest Bevy release, you can find a rendered version of the error code descriptions at 
+For the latest Bevy release, you can find a rendered version of the error code descriptions at
 [bevyengine.org/learn/errors].
 
 [bevyengine.org/learn/errors]: https://bevyengine.org/learn/errors

--- a/errors/README.md
+++ b/errors/README.md
@@ -1,0 +1,7 @@
+# Bevy Error Codes
+
+This crate lists and tests explanations and examples of Bevy's error codes.
+
+You can find a rendered version of the error code descriptions at [bevyengine.org/errors].
+
+[bevyengine.org/errors]: https://bevyengine.org/errors

--- a/errors/README.md
+++ b/errors/README.md
@@ -2,6 +2,7 @@
 
 This crate lists and tests explanations and examples of Bevy's error codes.
 
-For the latest Bevy release, you can find a rendered version of the error code descriptions at [bevyengine.org/errors].
+For the latest Bevy release, you can find a rendered version of the error code descriptions at 
+[bevyengine.org/learn/errors].
 
-[bevyengine.org/errors]: https://bevyengine.org/errors
+[bevyengine.org/learn/errors]: https://bevyengine.org/learn/errors

--- a/examples/ios/Cargo.toml
+++ b/examples/ios/Cargo.toml
@@ -2,12 +2,13 @@
 name = "bevy-ios-example"
 version = "0.1.0"
 edition = "2021"
+description = "Example for building an iOS app with Bevy"
+publish = false
+license = "MIT OR Apache-2.0"
 
 [lib]
 name = "bevy_ios_example"
 crate-type = ["staticlib"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 bevy = { path = "../../", features = [ "bevy_gilrs", "bevy_gltf", "bevy_wgpu", "bevy_winit", "render", "png", "hdr", "bevy_audio", "mp3"], default-features = false}

--- a/tools/ci/Cargo.toml
+++ b/tools/ci/Cargo.toml
@@ -2,8 +2,9 @@
 name = "ci"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+description = "CI script for Bevy"
+publish = false
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 xshell = "0.1"


### PR DESCRIPTION
# Objective

- Document that the error codes will be rendered on the bevy website (see bevyengine/bevy-website#216)
- Some Cargo.toml files did not include the license or a description field

## Solution

- Readme for the errors crate
- Mark internal/development crates with `publish = false`
- Add missing license/descriptions to some crates

- [x] merge bevyengine/bevy-website#216
