### PR TITLE
[Merged by Bors] - Made Time::time_since_startup return from last tick.

### DIFF
--- a/crates/bevy_core/src/time/time.rs
+++ b/crates/bevy_core/src/time/time.rs
@@ -61,7 +61,7 @@ impl Time {
         self.delta_seconds_f64
     }
 
-    /// The time since startup in seconds
+    /// The time from startup to the last update in seconds
     #[inline]
     pub fn seconds_since_startup(&self) -> f64 {
         self.seconds_since_startup
@@ -79,8 +79,9 @@ impl Time {
         self.last_update
     }
 
+    /// The ['Duration'] from startup to the last update
     pub fn time_since_startup(&self) -> Duration {
-        Instant::now() - self.startup
+        self.last_update.unwrap_or(self.startup) - self.startup
     }
 }
 
@@ -110,6 +111,7 @@ mod tests {
         assert_eq!(time.startup(), start_instant);
         assert_eq!(time.delta_seconds_f64(), 0.0);
         assert_eq!(time.seconds_since_startup(), 0.0);
+        assert_eq!(time.time_since_startup(), Duration::from_secs(0));
         assert_eq!(time.delta_seconds(), 0.0);
 
         // Update `time` and check results
@@ -124,6 +126,10 @@ mod tests {
         assert_eq!(
             time.seconds_since_startup(),
             (first_update_instant - start_instant).as_secs_f64()
+        );
+        assert_eq!(
+            time.time_since_startup(),
+            (first_update_instant - start_instant)
         );
         assert_eq!(time.delta_seconds, 0.0);
 
@@ -141,6 +147,10 @@ mod tests {
         assert_eq!(
             time.seconds_since_startup(),
             (second_update_instant - start_instant).as_secs_f64()
+        );
+        assert_eq!(
+            time.time_since_startup(),
+            (second_update_instant - start_instant)
         );
         assert_eq!(time.delta_seconds(), time.delta().as_secs_f32());
     }

--- a/crates/bevy_core/src/time/time.rs
+++ b/crates/bevy_core/src/time/time.rs
@@ -82,6 +82,7 @@ impl Time {
     }
 
     /// The ['Duration'] from startup to the last update
+    #[inline]
     pub fn time_since_startup(&self) -> Duration {
         self.time_since_startup
     }

--- a/crates/bevy_core/src/time/time.rs
+++ b/crates/bevy_core/src/time/time.rs
@@ -9,6 +9,7 @@ pub struct Time {
     delta_seconds_f64: f64,
     delta_seconds: f32,
     seconds_since_startup: f64,
+    time_since_startup: Duration,
     startup: Instant,
 }
 
@@ -20,6 +21,7 @@ impl Default for Time {
             startup: Instant::now(),
             delta_seconds_f64: 0.0,
             seconds_since_startup: 0.0,
+            time_since_startup: Duration::from_secs(0),
             delta_seconds: 0.0,
         }
     }
@@ -38,8 +40,8 @@ impl Time {
             self.delta_seconds = self.delta.as_secs_f32();
         }
 
-        let duration_since_startup = instant - self.startup;
-        self.seconds_since_startup = duration_since_startup.as_secs_f64();
+        self.time_since_startup = instant - self.startup;
+        self.seconds_since_startup = self.time_since_startup.as_secs_f64();
         self.last_update = Some(instant);
     }
 
@@ -81,7 +83,7 @@ impl Time {
 
     /// The ['Duration'] from startup to the last update
     pub fn time_since_startup(&self) -> Duration {
-        self.last_update.unwrap_or(self.startup) - self.startup
+        self.time_since_startup
     }
 }
 


### PR DESCRIPTION
Also added unit tests for it.

# Objective

- Fixes #3259 

## Solution

- As discussed in #3259