### PR TITLE
[Merged by Bors] - Fix `doc_markdown` lints in `bevy_text`

### DIFF
--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -107,7 +107,7 @@ pub struct QueuedText2d {
     entities: Vec<Entity>,
 }
 
-/// Updates the [`TextGlyphs`] with the new computed glyphs from the layout
+/// Updates the `TextGlyphs` with the new computed glyphs from the layout
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn text2d_system(
     mut queued_text: Local<QueuedText2d>,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -107,7 +107,7 @@ pub struct QueuedText2d {
     entities: Vec<Entity>,
 }
 
-/// Updates the TextGlyphs with the new computed glyphs from the layout
+/// Updates the [`TextGlyphs`] with the new computed glyphs from the layout
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn text2d_system(
     mut queued_text: Local<QueuedText2d>,


### PR DESCRIPTION
#3457 adds the `doc_markdown` clippy lint, which checks doc comments to make sure code identifiers are escaped with backticks. This causes a lot of lint errors, so this is one of a number of PR's that will fix those lint errors one crate at a time.

This PR fixes lints in the `bevy_text` crate.
