### PR TITLE
[Merged by Bors] - Update dependencies `ron` `winit`& fix `cargo-deny` lists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           components: rustfmt, clippy
           override: true
       - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
       - name: CI job
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci
@@ -262,7 +262,7 @@ jobs:
         with:
           toolchain: stable
       - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
         if: runner.os == 'linux'
       - name: Installs cargo-deadlinks
         run: cargo install --force cargo-deadlinks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           components: rustfmt, clippy
           override: true
       - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci
@@ -262,7 +262,7 @@ jobs:
         with:
           toolchain: stable
       - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
         if: runner.os == 'linux'
       - name: Installs cargo-deadlinks
         run: cargo install --force cargo-deadlinks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ bevy_internal = { path = "crates/bevy_internal", version = "0.5.0", default-feat
 [dev-dependencies]
 anyhow = "1.0.4"
 rand = "0.8.0"
-ron = "0.6.2"
+ron = "0.7.0"
 serde = { version = "1", features = ["derive"] }
 # Needed to poll Task examples
 futures-lite = "1.11.3"

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -22,7 +22,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }
-ron = { version = "0.6.2", optional = true }
+ron = { version = "0.7.0", optional = true }
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -39,7 +39,7 @@ wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = { version = "0.4" }
+ndk-glue = { version = "0.5" }
 
 [dev-dependencies]
 futures-lite = "1.4.0"

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -80,4 +80,4 @@ bevy_winit = { path = "../bevy_winit", optional = true, version = "0.5.0" }
 bevy_gilrs = { path = "../bevy_gilrs", optional = true, version = "0.5.0" }
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = {version = "0.4", features = ["logger"]}
+ndk-glue = {version = "0.5", features = ["logger"]}

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -27,4 +27,4 @@ smallvec = { version = "1.6", features = ["serde", "union", "const_generics"], o
 glam = { version = "0.20.0", features = ["serde"], optional = true }
 
 [dev-dependencies]
-ron = "0.6.2"
+ron = "0.7.0"

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -19,7 +19,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 
 # other
 serde = { version = "1.0", features = ["derive"] }
-ron = "0.6.2"
+ron = "0.7.0"
 uuid = { version = "0.8", features = ["v4", "serde"] }
 anyhow = "1.0.4"
 thiserror = "1.0"

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -114,9 +114,9 @@ where
     S: Serialize,
 {
     let pretty_config = ron::ser::PrettyConfig::default()
-        .with_decimal_floats(true)
-        .with_indentor("  ".to_string())
-        .with_new_line("\n".to_string());
+        .decimal_floats(true)
+        .indentor("  ".to_string())
+        .new_line("\n".to_string());
     let mut buf = Vec::new();
     let mut ron_serializer = ron::ser::Serializer::new(&mut buf, Some(pretty_config), false)?;
     serialize.serialize(&mut ron_serializer)?;

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["bevy"]
 bevy_app = { path = "../bevy_app", version = "0.5.0" }
 bevy_math = { path = "../bevy_math", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
-raw-window-handle = "0.3.0"
+raw-window-handle = "0.4.2"
 
 # other
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -550,9 +550,10 @@ pub struct WindowDescriptor {
     /// Sets whether the background of the window should be transparent.
     /// # Platform-specific
     /// - iOS / Android / Web: Unsupported.
-    /// - OSX / Linux : Not working as expected.
-    /// OSX transparent works with winit out of the box, so this issue might be related to: https://github.com/gfx-rs/wgpu/issues/687
-    /// Linux now works with this pr merged in, which should work with the next release of winit : https://github.com/rust-windowing/winit/pull/2006
+    /// - macOS X: Not working as expected.
+    /// - Windows 11: Not working as expected
+    /// macOS X transparent works with winit out of the box, so this issue might be related to: https://github.com/gfx-rs/wgpu/issues/687
+    /// Windows 11 is related to https://github.com/rust-windowing/winit/issues/2082
     pub transparent: bool,
     #[cfg(target_arch = "wasm32")]
     pub canvas: Option<String>,

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -22,12 +22,12 @@ bevy_window = { path = "../bevy_window", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 
 # other
-winit = { version = "0.25.0", default-features = false }
+winit = { version = "0.26.0", default-features = false }
 approx = { version = "0.5.0", default-features = false }
-raw-window-handle = "0.3.0"
+raw-window-handle = "0.4.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-winit = { version = "0.25.0", features = ["web-sys"], default-features = false }
+winit = { version = "0.26.0", default-features = false }
 wasm-bindgen = { version = "0.2" }
 web-sys = "0.3"
 

--- a/deny.toml
+++ b/deny.toml
@@ -6,8 +6,11 @@ unmaintained = "deny"
 yanked = "deny"
 notice = "deny"
 ignore = [
-    "RUSTSEC-2020-0056", # stdweb unmaintained - https://github.com/koute/stdweb/issues/403
-    "RUSTSEC-2021-0047", # security issue - https://github.com/gnzlbg/slice_deque/issues/90
+    "RUSTSEC-2020-0056", # from gilrs v0.8.1 - unmaintained - https://github.com/koute/stdweb/issues/403
+    "RUSTSEC-2020-0158", # from rodio v0.14.0 - unmaintained - https://github.com/gnzlbg/slice_deque/issues/94
+    "RUSTSEC-2021-0047", # from rodio v0.14.0 - unsafety - https://github.com/gnzlbg/slice_deque/issues/90
+    "RUSTSEC-2020-0095", # from crevice dev dependency - unmaintained - https://github.com/johannhof/difference.rs/issues/45
+    "RUSTSEC-2021-0119", # from rodio 0.14.0 - unsafety - https://github.com/nix-rust/nix/issues/1541
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -39,21 +39,26 @@ wildcards = "deny"
 highlight = "all"
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    { name = "ahash", version = "0.4" },
-    { name = "cfg-if", version = "0.1" },             # https://github.com/rustwasm/console_error_panic_hook/pull/18
-    { name = "core-foundation", version = "0.6" },
-    { name = "core-foundation", version = "0.7" },
-    { name = "core-foundation-sys", version = "0.6" },
-    { name = "core-foundation-sys", version = "0.7" },
-    { name = "core-graphics", version = "0.19" },
-    { name = "fixedbitset", version = "0.2" },
-    { name = "hashbrown", version = "0.9" },
-    { name = "libm", version = "0.1" },
-    { name = "mach", version = "0.2" },
-    { name = "ndk", version = "0.3" },
-    { name = "ndk-glue", version = "0.3" },
-    { name = "proc-macro-crate", version = "0.1" },
-    { name = "stdweb", version = "0.1" },
+    { name = "cfg-if", version = "0.1" },               # from winit v0.26.0
+    { name = "core-foundation", version = "0.6" },      # from gilrs v0.8.1
+    { name = "core-foundation", version = "0.7" },      # from winit v0.26.0
+    { name = "core-foundation-sys", version = "0.6" },  # from gilrs v0.8.1
+    { name = "core-foundation-sys", version = "0.7" },  # from winit v0.26.0
+    { name = "core-graphics", version = "0.19" },       # from winit v0.26.0
+    { name = "darling", version = "0.10" },             # from rodio v0.14.0
+    { name = "darling_core", version = "0.10" },        # from rodio v0.14.0
+    { name = "darling_macro", version = "0.10" },       # from rodio v0.14.0
+    { name = "mach", version = "0.2" },                 # from gilrs v0.8.1
+    { name = "mio", version = "0.7" },                  # from notify v5.0.0-pre.11
+    { name = "ndk", version = "0.3" },                  # from rodio v0.14.0
+    { name = "ndk", version = "0.4" },                  # from rodio v0.14.0
+    { name = "ndk-macro", version = "0.2" },            # from rodio v0.14.0
+    { name = "ndk-glue", version = "0.3" },             # from rodio v0.14.0
+    { name = "ndk-glue", version = "0.4" },             # from rodio v0.14.0
+    { name = "proc-macro-crate", version = "0.1" },     # from rodio v0.14.0
+    { name = "stdweb", version = "0.1" },               # from rodio v0.14.0
+    { name = "strsim", version = "0.9" },               # from rodio v0.14.0
+    { name = "raw-window-handle", version = "0.3" },    # from wgpu v0.11.1
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,7 @@ ignore = [
     "RUSTSEC-2020-0158", # from rodio v0.14.0 - unmaintained - https://github.com/gnzlbg/slice_deque/issues/94
     "RUSTSEC-2021-0047", # from rodio v0.14.0 - unsafety - https://github.com/gnzlbg/slice_deque/issues/90
     "RUSTSEC-2020-0095", # from crevice dev dependency - unmaintained - https://github.com/johannhof/difference.rs/issues/45
+    "RUSTSEC-2021-0096", # from spirv-reflect v0.2.3 - unmaintained - https://github.com/gfx-rs/rspirv/issues/197
     "RUSTSEC-2021-0119", # from rodio 0.14.0 - unsafety - https://github.com/nix-rust/nix/issues/1541
 ]
 

--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -10,6 +10,12 @@ If you don't see your distro present in the list, feel free to add the instructi
 sudo apt-get install g++ pkg-config libx11-dev libasound2-dev libudev-dev
 ```
 
+if using Wayland, you will also need to install
+
+```bash
+sudo apt-get install libwayland-dev libxkbcommon-dev
+```
+
 Depending on your graphics card, you may have to install one of the following:
 `vulkan-radeon`, `vulkan-intel`, or `mesa-vulkan-drivers`
 


### PR DESCRIPTION
# Objective

- there are a few new versions for `ron`, `winit`, `ndk`, `raw-window-handle`
- `cargo-deny` is failing due to new security issues / duplicated dependencies

## Solution

- Update our dependencies
- Note all new security issues, with which of Bevy direct dependency it comes from
- Update duplicate crate list, with which of Bevy direct dependency it comes from

`notify` is not updated here as it's in #2993