### PR TITLE
[Merged by Bors] - Use EventWriter for gilrs_system

### DIFF
--- a/crates/bevy_gilrs/src/gilrs_system.rs
+++ b/crates/bevy_gilrs/src/gilrs_system.rs
@@ -1,42 +1,36 @@
 use crate::converter::{convert_axis, convert_button, convert_gamepad_id};
-use bevy_app::Events;
-use bevy_ecs::system::{NonSend, NonSendMut, ResMut};
+use bevy_app::EventWriter;
+use bevy_ecs::system::{NonSend, NonSendMut};
 use bevy_input::{gamepad::GamepadEventRaw, prelude::*};
 use gilrs::{EventType, Gilrs};
 
-pub fn gilrs_event_startup_system(
-    gilrs: NonSend<Gilrs>,
-    mut event: ResMut<Events<GamepadEventRaw>>,
-) {
+pub fn gilrs_event_startup_system(gilrs: NonSend<Gilrs>, mut events: EventWriter<GamepadEventRaw>) {
     for (id, _) in gilrs.gamepads() {
-        event.send(GamepadEventRaw(
+        events.send(GamepadEventRaw(
             convert_gamepad_id(id),
             GamepadEventType::Connected,
         ));
     }
 }
 
-pub fn gilrs_event_system(
-    mut gilrs: NonSendMut<Gilrs>,
-    mut event: ResMut<Events<GamepadEventRaw>>,
-) {
+pub fn gilrs_event_system(mut gilrs: NonSendMut<Gilrs>, mut events: EventWriter<GamepadEventRaw>) {
     while let Some(gilrs_event) = gilrs.next_event() {
         match gilrs_event.event {
             EventType::Connected => {
-                event.send(GamepadEventRaw(
+                events.send(GamepadEventRaw(
                     convert_gamepad_id(gilrs_event.id),
                     GamepadEventType::Connected,
                 ));
             }
             EventType::Disconnected => {
-                event.send(GamepadEventRaw(
+                events.send(GamepadEventRaw(
                     convert_gamepad_id(gilrs_event.id),
                     GamepadEventType::Disconnected,
                 ));
             }
             EventType::ButtonChanged(gilrs_button, value, _) => {
                 if let Some(button_type) = convert_button(gilrs_button) {
-                    event.send(GamepadEventRaw(
+                    events.send(GamepadEventRaw(
                         convert_gamepad_id(gilrs_event.id),
                         GamepadEventType::ButtonChanged(button_type, value),
                     ));
@@ -44,7 +38,7 @@ pub fn gilrs_event_system(
             }
             EventType::AxisChanged(gilrs_axis, value, _) => {
                 if let Some(axis_type) = convert_axis(gilrs_axis) {
-                    event.send(GamepadEventRaw(
+                    events.send(GamepadEventRaw(
                         convert_gamepad_id(gilrs_event.id),
                         GamepadEventType::AxisChanged(axis_type, value),
                     ));


### PR DESCRIPTION
# Objective

- fixes #3397 

## Solution

- Uses EventWriter instead of ResMut<Event> in gilrs_system.rs.

I also renamed the argument from `event` to `events` for consistency. All other instances I could find in the engine of EventWriter use a plural argument name. Happy to undo or modify this change if desired.
