### PR TITLE
Prevent WGPU from re-initializing depth buffer

### DIFF
--- a/crates/bevy_core_pipeline/src/main_pass_3d.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_3d.rs
@@ -137,7 +137,7 @@ impl Node for MainPass3dNode {
                     // NOTE: For the transparent pass we load the depth buffer to allow opaque meshes from previous passes
                     // to occlude transparent ones. When creating the specialized pipeline for Transparent Meshes the
                     // depth buffer is set to read-only so even though `store: true` is set, the depth buffer is not updated.
-                    // 
+                    //
                     // There is a useful optimization to set `store: false` to prevent wasting bandwidth writing to the
                     // depth buffer. This only works if the `main_transparent_pass_3d` render pass is the last one executed (because
                     // no subsequent pass will need to use the depth buffer).

--- a/crates/bevy_core_pipeline/src/main_pass_3d.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_3d.rs
@@ -137,10 +137,10 @@ impl Node for MainPass3dNode {
                     // NOTE: There is a useful optimization to set `store: false` to prevent wasting bandwidth writing to the
                     // depth buffer. This only works if the `main_transparent_pass_3d` render pass is the last one executed (because
                     // no subsequent pass will need to use the depth buffer).
-                    // If it is not the last executed render pass then WGPU will re-initialize the depth buffer before the
+                    // If it is not the last executed render pass then wgpu will re-initialize the depth buffer before the
                     // next pass. This is affects users who want to perform post-processing using the depth buffer.
                     //
-                    // Some time in the future it may be possible to inspect if we will be the last render pass and apply
+                    // Sometime in the future it may be possible to inspect if this will be the last render pass and apply
                     // this optimization, but for now this must always be `true`.
                     // Some rendering linters may complain about this in the default case.
                     depth_ops: Some(Operations {

--- a/crates/bevy_core_pipeline/src/main_pass_3d.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_3d.rs
@@ -134,7 +134,11 @@ impl Node for MainPass3dNode {
                 })],
                 depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
                     view: &depth.view,
-                    // NOTE: There is a useful optimization to set `store: false` to prevent wasting bandwidth writing to the
+                    // NOTE: For the transparent pass we load the depth buffer to allow opaque meshes from previous passes
+                    // to occlude transparent ones. When creating the specialized pipeline for Transparent Meshes the
+                    // depth buffer is set to read-only so even though `store: true` is set, the depth buffer is not updated.
+                    // 
+                    // There is a useful optimization to set `store: false` to prevent wasting bandwidth writing to the
                     // depth buffer. This only works if the `main_transparent_pass_3d` render pass is the last one executed (because
                     // no subsequent pass will need to use the depth buffer).
                     // If it is not the last executed render pass then wgpu will re-initialize the depth buffer before the


### PR DESCRIPTION
If a render pass is added after the "main_transparent_pass_3d" then WGPU will decide to re-initialize the depth buffer. 
This prevents subsequent render passes from rendering properly.

# Objective

Fixes #3776 

## Solution

Unconditionally setting `store: true` will prevent WGPU from deciding that the Depth buffer is invalid if there is a subsequent render stage. 
This is slightly sub-optimal for performance in the base case, but makes behavior more expected when customizing the render graph. 
