### PR TITLE
[Merged by Bors] - gltf loader: do not use the taskpool for only one task

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -247,6 +247,9 @@ async fn load_gltf<'a, 'b>(
         .collect();
 
     // TODO: use the threaded impl on wasm once wasm thread pool doesn't deadlock on it
+    // See https://github.com/bevyengine/bevy/issues/1924 for more details
+    // The taskpool use is also avoided when there is only one texture for performance reasons and
+    // to avoid https://github.com/bevyengine/bevy/pull/2725
     if gltf.textures().len() == 1 || cfg!(target_arch = "wasm32") {
         for gltf_texture in gltf.textures() {
             let (texture, label) =

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -253,7 +253,7 @@ async fn load_gltf<'a, 'b>(
     if gltf.textures().len() == 1 || cfg!(target_arch = "wasm32") {
         for gltf_texture in gltf.textures() {
             let (texture, label) =
-                load_texture(gltf_texture, &buffer_data, &linear_textures, &load_context).await?;
+                load_texture(gltf_texture, &buffer_data, &linear_textures, load_context).await?;
             load_context.set_labeled_asset(&label, LoadedAsset::new(texture));
         }
     } else {

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -254,6 +254,7 @@ async fn load_gltf<'a, 'b>(
             load_context.set_labeled_asset(&label, LoadedAsset::new(texture));
         }
     } else {
+        #[cfg(not(target_arch = "wasm32"))]
         load_context
             .task_pool()
             .scope(|scope| {


### PR DESCRIPTION
# Objective

- Fix the case mentioned in https://github.com/bevyengine/bevy/pull/2725#issuecomment-1007014024.
- On a machine with 4 cores, so 1 thread for assets, loading a gltf with only one textures hangs all asset loading

## Solution

- Do not use the task pool when there is only one texture to load
