### PR TITLE
[Merged by Bors] - enable Webgl2 optimisation in pbr under feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ x11 = ["bevy_internal/x11"]
 subpixel_glyph_atlas = ["bevy_internal/subpixel_glyph_atlas"]
 
 # Optimise for WebGL2
-webgl2 = ["bevy_internal/webgl2"]
+webgl = ["bevy_internal/webgl"]
 
 # enable systems that allow for automated testing on CI
 bevy_ci_testing = ["bevy_internal/bevy_ci_testing"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,15 +85,15 @@ x11 = ["bevy_internal/x11"]
 # enable rendering of font glyphs using subpixel accuracy
 subpixel_glyph_atlas = ["bevy_internal/subpixel_glyph_atlas"]
 
-# Optimise for WebGL2
-webgl = ["bevy_internal/webgl"]
-
 # enable systems that allow for automated testing on CI
 bevy_ci_testing = ["bevy_internal/bevy_ci_testing"]
 
 [dependencies]
 bevy_dylib = { path = "crates/bevy_dylib", version = "0.5.0", default-features = false, optional = true }
 bevy_internal = { path = "crates/bevy_internal", version = "0.5.0", default-features = false }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+bevy_internal = { path = "crates/bevy_internal", version = "0.5.0", default-features = false, features = ["webgl"] }
 
 [dev-dependencies]
 anyhow = "1.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,9 @@ x11 = ["bevy_internal/x11"]
 # enable rendering of font glyphs using subpixel accuracy
 subpixel_glyph_atlas = ["bevy_internal/subpixel_glyph_atlas"]
 
+# Optimise for WebGL2
+webgl2 = ["bevy_internal/webgl2"]
+
 # enable systems that allow for automated testing on CI
 bevy_ci_testing = ["bevy_internal/bevy_ci_testing"]
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -41,6 +41,9 @@ x11 = ["bevy_winit/x11"]
 # enable rendering of font glyphs using subpixel accuracy
 subpixel_glyph_atlas = ["bevy_text/subpixel_glyph_atlas"]
 
+# Optimise for WebGL2
+webgl2 = ["bevy_pbr/webgl2"]
+
 # enable systems that allow for automated testing on CI
 bevy_ci_testing = ["bevy_app/bevy_ci_testing", "bevy_render/ci_limits"]
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -42,7 +42,7 @@ x11 = ["bevy_winit/x11"]
 subpixel_glyph_atlas = ["bevy_text/subpixel_glyph_atlas"]
 
 # Optimise for WebGL2
-webgl2 = ["bevy_pbr/webgl2"]
+webgl = ["bevy_pbr/webgl"]
 
 # enable systems that allow for automated testing on CI
 bevy_ci_testing = ["bevy_app/bevy_ci_testing", "bevy_render/ci_limits"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -42,7 +42,7 @@ x11 = ["bevy_winit/x11"]
 subpixel_glyph_atlas = ["bevy_text/subpixel_glyph_atlas"]
 
 # Optimise for WebGL2
-webgl = ["bevy_pbr/webgl"]
+webgl = ["bevy_pbr/webgl", "bevy_render/webgl"]
 
 # enable systems that allow for automated testing on CI
 bevy_ci_testing = ["bevy_app/bevy_ci_testing", "bevy_render/ci_limits"]

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-webgl2 = []
+webgl = []
 
 [dependencies]
 # bevy

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
+[features]
+default = []
+webgl2 = []
+
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.5.0" }

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = []
 webgl2 = []
 
 [dependencies]

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -151,7 +151,10 @@ pub struct DirectionalLightShadowMap {
 
 impl Default for DirectionalLightShadowMap {
     fn default() -> Self {
-        Self { size: 4096 }
+        #[cfg(feature = "webgl2")]
+        return Self { size: 4096 };
+        #[cfg(not(feature = "webgl2"))]
+        return Self { size: 2048 };
     }
 }
 

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -151,10 +151,10 @@ pub struct DirectionalLightShadowMap {
 
 impl Default for DirectionalLightShadowMap {
     fn default() -> Self {
-        #[cfg(feature = "webgl2")]
-        return Self { size: 4096 };
-        #[cfg(not(feature = "webgl2"))]
+        #[cfg(feature = "webgl")]
         return Self { size: 2048 };
+        #[cfg(not(feature = "webgl"))]
+        return Self { size: 4096 };
     }
 }
 

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -600,7 +600,7 @@ pub fn prepare_lights(
             .shadows_enabled
             .cmp(&light_2.shadows_enabled)
             .reverse()
-            .then_with(|| entity_1.cmp(&entity_2))
+            .then_with(|| entity_1.cmp(entity_2))
     });
 
     if global_light_meta.entity_to_index.capacity() < point_lights.len() {

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -142,6 +142,9 @@ pub struct GpuLights {
 pub const MAX_POINT_LIGHTS: usize = 256;
 // FIXME: How should we handle shadows for clustered forward? Limiting to maximum 10
 // point light shadow maps for now
+#[cfg(feature = "webgl2")]
+pub const MAX_POINT_LIGHT_SHADOW_MAPS: usize = 1;
+#[cfg(not(feature = "webgl2"))]
 pub const MAX_POINT_LIGHT_SHADOW_MAPS: usize = 10;
 pub const MAX_DIRECTIONAL_LIGHTS: usize = 1;
 pub const POINT_SHADOW_LAYERS: u32 = (6 * MAX_POINT_LIGHT_SHADOW_MAPS) as u32;

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -833,7 +833,10 @@ pub fn prepare_lights(
                 .create_view(&TextureViewDescriptor {
                     label: Some("point_light_shadow_map_array_texture_view"),
                     format: None,
+                    #[cfg(not(feature = "webgl2"))]
                     dimension: Some(TextureViewDimension::CubeArray),
+                    #[cfg(feature = "webgl2")]
+                    dimension: Some(TextureViewDimension::Cube),
                     aspect: TextureAspect::All,
                     base_mip_level: 0,
                     mip_level_count: None,
@@ -845,7 +848,10 @@ pub fn prepare_lights(
             .create_view(&TextureViewDescriptor {
                 label: Some("directional_light_shadow_map_array_texture_view"),
                 format: None,
+                #[cfg(not(feature = "webgl2"))]
                 dimension: Some(TextureViewDimension::D2Array),
+                #[cfg(feature = "webgl2")]
+                dimension: Some(TextureViewDimension::D2),
                 aspect: TextureAspect::All,
                 base_mip_level: 0,
                 mip_level_count: None,

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -142,9 +142,9 @@ pub struct GpuLights {
 pub const MAX_POINT_LIGHTS: usize = 256;
 // FIXME: How should we handle shadows for clustered forward? Limiting to maximum 10
 // point light shadow maps for now
-#[cfg(feature = "webgl2")]
+#[cfg(feature = "webgl")]
 pub const MAX_POINT_LIGHT_SHADOW_MAPS: usize = 1;
-#[cfg(not(feature = "webgl2"))]
+#[cfg(not(feature = "webgl"))]
 pub const MAX_POINT_LIGHT_SHADOW_MAPS: usize = 10;
 pub const MAX_DIRECTIONAL_LIGHTS: usize = 1;
 pub const POINT_SHADOW_LAYERS: u32 = (6 * MAX_POINT_LIGHT_SHADOW_MAPS) as u32;
@@ -833,9 +833,9 @@ pub fn prepare_lights(
                 .create_view(&TextureViewDescriptor {
                     label: Some("point_light_shadow_map_array_texture_view"),
                     format: None,
-                    #[cfg(not(feature = "webgl2"))]
+                    #[cfg(not(feature = "webgl"))]
                     dimension: Some(TextureViewDimension::CubeArray),
-                    #[cfg(feature = "webgl2")]
+                    #[cfg(feature = "webgl")]
                     dimension: Some(TextureViewDimension::Cube),
                     aspect: TextureAspect::All,
                     base_mip_level: 0,
@@ -848,9 +848,9 @@ pub fn prepare_lights(
             .create_view(&TextureViewDescriptor {
                 label: Some("directional_light_shadow_map_array_texture_view"),
                 format: None,
-                #[cfg(not(feature = "webgl2"))]
+                #[cfg(not(feature = "webgl"))]
                 dimension: Some(TextureViewDimension::D2Array),
-                #[cfg(feature = "webgl2")]
+                #[cfg(feature = "webgl")]
                 dimension: Some(TextureViewDimension::D2),
                 aspect: TextureAspect::All,
                 base_mip_level: 0,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -202,7 +202,10 @@ impl FromWorld for MeshPipeline {
                     ty: BindingType::Texture {
                         multisampled: false,
                         sample_type: TextureSampleType::Depth,
+                        #[cfg(not(feature = "webgl2"))]
                         view_dimension: TextureViewDimension::CubeArray,
+                        #[cfg(feature = "webgl2")]
+                        view_dimension: TextureViewDimension::Cube,
                     },
                     count: None,
                 },
@@ -220,7 +223,10 @@ impl FromWorld for MeshPipeline {
                     ty: BindingType::Texture {
                         multisampled: false,
                         sample_type: TextureSampleType::Depth,
+                        #[cfg(not(feature = "webgl2"))]
                         view_dimension: TextureViewDimension::D2Array,
+                        #[cfg(feature = "webgl2")]
+                        view_dimension: TextureViewDimension::D2,
                     },
                     count: None,
                 },
@@ -484,6 +490,9 @@ impl SpecializedPipeline for MeshPipeline {
             // depth buffer
             depth_write_enabled = true;
         }
+
+        #[cfg(feature = "webgl2")]
+        shader_defs.push(String::from("NO_ARRAY_TEXTURES_SUPPORT"));
 
         RenderPipelineDescriptor {
             vertex: VertexState {

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -202,9 +202,9 @@ impl FromWorld for MeshPipeline {
                     ty: BindingType::Texture {
                         multisampled: false,
                         sample_type: TextureSampleType::Depth,
-                        #[cfg(not(feature = "webgl2"))]
+                        #[cfg(not(feature = "webgl"))]
                         view_dimension: TextureViewDimension::CubeArray,
-                        #[cfg(feature = "webgl2")]
+                        #[cfg(feature = "webgl")]
                         view_dimension: TextureViewDimension::Cube,
                     },
                     count: None,
@@ -223,9 +223,9 @@ impl FromWorld for MeshPipeline {
                     ty: BindingType::Texture {
                         multisampled: false,
                         sample_type: TextureSampleType::Depth,
-                        #[cfg(not(feature = "webgl2"))]
+                        #[cfg(not(feature = "webgl"))]
                         view_dimension: TextureViewDimension::D2Array,
-                        #[cfg(feature = "webgl2")]
+                        #[cfg(feature = "webgl")]
                         view_dimension: TextureViewDimension::D2,
                     },
                     count: None,
@@ -491,7 +491,7 @@ impl SpecializedPipeline for MeshPipeline {
             depth_write_enabled = true;
         }
 
-        #[cfg(feature = "webgl2")]
+        #[cfg(feature = "webgl")]
         shader_defs.push(String::from("NO_ARRAY_TEXTURES_SUPPORT"));
 
         RenderPipelineDescriptor {

--- a/crates/bevy_pbr/src/render/mesh_view_bind_group.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bind_group.wgsl
@@ -73,12 +73,22 @@ struct ClusterOffsetsAndCounts {
 var<uniform> view: View;
 [[group(0), binding(1)]]
 var<uniform> lights: Lights;
+#ifdef NO_ARRAY_TEXTURES_SUPPORT
+[[group(0), binding(2)]]
+var point_shadow_textures: texture_depth_cube;
+#else
 [[group(0), binding(2)]]
 var point_shadow_textures: texture_depth_cube_array;
+#endif
 [[group(0), binding(3)]]
 var point_shadow_textures_sampler: sampler_comparison;
+#ifdef NO_ARRAY_TEXTURES_SUPPORT
+[[group(0), binding(4)]]
+var directional_shadow_textures: texture_depth_2d;
+#else
 [[group(0), binding(4)]]
 var directional_shadow_textures: texture_depth_2d_array;
+#endif
 [[group(0), binding(5)]]
 var directional_shadow_textures_sampler: sampler_comparison;
 [[group(0), binding(6)]]

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -381,7 +381,11 @@ fn fetch_point_shadow(light_id: u32, frag_position: vec4<f32>, surface_normal: v
     // a quad (2x2 fragments) being processed not being sampled, and this messing with
     // mip-mapping functionality. The shadow maps have no mipmaps so Level just samples
     // from LOD 0.
+#ifdef NO_ARRAY_TEXTURES_SUPPORT
+    return textureSampleCompare(point_shadow_textures, point_shadow_textures_sampler, frag_ls, depth);
+#else
     return textureSampleCompareLevel(point_shadow_textures, point_shadow_textures_sampler, frag_ls, i32(light_id), depth);
+#endif
 }
 
 fn fetch_directional_shadow(light_id: u32, frag_position: vec4<f32>, surface_normal: vec3<f32>) -> f32 {
@@ -412,7 +416,11 @@ fn fetch_directional_shadow(light_id: u32, frag_position: vec4<f32>, surface_nor
     // do the lookup, using HW PCF and comparison
     // NOTE: Due to non-uniform control flow above, we must use the level variant of the texture
     // sampler to avoid use of implicit derivatives causing possible undefined behavior.
+#ifdef NO_ARRAY_TEXTURES_SUPPORT
+    return textureSampleCompareLevel(directional_shadow_textures, directional_shadow_textures_sampler, light_local, depth);
+#else
     return textureSampleCompareLevel(directional_shadow_textures, directional_shadow_textures_sampler, light_local, i32(light_id), depth);
+#endif
 }
 
 fn hsv2rgb(hue: f32, saturation: f32, value: f32) -> vec3<f32> {

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -18,6 +18,7 @@ bmp = ["image/bmp"]
 trace = []
 wgpu_trace = ["wgpu/trace"]
 ci_limits = []
+webgl = ["wgpu/webgl"]
 
 [dependencies]
 # bevy
@@ -51,6 +52,3 @@ hexasphere = "6.0.0"
 parking_lot = "0.11.0"
 regex = "1.5"
 crevice = { path = "../crevice", version = "0.8.0", features = ["glam"] }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-wgpu = { version = "0.12.0", features = ["spirv", "webgl"] }

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -629,7 +629,7 @@ impl RenderAsset for Mesh {
 
         let index_info = mesh.get_index_buffer_bytes().map(|data| GpuIndexInfo {
             buffer: render_device.create_buffer_with_data(&BufferInitDescriptor {
-                usage: BufferUsages::INDEX | BufferUsages::MAP_WRITE,
+                usage: BufferUsages::INDEX,
                 contents: data,
                 label: Some("Mesh Index Buffer"),
             }),

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -623,15 +623,15 @@ impl RenderAsset for Mesh {
         let vertex_buffer_data = mesh.get_vertex_buffer_data();
         let vertex_buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
             usage: BufferUsages::VERTEX,
-            label: None,
+            label: Some("Mesh Vertex Buffer"),
             contents: &vertex_buffer_data,
         });
 
         let index_info = mesh.get_index_buffer_bytes().map(|data| GpuIndexInfo {
             buffer: render_device.create_buffer_with_data(&BufferInitDescriptor {
-                usage: BufferUsages::INDEX,
+                usage: BufferUsages::INDEX | BufferUsages::MAP_WRITE,
                 contents: data,
-                label: None,
+                label: Some("Mesh Index Buffer"),
             }),
             count: mesh.indices().unwrap().len() as u32,
             index_format: mesh.indices().unwrap().into(),

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -72,7 +72,6 @@ pub async fn initialize_renderer(
         .await
         .expect("Unable to find a GPU! Make sure you have installed required drivers!");
 
-    #[cfg(not(target_arch = "wasm32"))]
     info!("{:?}", adapter.get_info());
 
     #[cfg(feature = "wgpu_trace")]

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -44,12 +44,18 @@ pub struct Msaa {
     /// smoother edges. Note that WGPU currently only supports 1 or 4 samples.
     /// Ultimately we plan on supporting whatever is natively supported on a given device.
     /// Check out this issue for more info: <https://github.com/gfx-rs/wgpu/issues/1832>
+    /// It defaults to 1 in wasm - https://github.com/gfx-rs/wgpu/issues/2149     
     pub samples: u32,
 }
 
 impl Default for Msaa {
     fn default() -> Self {
-        Self { samples: 4 }
+        Self {
+            #[cfg(feature = "webgl")]
+            samples: 1,
+            #[cfg(not(feature = "webgl"))]
+            samples: 4,
+        }
     }
 }
 

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -44,7 +44,7 @@ pub struct Msaa {
     /// smoother edges. Note that WGPU currently only supports 1 or 4 samples.
     /// Ultimately we plan on supporting whatever is natively supported on a given device.
     /// Check out this issue for more info: <https://github.com/gfx-rs/wgpu/issues/1832>
-    /// It defaults to 1 in wasm - https://github.com/gfx-rs/wgpu/issues/2149     
+    /// It defaults to 1 in wasm - <https://github.com/gfx-rs/wgpu/issues/2149>
     pub samples: u32,
 }
 

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -34,6 +34,5 @@
 |vorbis|Vorbis audio format support.|
 |serialize|Enables serialization of `bevy_input` types.|
 |wayland|Enable this to use Wayland display server protocol other than X11.|
-|webgl|Enable this to use WebGL2 optimised code.|
 |subpixel_glyph_atlas|Enable this to cache glyphs using subpixel accuracy. This increases texture memory usage as each position requires a separate sprite in the glyph atlas, but provide more accurate character spacing.|
 |bevy_ci_testing|Used for running examples in CI.|

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -34,5 +34,6 @@
 |vorbis|Vorbis audio format support.|
 |serialize|Enables serialization of `bevy_input` types.|
 |wayland|Enable this to use Wayland display server protocol other than X11.|
+|webgl2|Enable this to use WebGL2 optimised code.|
 |subpixel_glyph_atlas|Enable this to cache glyphs using subpixel accuracy. This increases texture memory usage as each position requires a separate sprite in the glyph atlas, but provide more accurate character spacing.|
 |bevy_ci_testing|Used for running examples in CI.|

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -34,6 +34,6 @@
 |vorbis|Vorbis audio format support.|
 |serialize|Enables serialization of `bevy_input` types.|
 |wayland|Enable this to use Wayland display server protocol other than X11.|
-|webgl2|Enable this to use WebGL2 optimised code.|
+|webgl|Enable this to use WebGL2 optimised code.|
 |subpixel_glyph_atlas|Enable this to cache glyphs using subpixel accuracy. This increases texture memory usage as each position requires a separate sprite in the glyph atlas, but provide more accurate character spacing.|
 |bevy_ci_testing|Used for running examples in CI.|


### PR DESCRIPTION
# Objective

- 3d examples fail to run in webgl2 because of unsupported texture formats or texture too large

## Solution

- switch to supported formats if a feature is enabled. I choose a feature instead of a build target to not conflict with a potential webgpu support

Very inspired by https://github.com/superdump/bevy/commit/6813b2edc5eb5833b11bb7b4f01a3c662d1953e2, and need #3290 to work.

I named the feature `webgl2`, but it's only needed if one want to use PBR in webgl2. Examples using only 2D already work.