### PR TITLE
[Merged by Bors] - report shader processing errors in `RenderPipelineCache`

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -37,6 +37,7 @@ image = { version = "0.23.12", default-features = false }
 
 # misc
 wgpu = { version = "0.12.0", features = ["spirv"] }
+codespan-reporting = "0.11.0"
 naga = { version = "0.8.0", features = ["glsl-in", "spv-in", "spv-out", "wgsl-in", "wgsl-out"] }
 serde = { version = "1", features = ["derive"] }
 bitflags = "1.2.1"

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -414,9 +414,9 @@ fn log_shader_error(source: &ProcessedShader, err: &AsModuleDescriptorError) {
         term,
     };
 
-    match source {
-        ProcessedShader::Wgsl(source) => match err {
-            AsModuleDescriptorError::ShaderReflectError(err) => match err {
+    if let ProcessedShader::Wgsl(source) = source {
+        if let AsModuleDescriptorError::ShaderReflectError(err) = err {
+            match err {
                 ShaderReflectError::WgslParse(parse) => {
                     let msg = parse.emit_to_string(source);
                     error!("failed to process shader:\n{}", msg);
@@ -446,9 +446,7 @@ fn log_shader_error(source: &ProcessedShader, err: &AsModuleDescriptorError) {
                 }
                 ShaderReflectError::GlslParse(_) => {}
                 ShaderReflectError::SpirVParse(_) => {}
-            },
-            _ => (),
-        },
-        _ => error!("failed to process shader: {}", err),
+            }
+        }
     }
 }

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -54,7 +54,16 @@ impl ShaderCache {
             .get(handle)
             .ok_or_else(|| RenderPipelineError::ShaderNotLoaded(handle.clone_weak()))?;
         let data = self.data.entry(handle.clone_weak()).or_default();
-        if shader.imports().len() != data.resolved_imports.len() {
+        let n_asset_imports = shader
+            .imports()
+            .filter(|import| matches!(import, ShaderImport::AssetPath(_)))
+            .count();
+        let n_resolved_asset_imports = data
+            .resolved_imports
+            .keys()
+            .filter(|import| matches!(import, ShaderImport::AssetPath(_)))
+            .count();
+        if n_asset_imports != n_resolved_asset_imports {
             return Err(RenderPipelineError::ShaderImportNotYetAvailable);
         }
 

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -2,7 +2,7 @@ use crate::{
     render_resource::{
         AsModuleDescriptorError, BindGroupLayout, BindGroupLayoutId, ProcessShaderError,
         RawFragmentState, RawRenderPipelineDescriptor, RawVertexState, RenderPipeline,
-        RenderPipelineDescriptor, Shader, ShaderImport, ShaderProcessor,
+        RenderPipelineDescriptor, Shader, ShaderImport, ShaderProcessor, ShaderReflectError,
     },
     renderer::RenderDevice,
     RenderWorld,
@@ -10,10 +10,12 @@ use crate::{
 use bevy_app::EventReader;
 use bevy_asset::{AssetEvent, Assets, Handle};
 use bevy_ecs::system::{Res, ResMut};
-use bevy_utils::{HashMap, HashSet};
+use bevy_utils::{tracing::error, HashMap, HashSet};
 use std::{collections::hash_map::Entry, hash::Hash, ops::Deref, sync::Arc};
 use thiserror::Error;
 use wgpu::{PipelineLayoutDescriptor, ShaderModule, VertexBufferLayout};
+
+use super::ProcessedShader;
 
 #[derive(Default)]
 pub struct ShaderData {
@@ -68,7 +70,12 @@ impl ShaderCache {
                     &self.shaders,
                     &self.import_path_shaders,
                 )?;
-                let module_descriptor = processed.get_module_descriptor()?;
+                let module_descriptor = match processed.get_module_descriptor() {
+                    Ok(module_descriptor) => module_descriptor,
+                    Err(err) => {
+                        return Err(RenderPipelineError::AsModuleDescriptorError(err, processed));
+                    }
+                };
                 entry.insert(Arc::new(
                     render_device.create_shader_module(&module_descriptor),
                 ))
@@ -206,8 +213,8 @@ pub enum RenderPipelineError {
     ShaderNotLoaded(Handle<Shader>),
     #[error(transparent)]
     ProcessShaderError(#[from] ProcessShaderError),
-    #[error(transparent)]
-    AsModuleDescriptorError(#[from] AsModuleDescriptorError),
+    #[error("{0}")]
+    AsModuleDescriptorError(AsModuleDescriptorError, ProcessedShader),
     #[error("Shader import not yet available.")]
     ShaderImportNotYetAvailable,
 }
@@ -274,9 +281,13 @@ impl RenderPipelineCache {
                     match err {
                         RenderPipelineError::ShaderNotLoaded(_)
                         | RenderPipelineError::ShaderImportNotYetAvailable => { /* retry */ }
-                        RenderPipelineError::ProcessShaderError(_)
-                        | RenderPipelineError::AsModuleDescriptorError(_) => {
-                            // shader could not be processed ... retrying won't help
+                        // shader could not be processed ... retrying won't help
+                        RenderPipelineError::ProcessShaderError(err) => {
+                            error!("failed to process shader: {}", err);
+                            continue;
+                        }
+                        RenderPipelineError::AsModuleDescriptorError(err, source) => {
+                            log_shader_error(source, err);
                             continue;
                         }
                     }
@@ -384,5 +395,51 @@ impl RenderPipelineCache {
                 AssetEvent::Removed { handle } => cache.remove_shader(handle),
             }
         }
+    }
+}
+
+fn log_shader_error(source: &ProcessedShader, err: &AsModuleDescriptorError) {
+    use codespan_reporting::{
+        diagnostic::{Diagnostic, Label},
+        files::SimpleFile,
+        term,
+    };
+
+    match source {
+        ProcessedShader::Wgsl(source) => match err {
+            AsModuleDescriptorError::ShaderReflectError(err) => match err {
+                ShaderReflectError::WgslParse(parse) => {
+                    let msg = parse.emit_to_string(source);
+                    error!("failed to process shader:\n{}", msg);
+                }
+                ShaderReflectError::Validation(error) => {
+                    let files = SimpleFile::new("wgsl", &source);
+                    let config = term::Config::default();
+                    let mut writer = term::termcolor::Ansi::new(Vec::new());
+
+                    let diagnostic = Diagnostic::error().with_labels(
+                        error
+                            .spans()
+                            .map(|(span, desc)| {
+                                Label::primary((), span.to_range().unwrap())
+                                    .with_message(desc.to_owned())
+                            })
+                            .collect(),
+                    );
+
+                    term::emit(&mut writer, &config, &files, &diagnostic)
+                        .expect("cannot write error");
+
+                    let msg = writer.into_inner();
+                    let msg = String::from_utf8_lossy(&msg);
+
+                    error!("failed to process shader: \n{}", msg);
+                }
+                ShaderReflectError::GlslParse(_) => {}
+                ShaderReflectError::SpirVParse(_) => {}
+            },
+            _ => (),
+        },
+        _ => error!("failed to process shader: {}", err),
     }
 }


### PR DESCRIPTION
### Problem
- shader processing errors are not displayed
- during hot reloading when encountering a shader with errors, the whole app crashes

### Solution
- log `error!`s for shader processing errors 
- when `cfg(debug_assertions)` is enabled (i.e. you're running in `debug` mode), parse shaders before passing them to wgpu. This lets us handle errors early.