### PR TITLE
[Merged by Bors] - Fix `doc_markdown` lints in `bevy_sprite`

### DIFF
--- a/crates/bevy_sprite/src/collide_aabb.rs
+++ b/crates/bevy_sprite/src/collide_aabb.rs
@@ -12,8 +12,9 @@ pub enum Collision {
 
 // TODO: ideally we can remove this once bevy gets a physics system
 /// Axis-aligned bounding box collision with "side" detection
-/// *   a_pos and b_pos are the center positions of the rectangles, typically obtained by extracting the `translation` field from a `Transform` component
-/// *   a_size and b_size are the dimensions (width and height) of the rectangles.
+/// * `a_pos` and `b_pos` are the center positions of the rectangles, typically obtained by
+/// extracting the `translation` field from a `Transform` component
+/// * `a_size` and `b_size` are the dimensions (width and height) of the rectangles.
 pub fn collide(a_pos: Vec3, a_size: Vec2, b_pos: Vec3, b_size: Vec2) -> Option<Collision> {
     let a_min = a_pos.truncate() - a_size / 2.0;
     let a_max = a_pos.truncate() + a_size / 2.0;


### PR DESCRIPTION
#3457 adds the `doc_markdown` clippy lint, which checks doc comments to make sure code identifiers are escaped with backticks. This causes a lot of lint errors, so this is one of a number of PR's that will fix those lint errors one crate at a time.

This PR fixes lints in the `bevy_sprite` crate.
