### PR TITLE
[Merged by Bors] - Don't panic in macro shape validation

### DIFF
--- a/crates/bevy_crevice/bevy-crevice-derive/src/glsl.rs
+++ b/crates/bevy_crevice/bevy-crevice-derive/src/glsl.rs
@@ -1,17 +1,14 @@
+use bevy_macro_utils::get_named_struct_fields;
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
-use syn::{parse_quote, Data, DeriveInput, Fields, Path};
+use syn::{parse_quote, DeriveInput, Path};
 
 pub fn emit(input: DeriveInput) -> TokenStream {
     let bevy_crevice_path = crate::bevy_crevice_path();
 
-    let fields = match &input.data {
-        Data::Struct(data) => match &data.fields {
-            Fields::Named(fields) => fields,
-            Fields::Unnamed(_) => panic!("Tuple structs are not supported"),
-            Fields::Unit => panic!("Unit structs are not supported"),
-        },
-        Data::Enum(_) | Data::Union(_) => panic!("Only structs are supported"),
+    let fields = match get_named_struct_fields(&input.data) {
+        Ok(fields) => fields,
+        Err(e) => return e.into_compile_error(),
     };
 
     let base_trait_path: Path = parse_quote!(#bevy_crevice_path::glsl::Glsl);

--- a/crates/bevy_derive/src/enum_variant_meta.rs
+++ b/crates/bevy_derive/src/enum_variant_meta.rs
@@ -1,5 +1,5 @@
 use bevy_macro_utils::BevyManifest;
-use proc_macro::TokenStream;
+use proc_macro::{Span, TokenStream};
 use quote::quote;
 use syn::{parse_macro_input, Data, DeriveInput};
 
@@ -7,7 +7,11 @@ pub fn derive_enum_variant_meta(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     let variants = match &ast.data {
         Data::Enum(v) => &v.variants,
-        _ => panic!("Expected an enum."),
+        _ => {
+            return syn::Error::new(Span::call_site().into(), "Only enums are supported")
+                .into_compile_error()
+                .into()
+        }
     };
 
     let bevy_util_path = BevyManifest::default().get_path(crate::modules::BEVY_UTILS);

--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -1,9 +1,11 @@
 extern crate proc_macro;
 
 mod attrs;
+mod shape;
 mod symbol;
 
 pub use attrs::*;
+pub use shape::*;
 pub use symbol::*;
 
 use cargo_manifest::{DepsSet, Manifest};

--- a/crates/bevy_macro_utils/src/shape.rs
+++ b/crates/bevy_macro_utils/src/shape.rs
@@ -1,0 +1,20 @@
+use proc_macro::Span;
+use syn::{Data, DataStruct, Error, Fields, FieldsNamed};
+
+/// Get the fields of a data structure if that structure is a struct with named fields;
+/// otherwise, return a compile error that points to the site of the macro invocation.
+pub fn get_named_struct_fields(data: &syn::Data) -> syn::Result<&FieldsNamed> {
+    match data {
+        Data::Struct(DataStruct {
+            fields: Fields::Named(fields),
+            ..
+        }) => Ok(fields),
+        _ => Err(Error::new(
+            // This deliberately points to the call site rather than the structure
+            // body; marking the entire body as the source of the error makes it
+            // impossible to figure out which `derive` has a problem.
+            Span::call_site().into(),
+            "Only structs with named fields are supported",
+        )),
+    }
+}


### PR DESCRIPTION
# Objective
Emitting compile errors produces cleaner messages than panicking in a proc-macro.

## Solution
- Replace match-with-panic code with call to new `bevy_macro_utils::get_named_struct_fields` function
- Replace one use of match-with-panic for enums with inline match

_Aside:_ I'm also the maintainer of [`darling`](https://docs.rs/darling), a crate which provides a serde-like API for parsing macro inputs. I avoided using it here because it seemed like overkill, but if there are plans to add lots more attributes/macros then that might be a good way of offloading macro error handling.