### PR TITLE
[Merged by Bors] - Fix path used by macro not considering that we can use a sub-crate

### DIFF
--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -34,7 +34,9 @@ impl BevyManifest {
         const BEVY_INTERNAL: &str = "bevy_internal";
 
         let find_in_deps = |deps: &DepsSet| -> Option<syn::Path> {
-            let package = if let Some(dep) = deps.get(BEVY) {
+            let package = if let Some(dep) = deps.get(name) {
+                return Some(get_path(dep.package().unwrap_or(name)));
+            } else if let Some(dep) = deps.get(BEVY) {
                 dep.package().unwrap_or(BEVY)
             } else if let Some(dep) = deps.get(BEVY_INTERNAL) {
                 dep.package().unwrap_or(BEVY_INTERNAL)


### PR DESCRIPTION
# Problem

Let's say I am writting a simple bevy plugin, and I want to depend on `bevy_ecs` crate instead of depending on the full `bevy`. 

So I write the following:

*Cargo.toml*:
```toml
[dependencies]
bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "94db0176fecfac7e7e9763f2dc7458a54c105886" }
```

*lib.rs*:
```rust
use bevy_ecs::prelude::*;

#[derive(Debug, Default, Component)
pub struct MyFancyComponent;
```

So far, so good. Everything works. But let's say I want to write some examples for using my plugin. And for theses I'd like to use the `bevy` crate, so that I can write complete examples (rendering stuff, etc.) that are simple and look like what the consumer of my plugin will do (`use bevy::prelude::*` and `DefaultPlugins`)

So I amend my *Cargo.toml*:
```toml
[dependencies]
bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "94db0176fecfac7e7e9763f2dc7458a54c105886" }

[dev-dependencies]
bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "94db0176fecfac7e7e9763f2dc7458a54c105886", default-features = false }
```

And that  leads to a complilation error 

```
error[E0433]: failed to resolve: use of undeclared crate or module `bevy`
```

Basically, because `bevy` is in the `dev-dependencies`, the macro (of the production code) decides to use the `bevy::ecs` path instead of `bevy_ecs`. But `bevy` is not available there.

## Solution

This PR fixes the problem. I amend the macro utility responsible of finding the path of a module.

If we try to find a path, we first test if this correspond to a crate that the user directly depend on. (Like, if we search for `bevy_ecs`, we first check if there is a `bevy_ecs` dependency). If yes, we can depend on that directly. Otherwise, we proceed with the existing logic (testing `bevy` and `bevy_internal`)
