### PR TITLE
[Merged by Bors] - use error scope to handle errors on shader module creation

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -66,4 +66,3 @@ flate2 = { version = "1.0.22", optional = true }
 ruzstd = { version = "0.2.4", optional = true }
 # For transcoding of UASTC/ETC1S universal formats, and for .basis file support
 basis-universal = { version = "0.2.0", optional = true }
-futures-util = "0.3"

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -66,3 +66,4 @@ flate2 = { version = "1.0.22", optional = true }
 ruzstd = { version = "0.2.4", optional = true }
 # For transcoding of UASTC/ETC1S universal formats, and for .basis file support
 basis-universal = { version = "0.2.0", optional = true }
+futures-util = "0.3"

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -135,6 +135,11 @@ impl ShaderCache {
                     .push_error_scope(wgpu::ErrorFilter::Validation);
                 let shader_module = render_device.create_shader_module(&module_descriptor);
                 let error = render_device.wgpu_device().pop_error_scope();
+
+                // `now_or_never` will return Some if the future is ready and None otherwise.
+                // On native platforms, wgpu will yield the error immediatly while on wasm it may take longer since the browser APIs are asynchronous.
+                // So to keep the complexity of the ShaderCache low, we will only catch this error early on native platforms,
+                // and on wasm the error will be handled by wgpu and crash the application.
                 if let Some(Some(wgpu::Error::Validation { description, .. })) =
                     futures_helper::now_or_never(error)
                 {

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -161,9 +161,9 @@ impl ProcessedShader {
             source: match self {
                 ProcessedShader::Wgsl(source) => {
                     #[cfg(debug_assertions)]
-                    // This isn't neccessary, but catches errors early during hot reloading of invalid wgsl shaders.
-                    // Eventually, wgpu will have features that will make this unneccessary like compilation info
-                    // or error scopes, but until then parsing the shader twice during development the easiest solution.
+                    // Parse and validate the shader early, so that (e.g. while hot reloading) we can
+                    // display nicely formatted error messages instead of relying on just displaying the error string
+                    // returned by wgpu upon creating the shader module.
                     let _ = self.reflect()?;
 
                     ShaderSource::Wgsl(source.clone())

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -2,6 +2,7 @@ pub mod prelude {
     pub use crate::default;
 }
 
+pub mod futures;
 pub mod label;
 
 mod default;


### PR DESCRIPTION
related: https://github.com/bevyengine/bevy/pull/3289

In addition to validating shaders early when debug assertions are enabled, use the new [error scopes](https://gpuweb.github.io/gpuweb/#error-scopes) API when creating a shader module.

I chose to keep the early validation (and thereby parsing twice) when debug assertions are enabled in, because it lets as handle errors ourselves and display them with pretty colors, while the error scopes API just gives us a string we can display.



This change pulls in `futures-util` as a new dependency for `future.now_or_never()`. I can inline that part of futures-lite into `bevy_render` to keep the compilation time lower if that's preferred.