### PR TITLE
[Merged by Bors] - Useful error message when two assets have the save UUID

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -93,6 +93,15 @@ impl AssetServer {
     }
 
     pub(crate) fn register_asset_type<T: Asset>(&self) -> Assets<T> {
+        if self
+            .server
+            .asset_lifecycles
+            .read()
+            .contains_key(&T::TYPE_UUID)
+        {
+            panic!("Error while registering new asset type. Asset with UUID: {:?} is already registered. Can not register another type with the same UUID",
+                T::TYPE_UUID);
+        }
         self.server.asset_lifecycles.write().insert(
             T::TYPE_UUID,
             Box::new(AssetLifecycleChannel::<T>::default()),

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -99,8 +99,8 @@ impl AssetServer {
             .read()
             .contains_key(&T::TYPE_UUID)
         {
-            panic!("Error while registering new asset type. Asset with UUID: {:?} is already registered. Can not register another type with the same UUID",
-                T::TYPE_UUID);
+            panic!("Error while registering new asset type: {:?} with UUID: {:?}. Another type with the same UUID is already registered. Can not register new asset type with the same UUID",
+                std::any::type_name::<T>(), T::TYPE_UUID);
         }
         self.server.asset_lifecycles.write().insert(
             T::TYPE_UUID,

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -93,15 +93,19 @@ impl AssetServer {
     }
 
     pub(crate) fn register_asset_type<T: Asset>(&self) -> Assets<T> {
-        let mut asset_lifecycles = self.server.asset_lifecycles.write();
-        if asset_lifecycles.contains_key(&T::TYPE_UUID) {
+        if self
+            .server
+            .asset_lifecycles
+            .write()
+            .insert(
+                T::TYPE_UUID,
+                Box::new(AssetLifecycleChannel::<T>::default()),
+            )
+            .is_some()
+        {
             panic!("Error while registering new asset type: {:?} with UUID: {:?}. Another type with the same UUID is already registered. Can not register new asset type with the same UUID",
                 std::any::type_name::<T>(), T::TYPE_UUID);
         }
-        asset_lifecycles.insert(
-            T::TYPE_UUID,
-            Box::new(AssetLifecycleChannel::<T>::default()),
-        );
         Assets::new(self.server.asset_ref_counter.channel.sender.clone())
     }
 

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -93,16 +93,12 @@ impl AssetServer {
     }
 
     pub(crate) fn register_asset_type<T: Asset>(&self) -> Assets<T> {
-        if self
-            .server
-            .asset_lifecycles
-            .read()
-            .contains_key(&T::TYPE_UUID)
-        {
+        let mut asset_lifecycles = self.server.asset_lifecycles.write();
+        if asset_lifecycles.contains_key(&T::TYPE_UUID) {
             panic!("Error while registering new asset type: {:?} with UUID: {:?}. Another type with the same UUID is already registered. Can not register new asset type with the same UUID",
                 std::any::type_name::<T>(), T::TYPE_UUID);
         }
-        self.server.asset_lifecycles.write().insert(
+        asset_lifecycles.insert(
             T::TYPE_UUID,
             Box::new(AssetLifecycleChannel::<T>::default()),
         );


### PR DESCRIPTION
# Objective
Fixes #2610 and #3731

## Solution

Added check for TYPE_UUID duplication in  `register_asset_type` with an error message
