### PR TITLE
[Merged by Bors] - Updated bevy_dylib documentation and added missing_doc warning.

### DIFF
--- a/crates/bevy_dylib/src/lib.rs
+++ b/crates/bevy_dylib/src/lib.rs
@@ -1,12 +1,26 @@
+#![warn(missing_docs)]
 #![allow(clippy::single_component_path_imports)]
 
 //! Forces dynamic linking of Bevy.
 //!
 //! Dynamically linking Bevy makes the "link" step much faster. This can be achieved by adding
-//! `bevy_dylib` as dependency and `#[allow(unused_imports)] use bevy_dylib` to `main.rs`. It is
-//! recommended to disable the `bevy_dylib` dependency in release mode by adding
-//! `#[cfg(debug_assertions)]` to the `use` statement. Otherwise you will have to ship `libstd.so`
-//! and `libbevy_dylib.so` with your game.
+//! `bevy_dylib` as a dependency and adding the following code to the `main.rs` file:
+//!
+//! ```rust
+//! #[allow(unused_imports)]
+//! use bevy_dylib;
+//! ```
+//!
+//! It is recommended to disable the `bevy_dylib` dependency in release mode by adding the
+//! following code to the `use` statement:
+//!
+//! ```rust
+//! #[allow(unused_imports)]
+//! #[cfg(debug_assertions)] // new
+//! use bevy_dylib;
+//! ```
+//!
+//! If you don't do this you will have to ship `libstd.so` and `libbevy_dylib.so` with your game.
 
 // Force linking of the main bevy crate
 #[allow(unused_imports)]

--- a/crates/bevy_dylib/src/lib.rs
+++ b/crates/bevy_dylib/src/lib.rs
@@ -3,8 +3,38 @@
 
 //! Forces dynamic linking of Bevy.
 //!
-//! Dynamically linking Bevy makes the "link" step much faster. This can be achieved by adding
-//! `bevy_dylib` as a dependency and adding the following code to the `main.rs` file:
+//! Dynamic linking causes Bevy to be built and linked as a dynamic library. This will make
+//! incremental builds compile much faster.
+//!
+//! # Warning
+//!
+//! Do not enable this feature for release builds because this would require you to ship
+//! `libstd.so` and `libbevy_dylib.so` with your game.
+//!
+//! # Enabling dynamic linking
+//!
+//! ## The recommended way
+//!
+//! The easiest way to enable dynamic linking is to use the `--features bevy/dynamic` flag when
+//! using the `cargo run` command:
+//!
+//! `cargo run --features bevy/dynamic`
+//!
+//! ## The unrecommended way
+//!
+//! It is also possible to enable the `dynamic` feature inside of the `Cargo.toml` file. This is
+//! unrecommended because it requires you to remove this feature every time you want to create a
+//! release build to avoid having to ship additional files with your game.
+//!
+//! To enable dynamic linking inside of the `Cargo.toml` file add the `dynamic` feature to the
+//! bevy dependency:
+//!
+//! `features = ["dynamic"]`
+//!
+//! ## The manual way
+//!
+//! Manually enabling dynamic linking is achieved by adding `bevy_dylib` as a dependency and
+//! adding the following code to the `main.rs` file:
 //!
 //! ```rust
 //! #[allow(unused_imports)]
@@ -12,15 +42,13 @@
 //! ```
 //!
 //! It is recommended to disable the `bevy_dylib` dependency in release mode by adding the
-//! following code to the `use` statement:
+//! following code to the `use` statement to avoid having to ship additional files with your game:
 //!
 //! ```rust
 //! #[allow(unused_imports)]
 //! #[cfg(debug_assertions)] // new
 //! use bevy_dylib;
 //! ```
-//!
-//! If you don't do this you will have to ship `libstd.so` and `libbevy_dylib.so` with your game.
 
 // Force linking of the main bevy crate
 #[allow(unused_imports)]


### PR DESCRIPTION
This PR is part of the issue #3492.

# Objective
- Add and update the bevy_dylib documentation to achieve a 100% documentation coverage.
- Add the #![warn(missing_docs)] lint to keep the documentation coverage for the future.

# Solution
- Add and update the bevy_dylib documentation.
- Add the #![warn(missing_docs)] lint.