### PR TITLE
[Merged by Bors] - Fix `doc_markdown` lints in `bevy_asset`

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -14,7 +14,7 @@ use parking_lot::{Mutex, RwLock};
 use std::{collections::hash_map::Entry, path::Path, sync::Arc};
 use thiserror::Error;
 
-/// Errors that occur while loading assets with an AssetServer
+/// Errors that occur while loading assets with an `AssetServer`
 #[derive(Error, Debug)]
 pub enum AssetServerError {
     #[error("asset folder path is not a directory: {0}")]
@@ -215,7 +215,7 @@ impl AssetServer {
 
     /// Queue an [`Asset`] at the provided relative path for asynchronous loading.
     ///
-    /// The absolute Path to the asset is "ROOT/ASSET_FOLDER_NAME/path".
+    /// The absolute Path to the asset is `"ROOT/ASSET_FOLDER_NAME/path"`.
     ///
     /// By default the ROOT is the directory of the Application, but this can be overridden by
     /// setting the `"CARGO_MANIFEST_DIR"` environment variable

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -32,7 +32,7 @@ pub enum AssetIoError {
     PathWatchError(PathBuf),
 }
 
-/// Handles load requests from an AssetServer
+/// Handles load requests from an `AssetServer`
 pub trait AssetIo: Downcast + Send + Sync + 'static {
     fn load_path<'a>(&'a self, path: &'a Path) -> BoxedFuture<'a, Result<Vec<u8>, AssetIoError>>;
     fn read_directory(

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -155,7 +155,7 @@ pub struct AssetResult<T> {
     pub version: usize,
 }
 
-/// A channel to send and receive [AssetResult]s
+/// A channel to send and receive [`AssetResult`]s
 #[derive(Debug)]
 pub struct AssetLifecycleChannel<T> {
     pub sender: Sender<AssetLifecycleEvent<T>>,
@@ -203,7 +203,7 @@ impl<T> Default for AssetLifecycleChannel<T> {
     }
 }
 
-/// Updates the [Assets] collection according to the changes queued up by [AssetServer].
+/// Updates the [`Assets`] collection according to the changes queued up by [`AssetServer`].
 pub fn update_asset_storage_system<T: Asset + AssetDynamic>(
     asset_server: Res<AssetServer>,
     assets: ResMut<Assets<T>>,


### PR DESCRIPTION
#3457 adds the `doc_markdown` clippy lint, which checks doc comments to make sure code identifiers are escaped with backticks. This causes a lot of lint errors, so this is one of a number of PR's that will fix those lint errors one crate at a time.

This PR fixes lints in the `bevy_asset` crate.
