### PR TITLE
[Merged by Bors] - Nightly clippy fixes

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -840,7 +840,7 @@ impl<'w, T: Component> WorldQueryGats<'w> for &mut T {
     type _State = WriteState<T>;
 }
 
-impl<'w, 's, T: Component> Fetch<'w> for WriteFetch<'w, T> {
+impl<'w, T: Component> Fetch<'w> for WriteFetch<'w, T> {
     type Item = Mut<'w, T>;
     type State = WriteState<T>;
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -510,11 +510,11 @@ unsafe impl ReadOnlySystemParamFetch for WorldState {}
 #[doc(hidden)]
 pub struct WorldState;
 
-impl<'w, 's> SystemParam for &'w World {
+impl<'w> SystemParam for &'w World {
     type Fetch = WorldState;
 }
 
-unsafe impl<'w, 's> SystemParamState for WorldState {
+unsafe impl SystemParamState for WorldState {
     fn init(_world: &mut World, system_meta: &mut SystemMeta) -> Self {
         let mut access = Access::default();
         access.read_all();
@@ -1365,7 +1365,7 @@ impl<'w, 's, P: SystemParam> StaticSystemParam<'w, 's, P> {
 pub struct StaticSystemParamState<S, P>(S, PhantomData<fn() -> P>);
 
 // Safe: This doesn't add any more reads, and the delegated fetch confirms it
-unsafe impl<'w, 's, S: ReadOnlySystemParamFetch, P> ReadOnlySystemParamFetch
+unsafe impl<S: ReadOnlySystemParamFetch, P> ReadOnlySystemParamFetch
     for StaticSystemParamState<S, P>
 {
 }
@@ -1394,7 +1394,7 @@ where
     }
 }
 
-unsafe impl<'w, 's, S: SystemParamState, P: SystemParam + 'static> SystemParamState
+unsafe impl<S: SystemParamState, P: SystemParam + 'static> SystemParamState
     for StaticSystemParamState<S, P>
 {
     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -74,7 +74,7 @@ impl<'w> Drop for WorldCell<'w> {
     fn drop(&mut self) {
         let mut access = self.access.borrow_mut();
         // give world ArchetypeComponentAccess back to reuse allocations
-        let _ = std::mem::swap(&mut self.world.archetype_component_access, &mut *access);
+        std::mem::swap(&mut self.world.archetype_component_access, &mut *access);
     }
 }
 

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -210,7 +210,7 @@ impl<'a> Iterator for ArrayIter<'a> {
 
 impl<'a> ExactSizeIterator for ArrayIter<'a> {}
 
-impl<'a> serde::Serialize for dyn Array {
+impl serde::Serialize for dyn Array {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -76,6 +76,7 @@ impl RenderLayers {
     ///
     /// # Panics
     /// Panics when called with a layer greater than `TOTAL_LAYERS - 1`.
+    #[must_use]
     pub const fn with(mut self, layer: Layer) -> Self {
         assert!((layer as usize) < Self::TOTAL_LAYERS);
         self.0 |= 1 << layer;
@@ -86,6 +87,7 @@ impl RenderLayers {
     ///
     /// # Panics
     /// Panics when called with a layer greater than `TOTAL_LAYERS - 1`.
+    #[must_use]
     pub const fn without(mut self, layer: Layer) -> Self {
         assert!((layer as usize) < Self::TOTAL_LAYERS);
         self.0 &= !(1 << layer);

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -102,6 +102,7 @@ impl GlobalTransform {
 
     #[doc(hidden)]
     #[inline]
+    #[must_use]
     pub const fn with_translation(mut self, translation: Vec3) -> Self {
         self.translation = translation;
         self
@@ -109,6 +110,7 @@ impl GlobalTransform {
 
     #[doc(hidden)]
     #[inline]
+    #[must_use]
     pub const fn with_rotation(mut self, rotation: Quat) -> Self {
         self.rotation = rotation;
         self
@@ -116,6 +118,7 @@ impl GlobalTransform {
 
     #[doc(hidden)]
     #[inline]
+    #[must_use]
     pub const fn with_scale(mut self, scale: Vec3) -> Self {
         self.scale = scale;
         self

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -112,6 +112,7 @@ impl Transform {
 
     /// Returns this [`Transform`] with a new translation.
     #[inline]
+    #[must_use]
     pub const fn with_translation(mut self, translation: Vec3) -> Self {
         self.translation = translation;
         self
@@ -119,6 +120,7 @@ impl Transform {
 
     /// Returns this [`Transform`] with a new rotation.
     #[inline]
+    #[must_use]
     pub const fn with_rotation(mut self, rotation: Quat) -> Self {
         self.rotation = rotation;
         self
@@ -126,6 +128,7 @@ impl Transform {
 
     /// Returns this [`Transform`] with a new scale.
     #[inline]
+    #[must_use]
     pub const fn with_scale(mut self, scale: Vec3) -> Self {
         self.scale = scale;
         self


### PR DESCRIPTION
Fixes the following nightly clippy lints:
- ~~[map_flatten](https://rust-lang.github.io/rust-clippy/master/index.html#map_flatten)~~ (Fixed on main)
- ~~[needless_borrow](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow)~~ (Fixed on main)
- [return_self_not_must_use](https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use) (Added in 1.59.0)
- ~~[unnecessary_lazy_evaluations](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations)~~ (Fixed on main)
- [extra_unused_lifetimes](https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes) outside of macros
- [let_unit_value](https://rust-lang.github.io/rust-clippy/master/index.html#let_unit_value)
