### PR TITLE
[Merged by Bors] - Fix `doc_markdown` lints in `bevy_transform`

### DIFF
--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -139,13 +139,13 @@ impl GlobalTransform {
         self.rotation * Vec3::X
     }
 
-    /// Equivalent to `-local_x()`
+    /// Equivalent to [`-local_x()`][GlobalTransform::local_x]
     #[inline]
     pub fn left(&self) -> Vec3 {
         -self.local_x()
     }
 
-    /// Equivalent to `local_x()`
+    /// Equivalent to [`local_x()`][GlobalTransform::local_x]
     #[inline]
     pub fn right(&self) -> Vec3 {
         self.local_x()
@@ -157,13 +157,13 @@ impl GlobalTransform {
         self.rotation * Vec3::Y
     }
 
-    /// Equivalent to `local_y()`
+    /// Equivalent to [`local_y()`][GlobalTransform::local_y]
     #[inline]
     pub fn up(&self) -> Vec3 {
         self.local_y()
     }
 
-    /// Equivalent to `-local_y()`
+    /// Equivalent to [`-local_y()`][GlobalTransform::local_y]
     #[inline]
     pub fn down(&self) -> Vec3 {
         -self.local_y()
@@ -175,13 +175,13 @@ impl GlobalTransform {
         self.rotation * Vec3::Z
     }
 
-    /// Equivalent to `-local_z()`
+    /// Equivalent to [`-local_z()`][[GlobalTransform::local_z]
     #[inline]
     pub fn forward(&self) -> Vec3 {
         -self.local_z()
     }
 
-    /// Equivalent to `local_z()`
+    /// Equivalent to [`local_z()`][GlobalTransform::local_z]
     #[inline]
     pub fn back(&self) -> Vec3 {
         self.local_z()

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -139,13 +139,13 @@ impl GlobalTransform {
         self.rotation * Vec3::X
     }
 
-    /// Equivalent to -local_x()
+    /// Equivalent to `-local_x()`
     #[inline]
     pub fn left(&self) -> Vec3 {
         -self.local_x()
     }
 
-    /// Equivalent to local_x()
+    /// Equivalent to `local_x()`
     #[inline]
     pub fn right(&self) -> Vec3 {
         self.local_x()
@@ -157,13 +157,13 @@ impl GlobalTransform {
         self.rotation * Vec3::Y
     }
 
-    /// Equivalent to local_y()
+    /// Equivalent to `local_y()`
     #[inline]
     pub fn up(&self) -> Vec3 {
         self.local_y()
     }
 
-    /// Equivalent to -local_y()
+    /// Equivalent to `-local_y()`
     #[inline]
     pub fn down(&self) -> Vec3 {
         -self.local_y()
@@ -175,13 +175,13 @@ impl GlobalTransform {
         self.rotation * Vec3::Z
     }
 
-    /// Equivalent to -local_z()
+    /// Equivalent to `-local_z()`
     #[inline]
     pub fn forward(&self) -> Vec3 {
         -self.local_z()
     }
 
-    /// Equivalent to local_z()
+    /// Equivalent to `local_z()`
     #[inline]
     pub fn back(&self) -> Vec3 {
         self.local_z()

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -151,13 +151,13 @@ impl Transform {
         self.rotation * Vec3::X
     }
 
-    /// Equivalent to `-local_x()`
+    /// Equivalent to [`-local_x()`][Transform::local_x()]
     #[inline]
     pub fn left(&self) -> Vec3 {
         -self.local_x()
     }
 
-    /// Equivalent to `local_x()`
+    /// Equivalent to [`local_x()`][Transform::local_x()]
     #[inline]
     pub fn right(&self) -> Vec3 {
         self.local_x()
@@ -169,13 +169,13 @@ impl Transform {
         self.rotation * Vec3::Y
     }
 
-    /// Equivalent to `local_y()`
+    /// Equivalent to [`local_y()`][Transform::local_y]
     #[inline]
     pub fn up(&self) -> Vec3 {
         self.local_y()
     }
 
-    /// Equivalent to `-local_y()`
+    /// Equivalent to [`-local_y()`][Transform::local_y]
     #[inline]
     pub fn down(&self) -> Vec3 {
         -self.local_y()
@@ -187,13 +187,13 @@ impl Transform {
         self.rotation * Vec3::Z
     }
 
-    /// Equivalent to `-local_z()`
+    /// Equivalent to [`-local_z()`][Transform::local_z]
     #[inline]
     pub fn forward(&self) -> Vec3 {
         -self.local_z()
     }
 
-    /// Equivalent to `local_z()`
+    /// Equivalent to [`local_z()`][Transform::local_z]
     #[inline]
     pub fn back(&self) -> Vec3 {
         self.local_z()

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -151,13 +151,13 @@ impl Transform {
         self.rotation * Vec3::X
     }
 
-    /// Equivalent to -local_x()
+    /// Equivalent to `-local_x()`
     #[inline]
     pub fn left(&self) -> Vec3 {
         -self.local_x()
     }
 
-    /// Equivalent to local_x()
+    /// Equivalent to `local_x()`
     #[inline]
     pub fn right(&self) -> Vec3 {
         self.local_x()
@@ -169,13 +169,13 @@ impl Transform {
         self.rotation * Vec3::Y
     }
 
-    /// Equivalent to local_y()
+    /// Equivalent to `local_y()`
     #[inline]
     pub fn up(&self) -> Vec3 {
         self.local_y()
     }
 
-    /// Equivalent to -local_y()
+    /// Equivalent to `-local_y()`
     #[inline]
     pub fn down(&self) -> Vec3 {
         -self.local_y()
@@ -187,13 +187,13 @@ impl Transform {
         self.rotation * Vec3::Z
     }
 
-    /// Equivalent to -local_z()
+    /// Equivalent to `-local_z()`
     #[inline]
     pub fn forward(&self) -> Vec3 {
         -self.local_z()
     }
 
-    /// Equivalent to local_z()
+    /// Equivalent to `local_z()`
     #[inline]
     pub fn back(&self) -> Vec3 {
         self.local_z()


### PR DESCRIPTION
#3457 adds the `doc_markdown` clippy lint, which checks doc comments to make sure code identifiers are escaped with backticks. This causes a lot of lint errors, so this is one of a number of PR's that will fix those lint errors one crate at a time.

This PR fixes lints in the `bevy_transform` crate.
