### PR TITLE
[Merged by Bors] - Add instruction to enable ALSA api routing on Arch / Manjaro systems

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -55,6 +55,8 @@ sudo dnf install alsa-lib-devel.x86_64
 sudo pacman -S libx11 pkgconf alsa-lib
 ```
 
+Install `pipewire-alsa` or `pulseaudio-alsa` depending on the sound server you are using.
+
 ## Void
 
 ```bash


### PR DESCRIPTION
# Objective

Every few months a person using Arch asks for help with the following error on discord:
```
ALSA lib pcm_dmix.c:1032:(snd_pcm_dmix_open) unable to open slave
```
This error is caused by their sound server not being configured for ALSA. The fix is to install `pipewire-alsa` or `pulseaudio-alsa` depending on the sound server they use.

Examples:
- https://discord.com/channels/691052431525675048/749690364792668301/924380204237987861
- https://discord.com/channels/691052431525675048/742884593551802431/907392651689619486
- https://discord.com/channels/691052431525675048/742884593551802431/838062316360433664

## Solution

Add the instruction to install either `pipewire-alsa` or `pulseaudio-alsa` to [linux_dependencies.md](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md#arch--manjaro)

## Extra Info

A lot of people don't run into this issue because `pipewire-alsa` / `pulseaudio-alsa` is a dependency for gnome and cinnamon.

@alice-i-cecile Sorry, had to recreate the pr. It doesn't let me reopen and change the branch of the original pr.
