### PR TITLE
[Merged by Bors] - StorageType parameter removed from ComponentDescriptor::new_resource

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -200,7 +200,7 @@ impl ComponentDescriptor {
     pub fn new_resource<T: Resource>() -> Self {
         Self {
             name: std::any::type_name::<T>().to_string(),
-            // NOTE: `SparseStorage` may actually be a more
+            // PERF: `SparseStorage` may actually be a more
             // reasonable choice as `storage_type` for resources.
             storage_type: StorageType::Table,
             is_send_and_sync: true,

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -194,10 +194,15 @@ impl ComponentDescriptor {
         }
     }
 
-    pub fn new_resource<T: Resource>(storage_type: StorageType) -> Self {
+    /// Create a new `ComponentDescriptor` for a resource.
+    ///
+    /// The [`StorageType`] for resources is always [`TableStorage`].
+    pub fn new_resource<T: Resource>() -> Self {
         Self {
             name: std::any::type_name::<T>().to_string(),
-            storage_type,
+            // NOTE: `SparseStorage` may actually be a more
+            // resonable choice as `storage_type` for resources.
+            storage_type: StorageType::Table,
             is_send_and_sync: true,
             type_id: Some(TypeId::of::<T>()),
             layout: Layout::new::<T>(),
@@ -308,7 +313,7 @@ impl Components {
         // SAFE: The [`ComponentDescriptor`] matches the [`TypeId`]
         unsafe {
             self.get_or_insert_resource_with(TypeId::of::<T>(), || {
-                ComponentDescriptor::new_resource::<T>(StorageType::default())
+                ComponentDescriptor::new_resource::<T>()
             })
         }
     }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -201,7 +201,7 @@ impl ComponentDescriptor {
         Self {
             name: std::any::type_name::<T>().to_string(),
             // NOTE: `SparseStorage` may actually be a more
-            // resonable choice as `storage_type` for resources.
+            // reasonable choice as `storage_type` for resources.
             storage_type: StorageType::Table,
             is_send_and_sync: true,
             type_id: Some(TypeId::of::<T>()),


### PR DESCRIPTION
# Objective

Remove the `StorageType` parameter from `ComponentDescriptor::new_resource` as discussed in #3361.

- fixes #3361

## Solution

- Parameter removed.
- Basic docs added.

## Note

Left a [comment](https://github.com/bevyengine/bevy/issues/3361#issuecomment-996433346) about `SparseStorage` being the more reasonable choice.

