### PR TITLE
Add Copy derive for `KeyboardInput`

### DIFF
--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -3,7 +3,7 @@ use bevy_app::EventReader;
 use bevy_ecs::system::ResMut;
 
 /// A key input event from a keyboard device
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct KeyboardInput {
     pub scan_code: u32,
     pub key_code: Option<KeyCode>,


### PR DESCRIPTION
Although 3213 is about `KeyCode`, @ickk pointed that `KeyCode` does implement `Copy` but `KeyboardInput` does not.
Since all fields of `KeyboardInput` are plain values, I think there is no reason not to add `Copy` in derives
# Objective

- Fixes #3213

## Solution

- Add derive because why not
