### PR TITLE
[Merged by Bors] - Remove tests from example style guide

### DIFF
--- a/.github/contributing/example_style_guide.md
+++ b/.github/contributing/example_style_guide.md
@@ -11,8 +11,8 @@ For more advice on writing examples, see the [relevant section](../../CONTRIBUTI
    1. Imports
    2. A `fn main()` block
    3. Example logic
-   4. \[Optional\] Tests
 5. Try to structure app / plugin construction in the same fashion as the actual code.
+6. Examples should typically not have tests, as they are not directly reusable by the Bevy user.
 
 ## Stylistic preferences
 


### PR DESCRIPTION
# Objective

- Consensus has emerged that examples shouldn't have tests.

## Solution

- Discourage tests in examples.