### PR TITLE
[Merged by Bors] - Fix `doc_markdown` lints in `bevy_ecs`

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -470,7 +470,7 @@ impl Archetypes {
     /// `table_components` and `sparse_set_components` must be sorted
     ///
     /// # Safety
-    /// TableId must exist in tables
+    /// [`TableId`] must exist in tables
     pub(crate) fn get_id_or_insert(
         &mut self,
         table_id: TableId,

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -71,12 +71,12 @@ use std::{any::TypeId, collections::HashMap};
 ///
 /// # Safety
 ///
-/// - [Bundle::component_ids] must return the ComponentId for each component type in the bundle, in the
-///   _exact_ order that [Bundle::get_components] is called.
-/// - [Bundle::from_components] must call `func` exactly once for each [ComponentId] returned by
-///   [Bundle::component_ids].
+/// - [`Bundle::component_ids`] must return the [`ComponentId`] for each component type in the
+/// bundle, in the _exact_ order that [`Bundle::get_components`] is called.
+/// - [`Bundle::from_components`] must call `func` exactly once for each [`ComponentId`] returned by
+///   [`Bundle::component_ids`].
 pub unsafe trait Bundle: Send + Sync + 'static {
-    /// Gets this [Bundle]'s component ids, in the order of this bundle's Components
+    /// Gets this [`Bundle`]'s component ids, in the order of this bundle's [`Components`]
     fn component_ids(components: &mut Components, storages: &mut Storages) -> Vec<ComponentId>;
 
     /// Calls `func`, which should return data for each component in the bundle, in the order of
@@ -89,15 +89,16 @@ pub unsafe trait Bundle: Send + Sync + 'static {
     where
         Self: Sized;
 
-    /// Calls `func` on each value, in the order of this bundle's Components. This will
-    /// "mem::forget" the bundle fields, so callers are responsible for dropping the fields if
+    /// Calls `func` on each value, in the order of this bundle's [`Components`]. This will
+    /// `mem::forget` the bundle fields, so callers are responsible for dropping the fields if
     /// that is desirable.
     fn get_components(self, func: impl FnMut(*mut u8));
 }
 
 macro_rules! tuple_impl {
     ($($name: ident),*) => {
-        /// SAFE: Component is returned in tuple-order. [Bundle::from_components] and [Bundle::get_components] use tuple-order
+        /// SAFE: Component is returned in tuple-order. [`Bundle::from_components`] and
+        /// [`Bundle::get_components`] use tuple-order
         unsafe impl<$($name: Component),*> Bundle for ($($name,)*) {
             #[allow(unused_variables)]
             fn component_ids(components: &mut Components, storages: &mut Storages) -> Vec<ComponentId> {
@@ -258,7 +259,8 @@ impl BundleInfo {
     }
 
     /// # Safety
-    /// `table` must be the "new" table for `entity`. `table_row` must have space allocated for the `entity`, `bundle` must match this BundleInfo's type
+    /// `table` must be the "new" table for `entity`. `table_row` must have space allocated for the
+    /// `entity`, `bundle` must match this [`BundleInfo`]'s type
     #[inline]
     #[allow(clippy::too_many_arguments)]
     unsafe fn write_components<T: Bundle>(
@@ -301,9 +303,9 @@ impl BundleInfo {
         });
     }
 
-    /// Adds a bundle to the given archetype and returns the resulting archetype. This could be the same
-    /// [ArchetypeId], in the event that adding the given bundle does not result in an Archetype change.
-    /// Results are cached in the Archetype Graph to avoid redundant work.
+    /// Adds a bundle to the given archetype and returns the resulting archetype. This could be the
+    /// same [`ArchetypeId`], in the event that adding the given bundle does not result in an
+    /// [`Archetype`] change. Results are cached in the [`Archetype`] graph to avoid redundant work.
     pub(crate) fn add_bundle_to_archetype(
         &self,
         archetypes: &mut Archetypes,
@@ -409,8 +411,8 @@ pub(crate) enum InsertBundleResult<'a> {
 
 impl<'a, 'b> BundleInserter<'a, 'b> {
     /// # Safety
-    /// `entity` must currently exist in the source archetype for this inserter. `archetype_index` must be `entity`'s location in the archetype.
-    /// `T` must match this BundleInfo's type
+    /// `entity` must currently exist in the source archetype for this inserter. `archetype_index`
+    /// must be `entity`'s location in the archetype. `T` must match this [`BundleInfo`]'s type
     #[inline]
     pub unsafe fn insert<T: Bundle>(
         &mut self,
@@ -538,7 +540,7 @@ impl<'a, 'b> BundleSpawner<'a, 'b> {
         self.table.reserve(additional);
     }
     /// # Safety
-    /// `entity` must be allocated (but non existent), `T` must match this BundleInfo's type
+    /// `entity` must be allocated (but non-existent), `T` must match this [`BundleInfo`]'s type
     #[inline]
     pub unsafe fn spawn_non_existent<T: Bundle>(
         &mut self,
@@ -562,7 +564,7 @@ impl<'a, 'b> BundleSpawner<'a, 'b> {
     }
 
     /// # Safety
-    /// `T` must match this BundleInfo's type
+    /// `T` must match this [`BundleInfo`]'s type
     #[inline]
     pub unsafe fn spawn<T: Bundle>(&mut self, bundle: T) -> Entity {
         let entity = self.entities.alloc();
@@ -612,7 +614,7 @@ impl Bundles {
 
 /// # Safety
 ///
-/// `component_id` must be valid [ComponentId]'s
+/// `component_id` must be valid [`ComponentId`]'s
 unsafe fn initialize_bundle(
     bundle_type_name: &'static str,
     component_ids: Vec<ComponentId>,

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -97,8 +97,6 @@ pub unsafe trait Bundle: Send + Sync + 'static {
 
 macro_rules! tuple_impl {
     ($($name: ident),*) => {
-        /// SAFE: Component is returned in tuple-order. [`Bundle::from_components`] and
-        /// [`Bundle::get_components`] use tuple-order
         unsafe impl<$($name: Component),*> Bundle for ($($name,)*) {
             #[allow(unused_variables)]
             fn component_ids(components: &mut Components, storages: &mut Storages) -> Vec<ComponentId> {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -1,6 +1,6 @@
 //! Types for handling [`Bundle`]s.
 //!
-//! This module contains the `Bundle` trait and some other helper types.
+//! This module contains the [`Bundle`] trait and some other helper types.
 
 pub use bevy_ecs_macros::Bundle;
 
@@ -13,7 +13,7 @@ use crate::{
 use bevy_ecs_macros::all_tuples;
 use std::{any::TypeId, collections::HashMap};
 
-/// An ordered collection of components.
+/// An ordered collection of [`Component`]s.
 ///
 /// Commonly used for spawning entities and adding and removing components in bulk. This
 /// trait is automatically implemented for tuples of components: `(ComponentA, ComponentB)`
@@ -76,22 +76,22 @@ use std::{any::TypeId, collections::HashMap};
 /// - [`Bundle::from_components`] must call `func` exactly once for each [`ComponentId`] returned by
 ///   [`Bundle::component_ids`].
 pub unsafe trait Bundle: Send + Sync + 'static {
-    /// Gets this [`Bundle`]'s component ids, in the order of this bundle's [`Components`]
+    /// Gets this [`Bundle`]'s component ids, in the order of this bundle's [`Component`]s
     fn component_ids(components: &mut Components, storages: &mut Storages) -> Vec<ComponentId>;
 
     /// Calls `func`, which should return data for each component in the bundle, in the order of
-    /// this bundle's Components
+    /// this bundle's [`Component`]s
     ///
     /// # Safety
     /// Caller must return data for each component in the bundle, in the order of this bundle's
-    /// Components
+    /// [`Component`]s
     unsafe fn from_components(func: impl FnMut() -> *mut u8) -> Self
     where
         Self: Sized;
 
-    /// Calls `func` on each value, in the order of this bundle's [`Components`]. This will
-    /// `mem::forget` the bundle fields, so callers are responsible for dropping the fields if
-    /// that is desirable.
+    /// Calls `func` on each value, in the order of this bundle's [`Component`]s. This will
+    /// [`std::mem::forget`] the bundle fields, so callers are responsible for dropping the fields
+    /// if that is desirable.
     fn get_components(self, func: impl FnMut(*mut u8));
 }
 

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -284,7 +284,7 @@ impl Components {
 
     /// # Safety
     ///
-    /// `id` must be a valid [ComponentId]
+    /// `id` must be a valid [`ComponentId`]
     #[inline]
     pub unsafe fn get_info_unchecked(&self, id: ComponentId) -> &ComponentInfo {
         debug_assert!(id.index() < self.components.len());

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -454,9 +454,9 @@ impl Entities {
     /// `reserve_entities`, then initializes each one using the supplied function.
     ///
     /// # Safety
-    /// Flush _must_ set the entity location to the correct ArchetypeId for the given Entity
-    /// each time init is called. This _can_ be ArchetypeId::INVALID, provided the Entity has
-    /// not been assigned to an Archetype.
+    /// Flush _must_ set the entity location to the correct [`ArchetypeId`] for the given [`Entity`]
+    /// each time init is called. This _can_ be [`ArchetypeId::INVALID`], provided the [`Entity`]
+    /// has not been assigned to an [`Archetype`].
     pub unsafe fn flush(&mut self, mut init: impl FnMut(Entity, &mut EntityLocation)) {
         let free_cursor = self.free_cursor.get_mut();
         let current_free_cursor = *free_cursor;

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -456,7 +456,7 @@ impl Entities {
     /// # Safety
     /// Flush _must_ set the entity location to the correct [`ArchetypeId`] for the given [`Entity`]
     /// each time init is called. This _can_ be [`ArchetypeId::INVALID`], provided the [`Entity`]
-    /// has not been assigned to an [`Archetype`].
+    /// has not been assigned to an [`Archetype`][crate::archetype::Archetype].
     pub unsafe fn flush(&mut self, mut init: impl FnMut(Entity, &mut EntityLocation)) {
         let free_cursor = self.free_cursor.get_mut();
         let current_free_cursor = *free_cursor;

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -67,7 +67,7 @@ enum State {
 /// [`Events::update`] exactly once per update/frame.
 ///
 /// [`Events::update_system`] is a system that does this, typically intialized automatically using
-/// [`App::add_event`]. [EventReader]s are expected to read events from this collection at
+/// [`App::add_event`]. [`EventReader`]s are expected to read events from this collection at
 /// least once per loop/frame.
 /// Events will persist across a single frame boundary and so ordering of event producers and
 /// consumers is not critical (although poorly-planned ordering may cause accumulating lag).
@@ -103,16 +103,16 @@ enum State {
 ///
 /// # Details
 ///
-/// [Events] is implemented using a double buffer. Each call to [Events::update] swaps buffers and
-/// clears out the oldest buffer. [EventReader]s that read at least once per update will never drop
-/// events. [EventReader]s that read once within two updates might still receive some events.
-/// [EventReader]s that read after two updates are guaranteed to drop all events that occurred
+/// [`Events`] is implemented using a double buffer. Each call to [`Events::update`] swaps buffers
+/// and clears out the oldest buffer. [`EventReader`]s that read at least once per update will never
+/// drop events. [`EventReader`]s that read once within two updates might still receive some events.
+/// [`EventReader`]s that read after two updates are guaranteed to drop all events that occurred
 /// before those updates.
 ///
-/// The buffers in [Events] will grow indefinitely if [Events::update] is never called.
+/// The buffers in [`Events`] will grow indefinitely if [`Events::update`] is never called.
 ///
-/// An alternative call pattern would be to call [Events::update] manually across frames to control
-/// when events are cleared.
+/// An alternative call pattern would be to call [`Events::update`] manually across frames to
+/// control when events are cleared.
 /// This complicates consumption and risks ever-expanding memory usage if not cleaned up,
 /// but can be done by adding your event as a resource instead of using [`App::add_event`].
 ///
@@ -254,9 +254,9 @@ fn internal_event_reader<'a, T>(
 }
 
 impl<'w, 's, T: Resource> EventReader<'w, 's, T> {
-    /// Iterates over the events this EventReader has not seen yet. This updates the EventReader's
-    /// event counter, which means subsequent event reads will not include events that happened
-    /// before now.
+    /// Iterates over the events this [`EventReader`] has not seen yet. This updates the
+    /// [`EventReader`]'s event counter, which means subsequent event reads will not include events
+    /// that happened before now.
     pub fn iter(&mut self) -> impl DoubleEndedIterator<Item = &T> {
         self.iter_with_id().map(|(event, _id)| event)
     }
@@ -271,7 +271,7 @@ impl<'w, 's, T: Resource> EventReader<'w, 's, T> {
 }
 
 impl<T: Resource> Events<T> {
-    /// "Sends" an `event` by writing it to the current event buffer. [EventReader]s can then read
+    /// "Sends" an `event` by writing it to the current event buffer. [`EventReader`]s can then read
     /// the event.
     pub fn send(&mut self, event: T) {
         let event_id = EventId {
@@ -290,7 +290,7 @@ impl<T: Resource> Events<T> {
         self.event_count += 1;
     }
 
-    /// Gets a new [ManualEventReader]. This will include all events already in the event buffers.
+    /// Gets a new [`ManualEventReader`]. This will include all events already in the event buffers.
     pub fn get_reader(&self) -> ManualEventReader<T> {
         ManualEventReader {
             last_event_count: 0,
@@ -298,8 +298,8 @@ impl<T: Resource> Events<T> {
         }
     }
 
-    /// Gets a new [ManualEventReader]. This will ignore all events already in the event buffers. It
-    /// will read all future events.
+    /// Gets a new [`ManualEventReader`]. This will ignore all events already in the event buffers.
+    /// It will read all future events.
     pub fn get_reader_current(&self) -> ManualEventReader<T> {
         ManualEventReader {
             last_event_count: self.event_count,
@@ -324,7 +324,7 @@ impl<T: Resource> Events<T> {
         }
     }
 
-    /// A system that calls [Events::update] once per frame.
+    /// A system that calls [`Events::update`] once per frame.
     pub fn update_system(mut events: ResMut<Self>) {
         events.update();
     }

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -21,13 +21,13 @@ use std::{
 ///
 /// See [`Query`](crate::system::Query) for a primer on queries.
 ///
-/// # Basic WorldQueries
+/// # Basic [`WorldQuery`]'s
 ///
 /// Here is a small list of the most important world queries to know about where `C` stands for a
 /// [`Component`] and `WQ` stands for a [`WorldQuery`]:
 /// - `&C`: Queries immutably for the component `C`
 /// - `&mut C`: Queries mutably for the component `C`
-/// - `Option<WQ>`: Queries the inner WorldQuery `WQ` but instead of discarding the entity if the world
+/// - `Option<WQ>`: Queries the inner [`WorldQuery`] `WQ` but instead of discarding the entity if the world
 ///     query fails it returns [`None`]. See [`Query`](crate::system::Query).
 /// - `(WQ1, WQ2, ...)`: Queries all contained world queries allowing to query for more than one thing.
 ///     This is the `And` operator for filters. See [`Or`].
@@ -57,8 +57,8 @@ pub trait Fetch<'world, 'state>: Sized {
     ///
     /// # Safety
     ///
-    /// `state` must have been initialized (via [FetchState::init]) using the same `world` passed in
-    /// to this function.
+    /// `state` must have been initialized (via [`FetchState::init`]) using the same `world` passed
+    /// in to this function.
     unsafe fn init(
         world: &World,
         state: &Self::State,
@@ -78,8 +78,8 @@ pub trait Fetch<'world, 'state>: Sized {
     ///
     /// # Safety
     ///
-    /// `archetype` and `tables` must be from the [`World`] [`Fetch::init`] was called on. `state` must
-    /// be the [Self::State] this was initialized with.
+    /// `archetype` and `tables` must be from the [`World`] [`Fetch::init`] was called on. `state`
+    /// must be the [`Self::State`] this was initialized with.
     unsafe fn set_archetype(&mut self, state: &Self::State, archetype: &Archetype, tables: &Tables);
 
     /// Adjusts internal state to account for the next [`Table`]. This will always be called on tables
@@ -88,7 +88,7 @@ pub trait Fetch<'world, 'state>: Sized {
     /// # Safety
     ///
     /// `table` must be from the [`World`] [`Fetch::init`] was called on. `state` must be the
-    /// [Self::State] this was initialized with.
+    /// [`Self::State`] this was initialized with.
     unsafe fn set_table(&mut self, state: &Self::State, table: &Table);
 
     /// Fetch [`Self::Item`] for the given `archetype_index` in the current [`Archetype`]. This must
@@ -677,7 +677,7 @@ pub struct OptionFetch<T> {
     matches: bool,
 }
 
-/// SAFETY: OptionFetch is read only because T is read only
+/// SAFETY: [`OptionFetch`] is read only because `T` is read only
 unsafe impl<T: ReadOnlyFetch> ReadOnlyFetch for OptionFetch<T> {}
 
 /// The [`FetchState`] of `Option<T>`.

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -35,7 +35,7 @@ where
     /// This does not check for mutable query correctness. To be safe, make sure mutable queries
     /// have unique access to the components they query.
     /// This does not validate that `world.id()` matches `query_state.world_id`. Calling this on a `world`
-    /// with a mismatched WorldId is unsound.
+    /// with a mismatched [`WorldId`] is unsound.
     pub(crate) unsafe fn new(
         world: &'w World,
         query_state: &'s QueryState<Q, F>,
@@ -174,8 +174,8 @@ where
     /// # Safety
     /// This does not check for mutable query correctness. To be safe, make sure mutable queries
     /// have unique access to the components they query.
-    /// This does not validate that `world.id()` matches `query_state.world_id`. Calling this on a `world`
-    /// with a mismatched WorldId is unsound.
+    /// This does not validate that `world.id()` matches `query_state.world_id`. Calling this on a
+    /// `world` with a mismatched [`WorldId`] is unsound.
     pub(crate) unsafe fn new(
         world: &'w World,
         query_state: &'s QueryState<Q, F>,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -391,7 +391,7 @@ where
     /// This does not check for mutable query correctness. To be safe, make sure mutable queries
     /// have unique access to the components they query.
     /// This does not validate that `world.id()` matches `self.world_id`. Calling this on a `world`
-    /// with a mismatched WorldId is unsound.
+    /// with a mismatched [`WorldId`] is unsound.
     #[inline]
     pub(crate) unsafe fn iter_unchecked_manual<'w, 's, QF: Fetch<'w, 's, State = Q::State>>(
         &'s self,
@@ -411,7 +411,7 @@ where
     /// This does not check for mutable query correctness. To be safe, make sure mutable queries
     /// have unique access to the components they query.
     /// This does not validate that `world.id()` matches `self.world_id`. Calling this on a `world`
-    /// with a mismatched WorldId is unsound.
+    /// with a mismatched [`WorldId`] is unsound.
     #[inline]
     pub(crate) unsafe fn iter_combinations_unchecked_manual<
         'w,
@@ -450,7 +450,7 @@ where
     }
 
     /// Runs `func` on each query result for the given [`World`]. This is faster than the equivalent
-    /// iter_mut() method, but cannot be chained like a normal [`Iterator`].
+    /// `iter_mut()` method, but cannot be chained like a normal [`Iterator`].
     #[inline]
     pub fn for_each_mut<'w, 's, FN: FnMut(<Q::Fetch as Fetch<'w, 's>>::Item)>(
         &'s mut self,
@@ -590,7 +590,7 @@ where
     /// This does not check for mutable query correctness. To be safe, make sure mutable queries
     /// have unique access to the components they query.
     /// This does not validate that `world.id()` matches `self.world_id`. Calling this on a `world`
-    /// with a mismatched WorldId is unsound.
+    /// with a mismatched [`WorldId`] is unsound.
     pub(crate) unsafe fn for_each_unchecked_manual<
         'w,
         's,
@@ -650,7 +650,7 @@ where
     /// This does not check for mutable query correctness. To be safe, make sure mutable queries
     /// have unique access to the components they query.
     /// This does not validate that `world.id()` matches `self.world_id`. Calling this on a `world`
-    /// with a mismatched WorldId is unsound.
+    /// with a mismatched [`WorldId`] is unsound.
     pub(crate) unsafe fn par_for_each_unchecked_manual<
         'w,
         's,

--- a/crates/bevy_ecs/src/schedule/executor.rs
+++ b/crates/bevy_ecs/src/schedule/executor.rs
@@ -41,8 +41,8 @@ impl ParallelSystemExecutor for SingleThreadedExecutor {
 }
 
 impl SingleThreadedExecutor {
-    /// Calls system.new_archetype() for each archetype added since the last call to
-    /// [update_archetypes] and updates cached archetype_component_access.
+    /// Calls `system.new_archetype()` for each archetype added since the last call to
+    /// `update_archetypes` and updates cached `archetype_component_access`.
     fn update_archetypes(&mut self, systems: &mut [ParallelSystemContainer], world: &World) {
         let archetypes = world.archetypes();
         let new_generation = archetypes.generation();

--- a/crates/bevy_ecs/src/schedule/executor_parallel.rs
+++ b/crates/bevy_ecs/src/schedule/executor_parallel.rs
@@ -154,8 +154,8 @@ impl ParallelSystemExecutor for ParallelExecutor {
 }
 
 impl ParallelExecutor {
-    /// Calls system.new_archetype() for each archetype added since the last call to
-    /// [update_archetypes] and updates cached archetype_component_access.
+    /// Calls `system.new_archetype()` for each archetype added since the last call to
+    /// `update_archetypes` and updates cached `archetype_component_access`.
     fn update_archetypes(&mut self, systems: &mut [ParallelSystemContainer], world: &World) {
         #[cfg(feature = "trace")]
         let span = bevy_utils::tracing::info_span!("update_archetypes");

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -282,7 +282,7 @@ where
         Ok(())
     }
 
-    /// Same as [Self::set], but if there is already a next state, it will be overwritten
+    /// Same as [`Self::set`], but if there is already a next state, it will be overwritten
     /// instead of failing
     pub fn overwrite_set(&mut self, state: T) -> Result<(), StateError> {
         if self.stack.last().unwrap() == &state {
@@ -309,7 +309,7 @@ where
         Ok(())
     }
 
-    /// Same as [Self::replace], but if there is already a next state, it will be overwritten
+    /// Same as [`Self::replace`], but if there is already a next state, it will be overwritten
     /// instead of failing
     pub fn overwrite_replace(&mut self, state: T) -> Result<(), StateError> {
         if self.stack.last().unwrap() == &state {
@@ -320,7 +320,7 @@ where
         Ok(())
     }
 
-    /// Same as [Self::set], but does a push operation instead of a next operation
+    /// Same as [`Self::set`], but does a push operation instead of a next operation
     pub fn push(&mut self, state: T) -> Result<(), StateError> {
         if self.stack.last().unwrap() == &state {
             return Err(StateError::AlreadyInState);
@@ -334,7 +334,7 @@ where
         Ok(())
     }
 
-    /// Same as [Self::push], but if there is already a next state, it will be overwritten
+    /// Same as [`Self::push`], but if there is already a next state, it will be overwritten
     /// instead of failing
     pub fn overwrite_push(&mut self, state: T) -> Result<(), StateError> {
         if self.stack.last().unwrap() == &state {
@@ -345,7 +345,7 @@ where
         Ok(())
     }
 
-    /// Same as [Self::set], but does a pop operation instead of a set operation
+    /// Same as [`Self::set`], but does a pop operation instead of a set operation
     pub fn pop(&mut self) -> Result<(), StateError> {
         if self.scheduled.is_some() {
             return Err(StateError::StateAlreadyQueued);
@@ -359,7 +359,7 @@ where
         Ok(())
     }
 
-    /// Same as [Self::pop], but if there is already a next state, it will be overwritten
+    /// Same as [`Self::pop`], but if there is already a next state, it will be overwritten
     /// instead of failing
     pub fn overwrite_pop(&mut self) -> Result<(), StateError> {
         if self.stack.len() == 1 {

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -105,11 +105,11 @@ impl BlobVec {
 
     /// # Safety
     /// - index must be in-bounds
-    /// - the memory in the `BlobVec` starting at index `index`, of a size matching this `BlobVec`'s
-    /// `item_layout`, must have been previously initialized with an item matching this `BlobVec`'s
-    /// item_layout
+    /// - the memory in the [`BlobVec`] starting at index `index`, of a size matching this
+    /// [`BlobVec`]'s `item_layout`, must have been previously initialized with an item matching
+    /// this [`BlobVec`]'s `item_layout`
     /// - the memory at `*value` must also be previously initialized with an item matching this
-    /// `BlobVec`'s `item_layout`
+    /// [`BlobVec`]'s `item_layout`
     /// - the item that was stored in `*value` is left logically uninitialised/moved out of after
     /// calling this function, and as such should not be used or dropped by the caller.
     pub unsafe fn replace_unchecked(&mut self, index: usize, value: *mut u8) {
@@ -139,9 +139,9 @@ impl BlobVec {
     }
 
     /// # Safety
-    /// len must be <= capacity. if length is decreased, "out of bounds" items must be dropped.
+    /// `len` must be <= `capacity`. if length is decreased, "out of bounds" items must be dropped.
     /// Newly added items must be immediately populated with valid values and length must be
-    /// increased. For better unwind safety, call [BlobVec::set_len] _after_ populating a new
+    /// increased. For better unwind safety, call [`BlobVec::set_len`] _after_ populating a new
     /// value.
     pub unsafe fn set_len(&mut self, len: usize) {
         debug_assert!(len <= self.capacity());
@@ -149,11 +149,11 @@ impl BlobVec {
     }
 
     /// Performs a "swap remove" at the given `index`, which removes the item at `index` and moves
-    /// the last item in the [BlobVec] to `index` (if `index` is not the last item). It is the
+    /// the last item in the [`BlobVec`] to `index` (if `index` is not the last item). It is the
     /// caller's responsibility to drop the returned pointer, if that is desirable.
     ///
     /// # Safety
-    /// It is the caller's responsibility to ensure that `index` is < self.len()
+    /// It is the caller's responsibility to ensure that `index` is < `self.len()`
     /// Callers should _only_ access the returned pointer immediately after calling this function.
     #[inline]
     pub unsafe fn swap_remove_and_forget_unchecked(&mut self, index: usize) -> *mut u8 {
@@ -230,15 +230,15 @@ impl Drop for BlobVec {
     }
 }
 
-/// From https://doc.rust-lang.org/beta/src/core/alloc/layout.rs.html
+/// From <https://doc.rust-lang.org/beta/src/core/alloc/layout.rs.html>
 fn array_layout(layout: &Layout, n: usize) -> Option<Layout> {
     let (array_layout, offset) = repeat_layout(layout, n)?;
     debug_assert_eq!(layout.size(), offset);
     Some(array_layout)
 }
 
-// TODO: replace with Layout::repeat if/when it stabilizes
-/// From https://doc.rust-lang.org/beta/src/core/alloc/layout.rs.html
+// TODO: replace with `Layout::repeat` if/when it stabilizes
+/// From <https://doc.rust-lang.org/beta/src/core/alloc/layout.rs.html>
 fn repeat_layout(layout: &Layout, n: usize) -> Option<(Layout, usize)> {
     // This cannot overflow. Quoting from the invariant of Layout:
     // > `size`, when rounded up to the nearest multiple of `align`,
@@ -257,7 +257,7 @@ fn repeat_layout(layout: &Layout, n: usize) -> Option<(Layout, usize)> {
     }
 }
 
-/// From https://doc.rust-lang.org/beta/src/core/alloc/layout.rs.html
+/// From <https://doc.rust-lang.org/beta/src/core/alloc/layout.rs.html>
 const fn padding_needed_for(layout: &Layout, align: usize) -> usize {
     let len = layout.size();
 
@@ -296,7 +296,7 @@ mod tests {
 
     /// # Safety
     ///
-    /// `blob_vec` must have a layout that matches Layout::new::<T>()
+    /// `blob_vec` must have a layout that matches `Layout::new::<T>()`
     unsafe fn push<T>(blob_vec: &mut BlobVec, mut value: T) {
         let index = blob_vec.push_uninit();
         blob_vec.initialize_unchecked(index, (&mut value as *mut T).cast::<u8>());
@@ -305,7 +305,7 @@ mod tests {
 
     /// # Safety
     ///
-    /// `blob_vec` must have a layout that matches Layout::new::<T>()
+    /// `blob_vec` must have a layout that matches `Layout::new::<T>()`
     unsafe fn swap_remove<T>(blob_vec: &mut BlobVec, index: usize) -> T {
         assert!(index < blob_vec.len());
         let value = blob_vec.swap_remove_and_forget_unchecked(index);
@@ -314,8 +314,8 @@ mod tests {
 
     /// # Safety
     ///
-    /// `blob_vec` must have a layout that matches Layout::new::<T>(), it most store a valid T value
-    /// at the given `index`
+    /// `blob_vec` must have a layout that matches `Layout::new::<T>()`, it most store a valid `T`
+    /// value at the given `index`
     unsafe fn get_mut<T>(blob_vec: &mut BlobVec, index: usize) -> &mut T {
         assert!(index < blob_vec.len());
         &mut *blob_vec.get_unchecked(index).cast::<T>()

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -397,9 +397,9 @@ macro_rules! impl_sparse_set_index {
 
 impl_sparse_set_index!(u8, u16, u32, u64, usize);
 
-/// A collection of [ComponentSparseSet] storages, indexed by [ComponentId]
+/// A collection of [`ComponentSparseSet`] storages, indexed by [`ComponentId`]
 ///
-/// Can be accessed via [Storages](crate::storage::Storages)
+/// Can be accessed via [`Storages`](crate::storage::Storages)
 #[derive(Default)]
 pub struct SparseSets {
     sets: SparseSet<ComponentId, ComponentSparseSet>,

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -410,9 +410,9 @@ impl Table {
     }
 }
 
-/// A collection of [Table] storages, indexed by [TableId]
+/// A collection of [`Table`] storages, indexed by [`TableId`]
 ///
-/// Can be accessed via [Storages](crate::storage::Storages)
+/// Can be accessed via [`Storages`](crate::storage::Storages)
 pub struct Tables {
     tables: Vec<Table>,
     table_ids: HashMap<u64, TableId>,

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -88,13 +88,14 @@ impl<'w, 's> Commands<'w, 's> {
         }
     }
 
-    /// Returns an [EntityCommands] for the given `entity` (if it exists) or spawns one if it doesn't exist.
-    /// This will return [None] if the `entity` exists with a different generation.
+    /// Returns an [`EntityCommands`] for the given `entity` (if it exists) or spawns one if it
+    /// doesn't exist. This will return [`None`] if the `entity` exists with a different generation.
     ///
     /// # Note
-    /// Spawning a specific `entity` value is rarely the right choice. Most apps should favor [`Commands::spawn`].
-    /// This method should generally only be used for sharing entities across apps, and only when they have a
-    /// scheme worked out to share an ID space (which doesn't happen by default).
+    /// Spawning a specific `entity` value is rarely the right choice. Most apps should favor
+    /// [`Commands::spawn`]. This method should generally only be used for sharing entities across
+    /// apps, and only when they have a scheme worked out to share an ID space (which doesn't happen
+    /// by default).
     pub fn get_or_spawn<'a>(&'a mut self, entity: Entity) -> EntityCommands<'w, 's, 'a> {
         self.add(GetOrSpawn { entity });
         EntityCommands {
@@ -103,8 +104,8 @@ impl<'w, 's> Commands<'w, 's> {
         }
     }
 
-    /// Spawns a [Bundle] without pre-allocating an [Entity]. The [Entity] will be allocated when
-    /// this [Command] is applied.
+    /// Spawns a [`Bundle`] without pre-allocating an [`Entity`]. The [`Entity`] will be allocated
+    /// when this [`Command`] is applied.
     pub fn spawn_and_forget(&mut self, bundle: impl Bundle) {
         self.queue.push(Spawn { bundle })
     }

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -8,16 +8,17 @@ use crate::{
 };
 use std::borrow::Cow;
 
-/// An ECS system that can be added to a [Schedule](crate::schedule::Schedule)
+/// An ECS system that can be added to a [`Schedule`](crate::schedule::Schedule)
 ///
-/// Systems are functions with all arguments implementing [SystemParam](crate::system::SystemParam).
+/// Systems are functions with all arguments implementing
+/// [`SystemParam`](crate::system::SystemParam).
 ///
 /// Systems are added to an application using `App::add_system(my_system)`
 /// or similar methods, and will generally run once per pass of the main loop.
 ///
 /// Systems are executed in parallel, in opportunistic order; data access is managed automatically.
 /// It's possible to specify explicit execution order between specific systems,
-/// see [SystemDescriptor](crate::schedule::SystemDescriptor).
+/// see [`SystemDescriptor`](crate::schedule::SystemDescriptor).
 pub trait System: Send + Sync + 'static {
     /// The system's input. See [`In`](crate::system::In) for
     /// [`FunctionSystem`](crate::system::FunctionSystem)s.

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -55,9 +55,9 @@ pub type SystemParamItem<'w, 's, P> = <<P as SystemParam>::Fetch as SystemParamF
 /// # Safety
 ///
 /// It is the implementor's responsibility to ensure `system_meta` is populated with the _exact_
-/// [`World`] access used by the `SystemParamState` (and associated [`SystemParamFetch`]).
+/// [`World`] access used by the [`SystemParamState`] (and associated [`SystemParamFetch`]).
 /// Additionally, it is the implementor's responsibility to ensure there is no
-/// conflicting access across all SystemParams.
+/// conflicting access across all [`SystemParam`]'s.
 pub unsafe trait SystemParamState: Send + Sync + 'static {
     /// Values of this type can be used to adjust the behavior of the
     /// system parameter. For instance, this can be used to pass
@@ -1201,7 +1201,7 @@ macro_rules! impl_system_param_tuple {
             }
         }
 
-        /// SAFE: implementors of each SystemParamState in the tuple have validated their impls
+        /// SAFE: implementors of each `SystemParamState` in the tuple have validated their impls
         #[allow(non_snake_case)]
         unsafe impl<$($param: SystemParamState),*> SystemParamState for ($($param,)*) {
             type Config = ($(<$param as SystemParamState>::Config,)*);

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -448,16 +448,16 @@ impl<'w> EntityMut<'w> {
 
     /// # Safety
     /// Caller must not modify the world in a way that changes the current entity's location
-    /// If the caller _does_ do something that could change the location, self.update_location()
-    /// must be called before using any other methods in EntityMut
+    /// If the caller _does_ do something that could change the location, `self.update_location()`
+    /// must be called before using any other methods in [`EntityMut`]
     #[inline]
     pub unsafe fn world_mut(&mut self) -> &mut World {
         self.world
     }
 
-    /// Updates the internal entity location to match the current location in the internal [World].
-    /// This is only needed if the user called [EntityMut::world], which enables the location to
-    /// change.
+    /// Updates the internal entity location to match the current location in the internal
+    /// [`World`]. This is only needed if the user called [`EntityMut::world`], which enables the
+    /// location to change.
     pub fn update_location(&mut self) {
         self.location = self.world.entities().get(self.entity).unwrap();
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -163,7 +163,7 @@ impl World {
         &self.bundles
     }
 
-    /// Retrieves a [WorldCell], which safely enables multiple mutable World accesses at the same
+    /// Retrieves a [`WorldCell`], which safely enables multiple mutable World accesses at the same
     /// time, provided those accesses do not conflict with each other.
     #[inline]
     pub fn cell(&mut self) -> WorldCell<'_> {
@@ -174,8 +174,8 @@ impl World {
         self.components.init_component::<T>(&mut self.storages)
     }
 
-    /// Retrieves an [EntityRef] that exposes read-only operations for the given `entity`.
-    /// This will panic if the `entity` does not exist. Use [World::get_entity] if you want
+    /// Retrieves an [`EntityRef`] that exposes read-only operations for the given `entity`.
+    /// This will panic if the `entity` does not exist. Use [`World::get_entity`] if you want
     /// to check for entity existence instead of implicitly panic-ing.
     ///
     /// ```
@@ -202,8 +202,8 @@ impl World {
             .unwrap_or_else(|| panic!("Entity {:?} does not exist", entity))
     }
 
-    /// Retrieves an [EntityMut] that exposes read and write operations for the given `entity`.
-    /// This will panic if the `entity` does not exist. Use [World::get_entity_mut] if you want
+    /// Retrieves an [`EntityMut`] that exposes read and write operations for the given `entity`.
+    /// This will panic if the `entity` does not exist. Use [`World::get_entity_mut`] if you want
     /// to check for entity existence instead of implicitly panic-ing.
     ///
     /// ```
@@ -230,8 +230,8 @@ impl World {
             .unwrap_or_else(|| panic!("Entity {:?} does not exist", entity))
     }
 
-    /// Returns an [EntityMut] for the given `entity` (if it exists) or spawns one if it doesn't exist.
-    /// This will return [None] if the `entity` exists with a different generation.
+    /// Returns an [`EntityMut`] for the given `entity` (if it exists) or spawns one if it doesn't exist.
+    /// This will return [`None`] if the `entity` exists with a different generation.
     ///
     /// # Note
     /// Spawning a specific `entity` value is rarely the right choice. Most apps should favor [`World::spawn`].
@@ -253,9 +253,9 @@ impl World {
         }
     }
 
-    /// Retrieves an [EntityRef] that exposes read-only operations for the given `entity`.
-    /// Returns [None] if the `entity` does not exist. Use [World::entity] if you don't want
-    /// to unwrap the [EntityRef] yourself.
+    /// Retrieves an [`EntityRef`] that exposes read-only operations for the given `entity`.
+    /// Returns [`None`] if the `entity` does not exist. Use [`World::entity`] if you don't want
+    /// to unwrap the [`EntityRef`] yourself.
     ///
     /// ```
     /// use bevy_ecs::{component::Component, world::World};
@@ -281,9 +281,9 @@ impl World {
         Some(EntityRef::new(self, entity, location))
     }
 
-    /// Retrieves an [EntityMut] that exposes read and write operations for the given `entity`.
-    /// Returns [None] if the `entity` does not exist. Use [World::entity_mut] if you don't want
-    /// to unwrap the [EntityMut] yourself.
+    /// Retrieves an [`EntityMut`] that exposes read and write operations for the given `entity`.
+    /// Returns [`None`] if the `entity` does not exist. Use [`World::entity_mut`] if you don't want
+    /// to unwrap the [`EntityMut`] yourself.
     ///
     /// ```
     /// use bevy_ecs::{component::Component, world::World};
@@ -310,7 +310,7 @@ impl World {
         Some(unsafe { EntityMut::new(self, entity, location) })
     }
 
-    /// Spawns a new [Entity] and returns a corresponding [EntityMut], which can be used
+    /// Spawns a new [`Entity`] and returns a corresponding [`EntityMut`], which can be used
     /// to add components to the entity or retrieve its id.
     ///
     /// ```
@@ -474,8 +474,8 @@ impl World {
         self.last_change_tick = self.increment_change_tick();
     }
 
-    /// Returns [QueryState] for the given [WorldQuery], which is used to efficiently
-    /// run queries on the [World] by storing and reusing the [QueryState].
+    /// Returns [`QueryState`] for the given [`WorldQuery`], which is used to efficiently
+    /// run queries on the [`World`] by storing and reusing the [`QueryState`].
     /// ```
     /// use bevy_ecs::{component::Component, entity::Entity, world::World};
     ///
@@ -541,8 +541,8 @@ impl World {
         QueryState::new(self)
     }
 
-    /// Returns [QueryState] for the given filtered [WorldQuery], which is used to efficiently
-    /// run queries on the [World] by storing and reusing the [QueryState].
+    /// Returns [`QueryState`] for the given filtered [`WorldQuery`], which is used to efficiently
+    /// run queries on the [`World`] by storing and reusing the [`QueryState`].
     /// ```
     /// use bevy_ecs::{component::Component, entity::Entity, world::World, query::With};
     ///
@@ -569,7 +569,7 @@ impl World {
     }
 
     /// Returns an iterator of entities that had components of type `T` removed
-    /// since the last call to [World::clear_trackers].
+    /// since the last call to [`World::clear_trackers`].
     pub fn removed<T: Component>(&self) -> std::iter::Cloned<std::slice::Iter<'_, Entity>> {
         if let Some(component_id) = self.components.get_id(TypeId::of::<T>()) {
             self.removed_with_id(component_id)
@@ -579,7 +579,7 @@ impl World {
     }
 
     /// Returns an iterator of entities that had components with the given `component_id` removed
-    /// since the last call to [World::clear_trackers].
+    /// since the last call to [`World::clear_trackers`].
     pub fn removed_with_id(
         &self,
         component_id: ComponentId,


### PR DESCRIPTION
#3457 adds the `doc_markdown` clippy lint, which checks doc comments to make sure code identifiers are escaped with backticks. This causes a lot of lint errors, so this is one of a number of PR's that will fix those lint errors one crate at a time.

This PR fixes lints in the `bevy_ecs` crate.
