### PR TITLE
[Merged by Bors] - derive clone for Input

### DIFF
--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -28,7 +28,7 @@ use bevy_ecs::schedule::State;
 /// * Call the [`Input::press`] method for each press event.
 /// * Call the [`Input::release`] method for each release event.
 /// * Call the [`Input::clear`] method at each frame start, before processing events.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Input<T> {
     pressed: HashSet<T>,
     just_pressed: HashSet<T>,


### PR DESCRIPTION
# Objective

- As part of exploring input event suppression in bevy_egui here: https://github.com/mvlabat/bevy_egui/pull/50/commits/53c1773583f2dfc2a8f8bc2aa93de1c9c5fd05ec
- I found that the only way to suppress events properly, is to allow to clone the relevant Input<Whatever>, and update with events manually from within the system. This cloned Input then is discarded, the Events<*> structs are cleared, and bevy_input's normal update of Input proceeds, without the events that have been suppressed.

## Solution

- This enables Input to be cloned, allowing it to be manually updated with events.
