### PR TITLE
[Merged by Bors] - Ignore reddit when checking markdown links

### DIFF
--- a/.github/linters/markdown-link-check.json
+++ b/.github/linters/markdown-link-check.json
@@ -2,6 +2,9 @@
   "ignorePatterns": [
     {
       "pattern": "^https?://github\\.com/"
+    },
+    {
+      "pattern": "^https?://reddit\\.com/"
     }
   ],
   "replacementPatterns": [],


### PR DESCRIPTION
Reddit regularly blocks CI requests (ex: 403s), causing disruptions. It is better to just not check.