### PR TITLE
[Merged by Bors] - add default standard material in PbrBundle

### DIFF
--- a/crates/bevy_pbr/src/bundle.rs
+++ b/crates/bevy_pbr/src/bundle.rs
@@ -1,4 +1,4 @@
-use crate::{DirectionalLight, PointLight, StandardMaterial};
+use crate::{DirectionalLight, PointLight, StandardMaterial, DEFAULT_STANDARD_MATERIAL_HANDLE};
 use bevy_asset::Handle;
 use bevy_ecs::{bundle::Bundle, component::Component};
 use bevy_render::{
@@ -9,7 +9,7 @@ use bevy_render::{
 use bevy_transform::components::{GlobalTransform, Transform};
 
 /// A component bundle for PBR entities with a [`Mesh`] and a [`StandardMaterial`].
-#[derive(Bundle, Clone, Default)]
+#[derive(Bundle, Clone)]
 pub struct PbrBundle {
     pub mesh: Handle<Mesh>,
     pub material: Handle<StandardMaterial>,
@@ -19,6 +19,19 @@ pub struct PbrBundle {
     pub visibility: Visibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub computed_visibility: ComputedVisibility,
+}
+
+impl Default for PbrBundle {
+    fn default() -> Self {
+        Self {
+            mesh: Default::default(),
+            material: DEFAULT_STANDARD_MATERIAL_HANDLE.typed(),
+            transform: Default::default(),
+            global_transform: Default::default(),
+            visibility: Default::default(),
+            computed_visibility: Default::default(),
+        }
+    }
 }
 
 #[derive(Component, Clone, Debug, Default)]

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -35,6 +35,7 @@ use bevy_core_pipeline::{AlphaMask3d, Opaque3d, Transparent3d};
 use bevy_ecs::prelude::*;
 use bevy_reflect::TypeUuid;
 use bevy_render::{
+    prelude::Color,
     render_component::ExtractComponentPlugin,
     render_graph::RenderGraph,
     render_phase::{sort_phase_system, AddRenderCommand, DrawFunctions},
@@ -127,7 +128,11 @@ impl Plugin for PbrPlugin {
             .unwrap()
             .set_untracked(
                 DEFAULT_STANDARD_MATERIAL_HANDLE,
-                StandardMaterial::high_vis(),
+                StandardMaterial {
+                    base_color: Color::rgb(1.0, 0.0, 0.5),
+                    unlit: true,
+                    ..Default::default()
+                },
             );
 
         let render_app = app.sub_app(RenderApp);

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -122,6 +122,14 @@ impl Plugin for PbrPlugin {
                     .after(VisibilitySystems::CheckVisibility),
             );
 
+        app.world
+            .get_resource_mut::<Assets<StandardMaterial>>()
+            .unwrap()
+            .set_untracked(
+                DEFAULT_STANDARD_MATERIAL_HANDLE,
+                StandardMaterial::high_vis(),
+            );
+
         let render_app = app.sub_app(RenderApp);
         render_app
             .add_system_to_stage(

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1,6 +1,6 @@
 use crate::{AlphaMode, PbrPipeline, StandardMaterialFlags};
 use bevy_app::{App, Plugin};
-use bevy_asset::{AddAsset, Handle};
+use bevy_asset::{AddAsset, Handle, HandleUntyped};
 use bevy_ecs::system::{lifetimeless::SRes, SystemParamItem};
 use bevy_math::Vec4;
 use bevy_reflect::TypeUuid;
@@ -13,6 +13,9 @@ use bevy_render::{
 };
 use crevice::std140::{AsStd140, Std140};
 use wgpu::{BindGroupDescriptor, BindGroupEntry, BindingResource};
+
+pub const DEFAULT_STANDARD_MATERIAL_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(StandardMaterial::TYPE_UUID, 13142262394054731189);
 
 /// A material with "standard" properties used in PBR lighting
 /// Standard property values with pictures here
@@ -77,6 +80,17 @@ impl Default for StandardMaterial {
             double_sided: false,
             unlit: false,
             alpha_mode: AlphaMode::Opaque,
+        }
+    }
+}
+
+impl StandardMaterial {
+    /// Create a high visibility material. It will be used by default when no material are specified in a `PbrBundle`
+    pub fn high_vis() -> Self {
+        StandardMaterial {
+            base_color: Color::rgb(1.0, 0.0, 0.5),
+            unlit: true,
+            ..Default::default()
         }
     }
 }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -84,17 +84,6 @@ impl Default for StandardMaterial {
     }
 }
 
-impl StandardMaterial {
-    /// Create a high visibility material. It will be used by default when no material are specified in a `PbrBundle`
-    pub fn high_vis() -> Self {
-        StandardMaterial {
-            base_color: Color::rgb(1.0, 0.0, 0.5),
-            unlit: true,
-            ..Default::default()
-        }
-    }
-}
-
 impl From<Color> for StandardMaterial {
     fn from(color: Color) -> Self {
         StandardMaterial {


### PR DESCRIPTION
# Objective

- Fix #3323 


## Solution

- Add a default standard material that is very visible. It is similar to the previous standard material that was used

<img width="1392" alt="Screenshot 2021-12-14 at 15 39 01" src="https://user-images.githubusercontent.com/8672791/146019401-ed4b5fc1-7cce-4a8f-a511-a6f9665a51d7.png">

