### PR TITLE
bevy_pbr: Calculate point light range from luminous power

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -19,7 +19,10 @@ pub mod prelude {
     pub use crate::{
         alpha::AlphaMode,
         bundle::{DirectionalLightBundle, MaterialMeshBundle, PbrBundle, PointLightBundle},
-        light::{AmbientLight, DirectionalLight, PointLight},
+        light::{
+            AmbientLight, DirectionalLight, DirectionalLightConfig, PointLight, PointLightConfig,
+            PointLightRange,
+        },
         material::{Material, MaterialPlugin},
         pbr_material::StandardMaterial,
     };
@@ -73,8 +76,8 @@ impl Plugin for PbrPlugin {
             .add_plugin(MeshRenderPlugin)
             .add_plugin(MaterialPlugin::<StandardMaterial>::default())
             .init_resource::<AmbientLight>()
-            .init_resource::<DirectionalLightShadowMap>()
-            .init_resource::<PointLightShadowMap>()
+            .init_resource::<DirectionalLightConfig>()
+            .init_resource::<PointLightConfig>()
             .init_resource::<AmbientLight>()
             .init_resource::<VisiblePointLights>()
             .add_system_to_stage(
@@ -91,6 +94,12 @@ impl Plugin for PbrPlugin {
                 update_clusters
                     .label(SimulationLightSystems::UpdateClusters)
                     .after(TransformSystem::TransformPropagate),
+            )
+            .add_system_to_stage(
+                CoreStage::PostUpdate,
+                update_point_light_ranges
+                    .label(SimulationLightSystems::UpdatePointLightRanges)
+                    .before(SimulationLightSystems::AssignLightsToClusters),
             )
             .add_system_to_stage(
                 CoreStage::PostUpdate,

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -89,9 +89,9 @@ fn saturate(value: f32) -> f32 {
 }
 
 // distanceAttenuation is simply the square falloff of light intensity
-// combined with a smooth attenuation at the edge of the light radius
+// combined with a smooth attenuation at the edge of the light range
 //
-// light radius is a non-physical construct for efficiency purposes,
+// light range is a non-physical construct for efficiency purposes,
 // because otherwise every light affects every fragment in the scene
 fn getDistanceAttenuation(distanceSquare: f32, inverseRangeSquared: f32) -> f32 {
     let factor = distanceSquare * inverseRangeSquared;

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -57,7 +57,7 @@ fn setup(
         transform: Transform::from_translation(Vec3::new(50.0, 50.0, 50.0)),
         point_light: PointLight {
             intensity: 600000.,
-            range: 100.,
+            range: PointLightRange::Manual(100.),
             ..Default::default()
         },
         ..Default::default()

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -49,7 +49,7 @@ fn setup(
         transform: Transform::from_xyz(5.0, 5.0, 0.0),
         point_light: PointLight {
             intensity: 0.0,
-            range: spawn_plane_depth,
+            range: PointLightRange::Manual(spawn_plane_depth),
             color: Color::WHITE,
             shadow_depth_bias: 0.0,
             shadow_normal_bias: 0.0,

--- a/examples/3d/shadow_caster_receiver.rs
+++ b/examples/3d/shadow_caster_receiver.rs
@@ -79,7 +79,7 @@ fn setup(
         transform: Transform::from_xyz(5.0, 5.0, 0.0),
         point_light: PointLight {
             intensity: 0.0,
-            range: spawn_plane_depth,
+            range: PointLightRange::Manual(spawn_plane_depth),
             color: Color::WHITE,
             shadows_enabled: true,
             ..Default::default()

--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -103,7 +103,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
         point_light: PointLight {
             intensity: 3000.0,
             shadows_enabled: true,
-            range: 30.0,
+            range: PointLightRange::Manual(30.0),
             ..Default::default()
         },
         ..Default::default()
@@ -340,7 +340,7 @@ fn spawn_bonus(
                     point_light: PointLight {
                         color: Color::rgb(1.0, 1.0, 0.0),
                         intensity: 1000.0,
-                        range: 10.0,
+                        range: PointLightRange::Manual(10.0),
                         ..Default::default()
                     },
                     transform: Transform::from_xyz(0.0, 2.0, 0.0),


### PR DESCRIPTION
# Objective

- Avoid artificially limiting point light range to a fairly arbitrary constant default value regardless of the light's intensity (luminous power)
- Avoid users having to figure out the 'real' range of point lights
- Have a simple way for API users to deal with the "cluster light index lists is full" warning message and inform them of how to deal with the warning in the warning message itself

## Background and Reasoning

Light has an inverse square falloff. As such, if we decide a minimum illuminance (lumens / m^2) and provide a point light source luminous power (lumens) then we can calculate a range at which the point light will reach that minimum illuminance as:

luminous intensity (in lumens / steradian) = luminous power / (4 * pi)
range = sqrt(luminous intensity / minimum illuminance)

The default minimum illuminance is conservative to be safe as to not unnecessarily constrain the range of lights and rather just encompass their natural range. This can lead to point lights being allocated to too many clusters. A simple way to manage this situation is to then allow global adjustment of the minimum illuminance and recalculation of light ranges to allow consistent visual constraint while also meeting the cluster assignment constraints.

## Solution

- Rename `PointLightShadowMap` and `DirectionalLightShadowMap` to `PointLightConfig` and `DirectionalLightConfig`
- Add `minimum_illuminance: f32` member to `PointLightConfig` with a conservative default value of 0.1. This value was tested with a range of light intensities and does not overly-constrain the range, but this can lead to larger ranges than the previous default of 20m. This larger range can then trigger the cluster light index lists is full warning but not many people have been using the new renderer yet so I deemed this ok. Plus as you will see this aspect is also addressed. :)
- Make the `PointLight` `range: f32` member into a `PointLightRange` enum with `Automatic`, `CachedAutomatic(f32)` and `Manual(f32)` members. Setting the `range` to `PointLightRange::Manual(SOME_VALUE)` will behave the same as before.
- Add a `calculate_range` function to `PointLight` that calculates the range at which light illuminance can be considered 0, based on the light's intensity (luminous power) and a given minimum illuminance.
- Add an `update_range` function to `PointLight` that updates the range if the `range` using `calculate_range` if it is `PointLightRange::Automatic`, or if the `PointLightConfig` `minimum_illuminance` was added or changed _and_ the `range` is `PointLightRange::CachedAutomatic`. If the `range` is `PointLightRange::Manual` then leave it alone as it was manually specified.
- Add an `update_point_light_ranges` system that iterates over all point lights and updates them using `PointLight::update_range`
- Add a `range` function to `PointLight` that returns an `Option<f32>`. It returns `None` for `PointLightRange::Automatic` (i.e. if the cached value has not yet been calculated) or otherwise `Some()`
- Improve documentation in various places relating to the `PointLight` `range` as the purpose of `range` and `radius` was confusing
- Inform the user what to do when they see the 'cluster light index lists is full' warning message, in the warning message itself so that it becomes actionable.
  - The approach to fix the warning is to use `PointLight`s with `PointLightRange::Automatic` and then increase the `PointLightConfig` `minimum_illuminance` until the warning (and visual artifacts) stop.
  - For clarity here, the 'cluster light index lists' is a uniform binding that is limited to 16kB. For each cluster, if any lights affect it, the list of the indices of those point lights is stored in the 'cluster light index lists' array. These are concatenated. So, if the lights in view have spheres of influence that intersect with more clusters than there is space for in this uniform buffer, the warning message is printed. This is usually visible as squares on the screen that are not lit by any point lights.

## Known issues

- Due to the exponential depth slicing used for calculating the cluster near/far bounds, there are a lot of clusters close to the camera. This means that if you just move close to a collection of lights, that can easily trigger the 'cluster light index lists is full' warning. I will make a separate PR that introduces a special first depth slice that is larger to avoid this problem.