### PR TITLE
add optional viewport to camera

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,10 @@ name = "3d_scene"
 path = "examples/3d/3d_scene.rs"
 
 [[example]]
+name = "split_screen_viewport"
+path = "examples/3d/split_screen_viewport.rs"
+
+[[example]]
 name = "lighting"
 path = "examples/3d/lighting.rs"
 

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -19,4 +19,5 @@ bevy_asset = { path = "../bevy_asset", version = "0.6.0" }
 bevy_core = { path = "../bevy_core", version = "0.6.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
 bevy_render = { path = "../bevy_render", version = "0.6.0" }
-
+bevy_math = { path = "../bevy_math", version = "0.6.0" }
+wgpu = "0.12"

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -782,6 +782,7 @@ pub fn prepare_lights(
                             projection: cube_face_projection,
                             near: POINT_LIGHT_NEAR_Z,
                             far: light.range,
+                            viewport: None,
                         },
                         RenderPhase::<Shadow>::default(),
                         LightEntity::Point {
@@ -867,6 +868,7 @@ pub fn prepare_lights(
                             projection,
                             near: light.near,
                             far: light.far,
+                            viewport: None,
                         },
                         RenderPhase::<Shadow>::default(),
                         LightEntity::Directional { light_entity },

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -98,6 +98,7 @@ fn extract_cameras(
                         height: window.physical_height().max(1),
                         near: camera.near,
                         far: camera.far,
+                        viewport: camera.viewport.clone(),
                     },
                     visible_entities.clone(),
                 ));

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -47,11 +47,13 @@ impl Plugin for CameraPlugin {
             .add_system_to_stage(CoreStage::PostUpdate, crate::camera::active_cameras_system)
             .add_system_to_stage(
                 CoreStage::PostUpdate,
-                crate::camera::camera_system::<OrthographicProjection>,
+                crate::camera::camera_system::<OrthographicProjection>
+                    .label(UpdateCameraProjectionSystem),
             )
             .add_system_to_stage(
                 CoreStage::PostUpdate,
-                crate::camera::camera_system::<PerspectiveProjection>,
+                crate::camera::camera_system::<PerspectiveProjection>
+                    .label(UpdateCameraProjectionSystem),
             );
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
@@ -60,6 +62,9 @@ impl Plugin for CameraPlugin {
         }
     }
 }
+
+#[derive(SystemLabel, Debug, PartialEq, Eq, Clone, Hash)]
+pub struct UpdateCameraProjectionSystem;
 
 #[derive(Default)]
 pub struct ExtractedCameraNames {

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -9,7 +9,7 @@ use wgpu::{
 pub use window::*;
 
 use crate::{
-    camera::{ExtractedCamera, ExtractedCameraNames},
+    camera::{ExtractedCamera, ExtractedCameraNames, Viewport},
     render_resource::{std140::AsStd140, DynamicUniformVec, Texture, TextureView},
     renderer::{RenderDevice, RenderQueue},
     texture::{BevyDefault, TextureCache},
@@ -81,6 +81,7 @@ pub struct ExtractedView {
     pub height: u32,
     pub near: f32,
     pub far: f32,
+    pub viewport: Option<Viewport>,
 }
 
 #[derive(Clone, AsStd140)]
@@ -148,6 +149,7 @@ fn prepare_view_uniforms(
         let projection = camera.projection;
         let view = camera.transform.compute_matrix();
         let inverse_view = view.inverse();
+
         let view_uniforms = ViewUniformOffset {
             offset: view_uniforms.uniforms.push(ViewUniform {
                 view_proj: projection * inverse_view,

--- a/examples/3d/split_screen_viewport.rs
+++ b/examples/3d/split_screen_viewport.rs
@@ -1,0 +1,138 @@
+use bevy::{
+    core_pipeline::{draw_3d_graph, AlphaMask3d, Opaque3d, Transparent3d},
+    prelude::*,
+    render::{
+        camera::{ActiveCameras, CameraPlugin, ExtractedCameraNames, Viewport},
+        render_graph::{self, NodeRunError, RenderGraph, RenderGraphContext, SlotValue},
+        render_phase::RenderPhase,
+        renderer::RenderContext,
+        RenderApp, RenderStage,
+    },
+};
+
+fn main() {
+    App::new()
+        // MSAA doesn't work due to https://github.com/bevyengine/bevy/issues/3499
+        .insert_resource(Msaa { samples: 1 })
+        .add_plugins(DefaultPlugins)
+        .add_plugin(SecondaryCamPlugin)
+        .add_startup_system(setup)
+        .run();
+}
+
+/// set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut active_cameras: ResMut<ActiveCameras>,
+) {
+    // plane
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        ..Default::default()
+    });
+    // cube
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        ..Default::default()
+    });
+    // light
+    commands.spawn_bundle(PointLightBundle {
+        point_light: PointLight {
+            intensity: 1500.0,
+            shadows_enabled: true,
+            ..Default::default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..Default::default()
+    });
+
+    // top camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        camera: Camera {
+            name: Some(CameraPlugin::CAMERA_3D.to_string()),
+            viewport: Some(Viewport {
+                x: 0.0,
+                y: 0.0,
+                w: 1.0,
+                h: 0.5,
+                ..Default::default()
+            }),
+            ..Camera::default()
+        },
+        ..Default::default()
+    });
+    // bottom camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        camera: Camera {
+            name: Some(SECONDARY_CAMERA_NAME.to_string()),
+            viewport: Some(Viewport {
+                x: 0.0,
+                y: 0.5,
+                w: 1.0,
+                h: 0.5,
+                ..Default::default()
+            }),
+            ..Camera::default()
+        },
+        ..Default::default()
+    });
+    active_cameras.add(SECONDARY_CAMERA_NAME);
+}
+
+const SECONDARY_CAMERA_NAME: &str = "Secondary";
+const SECONDARY_PASS_DRIVER: &str = "secondary_pass_driver";
+
+struct SecondaryCamPlugin;
+
+impl Plugin for SecondaryCamPlugin {
+    fn build(&self, app: &mut App) {
+        let render_app = app.sub_app_mut(RenderApp);
+        render_app.add_system_to_stage(RenderStage::Extract, extract_secondary_camera_phases);
+        let mut graph = render_app.world.get_resource_mut::<RenderGraph>().unwrap();
+        graph.add_node(SECONDARY_PASS_DRIVER, SecondaryCameraDriver);
+        graph
+            .add_node_edge(
+                bevy::core_pipeline::node::MAIN_PASS_DEPENDENCIES,
+                SECONDARY_PASS_DRIVER,
+            )
+            .unwrap();
+        graph
+            .add_node_edge(SECONDARY_PASS_DRIVER, bevy::ui::node::UI_PASS_DRIVER)
+            .unwrap();
+    }
+}
+
+fn extract_secondary_camera_phases(mut commands: Commands, active_cameras: Res<ActiveCameras>) {
+    if let Some(secondary) = active_cameras.get(SECONDARY_CAMERA_NAME) {
+        if let Some(entity) = secondary.entity {
+            commands.get_or_spawn(entity).insert_bundle((
+                RenderPhase::<Opaque3d>::default(),
+                RenderPhase::<AlphaMask3d>::default(),
+                RenderPhase::<Transparent3d>::default(),
+            ));
+        }
+    }
+}
+
+struct SecondaryCameraDriver;
+impl render_graph::Node for SecondaryCameraDriver {
+    fn run(
+        &self,
+        graph: &mut RenderGraphContext,
+        _render_context: &mut RenderContext,
+        world: &World,
+    ) -> Result<(), NodeRunError> {
+        let extracted_cameras = world.get_resource::<ExtractedCameraNames>().unwrap();
+        if let Some(camera_3d) = extracted_cameras.entities.get(SECONDARY_CAMERA_NAME) {
+            graph.run_sub_graph(draw_3d_graph::NAME, vec![SlotValue::Entity(*camera_3d)])?;
+        }
+        Ok(())
+    }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -100,6 +100,7 @@ Example | File | Description
 Example | File | Description
 --- | --- | ---
 `3d_scene` | [`3d/3d_scene.rs`](./3d/3d_scene.rs) | Simple 3D scene with basic shapes and lighting
+`split_screen_viewport` | [`3d/split_screen_viewport.rs`](./3d/split_screen_viewport.rs) | 3D scene drawn twice on top of each other
 `lighting` | [`3d/lighting.rs`](./3d/lighting.rs) | Illustrates various lighting options in a simple scene
 `load_gltf` | [`3d/load_gltf.rs`](./3d/load_gltf.rs) | Loads and renders a gltf file as a scene
 `many_cubes` | [`3d/many_cubes.rs`](./3d/many_cubes.rs) | Simple benchmark to test per-entity draw overhead


### PR DESCRIPTION
# Objective

Sometimes it is useful to render only to a subregion in the camera's render target, for example when rendering two split view cameras for a local multiplayer game.

## Solution

Add a `Option<Viewport>` to the camera, with a definition of
```rust
struct Viewport {
    pub x: f32,
    pub y: f32,
    pub w: f32,
    pub h: f32,
    pub min_depth: f32,
    pub max_depth: f32,
    pub scaling_mode: ViewportScalingMode,
}
enum ViewportScalingMode {
    /// `x`, `y`, `w` and `h` are in `0..=1`
    Normalized,
    /// Pixel units
    Pixels,
}
```

The scaling mode is introduced, so that when rendering to fractions of the screen like `x: 0.0, y: 0.0, w: 1.0, h: 1.0` you don't need additional setup to set the values on window resize, and the pixel unit mode is still allowed for maximum flexibilty.


### Open questions

Should the depth be scaled as well according to the camera projection?

**Note: MSAA is currently disabled in the example because only one view would be displayed, possibly due to https://github.com/bevyengine/bevy/issues/3499**


![grafik](https://user-images.githubusercontent.com/22177966/148773820-38557f4f-4bde-4168-8f37-ecabe37fbc85.png)
