### PR TITLE
[Merged by Bors] - Fix iOS CI

### DIFF
--- a/examples/ios/Makefile
+++ b/examples/ios/Makefile
@@ -12,13 +12,13 @@ boot-sim:
 	xcrun simctl boot $(DEVICE) || true
 
 install: xcodebuild-simulator boot-sim
-	 xcrun simctl install $(DEVICE) build/Build/Products/Debug-iphonesimulator/bevy_ios_example.app
+	xcrun simctl install $(DEVICE) build/Build/Products/Debug-iphonesimulator/bevy_ios_example.app
 
 xcodebuild-simulator:
- 	IOS_TARGETS=x86_64-apple-ios xcodebuild -scheme bevy_ios_example -configuration Debug -derivedDataPath build -destination "id=$(DEVICE)"
+	IOS_TARGETS=x86_64-apple-ios xcodebuild -scheme bevy_ios_example -configuration Debug -derivedDataPath build -destination "id=$(DEVICE)"
 
 xcodebuild-iphone:
- 	IOS_TARGETS=aarch64-apple-ios xcodebuild -scheme bevy_ios_example -configuration Debug -derivedDataPath build -arch arm64
+	IOS_TARGETS=aarch64-apple-ios xcodebuild -scheme bevy_ios_example -configuration Debug -derivedDataPath build -arch arm64
 
 clean:
 	rm -r build

--- a/examples/ios/bevy_ios_example.xcodeproj/xcshareddata/xcschemes/bevy_ios_example.xcscheme
+++ b/examples/ios/bevy_ios_example.xcodeproj/xcshareddata/xcschemes/bevy_ios_example.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3BDB8152E4962373181B4FE5"
+               BuildableName = "bevy_ios_example.app"
+               BlueprintName = "bevy_ios_example"
+               ReferencedContainer = "container:bevy_ios_example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3BDB8152E4962373181B4FE5"
+            BuildableName = "bevy_ios_example.app"
+            BlueprintName = "bevy_ios_example"
+            ReferencedContainer = "container:bevy_ios_example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3BDB8152E4962373181B4FE5"
+            BuildableName = "bevy_ios_example.app"
+            BlueprintName = "bevy_ios_example"
+            ReferencedContainer = "container:bevy_ios_example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
# Objective

- With #3109 I broke iOS CI: https://github.com/bevyengine/bevy/runs/4374891646?check_suite_focus=true

## Solution

- Fix indentation in makefile
- Adds scheme that is now needed

With this, `make install` works on my m1 Mac but still fails on my intel Mac unless I run something like `make install; cargo build --target x86_64-apple-ios; make install; cargo build --target x86_64-apple-ios; make install`. It seems something is off when executing cargo through `xcodebuild` on my setup but not sure what. So this PR will probably not fix iOS CI 😞 
