### PR TITLE
Improve NixOS/Wayland documentation

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -148,6 +148,24 @@ If you run into issues with building basic apps or activating the GPU ('thread '
     buildInputs = [
 ```
 
+### Wayland support
+
+For wayland support, add the `wayland` and `libxkbcommon` packages to the `makeLibraryPath` inputs in your `shell.nix`:
+
+``` diff
+  { pkgs ? import <nixpkgs> { } }:
+  with pkgs;
+  mkShell {
+    shellHook = ''export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${pkgs.lib.makeLibraryPath [
+      alsaLib
+      udev
+      vulkan-loader
++     wayland
++     libxkbcommon
+    ]}"'';
+    buildInputs = [
+```
+
 ## Opensuse Tumbleweed
 
 ```bash

--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -141,9 +141,9 @@ If you run into issues with building basic apps or activating the GPU ('thread '
   with pkgs;
   mkShell {
 +   shellHook = ''export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${pkgs.lib.makeLibraryPath [
-+     pkgs.alsaLib
-+     pkgs.udev
-+     pkgs.vulkan-loader
++     alsaLib
++     udev
++     vulkan-loader
 +   ]}"'';
     buildInputs = [
 ```


### PR DESCRIPTION
# Objective

Some additional requirements for Wayland on NixOS are not documented. Also, there are some unnecessary package qualifications in the current documentation.

## Solution

Remove unnecessary package qualifications and document Wayland requirements on NixOS.
