### PR TITLE
Implemented conversion from vec3 to transform

### DIFF
--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -278,6 +278,7 @@ impl Mul<Vec3> for Transform {
     }
 }
 
+/// Conversion from Vec3 to Transform, using the Vec3's contents for the Transform's translation
 impl From<Vec3> for Transform {
     fn from(vec: Vec3) -> Self {
         Transform::from_translation(vec)

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -277,3 +277,9 @@ impl Mul<Vec3> for Transform {
         self.mul_vec3(value)
     }
 }
+
+impl From<Vec3> for Transform {
+    fn from(vec: Vec3) -> Self {
+        Transform::from_translation(vec)
+    }
+}


### PR DESCRIPTION
# Objective

Allow conversion from Vec3 to Transform with corresponding translation

## Solution

Implement From<Vec3> for Transform to provide an alternative to using the more wordy 
`Transform::from_translation(Vec3::new(x,y,z))`
This lets you do 
`Vec3::new(x,y,z).into()` 
instead 