### PR TITLE
[Merged by Bors] - Faster gltf loader

### DIFF
--- a/pipelined/bevy_gltf2/Cargo.toml
+++ b/pipelined/bevy_gltf2/Cargo.toml
@@ -22,6 +22,7 @@ bevy_pbr2 = { path = "../bevy_pbr2", version = "0.5.0" }
 bevy_reflect = { path = "../../crates/bevy_reflect", version = "0.5.0", features = ["bevy"] }
 bevy_render2 = { path = "../bevy_render2", version = "0.5.0" }
 bevy_transform = { path = "../../crates/bevy_transform", version = "0.5.0" }
+bevy_utils = { path = "../../crates/bevy_utils", version = "0.5.0" }
 bevy_math = { path = "../../crates/bevy_math", version = "0.5.0" }
 bevy_scene = { path = "../../crates/bevy_scene", version = "0.5.0" }
 bevy_log = { path = "../../crates/bevy_log", version = "0.5.0" }

--- a/pipelined/bevy_gltf2/src/lib.rs
+++ b/pipelined/bevy_gltf2/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use bevy_utils::HashMap;
 
 mod loader;
 pub use loader::*;

--- a/pipelined/bevy_gltf2/src/loader.rs
+++ b/pipelined/bevy_gltf2/src/loader.rs
@@ -734,18 +734,20 @@ fn resolve_node_hierarchy(
         let (label, node, children) = nodes_step.remove(&index).unwrap();
         assert!(children.is_empty());
         nodes.insert(index, (label, node));
-        for (_label, node, children) in nodes_step.values_mut() {
-            if children.remove(&index) {
+        for (parent_index, (_, parent_node, parent_children)) in nodes_step.iter_mut() {
+            if parent_children.remove(&index) {
                 if let Some((_, child_node)) = nodes.get(&index) {
-                    node.children.push(child_node.clone())
+                    parent_node.children.push(child_node.clone())
                 }
-                if children.is_empty() {
-                    empty_children.push_back(index);
+                if parent_children.is_empty() {
+                    empty_children.push_back(*parent_index);
                 }
+                // GLTF is a tree, so each item only has one parent
+                continue;
             }
         }
     }
-
+    assert!(nodes_step.is_empty(), "GLTF must be a tree");
     let mut nodes_to_sort = nodes.into_iter().collect::<Vec<_>>();
     nodes_to_sort.sort_by_key(|(i, _)| *i);
     nodes_to_sort

--- a/pipelined/bevy_gltf2/src/loader.rs
+++ b/pipelined/bevy_gltf2/src/loader.rs
@@ -21,15 +21,13 @@ use bevy_transform::{
     hierarchy::{BuildWorldChildren, WorldChildBuilder},
     prelude::{GlobalTransform, Transform},
 };
+use bevy_utils::{HashMap, HashSet};
 use gltf::{
     mesh::Mode,
     texture::{MagFilter, MinFilter, WrappingMode},
     Material, Primitive,
 };
-use std::{
-    collections::{HashMap, HashSet, VecDeque},
-    path::Path,
-};
+use std::{collections::VecDeque, path::Path};
 use thiserror::Error;
 use wgpu::{AddressMode, FilterMode, PrimitiveTopology, SamplerDescriptor, TextureFormat};
 
@@ -83,8 +81,8 @@ async fn load_gltf<'a, 'b>(
     let buffer_data = load_buffers(&gltf, load_context, load_context.path()).await?;
 
     let mut materials = vec![];
-    let mut named_materials = HashMap::new();
-    let mut linear_textures = HashSet::new();
+    let mut named_materials = HashMap::default();
+    let mut linear_textures = HashSet::default();
     for material in gltf.materials() {
         let handle = load_material(&material, load_context);
         if let Some(name) = material.name() {
@@ -106,7 +104,7 @@ async fn load_gltf<'a, 'b>(
     }
 
     let mut meshes = vec![];
-    let mut named_meshes = HashMap::new();
+    let mut named_meshes = HashMap::default();
     for mesh in gltf.meshes() {
         let mut primitives = vec![];
         for primitive in mesh.primitives() {
@@ -195,7 +193,7 @@ async fn load_gltf<'a, 'b>(
     }
 
     let mut nodes_intermediate = vec![];
-    let mut named_nodes_intermediate = HashMap::new();
+    let mut named_nodes_intermediate = HashMap::default();
     for node in gltf.nodes() {
         let node_label = node_label(&node);
         nodes_intermediate.push((
@@ -275,7 +273,7 @@ async fn load_gltf<'a, 'b>(
         });
 
     let mut scenes = vec![];
-    let mut named_scenes = HashMap::new();
+    let mut named_scenes = HashMap::default();
     for scene in gltf.scenes() {
         let mut err = None;
         let mut world = World::default();


### PR DESCRIPTION
# Objective

- @superdump was having trouble with this loop in the GLTF loader.

## Solution

- Make it probably linear.
- Measured times: 
- Old: 40s, new: 200ms

I'm sure there's still room for improvement. For example, I think making the nodes be in `Arc`s could be a significant gain, since currently there's duplication all the way down the tree.