### PR TITLE
[Merged by Bors] - Allow `String` and `&String` as `Id` for `AssetServer.get_handle(id)`

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -178,6 +178,18 @@ impl From<&str> for HandleId {
     }
 }
 
+impl From<&String> for HandleId {
+    fn from(value: &String) -> Self {
+        AssetPathId::from(value).into()
+    }
+}
+
+impl From<String> for HandleId {
+    fn from(value: String) -> Self {
+        AssetPathId::from(&value).into()
+    }
+}
+
 impl<T: Asset> From<&Handle<T>> for HandleId {
     fn from(value: &Handle<T>) -> Self {
         value.id

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -152,6 +152,12 @@ impl<'a> From<&'a str> for AssetPath<'a> {
     }
 }
 
+impl<'a> From<&'a String> for AssetPath<'a> {
+    fn from(asset_path: &'a String) -> Self {
+        asset_path.as_str().into()
+    }
+}
+
 impl<'a> From<&'a Path> for AssetPath<'a> {
     fn from(path: &'a Path) -> Self {
         AssetPath {


### PR DESCRIPTION
# Objective

Make it easier to build and use an asset path with `format!()`. This can be useful for accessing assets in a loop.

Enabled by this PR:
```rust
let monkey_handle = asset_server.get_handle(&format!("models/monkey/Monkey.gltf#Mesh0/Primitive0"));
let monkey_handle = asset_server.get_handle(format!("models/monkey/Monkey.gltf#Mesh0/Primitive0"));
```

Before this PR:
```rust
let monkey_handle = asset_server.get_handle(format!("models/monkey/Monkey.gltf#Mesh0/Primitive0").as_str());
```

It's just a tiny improvement in ergonomics, but i ran into it and was wondering why the function does not accept a `String` and Bevy is all about simplicity/ergonomics, right? 😄😉

## Solution

Implement `Into<HandleId>` for `String` and `&String`.
