### PR TITLE
[Merged by Bors] - crevice derive macro: fix path to render_resource when importing from bevy

### DIFF
--- a/crates/bevy_crevice/bevy-crevice-derive/src/lib.rs
+++ b/crates/bevy_crevice/bevy-crevice-derive/src/lib.rs
@@ -41,7 +41,6 @@ fn bevy_crevice_path() -> Path {
         .map(|bevy_path| {
             let mut segments = bevy_path.segments;
             segments.push(BevyManifest::parse_str("render"));
-            segments.push(BevyManifest::parse_str("render_resource"));
             Path {
                 leading_colon: None,
                 segments,


### PR DESCRIPTION
# Objective

- Fix #3436 

## Solution

- Do not add twice `render_resource` when coming from `bevy`
