### PR TITLE
[Merged by Bors] - Add missing dependencies for Fedora with Wayland

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -32,6 +32,12 @@ Please see the ubuntu [WSL documentation](https://wiki.ubuntu.com/WSL) on how to
 sudo dnf install gcc-c++ libX11-devel alsa-lib-devel systemd-devel
 ```
 
+if using Wayland, you will also need to install
+
+```bash
+sudo dnf install wayland-devel libxkbcommon-devel
+```
+
 If there are errors with linking during the build process such as:
 
 ```bash


### PR DESCRIPTION
# Objective

- The Linux dependencies document lacks packages for Fedora with Wayland.

## Solution

- Add instructions to install packages for running Bevy apps in Fedora with Wayland.
