### PR TITLE
[Merged by Bors] - Use crevice std140_size_static everywhere

### DIFF
--- a/pipelined/bevy_pbr2/src/render/light.rs
+++ b/pipelined/bevy_pbr2/src/render/light.rs
@@ -25,7 +25,9 @@ use bevy_render2::{
     render_resource::*,
     renderer::{RenderContext, RenderDevice, RenderQueue},
     texture::*,
-    view::{ExtractedView, ViewUniformOffset, ViewUniforms, VisibleEntities, VisibleEntity},
+    view::{
+        ExtractedView, ViewUniform, ViewUniformOffset, ViewUniforms, VisibleEntities, VisibleEntity,
+    },
 };
 use bevy_transform::components::GlobalTransform;
 use crevice::std140::AsStd140;
@@ -155,9 +157,7 @@ impl FromWorld for ShadowPipeline {
                     ty: BindingType::Buffer {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: true,
-                        // TODO: change this to ViewUniform::std140_size_static once crevice fixes this!
-                        // Context: https://github.com/LPGhatguy/crevice/issues/29
-                        min_binding_size: BufferSize::new(144),
+                        min_binding_size: BufferSize::new(ViewUniform::std140_size_static() as u64),
                     },
                     count: None,
                 },

--- a/pipelined/bevy_pbr2/src/render/mesh.rs
+++ b/pipelined/bevy_pbr2/src/render/mesh.rs
@@ -1,6 +1,6 @@
 use crate::{
-    LightMeta, NotShadowCaster, NotShadowReceiver, ShadowPipeline, ViewLightsUniformOffset,
-    ViewShadowBindings,
+    GpuLights, LightMeta, NotShadowCaster, NotShadowReceiver, ShadowPipeline,
+    ViewLightsUniformOffset, ViewShadowBindings,
 };
 use bevy_app::Plugin;
 use bevy_asset::{Assets, Handle, HandleUntyped};
@@ -18,7 +18,7 @@ use bevy_render2::{
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
     texture::{BevyDefault, GpuImage, Image, TextureFormatPixelInfo},
-    view::{ComputedVisibility, ViewUniformOffset, ViewUniforms},
+    view::{ComputedVisibility, ViewUniform, ViewUniformOffset, ViewUniforms},
     RenderApp, RenderStage,
 };
 use bevy_transform::components::GlobalTransform;
@@ -180,9 +180,7 @@ impl FromWorld for MeshPipeline {
                     ty: BindingType::Buffer {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: true,
-                        // TODO: change this to ViewUniform::std140_size_static once crevice fixes this!
-                        // Context: https://github.com/LPGhatguy/crevice/issues/29
-                        min_binding_size: BufferSize::new(144),
+                        min_binding_size: BufferSize::new(ViewUniform::std140_size_static() as u64),
                     },
                     count: None,
                 },
@@ -193,9 +191,7 @@ impl FromWorld for MeshPipeline {
                     ty: BindingType::Buffer {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: true,
-                        // TODO: change this to GpuLights::std140_size_static once crevice fixes this!
-                        // Context: https://github.com/LPGhatguy/crevice/issues/29
-                        min_binding_size: BufferSize::new(1424),
+                        min_binding_size: BufferSize::new(GpuLights::std140_size_static() as u64),
                     },
                     count: None,
                 },
@@ -252,9 +248,7 @@ impl FromWorld for MeshPipeline {
                 ty: BindingType::Buffer {
                     ty: BufferBindingType::Uniform,
                     has_dynamic_offset: true,
-                    // TODO: change this to MeshUniform::std140_size_static once crevice fixes this!
-                    // Context: https://github.com/LPGhatguy/crevice/issues/29
-                    min_binding_size: BufferSize::new(144),
+                    min_binding_size: BufferSize::new(MeshUniform::std140_size_static() as u64),
                 },
                 count: None,
             }],

--- a/pipelined/bevy_sprite2/Cargo.toml
+++ b/pipelined/bevy_sprite2/Cargo.toml
@@ -30,6 +30,7 @@ bevy_utils = { path = "../../crates/bevy_utils", version = "0.5.0" }
 
 # other
 bytemuck = { version = "1.5", features = ["derive"] }
+crevice = { path = "../../crates/crevice", version = "0.8.0", features = ["glam"] }
 guillotiere = "0.6.0"
 thiserror = "1.0"
 rectangle-pack = "0.4"

--- a/pipelined/bevy_sprite2/src/render/mod.rs
+++ b/pipelined/bevy_sprite2/src/render/mod.rs
@@ -19,12 +19,13 @@ use bevy_render2::{
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
     texture::{BevyDefault, Image},
-    view::{ComputedVisibility, ViewUniformOffset, ViewUniforms},
+    view::{ComputedVisibility, ViewUniform, ViewUniformOffset, ViewUniforms},
     RenderWorld,
 };
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::HashMap;
 use bytemuck::{Pod, Zeroable};
+use crevice::std140::AsStd140;
 
 pub struct SpritePipeline {
     view_layout: BindGroupLayout,
@@ -43,9 +44,7 @@ impl FromWorld for SpritePipeline {
                 ty: BindingType::Buffer {
                     ty: BufferBindingType::Uniform,
                     has_dynamic_offset: true,
-                    // TODO: change this to ViewUniform::std140_size_static once crevice fixes this!
-                    // Context: https://github.com/LPGhatguy/crevice/issues/29
-                    min_binding_size: BufferSize::new(144),
+                    min_binding_size: BufferSize::new(ViewUniform::std140_size_static() as u64),
                 },
                 count: None,
             }],


### PR DESCRIPTION
# Objective

- Use `std140_size_static()` everywhere instead of manual sizes as the crevice rewrite appears to have fixed all the problems as it claimed to do.

I've tested `3d_scene_pipelined`, `bevymark_pipelined`, and `load_gltf_pipelined` and all three look fine.