### PR TITLE
[Merged by Bors] - Enable trace feature for subfeatures using it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ bevy_gilrs = ["bevy_internal/bevy_gilrs"]
 bevy_gltf = ["bevy_internal/bevy_gltf"]
 bevy_winit = ["bevy_internal/bevy_winit"]
 
-trace_chrome = ["bevy_internal/trace_chrome"]
-trace_tracy = ["bevy_internal/trace_tracy"]
+trace_chrome = ["trace", "bevy_internal/trace_chrome"]
+trace_tracy = ["trace", "bevy_internal/trace_tracy"]
 trace = ["bevy_internal/trace"]
 wgpu_trace = ["bevy_internal/wgpu_trace"]
 

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -21,7 +21,7 @@
 |-|-|
 |bevy_dynamic_plugin|Plugin for dynamic loading (using [libloading](https://crates.io/crates/libloading)).|
 |dynamic|Forces bevy to be dynamically linked, which improves iterative compile times.|
-|trace|Enables system tracing (useful in tandem with a feature like trace_chrome).|
+|trace|Enables system tracing.|
 |trace_chrome|Enables [tracing-chrome](https://github.com/thoren-d/tracing-chrome) as bevy_log output. This allows you to visualize system execution.|
 |trace_tracy|Enables [Tracy](https://github.com/wolfpld/tracy) as bevy_log output. This allows `Tracy` to connect to and capture profiling data as well as visualize system execution in real-time, present statistics about system execution times, and more.|
 |wgpu_trace|For tracing wgpu.|

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -6,7 +6,7 @@ Bevy has built-in [tracing](https://github.com/tokio-rs/tracing) spans to make i
 
 ### Backend: trace_chrome
 
-`cargo run --release --features trace,trace_chrome`
+`cargo run --release --features trace_chrome`
 
 After running your app a `json` file in the "chrome tracing format" will be produced. You can open this file in your browser using <https://ui.perfetto.dev>. It will look something like this (make sure you expand `Process 1`):
 


### PR DESCRIPTION
# Objective

- It isn't very useful to be able to enable feature `trace_chrome` on its own

## Solution

- Enable `trace` feature when enabling `trace_chrome` or `trace_tracy`
