### PR TITLE
[Merged by Bors] - Add `World::clear_resources` & `World::clear_all`

### DIFF
--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -236,6 +236,12 @@ impl<const SEND: bool> Resources<SEND> {
         self.resources.get(component_id)
     }
 
+    /// Clears all resources.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.resources.clear();
+    }
+
     /// Gets mutable access to a resource, if it exists.
     #[inline]
     pub(crate) fn get_mut(&mut self, component_id: ComponentId) -> Option<&mut ResourceData<SEND>> {

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -447,6 +447,12 @@ impl<I: SparseSetIndex, V> SparseSet<I, V> {
         })
     }
 
+    pub fn clear(&mut self) {
+        self.dense.clear();
+        self.indices.clear();
+        self.sparse.clear();
+    }
+
     pub(crate) fn into_immutable(self) -> ImmutableSparseSet<I, V> {
         ImmutableSparseSet {
             dense: self.dense.into_boxed_slice(),

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1624,7 +1624,7 @@ impl World {
         self.last_check_tick = change_tick;
     }
 
-    /// Runs both [`clear_entities`](Self::clear_entities) and [`clear_entities`](Self::clear_resources),
+    /// Runs both [`clear_entities`](Self::clear_entities) and [`clear_resources`](Self::clear_resources),
     /// invalidating all [`Entity`] and resource fetches such as [`Res`](crate::system::Res), [`ResMut`](crate::system::ResMut)
     pub fn clear_all(&mut self) {
         self.clear_entities();

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1625,14 +1625,13 @@ impl World {
     }
 
     /// Runs both [`clear_entities`](Self::clear_entities) and [`clear_entities`](Self::clear_resources),
-    /// invalidating all [Entity] and resource fetches such as [`Res`](crate::system::Res), [`ResMut`](crate::system::ResMut)
+    /// invalidating all [`Entity`] and resource fetches such as [`Res`](crate::system::Res), [`ResMut`](crate::system::ResMut)
     pub fn clear_all(&mut self) {
         self.clear_entities();
         self.clear_resources();
     }
 
-    /// Clears entities in this [World] including entities in [Archetypes].
-    /// All [Entity] will be invalidated.
+    /// Despawns all entities in this [`World`].
     pub fn clear_entities(&mut self) {
         self.storages.tables.clear();
         self.storages.sparse_sets.clear();
@@ -1640,7 +1639,8 @@ impl World {
         self.entities.clear();
     }
 
-    /// Clears all resources in this [World].
+    /// Clears all resources in this [`World`].
+    ///
     /// Any resource fetch to this [World] will fail unless they are re-initialized.
     pub fn clear_resources(&mut self) {
         let resource_archetype = self.archetypes.resource_mut();

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1624,11 +1624,22 @@ impl World {
         self.last_check_tick = change_tick;
     }
 
+    pub fn clear_all(&mut self) {
+        self.clear_entities();
+        self.clear_resources();
+    }
+
     pub fn clear_entities(&mut self) {
         self.storages.tables.clear();
         self.storages.sparse_sets.clear();
         self.archetypes.clear_entities();
         self.entities.clear();
+    }
+
+    pub fn clear_resources(&mut self) {
+        for column in self.archetypes.resource_mut().unique_components.values_mut() {
+            column.clear();
+        }
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1641,7 +1641,11 @@ impl World {
 
     /// Clears all resources in this [`World`].
     ///
-    /// Any resource fetch to this [World] will fail unless they are re-initialized.
+    /// **Note:** Any resource fetch to this [World] will fail unless they are re-initialized,
+    /// including engine-internal resources that are only initialized on app/world construction.
+    ///
+    /// This can easily cause systems expecting certain resources to immediately start panicking.
+    /// Use with caution.
     pub fn clear_resources(&mut self) {
         let resource_archetype = self.archetypes.resource_mut();
         for column in resource_archetype.unique_components.values_mut() {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1624,7 +1624,7 @@ impl World {
         self.last_check_tick = change_tick;
     }
 
-    /// Runs both [`clear_entities`](Self::clear_entities) and [`clear_entities`](clear_resources),
+    /// Runs both [`clear_entities`](Self::clear_entities) and [`clear_entities`](Self::clear_resources),
     /// invalidating all [Entity] and resource fetches such as [`Res`](crate::system::Res), [`ResMut`](crate::system::ResMut)
     pub fn clear_all(&mut self) {
         self.clear_entities();

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1624,11 +1624,15 @@ impl World {
         self.last_check_tick = change_tick;
     }
 
+    /// Runs both [`clear_entities`](Self::clear_entities) and [`clear_entities`](clear_resources),
+    /// invalidating all [Entity] and resource fetches such as [`Res`](crate::system::Res), [`ResMut`](crate::system::ResMut)
     pub fn clear_all(&mut self) {
         self.clear_entities();
         self.clear_resources();
     }
 
+    /// Clears entities in this [World] including entities in [Archetypes].
+    /// All [Entity] will be invalidated.
     pub fn clear_entities(&mut self) {
         self.storages.tables.clear();
         self.storages.sparse_sets.clear();
@@ -1636,6 +1640,8 @@ impl World {
         self.entities.clear();
     }
 
+    /// Clears all resources in this [World].
+    /// Any resource fetch to this [World] will fail unless they are re-initialized.
     pub fn clear_resources(&mut self) {
         let resource_archetype = self.archetypes.resource_mut();
         for column in resource_archetype.unique_components.values_mut() {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1638,7 +1638,7 @@ impl World {
 
     pub fn clear_resources(&mut self) {
         let resource_archetype = self.archetypes.resource_mut();
-        for column in resource_archetype.values_mut() {
+        for column in resource_archetype.unique_components.values_mut() {
             column.clear();
         }
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1647,10 +1647,8 @@ impl World {
     /// This can easily cause systems expecting certain resources to immediately start panicking.
     /// Use with caution.
     pub fn clear_resources(&mut self) {
-        let resource_archetype = self.archetypes.resource_mut();
-        for column in resource_archetype.unique_components.values_mut() {
-            column.clear();
-        }
+        self.storages.resources.clear();
+        self.storages.non_send_resources.clear();
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1637,7 +1637,8 @@ impl World {
     }
 
     pub fn clear_resources(&mut self) {
-        for column in self.archetypes.resource_mut().unique_components.values_mut() {
+        let resource_archetype = self.archetypes.resource_mut();
+        for column in resource_archetype.values_mut() {
             column.clear();
         }
     }


### PR DESCRIPTION
# Objective

- Fixes #3158

## Solution

- clear columns

## Change Log

- Added `SparseSet::clear`
- Added `Resources::clear`
- Added `World::clear_resources`
- Added `World::clear_all`

My implementation of `clear_resources` do not remove the components itself but it clears the columns that keeps the resource data. I'm not sure if the issue meant to clear all resources, even the components and component ids (which I'm not sure if it's possible)