### PR TITLE
[Merged by Bors] - Deprecate `.system`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -418,7 +418,7 @@ impl App {
     /// }
     ///
     /// App::new()
-    ///     .add_startup_system(my_startup_system.system());
+    ///     .add_startup_system(my_startup_system);
     /// ```
     pub fn add_startup_system<Params>(
         &mut self,

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -556,6 +556,7 @@ pub fn free_unused_assets_system(asset_server: Res<AssetServer>) {
 mod test {
     use super::*;
     use crate::{loader::LoadedAsset, update_asset_storage_system};
+    use bevy_app::App;
     use bevy_ecs::prelude::*;
     use bevy_reflect::TypeUuid;
     use bevy_utils::BoxedFuture;
@@ -769,21 +770,13 @@ mod test {
         asset_server.add_loader(FakePngLoader);
         let assets = asset_server.register_asset_type::<PngAsset>();
 
-        let mut world = World::new();
-        world.insert_resource(assets);
-        world.insert_resource(asset_server);
-
-        let mut tick = {
-            let mut free_unused_assets_system = free_unused_assets_system.system();
-            free_unused_assets_system.initialize(&mut world);
-            let mut update_asset_storage_system = update_asset_storage_system::<PngAsset>.system();
-            update_asset_storage_system.initialize(&mut world);
-
-            move |world: &mut World| {
-                free_unused_assets_system.run((), world);
-                update_asset_storage_system.run((), world);
-            }
-        };
+        #[derive(SystemLabel, Clone, Hash, Debug, PartialEq, Eq)]
+        struct FreeUnusedAssets;
+        let mut app = App::new();
+        app.insert_resource(assets);
+        app.insert_resource(asset_server);
+        app.add_system(free_unused_assets_system.label(FreeUnusedAssets));
+        app.add_system(update_asset_storage_system::<PngAsset>.after(FreeUnusedAssets));
 
         fn load_asset(path: AssetPath, world: &World) -> HandleUntyped {
             let asset_server = world.get_resource::<AssetServer>().unwrap();
@@ -811,37 +804,43 @@ mod test {
         // ---
 
         let path: AssetPath = "fake.png".into();
-        assert_eq!(LoadState::NotLoaded, get_load_state(path.get_id(), &world));
+        assert_eq!(
+            LoadState::NotLoaded,
+            get_load_state(path.get_id(), &app.world)
+        );
 
         // load the asset
-        let handle = load_asset(path.clone(), &world);
+        let handle = load_asset(path.clone(), &app.world);
         let weak_handle = handle.clone_weak();
 
         // asset is loading
-        assert_eq!(LoadState::Loading, get_load_state(&handle, &world));
+        assert_eq!(LoadState::Loading, get_load_state(&handle, &app.world));
 
-        tick(&mut world);
+        app.update();
         // asset should exist and be loaded at this point
-        assert_eq!(LoadState::Loaded, get_load_state(&handle, &world));
-        assert!(get_asset(&handle, &world).is_some());
+        assert_eq!(LoadState::Loaded, get_load_state(&handle, &app.world));
+        assert!(get_asset(&handle, &app.world).is_some());
 
         // after dropping the handle, next call to `tick` will prepare the assets for removal.
         drop(handle);
-        tick(&mut world);
-        assert_eq!(LoadState::Loaded, get_load_state(&weak_handle, &world));
-        assert!(get_asset(&weak_handle, &world).is_some());
+        app.update();
+        assert_eq!(LoadState::Loaded, get_load_state(&weak_handle, &app.world));
+        assert!(get_asset(&weak_handle, &app.world).is_some());
 
         // second call to tick will actually remove the asset.
-        tick(&mut world);
-        assert_eq!(LoadState::Unloaded, get_load_state(&weak_handle, &world));
-        assert!(get_asset(&weak_handle, &world).is_none());
+        app.update();
+        assert_eq!(
+            LoadState::Unloaded,
+            get_load_state(&weak_handle, &app.world)
+        );
+        assert!(get_asset(&weak_handle, &app.world).is_none());
 
         // finally, reload the asset
-        let handle = load_asset(path.clone(), &world);
-        assert_eq!(LoadState::Loading, get_load_state(&handle, &world));
-        tick(&mut world);
-        assert_eq!(LoadState::Loaded, get_load_state(&handle, &world));
-        assert!(get_asset(&handle, &world).is_some());
+        let handle = load_asset(path.clone(), &app.world);
+        assert_eq!(LoadState::Loading, get_load_state(&handle, &app.world));
+        app.update();
+        assert_eq!(LoadState::Loaded, get_load_state(&handle, &app.world));
+        assert!(get_asset(&handle, &app.world).is_some());
     }
 
     #[test]

--- a/crates/bevy_core/src/time/fixed_timestep.rs
+++ b/crates/bevy_core/src/time/fixed_timestep.rs
@@ -79,7 +79,7 @@ impl Default for FixedTimestep {
     fn default() -> Self {
         Self {
             state: LocalFixedTimestepState::default(),
-            internal_system: Box::new(Self::prepare_system.system()),
+            internal_system: Box::new(IntoSystem::into_system(Self::prepare_system)),
         }
     }
 }

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -806,7 +806,7 @@ impl<'w, 's, T: Fetch<'w, 's>> Fetch<'w, 's> for OptionFetch<T> {
 ///         }
 ///     }
 /// }
-/// # IntoSystem::into_system(print_moving_objects_system);
+/// # bevy_ecs::system::assert_is_system(print_moving_objects_system);
 /// ```
 #[derive(Clone)]
 pub struct ChangeTrackers<T: Component> {

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -806,7 +806,7 @@ impl<'w, 's, T: Fetch<'w, 's>> Fetch<'w, 's> for OptionFetch<T> {
 ///         }
 ///     }
 /// }
-/// # print_moving_objects_system.system();
+/// # IntoSystem::into_system(print_moving_objects_system);
 /// ```
 #[derive(Clone)]
 pub struct ChangeTrackers<T: Component> {

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -65,7 +65,7 @@ where
 ///         println!("{} is looking lovely today!", name.name);
 ///     }
 /// }
-/// # IntoSystem::into_system(compliment_entity_system);
+/// # bevy_ecs::system::assert_is_system(compliment_entity_system);
 /// ```
 pub struct With<T>(PhantomData<T>);
 
@@ -188,7 +188,7 @@ unsafe impl<T> ReadOnlyFetch for WithFetch<T> {}
 ///         println!("{} has no permit!", name.name);
 ///     }
 /// }
-/// # IntoSystem::into_system(no_permit_system);
+/// # bevy_ecs::system::assert_is_system(no_permit_system);
 /// ```
 pub struct Without<T>(PhantomData<T>);
 
@@ -317,7 +317,7 @@ unsafe impl<T> ReadOnlyFetch for WithoutFetch<T> {}
 ///         println!("Entity {:?} got a new style or color", entity);
 ///     }
 /// }
-/// # IntoSystem::into_system(print_cool_entity_system);
+/// # bevy_ecs::system::assert_is_system(print_cool_entity_system);
 /// ```
 pub struct Or<T>(pub T);
 
@@ -619,7 +619,7 @@ impl_tick_filter!(
     ///     }
     /// }
     ///
-    /// # IntoSystem::into_system(print_add_name_component);
+    /// # bevy_ecs::system::assert_is_system(print_add_name_component);
     /// ```
     Added,
     /// The [`FetchState`] of [`Added`].
@@ -662,7 +662,7 @@ impl_tick_filter!(
     ///     }
     /// }
     ///
-    /// # IntoSystem::into_system(print_moving_objects_system);
+    /// # bevy_ecs::system::assert_is_system(print_moving_objects_system);
     /// ```
     Changed,
     /// The [`FetchState`] of [`Changed`].

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -65,7 +65,7 @@ where
 ///         println!("{} is looking lovely today!", name.name);
 ///     }
 /// }
-/// # compliment_entity_system.system();
+/// # IntoSystem::into_system(compliment_entity_system);
 /// ```
 pub struct With<T>(PhantomData<T>);
 
@@ -188,7 +188,7 @@ unsafe impl<T> ReadOnlyFetch for WithFetch<T> {}
 ///         println!("{} has no permit!", name.name);
 ///     }
 /// }
-/// # no_permit_system.system();
+/// # IntoSystem::into_system(no_permit_system);
 /// ```
 pub struct Without<T>(PhantomData<T>);
 
@@ -317,7 +317,7 @@ unsafe impl<T> ReadOnlyFetch for WithoutFetch<T> {}
 ///         println!("Entity {:?} got a new style or color", entity);
 ///     }
 /// }
-/// # print_cool_entity_system.system();
+/// # IntoSystem::into_system(print_cool_entity_system);
 /// ```
 pub struct Or<T>(pub T);
 
@@ -619,7 +619,7 @@ impl_tick_filter!(
     ///     }
     /// }
     ///
-    /// # print_add_name_component.system();
+    /// # IntoSystem::into_system(print_add_name_component);
     /// ```
     Added,
     /// The [`FetchState`] of [`Added`].
@@ -662,7 +662,7 @@ impl_tick_filter!(
     ///     }
     /// }
     ///
-    /// # print_moving_objects_system.system();
+    /// # IntoSystem::into_system(print_moving_objects_system);
     /// ```
     Changed,
     /// The [`FetchState`] of [`Changed`].

--- a/crates/bevy_ecs/src/schedule/run_criteria.rs
+++ b/crates/bevy_ecs/src/schedule/run_criteria.rs
@@ -366,6 +366,8 @@ impl RunCriteria {
 
 pub trait RunCriteriaPiping {
     /// See [`RunCriteria::pipe()`].
+    // TODO: Support `IntoSystem` here instead, and stop using
+    // `IntoSystem::into_system` in the call sites
     fn pipe(self, system: impl System<In = ShouldRun, Out = ShouldRun>) -> RunCriteriaDescriptor;
 }
 

--- a/crates/bevy_ecs/src/schedule/run_criteria.rs
+++ b/crates/bevy_ecs/src/schedule/run_criteria.rs
@@ -235,7 +235,7 @@ where
 {
     fn into(self) -> RunCriteriaDescriptorOrLabel {
         RunCriteriaDescriptorOrLabel::Descriptor(new_run_criteria_descriptor(Box::new(
-            self.system(),
+            IntoSystem::into_system(self),
         )))
     }
 }
@@ -333,19 +333,20 @@ where
     S: IntoSystem<(), ShouldRun, Param>,
 {
     fn label(self, label: impl RunCriteriaLabel) -> RunCriteriaDescriptor {
-        new_run_criteria_descriptor(Box::new(self.system())).label(label)
+        new_run_criteria_descriptor(Box::new(IntoSystem::into_system(self))).label(label)
     }
 
     fn label_discard_if_duplicate(self, label: impl RunCriteriaLabel) -> RunCriteriaDescriptor {
-        new_run_criteria_descriptor(Box::new(self.system())).label_discard_if_duplicate(label)
+        new_run_criteria_descriptor(Box::new(IntoSystem::into_system(self)))
+            .label_discard_if_duplicate(label)
     }
 
     fn before(self, label: impl RunCriteriaLabel) -> RunCriteriaDescriptor {
-        new_run_criteria_descriptor(Box::new(self.system())).before(label)
+        new_run_criteria_descriptor(Box::new(IntoSystem::into_system(self))).before(label)
     }
 
     fn after(self, label: impl RunCriteriaLabel) -> RunCriteriaDescriptor {
-        new_run_criteria_descriptor(Box::new(self.system())).after(label)
+        new_run_criteria_descriptor(Box::new(IntoSystem::into_system(self))).after(label)
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/system_descriptor.rs
+++ b/crates/bevy_ecs/src/schedule/system_descriptor.rs
@@ -56,7 +56,7 @@ where
     S: IntoSystem<(), (), Params>,
 {
     fn into_descriptor(self) -> SystemDescriptor {
-        new_parallel_descriptor(Box::new(self.system())).into_descriptor()
+        new_parallel_descriptor(Box::new(IntoSystem::into_system(self))).into_descriptor()
     }
 }
 
@@ -174,23 +174,24 @@ where
         self,
         run_criteria: impl IntoRunCriteria<Marker>,
     ) -> ParallelSystemDescriptor {
-        new_parallel_descriptor(Box::new(self.system())).with_run_criteria(run_criteria)
+        new_parallel_descriptor(Box::new(IntoSystem::into_system(self)))
+            .with_run_criteria(run_criteria)
     }
 
     fn label(self, label: impl SystemLabel) -> ParallelSystemDescriptor {
-        new_parallel_descriptor(Box::new(self.system())).label(label)
+        new_parallel_descriptor(Box::new(IntoSystem::into_system(self))).label(label)
     }
 
     fn before(self, label: impl SystemLabel) -> ParallelSystemDescriptor {
-        new_parallel_descriptor(Box::new(self.system())).before(label)
+        new_parallel_descriptor(Box::new(IntoSystem::into_system(self))).before(label)
     }
 
     fn after(self, label: impl SystemLabel) -> ParallelSystemDescriptor {
-        new_parallel_descriptor(Box::new(self.system())).after(label)
+        new_parallel_descriptor(Box::new(IntoSystem::into_system(self))).after(label)
     }
 
     fn in_ambiguity_set(self, set: impl AmbiguitySetLabel) -> ParallelSystemDescriptor {
-        new_parallel_descriptor(Box::new(self.system())).in_ambiguity_set(set)
+        new_parallel_descriptor(Box::new(IntoSystem::into_system(self))).in_ambiguity_set(set)
     }
 }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -78,7 +78,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///         // adds a single component to the entity
     ///         .insert(Label("hello world"));
     /// }
-    /// # example_system.system();
+    /// # IntoSystem::into_system(example_system);
     /// ```
     pub fn spawn<'a>(&'a mut self) -> EntityCommands<'w, 's, 'a> {
         let entity = self.entities.reserve_entity();
@@ -156,7 +156,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///         // or insert single components like this:
     ///         .insert(Label("hello world"));
     /// }
-    /// # example_system.system();
+    /// # IntoSystem::into_system(example_system);
     /// ```
     pub fn spawn_bundle<'a, T: Bundle>(&'a mut self, bundle: T) -> EntityCommands<'w, 's, 'a> {
         let mut e = self.spawn();
@@ -188,7 +188,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///         // adds a single component to the entity
     ///         .insert(Label("hello world"));
     /// }
-    /// # example_system.system();
+    /// # IntoSystem::into_system(example_system);
     /// ```
     #[track_caller]
     pub fn entity<'a>(&'a mut self, entity: Entity) -> EntityCommands<'w, 's, 'a> {
@@ -232,7 +232,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///     ),
     /// ]);
     /// # }
-    /// # system.system();
+    /// # IntoSystem::into_system(system);
     /// ```
     pub fn spawn_batch<I>(&mut self, bundles_iter: I)
     where
@@ -281,7 +281,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///     high_score: 0,
     /// });
     /// # }
-    /// # system.system();
+    /// # IntoSystem::into_system(system);
     /// ```
     pub fn insert_resource<T: Resource>(&mut self, resource: T) {
         self.queue.push(InsertResource { resource })
@@ -304,7 +304,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// # fn system(mut commands: Commands) {
     /// commands.remove_resource::<Scoreboard>();
     /// # }
-    /// # system.system();
+    /// # IntoSystem::into_system(system);
     /// ```
     pub fn remove_resource<T: Resource>(&mut self) {
         self.queue.push(RemoveResource::<T> {
@@ -345,7 +345,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///         },
     ///     });
     /// }
-    /// # add_combat_stats_system.system();
+    /// # IntoSystem::into_system(add_combat_stats_system);
     /// ```
     pub fn add<C: Command>(&mut self, command: C) {
         self.queue.push(command);
@@ -369,7 +369,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// fn my_system(mut commands: Commands) {
     ///     let entity_id = commands.spawn().id();
     /// }
-    /// # my_system.system();
+    /// # IntoSystem::into_system(my_system);
     /// ```
     #[inline]
     pub fn id(&self) -> Entity {
@@ -405,7 +405,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     ///         defense: Defense(20),
     ///     });
     /// }
-    /// # add_combat_stats_system.system();
+    /// # IntoSystem::into_system(add_combat_stats_system);
     /// ```
     pub fn insert_bundle(&mut self, bundle: impl Bundle) -> &mut Self {
         self.commands.add(InsertBundle {
@@ -449,7 +449,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     ///     commands.spawn().insert_bundle((Component1, Component2));
     ///     commands.spawn_bundle((Component1, Component2));
     /// }
-    /// # example_system.system();
+    /// # IntoSystem::into_system(example_system);
     /// ```
     pub fn insert(&mut self, component: impl Component) -> &mut Self {
         self.commands.add(Insert {
@@ -479,7 +479,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// fn remove_combat_stats_system(mut commands: Commands, player: Res<PlayerEntity>) {
     ///     commands.entity(player.entity).remove_bundle::<CombatBundle>();
     /// }
-    /// # remove_combat_stats_system.system();
+    /// # IntoSystem::into_system(remove_combat_stats_system);
     /// ```
     pub fn remove_bundle<T>(&mut self) -> &mut Self
     where
@@ -508,7 +508,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// fn convert_enemy_system(mut commands: Commands, enemy: Res<TargetEnemy>) {
     ///     commands.entity(enemy.entity).remove::<Enemy>();
     /// }
-    /// # convert_enemy_system.system();
+    /// # IntoSystem::into_system(convert_enemy_system);
     /// ```
     pub fn remove<T>(&mut self) -> &mut Self
     where
@@ -539,7 +539,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// {
     ///     commands.entity(character_to_remove.entity).despawn();
     /// }
-    /// # remove_character_system.system();
+    /// # IntoSystem::into_system(remove_character_system);
     /// ```
     pub fn despawn(&mut self) {
         self.commands.add(Despawn {

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -78,7 +78,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///         // adds a single component to the entity
     ///         .insert(Label("hello world"));
     /// }
-    /// # IntoSystem::into_system(example_system);
+    /// # bevy_ecs::system::assert_is_system(example_system);
     /// ```
     pub fn spawn<'a>(&'a mut self) -> EntityCommands<'w, 's, 'a> {
         let entity = self.entities.reserve_entity();
@@ -156,7 +156,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///         // or insert single components like this:
     ///         .insert(Label("hello world"));
     /// }
-    /// # IntoSystem::into_system(example_system);
+    /// # bevy_ecs::system::assert_is_system(example_system);
     /// ```
     pub fn spawn_bundle<'a, T: Bundle>(&'a mut self, bundle: T) -> EntityCommands<'w, 's, 'a> {
         let mut e = self.spawn();
@@ -188,7 +188,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///         // adds a single component to the entity
     ///         .insert(Label("hello world"));
     /// }
-    /// # IntoSystem::into_system(example_system);
+    /// # bevy_ecs::system::assert_is_system(example_system);
     /// ```
     #[track_caller]
     pub fn entity<'a>(&'a mut self, entity: Entity) -> EntityCommands<'w, 's, 'a> {
@@ -232,7 +232,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///     ),
     /// ]);
     /// # }
-    /// # IntoSystem::into_system(system);
+    /// # bevy_ecs::system::assert_is_system(system);
     /// ```
     pub fn spawn_batch<I>(&mut self, bundles_iter: I)
     where
@@ -281,7 +281,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///     high_score: 0,
     /// });
     /// # }
-    /// # IntoSystem::into_system(system);
+    /// # bevy_ecs::system::assert_is_system(system);
     /// ```
     pub fn insert_resource<T: Resource>(&mut self, resource: T) {
         self.queue.push(InsertResource { resource })
@@ -304,7 +304,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// # fn system(mut commands: Commands) {
     /// commands.remove_resource::<Scoreboard>();
     /// # }
-    /// # IntoSystem::into_system(system);
+    /// # bevy_ecs::system::assert_is_system(system);
     /// ```
     pub fn remove_resource<T: Resource>(&mut self) {
         self.queue.push(RemoveResource::<T> {
@@ -345,7 +345,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///         },
     ///     });
     /// }
-    /// # IntoSystem::into_system(add_combat_stats_system);
+    /// # bevy_ecs::system::assert_is_system(add_combat_stats_system);
     /// ```
     pub fn add<C: Command>(&mut self, command: C) {
         self.queue.push(command);
@@ -369,7 +369,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// fn my_system(mut commands: Commands) {
     ///     let entity_id = commands.spawn().id();
     /// }
-    /// # IntoSystem::into_system(my_system);
+    /// # bevy_ecs::system::assert_is_system(my_system);
     /// ```
     #[inline]
     pub fn id(&self) -> Entity {
@@ -405,7 +405,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     ///         defense: Defense(20),
     ///     });
     /// }
-    /// # IntoSystem::into_system(add_combat_stats_system);
+    /// # bevy_ecs::system::assert_is_system(add_combat_stats_system);
     /// ```
     pub fn insert_bundle(&mut self, bundle: impl Bundle) -> &mut Self {
         self.commands.add(InsertBundle {
@@ -449,7 +449,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     ///     commands.spawn().insert_bundle((Component1, Component2));
     ///     commands.spawn_bundle((Component1, Component2));
     /// }
-    /// # IntoSystem::into_system(example_system);
+    /// # bevy_ecs::system::assert_is_system(example_system);
     /// ```
     pub fn insert(&mut self, component: impl Component) -> &mut Self {
         self.commands.add(Insert {
@@ -479,7 +479,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// fn remove_combat_stats_system(mut commands: Commands, player: Res<PlayerEntity>) {
     ///     commands.entity(player.entity).remove_bundle::<CombatBundle>();
     /// }
-    /// # IntoSystem::into_system(remove_combat_stats_system);
+    /// # bevy_ecs::system::assert_is_system(remove_combat_stats_system);
     /// ```
     pub fn remove_bundle<T>(&mut self) -> &mut Self
     where
@@ -508,7 +508,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// fn convert_enemy_system(mut commands: Commands, enemy: Res<TargetEnemy>) {
     ///     commands.entity(enemy.entity).remove::<Enemy>();
     /// }
-    /// # IntoSystem::into_system(convert_enemy_system);
+    /// # bevy_ecs::system::assert_is_system(convert_enemy_system);
     /// ```
     pub fn remove<T>(&mut self) -> &mut Self
     where
@@ -539,7 +539,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// {
     ///     commands.entity(character_to_remove.entity).despawn();
     /// }
-    /// # IntoSystem::into_system(remove_character_system);
+    /// # bevy_ecs::system::assert_is_system(remove_character_system);
     /// ```
     pub fn despawn(&mut self) {
         self.commands.add(Despawn {

--- a/crates/bevy_ecs/src/system/exclusive_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system.rs
@@ -107,7 +107,7 @@ where
 {
     fn exclusive_system(self) -> ExclusiveSystemCoerced {
         ExclusiveSystemCoerced {
-            system: Box::new(self.system()),
+            system: Box::new(IntoSystem::into_system(self)),
             archetype_generation: ArchetypeGeneration::initial(),
         }
     }

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -265,11 +265,13 @@ pub trait IntoSystem<In, Out, Params>: Sized {
     ///
     /// In future, this method will be removed.
     ///
-    /// One valid use of this method is to assert that a given function is a valid system.
-    /// For this case, use `bevy_ecs::system::assert_is_system` instead.
+    /// One use of this method is to assert that a given function is a valid system.
+    /// For this case, use [`bevy_ecs::system::assert_is_system`] instead.
+    ///
+    /// [`bevy_ecs::system::assert_is_system`]: [`crate::system::assert_is_system`]:
     #[deprecated(
-        since = "0.6.0",
-        note = "In most cases, using `.system()` is no longer necessary, and so it can be removed"
+        since = "0.7.0",
+        note = "`.system()` is no longer needed, as methods which accept systems will convert functions into a system automatically"
     )]
     fn system(self) -> Self::System {
         IntoSystem::into_system(self)

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -266,7 +266,7 @@ pub trait IntoSystem<In, Out, Params>: Sized {
     /// In future, this method will be removed.
     ///
     /// One valid use of this method is to assert that a given function is a valid system.
-    /// For this case, use `IntoSystem::into_system` instead.
+    /// For this case, use `bevy_ecs::system::assert_is_system` instead.
     #[deprecated(
         since = "0.6.0",
         note = "In most cases, using `.system()` is no longer necessary, and so it can be removed"

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -303,7 +303,7 @@ impl<In, Out, Sys: System<In = In, Out = Out>> IntoSystem<In, Out, AlreadyWasSys
 /// use bevy_ecs::prelude::*;
 ///
 /// fn main() {
-///     let mut square_system = square.system();
+///     let mut square_system = IntoSystem::into_system(square);
 ///
 ///     let mut world = World::default();
 ///     square_system.initialize(&mut world);
@@ -391,7 +391,7 @@ where
         self,
         f: impl FnOnce(&mut <<Param as SystemParam>::Fetch as SystemParamState>::Config),
     ) -> Self::System {
-        self.system().config(f)
+        IntoSystem::into_system(self).config(f)
     }
 }
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -30,7 +30,7 @@
 //!     }
 //!     round.0 += 1;
 //! }
-//! # IntoSystem::into_system(update_score_system);
+//! # bevy_ecs::system::assert_is_system(update_score_system);
 //! ```
 //!
 //! # System ordering
@@ -81,6 +81,13 @@ pub use query::*;
 pub use system::*;
 pub use system_chaining::*;
 pub use system_param::*;
+
+pub fn assert_is_system<In, Out, Params, S: IntoSystem<In, Out, Params>>(sys: S) {
+    if false {
+        // Check it can be converted into a system
+        IntoSystem::into_system(sys);
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -30,7 +30,7 @@
 //!     }
 //!     round.0 += 1;
 //! }
-//! # update_score_system.system();
+//! # IntoSystem::into_system(update_score_system);
 //! ```
 //!
 //! # System ordering
@@ -125,7 +125,7 @@ mod tests {
             }
         }
 
-        let mut system = sys.system();
+        let mut system = IntoSystem::into_system(sys);
         let mut world = World::new();
         world.spawn().insert(A);
 
@@ -583,8 +583,8 @@ mod tests {
         fn sys_y(_: Res<A>, _: ResMut<B>, _: Query<(&C, &mut D)>) {}
 
         let mut world = World::default();
-        let mut x = sys_x.system();
-        let mut y = sys_y.system();
+        let mut x = IntoSystem::into_system(sys_x);
+        let mut y = IntoSystem::into_system(sys_y);
         x.initialize(&mut world);
         y.initialize(&mut world);
 
@@ -612,11 +612,11 @@ mod tests {
         let mut world = World::default();
         world.spawn().insert(A).insert(C);
 
-        let mut without_filter = without_filter.system();
+        let mut without_filter = IntoSystem::into_system(without_filter);
         without_filter.initialize(&mut world);
         without_filter.run((), &mut world);
 
-        let mut with_filter = with_filter.system();
+        let mut with_filter = IntoSystem::into_system(with_filter);
         with_filter.initialize(&mut world);
         with_filter.run((), &mut world);
     }
@@ -663,8 +663,8 @@ mod tests {
         ) {
         }
         let mut world = World::default();
-        let mut x = sys_x.system();
-        let mut y = sys_y.system();
+        let mut x = IntoSystem::into_system(sys_x);
+        let mut y = IntoSystem::into_system(sys_y);
         x.initialize(&mut world);
         y.initialize(&mut world);
     }

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -53,7 +53,7 @@ use thiserror::Error;
 /// # fn system(
 /// query: Query<(&ComponentA, &ComponentB)>
 /// # ) {}
-/// # system.system();
+/// # IntoSystem::into_system(system);
 /// ```
 ///
 /// ## Mutable component access
@@ -74,7 +74,7 @@ use thiserror::Error;
 /// // `ComponentA` is accessed mutably, while `ComponentB` is accessed immutably.
 /// mut query: Query<(&mut ComponentA, &ComponentB)>
 /// # ) {}
-/// # system.system();
+/// # IntoSystem::into_system(system);
 /// ```
 ///
 /// Two systems cannot be executed in parallel if both access a certain component and
@@ -99,7 +99,7 @@ use thiserror::Error;
 /// # fn system(
 /// query: Query<(Entity, &ComponentA, &ComponentB)>
 /// # ) {}
-/// # system.system();
+/// # IntoSystem::into_system(system);
 /// ```
 ///
 /// ## Query filtering
@@ -119,7 +119,7 @@ use thiserror::Error;
 /// // `ComponentC` data won't be accessed, but only entities that contain it will be queried.
 /// query: Query<(&ComponentA, &ComponentB), With<ComponentC>>
 /// # ) {}
-/// # system.system();
+/// # IntoSystem::into_system(system);
 /// ```
 ///
 /// If you need to apply more filters in a single query, group them into a tuple:
@@ -136,7 +136,7 @@ use thiserror::Error;
 /// // Similar to the previous query, but with the addition of a `Changed` filter.
 /// query: Query<(&ComponentA, &ComponentB), (With<ComponentC>, Changed<ComponentA>)>
 /// # ) {}
-/// # system.system();
+/// # IntoSystem::into_system(system);
 /// ```
 ///
 /// The following list contains all the available query filters:
@@ -162,7 +162,7 @@ use thiserror::Error;
 /// # fn system(
 /// query: Query<(&ComponentA, Option<&ComponentB>)>
 /// # ) {}
-/// # system.system();
+/// # IntoSystem::into_system(system);
 /// ```
 ///
 /// If an entity does not contain a component, its corresponding query result value will be
@@ -184,13 +184,13 @@ use thiserror::Error;
 /// // This is correct, but can be avoided.
 /// query: Query<(&MyComponent,)>
 /// # ) {}
-/// # tuple_system.system();
+/// # IntoSystem::into_system(tuple_system);
 ///
 /// # fn non_tuple_system(
 /// // This is the preferred method.
 /// query: Query<&MyComponent>
 /// # ) {}
-/// # non_tuple_system.system();
+/// # IntoSystem::into_system(non_tuple_system);
 /// ```
 ///
 /// # Usage of query results
@@ -217,7 +217,7 @@ use thiserror::Error;
 ///         // `&ComponentA` and `&ComponentB` types.
 ///     }
 /// }
-/// # immutable_query_system.system();
+/// # IntoSystem::into_system(immutable_query_system);
 ///
 /// fn mutable_query_system(mut query: Query<(&mut ComponentA, &ComponentB)>) {
 ///     for (mut a, b) in query.iter_mut() {
@@ -225,7 +225,7 @@ use thiserror::Error;
 ///         // Note the usage of `mut` in the tuple and the call to `iter_mut` instead of `iter`.
 ///     }
 /// }
-/// # mutable_query_system.system();
+/// # IntoSystem::into_system(mutable_query_system);
 /// ```
 ///
 /// ## Getting the query result for a particular entity
@@ -296,7 +296,7 @@ where
     ///         println!("Say hello to {}!", player.name);
     ///     }
     /// }
-    /// # report_names_system.system();
+    /// # IntoSystem::into_system(report_names_system);
     /// ```
     #[inline]
     pub fn iter(&'s self) -> QueryIter<'w, 's, Q, Q::ReadOnlyFetch, F> {
@@ -326,7 +326,7 @@ where
     ///         velocity.y -= 9.8 * DELTA;
     ///     }
     /// }
-    /// # gravity_system.system();
+    /// # IntoSystem::into_system(gravity_system);
     /// ```
     #[inline]
     pub fn iter_mut(&mut self) -> QueryIter<'_, '_, Q, Q::Fetch, F> {
@@ -451,7 +451,7 @@ where
     ///         println!("Say hello to {}!", player.name);
     ///     });
     /// }
-    /// # report_names_system.system();
+    /// # IntoSystem::into_system(report_names_system);
     /// ```
     #[inline]
     pub fn for_each<FN: FnMut(<Q::ReadOnlyFetch as Fetch<'w, 's>>::Item)>(&'s self, f: FN) {
@@ -487,7 +487,7 @@ where
     ///         velocity.y -= 9.8 * DELTA;
     ///     });
     /// }
-    /// # gravity_system.system();
+    /// # IntoSystem::into_system(gravity_system);
     /// ```
     #[inline]
     pub fn for_each_mut<'a, FN: FnMut(<Q::Fetch as Fetch<'a, 'a>>::Item)>(&'a mut self, f: FN) {
@@ -580,7 +580,7 @@ where
     ///         println!("{}", selected_character.name);
     ///     }
     /// }
-    /// # print_selected_character_name_system.system();
+    /// # IntoSystem::into_system(print_selected_character_name_system);
     /// ```
     #[inline]
     pub fn get(
@@ -621,7 +621,7 @@ where
     ///         health.0 -= 1;
     ///     }
     /// }
-    /// # poison_system.system();
+    /// # IntoSystem::into_system(poison_system);
     /// ```
     #[inline]
     pub fn get_mut(
@@ -690,7 +690,7 @@ where
     ///         println!("{}", selected_character.name);
     ///     }
     /// }
-    /// # print_selected_character_name_system.system();
+    /// # IntoSystem::into_system(print_selected_character_name_system);
     /// ```
     #[inline]
     pub fn get_component<T: Component>(&self, entity: Entity) -> Result<&T, QueryComponentError> {
@@ -741,7 +741,7 @@ where
     ///         health.0 -= 1;
     ///     }
     /// }
-    /// # poison_system.system();
+    /// # IntoSystem::into_system(poison_system);
     /// ```
     #[inline]
     pub fn get_component_mut<T: Component>(
@@ -809,7 +809,7 @@ where
     ///     let player_position = query.single();
     ///     // do something with player_position
     /// }
-    /// # player_system.system();
+    /// # IntoSystem::into_system(player_system);
     /// ```
     ///
     /// # Panics
@@ -850,7 +850,7 @@ where
     ///         }
     ///     }
     /// }
-    /// # player_scoring_system.system();
+    /// # IntoSystem::into_system(player_scoring_system);
     /// ```
     pub fn get_single(
         &'s self,
@@ -885,7 +885,7 @@ where
     ///     let mut health = query.single_mut();
     ///     health.0 += 1;
     /// }
-    /// # regenerate_player_health_system.system();
+    /// # IntoSystem::into_system(regenerate_player_health_system);
     /// ```
     ///
     /// # Panics
@@ -917,7 +917,7 @@ where
     ///     let mut health = query.get_single_mut().expect("Error: Could not find a single player.");
     ///     health.0 += 1;
     /// }
-    /// # regenerate_player_health_system.system();
+    /// # IntoSystem::into_system(regenerate_player_health_system);
     /// ```
     pub fn get_single_mut(
         &mut self,
@@ -954,7 +954,7 @@ where
     ///         score.0 += 1;
     ///     }
     /// }
-    /// # update_score_system.system();
+    /// # IntoSystem::into_system(update_score_system);
     /// ```
     #[inline]
     pub fn is_empty(&self) -> bool {

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -53,7 +53,7 @@ use thiserror::Error;
 /// # fn system(
 /// query: Query<(&ComponentA, &ComponentB)>
 /// # ) {}
-/// # IntoSystem::into_system(system);
+/// # bevy_ecs::system::assert_is_system(system);
 /// ```
 ///
 /// ## Mutable component access
@@ -74,7 +74,7 @@ use thiserror::Error;
 /// // `ComponentA` is accessed mutably, while `ComponentB` is accessed immutably.
 /// mut query: Query<(&mut ComponentA, &ComponentB)>
 /// # ) {}
-/// # IntoSystem::into_system(system);
+/// # bevy_ecs::system::assert_is_system(system);
 /// ```
 ///
 /// Two systems cannot be executed in parallel if both access a certain component and
@@ -99,7 +99,7 @@ use thiserror::Error;
 /// # fn system(
 /// query: Query<(Entity, &ComponentA, &ComponentB)>
 /// # ) {}
-/// # IntoSystem::into_system(system);
+/// # bevy_ecs::system::assert_is_system(system);
 /// ```
 ///
 /// ## Query filtering
@@ -119,7 +119,7 @@ use thiserror::Error;
 /// // `ComponentC` data won't be accessed, but only entities that contain it will be queried.
 /// query: Query<(&ComponentA, &ComponentB), With<ComponentC>>
 /// # ) {}
-/// # IntoSystem::into_system(system);
+/// # bevy_ecs::system::assert_is_system(system);
 /// ```
 ///
 /// If you need to apply more filters in a single query, group them into a tuple:
@@ -136,7 +136,7 @@ use thiserror::Error;
 /// // Similar to the previous query, but with the addition of a `Changed` filter.
 /// query: Query<(&ComponentA, &ComponentB), (With<ComponentC>, Changed<ComponentA>)>
 /// # ) {}
-/// # IntoSystem::into_system(system);
+/// # bevy_ecs::system::assert_is_system(system);
 /// ```
 ///
 /// The following list contains all the available query filters:
@@ -162,7 +162,7 @@ use thiserror::Error;
 /// # fn system(
 /// query: Query<(&ComponentA, Option<&ComponentB>)>
 /// # ) {}
-/// # IntoSystem::into_system(system);
+/// # bevy_ecs::system::assert_is_system(system);
 /// ```
 ///
 /// If an entity does not contain a component, its corresponding query result value will be
@@ -184,13 +184,13 @@ use thiserror::Error;
 /// // This is correct, but can be avoided.
 /// query: Query<(&MyComponent,)>
 /// # ) {}
-/// # IntoSystem::into_system(tuple_system);
+/// # bevy_ecs::system::assert_is_system(tuple_system);
 ///
 /// # fn non_tuple_system(
 /// // This is the preferred method.
 /// query: Query<&MyComponent>
 /// # ) {}
-/// # IntoSystem::into_system(non_tuple_system);
+/// # bevy_ecs::system::assert_is_system(non_tuple_system);
 /// ```
 ///
 /// # Usage of query results
@@ -217,7 +217,7 @@ use thiserror::Error;
 ///         // `&ComponentA` and `&ComponentB` types.
 ///     }
 /// }
-/// # IntoSystem::into_system(immutable_query_system);
+/// # bevy_ecs::system::assert_is_system(immutable_query_system);
 ///
 /// fn mutable_query_system(mut query: Query<(&mut ComponentA, &ComponentB)>) {
 ///     for (mut a, b) in query.iter_mut() {
@@ -225,7 +225,7 @@ use thiserror::Error;
 ///         // Note the usage of `mut` in the tuple and the call to `iter_mut` instead of `iter`.
 ///     }
 /// }
-/// # IntoSystem::into_system(mutable_query_system);
+/// # bevy_ecs::system::assert_is_system(mutable_query_system);
 /// ```
 ///
 /// ## Getting the query result for a particular entity
@@ -296,7 +296,7 @@ where
     ///         println!("Say hello to {}!", player.name);
     ///     }
     /// }
-    /// # IntoSystem::into_system(report_names_system);
+    /// # bevy_ecs::system::assert_is_system(report_names_system);
     /// ```
     #[inline]
     pub fn iter(&'s self) -> QueryIter<'w, 's, Q, Q::ReadOnlyFetch, F> {
@@ -326,7 +326,7 @@ where
     ///         velocity.y -= 9.8 * DELTA;
     ///     }
     /// }
-    /// # IntoSystem::into_system(gravity_system);
+    /// # bevy_ecs::system::assert_is_system(gravity_system);
     /// ```
     #[inline]
     pub fn iter_mut(&mut self) -> QueryIter<'_, '_, Q, Q::Fetch, F> {
@@ -451,7 +451,7 @@ where
     ///         println!("Say hello to {}!", player.name);
     ///     });
     /// }
-    /// # IntoSystem::into_system(report_names_system);
+    /// # bevy_ecs::system::assert_is_system(report_names_system);
     /// ```
     #[inline]
     pub fn for_each<FN: FnMut(<Q::ReadOnlyFetch as Fetch<'w, 's>>::Item)>(&'s self, f: FN) {
@@ -487,7 +487,7 @@ where
     ///         velocity.y -= 9.8 * DELTA;
     ///     });
     /// }
-    /// # IntoSystem::into_system(gravity_system);
+    /// # bevy_ecs::system::assert_is_system(gravity_system);
     /// ```
     #[inline]
     pub fn for_each_mut<'a, FN: FnMut(<Q::Fetch as Fetch<'a, 'a>>::Item)>(&'a mut self, f: FN) {
@@ -580,7 +580,7 @@ where
     ///         println!("{}", selected_character.name);
     ///     }
     /// }
-    /// # IntoSystem::into_system(print_selected_character_name_system);
+    /// # bevy_ecs::system::assert_is_system(print_selected_character_name_system);
     /// ```
     #[inline]
     pub fn get(
@@ -621,7 +621,7 @@ where
     ///         health.0 -= 1;
     ///     }
     /// }
-    /// # IntoSystem::into_system(poison_system);
+    /// # bevy_ecs::system::assert_is_system(poison_system);
     /// ```
     #[inline]
     pub fn get_mut(
@@ -690,7 +690,7 @@ where
     ///         println!("{}", selected_character.name);
     ///     }
     /// }
-    /// # IntoSystem::into_system(print_selected_character_name_system);
+    /// # bevy_ecs::system::assert_is_system(print_selected_character_name_system);
     /// ```
     #[inline]
     pub fn get_component<T: Component>(&self, entity: Entity) -> Result<&T, QueryComponentError> {
@@ -741,7 +741,7 @@ where
     ///         health.0 -= 1;
     ///     }
     /// }
-    /// # IntoSystem::into_system(poison_system);
+    /// # bevy_ecs::system::assert_is_system(poison_system);
     /// ```
     #[inline]
     pub fn get_component_mut<T: Component>(
@@ -809,7 +809,7 @@ where
     ///     let player_position = query.single();
     ///     // do something with player_position
     /// }
-    /// # IntoSystem::into_system(player_system);
+    /// # bevy_ecs::system::assert_is_system(player_system);
     /// ```
     ///
     /// # Panics
@@ -850,7 +850,7 @@ where
     ///         }
     ///     }
     /// }
-    /// # IntoSystem::into_system(player_scoring_system);
+    /// # bevy_ecs::system::assert_is_system(player_scoring_system);
     /// ```
     pub fn get_single(
         &'s self,
@@ -885,7 +885,7 @@ where
     ///     let mut health = query.single_mut();
     ///     health.0 += 1;
     /// }
-    /// # IntoSystem::into_system(regenerate_player_health_system);
+    /// # bevy_ecs::system::assert_is_system(regenerate_player_health_system);
     /// ```
     ///
     /// # Panics
@@ -917,7 +917,7 @@ where
     ///     let mut health = query.get_single_mut().expect("Error: Could not find a single player.");
     ///     health.0 += 1;
     /// }
-    /// # IntoSystem::into_system(regenerate_player_health_system);
+    /// # bevy_ecs::system::assert_is_system(regenerate_player_health_system);
     /// ```
     pub fn get_single_mut(
         &mut self,
@@ -954,7 +954,7 @@ where
     ///         score.0 += 1;
     ///     }
     /// }
-    /// # IntoSystem::into_system(update_score_system);
+    /// # bevy_ecs::system::assert_is_system(update_score_system);
     /// ```
     #[inline]
     pub fn is_empty(&self) -> bool {

--- a/crates/bevy_ecs/src/system/system_chaining.rs
+++ b/crates/bevy_ecs/src/system/system_chaining.rs
@@ -130,8 +130,8 @@ where
     SystemB: IntoSystem<Payload, Out, ParamB>,
 {
     fn chain(self, system: SystemB) -> ChainSystem<SystemA::System, SystemB::System> {
-        let system_a = self.system();
-        let system_b = system.system();
+        let system_a = IntoSystem::into_system(self);
+        let system_b = IntoSystem::into_system(system);
         ChainSystem {
             name: Cow::Owned(format!("Chain({}, {})", system_a.name(), system_b.name())),
             system_a,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -42,7 +42,7 @@ use std::{
 ///     // Access the resource through `param.foo`
 /// }
 ///
-/// # my_system.system();
+/// # IntoSystem::into_system(my_system);
 /// ```
 pub trait SystemParam: Sized {
     type Fetch: for<'w, 's> SystemParamFetch<'w, 's>;
@@ -548,8 +548,8 @@ impl<'w, 's> SystemParamFetch<'w, 's> for CommandQueue {
 /// fn read_from_local(local: Local<usize>) -> usize {
 ///     *local
 /// }
-/// let mut write_system = write_to_local.system();
-/// let mut read_system = read_from_local.system();
+/// let mut write_system = IntoSystem::into_system(write_to_local);
+/// let mut read_system = IntoSystem::into_system(read_from_local);
 /// write_system.initialize(world);
 /// read_system.initialize(world);
 ///
@@ -652,7 +652,7 @@ impl<'w, 's, T: Resource + FromWorld> SystemParamFetch<'w, 's> for LocalState<T>
 ///     removed.iter().for_each(|removed_entity| println!("{:?}", removed_entity));
 /// }
 ///
-/// # react_on_removal.system();
+/// # IntoSystem::into_system(react_on_removal);
 /// ```
 pub struct RemovedComponents<'a, T: Component> {
     world: &'a World,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -42,7 +42,7 @@ use std::{
 ///     // Access the resource through `param.foo`
 /// }
 ///
-/// # IntoSystem::into_system(my_system);
+/// # bevy_ecs::system::assert_is_system(my_system);
 /// ```
 pub trait SystemParam: Sized {
     type Fetch: for<'w, 's> SystemParamFetch<'w, 's>;
@@ -652,7 +652,7 @@ impl<'w, 's, T: Resource + FromWorld> SystemParamFetch<'w, 's> for LocalState<T>
 ///     removed.iter().for_each(|removed_entity| println!("{:?}", removed_entity));
 /// }
 ///
-/// # IntoSystem::into_system(react_on_removal);
+/// # bevy_ecs::system::assert_is_system(react_on_removal);
 /// ```
 pub struct RemovedComponents<'a, T: Component> {
     world: &'a World,

--- a/crates/bevy_render/src/render_component.rs
+++ b/crates/bevy_render/src/render_component.rs
@@ -65,10 +65,7 @@ impl<C: Component + AsStd140 + Clone> Plugin for UniformComponentPlugin<C> {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .insert_resource(ComponentUniforms::<C>::default())
-                .add_system_to_stage(
-                    RenderStage::Prepare,
-                    prepare_uniform_components::<C>.system(),
-                );
+                .add_system_to_stage(RenderStage::Prepare, prepare_uniform_components::<C>);
         }
     }
 }

--- a/examples/ecs/system_sets.rs
+++ b/examples/ecs/system_sets.rs
@@ -87,7 +87,10 @@ fn main() {
                 // Here we create a _not done_ criteria by piping the output of
                 // the `is_done` system and inverting the output.
                 // Notice a string literal also works as a label.
-                .with_run_criteria(RunCriteria::pipe("is_done_label", inverse.system()))
+                .with_run_criteria(RunCriteria::pipe(
+                    "is_done_label",
+                    IntoSystem::into_system(inverse),
+                ))
                 // `collision` and `sfx` are not ordered with respect to
                 // each other, and may run in any order
                 .with_system(collision)


### PR DESCRIPTION
# Objective

- Using `.system()` is no longer idiomatic.

## Solution

- Give a warning when using it
