### PR TITLE
[Merged by Bors] - Fix `doc_markdown` lints in `bevy_app`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -500,11 +500,11 @@ impl App {
         self
     }
 
-    /// Adds a new [State] with the given `initial` value.
-    /// This inserts a new `State<T>` resource and adds a new "driver" to [CoreStage::Update].
+    /// Adds a new [`State`] with the given `initial` value.
+    /// This inserts a new `State<T>` resource and adds a new "driver" to [`CoreStage::Update`].
     /// Each stage that uses `State<T>` for system run criteria needs a driver. If you need to use
-    /// your state in a different stage, consider using [Self::add_state_to_stage] or manually
-    /// adding [State::get_driver] to additional stages you need it in.
+    /// your state in a different stage, consider using [`Self::add_state_to_stage`] or manually
+    /// adding [`State::get_driver`] to additional stages you need it in.
     pub fn add_state<T>(&mut self, initial: T) -> &mut Self
     where
         T: StateData,
@@ -515,7 +515,7 @@ impl App {
     /// Adds a new [State] with the given `initial` value.
     /// This inserts a new `State<T>` resource and adds a new "driver" to the given stage.
     /// Each stage that uses `State<T>` for system run criteria needs a driver. If you need to use
-    /// your state in more than one stage, consider manually adding [State::get_driver] to the
+    /// your state in more than one stage, consider manually adding [`State::get_driver`] to the
     /// stages you need it in.
     pub fn add_state_to_stage<T>(&mut self, stage: impl StageLabel, initial: T) -> &mut Self
     where
@@ -759,7 +759,7 @@ impl App {
     /// Adds a group of plugins
     ///
     /// Bevy plugins can be grouped into a set of plugins. Bevy provides
-    /// built-in PluginGroups that provide core engine functionality.
+    /// built-in `PluginGroups` that provide core engine functionality.
     ///
     /// The plugin groups available by default are `DefaultPlugins` and `MinimalPlugins`.
     ///

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -512,7 +512,7 @@ impl App {
         self.add_state_to_stage(CoreStage::Update, initial)
     }
 
-    /// Adds a new [State] with the given `initial` value.
+    /// Adds a new [`State`] with the given `initial` value.
     /// This inserts a new `State<T>` resource and adds a new "driver" to the given stage.
     /// Each stage that uses `State<T>` for system run criteria needs a driver. If you need to use
     /// your state in more than one stage, consider manually adding [`State::get_driver`] to the

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -3,8 +3,8 @@ use std::any::Any;
 
 /// A collection of Bevy App logic and configuration
 ///
-/// Plugins configure an [App](crate::App). When an [App](crate::App) registers
-/// a plugin, the plugin's [Plugin::build] function is run.
+/// Plugins configure an [`App`](crate::App). When an [`App`](crate::App) registers
+/// a plugin, the plugin's [`Plugin::build`] function is run.
 pub trait Plugin: Any + Send + Sync {
     fn build(&self, app: &mut App);
     fn name(&self) -> &str {

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -45,8 +45,8 @@ impl ScheduleRunnerSettings {
     }
 }
 
-/// Configures an App to run its [Schedule](bevy_ecs::schedule::Schedule) according to a given
-/// [RunMode]
+/// Configures an `App` to run its [`Schedule`](bevy_ecs::schedule::Schedule) according to a given
+/// [`RunMode`]
 #[derive(Default)]
 pub struct ScheduleRunnerPlugin;
 

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
 
     // See if clippy has any complaints.
     // - Type complexity must be ignored because we use huge templates for queries
-    cmd!("cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::type_complexity")
+    cmd!("cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::type_complexity -W clippy::doc_markdown")
         .run()
         .expect("Please fix clippy errors in output above.");
 

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
 
     // See if clippy has any complaints.
     // - Type complexity must be ignored because we use huge templates for queries
-    cmd!("cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::type_complexity -W clippy::doc_markdown")
+    cmd!("cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::type_complexity")
         .run()
         .expect("Please fix clippy errors in output above.");
 


### PR DESCRIPTION
#3457 adds the `doc_markdown` clippy lint, which checks doc comments to make sure code identifiers are escaped with backticks. This causes a lot of lint errors, so this is one of a number of PR's that will fix those lint errors one crate at a time.

This PR fixes lints in the `bevy_app` crate.
