### PR TITLE
[Merged by Bors] - Default image used in PipelinedSpriteBundle to be able to render without loading a texture

### DIFF
--- a/pipelined/bevy_render2/src/texture/image.rs
+++ b/pipelined/bevy_render2/src/texture/image.rs
@@ -5,6 +5,7 @@ use crate::{
     renderer::{RenderDevice, RenderQueue},
     texture::BevyDefault,
 };
+use bevy_asset::HandleUntyped;
 use bevy_ecs::system::{lifetimeless::SRes, SystemParamItem};
 use bevy_reflect::TypeUuid;
 use thiserror::Error;
@@ -15,6 +16,8 @@ use wgpu::{
 
 pub const TEXTURE_ASSET_INDEX: u64 = 0;
 pub const SAMPLER_ASSET_INDEX: u64 = 1;
+pub const DEFAULT_IMAGE_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(Image::TYPE_UUID, 13148262314052771789);
 
 #[derive(Debug, Clone, TypeUuid)]
 #[uuid = "6ea26da6-6cf8-4ea2-9986-1d7bf6c17d6f"]

--- a/pipelined/bevy_render2/src/texture/image.rs
+++ b/pipelined/bevy_render2/src/texture/image.rs
@@ -28,7 +28,7 @@ pub struct Image {
 impl Default for Image {
     fn default() -> Self {
         let format = wgpu::TextureFormat::bevy_default();
-        let data = vec![1; format.pixel_size() as usize];
+        let data = vec![255; format.pixel_size() as usize];
         Image {
             data,
             texture_descriptor: wgpu::TextureDescriptor {

--- a/pipelined/bevy_render2/src/texture/mod.rs
+++ b/pipelined/bevy_render2/src/texture/mod.rs
@@ -15,7 +15,7 @@ pub use texture_cache::*;
 
 use crate::{render_asset::RenderAssetPlugin, RenderApp, RenderStage};
 use bevy_app::{App, Plugin};
-use bevy_asset::AddAsset;
+use bevy_asset::{AddAsset, Assets};
 
 // TODO: replace Texture names with Image names?
 /// Adds the [`Image`] as an asset and makes sure that they are extracted and prepared for the GPU.
@@ -30,6 +30,10 @@ impl Plugin for ImagePlugin {
 
         app.add_plugin(RenderAssetPlugin::<Image>::default())
             .add_asset::<Image>();
+        app.world
+            .get_resource_mut::<Assets<Image>>()
+            .unwrap()
+            .set_untracked(DEFAULT_IMAGE_HANDLE, Image::default());
 
         app.sub_app(RenderApp)
             .init_resource::<TextureCache>()

--- a/pipelined/bevy_sprite2/src/bundle.rs
+++ b/pipelined/bevy_sprite2/src/bundle.rs
@@ -5,12 +5,12 @@ use crate::{
 use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
 use bevy_render2::{
-    texture::Image,
+    texture::{Image, DEFAULT_IMAGE_HANDLE},
     view::{ComputedVisibility, Visibility},
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 
-#[derive(Bundle, Clone, Default)]
+#[derive(Bundle, Clone)]
 pub struct PipelinedSpriteBundle {
     pub sprite: Sprite,
     pub transform: Transform,
@@ -22,6 +22,18 @@ pub struct PipelinedSpriteBundle {
     pub computed_visibility: ComputedVisibility,
 }
 
+impl Default for PipelinedSpriteBundle {
+    fn default() -> Self {
+        Self {
+            sprite: Default::default(),
+            transform: Default::default(),
+            global_transform: Default::default(),
+            texture: DEFAULT_IMAGE_HANDLE.typed(),
+            visibility: Default::default(),
+            computed_visibility: Default::default(),
+        }
+    }
+}
 /// A Bundle of components for drawing a single sprite from a sprite sheet (also referred
 /// to as a `TextureAtlas`)
 #[derive(Bundle, Clone, Default)]


### PR DESCRIPTION
# Objective

- Fix #3188 
- Allow creating a `PipelinedSpriteBundle` without an image, just a plain color

```rust
PipelinedSpriteBundle {
    sprite: Sprite {
        color: Color::rgba(0.8, 0.0, 0.0, 0.3),
        custom_size: Some(Vec2::new(500.0, 500.0)),
        ..Default::default()
    },
    ..Default::default()
}
```

## Solution

- The default impl for `Image` was creating a one pixel image with all values at `1`. I changed it to `255` as picking `1` for it doesn't really make sense, it should be either `0` or `255`
- I created a static handle and added the default image to the assets with this handle
- I changed the default impl for `PipelinedSpriteBundle` to use this handle
