### PR TITLE
[Merged by Bors] - Added missing docs to bevy_internal and added warn on missing docs

### DIFF
--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -1,7 +1,5 @@
 #![warn(missing_docs)]
-//! This module contains plugins for quickly setting up a Bevy app, as well as publicizing of the subcrates Bevy contains
-//!
-//! This module is separated into its own crate to enable simple dynamic linking for Bevy
+//! This module is separated into its own crate to enable simple dynamic linking for Bevy, and should not be used directly
 
 /// `use bevy::prelude::*;` to import common components, bundles, and plugins.
 pub mod prelude;

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -1,5 +1,7 @@
 #![warn(missing_docs)]
 //! This module contains plugins for quickly setting up a Bevy app, as well as publicizing of the subcrates Bevy contains
+//!
+//! This module is separated into its own crate to enable simple dynamic linking for Bevy
 
 /// `use bevy::prelude::*;` to import common components, bundles, and plugins.
 pub mod prelude;

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+//! This module contains plugins for quickly setting up a Bevy app, as well as publicizing of the subcrates Bevy contains
+
 /// `use bevy::prelude::*;` to import common components, bundles, and plugins.
 pub mod prelude;
 
@@ -68,6 +71,7 @@ pub mod transform {
 }
 
 pub mod utils {
+    //! Various miscellaneous utilities for easing development
     pub use bevy_utils::*;
 }
 
@@ -90,6 +94,7 @@ pub mod core_pipeline {
 
 #[cfg(feature = "bevy_gilrs")]
 pub mod gilrs {
+    //! Bevy interface with GilRs - Game Input Library for Rust to handle gamepad inputs
     pub use bevy_gilrs::*;
 }
 
@@ -131,6 +136,7 @@ pub mod ui {
 
 #[cfg(feature = "bevy_winit")]
 pub mod winit {
+    //! Window creation, configuration, and handling
     pub use bevy_winit::*;
 }
 

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -142,6 +142,7 @@ pub mod winit {
 
 #[cfg(feature = "bevy_dynamic_plugin")]
 pub mod dynamic_plugin {
+    //! Dynamic linking of plugins
     pub use bevy_dynamic_plugin::*;
 }
 


### PR DESCRIPTION
# Objective
This contributes documentation that should cover the entirety of bevy_internal as requested in #3492 

## Solution
warn(missing_docs) has been activated and documentation has been added to missing parts so that no warnings appear from this setting
