### PR TITLE
[Merged by Bors] - Improve shader_material example documentation

### DIFF
--- a/examples/shader/shader_material.rs
+++ b/examples/shader/shader_material.rs
@@ -101,7 +101,7 @@ impl Material for CustomMaterial {
 
     // For this example we don't need a vertex shader
     // fn vertex_shader(asset_server: &AssetServer) -> Option<Handle<Shader>> {
-    //     // Use the same path as the fragment shader since wgsl let's you define both sahder in the same file
+    //     // Use the same path as the fragment shader since wgsl let's you define both shader in the same file
     //     Some(asset_server.load("shaders/custom_material.wgsl"))
     // }
 

--- a/examples/shader/shader_material.rs
+++ b/examples/shader/shader_material.rs
@@ -7,7 +7,9 @@ use bevy::{
         render_asset::{PrepareAssetError, RenderAsset},
         render_resource::{
             std140::{AsStd140, Std140},
-            *,
+            BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayout,
+            BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingType, Buffer,
+            BufferBindingType, BufferInitDescriptor, BufferSize, BufferUsages, ShaderStages,
         },
         renderer::RenderDevice,
     },
@@ -44,6 +46,7 @@ fn setup(
     });
 }
 
+// This is the struct that will be passed to your shader
 #[derive(Debug, Clone, TypeUuid)]
 #[uuid = "4ee9c363-1124-4113-890e-199d81b00281"]
 pub struct CustomMaterial {
@@ -56,6 +59,7 @@ pub struct GpuCustomMaterial {
     bind_group: BindGroup,
 }
 
+// The implementation of [`Material`] needs this impl to work properly.
 impl RenderAsset for CustomMaterial {
     type ExtractedAsset = CustomMaterial;
     type PreparedAsset = GpuCustomMaterial;
@@ -91,6 +95,16 @@ impl RenderAsset for CustomMaterial {
 }
 
 impl Material for CustomMaterial {
+    // When creating a custom material, you need to define either a vertex shader, a fragment shader or both.
+    // If you don't define one of them it will use the default mesh shader which can be found at
+    // <https://github.com/bevyengine/bevy/blob/latest/crates/bevy_pbr/src/render/mesh.wgsl>
+
+    // For this example we don't need a vertex shader
+    // fn vertex_shader(asset_server: &AssetServer) -> Option<Handle<Shader>> {
+    //     // Use the same path as the fragment shader since wgsl let's you define both sahder in the same file
+    //     Some(asset_server.load("shaders/custom_material.wgsl"))
+    // }
+
     fn fragment_shader(asset_server: &AssetServer) -> Option<Handle<Shader>> {
         Some(asset_server.load("shaders/custom_material.wgsl"))
     }


### PR DESCRIPTION
# Objective

While trying to learn how to use custom shaders, I had difficulty figuring out how to use a vertex shader. My confusion was mostly because all the other shader examples used a custom pipeline, but I didn't want a custom pipeline. After digging around I realised that I simply needed to add a function to the `impl Material` block. I also searched what was the default shader used, because it wasn't obvious to me where to find it.

## Solution

Added a few comments explaining what is going on in the example and a link to the default shader.
