### PR TITLE
[Merged by Bors] - Fix clippy lints for 1.57

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -18,7 +18,7 @@ impl<'a> AssetPath<'a> {
     pub fn new_ref(path: &'a Path, label: Option<&'a str>) -> AssetPath<'a> {
         AssetPath {
             path: Cow::Borrowed(path),
-            label: label.map(|val| Cow::Borrowed(val)),
+            label: label.map(Cow::Borrowed),
         }
     }
 
@@ -147,7 +147,7 @@ impl<'a> From<&'a str> for AssetPath<'a> {
         let label = parts.next();
         AssetPath {
             path: Cow::Borrowed(path),
-            label: label.map(|label| Cow::Borrowed(label)),
+            label: label.map(Cow::Borrowed),
         }
     }
 }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -478,7 +478,7 @@ impl<'a, 'b> BundleInserter<'a, 'b> {
                 // redundant copies
                 let move_result = self
                     .table
-                    .move_to_superset_unchecked(result.table_row, &mut *new_table);
+                    .move_to_superset_unchecked(result.table_row, *new_table);
                 let new_location = new_archetype.allocate(entity, move_result.new_row);
                 self.entities.meta[entity.id as usize].location = new_location;
 

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -132,7 +132,11 @@ pub unsafe trait FetchState: Send + Sync + Sized {
     fn matches_table(&self, table: &Table) -> bool;
 }
 
-/// A fetch that is read only. This must only be implemented for read-only fetches.
+/// A fetch that is read only.
+///
+/// # Safety
+///
+/// This must only be implemented for read-only fetches.
 pub unsafe trait ReadOnlyFetch {}
 
 impl WorldQuery for Entity {

--- a/crates/bevy_ecs/src/schedule/run_criteria.rs
+++ b/crates/bevy_ecs/src/schedule/run_criteria.rs
@@ -396,20 +396,11 @@ where
     }
 }
 
+#[derive(Default)]
 pub struct RunOnce {
     ran: bool,
     archetype_component_access: Access<ArchetypeComponentId>,
     component_access: Access<ComponentId>,
-}
-
-impl Default for RunOnce {
-    fn default() -> Self {
-        Self {
-            ran: false,
-            archetype_component_access: Default::default(),
-            component_access: Default::default(),
-        }
-    }
 }
 
 impl System for RunOnce {

--- a/crates/bevy_ecs/src/schedule/system_set.rs
+++ b/crates/bevy_ecs/src/schedule/system_set.rs
@@ -6,6 +6,7 @@ use crate::schedule::{
 use super::IntoSystemDescriptor;
 
 /// A builder for describing several systems at the same time.
+#[derive(Default)]
 pub struct SystemSet {
     pub(crate) systems: Vec<SystemDescriptor>,
     pub(crate) run_criteria: Option<RunCriteriaDescriptorOrLabel>,
@@ -13,19 +14,6 @@ pub struct SystemSet {
     pub(crate) before: Vec<BoxedSystemLabel>,
     pub(crate) after: Vec<BoxedSystemLabel>,
     pub(crate) ambiguity_sets: Vec<BoxedAmbiguitySetLabel>,
-}
-
-impl Default for SystemSet {
-    fn default() -> SystemSet {
-        SystemSet {
-            systems: Vec::new(),
-            run_criteria: None,
-            labels: Vec::new(),
-            before: Vec::new(),
-            after: Vec::new(),
-            ambiguity_sets: Vec::new(),
-        }
-    }
 }
 
 impl SystemSet {

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_lifetime_safety.stderr
@@ -2,9 +2,9 @@ error[E0499]: cannot borrow `query` as mutable more than once at a time
   --> tests/ui/system_query_get_lifetime_safety.rs:8:14
    |
 7  |     let a1 = query.get_mut(*e).unwrap();
-   |              ----- first mutable borrow occurs here
+   |              ----------------- first mutable borrow occurs here
 8  |     let a2 = query.get_mut(*e).unwrap();
-   |              ^^^^^ second mutable borrow occurs here
+   |              ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
 9  |     // this should fail to compile
 10 |     println!("{} {}", a1.0, a2.0);
    |                       -- first borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_iter_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_iter_lifetime_safety.stderr
@@ -2,10 +2,10 @@ error[E0499]: cannot borrow `query` as mutable more than once at a time
   --> tests/ui/system_query_iter_lifetime_safety.rs:10:21
    |
 7  |     let mut iter = query.iter_mut();
-   |                    ----- first mutable borrow occurs here
+   |                    ---------------- first mutable borrow occurs here
 ...
 10 |     let mut iter2 = query.iter_mut();
-   |                     ^^^^^ second mutable borrow occurs here
+   |                     ^^^^^^^^^^^^^^^^ second mutable borrow occurs here
 ...
 14 |     println!("{}", a.0);
    |                    --- first borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_set_get_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_set_get_lifetime_safety.stderr
@@ -2,10 +2,10 @@ error[E0499]: cannot borrow `queries` as mutable more than once at a time
   --> tests/ui/system_query_set_get_lifetime_safety.rs:10:14
    |
 7  |     let mut q2 = queries.q0();
-   |                  ------- first mutable borrow occurs here
+   |                  ------------ first mutable borrow occurs here
 ...
 10 |     let q1 = queries.q1();
-   |              ^^^^^^^ second mutable borrow occurs here
+   |              ^^^^^^^^^^^^ second mutable borrow occurs here
 ...
 14 |     b.0 = a.0
    |     - first borrow later used here
@@ -14,10 +14,10 @@ error[E0499]: cannot borrow `queries` as mutable more than once at a time
   --> tests/ui/system_query_set_get_lifetime_safety.rs:21:18
    |
 18 |     let q1 = queries.q1();
-   |              ------- first mutable borrow occurs here
+   |              ------------ first mutable borrow occurs here
 ...
 21 |     let mut q2 = queries.q0();
-   |                  ^^^^^^^ second mutable borrow occurs here
+   |                  ^^^^^^^^^^^^ second mutable borrow occurs here
 ...
 25 |     b.0 = a.0
    |           --- first borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_set_iter_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_set_iter_lifetime_safety.stderr
@@ -2,10 +2,10 @@ error[E0499]: cannot borrow `queries` as mutable more than once at a time
   --> tests/ui/system_query_set_iter_lifetime_safety.rs:11:14
    |
 7  |     let mut q2 = queries.q0();
-   |                  ------- first mutable borrow occurs here
+   |                  ------------ first mutable borrow occurs here
 ...
 11 |     let q1 = queries.q1();
-   |              ^^^^^^^ second mutable borrow occurs here
+   |              ^^^^^^^^^^^^ second mutable borrow occurs here
 ...
 16 |     b.0 = a.0
    |     - first borrow later used here
@@ -14,10 +14,10 @@ error[E0499]: cannot borrow `queries` as mutable more than once at a time
   --> tests/ui/system_query_set_iter_lifetime_safety.rs:24:18
    |
 20 |     let q1 = queries.q1();
-   |              ------- first mutable borrow occurs here
+   |              ------------ first mutable borrow occurs here
 ...
 24 |     let mut q2 = queries.q0();
-   |                  ^^^^^^^ second mutable borrow occurs here
+   |                  ^^^^^^^^^^^^ second mutable borrow occurs here
 ...
 29 |     b.0 = a.0;
    |           --- first borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_state_iter_mut_overlap_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_state_iter_mut_overlap_safety.stderr
@@ -2,10 +2,10 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
   --> tests/ui/system_state_iter_mut_overlap_safety.rs:18:13
    |
 15 |         let mut_vec = query.iter_mut().collect::<Vec<bevy_ecs::prelude::Mut<A>>>();
-   |                       ----- mutable borrow occurs here
+   |                       ---------------- mutable borrow occurs here
 ...
 18 |             query.iter().collect::<Vec<&A>>(),
-   |             ^^^^^ immutable borrow occurs here
+   |             ^^^^^^^^^^^^ immutable borrow occurs here
 ...
 23 |             mut_vec.iter().map(|m| **m).collect::<Vec<A>>(),
-   |             ------- mutable borrow later used here
+   |             -------------- mutable borrow later used here

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -354,9 +354,7 @@ async fn load_texture<'a>(
 
             Texture::from_buffer(
                 &bytes,
-                mime_type
-                    .map(|mt| ImageType::MimeType(mt))
-                    .unwrap_or(image_type),
+                mime_type.map(ImageType::MimeType).unwrap_or(image_type),
             )?
         }
     };

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 pub mod camera;
 pub mod color;
 pub mod colorspace;

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -38,21 +38,13 @@ use bevy_render::{
 };
 use sprite::sprite_system;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SpriteSettings {
     /// Enable sprite frustum culling.
     ///
     /// # Warning
     /// This is currently experimental. It does not work correctly in all cases.
     pub frustum_culling_enabled: bool,
-}
-
-impl Default for SpriteSettings {
-    fn default() -> Self {
-        Self {
-            frustum_culling_enabled: false,
-        }
-    }
 }
 
 #[derive(Default)]

--- a/crates/crevice/src/lib.rs
+++ b/crates/crevice/src/lib.rs
@@ -2,7 +2,8 @@
     clippy::new_without_default,
     clippy::needless_update,
     clippy::len_without_is_empty,
-    clippy::needless_range_loop
+    clippy::needless_range_loop,
+    clippy::all
 )]
 /*!
 [![GitHub CI Status](https://github.com/LPGhatguy/crevice/workflows/CI/badge.svg)](https://github.com/LPGhatguy/crevice/actions)

--- a/pipelined/bevy_gltf2/src/loader.rs
+++ b/pipelined/bevy_gltf2/src/loader.rs
@@ -354,9 +354,7 @@ async fn load_texture<'a>(
 
             Image::from_buffer(
                 &bytes,
-                mime_type
-                    .map(|mt| ImageType::MimeType(mt))
-                    .unwrap_or(image_type),
+                mime_type.map(ImageType::MimeType).unwrap_or(image_type),
             )?
         }
     };

--- a/pipelined/bevy_pbr2/src/bundle.rs
+++ b/pipelined/bevy_pbr2/src/bundle.rs
@@ -9,7 +9,7 @@ use bevy_render2::{
 use bevy_transform::components::{GlobalTransform, Transform};
 
 /// A component bundle for PBR entities with a [`Mesh`] and a [`StandardMaterial`].
-#[derive(Bundle, Clone)]
+#[derive(Bundle, Clone, Default)]
 pub struct PbrBundle {
     pub mesh: Handle<Mesh>,
     pub material: Handle<StandardMaterial>,
@@ -19,19 +19,6 @@ pub struct PbrBundle {
     pub visibility: Visibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub computed_visibility: ComputedVisibility,
-}
-
-impl Default for PbrBundle {
-    fn default() -> Self {
-        Self {
-            mesh: Default::default(),
-            material: Default::default(),
-            transform: Default::default(),
-            global_transform: Default::default(),
-            visibility: Default::default(),
-            computed_visibility: Default::default(),
-        }
-    }
 }
 
 #[derive(Component, Clone, Debug, Default)]

--- a/pipelined/bevy_sprite2/src/bundle.rs
+++ b/pipelined/bevy_sprite2/src/bundle.rs
@@ -10,7 +10,7 @@ use bevy_render2::{
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 
-#[derive(Bundle, Clone)]
+#[derive(Bundle, Clone, Default)]
 pub struct PipelinedSpriteBundle {
     pub sprite: Sprite,
     pub transform: Transform,
@@ -22,22 +22,9 @@ pub struct PipelinedSpriteBundle {
     pub computed_visibility: ComputedVisibility,
 }
 
-impl Default for PipelinedSpriteBundle {
-    fn default() -> Self {
-        Self {
-            sprite: Default::default(),
-            transform: Default::default(),
-            global_transform: Default::default(),
-            texture: Default::default(),
-            visibility: Default::default(),
-            computed_visibility: Default::default(),
-        }
-    }
-}
-
 /// A Bundle of components for drawing a single sprite from a sprite sheet (also referred
 /// to as a `TextureAtlas`)
-#[derive(Bundle, Clone)]
+#[derive(Bundle, Clone, Default)]
 pub struct PipelinedSpriteSheetBundle {
     /// The specific sprite from the texture atlas to be drawn
     pub sprite: TextureAtlasSprite,
@@ -50,17 +37,4 @@ pub struct PipelinedSpriteSheetBundle {
     pub visibility: Visibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub computed_visibility: ComputedVisibility,
-}
-
-impl Default for PipelinedSpriteSheetBundle {
-    fn default() -> Self {
-        Self {
-            sprite: Default::default(),
-            texture_atlas: Default::default(),
-            transform: Default::default(),
-            global_transform: Default::default(),
-            visibility: Default::default(),
-            computed_visibility: Default::default(),
-        }
-    }
 }


### PR DESCRIPTION
# Objective

- New clippy lints with rust 1.57 are failing

## Solution

- Fixed clippy lints following suggestions
- I ignored clippy in old renderer because there was many and it will be removed soon
