### PR TITLE
[Merged by Bors] - Enforce linux-style line endings for `.rs` and `.toml`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,8 +6,9 @@
 # to native line endings on checkout.
 *.rs text eol=lf
 *.toml text eol=lf
-*.frag text
-*.vert text
+*.frag text eol=lf
+*.vert text eol=lf
+*.wgsl text eol=lf
 
 # Declare files that will always have CRLF line endings on checkout.
 *.sln text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,8 +4,8 @@
 
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.
-*.rs text eof=lf
-*.toml text eof=lf
+*.rs text eol=lf
+*.toml text eol=lf
 *.frag text
 *.vert text
 


### PR DESCRIPTION
# Objective

Fixes #3160 

Unless I'm mistaken, the problem was caused by a simple typo

## Solution

- Fix the typo

Reference documentation: https://git-scm.com/docs/gitattributes#_eol

## Question

Are there other file-types that should be included here?
