### PR TITLE
[Merged by Bors] - Fix `doc_markdown` lints in `bevy_input`

### DIFF
--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -8,9 +8,9 @@ use bevy_utils::{tracing::info, HashMap, HashSet};
 pub struct Gamepad(pub usize);
 
 #[derive(Default)]
-/// Container of unique connected [Gamepad]s
+/// Container of unique connected [`Gamepad`]s
 ///
-/// [Gamepad]s are registered and deregistered in [gamepad_connection_system]
+/// [`Gamepad`]s are registered and deregistered in [`gamepad_connection_system`]
 pub struct Gamepads {
     gamepads: HashSet<Gamepad>,
 }

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -10,7 +10,7 @@ pub struct KeyboardInput {
     pub state: ElementState,
 }
 
-/// Updates the Input<KeyCode> resource with the latest KeyboardInput events
+/// Updates the `Input<KeyCode>` resource with the latest `KeyboardInput` events
 pub fn keyboard_input_system(
     mut keyboard_input: ResMut<Input<KeyCode>>,
     mut keyboard_input_events: EventReader<KeyboardInput>,

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -41,7 +41,7 @@ pub struct MouseWheel {
     pub y: f32,
 }
 
-/// Updates the Input<MouseButton> resource with the latest MouseButtonInput events
+/// Updates the `Input<MouseButton>` resource with the latest `MouseButtonInput` events
 pub fn mouse_button_input_system(
     mut mouse_button_input: ResMut<Input<MouseButton>>,
     mut mouse_button_input_events: EventReader<MouseButtonInput>,

--- a/crates/bevy_input/src/system.rs
+++ b/crates/bevy_input/src/system.rs
@@ -5,7 +5,7 @@ use crate::{
 use bevy_app::AppExit;
 use bevy_ecs::prelude::{EventReader, EventWriter};
 
-/// Sends the AppExit event whenever the "esc" key is pressed.
+/// Sends the `AppExit` event whenever the "esc" key is pressed.
 pub fn exit_on_esc_system(
     mut keyboard_input_events: EventReader<KeyboardInput>,
     mut app_exit_events: EventWriter<AppExit>,

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -220,7 +220,7 @@ impl Touches {
     }
 }
 
-/// Updates the Touches resource with the latest TouchInput events
+/// Updates the `Touches` resource with the latest `TouchInput` events
 pub fn touch_screen_input_system(
     mut touch_state: ResMut<Touches>,
     mut touch_input_events: EventReader<TouchInput>,


### PR DESCRIPTION
#3457 adds the `doc_markdown` clippy lint, which checks doc comments to make sure code identifiers are escaped with backticks. This causes a lot of lint errors, so this is one of a number of PR's that will fix those lint errors one crate at a time.

This PR fixes lints in the `bevy_input` crate.
