### PR TITLE
Add `random_query` example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -323,6 +323,10 @@ name = "parallel_query"
 path = "examples/ecs/parallel_query.rs"
 
 [[example]]
+name = "random_query"
+path = "examples/ecs/random_query.rs"
+
+[[example]]
 name = "removal_detection"
 path = "examples/ecs/removal_detection.rs"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -168,7 +168,7 @@ Example | File | Description
 `hierarchy` | [`ecs/hierarchy.rs`](./ecs/hierarchy.rs) | Creates a hierarchy of parents and children entities
 `iter_combinations` | [`ecs/iter_combinations.rs`](./ecs/iter_combinations.rs) | Shows how to iterate over combinations of query results.
 `parallel_query` | [`ecs/parallel_query.rs`](./ecs/parallel_query.rs) | Illustrates parallel queries with `ParallelIterator`
-`random_query` | [`ecs/random_query.rs`](./ecs/random_query.rs) | Get random components from a query with `rand::seq::IteratorRandom`
+`random_query` | [`ecs/random_query.rs`](./ecs/random_query.rs) | Sample random elements of a query with `rand::seq::IteratorRandom`
 `removal_detection` | [`ecs/removal_detection.rs`](./ecs/removal_detection.rs) | Query for entities that had a specific component removed in a previous stage during the current frame.
 `startup_system` | [`ecs/startup_system.rs`](./ecs/startup_system.rs) | Demonstrates a startup system (one that runs once when the app starts up)
 `state` | [`ecs/state.rs`](./ecs/state.rs) | Illustrates how to use States to control transitioning from a Menu state to an InGame state

--- a/examples/README.md
+++ b/examples/README.md
@@ -168,6 +168,7 @@ Example | File | Description
 `hierarchy` | [`ecs/hierarchy.rs`](./ecs/hierarchy.rs) | Creates a hierarchy of parents and children entities
 `iter_combinations` | [`ecs/iter_combinations.rs`](./ecs/iter_combinations.rs) | Shows how to iterate over combinations of query results.
 `parallel_query` | [`ecs/parallel_query.rs`](./ecs/parallel_query.rs) | Illustrates parallel queries with `ParallelIterator`
+`random_query` | [`ecs/random_query.rs`](./ecs/random_query.rs) | Get random components from a query with `rand::seq::IteratorRandom`
 `removal_detection` | [`ecs/removal_detection.rs`](./ecs/removal_detection.rs) | Query for entities that had a specific component removed in a previous stage during the current frame.
 `startup_system` | [`ecs/startup_system.rs`](./ecs/startup_system.rs) | Demonstrates a startup system (one that runs once when the app starts up)
 `state` | [`ecs/state.rs`](./ecs/state.rs) | Illustrates how to use States to control transitioning from a Menu state to an InGame state

--- a/examples/ecs/random_query.rs
+++ b/examples/ecs/random_query.rs
@@ -31,7 +31,7 @@ fn generate_pets(mut commands: Commands) {
 
 fn random_people(name_query: Query<&Name>, pet_query: Query<&Pet>) {
     let mut rng = rand::thread_rng();
-    // Use [`IteratorRandom::choose_multiple`] to pick two random names
+    // Use [`IteratorRandom::choose_multiple`] to pick three random names
     let names: Vec<&Name> = name_query.iter().choose_multiple(&mut rng, 3);
     for name in names {
         // Use [`IteratorRandom::choose`] to pick one random pet

--- a/examples/ecs/random_query.rs
+++ b/examples/ecs/random_query.rs
@@ -1,0 +1,43 @@
+use bevy::prelude::*;
+use rand::seq::IteratorRandom;
+
+#[derive(Component, Clone, Copy)]
+struct Pet(char);
+
+#[derive(Component, Clone)]
+struct Name(String);
+
+fn main() {
+    App::new()
+        .add_startup_system(generate_names)
+        .add_startup_system(generate_pets)
+        .add_system(random_people)
+        .run();
+}
+
+fn generate_names(mut commands: Commands) {
+    let names = ["Linus", "Noah", "Elijah", "Olivia", "Ava", "Charlotte"];
+    for name in names {
+        commands.spawn().insert(Name(name.to_owned()));
+    }
+}
+
+fn generate_pets(mut commands: Commands) {
+    let pets = ['🐀', '🐄', '🐅', '🐇', '🐊', '🐓', '🐖'];
+    for pet in pets {
+        commands.spawn().insert(Pet(pet));
+    }
+}
+
+fn random_people(name_query: Query<&Name>, pet_query: Query<&Pet>) {
+    let mut rng = rand::thread_rng();
+    // Use [`IteratorRandom::choose_multiple`] to pick two random names
+    let names: Vec<&Name> = name_query.iter().choose_multiple(&mut rng, 3);
+    for name in names {
+        // Use [`IteratorRandom::choose`] to pick one random pet
+        let pet: Option<&Pet> = pet_query.iter().choose(&mut rng);
+        // `pet` will only be `None` if the query found no pets. That shouldn't happen here.
+        let pet = pet.unwrap();
+        println!("{} owns a {}.", name.0, pet.0);
+    }
+}


### PR DESCRIPTION
# Objective

Showcase how to select random elements from a query, as requested in #3652.

## Solution

Add an example that shows how one can use [`rand::seq::IteratorRandom::choose`] and [`rand::seq::IteratorRandom::choose_multiple`] to choose one or multiple random items from a query.

[`rand::seq::IteratorRandom::choose`]: https://docs.rs/rand/latest/rand/seq/trait.IteratorRandom.html#method.choose
[`rand::seq::IteratorRandom::choose_multiple`]: https://docs.rs/rand/latest/rand/seq/trait.IteratorRandom.html#method.choose_multiple