### PR TITLE
Fix ANSI colors in chrome and tracy traces

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -97,8 +97,15 @@ impl Plugin for LogPlugin {
 
         #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
         {
+            let fmt_layer = tracing_subscriber::fmt::Layer::default();
+
+            #[cfg(any(feature = "tracing-chrome", feature = "tracing-tracy"))]
+            let fmt_layer = fmt_layer.with_ansi(false);
+
+            let subscriber = subscriber.with(fmt_layer);
+
             #[cfg(feature = "tracing-chrome")]
-            let chrome_layer = {
+            let subscriber = {
                 let (chrome_layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
                     .name_fn(Box::new(|event_or_span| match event_or_span {
                         tracing_chrome::EventOrSpan::Event(event) => event.metadata().name().into(),
@@ -114,19 +121,11 @@ impl Plugin for LogPlugin {
                     }))
                     .build();
                 app.world.insert_non_send(guard);
-                chrome_layer
+                subscriber.with(chrome_layer)
             };
 
             #[cfg(feature = "tracing-tracy")]
-            let tracy_layer = tracing_tracy::TracyLayer::new();
-
-            let fmt_layer = tracing_subscriber::fmt::Layer::default();
-            let subscriber = subscriber.with(fmt_layer);
-
-            #[cfg(feature = "tracing-chrome")]
-            let subscriber = subscriber.with(chrome_layer);
-            #[cfg(feature = "tracing-tracy")]
-            let subscriber = subscriber.with(tracy_layer);
+            let subscriber = subscriber.with(tracing_tracy::TracyLayer::new());
 
             bevy_utils::tracing::subscriber::set_global_default(subscriber)
                 .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");


### PR DESCRIPTION
# Objective

Fix ANSI colors in chrome and tracy traces, at the cost of losing ANSI colors in logs to stdout when trace_chrome or trace_tracy features are used.

Note: enabling trace features alters the output logs in other undesirable ways. I think we might need separate subscribers or something to fix that.

Fixes #3563

## Solution

Add `.with_ansi(false)` to the "fmt layer" when `trace_chrome` or `trace_tracy` are enabled.

I'd appreciate someone checking the `tracy` output, as I wasn't able to test that (except to see that bevy still builds with that feature)