### PR TITLE
[Merged by Bors] - Add a warning when `watch_for_changes` has no effect

### DIFF
--- a/crates/bevy_asset/src/io/android_asset_io.rs
+++ b/crates/bevy_asset/src/io/android_asset_io.rs
@@ -42,6 +42,7 @@ impl AssetIo for AndroidAssetIo {
     }
 
     fn watch_for_changes(&self) -> Result<(), AssetIoError> {
+        warn!("Watching for changes is not supported on Android");
         Ok(())
     }
 

--- a/crates/bevy_asset/src/io/android_asset_io.rs
+++ b/crates/bevy_asset/src/io/android_asset_io.rs
@@ -42,7 +42,7 @@ impl AssetIo for AndroidAssetIo {
     }
 
     fn watch_for_changes(&self) -> Result<(), AssetIoError> {
-        warn!("Watching for changes is not supported on Android");
+        bevy_log::warn!("Watching for changes is not supported on Android");
         Ok(())
     }
 

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -4,6 +4,7 @@ use crate::{AssetIo, AssetIoError};
 use anyhow::Result;
 #[cfg(feature = "filesystem_watcher")]
 use bevy_ecs::system::Res;
+use bevy_log::warn;
 use bevy_utils::BoxedFuture;
 #[cfg(feature = "filesystem_watcher")]
 use bevy_utils::HashSet;
@@ -104,6 +105,8 @@ impl AssetIo for FileAssetIo {
         {
             *self.filesystem_watcher.write() = Some(FilesystemWatcher::default());
         }
+        #[cfg(not(feature = "filesystem_watcher"))]
+        warn!("Watching for changes is not supported when the `filesystem_watcher` feature is disabled");
 
         Ok(())
     }

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -4,7 +4,6 @@ use crate::{AssetIo, AssetIoError};
 use anyhow::Result;
 #[cfg(feature = "filesystem_watcher")]
 use bevy_ecs::system::Res;
-use bevy_log::warn;
 use bevy_utils::BoxedFuture;
 #[cfg(feature = "filesystem_watcher")]
 use bevy_utils::HashSet;
@@ -106,7 +105,7 @@ impl AssetIo for FileAssetIo {
             *self.filesystem_watcher.write() = Some(FilesystemWatcher::default());
         }
         #[cfg(not(feature = "filesystem_watcher"))]
-        warn!("Watching for changes is not supported when the `filesystem_watcher` feature is disabled");
+        bevy_log::warn!("Watching for changes is not supported when the `filesystem_watcher` feature is disabled");
 
         Ok(())
     }

--- a/crates/bevy_asset/src/io/wasm_asset_io.rs
+++ b/crates/bevy_asset/src/io/wasm_asset_io.rs
@@ -46,7 +46,7 @@ impl AssetIo for WasmAssetIo {
     }
 
     fn watch_for_changes(&self) -> Result<(), AssetIoError> {
-        warn!("Watching for changes is not supported in WASM");
+        bevy_log::warn!("Watching for changes is not supported in WASM");
         Ok(())
     }
 

--- a/crates/bevy_asset/src/io/wasm_asset_io.rs
+++ b/crates/bevy_asset/src/io/wasm_asset_io.rs
@@ -46,6 +46,7 @@ impl AssetIo for WasmAssetIo {
     }
 
     fn watch_for_changes(&self) -> Result<(), AssetIoError> {
+        warn!("Watching for changes is not supported in WASM");
         Ok(())
     }
 


### PR DESCRIPTION
# Objective

- Users can get confused when they ask for watching to be unsupported, then find it isn't supported
- Fixes https://github.com/bevyengine/bevy/issues/3683

## Solution

- Add a warning if the `watch_for_changes` call would do nothing