### PR TITLE
[Merged by Bors] - Fix hierarchy example panic

### DIFF
--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -107,7 +107,7 @@ fn rotate(
         // seconds
         if time.seconds_since_startup() >= 2.0 && children.len() == 3 {
             let child = children.last().copied().unwrap();
-            commands.entity(child).despawn();
+            commands.entity(child).despawn_recursive();
         }
 
         if time.seconds_since_startup() >= 4.0 {


### PR DESCRIPTION
# Objective
Fixes #3321 

## Solution
Uses `despawn_recursive()` instead of `despawn()` when removing children.