### PR TITLE
[Merged by Bors] - Change default window title to "app"

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -578,7 +578,7 @@ pub struct WindowDescriptor {
 impl Default for WindowDescriptor {
     fn default() -> Self {
         WindowDescriptor {
-            title: "bevy".to_string(),
+            title: "app".to_string(),
             width: 1280.,
             height: 720.,
             position: None,


### PR DESCRIPTION
Implements the changes cart decided on in https://github.com/bevyengine/bevy/pull/3404#issuecomment-999806086

> - The default title should be changed to app so we don't leak the "bevy context" by default. app is generic enough that most people building real games will probably want to change it, but also generic enough that if someone doesn't manually set it, users won't bat an eye. I prefer this to binary names because they won't be consistent on all platforms / setups. A user (or developer) renaming a binary would implicitly rename the window title, which feels odd to me.
> - No debug info in the title by default. An opt in plugin for that would be nice though.

closes #3404 ?
