### PR TITLE
[Merged by Bors] - Basic EntityRef and EntityMut docs

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use std::any::TypeId;
 
+/// A read-only reference to a particular [Entity] and all of its components
 pub struct EntityRef<'w> {
     world: &'w World,
     entity: Entity,
@@ -98,6 +99,7 @@ impl<'w> EntityRef<'w> {
     }
 }
 
+/// A mutable reference to a particular [Entity] and all of its components
 pub struct EntityMut<'w> {
     world: &'w mut World,
     entity: Entity,
@@ -464,6 +466,8 @@ impl<'w> EntityMut<'w> {
 }
 
 // TODO: move to Storages?
+/// Get a raw pointer to a particular [Component] on a particular [Entity] in the provided [World].
+///
 /// # Safety
 /// `entity_location` must be within bounds of the given archetype and `entity` must exist inside
 /// the archetype
@@ -494,6 +498,8 @@ unsafe fn get_component(
 }
 
 // TODO: move to Storages?
+/// Get a raw pointer to and the [ComponentTicks] of a particular [Component] on a particular [Entity] in the provided [World].
+///
 /// # Safety
 /// Caller must ensure that `component_id` is valid
 #[inline]
@@ -566,6 +572,8 @@ unsafe fn take_component(
     }
 }
 
+/// Get a raw pointer to a particular [Component] by [TypeId] on a particular [Entity] in the provided [World].
+///
 /// # Safety
 /// `entity_location` must be within bounds of an archetype that exists.
 unsafe fn get_component_with_type(
@@ -578,6 +586,8 @@ unsafe fn get_component_with_type(
     get_component(world, component_id, entity, location)
 }
 
+/// Get a raw pointer to and [ComponentTicks] of a particular [Component] by [TypeId] on a particular [Entity] in the provided [World].
+///
 /// # Safety
 /// `entity_location` must be within bounds of an archetype that exists.
 pub(crate) unsafe fn get_component_and_ticks_with_type(

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -466,7 +466,7 @@ impl<'w> EntityMut<'w> {
 }
 
 // TODO: move to Storages?
-/// Get a raw pointer to a particular [Component] on a particular [Entity] in the provided [World].
+/// Get a raw pointer to a particular [`Component`] on a particular [`Entity`] in the provided [`World`].
 ///
 /// # Safety
 /// `entity_location` must be within bounds of the given archetype and `entity` must exist inside
@@ -498,7 +498,7 @@ unsafe fn get_component(
 }
 
 // TODO: move to Storages?
-/// Get a raw pointer to and the [ComponentTicks] of a particular [Component] on a particular [Entity] in the provided [World].
+/// Get a raw pointer to the [`ComponentTicks`] of a particular [`Component`] on a particular [`Entity`] in the provided [World].
 ///
 /// # Safety
 /// Caller must ensure that `component_id` is valid
@@ -572,7 +572,7 @@ unsafe fn take_component(
     }
 }
 
-/// Get a raw pointer to a particular [Component] by [TypeId] on a particular [Entity] in the provided [World].
+/// Get a raw pointer to a particular [`Component`] by [`TypeId`] on a particular [`Entity`] in the provided [`World`].
 ///
 /// # Safety
 /// `entity_location` must be within bounds of an archetype that exists.
@@ -586,7 +586,7 @@ unsafe fn get_component_with_type(
     get_component(world, component_id, entity, location)
 }
 
-/// Get a raw pointer to and [ComponentTicks] of a particular [Component] by [TypeId] on a particular [Entity] in the provided [World].
+/// Get a raw pointer to the [`ComponentTicks`] of a particular [`Component`] by [`TypeId`] on a particular [`Entity`] in the provided [`World`].
 ///
 /// # Safety
 /// `entity_location` must be within bounds of an archetype that exists.

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use std::any::TypeId;
 
-/// A read-only reference to a particular [Entity] and all of its components
+/// A read-only reference to a particular [`Entity`] and all of its components
 pub struct EntityRef<'w> {
     world: &'w World,
     entity: Entity,
@@ -99,7 +99,7 @@ impl<'w> EntityRef<'w> {
     }
 }
 
-/// A mutable reference to a particular [Entity] and all of its components
+/// A mutable reference to a particular [`Entity`] and all of its components
 pub struct EntityMut<'w> {
     world: &'w mut World,
     entity: Entity,


### PR DESCRIPTION
# Objective

- `EntityRef` and `EntityMut` are surpisingly important public types when working directly with the `World`.
- They're undocumented.

## Solution

- Just add docs!