### PR TITLE
[Merged by Bors] - Fix `doc_markdown` lints in `examples`

### DIFF
--- a/examples/2d/many_sprites.rs
+++ b/examples/2d/many_sprites.rs
@@ -10,7 +10,7 @@ use rand::Rng;
 const CAMERA_SPEED: f32 = 1000.0;
 
 /// This example is for performance testing purposes.
-/// See https://github.com/bevyengine/bevy/pull/1492
+/// See <https://github.com/bevyengine/bevy/pull/1492>
 fn main() {
     App::new()
         .add_plugin(LogDiagnosticsPlugin::default())

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 /// expensive).
 /// Note that WGPU currently only supports 1 or 4 samples.
 /// Ultimately we plan on supporting whatever is natively supported on a given device.
-/// Check out this issue for more info: https://github.com/gfx-rs/wgpu/issues/1832
+/// Check out [this issue](https://github.com/gfx-rs/wgpu/issues/1832) for more info.
 fn main() {
     App::new()
         .insert_resource(Msaa { samples: 4 })

--- a/examples/app/plugin_group.rs
+++ b/examples/app/plugin_group.rs
@@ -1,6 +1,6 @@
 use bevy::{app::PluginGroupBuilder, prelude::*};
 
-/// PluginGroups are a way to group sets of plugins that should be registered together.
+/// [`PluginGroups`] are a way to group sets of plugins that should be registered together.
 fn main() {
     App::new()
         // Two PluginGroups that are included with bevy are DefaultPlugins and MinimalPlugins

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -6,7 +6,7 @@ use futures_lite::future;
 use rand::Rng;
 use std::time::{Duration, Instant};
 
-/// This example shows how to use the ECS and the AsyncComputeTaskPool
+/// This example shows how to use the ECS and the [`AsyncComputeTaskPool`]
 /// to spawn, poll, and complete tasks across systems and system ticks.
 fn main() {
     App::new()
@@ -43,7 +43,7 @@ fn add_assets(
 
 /// This system generates tasks simulating computationally intensive
 /// work that potentially spans multiple frames/ticks. A separate
-/// system, handle_tasks, will poll the spawned tasks on subsequent
+/// system, `handle_tasks`, will poll the spawned tasks on subsequent
 /// frames/ticks, and use the results to spawn cubes
 fn spawn_tasks(mut commands: Commands, thread_pool: Res<AsyncComputeTaskPool>) {
     for x in 0..NUM_CUBES {
@@ -72,7 +72,7 @@ fn spawn_tasks(mut commands: Commands, thread_pool: Res<AsyncComputeTaskPool>) {
 
 /// This system queries for entities that have our Task<Transform> component. It polls the
 /// tasks to see if they're complete. If the task is complete it takes the result, adds a
-/// new PbrBundle of components to the entity using the result from the task's work, and
+/// new [`PbrBundle`] of components to the entity using the result from the task's work, and
 /// removes the task component from the entity.
 fn handle_tasks(
     mut commands: Commands,

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -25,10 +25,10 @@ use rand::random;
 /// }
 
 /// Resource: a shared global piece of data
-///     Examples: asset_storage, events, system state
+///     Examples: asset storage, events, system state
 ///
 /// System: runs logic on entities, components, and resources
-///     Examples: move_system, damage_system
+///     Examples: move system, damage system
 ///
 /// Now that you know a little bit about ECS, lets look at some Bevy code!
 /// We will now make a simple "game" to illustrate what Bevy's ECS looks like in practice.

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
-/// This example illustrates how to use States to control transitioning from a Menu state to an
-/// InGame state.
+/// This example illustrates how to use [`States`] to control transitioning from a `Menu` state to
+/// an `InGame` state.
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)

--- a/examples/ecs/system_param.rs
+++ b/examples/ecs/system_param.rs
@@ -1,6 +1,6 @@
 use bevy::{ecs::system::SystemParam, prelude::*};
 
-/// This example creates a SystemParam struct that counts the number of players
+/// This example creates a [`SystemParam`] struct that counts the number of players
 fn main() {
     App::new()
         .insert_resource(PlayerCount(0))
@@ -14,7 +14,7 @@ pub struct Player;
 #[derive(Component)]
 pub struct PlayerCount(usize);
 
-/// The SystemParam struct can contain any types that can also be included in a
+/// The [`SystemParam`] struct can contain any types that can also be included in a
 /// system function signature.
 ///
 /// In this example, it includes a query and a mutable resource.
@@ -37,7 +37,7 @@ fn spawn(mut commands: Commands) {
     commands.spawn().insert(Player);
 }
 
-/// The SystemParam can be used directly in a system argument.
+/// The [`SystemParam`] can be used directly in a system argument.
 fn count_players(mut counter: PlayerCounter) {
     counter.count();
 

--- a/examples/ecs/system_sets.rs
+++ b/examples/ecs/system_sets.rs
@@ -1,11 +1,11 @@
 use bevy::{app::AppExit, ecs::schedule::ShouldRun, prelude::*};
 
-/// A [SystemLabel] can be applied as a label to systems and system sets,
+/// A [`SystemLabel`] can be applied as a label to systems and system sets,
 /// which can then be referred to from other systems.
 /// This is useful in case a user wants to e.g. run _before_ or _after_
 /// some label.
 /// `Clone`, `Hash`, `Debug`, `PartialEq`, `Eq`, are all required to derive
-/// [SystemLabel].
+/// [`SystemLabel`].
 #[derive(Clone, Hash, Debug, PartialEq, Eq, SystemLabel)]
 struct Physics;
 
@@ -16,7 +16,7 @@ struct PostPhysics;
 #[derive(Default)]
 struct Done(bool);
 
-/// This is used to show that within a [SystemSet], individual systems can also
+/// This is used to show that within a [`SystemSet`], individual systems can also
 /// be labelled, allowing further fine tuning of run ordering.
 #[derive(Clone, Hash, Debug, PartialEq, Eq, SystemLabel)]
 pub enum PhysicsSystem {
@@ -36,9 +36,9 @@ pub enum PhysicsSystem {
 ///     \--> exit
 /// ```
 ///
-/// The `Physics` label represents a [SystemSet] containing two systems.
+/// The `Physics` label represents a [`SystemSet`] containing two systems.
 /// This set's criteria is to stop after a second has elapsed.
-/// The two systems (update_velocity, movement) runs in a specified order.
+/// The two systems (`update_velocity`, `movement`) run in a specified order.
 ///
 /// Another label `PostPhysics` uses run criteria to only run after `Physics` has finished.
 /// This set's criteria is to run only when _not done_, as specified via a resource.
@@ -128,7 +128,7 @@ fn is_done(done: Res<Done>) -> ShouldRun {
     }
 }
 
-/// Used with [RunCritera::pipe], inverts the result of the
+/// Used with [`RunCritera::pipe`], inverts the result of the
 /// passed system.
 fn inverse(input: In<ShouldRun>) -> ShouldRun {
     match input.0 {

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -41,7 +41,7 @@ pub struct D {
 
 /// By default, deriving with Reflect assumes the type is a "struct". You can tell reflect to treat
 /// your type as a "value type" by using the `reflect_value` attribute instead of `reflect`. It is
-/// generally a good idea to implement (and reflect) the PartialEq, Serialize, and Deserialize
+/// generally a good idea to implement (and reflect) the `PartialEq`, `Serialize`, and `Deserialize`
 /// traits on `reflect_value` types to ensure that these values behave as expected when nested
 /// underneath Reflect-ed structs.
 #[derive(Reflect, Copy, Clone, PartialEq, Serialize, Deserialize)]

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -1,8 +1,8 @@
 use bevy::{prelude::*, text::FontAtlasSet};
 
 // TODO: This is now broken. See #1243
-/// This example illustrates how FontAtlases are populated. Bevy uses FontAtlases under the hood to
-/// optimize text rendering.
+/// This example illustrates how `FontAtlas`'s are populated. Bevy uses `FontAtlas`'s under the hood
+/// to optimize text rendering.
 fn main() {
     App::new()
         .init_resource::<State>()


### PR DESCRIPTION
#3457 adds the `doc_markdown` clippy lint, which checks doc comments to make sure code identifiers are escaped with backticks. This causes a lot of lint errors, so this is one of a number of PR's that will fix those lint errors one crate at a time.

This PR fixes lints in the `examples` folder.
