### PR TITLE
[Merged by Bors] - bevy_pbr: Do not panic when more than 256 point lights are added the scene

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -641,7 +641,7 @@ pub fn prepare_lights(
     }
 
     let mut gpu_point_lights = [GpuPointLight::default(); MAX_POINT_LIGHTS];
-    for (index, &(entity, light)) in point_lights.iter().enumerate() {
+    for (index, &(entity, light)) in point_lights.iter().enumerate().take(MAX_POINT_LIGHTS) {
         let mut flags = PointLightFlags::NONE;
         // Lights are sorted, shadow enabled lights are first
         if light.shadows_enabled && index < MAX_POINT_LIGHT_SHADOW_MAPS {


### PR DESCRIPTION
# Objective

- Do not panic when mroe than 256 point lights are added the scene
- Fixes https://github.com/bevyengine/bevy/issues/3682

## Solution

- Only iterate the first `MAX_POINT_LIGHTS` lights instead of as many as there are

## Open questions

- Should we warn that there are more than the maximum allowed number of point lights in the scene?
