### PR TITLE
[Merged by Bors] - remove advisory for spirv-reflect

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,7 +10,6 @@ ignore = [
     "RUSTSEC-2020-0158", # from rodio v0.14.0 - unmaintained - https://github.com/gnzlbg/slice_deque/issues/94
     "RUSTSEC-2021-0047", # from rodio v0.14.0 - unsafety - https://github.com/gnzlbg/slice_deque/issues/90
     "RUSTSEC-2020-0095", # from crevice dev dependency - unmaintained - https://github.com/johannhof/difference.rs/issues/45
-    "RUSTSEC-2021-0096", # from spirv-reflect v0.2.3 - unmaintained - https://github.com/gfx-rs/rspirv/issues/197
     "RUSTSEC-2021-0119", # from rodio 0.14.0 - unsafety - https://github.com/nix-rust/nix/issues/1541
 ]
 


### PR DESCRIPTION
# Objective

- With the removal of the old renderer, Bevy doesn't depend on spirv-reflect 🎉 

## Solution

- Remove its advisory from the ignored list
