### PR TITLE
[Merged by Bors] - Make currently required features for some examples explicit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ path = "examples/3d/cornell_box_pipelined.rs"
 [[example]]
 name = "load_gltf"
 path = "examples/3d/load_gltf.rs"
+required-features = ["bevy_gltf"]
 
 [[example]]
 name = "load_gltf_pipelined"
@@ -228,6 +229,7 @@ path = "examples/3d/texture_pipelined.rs"
 [[example]]
 name = "update_gltf_scene"
 path = "examples/3d/update_gltf_scene.rs"
+required-features = ["bevy_gltf"]
 
 [[example]]
 name = "wireframe"
@@ -282,6 +284,7 @@ path = "examples/app/thread_pool_resources.rs"
 [[example]]
 name = "asset_loading"
 path = "examples/asset/asset_loading.rs"
+required-features = ["bevy_gltf"]
 
 [[example]]
 name = "custom_asset"
@@ -294,6 +297,7 @@ path = "examples/asset/custom_asset_io.rs"
 [[example]]
 name = "hot_asset_reloading"
 path = "examples/asset/hot_asset_reloading.rs"
+required-features = ["bevy_gltf"]
 
 # Async Tasks
 [[example]]
@@ -375,6 +379,7 @@ path = "examples/ecs/timers.rs"
 [[example]]
 name = "alien_cake_addict"
 path = "examples/game/alien_cake_addict.rs"
+required-features = ["bevy_gltf"]
 
 [[example]]
 name = "breakout"
@@ -518,6 +523,7 @@ path = "examples/window/clear_color_pipelined.rs"
 [[example]]
 name = "multiple_windows"
 path = "examples/window/multiple_windows.rs"
+required-features = ["bevy_gltf"]
 
 [[example]]
 name = "scale_factor_override"


### PR DESCRIPTION
# Objective

Fixes #3255 

## Solution

- mark the `bevy_gltf` feature as required for some examples

This should be cleaned up when we remove the old renderer
