### PR TITLE
[Merged by Bors] - Add a size method on Image.

### DIFF
--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use bevy_asset::HandleUntyped;
 use bevy_ecs::system::{lifetimeless::SRes, SystemParamItem};
-use bevy_math::Size;
+use bevy_math::{Size, Vec2};
 use bevy_reflect::TypeUuid;
 use thiserror::Error;
 use wgpu::{
@@ -116,6 +116,14 @@ impl Image {
     /// Returns the aspect ratio (height/width) of a 2D image.
     pub fn aspect_2d(&self) -> f32 {
         self.texture_descriptor.size.height as f32 / self.texture_descriptor.size.width as f32
+    }
+
+    /// Returns the size of a 2D image.
+    pub fn size_2d(&self) -> Vec2 {
+        Vec2::new(
+            self.texture_descriptor.size.width as f32,
+            self.texture_descriptor.size.height as f32,
+        )
     }
 
     /// Resizes the image to the new size, by removing information or appending 0 to the `data`.
@@ -438,5 +446,35 @@ impl RenderAsset for Image {
             sampler,
             size,
         })
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn image_size_2d() {
+        let size = Extent3d {
+            width: 200,
+            height: 100,
+            depth_or_array_layers: 1,
+        };
+        let image = Image::new_fill(
+            size,
+            TextureDimension::D2,
+            &[0, 0, 0, 255],
+            TextureFormat::Rgba8Unorm,
+        );
+        assert_eq!(
+            Vec2::new(size.width as f32, size.height as f32),
+            image.size_2d()
+        );
+    }
+    #[test]
+    fn image_default_size_2d() {
+        let image = Image::default();
+        assert_eq!(Vec2::new(1.0, 1.0), image.size_2d());
     }
 }

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -119,7 +119,7 @@ impl Image {
     }
 
     /// Returns the size of a 2D image.
-    pub fn size_2d(&self) -> Vec2 {
+    pub fn size(&self) -> Vec2 {
         Vec2::new(
             self.texture_descriptor.size.width as f32,
             self.texture_descriptor.size.height as f32,
@@ -455,7 +455,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn image_size_2d() {
+    fn image_size() {
         let size = Extent3d {
             width: 200,
             height: 100,
@@ -469,12 +469,12 @@ mod test {
         );
         assert_eq!(
             Vec2::new(size.width as f32, size.height as f32),
-            image.size_2d()
+            image.size()
         );
     }
     #[test]
-    fn image_default_size_2d() {
+    fn image_default_size() {
         let image = Image::default();
-        assert_eq!(Vec2::new(1.0, 1.0), image.size_2d());
+        assert_eq!(Vec2::new(1.0, 1.0), image.size());
     }
 }


### PR DESCRIPTION
# Objective

Add a simple way for user to get the size of a loaded texture in an Image object.
Aims to solve #3689

## Solution

Add a `size() -> Vec2` method
Add two simple tests for this method.

Updates:
. method named changed from `size_2d` to `size`
