### PR TITLE
[Merged by Bors] - enable `wasm-bindgen` feature on gilrs

### DIFF
--- a/crates/bevy_gilrs/Cargo.toml
+++ b/crates/bevy_gilrs/Cargo.toml
@@ -16,4 +16,4 @@ bevy_input = { path = "../bevy_input", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
 
 # other
-gilrs = "0.8.0"
+gilrs = { version = "0.8.0", features = ["wasm-bindgen"] }


### PR DESCRIPTION
WIthout the feature, `gilrs` uses `stdweb` instead of `wasm-bindgen` which isn't compatible with the rest of bevy.

Unfortunately, the `stdweb` dependency is still in the dependency tree, it just isn't used (https://gitlab.com/gilrs-project/gilrs/-/issues/101). This will be fixed in `gilrs 0.9` when it releases.