### PR TITLE
[Merged by Bors] - Implement the `Overflow::Hidden` style property for UI

### DIFF
--- a/crates/bevy_sprite/src/rect.rs
+++ b/crates/bevy_sprite/src/rect.rs
@@ -1,9 +1,10 @@
 use bevy_math::Vec2;
+use bevy_reflect::Reflect;
 
 /// A rectangle defined by two points. There is no defined origin, so 0,0 could be anywhere
 /// (top-left, bottom-left, etc)
 #[repr(C)]
-#[derive(Default, Clone, Copy, Debug)]
+#[derive(Default, Clone, Copy, Debug, Reflect)]
 pub struct Rect {
     /// The beginning point of the rect
     pub min: Vec2,

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -26,7 +26,7 @@ use bevy_ecs::schedule::{ParallelSystemDescriptorCoercion, SystemLabel};
 use bevy_input::InputSystem;
 use bevy_math::{Rect, Size};
 use bevy_transform::TransformSystem;
-use update::ui_z_system;
+use update::{ui_z_system, update_clipping_system};
 
 #[derive(Default)]
 pub struct UiPlugin;
@@ -89,6 +89,10 @@ impl Plugin for UiPlugin {
                 ui_z_system
                     .after(UiSystem::Flex)
                     .before(TransformSystem::TransformPropagate),
+            )
+            .add_system_to_stage(
+                CoreStage::PostUpdate,
+                update_clipping_system.after(TransformSystem::TransformPropagate),
             );
 
         crate::render::build_ui_render(app);

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -76,6 +76,7 @@ pub struct Style {
     pub min_size: Size<Val>,
     pub max_size: Size<Val>,
     pub aspect_ratio: Option<f32>,
+    pub overflow: Overflow,
 }
 
 impl Default for Style {
@@ -101,6 +102,7 @@ impl Default for Style {
             min_size: Size::new(Val::Auto, Val::Auto),
             max_size: Size::new(Val::Auto, Val::Auto),
             aspect_ratio: Default::default(),
+            overflow: Default::default(),
         }
     }
 }
@@ -214,19 +216,19 @@ impl Default for JustifyContent {
     }
 }
 
-// TODO: add support for overflow settings
-// #[derive(Copy, Clone, PartialEq, Debug)]
-// pub enum Overflow {
-//     Visible,
-//     Hidden,
-//     Scroll,
-// }
+#[derive(Copy, Clone, PartialEq, Debug, Reflect, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Serialize, Deserialize)]
+pub enum Overflow {
+    Visible,
+    Hidden,
+    // Scroll,
+}
 
-// impl Default for Overflow {
-//     fn default() -> Overflow {
-//         Overflow::Visible
-//     }
-// }
+impl Default for Overflow {
+    fn default() -> Overflow {
+        Overflow::Visible
+    }
+}
 
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
 #[reflect_value(PartialEq, Serialize, Deserialize)]
@@ -285,4 +287,10 @@ impl From<Handle<Image>> for UiImage {
     fn from(handle: Handle<Image>) -> Self {
         Self(handle)
     }
+}
+
+#[derive(Component, Default, Copy, Clone, Debug, Reflect)]
+#[reflect(Component)]
+pub struct CalculatedClip {
+    pub clip: bevy_sprite::Rect,
 }

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -1,10 +1,17 @@
+use crate::{CalculatedClip, Overflow, Style};
+
 use super::Node;
 use bevy_ecs::{
     entity::Entity,
     query::{With, Without},
-    system::Query,
+    system::{Commands, Query},
 };
-use bevy_transform::prelude::{Children, Parent, Transform};
+use bevy_math::Vec2;
+use bevy_sprite::Rect;
+use bevy_transform::{
+    components::GlobalTransform,
+    prelude::{Children, Parent, Transform},
+};
 
 pub const UI_Z_STEP: f32 = 0.001;
 
@@ -50,6 +57,73 @@ fn update_hierarchy(
     }
     current_global_z
 }
+
+pub fn update_clipping_system(
+    mut commands: Commands,
+    root_node_query: Query<Entity, (With<Node>, Without<Parent>)>,
+    mut node_query: Query<(&Node, &GlobalTransform, &Style, Option<&mut CalculatedClip>)>,
+    children_query: Query<&Children>,
+) {
+    for root_node in root_node_query.iter() {
+        update_clipping(
+            &mut commands,
+            &children_query,
+            &mut node_query,
+            root_node,
+            None,
+        )
+    }
+}
+
+fn update_clipping(
+    commands: &mut Commands,
+    children_query: &Query<&Children>,
+    node_query: &mut Query<(&Node, &GlobalTransform, &Style, Option<&mut CalculatedClip>)>,
+    entity: Entity,
+    clip: Option<Rect>,
+) {
+    let (node, global_transform, style, calculated_clip) = node_query.get_mut(entity).unwrap();
+    // Update this node's CalculatedClip component
+    match (clip, calculated_clip) {
+        (None, None) => {}
+        (None, Some(_)) => {
+            commands.entity(entity).remove::<CalculatedClip>();
+        }
+        (Some(clip), None) => {
+            commands.entity(entity).insert(CalculatedClip { clip });
+        }
+        (Some(clip), Some(mut old_clip)) => {
+            *old_clip = CalculatedClip { clip };
+        }
+    }
+
+    // Calculate new clip for its children
+    let children_clip = match style.overflow {
+        Overflow::Visible => clip,
+        Overflow::Hidden => {
+            let node_center = global_transform.translation.truncate();
+            let node_rect = Rect {
+                min: node_center - node.size / 2.,
+                max: node_center + node.size / 2.,
+            };
+            if let Some(clip) = clip {
+                Some(Rect {
+                    min: Vec2::max(clip.min, node_rect.min),
+                    max: Vec2::min(clip.max, node_rect.max),
+                })
+            } else {
+                Some(node_rect)
+            }
+        }
+    };
+
+    if let Ok(children) = children_query.get(entity) {
+        for child in children.iter().cloned() {
+            update_clipping(commands, children_query, node_query, child, children_clip);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use bevy_ecs::{

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -1,10 +1,14 @@
-use bevy::prelude::*;
+use bevy::{
+    input::mouse::{MouseScrollUnit, MouseWheel},
+    prelude::*,
+};
 
 /// This example illustrates the various features of Bevy UI.
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
+        .add_system(mouse_scroll)
         .run();
 }
 
@@ -68,14 +72,97 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         });
                 });
             // right vertical fill
-            parent.spawn_bundle(NodeBundle {
-                style: Style {
-                    size: Size::new(Val::Px(200.0), Val::Percent(100.0)),
+            parent
+                .spawn_bundle(NodeBundle {
+                    style: Style {
+                        flex_direction: FlexDirection::ColumnReverse,
+                        justify_content: JustifyContent::Center,
+                        size: Size::new(Val::Px(200.0), Val::Percent(100.0)),
+                        ..Default::default()
+                    },
+                    color: Color::rgb(0.15, 0.15, 0.15).into(),
                     ..Default::default()
-                },
-                color: Color::rgb(0.15, 0.15, 0.15).into(),
-                ..Default::default()
-            });
+                })
+                .with_children(|parent| {
+                    // Title
+                    parent.spawn_bundle(TextBundle {
+                        style: Style {
+                            size: Size::new(Val::Undefined, Val::Px(25.)),
+                            margin: Rect {
+                                left: Val::Auto,
+                                right: Val::Auto,
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        },
+                        text: Text::with_section(
+                            "Scrolling list",
+                            TextStyle {
+                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                font_size: 25.,
+                                color: Color::WHITE,
+                            },
+                            Default::default(),
+                        ),
+                        ..Default::default()
+                    });
+                    // List with hidden overflow
+                    parent
+                        .spawn_bundle(NodeBundle {
+                            style: Style {
+                                flex_direction: FlexDirection::ColumnReverse,
+                                align_self: AlignSelf::Center,
+                                size: Size::new(Val::Percent(100.0), Val::Percent(50.0)),
+                                overflow: Overflow::Hidden,
+                                ..Default::default()
+                            },
+                            color: Color::rgb(0.10, 0.10, 0.10).into(),
+                            ..Default::default()
+                        })
+                        .with_children(|parent| {
+                            // Moving panel
+                            parent
+                                .spawn_bundle(NodeBundle {
+                                    style: Style {
+                                        flex_direction: FlexDirection::ColumnReverse,
+                                        flex_grow: 1.0,
+                                        max_size: Size::new(Val::Undefined, Val::Undefined),
+                                        ..Default::default()
+                                    },
+                                    color: Color::NONE.into(),
+                                    ..Default::default()
+                                })
+                                .insert(ScrollingList::default())
+                                .with_children(|parent| {
+                                    // List items
+                                    for i in 0..30 {
+                                        parent.spawn_bundle(TextBundle {
+                                            style: Style {
+                                                flex_shrink: 0.,
+                                                size: Size::new(Val::Undefined, Val::Px(20.)),
+                                                margin: Rect {
+                                                    left: Val::Auto,
+                                                    right: Val::Auto,
+                                                    ..Default::default()
+                                                },
+                                                ..Default::default()
+                                            },
+                                            text: Text::with_section(
+                                                format!("Item {}", i),
+                                                TextStyle {
+                                                    font: asset_server
+                                                        .load("fonts/FiraSans-Bold.ttf"),
+                                                    font_size: 20.,
+                                                    color: Color::WHITE,
+                                                },
+                                                Default::default(),
+                                            ),
+                                            ..Default::default()
+                                        });
+                                    }
+                                });
+                        });
+                });
             // absolute positioning
             parent
                 .spawn_bundle(NodeBundle {
@@ -211,4 +298,33 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     });
                 });
         });
+}
+
+#[derive(Component, Default)]
+struct ScrollingList {
+    position: f32,
+}
+
+fn mouse_scroll(
+    mut mouse_wheel_events: EventReader<MouseWheel>,
+    mut query_list: Query<(&mut ScrollingList, &mut Style, &Children, &Node)>,
+    query_item: Query<&Node>,
+) {
+    for mouse_wheel_event in mouse_wheel_events.iter() {
+        for (mut scrolling_list, mut style, children, uinode) in query_list.iter_mut() {
+            let items_height: f32 = children
+                .iter()
+                .map(|entity| query_item.get(*entity).unwrap().size.y)
+                .sum();
+            let panel_height = uinode.size.y;
+            let max_scroll = (items_height - panel_height).max(0.);
+            let dy = match mouse_wheel_event.unit {
+                MouseScrollUnit::Line => mouse_wheel_event.y * 20.,
+                MouseScrollUnit::Pixel => mouse_wheel_event.y,
+            };
+            scrolling_list.position += dy;
+            scrolling_list.position = scrolling_list.position.clamp(-max_scroll, 0.);
+            style.position.top = Val::Px(scrolling_list.position);
+        }
+    }
 }


### PR DESCRIPTION
# Objective

This PR implements the `overflow` style property in `bevy_ui`. When set to `Overflow::Hidden`, the children of that node are clipped so that overflowing parts are not rendered. This is an important building block for UI widgets.

## Solution

Clipping is done on the CPU so that it does not break batching.

The clip regions update was implemented as a separate system for clarity, but it could be merged with the other UI systems to avoid doing an additional tree traversal. (I don't think it's important until we fix the layout performance issues though).

A scrolling list was added to the `ui_pipelined` example to showcase `Overflow::Hidden`. For the sake of simplicity, it can only be scrolled with a mouse.