### PR TITLE
Split buttons and axes and improve ergonomics of working with gamepad input

### DIFF
--- a/crates/bevy_gilrs/src/converter.rs
+++ b/crates/bevy_gilrs/src/converter.rs
@@ -1,30 +1,30 @@
-use bevy_input::gamepad::{Gamepad, GamepadAxisType, GamepadButtonType};
+use bevy_input::gamepad::{Gamepad, GamepadAxisType, GamepadButton};
 
 pub fn convert_gamepad_id(gamepad_id: gilrs::GamepadId) -> Gamepad {
     Gamepad(gamepad_id.into())
 }
 
-pub fn convert_button(button: gilrs::Button) -> Option<GamepadButtonType> {
+pub fn convert_button(button: gilrs::Button) -> Option<GamepadButton> {
     match button {
-        gilrs::Button::South => Some(GamepadButtonType::South),
-        gilrs::Button::East => Some(GamepadButtonType::East),
-        gilrs::Button::North => Some(GamepadButtonType::North),
-        gilrs::Button::West => Some(GamepadButtonType::West),
-        gilrs::Button::C => Some(GamepadButtonType::C),
-        gilrs::Button::Z => Some(GamepadButtonType::Z),
-        gilrs::Button::LeftTrigger => Some(GamepadButtonType::LeftTrigger),
-        gilrs::Button::LeftTrigger2 => Some(GamepadButtonType::LeftTrigger2),
-        gilrs::Button::RightTrigger => Some(GamepadButtonType::RightTrigger),
-        gilrs::Button::RightTrigger2 => Some(GamepadButtonType::RightTrigger2),
-        gilrs::Button::Select => Some(GamepadButtonType::Select),
-        gilrs::Button::Start => Some(GamepadButtonType::Start),
-        gilrs::Button::Mode => Some(GamepadButtonType::Mode),
-        gilrs::Button::LeftThumb => Some(GamepadButtonType::LeftThumb),
-        gilrs::Button::RightThumb => Some(GamepadButtonType::RightThumb),
-        gilrs::Button::DPadUp => Some(GamepadButtonType::DPadUp),
-        gilrs::Button::DPadDown => Some(GamepadButtonType::DPadDown),
-        gilrs::Button::DPadLeft => Some(GamepadButtonType::DPadLeft),
-        gilrs::Button::DPadRight => Some(GamepadButtonType::DPadRight),
+        gilrs::Button::South => Some(GamepadButton::South),
+        gilrs::Button::East => Some(GamepadButton::East),
+        gilrs::Button::North => Some(GamepadButton::North),
+        gilrs::Button::West => Some(GamepadButton::West),
+        gilrs::Button::C => Some(GamepadButton::C),
+        gilrs::Button::Z => Some(GamepadButton::Z),
+        gilrs::Button::LeftTrigger => Some(GamepadButton::LeftTrigger),
+        gilrs::Button::LeftTrigger2 => Some(GamepadButton::LeftTrigger2),
+        gilrs::Button::RightTrigger => Some(GamepadButton::RightTrigger),
+        gilrs::Button::RightTrigger2 => Some(GamepadButton::RightTrigger2),
+        gilrs::Button::Select => Some(GamepadButton::Select),
+        gilrs::Button::Start => Some(GamepadButton::Start),
+        gilrs::Button::Mode => Some(GamepadButton::Mode),
+        gilrs::Button::LeftThumb => Some(GamepadButton::LeftThumb),
+        gilrs::Button::RightThumb => Some(GamepadButton::RightThumb),
+        gilrs::Button::DPadUp => Some(GamepadButton::DPadUp),
+        gilrs::Button::DPadDown => Some(GamepadButton::DPadDown),
+        gilrs::Button::DPadLeft => Some(GamepadButton::DPadLeft),
+        gilrs::Button::DPadRight => Some(GamepadButton::DPadRight),
         gilrs::Button::Unknown => None,
     }
 }

--- a/crates/bevy_gilrs/src/converter.rs
+++ b/crates/bevy_gilrs/src/converter.rs
@@ -1,4 +1,4 @@
-use bevy_input::gamepad::{Gamepad, GamepadAxisType, GamepadButton};
+use bevy_input::gamepad::{Gamepad, GamepadAxis, GamepadButton};
 
 pub fn convert_gamepad_id(gamepad_id: gilrs::GamepadId) -> Gamepad {
     Gamepad(gamepad_id.into())
@@ -29,16 +29,16 @@ pub fn convert_button(button: gilrs::Button) -> Option<GamepadButton> {
     }
 }
 
-pub fn convert_axis(axis: gilrs::Axis) -> Option<GamepadAxisType> {
+pub fn convert_axis(axis: gilrs::Axis) -> Option<GamepadAxis> {
     match axis {
-        gilrs::Axis::LeftStickX => Some(GamepadAxisType::LeftStickX),
-        gilrs::Axis::LeftStickY => Some(GamepadAxisType::LeftStickY),
-        gilrs::Axis::LeftZ => Some(GamepadAxisType::LeftZ),
-        gilrs::Axis::RightStickX => Some(GamepadAxisType::RightStickX),
-        gilrs::Axis::RightStickY => Some(GamepadAxisType::RightStickY),
-        gilrs::Axis::RightZ => Some(GamepadAxisType::RightZ),
-        gilrs::Axis::DPadX => Some(GamepadAxisType::DPadX),
-        gilrs::Axis::DPadY => Some(GamepadAxisType::DPadY),
+        gilrs::Axis::LeftStickX => Some(GamepadAxis::LeftStickX),
+        gilrs::Axis::LeftStickY => Some(GamepadAxis::LeftStickY),
+        gilrs::Axis::LeftZ => Some(GamepadAxis::LeftZ),
+        gilrs::Axis::RightStickX => Some(GamepadAxis::RightStickX),
+        gilrs::Axis::RightStickY => Some(GamepadAxis::RightStickY),
+        gilrs::Axis::RightZ => Some(GamepadAxis::RightZ),
+        gilrs::Axis::DPadX => Some(GamepadAxis::DPadX),
+        gilrs::Axis::DPadY => Some(GamepadAxis::DPadY),
         gilrs::Axis::Unknown => None,
     }
 }

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -21,3 +21,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 
 # other
 serde = { version = "1", features = ["derive"], optional = true }
+strum = {version = "0.23"}
+strum_macros = {version = "0.23"}
+

--- a/crates/bevy_input/src/axis.rs
+++ b/crates/bevy_input/src/axis.rs
@@ -1,5 +1,6 @@
 use bevy_utils::HashMap;
 use std::hash::Hash;
+use strum::IntoEnumIterator;
 
 /// Stores the position data of input devices of type T
 ///
@@ -9,14 +10,13 @@ use std::hash::Hash;
 /// If you need to represent a continous input with a scalar intensity such as a trigger,
 /// use [Input](crate::Input) instead.
 #[derive(Debug)]
-pub struct Axis<T> {
+pub struct Axis<T: Axislike> {
     axis_data: HashMap<T, f32>,
 }
 
-impl<T> Default for Axis<T>
-where
-    T: Copy + Eq + Hash,
-{
+pub trait Axislike: Clone + Copy + PartialEq + Eq + Hash + IntoEnumIterator {}
+
+impl<T: Axislike> Default for Axis<T> {
     fn default() -> Self {
         Axis {
             axis_data: HashMap::default(),
@@ -24,10 +24,7 @@ where
     }
 }
 
-impl<T> Axis<T>
-where
-    T: Copy + Eq + Hash,
-{
+impl<T: Axislike> Axis<T> {
     pub const MIN: f32 = -1.0;
     pub const MAX: f32 = 1.0;
 
@@ -56,10 +53,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        gamepad::{Gamepad, GamepadAxis, GamepadAxisType},
-        Axis,
-    };
+    use crate::{gamepad::GamepadAxis, Axis};
 
     #[test]
     fn test_axis_set() {
@@ -78,7 +72,7 @@ mod tests {
         ];
 
         for (value, expected) in cases {
-            let gamepad_axis = GamepadAxis(Gamepad(1), GamepadAxisType::LeftStickX);
+            let gamepad_axis = GamepadAxis::LeftStickX;
             let mut axis = Axis::<GamepadAxis>::default();
 
             axis.set(gamepad_axis, value);
@@ -93,7 +87,7 @@ mod tests {
         let cases = [-1.0, -0.9, -0.1, 0.0, 0.1, 0.9, 1.0];
 
         for value in cases {
-            let gamepad_axis = GamepadAxis(Gamepad(1), GamepadAxisType::LeftStickX);
+            let gamepad_axis = GamepadAxis::LeftStickX;
             let mut axis = Axis::<GamepadAxis>::default();
 
             axis.set(gamepad_axis, value);

--- a/crates/bevy_input/src/axis.rs
+++ b/crates/bevy_input/src/axis.rs
@@ -57,7 +57,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        gamepad::{Gamepad, GamepadButton, GamepadButtonType},
+        gamepad::{Gamepad, GamepadAxis, GamepadAxisType},
         Axis,
     };
 
@@ -78,12 +78,12 @@ mod tests {
         ];
 
         for (value, expected) in cases {
-            let gamepad_button = GamepadButton(Gamepad(1), GamepadButtonType::RightTrigger);
-            let mut axis = Axis::<GamepadButton>::default();
+            let gamepad_axis = GamepadAxis(Gamepad(1), GamepadAxisType::LeftStickX);
+            let mut axis = Axis::<GamepadAxis>::default();
 
-            axis.set(gamepad_button, value);
+            axis.set(gamepad_axis, value);
 
-            let actual = axis.get(gamepad_button);
+            let actual = axis.get(gamepad_axis);
             assert_eq!(expected, actual);
         }
     }
@@ -93,14 +93,14 @@ mod tests {
         let cases = [-1.0, -0.9, -0.1, 0.0, 0.1, 0.9, 1.0];
 
         for value in cases {
-            let gamepad_button = GamepadButton(Gamepad(1), GamepadButtonType::RightTrigger);
-            let mut axis = Axis::<GamepadButton>::default();
+            let gamepad_axis = GamepadAxis(Gamepad(1), GamepadAxisType::LeftStickX);
+            let mut axis = Axis::<GamepadAxis>::default();
 
-            axis.set(gamepad_button, value);
-            assert!(axis.get(gamepad_button).is_some());
+            axis.set(gamepad_axis, value);
+            assert!(axis.get(gamepad_axis).is_some());
 
-            axis.remove(gamepad_button);
-            let actual = axis.get(gamepad_button);
+            axis.remove(gamepad_axis);
+            let actual = axis.get(gamepad_axis);
             let expected = None;
 
             assert_eq!(expected, actual);

--- a/crates/bevy_input/src/axis.rs
+++ b/crates/bevy_input/src/axis.rs
@@ -5,6 +5,9 @@ use std::hash::Hash;
 ///
 /// Values are stored as `f32` values, which range from `min` to `max`.
 /// The valid range is from -1.0 to 1.0, inclusive.
+///
+/// If you need to represent a continous input with a scalar intensity such as a trigger,
+/// use [Input](crate::Input) instead.
 #[derive(Debug)]
 pub struct Axis<T> {
     axis_data: HashMap<T, f32>,

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -5,6 +5,9 @@ use bevy_utils::{HashMap, HashSet};
 
 use strum_macros::EnumIter;
 
+/// A unique identifier for a gamepad, assigned sequentially
+///
+/// These are managed through the use of the [Gamepads] resource
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Gamepad(pub usize);
@@ -12,7 +15,8 @@ pub struct Gamepad(pub usize);
 #[derive(Default)]
 /// Container of unique connected [Gamepad]s
 ///
-/// [Gamepad]s are registered and deregistered in [gamepad_connection_system]
+/// Gamepads are registered and deregistered automatically in [gamepad_event_system],
+/// which also updates the input values stored in `buttons` and `axes`.
 pub struct Gamepads {
     gamepads: HashSet<Gamepad>,
     pub buttons: HashMap<Gamepad, Input<GamepadButton>>,

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -271,7 +271,7 @@ pub fn gamepad_event_system(
             }
             GamepadEventType::ButtonChanged(button_type, value) => {
                 let gamepad_button = GamepadButton(gamepad, *button_type);
-                button_input.set_value(gamepad_button, value);
+                button_input.set_value(gamepad_button, *value);
 
                 let button_property = settings.button_settings(gamepad_button);
                 if button_input.pressed(gamepad_button) {

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -45,7 +45,7 @@ impl Gamepads {
 pub enum GamepadEventType {
     Connected,
     Disconnected,
-    ButtonChanged(GamepadButtonType, f32),
+    ButtonChanged(GamepadButton, f32),
     AxisChanged(GamepadAxisType, f32),
 }
 
@@ -59,7 +59,7 @@ pub struct GamepadEventRaw(pub Gamepad, pub GamepadEventType);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, EnumIter)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-pub enum GamepadButtonType {
+pub enum GamepadButton {
     South,
     East,
     North,
@@ -80,10 +80,6 @@ pub enum GamepadButtonType {
     DPadLeft,
     DPadRight,
 }
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-pub struct GamepadButton(pub Gamepad, pub GamepadButtonType);
 
 impl Inputlike for GamepadButton {}
 
@@ -238,7 +234,7 @@ pub fn gamepad_event_system(
         match event {
             GamepadEventType::Connected => {
                 events.send(GamepadEvent(gamepad, event.clone()));
-                for button_type in GamepadButtonType::iter() {
+                for button_type in GamepadButton::iter() {
                     let gamepad_button = GamepadButton(gamepad, button_type);
                     button_input.reset(gamepad_button);
                 }
@@ -248,7 +244,7 @@ pub fn gamepad_event_system(
             }
             GamepadEventType::Disconnected => {
                 events.send(GamepadEvent(gamepad, event.clone()));
-                for button_type in GamepadButtonType::iter() {
+                for button_type in GamepadButton::iter() {
                     let gamepad_button = GamepadButton(gamepad, button_type);
                     button_input.reset(gamepad_button);
                 }

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -271,6 +271,7 @@ pub fn gamepad_event_system(
             }
             GamepadEventType::ButtonChanged(button_type, value) => {
                 let gamepad_button = GamepadButton(gamepad, *button_type);
+                button_input.set_value(gamepad_button, value);
 
                 let button_property = settings.button_settings(gamepad_button);
                 if button_input.pressed(gamepad_button) {

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -108,13 +108,13 @@ pub struct GamepadSettings {
 }
 
 impl GamepadSettings {
-    pub fn get_button_settings(&self, button: GamepadButton) -> &ButtonSettings {
+    pub fn button_settings(&self, button: GamepadButton) -> &ButtonSettings {
         self.button_settings
             .get(&button)
             .unwrap_or(&self.default_button_settings)
     }
 
-    pub fn get_axis_settings(&self, axis: GamepadAxis) -> &AxisSettings {
+    pub fn axis_settings(&self, axis: GamepadAxis) -> &AxisSettings {
         self.axis_settings
             .get(&axis)
             .unwrap_or(&self.default_axis_settings)
@@ -254,7 +254,7 @@ pub fn gamepad_event_system(
             GamepadEventType::AxisChanged(axis_type, value) => {
                 let gamepad_axis = GamepadAxis(gamepad, *axis_type);
                 if let Some(filtered_value) = settings
-                    .get_axis_settings(gamepad_axis)
+                    .axis_settings(gamepad_axis)
                     .filter(*value, axis.get(gamepad_axis))
                 {
                     axis.set(gamepad_axis, filtered_value);
@@ -267,7 +267,7 @@ pub fn gamepad_event_system(
             GamepadEventType::ButtonChanged(button_type, value) => {
                 let gamepad_button = GamepadButton(gamepad, *button_type);
 
-                let button_property = settings.get_button_settings(gamepad_button);
+                let button_property = settings.button_settings(gamepad_button);
                 if button_input.pressed(gamepad_button) {
                     if button_property.is_released(*value) {
                         button_input.release(gamepad_button);

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -103,10 +103,8 @@ pub struct GamepadAxis(pub Gamepad, pub GamepadAxisType);
 pub struct GamepadSettings {
     pub default_button_settings: ButtonSettings,
     pub default_axis_settings: AxisSettings,
-    pub default_button_axis_settings: ButtonAxisSettings,
     pub button_settings: HashMap<GamepadButton, ButtonSettings>,
     pub axis_settings: HashMap<GamepadAxis, AxisSettings>,
-    pub button_axis_settings: HashMap<GamepadButton, ButtonAxisSettings>,
 }
 
 impl GamepadSettings {
@@ -120,12 +118,6 @@ impl GamepadSettings {
         self.axis_settings
             .get(&axis)
             .unwrap_or(&self.default_axis_settings)
-    }
-
-    pub fn get_button_axis_settings(&self, button: GamepadButton) -> &ButtonAxisSettings {
-        self.button_axis_settings
-            .get(&button)
-            .unwrap_or(&self.default_button_axis_settings)
     }
 }
 
@@ -206,43 +198,6 @@ impl AxisSettings {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct ButtonAxisSettings {
-    pub high: f32,
-    pub low: f32,
-    pub threshold: f32,
-}
-
-impl Default for ButtonAxisSettings {
-    fn default() -> Self {
-        ButtonAxisSettings {
-            high: 0.95,
-            low: 0.05,
-            threshold: 0.01,
-        }
-    }
-}
-
-impl ButtonAxisSettings {
-    fn filter(&self, new_value: f32, old_value: Option<f32>) -> Option<f32> {
-        let new_value = if new_value <= self.low {
-            0.0
-        } else if new_value >= self.high {
-            1.0
-        } else {
-            new_value
-        };
-
-        if let Some(old_value) = old_value {
-            if (new_value - old_value).abs() <= self.threshold {
-                return None;
-            }
-        }
-
-        Some(new_value)
-    }
-}
-
 /// Monitors gamepad connection and disconnection events, updating the [`Gamepads`] resource accordingly
 ///
 /// By default, runs during `CoreStage::PreUpdate` when added via [`InputPlugin`](crate::InputPlugin).
@@ -268,7 +223,6 @@ pub fn gamepad_connection_system(
 pub fn gamepad_event_system(
     mut button_input: ResMut<Input<GamepadButton>>,
     mut axis: ResMut<Axis<GamepadAxis>>,
-    mut button_axis: ResMut<Axis<GamepadButton>>,
     mut raw_events: EventReader<GamepadEventRaw>,
     mut events: EventWriter<GamepadEvent>,
     settings: Res<GamepadSettings>,
@@ -282,7 +236,6 @@ pub fn gamepad_event_system(
                 for button_type in ALL_BUTTON_TYPES.iter() {
                     let gamepad_button = GamepadButton(gamepad, *button_type);
                     button_input.reset(gamepad_button);
-                    button_axis.set(gamepad_button, 0.0);
                 }
                 for axis_type in ALL_AXIS_TYPES.iter() {
                     axis.set(GamepadAxis(gamepad, *axis_type), 0.0);
@@ -293,7 +246,6 @@ pub fn gamepad_event_system(
                 for button_type in ALL_BUTTON_TYPES.iter() {
                     let gamepad_button = GamepadButton(gamepad, *button_type);
                     button_input.reset(gamepad_button);
-                    button_axis.remove(gamepad_button);
                 }
                 for axis_type in ALL_AXIS_TYPES.iter() {
                     axis.remove(GamepadAxis(gamepad, *axis_type));
@@ -314,16 +266,6 @@ pub fn gamepad_event_system(
             }
             GamepadEventType::ButtonChanged(button_type, value) => {
                 let gamepad_button = GamepadButton(gamepad, *button_type);
-                if let Some(filtered_value) = settings
-                    .get_button_axis_settings(gamepad_button)
-                    .filter(*value, button_axis.get(gamepad_button))
-                {
-                    button_axis.set(gamepad_button, filtered_value);
-                    events.send(GamepadEvent(
-                        gamepad,
-                        GamepadEventType::ButtonChanged(*button_type, filtered_value),
-                    ))
-                }
 
                 let button_property = settings.get_button_settings(gamepad_button);
                 if button_input.pressed(gamepad_button) {
@@ -373,63 +315,7 @@ const ALL_AXIS_TYPES: [GamepadAxisType; 8] = [
 
 #[cfg(test)]
 mod tests {
-    use super::{AxisSettings, ButtonAxisSettings, ButtonSettings};
-
-    fn test_button_axis_settings_filter(
-        settings: ButtonAxisSettings,
-        new_value: f32,
-        old_value: Option<f32>,
-        expected: Option<f32>,
-    ) {
-        let actual = settings.filter(new_value, old_value);
-        assert_eq!(
-            expected, actual,
-            "Testing filtering for {:?} with new_value = {:?}, old_value = {:?}",
-            settings, new_value, old_value
-        );
-    }
-
-    #[test]
-    fn test_button_axis_settings_default_filter() {
-        let cases = [
-            (1.0, None, Some(1.0)),
-            (0.99, None, Some(1.0)),
-            (0.96, None, Some(1.0)),
-            (0.95, None, Some(1.0)),
-            (0.9499, None, Some(0.9499)),
-            (0.84, None, Some(0.84)),
-            (0.43, None, Some(0.43)),
-            (0.05001, None, Some(0.05001)),
-            (0.05, None, Some(0.0)),
-            (0.04, None, Some(0.0)),
-            (0.01, None, Some(0.0)),
-            (0.0, None, Some(0.0)),
-        ];
-
-        for (new_value, old_value, expected) in cases {
-            let settings = ButtonAxisSettings::default();
-            test_button_axis_settings_filter(settings, new_value, old_value, expected);
-        }
-    }
-
-    #[test]
-    fn test_button_axis_settings_default_filter_with_old_value() {
-        let cases = [
-            (0.43, Some(0.44001), Some(0.43)),
-            (0.43, Some(0.44), None),
-            (0.43, Some(0.43), None),
-            (0.43, Some(0.41999), Some(0.43)),
-            (0.43, Some(0.17), Some(0.43)),
-            (0.43, Some(0.84), Some(0.43)),
-            (0.05, Some(0.055), Some(0.0)),
-            (0.95, Some(0.945), Some(1.0)),
-        ];
-
-        for (new_value, old_value, expected) in cases {
-            let settings = ButtonAxisSettings::default();
-            test_button_axis_settings_filter(settings, new_value, old_value, expected);
-        }
-    }
+    use super::{AxisSettings, ButtonSettings};
 
     fn test_axis_settings_filter(
         settings: AxisSettings,

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -85,7 +85,7 @@ where
         }
 
         self.pressed.insert(input);
-        self.values.insert(input, 1.0)
+        self.values.insert(input, 1.0);
     }
 
     /// Check if `input` has been pressed.
@@ -105,7 +105,7 @@ where
     pub fn release(&mut self, input: T) {
         self.pressed.remove(&input);
         self.just_released.insert(input);
-        self.values.insert(input, 0.0)
+        self.values.insert(input, 0.0);
     }
 
     /// Check if `input` has been just pressed.

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -45,11 +45,6 @@ pub struct Input<T: Inputlike> {
 
 /// Allows a type to be used with the [Input] type
 ///
-/// The [`InputVariants`](Self::InputVariants) associated type is the type (almost always an enum) that contains
-/// the set of possible valid inputs for inputs of this type (e.g. all of the letters on a keyboard of all mouse buttons).
-///
-/// This will often be the same type (`Self`) as the type you are implementing this trait for.
-///
 /// The [IntoEnumIterator] trait bound on this assocaited type allows users to iterate over all possible valid values of an input.
 /// If you are looking to implement this trait for you own type, you will need to derive that trait using the `strum` crate.
 pub trait Inputlike: Clone + Copy + PartialEq + Eq + Hash + IntoEnumIterator {}

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -58,7 +58,7 @@ impl<T: Inputlike> Default for Input<T> {
     fn default() -> Self {
         // PERF: this is pointlessly slow;
         // should use HashMap::from_iter() instead
-        let values = HashMap::default();
+        let mut values = HashMap::default();
 
         for input_variant in T::iter() {
             values.insert(input_variant, 0.0);

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -8,6 +8,12 @@ use bevy_ecs::schedule::State;
 
 /// A "press-able" input of type `T`.
 ///
+/// Pressable inputs of this sort can either be continuous or discrete.
+/// Their [`value`](Self::value) will always be between 0.0 and 1.0,
+/// where 0.0 represents a fully released state and 1.0 is the fully pressed state.
+/// If you need to represent an input value with a neutral position and a direction,
+/// use an [Axis](crate::Axis) instead.
+///
 /// This type can be used as a resource to keep the current state of an input, by reacting to
 /// events from the input. For a given input value:
 ///
@@ -23,7 +29,6 @@ use bevy_ecs::schedule::State;
 /// * Calling [`Input::clear`] or [`Input::reset`] immediately after the state change.
 ///
 /// ## Notes when adding this resource for a new input type
-///
 ///
 /// When adding this resource for a new input type, you should:
 ///

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -73,6 +73,7 @@ where
     T: Copy + Eq + Hash,
 {
     /// Register a press for input `input`.
+    #[inline]
     pub fn press(&mut self, input: T) {
         if !self.pressed(input) {
             self.just_pressed.insert(input);
@@ -83,16 +84,19 @@ where
     }
 
     /// Check if `input` has been pressed.
+    #[inline]
     pub fn pressed(&self, input: T) -> bool {
         self.pressed.contains(&input)
     }
 
     /// Check if any item in `inputs` has been pressed.
+    #[inline]
     pub fn any_pressed(&self, inputs: impl IntoIterator<Item = T>) -> bool {
         inputs.into_iter().any(|it| self.pressed(it))
     }
 
     /// Register a release for input `input`.
+    #[inline]
     pub fn release(&mut self, input: T) {
         self.pressed.remove(&input);
         self.just_released.insert(input);
@@ -100,11 +104,13 @@ where
     }
 
     /// Check if `input` has been just pressed.
+    #[inline]
     pub fn just_pressed(&self, input: T) -> bool {
         self.just_pressed.contains(&input)
     }
 
     /// Check if any item in `inputs` has just been pressed.
+    #[inline]
     pub fn any_just_pressed(&self, inputs: impl IntoIterator<Item = T>) -> bool {
         inputs.into_iter().any(|it| self.just_pressed(it))
     }
@@ -112,16 +118,19 @@ where
     /// Clear the "just pressed" state of `input`. Future calls to [`Input::just_pressed`] for the
     /// given input will return false until a new press event occurs.
     /// Returns true if `input` is currently "just pressed"
+    #[inline]
     pub fn clear_just_pressed(&mut self, input: T) -> bool {
         self.just_pressed.remove(&input)
     }
 
     /// Check if `input` has been just released.
+    #[inline]
     pub fn just_released(&self, input: T) -> bool {
         self.just_released.contains(&input)
     }
 
     /// Check if any item in `inputs` has just been released.
+    #[inline]
     pub fn any_just_released(&self, inputs: impl IntoIterator<Item = T>) -> bool {
         inputs.into_iter().any(|it| self.just_released(it))
     }
@@ -129,6 +138,7 @@ where
     /// Clear the "just released" state of `input`. Future calls to [`Input::just_released`] for the
     /// given input will return false until a new release event occurs.
     /// Returns true if `input` is currently "just released"
+    #[inline]
     pub fn clear_just_released(&mut self, input: T) -> bool {
         self.just_released.remove(&input)
     }
@@ -138,6 +148,7 @@ where
     /// Most buttons and other inputs are fully binary,
     /// and this method will only ever return 0.0 or 1.0.
     /// Values returned will always be in [0.0, 1.0].
+    #[inline]
     pub fn value(&self, input: T) -> f32 {
         *self
             .values
@@ -148,11 +159,13 @@ where
     /// Manually set the value of an input
     ///
     /// This is particularly useful for mocking analogue inputs during tests.
+    #[inline]
     pub fn set_value(&mut self, input: T, value: f32) {
         self.values.insert(input, value.clamp(0.0, 1.0));
     }
 
     /// Reset all status for input `input`.
+    #[inline]
     pub fn reset(&mut self, input: T) {
         self.pressed.remove(&input);
         self.just_pressed.remove(&input);
@@ -160,22 +173,26 @@ where
     }
 
     /// Clear just pressed and just released information.
+    #[inline]
     pub fn clear(&mut self) {
         self.just_pressed.clear();
         self.just_released.clear();
     }
 
     /// List all inputs that are pressed.
+    #[inline]
     pub fn get_pressed(&self) -> impl ExactSizeIterator<Item = &T> {
         self.pressed.iter()
     }
 
     /// List all inputs that are just pressed.
+    #[inline]
     pub fn get_just_pressed(&self) -> impl ExactSizeIterator<Item = &T> {
         self.just_pressed.iter()
     }
 
     /// List all inputs that are just released.
+    #[inline]
     pub fn get_just_released(&self) -> impl ExactSizeIterator<Item = &T> {
         self.just_released.iter()
     }

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -1,5 +1,6 @@
-use bevy_utils::HashSet;
-use std::hash::Hash;
+use bevy_utils::{HashMap, HashSet};
+use std::{fmt::Debug, hash::Hash};
+use strum::IntoEnumIterator;
 
 // unused import, but needed for intra doc link to work
 #[allow(unused_imports)]
@@ -23,29 +24,51 @@ use bevy_ecs::schedule::State;
 ///
 /// ## Notes when adding this resource for a new input type
 ///
+///
 /// When adding this resource for a new input type, you should:
 ///
 /// * Call the [`Input::press`] method for each press event.
 /// * Call the [`Input::release`] method for each release event.
 /// * Call the [`Input::clear`] method at each frame start, before processing events.
 #[derive(Debug)]
-pub struct Input<T> {
+pub struct Input<T: Inputlike> {
     pressed: HashSet<T>,
     just_pressed: HashSet<T>,
     just_released: HashSet<T>,
+    values: HashMap<T, f32>,
 }
 
-impl<T> Default for Input<T> {
+/// Allows a type to be used with the [Input] type
+///
+/// The [`InputVariants`](Self::InputVariants) associated type is the type (almost always an enum) that contains
+/// the set of possible valid inputs for inputs of this type (e.g. all of the letters on a keyboard of all mouse buttons).
+///
+/// This will often be the same type (`Self`) as the type you are implementing this trait for.
+///
+/// The [IntoEnumIterator] trait bound on this assocaited type allows users to iterate over all possible valid values of an input.
+/// If you are looking to implement this trait for you own type, you will need to derive that trait using the `strum` crate.
+pub trait Inputlike: Clone + Copy + PartialEq + Eq + Hash + IntoEnumIterator {}
+
+impl<T: Inputlike> Default for Input<T> {
     fn default() -> Self {
+        // PERF: this is pointlessly slow;
+        // should use HashMap::from_iter() instead
+        let values = HashMap::default();
+
+        for input_variant in T::iter() {
+            values.insert(input_variant, 0.0);
+        }
+
         Self {
             pressed: Default::default(),
             just_pressed: Default::default(),
             just_released: Default::default(),
+            values,
         }
     }
 }
 
-impl<T> Input<T>
+impl<T: Inputlike> Input<T>
 where
     T: Copy + Eq + Hash,
 {
@@ -56,6 +79,7 @@ where
         }
 
         self.pressed.insert(input);
+        self.values.insert(input, 1.0)
     }
 
     /// Check if `input` has been pressed.
@@ -72,6 +96,7 @@ where
     pub fn release(&mut self, input: T) {
         self.pressed.remove(&input);
         self.just_released.insert(input);
+        self.values.insert(input, 0.0)
     }
 
     /// Check if `input` has been just pressed.
@@ -108,6 +133,25 @@ where
         self.just_released.remove(&input)
     }
 
+    /// Returns the degree to which an input is pressed: 0.0 if it is fully released, and 1.0 if it is fully pressed
+    ///
+    /// Most buttons and other inputs are fully binary,
+    /// and this method will only ever return 0.0 or 1.0.
+    /// Values returned will always be in [0.0, 1.0].
+    pub fn value(&self, input: T) -> f32 {
+        *self
+            .values
+            .get(&input)
+            .expect("Input value not found in in Input<T> resource.")
+    }
+
+    /// Manually set the value of an input
+    ///
+    /// This is particularly useful for mocking analogue inputs during tests.
+    pub fn set_value(&mut self, input: T, value: f32) {
+        self.values.insert(input, value.clamp(0.0, 1.0));
+    }
+
     /// Reset all status for input `input`.
     pub fn reset(&mut self, input: T) {
         self.pressed.remove(&input);
@@ -142,14 +186,17 @@ mod test {
 
     #[test]
     fn input_test() {
-        use crate::Input;
+        use crate::{Input, Inputlike};
+        use strum_macros::EnumIter;
 
         /// Used for testing `Input` functionality
-        #[derive(Copy, Clone, Eq, PartialEq, Hash)]
+        #[derive(Copy, Clone, Eq, PartialEq, Hash, EnumIter, Debug)]
         enum DummyInput {
             Input1,
             Input2,
         }
+
+        impl Inputlike for DummyInput {}
 
         let mut input = Input::default();
 
@@ -164,6 +211,10 @@ mod test {
         // Check if they are also marked as pressed
         assert!(input.pressed(DummyInput::Input1));
         assert!(input.pressed(DummyInput::Input2));
+
+        // Check that their value was set to 1.0 when pressed
+        assert!(input.value(DummyInput::Input1) == 1.0);
+        assert!(input.value(DummyInput::Input2) == 1.0);
 
         // Clear the `input`, removing just pressed and just released
         input.clear();
@@ -189,6 +240,10 @@ mod test {
         assert!(!input.pressed(DummyInput::Input1));
         assert!(!input.pressed(DummyInput::Input2));
 
+        // Check that their value was set to 0.0 when released
+        assert!(input.value(DummyInput::Input1) == 0.0);
+        assert!(input.value(DummyInput::Input2) == 0.0);
+
         // Clear the `Input` and check for removal from `just_released`
         input.clear();
 
@@ -210,5 +265,16 @@ mod test {
         assert!(!input.pressed(DummyInput::Input1));
 
         assert!(!input.just_released(DummyInput::Input2));
+
+        // Manually set a value to an intermediate valid value
+        input.set_value(DummyInput::Input1, 0.42);
+        assert!(input.value(DummyInput::Input1) == 0.42);
+
+        // Manually set to values that are outside of the valid range
+        input.set_value(DummyInput::Input1, -1.0);
+        assert!(input.value(DummyInput::Input1) == 0.0);
+
+        input.set_value(DummyInput::Input2, 2.7);
+        assert!(input.value(DummyInput::Input2) == 1.0);
     }
 }

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -1,6 +1,8 @@
-use crate::{ElementState, Input};
+use crate::{ElementState, Input, Inputlike};
 use bevy_app::EventReader;
 use bevy_ecs::system::ResMut;
+
+use strum_macros::EnumIter;
 
 /// A key input event from a keyboard device
 #[derive(Debug, Clone)]
@@ -32,7 +34,7 @@ pub fn keyboard_input_system(
 }
 
 /// The key code of a keyboard input.
-#[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, EnumIter)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u32)]
 pub enum KeyCode {
@@ -234,3 +236,5 @@ pub enum KeyCode {
     Paste,
     Cut,
 }
+
+impl Inputlike for KeyCode {}

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -27,10 +27,7 @@ use mouse::{mouse_button_input_system, MouseButton, MouseButtonInput, MouseMotio
 use prelude::Gamepads;
 use touch::{touch_screen_input_system, TouchInput, Touches};
 
-use gamepad::{
-    gamepad_event_system, GamepadAxis, GamepadButton, GamepadEvent, GamepadEventRaw,
-    GamepadSettings,
-};
+use gamepad::{gamepad_event_system, GamepadEvent, GamepadEventRaw, GamepadSettings};
 
 /// Adds keyboard and mouse input to an App
 #[derive(Default)]

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -68,7 +68,6 @@ impl Plugin for InputPlugin {
             .init_resource::<Gamepads>()
             .init_resource::<Input<GamepadButton>>()
             .init_resource::<Axis<GamepadAxis>>()
-            .init_resource::<Axis<GamepadButton>>()
             .add_system_to_stage(
                 CoreStage::PreUpdate,
                 gamepad_event_system.label(InputSystem),

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -13,10 +13,7 @@ pub use input::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        gamepad::{
-            Gamepad, GamepadAxis, GamepadAxisType, GamepadButton, GamepadEvent, GamepadEventType,
-            Gamepads,
-        },
+        gamepad::{Gamepad, GamepadAxis, GamepadButton, GamepadEvent, GamepadEventType, Gamepads},
         keyboard::KeyCode,
         mouse::MouseButton,
         touch::{TouchInput, Touches},

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -31,8 +31,8 @@ use prelude::Gamepads;
 use touch::{touch_screen_input_system, TouchInput, Touches};
 
 use gamepad::{
-    gamepad_connection_system, gamepad_event_system, GamepadAxis, GamepadButton, GamepadEvent,
-    GamepadEventRaw, GamepadSettings,
+    gamepad_event_system, GamepadAxis, GamepadButton, GamepadEvent, GamepadEventRaw,
+    GamepadSettings,
 };
 
 /// Adds keyboard and mouse input to an App
@@ -71,10 +71,6 @@ impl Plugin for InputPlugin {
             .add_system_to_stage(
                 CoreStage::PreUpdate,
                 gamepad_event_system.label(InputSystem),
-            )
-            .add_system_to_stage(
-                CoreStage::PreUpdate,
-                gamepad_connection_system.label(InputSystem),
             )
             // touch
             .add_event::<TouchInput>()

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -14,8 +14,8 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
         gamepad::{
-            Gamepad, GamepadAxis, GamepadAxisType, GamepadButton, GamepadButtonType, GamepadEvent,
-            GamepadEventType, Gamepads,
+            Gamepad, GamepadAxis, GamepadAxisType, GamepadButton, GamepadEvent, GamepadEventType,
+            Gamepads,
         },
         keyboard::KeyCode,
         mouse::MouseButton,

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -63,8 +63,6 @@ impl Plugin for InputPlugin {
             .add_event::<GamepadEventRaw>()
             .init_resource::<GamepadSettings>()
             .init_resource::<Gamepads>()
-            .init_resource::<Input<GamepadButton>>()
-            .init_resource::<Axis<GamepadAxis>>()
             .add_system_to_stage(
                 CoreStage::PreUpdate,
                 gamepad_event_system.label(InputSystem),

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -1,6 +1,8 @@
-use crate::{ElementState, Input};
+use crate::{ElementState, Input, Inputlike};
 use bevy_ecs::{event::EventReader, system::ResMut};
 use bevy_math::Vec2;
+
+use strum_macros::EnumIter;
 
 /// A mouse button input event
 #[derive(Debug, Clone)]
@@ -10,7 +12,7 @@ pub struct MouseButtonInput {
 }
 
 /// A button on a mouse device
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, EnumIter)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum MouseButton {
     Left,
@@ -18,6 +20,8 @@ pub enum MouseButton {
     Middle,
     Other(u16),
 }
+
+impl Inputlike for MouseButton {}
 
 /// A mouse motion event
 #[derive(Debug, Clone)]

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -360,16 +360,16 @@ impl ShaderProcessor {
             }
         };
 
-        let shader_defs = HashSet::<String>::from_iter(shader_defs.iter().cloned());
+        let shader_defs_unique = HashSet::<String>::from_iter(shader_defs.iter().cloned());
         let mut scopes = vec![true];
         let mut final_string = String::new();
         for line in shader_str.split('\n') {
             if let Some(cap) = self.ifdef_regex.captures(line) {
                 let def = cap.get(1).unwrap();
-                scopes.push(*scopes.last().unwrap() && shader_defs.contains(def.as_str()));
+                scopes.push(*scopes.last().unwrap() && shader_defs_unique.contains(def.as_str()));
             } else if let Some(cap) = self.ifndef_regex.captures(line) {
                 let def = cap.get(1).unwrap();
-                scopes.push(*scopes.last().unwrap() && !shader_defs.contains(def.as_str()));
+                scopes.push(*scopes.last().unwrap() && !shader_defs_unique.contains(def.as_str()));
             } else if self.else_regex.is_match(line) {
                 let mut is_parent_scope_truthy = true;
                 if scopes.len() > 1 {
@@ -388,19 +388,32 @@ impl ShaderProcessor {
                 .captures(line)
             {
                 let import = ShaderImport::AssetPath(cap.get(1).unwrap().as_str().to_string());
-                apply_import(import_handles, shaders, &import, shader, &mut final_string)?;
+                self.apply_import(
+                    import_handles,
+                    shaders,
+                    &import,
+                    shader,
+                    shader_defs,
+                    &mut final_string,
+                )?;
             } else if let Some(cap) = SHADER_IMPORT_PROCESSOR
                 .import_custom_path_regex
                 .captures(line)
             {
                 let import = ShaderImport::Custom(cap.get(1).unwrap().as_str().to_string());
-                apply_import(import_handles, shaders, &import, shader, &mut final_string)?;
+                self.apply_import(
+                    import_handles,
+                    shaders,
+                    &import,
+                    shader,
+                    shader_defs,
+                    &mut final_string,
+                )?;
             } else if *scopes.last().unwrap() {
                 final_string.push_str(line);
                 final_string.push('\n');
             }
         }
-
         final_string.pop();
 
         if scopes.len() != 1 {
@@ -417,45 +430,51 @@ impl ShaderProcessor {
             }
         }
     }
-}
 
-fn apply_import(
-    import_handles: &HashMap<ShaderImport, Handle<Shader>>,
-    shaders: &HashMap<Handle<Shader>, Shader>,
-    import: &ShaderImport,
-    shader: &Shader,
-    final_string: &mut String,
-) -> Result<(), ProcessShaderError> {
-    let imported_shader = import_handles
-        .get(import)
-        .and_then(|handle| shaders.get(handle))
-        .ok_or_else(|| ProcessShaderError::UnresolvedImport(import.clone()))?;
-    match &shader.source {
-        Source::Wgsl(_) => {
-            if let Source::Wgsl(import_source) = &imported_shader.source {
-                final_string.push_str(import_source);
-            } else {
-                return Err(ProcessShaderError::MismatchedImportFormat(import.clone()));
+    fn apply_import(
+        &self,
+        import_handles: &HashMap<ShaderImport, Handle<Shader>>,
+        shaders: &HashMap<Handle<Shader>, Shader>,
+        import: &ShaderImport,
+        shader: &Shader,
+        shader_defs: &[String],
+        final_string: &mut String,
+    ) -> Result<(), ProcessShaderError> {
+        let imported_shader = import_handles
+            .get(import)
+            .and_then(|handle| shaders.get(handle))
+            .ok_or_else(|| ProcessShaderError::UnresolvedImport(import.clone()))?;
+        let imported_processed =
+            self.process(imported_shader, shader_defs, shaders, import_handles)?;
+
+        match &shader.source {
+            Source::Wgsl(_) => {
+                if let ProcessedShader::Wgsl(import_source) = &imported_processed {
+                    final_string.push_str(import_source);
+                } else {
+                    return Err(ProcessShaderError::MismatchedImportFormat(import.clone()));
+                }
+            }
+            Source::Glsl(_, _) => {
+                if let ProcessedShader::Glsl(import_source, _) = &imported_processed {
+                    final_string.push_str(import_source);
+                } else {
+                    return Err(ProcessShaderError::MismatchedImportFormat(import.clone()));
+                }
+            }
+            Source::SpirV(_) => {
+                return Err(ProcessShaderError::ShaderFormatDoesNotSupportImports);
             }
         }
-        Source::Glsl(_, _) => {
-            if let Source::Glsl(import_source, _) = &imported_shader.source {
-                final_string.push_str(import_source);
-            } else {
-                return Err(ProcessShaderError::MismatchedImportFormat(import.clone()));
-            }
-        }
-        Source::SpirV(_) => {
-            return Err(ProcessShaderError::ShaderFormatDoesNotSupportImports);
-        }
+
+        Ok(())
     }
-
-    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use bevy_asset::Handle;
+    use bevy_asset::{Handle, HandleUntyped};
+    use bevy_reflect::TypeUuid;
     use bevy_utils::HashMap;
     use naga::ShaderStage;
 
@@ -1077,6 +1096,108 @@ fn vertex(
                 &["TEXTURE".to_string(), "ATTRIBUTE".to_string()],
                 &HashMap::default(),
                 &HashMap::default(),
+            )
+            .unwrap();
+        assert_eq!(result.get_wgsl_source().unwrap(), EXPECTED);
+    }
+
+    #[test]
+    fn process_import_ifdef() {
+        #[rustfmt::skip]
+        const FOO: &str = r"
+#ifdef IMPORT_MISSING
+fn in_import_missing() { }
+#endif
+#ifdef IMPORT_PRESENT
+fn in_import_present() { }
+#endif
+";
+        #[rustfmt::skip]
+        const INPUT: &str = r"
+#import FOO
+#ifdef MAIN_MISSING
+fn in_main_missing() { }
+#endif
+#ifdef MAIN_PRESENT
+fn in_main_present() { }
+#endif
+";
+        #[rustfmt::skip]
+        const EXPECTED: &str = r"
+
+fn in_import_present() { }
+fn in_main_present() { }
+";
+        let processor = ShaderProcessor::default();
+        let mut shaders = HashMap::default();
+        let mut import_handles = HashMap::default();
+        let foo_handle = Handle::<Shader>::default();
+        shaders.insert(foo_handle.clone_weak(), Shader::from_wgsl(FOO));
+        import_handles.insert(
+            ShaderImport::Custom("FOO".to_string()),
+            foo_handle.clone_weak(),
+        );
+        let result = processor
+            .process(
+                &Shader::from_wgsl(INPUT),
+                &["MAIN_PRESENT".to_string(), "IMPORT_PRESENT".to_string()],
+                &shaders,
+                &import_handles,
+            )
+            .unwrap();
+        assert_eq!(result.get_wgsl_source().unwrap(), EXPECTED);
+    }
+
+    #[test]
+    fn process_import_in_import() {
+        #[rustfmt::skip]
+        const BAR: &str = r"
+#ifdef DEEP
+fn inner_import() { }
+#endif
+";
+        const FOO: &str = r"
+#import BAR
+fn import() { }
+";
+        #[rustfmt::skip]
+        const INPUT: &str = r"
+#import FOO
+fn in_main() { }
+";
+        #[rustfmt::skip]
+        const EXPECTED: &str = r"
+
+
+fn inner_import() { }
+fn import() { }
+fn in_main() { }
+";
+        let processor = ShaderProcessor::default();
+        let mut shaders = HashMap::default();
+        let mut import_handles = HashMap::default();
+        {
+            let bar_handle = Handle::<Shader>::default();
+            shaders.insert(bar_handle.clone_weak(), Shader::from_wgsl(BAR));
+            import_handles.insert(
+                ShaderImport::Custom("BAR".to_string()),
+                bar_handle.clone_weak(),
+            );
+        }
+        {
+            let foo_handle = HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 1).typed();
+            shaders.insert(foo_handle.clone_weak(), Shader::from_wgsl(FOO));
+            import_handles.insert(
+                ShaderImport::Custom("FOO".to_string()),
+                foo_handle.clone_weak(),
+            );
+        }
+        let result = processor
+            .process(
+                &Shader::from_wgsl(INPUT),
+                &["DEEP".to_string()],
+                &shaders,
+                &import_handles,
             )
             .unwrap();
         assert_eq!(result.get_wgsl_source().unwrap(), EXPECTED);

--- a/examples/input/gamepad_input.rs
+++ b/examples/input/gamepad_input.rs
@@ -7,26 +7,23 @@ fn main() {
         .run();
 }
 
-fn gamepad_system(
-    gamepads: Res<Gamepads>,
-    button_inputs: Res<Input<GamepadButton>>,
-    axes: Res<Axis<GamepadAxis>>,
-) {
-    for gamepad in gamepads.iter().cloned() {
-        if button_inputs.just_pressed(GamepadButton(gamepad, GamepadButtonType::South)) {
+fn gamepad_system(gamepads: Res<Gamepads>) {
+    for (gamepad, button_input) in gamepads.buttons.iter() {
+        if button_input.just_pressed(GamepadButton::South) {
             info!("{:?} just pressed South", gamepad);
-        } else if button_inputs.just_released(GamepadButton(gamepad, GamepadButtonType::South)) {
+        } else if button_input.just_released(GamepadButton::South) {
             info!("{:?} just released South", gamepad);
         }
 
-        let right_trigger =
-            button_inputs.value(GamepadButton(gamepad, GamepadButtonType::RightTrigger));
+        let right_trigger = button_input.value(GamepadButton::RightTrigger);
         if right_trigger > 0.01 {
             info!("{:?} RightTrigger2 value is {}", gamepad, right_trigger);
         }
+    }
 
+    for (gamepad, axes) in gamepads.axes.iter() {
         let left_stick_x = axes
-            .get(GamepadAxis(gamepad, GamepadAxisType::LeftStickX))
+            .get(GamepadAxis(*gamepad, GamepadAxisType::LeftStickX))
             .unwrap();
         if left_stick_x.abs() > 0.01 {
             info!("{:?} LeftStickX value is {}", gamepad, left_stick_x);

--- a/examples/input/gamepad_input.rs
+++ b/examples/input/gamepad_input.rs
@@ -15,9 +15,9 @@ fn gamepad_system(gamepads: Res<Gamepads>) {
             info!("{:?} just released South", gamepad);
         }
 
-        let right_trigger = button_input.value(GamepadButton::RightTrigger);
-        if right_trigger > 0.01 {
-            info!("{:?} RightTrigger2 value is {}", gamepad, right_trigger);
+        let right_trigger2 = button_input.value(GamepadButton::RightTrigger2);
+        if right_trigger2 > 0.01 {
+            info!("{:?} RightTrigger2 value is {}", gamepad, right_trigger2);
         }
     }
 

--- a/examples/input/gamepad_input.rs
+++ b/examples/input/gamepad_input.rs
@@ -8,14 +8,14 @@ fn main() {
 }
 
 fn gamepad_system(gamepads: Res<Gamepads>) {
-    for (gamepad, button_input) in gamepads.buttons.iter() {
-        if button_input.just_pressed(GamepadButton::South) {
+    for (gamepad, buttons) in gamepads.buttons.iter() {
+        if buttons.just_pressed(GamepadButton::South) {
             info!("{:?} just pressed South", gamepad);
-        } else if button_input.just_released(GamepadButton::South) {
+        } else if buttons.just_released(GamepadButton::South) {
             info!("{:?} just released South", gamepad);
         }
 
-        let right_trigger2 = button_input.value(GamepadButton::RightTrigger2);
+        let right_trigger2 = buttons.value(GamepadButton::RightTrigger2);
         if right_trigger2 > 0.01 {
             info!("{:?} RightTrigger2 value is {}", gamepad, right_trigger2);
         }

--- a/examples/input/gamepad_input.rs
+++ b/examples/input/gamepad_input.rs
@@ -10,7 +10,6 @@ fn main() {
 fn gamepad_system(
     gamepads: Res<Gamepads>,
     button_inputs: Res<Input<GamepadButton>>,
-    button_axes: Res<Axis<GamepadButton>>,
     axes: Res<Axis<GamepadAxis>>,
 ) {
     for gamepad in gamepads.iter().cloned() {
@@ -20,10 +19,9 @@ fn gamepad_system(
             info!("{:?} just released South", gamepad);
         }
 
-        let right_trigger = button_axes
-            .get(GamepadButton(gamepad, GamepadButtonType::RightTrigger2))
-            .unwrap();
-        if right_trigger.abs() > 0.01 {
+        let right_trigger =
+            button_inputs.value(GamepadButton(gamepad, GamepadButtonType::RightTrigger));
+        if right_trigger > 0.01 {
             info!("{:?} RightTrigger2 value is {}", gamepad, right_trigger);
         }
 

--- a/examples/input/gamepad_input.rs
+++ b/examples/input/gamepad_input.rs
@@ -22,9 +22,7 @@ fn gamepad_system(gamepads: Res<Gamepads>) {
     }
 
     for (gamepad, axes) in gamepads.axes.iter() {
-        let left_stick_x = axes
-            .get(GamepadAxis(*gamepad, GamepadAxisType::LeftStickX))
-            .unwrap();
+        let left_stick_x = axes.get(GamepadAxis::LeftStickX).unwrap();
         if left_stick_x.abs() > 0.01 {
             info!("{:?} LeftStickX value is {}", gamepad, left_stick_x);
         }


### PR DESCRIPTION
# Objective

- Principally fixes #3398.
- Incidentally fixes #3224.
- Significantly improves the ergonomics of working with gamepad axes and buttons, as you no longer need to constantly generate `GamepadButton` structs which store both the gamepad id and the button that is being pressed.

## Solution

1. Adds a `value` and `set_value` method to `Input`, which is appropriately updated. 0.0 is unpressed, 1.0 is pressed, following industry convention.
2. Made it impossible to use a button-like type (0.0 to 1.0) as an axis (-1.0 to 1.0) by adding the methodless `Inputlike` and `Axislike` traits.
3. Incidentally made it possible to iterate over all of the possible variants of the input types, by pulling in the `strum` crate's `EnumIter` trait. We already had some constants for this, which have been removed.

This was simple enough, except that I could not accomplish this nicely for `GamepadButton`, as its variant type and the input type were not the same (see #3224). Instead of adding an ugly hack with an associated type that was almost always `Self` I:

1.  Eliminated the existing `GamepadButton` type, and gave the nice name to `GamepadButtonType`.
2. Changed the appropriate `Input` type to accept the enum.
3. Managed the "you can have multiple controllers" problem by handing out multiple `Input<GamepadButton>` types using the freshly added `Gamepads` type (#3245), rather than a single resource which required you to pass in the `Gamepad` constantly.
4. Eliminated the dedicated `Gamepads` management system by rolling it all into the existing `gamepad_event_system`.
5. Did the same for `GamepadAxis` and `GamepadAxisType` for consistency and a wonderfully smooth API.

## Showcase

Before:
```rust
fn gamepad_system(
    gamepads: Res<Gamepads>,
    button_inputs: Res<Input<GamepadButton>>,
    button_axes: Res<Axis<GamepadButton>>,
    axes: Res<Axis<GamepadAxis>>,
) {
    for gamepad in gamepads.iter().cloned() {
        if button_inputs.just_pressed(GamepadButton(gamepad, GamepadButtonType::South)) {
            info!("{:?} just pressed South", gamepad);
        } else if button_inputs.just_released(GamepadButton(gamepad, GamepadButtonType::South)) {
            info!("{:?} just released South", gamepad);
        }

        let right_trigger = button_axes
            .get(GamepadButton(gamepad, GamepadButtonType::RightTrigger2))
            .unwrap();
        if right_trigger.abs() > 0.01 {
            info!("{:?} RightTrigger2 value is {}", gamepad, right_trigger2);
        }

        let left_stick_x = axes
            .get(GamepadAxis(gamepad, GamepadAxisType::LeftStickX))
            .unwrap();
        if left_stick_x.abs() > 0.01 {
            info!("{:?} LeftStickX value is {}", gamepad, left_stick_x);
        }
    }
```
After:
```rust
fn gamepad_system(gamepads: Res<Gamepads>) {
    for (gamepad, buttons) in gamepads.buttons.iter() {
        if buttons.just_pressed(GamepadButton::South) {
            info!("{:?} just pressed South", gamepad);
        } else if buttons.just_released(GamepadButton::South) {
            info!("{:?} just released South", gamepad);
        }

        let right_trigger2 = buttons.value(GamepadButton::RightTrigger2);
        if right_trigger2 > 0.01 {
            info!("{:?} RightTrigger2 value is {}", gamepad, right_trigger);
        }
    }

    for (gamepad, axes) in gamepads.axes.iter() {
        let left_stick_x = axes.get(GamepadAxis::LeftStickX).unwrap();
        if left_stick_x.abs() > 0.01 {
            info!("{:?} LeftStickX value is {}", gamepad, left_stick_x);
        }
    }
}
```