### PR TITLE
Increased winit version to 0.26

### DIFF
--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -22,7 +22,7 @@ bevy_window = { path = "../bevy_window", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 
 # other
-winit = { version = "0.25.0", default-features = false }
+winit = { version = "0.26.0", default-features = false }
 approx = { version = "0.5.0", default-features = false }
 raw-window-handle = "0.3.0"
 


### PR DESCRIPTION
# Objective

- Fix pipeline error related to winit

## Solution

Increase winit version to `0.26.0` for all the targets except wasm32.

Currently wasm32 depends on `web-sys` feature of `winit`, which is not found in version `0.26.0`
