### PR TITLE
Better render graph

### DIFF
--- a/crates/bevy_core_pipeline/src/clear_pass.rs
+++ b/crates/bevy_core_pipeline/src/clear_pass.rs
@@ -33,20 +33,13 @@ impl ClearPassNode {
 }
 
 impl Node for ClearPassNode {
-    fn input(&self) -> Vec<SlotInfo> {
-        vec![]
-    }
 
     fn update(&mut self, world: &mut World) {
         self.query.update_archetypes(world);
     }
 
-    fn run(
-        &self,
-        _graph: &mut RenderGraphContext,
-        render_context: &mut RenderContext,
-        world: &World,
-    ) -> Result<(), NodeRunError> {
+    fn record(&self, graph: &RenderGraphContext, render_context: &mut RenderContext, world: &World) -> Result<(), NodeRunError> {
+        
         let mut cleared_windows = HashSet::new();
         let clear_color = world.get_resource::<ClearColor>().unwrap();
 

--- a/crates/bevy_core_pipeline/src/clear_pass.rs
+++ b/crates/bevy_core_pipeline/src/clear_pass.rs
@@ -4,7 +4,7 @@ use crate::ClearColor;
 use bevy_ecs::prelude::*;
 use bevy_render::{
     camera::ExtractedCamera,
-    render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo},
+    render_graph::{Node, NodeRunError, RenderGraphContext},
     render_resource::{
         LoadOp, Operations, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
         RenderPassDescriptor,
@@ -33,13 +33,16 @@ impl ClearPassNode {
 }
 
 impl Node for ClearPassNode {
-
     fn update(&mut self, world: &mut World) {
         self.query.update_archetypes(world);
     }
 
-    fn record(&self, graph: &RenderGraphContext, render_context: &mut RenderContext, world: &World) -> Result<(), NodeRunError> {
-        
+    fn record(
+        &self,
+        _graph: &RenderGraphContext,
+        render_context: &mut RenderContext,
+        world: &World,
+    ) -> Result<(), NodeRunError> {
         let mut cleared_windows = HashSet::new();
         let clear_color = world.get_resource::<ClearColor>().unwrap();
 

--- a/crates/bevy_core_pipeline/src/clear_pass_driver.rs
+++ b/crates/bevy_core_pipeline/src/clear_pass_driver.rs
@@ -7,10 +7,13 @@ use bevy_render::{
 pub struct ClearPassDriverNode;
 
 impl Node for ClearPassDriverNode {
-    fn queue_graphs(&self, graph: &RenderGraphContext, world: &World) -> Result<bevy_render::render_graph::RunSubGraphs, NodeRunError> {
-        
+    fn queue_graphs(
+        &self,
+        graph: &RenderGraphContext,
+        world: &World,
+    ) -> Result<bevy_render::render_graph::RunSubGraphs, NodeRunError> {
         let mut sub_graph_runs = RunSubGraphs::default();
-        sub_graph_runs.run(crate::clear_graph::NAME, SlotValues::empty());
+        sub_graph_runs.run(graph, crate::clear_graph::NAME, SlotValues::empty());
 
         Ok(sub_graph_runs)
     }

--- a/crates/bevy_core_pipeline/src/clear_pass_driver.rs
+++ b/crates/bevy_core_pipeline/src/clear_pass_driver.rs
@@ -1,20 +1,17 @@
 use bevy_ecs::world::World;
 use bevy_render::{
-    render_graph::{Node, NodeRunError, RenderGraphContext},
+    render_graph::{Node, NodeRunError, RenderGraphContext, RunSubGraphs, SlotValues},
     renderer::RenderContext,
 };
 
 pub struct ClearPassDriverNode;
 
 impl Node for ClearPassDriverNode {
-    fn run(
-        &self,
-        graph: &mut RenderGraphContext,
-        _render_context: &mut RenderContext,
-        _world: &World,
-    ) -> Result<(), NodeRunError> {
-        graph.run_sub_graph(crate::clear_graph::NAME, vec![])?;
+    fn queue_graphs(&self, graph: &RenderGraphContext, world: &World) -> Result<bevy_render::render_graph::RunSubGraphs, NodeRunError> {
+        
+        let mut sub_graph_runs = RunSubGraphs::default();
+        sub_graph_runs.run(crate::clear_graph::NAME, SlotValues::empty());
 
-        Ok(())
+        Ok(sub_graph_runs)
     }
 }

--- a/crates/bevy_core_pipeline/src/clear_pass_driver.rs
+++ b/crates/bevy_core_pipeline/src/clear_pass_driver.rs
@@ -1,8 +1,5 @@
 use bevy_ecs::world::World;
-use bevy_render::{
-    render_graph::{Node, NodeRunError, RenderGraphContext, RunSubGraphs, SlotValues},
-    renderer::RenderContext,
-};
+use bevy_render::render_graph::{Node, NodeRunError, RenderGraphContext, RunSubGraphs, SlotValues};
 
 pub struct ClearPassDriverNode;
 
@@ -10,10 +7,10 @@ impl Node for ClearPassDriverNode {
     fn queue_graphs(
         &self,
         graph: &RenderGraphContext,
-        world: &World,
+        _world: &World,
     ) -> Result<bevy_render::render_graph::RunSubGraphs, NodeRunError> {
         let mut sub_graph_runs = RunSubGraphs::default();
-        sub_graph_runs.run(graph, crate::clear_graph::NAME, SlotValues::empty());
+        sub_graph_runs.run(graph, crate::clear_graph::NAME, SlotValues::empty())?;
 
         Ok(sub_graph_runs)
     }

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -21,7 +21,7 @@ use bevy_ecs::prelude::*;
 use bevy_render::{
     camera::{ActiveCameras, CameraPlugin},
     color::Color,
-    render_graph::{EmptyNode, RenderGraph, RenderGraphs, SlotInfo, SlotType},
+    render_graph::{EmptyNode, RenderGraph, RenderGraphs},
     render_phase::{
         sort_phase_system, CachedPipelinePhaseItem, DrawFunctionId, DrawFunctions, EntityPhaseItem,
         PhaseItem, RenderPhase,

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -109,34 +109,11 @@ impl Plugin for CorePipelinePlugin {
 
         let mut draw_2d_graph = RenderGraph::default();
         draw_2d_graph.add_node(draw_2d_graph::node::MAIN_PASS, pass_node_2d);
-        let input_node_id = draw_2d_graph.set_input(vec![SlotInfo::new(
-            draw_2d_graph::input::VIEW_ENTITY,
-            SlotType::Entity,
-        )]);
-        draw_2d_graph
-            .add_slot_edge(
-                input_node_id,
-                draw_2d_graph::input::VIEW_ENTITY,
-                draw_2d_graph::node::MAIN_PASS,
-                MainPass2dNode::IN_VIEW,
-            )
-            .unwrap();
+        
         graph.add_sub_graph(draw_2d_graph::NAME, draw_2d_graph);
 
         let mut draw_3d_graph = RenderGraph::default();
         draw_3d_graph.add_node(draw_3d_graph::node::MAIN_PASS, pass_node_3d);
-        let input_node_id = draw_3d_graph.set_input(vec![SlotInfo::new(
-            draw_3d_graph::input::VIEW_ENTITY,
-            SlotType::Entity,
-        )]);
-        draw_3d_graph
-            .add_slot_edge(
-                input_node_id,
-                draw_3d_graph::input::VIEW_ENTITY,
-                draw_3d_graph::node::MAIN_PASS,
-                MainPass3dNode::IN_VIEW,
-            )
-            .unwrap();
         graph.add_sub_graph(draw_3d_graph::NAME, draw_3d_graph);
 
         let mut clear_graph = RenderGraph::default();
@@ -146,11 +123,11 @@ impl Plugin for CorePipelinePlugin {
         graph.add_node(node::MAIN_PASS_DEPENDENCIES, EmptyNode);
         graph.add_node(node::MAIN_PASS_DRIVER, MainPassDriverNode);
         graph
-            .add_node_edge(node::MAIN_PASS_DEPENDENCIES, node::MAIN_PASS_DRIVER)
+            .add_edge(node::MAIN_PASS_DEPENDENCIES, node::MAIN_PASS_DRIVER)
             .unwrap();
         graph.add_node(node::CLEAR_PASS_DRIVER, ClearPassDriverNode);
         graph
-            .add_node_edge(node::CLEAR_PASS_DRIVER, node::MAIN_PASS_DRIVER)
+            .add_edge(node::CLEAR_PASS_DRIVER, node::MAIN_PASS_DRIVER)
             .unwrap();
     }
 }

--- a/crates/bevy_core_pipeline/src/main_pass_2d.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_2d.rs
@@ -1,7 +1,7 @@
 use crate::Transparent2d;
 use bevy_ecs::prelude::*;
 use bevy_render::{
-    render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
+    render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType, SlotInfos},
     render_phase::{DrawFunctions, RenderPhase, TrackedRenderPass},
     render_resource::{LoadOp, Operations, RenderPassColorAttachment, RenderPassDescriptor},
     renderer::RenderContext,
@@ -24,21 +24,18 @@ impl MainPass2dNode {
 }
 
 impl Node for MainPass2dNode {
-    fn input(&self) -> Vec<SlotInfo> {
-        vec![SlotInfo::new(MainPass2dNode::IN_VIEW, SlotType::Entity)]
+    fn slot_requirements(&self) -> SlotInfos {
+        
+        vec![SlotInfo::new(MainPass2dNode::IN_VIEW, SlotType::Entity)].into()
     }
 
     fn update(&mut self, world: &mut World) {
         self.query.update_archetypes(world);
     }
 
-    fn run(
-        &self,
-        graph: &mut RenderGraphContext,
-        render_context: &mut RenderContext,
-        world: &World,
-    ) -> Result<(), NodeRunError> {
-        let view_entity = graph.get_input_entity(Self::IN_VIEW)?;
+    fn record(&self, graph: &RenderGraphContext, render_context: &mut RenderContext, world: &World) -> Result<(), NodeRunError> {
+        
+        let view_entity = *graph.get_entity(Self::IN_VIEW)?;
         let (transparent_phase, target) = self
             .query
             .get_manual(world, view_entity)

--- a/crates/bevy_core_pipeline/src/main_pass_2d.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_2d.rs
@@ -1,4 +1,4 @@
-use crate::Transparent2d;
+use crate::{draw_2d_graph, Transparent2d};
 use bevy_ecs::prelude::*;
 use bevy_render::{
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotInfos, SlotType},
@@ -14,7 +14,7 @@ pub struct MainPass2dNode {
 }
 
 impl MainPass2dNode {
-    pub const IN_VIEW: &'static str = "view";
+    pub const IN_VIEW: &'static str = draw_2d_graph::input::VIEW_ENTITY;
 
     pub fn new(world: &mut World) -> Self {
         Self {

--- a/crates/bevy_core_pipeline/src/main_pass_2d.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_2d.rs
@@ -1,7 +1,7 @@
 use crate::Transparent2d;
 use bevy_ecs::prelude::*;
 use bevy_render::{
-    render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType, SlotInfos},
+    render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotInfos, SlotType},
     render_phase::{DrawFunctions, RenderPhase, TrackedRenderPass},
     render_resource::{LoadOp, Operations, RenderPassColorAttachment, RenderPassDescriptor},
     renderer::RenderContext,
@@ -25,7 +25,6 @@ impl MainPass2dNode {
 
 impl Node for MainPass2dNode {
     fn slot_requirements(&self) -> SlotInfos {
-        
         vec![SlotInfo::new(MainPass2dNode::IN_VIEW, SlotType::Entity)].into()
     }
 
@@ -33,8 +32,12 @@ impl Node for MainPass2dNode {
         self.query.update_archetypes(world);
     }
 
-    fn record(&self, graph: &RenderGraphContext, render_context: &mut RenderContext, world: &World) -> Result<(), NodeRunError> {
-        
+    fn record(
+        &self,
+        graph: &RenderGraphContext,
+        render_context: &mut RenderContext,
+        world: &World,
+    ) -> Result<(), NodeRunError> {
         let view_entity = *graph.get_entity(Self::IN_VIEW)?;
         let (transparent_phase, target) = self
             .query

--- a/crates/bevy_core_pipeline/src/main_pass_3d.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_3d.rs
@@ -1,4 +1,4 @@
-use crate::{AlphaMask3d, Opaque3d, Transparent3d};
+use crate::{draw_3d_graph, AlphaMask3d, Opaque3d, Transparent3d};
 use bevy_ecs::prelude::*;
 use bevy_render::{
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotInfos, SlotType},
@@ -22,7 +22,7 @@ pub struct MainPass3dNode {
 }
 
 impl MainPass3dNode {
-    pub const IN_VIEW: &'static str = "view";
+    pub const IN_VIEW: &'static str = draw_3d_graph::input::VIEW_ENTITY;
 
     pub fn new(world: &mut World) -> Self {
         Self {

--- a/crates/bevy_core_pipeline/src/main_pass_3d.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_3d.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use crate::{AlphaMask3d, Opaque3d, Transparent3d};
 use bevy_ecs::prelude::*;
 use bevy_render::{
-    render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType, SlotInfos},
+    render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotInfos, SlotType},
     render_phase::{DrawFunctions, RenderPhase, TrackedRenderPass},
     render_resource::{LoadOp, Operations, RenderPassDepthStencilAttachment, RenderPassDescriptor},
     renderer::RenderContext,
@@ -42,8 +42,12 @@ impl Node for MainPass3dNode {
         self.query.update_archetypes(world);
     }
 
-    fn record(&self, graph: &RenderGraphContext, render_context: &mut RenderContext, world: &World) -> Result<(), NodeRunError> {
-        
+    fn record(
+        &self,
+        graph: &RenderGraphContext,
+        render_context: &mut RenderContext,
+        world: &World,
+    ) -> Result<(), NodeRunError> {
         let view_entity = *graph.get_entity(Self::IN_VIEW)?;
         let (opaque_phase, alpha_mask_phase, transparent_phase, target, depth) =
             match self.query.get_manual(world, view_entity) {

--- a/crates/bevy_core_pipeline/src/main_pass_3d.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_3d.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::{AlphaMask3d, Opaque3d, Transparent3d};
 use bevy_ecs::prelude::*;
 use bevy_render::{

--- a/crates/bevy_core_pipeline/src/main_pass_3d.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_3d.rs
@@ -1,7 +1,9 @@
+use std::borrow::Cow;
+
 use crate::{AlphaMask3d, Opaque3d, Transparent3d};
 use bevy_ecs::prelude::*;
 use bevy_render::{
-    render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
+    render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType, SlotInfos},
     render_phase::{DrawFunctions, RenderPhase, TrackedRenderPass},
     render_resource::{LoadOp, Operations, RenderPassDepthStencilAttachment, RenderPassDescriptor},
     renderer::RenderContext,
@@ -32,21 +34,17 @@ impl MainPass3dNode {
 }
 
 impl Node for MainPass3dNode {
-    fn input(&self) -> Vec<SlotInfo> {
-        vec![SlotInfo::new(MainPass3dNode::IN_VIEW, SlotType::Entity)]
+    fn slot_requirements(&self) -> SlotInfos {
+        vec![SlotInfo::new(MainPass3dNode::IN_VIEW, SlotType::Entity)].into()
     }
 
     fn update(&mut self, world: &mut World) {
         self.query.update_archetypes(world);
     }
 
-    fn run(
-        &self,
-        graph: &mut RenderGraphContext,
-        render_context: &mut RenderContext,
-        world: &World,
-    ) -> Result<(), NodeRunError> {
-        let view_entity = graph.get_input_entity(Self::IN_VIEW)?;
+    fn record(&self, graph: &RenderGraphContext, render_context: &mut RenderContext, world: &World) -> Result<(), NodeRunError> {
+        
+        let view_entity = *graph.get_entity(Self::IN_VIEW)?;
         let (opaque_phase, alpha_mask_phase, transparent_phase, target, depth) =
             match self.query.get_manual(world, view_entity) {
                 Ok(query) => query,

--- a/crates/bevy_core_pipeline/src/main_pass_driver.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_driver.rs
@@ -4,6 +4,8 @@ use bevy_render::{
     render_graph::{Node, NodeRunError, RenderGraphContext, RunSubGraphs, SlotValue},
 };
 
+use crate::draw_2d_graph;
+
 pub struct MainPassDriverNode;
 
 impl Node for MainPassDriverNode {
@@ -19,7 +21,10 @@ impl Node for MainPassDriverNode {
             sub_graph_runs.run(
                 graph,
                 crate::draw_2d_graph::NAME,
-                vec![("view", SlotValue::Entity(*camera_2d))],
+                vec![(
+                    crate::draw_2d_graph::input::VIEW_ENTITY,
+                    SlotValue::Entity(*camera_2d),
+                )],
             )?;
         }
 
@@ -27,7 +32,10 @@ impl Node for MainPassDriverNode {
             sub_graph_runs.run(
                 graph,
                 crate::draw_3d_graph::NAME,
-                vec![("view", SlotValue::Entity(*camera_3d))],
+                vec![(
+                    crate::draw_3d_graph::input::VIEW_ENTITY,
+                    SlotValue::Entity(*camera_3d),
+                )],
             )?;
         }
 

--- a/crates/bevy_core_pipeline/src/main_pass_driver.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_driver.rs
@@ -1,20 +1,24 @@
 use bevy_ecs::world::World;
 use bevy_render::{
     camera::{CameraPlugin, ExtractedCameraNames},
-    render_graph::{Node, NodeRunError, RenderGraphContext, SlotValue, RunSubGraphs},
+    render_graph::{Node, NodeRunError, RenderGraphContext, RunSubGraphs, SlotValue},
     renderer::RenderContext,
 };
 
 pub struct MainPassDriverNode;
 
 impl Node for MainPassDriverNode {
-
-    fn queue_graphs(&self, graph: &RenderGraphContext, world: &World) -> Result<RunSubGraphs, NodeRunError> {
+    fn queue_graphs(
+        &self,
+        graph: &RenderGraphContext,
+        world: &World,
+    ) -> Result<RunSubGraphs, NodeRunError> {
         let extracted_cameras = world.get_resource::<ExtractedCameraNames>().unwrap();
         let mut sub_graph_runs = RunSubGraphs::default();
 
         if let Some(camera_2d) = extracted_cameras.entities.get(CameraPlugin::CAMERA_2D) {
             sub_graph_runs.run(
+                graph,
                 crate::draw_2d_graph::NAME,
                 vec![("view", SlotValue::Entity(*camera_2d))],
             );
@@ -22,6 +26,7 @@ impl Node for MainPassDriverNode {
 
         if let Some(camera_3d) = extracted_cameras.entities.get(CameraPlugin::CAMERA_3D) {
             sub_graph_runs.run(
+                graph,
                 crate::draw_3d_graph::NAME,
                 vec![("view", SlotValue::Entity(*camera_3d))],
             );
@@ -29,5 +34,4 @@ impl Node for MainPassDriverNode {
 
         Ok(sub_graph_runs)
     }
-
 }

--- a/crates/bevy_core_pipeline/src/main_pass_driver.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_driver.rs
@@ -2,7 +2,6 @@ use bevy_ecs::world::World;
 use bevy_render::{
     camera::{CameraPlugin, ExtractedCameraNames},
     render_graph::{Node, NodeRunError, RenderGraphContext, RunSubGraphs, SlotValue},
-    renderer::RenderContext,
 };
 
 pub struct MainPassDriverNode;
@@ -21,7 +20,7 @@ impl Node for MainPassDriverNode {
                 graph,
                 crate::draw_2d_graph::NAME,
                 vec![("view", SlotValue::Entity(*camera_2d))],
-            );
+            )?;
         }
 
         if let Some(camera_3d) = extracted_cameras.entities.get(CameraPlugin::CAMERA_3D) {
@@ -29,7 +28,7 @@ impl Node for MainPassDriverNode {
                 graph,
                 crate::draw_3d_graph::NAME,
                 vec![("view", SlotValue::Entity(*camera_3d))],
-            );
+            )?;
         }
 
         Ok(sub_graph_runs)

--- a/crates/bevy_core_pipeline/src/main_pass_driver.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_driver.rs
@@ -4,8 +4,6 @@ use bevy_render::{
     render_graph::{Node, NodeRunError, RenderGraphContext, RunSubGraphs, SlotValue},
 };
 
-use crate::draw_2d_graph;
-
 pub struct MainPassDriverNode;
 
 impl Node for MainPassDriverNode {

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -38,11 +38,11 @@ use bevy_ecs::prelude::*;
 use bevy_reflect::TypeUuid;
 use bevy_render::{
     prelude::Color,
-    render_graph::RenderGraph,
+    render_graph::{RenderGraph, RenderGraphs},
     render_phase::{sort_phase_system, AddRenderCommand, DrawFunctions},
     render_resource::{Shader, SpecializedPipelines},
     view::VisibilitySystems,
-    RenderApp, RenderStage,
+    RenderApp, RenderStage, MAIN_GRAPH_ID,
 };
 use bevy_transform::TransformSystem;
 
@@ -179,9 +179,9 @@ impl Plugin for PbrPlugin {
 
         let shadow_pass_node = ShadowPassNode::new(&mut render_app.world);
         render_app.add_render_command::<Shadow, DrawShadowMesh>();
-        let mut graph = render_app.world.get_resource_mut::<RenderGraph>().unwrap();
-        let draw_3d_graph = graph
-            .get_sub_graph_mut(bevy_core_pipeline::draw_3d_graph::NAME)
+        let mut graphs = render_app.world.get_resource_mut::<RenderGraphs>().unwrap();
+        let draw_3d_graph = graphs
+            .get_graph_mut(bevy_core_pipeline::draw_3d_graph::NAME)
             .unwrap();
         draw_3d_graph.add_node(draw_3d_graph::node::SHADOW_PASS, shadow_pass_node);
         draw_3d_graph

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -38,11 +38,11 @@ use bevy_ecs::prelude::*;
 use bevy_reflect::TypeUuid;
 use bevy_render::{
     prelude::Color,
-    render_graph::{RenderGraph, RenderGraphs},
+    render_graph::RenderGraphs,
     render_phase::{sort_phase_system, AddRenderCommand, DrawFunctions},
     render_resource::{Shader, SpecializedPipelines},
     view::VisibilitySystems,
-    RenderApp, RenderStage, MAIN_GRAPH_ID,
+    RenderApp, RenderStage,
 };
 use bevy_transform::TransformSystem;
 

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -185,17 +185,9 @@ impl Plugin for PbrPlugin {
             .unwrap();
         draw_3d_graph.add_node(draw_3d_graph::node::SHADOW_PASS, shadow_pass_node);
         draw_3d_graph
-            .add_node_edge(
+            .add_edge(
                 draw_3d_graph::node::SHADOW_PASS,
                 bevy_core_pipeline::draw_3d_graph::node::MAIN_PASS,
-            )
-            .unwrap();
-        draw_3d_graph
-            .add_slot_edge(
-                draw_3d_graph.input_node().unwrap().id,
-                bevy_core_pipeline::draw_3d_graph::input::VIEW_ENTITY,
-                draw_3d_graph::node::SHADOW_PASS,
-                ShadowPassNode::IN_VIEW,
             )
             .unwrap();
     }

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -17,7 +17,7 @@ use bevy_render::{
     mesh::Mesh,
     options::WgpuOptions,
     render_asset::RenderAssets,
-    render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
+    render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType, SlotInfos},
     render_phase::{
         CachedPipelinePhaseItem, DrawFunctionId, DrawFunctions, EntityPhaseItem,
         EntityRenderCommand, PhaseItem, RenderCommandResult, RenderPhase, SetItemPipeline,
@@ -1164,8 +1164,9 @@ impl ShadowPassNode {
 }
 
 impl Node for ShadowPassNode {
-    fn input(&self) -> Vec<SlotInfo> {
-        vec![SlotInfo::new(ShadowPassNode::IN_VIEW, SlotType::Entity)]
+    fn slot_requirements(&self) -> SlotInfos {
+        
+        vec![SlotInfo::new(ShadowPassNode::IN_VIEW, SlotType::Entity)].into()
     }
 
     fn update(&mut self, world: &mut World) {
@@ -1173,13 +1174,10 @@ impl Node for ShadowPassNode {
         self.view_light_query.update_archetypes(world);
     }
 
-    fn run(
-        &self,
-        graph: &mut RenderGraphContext,
-        render_context: &mut RenderContext,
-        world: &World,
-    ) -> Result<(), NodeRunError> {
-        let view_entity = graph.get_input_entity(Self::IN_VIEW)?;
+    fn record(&self, graph: &RenderGraphContext, render_context: &mut RenderContext, world: &World) -> Result<(), NodeRunError> {
+        
+        let view_entity = *graph.get_entity(Self::IN_VIEW)?;
+
         if let Ok(view_lights) = self.main_view_query.get_manual(world, view_entity) {
             for view_light_entity in view_lights.lights.iter().copied() {
                 let (view_light, shadow_phase) = self

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -17,7 +17,7 @@ use bevy_render::{
     mesh::Mesh,
     options::WgpuOptions,
     render_asset::RenderAssets,
-    render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType, SlotInfos},
+    render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotInfos, SlotType},
     render_phase::{
         CachedPipelinePhaseItem, DrawFunctionId, DrawFunctions, EntityPhaseItem,
         EntityRenderCommand, PhaseItem, RenderCommandResult, RenderPhase, SetItemPipeline,
@@ -1165,7 +1165,6 @@ impl ShadowPassNode {
 
 impl Node for ShadowPassNode {
     fn slot_requirements(&self) -> SlotInfos {
-        
         vec![SlotInfo::new(ShadowPassNode::IN_VIEW, SlotType::Entity)].into()
     }
 
@@ -1174,8 +1173,12 @@ impl Node for ShadowPassNode {
         self.view_light_query.update_archetypes(world);
     }
 
-    fn record(&self, graph: &RenderGraphContext, render_context: &mut RenderContext, world: &World) -> Result<(), NodeRunError> {
-        
+    fn record(
+        &self,
+        graph: &RenderGraphContext,
+        render_context: &mut RenderContext,
+        world: &World,
+    ) -> Result<(), NodeRunError> {
         let view_entity = *graph.get_entity(Self::IN_VIEW)?;
 
         if let Ok(view_lights) = self.main_view_query.get_manual(world, view_entity) {

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use bevy_asset::Handle;
 use bevy_core::FloatOrd;
-use bevy_core_pipeline::Transparent3d;
+use bevy_core_pipeline::{draw_3d_graph, Transparent3d};
 use bevy_ecs::{
     prelude::*,
     system::{lifetimeless::*, SystemParamItem},
@@ -1153,7 +1153,7 @@ pub struct ShadowPassNode {
 }
 
 impl ShadowPassNode {
-    pub const IN_VIEW: &'static str = "view";
+    pub const IN_VIEW: &'static str = draw_3d_graph::input::VIEW_ENTITY;
 
     pub fn new(world: &mut World) -> Self {
         Self {

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -33,6 +33,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.5.0", features = ["bevy"
 bevy_transform = { path = "../bevy_transform", version = "0.5.0" }
 bevy_window = { path = "../bevy_window", version = "0.5.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.5.0" }
+bevy_tasks = { path = "../bevy_tasks", version = "0.5.0" }
 
 # rendering
 image = { version = "0.23.12", default-features = false }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -33,7 +33,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", features = ["bevy"
 bevy_transform = { path = "../bevy_transform", version = "0.6.0" }
 bevy_window = { path = "../bevy_window", version = "0.6.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
-
+bevy_tasks = { path = "../bevy_tasks", version = "0.6.0"}
 # rendering
 image = { version = "0.23.12", default-features = false }
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -176,7 +176,10 @@ impl Plugin for RenderPlugin {
                 .insert_resource(options)
                 .insert_resource(render_pipeline_cache)
                 .insert_resource(asset_server)
-                .init_resource::<RenderGraph>();
+                .init_resource::<RenderGraphs>();
+
+            let mut graphs = render_app.world.get_resource_mut::<RenderGraphs>().unwrap();
+            graphs.add_graph(RenderGraph::new(MAIN_GRAPH_ID));
 
             app.add_sub_app(RenderApp, render_app, move |app_world, render_app| {
                 #[cfg(feature = "trace")]

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -29,13 +29,14 @@ pub mod prelude {
 
 use bevy_utils::tracing::debug;
 pub use once_cell;
+use render_graph::RenderGraphId;
 
 use crate::{
     camera::CameraPlugin,
     color::Color,
     mesh::MeshPlugin,
     primitives::{CubemapFrusta, Frustum},
-    render_graph::RenderGraph,
+    render_graph::{RenderGraph, RenderGraphs},
     render_resource::{RenderPipelineCache, Shader, ShaderLoader},
     renderer::render_system,
     texture::ImagePlugin,
@@ -105,6 +106,8 @@ pub struct RenderApp;
 #[derive(Default)]
 struct ScratchRenderWorld(World);
 
+pub const MAIN_GRAPH_ID: &'static str = "main_graph";
+
 impl Plugin for RenderPlugin {
     /// Initializes the renderer, sets up the [`RenderStage`](RenderStage) and creates the rendering sub-app.
     fn build(&self, app: &mut App) {
@@ -171,7 +174,11 @@ impl Plugin for RenderPlugin {
             .insert_resource(options)
             .insert_resource(render_pipeline_cache)
             .insert_resource(asset_server)
-            .init_resource::<RenderGraph>();
+            .init_resource::<RenderGraphs>();
+
+        let main_graph = RenderGraph::new(MAIN_GRAPH_ID);
+        let mut graphs = render_app.world.get_resource_mut::<RenderGraphs>().unwrap();
+        graphs.add_graph(main_graph);
 
         app.add_sub_app(RenderApp, render_app, move |app_world, render_app| {
             #[cfg(feature = "trace")]

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -29,7 +29,6 @@ pub mod prelude {
 
 use bevy_utils::tracing::debug;
 pub use once_cell;
-use render_graph::RenderGraphId;
 
 use crate::{
     camera::CameraPlugin,
@@ -106,7 +105,7 @@ pub struct RenderApp;
 #[derive(Default)]
 struct ScratchRenderWorld(World);
 
-pub const MAIN_GRAPH_ID: &'static str = "main_graph";
+pub const MAIN_GRAPH_ID: &str = "main_graph";
 
 impl Plugin for RenderPlugin {
     /// Initializes the renderer, sets up the [`RenderStage`](RenderStage) and creates the rendering sub-app.

--- a/crates/bevy_render/src/render_graph/context.rs
+++ b/crates/bevy_render/src/render_graph/context.rs
@@ -50,21 +50,22 @@ impl RunSubGraphs {
 /// This context is created for each node by the `RenderGraphRunner`.
 ///
 /// The slot input can be read from here
+#[derive(Clone)]
 pub struct RenderGraphContext<'a> {
-    inputs: &'a SlotValues,
+    inputs: SlotValues,
     graphs: &'a RenderGraphs,
 }
 
 impl<'a> RenderGraphContext<'a> {
     /// Creates a new render graph context.
-    pub fn new(inputs: &'a SlotValues, graphs: &'a RenderGraphs) -> Self {
+    pub fn new(inputs: SlotValues, graphs: &'a RenderGraphs) -> Self {
         Self { inputs, graphs }
     }
 
     /// Returns the input slot values for the node.
     #[inline]
     pub fn inputs(&self) -> &SlotValues {
-        self.inputs
+        &self.inputs
     }
 
     pub fn get_entity(&self, label: impl Into<&'static str>) -> Result<&Entity, SlotError> {

--- a/crates/bevy_render/src/render_graph/context.rs
+++ b/crates/bevy_render/src/render_graph/context.rs
@@ -1,12 +1,9 @@
-use crate::{
-    render_graph::{NodeState, RenderGraph, SlotInfos, SlotLabel, SlotType, SlotValue},
-    render_resource::{Buffer, Sampler, TextureView},
-};
+use crate::render_graph::{SlotType, SlotValue};
 use bevy_ecs::entity::Entity;
 use std::borrow::Cow;
 use thiserror::Error;
 
-use super::{GraphLabel, RenderGraphId, RenderGraphs, SlotInfo, SlotValues};
+use super::{GraphLabel, RenderGraphId, RenderGraphs, SlotValues};
 
 /// A command that signals the graph runner to run the sub graph corresponding to the `name`
 /// with the specified `inputs` next.
@@ -67,16 +64,16 @@ impl<'a> RenderGraphContext<'a> {
     /// Returns the input slot values for the node.
     #[inline]
     pub fn inputs(&self) -> &SlotValues {
-        &self.inputs
+        self.inputs
     }
 
-    pub fn get_entity(&self, label: impl Into<SlotLabel>) -> Result<&Entity, SlotError> {
+    pub fn get_entity(&self, label: impl Into<&'static str>) -> Result<&Entity, SlotError> {
         let label = label.into();
 
         match self.inputs.get_value(&label)? {
             SlotValue::Entity(e) => Ok(e),
             val => Err(SlotError::MismatchedSlotType {
-                label: label.clone(),
+                label,
                 expected: SlotType::Entity,
                 actual: val.slot_type(),
             }),
@@ -100,7 +97,7 @@ pub enum RunSubGraphError {
     MismatchedInputSlotType {
         graph_name: Cow<'static, str>,
         slot_index: usize,
-        label: SlotLabel,
+        label: &'static str,
         expected: SlotType,
         actual: SlotType,
     },
@@ -109,10 +106,10 @@ pub enum RunSubGraphError {
 #[derive(Error, Debug, Eq, PartialEq)]
 pub enum SlotError {
     #[error("slot does not exist")]
-    InvalidSlot(SlotLabel),
+    InvalidSlot(&'static str),
     #[error("attempted to retrieve the wrong type from input slot")]
     MismatchedSlotType {
-        label: SlotLabel,
+        label: &'static str,
         expected: SlotType,
         actual: SlotType,
     },

--- a/crates/bevy_render/src/render_graph/edge.rs
+++ b/crates/bevy_render/src/render_graph/edge.rs
@@ -20,12 +20,12 @@ pub struct Edge {
 }
 
 impl Edge {
-    /// Returns the id of the 'input_node'.
+    /// Returns the id of the before node.
     pub fn get_before_node(&self) -> NodeId {
         self.before
     }
 
-    /// Returns the id of the 'output_node'.
+    /// Returns the id of the after node.
     pub fn get_after_node(&self) -> NodeId {
         self.after
     }

--- a/crates/bevy_render/src/render_graph/edge.rs
+++ b/crates/bevy_render/src/render_graph/edge.rs
@@ -3,16 +3,9 @@ use super::NodeId;
 /// An edge, which connects two [`Nodes`](super::Node) in
 /// a [`RenderGraph`](crate::render_graph::RenderGraph).
 ///
-/// They are used to describe the ordering (which node has to run first)
-/// and may be of two kinds: [`NodeEdge`](Self::NodeEdge) and [`SlotEdge`](Self::SlotEdge).
+/// They are used to describe the ordering **on the gpu side** (the order which the commands are run)
 ///
-/// Edges are added via the `render_graph::add_node_edge(output_node, input_node)` and the
-/// `render_graph::add_slot_edge(output_node, output_slot, input_node, input_slot)` methods.
-///
-/// The former simply states that the `output_node` has to be run before the `input_node`,
-/// while the later connects an output slot of the `output_node`
-/// with an input slot of the `input_node` to pass additional data along.
-/// For more information see [`SlotType`](super::SlotType).
+/// Edges are added via the `render_graph::add_edge(before, after)`
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Edge {
     pub before: NodeId,

--- a/crates/bevy_render/src/render_graph/edge.rs
+++ b/crates/bevy_render/src/render_graph/edge.rs
@@ -14,37 +14,20 @@ use super::NodeId;
 /// with an input slot of the `input_node` to pass additional data along.
 /// For more information see [`SlotType`](super::SlotType).
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Edge {
-    /// An edge describing to ordering of both nodes (`output_node` before `input_node`)
-    /// and connecting the output slot at the `output_index` of the output_node
-    /// with the slot at the `input_index` of the `input_node`.
-    SlotEdge {
-        input_node: NodeId,
-        input_index: usize,
-        output_node: NodeId,
-        output_index: usize,
-    },
-    /// An edge describing to ordering of both nodes (`output_node` before `input_node`).
-    NodeEdge {
-        input_node: NodeId,
-        output_node: NodeId,
-    },
+pub struct Edge {
+    pub before: NodeId,
+    pub after: NodeId,
 }
+
 
 impl Edge {
     /// Returns the id of the 'input_node'.
-    pub fn get_input_node(&self) -> NodeId {
-        match self {
-            Edge::SlotEdge { input_node, .. } => *input_node,
-            Edge::NodeEdge { input_node, .. } => *input_node,
-        }
+    pub fn get_before_node(&self) -> NodeId {
+        self.before
     }
 
     /// Returns the id of the 'output_node'.
-    pub fn get_output_node(&self) -> NodeId {
-        match self {
-            Edge::SlotEdge { output_node, .. } => *output_node,
-            Edge::NodeEdge { output_node, .. } => *output_node,
-        }
+    pub fn get_after_node(&self) -> NodeId {
+        self.after
     }
 }

--- a/crates/bevy_render/src/render_graph/edge.rs
+++ b/crates/bevy_render/src/render_graph/edge.rs
@@ -19,7 +19,6 @@ pub struct Edge {
     pub after: NodeId,
 }
 
-
 impl Edge {
     /// Returns the id of the 'input_node'.
     pub fn get_before_node(&self) -> NodeId {

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -162,7 +162,7 @@ impl RenderGraph {
         self.get_node_state_mut(label).and_then(|n| n.node_mut())
     }
 
-    /// Adds the [`Edge::NodeEdge`] to the graph. This guarantees that the `output_node`
+    /// Adds the [`Edge`] to the graph. This guarantees that the `output_node`
     /// is run before the `input_node`.
     pub fn add_edge(
         &mut self,

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -1,16 +1,10 @@
-use crate::{
-    render_graph::{
-        Edge, Node, NodeId, NodeLabel, NodeRunError, NodeState, RenderGraphContext,
-        RenderGraphError, SlotInfo, SlotLabel,
-    },
-    renderer::RenderContext,
-};
+use crate::render_graph::{Edge, Node, NodeId, NodeLabel, NodeState, RenderGraphError};
 use bevy_ecs::prelude::World;
 use bevy_reflect::Uuid;
 use bevy_utils::HashMap;
 use std::{borrow::Cow, fmt::Debug};
 
-use super::SlotInfos;
+use super::{RunSubGraphError, SlotInfos};
 
 /// The render graph configures the modular, parallel and re-usable render logic.
 /// It is a retained and stateless (nodes itself my have their internal state) structure,
@@ -66,8 +60,17 @@ impl RenderGraph {
             slot_requirements: Default::default(),
         }
     }
+
+    pub fn get_name(&self) -> &Cow<'static, str> {
+        &self.name
+    }
+
     pub fn id(&self) -> &RenderGraphId {
         &self.id
+    }
+
+    pub fn get_slot_requirements(&self) -> &SlotInfos {
+        &self.slot_requirements
     }
 
     /// Updates all nodes and sub graphs of the render graph. Should be called before executing it.
@@ -86,6 +89,10 @@ impl RenderGraph {
         todo!();
     }
 
+    pub fn assert_matching_slots(&self, _infos: &SlotInfos) -> Result<(), RunSubGraphError> {
+        todo!()
+    }
+
     /// Adds the `node` with the `name` to the graph.
     /// If the name is already present replaces it instead.
     pub fn add_node<T>(&mut self, name: impl Into<Cow<'static, str>>, node: T) -> NodeId
@@ -95,7 +102,7 @@ impl RenderGraph {
         let id = NodeId::new();
         let name = name.into();
         let mut node_state = NodeState::new(id, node);
-        node_state.name = Some(name.clone());
+        node_state.name = name.clone();
         self.nodes.insert(id, node_state);
         self.node_names.insert(name, id);
         id
@@ -248,7 +255,7 @@ impl RenderGraph {
             .input_edges
             .iter()
             .map(|edge| (edge, edge.get_after_node()))
-            .map(|(edge, output_node_id)| &edge.before))
+            .map(|(edge, _output_node_id)| &edge.before))
     }
 
     /// Returns an iterator over a tuple of the ouput edges and the corresponding input nodes
@@ -427,7 +434,7 @@ impl RenderGraphs {
 //         graph.add_edge("B", "C").unwrap();
 //         graph.add_slot_edge("C", 0, "D", 0).unwrap();
 
-//         fn input_nodes(name: &'static str, graph: &RenderGraph) -> HashSet<NodeId> {
+//         fn input_nodes(name: Cow<'static, str>, graph: &RenderGraph) -> HashSet<NodeId> {
 //             graph
 //                 .iter_node_inputs(name)
 //                 .unwrap()
@@ -435,7 +442,7 @@ impl RenderGraphs {
 //                 .collect::<HashSet<NodeId>>()
 //         }
 
-//         fn output_nodes(name: &'static str, graph: &RenderGraph) -> HashSet<NodeId> {
+//         fn output_nodes(name: Cow<'static, str>, graph: &RenderGraph) -> HashSet<NodeId> {
 //             graph
 //                 .iter_node_outputs(name)
 //                 .unwrap()

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -6,21 +6,19 @@ use std::{borrow::Cow, fmt::Debug};
 
 use super::{RunSubGraphError, SlotInfos};
 
-/// The render graph configures the modular, parallel and re-usable render logic.
-/// It is a retained and stateless (nodes itself my have their internal state) structure,
+/// A render graph configures the modular, parallel and re-usable render logic.
+/// It is a retained and stateless (nodes itself may have their internal state) structure,
 /// which can not be modified while it is executed by the graph runner.
 ///
 /// The `RenderGraphRunner` is responsible for executing the entire graph each frame.
 ///
-/// It consists of three main components: [`Nodes`](Node), [`Edges`](Edge)
-/// and [`Slots`](super::SlotType).
+/// It consists of two main components: [`Nodes`](Node) and [`Edges`](Edge)
 ///
-/// Nodes are responsible for generating draw calls and operating on input and output slots.
-/// Edges specify the order of execution for nodes and connect input and output slots together.
-/// Slots describe the render resources created or used by the nodes.
+/// Nodes are responsible for generating draw calls (`record`) and queuing other graphs for execution (`queue_graphs`).
+/// Edges specify the order of recording.
 ///
 /// ## Example
-/// Here is a simple render graph example with two nodes connected by a node edge.
+/// Here is a simple render graph example with two nodes connected by an edge.
 /// ```
 /// # use bevy_app::prelude::*;
 /// # use bevy_ecs::prelude::World;

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -30,15 +30,15 @@ use super::{RunSubGraphError, SlotInfos};
 /// # struct MyNode;
 /// #
 /// # impl Node for MyNode {
-/// #     fn run(&self, graph: &mut RenderGraphContext, render_context: &mut RenderContext, world: &World) -> Result<(), NodeRunError> {
+/// #     fn record(&self, graph: &RenderGraphContext, render_context: &mut RenderContext, world: &World) -> Result<(), NodeRunError> {
 /// #         unimplemented!()
 /// #     }
 /// # }
 /// #
-/// let mut graph = RenderGraph::default();
+/// let mut graph = RenderGraph::new("my_graph");
 /// graph.add_node("input_node", MyNode);
 /// graph.add_node("output_node", MyNode);
-/// graph.add_node_edge("output_node", "input_node").unwrap();
+/// graph.add_edge("output_node", "input_node").unwrap();
 /// ```
 pub struct RenderGraph {
     id: RenderGraphId,

--- a/crates/bevy_render/src/render_graph/mod.rs
+++ b/crates/bevy_render/src/render_graph/mod.rs
@@ -17,9 +17,9 @@ pub enum RenderGraphError {
     #[error("node does not exist")]
     InvalidNode(NodeLabel),
     #[error("output node slot does not exist")]
-    InvalidOutputNodeSlot(SlotLabel),
+    InvalidOutputNodeSlot(&'static str),
     #[error("input node slot does not exist")]
-    InvalidInputNodeSlot(SlotLabel),
+    InvalidInputNodeSlot(&'static str),
     #[error("node does not match the given type")]
     WrongNodeType,
     #[error("attempted to connect a node output slot to an incompatible input node slot")]

--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -1,7 +1,6 @@
 use crate::{
     render_graph::{
-        Edge, RenderGraphContext, RenderGraphError, RunSubGraphError, SlotError, SlotInfo,
-        SlotInfos,
+        Edge, RenderGraphContext, RenderGraphError, RunSubGraphError, SlotError, SlotInfos,
     },
     renderer::RenderContext,
 };
@@ -128,7 +127,7 @@ impl Edges {
 /// The `input_slots` and `output_slots` are provided by the `node`.
 pub struct NodeState {
     pub id: NodeId,
-    pub name: Option<Cow<'static, str>>,
+    pub name: Cow<'static, str>,
     /// The name of the type that implements [`Node`].
     pub type_name: &'static str,
     pub node: Box<dyn Node>,
@@ -151,7 +150,7 @@ impl NodeState {
     {
         NodeState {
             id,
-            name: None,
+            name: "".into(),
             required_slots: node.slot_requirements(),
             node: Box::new(node),
             type_name: std::any::type_name::<T>(),

--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -1,7 +1,7 @@
 use crate::{
     render_graph::{
-        Edge, SlotError, RenderGraphContext, RenderGraphError,
-        RunSubGraphError, SlotInfo, SlotInfos,
+        Edge, RenderGraphContext, RenderGraphError, RunSubGraphError, SlotError, SlotInfo,
+        SlotInfos,
     },
     renderer::RenderContext,
 };
@@ -57,17 +57,21 @@ pub trait Node: Downcast + Send + Sync + 'static {
     /// passed via the [`RenderGraphContext`].
     fn record(
         &self,
-        graph: &RenderGraphContext,
-        render_context: &mut RenderContext,
-        world: &World,
-    ) -> Result<(), NodeRunError> { Ok(()) }
+        _graph: &RenderGraphContext,
+        _render_context: &mut RenderContext,
+        _world: &World,
+    ) -> Result<(), NodeRunError> {
+        Ok(())
+    }
 
-    /// Queues graphs for execution
+    /// Queues graphs for execution.
     fn queue_graphs(
         &self,
-        graph: &RenderGraphContext,
-        world: &World,
-    ) -> Result<RunSubGraphs, NodeRunError> { Ok(Default::default()) }
+        _graph: &RenderGraphContext,
+        _world: &World,
+    ) -> Result<RunSubGraphs, NodeRunError> {
+        Ok(Default::default())
+    }
 }
 
 impl_downcast!(Node);
@@ -116,8 +120,6 @@ impl Edges {
     pub fn has_output_edge(&self, edge: &Edge) -> bool {
         self.output_edges.contains(edge)
     }
-
-
 }
 
 /// The internal representation of a [`Node`], with all data required
@@ -180,7 +182,6 @@ impl NodeState {
             .downcast_mut::<T>()
             .ok_or(RenderGraphError::WrongNodeType)
     }
-
 }
 
 /// A [`NodeLabel`] is used to reference a [`NodeState`] by either its name or [`NodeId`]
@@ -220,6 +221,4 @@ impl From<NodeId> for NodeLabel {
 /// the [`RenderGraph`](super::RenderGraph).
 pub struct EmptyNode;
 
-impl Node for EmptyNode {
-    
-}
+impl Node for EmptyNode {}

--- a/crates/bevy_render/src/render_graph/node_slot.rs
+++ b/crates/bevy_render/src/render_graph/node_slot.rs
@@ -35,7 +35,7 @@ impl SlotValue {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct SlotValues {
     values: Vec<(&'static str, SlotValue)>,
 }

--- a/crates/bevy_render/src/renderer/graph_runner.rs
+++ b/crates/bevy_render/src/renderer/graph_runner.rs
@@ -1,17 +1,14 @@
 use bevy_ecs::world::World;
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::info_span;
-use bevy_utils::{HashMap, HashSet};
-use smallvec::{smallvec, SmallVec};
-#[cfg(feature = "trace")]
-use std::ops::Deref;
-use std::{borrow::Cow, collections::VecDeque, rc::Rc};
+use bevy_utils::HashSet;
+use std::{borrow::Cow, collections::VecDeque};
 use thiserror::Error;
 
 use crate::{
     render_graph::{
-        Edge, Node, NodeId, NodeRunError, NodeState, RenderGraph, RenderGraphContext,
-        RenderGraphId, RenderGraphs, SlotLabel, SlotType, SlotValue, SlotValues,
+        NodeId, NodeRunError, NodeState, RenderGraphContext, RenderGraphId, RenderGraphs, SlotType,
+        SlotValues,
     },
     renderer::{RenderContext, RenderDevice},
 };
@@ -37,7 +34,7 @@ pub enum RenderGraphRunnerError {
     #[error("attempted to use the wrong type for input slot")]
     MismatchedInputSlotType {
         slot_index: usize,
-        label: SlotLabel,
+        label: &'static str,
         expected: SlotType,
         actual: SlotType,
     },
@@ -86,11 +83,7 @@ impl RenderGraphRunner {
         let context = RenderGraphContext::new(inputs, graphs);
 
         #[cfg(feature = "trace")]
-        let span = if let Some(name) = &graph_name {
-            info_span!("run_graph", name = name.deref())
-        } else {
-            info_span!("run_graph", name = "main_graph")
-        };
+        let span = info_span!("run_graph", name = "main_graph");
         #[cfg(feature = "trace")]
         let _guard = span.enter();
 
@@ -108,7 +101,7 @@ impl RenderGraphRunner {
                 .iter_node_dependencies(node_state.id)
                 .expect("node is in graph")
             {
-                if !nodes_ran.contains(&id) {
+                if !nodes_ran.contains(id) {
                     node_queue.push_front(node_state);
                     continue 'handle_node;
                 }

--- a/crates/bevy_render/src/renderer/graph_runner.rs
+++ b/crates/bevy_render/src/renderer/graph_runner.rs
@@ -1,8 +1,10 @@
 use bevy_ecs::world::World;
+use bevy_tasks::ComputeTaskPool;
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::info_span;
 use bevy_utils::HashSet;
-use std::{borrow::Cow, collections::VecDeque};
+use parking_lot::Mutex;
+use std::{borrow::Cow, collections::VecDeque, iter::once, sync::Arc};
 use thiserror::Error;
 
 use crate::{
@@ -59,7 +61,7 @@ impl RenderGraphRunner {
             main_id,
             &mut render_context,
             world,
-            &SlotValues::default(),
+            SlotValues::default(),
         )?;
         {
             #[cfg(feature = "trace")]
@@ -68,6 +70,7 @@ impl RenderGraphRunner {
             let _guard = span.enter();
             queue.submit(vec![render_context.command_encoder.finish()]);
         }
+
         Ok(())
     }
 
@@ -76,7 +79,7 @@ impl RenderGraphRunner {
         graph_id: &RenderGraphId,
         render_context: &mut RenderContext,
         world: &World,
-        inputs: &SlotValues,
+        inputs: SlotValues,
     ) -> Result<(), RenderGraphRunnerError> {
         let mut nodes_ran: HashSet<NodeId> = HashSet::default();
         let graph = graphs.get_graph(graph_id).expect("graph exists");
@@ -130,7 +133,7 @@ impl RenderGraphRunner {
                         sub_graph.id(),
                         render_context,
                         world,
-                        &run_sub_graph.inputs,
+                        run_sub_graph.inputs,
                     )?;
                 }
             }
@@ -146,88 +149,142 @@ impl RenderGraphRunner {
     }
 }
 
-// pub(crate) struct ParalellRenderGraphRunner {
+pub(crate) struct ParalellRenderGraphRunner {
+    threads: usize,
+}
 
-// }
+impl ParalellRenderGraphRunner {
+    pub fn new() -> Self {
+        Self { threads: 4 }
+    }
 
-// impl ParalellRenderGraphRunner {
-//     pub fn new() -> Self {
-//         Self {}
-//     }
+    pub fn run(
+        &self,
+        main_graph_id: &RenderGraphId,
+        render_device: RenderDevice,
+        queue: &wgpu::Queue,
+        world: &World,
+    ) -> Result<(), RenderGraphRunnerError> {
+        let graphs = world.get_resource::<RenderGraphs>().unwrap();
 
-//     pub fn run(
-//         graph: &RenderGraph,
-//         render_device: RenderDevice,
-//         queue: &wgpu::Queue,
-//         world: &World,
-//     ) -> Result<(), RenderGraphRunnerError> {
+        let slot_values = SlotValues::empty();
+        let context = RenderGraphContext::new(slot_values, graphs);
 
-//         Ok(())
-//     }
+        let recording_nodes = self.flatten(main_graph_id, graphs, world, context)?;
+        let compute_pool = world.get_resource::<ComputeTaskPool>().unwrap();
 
-//     pub fn flatten(
-//         &self,
-//         graph: &RenderGraph,
-//         world: &World,
-//         inputs: &SlotValues,
-//     ) -> Result<Vec<Rc<dyn Node>>, RenderGraphRunnerError> {
-//         let mut nodes_ordered = Vec::default();
-//         let mut nodes_ran: HashSet<NodeId> = HashSet::default();
+        let len = recording_nodes.len();
 
-//         let context = RenderGraphContext::new(inputs);
+        // TODO: split into workgroups based on estimated time to complete nodes instead of just the number of nodes
+        let workgroup_size = (len / self.threads) + (len % self.threads != 0) as usize; // Ceiled division
+        let node_ranges = (0..self.threads).map(|s| {
+            (s * workgroup_size)..(*vec![(s + 1) * workgroup_size, len].iter().min().unwrap())
+        }); // Which ranges of nodes to be recorded on the same thread
 
-//         #[cfg(feature = "trace")]
-//         let span = if let Some(name) = &graph_name {
-//             info_span!("run_graph", name = name.deref())
-//         } else {
-//             info_span!("run_graph", name = "main_graph")
-//         };
-//         #[cfg(feature = "trace")]
-//         let _guard = span.enter();
+        let finished_buffers = compute_pool.scope(|scope| {
+            for range in node_ranges {
+                let command_encoder = render_device
+                    .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+                let mut render_context = RenderContext {
+                    render_device: render_device.clone(),
+                    command_encoder,
+                };
+                scope.spawn(async {
+                    for node in range {
+                        let (state, ctx) = &recording_nodes[node];
+                        state.node.record(&ctx, &mut render_context, world).unwrap();
+                    }
+                    render_context.command_encoder.finish()
+                });
+            }
+        });
 
-//         // Queue up nodes
-//         let mut node_queue: VecDeque<&NodeState> = graph
-//             .iter_nodes()
-//             .collect();
+        // for (node, ctx) in recording_nodes {
+        //     node.node.record(&ctx, &mut render_context, world)?;
+        // }
 
-//         'handle_node: while let Some(node_state) = node_queue.pop_back() {
-//             // skip nodes that are already processed
-//             if nodes_ran.contains(&node_state.id) {
-//                 continue;
-//             }
+        {
+            #[cfg(feature = "trace")]
+            let span = info_span!("submit_graph_commands");
+            #[cfg(feature = "trace")]
+            let _guard = span.enter();
 
-//             // check if all dependencies have finished running
-//             for id in graph
-//                 .iter_node_dependencies(node_state.id)
-//                 .expect("node is in graph")
-//             {
-//                 if !nodes_ran.contains(&id) {
-//                     node_queue.push_front(node_state);
-//                     continue 'handle_node;
-//                 }
-//             }
+            queue.submit(finished_buffers);
+        }
 
-//             {
+        Ok(())
+    }
+    /// Runs the `queue_graphs` methods of all of the nodes in the graph and returns a
+    /// topologically sorted vector of the resulting nodes
+    pub fn flatten<'g>(
+        &'g self,
+        graph_id: &RenderGraphId,
+        graphs: &'g RenderGraphs,
+        world: &World,
+        context: RenderGraphContext<'g>,
+    ) -> Result<Vec<(&'g NodeState, RenderGraphContext)>, RenderGraphRunnerError> {
+        let mut nodes_ordered = Vec::default();
+        let mut nodes_ran: HashSet<NodeId> = HashSet::default();
 
-//                 #[cfg(feature = "trace")]
-//                 let span = info_span!("node", name = node_state.type_name);
-//                 #[cfg(feature = "trace")]
-//                 let guard = span.enter();
+        let graph = graphs.get_graph(graph_id).unwrap();
 
-//                 let sub_graph_runs = node_state.node.queue_graphs(&context, world)?;
-//                 // node_state.no
+        #[cfg(feature = "trace")]
+        let span = if let Some(name) = &graph_name {
+            info_span!("run_graph", name = name.deref())
+        } else {
+            info_span!("run_graph", name = "main_graph")
+        };
+        #[cfg(feature = "trace")]
+        let _guard = span.enter();
 
-//                 #[cfg(feature = "trace")]
-//                 drop(guard);
+        // Queue up nodes
+        let mut node_queue: VecDeque<&NodeState> = graph.iter_nodes().collect();
 
-//             }
+        'handle_node: while let Some(node_state) = node_queue.pop_back() {
+            // skip nodes that are already processed
+            if nodes_ran.contains(&node_state.id) {
+                continue;
+            }
 
-//             nodes_ran.insert(node_state.id);
+            // check if all dependencies have finished running
+            for id in graph
+                .iter_node_dependencies(node_state.id)
+                .expect("node is in graph")
+            {
+                if !nodes_ran.contains(&id) {
+                    node_queue.push_front(node_state);
+                    continue 'handle_node;
+                }
+            }
 
-//             for (_, node_state) in graph.iter_node_outputs(node_state.id).expect("node exists") {
-//                 node_queue.push_front(node_state);
-//             }
-//         }
-//         return Ok(nodes_ordered);
-//     }
-// }
+            {
+                #[cfg(feature = "trace")]
+                let span = info_span!("node", name = node_state.type_name);
+                #[cfg(feature = "trace")]
+                let guard = span.enter();
+
+                let sub_graph_runs = node_state.node.queue_graphs(&context, world)?;
+
+                for graph in sub_graph_runs.drain() {
+                    let sub_context = RenderGraphContext::new(graph.inputs, graphs);
+                    nodes_ordered.extend(
+                        self.flatten(&graph.id, graphs, world, sub_context)?
+                            .into_iter(),
+                    )
+                }
+                nodes_ordered.push((node_state, context.clone()));
+
+                #[cfg(feature = "trace")]
+                drop(guard);
+            }
+
+            nodes_ran.insert(node_state.id);
+
+            for (_, node_state) in graph.iter_node_outputs(node_state.id).expect("node exists") {
+                node_queue.push_front(node_state);
+            }
+        }
+
+        Ok(nodes_ordered)
+    }
+}

--- a/crates/bevy_render/src/renderer/graph_runner.rs
+++ b/crates/bevy_render/src/renderer/graph_runner.rs
@@ -3,6 +3,7 @@ use bevy_tasks::ComputeTaskPool;
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::info_span;
 use bevy_utils::HashSet;
+#[cfg(feature = "trace")]
 use std::ops::Deref;
 use std::{borrow::Cow, collections::VecDeque};
 use thiserror::Error;

--- a/crates/bevy_render/src/renderer/graph_runner.rs
+++ b/crates/bevy_render/src/renderer/graph_runner.rs
@@ -1,17 +1,17 @@
 use bevy_ecs::world::World;
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::info_span;
-use bevy_utils::HashMap;
+use bevy_utils::{HashMap, HashSet};
 use smallvec::{smallvec, SmallVec};
 #[cfg(feature = "trace")]
 use std::ops::Deref;
-use std::{borrow::Cow, collections::VecDeque};
+use std::{borrow::Cow, collections::VecDeque, rc::Rc};
 use thiserror::Error;
 
 use crate::{
     render_graph::{
         Edge, NodeId, NodeRunError, NodeState, RenderGraph, RenderGraphContext, SlotLabel,
-        SlotType, SlotValue,
+        SlotType, SlotValue, SlotValues, Node,
     },
     renderer::{RenderContext, RenderDevice},
 };
@@ -57,7 +57,7 @@ impl RenderGraphRunner {
             command_encoder,
         };
 
-        Self::run_graph(graph, None, &mut render_context, world, &[])?;
+        Self::run_graph(graph, None, &mut render_context, world, &SlotValues::default())?;
         {
             #[cfg(feature = "trace")]
             let span = info_span!("submit_graph_commands");
@@ -73,9 +73,12 @@ impl RenderGraphRunner {
         graph_name: Option<Cow<'static, str>>,
         render_context: &mut RenderContext,
         world: &World,
-        inputs: &[SlotValue],
+        inputs: &SlotValues,
     ) -> Result<(), RenderGraphRunnerError> {
-        let mut node_outputs: HashMap<NodeId, SmallVec<[SlotValue; 4]>> = HashMap::default();
+        let mut nodes_ran: HashSet<NodeId> = HashSet::default();
+
+        let context = RenderGraphContext::new(inputs);
+
         #[cfg(feature = "trace")]
         let span = if let Some(name) = &graph_name {
             info_span!("run_graph", name = name.deref())
@@ -85,102 +88,47 @@ impl RenderGraphRunner {
         #[cfg(feature = "trace")]
         let _guard = span.enter();
 
-        // Queue up nodes without inputs, which can be run immediately
+        // Queue up nodes
         let mut node_queue: VecDeque<&NodeState> = graph
             .iter_nodes()
-            .filter(|node| node.input_slots.is_empty())
             .collect();
 
-        // pass inputs into the graph
-        if let Some(input_node) = graph.input_node() {
-            let mut input_values: SmallVec<[SlotValue; 4]> = SmallVec::new();
-            for (i, input_slot) in input_node.input_slots.iter().enumerate() {
-                if let Some(input_value) = inputs.get(i) {
-                    if input_slot.slot_type != input_value.slot_type() {
-                        return Err(RenderGraphRunnerError::MismatchedInputSlotType {
-                            slot_index: i,
-                            actual: input_value.slot_type(),
-                            expected: input_slot.slot_type,
-                            label: input_slot.name.clone().into(),
-                        });
-                    } else {
-                        input_values.push(input_value.clone());
-                    }
-                } else {
-                    return Err(RenderGraphRunnerError::MissingInput {
-                        slot_index: i,
-                        slot_name: input_slot.name.clone(),
-                        graph_name: graph_name.clone(),
-                    });
-                }
-            }
-
-            node_outputs.insert(input_node.id, input_values);
-
-            for (_, node_state) in graph.iter_node_outputs(input_node.id).expect("node exists") {
-                node_queue.push_front(node_state);
-            }
-        }
 
         'handle_node: while let Some(node_state) = node_queue.pop_back() {
             // skip nodes that are already processed
-            if node_outputs.contains_key(&node_state.id) {
+            if nodes_ran.contains(&node_state.id) {
                 continue;
             }
 
-            let mut slot_indices_and_inputs: SmallVec<[(usize, SlotValue); 4]> = SmallVec::new();
             // check if all dependencies have finished running
-            for (edge, input_node) in graph
-                .iter_node_inputs(node_state.id)
+            for id in graph
+                .iter_node_dependencies(node_state.id)
                 .expect("node is in graph")
             {
-                match edge {
-                    Edge::SlotEdge {
-                        output_index,
-                        input_index,
-                        ..
-                    } => {
-                        if let Some(outputs) = node_outputs.get(&input_node.id) {
-                            slot_indices_and_inputs
-                                .push((*input_index, outputs[*output_index].clone()));
-                        } else {
-                            node_queue.push_front(node_state);
-                            continue 'handle_node;
-                        }
-                    }
-                    Edge::NodeEdge { .. } => {
-                        if !node_outputs.contains_key(&input_node.id) {
-                            node_queue.push_front(node_state);
-                            continue 'handle_node;
-                        }
-                    }
+                if !nodes_ran.contains(&id) {
+                    node_queue.push_front(node_state);
+                    continue 'handle_node;
                 }
             }
 
-            // construct final sorted input list
-            slot_indices_and_inputs.sort_by_key(|(index, _)| *index);
-            let inputs: SmallVec<[SlotValue; 4]> = slot_indices_and_inputs
-                .into_iter()
-                .map(|(_, value)| value)
-                .collect();
 
-            assert_eq!(inputs.len(), node_state.input_slots.len());
-
-            let mut outputs: SmallVec<[Option<SlotValue>; 4]> =
-                smallvec![None; node_state.output_slots.len()];
+            
             {
-                let mut context = RenderGraphContext::new(graph, node_state, &inputs, &mut outputs);
+                
                 #[cfg(feature = "trace")]
                 let span = info_span!("node", name = node_state.type_name);
                 #[cfg(feature = "trace")]
                 let guard = span.enter();
 
-                node_state.node.run(&mut context, render_context, world)?;
+
+                let sub_graph_runs = node_state.node.queue_graphs(&context, world)?;
+
+                node_state.node.record(&context, render_context, world)?;
 
                 #[cfg(feature = "trace")]
                 drop(guard);
 
-                for run_sub_graph in context.finish() {
+                for run_sub_graph in sub_graph_runs.drain() {
                     let sub_graph = graph
                         .get_sub_graph(&run_sub_graph.name)
                         .expect("sub graph exists because it was validated when queued.");
@@ -194,20 +142,8 @@ impl RenderGraphRunner {
                 }
             }
 
-            let mut values: SmallVec<[SlotValue; 4]> = SmallVec::new();
-            for (i, output) in outputs.into_iter().enumerate() {
-                if let Some(value) = output {
-                    values.push(value);
-                } else {
-                    let empty_slot = node_state.output_slots.get_slot(i).unwrap();
-                    return Err(RenderGraphRunnerError::EmptyNodeOutputSlot {
-                        type_name: node_state.type_name,
-                        slot_index: i,
-                        slot_name: empty_slot.name.clone(),
-                    });
-                }
-            }
-            node_outputs.insert(node_state.id, values);
+            
+            nodes_ran.insert(node_state.id);
 
             for (_, node_state) in graph.iter_node_outputs(node_state.id).expect("node exists") {
                 node_queue.push_front(node_state);
@@ -215,5 +151,103 @@ impl RenderGraphRunner {
         }
 
         Ok(())
+    }
+}
+
+
+
+pub(crate) struct ParalellRenderGraphRunner {
+
+}
+
+
+impl ParalellRenderGraphRunner {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn run(
+        graph: &RenderGraph,
+        render_device: RenderDevice,
+        queue: &wgpu::Queue,
+        world: &World,
+    ) -> Result<(), RenderGraphRunnerError> {
+
+
+
+
+        Ok(())
+    }
+
+
+    pub fn flatten(
+        &self,
+        graph: &RenderGraph,
+        world: &World,
+        inputs: &SlotValues,
+    ) -> Result<Vec<Rc<dyn Node>>, RenderGraphRunnerError> {
+        let mut nodes_ordered = Vec::default();
+        let mut nodes_ran: HashSet<NodeId> = HashSet::default();
+
+        let context = RenderGraphContext::new(inputs);
+
+        #[cfg(feature = "trace")]
+        let span = if let Some(name) = &graph_name {
+            info_span!("run_graph", name = name.deref())
+        } else {
+            info_span!("run_graph", name = "main_graph")
+        };
+        #[cfg(feature = "trace")]
+        let _guard = span.enter();
+
+        // Queue up nodes
+        let mut node_queue: VecDeque<&NodeState> = graph
+            .iter_nodes()
+            .collect();
+
+
+        'handle_node: while let Some(node_state) = node_queue.pop_back() {
+            // skip nodes that are already processed
+            if nodes_ran.contains(&node_state.id) {
+                continue;
+            }
+
+            // check if all dependencies have finished running
+            for id in graph
+                .iter_node_dependencies(node_state.id)
+                .expect("node is in graph")
+            {
+                if !nodes_ran.contains(&id) {
+                    node_queue.push_front(node_state);
+                    continue 'handle_node;
+                }
+            }
+
+
+            
+            {
+                
+                #[cfg(feature = "trace")]
+                let span = info_span!("node", name = node_state.type_name);
+                #[cfg(feature = "trace")]
+                let guard = span.enter();
+
+
+                let sub_graph_runs = node_state.node.queue_graphs(&context, world)?;
+                // node_state.no
+
+                #[cfg(feature = "trace")]
+                drop(guard);
+
+            }
+
+            
+            nodes_ran.insert(node_state.id);
+
+            for (_, node_state) in graph.iter_node_outputs(node_state.id).expect("node exists") {
+                node_queue.push_front(node_state);
+            }
+        }
+        return Ok(nodes_ordered);
     }
 }

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -15,7 +15,7 @@ use bevy_ecs::prelude::*;
 use std::sync::Arc;
 use wgpu::{CommandEncoder, Instance, Queue, RequestAdapterOptions};
 
-/// Updates the [`RenderGraph`] with all of its nodes and then runs it to render the entire frame.
+/// Updates the [`RenderGraphs`] with all of its nodes and then runs it to render the entire frame.
 pub fn render_system(world: &mut World) {
     world.resource_scope(|world, mut graphs: Mut<RenderGraphs>| {
         graphs.update(world);

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -23,7 +23,15 @@ pub fn render_system(world: &mut World) {
     let render_device = world.get_resource::<RenderDevice>().unwrap();
     let render_queue = world.get_resource::<RenderQueue>().unwrap();
     let graphs = world.get_resource::<RenderGraphs>().unwrap();
-
+    // let paralell = ParalellRenderGraphRunner::new();
+    // paralell
+    //     .run(
+    //         &graphs.get_graph_id(MAIN_GRAPH_ID).unwrap(),
+    //         render_device.clone(), // TODO: is this clone really necessary?
+    //         render_queue,
+    //         world,
+    //     )
+    //     .unwrap();
     RenderGraphRunner::run(
         &graphs.get_graph_id(MAIN_GRAPH_ID).unwrap(),
         render_device.clone(), // TODO: is this clone really necessary?

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -7,8 +7,9 @@ pub use render_device::*;
 
 use crate::{
     options::{WgpuOptions, WgpuOptionsPriority},
-    render_graph::RenderGraph,
+    render_graph::{RenderGraph, RenderGraphs},
     view::{ExtractedWindows, ViewTarget},
+    MAIN_GRAPH_ID,
 };
 use bevy_ecs::prelude::*;
 use std::sync::Arc;
@@ -16,14 +17,15 @@ use wgpu::{CommandEncoder, Instance, Queue, RequestAdapterOptions};
 
 /// Updates the [`RenderGraph`] with all of its nodes and then runs it to render the entire frame.
 pub fn render_system(world: &mut World) {
-    world.resource_scope(|world, mut graph: Mut<RenderGraph>| {
-        graph.update(world);
+    world.resource_scope(|world, mut graphs: Mut<RenderGraphs>| {
+        graphs.update(world);
     });
-    let graph = world.get_resource::<RenderGraph>().unwrap();
     let render_device = world.get_resource::<RenderDevice>().unwrap();
     let render_queue = world.get_resource::<RenderQueue>().unwrap();
+    let graphs = world.get_resource::<RenderGraphs>().unwrap();
+
     RenderGraphRunner::run(
-        graph,
+        &graphs.get_graph_id(MAIN_GRAPH_ID).unwrap(),
         render_device.clone(), // TODO: is this clone really necessary?
         render_queue,
         world,

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -7,7 +7,7 @@ pub use render_device::*;
 
 use crate::{
     options::{WgpuOptions, WgpuOptionsPriority},
-    render_graph::{RenderGraph, RenderGraphs},
+    render_graph::RenderGraphs,
     view::{ExtractedWindows, ViewTarget},
     MAIN_GRAPH_ID,
 };

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -23,22 +23,22 @@ pub fn render_system(world: &mut World) {
     let render_device = world.get_resource::<RenderDevice>().unwrap();
     let render_queue = world.get_resource::<RenderQueue>().unwrap();
     let graphs = world.get_resource::<RenderGraphs>().unwrap();
-    // let paralell = ParalellRenderGraphRunner::new();
-    // paralell
-    //     .run(
-    //         &graphs.get_graph_id(MAIN_GRAPH_ID).unwrap(),
-    //         render_device.clone(), // TODO: is this clone really necessary?
-    //         render_queue,
-    //         world,
-    //     )
-    //     .unwrap();
-    RenderGraphRunner::run(
-        &graphs.get_graph_id(MAIN_GRAPH_ID).unwrap(),
-        render_device.clone(), // TODO: is this clone really necessary?
-        render_queue,
-        world,
-    )
-    .unwrap();
+    let paralell = ParalellRenderGraphRunner::new();
+    paralell
+        .run(
+            &graphs.get_graph_id(MAIN_GRAPH_ID).unwrap(),
+            render_device.clone(), // TODO: is this clone really necessary?
+            render_queue,
+            world,
+        )
+        .unwrap();
+    // RenderGraphRunner::run(
+    //     &graphs.get_graph_id(MAIN_GRAPH_ID).unwrap(),
+    //     render_device.clone(), // TODO: is this clone really necessary?
+    //     render_queue,
+    //     world,
+    // )
+    // .unwrap();
     {
         let span = info_span!("present_frames");
         let _guard = span.enter();

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -18,13 +18,13 @@ use bevy_render::{
     camera::ActiveCameras,
     color::Color,
     render_asset::RenderAssets,
-    render_graph::{RenderGraph, SlotInfo, SlotType},
+    render_graph::{RenderGraph, RenderGraphs, SlotInfo, SlotType},
     render_phase::{sort_phase_system, AddRenderCommand, DrawFunctions, RenderPhase},
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
     texture::Image,
     view::{ViewUniforms, Visibility},
-    RenderApp, RenderStage, RenderWorld,
+    RenderApp, RenderStage, RenderWorld, MAIN_GRAPH_ID,
 };
 use bevy_sprite::{Rect, SpriteAssetEvents, TextureAtlas};
 use bevy_text::{DefaultTextPipeline, Text};
@@ -90,12 +90,14 @@ pub fn build_ui_render(app: &mut App) {
 
     // Render graph
     let ui_pass_node = UiPassNode::new(&mut render_app.world);
-    let mut graph = render_app.world.get_resource_mut::<RenderGraph>().unwrap();
 
-    let mut draw_ui_graph = RenderGraph::default();
+    let mut graphs = render_app.world.get_resource_mut::<RenderGraphs>().unwrap();
+    let mut draw_ui_graph = RenderGraph::new(draw_ui_graph::NAME);
     draw_ui_graph.add_node(draw_ui_graph::node::UI_PASS, ui_pass_node);
-    
-    graph.add_sub_graph(draw_ui_graph::NAME, draw_ui_graph);
+
+    graphs.add_graph(draw_ui_graph);
+
+    let graph = graphs.get_graph_mut(MAIN_GRAPH_ID).unwrap();
 
     graph.add_node(node::UI_PASS_DRIVER, UiPassDriverNode);
     graph

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -18,7 +18,7 @@ use bevy_render::{
     camera::ActiveCameras,
     color::Color,
     render_asset::RenderAssets,
-    render_graph::{RenderGraph, RenderGraphs, SlotInfo, SlotType},
+    render_graph::{RenderGraph, RenderGraphs},
     render_phase::{sort_phase_system, AddRenderCommand, DrawFunctions, RenderPhase},
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -94,23 +94,12 @@ pub fn build_ui_render(app: &mut App) {
 
     let mut draw_ui_graph = RenderGraph::default();
     draw_ui_graph.add_node(draw_ui_graph::node::UI_PASS, ui_pass_node);
-    let input_node_id = draw_ui_graph.set_input(vec![SlotInfo::new(
-        draw_ui_graph::input::VIEW_ENTITY,
-        SlotType::Entity,
-    )]);
-    draw_ui_graph
-        .add_slot_edge(
-            input_node_id,
-            draw_ui_graph::input::VIEW_ENTITY,
-            draw_ui_graph::node::UI_PASS,
-            UiPassNode::IN_VIEW,
-        )
-        .unwrap();
+    
     graph.add_sub_graph(draw_ui_graph::NAME, draw_ui_graph);
 
     graph.add_node(node::UI_PASS_DRIVER, UiPassDriverNode);
     graph
-        .add_node_edge(
+        .add_edge(
             bevy_core_pipeline::node::MAIN_PASS_DRIVER,
             node::UI_PASS_DRIVER,
         )

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -19,18 +19,15 @@ use super::{draw_ui_graph, UiBatch, UiImageBindGroups, UiMeta, CAMERA_UI};
 pub struct UiPassDriverNode;
 
 impl bevy_render::render_graph::Node for UiPassDriverNode {
-    fn run(
-        &self,
-        graph: &mut RenderGraphContext,
-        _render_context: &mut RenderContext,
-        world: &World,
-    ) -> Result<(), NodeRunError> {
+    fn queue_graphs(&self, graph: &RenderGraphContext, world: &World) -> Result<RunSubGraphs, NodeRunError> {
+        let mut run_sub_graphs = RunSubGraphs::default();
+
         let extracted_cameras = world.get_resource::<ExtractedCameraNames>().unwrap();
         if let Some(camera_ui) = extracted_cameras.entities.get(CAMERA_UI) {
-            graph.run_sub_graph(draw_ui_graph::NAME, vec![SlotValue::Entity(*camera_ui)])?;
+            run_sub_graphs.run(draw_ui_graph::NAME, vec![("view", SlotValue::Entity(*camera_ui))]);
         }
 
-        Ok(())
+        Ok(run_sub_graphs)
     }
 }
 
@@ -50,21 +47,18 @@ impl UiPassNode {
 }
 
 impl bevy_render::render_graph::Node for UiPassNode {
-    fn input(&self) -> Vec<SlotInfo> {
-        vec![SlotInfo::new(UiPassNode::IN_VIEW, SlotType::Entity)]
+    fn slot_requirements(&self) -> SlotInfos {
+        
+        vec![SlotInfo::new(UiPassNode::IN_VIEW, SlotType::Entity)].into()
     }
 
     fn update(&mut self, world: &mut World) {
         self.query.update_archetypes(world);
     }
 
-    fn run(
-        &self,
-        graph: &mut RenderGraphContext,
-        render_context: &mut RenderContext,
-        world: &World,
-    ) -> Result<(), NodeRunError> {
-        let view_entity = graph.get_input_entity(Self::IN_VIEW)?;
+    fn record(&self, graph: &RenderGraphContext, render_context: &mut RenderContext, world: &World) -> Result<(), NodeRunError> {
+        
+        let view_entity = *graph.get_entity(Self::IN_VIEW)?;
         let (transparent_phase, target) = self
             .query
             .get_manual(world, view_entity)

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -19,12 +19,20 @@ use super::{draw_ui_graph, UiBatch, UiImageBindGroups, UiMeta, CAMERA_UI};
 pub struct UiPassDriverNode;
 
 impl bevy_render::render_graph::Node for UiPassDriverNode {
-    fn queue_graphs(&self, graph: &RenderGraphContext, world: &World) -> Result<RunSubGraphs, NodeRunError> {
+    fn queue_graphs(
+        &self,
+        graph: &RenderGraphContext,
+        world: &World,
+    ) -> Result<RunSubGraphs, NodeRunError> {
         let mut run_sub_graphs = RunSubGraphs::default();
 
         let extracted_cameras = world.get_resource::<ExtractedCameraNames>().unwrap();
         if let Some(camera_ui) = extracted_cameras.entities.get(CAMERA_UI) {
-            run_sub_graphs.run(draw_ui_graph::NAME, vec![("view", SlotValue::Entity(*camera_ui))]);
+            run_sub_graphs.run(
+                graph,
+                draw_ui_graph::NAME,
+                vec![("view", SlotValue::Entity(*camera_ui))],
+            );
         }
 
         Ok(run_sub_graphs)
@@ -48,7 +56,6 @@ impl UiPassNode {
 
 impl bevy_render::render_graph::Node for UiPassNode {
     fn slot_requirements(&self) -> SlotInfos {
-        
         vec![SlotInfo::new(UiPassNode::IN_VIEW, SlotType::Entity)].into()
     }
 
@@ -56,8 +63,12 @@ impl bevy_render::render_graph::Node for UiPassNode {
         self.query.update_archetypes(world);
     }
 
-    fn record(&self, graph: &RenderGraphContext, render_context: &mut RenderContext, world: &World) -> Result<(), NodeRunError> {
-        
+    fn record(
+        &self,
+        graph: &RenderGraphContext,
+        render_context: &mut RenderContext,
+        world: &World,
+    ) -> Result<(), NodeRunError> {
         let view_entity = *graph.get_entity(Self::IN_VIEW)?;
         let (transparent_phase, target) = self
             .query

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -1,4 +1,5 @@
 use bevy_core::FloatOrd;
+use bevy_core_pipeline::draw_2d_graph;
 use bevy_ecs::{
     prelude::*,
     system::{lifetimeless::*, SystemParamItem},
@@ -31,7 +32,10 @@ impl bevy_render::render_graph::Node for UiPassDriverNode {
             run_sub_graphs.run(
                 graph,
                 draw_ui_graph::NAME,
-                vec![("view", SlotValue::Entity(*camera_ui))],
+                vec![(
+                    draw_ui_graph::input::VIEW_ENTITY,
+                    SlotValue::Entity(*camera_ui),
+                )],
             )?;
         }
 
@@ -45,7 +49,7 @@ pub struct UiPassNode {
 }
 
 impl UiPassNode {
-    pub const IN_VIEW: &'static str = "view";
+    pub const IN_VIEW: &'static str = draw_2d_graph::input::VIEW_ENTITY;
 
     pub fn new(world: &mut World) -> Self {
         Self {

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -32,7 +32,7 @@ impl bevy_render::render_graph::Node for UiPassDriverNode {
                 graph,
                 draw_ui_graph::NAME,
                 vec![("view", SlotValue::Entity(*camera_ui))],
-            );
+            )?;
         }
 
         Ok(run_sub_graphs)

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -3,10 +3,10 @@ use bevy::{
     prelude::*,
     render::{
         render_asset::RenderAssets,
-        render_graph::{self, RenderGraph},
+        render_graph::{self, RenderGraph, RenderGraphs},
         render_resource::*,
         renderer::{RenderContext, RenderDevice},
-        RenderApp, RenderStage,
+        RenderApp, RenderStage, MAIN_GRAPH_ID,
     },
     window::WindowDescriptor,
 };
@@ -66,10 +66,11 @@ impl Plugin for GameOfLifeComputePlugin {
             .add_system_to_stage(RenderStage::Extract, extract_game_of_life_image)
             .add_system_to_stage(RenderStage::Queue, queue_bind_group);
 
-        let mut render_graph = render_app.world.get_resource_mut::<RenderGraph>().unwrap();
+        let mut render_graphs = render_app.world.get_resource_mut::<RenderGraphs>().unwrap();
+        let mut render_graph = render_graphs.get_graph_mut(MAIN_GRAPH_ID);
         render_graph.add_node("game_of_life", DispatchGameOfLife::default());
         render_graph
-            .add_node_edge("game_of_life", MAIN_PASS_DEPENDENCIES)
+            .add_edge("game_of_life", MAIN_PASS_DEPENDENCIES)
             .unwrap();
     }
 }

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -3,7 +3,7 @@ use bevy::{
     prelude::*,
     render::{
         render_asset::RenderAssets,
-        render_graph::{self, RenderGraph, RenderGraphs},
+        render_graph::{self, NodeRunError, RenderGraphContext, RenderGraphs},
         render_resource::*,
         renderer::{RenderContext, RenderDevice},
         RenderApp, RenderStage, MAIN_GRAPH_ID,
@@ -67,7 +67,7 @@ impl Plugin for GameOfLifeComputePlugin {
             .add_system_to_stage(RenderStage::Queue, queue_bind_group);
 
         let mut render_graphs = render_app.world.get_resource_mut::<RenderGraphs>().unwrap();
-        let mut render_graph = render_graphs.get_graph_mut(MAIN_GRAPH_ID);
+        let render_graph = render_graphs.get_graph_mut(MAIN_GRAPH_ID).unwrap();
         render_graph.add_node("game_of_life", DispatchGameOfLife::default());
         render_graph
             .add_edge("game_of_life", MAIN_PASS_DEPENDENCIES)
@@ -182,12 +182,12 @@ impl render_graph::Node for DispatchGameOfLife {
         }
     }
 
-    fn run(
+    fn record(
         &self,
-        _graph: &mut render_graph::RenderGraphContext,
+        _graph: &RenderGraphContext,
         render_context: &mut RenderContext,
         world: &World,
-    ) -> Result<(), render_graph::NodeRunError> {
+    ) -> Result<(), NodeRunError> {
         let pipeline = world.get_resource::<GameOfLifePipeline>().unwrap();
         let texture_bind_group = &world.get_resource::<GameOfLifeImageBindGroup>().unwrap().0;
 

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -3,10 +3,12 @@ use bevy::{
     prelude::*,
     render::{
         camera::{ActiveCameras, ExtractedCameraNames},
-        render_graph::{Node, NodeRunError, RenderGraph, RenderGraphContext, SlotValue},
+        render_graph::{
+            Node, NodeRunError, RenderGraph, RenderGraphContext, RenderGraphs, SlotValue,
+        },
         render_phase::RenderPhase,
         renderer::RenderContext,
-        RenderApp, RenderStage,
+        RenderApp, RenderStage, MAIN_GRAPH_ID,
     },
     window::{CreateWindow, WindowId},
 };
@@ -20,10 +22,11 @@ fn main() {
 
     let render_app = app.sub_app_mut(RenderApp);
     render_app.add_system_to_stage(RenderStage::Extract, extract_secondary_camera_phases);
-    let mut graph = render_app.world.get_resource_mut::<RenderGraph>().unwrap();
+    let mut graphs = render_app.world.get_resource_mut::<RenderGraphs>().unwrap();
+    let mut graph = graphs.get_graph_mut(MAIN_GRAPH_ID);
     graph.add_node(SECONDARY_PASS_DRIVER, SecondaryCameraDriver);
     graph
-        .add_node_edge(node::MAIN_PASS_DEPENDENCIES, SECONDARY_PASS_DRIVER)
+        .add_edge(node::MAIN_PASS_DEPENDENCIES, SECONDARY_PASS_DRIVER)
         .unwrap();
     app.run();
 }


### PR DESCRIPTION
# Objective
Improve the flexibility and ergonomics of the render graph. 

### Move graphs to being stored in a `RenderGraphs` resource instead of as subgraphs

It's unnecessarily limiting for graphs to be in a hierarchical order. For example there could be two nodes in two different subgraphs (say `draw_3d_graph` and `draw_2d_graph`) that want to use the same post processing graph. Graphs are instead identified by `RenderGraphId`:s and can be acquired (mutably or immutably) from the `RenderGraphs` resource.

This makes the architecture a lot more extensible at the cost of allowing nodes to queue graphs in a way that leads to cycles. This class of bugs should be easy to detect and very uncommon though.

### Split the "recording" logic and the "queueing of graphs" logic in the Node trait

Replace `run` with `record` and `queue_graphs`

- Pros
  - More clearly communicates intent
  - Allows for "expanding" graphs as a first step during execution, increasing the granularity by which workgroups can be selected
- Cons
  - Slightly less simple `Node` trait
  - (?)

Most likely a node will only implement one of these methods (in a non-trivial fashion).

### Remove `SlotEdge`:s (and `GraphInputNode`)
- Inputs are avaliable globally for every node in a render graph (slots are at a `RenderGraph` level)
- Nodes can specify their slot requirements by implementing the `slot_requirements` method.
- Calling a graph requires the slot requirements for all of its nodes to be satisfied

Having cpu-side data dependencies in a render graph doesn't seem to have any point (in current main, the only way slot edges are used is from the graph input node). A render graph is more suited to represent the dependencies on the gpu-side.
