### PR TITLE
[Merged by Bors] - Fixes minimization crash because of cluster updates.

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -220,7 +220,7 @@ impl Clusters {
         clusters
     }
 
-    fn from_screen_size_and_z_slices(screen_size: UVec2, z_slices: u32) -> Self {     
+    fn from_screen_size_and_z_slices(screen_size: UVec2, z_slices: u32) -> Self {
         let aspect_ratio = screen_size.x as f32 / screen_size.y as f32;
         let n_tiles_y =
             ((ViewClusterBindings::MAX_OFFSETS as u32 / z_slices) as f32 / aspect_ratio).sqrt();

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -361,7 +361,7 @@ pub fn update_clusters(windows: Res<Windows>, mut views: Query<(&Camera, &mut Cl
         let screen_size_u32 = UVec2::new(window.physical_width(), window.physical_height());
         // Don't update clusters if screen size is 0.
         if screen_size_u32 == UVec2::ZERO {
-            return;
+            continue;
         }
         *clusters =
             Clusters::from_screen_size_and_z_slices(screen_size_u32, clusters.axis_slices.z);

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -360,7 +360,7 @@ pub fn update_clusters(windows: Res<Windows>, mut views: Query<(&Camera, &mut Cl
         let window = windows.get(camera.window).unwrap();
         let screen_size_u32 = UVec2::new(window.physical_width(), window.physical_height());
         // Don't update clusters if screen size is 0.
-        if screen_size_u32 == UVec2::ZERO {
+        if screen_size_u32.x == 0 || screen_size_u32.y == 0 {
             continue;
         }
         *clusters =

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -220,7 +220,7 @@ impl Clusters {
         clusters
     }
 
-    fn from_screen_size_and_z_slices(screen_size: UVec2, z_slices: u32) -> Self {
+    fn from_screen_size_and_z_slices(screen_size: UVec2, z_slices: u32) -> Self {     
         let aspect_ratio = screen_size.x as f32 / screen_size.y as f32;
         let n_tiles_y =
             ((ViewClusterBindings::MAX_OFFSETS as u32 / z_slices) as f32 / aspect_ratio).sqrt();
@@ -359,6 +359,10 @@ pub fn update_clusters(windows: Res<Windows>, mut views: Query<(&Camera, &mut Cl
         let inverse_projection = camera.projection_matrix.inverse();
         let window = windows.get(camera.window).unwrap();
         let screen_size_u32 = UVec2::new(window.physical_width(), window.physical_height());
+        // Don't update clusters if screen size is 0.
+        if screen_size_u32 == UVec2::ZERO {
+            return;
+        }
         *clusters =
             Clusters::from_screen_size_and_z_slices(screen_size_u32, clusters.axis_slices.z);
         let screen_size = screen_size_u32.as_vec2();


### PR DESCRIPTION
# Objective
Fixes: #3368

Issue was caused by screen size being: `(0, 0)`.

## Solution
Don't update clusters if the screen size is zero. A better solution might be to not render when minimized, but this works in the meantime.
