### PR TITLE
[Merged by Bors] - Use fully-qualified type names in proc macro.

### DIFF
--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -86,8 +86,8 @@ pub fn derive_label(input: syn::DeriveInput, trait_path: syn::Path) -> TokenStre
 
     (quote! {
         impl #impl_generics #trait_path for #ident #ty_generics #where_clause {
-            fn dyn_clone(&self) -> Box<dyn #trait_path> {
-                Box::new(Clone::clone(self))
+            fn dyn_clone(&self) -> std::boxed::Box<dyn #trait_path> {
+                std::boxed::Box::new(std::clone::Clone::clone(self))
             }
         }
     })


### PR DESCRIPTION
Modifies the code emitted by `derive_label` to use fully-qualified type
names (e.g. `std::boxed::Box` instead of `Box`).

# Objective

- Using unqualified types here causes errors when the proc macro is used in contexts that locally define types with conflicting names (e.g. a local definition of `Box`).

## Solution

- Fully qualify standard types emitted by the proc macro code.
