### PR TITLE
[Merged by Bors] - Enable drag-and-drop events on windows

### DIFF
--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -19,9 +19,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
 # other
 anyhow = "1.0.4"
 rodio = { version = "0.15", default-features = false }
-# we do not directly depend on cpal, but we require at least this version to be used by rodio
-# so that the winit feature of drag and drop can be enabled https://github.com/RustAudio/cpal/issues/572
-cpal = ">=0.13.4"
 parking_lot = "0.11.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -18,11 +18,14 @@ bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
 
 # other
 anyhow = "1.0.4"
-rodio = { version = "0.14", default-features = false }
+rodio = { version = "0.15", default-features = false }
+# we do not directly depend on cpal, but we require at least this version to be used by rodio
+# so that the winit feature of drag and drop can be enabled https://github.com/RustAudio/cpal/issues/572
+cpal = ">=0.13.4"
 parking_lot = "0.11.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-rodio = { version = "0.14", default-features = false, features = ["wasm-bindgen"] }
+rodio = { version = "0.15", default-features = false, features = ["wasm-bindgen"] }
 
 [dev-dependencies]
 # bevy

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -18,13 +18,6 @@ impl WinitWindows {
         window_id: WindowId,
         window_descriptor: &WindowDescriptor,
     ) -> Window {
-        #[cfg(target_os = "windows")]
-        let mut winit_window_builder = {
-            use winit::platform::windows::WindowBuilderExtWindows;
-            winit::window::WindowBuilder::new().with_drag_and_drop(false)
-        };
-
-        #[cfg(not(target_os = "windows"))]
         let mut winit_window_builder = winit::window::WindowBuilder::new();
 
         winit_window_builder = match window_descriptor.mode {


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/2096

## Solution

- This PR enables the drag-and-drop feature for winit on windows again, as the collision issue between cpal and winit has been fixed in https://github.com/RustAudio/cpal/pull/597. I confirmed the drag and drop example working on windows 10 with this change.
- ~~It also bumps the rodio version, though this is not strictly necessary.~~
