### PR TITLE
[Merged by Bors] - Enable Msaa for webgl by default

### DIFF
--- a/crates/bevy_render/src/options.rs
+++ b/crates/bevy_render/src/options.rs
@@ -13,7 +13,7 @@ pub struct WgpuOptions {
 
 impl Default for WgpuOptions {
     fn default() -> Self {
-        let default_backends = if cfg!(target_arch = "wasm32") {
+        let default_backends = if cfg!(feature = "webgl") {
             Backends::GL
         } else {
             Backends::PRIMARY
@@ -21,7 +21,7 @@ impl Default for WgpuOptions {
 
         let backends = wgpu::util::backend_bits_from_env().unwrap_or(default_backends);
 
-        let limits = if cfg!(target_arch = "wasm32") {
+        let limits = if cfg!(feature = "webgl") {
             wgpu::Limits::downlevel_webgl2_defaults()
         } else {
             #[allow(unused_mut)]

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -49,12 +49,7 @@ pub struct Msaa {
 
 impl Default for Msaa {
     fn default() -> Self {
-        Self {
-            #[cfg(feature = "webgl")]
-            samples: 1,
-            #[cfg(not(feature = "webgl"))]
-            samples: 4,
-        }
+        Self { samples: 4 }
     }
 }
 


### PR DESCRIPTION
# Objective

- `Msaa` was disabled in webgl due to a bug in wgpu
- Bug has been fixed (https://github.com/gfx-rs/wgpu/pull/2307) and backported (https://github.com/gfx-rs/wgpu/pull/2327), and updates for [`wgpu-core`](https://crates.io/crates/wgpu-core/0.12.1) and [`wgpu-hal`](https://crates.io/crates/wgpu-hal/0.12.1) have been released

## Solution

- Remove custom config for `Msaa` in webgl
- I also changed two options that were using the arch instead of the `webgl` feature. it shouldn't change much for webgl, but could help if someone wants to target wasm but not webgl2
