### PR TITLE
bevy_ui: Fix scaling issues

### DIFF
--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -44,6 +44,7 @@ pub struct ExtractedWindow {
     pub vsync: bool,
     pub swap_chain_texture: Option<TextureView>,
     pub size_changed: bool,
+    pub scale_factor: f64,
 }
 
 #[derive(Default)]
@@ -84,6 +85,7 @@ fn extract_windows(mut render_world: ResMut<RenderWorld>, windows: Res<Windows>)
                     vsync: window.vsync(),
                     swap_chain_texture: None,
                     size_changed: false,
+                    scale_factor: window.scale_factor(),
                 });
 
         // NOTE: Drop the swap chain frame here

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -283,7 +283,7 @@ pub fn prepare_uinodes(
     let scale_factor = if let Some(extracted_window) = extracted_windows.get(&WindowId::primary()) {
         extracted_window.scale_factor as f32
     } else {
-        return;
+        1.
     };
 
     // sort by increasing z for correct transparency


### PR DESCRIPTION
# Objective

Fixes #3493. 
The issue was that `extracted_uinode.rect` is scaled according to the window's scale factor when `extracted_uinode.atlas_size` is `None`, but it's not scaled when `extracted_uinode.atlas_size` is `Some`.

## Solution

I changed one condition to avoid relying on `extracted_uinode.rect`, extracted the window's scale factor into the render app, and applied it as necessary when calculating the clipped UVs.
To be honest, I can't properly explain why it works this way, and I'm not confident I covered all cases. In #3460, the similar fields `extracted_sprite.rect` and `extracted_sprite.atlas_size` are changed to cleanly separate what affects position/size and what affects UVs. I hope to port to UI the sprite improvements of that PR after it's accepted, but meanwhile this smaller PR can fix the issue.