### PR TITLE
Improve sprite ordering speed

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -322,7 +322,7 @@ pub fn prepare_sprites(
 
     // sort first by z and then by handle. this ensures that, when possible, batches span multiple z layers
     // batches won't span z-layers if there is another batch between them
-    extracted_sprites.sprites.sort_by(|a, b| {
+    extracted_sprites.sprites.sort_unstable_by(|a, b| {
         match a.transform.w_axis[2].partial_cmp(&b.transform.w_axis[2]) {
             Some(Ordering::Equal) | None => a.handle.cmp(&b.handle),
             Some(other) => other,

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -323,9 +323,9 @@ pub fn prepare_sprites(
     // sort first by z and then by handle. this ensures that, when possible, batches span multiple z layers
     // batches won't span z-layers if there is another batch between them
     extracted_sprites.sprites.sort_by(|a, b| {
-        match FloatOrd(a.transform.w_axis[2]).cmp(&FloatOrd(b.transform.w_axis[2])) {
-            Ordering::Equal => a.handle.cmp(&b.handle),
-            other => other,
+        match a.transform.w_axis[2].partial_cmp(&b.transform.w_axis[2]) {
+            Some(Ordering::Equal) | None => a.handle.cmp(&b.handle),
+            Some(other) => other,
         }
     });
 


### PR DESCRIPTION
# Objective

- Sprite z ordering can be slow with many sprites

## Solution

- use `partial_cmp` instead of `cmp` through `FloatOrd`
- use `sort_unstable_by` instead of `sort_by`

results on my laptop:
|fps|bevymark -- 25000 40|many_sprites|
|-|-|-|
|base|9.84|33.75|
|`partial_cmp`|10.44|44.60|
|`sort_unstable_by`|10.27|59.96|
|both|10.59|66.03|


<details><summary>the screenshots!</summary>
<p>

### base
<img width="1281" alt="many_sprites stable-cmp" src="https://user-images.githubusercontent.com/8672791/148201546-fab48515-68e1-4c12-9fc1-89be99230451.png">
<img width="912" alt="bevymark stable-cmp" src="https://user-images.githubusercontent.com/8672791/148201559-04e9504d-4490-4312-96ce-0468e027473d.png">

### `partial_cmp`
<img width="1279" alt="many_sprites stable-partial_cmp" src="https://user-images.githubusercontent.com/8672791/148201624-ff63b79a-2906-4bb4-b807-5afb8910b8d5.png">
<img width="912" alt="bevymark stable-partial_cmp" src="https://user-images.githubusercontent.com/8672791/148201632-8c37126b-b385-4b9e-8caa-661706a8078b.png">

### `sort_unstable_by`
<img width="1276" alt="many_sprites unstable-cmp" src="https://user-images.githubusercontent.com/8672791/148201693-fb52f75d-89a8-47bb-af48-f0ee1cc579ab.png">
<img width="912" alt="bevymark unstable-cmp" src="https://user-images.githubusercontent.com/8672791/148201702-cd5fe4cc-501a-431e-b339-2b01622f46f7.png">

### both
<img width="1280" alt="many_sprites unstable-partial_cmp" src="https://user-images.githubusercontent.com/8672791/148201736-1a4d16af-0f78-4429-8770-bd7ee4ffee11.png">
<img width="912" alt="bevymark unstable-partial_cmp" src="https://user-images.githubusercontent.com/8672791/148201732-94a93e1a-ef65-40ef-88c8-65cfb5fd2433.png">


</p>
</details>