### PR TITLE
Added system parameters to the extract function for render assets.

### DIFF
--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -158,19 +158,20 @@ pub struct GpuStandardMaterial {
 impl RenderAsset for StandardMaterial {
     type ExtractedAsset = StandardMaterial;
     type PreparedAsset = GpuStandardMaterial;
-    type Param = (
+    type ExtractParam = ();
+    type PrepareParam = (
         SRes<RenderDevice>,
         SRes<MaterialPipeline<StandardMaterial>>,
         SRes<RenderAssets<Image>>,
     );
 
-    fn extract_asset(&self) -> Self::ExtractedAsset {
+    fn extract_asset(&self, _: &mut SystemParamItem<Self::ExtractParam>) -> Self::ExtractedAsset {
         self.clone()
     }
 
     fn prepare_asset(
         material: Self::ExtractedAsset,
-        (render_device, pbr_pipeline, gpu_images): &mut SystemParamItem<Self::Param>,
+        (render_device, pbr_pipeline, gpu_images): &mut SystemParamItem<Self::PrepareParam>,
     ) -> Result<Self::PreparedAsset, PrepareAssetError<Self::ExtractedAsset>> {
         let (base_color_texture_view, base_color_sampler) = if let Some(result) = pbr_pipeline
             .mesh_pipeline

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -613,17 +613,18 @@ pub enum GpuBufferInfo {
 impl RenderAsset for Mesh {
     type ExtractedAsset = Mesh;
     type PreparedAsset = GpuMesh;
-    type Param = SRes<RenderDevice>;
+    type ExtractParam = ();
+    type PrepareParam = SRes<RenderDevice>;
 
     /// Clones the mesh.
-    fn extract_asset(&self) -> Self::ExtractedAsset {
+    fn extract_asset(&self, _: &mut SystemParamItem<Self::ExtractParam>) -> Self::ExtractedAsset {
         self.clone()
     }
 
     /// Converts the extracted mesh a into [`GpuMesh`].
     fn prepare_asset(
         mesh: Self::ExtractedAsset,
-        render_device: &mut SystemParamItem<Self::Param>,
+        render_device: &mut SystemParamItem<Self::PrepareParam>,
     ) -> Result<Self::PreparedAsset, PrepareAssetError<Self::ExtractedAsset>> {
         let vertex_buffer_data = mesh.get_vertex_buffer_data();
         let vertex_buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -384,17 +384,18 @@ pub struct GpuImage {
 impl RenderAsset for Image {
     type ExtractedAsset = Image;
     type PreparedAsset = GpuImage;
-    type Param = (SRes<RenderDevice>, SRes<RenderQueue>);
+    type ExtractParam = ();
+    type PrepareParam = (SRes<RenderDevice>, SRes<RenderQueue>);
 
     /// Clones the Image.
-    fn extract_asset(&self) -> Self::ExtractedAsset {
+    fn extract_asset(&self, _: &mut SystemParamItem<Self::ExtractParam>) -> Self::ExtractedAsset {
         self.clone()
     }
 
     /// Converts the extracted image into a [`GpuImage`].
     fn prepare_asset(
         image: Self::ExtractedAsset,
-        (render_device, render_queue): &mut SystemParamItem<Self::Param>,
+        (render_device, render_queue): &mut SystemParamItem<Self::PrepareParam>,
     ) -> Result<Self::PreparedAsset, PrepareAssetError<Self::ExtractedAsset>> {
         let texture = render_device.create_texture(&image.texture_descriptor);
         let sampler = render_device.create_sampler(&image.sampler_descriptor);

--- a/examples/shader/shader_material.rs
+++ b/examples/shader/shader_material.rs
@@ -59,14 +59,17 @@ pub struct GpuCustomMaterial {
 impl RenderAsset for CustomMaterial {
     type ExtractedAsset = CustomMaterial;
     type PreparedAsset = GpuCustomMaterial;
-    type Param = (SRes<RenderDevice>, SRes<MaterialPipeline<Self>>);
-    fn extract_asset(&self) -> Self::ExtractedAsset {
+
+    type ExtractParam = ();
+    type PrepareParam = (SRes<RenderDevice>, SRes<MaterialPipeline<Self>>);
+
+    fn extract_asset(&self, _: &mut SystemParamItem<Self::ExtractParam>) -> Self::ExtractedAsset {
         self.clone()
     }
 
     fn prepare_asset(
         extracted_asset: Self::ExtractedAsset,
-        (render_device, material_pipeline): &mut SystemParamItem<Self::Param>,
+        (render_device, material_pipeline): &mut SystemParamItem<Self::PrepareParam>,
     ) -> Result<Self::PreparedAsset, PrepareAssetError<Self::ExtractedAsset>> {
         let color = Vec4::from_slice(&extracted_asset.color.as_linear_rgba_f32());
         let buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {


### PR DESCRIPTION
# Objective
I would like to access the world during a `RenderAsset`'s extract phase. This is useful for pulling data from the world to create the GPU resource. 

## Solution
It behaves similar to how the current prepare function works. Instead of the system being built off of `render_app.world` it's built off of the `app.world`. 