### PR TITLE
[Merged by Bors] - Add missing closing ticks for inline examples and some cleanup

### DIFF
--- a/crates/bevy_dylib/src/lib.rs
+++ b/crates/bevy_dylib/src/lib.rs
@@ -36,7 +36,7 @@
 //! Manually enabling dynamic linking is achieved by adding `bevy_dylib` as a dependency and
 //! adding the following code to the `main.rs` file:
 //!
-//! ```rust
+//! ```
 //! #[allow(unused_imports)]
 //! use bevy_dylib;
 //! ```
@@ -44,7 +44,7 @@
 //! It is recommended to disable the `bevy_dylib` dependency in release mode by adding the
 //! following code to the `use` statement to avoid having to ship additional files with your game:
 //!
-//! ```rust
+//! ```
 //! #[allow(unused_imports)]
 //! #[cfg(debug_assertions)] // new
 //! use bevy_dylib;

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -161,6 +161,7 @@ impl Schedule {
     /// # schedule.add_stage("target_stage", SystemStage::parallel());
     /// #
     /// schedule.add_stage_before("target_stage", "my_stage", SystemStage::parallel());
+    /// ```
     pub fn add_stage_before<S: Stage>(
         &mut self,
         target: impl StageLabel,
@@ -197,6 +198,7 @@ impl Schedule {
     /// # schedule.add_stage("my_stage", SystemStage::parallel());
     /// #
     /// schedule.add_system_to_stage("my_stage", my_system);
+    /// ```
     pub fn add_system_to_stage<Params>(
         &mut self,
         stage_label: impl StageLabel,
@@ -324,6 +326,7 @@ impl Schedule {
     /// # schedule.add_stage("my_stage", SystemStage::parallel());
     /// #
     /// let stage = schedule.get_stage_mut::<SystemStage>(&"my_stage").unwrap();
+    /// ```
     pub fn get_stage_mut<T: Stage>(&mut self, label: &dyn StageLabel) -> Option<&mut T> {
         self.stages
             .get_mut(label)

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -367,7 +367,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// # use bevy_ecs::prelude::*;
     /// #
     /// fn my_system(mut commands: Commands) {
-    ///     let entity_id = commands.spawn().id();    
+    ///     let entity_id = commands.spawn().id();
     /// }
     /// # my_system.system();
     /// ```
@@ -403,7 +403,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     ///         health: Health(100),
     ///         strength: Strength(40),
     ///         defense: Defense(20),
-    ///     });    
+    ///     });
     /// }
     /// # add_combat_stats_system.system();
     /// ```
@@ -477,7 +477,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// # struct CombatBundle { a: Dummy }; // dummy field, unit bundles are not permitted.
     /// #
     /// fn remove_combat_stats_system(mut commands: Commands, player: Res<PlayerEntity>) {
-    ///     commands.entity(player.entity).remove_bundle::<CombatBundle>();    
+    ///     commands.entity(player.entity).remove_bundle::<CombatBundle>();
     /// }
     /// # remove_combat_stats_system.system();
     /// ```

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -55,7 +55,7 @@ impl SystemMeta {
 
 // TODO: Actually use this in FunctionSystem. We should probably only do this once Systems are constructed using a World reference
 // (to avoid the need for unwrapping to retrieve SystemMeta)
-/// Holds on to persistent state required to drive [`SystemParam`] for a [`System`].  
+/// Holds on to persistent state required to drive [`SystemParam`] for a [`System`].
 pub struct SystemState<Param: SystemParam> {
     meta: SystemMeta,
     param_state: <Param as SystemParam>::Fetch,
@@ -115,7 +115,7 @@ impl<Param: SystemParam> SystemState<Param> {
 
     /// Applies all state queued up for [`SystemParam`] values. For example, this will apply commands queued up
     /// by a [`Commands`](`super::Commands`) parameter to the given [`World`].
-    /// This function should be called manually after the values returned by [`SystemState::get`] and [`SystemState::get_mut`]  
+    /// This function should be called manually after the values returned by [`SystemState::get`] and [`SystemState::get_mut`]
     /// are finished being used.
     pub fn apply(&mut self, world: &mut World) {
         self.param_state.apply(world);
@@ -150,7 +150,7 @@ impl<Param: SystemParam> SystemState<Param> {
     /// # Safety
     /// This call might access any of the input parameters in a way that violates Rust's mutability rules. Make sure the data
     /// access is safe in the context of global [`World`] access. The passed-in [`World`] _must_ be the [`World`] the [`SystemState`] was
-    /// created with.   
+    /// created with.
     #[inline]
     pub unsafe fn get_unchecked_manual<'w, 's>(
         &'s mut self,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -187,7 +187,7 @@ use thiserror::Error;
 /// # tuple_system.system();
 ///
 /// # fn non_tuple_system(
-/// // This is the preferred method.    
+/// // This is the preferred method.
 /// query: Query<&MyComponent>
 /// # ) {}
 /// # non_tuple_system.system();

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -493,15 +493,15 @@ impl World {
     ///
     /// let mut world = World::new();
     /// let entities = world.spawn_batch(vec![
-    ///     (Position { x: 0.0, y: 0.0}, Velocity { x: 1.0, y: 0.0 }),    
-    ///     (Position { x: 0.0, y: 0.0}, Velocity { x: 0.0, y: 1.0 }),    
+    ///     (Position { x: 0.0, y: 0.0}, Velocity { x: 1.0, y: 0.0 }),
+    ///     (Position { x: 0.0, y: 0.0}, Velocity { x: 0.0, y: 1.0 }),
     /// ]).collect::<Vec<Entity>>();
     ///
     /// let mut query = world.query::<(&mut Position, &Velocity)>();
     /// for (mut position, velocity) in query.iter_mut(&mut world) {
     ///    position.x += velocity.x;
     ///    position.y += velocity.y;
-    /// }     
+    /// }
     ///
     /// assert_eq!(world.get::<Position>(entities[0]).unwrap(), &Position { x: 1.0, y: 0.0 });
     /// assert_eq!(world.get::<Position>(entities[1]).unwrap(), &Position { x: 0.0, y: 1.0 });

--- a/crates/bevy_render/src/mesh/mesh/conversions.rs
+++ b/crates/bevy_render/src/mesh/mesh/conversions.rs
@@ -3,7 +3,7 @@
 //!
 //! # Examples
 //!
-//! ```rust
+//! ```
 //! use bevy_render::mesh::VertexAttributeValues;
 //!
 //! // creating std::vec::Vec

--- a/examples/ecs/system_sets.rs
+++ b/examples/ecs/system_sets.rs
@@ -46,7 +46,6 @@ pub enum PhysicsSystem {
 /// ordering can then change between invocations.
 ///
 /// Lastly a system with run criterion _done_ is used to exit the app.
-/// ```
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!    println!("hello world");
 //! }
 //! ```
-
+//!
 //! Don't let the simplicity of the example above fool you. Bevy is a [fully featured game engine](https://bevyengine.org)
 //! and it gets more powerful every day!
 //!


### PR DESCRIPTION
# Objective

- clean up documentation and inline examples

## Solution

- add missing closing "```"
- remove stray "```"
- remove whitespace in inline examples
- unify inline examples (remove some `rust` labels)
