### PR TITLE
[Merged by Bors] - Thread local example cleanup

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -71,7 +71,7 @@ impl Default for App {
 
         app.add_default_stages()
             .add_event::<AppExit>()
-            .add_system_to_stage(CoreStage::Last, World::clear_trackers);
+            .add_system_to_stage(CoreStage::Last, World::clear_trackers.exclusive_system());
 
         #[cfg(feature = "bevy_ci_testing")]
         {

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -71,7 +71,7 @@ impl Default for App {
 
         app.add_default_stages()
             .add_event::<AppExit>()
-            .add_system_to_stage(CoreStage::Last, World::clear_trackers.exclusive_system());
+            .add_system_to_stage(CoreStage::Last, World::clear_trackers);
 
         #[cfg(feature = "bevy_ci_testing")]
         {

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -333,7 +333,7 @@ fn main() {
             MyStage::BeforeRound,
             exclusive_player_system.exclusive_system(),
         )
-        // Systems which take a `World` as an argument must call `.exclusive_system()`.
+        // Systems which take `&mut World` as an argument must call `.exclusive_system()`.
         // The following will not compile.
         //.add_system_to_stage(MyStage::BeforeRound, exclusive_player_system)
         //

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -329,6 +329,10 @@ fn main() {
         )
         .add_system_to_stage(MyStage::BeforeRound, new_round_system)
         .add_system_to_stage(MyStage::BeforeRound, new_player_system)
+        .add_system_to_stage(
+            MyStage::BeforeRound,
+            exclusive_player_system.exclusive_system(),
+        )
         // Systems which take a `World` as an argument must call `.exclusive_system()`.
         // The following will not compile.
         //.add_system_to_stage(MyStage::BeforeRound, exclusive_player_system)

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -198,12 +198,12 @@ fn new_player_system(
     }
 }
 
-// If you really need full, immediate read/write access to the world or resources, you can use a
-// "thread local system". These run on the main app thread (hence the name "thread local")
+// If you really need full, immediate read/write access to the world or resources, you can use an
+// "exclusive system".
 // WARNING: These will block all parallel execution of other systems until they finish, so they
-// should generally be avoided if you care about performance
+// should generally be avoided if you care about performance.
 #[allow(dead_code)]
-fn thread_local_system(world: &mut World) {
+fn exclusive_player_system(world: &mut World) {
     // this does the same thing as "new_player_system"
     let total_players = world.get_resource_mut::<GameState>().unwrap().total_players;
     let should_add_player = {
@@ -329,6 +329,10 @@ fn main() {
         )
         .add_system_to_stage(MyStage::BeforeRound, new_round_system)
         .add_system_to_stage(MyStage::BeforeRound, new_player_system)
+        // Systems which take a `World` as an argument must call `.exclusive_system()`.
+        // The following will not compile.
+        //.add_system_to_stage(MyStage::BeforeRound, exclusive_player_system)
+        //
         // We can ensure that game_over system runs after score_check_system using explicit ordering
         // constraints First, we label the system we want to refer to using `.label`
         // Then, we use either `.before` or `.after` to describe the order we want the relationship


### PR DESCRIPTION
# Objective

Fixes #1917

## Solution

- Change use of "thread local system" wording to "exclusive system".
- Add .exclusive_system() call to example.
