### PR TITLE
[Merged by Bors] - Added method to restart the current state

### DIFF
--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -21,6 +21,9 @@ impl<T> StateData for T where T: Send + Sync + Clone + Eq + Debug + Hash + 'stat
 #[derive(Debug)]
 pub struct State<T: StateData> {
     transition: Option<StateTransition<T>>,
+    /// The current states in the stack.
+    ///
+    /// There is always guaranteed to be at least one.
     stack: Vec<T>,
     scheduled: Option<ScheduledOperation<T>>,
     end_next_loop: bool,

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -380,7 +380,7 @@ where
             self.scheduled = Some(ScheduledOperation::Set(state.clone()));
             Ok(())
         } else {
-            return Err(StateError::StackEmpty);
+            Err(StateError::StackEmpty)
         }
     }
 
@@ -391,7 +391,7 @@ where
             self.scheduled = Some(ScheduledOperation::Set(state.clone()));
             Ok(())
         } else {
-            return Err(StateError::StackEmpty);
+            Err(StateError::StackEmpty)
         }
     }
 

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -376,23 +376,17 @@ where
             return Err(StateError::StateAlreadyQueued);
         }
 
-        if let Some(state) = self.stack.last() {
-            self.scheduled = Some(ScheduledOperation::Set(state.clone()));
-            Ok(())
-        } else {
-            Err(StateError::StackEmpty)
-        }
+        let state = self.stack.last().unwrap();
+        self.scheduled = Some(ScheduledOperation::Set(state.clone()));
+        Ok(())
     }
 
     /// Same as [Self::restart], but if there is already a scheduled state operation,
     /// it will be overwritten instead of failing
     pub fn overwrite_restart(&mut self) -> Result<(), StateError> {
-        if let Some(state) = self.stack.last() {
-            self.scheduled = Some(ScheduledOperation::Set(state.clone()));
-            Ok(())
-        } else {
-            Err(StateError::StackEmpty)
-        }
+        let state = self.stack.last().unwrap();
+        self.scheduled = Some(ScheduledOperation::Set(state.clone()));
+        Ok(())
     }
 
     pub fn current(&self) -> &T {

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -386,10 +386,9 @@ where
 
     /// Same as [Self::restart], but if there is already a scheduled state operation,
     /// it will be overwritten instead of failing
-    pub fn overwrite_restart(&mut self) -> Result<(), StateError> {
+    pub fn overwrite_restart(&mut self) {
         let state = self.stack.last().unwrap();
         self.scheduled = Some(ScheduledOperation::Set(state.clone()));
-        Ok(())
     }
 
     pub fn current(&self) -> &T {
@@ -727,8 +726,7 @@ mod test {
         // B. Restart state (overwrite schedule)
         let mut state = world.get_resource_mut::<State<LoadState>>().unwrap();
         state.set(LoadState::Finish).unwrap();
-        let result = state.overwrite_restart();
-        assert!(matches!(result, Ok(())));
+        state.overwrite_restart();
         stage.run(&mut world);
 
         // C. Fail restart state (transition already scheduled)

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -369,6 +369,32 @@ where
         Ok(())
     }
 
+    /// Schedule a state change that restarts the active state.
+    /// This will fail if there is a scheduled operation
+    pub fn restart(&mut self) -> Result<(), StateError> {
+        if self.scheduled.is_some() {
+            return Err(StateError::StateAlreadyQueued);
+        }
+
+        if let Some(state) = self.stack.last() {
+            self.scheduled = Some(ScheduledOperation::Set(state.clone()));
+            Ok(())
+        } else {
+            return Err(StateError::StackEmpty);
+        }
+    }
+
+    /// Same as [Self::restart], but if there is already a scheduled state operation,
+    /// it will be overwritten instead of failing
+    pub fn overwrite_restart(&mut self) -> Result<(), StateError> {
+        if let Some(state) = self.stack.last() {
+            self.scheduled = Some(ScheduledOperation::Set(state.clone()));
+            Ok(())
+        } else {
+            return Err(StateError::StackEmpty);
+        }
+    }
+
     pub fn current(&self) -> &T {
         self.stack.last().unwrap()
     }

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -384,7 +384,7 @@ where
         Ok(())
     }
 
-    /// Same as [Self::restart], but if there is already a scheduled state operation,
+    /// Same as [`Self::restart`], but if there is already a scheduled state operation,
     /// it will be overwritten instead of failing
     pub fn overwrite_restart(&mut self) {
         let state = self.stack.last().unwrap();


### PR DESCRIPTION
# Objective

It would be useful to be able to restart a state (such as if an operation fails and needs to be retried from `on_enter`). Currently, it seems the way to restart a state is to transition to a dummy state and then transition back.

## Solution

The solution is to add a `restart` method on `State<T>` that allows for transitioning to the already-active state.

## Context

Based on [this](https://discord.com/channels/691052431525675048/742884593551802431/920335041756815441) question from the Discord.

Closes #2385
