### PR TITLE
Remove documentation warning on EntityCommands::insert that is no longer necessary

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -420,13 +420,6 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// See [`EntityMut::insert`](crate::world::EntityMut::insert) for more
     /// details.
     ///
-    /// # Warning
-    ///
-    /// It's possible to call this with a bundle, but this is likely not intended and
-    /// [`Self::insert_bundle`] should be used instead. If `with` is called with a bundle, the
-    /// bundle itself will be added as a component instead of the bundles' inner components each
-    /// being added.
-    ///
     /// # Example
     ///
     /// `Self::insert` can be chained with [`Commands::spawn`].


### PR DESCRIPTION
# Objective

- Removes warning about accidently inserting bundles with `EntityCommands::insert`, but since a component now needs to implement `Component` it is unnecessary.
