### PR TITLE
[Merged by Bors] - Fixed doc comment with render Node input/output methods

### DIFF
--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -43,13 +43,13 @@ impl NodeId {
 /// inside the graph. For more information see [`SlotType`](super::SlotType).
 pub trait Node: Downcast + Send + Sync + 'static {
     /// Specifies the required input slots for this node.
-    /// They will then be available during the run method inside the [`RenderContext`].
+    /// They will then be available during the run method inside the [`RenderGraphContext`].
     fn input(&self) -> Vec<SlotInfo> {
         Vec::new()
     }
 
     /// Specifies the produced output slots for this node.
-    /// They can then be passed one inside [`RenderContext`] during the run method.
+    /// They can then be passed one inside [`RenderGraphContext`] during the run method.
     fn output(&self) -> Vec<SlotInfo> {
         Vec::new()
     }


### PR DESCRIPTION
Fixed doc comment where render Node input/output methods refered to using `RenderContext` for interaction instead of `RenderGraphContext`

# Objective

The doc comments for `Node` refer to `RenderContext` for slots instead of `RenderGraphContext`, which is only confusing because `Node::run` is passed both `RenderContext` and `RenderGraphContext`

## Solution

Fixed the typo