### PR TITLE
[Merged by Bors] - Faster gltf loader (re-merge of #3165)

### DIFF
--- a/pipelined/bevy_gltf2/Cargo.toml
+++ b/pipelined/bevy_gltf2/Cargo.toml
@@ -22,6 +22,7 @@ bevy_pbr2 = { path = "../bevy_pbr2", version = "0.5.0" }
 bevy_reflect = { path = "../../crates/bevy_reflect", version = "0.5.0", features = ["bevy"] }
 bevy_render2 = { path = "../bevy_render2", version = "0.5.0" }
 bevy_transform = { path = "../../crates/bevy_transform", version = "0.5.0" }
+bevy_utils = { path = "../../crates/bevy_utils", version = "0.5.0" }
 bevy_math = { path = "../../crates/bevy_math", version = "0.5.0" }
 bevy_scene = { path = "../../crates/bevy_scene", version = "0.5.0" }
 bevy_log = { path = "../../crates/bevy_log", version = "0.5.0" }

--- a/pipelined/bevy_gltf2/src/lib.rs
+++ b/pipelined/bevy_gltf2/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use bevy_utils::HashMap;
 
 mod loader;
 pub use loader::*;


### PR DESCRIPTION
See #3165 and #3175

# Objective

- @superdump was having trouble with this loop in the GLTF loader.

## Solution

- Make it probably linear.
- Measured times: 
- Old: 40s, new: 200ms

I think there's still room for improvement. For example, I think making the nodes be in `Arc`s could be a significant gain, since currently there's duplication all the way down the tree.

Co-authored-by: Carter Anderson <mcanders1@gmail.com>