### PR TITLE
Add TrackedRenderPass::inner method

### DIFF
--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -339,4 +339,12 @@ impl<'a> TrackedRenderPass<'a> {
         trace!("set blend constant: {:?}", color);
         self.pass.set_blend_constant(wgpu::Color::from(color))
     }
+
+    /// Get the underlying RenderPass.
+    ///
+    /// Resets all tracked state in the process.
+    pub fn inner(&mut self) -> &mut RenderPass<'a> {
+        self.state = Default::default();
+        &mut self.pass
+    }
 }

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -340,7 +340,7 @@ impl<'a> TrackedRenderPass<'a> {
         self.pass.set_blend_constant(wgpu::Color::from(color))
     }
 
-    /// Get the underlying RenderPass.
+    /// Get the underlying [`RenderPass`].
     ///
     /// Resets all tracked state in the process.
     pub fn inner(&mut self) -> &mut RenderPass<'a> {


### PR DESCRIPTION
# Objective

Enable implementations of [`Draw`](https://docs.rs/bevy/latest/bevy/render/render_phase/trait.Draw.html#tymethod.draw) and [`RenderCommand`](https://docs.rs/bevy/latest/bevy/render/render_phase/trait.RenderCommand.html) to directly work with wgpu types.

## Solution

- A method that converts a `TrackedRenderPass` into a `wgpu::RenderPass`