### PR TITLE
[Merged by Bors] - Bevy release train - add a workflow to manually create a PR updating Bevy version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 1-7 3,6,9,12 *"
-    # at 0:00, on the first seven days of the month, in march, june, september and december
-    # in cron, it is not possible to say "first monday of the month", so the cron is selecting
-    # the first week, and the action is only running if the day is a monday using the 
-    # is-it-monday step
 
 env:
   CARGO_TERM_COLOR: always
@@ -18,21 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Only run on mondays
-        id: is-it-monday
-        continue-on-error: true
-        run: |
-          if [[ ! $(date +%u) -eq 1 ]]; then
-            echo 'This is not a monday.'
-            exit 1
-          fi
-
       - name: Install cargo-release
-        if: steps.is-it-monday.outcome=='success'
         run: cargo install cargo-release
 
       - name: Setup release
-        if: steps.is-it-monday.outcome=='success'
         run: |
           git config user.name 'Bevy Auto Releaser'
           git config user.email 'bevy@users.noreply.github.com'
@@ -54,7 +37,6 @@ jobs:
             --exclude bevy-ios-example
 
       - name: Create PR
-        if: steps.is-it-monday.outcome=='success'
         uses: peter-evans/create-pull-request@v3
         with:
           delete-branch: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 1-7 3,6,9,12 *"
+    
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Only run on mondays
+        id: is-it-monday
+        continue-on-error: true
+        run: |
+          if [[ ! $(date +%u) -eq 1 ]]; then
+            echo 'This is not a monday.'
+            exit 1
+          fi
+
+      - name: Install cargo-release
+        if: steps.is-it-monday.outcome=='success'
+        run: cargo install cargo-release
+
+      - name: Setup release
+        if: steps.is-it-monday.outcome=='success'
+        run: |
+          git config user.name 'Bevy Auto Releaser'
+          git config user.email 'bevy@users.noreply.github.com'
+          # --workspace: updating all crates in the workspace
+          # --no-publish: do not publish to crates.io
+          # --execute: not a dry run
+          # --no-tag: do not push tag for each new version
+          # --no-push: do not push the update commits
+          # --exclude: ignore those packages
+          cargo release minor \
+            --workspace \
+            --no-publish \
+            --execute \
+            --no-tag \
+            --no-confirm \
+            --no-push \
+            --exclude ci \
+            --exclude errors \
+            --exclude bevy-ios-example
+
+      - name: Create PR
+        if: steps.is-it-monday.outcome=='success'
+        uses: peter-evans/create-pull-request@v3
+        with:
+          delete-branch: true
+          base: "main"
+          title: "Preparing Next Release"
+          body: |
+            Preparing next release
+            This PR has been auto-generated

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 1-7 3,6,9,12 *"
-    
+    # at 0:00, on the first seven days of the month, in march, june, september and december
+    # in cron, it is not possible to say "first monday of the month", so the cron is selecting
+    # the first week, and the action is only running if the day is a monday using the 
+    # is-it-monday step
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
 
+# how to trigger: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
# Objective

- Ensure future Bevy releases happens smoothly

## Solution

- Add a workflow that will open a PR updating all Bevy crate that can be created manually

example PR opened: https://github.com/mockersf/bevy/pull/62

The day from this PR does not need to be the release day, it will just open the PR to prepare it. Later if we feel confident, it could push automatically to crates.io.


how to trigger the workflow: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow