### PR TITLE
[Merged by Bors] - make texture from sprite pipeline filterable

### DIFF
--- a/pipelined/bevy_sprite2/src/render/mod.rs
+++ b/pipelined/bevy_sprite2/src/render/mod.rs
@@ -58,7 +58,7 @@ impl FromWorld for SpritePipeline {
                     visibility: ShaderStages::FRAGMENT,
                     ty: BindingType::Texture {
                         multisampled: false,
-                        sample_type: TextureSampleType::Float { filterable: false },
+                        sample_type: TextureSampleType::Float { filterable: true },
                         view_dimension: TextureViewDimension::D2,
                     },
                     count: None,


### PR DESCRIPTION
# Objective

- Fix #3235

## Solution

- in `sprite_pipeline`, make the texture filterable
