### PR TITLE
Slightly nicer handling of parent/child failure modes

### DIFF
--- a/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
@@ -8,6 +8,8 @@ use bevy_ecs::{
 use bevy_utils::HashMap;
 use smallvec::SmallVec;
 
+use super::DespawnRecursiveExt;
+
 pub fn parent_update_system(
     mut commands: Commands,
     removed_parent_query: Query<(Entity, &PreviousParent), Without<Parent>>,
@@ -61,10 +63,11 @@ pub fn parent_update_system(
                     .push(entity);
             }
             Err(bevy_ecs::query::QueryEntityError::NoSuchEntity) => {
-                panic!(
-                    "{:?}'s parent is {:?}, which no longer exists",
-                    entity, parent.0
-                );
+                // Our parent does not exist, so we should no longer exist.
+                // Please note that this is only triggered if `Parent` is changed.
+                // (e.g. if `Parent` is newly added, such as from scene spawning)
+                // So this is a slight hack
+                commands.entity(entity).despawn_recursive();
             }
         }
     }


### PR DESCRIPTION
# Objective

- Fix #3195

## Solution

- If a `Parent`'s parent doesn't exist, despawn the entity containing it.

I think that for the case of scene spawning, we should probably have handling for when the parent of the scene doesn't exist and stop the spawning. However, this change also fixes that, with significantly less work required (as the `SceneSpawner` data structures are sub-optimal for adding that check).
 
Even with this fix, a 'general' case of this problem still remains. For example, if 'despawn' is called instead of `despawn_recursive`, we end up with a 'floating' entity. This entity would not have its `GlobalTransform` updated ever, amongst other issues. Detecting this is not cheap without a way to know the previous value of a removed `Children` component. (🎟️ ?) However, this version is still a better state of affairs.

In theory, we could have different behaviour here if the parent was despawned explicitly non-recursively. That is, one could argue that panicking in that case would be 'better'. However, we don't store that information, and cannot reasonably do so; taking the most 'optimistic' approach here is probably best.