### PR TITLE
Reflect and (de)serialize resources in scenes

### DIFF
--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -1,64 +1,67 @@
-[
-  (
-    entity: 0,
-    components: [
-      {
-        "type": "bevy_transform::components::transform::Transform",
-        "struct": {
-          "translation": {
-            "type": "glam::vec3::Vec3",
-            "value": (0.0, 0.0, 0.0),
-          },
-          "rotation": {
-            "type": "glam::quat::Quat",
-            "value": (0.0, 0.0, 0.0, 1.0),
-          },
-          "scale": {
-            "type": "glam::vec3::Vec3",
-            "value": (1.0, 1.0, 1.0),
-          },
-        },
-      },
-      {
-        "type": "scene::ComponentB",
-        "struct": {
-          "value": {
-            "type": "alloc::string::String",
-            "value": "hello",
+(
+  resources: [],
+  entities: [
+    (
+      entity: 0,
+      components: [
+        {
+          "type": "bevy_transform::components::transform::Transform",
+          "struct": {
+            "translation": {
+              "type": "glam::vec3::Vec3",
+              "value": (0.0, 0.0, 0.0),
+            },
+            "rotation": {
+              "type": "glam::quat::Quat",
+              "value": (0.0, 0.0, 0.0, 1.0),
+            },
+            "scale": {
+              "type": "glam::vec3::Vec3",
+              "value": (1.0, 1.0, 1.0),
+            },
           },
         },
-      },
-      {
-        "type": "scene::ComponentA",
-        "struct": {
-          "x": {
-            "type": "f32",
-            "value": 1.0,
-          },
-          "y": {
-            "type": "f32",
-            "value": 2.0,
+        {
+          "type": "scene::ComponentB",
+          "struct": {
+            "value": {
+              "type": "alloc::string::String",
+              "value": "hello",
+            },
           },
         },
-      },
-    ],
-  ),
-  (
-    entity: 1,
-    components: [
-      {
-        "type": "scene::ComponentA",
-        "struct": {
-          "x": {
-            "type": "f32",
-            "value": 3.0,
-          },
-          "y": {
-            "type": "f32",
-            "value": 4.0,
+        {
+          "type": "scene::ComponentA",
+          "struct": {
+            "x": {
+              "type": "f32",
+              "value": 1.0,
+            },
+            "y": {
+              "type": "f32",
+              "value": 2.0,
+            },
           },
         },
-      },
-    ],
-  ),
-]
+      ],
+    ),
+    (
+      entity: 1,
+      components: [
+        {
+          "type": "scene::ComponentA",
+          "struct": {
+            "x": {
+              "type": "f32",
+              "value": 3.0,
+            },
+            "y": {
+              "type": "f32",
+              "value": 4.0,
+            },
+          },
+        },
+      ],
+    ),
+  ],
+)

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -19,4 +19,4 @@ bevy_asset = { path = "../bevy_asset", version = "0.5.0" }
 bevy_core = { path = "../bevy_core", version = "0.5.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.5.0" }
 bevy_render = { path = "../bevy_render", version = "0.5.0" }
-
+bevy_reflect = { path = "../bevy_reflect", version = "0.5.0" }

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -18,6 +18,7 @@ pub use main_pass_driver::*;
 use bevy_app::{App, Plugin};
 use bevy_core::FloatOrd;
 use bevy_ecs::prelude::*;
+use bevy_reflect::Reflect;
 use bevy_render::{
     camera::{ActiveCameras, CameraPlugin},
     color::Color,
@@ -34,7 +35,8 @@ use bevy_render::{
 };
 
 /// Resource that configures the clear color
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Reflect)]
+#[reflect(Resource)]
 pub struct ClearColor(pub Color);
 
 impl Default for ClearColor {
@@ -86,7 +88,8 @@ pub struct CorePipelinePlugin;
 
 impl Plugin for CorePipelinePlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<ClearColor>();
+        app.register_type::<ClearColor>()
+            .init_resource::<ClearColor>();
 
         let render_app = app.sub_app_mut(RenderApp);
         render_app

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -188,7 +188,7 @@ change_detection_impl!(Mut<'a, T>, T,);
 impl_into_inner!(Mut<'a, T>, T,);
 impl_debug!(Mut<'a, T>,);
 
-/// Unique mutable borrow of a Reflected component
+/// Unique mutable borrow of a reflected component or resource
 #[cfg(feature = "bevy_reflect")]
 pub struct ReflectMut<'a> {
     pub(crate) value: &'a mut dyn Reflect,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -18,7 +18,7 @@ pub mod world;
 pub mod prelude {
     #[doc(hidden)]
     #[cfg(feature = "bevy_reflect")]
-    pub use crate::reflect::ReflectComponent;
+    pub use crate::reflect::{ReflectComponent, ReflectResource};
     #[doc(hidden)]
     pub use crate::{
         bundle::Bundle,

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -4,6 +4,7 @@ pub use crate::change_detection::ReflectMut;
 use crate::{
     component::Component,
     entity::{Entity, EntityMap, MapEntities, MapEntitiesError},
+    system::Resource,
     world::{FromWorld, World},
 };
 use bevy_reflect::{
@@ -117,6 +118,82 @@ impl<C: Component + Reflect + FromWorld> FromType<C> for ReflectComponent {
                         value: c.value as &mut dyn Reflect,
                         ticks: c.ticks,
                     })
+            },
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ReflectResource {
+    insert_resource: fn(&mut World, &dyn Reflect),
+    apply_resource: fn(&mut World, &dyn Reflect),
+    remove_resource: fn(&mut World),
+    reflect_resource: fn(&World) -> Option<&dyn Reflect>,
+    reflect_resource_mut: unsafe fn(&World) -> Option<ReflectMut>,
+    copy_resource: fn(&World, &mut World),
+}
+
+impl ReflectResource {
+    pub fn insert_resource(&self, world: &mut World, resource: &dyn Reflect) {
+        (self.insert_resource)(world, resource);
+    }
+
+    pub fn apply_resource(&self, world: &mut World, resource: &dyn Reflect) {
+        (self.apply_resource)(world, resource);
+    }
+
+    pub fn remove_resource(&self, world: &mut World) {
+        (self.remove_resource)(world);
+    }
+
+    pub fn reflect_resource<'a>(&self, world: &'a World) -> Option<&'a dyn Reflect> {
+        (self.reflect_resource)(world)
+    }
+
+    /// # Safety
+    /// This method does not prevent you from having two mutable pointers to the same data,
+    /// violating Rust's aliasing rules. To avoid this:
+    /// * Only call this method in an exclusive system to avoid sharing across threads (or use a
+    ///   scheduler that enforces safe memory access).
+    /// * Don't call this method more than once in the same scope for a given resource.
+    pub unsafe fn reflect_resource_mut<'a>(&self, world: &'a World) -> Option<ReflectMut<'a>> {
+        (self.reflect_resource_mut)(world)
+    }
+
+    pub fn copy_resource(&self, source_world: &World, destination_world: &mut World) {
+        (self.copy_resource)(source_world, destination_world);
+    }
+}
+
+impl<C: Resource + Reflect + FromWorld> FromType<C> for ReflectResource {
+    fn from_type() -> Self {
+        ReflectResource {
+            insert_resource: |world, reflected_resource| {
+                let mut resource = C::from_world(world);
+                resource.apply(reflected_resource);
+                world.insert_resource(resource);
+            },
+            apply_resource: |world, reflected_resource| {
+                let mut resource = world.get_resource_mut::<C>().unwrap();
+                resource.apply(reflected_resource);
+            },
+            remove_resource: |world| {
+                world.remove_resource::<C>();
+            },
+            reflect_resource: |world| world.get_resource::<C>().map(|res| res as &dyn Reflect),
+            reflect_resource_mut: |world| unsafe {
+                world
+                    .get_resource_unchecked_mut::<C>()
+                    .map(|res| ReflectMut {
+                        value: res.value as &mut dyn Reflect,
+                        ticks: res.ticks,
+                    })
+            },
+            copy_resource: |source_world, destination_world| {
+                let source_resource = source_world.get_resource::<C>().unwrap();
+                let mut destination_resource = C::from_world(destination_world);
+                destination_resource.apply(source_resource);
+                destination_world.insert_resource(destination_resource);
             },
         }
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -644,21 +644,27 @@ impl World {
         Some(unsafe { ptr.cast::<T>().read() })
     }
 
+    /// Returns `true` if a resource of a given [`ComponentId`] exists. Otherwise returns `false`.
+    #[inline]
+    pub fn contains_resource_with_id(&self, component_id: ComponentId) -> bool {
+        self.get_populated_resource_column(component_id).is_some()
+    }
+
     /// Returns `true` if a resource of a given [`TypeId`] exists. Otherwise returns `false`.
     #[inline]
-    pub fn contains_resource_type_id(&self, type_id: TypeId) -> bool {
+    pub fn contains_resource_with_type(&self, type_id: TypeId) -> bool {
         let component_id = if let Some(component_id) = self.components.get_resource_id(type_id) {
             component_id
         } else {
             return false;
         };
-        self.get_populated_resource_column(component_id).is_some()
+        self.contains_resource_with_id(component_id)
     }
 
     /// Returns `true` if a resource of type `T` exists. Otherwise returns `false`.
     #[inline]
     pub fn contains_resource<T: Resource>(&self) -> bool {
-        self.contains_resource_type_id(TypeId::of::<T>())
+        self.contains_resource_with_type(TypeId::of::<T>())
     }
 
     /// Gets a reference to the resource of the given type, if it exists. Otherwise returns [None]

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -644,16 +644,21 @@ impl World {
         Some(unsafe { ptr.cast::<T>().read() })
     }
 
+    /// Returns `true` if a resource of a given [`TypeId`] exists. Otherwise returns `false`.
+    #[inline]
+    pub fn contains_resource_type_id(&self, type_id: TypeId) -> bool {
+        let component_id = if let Some(component_id) = self.components.get_resource_id(type_id) {
+            component_id
+        } else {
+            return false;
+        };
+        self.get_populated_resource_column(component_id).is_some()
+    }
+
     /// Returns `true` if a resource of type `T` exists. Otherwise returns `false`.
     #[inline]
     pub fn contains_resource<T: Resource>(&self) -> bool {
-        let component_id =
-            if let Some(component_id) = self.components.get_resource_id(TypeId::of::<T>()) {
-                component_id
-            } else {
-                return false;
-            };
-        self.get_populated_resource_column(component_id).is_some()
+        self.contains_resource_type_id(TypeId::of::<T>())
     }
 
     /// Gets a reference to the resource of the given type, if it exists. Otherwise returns [None]

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -69,10 +69,12 @@ impl Plugin for PbrPlugin {
 
         app.add_plugin(MeshRenderPlugin)
             .add_plugin(MaterialPlugin::<StandardMaterial>::default())
+            .register_type::<AmbientLight>()
+            .register_type::<DirectionalLightShadowMap>()
+            .register_type::<PointLightShadowMap>()
             .init_resource::<AmbientLight>()
             .init_resource::<DirectionalLightShadowMap>()
             .init_resource::<PointLightShadowMap>()
-            .init_resource::<AmbientLight>()
             .init_resource::<VisiblePointLights>()
             .add_system_to_stage(
                 CoreStage::PostUpdate,

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use bevy_ecs::prelude::*;
 use bevy_math::{Mat4, UVec2, UVec3, Vec2, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles};
+use bevy_reflect::Reflect;
 use bevy_render::{
     camera::{Camera, CameraProjection, OrthographicProjection},
     color::Color,
@@ -67,7 +68,8 @@ impl PointLight {
     pub const DEFAULT_SHADOW_NORMAL_BIAS: f32 = 0.6;
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Reflect)]
+#[reflect(Resource)]
 pub struct PointLightShadowMap {
     pub size: usize,
 }
@@ -144,7 +146,8 @@ impl DirectionalLight {
     pub const DEFAULT_SHADOW_NORMAL_BIAS: f32 = 0.6;
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Reflect)]
+#[reflect(Resource)]
 pub struct DirectionalLightShadowMap {
     pub size: usize,
 }
@@ -159,7 +162,8 @@ impl Default for DirectionalLightShadowMap {
 }
 
 /// An ambient light, which lights the entire scene equally.
-#[derive(Debug)]
+#[derive(Debug, Reflect)]
+#[reflect(Resource)]
 pub struct AmbientLight {
     pub color: Color,
     /// A direct scale factor multiplied with `color` before being passed to the shader.

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -29,7 +29,8 @@ impl Plugin for WireframePlugin {
             Shader::from_wgsl(include_str!("render/wireframe.wgsl")),
         );
 
-        app.init_resource::<WireframeConfig>();
+        app.register_type::<WireframeConfig>()
+            .init_resource::<WireframeConfig>();
 
         app.sub_app_mut(RenderApp)
             .add_render_command::<Opaque3d, DrawWireframes>()
@@ -58,7 +59,8 @@ fn extract_wireframes(mut commands: Commands, query: Query<Entity, With<Wirefram
 #[reflect(Component)]
 pub struct Wireframe;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Reflect)]
+#[reflect(Resource)]
 pub struct WireframeConfig {
     /// Whether to show wireframes for all meshes. If `false`, only meshes with a [Wireframe] component will be rendered.
     pub global: bool,

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -18,13 +18,16 @@ use crate::{
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
 use bevy_math::{Mat4, Vec3};
+use bevy_reflect::Reflect;
 use bevy_transform::components::GlobalTransform;
 
 pub struct ViewPlugin;
 
 impl Plugin for ViewPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<Msaa>().add_plugin(VisibilityPlugin);
+        app.register_type::<Msaa>()
+            .init_resource::<Msaa>()
+            .add_plugin(VisibilityPlugin);
 
         app.sub_app_mut(RenderApp)
             .init_resource::<ViewUniforms>()
@@ -37,7 +40,8 @@ impl Plugin for ViewPlugin {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Reflect)]
+#[reflect(Resource)]
 pub struct Msaa {
     /// The number of samples to run for Multi-Sample Anti-Aliasing. Higher numbers result in
     /// smoother edges. Note that WGPU currently only supports 1 or 4 samples.

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -36,13 +36,8 @@ impl DynamicScene {
         let mut scene = DynamicScene::default();
         let type_registry = type_registry.read();
 
-        let mut archetypes = world.archetypes().iter();
-
-        // Empty archetype
-        let _ = archetypes.next().unwrap();
-
         // Resources archetype
-        let resources_archetype = archetypes.next().unwrap();
+        let resources_archetype = world.archetypes().resource();
         for component_id in resources_archetype.components() {
             let reflect_resource = world
                 .components()
@@ -57,7 +52,11 @@ impl DynamicScene {
         }
 
         // Other archetypes
-        for archetype in archetypes {
+        for archetype in world.archetypes().iter() {
+            if archetype.entities().is_empty() {
+                continue;
+            }
+
             let entities_offset = scene.entities.len();
 
             // Create a new dynamic entity for each entity of the given archetype

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -116,7 +116,7 @@ impl DynamicScene {
                 }
             })?;
 
-            // If the entity already has the given resource attached,
+            // If the world already contains an instance of the given resource
             // just apply the (possibly) new value, otherwise insert the resource
             if world.contains_resource_type_id(registration.type_id()) {
                 reflect_resource.apply_resource(world, &**resource);

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -119,7 +119,7 @@ impl DynamicScene {
 
             // If the world already contains an instance of the given resource
             // just apply the (possibly) new value, otherwise insert the resource
-            if world.contains_resource_type_id(registration.type_id()) {
+            if world.contains_resource_with_type(registration.type_id()) {
                 reflect_resource.apply_resource(world, &**resource);
             } else {
                 reflect_resource.insert_resource(world, &**resource);

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -42,7 +42,8 @@ impl DynamicScene {
             let reflect_resource = world
                 .components()
                 .get_info(component_id)
-                .and_then(|info| type_registry.get(info.type_id().unwrap()))
+                .and_then(|info| info.type_id())
+                .and_then(|type_id| type_registry.get(type_id))
                 .and_then(|registration| registration.data::<ReflectResource>());
             if let Some(reflect_resource) = reflect_resource {
                 if let Some(resource) = reflect_resource.reflect_resource(world) {
@@ -73,7 +74,8 @@ impl DynamicScene {
                 let reflect_component = world
                     .components()
                     .get_info(component_id)
-                    .and_then(|info| type_registry.get(info.type_id().unwrap()))
+                    .and_then(|info| info.type_id())
+                    .and_then(|type_id| type_registry.get(type_id))
                     .and_then(|registration| registration.data::<ReflectComponent>());
                 if let Some(reflect_component) = reflect_component {
                     for (i, entity) in archetype.entities().iter().enumerate() {

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -161,13 +161,8 @@ impl SceneSpawner {
                         handle: scene_handle.clone(),
                     })?;
 
-            let mut archetypes = scene.world.archetypes().iter();
-
-            // Empty archetype
-            let _ = archetypes.next().unwrap();
-
             // Resources archetype
-            let resources_archetype = archetypes.next().unwrap();
+            let resources_archetype = scene.world.archetypes().resource();
             for component_id in resources_archetype.components() {
                 let component_info = scene
                     .world
@@ -193,7 +188,7 @@ impl SceneSpawner {
             }
 
             // Other archetypes
-            for archetype in archetypes {
+            for archetype in scene.world.archetypes().iter() {
                 for scene_entity in archetype.entities() {
                     let entity = *instance_info
                         .entity_map


### PR DESCRIPTION
# Objective

Fixes #3576.
Enables editors/inspectors to show and edit resources.

## Solution

- change the scene format to include resources:
```rust
(
  resources: [
    // List of resources here, same fomat as an entity's list of components
  ],
  entities: [
    // Previous scene format here
  ],
)
```
- enable reflection on a resource type (by adding `ReflectResource`)
```rust
#[derive(Reflect)]
#[reflect(Resource)]
struct MyResourse;
```
- add a vec of reflected resources to `DynamicScene`s and implement their (de)serialization
- adapt `Scene`s and `DynamicScene`s to actually import/export reflected resources from the world

## Remaining work

- [ ] write some tests
- [ ] modify the scene example to show resources too
- [x] gather feedback on a list of bevy's resources that should be reflected

## Notes

I ignored non send resources as I don't think they should be loaded from scenes, but it may make sense to reflect them so that they are accessible to editors/inspectors.