### PR TITLE
[Merged by Bors] - Improved bevymark: no bouncing offscreen and spawn waves from CLI

### DIFF
--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -47,7 +47,7 @@ fn main() {
         .add_system_set(
             SystemSet::new()
                 .with_run_criteria(FixedTimestep::step(0.2))
-                .with_system(scheduled_spawne),
+                .with_system(scheduled_spawner),
         )
         .run();
 }
@@ -57,7 +57,7 @@ struct BirdScheduled {
     per_wave: u128,
 }
 
-fn scheduled_spawne(
+fn scheduled_spawner(
     mut commands: Commands,
     windows: Res<Windows>,
     mut scheduled: ResMut<BirdScheduled>,

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -3,7 +3,7 @@ use bevy::{
     diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
 };
-use rand::{random, Rng};
+use rand::random;
 
 const BIRDS_PER_SECOND: u32 = 10000;
 const _BASE_COLOR: Color = Color::rgb(5.0, 5.0, 5.0);
@@ -254,16 +254,4 @@ fn counter_system(
             }
         }
     };
-}
-
-/// Generate a color modulation
-///
-/// Because there is no `Mul<Color> for Color` instead `[f32; 3]` is
-/// used.
-fn _gen_color(rng: &mut impl Rng) -> [f32; 3] {
-    let r = rng.gen_range(0.2..1.0);
-    let g = rng.gen_range(0.2..1.0);
-    let b = rng.gen_range(0.2..1.0);
-    let v = Vec3::new(r, g, b);
-    v.normalize().into()
 }

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -65,7 +65,6 @@ fn scheduled_spawner(
     bird_texture: Res<BirdTexture>,
 ) {
     if scheduled.wave > 0 {
-        counter.color = Color::rgb(random(), random(), random());
         spawn_birds(
             &mut commands,
             &windows,
@@ -73,6 +72,7 @@ fn scheduled_spawner(
             scheduled.per_wave,
             bird_texture.0.clone_weak(),
         );
+        counter.color = Color::rgb(random(), random(), random());
         scheduled.wave -= 1;
     }
 }

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -235,6 +235,9 @@ fn collision_system(windows: Res<Windows>, mut bird_query: Query<(&mut Bird, &Tr
         if y_vel < 0. && y_pos - HALF_BIRD_SIZE < -half_height {
             bird.velocity.y = -y_vel;
         }
+        if y_pos + HALF_BIRD_SIZE > half_height && y_vel > 0.0 {
+            bird.velocity.y = 0.0;
+        }
     }
 }
 

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -72,7 +72,7 @@ fn scheduled_spawner(
             scheduled.per_wave,
             bird_texture.0.clone_weak(),
         );
-        counter.color = Color::rgb(random(), random(), random());
+        counter.color = Color::rgb_linear(random(), random(), random());
         scheduled.wave -= 1;
     }
 }
@@ -156,7 +156,7 @@ fn mouse_handler(
     mut counter: ResMut<BevyCounter>,
 ) {
     if mouse_button_input.just_released(MouseButton::Left) {
-        counter.color = Color::rgb(random(), random(), random());
+        counter.color = Color::rgb_linear(random(), random(), random());
     }
 
     if mouse_button_input.pressed(MouseButton::Left) {
@@ -166,7 +166,7 @@ fn mouse_handler(
             &windows,
             &mut counter,
             spawn_count,
-            bird_texture.0.clone(),
+            bird_texture.0.clone_weak(),
         );
     }
 }


### PR DESCRIPTION
# Objective

- In bevymark, bevies were very bouncy and could go off screen after a while, skewing the FPS

https://user-images.githubusercontent.com/8672791/146540848-282fa11b-d058-4da9-8e95-688ae67d9406.mp4

## Solution

- Make bevies bounce also on top of the screen
- I also changed how the examples read args from CLI to be able to spawn waves: `cargo run --example bevymark --release -- 5 100` (first is number of bevy per wave, second is number of wave, with one wave every 0.2 seconds). This makes it easier to reproduce some exact situations

https://user-images.githubusercontent.com/8672791/146542857-2f953fa0-7b8d-4772-93f8-b8d7a31259dc.mp4


