### PR TITLE
[Merged by Bors] - Mut to immut impls

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -269,6 +269,17 @@ impl<'w, T: Resource> AsRef<T> for Res<'w, T> {
     }
 }
 
+impl<'w, T: Resource> From<ResMut<'w, T>> for Res<'w, T> {
+    fn from(res: ResMut<'w, T>) -> Self {
+        Self {
+            value: res.value,
+            ticks: res.ticks.component_ticks,
+            change_tick: res.ticks.change_tick,
+            last_change_tick: res.ticks.last_change_tick,
+        }
+    }
+}
+
 /// The [`SystemParamState`] of [`Res<T>`].
 pub struct ResState<T> {
     component_id: ComponentId,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -777,6 +777,16 @@ impl<'w, T> Deref for NonSend<'w, T> {
         self.value
     }
 }
+impl<'a, T> From<NonSendMut<'a, T>> for NonSend<'a, T> {
+    fn from(nsm: NonSendMut<'a, T>) -> Self {
+        Self {
+            value: nsm.value,
+            ticks: nsm.ticks.component_ticks.to_owned(),
+            change_tick: nsm.ticks.change_tick,
+            last_change_tick: nsm.ticks.last_change_tick,
+        }
+    }
+}
 
 /// The [`SystemParamState`] of [`NonSend<T>`].
 pub struct NonSendState<T> {


### PR DESCRIPTION
# Objective
- Provide impls for mutable types to relevant immutable types. 
- Closes #2005 

## Solution

- impl From<ResMut> for Res
- impl From<NonSendMut> for NonSend
- Mut to &/&mut already impl'd in change_detection_impl! macro
