### PR TITLE
[Merged by Bors] - Clustered forward rendering

### DIFF
--- a/pipelined/bevy_core_pipeline/src/main_pass_3d.rs
+++ b/pipelined/bevy_core_pipeline/src/main_pass_3d.rs
@@ -59,7 +59,7 @@ impl Node for MainPass3dNode {
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("main_opaque_pass_3d"),
                 // NOTE: The opaque pass clears and initializes the color
-                //       buffer as well as writing to it.
+                // buffer as well as writing to it.
                 color_attachments: &[target.get_color_attachment(Operations {
                     load: LoadOp::Clear(clear_color.0.into()),
                     store: true,
@@ -135,8 +135,8 @@ impl Node for MainPass3dNode {
                 depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
                     view: &depth.view,
                     // NOTE: For the transparent pass we load the depth buffer but do not write to it.
-                    //       As the opaque and alpha mask passes run first, opaque meshes can occlude
-                    //       transparent ones.
+                    // As the opaque and alpha mask passes run first, opaque meshes can occlude
+                    // transparent ones.
                     depth_ops: Some(Operations {
                         load: LoadOp::Load,
                         store: false,

--- a/pipelined/bevy_pbr2/Cargo.toml
+++ b/pipelined/bevy_pbr2/Cargo.toml
@@ -24,6 +24,7 @@ bevy_reflect = { path = "../../crates/bevy_reflect", version = "0.5.0", features
 bevy_render2 = { path = "../bevy_render2", version = "0.5.0" }
 bevy_transform = { path = "../../crates/bevy_transform", version = "0.5.0" }
 bevy_utils = { path = "../../crates/bevy_utils", version = "0.5.0" }
+bevy_window = { path = "../../crates/bevy_window", version = "0.5.0" }
 
 # other
 bitflags = "1.2"

--- a/pipelined/bevy_pbr2/src/lib.rs
+++ b/pipelined/bevy_pbr2/src/lib.rs
@@ -60,6 +60,7 @@ impl Plugin for PbrPlugin {
             .init_resource::<DirectionalLightShadowMap>()
             .init_resource::<PointLightShadowMap>()
             .init_resource::<AmbientLight>()
+            .init_resource::<VisiblePointLights>()
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 add_clusters
@@ -145,6 +146,7 @@ impl Plugin for PbrPlugin {
             .init_resource::<ShadowPipeline>()
             .init_resource::<DrawFunctions<Shadow>>()
             .init_resource::<LightMeta>()
+            .init_resource::<GlobalLightMeta>()
             .init_resource::<SpecializedPipelines<PbrPipeline>>()
             .init_resource::<SpecializedPipelines<ShadowPipeline>>();
 

--- a/pipelined/bevy_pbr2/src/lib.rs
+++ b/pipelined/bevy_pbr2/src/lib.rs
@@ -61,8 +61,10 @@ impl Plugin for PbrPlugin {
             .init_resource::<PointLightShadowMap>()
             .init_resource::<AmbientLight>()
             .init_resource::<VisiblePointLights>()
+            // NOTE: Clusters need to have been added before update_clusters is run so
+            //       run in the stage before...
             .add_system_to_stage(
-                CoreStage::PostUpdate,
+                CoreStage::Update,
                 add_clusters
                     .label(SimulationLightSystems::AddClusters)
                     .after(TransformSystem::TransformPropagate),
@@ -120,20 +122,21 @@ impl Plugin for PbrPlugin {
             )
             .add_system_to_stage(
                 RenderStage::Prepare,
-                // FIXME: Is this true?
                 // this is added as an exclusive system because it contributes new views. it must run (and have Commands applied)
                 // _before_ the `prepare_views()` system is run. ideally this becomes a normal system when "stageless" features come out
-                render::prepare_clusters
+                render::prepare_lights
                     .exclusive_system()
                     .label(RenderLightSystems::PrepareClusters),
             )
             .add_system_to_stage(
                 RenderStage::Prepare,
+                // FIXME: Is this true?
                 // this is added as an exclusive system because it contributes new views. it must run (and have Commands applied)
                 // _before_ the `prepare_views()` system is run. ideally this becomes a normal system when "stageless" features come out
-                render::prepare_lights
+                render::prepare_clusters
                     .exclusive_system()
-                    .label(RenderLightSystems::PrepareLights),
+                    .label(RenderLightSystems::PrepareClusters)
+                    .after(RenderLightSystems::PrepareLights),
             )
             .add_system_to_stage(
                 RenderStage::Queue,

--- a/pipelined/bevy_pbr2/src/lib.rs
+++ b/pipelined/bevy_pbr2/src/lib.rs
@@ -132,7 +132,6 @@ impl Plugin for PbrPlugin {
             )
             .add_system_to_stage(
                 RenderStage::Prepare,
-                // FIXME: Is this true?
                 // this is added as an exclusive system because it contributes new views. it must run (and have Commands applied)
                 // _before_ the `prepare_views()` system is run. ideally this becomes a normal system when "stageless" features come out
                 render::prepare_clusters

--- a/pipelined/bevy_pbr2/src/lib.rs
+++ b/pipelined/bevy_pbr2/src/lib.rs
@@ -64,7 +64,7 @@ impl Plugin for PbrPlugin {
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 // NOTE: Clusters need to have been added before update_clusters is run so
-                //       add as an exclusive system
+                // add as an exclusive system
                 add_clusters
                     .exclusive_system()
                     .label(SimulationLightSystems::AddClusters),

--- a/pipelined/bevy_pbr2/src/lib.rs
+++ b/pipelined/bevy_pbr2/src/lib.rs
@@ -72,6 +72,7 @@ impl Plugin for PbrPlugin {
             )
             .add_system_to_stage(
                 CoreStage::PostUpdate,
+                // NOTE: Must come after add_clusters!
                 update_clusters
                     .label(SimulationLightSystems::UpdateClusters)
                     .after(TransformSystem::TransformPropagate)

--- a/pipelined/bevy_pbr2/src/lib.rs
+++ b/pipelined/bevy_pbr2/src/lib.rs
@@ -74,7 +74,7 @@ impl Plugin for PbrPlugin {
             )
             .add_system_to_stage(
                 CoreStage::PostUpdate,
-                check_light_visibility
+                check_light_mesh_visibility
                     .label(SimulationLightSystems::CheckLightVisibility)
                     .after(TransformSystem::TransformPropagate)
                     .after(VisibilitySystems::CalculateBounds)

--- a/pipelined/bevy_pbr2/src/lib.rs
+++ b/pipelined/bevy_pbr2/src/lib.rs
@@ -67,16 +67,14 @@ impl Plugin for PbrPlugin {
                 //       add as an exclusive system
                 add_clusters
                     .exclusive_system()
-                    .label(SimulationLightSystems::AddClusters)
-                    .after(TransformSystem::TransformPropagate),
+                    .label(SimulationLightSystems::AddClusters),
             )
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 // NOTE: Must come after add_clusters!
                 update_clusters
                     .label(SimulationLightSystems::UpdateClusters)
-                    .after(TransformSystem::TransformPropagate)
-                    .after(SimulationLightSystems::AddClusters),
+                    .after(TransformSystem::TransformPropagate),
             )
             .add_system_to_stage(
                 CoreStage::PostUpdate,
@@ -128,7 +126,7 @@ impl Plugin for PbrPlugin {
                 // _before_ the `prepare_views()` system is run. ideally this becomes a normal system when "stageless" features come out
                 render::prepare_lights
                     .exclusive_system()
-                    .label(RenderLightSystems::PrepareClusters),
+                    .label(RenderLightSystems::PrepareLights),
             )
             .add_system_to_stage(
                 RenderStage::Prepare,

--- a/pipelined/bevy_pbr2/src/lib.rs
+++ b/pipelined/bevy_pbr2/src/lib.rs
@@ -61,11 +61,12 @@ impl Plugin for PbrPlugin {
             .init_resource::<PointLightShadowMap>()
             .init_resource::<AmbientLight>()
             .init_resource::<VisiblePointLights>()
-            // NOTE: Clusters need to have been added before update_clusters is run so
-            //       run in the stage before...
             .add_system_to_stage(
-                CoreStage::Update,
+                CoreStage::PostUpdate,
+                // NOTE: Clusters need to have been added before update_clusters is run so
+                //       add as an exclusive system
                 add_clusters
+                    .exclusive_system()
                     .label(SimulationLightSystems::AddClusters)
                     .after(TransformSystem::TransformPropagate),
             )

--- a/pipelined/bevy_pbr2/src/light.rs
+++ b/pipelined/bevy_pbr2/src/light.rs
@@ -311,8 +311,8 @@ pub fn update_clusters(windows: Res<Windows>, mut views: Query<(&Camera, &mut Cl
 
         // Calculate view space AABBs
         // NOTE: It is important that these are iterated in a specific order
-        //       so that we can calculate the cluster index in the fragment shader!
-        // I (robswain) choose to scan along rows of tiles in x,y, and for each tile then scan
+        // so that we can calculate the cluster index in the fragment shader!
+        // I (Rob Swain) choose to scan along rows of tiles in x,y, and for each tile then scan
         // along z
         let mut aabbs = Vec::with_capacity(
             (clusters.axis_slices.y * clusters.axis_slices.x * clusters.axis_slices.z) as usize,

--- a/pipelined/bevy_pbr2/src/light.rs
+++ b/pipelined/bevy_pbr2/src/light.rs
@@ -589,7 +589,7 @@ pub fn update_point_light_frusta(
 
 pub fn check_light_mesh_visibility(
     // NOTE: VisiblePointLights is an alias for VisibleEntities so the Without<DirectionalLight>
-    //       is needed to avoid an unnecessary QuerySet
+    // is needed to avoid an unnecessary QuerySet
     visible_point_lights: Query<&VisiblePointLights, Without<DirectionalLight>>,
     mut point_lights: Query<(
         &PointLight,

--- a/pipelined/bevy_pbr2/src/light.rs
+++ b/pipelined/bevy_pbr2/src/light.rs
@@ -444,7 +444,9 @@ pub fn update_point_light_frusta(
 }
 
 pub fn check_light_mesh_visibility(
-    visible_point_lights: Query<&VisiblePointLights>,
+    // NOTE: VisiblePointLights is an alias for VisibleEntities so the Without<DirectionalLight>
+    //       is needed to avoid an unnecessary QuerySet
+    visible_point_lights: Query<&VisiblePointLights, Without<DirectionalLight>>,
     mut point_lights: Query<(
         &PointLight,
         &GlobalTransform,

--- a/pipelined/bevy_pbr2/src/light.rs
+++ b/pipelined/bevy_pbr2/src/light.rs
@@ -296,29 +296,18 @@ pub fn add_clusters(
     windows: Res<Windows>,
     cameras: Query<(Entity, &Camera), Without<Clusters>>,
 ) {
-    // println!("Running add_clusters with {} cameras", cameras.iter().count());
     for (entity, camera) in cameras.iter() {
         let window = windows.get(camera.window).unwrap();
-        // let divisions = 8;
         let clusters = Clusters::new(
             UVec2::splat(window.physical_width() / 16),
-            // UVec2::new(
-            //     window.physical_width() / divisions,
-            //     window.physical_height() / divisions,
-            // ),
-            // UVec2::new(window.physical_width() / 2, window.physical_height()),
             UVec2::new(window.physical_width(), window.physical_height()),
             24,
-            // divisions,
-            // 1,
         );
-        // dbg!(&clusters);
         commands.entity(entity).insert(clusters);
     }
 }
 
 pub fn update_clusters(windows: Res<Windows>, mut views: Query<(&Camera, &mut Clusters)>) {
-    // println!("Running add_clusters with {} cameras", cameras.iter().count());
     for (camera, mut clusters) in views.iter_mut() {
         let inverse_projection = camera.projection_matrix.inverse();
         let window = windows.get(camera.window).unwrap();
@@ -353,8 +342,6 @@ pub fn update_clusters(windows: Res<Windows>, mut views: Query<(&Camera, &mut Cl
                 }
             }
         }
-        // dbg!(&aabbs);
-        // panic!("blerp");
         clusters.aabbs = aabbs;
     }
 }
@@ -388,22 +375,14 @@ pub fn assign_lights_to_clusters(
         let cluster_count = clusters.aabbs.len();
         let mut clusters_lights = Vec::with_capacity(cluster_count);
         let mut visible_lights = HashSet::with_capacity(light_count);
-        for (cluster_index, cluster_aabb) in clusters.aabbs.iter().enumerate() {
+        for cluster_aabb in clusters.aabbs.iter() {
             let mut cluster_lights = Vec::with_capacity(light_count);
-            for (light_index, (light_entity, transform, light)) in lights.iter().enumerate() {
+            for (light_entity, transform, light) in lights.iter() {
                 let light_sphere = Sphere {
                     center: transform.translation,
                     radius: light.range,
                 };
                 if light_sphere.intersects_obb(cluster_aabb, &view_transform) {
-                    // println!("cluster {} assigned light {}", cluster_index, light_index);
-                    // println!(
-                    //     "Light {:?} intersects cluster at {:?} with {:?}",
-                    //     light_sphere,
-                    //     view_transform.transform_vector3(cluster_aabb.center),
-                    //     cluster_aabb.half_extents,
-                    // );
-                    // panic!("blerp");
                     global_lights_set.insert(light_entity);
                     visible_lights.insert(light_entity);
                     cluster_lights.push(light_entity);

--- a/pipelined/bevy_pbr2/src/light.rs
+++ b/pipelined/bevy_pbr2/src/light.rs
@@ -225,7 +225,12 @@ fn clip_to_view(inverse_projection: Mat4, clip: Vec4) -> Vec4 {
 
 fn screen_to_view(screen_size: Vec2, inverse_projection: Mat4, screen: Vec2, ndc_z: f32) -> Vec4 {
     let tex_coord = screen / screen_size;
-    let clip = Vec4::new(tex_coord.x * 2.0 - 1.0, tex_coord.y * 2.0 - 1.0, ndc_z, 1.0);
+    let clip = Vec4::new(
+        tex_coord.x * 2.0 - 1.0,
+        (1.0 - tex_coord.y) * 2.0 - 1.0,
+        ndc_z,
+        1.0,
+    );
     clip_to_view(inverse_projection, clip)
 }
 

--- a/pipelined/bevy_pbr2/src/light.rs
+++ b/pipelined/bevy_pbr2/src/light.rs
@@ -294,17 +294,17 @@ pub fn add_clusters(
     // println!("Running add_clusters with {} cameras", cameras.iter().count());
     for (entity, camera) in cameras.iter() {
         let window = windows.get(camera.window).unwrap();
-        let divisions = 4;
+        // let divisions = 8;
         let clusters = Clusters::new(
-            // UVec2::splat(window.physical_width() / 16),
-            UVec2::new(
-                window.physical_width() / divisions,
-                window.physical_height() / divisions,
-            ),
+            UVec2::splat(window.physical_width() / 16),
+            // UVec2::new(
+            //     window.physical_width() / divisions,
+            //     window.physical_height() / divisions,
+            // ),
             // UVec2::new(window.physical_width() / 2, window.physical_height()),
             UVec2::new(window.physical_width(), window.physical_height()),
-            // 24,
-            divisions,
+            24,
+            // divisions,
             // 1,
         );
         // dbg!(&clusters);

--- a/pipelined/bevy_pbr2/src/light.rs
+++ b/pipelined/bevy_pbr2/src/light.rs
@@ -186,6 +186,15 @@ pub enum SimulationLightSystems {
     CheckLightVisibility,
 }
 
+// Clustered-forward rendering notes
+// The main initial reference material used was this rather accessible article:
+// http://www.aortiz.me/2018/12/21/CG.html
+// Some inspiration was taken from “Practical Clustered Shading” which is part 2 of:
+// https://efficientshading.com/2015/01/01/real-time-many-light-management-and-shadows-with-clustered-shading/
+// (Also note that Part 3 of the above shows how we could support the shadow mapping for many lights.)
+// The z-slicing method mentioned in the aortiz article is originally from Tiago Sousa’s Siggraph 2016 talk about Doom 2016:
+// http://advances.realtimerendering.com/s2016/Siggraph2016_idTech6.pdf
+
 #[derive(Component, Debug)]
 pub struct Clusters {
     /// Tile size

--- a/pipelined/bevy_pbr2/src/light.rs
+++ b/pipelined/bevy_pbr2/src/light.rs
@@ -11,7 +11,7 @@ use bevy_render2::{
 use bevy_transform::components::GlobalTransform;
 use bevy_window::Windows;
 
-use crate::{CubeMapFace, CubemapVisibleEntities, CUBE_MAP_FACES};
+use crate::{CubeMapFace, CubemapVisibleEntities, CUBE_MAP_FACES, POINT_LIGHT_NEAR_Z};
 
 /// A light that emits light in all directions from a central point.
 ///
@@ -449,7 +449,8 @@ pub fn update_point_light_frusta(
     global_lights: Res<VisiblePointLights>,
     mut views: Query<(Entity, &GlobalTransform, &PointLight, &mut CubemapFrusta)>,
 ) {
-    let projection = Mat4::perspective_infinite_reverse_rh(std::f32::consts::FRAC_PI_2, 1.0, 0.1);
+    let projection =
+        Mat4::perspective_infinite_reverse_rh(std::f32::consts::FRAC_PI_2, 1.0, POINT_LIGHT_NEAR_Z);
     let view_rotations = CUBE_MAP_FACES
         .iter()
         .map(|CubeMapFace { target, up }| GlobalTransform::identity().looking_at(*target, *up))

--- a/pipelined/bevy_pbr2/src/render/light.rs
+++ b/pipelined/bevy_pbr2/src/render/light.rs
@@ -430,7 +430,7 @@ pub fn extract_lights(
     }
 }
 
-const POINT_LIGHT_NEAR_Z: f32 = 0.1f32;
+pub(crate) const POINT_LIGHT_NEAR_Z: f32 = 0.1f32;
 
 // Can't do `Vec3::Y * -1.0` because mul isn't const
 const NEGATIVE_X: Vec3 = const_vec3!([-1.0, 0.0, 0.0]);

--- a/pipelined/bevy_pbr2/src/render/light.rs
+++ b/pipelined/bevy_pbr2/src/render/light.rs
@@ -587,6 +587,7 @@ pub fn prepare_lights(
         });
         global_light_meta.entity_to_index.insert(entity, index);
     }
+    // NOTE: Pad up to max point lights to meet the fixed size uniform buffer requirement
     for _ in n_point_lights..MAX_POINT_LIGHTS {
         global_light_meta
             .gpu_point_lights
@@ -642,6 +643,9 @@ pub fn prepare_lights(
 
         // TODO: this should select lights based on relevance to the view instead of the first ones that show up in a query
         for (light_entity, light) in point_lights.iter() {
+            if !light.shadows_enabled {
+                continue;
+            }
             let light_index = *global_light_meta
                 .entity_to_index
                 .get(&light_entity)

--- a/pipelined/bevy_pbr2/src/render/light.rs
+++ b/pipelined/bevy_pbr2/src/render/light.rs
@@ -141,7 +141,7 @@ pub struct GpuLights {
 // NOTE: this must be kept in sync with the same constants in pbr.frag
 pub const MAX_POINT_LIGHTS: usize = 256;
 // FIXME: How should we handle shadows for clustered forward? Limiting to maximum 10
-//        point light shadow maps for now
+// point light shadow maps for now
 pub const MAX_POINT_LIGHT_SHADOW_MAPS: usize = 10;
 pub const MAX_DIRECTIONAL_LIGHTS: usize = 1;
 pub const POINT_SHADOW_LAYERS: u32 = (6 * MAX_POINT_LIGHT_SHADOW_MAPS) as u32;
@@ -743,7 +743,7 @@ pub fn prepare_lights(
             let intensity = light.illuminance * exposure;
 
             // NOTE: A directional light seems to have to have an eye position on the line along the direction of the light
-            //       through the world origin. I (Rob Swain) do not yet understand why it cannot be translated away from this.
+            // through the world origin. I (Rob Swain) do not yet understand why it cannot be translated away from this.
             let view = Mat4::look_at_rh(Vec3::ZERO, light.direction, Vec3::Y);
             // NOTE: This orthographic projection defines the volume within which shadows from a directional light can be cast
             let projection = light.projection;
@@ -855,14 +855,14 @@ const CLUSTER_COUNT_MASK: u32 = (1 << 8) - 1;
 const POINT_LIGHT_INDEX_MASK: u32 = (1 << 8) - 1;
 
 // NOTE: With uniform buffer max binding size as 16384 bytes
-//       that means we can fit say 128 point lights in one uniform
-//       buffer, which means the count can be at most 128 so it
-//       needs 7 bits, use 8 for convenience.
-//       The array of indices can also use u8 and that means the
-//       offset in to the array of indices needs to be able to address
-//       16384 values. lod2(16384) = 21 bits.
-//       This means we can pack the offset into the upper 24 bits of a u32
-//       and the count into the lower 8 bits.
+// that means we can fit say 128 point lights in one uniform
+// buffer, which means the count can be at most 128 so it
+// needs 7 bits, use 8 for convenience.
+// The array of indices can also use u8 and that means the
+// offset in to the array of indices needs to be able to address
+// 16384 values. lod2(16384) = 21 bits.
+// This means we can pack the offset into the upper 24 bits of a u32
+// and the count into the lower 8 bits.
 // FIXME: Probably there are endianness concerns here????!!!!!
 fn pack_offset_and_count(offset: usize, count: usize) -> u32 {
     ((offset as u32 & CLUSTER_OFFSET_MASK) << CLUSTER_COUNT_SIZE)
@@ -1037,7 +1037,7 @@ pub fn queue_shadows(
                     .get(*face_index),
             };
             // NOTE: Lights with shadow mapping disabled will have no visible entities
-            //       so no meshes will be queued
+            // so no meshes will be queued
             for entity in visible_entities.iter().copied() {
                 let mut key = ShadowPipelineKey::empty();
                 if let Ok(mesh_handle) = casting_meshes.get(entity) {

--- a/pipelined/bevy_pbr2/src/render/light.rs
+++ b/pipelined/bevy_pbr2/src/render/light.rs
@@ -131,7 +131,7 @@ pub struct GpuLights {
     directional_lights: [GpuDirectionalLight; MAX_DIRECTIONAL_LIGHTS],
     ambient_color: Vec4,
     cluster_dimensions: UVec4,
-    // xy are vec2<f32<(cluster_dimensions.xy) / vec2<f32<(view.width, view.height)
+    // xy are vec2<f32>(cluster_dimensions.xy) / vec2<f32>(view.width, view.height)
     // z is cluster_dimensions.z / log(far / near)
     // w is cluster_dimensions.z * log(near) / log(far / near)
     cluster_factors: Vec4,

--- a/pipelined/bevy_pbr2/src/render/light.rs
+++ b/pipelined/bevy_pbr2/src/render/light.rs
@@ -875,14 +875,13 @@ impl ViewClusterBindings {
     pub fn push_offset_and_count(&mut self, offset: usize, count: usize) {
         let packed = pack_offset_and_count(offset, count);
 
-        let sub_indices = self.n_offsets & ((1 << 4) - 1);
-        if sub_indices == 0 {
+        let component = self.n_offsets & ((1 << 2) - 1);
+        if component == 0 {
             self.cluster_offsets_and_counts
                 .push(UVec4::new(packed, 0, 0, 0));
         } else {
-            let array_index = self.n_offsets >> 4; // >> 4 is equivalent to / 16
+            let array_index = self.n_offsets >> 2; // >> 2 is equivalent to / 4
             let array_value = self.cluster_offsets_and_counts.get_mut(array_index);
-            let component = sub_indices >> 2;
             array_value[component] = packed;
         }
 
@@ -907,7 +906,7 @@ impl ViewClusterBindings {
         } else {
             let array_index = self.n_indices >> 4; // >> 4 is equivalent to / 16
             let array_value = self.cluster_light_index_lists.get_mut(array_index);
-            let component = sub_indices >> 2;
+            let component = (sub_indices >> 2) & ((1 << 2) - 1);
             let sub_index = sub_indices & ((1 << 2) - 1);
             array_value[component] |= index << (8 * sub_index);
         }

--- a/pipelined/bevy_pbr2/src/render/light.rs
+++ b/pipelined/bevy_pbr2/src/render/light.rs
@@ -979,10 +979,6 @@ pub fn prepare_clusters(
             .cluster_offsets_and_counts
             .write_buffer(&render_device, &render_queue);
 
-        // dbg!(view_clusters_bindings.cluster_light_index_lists.values());
-        // dbg!(view_clusters_bindings.cluster_offsets_and_counts.values());
-        // panic!("SMURF");
-
         commands.get_or_spawn(entity).insert(view_clusters_bindings);
     }
 }

--- a/pipelined/bevy_pbr2/src/render/light.rs
+++ b/pipelined/bevy_pbr2/src/render/light.rs
@@ -10,7 +10,7 @@ use bevy_ecs::{
     prelude::*,
     system::{lifetimeless::*, SystemParamItem},
 };
-use bevy_math::{const_vec3, Mat4, UVec3, UVec4, Vec3, Vec4};
+use bevy_math::{const_vec3, Mat4, UVec3, UVec4, Vec3, Vec4, Vec4Swizzles};
 use bevy_render2::{
     camera::{Camera, CameraProjection},
     color::Color,

--- a/pipelined/bevy_pbr2/src/render/light.rs
+++ b/pipelined/bevy_pbr2/src/render/light.rs
@@ -10,7 +10,7 @@ use bevy_ecs::{
     prelude::*,
     system::{lifetimeless::*, SystemParamItem},
 };
-use bevy_math::{const_vec3, Mat4, Vec3, Vec4};
+use bevy_math::{const_vec3, Mat4, UVec4, Vec3, Vec4};
 use bevy_render2::{
     camera::CameraProjection,
     color::Color,
@@ -69,6 +69,8 @@ pub struct ExtractedDirectionalLight {
     shadows_enabled: bool,
     shadow_depth_bias: f32,
     shadow_normal_bias: f32,
+    near: f32,
+    far: f32,
 }
 
 pub type ExtractedDirectionalLightShadowMap = DirectionalLightShadowMap;
@@ -123,10 +125,9 @@ bitflags::bitflags! {
 #[derive(Copy, Clone, Debug, AsStd140)]
 pub struct GpuLights {
     // TODO: this comes first to work around a WGSL alignment issue. We need to solve this issue before releasing the renderer rework
-    point_lights: [GpuPointLight; MAX_POINT_LIGHTS],
     directional_lights: [GpuDirectionalLight; MAX_DIRECTIONAL_LIGHTS],
     ambient_color: Vec4,
-    n_point_lights: u32,
+    cluster_dimensions: UVec4,
     n_directional_lights: u32,
 }
 
@@ -390,11 +391,15 @@ pub fn extract_lights(
                 shadow_normal_bias: directional_light.shadow_normal_bias
                     * directional_light_texel_size
                     * std::f32::consts::SQRT_2,
+                near: directional_light.shadow_projection.near,
+                far: directional_light.shadow_projection.far,
             },
             render_visible_entities,
         ));
     }
 }
+
+const POINT_LIGHT_NEAR_Z: f32 = 0.1f32;
 
 // Can't do `Vec3::Y * -1.0` because mul isn't const
 const NEGATIVE_X: Vec3 = const_vec3!([-1.0, 0.0, 0.0]);
@@ -476,6 +481,10 @@ pub struct ViewLightsUniformOffset {
     pub offset: u32,
 }
 
+pub struct GlobalLightMeta {
+    pub gpu_point_lights: UniformVec<GpuPointLight>,
+}
+
 #[derive(Default)]
 pub struct LightMeta {
     pub view_gpu_lights: DynamicUniformVec<GpuLights>,
@@ -499,6 +508,7 @@ pub fn prepare_lights(
     mut texture_cache: ResMut<TextureCache>,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
+    mut global_light_meta: ResMut<GlobalLightMeta>,
     mut light_meta: ResMut<LightMeta>,
     views: Query<Entity, With<RenderPhase<Transparent3d>>>,
     ambient_light: Res<ExtractedAmbientLight>,
@@ -511,11 +521,36 @@ pub fn prepare_lights(
 
     // Pre-calculate for PointLights
     let cube_face_projection =
-        Mat4::perspective_infinite_reverse_rh(std::f32::consts::FRAC_PI_2, 1.0, 0.1);
+        Mat4::perspective_infinite_reverse_rh(std::f32::consts::FRAC_PI_2, 1.0, POINT_LIGHT_NEAR_Z);
     let cube_face_rotations = CUBE_MAP_FACES
         .iter()
         .map(|CubeMapFace { target, up }| GlobalTransform::identity().looking_at(*target, *up))
         .collect::<Vec<_>>();
+
+    global_light_meta.gpu_point_lights.clear();
+    for (_, light) in point_lights.iter() {
+        let mut flags = PointLightFlags::NONE;
+        if light.shadows_enabled {
+            flags |= PointLightFlags::SHADOWS_ENABLED;
+        }
+        global_light_meta.gpu_point_lights.push(GpuPointLight {
+            projection: cube_face_projection,
+            // premultiply color by intensity
+            // we don't use the alpha at all, so no reason to multiply only [0..3]
+            color: Vec4::from_slice(&light.color.as_linear_rgba_f32()) * light.intensity,
+            radius: light.radius,
+            position: light.transform.translation,
+            inverse_square_range: 1.0 / (light.range * light.range),
+            near: POINT_LIGHT_NEAR_Z,
+            far: light.range,
+            flags: flags.bits,
+            shadow_depth_bias: light.shadow_depth_bias,
+            shadow_normal_bias: light.shadow_normal_bias,
+        });
+    }
+    global_light_meta
+        .gpu_point_lights
+        .write_buffer(&render_device, &render_queue);
 
     // set up light data for each view
     for entity in views.iter() {
@@ -554,12 +589,11 @@ pub fn prepare_lights(
         let mut view_lights = Vec::new();
 
         let mut gpu_lights = GpuLights {
+            directional_lights: [GpuDirectionalLight::default(); MAX_DIRECTIONAL_LIGHTS],
             ambient_color: Vec4::from_slice(&ambient_light.color.as_linear_rgba_f32())
                 * ambient_light.brightness,
-            n_point_lights: point_lights.iter().len() as u32,
+            cluster_dimensions: UVec4::new(16, 9, 24, 0),
             n_directional_lights: directional_lights.iter().len() as u32,
-            point_lights: [GpuPointLight::default(); MAX_POINT_LIGHTS],
-            directional_lights: [GpuDirectionalLight::default(); MAX_DIRECTIONAL_LIGHTS],
         };
 
         // TODO: this should select lights based on relevance to the view instead of the first ones that show up in a query
@@ -601,6 +635,8 @@ pub fn prepare_lights(
                                 height: point_light_shadow_map.size as u32,
                                 transform: view_translation * *view_rotation,
                                 projection: cube_face_projection,
+                                near: POINT_LIGHT_NEAR_Z,
+                                far: light.range,
                             },
                             RenderPhase::<Shadow>::default(),
                             LightEntity::Point {
@@ -612,26 +648,6 @@ pub fn prepare_lights(
                     view_lights.push(view_light_entity);
                 }
             }
-
-            let mut flags = PointLightFlags::NONE;
-            if light.shadows_enabled {
-                flags |= PointLightFlags::SHADOWS_ENABLED;
-            }
-
-            gpu_lights.point_lights[light_index] = GpuPointLight {
-                projection: cube_face_projection,
-                // premultiply color by intensity
-                // we don't use the alpha at all, so no reason to multiply only [0..3]
-                color: Vec4::from_slice(&light.color.as_linear_rgba_f32()) * light.intensity,
-                radius: light.radius,
-                position: light.transform.translation,
-                inverse_square_range: 1.0 / (light.range * light.range),
-                near: 0.1,
-                far: light.range,
-                flags: flags.bits,
-                shadow_depth_bias: light.shadow_depth_bias,
-                shadow_normal_bias: light.shadow_normal_bias,
-            };
         }
 
         for (i, (light_entity, light)) in directional_lights
@@ -705,6 +721,8 @@ pub fn prepare_lights(
                             height: directional_light_shadow_map.size as u32,
                             transform: GlobalTransform::from_matrix(view.inverse()),
                             projection,
+                            near: light.near,
+                            far: light.far,
                         },
                         RenderPhase::<Shadow>::default(),
                         LightEntity::Directional { light_entity },

--- a/pipelined/bevy_pbr2/src/render/light.rs
+++ b/pipelined/bevy_pbr2/src/render/light.rs
@@ -10,7 +10,7 @@ use bevy_ecs::{
     prelude::*,
     system::{lifetimeless::*, SystemParamItem},
 };
-use bevy_math::{const_vec3, Mat4, UVec2, UVec3, UVec4, Vec3, Vec4};
+use bevy_math::{const_vec3, Mat4, UVec3, UVec4, Vec3, Vec4};
 use bevy_render2::{
     camera::{Camera, CameraProjection},
     color::Color,

--- a/pipelined/bevy_pbr2/src/render/light.rs
+++ b/pipelined/bevy_pbr2/src/render/light.rs
@@ -141,7 +141,9 @@ pub struct GpuLights {
 // NOTE: this must be kept in sync with the same constants in pbr.frag
 pub const MAX_POINT_LIGHTS: usize = 256;
 pub const MAX_DIRECTIONAL_LIGHTS: usize = 1;
-pub const POINT_SHADOW_LAYERS: u32 = (6 * MAX_POINT_LIGHTS) as u32;
+// FIXME: How should we handle shadows for clustered forward? Limiting to maximum 10
+//        point light shadow maps for now
+pub const POINT_SHADOW_LAYERS: u32 = (6 * 10) as u32;
 pub const DIRECTIONAL_SHADOW_LAYERS: u32 = MAX_DIRECTIONAL_LIGHTS as u32;
 pub const SHADOW_FORMAT: TextureFormat = TextureFormat::Depth32Float;
 

--- a/pipelined/bevy_pbr2/src/render/light.rs
+++ b/pipelined/bevy_pbr2/src/render/light.rs
@@ -880,7 +880,8 @@ pub struct ViewClusterBindings {
 }
 
 impl ViewClusterBindings {
-    const MAX_UNIFORM_ITEMS: usize = 16384 / (4 * 4);
+    pub const MAX_OFFSETS: usize = 16384 / 4;
+    const MAX_UNIFORM_ITEMS: usize = Self::MAX_OFFSETS / 4;
     const MAX_INDICES: usize = 16384;
 
     pub fn reserve_and_clear(&mut self) {

--- a/pipelined/bevy_pbr2/src/render/mesh.rs
+++ b/pipelined/bevy_pbr2/src/render/mesh.rs
@@ -246,7 +246,7 @@ impl FromWorld for MeshPipeline {
                         has_dynamic_offset: false,
                         // NOTE: Static size for uniform buffers. GpuPointLight has a padded
                         //       size of 128 bytes, so 16384 / 128 = 128 point lights max
-                        min_binding_size: BufferSize::new(0),
+                        min_binding_size: BufferSize::new(16384),
                     },
                     count: None,
                 },
@@ -259,7 +259,7 @@ impl FromWorld for MeshPipeline {
                         has_dynamic_offset: false,
                         // NOTE: With 128 point lights max, indices need 7 bits. Use u8 for
                         //       convenience.
-                        min_binding_size: BufferSize::new(0),
+                        min_binding_size: BufferSize::new(16384),
                     },
                     count: None,
                 },
@@ -274,7 +274,7 @@ impl FromWorld for MeshPipeline {
                         //       The count can be at most all 128 lights so 7 bits.
                         //       Pack the offset into the upper 24 bits and the count into the
                         //       lower 8 bits for convenience.
-                        min_binding_size: BufferSize::new(0),
+                        min_binding_size: BufferSize::new(16384),
                     },
                     count: None,
                 },

--- a/pipelined/bevy_pbr2/src/render/mesh.rs
+++ b/pipelined/bevy_pbr2/src/render/mesh.rs
@@ -237,6 +237,42 @@ impl FromWorld for MeshPipeline {
                     },
                     count: None,
                 },
+                // PointLights
+                BindGroupLayoutEntry {
+                    binding: 6,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        // NOTE: 0 if no point lights?
+                        min_binding_size: BufferSize::new(0),
+                    },
+                    count: None,
+                },
+                // ClusteredLightIndexLists
+                BindGroupLayoutEntry {
+                    binding: 7,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        // NOTE: 0 if no point lights?
+                        min_binding_size: BufferSize::new(0),
+                    },
+                    count: None,
+                },
+                // ClusterOffsetsAndCounts
+                BindGroupLayoutEntry {
+                    binding: 8,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        // NOTE: number of clusters * u32, so minimum clusters = 1 => 4
+                        min_binding_size: BufferSize::new(4),
+                    },
+                    count: None,
+                },
             ],
             label: Some("mesh_view_layout"),
         });

--- a/pipelined/bevy_pbr2/src/render/mesh.rs
+++ b/pipelined/bevy_pbr2/src/render/mesh.rs
@@ -245,7 +245,7 @@ impl FromWorld for MeshPipeline {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: false,
                         // NOTE: 0 if no point lights?
-                        min_binding_size: BufferSize::new(0),
+                        min_binding_size: BufferSize::new(16384),
                     },
                     count: None,
                 },
@@ -257,7 +257,7 @@ impl FromWorld for MeshPipeline {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: false,
                         // NOTE: 0 if no point lights?
-                        min_binding_size: BufferSize::new(0),
+                        min_binding_size: BufferSize::new(16384),
                     },
                     count: None,
                 },
@@ -269,7 +269,7 @@ impl FromWorld for MeshPipeline {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: false,
                         // NOTE: number of clusters * u32, so minimum clusters = 1 => 4
-                        min_binding_size: BufferSize::new(4),
+                        min_binding_size: BufferSize::new(16384),
                     },
                     count: None,
                 },

--- a/pipelined/bevy_pbr2/src/render/mesh.rs
+++ b/pipelined/bevy_pbr2/src/render/mesh.rs
@@ -244,7 +244,8 @@ impl FromWorld for MeshPipeline {
                     ty: BindingType::Buffer {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        // NOTE: 0 if no point lights?
+                        // NOTE: Static size for uniform buffers. GpuPointLight has a padded
+                        //       size of 128 bytes, so 16384 / 128 = 128 point lights max
                         min_binding_size: BufferSize::new(0),
                     },
                     count: None,
@@ -256,7 +257,8 @@ impl FromWorld for MeshPipeline {
                     ty: BindingType::Buffer {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        // NOTE: 0 if no point lights?
+                        // NOTE: With 128 point lights max, indices need 7 bits. Use u8 for
+                        //       convenience.
                         min_binding_size: BufferSize::new(0),
                     },
                     count: None,
@@ -268,7 +270,10 @@ impl FromWorld for MeshPipeline {
                     ty: BindingType::Buffer {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        // NOTE: number of clusters * u32, so minimum clusters = 1 => 4
+                        // NOTE: The offset needs to address 16384 indices, which needs 21 bits.
+                        //       The count can be at most all 128 lights so 7 bits.
+                        //       Pack the offset into the upper 24 bits and the count into the
+                        //       lower 8 bits for convenience.
                         min_binding_size: BufferSize::new(0),
                     },
                     count: None,

--- a/pipelined/bevy_pbr2/src/render/mesh.rs
+++ b/pipelined/bevy_pbr2/src/render/mesh.rs
@@ -245,7 +245,7 @@ impl FromWorld for MeshPipeline {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: false,
                         // NOTE: Static size for uniform buffers. GpuPointLight has a padded
-                        //       size of 128 bytes, so 16384 / 128 = 128 point lights max
+                        // size of 128 bytes, so 16384 / 128 = 128 point lights max
                         min_binding_size: BufferSize::new(16384),
                     },
                     count: None,
@@ -258,7 +258,7 @@ impl FromWorld for MeshPipeline {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: false,
                         // NOTE: With 128 point lights max, indices need 7 bits. Use u8 for
-                        //       convenience.
+                        // convenience.
                         min_binding_size: BufferSize::new(16384),
                     },
                     count: None,
@@ -271,9 +271,9 @@ impl FromWorld for MeshPipeline {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: false,
                         // NOTE: The offset needs to address 16384 indices, which needs 21 bits.
-                        //       The count can be at most all 128 lights so 7 bits.
-                        //       Pack the offset into the upper 24 bits and the count into the
-                        //       lower 8 bits for convenience.
+                        // The count can be at most all 128 lights so 7 bits.
+                        // Pack the offset into the upper 24 bits and the count into the
+                        // lower 8 bits for convenience.
                         min_binding_size: BufferSize::new(16384),
                     },
                     count: None,

--- a/pipelined/bevy_pbr2/src/render/mesh.rs
+++ b/pipelined/bevy_pbr2/src/render/mesh.rs
@@ -245,7 +245,7 @@ impl FromWorld for MeshPipeline {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: false,
                         // NOTE: 0 if no point lights?
-                        min_binding_size: BufferSize::new(16384),
+                        min_binding_size: BufferSize::new(0),
                     },
                     count: None,
                 },
@@ -257,7 +257,7 @@ impl FromWorld for MeshPipeline {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: false,
                         // NOTE: 0 if no point lights?
-                        min_binding_size: BufferSize::new(16384),
+                        min_binding_size: BufferSize::new(0),
                     },
                     count: None,
                 },
@@ -269,7 +269,7 @@ impl FromWorld for MeshPipeline {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: false,
                         // NOTE: number of clusters * u32, so minimum clusters = 1 => 4
-                        min_binding_size: BufferSize::new(16384),
+                        min_binding_size: BufferSize::new(0),
                     },
                     count: None,
                 },

--- a/pipelined/bevy_pbr2/src/render/mesh.rs
+++ b/pipelined/bevy_pbr2/src/render/mesh.rs
@@ -555,6 +555,7 @@ pub struct MeshViewBindGroup {
     pub value: BindGroup,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn queue_mesh_view_bind_groups(
     mut commands: Commands,
     render_device: Res<RenderDevice>,

--- a/pipelined/bevy_pbr2/src/render/mesh_view_bind_group.wgsl
+++ b/pipelined/bevy_pbr2/src/render/mesh_view_bind_group.wgsl
@@ -11,13 +11,10 @@ struct View {
 };
 
 struct PointLight {
-    projection: mat4x4<f32>;
-    color: vec4<f32>;
-    position: vec3<f32>;
-    inverse_square_range: f32;
-    radius: f32;
-    near: f32;
-    far: f32;
+    // NOTE: .z.z .z.w .w.z .w.w
+    projection_lr: vec4<f32>;
+    color_inverse_square_range: vec4<f32>;
+    position_radius: vec4<f32>;
     // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
     flags: u32;
     shadow_depth_bias: f32;

--- a/pipelined/bevy_pbr2/src/render/mesh_view_bind_group.wgsl
+++ b/pipelined/bevy_pbr2/src/render/mesh_view_bind_group.wgsl
@@ -41,7 +41,7 @@ let DIRECTIONAL_LIGHT_FLAGS_SHADOWS_ENABLED_BIT: u32 = 1u;
 [[block]]
 struct Lights {
     // NOTE: this array size must be kept in sync with the constants defined bevy_pbr2/src/render/light.rs
-    directional_lights: array<DirectionalLight, 1>;
+    directional_lights: array<DirectionalLight, 1u>;
     ambient_color: vec4<f32>;
     cluster_dimensions: vec4<u32>; // x/y/z dimensions
     n_directional_lights: u32;
@@ -49,18 +49,18 @@ struct Lights {
 
 [[block]]
 struct PointLights {
-    data: array<PointLight, 128>;
+    data: array<PointLight, 128u>;
 };
 
 [[block]]
 struct ClusterLightIndexLists {
-    data: array<u32, 4096>; // each u32 contains 4 u8 indices into the PointLights array
+    data: array<vec4<u32>, 1024u>; // each u32 contains 4 u8 indices into the PointLights array
 };
 
 [[block]]
 struct ClusterOffsetsAndCounts {
-    data: array<u32, 4096>; // each u32 contains a 24-bit index into ClusterLightIndexLists in the high 24 bits
-                            // and an 8-bit count of the number of lights in the low 8 bits
+    data: array<vec4<u32>, 1024u>; // each u32 contains a 24-bit index into ClusterLightIndexLists in the high 24 bits
+                             // and an 8-bit count of the number of lights in the low 8 bits
 };
 
 [[group(0), binding(0)]]

--- a/pipelined/bevy_pbr2/src/render/mesh_view_bind_group.wgsl
+++ b/pipelined/bevy_pbr2/src/render/mesh_view_bind_group.wgsl
@@ -11,7 +11,7 @@ struct View {
 };
 
 struct PointLight {
-    // NOTE: .z.z .z.w .w.z .w.w
+    // NOTE: [2][2] [2][3] [3][2] [3][3]
     projection_lr: vec4<f32>;
     color_inverse_square_range: vec4<f32>;
     position_radius: vec4<f32>;
@@ -40,10 +40,12 @@ struct Lights {
     // NOTE: this array size must be kept in sync with the constants defined bevy_pbr2/src/render/light.rs
     directional_lights: array<DirectionalLight, 1u>;
     ambient_color: vec4<f32>;
-    cluster_dimensions: vec4<u32>; // x/y/z dimensions
-    cluster_factors: vec4<f32>; // xy are vec2<f32>(cluster_dimensions.xy) / vec2<f32>(view.width, view.height)
-                                // z is cluster_dimensions.z / log(far / near)
-                                // w is cluster_dimensions.z * log(near) / log(far / near)
+    // x/y/z dimensions
+    cluster_dimensions: vec4<u32>;
+    // xy are vec2<f32>(cluster_dimensions.xy) / vec2<f32>(view.width, view.height)
+    // z is cluster_dimensions.z / log(far / near)
+    // w is cluster_dimensions.z * log(near) / log(far / near)
+    cluster_factors: vec4<f32>;
     n_directional_lights: u32;
 };
 
@@ -54,13 +56,15 @@ struct PointLights {
 
 [[block]]
 struct ClusterLightIndexLists {
-    data: array<vec4<u32>, 1024u>; // each u32 contains 4 u8 indices into the PointLights array
+    // each u32 contains 4 u8 indices into the PointLights array
+    data: array<vec4<u32>, 1024u>;
 };
 
 [[block]]
 struct ClusterOffsetsAndCounts {
-    data: array<vec4<u32>, 1024u>; // each u32 contains a 24-bit index into ClusterLightIndexLists in the high 24 bits
-                             // and an 8-bit count of the number of lights in the low 8 bits
+    // each u32 contains a 24-bit index into ClusterLightIndexLists in the high 24 bits
+    // and an 8-bit count of the number of lights in the low 8 bits
+    data: array<vec4<u32>, 1024u>;
 };
 
 [[group(0), binding(0)]]

--- a/pipelined/bevy_pbr2/src/render/mesh_view_bind_group.wgsl
+++ b/pipelined/bevy_pbr2/src/render/mesh_view_bind_group.wgsl
@@ -76,8 +76,8 @@ var directional_shadow_textures: texture_depth_2d_array;
 [[group(0), binding(5)]]
 var directional_shadow_textures_sampler: sampler_comparison;
 [[group(0), binding(6)]]
-var point_lights: PointLights;
+var<uniform> point_lights: PointLights;
 [[group(0), binding(7)]]
-var cluster_light_index_lists: ClusterLightIndexLists;
+var<uniform> cluster_light_index_lists: ClusterLightIndexLists;
 [[group(0), binding(8)]]
-var cluster_offsets_and_counts: ClusterOffsetsAndCounts;
+var<uniform> cluster_offsets_and_counts: ClusterOffsetsAndCounts;

--- a/pipelined/bevy_pbr2/src/render/mesh_view_bind_group.wgsl
+++ b/pipelined/bevy_pbr2/src/render/mesh_view_bind_group.wgsl
@@ -49,7 +49,7 @@ struct Lights {
 
 [[block]]
 struct PointLights {
-    data: array<PointLight, 128u>;
+    data: array<PointLight, 256u>;
 };
 
 [[block]]

--- a/pipelined/bevy_pbr2/src/render/mesh_view_bind_group.wgsl
+++ b/pipelined/bevy_pbr2/src/render/mesh_view_bind_group.wgsl
@@ -41,7 +41,7 @@ struct Lights {
     directional_lights: array<DirectionalLight, 1u>;
     ambient_color: vec4<f32>;
     cluster_dimensions: vec4<u32>; // x/y/z dimensions
-    cluster_factors: vec4<f32>; // xy are vec2<f32<(cluster_dimensions.xy) / vec2<f32<(view.width, view.height)
+    cluster_factors: vec4<f32>; // xy are vec2<f32>(cluster_dimensions.xy) / vec2<f32>(view.width, view.height)
                                 // z is cluster_dimensions.z / log(far / near)
                                 // w is cluster_dimensions.z * log(near) / log(far / near)
     n_directional_lights: u32;

--- a/pipelined/bevy_pbr2/src/render/mesh_view_bind_group.wgsl
+++ b/pipelined/bevy_pbr2/src/render/mesh_view_bind_group.wgsl
@@ -44,6 +44,9 @@ struct Lights {
     directional_lights: array<DirectionalLight, 1u>;
     ambient_color: vec4<f32>;
     cluster_dimensions: vec4<u32>; // x/y/z dimensions
+    cluster_factors: vec4<f32>; // xy are vec2<f32<(cluster_dimensions.xy) / vec2<f32<(view.width, view.height)
+                                // z is cluster_dimensions.z / log(far / near)
+                                // w is cluster_dimensions.z * log(near) / log(far / near)
     n_directional_lights: u32;
 };
 

--- a/pipelined/bevy_pbr2/src/render/mod.rs
+++ b/pipelined/bevy_pbr2/src/render/mod.rs
@@ -219,6 +219,7 @@ pub fn queue_meshes(
     mut pipelines: ResMut<SpecializedPipelines<PbrPipeline>>,
     mut pipeline_cache: ResMut<RenderPipelineCache>,
     msaa: Res<Msaa>,
+    global_light_meta: Res<GlobalLightMeta>,
     render_meshes: Res<RenderAssets<Mesh>>,
     render_materials: Res<RenderAssets<StandardMaterial>>,
     standard_material_meshes: Query<(&Handle<StandardMaterial>, &Handle<Mesh>, &MeshUniform)>,
@@ -249,7 +250,7 @@ pub fn queue_meshes(
 
         for visible_entity in &visible_entities.entities {
             if let Ok((material_handle, mesh_handle, mesh_uniform)) =
-                standard_material_meshes.get(visible_entity.entity)
+                standard_material_meshes.get(*visible_entity)
             {
                 if let Some(material) = render_materials.get(material_handle) {
                     let mut pbr_key = PbrPipelineKey {
@@ -275,7 +276,7 @@ pub fn queue_meshes(
                     match material.alpha_mode {
                         AlphaMode::Opaque => {
                             opaque_phase.add(Opaque3d {
-                                entity: visible_entity.entity,
+                                entity: *visible_entity,
                                 draw_function: draw_opaque_pbr,
                                 pipeline: pipeline_id,
                                 // NOTE: Front-to-back ordering for opaque with ascending sort means near should have the
@@ -287,7 +288,7 @@ pub fn queue_meshes(
                         }
                         AlphaMode::Mask(_) => {
                             alpha_mask_phase.add(AlphaMask3d {
-                                entity: visible_entity.entity,
+                                entity: *visible_entity,
                                 draw_function: draw_alpha_mask_pbr,
                                 pipeline: pipeline_id,
                                 // NOTE: Front-to-back ordering for alpha mask with ascending sort means near should have the
@@ -299,7 +300,7 @@ pub fn queue_meshes(
                         }
                         AlphaMode::Blend => {
                             transparent_phase.add(Transparent3d {
-                                entity: visible_entity.entity,
+                                entity: *visible_entity,
                                 draw_function: draw_transparent_pbr,
                                 pipeline: pipeline_id,
                                 // NOTE: Back-to-front ordering for transparent with ascending sort means far should have the

--- a/pipelined/bevy_pbr2/src/render/mod.rs
+++ b/pipelined/bevy_pbr2/src/render/mod.rs
@@ -279,9 +279,9 @@ pub fn queue_meshes(
                                 draw_function: draw_opaque_pbr,
                                 pipeline: pipeline_id,
                                 // NOTE: Front-to-back ordering for opaque with ascending sort means near should have the
-                                //       lowest sort key and getting further away should increase. As we have
-                                //       -z in front of the camera, values in view space decrease away from the
-                                //       camera. Flipping the sign of mesh_z results in the correct front-to-back ordering
+                                // lowest sort key and getting further away should increase. As we have
+                                // -z in front of the camera, values in view space decrease away from the
+                                // camera. Flipping the sign of mesh_z results in the correct front-to-back ordering
                                 distance: -mesh_z,
                             });
                         }
@@ -291,9 +291,9 @@ pub fn queue_meshes(
                                 draw_function: draw_alpha_mask_pbr,
                                 pipeline: pipeline_id,
                                 // NOTE: Front-to-back ordering for alpha mask with ascending sort means near should have the
-                                //       lowest sort key and getting further away should increase. As we have
-                                //       -z in front of the camera, values in view space decrease away from the
-                                //       camera. Flipping the sign of mesh_z results in the correct front-to-back ordering
+                                // lowest sort key and getting further away should increase. As we have
+                                // -z in front of the camera, values in view space decrease away from the
+                                // camera. Flipping the sign of mesh_z results in the correct front-to-back ordering
                                 distance: -mesh_z,
                             });
                         }
@@ -303,9 +303,9 @@ pub fn queue_meshes(
                                 draw_function: draw_transparent_pbr,
                                 pipeline: pipeline_id,
                                 // NOTE: Back-to-front ordering for transparent with ascending sort means far should have the
-                                //       lowest sort key and getting closer should increase. As we have
-                                //       -z in front of the camera, the largest distance is -far with values increasing toward the
-                                //       camera. As such we can just use mesh_z as the distance
+                                // lowest sort key and getting closer should increase. As we have
+                                // -z in front of the camera, the largest distance is -far with values increasing toward the
+                                // camera. As such we can just use mesh_z as the distance
                                 distance: mesh_z,
                             });
                         }

--- a/pipelined/bevy_pbr2/src/render/mod.rs
+++ b/pipelined/bevy_pbr2/src/render/mod.rs
@@ -219,7 +219,6 @@ pub fn queue_meshes(
     mut pipelines: ResMut<SpecializedPipelines<PbrPipeline>>,
     mut pipeline_cache: ResMut<RenderPipelineCache>,
     msaa: Res<Msaa>,
-    global_light_meta: Res<GlobalLightMeta>,
     render_meshes: Res<RenderAssets<Mesh>>,
     render_materials: Res<RenderAssets<StandardMaterial>>,
     standard_material_meshes: Query<(&Handle<StandardMaterial>, &Handle<Mesh>, &MeshUniform)>,

--- a/pipelined/bevy_pbr2/src/render/pbr.wgsl
+++ b/pipelined/bevy_pbr2/src/render/pbr.wgsl
@@ -365,18 +365,18 @@ fn fetch_point_shadow(light_id: u32, frag_position: vec4<f32>, surface_normal: v
     let major_axis_magnitude = max(abs_position_ls.x, max(abs_position_ls.y, abs_position_ls.z));
 
     // NOTE: These simplifications come from multiplying:
-    //       projection * vec4(0, 0, -major_axis_magnitude, 1.0)
-    //       and keeping only the terms that have any impact on the depth.
+    // projection * vec4(0, 0, -major_axis_magnitude, 1.0)
+    // and keeping only the terms that have any impact on the depth.
     // Projection-agnostic approach:
     let zw = -major_axis_magnitude * light.projection_lr.xy + light.projection_lr.zw;
     let depth = zw.x / zw.y;
 
     // do the lookup, using HW PCF and comparison
     // NOTE: Due to the non-uniform control flow above, we must use the Level variant of
-    //       textureSampleCompare to avoid undefined behaviour due to some of the fragments in
-    //       a quad (2x2 fragments) being processed not being sampled, and this messing with
-    //       mip-mapping functionality. The shadow maps have no mipmaps so Level just samples
-    //       from LOD 0.
+    // textureSampleCompare to avoid undefined behaviour due to some of the fragments in
+    // a quad (2x2 fragments) being processed not being sampled, and this messing with
+    // mip-mapping functionality. The shadow maps have no mipmaps so Level just samples
+    // from LOD 0.
     return textureSampleCompareLevel(point_shadow_textures, point_shadow_textures_sampler, frag_ls, i32(light_id), depth);
 }
 
@@ -407,7 +407,7 @@ fn fetch_directional_shadow(light_id: u32, frag_position: vec4<f32>, surface_nor
     let depth = offset_position_ndc.z;
     // do the lookup, using HW PCF and comparison
     // NOTE: Due to non-uniform control flow above, we must use the level variant of the texture
-    //       sampler to avoid use of implicit derivatives causing possible undefined behavior.
+    // sampler to avoid use of implicit derivatives causing possible undefined behavior.
     return textureSampleCompareLevel(directional_shadow_textures, directional_shadow_textures_sampler, light_local, i32(light_id), depth);
 }
 

--- a/pipelined/bevy_pbr2/src/render/pbr.wgsl
+++ b/pipelined/bevy_pbr2/src/render/pbr.wgsl
@@ -277,19 +277,19 @@ fn point_light(
     world_position: vec3<f32>, light: PointLight, roughness: f32, NdotV: f32, N: vec3<f32>, V: vec3<f32>,
     R: vec3<f32>, F0: vec3<f32>, diffuseColor: vec3<f32>
 ) -> vec3<f32> {
-    let light_to_frag = light.position.xyz - world_position.xyz;
+    let light_to_frag = light.position_radius.xyz - world_position.xyz;
     let distance_square = dot(light_to_frag, light_to_frag);
     let rangeAttenuation =
-        getDistanceAttenuation(distance_square, light.inverse_square_range);
+        getDistanceAttenuation(distance_square, light.color_inverse_square_range.w);
 
     // Specular.
     // Representative Point Area Lights.
     // see http://blog.selfshadow.com/publications/s2013-shading-course/karis/s2013_pbs_epic_notes_v2.pdf p14-16
     let a = roughness;
     let centerToRay = dot(light_to_frag, R) * R - light_to_frag;
-    let closestPoint = light_to_frag + centerToRay * saturate(light.radius * inverseSqrt(dot(centerToRay, centerToRay)));
+    let closestPoint = light_to_frag + centerToRay * saturate(light.position_radius.w * inverseSqrt(dot(centerToRay, centerToRay)));
     let LspecLengthInverse = inverseSqrt(dot(closestPoint, closestPoint));
-    let normalizationFactor = a / saturate(a + (light.radius * 0.5 * LspecLengthInverse));
+    let normalizationFactor = a / saturate(a + (light.position_radius.w * 0.5 * LspecLengthInverse));
     let specularIntensity = normalizationFactor * normalizationFactor;
 
     var L: vec3<f32> = closestPoint * LspecLengthInverse; // normalize() equivalent?
@@ -325,7 +325,7 @@ fn point_light(
 
     // TODO compensate for energy loss https://google.github.io/filament/Filament.html#materialsystem/improvingthebrdfs/energylossinspecularreflectance
 
-    return ((diffuse + specular_light) * light.color.rgb) * (rangeAttenuation * NoL);
+    return ((diffuse + specular_light) * light.color_inverse_square_range.rgb) * (rangeAttenuation * NoL);
 }
 
 fn directional_light(light: DirectionalLight, roughness: f32, NdotV: f32, normal: vec3<f32>, view: vec3<f32>, R: vec3<f32>, F0: vec3<f32>, diffuseColor: vec3<f32>) -> vec3<f32> {
@@ -348,7 +348,7 @@ fn fetch_point_shadow(light_id: u32, frag_position: vec4<f32>, surface_normal: v
 
     // because the shadow maps align with the axes and the frustum planes are at 45 degrees
     // we can get the worldspace depth by taking the largest absolute axis
-    let surface_to_light = light.position.xyz - frag_position.xyz;
+    let surface_to_light = light.position_radius.xyz - frag_position.xyz;
     let surface_to_light_abs = abs(surface_to_light);
     let distance_to_light = max(surface_to_light_abs.x, max(surface_to_light_abs.y, surface_to_light_abs.z));
 
@@ -360,7 +360,7 @@ fn fetch_point_shadow(light_id: u32, frag_position: vec4<f32>, surface_normal: v
     let offset_position = frag_position.xyz + normal_offset + depth_offset;
 
     // similar largest-absolute-axis trick as above, but now with the offset fragment position
-    let frag_ls = light.position.xyz - offset_position.xyz;
+    let frag_ls = light.position_radius.xyz - offset_position.xyz;
     let abs_position_ls = abs(frag_ls);
     let major_axis_magnitude = max(abs_position_ls.x, max(abs_position_ls.y, abs_position_ls.z));
 
@@ -368,19 +368,8 @@ fn fetch_point_shadow(light_id: u32, frag_position: vec4<f32>, surface_normal: v
     //       projection * vec4(0, 0, -major_axis_magnitude, 1.0)
     //       and keeping only the terms that have any impact on the depth.
     // Projection-agnostic approach:
-    let z = -major_axis_magnitude * light.projection[2][2] + light.projection[3][2];
-    let w = -major_axis_magnitude * light.projection[2][3] + light.projection[3][3];
-
-    // For perspective_rh:
-    // let proj_r = light.far / (light.near - light.far);
-    // let z = -major_axis_magnitude * proj_r + light.near * proj_r;
-    // let w = major_axis_magnitude;
-
-    // For perspective_infinite_reverse_rh:
-    // let z = light.near;
-    // let w = major_axis_magnitude;
-
-    let depth = z / w;
+    let zw = -major_axis_magnitude * light.projection_lr.xy + light.projection_lr.zw;
+    let depth = zw.x / zw.y;
 
     // do the lookup, using HW PCF and comparison
     // NOTE: Due to the non-uniform control flow above, we must use the Level variant of

--- a/pipelined/bevy_pbr2/src/render/pbr.wgsl
+++ b/pipelined/bevy_pbr2/src/render/pbr.wgsl
@@ -533,10 +533,10 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
         var light_accum: vec3<f32> = vec3<f32>(0.0);
 
         let view_z = dot(vec4<f32>(
-            view.inverse_view.x.z,
-            view.inverse_view.y.z,
-            view.inverse_view.z.z,
-            view.inverse_view.w.z
+            view.inverse_view[0].z,
+            view.inverse_view[1].z,
+            view.inverse_view[2].z,
+            view.inverse_view[3].z
         ), in.world_position);
         let cluster_index = fragment_cluster_index(in.frag_coord.xy, view_z);
         let offset_and_count = unpack_offset_and_count(cluster_index);

--- a/pipelined/bevy_pbr2/src/render/pbr.wgsl
+++ b/pipelined/bevy_pbr2/src/render/pbr.wgsl
@@ -573,10 +573,12 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
                 emissive.rgb * output_color.a,
             output_color.a);
 
+#ifdef CLUSTERED_FORWARD_DEBUG
         // Cluster allocation debug (using 'over' alpha blending)
-        let cluster_debug_mode = 2;
-        let cluster_overlay_alpha = 0.05;
-        if (cluster_debug_mode == 1) {
+        let cluster_debug_mode = 1;
+        let cluster_overlay_alpha = 1.0;
+        if (cluster_debug_mode == 0) {
+            // NOTE: This debug mode visualises the z-slices
             var z_slice: u32 = view_z_to_z_slice(view_z);
             // A hack to make the colors alternate a bit more
             if ((z_slice & 1u) == 1u) {
@@ -587,12 +589,15 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
                 (1.0 - cluster_overlay_alpha) * output_color.rgb + cluster_overlay_alpha * slice_color,
                 output_color.a
             );
-        } elseif (cluster_debug_mode == 2) {
+        } elseif (cluster_debug_mode == 1) {
+            // NOTE: This debug mode visualises the number of lights within the cluster that contains
+            // the fragment. It shows a sort of lighting complexity measure.
             output_color.r = (1.0 - cluster_overlay_alpha) * output_color.r
                 + cluster_overlay_alpha * smoothStep(0.0, 16.0, f32(offset_and_count.count));
             output_color.g = (1.0 - cluster_overlay_alpha) * output_color.g
                 + cluster_overlay_alpha * (1.0 - smoothStep(0.0, 16.0, f32(offset_and_count.count)));
         }
+#endif
 
         // tone_mapping
         output_color = vec4<f32>(reinhard_luminance(output_color.rgb), output_color.a);

--- a/pipelined/bevy_pbr2/src/render/pbr.wgsl
+++ b/pipelined/bevy_pbr2/src/render/pbr.wgsl
@@ -240,22 +240,14 @@ fn reinhard_extended_luminance(color: vec3<f32>, max_white_l: f32) -> vec3<f32> 
 }
 
 fn view_z_to_z_slice(view_z: f32) -> u32 {
-    let n_z_slices = lights.cluster_dimensions.z;
-    // FIXME: Precalculate cluster_dimensions.z / log(far / near) and cluster_dimensions.z * log(near) / log(far / near) for performance
-    // FIXME: NOTE: had to use -view_z to make it positive else log(negative) is nan
-    return u32(floor(
-        log(-view_z) * f32(n_z_slices) / log(view.far / view.near)
-        - f32(n_z_slices) * log(view.near) / log(view.far / view.near)
-    ));
+    // NOTE: had to use -view_z to make it positive else log(negative) is nan
+    return u32(floor(log(-view_z) * lights.cluster_factors.z - lights.cluster_factors.w));
 }
 
 fn fragment_cluster_index(frag_coord: vec2<f32>, view_z: f32) -> u32 {
-    let cluster_dimensions = lights.cluster_dimensions;
-    // FIXME: Precalculate cluster_dimensions.xy / (view.width * view.height)
-    let xy = vec2<u32>(floor(vec2<f32>(cluster_dimensions.xy) * frag_coord / vec2<f32>(view.width, view.height)));
+    let xy = vec2<u32>(floor(frag_coord * lights.cluster_factors.xy));
     let z_slice = view_z_to_z_slice(view_z);
-    return (xy.y * cluster_dimensions.x + xy.x) * cluster_dimensions.z + z_slice;
-    // return xy.y * cluster_dimensions.x * cluster_dimensions.z + xy.x * cluster_dimensions.z + z_slice;
+    return (xy.y * lights.cluster_dimensions.x + xy.x) * lights.cluster_dimensions.z + z_slice;
 }
 
 struct ClusterOffsetAndCount {

--- a/pipelined/bevy_render2/src/camera/bundle.rs
+++ b/pipelined/bevy_render2/src/camera/bundle.rs
@@ -42,6 +42,8 @@ impl PerspectiveCameraBundle {
         PerspectiveCameraBundle {
             camera: Camera {
                 name: Some(name.to_string()),
+                near: perspective_projection.near,
+                far: perspective_projection.far,
                 ..Default::default()
             },
             perspective_projection,
@@ -94,6 +96,8 @@ impl OrthographicCameraBundle {
         OrthographicCameraBundle {
             camera: Camera {
                 name: Some(CameraPlugin::CAMERA_2D.to_string()),
+                near: orthographic_projection.near,
+                far: orthographic_projection.far,
                 ..Default::default()
             },
             orthographic_projection,
@@ -120,6 +124,8 @@ impl OrthographicCameraBundle {
         OrthographicCameraBundle {
             camera: Camera {
                 name: Some(CameraPlugin::CAMERA_3D.to_string()),
+                near: orthographic_projection.near,
+                far: orthographic_projection.far,
                 ..Default::default()
             },
             orthographic_projection,
@@ -142,6 +148,8 @@ impl OrthographicCameraBundle {
         OrthographicCameraBundle {
             camera: Camera {
                 name: Some(name.to_string()),
+                near: orthographic_projection.near,
+                far: orthographic_projection.far,
                 ..Default::default()
             },
             orthographic_projection,

--- a/pipelined/bevy_render2/src/camera/camera.rs
+++ b/pipelined/bevy_render2/src/camera/camera.rs
@@ -23,6 +23,8 @@ pub struct Camera {
     pub window: WindowId,
     #[reflect(ignore)]
     pub depth_calculation: DepthCalculation,
+    pub near: f32,
+    pub far: f32,
 }
 
 #[derive(Debug, Clone, Copy, Reflect, Serialize, Deserialize)]

--- a/pipelined/bevy_render2/src/camera/mod.rs
+++ b/pipelined/bevy_render2/src/camera/mod.rs
@@ -88,6 +88,8 @@ fn extract_cameras(
                         transform: *transform,
                         width: window.physical_width().max(1),
                         height: window.physical_height().max(1),
+                        near: camera.near,
+                        far: camera.far,
                     },
                     visible_entities.clone(),
                 ));

--- a/pipelined/bevy_render2/src/primitives/mod.rs
+++ b/pipelined/bevy_render2/src/primitives/mod.rs
@@ -41,12 +41,12 @@ pub struct Sphere {
 }
 
 impl Sphere {
-    pub fn intersects_obb(&self, aabb: &Aabb, model_to_world: &Mat4) -> bool {
-        let aabb_center_world = *model_to_world * aabb.center.extend(1.0);
+    pub fn intersects_obb(&self, aabb: &Aabb, local_to_world: &Mat4) -> bool {
+        let aabb_center_world = *local_to_world * aabb.center.extend(1.0);
         let axes = [
-            Vec3A::from(model_to_world.x_axis),
-            Vec3A::from(model_to_world.y_axis),
-            Vec3A::from(model_to_world.z_axis),
+            Vec3A::from(local_to_world.x_axis),
+            Vec3A::from(local_to_world.y_axis),
+            Vec3A::from(local_to_world.z_axis),
         ];
         let v = Vec3A::from(aabb_center_world) - Vec3A::from(self.center);
         let d = v.length();

--- a/pipelined/bevy_render2/src/primitives/mod.rs
+++ b/pipelined/bevy_render2/src/primitives/mod.rs
@@ -32,6 +32,23 @@ impl Aabb {
         .abs()
         .dot(half_extents)
     }
+
+    pub fn min(&self) -> Vec3 {
+        self.center - self.half_extents
+    }
+
+    pub fn max(&self) -> Vec3 {
+        self.center + self.half_extents
+    }
+}
+
+impl From<Sphere> for Aabb {
+    fn from(sphere: Sphere) -> Self {
+        Self {
+            center: sphere.center,
+            half_extents: Vec3::splat(sphere.radius),
+        }
+    }
 }
 
 #[derive(Debug, Default)]

--- a/pipelined/bevy_render2/src/render_resource/uniform_vec.rs
+++ b/pipelined/bevy_render2/src/render_resource/uniform_vec.rs
@@ -63,6 +63,10 @@ impl<T: AsStd140> UniformVec<T> {
         index
     }
 
+    pub fn get_mut(&mut self, index: usize) -> &mut T {
+        &mut self.values[index]
+    }
+
     pub fn reserve(&mut self, capacity: usize, device: &RenderDevice) -> bool {
         if capacity > self.capacity {
             self.capacity = capacity;

--- a/pipelined/bevy_render2/src/render_resource/uniform_vec.rs
+++ b/pipelined/bevy_render2/src/render_resource/uniform_vec.rs
@@ -90,9 +90,6 @@ impl<T: AsStd140> UniformVec<T> {
         }
         self.reserve(self.values.len(), device);
         if let Some(uniform_buffer) = &self.uniform_buffer {
-            if self.item_size * self.values.len() == 128 {
-                panic!("ARGH");
-            }
             let range = 0..self.item_size * self.values.len();
             let mut writer = std140::Writer::new(&mut self.scratch[range.clone()]);
             writer.write(self.values.as_slice()).unwrap();

--- a/pipelined/bevy_render2/src/render_resource/uniform_vec.rs
+++ b/pipelined/bevy_render2/src/render_resource/uniform_vec.rs
@@ -90,6 +90,9 @@ impl<T: AsStd140> UniformVec<T> {
         }
         self.reserve(self.values.len(), device);
         if let Some(uniform_buffer) = &self.uniform_buffer {
+            if self.item_size * self.values.len() == 128 {
+                panic!("ARGH");
+            }
             let range = 0..self.item_size * self.values.len();
             let mut writer = std140::Writer::new(&mut self.scratch[range.clone()]);
             writer.write(self.values.as_slice()).unwrap();
@@ -99,6 +102,10 @@ impl<T: AsStd140> UniformVec<T> {
 
     pub fn clear(&mut self) {
         self.values.clear();
+    }
+
+    pub fn values(&self) -> &[T] {
+        &self.values
     }
 }
 

--- a/pipelined/bevy_render2/src/view/mod.rs
+++ b/pipelined/bevy_render2/src/view/mod.rs
@@ -64,13 +64,20 @@ pub struct ExtractedView {
     pub transform: GlobalTransform,
     pub width: u32,
     pub height: u32,
+    pub near: f32,
+    pub far: f32,
 }
 
 #[derive(Clone, AsStd140)]
 pub struct ViewUniform {
     view_proj: Mat4,
+    inverse_view: Mat4,
     projection: Mat4,
     world_position: Vec3,
+    near: f32,
+    far: f32,
+    width: f32,
+    height: f32,
 }
 
 #[derive(Default)]
@@ -123,11 +130,17 @@ fn prepare_view_uniforms(
     view_uniforms.uniforms.clear();
     for (entity, camera) in views.iter() {
         let projection = camera.projection;
+        let inverse_view = camera.transform.compute_matrix().inverse();
         let view_uniforms = ViewUniformOffset {
             offset: view_uniforms.uniforms.push(ViewUniform {
-                view_proj: projection * camera.transform.compute_matrix().inverse(),
+                view_proj: projection * inverse_view,
+                inverse_view,
                 projection,
                 world_position: camera.transform.translation,
+                near: camera.near,
+                far: camera.far,
+                width: camera.width as f32,
+                height: camera.height as f32,
             }),
         };
 

--- a/pipelined/bevy_render2/src/view/visibility/mod.rs
+++ b/pipelined/bevy_render2/src/view/visibility/mod.rs
@@ -40,21 +40,20 @@ impl Default for ComputedVisibility {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct VisibleEntity {
-    pub entity: Entity,
-}
-
-#[derive(Component, Clone, Default, Debug, Reflect)]
+#[derive(Clone, Component, Default, Debug, Reflect)]
 #[reflect(Component)]
 pub struct VisibleEntities {
     #[reflect(ignore)]
-    pub entities: Vec<VisibleEntity>,
+    pub entities: Vec<Entity>,
 }
 
 impl VisibleEntities {
-    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &VisibleEntity> {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &Entity> {
         self.entities.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entities.len()
     }
 }
 
@@ -178,7 +177,7 @@ pub fn check_visibility(
             }
 
             computed_visibility.is_visible = true;
-            visible_entities.entities.push(VisibleEntity { entity });
+            visible_entities.entities.push(entity);
         }
 
         // TODO: check for big changes in visible entities len() vs capacity() (ex: 2x) and resize

--- a/pipelined/bevy_render2/src/view/visibility/mod.rs
+++ b/pipelined/bevy_render2/src/view/visibility/mod.rs
@@ -55,6 +55,10 @@ impl VisibleEntities {
     pub fn len(&self) -> usize {
         self.entities.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.entities.is_empty()
+    }
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]


### PR DESCRIPTION
# Objective

Implement clustered-forward rendering.

## Solution

~~FIXME - in the interest of keeping the merge train moving, I'm submitting this PR now before the description is ready. I want to add in some comments into the code with references for the various bits and pieces and I want to describe some of the key decisions I made here. I'll do that as soon as I can.~~ Anyone reviewing is welcome to add review comments where you want to know more about how something or other works.

* The summary of the technique is that the view frustum is divided into a grid of sub-volumes called clusters, point lights are tested against each of the clusters to see if they would affect that volume within the scene and if so, added to a list of lights affecting that cluster. Then when shading a fragment which is a point on the surface of a mesh within the scene, the point is mapped to a cluster and only the lights affecting that clusters are used in lighting calculations. This brings huge performance and scalability benefits as most of the time lights are placed so that there are not that many that overlap each other in terms of their sphere of influence, but there may be many distinct point lights visible in the scene. Doing all the lighting calculations for all visible lights in the scene for every pixel on the screen quickly becomes a performance limitation. Clustered forward rendering allows us to make an approximate list of lights that affect each pixel, indeed each surface in the scene (as it works along the view z axis too, unlike tiled/forward+).
* WebGL2 is a platform we want to support and it does not support storage buffers. Uniform buffer bindings are limited to a maximum of 16384 bytes per binding. I used bit shifting and masking to pack the cluster light lists and various indices into a uniform buffer and the 16kB limit is very likely the first bottleneck in scaling the number of lights in a scene at the moment if the lights can affect many clusters due to their range or proximity to the camera (there are a lot of clusters close to the camera, which is an area for improvement). We could store the information in textures instead of uniform buffers to remove this bottleneck though I don’t know if there are performance implications to reading from textures instead if uniform buffers.
* Because of the uniform buffer binding size limitations we can support a maximum of 256 lights with the current size of the PointLight struct
* The z-slicing method (i.e. the mapping from view space z to a depth slice which defines the near and far planes of a cluster) is using the Doom 2016 method. I need to add comments with references to this. It’s an exponential function that simplifies well for the purposes of optimising the fragment shader. xy grid divisions are regular in screen space.
* Some optimisation work was done on the allocation of lights to clusters, which involves intersection tests, and for this number of clusters and lights the system has insignificant cost using a fairly naïve algorithm. I think for more lights / finer-grained clusters we could use a BVH, but at some point it would be just much better to use compute shaders and storage buffers.
* Something else to note is that it is absolutely infeasible to use plain cube map point light shadow mapping for many lights. It does not scale in terms of performance nor memory usage. There are some interesting methods I saw discussed in reference material that I will add a link to which render and update shadow maps piece-wise, but they also need compute shaders to work well. Basically for now you need to sacrifice point light shadows for all but a handful of point lights if you don’t want to kill performance. I set the limit to 10 but that’s just what we had from before where 10 was the maximum number of point lights before this PR.
* I added a couple of debug visualisations behind a shader def that were useful for seeing performance impact of light distribution - I should make the debug mode configurable without modifying the shader code. One mode shows the number of lights affecting each cluster by tinting toward red for few lights or green for many lights (maxes out at 16, but not sure that’s a reasonable max). The other shows which cluster the surface at a fragment belongs to by tinting it with a randomish colour. This can help to understand deeper performance issues due to screen space tiles spanning multiple clusters in depth with divergent shader execution times.

Also, there are more things that could be done as improvements, and I will document those somewhere (I'm not sure where will be the best place... in a todo alongside the code, a GitHub issue, somewhere else?) but I think it works well enough and brings significant performance and scalability benefits that it's worth integrating already now and then iterating on.
* Calculate the light’s effective range based on its intensity and physical falloff and either just use this, or take the minimum of the user-supplied range and this. This would avoid unnecessary lighting calculations for clusters that cannot be affected. This would need to take into account HDR tone mapping as in my not-fully-understanding-the-details understanding, the threshold is relative to how bright the scene is.
* Improve the z-slicing to use a larger first slice.
* More gracefully handle the cluster light list uniform buffer binding size limitations by prioritising which lights are included (some heuristic for most significant like closest to the camera, brightest, affecting the most pixels, …)
* Switch to using a texture instead of uniform buffer
* Figure out the / a better story for shadows

I will also probably add an example that demonstrates some of the issues:
* What situations exhaust the space available in the uniform buffers
  * Light range too large making lights affect many clusters and so exhausting the space for the lists of lights that affect clusters
  * Light range set to be too small producing visible artifacts where clusters the light would physically affect are not affected by the light
* Perhaps some performance issues
  * How many lights can be closely packed or affect large portions of the view before performance drops?