### PR TITLE
Label conflicting PRs

### DIFF
--- a/.github/workflows/conflicting-PR.yml
+++ b/.github/workflows/conflicting-PR.yml
@@ -1,0 +1,14 @@
+name: PR-Conflict-Labeler
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  conflicts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@5981f8933e92b78098af86b9e33fe0871cc7a3be
+        with:
+          CONFLICT_LABEL_NAME: "S-Conflicts"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/conflicting-PR.yml
+++ b/.github/workflows/conflicting-PR.yml
@@ -8,7 +8,7 @@ jobs:
   conflicts:
     runs-on: ubuntu-latest
     steps:
-      - uses: mschilde/auto-label-merge-conflicts@5981f8933e92b78098af86b9e33fe0871cc7a3be
+      - uses: mschilde/auto-label-merge-conflicts@8c6faa8a252e35ba5e15703b3d747bf726cdb95c
         with:
           CONFLICT_LABEL_NAME: "S-Conflicts"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Objective

- PRs can get conflicts due to other PRs merged
- It's painful to manually check for conflicts on each PR

## Solution

- Add an action to label conflicting PR on every push

@cart if you agree with this action, you would need to add the label `S-Conflicts` and add a GitHub token for the secret. I reviewed the action, I won't guarantee it's bug free but it doesn't do anything nefarious with the token. I've set it up with the version I reviewed
