### PR TITLE
[Merged by Bors] - Ported WgpuOptions to bevy_render2

### DIFF
--- a/pipelined/bevy_render2/src/lib.rs
+++ b/pipelined/bevy_render2/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod camera;
 pub mod color;
 pub mod mesh;
+pub mod options;
 pub mod primitives;
 pub mod render_asset;
 pub mod render_component;
@@ -26,7 +27,6 @@ use bevy_app::{App, AppLabel, Plugin};
 use bevy_asset::{AddAsset, AssetServer};
 use bevy_ecs::prelude::*;
 use std::ops::{Deref, DerefMut};
-use wgpu::Backends;
 
 /// Contains the default Bevy rendering backend based on wgpu.
 #[derive(Default)]
@@ -90,13 +90,12 @@ struct ScratchRenderWorld(World);
 impl Plugin for RenderPlugin {
     /// Initializes the renderer, sets up the [`RenderStage`](RenderStage) and creates the rendering sub-app.
     fn build(&self, app: &mut App) {
-        let default_backend = if cfg!(not(target_arch = "wasm32")) {
-            Backends::PRIMARY
-        } else {
-            Backends::GL
-        };
-        let backends = wgpu::util::backend_bits_from_env().unwrap_or(default_backend);
-        let instance = wgpu::Instance::new(backends);
+        let options = app
+            .world
+            .get_resource::<options::WgpuOptions>()
+            .cloned()
+            .unwrap_or_default();
+        let instance = wgpu::Instance::new(options.backends);
         let surface = {
             let world = app.world.cell();
             let windows = world.get_resource_mut::<bevy_window::Windows>().unwrap();
@@ -109,19 +108,14 @@ impl Plugin for RenderPlugin {
         let (device, queue) = futures_lite::future::block_on(renderer::initialize_renderer(
             &instance,
             &wgpu::RequestAdapterOptions {
-                power_preference: wgpu::PowerPreference::HighPerformance,
+                power_preference: options.power_preference,
                 compatible_surface: surface.as_ref(),
                 ..Default::default()
             },
             &wgpu::DeviceDescriptor {
-                features: wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
-                #[cfg(not(target_arch = "wasm32"))]
-                limits: wgpu::Limits::default(),
-                #[cfg(target_arch = "wasm32")]
-                limits: wgpu::Limits {
-                    ..wgpu::Limits::downlevel_webgl2_defaults()
-                },
-                ..Default::default()
+                label: options.device_label.as_ref().map(|a| a.as_ref()),
+                features: options.features,
+                limits: options.limits,
             },
         ));
         app.insert_resource(device.clone())

--- a/pipelined/bevy_render2/src/options.rs
+++ b/pipelined/bevy_render2/src/options.rs
@@ -1,0 +1,38 @@
+use std::borrow::Cow;
+
+pub use wgpu::{Backends, Features, Limits, PowerPreference};
+
+#[derive(Clone)]
+pub struct WgpuOptions {
+    pub device_label: Option<Cow<'static, str>>,
+    pub backends: Backends,
+    pub power_preference: PowerPreference,
+    pub features: Features,
+    pub limits: Limits,
+}
+
+impl Default for WgpuOptions {
+    fn default() -> Self {
+        let default_backends = if cfg!(target_arch = "wasm32") {
+            Backends::GL
+        } else {
+            Backends::PRIMARY
+        };
+
+        let backends = wgpu::util::backend_bits_from_env().unwrap_or(default_backends);
+
+        let limits = if cfg!(target_arch = "wasm32") {
+            wgpu::Limits::downlevel_webgl2_defaults()
+        } else {
+            wgpu::Limits::default()
+        };
+
+        Self {
+            device_label: Default::default(),
+            backends,
+            power_preference: PowerPreference::HighPerformance,
+            features: wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
+            limits,
+        }
+    }
+}


### PR DESCRIPTION
# Objective

The new renderer does not support any options yet for wgpu. These are needed for example for rendering wireframes (see #3193).

## Solution

I've ported WgpuOptions to bevy_render2.

The defaults match the defaults that were used before this PR (meaning, some specific options when target_arch = wasm32).

Additionally, I removed `Auto` from WgpuBackends and added `Primary`. The default will use primary or GL based on the target_arch.
