### PR TITLE
[Merged by Bors] - Configurable wgpu features/limits priority

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -15,6 +15,7 @@ use bevy_render::{
     camera::{Camera, CameraProjection},
     color::Color,
     mesh::Mesh,
+    options::WgpuOptions,
     render_asset::RenderAssets,
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
     render_phase::{
@@ -576,6 +577,7 @@ pub fn prepare_lights(
     directional_light_shadow_map: Res<ExtractedDirectionalLightShadowMap>,
     point_lights: Query<(Entity, &ExtractedPointLight)>,
     directional_lights: Query<(Entity, &ExtractedDirectionalLight)>,
+    wgpu_options: Res<WgpuOptions>,
 ) {
     light_meta.view_gpu_lights.clear();
 
@@ -664,8 +666,10 @@ pub fn prepare_lights(
             &render_device,
             TextureDescriptor {
                 size: Extent3d {
-                    width: directional_light_shadow_map.size as u32,
-                    height: directional_light_shadow_map.size as u32,
+                    width: (directional_light_shadow_map.size as u32)
+                        .min(wgpu_options.limits.max_texture_dimension_2d),
+                    height: (directional_light_shadow_map.size as u32)
+                        .min(wgpu_options.limits.max_texture_dimension_2d),
                     depth_or_array_layers: DIRECTIONAL_SHADOW_LAYERS,
                 },
                 mip_level_count: 1,

--- a/crates/bevy_render/src/options.rs
+++ b/crates/bevy_render/src/options.rs
@@ -31,19 +31,18 @@ impl Default for WgpuOptions {
 
         let priority = options_priority_from_env().unwrap_or(WgpuOptionsPriority::Functionality);
 
-        let limits =
-            if cfg!(feature = "webgl") || matches!(priority, WgpuOptionsPriority::WebGL2) {
-                wgpu::Limits::downlevel_webgl2_defaults()
-            } else {
-                #[allow(unused_mut)]
-                let mut limits = wgpu::Limits::default();
-                #[cfg(feature = "ci_limits")]
-                {
-                    limits.max_storage_textures_per_shader_stage = 4;
-                    limits.max_texture_dimension_3d = 1024;
-                }
-                limits
-            };
+        let limits = if cfg!(feature = "webgl") || matches!(priority, WgpuOptionsPriority::WebGL2) {
+            wgpu::Limits::downlevel_webgl2_defaults()
+        } else {
+            #[allow(unused_mut)]
+            let mut limits = wgpu::Limits::default();
+            #[cfg(feature = "ci_limits")]
+            {
+                limits.max_storage_textures_per_shader_stage = 4;
+                limits.max_texture_dimension_3d = 1024;
+            }
+            limits
+        };
 
         Self {
             device_label: Default::default(),

--- a/crates/bevy_render/src/options.rs
+++ b/crates/bevy_render/src/options.rs
@@ -3,10 +3,18 @@ use std::borrow::Cow;
 pub use wgpu::{Backends, Features as WgpuFeatures, Limits as WgpuLimits, PowerPreference};
 
 #[derive(Clone)]
+pub enum WgpuOptionsPriority {
+    Compatibility,
+    Functionality,
+    WebGL2,
+}
+
+#[derive(Clone)]
 pub struct WgpuOptions {
     pub device_label: Option<Cow<'static, str>>,
     pub backends: Backends,
     pub power_preference: PowerPreference,
+    pub priority: WgpuOptionsPriority,
     pub features: WgpuFeatures,
     pub limits: WgpuLimits,
 }
@@ -21,25 +29,45 @@ impl Default for WgpuOptions {
 
         let backends = wgpu::util::backend_bits_from_env().unwrap_or(default_backends);
 
-        let limits = if cfg!(feature = "webgl") {
-            wgpu::Limits::downlevel_webgl2_defaults()
-        } else {
-            #[allow(unused_mut)]
-            let mut limits = wgpu::Limits::default();
-            #[cfg(feature = "ci_limits")]
-            {
-                limits.max_storage_textures_per_shader_stage = 4;
-                limits.max_texture_dimension_3d = 1024;
-            }
-            limits
-        };
+        let priority = options_priority_from_env().unwrap_or(WgpuOptionsPriority::Functionality);
+
+        let limits =
+            if cfg!(feature = "webgl") || matches!(priority, WgpuOptionsPriority::WebGL2) {
+                wgpu::Limits::downlevel_webgl2_defaults()
+            } else {
+                #[allow(unused_mut)]
+                let mut limits = wgpu::Limits::default();
+                #[cfg(feature = "ci_limits")]
+                {
+                    limits.max_storage_textures_per_shader_stage = 4;
+                    limits.max_texture_dimension_3d = 1024;
+                }
+                limits
+            };
 
         Self {
             device_label: Default::default(),
             backends,
             power_preference: PowerPreference::HighPerformance,
+            priority,
             features: wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
             limits,
         }
     }
+}
+
+/// Get a features/limits priority from the environment variable WGPU_OPTIONS_PRIO
+pub fn options_priority_from_env() -> Option<WgpuOptionsPriority> {
+    Some(
+        match std::env::var("WGPU_OPTIONS_PRIO")
+            .as_deref()
+            .map(str::to_lowercase)
+            .as_deref()
+        {
+            Ok("compatibility") => WgpuOptionsPriority::Compatibility,
+            Ok("functionality") => WgpuOptionsPriority::Functionality,
+            Ok("webgl2") => WgpuOptionsPriority::WebGL2,
+            _ => return None,
+        },
+    )
 }

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -5,7 +5,7 @@ use crate::{
         ShaderStages,
     },
 };
-use bevy_utils::tracing::debug;
+use bevy_utils::tracing::trace;
 use std::ops::Range;
 use wgpu::{IndexFormat, RenderPass};
 
@@ -108,7 +108,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// Subsequent draw calls will exhibit the behavior defined by the `pipeline`.
     pub fn set_render_pipeline(&mut self, pipeline: &'a RenderPipeline) {
-        debug!("set pipeline: {:?}", pipeline);
+        trace!("set pipeline: {:?}", pipeline);
         if self.state.is_pipeline_set(pipeline.id()) {
             return;
         }
@@ -128,15 +128,19 @@ impl<'a> TrackedRenderPass<'a> {
             .state
             .is_bind_group_set(index as usize, bind_group.id(), dynamic_uniform_indices)
         {
-            debug!(
+            trace!(
                 "set bind_group {} (already set): {:?} ({:?})",
-                index, bind_group, dynamic_uniform_indices
+                index,
+                bind_group,
+                dynamic_uniform_indices
             );
             return;
         } else {
-            debug!(
+            trace!(
                 "set bind_group {}: {:?} ({:?})",
-                index, bind_group, dynamic_uniform_indices
+                index,
+                bind_group,
+                dynamic_uniform_indices
             );
         }
         self.pass
@@ -158,7 +162,7 @@ impl<'a> TrackedRenderPass<'a> {
             .state
             .is_vertex_buffer_set(slot_index, buffer_slice.id(), offset)
         {
-            debug!(
+            trace!(
                 "set vertex buffer {} (already set): {:?} ({})",
                 slot_index,
                 buffer_slice.id(),
@@ -166,7 +170,7 @@ impl<'a> TrackedRenderPass<'a> {
             );
             return;
         } else {
-            debug!(
+            trace!(
                 "set vertex buffer {}: {:?} ({})",
                 slot_index,
                 buffer_slice.id(),
@@ -193,14 +197,14 @@ impl<'a> TrackedRenderPass<'a> {
             .state
             .is_index_buffer_set(buffer_slice.id(), offset, index_format)
         {
-            debug!(
+            trace!(
                 "set index buffer (already set): {:?} ({})",
                 buffer_slice.id(),
                 offset
             );
             return;
         } else {
-            debug!("set index buffer: {:?} ({})", buffer_slice.id(), offset);
+            trace!("set index buffer: {:?} ({})", buffer_slice.id(), offset);
         }
         self.pass.set_index_buffer(*buffer_slice, index_format);
         self.state
@@ -211,7 +215,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// The active vertex buffer(s) can be set with [`TrackedRenderPass::set_vertex_buffer`].
     pub fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>) {
-        debug!("draw: {:?} {:?}", vertices, instances);
+        trace!("draw: {:?} {:?}", vertices, instances);
         self.pass.draw(vertices, instances);
     }
 
@@ -220,15 +224,17 @@ impl<'a> TrackedRenderPass<'a> {
     /// The active index buffer can be set with [`TrackedRenderPass::set_index_buffer`], while the
     /// active vertex buffer(s) can be set with [`TrackedRenderPass::set_vertex_buffer`].
     pub fn draw_indexed(&mut self, indices: Range<u32>, base_vertex: i32, instances: Range<u32>) {
-        debug!(
+        trace!(
             "draw indexed: {:?} {} {:?}",
-            indices, base_vertex, instances
+            indices,
+            base_vertex,
+            instances
         );
         self.pass.draw_indexed(indices, base_vertex, instances);
     }
 
     pub fn set_stencil_reference(&mut self, reference: u32) {
-        debug!("set stencil reference: {}", reference);
+        trace!("set stencil reference: {}", reference);
 
         self.pass.set_stencil_reference(reference);
     }
@@ -237,7 +243,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// Subsequent draw calls will discard any fragments that fall outside this region.
     pub fn set_scissor_rect(&mut self, x: u32, y: u32, width: u32, height: u32) {
-        debug!("set_scissor_rect: {} {} {} {}", x, y, width, height);
+        trace!("set_scissor_rect: {} {} {} {}", x, y, width, height);
         self.pass.set_scissor_rect(x, y, width, height);
     }
 
@@ -245,7 +251,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// Features::PUSH_CONSTANTS must be enabled on the device in order to call these functions.
     pub fn set_push_constants(&mut self, stages: ShaderStages, offset: u32, data: &[u8]) {
-        debug!(
+        trace!(
             "set push constants: {:?} offset: {} data.len: {}",
             stages,
             offset,
@@ -266,9 +272,14 @@ impl<'a> TrackedRenderPass<'a> {
         min_depth: f32,
         max_depth: f32,
     ) {
-        debug!(
+        trace!(
             "set viewport: {} {} {} {} {} {}",
-            x, y, width, height, min_depth, max_depth
+            x,
+            y,
+            width,
+            height,
+            min_depth,
+            max_depth
         );
         self.pass
             .set_viewport(x, y, width, height, min_depth, max_depth)
@@ -278,7 +289,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// This is a GPU debugging feature. This has no effect on the rendering itself.
     pub fn insert_debug_marker(&mut self, label: &str) {
-        debug!("insert debug marker: {}", label);
+        trace!("insert debug marker: {}", label);
         self.pass.insert_debug_marker(label)
     }
 
@@ -303,7 +314,7 @@ impl<'a> TrackedRenderPass<'a> {
     /// [`push_debug_group`]: TrackedRenderPass::push_debug_group
     /// [`pop_debug_group`]: TrackedRenderPass::pop_debug_group
     pub fn push_debug_group(&mut self, label: &str) {
-        debug!("push_debug_group marker: {}", label);
+        trace!("push_debug_group marker: {}", label);
         self.pass.push_debug_group(label)
     }
 
@@ -320,12 +331,12 @@ impl<'a> TrackedRenderPass<'a> {
     /// [`push_debug_group`]: TrackedRenderPass::push_debug_group
     /// [`pop_debug_group`]: TrackedRenderPass::pop_debug_group
     pub fn pop_debug_group(&mut self) {
-        debug!("pop_debug_group");
+        trace!("pop_debug_group");
         self.pass.pop_debug_group()
     }
 
     pub fn set_blend_constant(&mut self, color: Color) {
-        debug!("set blend constant: {:?}", color);
+        trace!("set blend constant: {:?}", color);
         self.pass.set_blend_constant(wgpu::Color::from(color))
     }
 }


### PR DESCRIPTION
# Objective

- Allow the user to specify the priority when configuring wgpu features/limits and by default use the maximum capabilities of the chosen adapter.

## Solution

- Add a `WgpuOptionsPriority` enum with `Compatibility`, `Functionality` and `WebGL2` options.
- Add a `priority: WgpuOptionsPriority` member to `WgpuOptions`.
- When initialising the renderer, if `WgpuOptions::priority == WgpuOptionsPriority::Functionality`, query the adapter for the available features and limits, use them when creating a device, and update `WgpuOptions` with those values. If `Compatibility` use the behaviour as before this PR. If `WebGL2` then use the WebGL2 downlevel limits as used when when building for wasm, for convenience of testing WebGL2 limits without having to build for wasm.
- Add an environment variable `WGPU_OPTIONS_PRIO` that takes `compatibility`, `functionality`, `webgl2`.
- Default to `WgpuOptionsPriority::Functionality`.
- Insert updated `WgpuOptions` into render app world as well. This is useful for applying the limits when rendering, such as limiting the directional light shadow map texture to 2048x2048 when using WebGL2 downlevel limits but not on wasm.
- Reduced `draw_state` logs from `debug` to `trace` and added `debug` level logs for the wgpu features and limits. Use `RUST_LOG=bevy_render=debug` to see the output.