### PR TITLE
[Merged by Bors] - check if resource for asset already exists before adding it

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -44,4 +44,4 @@ ndk-glue = { version = "0.5" }
 [dev-dependencies]
 futures-lite = "1.4.0"
 tempfile = "3.2.0"
-bevy_core = { path = "../bevy_core", version = "0.5.0" }
+bevy_core = { path = "../bevy_core", version = "0.6.0" }

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -34,7 +34,7 @@ rand = "0.8.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }
-web-sys = { version = "0.3", features = ["Request", "Window", "Response"]}
+web-sys = { version = "0.3", features = ["Request", "Window", "Response"] }
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 
@@ -44,3 +44,4 @@ ndk-glue = { version = "0.5" }
 [dev-dependencies]
 futures-lite = "1.4.0"
 tempfile = "3.2.0"
+bevy_core = { path = "../bevy_core", version = "0.5.0" }

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -309,3 +309,19 @@ impl AddAsset for App {
         self
     }
 }
+
+#[test]
+fn asset_overwriting() {
+    #[derive(bevy_reflect::TypeUuid)]
+    #[uuid = "44115972-f31b-46e5-be5c-2b9aece6a52f"]
+    struct MyAsset;
+    let mut app = App::new();
+    app.add_plugin(bevy_core::CorePlugin)
+        .add_plugin(crate::AssetPlugin);
+    app.add_asset::<MyAsset>();
+    let mut assets_before = app.world.get_resource_mut::<Assets<MyAsset>>().unwrap();
+    let handle = assets_before.add(MyAsset);
+    app.add_asset::<MyAsset>(); // Ensure this doesn't overwrite the Asset
+    let assets_after = app.world.get_resource_mut::<Assets<MyAsset>>().unwrap();
+    assert!(assets_after.get(handle).is_some())
+}

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -274,16 +274,20 @@ impl AddAsset for App {
     where
         T: Asset,
     {
-        let assets = {
-            let asset_server = self.world.get_resource::<AssetServer>().unwrap();
-            asset_server.register_asset_type::<T>()
-        };
+        if !self.world.contains_resource::<Assets<T>>() {
+            let assets = {
+                let asset_server = self.world.get_resource::<AssetServer>().unwrap();
+                asset_server.register_asset_type::<T>()
+            };
 
-        self.insert_resource(assets)
-            .add_system_to_stage(AssetStage::AssetEvents, Assets::<T>::asset_event_system)
-            .add_system_to_stage(AssetStage::LoadAssets, update_asset_storage_system::<T>)
-            .register_type::<Handle<T>>()
-            .add_event::<AssetEvent<T>>()
+            self.insert_resource(assets)
+                .add_system_to_stage(AssetStage::AssetEvents, Assets::<T>::asset_event_system)
+                .add_system_to_stage(AssetStage::LoadAssets, update_asset_storage_system::<T>)
+                .register_type::<Handle<T>>()
+                .add_event::<AssetEvent<T>>()
+        } else {
+            self
+        }
     }
 
     fn init_asset_loader<T>(&mut self) -> &mut Self

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -312,18 +312,25 @@ impl AddAsset for App {
     }
 }
 
-#[test]
-fn asset_overwriting() {
-    #[derive(bevy_reflect::TypeUuid)]
-    #[uuid = "44115972-f31b-46e5-be5c-2b9aece6a52f"]
-    struct MyAsset;
-    let mut app = App::new();
-    app.add_plugin(bevy_core::CorePlugin)
-        .add_plugin(crate::AssetPlugin);
-    app.add_asset::<MyAsset>();
-    let mut assets_before = app.world.get_resource_mut::<Assets<MyAsset>>().unwrap();
-    let handle = assets_before.add(MyAsset);
-    app.add_asset::<MyAsset>(); // Ensure this doesn't overwrite the Asset
-    let assets_after = app.world.get_resource_mut::<Assets<MyAsset>>().unwrap();
-    assert!(assets_after.get(handle).is_some())
+#[cfg(test)]
+mod tests {
+    use bevy_app::App;
+
+    use crate::{AddAsset, Assets};
+
+    #[test]
+    fn asset_overwriting() {
+        #[derive(bevy_reflect::TypeUuid)]
+        #[uuid = "44115972-f31b-46e5-be5c-2b9aece6a52f"]
+        struct MyAsset;
+        let mut app = App::new();
+        app.add_plugin(bevy_core::CorePlugin)
+            .add_plugin(crate::AssetPlugin);
+        app.add_asset::<MyAsset>();
+        let mut assets_before = app.world.get_resource_mut::<Assets<MyAsset>>().unwrap();
+        let handle = assets_before.add(MyAsset);
+        app.add_asset::<MyAsset>(); // Ensure this doesn't overwrite the Asset
+        let assets_after = app.world.get_resource_mut::<Assets<MyAsset>>().unwrap();
+        assert!(assets_after.get(handle).is_some())
+    }
 }

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -270,6 +270,9 @@ pub trait AddAsset {
 }
 
 impl AddAsset for App {
+    /// Add an [`Asset`] to the [`App`].
+    ///
+    /// Adding the same [`Asset`] several time is idempotent.
     fn add_asset<T>(&mut self) -> &mut Self
     where
         T: Asset,


### PR DESCRIPTION
# Objective

- Fix #3559 
- Avoid erasing existing resource `Assets<T>` when adding it twice

## Solution

- Before creating a new `Assets<T>`, check if it has already been added to the world
