### PR TITLE
[Merged by Bors] - improve error message for attempting to add systems using add_system_to_stage

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -353,6 +353,10 @@ impl App {
         stage_label: impl StageLabel,
         system: impl IntoSystemDescriptor<Params>,
     ) -> &mut Self {
+        use std::any::TypeId;
+        if stage_label.type_id() == TypeId::of::<StartupStage>() {
+            panic!("add systems to a startup stage using App::add_startup_system_to_stage");
+        }
         self.schedule.add_system_to_stage(stage_label, system);
         self
     }
@@ -383,6 +387,10 @@ impl App {
         stage_label: impl StageLabel,
         system_set: SystemSet,
     ) -> &mut Self {
+        use std::any::TypeId;
+        if stage_label.type_id() == TypeId::of::<StartupStage>() {
+            panic!("add system sets to a startup stage using App::add_startup_system_set_to_stage");
+        }
         self.schedule
             .add_system_set_to_stage(stage_label, system_set);
         self


### PR DESCRIPTION
# Objective

Fixes #3250

## Solution

Since this panic occurs in bevy_ecs, and StartupStage is part of
bevy_app, we really only have access to the Debug string of the
`stage_label` parameter.  This led me to the hacky solution of
comparing the debug output of the label the user provides with the known
variants of StartupStage.

An alternative would be to do this error handling further up in
bevy_app, where we can access StartupStage's typeid, but I don't think
it is worth having a panic in 2 places (_ecs, and _app).
