### PR TITLE
Auto add default UI camera

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -6,6 +6,7 @@ mod flex;
 mod focus;
 mod margins;
 mod render;
+mod startup;
 mod ui_node;
 
 pub mod entity;
@@ -72,6 +73,10 @@ impl Plugin for UiPlugin {
             .register_type::<Val>()
             .register_type::<widget::Button>()
             .register_type::<widget::ImageMode>()
+            .add_system_to_stage(
+                StartupStage::PostStartup,
+                startup::add_default_ui_cam_if_needed,
+            )
             .add_system_to_stage(
                 CoreStage::PreUpdate,
                 ui_focus_system.label(UiSystem::Focus).after(InputSystem),

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -1,6 +1,7 @@
 //! This crate contains Bevy's UI system, which can be used to create UI for both 2D and 3D games
 //! # Basic usage
 //! Spawn [`entity::UiCameraBundle`] and spawn UI elements with [`entity::ButtonBundle`], [`entity::ImageBundle`], [`entity::TextBundle`] and [`entity::NodeBundle`]
+//! When UI elements are present during startup, the [`entity::UiCameraBundle`] will be added automatically.
 //! This UI is laid out with the Flexbox paradigm (see <https://cssreference.io/flexbox/> ) except the vertical axis is inverted
 mod flex;
 mod focus;
@@ -73,7 +74,7 @@ impl Plugin for UiPlugin {
             .register_type::<Val>()
             .register_type::<widget::Button>()
             .register_type::<widget::ImageMode>()
-            .add_system_to_stage(
+            .add_startup_system_to_stage(
                 StartupStage::PostStartup,
                 startup::add_default_ui_cam_if_needed,
             )

--- a/crates/bevy_ui/src/startup.rs
+++ b/crates/bevy_ui/src/startup.rs
@@ -1,0 +1,96 @@
+use crate::prelude::UiCameraBundle;
+use crate::ui_node::Node;
+use crate::CAMERA_UI;
+use bevy_ecs::prelude::{Commands, Entity, Query, With};
+use bevy_render::prelude::{Camera, OrthographicProjection};
+
+pub fn add_default_ui_cam_if_needed(
+    mut commands: Commands,
+    node_query: Query<Entity, With<Node>>,
+    ui_cam_query: Query<&Camera, With<OrthographicProjection>>,
+) {
+    let world_contains_nodes = node_query.iter().next().is_some();
+    let world_contains_ui_cam = ui_cam_query
+        .iter()
+        .any(|cam| cam.name.as_deref() == Some(CAMERA_UI));
+
+    if world_contains_nodes && !world_contains_ui_cam {
+        commands.spawn_bundle(UiCameraBundle::default());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::entity::{NodeBundle, UiCameraBundle};
+    use crate::startup::add_default_ui_cam_if_needed;
+    use bevy_ecs::prelude::{Stage, SystemStage, World};
+    use bevy_render::prelude::{Camera, OrthographicProjection};
+
+    #[test]
+    fn no_ui_camera_added_when_no_ui_nodes_exist() {
+        let mut world = World::default();
+
+        let mut startup_stage = SystemStage::parallel();
+        startup_stage.add_system(add_default_ui_cam_if_needed);
+
+        startup_stage.run(&mut world);
+
+        assert_eq!(
+            world
+                .query::<(&Camera, &OrthographicProjection)>()
+                .iter(&world)
+                .len(),
+            0
+        );
+    }
+
+    #[test]
+    fn ui_camera_added_when_ui_nodes_exist() {
+        let mut world = World::default();
+
+        world.spawn().insert_bundle(NodeBundle::default());
+
+        let mut startup_stage = SystemStage::parallel();
+        startup_stage.add_system(add_default_ui_cam_if_needed);
+
+        startup_stage.run(&mut world);
+
+        assert_eq!(
+            world
+                .query::<(&Camera, &OrthographicProjection)>()
+                .iter(&world)
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn no_duplicate_ui_camera_added_when_one_is_already_present() {
+        let mut world = World::default();
+
+        let cam_id = world.spawn().insert_bundle(UiCameraBundle::default()).id();
+
+        assert_eq!(
+            world
+                .query::<(&Camera, &OrthographicProjection)>()
+                .iter(&world)
+                .len(),
+            1
+        );
+
+        let mut startup_stage = SystemStage::parallel();
+        startup_stage.add_system(add_default_ui_cam_if_needed);
+
+        startup_stage.run(&mut world);
+
+        assert_eq!(
+            world
+                .query::<(&Camera, &OrthographicProjection)>()
+                .iter(&world)
+                .len(),
+            1
+        );
+
+        assert!(world.get::<Camera>(cam_id).is_some());
+    }
+}

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -118,7 +118,6 @@ fn setup_contributor_selection(mut commands: Commands, asset_server: Res<AssetSe
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
-    commands.spawn_bundle(UiCameraBundle::default());
 
     commands.spawn_bundle((SelectTimer, Timer::from_seconds(SHOWCASE_TIMER_SECS, true)));
 

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -50,7 +50,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // cameras
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
-    commands.spawn_bundle(UiCameraBundle::default());
     // paddle
     commands
         .spawn_bundle(SpriteBundle {

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -103,7 +103,6 @@ fn save_scene_system(world: &mut World) {
 // This is only necessary for the info message in the UI. See examples/ui/text.rs for a standalone
 // text example.
 fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn_bundle(UiCameraBundle::default());
     commands.spawn_bundle(TextBundle {
         style: Style {
             align_self: AlignSelf::FlexEnd,

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -83,7 +83,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let texture = asset_server.load("branding/icon.png");
 
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
-    commands.spawn_bundle(UiCameraBundle::default());
     commands.spawn_bundle(TextBundle {
         text: Text {
             sections: vec![

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -41,8 +41,6 @@ fn button_system(
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    // ui camera
-    commands.spawn_bundle(UiCameraBundle::default());
     commands
         .spawn_bundle(ButtonBundle {
             style: Style {

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -79,7 +79,6 @@ fn text_update_system(mut state: ResMut<State>, time: Res<Time>, mut query: Quer
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut state: ResMut<State>) {
     let font_handle = asset_server.load("fonts/FiraSans-Bold.ttf");
     state.handle = font_handle.clone();
-    commands.spawn_bundle(UiCameraBundle::default());
     commands.spawn_bundle(TextBundle {
         text: Text::with_section(
             "a",

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -25,8 +25,6 @@ struct FpsText;
 struct ColorText;
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    // UI camera
-    commands.spawn_bundle(UiCameraBundle::default());
     // Text with one section
     commands
         .spawn_bundle(TextBundle {

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -22,7 +22,6 @@ struct TextChanges;
 
 fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
     let font = asset_server.load("fonts/FiraSans-Bold.ttf");
-    commands.spawn_bundle(UiCameraBundle::default());
     commands.spawn_bundle(TextBundle {
         style: Style {
             align_self: AlignSelf::FlexEnd,

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -13,9 +13,6 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    // ui camera
-    commands.spawn_bundle(UiCameraBundle::default());
-
     // root node
     commands
         .spawn_bundle(NodeBundle {

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -16,8 +16,6 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    // ui camera
-    commands.spawn_bundle(UiCameraBundle::default());
     // root node
     commands
         .spawn_bundle(NodeBundle {


### PR DESCRIPTION
Adds a system to PostStartup that spawns a default UI camera if it finds UI nodes but no camera to render them.

Partial solution to #1432.

## Open question
When there are no UI elements present during startup, the system won't trigger. Elements added later on in the game won't therefore be visible.

One solution to this would be to move the new check from startup to some stage that runs every frame. Would this be overkill? And is there a possibility that a user might have UI nodes, but doesn't want them to be rendered at the moment?