### PR TITLE
[Merged by Bors] - re-export ClearPassNode

### DIFF
--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -33,8 +33,6 @@ use bevy_render::{
     RenderApp, RenderStage, RenderWorld,
 };
 
-use crate::clear_pass::ClearPassNode;
-
 /// Resource that configures the clear color
 #[derive(Clone, Debug)]
 pub struct ClearColor(pub Color);


### PR DESCRIPTION
Currently the `ClearPassNode` is not exported, due to an additional `use ...;` in the core pipeline's `lib.rs`. This seems unintentional, as there already is a public glob import in the file.

This just removes the explicit use. If it actually was intentional to keep the node internal, let me know.