### PR TITLE
[Merged by Bors] - do not set cursor grab on window creation if not asked for

### DIFF
--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -127,10 +127,12 @@ impl WinitWindows {
 
         let winit_window = winit_window_builder.build(event_loop).unwrap();
 
-        match winit_window.set_cursor_grab(window_descriptor.cursor_locked) {
-            Ok(_) => {}
-            Err(winit::error::ExternalError::NotSupported(_)) => {}
-            Err(err) => Err(err).unwrap(),
+        if window_descriptor.cursor_locked {
+            match winit_window.set_cursor_grab(true) {
+                Ok(_) => {}
+                Err(winit::error::ExternalError::NotSupported(_)) => {}
+                Err(err) => Err(err).unwrap(),
+            }
         }
 
         winit_window.set_cursor_visible(window_descriptor.cursor_visible);


### PR DESCRIPTION
# Objective

- On Safari mobile, calling `winit_window.set_cursor_grab(true)` fails as the API is not implemented (as there is no cursor on Safari mobile, the api doesn't make sense there). I don't know about other mobile browsers
```
[Error] Unhandled Promise Rejection: TypeError: getObject(arg0).exitPointerLock is not a function. (In 'getObject(arg0).exitPointerLock()', 'getObject(arg0).exitPointerLock' is undefined)
    (anonymous function) (rect.js:1089)
    wasm-stub
    <?>.wasm-function[web_sys::features::gen_Document::Document::exit_pointer_lock::h20ffc49be163fc45]
    <?>.wasm-function[winit::platform_impl::platform::backend::canvas::Canvas::set_cursor_grab::h6a9472cf55263e98]
    <?>.wasm-function[bevy_winit::winit_windows::WinitWindows::create_window::h9db5b3cbb24347c5]
    <?>.wasm-function[<bevy_winit::WinitPlugin as bevy_app::plugin::Plugin>::build::ha4a7c046b80c4280]
    <?>.wasm-function[bevy_app::plugin_group::PluginGroupBuilder::finish::h0e5bc78f71c37b2f]
    <?>.wasm-function[rect::main::h899852fd17f2d489]
    <?>.wasm-function[std::sys_common::backtrace::__rust_begin_short_backtrace::hfe38f282e8dda96b]
    <?>.wasm-function[std::rt::lang_start::{{closure}}::hc2f3b555ffc58618]
    <?>.wasm-function[std::rt::lang_start_internal::ha901ae30d88554f2]
    <?>.wasm-function[main]
    <?>.wasm-function[]
    wasm-stub
    21261
    (anonymous function) (rect.js:1664)
    asyncFunctionResume
    (anonymous function)
    promiseReactionJobWithoutPromise
    promiseReactionJob
```

## Solution

- Do not call the api to release cursor grab on window creation, as the cursor is not grabbed anyway at this point
