### PR TITLE
[Merged by Bors] - can specify an anchor for a sprite

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -191,6 +191,7 @@ pub struct ExtractedSprite {
     pub image_handle_id: HandleId,
     pub flip_x: bool,
     pub flip_y: bool,
+    pub anchor: Vec2,
 }
 
 #[derive(Default)]
@@ -257,6 +258,7 @@ pub fn extract_sprites(
             flip_x: sprite.flip_x,
             flip_y: sprite.flip_y,
             image_handle_id: handle.id,
+            anchor: sprite.anchor.as_vec(),
         });
     }
     for (visibility, atlas_sprite, transform, texture_atlas_handle) in atlas_query.iter() {
@@ -275,6 +277,7 @@ pub fn extract_sprites(
                 flip_x: atlas_sprite.flip_x,
                 flip_y: atlas_sprite.flip_y,
                 image_handle_id: texture_atlas.texture.id,
+                anchor: atlas_sprite.anchor.as_vec(),
             });
         }
     }
@@ -498,7 +501,7 @@ pub fn queue_sprites(
                 let positions = QUAD_VERTEX_POSITIONS.map(|quad_pos| {
                     extracted_sprite
                         .transform
-                        .mul_vec3((quad_pos * quad_size).extend(0.))
+                        .mul_vec3(((quad_pos - extracted_sprite.anchor) * quad_size).extend(0.))
                         .into()
                 });
 

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -16,4 +16,46 @@ pub struct Sprite {
     /// An optional custom size for the sprite that will be used when rendering, instead of the size
     /// of the sprite's image
     pub custom_size: Option<Vec2>,
+    /// [`Anchor`] point of the sprite in the world
+    pub anchor: Anchor,
+}
+
+/// How a sprite is positionned relative to it's [`Transform`](bevy_transform::Transform). It
+/// defaults to `Anchor::Center`.
+#[derive(Debug, Clone, Reflect)]
+pub enum Anchor {
+    Center,
+    BottomLeft,
+    BottomCenter,
+    BottomRight,
+    CenterLeft,
+    CenterRight,
+    TopLeft,
+    TopCenter,
+    TopRight,
+    /// Custom anchor point. Top Left is `(-0.5, 0.5)`.
+    Custom(Vec2),
+}
+
+impl Default for Anchor {
+    fn default() -> Self {
+        Anchor::Center
+    }
+}
+
+impl Anchor {
+    pub fn as_vec(&self) -> Vec2 {
+        match self {
+            Anchor::Center => Vec2::ZERO,
+            Anchor::BottomLeft => Vec2::new(-0.5, -0.5),
+            Anchor::BottomCenter => Vec2::new(0.0, -0.5),
+            Anchor::BottomRight => Vec2::new(0.5, -0.5),
+            Anchor::CenterLeft => Vec2::new(-0.5, 0.0),
+            Anchor::CenterRight => Vec2::new(0.5, 0.0),
+            Anchor::TopLeft => Vec2::new(-0.5, 0.5),
+            Anchor::TopCenter => Vec2::new(0.0, 0.5),
+            Anchor::TopRight => Vec2::new(0.5, 0.5),
+            Anchor::Custom(point) => *point,
+        }
+    }
 }

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -20,7 +20,7 @@ pub struct Sprite {
     pub anchor: Anchor,
 }
 
-/// How a sprite is positionned relative to it's [`Transform`](bevy_transform::components::Transform).
+/// How a sprite is positioned relative to its [`Transform`](bevy_transform::components::Transform).
 /// It defaults to `Anchor::Center`.
 #[derive(Debug, Clone, Reflect)]
 #[doc(alias = "pivot")]

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -20,8 +20,8 @@ pub struct Sprite {
     pub anchor: Anchor,
 }
 
-/// How a sprite is positionned relative to it's [`Transform`](bevy_transform::Transform). It
-/// defaults to `Anchor::Center`.
+/// How a sprite is positionned relative to it's [`Transform`](bevy_transform::components::Transform).
+/// It defaults to `Anchor::Center`.
 #[derive(Debug, Clone, Reflect)]
 pub enum Anchor {
     Center,

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -23,6 +23,7 @@ pub struct Sprite {
 /// How a sprite is positionned relative to it's [`Transform`](bevy_transform::components::Transform).
 /// It defaults to `Anchor::Center`.
 #[derive(Debug, Clone, Reflect)]
+#[doc(alias = "pivot")]
 pub enum Anchor {
     Center,
     BottomLeft,
@@ -33,7 +34,8 @@ pub enum Anchor {
     TopLeft,
     TopCenter,
     TopRight,
-    /// Custom anchor point. Top Left is `(-0.5, 0.5)`.
+    /// Custom anchor point. Top left is `(-0.5, 0.5)`, center is `(0.0, 0.0)`. The value will
+    /// be scaled with the sprite size.
     Custom(Vec2),
 }
 

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -1,4 +1,4 @@
-use crate::Rect;
+use crate::{Anchor, Rect};
 use bevy_asset::Handle;
 use bevy_ecs::component::Component;
 use bevy_math::Vec2;
@@ -31,6 +31,7 @@ pub struct TextureAtlasSprite {
     /// An optional custom size for the sprite that will be used when rendering, instead of the size
     /// of the sprite's image in the atlas
     pub custom_size: Option<Vec2>,
+    pub anchor: Anchor,
 }
 
 impl Default for TextureAtlasSprite {
@@ -41,6 +42,7 @@ impl Default for TextureAtlasSprite {
             flip_x: false,
             flip_y: false,
             custom_size: None,
+            anchor: Anchor::default(),
         }
     }
 }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
 };
 use bevy_math::{Size, Vec3};
 use bevy_render::{texture::Image, view::Visibility, RenderWorld};
-use bevy_sprite::{ExtractedSprite, ExtractedSprites, TextureAtlas};
+use bevy_sprite::{Anchor, ExtractedSprite, ExtractedSprites, TextureAtlas};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 use bevy_window::Windows;
 
@@ -103,6 +103,7 @@ pub fn extract_text2d_sprite(
                     image_handle_id: handle.id,
                     flip_x: false,
                     flip_y: false,
+                    anchor: Anchor::Center.as_vec(),
                 });
             }
         }


### PR DESCRIPTION
# Objective

- Fixes #1616, fixes #2225
- Let user specify an anchor for a sprite

## Solution

- Add an enum for an anchor point for most common values, with a variant for a custom point
- Defaults to Center to not change current behaviour
