### PR TITLE
[Merged by Bors] - Fix documentation for QueryState::iter_manual

### DIFF
--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -276,16 +276,10 @@ where
         }
     }
 
-    /// Returns an [`Iterator`] over all possible combinations of `K` query results without repetition.
+    /// Returns an [`Iterator`] over the query results for the given [`World`] without updating the query's archetypes.
+    /// Archetypes must be manually updated elsewhere using [`Self::update_archetypes`].
+    ///
     /// This can only be called for read-only queries.
-    ///
-    ///  For permutations of size K of query returning N results, you will get:
-    /// - if K == N: one permutation of all query results
-    /// - if K < N: all possible K-sized combinations of query results, without repetition
-    /// - if K > N: empty set (no K-sized combinations exist)
-    ///
-    /// This can only be called for read-only queries, see [`Self::iter_combinations_mut`] for
-    /// write-queries.
     #[inline]
     pub fn iter_manual<'w, 's>(
         &'s self,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -277,7 +277,7 @@ where
     }
 
     /// Returns an [`Iterator`] over the query results for the given [`World`] without updating the query's archetypes.
-    /// Archetypes must be manually updated elsewhere using [`Self::update_archetypes`].
+    /// Archetypes must be manually updated before by using [`Self::update_archetypes`].
     ///
     /// This can only be called for read-only queries.
     #[inline]


### PR DESCRIPTION
# Objective

- Fixes #3616 

## Solution

- As described in the issue, documentation for `iter_manual` was copied from `iter_combinations` and did not reflect the behavior of the method. I've pulled some information from #2351 to create a more accurate description.
