### PR TITLE
[Merged by Bors] - Update docstrings for `text_system` and `text2d_system`

### DIFF
--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -115,7 +115,7 @@ pub struct QueuedText2d {
 }
 
 /// Updates the layout and size information whenever the text or style is changed.
-/// This information is computed by the TextPipeline on insertion, then stored.
+/// This information is computed by the `TextPipeline` on insertion, then stored.
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn text2d_system(
     mut queued_text: Local<QueuedText2d>,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -114,7 +114,8 @@ pub struct QueuedText2d {
     entities: Vec<Entity>,
 }
 
-/// Updates the `TextGlyphs` with the new computed glyphs from the layout
+/// Updates the layout and size information whenever the text or style is changed.
+/// This information is computed by the TextPipeline on insertion, then stored.
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn text2d_system(
     mut queued_text: Local<QueuedText2d>,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -34,8 +34,8 @@ pub fn text_constraint(min_size: Val, size: Val, max_size: Val, scale_factor: f6
     }
 }
 
-/// Computes the size of a text block and updates the Text Glyphs with the
-/// new computed glyphs from the layout
+/// Updates the layout and size information whenever the text or style is changed.
+/// This information is computed by the TextPipeline on insertion, then stored.
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn text_system(
     mut queued_text: Local<QueuedText>,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -35,7 +35,7 @@ pub fn text_constraint(min_size: Val, size: Val, max_size: Val, scale_factor: f6
 }
 
 /// Updates the layout and size information whenever the text or style is changed.
-/// This information is computed by the TextPipeline on insertion, then stored.
+/// This information is computed by the `TextPipeline` on insertion, then stored.
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn text_system(
     mut queued_text: Local<QueuedText>,


### PR DESCRIPTION
# Objective

- Fixes #3562 

## Solution

- The outdated reference to `TextGlyphs` has been removed, and replaced with a more accurate docstring.

## What was `TextGlyphs`?
This is the real question of this Issue and PR. This is particulary interesting because not only is `TextGlyphs` not a type in bevy, but it _never was_. Indeed, this type never existed on main. Where did it come from?

`TextGlyphs` was originally a tuple struct wrapping a `Vec<PositionedGlyph>`. It was first introduced back in commit https://github.com/bevyengine/bevy/pull/765/commits/ec390aec4ebe7192e3470dddf1e8af36f10453e6 in #765. At the time, position information was being stored on the text entities directly. However, after design review, [it was decided](https://github.com/bevyengine/bevy/pull/765#issuecomment-725047186) to instead store the glyphs in a `HashMap` owned by the `TextPipeline`. When this was done, the original type was not only removed, but abstracted behind a few layers of the `TextPipeline` API. Obviously, the original docstring wasn't updated accordingly.

Later, as part of #1122, the incorrect docstring was swept up when copy/pasting `text_system` for `text2d`. (Although I don't blame @CleanCut for this; it took me like 3 hours to track all this down to find the original context.)
