### PR TITLE
[Merged by Bors] - bevy_render: Fix Quad flip

### DIFF
--- a/crates/bevy_render/src/mesh/shape/mod.rs
+++ b/crates/bevy_render/src/mesh/shape/mod.rs
@@ -125,7 +125,7 @@ impl From<Box> for Mesh {
 pub struct Quad {
     /// Full width and height of the rectangle.
     pub size: Vec2,
-    /// Flips the texture coords of the resulting vertices.
+    /// Horizontally-flip the texture coordinates of the resulting mesh.
     pub flip: bool,
 }
 
@@ -150,57 +150,13 @@ impl From<Quad> for Mesh {
         let extent_x = quad.size.x / 2.0;
         let extent_y = quad.size.y / 2.0;
 
-        let north_west = vec2(-extent_x, extent_y);
-        let north_east = vec2(extent_x, extent_y);
-        let south_west = vec2(-extent_x, -extent_y);
-        let south_east = vec2(extent_x, -extent_y);
-        let vertices = if quad.flip {
-            [
-                (
-                    [south_east.x, south_east.y, 0.0],
-                    [0.0, 0.0, 1.0],
-                    [1.0, 1.0],
-                ),
-                (
-                    [north_east.x, north_east.y, 0.0],
-                    [0.0, 0.0, 1.0],
-                    [1.0, 0.0],
-                ),
-                (
-                    [north_west.x, north_west.y, 0.0],
-                    [0.0, 0.0, 1.0],
-                    [0.0, 0.0],
-                ),
-                (
-                    [south_west.x, south_west.y, 0.0],
-                    [0.0, 0.0, 1.0],
-                    [0.0, 1.0],
-                ),
-            ]
-        } else {
-            [
-                (
-                    [south_west.x, south_west.y, 0.0],
-                    [0.0, 0.0, 1.0],
-                    [0.0, 1.0],
-                ),
-                (
-                    [north_west.x, north_west.y, 0.0],
-                    [0.0, 0.0, 1.0],
-                    [0.0, 0.0],
-                ),
-                (
-                    [north_east.x, north_east.y, 0.0],
-                    [0.0, 0.0, 1.0],
-                    [1.0, 0.0],
-                ),
-                (
-                    [south_east.x, south_east.y, 0.0],
-                    [0.0, 0.0, 1.0],
-                    [1.0, 1.0],
-                ),
-            ]
-        };
+        let (u_left, u_right) = if quad.flip { (1.0, 0.0) } else { (0.0, 1.0) };
+        let vertices = [
+            ([-extent_x, -extent_y, 0.0], [0.0, 0.0, 1.0], [u_left, 1.0]),
+            ([-extent_x, extent_y, 0.0], [0.0, 0.0, 1.0], [u_left, 0.0]),
+            ([extent_x, extent_y, 0.0], [0.0, 0.0, 1.0], [u_right, 0.0]),
+            ([extent_x, -extent_y, 0.0], [0.0, 0.0, 1.0], [u_right, 1.0]),
+        ];
 
         let indices = Indices::U32(vec![0, 2, 1, 0, 3, 2]);
 


### PR DESCRIPTION
# Objective

The documentation was unclear but it seemed like it was intended to _only_ flip the texture coordinates of the quad. However, it was also swapping the vertex positions, which resulted in inverted winding order so the front became a back face, and the normal was pointing into the face instead of out of it.

## Solution

- This change makes the only difference the UVs being horizontally flipped.