### PR TITLE
Add size_hint method to Fetch trait

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -108,6 +108,10 @@ pub trait Fetch<'world, 'state>: Sized {
     /// Must always be called _after_ [`Fetch::set_table`]. `table_row` must be in the range of the
     /// current table
     unsafe fn table_fetch(&mut self, table_row: usize) -> Self::Item;
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(std::mem::size_of::<Self::Item>()))
+    }
 }
 
 /// State used to construct a Fetch. This will be cached inside [`QueryState`](crate::query::QueryState),


### PR DESCRIPTION
# Objective

Fixes #3342 

## Solution

Adds a method to the Fetch trait where the upper bound is the `size_of::<Fetch::Item>()`.
