### PR TITLE
[Merged by Bors] - Add documentation to `KeyCode` for Mac users

### DIFF
--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -177,10 +177,12 @@ pub enum KeyCode {
     Grave,
     Kana,
     Kanji,
+    /// The left alt key. Maps to left option on Mac.
     LAlt,
     LBracket,
     LControl,
     LShift,
+    /// The left Windows key. Maps to left Command on Mac.
     LWin,
     Mail,
     MediaSelect,
@@ -201,10 +203,12 @@ pub enum KeyCode {
     PlayPause,
     Power,
     PrevTrack,
+    /// The right alt key. Maps to right option on Mac.
     RAlt,
     RBracket,
     RControl,
     RShift,
+    /// The right Windows key. Maps to right Command on Mac.
     RWin,
     Semicolon,
     Slash,


### PR DESCRIPTION
# Objective

`KeyCode::*Win` and `KeyCode::*Alt` might be confusing for some Mac users.

## Solution

Added some small documentation to clarify the mappings for those developing on a Mac.

## Additional Context

Related issue: #3240 