### PR TITLE
[Merged by Bors] - Fix `doc_markdown` lints in `bevy_pbr`

### DIFF
--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -53,7 +53,7 @@ fn extract_wireframes(mut commands: Commands, query: Query<Entity, With<Wirefram
     }
 }
 
-/// Controls whether an entity should rendered in wireframe-mode if the [WireframePlugin] is enabled
+/// Controls whether an entity should rendered in wireframe-mode if the [`WireframePlugin`] is enabled
 #[derive(Component, Debug, Clone, Default, Reflect)]
 #[reflect(Component)]
 pub struct Wireframe;


### PR DESCRIPTION
#3457 adds the `doc_markdown` clippy lint, which checks doc comments to make sure code identifiers are escaped with backticks. This causes a lot of lint errors, so this is one of a number of PR's that will fix those lint errors one crate at a time.

This PR fixes lints in the `bevy_pbr` crate.
