### PR TITLE
[Merged by Bors] - bevy_ui: register Overflow type

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -55,6 +55,7 @@ impl Plugin for UiPlugin {
             .register_type::<Node>()
             // NOTE: used by Style::aspect_ratio
             .register_type::<Option<f32>>()
+            .register_type::<Overflow>()
             .register_type::<PositionType>()
             .register_type::<Size<f32>>()
             .register_type::<Size<Val>>()


### PR DESCRIPTION
I forgot to register the new `Overflow` type in #3296.