### PR TITLE
[Merged by Bors] - Fix `doc_markdown` lints in `bevy_audio`

### DIFF
--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -68,7 +68,7 @@ where
     }
 }
 
-/// Plays audio currently queued in the [Audio] resource through the [AudioOutput] resource
+/// Plays audio currently queued in the [`Audio`] resource through the [`AudioOutput`] resource
 pub fn play_queued_audio_system<P: Asset>(world: &mut World)
 where
     P: Decodable,

--- a/crates/bevy_audio/src/audio_source.rs
+++ b/crates/bevy_audio/src/audio_source.rs
@@ -17,7 +17,7 @@ impl AsRef<[u8]> for AudioSource {
     }
 }
 
-/// Loads mp3 files as [AudioSource] [Assets](bevy_asset::Assets)
+/// Loads mp3 files as [`AudioSource`] [`Assets`](bevy_asset::Assets)
 #[derive(Default)]
 pub struct Mp3Loader;
 


### PR DESCRIPTION
#3457 adds the `doc_markdown` clippy lint, which checks doc comments to make sure code identifiers are escaped with backticks. This causes a lot of lint errors, so this is one of a number of PR's that will fix those lint errors one crate at a time.

This PR fixes lints in the `bevy_audio` crate.
