### PR TITLE
[Merged by Bors] - `iter_mut` on Assets: send modified event only when asset is iterated over

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -182,12 +182,12 @@ impl<T: Asset> Assets<T> {
 
     /// Get a mutable iterator over all assets in the collection.
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (HandleId, &mut T)> {
-        for id in self.assets.keys() {
+        self.assets.iter_mut().map(|(k, v)| {
             self.events.send(AssetEvent::Modified {
-                handle: Handle::weak(*id),
+                handle: Handle::weak(*k),
             });
-        }
-        self.assets.iter_mut().map(|(k, v)| (*k, v))
+            (*k, v)
+        })
     }
 
     /// Get an iterator over all HandleIds in the collection.


### PR DESCRIPTION
# Objective

- `Assets<T>::iter_mut` sends `Modified` event for all assets first, then returns the iterator
- This means that events could be sent for assets that would not have been mutated if iteration was stopped before

## Solution

- Send `Modified` event when assets are iterated over.
