### PR TITLE
[Merged by Bors] - rename Texture to Image in doc of `from_buffer` function

### DIFF
--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -188,7 +188,7 @@ impl Image {
             .map(super::image_texture_conversion::image_to_texture)
     }
 
-    /// Load a bytes buffer in a [`Texture`], according to type `image_type`, using the `image`
+    /// Load a bytes buffer in a [`Image`], according to type `image_type`, using the `image`
     /// crate
     pub fn from_buffer(buffer: &[u8], image_type: ImageType) -> Result<Image, TextureError> {
         let format = match image_type {


### PR DESCRIPTION
This doc link was missed when changing the type name.

Noticed in https://github.com/bevyengine/bevy/pull/3706 which will not be merged