### PR TITLE
[Merged by Bors] - CI: use lavapipe instead of swiftshader when running examples

### DIFF
--- a/.github/example-run/breakout.ron
+++ b/.github/example-run/breakout.ron
@@ -1,3 +1,3 @@
 (
-    exit_after: Some(1800)
+    exit_after: Some(900)
 )

--- a/.github/example-run/contributors.ron
+++ b/.github/example-run/contributors.ron
@@ -1,3 +1,3 @@
 (
-    exit_after: Some(1800)
+    exit_after: Some(900)
 )

--- a/.github/example-run/scene.ron
+++ b/.github/example-run/scene.ron
@@ -1,3 +1,3 @@
 (
-    exit_after: Some(1800)
+    exit_after: Some(100)
 )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,11 +216,17 @@ jobs:
   run-examples:
     runs-on: ubuntu-latest
     steps:
-      - name: Install dependencies
+      - name: Install Bevy dependencies
         run: |
           sudo apt-get update;
           DEBIAN_FRONTEND=noninteractive sudo apt-get install --no-install-recommends -yq \
-            libasound2-dev libudev-dev wget unzip xvfb;
+            libasound2-dev libudev-dev;
+      - name: install xvfb, llvmpipe and lavapipe
+        run: |
+          sudo apt-get update -y -qq
+          sudo add-apt-repository ppa:oibaf/graphics-drivers -y
+          sudo apt-get update
+          sudo apt install -y xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
@@ -234,23 +240,23 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - name: Setup swiftshader
-        run: |
-          wget https://github.com/qarmin/gtk_library_store/releases/download/3.24.0/swiftshader.zip;
-          unzip swiftshader.zip;
-          curr="$(pwd)/libvk_swiftshader.so";
-          sed -i "s|PATH_TO_CHANGE|$curr|" vk_swiftshader_icd.json;
       - name: Build bevy
         run: |
-          cargo build --no-default-features --features "bevy_dynamic_plugin,bevy_gilrs,bevy_gltf,bevy_winit,render,png,hdr,x11,bevy_ci_testing"
+          cargo build --no-default-features --features "bevy_dynamic_plugin,bevy_gilrs,bevy_gltf,bevy_winit,render,png,hdr,x11,bevy_ci_testing,trace,trace_chrome"
       - name: Run examples
         run: |
           for example in .github/example-run/*.ron; do
             example_name=`basename $example .ron`
             echo "running $example_name - "`date`
-            time CI_TESTING_CONFIG=$example VK_ICD_FILENAMES=$(pwd)/vk_swiftshader_icd.json DRI_PRIME=0 xvfb-run cargo run --example $example_name --no-default-features --features "bevy_dynamic_plugin,bevy_gilrs,bevy_gltf,bevy_winit,render,png,hdr,x11,bevy_ci_testing"
+            time CI_TESTING_CONFIG=$example xvfb-run cargo run --example $example_name --no-default-features --features "bevy_dynamic_plugin,bevy_gilrs,bevy_gltf,bevy_winit,render,png,hdr,x11,bevy_ci_testing,trace,trace_chrome"
             sleep 10
           done
+          zip traces.zip trace*.json
+      - name: save traces
+        uses: actions/upload-artifact@v1
+        with:
+          name: example-traces.zip
+          path: traces.zip
 
   check-doc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Objective

- fixes #3344
- have example run faster

## Solution

- thanks to the nice folks at wgpu, I was able to switch from swift shader to lavapipe which is faster
- I also reduced the runtime for some of the examples
- I enabled the trace_chrome feature on the examples, and stored the results as an artefact. it can be useful to debug
- runtime is back to around 10 minutes
