### PR TITLE
Make a dynamically applicable version of `Bundle`

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -105,13 +105,12 @@ mod sealed {
 
 /// A bundle which can be applied to a world
 ///
-/// # Safety:
+/// # Safety
 /// The bundle returned from `init_bundle_info` is the same as used for `get_component_box`.
 ///
 /// This trait is sealed and cannot be implemented outside of `bevy_ecs`
 ///
 /// However, it is implemented for every type which implements [`Bundle`]
-
 pub unsafe trait ApplicableBundle:
     Send + Sync + 'static + sealed::SealedApplicableBundle
 {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -103,10 +103,10 @@ mod sealed {
     impl SealedApplicableBundle for Box<dyn ApplicableBundle> {}
 }
 
-/// A bundle which can be applied to a world
+/// A bundle that can be added to entities
 ///
 /// # Safety
-/// The bundle returned from `init_bundle_info` is the same as used for `get_component_box`.
+/// The bundle returned from `init_bundle_info` must be the same as used for `get_component_box`.
 ///
 /// This trait is sealed and cannot be implemented outside of `bevy_ecs`
 ///

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -22,7 +22,31 @@ use std::{any::TypeId, collections::HashMap};
 /// particularly useful for spawning multiple empty entities by using
 /// [`Commands::spawn_batch`](crate::system::Commands::spawn_batch).
 ///
-/// To use a bundle dynamically, use [`Box<dyn ApplicableBundle>`](`ApplicableBundle`)
+/// This trait is not object-safe as the components added by a bundle are cached by the type
+/// of the [`Bundle`]. To create a version of a bundle which can be used dynamically, use
+/// [`Box<dyn ApplicableBundle>`](`ApplicableBundle`):
+///
+/// ```rust
+/// # use bevy_ecs::bundle::{ApplicableBundle, Bundle};
+/// # #[derive(Bundle)]
+/// # struct EnemyShip {}
+/// # #[derive(Bundle)]
+/// # struct TradePost {}
+/// /// # use bevy_ecs::bundle::Bundle;
+/// # let hostility = 10;
+/// let result: Box<dyn ApplicableBundle> = if hostility > 5 {
+///     Box::new(TradePost { /* ... */})
+/// } else {
+///     Box::new(EnemyShip { /* ... */})
+/// };
+/// # if false {
+/// # let commands: bevy_ecs::system::Commands = panic!(); // For type checking
+/// commands.spawn_bundle(result);
+/// # }
+/// ```
+///
+/// Note that this dynamic bundle cannot be nested within other bundles, again because of
+/// the caching features.
 ///
 /// # Examples
 ///
@@ -108,7 +132,8 @@ mod sealed {
 /// # Safety
 /// The bundle returned from `init_bundle_info` must be the same as used for `get_component_box`.
 ///
-/// This trait is sealed and cannot be implemented outside of `bevy_ecs`
+/// This trait is sealed and cannot be implemented outside of `bevy_ecs`, since it
+/// is not useful to implement for custom types.
 ///
 /// However, it is implemented for every type which implements [`Bundle`]
 pub unsafe trait ApplicableBundle:

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -160,13 +160,14 @@ unsafe impl ApplicableBundle for Box<dyn ApplicableBundle> {
         components: &mut Components,
         storages: &mut Storages,
     ) -> &'a BundleInfo {
+        let this = &**self;
         <dyn ApplicableBundle as ApplicableBundle>::init_bundle_info(
-            self, bundles, components, storages,
+            this, bundles, components, storages,
         )
     }
 
     fn get_components_box(self: Box<Self>, func: &mut dyn FnMut(*mut u8)) {
-        <dyn ApplicableBundle as ApplicableBundle>::get_components_box(self, func)
+        <dyn ApplicableBundle as ApplicableBundle>::get_components_box(*self, func)
     }
 
     fn get_components_self(self, mut func: impl FnMut(*mut u8))

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -21,7 +21,7 @@ pub mod prelude {
     pub use crate::reflect::ReflectComponent;
     #[doc(hidden)]
     pub use crate::{
-        bundle::Bundle,
+        bundle::{ApplicableBundle, Bundle},
         change_detection::DetectChanges,
         component::Component,
         entity::Entity,

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -50,7 +50,7 @@ impl<'w, 's> Commands<'w, 's> {
 
     /// Creates a new empty [`Entity`] and returns an [`EntityCommands`] builder for it.
     ///
-    /// To directly spawn an entity with a [`ApplicableBundle`] included, you can use
+    /// To directly spawn an entity with an [`ApplicableBundle`] included, you can use
     /// [`spawn_bundle`](Self::spawn_bundle) instead of `.spawn().insert_bundle()`.
     ///
     /// See [`World::spawn`] for more details.
@@ -104,7 +104,7 @@ impl<'w, 's> Commands<'w, 's> {
         }
     }
 
-    /// Spawns a [`ApplicableBundle`] without pre-allocating an [`Entity`]. The [`Entity`] will be allocated
+    /// Spawns an [`ApplicableBundle`] without pre-allocating an [`Entity`]. The [`Entity`] will be allocated
     /// when this [`Command`] is applied.
     pub fn spawn_and_forget(&mut self, bundle: impl ApplicableBundle) {
         self.queue.push(Spawn { bundle })
@@ -115,9 +115,9 @@ impl<'w, 's> Commands<'w, 's> {
     /// This returns an [`EntityCommands`] builder, which enables inserting more components and
     /// bundles using a "builder pattern".
     ///
-    /// Note that `bundle` is a [`ApplicableBundle`], which is a collection of components. [`ApplicableBundle`] is
+    /// Note that `bundle` is an [`ApplicableBundle`], which is a collection of components. [`ApplicableBundle`] is
     /// automatically implemented for tuples of components. You can also create your own bundle
-    /// types by deriving [`derive@ApplicableBundle`].
+    /// types by deriving [`derive@Bundle`].
     ///
     /// # Example
     ///
@@ -135,7 +135,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// #[derive(Component)]
     /// struct Agility(u32);
     ///
-    /// #[derive(ApplicableBundle)]
+    /// #[derive(Bundle)]
     /// struct ExampleBundle {
     ///     a: Component1,
     ///     b: Component2,
@@ -331,7 +331,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// # #[derive(Component)]
     /// # struct Defense(u32);
     /// #
-    /// # #[derive(ApplicableBundle)]
+    /// # #[derive(Bundle)]
     /// # struct CombatBundle {
     /// #     health: Health,
     /// #     strength: Strength,
@@ -379,7 +379,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
         self.entity
     }
 
-    /// Adds a [`ApplicableBundle`] of components to the entity.
+    /// Adds an [`ApplicableBundle`] of components to the entity.
     ///
     /// # Example
     ///
@@ -394,7 +394,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// # #[derive(Component)]
     /// # struct Defense(u32);
     /// #
-    /// # #[derive(ApplicableBundle)]
+    /// # #[derive(Bundle)]
     /// # struct CombatBundle {
     /// #     health: Health,
     /// #     strength: Strength,
@@ -452,7 +452,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
         self
     }
 
-    /// Removes a [`ApplicableBundle`] of components from the entity.
+    /// Removes a [`Bundle`] of components from the entity.
     ///
     /// See [`EntityMut::remove_bundle`](crate::world::EntityMut::remove_bundle) for more
     /// details.
@@ -466,7 +466,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// #
     /// # #[derive(Component)]
     /// struct Dummy;
-    /// # #[derive(ApplicableBundle)]
+    /// # #[derive(Bundle)]
     /// # struct CombatBundle { a: Dummy }; // dummy field, unit bundles are not permitted.
     /// #
     /// fn remove_combat_stats_system(mut commands: Commands, player: Res<PlayerEntity>) {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1,6 +1,6 @@
 use crate::{
     archetype::{Archetype, ArchetypeId, Archetypes},
-    bundle::{Bundle, BundleInfo},
+    bundle::{ApplicableBundle, Bundle, BundleInfo},
     change_detection::Ticks,
     component::{Component, ComponentId, ComponentTicks, Components, StorageType},
     entity::{Entities, Entity, EntityLocation},
@@ -189,12 +189,14 @@ impl<'w> EntityMut<'w> {
             })
     }
 
-    pub fn insert_bundle<T: Bundle>(&mut self, bundle: T) -> &mut Self {
+    pub fn insert_bundle<T: ApplicableBundle>(&mut self, bundle: T) -> &mut Self {
         let change_tick = self.world.change_tick();
-        let bundle_info = self
-            .world
-            .bundles
-            .init_info::<T>(&mut self.world.components, &mut self.world.storages);
+        let bundle_info = bundle.init_bundle_info(
+            &mut self.world.bundles,
+            &mut self.world.components,
+            &mut self.world.storages,
+        );
+
         let mut bundle_inserter = bundle_info.get_bundle_inserter(
             &mut self.world.entities,
             &mut self.world.archetypes,


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/3227 (I think? @alice-i-cecile please confirm)

## Solution

- For dynamic bundles, you can now use `Box<dyn ApplicableBundle>`
- Naming nitpicks welcome
