### PR TITLE
[Merged by Bors] - bevy_crevice: Fix incorrect iterator usage in WriteStd430 impl for [T]

### DIFF
--- a/crates/bevy_crevice/src/std430/traits.rs
+++ b/crates/bevy_crevice/src/std430/traits.rs
@@ -268,7 +268,7 @@ where
             offset = item.write_std430(writer)?;
         }
 
-        for item in self.iter() {
+        for item in iter {
             item.write_std430(writer)?;
         }
 


### PR DESCRIPTION
# Objective

- Fix incorrect iterator usage in WriteStd430 impl for [T]
  - The first item was being written twice. This is correct in the WriteStd140 impl for [T].

## Solution

- See the code.
