### PR TITLE
Do not incorrectly `impl Send for World` 

### DIFF
--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -327,7 +327,10 @@ impl CachedPipelinePhaseItem for Transparent3d {
     }
 }
 
-pub fn extract_clear_color(clear_color: Res<ClearColor>, mut render_world: ResMut<RenderWorld>) {
+pub fn extract_clear_color(
+    clear_color: Res<ClearColor>,
+    mut render_world: NonSendMut<RenderWorld>,
+) {
     // If the clear color has changed
     if clear_color.is_changed() {
         // Update the clear color resource in the render world

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -347,6 +347,13 @@ impl Components {
 
         ComponentId(*index)
     }
+
+    pub(crate) fn non_send_components(&'_ self) -> impl Iterator<Item = ComponentId> + '_ {
+        self.components
+            .iter()
+            .filter(|x| !x.is_send_and_sync())
+            .map(|x| x.id())
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1194,18 +1194,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn non_send_resource_panic() {
-        let mut world = World::default();
-        world.insert_non_send(0i32);
-        std::thread::spawn(move || {
-            let _ = world.get_non_send_resource_mut::<i32>();
-        })
-        .join()
-        .unwrap();
-    }
-
-    #[test]
     fn trackers_query() {
         let mut world = World::default();
         let e1 = world.spawn().insert_bundle((A(0), B(0))).id();

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1212,7 +1212,7 @@ impl Turtle {
     /// A view on this [`Turtle`]'s [`World`], which contains no [`!Send`] resources
     ///
     /// [`!Send`]: Send
-    // Safety: NonSend resources cannot be added using a raw reference
+    // Safety: NonSend resources cannot be added using a shared reference
     // to the world, so this cannot break our invariants
     pub fn world_ref(&self) -> &World {
         &self.world

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1196,6 +1196,8 @@ pub struct Turtle {
     world: World,
 }
 
+// I mean I guess clippy, that's the point. There's a reason we called it `unsafe`
+#[allow(clippy::non_send_fields_in_send_ty)]
 // Safety: The contained world does not contain anything which is !Send
 unsafe impl Send for Turtle {}
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1143,14 +1143,25 @@ impl World {
         self.entities.clear();
     }
 
+    /// Create a version of this [`World`] which can be sent to another thread
+    ///
+    /// # Panics
+    ///
+    /// If `self` contains any [`!Send`] resources, e.g. from calls to [`World::insert_non_send`]
+    ///
+    /// [`!Send`]: Send
+
     pub fn turtle(self) -> Turtle {
         let non_send = self.components().non_send_components().collect::<Vec<_>>();
         for id in non_send {
             assert!(
-                self.get_populated_resource_column(id).is_some(),
+                self.get_populated_resource_column(id).is_none(),
                 "Tried to create a Turtle from a World containing a !Send resource"
             );
         }
+        // Safety: this world does not contain anything !Send, as confirmed by the check above
+        // In practise this method is used for GLTF loading, which does not add any resources to the given world
+        // (i.e. the above check is trivially true)
         Turtle { world: self }
     }
 }
@@ -1173,29 +1184,44 @@ impl fmt::Debug for World {
 unsafe impl Sync for World {}
 
 /// A world which does not contain any [`!Send`] resources, and therefore
-/// can be safely sent between threads
+/// can be safely sent between threads.
+///
+/// The name turtle is derived from this being something which is moving a
+/// [`World`] (between threads)
 ///
 /// [`!Send`]: Send
 #[derive(Debug)]
 pub struct Turtle {
+    // Safety: does not have any !Send resources
     world: World,
 }
 
+// Safety: The contained world does not contain anything which is !Send
 unsafe impl Send for Turtle {}
 
 impl Turtle {
+    /// The [`World`] this [`Turtle`] was created from.
+    ///
+    /// The returned [`World`] does not contain any [`!Send`] resources
+    ///
+    /// [`!Send`]: Send
     pub fn world(self) -> World {
         self.world
     }
 
+    /// A view on this [`Turtle`]'s [`World`], which contains no [`!Send`] resources
+    ///
+    /// [`!Send`]: Send
+    // Safety: NonSend resources cannot be added using a raw reference
+    // to the world, so this cannot break our invariants
     pub fn world_ref(&self) -> &World {
         &self.world
     }
 }
 
-impl Into<World> for Turtle {
-    fn into(self) -> World {
-        self.world()
+impl From<Turtle> for World {
+    fn from(turtle: Turtle) -> Self {
+        turtle.world()
     }
 }
 

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -302,8 +302,12 @@ async fn load_gltf<'a, 'b>(
         if let Some(Err(err)) = err {
             return Err(err);
         }
-        let scene_handle = load_context
-            .set_labeled_asset(&scene_label(&scene), LoadedAsset::new(Scene::new(world)));
+        let scene_handle = load_context.set_labeled_asset(
+            &scene_label(&scene),
+            LoadedAsset::new(Scene {
+                turtle: world.turtle(),
+            }),
+        );
 
         if let Some(name) = scene.name() {
             named_scenes.insert(name.to_string(), scene_handle.clone());

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -144,7 +144,7 @@ impl Plugin for RenderPlugin {
             app.insert_resource(device.clone())
                 .insert_resource(queue.clone())
                 .insert_resource(options.clone())
-                .init_resource::<ScratchRenderWorld>()
+                .init_non_send_resource::<ScratchRenderWorld>()
                 .register_type::<Frustum>()
                 .register_type::<CubemapFrusta>();
             let render_pipeline_cache = RenderPipelineCache::new(device.clone());
@@ -303,16 +303,16 @@ fn extract(app_world: &mut World, render_app: &mut App) {
         .unwrap();
 
     // temporarily add the render world to the app world as a resource
-    let scratch_world = app_world.remove_resource::<ScratchRenderWorld>().unwrap();
+    let scratch_world = app_world.remove_non_send::<ScratchRenderWorld>().unwrap();
     let render_world = std::mem::replace(&mut render_app.world, scratch_world.0);
-    app_world.insert_resource(RenderWorld(render_world));
+    app_world.insert_non_send(RenderWorld(render_world));
 
     extract.run(app_world);
 
     // add the render world back to the render app
-    let render_world = app_world.remove_resource::<RenderWorld>().unwrap();
+    let render_world = app_world.remove_non_send::<RenderWorld>().unwrap();
     let scratch_world = std::mem::replace(&mut render_app.world, render_world.0);
-    app_world.insert_resource(ScratchRenderWorld(scratch_world));
+    app_world.insert_non_send(ScratchRenderWorld(scratch_world));
 
     extract.apply_buffers(&mut render_app.world);
 }

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use bevy_app::EventReader;
 use bevy_asset::{AssetEvent, Assets, Handle};
-use bevy_ecs::system::{Res, ResMut};
+use bevy_ecs::system::{NonSendMut, Res, ResMut};
 use bevy_utils::{tracing::error, HashMap, HashSet};
 use std::{collections::hash_map::Entry, hash::Hash, ops::Deref, sync::Arc};
 use thiserror::Error;
@@ -389,7 +389,7 @@ impl RenderPipelineCache {
     }
 
     pub(crate) fn extract_shaders(
-        mut world: ResMut<RenderWorld>,
+        mut world: NonSendMut<RenderWorld>,
         shaders: Res<Assets<Shader>>,
         mut events: EventReader<AssetEvent<Shader>>,
     ) {

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -67,7 +67,7 @@ impl DerefMut for ExtractedWindows {
     }
 }
 
-fn extract_windows(mut render_world: ResMut<RenderWorld>, windows: Res<Windows>) {
+fn extract_windows(mut render_world: NonSendMut<RenderWorld>, windows: Res<Windows>) {
     let mut extracted_windows = render_world.get_resource_mut::<ExtractedWindows>().unwrap();
     for window in windows.iter() {
         let (new_width, new_height) = (

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -27,7 +27,7 @@ pub struct DynamicEntity {
 impl DynamicScene {
     /// Create a new dynamic scene from a given scene.
     pub fn from_scene(scene: &Scene, type_registry: &TypeRegistryArc) -> Self {
-        Self::from_world(&scene.turtle.world_ref(), type_registry)
+        Self::from_world(scene.turtle.world_ref(), type_registry)
     }
 
     /// Create a new dynamic scene from a given world.

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -27,7 +27,7 @@ pub struct DynamicEntity {
 impl DynamicScene {
     /// Create a new dynamic scene from a given scene.
     pub fn from_scene(scene: &Scene, type_registry: &TypeRegistryArc) -> Self {
-        Self::from_world(&scene.world, type_registry)
+        Self::from_world(&scene.turtle.world_ref(), type_registry)
     }
 
     /// Create a new dynamic scene from a given world.

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -1,14 +1,8 @@
-use bevy_ecs::world::World;
+use bevy_ecs::world::Turtle;
 use bevy_reflect::TypeUuid;
 
 #[derive(Debug, TypeUuid)]
 #[uuid = "c156503c-edd9-4ec7-8d33-dab392df03cd"]
 pub struct Scene {
-    pub world: World,
-}
-
-impl Scene {
-    pub fn new(world: World) -> Self {
-        Self { world }
-    }
+    pub turtle: Turtle,
 }

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -154,15 +154,15 @@ impl SceneSpawner {
                         handle: scene_handle.clone(),
                     })?;
 
-            for archetype in scene.world.archetypes().iter() {
+            let scene_world = scene.turtle.world_ref();
+            for archetype in scene_world.archetypes().iter() {
                 for scene_entity in archetype.entities() {
                     let entity = *instance_info
                         .entity_map
                         .entry(*scene_entity)
                         .or_insert_with(|| world.spawn().id());
                     for component_id in archetype.components() {
-                        let component_info = scene
-                            .world
+                        let component_info = scene_world
                             .components()
                             .get_info(component_id)
                             .expect("component_ids in archetypes should have ComponentInfo");
@@ -180,7 +180,7 @@ impl SceneSpawner {
                                 })
                             })?;
                         reflect_component.copy_component(
-                            &scene.world,
+                            &scene_world,
                             world,
                             *scene_entity,
                             entity,

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -179,12 +179,7 @@ impl SceneSpawner {
                                     }
                                 })
                             })?;
-                        reflect_component.copy_component(
-                            &scene_world,
-                            world,
-                            *scene_entity,
-                            entity,
-                        );
+                        reflect_component.copy_component(scene_world, world, *scene_entity, entity);
                     }
                 }
             }

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -204,7 +204,7 @@ pub struct SpriteAssetEvents {
 }
 
 pub fn extract_sprite_events(
-    mut render_world: ResMut<RenderWorld>,
+    mut render_world: NonSendMut<RenderWorld>,
     mut image_events: EventReader<AssetEvent<Image>>,
 ) {
     let mut events = render_world
@@ -230,7 +230,7 @@ pub fn extract_sprite_events(
 }
 
 pub fn extract_sprites(
-    mut render_world: ResMut<RenderWorld>,
+    mut render_world: NonSendMut<RenderWorld>,
     texture_atlases: Res<Assets<TextureAtlas>>,
     sprite_query: Query<(&Visibility, &Sprite, &GlobalTransform, &Handle<Image>)>,
     atlas_query: Query<(

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -3,7 +3,7 @@ use bevy_ecs::{
     bundle::Bundle,
     entity::Entity,
     query::{Changed, QueryState, With},
-    system::{Local, Query, QuerySet, Res, ResMut},
+    system::{Local, NonSendMut, Query, QuerySet, Res, ResMut},
 };
 use bevy_math::{Size, Vec3};
 use bevy_render::{texture::Image, view::Visibility, RenderWorld};
@@ -42,7 +42,7 @@ impl Default for Text2dBundle {
 }
 
 pub fn extract_text2d_sprite(
-    mut render_world: ResMut<RenderWorld>,
+    mut render_world: NonSendMut<RenderWorld>,
     texture_atlases: Res<Assets<TextureAtlas>>,
     text_pipeline: Res<DefaultTextPipeline>,
     windows: Res<Windows>,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -136,7 +136,7 @@ pub struct ExtractedUiNodes {
 }
 
 pub fn extract_uinodes(
-    mut render_world: ResMut<RenderWorld>,
+    mut render_world: NonSendMut<RenderWorld>,
     images: Res<Assets<Image>>,
     uinode_query: Query<(
         &Node,
@@ -173,7 +173,7 @@ pub fn extract_uinodes(
 }
 
 pub fn extract_text_uinodes(
-    mut render_world: ResMut<RenderWorld>,
+    mut render_world: NonSendMut<RenderWorld>,
     texture_atlases: Res<Assets<TextureAtlas>>,
     text_pipeline: Res<DefaultTextPipeline>,
     windows: Res<Windows>,


### PR DESCRIPTION
Fixes https://github.com/bevyengine/bevy/issues/3310

For actual-pipelining, it might be required to change `RenderWorld` to contain a `Turtle` instead, but this version currently works.
I suspect that would also cause mutability problems, and `Turtle` would need to defer most of the non-non_send methods. 

As it happens, those checks would panic at runtime anyway, but we could remove the checks now that this change has happened.