### PR TITLE
[Merged by Bors] - Documented `Events`

### DIFF
--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -107,22 +107,21 @@ enum State {
 ///
 /// # Details
 ///
-/// [Events] is implemented using a variation of a double buffer strategy.
-/// Each call to [Events::update] swaps buffers and clears out the oldest one.
-/// [EventReader]s will read events from both buffers.
-/// [EventReader]s that read at least once per update will never drop events.
-/// [EventReader]s that read once within two updates might still receive some events.
-/// [EventReader]s that read after two updates are guaranteed to drop all events that occurred
+/// [`Events`] is implemented using a variation of a double buffer strategy.
+/// Each call to [`update`](Events::update) swaps buffers and clears out the oldest one.
+/// [`EventReader`]s will read events from both buffers.
+/// [`EventReader`]s that read at least once per update will never drop events.
+/// [`EventReader`]s that read once within two updates might still receive some events.
+/// [`EventReader`]s that read after two updates are guaranteed to drop all events that occurred
 /// before those updates.
 ///
-/// The buffers in [`Events`] will grow indefinitely if [`Events::update`] is never called.
+/// The buffers in [`Events`] will grow indefinitely if [`update`](Events::update) is never called.
 ///
-/// An alternative call pattern would be to call [`Events::update`] manually across frames to
-/// control when events are cleared.
+/// An alternative call pattern would be to call [`update`](Events::update)
+/// manually across frames to control when events are cleared.
 /// This complicates consumption and risks ever-expanding memory usage if not cleaned up,
-/// but can be done by adding your event as a resource instead of using [`App::add_event`].
-///
-/// [`App::add_event`]: https://docs.rs/bevy/*/bevy/app/struct.App.html#method.add_event
+/// but can be done by adding your event as a resource instead of using
+/// [`add_event`](https://docs.rs/bevy/*/bevy/app/struct.App.html#method.add_event).
 #[derive(Debug)]
 pub struct Events<T> {
     events_a: Vec<EventInstance<T>>,

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -60,10 +60,6 @@ enum State {
 /// Events can be written to using an [`EventWriter`]
 /// and are typically cheaply read using an [`EventReader`].
 ///
-/// If no [ordering](https://github.com/bevyengine/bevy/blob/main/examples/ecs/ecs_guide.rs)
-/// is applied between writing and reading systems, there is a risk of a race condition.
-/// This means that whether the events arrive before or after the next [`Events::update`] is unpredictable.
-///
 /// Each event can be consumed by multiple systems, in parallel,
 /// with consumption tracked by the [`EventReader`] on a per-system basis.
 ///

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -76,7 +76,7 @@ enum State {
 /// consumers is not critical (although poorly-planned ordering may cause accumulating lag).
 /// If events are not handled by the end of the frame after they are updated, they will be
 /// dropped silently.
-/// 
+///
 /// # Example
 /// ```
 /// use bevy_ecs::event::Events;

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -59,6 +59,9 @@ enum State {
 /// [`Events::update`] calls.
 /// Events can be written to using an [`EventWriter`]
 /// and are typically cheaply read using an [`EventReader`].
+/// 
+/// If no ordering is applied between writing and reading systems, there is a risk of a race condition.
+/// This means that whether the events arrive before or after the next [`Events::update`] is unpredictable.
 ///
 /// Each event can be consumed by multiple systems, in parallel,
 /// with consumption tracked by the [`EventReader`] on a per-system basis.
@@ -73,7 +76,7 @@ enum State {
 /// consumers is not critical (although poorly-planned ordering may cause accumulating lag).
 /// If events are not handled by the end of the frame after they are updated, they will be
 /// dropped silently.
-///
+/// 
 /// # Example
 /// ```
 /// use bevy_ecs::event::Events;
@@ -103,10 +106,12 @@ enum State {
 ///
 /// # Details
 ///
-/// [`Events`] is implemented using a double buffer. Each call to [`Events::update`] swaps buffers
-/// and clears out the oldest buffer. [`EventReader`]s that read at least once per update will never
-/// drop events. [`EventReader`]s that read once within two updates might still receive some events.
-/// [`EventReader`]s that read after two updates are guaranteed to drop all events that occurred
+/// [Events] is implemented using a variation of double buffer.
+/// Each call to [Events::update] swaps buffers and clears out the oldest one.
+/// [EventReader]s will read events from both buffers.
+/// [EventReader]s that read at least once per update will never drop events.
+/// [EventReader]s that read once within two updates might still receive some events.
+/// [EventReader]s that read after two updates are guaranteed to drop all events that occurred
 /// before those updates.
 ///
 /// The buffers in [`Events`] will grow indefinitely if [`Events::update`] is never called.

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -60,7 +60,7 @@ enum State {
 /// Events can be written to using an [`EventWriter`]
 /// and are typically cheaply read using an [`EventReader`].
 ///
-/// If no [ordering](https://github.com/bevyengine/bevy/blob/main/examples/ecs/ecs_guide.rs#L284)
+/// If no [ordering](https://github.com/bevyengine/bevy/blob/main/examples/ecs/ecs_guide.rs)
 /// is applied between writing and reading systems, there is a risk of a race condition.
 /// This means that whether the events arrive before or after the next [`Events::update`] is unpredictable.
 ///

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -60,12 +60,12 @@ enum State {
 /// Events can be written to using an [`EventWriter`]
 /// and are typically cheaply read using an [`EventReader`].
 ///
+/// Each event can be consumed by multiple systems, in parallel,
+/// with consumption tracked by the [`EventReader`] on a per-system basis.
+///
 /// If no [ordering](https://github.com/bevyengine/bevy/blob/main/examples/ecs/ecs_guide.rs)
 /// is applied between writing and reading systems, there is a risk of a race condition.
 /// This means that whether the events arrive before or after the next [`Events::update`] is unpredictable.
-///
-/// Each event can be consumed by multiple systems, in parallel,
-/// with consumption tracked by the [`EventReader`] on a per-system basis.
 ///
 /// This collection is meant to be paired with a system that calls
 /// [`Events::update`] exactly once per update/frame.

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -60,7 +60,8 @@ enum State {
 /// Events can be written to using an [`EventWriter`]
 /// and are typically cheaply read using an [`EventReader`].
 ///
-/// If no ordering is applied between writing and reading systems, there is a risk of a race condition.
+/// If no [ordering](https://bevy-cheatbook.github.io/programming/system-order.html)
+/// is applied between writing and reading systems, there is a risk of a race condition.
 /// This means that whether the events arrive before or after the next [`Events::update`] is unpredictable.
 ///
 /// Each event can be consumed by multiple systems, in parallel,

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -106,7 +106,7 @@ enum State {
 ///
 /// # Details
 ///
-/// [Events] is implemented using a variation of double buffer.
+/// [Events] is implemented using a variation of a double buffer strategy.
 /// Each call to [Events::update] swaps buffers and clears out the oldest one.
 /// [EventReader]s will read events from both buffers.
 /// [EventReader]s that read at least once per update will never drop events.

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -109,10 +109,10 @@ enum State {
 ///
 /// [`Events`] is implemented using a variation of a double buffer strategy.
 /// Each call to [`update`](Events::update) swaps buffers and clears out the oldest one.
-/// [`EventReader`]s will read events from both buffers.
-/// [`EventReader`]s that read at least once per update will never drop events.
-/// [`EventReader`]s that read once within two updates might still receive some events.
-/// [`EventReader`]s that read after two updates are guaranteed to drop all events that occurred
+/// - [`EventReader`]s will read events from both buffers.
+/// - [`EventReader`]s that read at least once per update will never drop events.
+/// - [`EventReader`]s that read once within two updates might still receive some events
+/// - [`EventReader`]s that read after two updates are guaranteed to drop all events that occurred
 /// before those updates.
 ///
 /// The buffers in [`Events`] will grow indefinitely if [`update`](Events::update) is never called.

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -59,7 +59,7 @@ enum State {
 /// [`Events::update`] calls.
 /// Events can be written to using an [`EventWriter`]
 /// and are typically cheaply read using an [`EventReader`].
-/// 
+///
 /// If no ordering is applied between writing and reading systems, there is a risk of a race condition.
 /// This means that whether the events arrive before or after the next [`Events::update`] is unpredictable.
 ///

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -80,7 +80,7 @@ enum State {
 /// consumers is not critical (although poorly-planned ordering may cause accumulating lag).
 /// If events are not handled by the end of the frame after they are updated, they will be
 /// dropped silently.
-/// 
+///
 /// # Example
 /// ```
 /// use bevy_ecs::event::Events;

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -71,8 +71,8 @@ enum State {
 /// [`Events::update`] exactly once per update/frame.
 ///
 /// [`Events::update_system`] is a system that does this, typically intialized automatically using
-/// [`App::add_event`]. [`EventReader`]s are expected to read events from this collection at
-/// least once per loop/frame.
+/// [`add_event`](https://docs.rs/bevy/*/bevy/app/struct.App.html#method.add_event).
+/// [`EventReader`]s are expected to read events from this collection at least once per loop/frame.
 /// Events will persist across a single frame boundary and so ordering of event producers and
 /// consumers is not critical (although poorly-planned ordering may cause accumulating lag).
 /// If events are not handled by the end of the frame after they are updated, they will be

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -60,7 +60,7 @@ enum State {
 /// Events can be written to using an [`EventWriter`]
 /// and are typically cheaply read using an [`EventReader`].
 ///
-/// If no [ordering](https://bevy-cheatbook.github.io/programming/system-order.html)
+/// If no [ordering](https://github.com/bevyengine/bevy/blob/main/examples/ecs/ecs_guide.rs#L284)
 /// is applied between writing and reading systems, there is a risk of a race condition.
 /// This means that whether the events arrive before or after the next [`Events::update`] is unpredictable.
 ///

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -59,6 +59,9 @@ enum State {
 /// [`Events::update`] calls.
 /// Events can be written to using an [`EventWriter`]
 /// and are typically cheaply read using an [`EventReader`].
+/// 
+/// If no ordering is applied between writing and reading systems, there is a risk of a race condition.
+/// This means that whether the events arrive before or after the next [`Events::update`] is unpredictable.
 ///
 /// Each event can be consumed by multiple systems, in parallel,
 /// with consumption tracked by the [`EventReader`] on a per-system basis.
@@ -77,7 +80,7 @@ enum State {
 /// consumers is not critical (although poorly-planned ordering may cause accumulating lag).
 /// If events are not handled by the end of the frame after they are updated, they will be
 /// dropped silently.
-///
+/// 
 /// # Example
 /// ```
 /// use bevy_ecs::event::Events;


### PR DESCRIPTION
# Objective

This PR extends the `Events` documentation by:
- informing user about the possible race condition
- explicitly explaining the unusual double buffer implementation

Fixes #3305 
