### PR TITLE
[Merged by Bors] - Support topologies other than TriangleList

### DIFF
--- a/crates/bevy_pbr/src/render/mod.rs
+++ b/crates/bevy_pbr/src/render/mod.rs
@@ -269,6 +269,8 @@ pub fn queue_meshes(
                         if mesh.has_tangents {
                             pbr_key.mesh_key |= MeshPipelineKey::VERTEX_TANGENTS;
                         }
+                        pbr_key.mesh_key |=
+                            MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
                     }
 
                     if let AlphaMode::Blend = material.alpha_mode {

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -593,6 +593,7 @@ pub struct GpuMesh {
     pub vertex_buffer: Buffer,
     pub index_info: Option<GpuIndexInfo>,
     pub has_tangents: bool,
+    pub primitive_topology: PrimitiveTopology,
 }
 
 /// The index info of a [`GpuMesh`].
@@ -640,6 +641,7 @@ impl RenderAsset for Mesh {
             vertex_buffer,
             index_info,
             has_tangents: mesh.attributes.contains_key(Mesh::ATTRIBUTE_TANGENT),
+            primitive_topology: mesh.primitive_topology(),
         })
     }
 }


### PR DESCRIPTION
# Objective

Fixes https://github.com/bevyengine/bevy/issues/3346

## Solution

I've encoded the topology in the `MeshKey` similar to how MSAA samples are handled.
