### PR TITLE
[Merged by Bors] - Change bevy_core::Name to implement Deref<Target = str>

### DIFF
--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -107,9 +107,9 @@ impl Ord for Name {
 }
 
 impl Deref for Name {
-    type Target = Cow<'static, str>;
+    type Target = str;
 
     fn deref(&self) -> &Self::Target {
-        &self.name
+        self.name.as_ref()
     }
 }


### PR DESCRIPTION
# Objective
Fixes #3613
[Link to issue](https://github.com/bevyengine/bevy/issues/3613)

## Solution
Changed the Deref Target to `str` and changed the `deref()` function body so that a `&str` is returned by using `as_ref() `.
