### PR TITLE
[Merged by Bors] - do not add plugin ExtractComponentPlugin twice for StandardMaterial

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -38,7 +38,6 @@ use bevy_ecs::prelude::*;
 use bevy_reflect::TypeUuid;
 use bevy_render::{
     prelude::Color,
-    render_component::ExtractComponentPlugin,
     render_graph::RenderGraph,
     render_phase::{sort_phase_system, AddRenderCommand, DrawFunctions},
     render_resource::{Shader, SpecializedPipelines},
@@ -70,7 +69,6 @@ impl Plugin for PbrPlugin {
 
         app.add_plugin(MeshRenderPlugin)
             .add_plugin(MaterialPlugin::<StandardMaterial>::default())
-            .add_plugin(ExtractComponentPlugin::<Handle<StandardMaterial>>::default())
             .init_resource::<AmbientLight>()
             .init_resource::<DirectionalLightShadowMap>()
             .init_resource::<PointLightShadowMap>()


### PR DESCRIPTION
# Objective

- After updating #2988, all the examples started crashing with
```
thread 'main' panicked at 'Plugin "bevy_render::render_component::ExtractComponentPlugin<bevy_asset::handle::Handle<bevy_pbr::pbr_material::StandardMaterial>>" was already added', crates/bevy_app/src/app.rs:831:33
```

## Solution

Plugin was added twice:
directly:
https://github.com/bevyengine/bevy/blob/1d0d8a3397bd6fc2c14d42ffd0668d2443748912/crates/bevy_pbr/src/lib.rs#L73
and through `MaterialPlugin`:
https://github.com/bevyengine/bevy/blob/1d0d8a3397bd6fc2c14d42ffd0668d2443748912/crates/bevy_pbr/src/lib.rs#L72
https://github.com/bevyengine/bevy/blob/1d0d8a3397bd6fc2c14d42ffd0668d2443748912/crates/bevy_pbr/src/material.rs#L183

I removed the extra plugin