### PR TITLE
Ensure `GlobalTransform` consistency when `Parent` is spawned without `Children`

### DIFF
--- a/crates/bevy_transform/src/components/mod.rs
+++ b/crates/bevy_transform/src/components/mod.rs
@@ -5,5 +5,5 @@ mod transform;
 
 pub use children::Children;
 pub use global_transform::*;
-pub use parent::{Parent, PreviousParent};
+pub use parent::{DirtyParent, Parent, PreviousParent};
 pub use transform::*;

--- a/crates/bevy_transform/src/components/parent.rs
+++ b/crates/bevy_transform/src/components/parent.rs
@@ -59,3 +59,6 @@ impl FromWorld for PreviousParent {
         PreviousParent(Entity::new(u32::MAX))
     }
 }
+
+#[derive(Component, Debug, Copy, Clone, Eq, PartialEq, Reflect)]
+pub struct DirtyParent;

--- a/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
+++ b/crates/bevy_transform/src/hierarchy/hierarchy_maintenance_system.rs
@@ -67,8 +67,8 @@ pub fn parent_update_system(
     // collect multiple new children that point to the same parent into the same
     // SmallVec, and to prevent redundant add+remove operations.
     children_additions.iter().for_each(|(e, v)| {
-        // Mark the entity with `Dirty` so that systems which run
-        // in the same stage have a way to `Query` for a missed update
+        // Mark the entity with a `DirtyParent` component so that systems which run
+        // in the same stage have a way to query for a missed update.
         commands
             .entity(*e)
             .insert_bundle((Children::with(v), DirtyParent));

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -9,7 +9,10 @@ pub mod prelude {
 
 use bevy_app::prelude::*;
 use bevy_ecs::schedule::{ParallelSystemDescriptorCoercion, SystemLabel};
-use prelude::{parent_update_system, Children, GlobalTransform, Parent, PreviousParent, Transform};
+use prelude::{
+    clean_dirty_parents, parent_update_system, Children, GlobalTransform, Parent, PreviousParent,
+    Transform,
+};
 
 #[derive(Default)]
 pub struct TransformPlugin;
@@ -47,6 +50,7 @@ impl Plugin for TransformPlugin {
                 transform_propagate_system::transform_propagate_system
                     .label(TransformSystem::TransformPropagate)
                     .after(TransformSystem::ParentUpdate),
-            );
+            )
+            .add_system_to_stage(CoreStage::PostUpdate, clean_dirty_parents);
     }
 }

--- a/crates/bevy_transform/src/transform_propagate_system.rs
+++ b/crates/bevy_transform/src/transform_propagate_system.rs
@@ -67,7 +67,7 @@ fn propagate_recursive(
         for child in children.0.iter() {
             propagate_recursive(
                 &global_matrix,
-                &dirty_parent_query,
+                dirty_parent_query,
                 changed_transform_query,
                 transform_query,
                 children_query,


### PR DESCRIPTION
# Objective

Closes #3329

# Solution

`parent_update` and `transform_propagate` run in the same stage but `parent_update` can spawn `Children`. This means that the `system` can enter an inconsistent state where the `GlobalTransform` has not been updated on `Children` when spawning an `Entity` where the `Parent` does not have an existing `Children` component.

Introduce a marker trait, `DirtyParent`, so that the system will revert to the correct state the next time the systems run.
