### PR TITLE
Add loading_screen example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,6 +319,10 @@ path = "examples/asset/custom_asset_io.rs"
 name = "hot_asset_reloading"
 path = "examples/asset/hot_asset_reloading.rs"
 
+[[example]]
+name = "loading_screen"
+path = "examples/asset/loading_screen.rs"
+
 # Async Tasks
 [[example]]
 name = "async_compute"

--- a/examples/README.md
+++ b/examples/README.md
@@ -153,6 +153,7 @@ Example | File | Description
 `custom_asset` | [`asset/custom_asset.rs`](./asset/custom_asset.rs) | Implements a custom asset loader
 `custom_asset_io` | [`asset/custom_asset_io.rs`](./asset/custom_asset_io.rs) | Implements a custom asset io loader
 `hot_asset_reloading` | [`asset/hot_asset_reloading.rs`](./asset/hot_asset_reloading.rs) | Demonstrates automatic reloading of assets when modified on disk
+`loading_screen` | [`asset/loading_screen.rs`](./asset/loading_screen.rs) | Demonstrates a way to create a loading screen and provides it as a plugin template
 
 ## Async Tasks
 

--- a/examples/asset/loading_screen.rs
+++ b/examples/asset/loading_screen.rs
@@ -57,7 +57,7 @@ fn setup_game(
 ) {
     // Change our default loading screen text to something more descriptive
     let children = loading_screen.single();
-    for child in children.first() {
+    if let Some(child) = children.first() {
         if let Ok(mut loading_text) = text_query.get_mut(*child) {
             loading_text.sections[0].value = "Loading \"FlightHelmet\"".to_string();
         }
@@ -206,7 +206,7 @@ pub mod plugin {
         // We only have one loading screen, so we can use `single()` instead of `iter()`
         let children = loading_screen.single();
         // We only have one `UiImage` in our loading screen, so `first()` does the trick
-        for child in children.first() {
+        if let Some(child) = children.first() {
             // Actually get the `Transform` of our child from all `UiImage`s
             if let Ok(mut transform) = images_query.get_mut(*child) {
                 // Rotate the image clockwise
@@ -224,7 +224,7 @@ pub mod plugin {
         let (mut style, children) = loading_screen.single_mut();
         style.display = Display::None;
         // We only have one `Text` in our loading screen, so `first()` does the trick
-        for child in children.first() {
+        if let Some(child) = children.first() {
             // Reset the text to our default text
             if let Ok(mut loading_text) = text_query.get_mut(*child) {
                 loading_text.sections[0].value = LOADING_SCREEN_DEFAULT_TEXT.to_string();

--- a/examples/asset/loading_screen.rs
+++ b/examples/asset/loading_screen.rs
@@ -1,9 +1,6 @@
-use bevy::{
-    prelude::*, gltf::Gltf,
-};
+use bevy::{gltf::Gltf, prelude::*};
 
 /// This example illustrates, how a loading screen can be implemented. It has an animated spinner and listens for an `AssetEvent`.
-
 
 #[derive(Clone, Eq, PartialEq, Debug, Hash)]
 enum GameState {
@@ -16,8 +13,12 @@ fn main() {
         .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         // Loading screen plugin and its `asset_listening_system`
-        .add_plugin(plugin::SimpleLoadingScreenPlugin { loading_state: GameState::Loading })
-        .add_system_set(SystemSet::on_update(GameState::Loading).with_system(asset_listening_system))
+        .add_plugin(plugin::SimpleLoadingScreenPlugin {
+            loading_state: GameState::Loading,
+        })
+        .add_system_set(
+            SystemSet::on_update(GameState::Loading).with_system(asset_listening_system),
+        )
         // system that sets up everything for our game
         .add_startup_system(setup_game)
         // system that will be run after everything is set up
@@ -39,10 +40,10 @@ fn asset_listening_system(
                 // in this case, we know that we only had one asset (FlightHelmet.gltf#Scene0) to load,
                 // so we can switch our game state from `GameState::Loading` over to `GameState::Playing`
                 let _ = state.overwrite_set(GameState::Playing);
-            },
+            }
             // we don't care about these events in our example
-            AssetEvent::Modified { handle: _ } => {},
-            AssetEvent::Removed { handle: _ } => {},
+            AssetEvent::Modified { handle: _ } => {}
+            AssetEvent::Removed { handle: _ } => {}
         }
     }
 }
@@ -52,7 +53,7 @@ fn setup_game(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     mut loading_screen: Query<(&mut Style, &Children), With<plugin::LoadingScreen>>,
-    mut text_query: Query<&mut Text>
+    mut text_query: Query<&mut Text>,
 ) {
     // Change our default loading screen text to something more descriptive
     for (mut _style, children) in loading_screen.iter_mut() {
@@ -91,10 +92,7 @@ fn setup_game(
 }
 
 // Your, or at least one of your, game systems.
-fn game_system(
-    _commands: Commands,
-    _asset_server: Res<AssetServer>,
-) {
+fn game_system(_commands: Commands, _asset_server: Res<AssetServer>) {
     // TODO: do your thing!
 }
 
@@ -103,7 +101,8 @@ fn game_system(
 // like `asset_listening_system`, to track your loading progress and to transition into your playing state.
 pub mod plugin {
     use bevy::{
-        ecs::schedule::{SystemSet, StateData}, prelude::*,
+        ecs::schedule::{StateData, SystemSet},
+        prelude::*,
     };
 
     pub struct SimpleLoadingScreenPlugin<S: StateData> {
@@ -112,11 +111,15 @@ pub mod plugin {
 
     impl<S: StateData> Plugin for SimpleLoadingScreenPlugin<S> {
         fn build(&self, app: &mut App) {
-            app
-                .add_state(self.loading_state.clone())
+            app.add_state(self.loading_state.clone())
                 .add_startup_system(setup_loading_screen)
-                .add_system_set(SystemSet::on_update(self.loading_state.clone()).with_system(animate_spinner))
-                .add_system_set(SystemSet::on_exit(self.loading_state.clone()).with_system(close_loading_screen));
+                .add_system_set(
+                    SystemSet::on_update(self.loading_state.clone()).with_system(animate_spinner),
+                )
+                .add_system_set(
+                    SystemSet::on_exit(self.loading_state.clone())
+                        .with_system(close_loading_screen),
+                );
         }
     }
 
@@ -126,10 +129,7 @@ pub mod plugin {
 
     // Setup our simple loading screen, it uses an image as spinner and a loading text bellow it.
     // INFO: you need to change this if you want something fancier 🙂
-    fn setup_loading_screen(
-        mut commands: Commands,
-        asset_server: Res<AssetServer>,
-    ) {
+    fn setup_loading_screen(mut commands: Commands, asset_server: Res<AssetServer>) {
         // UI camera
         commands.spawn_bundle(UiCameraBundle::default());
         commands
@@ -183,7 +183,7 @@ pub mod plugin {
                             },
                             TextAlignment {
                                 horizontal: HorizontalAlign::Center,
-                                vertical: VerticalAlign::Center
+                                vertical: VerticalAlign::Center,
                             },
                         ),
                         ..Default::default()
@@ -198,7 +198,7 @@ pub mod plugin {
         // This queries for the children and style of the `NodeBundle` we marked with `LoadingScreen`
         mut loading_screen: Query<(&mut Style, &Children), With<LoadingScreen>>,
         // Queries for the `Transform`s of all `UiImage`s, so that we can get our child from it.
-        mut images_query: Query<&mut Transform, With<UiImage>>
+        mut images_query: Query<&mut Transform, With<UiImage>>,
     ) {
         for (mut _style, children) in loading_screen.iter_mut() {
             // All children of the loading screen
@@ -215,7 +215,7 @@ pub mod plugin {
     // Close our loading screen. This system is called when we exit `GameState::Loading`.
     fn close_loading_screen(
         mut loading_screen: Query<(&mut Style, &Children), With<LoadingScreen>>,
-        mut text_query: Query<&mut Text>
+        mut text_query: Query<&mut Text>,
     ) {
         for (mut style, children) in loading_screen.iter_mut() {
             style.display = Display::None;

--- a/examples/asset/loading_screen.rs
+++ b/examples/asset/loading_screen.rs
@@ -1,68 +1,22 @@
-use bevy::{gltf::Gltf, prelude::*};
+use bevy::prelude::*;
 
 /// This example illustrates, how a loading screen can be implemented. It has an animated spinner and listens for an `AssetEvent`.
-
-#[derive(Clone, Eq, PartialEq, Debug, Hash)]
-enum GameState {
-    Loading,
-    Playing,
-}
 
 fn main() {
     App::new()
         .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         // Loading screen plugin and its `asset_listening_system`
-        .add_plugin(plugin::SimpleLoadingScreenPlugin {
-            loading_state: GameState::Loading,
-        })
-        .add_system_set(
-            SystemSet::on_update(GameState::Loading).with_system(asset_listening_system),
-        )
+        .add_plugin(plugin::SimpleLoadingScreenPlugin)
         // system that sets up everything for our game
         .add_startup_system(setup_game)
         // system that will be run after everything is set up
-        .add_system_set(SystemSet::on_enter(GameState::Playing).with_system(game_system))
+        .add_system_set(SystemSet::on_enter(plugin::LoadingState::Done).with_system(game_system))
         .run();
 }
 
-// System that listens for our `AssetEvent` and changes our game state after we finished loading our asset
-fn asset_listening_system(
-    // if you have different asset, either use another `EventReader` for your particular type of asset,
-    // or use `AssetServer::get_load_state` with a resource in which you track the handles of your assets.
-    mut asset_events: EventReader<AssetEvent<Gltf>>,
-    mut state: ResMut<State<GameState>>,
-) {
-    for event in asset_events.iter() {
-        match event {
-            AssetEvent::Created { handle: _ } => {
-                info!("Done loading, switch state to `GameState::Playing`");
-                // in this case, we know that we only had one asset (FlightHelmet.gltf#Scene0) to load,
-                // so we can switch our game state from `GameState::Loading` over to `GameState::Playing`
-                let _ = state.overwrite_set(GameState::Playing);
-            }
-            // we don't care about these events in our example
-            AssetEvent::Modified { handle: _ } => {}
-            AssetEvent::Removed { handle: _ } => {}
-        }
-    }
-}
-
 // Here we prepare our gaming scene, meaning we setup our ingame camera and load our asset.
-fn setup_game(
-    mut commands: Commands,
-    asset_server: Res<AssetServer>,
-    loading_screen: Query<&Children, With<plugin::LoadingScreen>>,
-    mut text_query: Query<&mut Text, With<plugin::LoadingScreenContent>>,
-) {
-    // Change our default loading screen text to something more descriptive
-    let children = loading_screen.single();
-    if let Some(child) = children.first() {
-        if let Ok(mut loading_text) = text_query.get_mut(*child) {
-            loading_text.sections[0].value = "Loading \"FlightHelmet\"".to_string();
-        }
-    }
-
+fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
     // actually load our asset
     commands.spawn_scene(asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0"));
     // spawn our camera
@@ -99,25 +53,28 @@ fn game_system(_commands: Commands, _asset_server: Res<AssetServer>) {
 // You can use this as a template for your own project/game. Don't forget, that you also need a system,
 // like `asset_listening_system`, to track your loading progress and to transition into your playing state.
 pub mod plugin {
-    use bevy::{
-        ecs::schedule::{StateData, SystemSet},
-        prelude::*,
-    };
+    use bevy::{ecs::schedule::SystemSet, gltf::Gltf, prelude::*};
 
-    pub struct SimpleLoadingScreenPlugin<S: StateData> {
-        pub loading_state: S,
+    #[derive(Clone, Eq, PartialEq, Debug, Hash)]
+    pub enum LoadingState {
+        Loading,
+        Done,
     }
 
-    impl<S: StateData> Plugin for SimpleLoadingScreenPlugin<S> {
+    pub struct SimpleLoadingScreenPlugin;
+
+    impl Plugin for SimpleLoadingScreenPlugin {
         fn build(&self, app: &mut App) {
-            app.add_state(self.loading_state.clone())
+            app.add_state(LoadingState::Loading)
                 .add_startup_system(setup_loading_screen)
                 .add_system_set(
-                    SystemSet::on_update(self.loading_state.clone()).with_system(animate_spinner),
+                    SystemSet::on_update(LoadingState::Loading).with_system(animate_spinner),
                 )
                 .add_system_set(
-                    SystemSet::on_exit(self.loading_state.clone())
-                        .with_system(close_loading_screen),
+                    SystemSet::on_update(LoadingState::Loading).with_system(asset_listening_system),
+                )
+                .add_system_set(
+                    SystemSet::on_exit(LoadingState::Loading).with_system(close_loading_screen),
                 );
         }
     }
@@ -144,7 +101,7 @@ pub mod plugin {
                     flex_direction: FlexDirection::ColumnReverse,
                     ..Default::default()
                 },
-                color: Color::rgba(0.1, 0.1, 0.1, 1.0).into(),
+                color: Color::rgba(0.14, 0.14, 0.15, 1.0).into(),
                 ..Default::default()
             })
             // add the stuff we want to see on the loading screen as children
@@ -195,6 +152,29 @@ pub mod plugin {
             .insert(LoadingScreen);
     }
 
+    // System that listens for our `AssetEvent` and changes our game state after we finished loading our asset
+    // INFO: you need to change this if you have different assets 🙂
+    fn asset_listening_system(
+        // if you have different assets, either use another `EventReader` for your particular type of asset,
+        // or use `AssetServer::get_load_state` with a resource in which you track the handles of your assets.
+        mut asset_events: EventReader<AssetEvent<Gltf>>,
+        mut state: ResMut<State<LoadingState>>,
+    ) {
+        for event in asset_events.iter() {
+            match event {
+                AssetEvent::Created { handle: _ } => {
+                    info!("Done loading, switch state to `LoadingState::Done`");
+                    // in this case, we know that we only had one asset (FlightHelmet.gltf#Scene0) to load,
+                    // so we can switch our game state from `LoadingState::Loading` over to `LoadingState::Done`
+                    let _ = state.overwrite_set(LoadingState::Done);
+                }
+                // we don't care about these events in our example
+                AssetEvent::Modified { handle: _ } => {}
+                AssetEvent::Removed { handle: _ } => {}
+            }
+        }
+    }
+
     // Animates aka rotates the bevy bird `UiIamge` clockwise.
     fn animate_spinner(
         time: Res<Time>,
@@ -215,10 +195,11 @@ pub mod plugin {
         }
     }
 
-    // Close our loading screen. This system is called when we exit `GameState::Loading`.
+    // Close our loading screen. This system is called when we exit `LoadingState::Loading`.
     fn close_loading_screen(
         mut loading_screen: Query<(&mut Style, &Children), With<LoadingScreen>>,
         mut text_query: Query<&mut Text, With<LoadingScreenContent>>,
+        mut images_query: Query<&mut Transform, (With<UiImage>, With<LoadingScreenContent>)>,
     ) {
         // We only have one loading screen, so we can use `single_mut()` instead of `iter_mut()`
         let (mut style, children) = loading_screen.single_mut();
@@ -228,6 +209,11 @@ pub mod plugin {
             // Reset the text to our default text
             if let Ok(mut loading_text) = text_query.get_mut(*child) {
                 loading_text.sections[0].value = LOADING_SCREEN_DEFAULT_TEXT.to_string();
+            }
+            // Actually get the `Transform` of our child from all `UiImage`s
+            if let Ok(mut transform) = images_query.get_mut(*child) {
+                // Reset to the default rotation
+                transform.rotation = Quat::default();
             }
         }
     }

--- a/examples/asset/loading_screen.rs
+++ b/examples/asset/loading_screen.rs
@@ -1,8 +1,8 @@
 use bevy::{
-    ecs::schedule::SystemSet, prelude::*, gltf::Gltf,
+    prelude::*, gltf::Gltf,
 };
 
-/// This example illustrates, how a loading screen can be implemented. It has an animated spinner and listens for an AssetEvent.
+/// This example illustrates, how a loading screen can be implemented. It has an animated spinner and listens for an `AssetEvent`.
 
 
 #[derive(Clone, Eq, PartialEq, Debug, Hash)]
@@ -15,113 +15,34 @@ fn main() {
     App::new()
         .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
-        .add_state(GameState::Loading)
-        .add_startup_system(setup_loading_screen)
-        .add_startup_system(setup_game)
-        .add_system_set(SystemSet::on_update(GameState::Loading).with_system(animate_spinner))
+        // Loading screen plugin and its `asset_listening_system`
+        .add_plugin(plugin::SimpleLoadingScreenPlugin { loading_state: GameState::Loading })
         .add_system_set(SystemSet::on_update(GameState::Loading).with_system(asset_listening_system))
-        .add_system_set(SystemSet::on_exit(GameState::Loading).with_system(close_loading_screen))
+        // system that sets up everything for our game
+        .add_startup_system(setup_game)
+        // system that will be run after everything is set up
         .add_system_set(SystemSet::on_enter(GameState::Playing).with_system(game_system))
         .run();
 }
 
-#[derive(Component)]
-pub struct LoadingScreen;
-const LOADING_SCREEN_DEFAULT_TEXT: &str = "Loading...";
-
-// Setup our simple loading screen, it uses an image as spinner and a loading text bellow it.
-fn setup_loading_screen(
-    mut commands: Commands,
-    asset_server: Res<AssetServer>,
+// System that listens for our `AssetEvent` and changes our game state after we finished loading our asset
+fn asset_listening_system(
+    // if you have different asset, either use another `EventReader` for your particular type of asset,
+    // or use `AssetServer::get_load_state` with a resource in which you track the handles of your assets.
+    mut asset_events: EventReader<AssetEvent<Gltf>>,
+    mut state: ResMut<State<GameState>>,
 ) {
-    // UI camera
-    commands.spawn_bundle(UiCameraBundle::default());
-    commands
-        // NodeBundle used as background
-        .spawn_bundle(NodeBundle {
-            style: Style {
-                size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
-                position_type: PositionType::Absolute,
-                align_items: AlignItems::Center,
-                justify_content: JustifyContent::Center,
-                flex_direction: FlexDirection::ColumnReverse,
-                ..Default::default()
+    for event in asset_events.iter() {
+        match event {
+            AssetEvent::Created { handle: _ } => {
+                println!("Done loading, switch state to `GameState::Playing`");
+                // in this case, we know that we only had one asset (FlightHelmet.gltf#Scene0) to load,
+                // so we can switch our game state from `GameState::Loading` over to `GameState::Playing`
+                let _ = state.overwrite_set(GameState::Playing);
             },
-            color: Color::rgba(0.1, 0.1, 0.1, 1.0).into(),
-            ..Default::default()
-        })
-        .with_children(|parent| {
-            parent
-                // The bevy bird used as s spinner
-                .spawn_bundle(ImageBundle {
-                    style: Style {
-                        position_type: PositionType::Relative,
-                        align_items: AlignItems::Center,
-                        justify_content: JustifyContent::Center,
-                        size: Size::new(Val::Auto, Val::Percent(25.0)),
-                        margin: UiRect {
-                            bottom: Val::Percent(3.0),
-                            ..Default::default()
-                        },
-                        ..Default::default()
-                    },
-                    image: asset_server.load("branding/icon.png").into(),
-                    ..Default::default()
-                });
-            parent
-                // Loading screen text bellow the bevy spinner
-                .spawn_bundle(TextBundle {
-                    style: Style {
-                        position_type: PositionType::Relative,
-                        align_items: AlignItems::Center,
-                        justify_content: JustifyContent::Center,
-                        ..Default::default()
-                    },
-                    text: Text::with_section(
-                        LOADING_SCREEN_DEFAULT_TEXT,
-                        TextStyle {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                            font_size: 50.0,
-                            color: Color::WHITE,
-                        },
-                        TextAlignment {
-                            horizontal: HorizontalAlign::Center,
-                            vertical: VerticalAlign::Center
-                        },
-                    ),
-                    ..Default::default()
-                });
-        })
-        .insert(LoadingScreen);
-}
-
-// Animates aka rotates the bevy bird UiIamge clockwise.
-fn animate_spinner(
-    time: Res<Time>,
-    mut loading_screen: Query<(&mut Style, &Children), With<LoadingScreen>>,
-    mut text_query: Query<&mut Transform, With<UiImage>>
-) {
-    for (mut _style, children) in loading_screen.iter_mut() {
-        for child in children.iter() {
-            if let Ok(mut transform) = text_query.get_mut(*child) {
-                transform.rotate(Quat::from_rotation_z(-time.delta_seconds() * 0.5));
-            }
-        }
-    }
-}
-
-// Close our loading screen. This system is called when we exit GameState::Loading.
-fn close_loading_screen(
-    mut loading_screen: Query<(&mut Style, &Children), With<LoadingScreen>>,
-    mut text_query: Query<&mut Text>
-) {
-    for (mut style, children) in loading_screen.iter_mut() {
-        style.display = Display::None;
-        // Reset the loading screen text to our default text
-        for child in children.iter() {
-            if let Ok(mut loading_text) = text_query.get_mut(*child) {
-                loading_text.sections[0].value = LOADING_SCREEN_DEFAULT_TEXT.to_string();
-            }
+            // we don't care about these events in our example
+            AssetEvent::Modified { handle: _ } => {},
+            AssetEvent::Removed { handle: _ } => {},
         }
     }
 }
@@ -130,7 +51,7 @@ fn close_loading_screen(
 fn setup_game(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
-    mut loading_screen: Query<(&mut Style, &Children), With<LoadingScreen>>,
+    mut loading_screen: Query<(&mut Style, &Children), With<plugin::LoadingScreen>>,
     mut text_query: Query<&mut Text>
 ) {
     // Change our default loading screen text to something more descriptive
@@ -169,31 +90,141 @@ fn setup_game(
     });
 }
 
-// System that listens for our AssetEvent and changes our game state after we finished loading our asset
-fn asset_listening_system(
-    mut asset_events: EventReader<AssetEvent<Gltf>>,
-    mut state: ResMut<State<GameState>>,
-) {
-    for event in asset_events.iter() {
-        match event {
-            AssetEvent::Created { handle: _ } => {
-                println!("Done loading, switch state to `GameState::Playing`");
-                // in this case, we know that we only had one asset (FlightHelmet.gltf#Scene0) to load,
-                // so we can switch our game state from GameState::Loading over to GameState::Playing
-                let _ = state.overwrite_set(GameState::Playing);
-            },
-            // we don't care about these events in our example
-            AssetEvent::Modified { handle: _ } => {},
-            AssetEvent::Removed { handle: _ } => {},
-        }
-
-    }
-}
-
 // Your, or at least one of your, game systems.
 fn game_system(
     _commands: Commands,
     _asset_server: Res<AssetServer>,
 ) {
     // TODO: do your thing!
+}
+
+//########################################## Example of a loading screen plugin ##########################################//
+// You can use this as a template for your own project/game. Don't forget, that you also need a system,
+// like `asset_listening_system`, to track your loading progress and to transition into your playing state.
+pub mod plugin {
+    use bevy::{
+        ecs::schedule::{SystemSet, StateData}, prelude::*,
+    };
+
+    pub struct SimpleLoadingScreenPlugin<S: StateData> {
+        pub loading_state: S,
+    }
+
+    impl<S: StateData> Plugin for SimpleLoadingScreenPlugin<S> {
+        fn build(&self, app: &mut App) {
+            app
+                .add_state(self.loading_state.clone())
+                .add_startup_system(setup_loading_screen)
+                .add_system_set(SystemSet::on_update(self.loading_state.clone()).with_system(animate_spinner))
+                .add_system_set(SystemSet::on_exit(self.loading_state.clone()).with_system(close_loading_screen));
+        }
+    }
+
+    #[derive(Component)]
+    pub struct LoadingScreen;
+    const LOADING_SCREEN_DEFAULT_TEXT: &str = "Loading...";
+
+    // Setup our simple loading screen, it uses an image as spinner and a loading text bellow it.
+    // INFO: you need to change this if you want something fancier 🙂
+    fn setup_loading_screen(
+        mut commands: Commands,
+        asset_server: Res<AssetServer>,
+    ) {
+        // UI camera
+        commands.spawn_bundle(UiCameraBundle::default());
+        commands
+            // NodeBundle used as background and root for our loading screen
+            .spawn_bundle(NodeBundle {
+                style: Style {
+                    size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
+                    position_type: PositionType::Absolute,
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::Center,
+                    flex_direction: FlexDirection::ColumnReverse,
+                    ..Default::default()
+                },
+                color: Color::rgba(0.1, 0.1, 0.1, 1.0).into(),
+                ..Default::default()
+            })
+            // add the stuff we want to see on the loading screen as children
+            .with_children(|parent| {
+                parent
+                    // The bevy bird used as a spinner
+                    .spawn_bundle(ImageBundle {
+                        style: Style {
+                            position_type: PositionType::Relative,
+                            align_items: AlignItems::Center,
+                            justify_content: JustifyContent::Center,
+                            size: Size::new(Val::Auto, Val::Percent(25.0)),
+                            margin: UiRect {
+                                bottom: Val::Percent(3.0),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        },
+                        image: asset_server.load("branding/icon.png").into(),
+                        ..Default::default()
+                    });
+                parent
+                    // Loading screen text bellow the bevy spinner
+                    .spawn_bundle(TextBundle {
+                        style: Style {
+                            position_type: PositionType::Relative,
+                            align_items: AlignItems::Center,
+                            justify_content: JustifyContent::Center,
+                            ..Default::default()
+                        },
+                        text: Text::with_section(
+                            LOADING_SCREEN_DEFAULT_TEXT,
+                            TextStyle {
+                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                font_size: 50.0,
+                                color: Color::WHITE,
+                            },
+                            TextAlignment {
+                                horizontal: HorizontalAlign::Center,
+                                vertical: VerticalAlign::Center
+                            },
+                        ),
+                        ..Default::default()
+                    });
+            })
+            .insert(LoadingScreen);
+    }
+
+    // Animates aka rotates the bevy bird `UiIamge` clockwise.
+    fn animate_spinner(
+        time: Res<Time>,
+        // This queries for the children and style of the `NodeBundle` we marked with `LoadingScreen`
+        mut loading_screen: Query<(&mut Style, &Children), With<LoadingScreen>>,
+        // Queries for the `Transform`s of all `UiImage`s, so that we can get our child from it.
+        mut images_query: Query<&mut Transform, With<UiImage>>
+    ) {
+        for (mut _style, children) in loading_screen.iter_mut() {
+            // All children of the loading screen
+            for child in children.iter() {
+                // Actually get the `Transform` of our child from all `UiImage`s
+                if let Ok(mut transform) = images_query.get_mut(*child) {
+                    // Rotate the image clockwise
+                    transform.rotate(Quat::from_rotation_z(-time.delta_seconds() * 0.5));
+                }
+            }
+        }
+    }
+
+    // Close our loading screen. This system is called when we exit `GameState::Loading`.
+    fn close_loading_screen(
+        mut loading_screen: Query<(&mut Style, &Children), With<LoadingScreen>>,
+        mut text_query: Query<&mut Text>
+    ) {
+        for (mut style, children) in loading_screen.iter_mut() {
+            style.display = Display::None;
+            // Reset the loading screen text to our default text
+            for child in children.iter() {
+                if let Ok(mut loading_text) = text_query.get_mut(*child) {
+                    loading_text.sections[0].value = LOADING_SCREEN_DEFAULT_TEXT.to_string();
+                }
+            }
+        }
+    }
 }

--- a/examples/asset/loading_screen.rs
+++ b/examples/asset/loading_screen.rs
@@ -1,0 +1,199 @@
+use bevy::{
+    ecs::schedule::SystemSet, prelude::*, gltf::Gltf,
+};
+
+/// This example illustrates, how a loading screen can be implemented. It has an animated spinner and listens for an AssetEvent.
+
+
+#[derive(Clone, Eq, PartialEq, Debug, Hash)]
+enum GameState {
+    Loading,
+    Playing,
+}
+
+fn main() {
+    App::new()
+        .insert_resource(Msaa { samples: 4 })
+        .add_plugins(DefaultPlugins)
+        .add_state(GameState::Loading)
+        .add_startup_system(setup_loading_screen)
+        .add_startup_system(setup_game)
+        .add_system_set(SystemSet::on_update(GameState::Loading).with_system(animate_spinner))
+        .add_system_set(SystemSet::on_update(GameState::Loading).with_system(asset_listening_system))
+        .add_system_set(SystemSet::on_exit(GameState::Loading).with_system(close_loading_screen))
+        .add_system_set(SystemSet::on_enter(GameState::Playing).with_system(game_system))
+        .run();
+}
+
+#[derive(Component)]
+pub struct LoadingScreen;
+const LOADING_SCREEN_DEFAULT_TEXT: &str = "Loading...";
+
+// Setup our simple loading screen, it uses an image as spinner and a loading text bellow it.
+fn setup_loading_screen(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+) {
+    // UI camera
+    commands.spawn_bundle(UiCameraBundle::default());
+    commands
+        // NodeBundle used as background
+        .spawn_bundle(NodeBundle {
+            style: Style {
+                size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
+                position_type: PositionType::Absolute,
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+                flex_direction: FlexDirection::ColumnReverse,
+                ..Default::default()
+            },
+            color: Color::rgba(0.1, 0.1, 0.1, 1.0).into(),
+            ..Default::default()
+        })
+        .with_children(|parent| {
+            parent
+                // The bevy bird used as s spinner
+                .spawn_bundle(ImageBundle {
+                    style: Style {
+                        position_type: PositionType::Relative,
+                        align_items: AlignItems::Center,
+                        justify_content: JustifyContent::Center,
+                        size: Size::new(Val::Auto, Val::Percent(25.0)),
+                        margin: UiRect {
+                            bottom: Val::Percent(3.0),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                    image: asset_server.load("branding/icon.png").into(),
+                    ..Default::default()
+                });
+            parent
+                // Loading screen text bellow the bevy spinner
+                .spawn_bundle(TextBundle {
+                    style: Style {
+                        position_type: PositionType::Relative,
+                        align_items: AlignItems::Center,
+                        justify_content: JustifyContent::Center,
+                        ..Default::default()
+                    },
+                    text: Text::with_section(
+                        LOADING_SCREEN_DEFAULT_TEXT,
+                        TextStyle {
+                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                            font_size: 50.0,
+                            color: Color::WHITE,
+                        },
+                        TextAlignment {
+                            horizontal: HorizontalAlign::Center,
+                            vertical: VerticalAlign::Center
+                        },
+                    ),
+                    ..Default::default()
+                });
+        })
+        .insert(LoadingScreen);
+}
+
+// Animates aka rotates the bevy bird UiIamge clockwise.
+fn animate_spinner(
+    time: Res<Time>,
+    mut loading_screen: Query<(&mut Style, &Children), With<LoadingScreen>>,
+    mut text_query: Query<&mut Transform, With<UiImage>>
+) {
+    for (mut _style, children) in loading_screen.iter_mut() {
+        for child in children.iter() {
+            if let Ok(mut transform) = text_query.get_mut(*child) {
+                transform.rotate(Quat::from_rotation_z(-time.delta_seconds() * 0.5));
+            }
+        }
+    }
+}
+
+// Close our loading screen. This system is called when we exit GameState::Loading.
+fn close_loading_screen(
+    mut loading_screen: Query<(&mut Style, &Children), With<LoadingScreen>>,
+    mut text_query: Query<&mut Text>
+) {
+    for (mut style, children) in loading_screen.iter_mut() {
+        style.display = Display::None;
+        // Reset the loading screen text to our default text
+        for child in children.iter() {
+            if let Ok(mut loading_text) = text_query.get_mut(*child) {
+                loading_text.sections[0].value = LOADING_SCREEN_DEFAULT_TEXT.to_string();
+            }
+        }
+    }
+}
+
+// Here we prepare our gaming scene, meaning we setup our ingame camera and load our asset.
+fn setup_game(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut loading_screen: Query<(&mut Style, &Children), With<LoadingScreen>>,
+    mut text_query: Query<&mut Text>
+) {
+    // Change our default loading screen text to something more descriptive
+    for (mut _style, children) in loading_screen.iter_mut() {
+        for child in children.iter() {
+            if let Ok(mut loading_text) = text_query.get_mut(*child) {
+                loading_text.sections[0].value = "Loading \"FlightHelmet\"".to_string();
+            }
+        }
+    }
+
+    // actually load our asset
+    commands.spawn_scene(asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0"));
+    // spawn our camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(0.7, 0.7, 1.0).looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
+        ..Default::default()
+    });
+    // bring light into the darkness
+    const HALF_SIZE: f32 = 1.0;
+    commands.spawn_bundle(DirectionalLightBundle {
+        directional_light: DirectionalLight {
+            shadow_projection: OrthographicProjection {
+                left: -HALF_SIZE,
+                right: HALF_SIZE,
+                bottom: -HALF_SIZE,
+                top: HALF_SIZE,
+                near: -10.0 * HALF_SIZE,
+                far: 10.0 * HALF_SIZE,
+                ..Default::default()
+            },
+            shadows_enabled: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+}
+
+// System that listens for our AssetEvent and changes our game state after we finished loading our asset
+fn asset_listening_system(
+    mut asset_events: EventReader<AssetEvent<Gltf>>,
+    mut state: ResMut<State<GameState>>,
+) {
+    for event in asset_events.iter() {
+        match event {
+            AssetEvent::Created { handle: _ } => {
+                println!("Done loading, switch state to `GameState::Playing`");
+                // in this case, we know that we only had one asset (FlightHelmet.gltf#Scene0) to load,
+                // so we can switch our game state from GameState::Loading over to GameState::Playing
+                let _ = state.overwrite_set(GameState::Playing);
+            },
+            // we don't care about these events in our example
+            AssetEvent::Modified { handle: _ } => {},
+            AssetEvent::Removed { handle: _ } => {},
+        }
+
+    }
+}
+
+// Your, or at least one of your, game systems.
+fn game_system(
+    _commands: Commands,
+    _asset_server: Res<AssetServer>,
+) {
+    // TODO: do your thing!
+}


### PR DESCRIPTION
# Objective
As stated here, https://github.com/bevyengine/bevy-website/issues/236, the examples with big assets can be problematic, depending on the internet connection.


## Solution
Add a `loading_screen` example and expose its system for other examples. This should (hopefully) be possible, with [this](https://users.rust-lang.org/t/shared-lib-between-two-example-binaries/51670).

This is a draft PR, because i first want to get feedback on the `loading_screen` example, if the way i do it, is the preferred one, or if there is a better one. Aaaaand...i didn't have more time today. Hope i can integrate it into `load_gltf` and `update_gltf_scene` example tomorrow. Are there more examples where a `loading_screen` makes sense?
