### PR TITLE
Make ScalingMode more flexible

### DIFF
--- a/crates/bevy_render/src/camera/bundle.rs
+++ b/crates/bevy_render/src/camera/bundle.rs
@@ -110,7 +110,7 @@ impl OrthographicCameraBundle {
 
     pub fn new_3d() -> Self {
         let orthographic_projection = OrthographicProjection {
-            scaling_mode: ScalingMode::FixedVertical,
+            scaling_mode: ScalingMode::FixedVertical(1.0),
             depth_calculation: DepthCalculation::Distance,
             ..Default::default()
         };


### PR DESCRIPTION
Adds ability to specify scaling factor for `WindowSize`, size of the fixed axis for `FixedVertical` and `FixedHorizontal` and a new `ScalingMode` that is a mix of `FixedVertical` and `FixedHorizontal`

# The issue

Currently, only available options are to:

* Have one of the axes fixed to value 1
* Have viewport size match the window size
* Manually adjust viewport size

In most of the games these options are not enough and more advanced scaling methods have to be used

## Solution

The solution is to provide additional parameters to current scaling modes, like scaling factor for `WindowSize`. Additionally, a more advanced `Auto` mode is added, which dynamically switches between behaving like `FixedVertical` and `FixedHorizontal` depending on the window's aspect ratio.