### PR TITLE
[Merged by Bors] - Sprite change image

### DIFF
--- a/pipelined/bevy_render2/src/render_asset.rs
+++ b/pipelined/bevy_render2/src/render_asset.rs
@@ -102,9 +102,8 @@ fn extract_render_asset<A: RenderAsset>(
                 changed_assets.insert(handle);
             }
             AssetEvent::Removed { handle } => {
-                if !changed_assets.remove(handle) {
-                    removed.push(handle.clone_weak());
-                }
+                changed_assets.remove(handle);
+                removed.push(handle.clone_weak());
             }
         }
     }

--- a/pipelined/bevy_sprite2/src/lib.rs
+++ b/pipelined/bevy_sprite2/src/lib.rs
@@ -43,8 +43,9 @@ impl Plugin for SpritePlugin {
             .init_resource::<SpecializedPipelines<SpritePipeline>>()
             .init_resource::<SpriteMeta>()
             .init_resource::<ExtractedSprites>()
+            .init_resource::<SpriteAssetEvents>()
             .add_system_to_stage(RenderStage::Extract, render::extract_sprites)
-            .add_system_to_stage(RenderStage::Extract, render::extract_events)
+            .add_system_to_stage(RenderStage::Extract, render::extract_sprite_events)
             .add_system_to_stage(RenderStage::Prepare, render::prepare_sprites)
             .add_system_to_stage(RenderStage::Queue, queue_sprites);
 

--- a/pipelined/bevy_sprite2/src/lib.rs
+++ b/pipelined/bevy_sprite2/src/lib.rs
@@ -44,6 +44,7 @@ impl Plugin for SpritePlugin {
             .init_resource::<SpriteMeta>()
             .init_resource::<ExtractedSprites>()
             .add_system_to_stage(RenderStage::Extract, render::extract_sprites)
+            .add_system_to_stage(RenderStage::Extract, render::extract_events)
             .add_system_to_stage(RenderStage::Prepare, render::prepare_sprites)
             .add_system_to_stage(RenderStage::Queue, queue_sprites);
 


### PR DESCRIPTION
# Objective

- Changing the underlying image would not update a sprite

## Solution

- 'Detect' if the underlying image changes to update the sprite

Currently, we don't support change detection on `RenderAssets`, so we have to manually check it. 
This method at least maintains the bind groups when the image isn't changing. They were cached, so I assume that's important.

This gives us correct behaviour here.