### PR TITLE
Fix `doc_markdown` lints in `bevy_crevice`

### DIFF
--- a/crates/bevy_crevice/src/std140/traits.rs
+++ b/crates/bevy_crevice/src/std140/traits.rs
@@ -26,9 +26,7 @@ pub unsafe trait Std140: Copy + Zeroable + Pod {
 
     /// Padded type ([`Std140Padded`] specialization)
     /// The usual implementation is
-    /// ```
-    /// type Padded = Std140Padded<Self, {align_offset(size_of::<Self>(), max(16, ALIGNMENT))}>`;
-    /// ```
+    /// `type Padded = Std140Padded<Self, {align_offset(size_of::<Self>(), max(16, ALIGNMENT))}>;`
     type Padded: Std140Convertible<Self>;
 
     /// Casts the type to a byte array. Implementors should not override this

--- a/crates/bevy_crevice/src/std140/traits.rs
+++ b/crates/bevy_crevice/src/std140/traits.rs
@@ -23,9 +23,12 @@ pub unsafe trait Std140: Copy + Zeroable + Pod {
     /// See <https://www.khronos.org/registry/OpenGL/specs/gl/glspec45.core.pdf#page=159>
     /// (rule 4 and 9)
     const PAD_AT_END: bool = false;
-    /// Padded type (Std140Padded specialization)
+
+    /// Padded type ([`Std140Padded`] specialization)
     /// The usual implementation is
-    /// type Padded = Std140Padded<Self, {align_offset(size_of::<Self>(), max(16, ALIGNMENT))}>;
+    /// ```
+    /// type Padded = Std140Padded<Self, {align_offset(size_of::<Self>(), max(16, ALIGNMENT))}>`;
+    /// ```
     type Padded: Std140Convertible<Self>;
 
     /// Casts the type to a byte array. Implementors should not override this
@@ -39,11 +42,12 @@ pub unsafe trait Std140: Copy + Zeroable + Pod {
     }
 }
 
-/// Trait specifically for Std140::Padded, implements conversions between padded type and base type.
+/// Trait specifically for [`Std140::Padded`], implements conversions between padded type and base
+/// type.
 pub trait Std140Convertible<T: Std140>: Copy {
-    /// Convert from self to Std140
+    /// Convert from `Self` to [`Std140`]
     fn into_std140(self) -> T;
-    /// Convert from Std140 to self
+    /// Convert from [`Std140`] to `Self`
     fn from_std140(_: T) -> Self;
 }
 

--- a/crates/bevy_crevice/src/std430/traits.rs
+++ b/crates/bevy_crevice/src/std430/traits.rs
@@ -25,9 +25,7 @@ pub unsafe trait Std430: Copy + Zeroable + Pod {
     const PAD_AT_END: bool = false;
     /// Padded type ([`Std430Padded`] specialization)
     /// The usual implementation is
-    /// ```
-    /// type Padded = Std430Padded<Self, {align_offset(size_of::<Self>(), ALIGNMENT)}>;
-    /// ```
+    /// `type Padded = Std430Padded<Self, {align_offset(size_of::<Self>(), ALIGNMENT)}>;`
     type Padded: Std430Convertible<Self>;
 
     /// Casts the type to a byte array. Implementors should not override this

--- a/crates/bevy_crevice/src/std430/traits.rs
+++ b/crates/bevy_crevice/src/std430/traits.rs
@@ -23,9 +23,11 @@ pub unsafe trait Std430: Copy + Zeroable + Pod {
     /// See <https://www.khronos.org/registry/OpenGL/specs/gl/glspec45.core.pdf#page=159>
     /// (rule 4 and 9)
     const PAD_AT_END: bool = false;
-    /// Padded type (Std430Padded specialization)
+    /// Padded type ([`Std430Padded`] specialization)
     /// The usual implementation is
+    /// ```
     /// type Padded = Std430Padded<Self, {align_offset(size_of::<Self>(), ALIGNMENT)}>;
+    /// ```
     type Padded: Std430Convertible<Self>;
 
     /// Casts the type to a byte array. Implementors should not override this
@@ -39,7 +41,8 @@ pub unsafe trait Std430: Copy + Zeroable + Pod {
     }
 }
 
-/// Trait specifically for Std430::Padded, implements conversions between padded type and base type.
+/// Trait specifically for [`Std430::Padded`], implements conversions between padded type and base
+/// type.
 pub trait Std430Convertible<T: Std430>: Copy {
     /// Convert from self to Std430
     fn into_std430(self) -> T;


### PR DESCRIPTION
#3457 adds the `doc_markdown` clippy lint, which checks doc comments to make sure code identifiers are escaped with backticks. This causes a lot of lint errors, so this is one of a number of PR's that will fix those lint errors one crate at a time.

This PR fixes lints in the `bevy_crevice` crate.
