### PR TITLE
Make the default window title more descriptive

### DIFF
--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -14,6 +14,7 @@ bevy_app = { path = "../bevy_app", version = "0.5.0" }
 bevy_math = { path = "../bevy_math", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 raw-window-handle = "0.4.2"
+once_cell = "1.9.0"
 
 # other
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -559,10 +559,22 @@ pub struct WindowDescriptor {
     pub canvas: Option<String>,
 }
 
+impl WindowDescriptor {
+    fn default_window_title() -> String {
+        fn inner() -> Option<String> {
+            Some(format!(
+                "{} - bevy",
+                std::env::current_exe().ok()?.file_stem()?.to_string_lossy()
+            ))
+        }
+        inner().unwrap_or_else(|| "bevy".to_string())
+    }
+}
+
 impl Default for WindowDescriptor {
     fn default() -> Self {
         WindowDescriptor {
-            title: "bevy".to_string(),
+            title: Self::default_window_title(),
             width: 1280.,
             height: 720.,
             position: None,

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -103,7 +103,7 @@ impl WinitWindows {
             };
 
         #[allow(unused_mut)]
-        let mut winit_window_builder = winit_window_builder.with_title(&window_descriptor.title);
+        let mut winit_window_builder = winit_window_builder.with_title(window_descriptor.title());
 
         #[cfg(target_arch = "wasm32")]
         {


### PR DESCRIPTION
# Objective

- Default bevy windows don't have a very useful name:
![image](https://user-images.githubusercontent.com/36049421/146833290-47905801-006b-4ce0-a20e-d8cb346c0b99.png)
- We can include the binary name in the default title:
![image](https://user-images.githubusercontent.com/36049421/146833581-b6171ae4-9108-4d42-9df3-26a6ec7a9ad6.png)

## Solution

- Get the current binary title when using a `WindowDescriptor` which doesn't have a name set.
- When I timed the function which gets this, in debug mode it takes `26.8µs` (i.e. `0.0268ms`)

Note: We already transitively depend on `once_cell` in `bevy_window`, via `ahash`.
