### PR TITLE
[Merged by Bors] - Check for NaN in `Camera::world_to_screen()`

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -56,12 +56,16 @@ impl Camera {
             self.projection_matrix * camera_transform.compute_matrix().inverse();
         let ndc_space_coords: Vec3 = world_to_ndc.project_point3(world_position);
         // NDC z-values outside of 0 < z < 1 are outside the camera frustum and are thus not in screen space
-        if ndc_space_coords.z < 0.0 || ndc_space_coords.z > 1.0 || ndc_space_coords.z.is_nan() {
+        if ndc_space_coords.z < 0.0 || ndc_space_coords.z > 1.0 {
             return None;
         }
         // Once in NDC space, we can discard the z element and rescale x/y to fit the screen
         let screen_space_coords = (ndc_space_coords.truncate() + Vec2::ONE) / 2.0 * window_size;
-        Some(screen_space_coords)
+        if !screen_space_coords.is_nan() {
+            Some(screen_space_coords)
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -55,8 +55,8 @@ impl Camera {
         let world_to_ndc: Mat4 =
             self.projection_matrix * camera_transform.compute_matrix().inverse();
         let ndc_space_coords: Vec3 = world_to_ndc.project_point3(world_position);
-        // NDC z-values outside of 0 < z < 1 are behind the camera and are thus not in screen space
-        if ndc_space_coords.z < 0.0 || ndc_space_coords.z > 1.0 {
+        // NDC z-values outside of 0 < z < 1 are outside the camera frustum and are thus not in screen space
+        if ndc_space_coords.z < 0.0 || ndc_space_coords.z > 1.0 || ndc_space_coords.z.is_nan() {
             return None;
         }
         // Once in NDC space, we can discard the z element and rescale x/y to fit the screen

--- a/pipelined/bevy_render2/src/camera/camera.rs
+++ b/pipelined/bevy_render2/src/camera/camera.rs
@@ -60,7 +60,11 @@ impl Camera {
         }
         // Once in NDC space, we can discard the z element and rescale x/y to fit the screen
         let screen_space_coords = (ndc_space_coords.truncate() + Vec2::ONE) / 2.0 * window_size;
-        Some(screen_space_coords)
+        if !screen_space_coords.is_nan() {
+            Some(screen_space_coords)
+        } else {
+            None
+        }
     }
 }
 

--- a/pipelined/bevy_render2/src/camera/camera.rs
+++ b/pipelined/bevy_render2/src/camera/camera.rs
@@ -54,7 +54,7 @@ impl Camera {
         let world_to_ndc: Mat4 =
             self.projection_matrix * camera_transform.compute_matrix().inverse();
         let ndc_space_coords: Vec3 = world_to_ndc.project_point3(world_position);
-        // NDC z-values outside of 0 < z < 1 are behind the camera and are thus not in screen space
+        // NDC z-values outside of 0 < z < 1 are outside the camera frustum and are thus not in screen space
         if ndc_space_coords.z < 0.0 || ndc_space_coords.z > 1.0 {
             return None;
         }


### PR DESCRIPTION
# Objective

- Checks for NaN in computed NDC space coordinates, fixing unexpected NaN in a fallible (`Option<T>`) function.

## Solution

- Adds a NaN check, in addition to the existing NDC bounds checks.
- This is a helper function, and should have no performance impact to the engine itself.
- This will help prevent hard-to-trace NaN propagation in user code, by returning `None` instead of `Some(NaN)`.


Depends on https://github.com/bevyengine/bevy/pull/3269 for CI error fix.