### PR TITLE
[Merged by Bors] - increase light intensity in pbr_pipelined example

### DIFF
--- a/examples/3d/pbr_pipelined.rs
+++ b/examples/3d/pbr_pipelined.rs
@@ -67,7 +67,7 @@ fn setup(
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(50.0, 50.0, 50.0)),
         point_light: PointLight {
-            intensity: 500000.,
+            intensity: 600000.,
             range: 100.,
             ..Default::default()
         },

--- a/examples/3d/pbr_pipelined.rs
+++ b/examples/3d/pbr_pipelined.rs
@@ -67,7 +67,7 @@ fn setup(
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(50.0, 50.0, 50.0)),
         point_light: PointLight {
-            intensity: 50000.,
+            intensity: 500000.,
             range: 100.,
             ..Default::default()
         },


### PR DESCRIPTION
# Objective

- example `pbr_pipelined` doesn't look like example `pbr`

`pbr`:
![pbr](https://user-images.githubusercontent.com/8672791/143328022-83797197-233c-4824-8daa-4d7bd092938d.png)


`pbr_pipelined`:
![pbr_pipelined](https://user-images.githubusercontent.com/8672791/143328034-8a8bdb39-0d75-472b-8880-7bb7cd48f448.png)


## Solution

- set the light intensity to a higher value

`pbr_pipelined` with this pr:
![pbr_pipelined_fixed](https://user-images.githubusercontent.com/8672791/143328040-4149e96c-dada-4940-9f6f-f8925e48b22e.png)

