### PR TITLE
add asset player to play audios with loop / pause / resume etc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,6 +284,11 @@ path = "examples/async_tasks/async_compute.rs"
 name = "audio"
 path = "examples/audio/audio.rs"
 
+# Play List
+[[example]]
+name = "playlist"
+path = "examples/audio/playlist.rs"
+
 # Diagnostics
 [[example]]
 name = "log_diagnostics"

--- a/crates/bevy_audio/src/asset_player.rs
+++ b/crates/bevy_audio/src/asset_player.rs
@@ -1,0 +1,184 @@
+use bevy_ecs::event::Events;
+use rodio::Sink;
+use std::fmt;
+use std::fmt::Debug;
+
+use bevy_asset::{Asset, Assets, Handle};
+use bevy_ecs::world::{World, WorldBorrowMut};
+use bevy_utils::tracing::info;
+
+use crate::{AudioOutput, AudioSource, Decodable};
+
+/// Used internally to play audio lists with simple control event on the current "audio device"
+/// This could be used for background loop music
+#[derive(Default)]
+pub struct AssetPlayer {
+    audios: Vec<Handle<AudioSource>>,
+    sink: Option<Sink>,
+    is_loop: bool,
+    output: AudioOutput<AudioSource>,
+}
+
+impl AssetPlayer {
+    fn play_once<T: Asset + Decodable>(&mut self, audio_source: &T) {
+        if let Some(h) = &self.output.stream_handle {
+            let sink = Sink::try_new(h).unwrap();
+            sink.append(audio_source.decoder());
+            sink.detach()
+        }
+    }
+
+    fn append_source<T: Asset + Decodable>(&mut self, audio_source: &T) {
+        if let Some(stream_handle) = &self.output.stream_handle {
+            if self.sink.is_none() {
+                let sink = Sink::try_new(stream_handle).unwrap();
+                sink.append(audio_source.decoder());
+                self.sink = Some(sink)
+            } else if let Some(sink) = self.sink.as_mut() {
+                sink.append(audio_source.decoder());
+            }
+        }
+    }
+
+    /// stop audio play
+    pub fn stop(&mut self) {
+        if let Some(sink) = self.sink.as_mut() {
+            sink.stop();
+        }
+    }
+
+    /// pause audio play
+    pub fn pause(&mut self) {
+        if let Some(sink) = self.sink.as_mut() {
+            sink.pause();
+        }
+    }
+
+    /// resume audio play
+    pub fn resume(&mut self) {
+        if let Some(sink) = self.sink.as_mut() {
+            sink.play();
+        }
+    }
+
+    fn try_handle_events<Source: Asset + Decodable>(
+        &mut self,
+        audio_sources: &Assets<Source>,
+        mut events: WorldBorrowMut<Events<PlayEvent>>,
+    ) {
+        let mut pending = vec![];
+        for ev in events.get_reader().iter(&events) {
+            info!("recv play event {:?}", ev);
+            match *ev {
+                PlayEvent::Resume => {
+                    self.resume();
+                }
+                PlayEvent::Pause => {
+                    self.pause();
+                }
+                PlayEvent::Clear => {
+                    self.audios.clear();
+                    self.sink.take();
+                }
+                PlayEvent::Loop(v) => {
+                    self.is_loop = v;
+                }
+                PlayEvent::Once(ref v) => {
+                    if let Some(audio_source) = audio_sources.get(v.id) {
+                        info!("failed to load asset, will reload");
+                        self.play_once(audio_source);
+                    } else {
+                        // audio source hasn't loaded yet. add it back to the queue
+                        pending.push(PlayEvent::Once(v.clone()));
+                    }
+                }
+                PlayEvent::Append(ref v) => {
+                    if let Some(audio_source) = audio_sources.get(v.id) {
+                        info!("failed to load asset, will reload");
+                        self.append_source(audio_source);
+                        self.audios.push(v.clone());
+                    } else {
+                        // audio source hasn't loaded yet. add it back to the queue
+                        pending.push(PlayEvent::Append(v.clone()));
+                    }
+                }
+            }
+        }
+        events.update();
+        let len_pend = pending.len();
+        pending.into_iter().for_each(|t| {
+            events.send(t);
+        });
+        if len_pend == 0 {
+            self.check_loop(audio_sources);
+        }
+    }
+
+    fn is_loop_end(&self) -> bool {
+        self.sink.as_ref().map(|v| v.empty()).unwrap_or(false)
+    }
+
+    fn check_loop<T: Asset + Decodable>(&mut self, audio_sources: &Assets<T>) {
+        if self.is_loop && self.sink.is_some() && self.is_loop_end() {
+            let sources = self
+                .audios
+                .iter()
+                .filter_map(|audio| audio_sources.get(audio.clone()))
+                .collect::<Vec<_>>();
+            for source in sources {
+                self.append_source(source);
+            }
+        }
+    }
+}
+
+/// Receiving play events and check loop
+pub fn play_assets_system<Source: Asset>(world: &mut World)
+where
+    Source: Decodable,
+{
+    let world = world.cell();
+    let mut asset_player = world.get_non_send_mut::<AssetPlayer>().unwrap();
+    let events = world
+        .get_resource_mut::<Events<PlayEvent<AudioSource>>>()
+        .unwrap();
+
+    if let Some(audio_sources) = world.get_resource::<Assets<Source>>() {
+        asset_player.try_handle_events(&*audio_sources, events);
+    };
+}
+
+///  play events for audio asset player
+pub enum PlayEvent<Source = AudioSource>
+where
+    Source: Asset + Decodable,
+{
+    /// clear play list, stop audio play
+    Clear,
+    /// set loop, stop when all audios played if loop value is false
+    Loop(bool),
+    /// pause audio play
+    Pause,
+    /// resume audio play
+    Resume,
+    /// just play once, no loop, no pause
+    Once(Handle<Source>),
+    /// add audio to playlist
+    Append(Handle<Source>),
+}
+
+impl<Source> Debug for PlayEvent<Source>
+where
+    Source: Asset + Decodable,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &PlayEvent::Clear => f.debug_struct("Clear").finish(),
+            &PlayEvent::Loop(v) => f.debug_struct("Loop").field("Loop", &v).finish(),
+            &PlayEvent::Pause => f.debug_struct("Pause").finish(),
+            PlayEvent::Append(v) => f.debug_struct("Append").field("handle", v).finish(),
+            PlayEvent::Once(v) => f.debug_struct("Once").field("handle", v).finish(),
+            &PlayEvent::Resume => f.debug_struct("Resume").finish(),
+        }
+    }
+}

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -11,7 +11,7 @@ where
     Source: Decodable,
 {
     _stream: Option<OutputStream>,
-    stream_handle: Option<OutputStreamHandle>,
+    pub(crate) stream_handle: Option<OutputStreamHandle>,
     phantom: PhantomData<Source>,
 }
 
@@ -41,7 +41,7 @@ impl<Source> AudioOutput<Source>
 where
     Source: Asset + Decodable,
 {
-    fn play_source(&self, audio_source: &Source) {
+    pub(crate) fn play_source(&self, audio_source: &Source) {
         if let Some(stream_handle) = &self.stream_handle {
             let sink = Sink::try_new(stream_handle).unwrap();
             sink.append(audio_source.decoder());

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ```
 //! # use bevy_ecs::{system::Res, event::EventWriter};
-//! # use bevy_audio::{Audio, AudioPlugin};
+//! # use bevy_audio::{Audio, AudioPlugin, PlayEvent};
 //! # use bevy_asset::{AssetPlugin, AssetServer};
 //! # use bevy_app::{App, AppExit};
 //! # use bevy_internal::MinimalPlugins;
@@ -13,11 +13,22 @@
 //!         .add_plugin(AudioPlugin)
 //! #       .add_system(stop)
 //!         .add_startup_system(play_background_audio)
+//!         .add_startup_system(loop_play_background_audio)
 //!         .run();
 //! }
 //!
 //! fn play_background_audio(asset_server: Res<AssetServer>, audio: Res<Audio>) {
 //!     audio.play(asset_server.load("background_audio.ogg"));
+//! }
+//!
+//!
+//! fn loop_play_background_audio(asset_server: Res<AssetServer>, mut ew : EventWriter<PlayEvent>) {
+//!     let sound = asset_server.load("background_audio.ogg");
+//!     ew.send(PlayEvent::Loop(true));
+//!     ew.send(PlayEvent::Append(sound));
+//!
+//!     let first = asset_server.load("start.ogg");
+//!     ew.send(PlayEvent::Once(first));
 //! }
 //!
 //! # fn stop(mut events: EventWriter<AppExit>) {
@@ -28,6 +39,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+mod asset_player;
 mod audio;
 mod audio_output;
 mod audio_source;
@@ -35,15 +47,17 @@ mod audio_source;
 #[allow(missing_docs)]
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{Audio, AudioOutput, AudioSource, Decodable};
+    pub use crate::{AssetPlayer, Audio, AudioOutput, AudioSource, Decodable, PlayEvent};
 }
 
+pub use asset_player::*;
 pub use audio::*;
 pub use audio_output::*;
 pub use audio_source::*;
 
 use bevy_app::prelude::*;
 use bevy_asset::AddAsset;
+use bevy_ecs::schedule::SystemSet;
 use bevy_ecs::system::IntoExclusiveSystem;
 
 /// Adds support for audio playback to a Bevy Application
@@ -55,11 +69,15 @@ pub struct AudioPlugin;
 impl Plugin for AudioPlugin {
     fn build(&self, app: &mut App) {
         app.init_non_send_resource::<AudioOutput<AudioSource>>()
+            .init_non_send_resource::<AssetPlayer>()
+            .add_event::<PlayEvent<AudioSource>>()
             .add_asset::<AudioSource>()
             .init_resource::<Audio<AudioSource>>()
-            .add_system_to_stage(
+            .add_system_set_to_stage(
                 CoreStage::PostUpdate,
-                play_queued_audio_system::<AudioSource>.exclusive_system(),
+                SystemSet::new()
+                    .with_system(play_queued_audio_system::<AudioSource>.exclusive_system())
+                    .with_system(play_assets_system::<AudioSource>.exclusive_system()),
             );
 
         #[cfg(any(feature = "mp3", feature = "flac", feature = "wav", feature = "vorbis"))]

--- a/examples/README.md
+++ b/examples/README.md
@@ -149,6 +149,7 @@ Example | File | Description
 Example | File | Description
 --- | --- | ---
 `audio` | [`audio/audio.rs`](./audio/audio.rs) | Shows how to load and play an audio file
+`playlist` | [`audio/playlist.rs`](./audio/playlist.rs) | Shows how to play and control audios
 
 ## Diagnostics
 

--- a/examples/audio/playlist.rs
+++ b/examples/audio/playlist.rs
@@ -1,0 +1,25 @@
+use bevy::prelude::*;
+
+/// This example illustrates how to load and play an audio file
+fn main() {
+    App::new()
+        .insert_resource(StopTimer(Timer::from_seconds(5.0, false)))
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(play_audio)
+        .add_system(play_control)
+        .run();
+}
+
+struct StopTimer(Timer);
+
+fn play_control(time: Res<Time>, mut timer: ResMut<StopTimer>, mut ev: EventWriter<PlayEvent>) {
+    if timer.0.tick(time.delta()).just_finished() {
+        ev.send(PlayEvent::Clear)
+    }
+}
+
+fn play_audio(res: Res<AssetServer>, mut ew: EventWriter<PlayEvent>) {
+    let music = res.load("sounds/Windless Slopes.ogg");
+    ew.send(PlayEvent::Loop(true));
+    ew.send(PlayEvent::Append(music));
+}


### PR DESCRIPTION
# Objective
I found audio couldn't support loop background music

# Solution
 So I just made one with some simple control commands.

* loop: loop play, for background music
* append: append to play list
* once: just play once, no stop, no pause, for combat music
* pause / resume / clear : control events

# Implementaion
add a new system function and read the play events for audio play. here is an edge case
if a member adds new audio and sends a clear command, since the audio asset load is async, the clear may not work. 
but anyway, the audio play is paused then.
