### PR TITLE
[Merged by Bors] - clearpass: also clear views without depth (2d)

### DIFF
--- a/pipelined/bevy_core_pipeline/src/clear_pass.rs
+++ b/pipelined/bevy_core_pipeline/src/clear_pass.rs
@@ -8,7 +8,8 @@ use bevy_render2::{
 };
 
 pub struct ClearPassNode {
-    query: QueryState<(&'static ViewTarget, &'static ViewDepthTexture), With<ExtractedView>>,
+    query:
+        QueryState<(&'static ViewTarget, Option<&'static ViewDepthTexture>), With<ExtractedView>>,
 }
 
 impl ClearPassNode {
@@ -43,7 +44,7 @@ impl Node for ClearPassNode {
                     load: LoadOp::Clear(clear_color.0.into()),
                     store: true,
                 })],
-                depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
+                depth_stencil_attachment: depth.map(|depth| RenderPassDepthStencilAttachment {
                     view: &depth.view,
                     depth_ops: Some(Operations {
                         load: LoadOp::Clear(0.0),


### PR DESCRIPTION
# Objective

- after #3209, 2d examples background were not cleared

<img width="912" alt="Screenshot 2021-12-10 at 00 48 04" src="https://user-images.githubusercontent.com/8672791/145494415-d4b7a149-6f9a-4036-9ac5-3d1227b4de69.png">

## Solution

- Change the query to also work when there isn't a `ViewDepthTexture`
