### PR TITLE
[Merged by Bors] - Remove the config api

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -220,8 +220,7 @@ pub fn impl_query_set(_input: TokenStream) -> TokenStream {
             unsafe impl<#(#query: WorldQuery + 'static,)* #(#filter: WorldQuery + 'static,)*> SystemParamState for QuerySetState<(#(QueryState<#query, #filter>,)*)>
                 where #(#filter::Fetch: FilterFetch,)*
             {
-                type Config = ();
-                fn init(world: &mut World, system_meta: &mut SystemMeta, config: Self::Config) -> Self {
+                fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {
                     #(
                         let mut #query = QueryState::<#query, #filter>::new(world);
                         assert_component_access_compatibility(
@@ -253,8 +252,6 @@ pub fn impl_query_set(_input: TokenStream) -> TokenStream {
                             .extend(&#query.archetype_component_access);
                     )*
                 }
-
-                fn default_config() {}
             }
 
             impl<'w, 's, #(#query: WorldQuery + 'static,)* #(#filter: WorldQuery + 'static,)*> SystemParamFetch<'w, 's> for QuerySetState<(#(QueryState<#query, #filter>,)*)>
@@ -387,20 +384,15 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
         }
 
         unsafe impl<TSystemParamState: #path::system::SystemParamState, #punctuated_generics> #path::system::SystemParamState for #fetch_struct_name<TSystemParamState, #punctuated_generic_idents> {
-            type Config = TSystemParamState::Config;
-            fn init(world: &mut #path::world::World, system_meta: &mut #path::system::SystemMeta, config: Self::Config) -> Self {
+            fn init(world: &mut #path::world::World, system_meta: &mut #path::system::SystemMeta) -> Self {
                 Self {
-                    state: TSystemParamState::init(world, system_meta, config),
+                    state: TSystemParamState::init(world, system_meta),
                     marker: std::marker::PhantomData,
                 }
             }
 
             fn new_archetype(&mut self, archetype: &#path::archetype::Archetype, system_meta: &mut #path::system::SystemMeta) {
                 self.state.new_archetype(archetype, system_meta)
-            }
-
-            fn default_config() -> TSystemParamState::Config {
-                TSystemParamState::default_config()
             }
 
             fn apply(&mut self, world: &mut #path::world::World) {

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -33,8 +33,8 @@ pub mod prelude {
             Schedule, Stage, StageLabel, State, SystemLabel, SystemSet, SystemStage,
         },
         system::{
-            Commands, ConfigurableSystem, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem,
-            Local, NonSend, NonSendMut, Query, QuerySet, RemovedComponents, Res, ResMut, System,
+            Commands, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend,
+            NonSendMut, Query, QuerySet, RemovedComponents, Res, ResMut, System,
         },
         world::{FromWorld, Mut, World},
     };

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -65,16 +65,8 @@ pub struct SystemState<Param: SystemParam> {
 
 impl<Param: SystemParam> SystemState<Param> {
     pub fn new(world: &mut World) -> Self {
-        let config = <Param::Fetch as SystemParamState>::default_config();
-        Self::with_config(world, config)
-    }
-
-    pub fn with_config(
-        world: &mut World,
-        config: <Param::Fetch as SystemParamState>::Config,
-    ) -> Self {
         let mut meta = SystemMeta::new::<Param>();
-        let param_state = <Param::Fetch as SystemParamState>::init(world, &mut meta, config);
+        let param_state = <Param::Fetch as SystemParamState>::init(world, &mut meta);
         Self {
             meta,
             param_state,
@@ -331,7 +323,6 @@ where
     func: F,
     param_state: Option<Param::Fetch>,
     system_meta: SystemMeta,
-    config: Option<<Param::Fetch as SystemParamState>::Config>,
     // NOTE: PhantomData<fn()-> T> gives this safe Send/Sync impls
     #[allow(clippy::type_complexity)]
     marker: PhantomData<fn() -> (In, Out, Marker)>,
@@ -352,7 +343,6 @@ where
         FunctionSystem {
             func,
             param_state: None,
-            config: Some(<Param::Fetch as SystemParamState>::default_config()),
             system_meta: SystemMeta::new::<F>(),
             marker: PhantomData,
         }
@@ -421,7 +411,6 @@ where
         self.param_state = Some(<Param::Fetch as SystemParamState>::init(
             world,
             &mut self.system_meta,
-            self.config.take().unwrap(),
         ));
     }
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -103,8 +103,8 @@ mod tests {
         query::{Added, Changed, Or, QueryState, With, Without},
         schedule::{Schedule, Stage, SystemStage},
         system::{
-            ConfigurableSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend, NonSendMut, Query,
-            QuerySet, RemovedComponents, Res, ResMut, System, SystemState,
+            IntoExclusiveSystem, IntoSystem, Local, NonSend, NonSendMut, Query, QuerySet,
+            RemovedComponents, Res, ResMut, System, SystemState,
         },
         world::{FromWorld, World},
     };
@@ -523,21 +523,6 @@ mod tests {
 
         // Verify that both systems actually ran
         assert_eq!(world.get_resource::<NSystems>().unwrap().0, 2);
-    }
-
-    #[test]
-    fn configure_system_local() {
-        let mut world = World::default();
-        world.insert_resource(false);
-        fn sys(local: Local<usize>, mut modified: ResMut<bool>) {
-            assert_eq!(*local, 42);
-            *modified = true;
-        }
-
-        run_system(&mut world, sys.config(|config| config.0 = Some(42)));
-
-        // ensure the system actually ran
-        assert!(*world.get_resource::<bool>().unwrap());
     }
 
     #[test]

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -587,6 +587,22 @@ impl<'w, 's> SystemParamFetch<'w, 's> for WorldState {
 /// // Note how the read local is still 0 due to the locals not being shared.
 /// assert_eq!(read_system.run((), world), 0);
 /// ```
+///
+/// N.B. A [`Local`]s value cannot be read or written to outside of the containing system.
+/// To add configuration to a system, convert a capturing closure into the system instead:
+///
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// struct Config(u32);
+/// struct Myu32Wrapper(u32);
+/// fn reset_to(value: Config) -> impl FnMut(ResMut<Myu32Wrapper>) {
+///     move |mut val| val.0 = value.0
+/// }
+///
+/// // .add_system(reset_to(my_config))
+/// # reset_to(Config(10)).system();
+/// ```
+
 pub struct Local<'a, T: Resource>(&'a mut T);
 
 // SAFE: Local only accesses internal state

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -518,9 +518,7 @@ impl<'w, 's> SystemParam for &'w World {
 }
 
 unsafe impl<'w, 's> SystemParamState for WorldState {
-    type Config = ();
-
-    fn init(_world: &mut World, system_meta: &mut SystemMeta, _config: Self::Config) -> Self {
+    fn init(_world: &mut World, system_meta: &mut SystemMeta) -> Self {
         let mut access = Access::default();
         access.read_all();
         if !system_meta
@@ -545,8 +543,6 @@ unsafe impl<'w, 's> SystemParamState for WorldState {
 
         WorldState
     }
-
-    fn default_config() -> Self::Config {}
 }
 
 impl<'w, 's> SystemParamFetch<'w, 's> for WorldState {
@@ -593,16 +589,16 @@ impl<'w, 's> SystemParamFetch<'w, 's> for WorldState {
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
+/// # use bevy_ecs::system::assert_is_system;
 /// struct Config(u32);
 /// struct Myu32Wrapper(u32);
-/// fn reset_to(value: Config) -> impl FnMut(ResMut<Myu32Wrapper>) {
+/// fn reset_to_system(value: Config) -> impl FnMut(ResMut<Myu32Wrapper>) {
 ///     move |mut val| val.0 = value.0
 /// }
 ///
 /// // .add_system(reset_to(my_config))
-/// # reset_to(Config(10)).system();
+/// # assert_is_system(reset_to_system(Config(10)));
 /// ```
-
 pub struct Local<'a, T: Resource>(&'a mut T);
 
 // SAFE: Local only accesses internal state

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -596,7 +596,7 @@ impl<'w, 's> SystemParamFetch<'w, 's> for WorldState {
 ///     move |mut val| val.0 = value.0
 /// }
 ///
-/// // .add_system(reset_to(my_config))
+/// // .add_system(reset_to_system(my_config))
 /// # assert_is_system(reset_to_system(Config(10)));
 /// ```
 pub struct Local<'a, T: Resource>(&'a mut T);


### PR DESCRIPTION
# Objective

- Fix the ugliness of the `config` api. 
- Supercedes #2440, #2463, #2491

## Solution

- Since #2398, capturing closure systems have worked.
- Use those instead where we needed config before
- Remove the rest of the config api. 
- Related: #2777
