### PR TITLE
[Merged by Bors] - bevy_render: Do not automatically enable MAPPABLE_PRIMARY_BUFFERS

### DIFF
--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -61,6 +61,11 @@ pub type RenderQueue = Arc<Queue>;
 /// aswell as to create [`WindowSurfaces`](crate::view::window::WindowSurfaces).
 pub type RenderInstance = Instance;
 
+/// `wgpu::Features` that are not automatically enabled due to having possibly-negative side effects.
+/// `MAPPABLE_PRIMARY_BUFFERS` can have a significant, negative performance impact so should not be
+/// automatically enabled.
+pub const DEFAULT_DISABLED_WGPU_FEATURES: wgpu::Features = wgpu::Features::MAPPABLE_PRIMARY_BUFFERS;
+
 /// Initializes the renderer by retrieving and preparing the GPU instance, device and queue
 /// for the specified backend.
 pub async fn initialize_renderer(
@@ -86,8 +91,9 @@ pub async fn initialize_renderer(
     let trace_path = None;
 
     if matches!(options.priority, WgpuOptionsPriority::Functionality) {
-        options.features =
-            adapter.features() | wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
+        options.features = (adapter.features()
+            | wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES)
+            - DEFAULT_DISABLED_WGPU_FEATURES;
         options.limits = adapter.limits();
     }
 


### PR DESCRIPTION
# Objective

- When using `WgpuOptionsPriority::Functionality`, which is the default, wgpu::Features::MAPPABLE_PRIMARY_BUFFERS would be automatically enabled. This feature can and does have a significant negative impact on performance for discrete GPUs where resizable bar is not supported, which is a common case. As such, this feature should not be automatically enabled.
- Fixes the performance regression part of https://github.com/bevyengine/bevy/issues/3686 and at least some, if not all cases of https://github.com/bevyengine/bevy/issues/3687

## Solution

- When using `WgpuOptionsPriority::Functionality`, use the adapter-supported features, enable `TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES` and disable `MAPPABLE_PRIMARY_BUFFERS`