### PR TITLE
[Merged by Bors] - Add some of the missing methods to `TrackedRenderPass`

### DIFF
--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -1,5 +1,9 @@
-use crate::render_resource::{
-    BindGroup, BindGroupId, BufferId, BufferSlice, RenderPipeline, RenderPipelineId, ShaderStages,
+use crate::{
+    prelude::Color,
+    render_resource::{
+        BindGroup, BindGroupId, BufferId, BufferSlice, RenderPipeline, RenderPipelineId,
+        ShaderStages,
+    },
 };
 use bevy_utils::tracing::debug;
 use std::ops::Range;
@@ -272,12 +276,17 @@ impl<'a> TrackedRenderPass<'a> {
     }
 
     pub fn push_debug_group(&mut self, label: &str) {
-        debug!("insert push_debug_group marker: {}", label);
+        debug!("push_debug_group marker: {}", label);
         self.pass.push_debug_group(label)
     }
 
     pub fn pop_debug_group(&mut self) {
-        debug!("insert pop_debug_group");
+        debug!("pop_debug_group");
         self.pass.pop_debug_group()
+    }
+
+    pub fn set_blend_constant(&mut self, color: Color) {
+        debug!("set blend constant: {:?}", color);
+        self.pass.set_blend_constant(wgpu::Color::from(color))
     }
 }

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -1,5 +1,5 @@
 use crate::render_resource::{
-    BindGroup, BindGroupId, BufferId, BufferSlice, RenderPipeline, RenderPipelineId,
+    BindGroup, BindGroupId, BufferId, BufferSlice, RenderPipeline, RenderPipelineId, ShaderStages,
 };
 use bevy_utils::tracing::debug;
 use std::ops::Range;
@@ -234,5 +234,18 @@ impl<'a> TrackedRenderPass<'a> {
     pub fn set_scissor_rect(&mut self, x: u32, y: u32, width: u32, height: u32) {
         debug!("set_scissor_rect: {} {} {} {}", x, y, width, height);
         self.pass.set_scissor_rect(x, y, width, height);
+    }
+
+    /// Set push constant data.
+    ///
+    /// Features::PUSH_CONSTANTS must be enabled on the device in order to call these functions.
+    pub fn set_push_constants(&mut self, stages: ShaderStages, offset: u32, data: &[u8]) {
+        debug!(
+            "set push constants: {:?} offset: {} data.len: {}",
+            stages,
+            offset,
+            data.len()
+        );
+        self.pass.set_push_constants(stages, offset, data)
     }
 }

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -265,4 +265,19 @@ impl<'a> TrackedRenderPass<'a> {
         self.pass
             .set_viewport(x, y, width, height, min_depth, max_depth)
     }
+
+    pub fn insert_debug_marker(&mut self, label: &str) {
+        debug!("insert debug marker: {}", label);
+        self.pass.insert_debug_marker(label)
+    }
+
+    pub fn push_debug_group(&mut self, label: &str) {
+        debug!("insert push_debug_group marker: {}", label);
+        self.pass.push_debug_group(label)
+    }
+
+    pub fn pop_debug_group(&mut self) {
+        debug!("insert pop_debug_group");
+        self.pass.pop_debug_group()
+    }
 }

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -248,4 +248,21 @@ impl<'a> TrackedRenderPass<'a> {
         );
         self.pass.set_push_constants(stages, offset, data)
     }
+
+    pub fn set_viewport(
+        &mut self,
+        x: f32,
+        y: f32,
+        width: f32,
+        height: f32,
+        min_depth: f32,
+        max_depth: f32,
+    ) {
+        debug!(
+            "set viewport: {} {} {} {} {} {}",
+            x, y, width, height, min_depth, max_depth
+        );
+        self.pass
+            .set_viewport(x, y, width, height, min_depth, max_depth)
+    }
 }


### PR DESCRIPTION
# Objective

Add missing methods to `TrackedRenderPass`

- `set_push_constants`
- `set_viewport`
- `insert_debug_marker`
- `push_debug_group`
- `pop_debug_group`
- `set_blend_constant`

https://docs.rs/wgpu/0.12.0/wgpu/struct.RenderPass.html

I need `set_push_constants` but started adding the others as I noticed they were also missing. The `draw indirect` family of methods are still missing as are the `timestamp query` methods. 


