### PR TITLE
Mirko/expect the unexpected and unwrapped

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -656,7 +656,7 @@ impl World {
         self.get_populated_resource_column(component_id).is_some()
     }
 
-    /// Gets a reference to the resource of the given type, if it exists. Otherwise returns [None]
+    /// Gets a reference to the resource of the given type, if it exists. Otherwise returns [None].
     /// Resources are "unique" data of a given type.
     #[inline]
     pub fn get_resource<T: Resource>(&self) -> Option<&T> {

--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -13,7 +13,7 @@ pub struct SceneLoader {
 
 impl FromWorld for SceneLoader {
     fn from_world(world: &mut World) -> Self {
-        let type_registry = world.get_resource::<TypeRegistryArc>().unwrap();
+        let type_registry = world.get_resource::<TypeRegistryArc>().expect("Failed to `get_resource::<TypeRegistryArc>()` in FromWorld for SceneLoader");
         SceneLoader {
             type_registry: (&*type_registry).clone(),
         }


### PR DESCRIPTION
# Objective

Add details to a panic to point user toward panicking source code.

## Solution

Change `unwrap()` to `expect()` with contextual error messages without presuming to know how the user/dev created such a panic.
