### PR TITLE
remove buffers from prepared assets that are never read

### DIFF
--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -144,8 +144,6 @@ pub struct StandardMaterialUniformData {
 /// The GPU representation of a [`StandardMaterial`].
 #[derive(Debug, Clone)]
 pub struct GpuStandardMaterial {
-    /// A buffer containing the [`StandardMaterialUniformData`] of the material.
-    pub buffer: Buffer,
     /// The bind group specifying how the [`StandardMaterialUniformData`] and
     /// all the textures of the material are bound.
     pub bind_group: BindGroup,
@@ -314,7 +312,6 @@ impl RenderAsset for StandardMaterial {
         });
 
         Ok(GpuStandardMaterial {
-            buffer,
             bind_group,
             flags,
             has_normal_map,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -327,7 +327,6 @@ impl FromWorld for MeshPipeline {
 
             let texture_view = texture.create_view(&TextureViewDescriptor::default());
             GpuImage {
-                texture,
                 texture_view,
                 sampler,
                 size: Size::new(

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -188,7 +188,7 @@ impl Image {
             .map(super::image_texture_conversion::image_to_texture)
     }
 
-    /// Load a bytes buffer in a [`Texture`], according to type `image_type`, using the `image`
+    /// Load a bytes buffer in a [`Image`], according to type `image_type`, using the `image`
     /// crate
     pub fn from_buffer(buffer: &[u8], image_type: ImageType) -> Result<Image, TextureError> {
         let format = match image_type {

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -374,7 +374,6 @@ impl TextureFormatPixelInfo for TextureFormat {
 }
 
 /// The GPU-representation of an [`Image`].
-/// Consists of the [`Texture`], its [`TextureView`] and the corresponding [`Sampler`], and the texture's [`Size`].
 #[derive(Debug, Clone)]
 pub struct GpuImage {
     pub texture_view: TextureView,

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -1,7 +1,7 @@
 use super::image_texture_conversion::image_to_texture;
 use crate::{
     render_asset::{PrepareAssetError, RenderAsset},
-    render_resource::{Sampler, Texture, TextureView},
+    render_resource::{Sampler, TextureView},
     renderer::{RenderDevice, RenderQueue},
     texture::BevyDefault,
 };
@@ -377,7 +377,6 @@ impl TextureFormatPixelInfo for TextureFormat {
 /// Consists of the [`Texture`], its [`TextureView`] and the corresponding [`Sampler`], and the texture's [`Size`].
 #[derive(Debug, Clone)]
 pub struct GpuImage {
-    pub texture: Texture,
     pub texture_view: TextureView,
     pub sampler: Sampler,
     pub size: Size,
@@ -433,7 +432,6 @@ impl RenderAsset for Image {
             image.texture_descriptor.size.height as f32,
         );
         Ok(GpuImage {
-            texture,
             texture_view,
             sampler,
             size,

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -101,8 +101,6 @@ pub struct ColorMaterialUniformData {
 /// The GPU representation of a [`ColorMaterial`].
 #[derive(Debug, Clone)]
 pub struct GpuColorMaterial {
-    /// A buffer containing the [`ColorMaterialUniformData`] of the material.
-    pub buffer: Buffer,
     /// The bind group specifying how the [`ColorMaterialUniformData`] and
     /// the texture of the material are bound.
     pub bind_group: BindGroup,
@@ -172,7 +170,6 @@ impl RenderAsset for ColorMaterial {
         });
 
         Ok(GpuColorMaterial {
-            buffer,
             bind_group,
             flags,
             texture: material.texture,

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -192,7 +192,6 @@ impl FromWorld for Mesh2dPipeline {
 
             let texture_view = texture.create_view(&TextureViewDescriptor::default());
             GpuImage {
-                texture,
                 texture_view,
                 sampler,
                 size: Size::new(

--- a/examples/shader/shader_material.rs
+++ b/examples/shader/shader_material.rs
@@ -52,7 +52,6 @@ pub struct CustomMaterial {
 
 #[derive(Clone)]
 pub struct GpuCustomMaterial {
-    _buffer: Buffer,
     bind_group: BindGroup,
 }
 
@@ -83,10 +82,7 @@ impl RenderAsset for CustomMaterial {
             layout: &material_pipeline.material_layout,
         });
 
-        Ok(GpuCustomMaterial {
-            _buffer: buffer,
-            bind_group,
-        })
+        Ok(GpuCustomMaterial { bind_group })
     }
 }
 

--- a/examples/shader/shader_material_glsl.rs
+++ b/examples/shader/shader_material_glsl.rs
@@ -52,7 +52,6 @@ pub struct CustomMaterial {
 
 #[derive(Clone)]
 pub struct GpuCustomMaterial {
-    _buffer: Buffer,
     bind_group: BindGroup,
 }
 
@@ -83,10 +82,7 @@ impl RenderAsset for CustomMaterial {
             layout: &material_pipeline.material_layout,
         });
 
-        Ok(GpuCustomMaterial {
-            _buffer: buffer,
-            bind_group,
-        })
+        Ok(GpuCustomMaterial { bind_group })
     }
 }
 


### PR DESCRIPTION
# Objective

- Some GPU assets have buffers that are never read. Are they actually needed?

## Solution

- Removed them to find out...
