### PR TITLE
Smaller extracted sprite struct

### DIFF
--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -487,6 +487,15 @@ impl Color {
             } => [hue, saturation, lightness, alpha],
         }
     }
+
+    pub fn as_linear_abgr_u32(self) -> u32 {
+        let color = self.as_linear_rgba_f32();
+        // encode color as a single u32 to save space
+        (color[0] * 255.0) as u32
+            | ((color[1] * 255.0) as u32) << 8
+            | ((color[2] * 255.0) as u32) << 16
+            | ((color[3] * 255.0) as u32) << 24
+    }
 }
 
 impl Default for Color {

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -488,6 +488,7 @@ impl Color {
         }
     }
 
+    #[inline]
     pub fn as_linear_abgr_u32(self) -> u32 {
         let color = self.as_linear_rgba_f32();
         // encode color as a single u32 to save space

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -11,9 +11,8 @@ use bevy_ecs::{
     prelude::*,
     system::{lifetimeless::*, SystemState},
 };
-use bevy_math::{const_vec3, Mat4, Vec2, Vec3, Vec4Swizzles};
+use bevy_math::{const_vec3, Vec2, Vec3, Vec4Swizzles};
 use bevy_render::{
-    color::Color,
     render_asset::RenderAssets,
     render_phase::{Draw, DrawFunctions, RenderPhase, TrackedRenderPass},
     render_resource::{std140::AsStd140, *},

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     query::{Changed, QueryState, With},
     system::{Local, Query, QuerySet, Res, ResMut},
 };
-use bevy_math::{Mat4, Size, Vec3};
+use bevy_math::{Size, Vec3};
 use bevy_render::{texture::Image, RenderWorld};
 use bevy_sprite::{ExtractedSprite, ExtractedSprites, TextureAtlas};
 use bevy_transform::prelude::{GlobalTransform, Transform};

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -81,12 +81,15 @@ pub fn extract_text2d_sprite(
                 let rect = atlas.textures[index];
                 let atlas_size = Some(atlas.size);
 
-                let transform =
-                    Mat4::from_rotation_translation(transform.rotation, transform.translation)
-                        * Mat4::from_scale(transform.scale / scale_factor)
-                        * Mat4::from_translation(
-                            alignment_offset * scale_factor + text_glyph.position.extend(0.),
-                        );
+                let transform = Transform::identity()
+                    .with_rotation(transform.rotation)
+                    .with_scale(transform.scale / scale_factor)
+                    .with_translation(
+                        transform.translation
+                            + alignment_offset * scale_factor
+                            + text_glyph.position.extend(0.),
+                    )
+                    .into();
 
                 extracted_sprites.sprites.push(ExtractedSprite {
                     transform,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -90,7 +90,7 @@ pub fn extract_text2d_sprite(
 
                 extracted_sprites.sprites.push(ExtractedSprite {
                     transform,
-                    color,
+                    color: color.as_linear_abgr_u32(),
                     rect,
                     handle,
                     atlas_size,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -81,15 +81,12 @@ pub fn extract_text2d_sprite(
                 let rect = atlas.textures[index];
                 let atlas_size = Some(atlas.size);
 
-                let transform = Transform::identity()
-                    .with_rotation(transform.rotation)
-                    .with_scale(transform.scale / scale_factor)
-                    .with_translation(
-                        transform.translation
-                            + alignment_offset * scale_factor
-                            + text_glyph.position.extend(0.),
-                    )
-                    .into();
+                let mut text_transform = transform.clone();
+                text_transform.scale /= scale_factor;
+                let glyph_transform = Transform::from_translation(
+                    alignment_offset * scale_factor + text_glyph.position.extend(0.),
+                );
+                let transform = text_transform.mul_transform(glyph_transform).into();
 
                 extracted_sprites.sprites.push(ExtractedSprite {
                     transform,


### PR DESCRIPTION
Optimize the `ExtractedSprite` struct to have smaller size.

With a large number of sprites (like in bevymark/many_sprites) this saves memory and slightly improves perf.

The struct size has been reduced from 176 bytes to 144 bytes.

This is accomplished by:
 - Storing the color as `u32` instead of `Color`, in the format that is later passed to the shader. The (cheap) conversion is moved to the Extract stage.
 - Storing the transform as `GlobalTransform` instead of `Mat4`. This moves the expensive matrix computation into the Prepare stage, instead of the Extract stage.
 
Due to touching the sorting function in `prepare_sprites`, this PR will have a merge conflict with #3554. One of us will have to rebase, depending on who makes it in first. I used `unstable_sort` and `partial_cmp` here, as that PR does (we already know it makes an improvement).