### PR TITLE
[Merged by Bors] - Do not panic on failed setting of GameOver state in AlienCakeAddict

### DIFF
--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -308,7 +308,8 @@ fn spawn_bonus(
         commands.entity(entity).despawn_recursive();
         game.bonus.entity = None;
         if game.score <= -5 {
-            state.set(GameState::GameOver).unwrap();
+            // We don't particularly care if this operation fails
+            let _ = state.set(GameState::GameOver);
             return;
         }
     }

--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -309,7 +309,7 @@ fn spawn_bonus(
         game.bonus.entity = None;
         if game.score <= -5 {
             // We don't particularly care if this operation fails
-            let _ = state.set(GameState::GameOver);
+            let _ = state.overwrite_set(GameState::GameOver);
             return;
         }
     }


### PR DESCRIPTION
# Objective

- Tentatively fixes #2525.

## Solution

- The panic seems to occur when the game-over state occurs nearly instantly.
- Discard the `Result`, rather than panicking. We could probably handle this better, but I want to see if this works first. Ping @qarmin.