### PR TITLE
Add `touch()` function to `Component`

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -33,6 +33,10 @@ use thiserror::Error;
 /// Components can be grouped together into a [`Bundle`](crate::bundle::Bundle).
 pub trait Component: Send + Sync + 'static {
     type Storage: ComponentStorage;
+
+    /// Calling this function `changes` a component. This means, that the change detection system
+    /// recognizes the component as `changed` and the query filter `Changed<T>` takes effect again.
+    fn touch(&mut self) {}
 }
 
 pub struct TableStorage;

--- a/examples/ecs/component_change_detection.rs
+++ b/examples/ecs/component_change_detection.rs
@@ -25,6 +25,8 @@ fn change_component(time: Res<Time>, mut query: Query<(Entity, &mut MyComponent)
         if rand::thread_rng().gen_bool(0.1) {
             info!("changing component {:?}", entity);
             component.0 = time.seconds_since_startup();
+            // You can even manually trigger a change on a component, without actually
+            // changing anything, you just need to call: `component.touch()`
         }
     }
 }


### PR DESCRIPTION
# Objective

Make it easy to manually trigger a `change` for a `Component`.

## Solution

Add a default function to the `Component` trait. I just adapted @TheRawMeatball's trick  (`&mut *component;`) into a function and the name is a taken with courtesy from @Ratysz.  
I am not sure if this has any memory/performance impacts, or if something like this is even needed, especially because it will be very "visible" as a default function on each `Component`. So...some discussion needed there is.
