### PR TITLE
[Merged by Bors] - More Bevy ECS schedule spans

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor_parallel.rs
+++ b/crates/bevy_ecs/src/schedule/executor_parallel.rs
@@ -150,6 +150,10 @@ impl ParallelExecutor {
     /// Calls system.new_archetype() for each archetype added since the last call to
     /// [update_archetypes] and updates cached archetype_component_access.
     fn update_archetypes(&mut self, systems: &mut [ParallelSystemContainer], world: &World) {
+        #[cfg(feature = "trace")]
+        let span = bevy_utils::tracing::info_span!("update_archetypes");
+        #[cfg(feature = "trace")]
+        let _guard = span.enter();
         let archetypes = world.archetypes();
         let new_generation = archetypes.generation();
         let old_generation = std::mem::replace(&mut self.archetype_generation, new_generation);
@@ -174,6 +178,10 @@ impl ParallelExecutor {
         systems: &'scope [ParallelSystemContainer],
         world: &'scope World,
     ) {
+        #[cfg(feature = "trace")]
+        let span = bevy_utils::tracing::info_span!("prepare_systems");
+        #[cfg(feature = "trace")]
+        let _guard = span.enter();
         self.should_run.clear();
         for (index, system_data) in self.system_metadata.iter_mut().enumerate() {
             // Spawn the system task.

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -830,6 +830,13 @@ impl Stage for SystemStage {
                 // Run systems that want to be at the start of stage.
                 for container in &mut self.exclusive_at_start {
                     if should_run(container, &self.run_criteria, default_should_run) {
+                        #[cfg(feature = "trace")]
+                        let system_span = bevy_utils::tracing::info_span!(
+                            "exclusive_system",
+                            name = &*container.name()
+                        );
+                        #[cfg(feature = "trace")]
+                        let _guard = system_span.enter();
                         container.system_mut().run(world);
                     }
                 }
@@ -845,6 +852,13 @@ impl Stage for SystemStage {
                 // Run systems that want to be between parallel systems and their command buffers.
                 for container in &mut self.exclusive_before_commands {
                     if should_run(container, &self.run_criteria, default_should_run) {
+                        #[cfg(feature = "trace")]
+                        let system_span = bevy_utils::tracing::info_span!(
+                            "exclusive_system",
+                            name = &*container.name()
+                        );
+                        #[cfg(feature = "trace")]
+                        let _guard = system_span.enter();
                         container.system_mut().run(world);
                     }
                 }
@@ -853,6 +867,13 @@ impl Stage for SystemStage {
                 if self.apply_buffers {
                     for container in &mut self.parallel {
                         if container.should_run {
+                            #[cfg(feature = "trace")]
+                            let span = bevy_utils::tracing::info_span!(
+                                "system_commands",
+                                name = &*container.name()
+                            );
+                            #[cfg(feature = "trace")]
+                            let _guard = span.enter();
                             container.system_mut().apply_buffers(world);
                         }
                     }
@@ -861,6 +882,13 @@ impl Stage for SystemStage {
                 // Run systems that want to be at the end of stage.
                 for container in &mut self.exclusive_at_end {
                     if should_run(container, &self.run_criteria, default_should_run) {
+                        #[cfg(feature = "trace")]
+                        let system_span = bevy_utils::tracing::info_span!(
+                            "exclusive_system",
+                            name = &*container.name()
+                        );
+                        #[cfg(feature = "trace")]
+                        let _guard = system_span.enter();
                         container.system_mut().run(world);
                     }
                 }


### PR DESCRIPTION
Fills in some gaps we had in our Bevy ECS tracing spans:

* Exclusive systems
* System Commands (for `apply_buffers = true` cases)
* System archetype updates
* Parallel system execution prep