### PR TITLE
WIP cull mode specialization

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -169,7 +169,7 @@ pub trait SpecializedMaterial: Asset + RenderAsset {
         AlphaMode::Opaque
     }
 
-    /// Returns this material's [`AlphaMode`]. Defaults to [`AlphaMode::Opaque`].
+    /// Returns whether this material is double-sided. Defaults to [`false`].
     #[allow(unused_variables)]
     fn double_sided(material: &<Self as RenderAsset>::PreparedAsset) -> bool {
         false

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -65,6 +65,12 @@ pub trait Material: Asset + RenderAsset {
         AlphaMode::Opaque
     }
 
+    /// Returns this material's [`AlphaMode`]. Defaults to [`AlphaMode::Opaque`].
+    #[allow(unused_variables)]
+    fn double_sided(material: &<Self as RenderAsset>::PreparedAsset) -> bool {
+        false
+    }
+
     /// The dynamic uniform indices to set for the given `material`'s [`BindGroup`].
     /// Defaults to an empty array / no dynamic uniform indices.
     #[allow(unused_variables)]
@@ -96,6 +102,11 @@ impl<M: Material> SpecializedMaterial for M {
     #[inline]
     fn alpha_mode(material: &<Self as RenderAsset>::PreparedAsset) -> AlphaMode {
         <M as Material>::alpha_mode(material)
+    }
+
+    #[inline]
+    fn double_sided(material: &<Self as RenderAsset>::PreparedAsset) -> bool {
+        <M as Material>::double_sided(material)
     }
 
     #[inline]
@@ -156,6 +167,12 @@ pub trait SpecializedMaterial: Asset + RenderAsset {
     #[allow(unused_variables)]
     fn alpha_mode(material: &<Self as RenderAsset>::PreparedAsset) -> AlphaMode {
         AlphaMode::Opaque
+    }
+
+    /// Returns this material's [`AlphaMode`]. Defaults to [`AlphaMode::Opaque`].
+    #[allow(unused_variables)]
+    fn double_sided(material: &<Self as RenderAsset>::PreparedAsset) -> bool {
+        false
     }
 
     /// The dynamic uniform indices to set for the given `material`'s [`BindGroup`].
@@ -325,6 +342,9 @@ pub fn queue_material_meshes<M: SpecializedMaterial>(
                     let alpha_mode = M::alpha_mode(material);
                     if let AlphaMode::Blend = alpha_mode {
                         mesh_key |= MeshPipelineKey::TRANSPARENT_MAIN_PASS
+                    }
+                    if M::double_sided(material) {
+                        mesh_key |= MeshPipelineKey::from_cull_mode(None)
                     }
 
                     let specialized_key = M::key(material);

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -23,7 +23,7 @@ use bevy_render::{
         SetItemPipeline, TrackedRenderPass,
     },
     render_resource::{
-        BindGroup, BindGroupLayout, RenderPipelineCache, RenderPipelineDescriptor, Shader,
+        BindGroup, BindGroupLayout, Face, RenderPipelineCache, RenderPipelineDescriptor, Shader,
         SpecializedPipeline, SpecializedPipelines,
     },
     renderer::RenderDevice,
@@ -343,8 +343,8 @@ pub fn queue_material_meshes<M: SpecializedMaterial>(
                     if let AlphaMode::Blend = alpha_mode {
                         mesh_key |= MeshPipelineKey::TRANSPARENT_MAIN_PASS
                     }
-                    if M::double_sided(material) {
-                        mesh_key |= MeshPipelineKey::from_cull_mode(None)
+                    if !M::double_sided(material) {
+                        mesh_key |= MeshPipelineKey::from_cull_mode(Some(Face::Back))
                     }
 
                     let specialized_key = M::key(material);

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -65,7 +65,7 @@ pub trait Material: Asset + RenderAsset {
         AlphaMode::Opaque
     }
 
-    /// Returns this material's [`AlphaMode`]. Defaults to [`AlphaMode::Opaque`].
+    /// Returns whether this material is double-sided. Defaults to [`false`].
     #[allow(unused_variables)]
     fn double_sided(material: &<Self as RenderAsset>::PreparedAsset) -> bool {
         false

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -153,6 +153,7 @@ pub struct GpuStandardMaterial {
     pub flags: StandardMaterialFlags,
     pub base_color_texture: Option<Handle<Image>>,
     pub alpha_mode: AlphaMode,
+    pub double_sided: bool,
 }
 
 impl RenderAsset for StandardMaterial {
@@ -320,6 +321,7 @@ impl RenderAsset for StandardMaterial {
             has_normal_map,
             base_color_texture: material.base_color_texture,
             alpha_mode: material.alpha_mode,
+            double_sided: material.double_sided,
         })
     }
 }
@@ -476,5 +478,10 @@ impl SpecializedMaterial for StandardMaterial {
     #[inline]
     fn alpha_mode(render_asset: &<Self as RenderAsset>::PreparedAsset) -> AlphaMode {
         render_asset.alpha_mode
+    }
+
+    #[inline]
+    fn double_sided(render_asset: &<Self as RenderAsset>::PreparedAsset) -> bool {
+        render_asset.double_sided
     }
 }

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -415,9 +415,9 @@ impl MeshPipelineKey {
 
     pub fn from_cull_mode(cull_mode: Option<Face>) -> Self {
         let cull_mode = match cull_mode {
-            Some(Face::Back) => 0,
+            None => 0,
             Some(Face::Front) => 1,
-            None => 2,
+            Some(Face::Back) => 2,
         };
         let cull_mode_bits = (cull_mode & Self::CULL_MODE_MASK_BITS) << Self::CULL_MODE_SHIFT_BITS;
         MeshPipelineKey::from_bits(cull_mode_bits).unwrap()

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -367,12 +367,12 @@ bitflags::bitflags! {
     // NOTE: Apparently quadro drivers support up to 64x MSAA.
     /// MSAA uses the highest 6 bits for the MSAA sample count - 1 to support up to 64x MSAA.
     pub struct MeshPipelineKey: u32 {
-        const NONE                        = 0;
-        const VERTEX_TANGENTS             = (1 << 0);
-        const TRANSPARENT_MAIN_PASS       = (1 << 1);
-        const MSAA_RESERVED_BITS          = MeshPipelineKey::MSAA_MASK_BITS << MeshPipelineKey::MSAA_SHIFT_BITS;
+        const NONE                             = 0;
+        const VERTEX_TANGENTS                  = (1 << 0);
+        const TRANSPARENT_MAIN_PASS            = (1 << 1);
+        const MSAA_RESERVED_BITS               = MeshPipelineKey::MSAA_MASK_BITS << MeshPipelineKey::MSAA_SHIFT_BITS;
         const PRIMITIVE_TOPOLOGY_RESERVED_BITS = MeshPipelineKey::PRIMITIVE_TOPOLOGY_MASK_BITS << MeshPipelineKey::PRIMITIVE_TOPOLOGY_SHIFT_BITS;
-        const CULL_MODE_RESERVED_BITS = MeshPipelineKey::CULL_MODE_MASK_BITS << MeshPipelineKey::CULL_MODE_SHIFT_BITS;
+        const CULL_MODE_RESERVED_BITS          = MeshPipelineKey::CULL_MODE_MASK_BITS << MeshPipelineKey::CULL_MODE_SHIFT_BITS;
     }
 }
 

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -426,9 +426,9 @@ impl MeshPipelineKey {
     pub fn cull_mode(&self) -> Option<Face> {
         let cull_mode_bits = (self.bits >> Self::CULL_MODE_SHIFT_BITS) & Self::CULL_MODE_MASK_BITS;
         match cull_mode_bits {
-            0 => Some(Face::Back),
+            0 => None,
             1 => Some(Face::Front),
-            2 => None,
+            2 => Some(Face::Back),
             _ => Some(Face::Back),
         }
     }


### PR DESCRIPTION
# Objective

Fixes #3729

## Solution

Add cull mode specialization

## Caveats

I never got around to tidying this up, but I'm pushing it here for the sake of potential collaboration.

- It seems like the front / back face end up being lit slightly differently. Is the "normal flip" right?
- Does it make sense to use 2 bits in the `MeshPipelineKey` for every possible cull mode? Or is on/off enough?
- If we're already using 2 bits, should I just use two separate fields for ON/OFF and FRONT/BACK?
- I ended up sprinkling a bunch of `fn double_sided` on various material... things. My "generic rust" skills aren't fantastic. Are all these even necessary?

Marking as a draft PR for now.
