### PR TITLE
[Merged by Bors] - revert new dependency for fedora added in #3517

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -29,7 +29,7 @@ Please see the ubuntu [WSL documentation](https://wiki.ubuntu.com/WSL) on how to
 ## Fedora
 
 ```bash
-sudo dnf install gcc-c++ libX11-devel alsa-lib-devel systemd-devel rust-libudev-devel
+sudo dnf install gcc-c++ libX11-devel alsa-lib-devel systemd-devel
 ```
 
 If there are errors with linking during the build process such as:


### PR DESCRIPTION
# Objective

- Revert #3517 as the dependency added (rust-libudev-devel) has a dependency on cargo which install the package manager version, which isn't compatible with rustup version and may break the setup of users
