### PR TITLE
[Merged by Bors] - Basic docs for Storages

### DIFF
--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -3,6 +3,9 @@ use std::{
     ptr::NonNull,
 };
 
+/// A flat, type-erased data storage type
+///
+/// Used to densely store homogeneous ECS data.
 #[derive(Debug)]
 pub struct BlobVec {
     item_layout: Layout,
@@ -122,7 +125,7 @@ impl BlobVec {
         self.len = old_len;
     }
 
-    /// increases the length by one (and grows the vec if needed) with uninitialized memory and
+    /// Increases the length by one (and grows the vec if needed) with uninitialized memory and
     /// returns the index
     ///
     /// # Safety

--- a/crates/bevy_ecs/src/storage/mod.rs
+++ b/crates/bevy_ecs/src/storage/mod.rs
@@ -8,6 +8,7 @@ pub use blob_vec::*;
 pub use sparse_set::*;
 pub use table::*;
 
+/// The raw data stores of a [World](crate::world::World)
 #[derive(Default)]
 pub struct Storages {
     pub sparse_sets: SparseSets,

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -88,6 +88,9 @@ impl<I: SparseSetIndex, V> SparseArray<I, V> {
     }
 }
 
+/// A sparse data structure of [Components](crate::component::Component)
+///
+/// Designed for relatively fast insertions and deletions.
 #[derive(Debug)]
 pub struct ComponentSparseSet {
     dense: BlobVec,
@@ -228,6 +231,9 @@ impl ComponentSparseSet {
     }
 }
 
+/// A data structure that blends dense and sparse storage
+///
+/// `I` is the type of the indices, while `V` is the type of data stored in the dense storage.
 #[derive(Debug)]
 pub struct SparseSet<I, V: 'static> {
     dense: Vec<V>,
@@ -391,6 +397,9 @@ macro_rules! impl_sparse_set_index {
 
 impl_sparse_set_index!(u8, u16, u32, u64, usize);
 
+/// A collection of [ComponentSparseSet] storages, indexed by [ComponentId]
+///
+/// Can be accessed via [Storages](crate::storage::Storages)
 #[derive(Default)]
 pub struct SparseSets {
     sets: SparseSet<ComponentId, ComponentSparseSet>,

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -410,6 +410,9 @@ impl Table {
     }
 }
 
+/// A collection of [Table] storages, indexed by [TableId]
+///
+/// Can be accessed via [Storages](crate::storage::Storages)
 pub struct Tables {
     tables: Vec<Table>,
     table_ids: HashMap<u64, TableId>,


### PR DESCRIPTION
# Objective

- Storages are used to store the ECS data.
- They're undocumented.

## Solution

- Add some very basic docs.

## Notes
- Some of this was hard to immediately understand when reading the code, so suggestions on improvements / things to add are particularly welcome.