### PR TITLE
[Merged by Bors] - Fix `doc_markdown` lints in `bevy_log`

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -64,7 +64,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 #[derive(Default)]
 pub struct LogPlugin;
 
-/// LogPlugin settings
+/// `LogPlugin` settings
 pub struct LogSettings {
     /// Filters logs using the [`EnvFilter`] format
     pub filter: String,


### PR DESCRIPTION
#3457 adds the `doc_markdown` clippy lint, which checks doc comments to make sure code identifiers are escaped with backticks. This causes a lot of lint errors, so this is one of a number of PR's that will fix those lint errors one crate at a time.

This PR fixes lints in the `bevy_log` crate.
