### PR TITLE
[Merged by Bors] - Remove cargo-lipo from iOS ci job

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -24,11 +24,6 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-check-test-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-lipo
-          version: latest
-
       - name: Add iOS targets
         run: rustup target add aarch64-apple-ios x86_64-apple-ios
 

--- a/examples/ios/Cargo.toml
+++ b/examples/ios/Cargo.toml
@@ -16,6 +16,5 @@ bevy = { path = "../../", features = [
   "bevy_winit",
   "render",
   "vorbis",
-  "x11",
   "filesystem_watcher"
 ], default-features = false}


### PR DESCRIPTION
# Objective

`cargo-lipo` no more required since #3109 merged. Also remove unused `x11` feature from example.
