### PR TITLE
[Merged by Bors] - create font atlas that can contains fonts of any size

### DIFF
--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -81,7 +81,7 @@ impl FontAtlasSet {
                 .size
                 .height
                 .max(glyph_texture.texture_descriptor.size.width);
-            let containing = (1u32 << 32 - glyph_max_size.leading_zeros()).max(512) as f32;
+            let containing = (1u32 << (32 - glyph_max_size.leading_zeros())).max(512) as f32;
             font_atlases.push(FontAtlas::new(
                 textures,
                 texture_atlases,

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -76,11 +76,13 @@ impl FontAtlasSet {
             )
         };
         if !font_atlases.iter_mut().any(add_char_to_font_atlas) {
-            let glyph_max_size = glyph_texture
+            // Find the largest dimension of the glyph, either its width or its height
+            let glyph_max_size: u32 = glyph_texture
                 .texture_descriptor
                 .size
                 .height
                 .max(glyph_texture.texture_descriptor.size.width);
+            // Pick the smaller 2^n value greather than glyph_max_size, and at least 512
             let containing = (1u32 << (32 - glyph_max_size.leading_zeros())).max(512) as f32;
             font_atlases.push(FontAtlas::new(
                 textures,

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -76,10 +76,16 @@ impl FontAtlasSet {
             )
         };
         if !font_atlases.iter_mut().any(add_char_to_font_atlas) {
+            let glyph_max_size = glyph_texture
+                .texture_descriptor
+                .size
+                .height
+                .max(glyph_texture.texture_descriptor.size.width);
+            let containing = (1u32 << 32 - glyph_max_size.leading_zeros()).max(512) as f32;
             font_atlases.push(FontAtlas::new(
                 textures,
                 texture_atlases,
-                Vec2::new(512.0, 512.0),
+                Vec2::new(containing, containing),
             ));
             if !font_atlases.last_mut().unwrap().add_glyph(
                 textures,

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -82,7 +82,7 @@ impl FontAtlasSet {
                 .size
                 .height
                 .max(glyph_texture.texture_descriptor.size.width);
-            // Pick the smaller 2^n value greather than glyph_max_size, and at least 512
+            // Pick the higher  of 512 or the smallest power of 2 greater than glyph_max_size
             let containing = (1u32 << (32 - glyph_max_size.leading_zeros())).max(512) as f32;
             font_atlases.push(FontAtlas::new(
                 textures,


### PR DESCRIPTION
# Objective

- Bevy currently panics when displaying text with a *very* big font size  (with font size greater than 400, the glyph would have a width or height greater than 512)
```
thread 'main' panicked at 'Fatal error when processing text: failed to add glyph to newly-created atlas GlyphId(514).', crates/bevy_ui/src/widget/text.rs:118:21
```

## Solution

- Create font atlas that scales up with the size of the glyphs
