### PR TITLE
[Merged by Bors] - Remove duplicate call to set_vertex_buffer(0, ...) in shader_instancing example

### DIFF
--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -231,7 +231,6 @@ impl EntityRenderCommand for DrawMeshInstanced {
         pass.set_vertex_buffer(0, gpu_mesh.vertex_buffer.slice(..));
         pass.set_vertex_buffer(1, instance_buffer.buffer.slice(..));
 
-        pass.set_vertex_buffer(0, gpu_mesh.vertex_buffer.slice(..));
         match &gpu_mesh.buffer_info {
             GpuBufferInfo::Indexed {
                 buffer,

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -241,7 +241,7 @@ impl EntityRenderCommand for DrawMeshInstanced {
                 pass.draw_indexed(0..*count, 0, 0..instance_buffer.length as u32);
             }
             GpuBufferInfo::NonIndexed { vertex_count } => {
-                pass.draw_indexed(0..*vertex_count, 0, 0..instance_buffer.length as u32);
+                pass.draw(0..*vertex_count, 0..instance_buffer.length as u32);
             }
         }
         RenderCommandResult::Success


### PR DESCRIPTION
## Objective

The [`DrawMeshInstanced`] command in the example sets vertex buffer 0 twice, with two identical calls to:

```rs
pass.set_vertex_buffer(0, gpu_mesh.vertex_buffer.slice(..));
```

## Solution

Remove the second call as it is unecessary.

[`DrawMeshInstanced`]: https://github.com/bevyengine/bevy/blob/f3de12bc5e03c58a9b863943b8db84a321422bec/examples/shader/shader_instancing.rs#L217-L258