### PR TITLE
[Merged by Bors] - Fix `doc_markdown` lints in `bevy_diagnostic`

### DIFF
--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -27,7 +27,7 @@ pub struct DiagnosticMeasurement {
     pub value: f64,
 }
 
-/// A timeline of [DiagnosticMeasurement]s of a specific type.
+/// A timeline of [`DiagnosticMeasurement`]s of a specific type.
 /// Diagnostic examples: frames per second, CPU usage, network latency
 #[derive(Debug)]
 pub struct Diagnostic {

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -12,7 +12,7 @@ pub struct LogDiagnosticsPlugin {
     pub filter: Option<Vec<DiagnosticId>>,
 }
 
-/// State used by the [LogDiagnosticsPlugin]
+/// State used by the [`LogDiagnosticsPlugin`]
 struct LogDiagnosticsState {
     timer: Timer,
     filter: Option<Vec<DiagnosticId>>,


### PR DESCRIPTION
#3457 adds the `doc_markdown` clippy lint, which checks doc comments to make sure code identifiers are escaped with backticks. This causes a lot of lint errors, so this is one of a number of PR's that will fix those lint errors one crate at a time.

This PR fixes lints in the `bevy_diagnostic` crate.
