### PR TITLE
[Merged by Bors] - Fix clippy errors related to IntoIter::new

### DIFF
--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -464,7 +464,7 @@ impl Mesh {
         let normals: Vec<_> = positions
             .chunks_exact(3)
             .map(|p| face_normal(p[0], p[1], p[2]))
-            .flat_map(|normal| [normal, normal, normal].into_iter())
+            .flat_map(|normal| [normal; 3])
             .collect();
 
         self.set_attribute(Mesh::ATTRIBUTE_NORMAL, normals);

--- a/crates/bevy_render/src/mesh/mesh.rs
+++ b/crates/bevy_render/src/mesh/mesh.rs
@@ -464,7 +464,7 @@ impl Mesh {
         let normals: Vec<_> = positions
             .chunks_exact(3)
             .map(|p| face_normal(p[0], p[1], p[2]))
-            .flat_map(|normal| std::array::IntoIter::new([normal, normal, normal]))
+            .flat_map(|normal| [normal, normal, normal].into_iter())
             .collect();
 
         self.set_attribute(Mesh::ATTRIBUTE_NORMAL, normals);

--- a/pipelined/bevy_render2/src/mesh/mesh/mod.rs
+++ b/pipelined/bevy_render2/src/mesh/mesh/mod.rs
@@ -284,7 +284,7 @@ impl Mesh {
         let normals: Vec<_> = positions
             .chunks_exact(3)
             .map(|p| face_normal(p[0], p[1], p[2]))
-            .flat_map(|normal| std::array::IntoIter::new([normal, normal, normal]))
+            .flat_map(|normal| [normal, normal, normal].into_iter())
             .collect();
 
         self.set_attribute(Mesh::ATTRIBUTE_NORMAL, normals);

--- a/pipelined/bevy_render2/src/mesh/mesh/mod.rs
+++ b/pipelined/bevy_render2/src/mesh/mesh/mod.rs
@@ -284,7 +284,7 @@ impl Mesh {
         let normals: Vec<_> = positions
             .chunks_exact(3)
             .map(|p| face_normal(p[0], p[1], p[2]))
-            .flat_map(|normal| [normal, normal, normal].into_iter())
+            .flat_map(|normal| [normal; 3])
             .collect();
 
         self.set_attribute(Mesh::ATTRIBUTE_NORMAL, normals);


### PR DESCRIPTION
# Objective

Fixes recent pipeline errors:
```
error: use of deprecated associated function `std::array::IntoIter::<T, N>::new`: use `IntoIterator::into_iter` instead
   --> crates/bevy_render/src/mesh/mesh.rs:467:54
    |
467 |             .flat_map(|normal| std::array::IntoIter::new([normal, normal, normal]))
    |                                                      ^^^
    |
    = note: `-D deprecated` implied by `-D warnings`

   Compiling bevy_render2 v0.5.0 (/home/runner/work/bevy/bevy/pipelined/bevy_render2)
error: use of deprecated associated function `std::array::IntoIter::<T, N>::new`: use `IntoIterator::into_iter` instead
   --> pipelined/bevy_render2/src/mesh/mesh/mod.rs:287:54
    |
287 |             .flat_map(|normal| std::array::IntoIter::new([normal, normal, normal]))
    |                                                      ^^^
    |
    = note: `-D deprecated` implied by `-D warnings`

error: could not compile `bevy_render` due to previous error
```

## Solution

- Replaced `IntoIter::new` with `IntoIterator::into_iter`

## Suggestions

For me it looks like two equivalent `Mesh` structs with the same methods. Should we refactor it? Or, they will be different in the near future?
