### PR TITLE
Fix `doc_markdown` lints in `bevy_derive`

### DIFF
--- a/crates/bevy_derive/src/lib.rs
+++ b/crates/bevy_derive/src/lib.rs
@@ -17,7 +17,7 @@ pub fn derive_bytes(input: TokenStream) -> TokenStream {
     bytes::derive_bytes(input)
 }
 
-/// Derives the ShaderDefs trait. Each field must implement ShaderDef or this will fail.
+/// Derives the [`ShaderDefs`] trait. Each field must implement [`ShaderDefs`] or this will fail.
 /// You can ignore fields using `#[shader_defs(ignore)]`.
 #[proc_macro_derive(ShaderDefs, attributes(shader_def))]
 pub fn derive_shader_defs(input: TokenStream) -> TokenStream {


### PR DESCRIPTION
#3457 adds the `doc_markdown` clippy lint, which checks doc comments to make sure code identifiers are escaped with backticks. This causes a lot of lint errors, so this is one of a number of PR's that will fix those lint errors one crate at a time.

This PR fixes lints in the `bevy_derive` crate.
