### PR TITLE
[Merged by Bors] - SystemState usage docs

### DIFF
--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -63,6 +63,8 @@ impl SystemMeta {
 /// Borrow-checking is handled for you, allowing you to mutably acccess multiple compatible system parameters at once,
 /// and arbitrary system parameters (like [`EventWriter`](crate::event::EventWriter)) can be conveniently fetched.
 ///
+/// For an alternative approach to split mutable access to the world, see [`World::resource_scope`].
+///
 /// # Example
 /// ```rust
 /// use bevy::ecs::system::SystemState;

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -70,7 +70,7 @@ impl SystemMeta {
 /// [`SystemState`] values created can be cached to improve performance,
 /// and *must* be cached and reused in order for system parameters that rely on local state to work correctly.
 /// These include:
-/// - [`Added`](crate::system::query::Added) and [`Changed`](crate::system::query::Changed) query filters
+/// - [`Added`](crate::query::Added) and [`Changed`](crate::query::Changed) query filters
 /// - [`Local`](crate::system::Local) variables that hold state
 /// - [`EventReader`](crate::event::EventReader) system parameters, which rely on a [`Local`](crate::system::Local) to track which events have been seen
 ///

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -56,6 +56,40 @@ impl SystemMeta {
 // TODO: Actually use this in FunctionSystem. We should probably only do this once Systems are constructed using a World reference
 // (to avoid the need for unwrapping to retrieve SystemMeta)
 /// Holds on to persistent state required to drive [`SystemParam`] for a [`System`].
+///
+/// This is a very powerful and convenient tool for working with exclusive world access,
+/// allowing you to fetch data from the [`World`] as if you were running a [`System`].
+///
+/// Borrow-checking is handled for you, allowing you to mutably acccess multiple compatible system parameters at once,
+/// and arbitrary system parameters (like [`EventWriter`](crate::event::EventWriter)) can be conveniently fetched.
+///
+/// # Example
+/// ```rust
+/// use bevy::ecs::system::SystemState;
+/// use bevy::ecs::world::World;
+///
+/// struct MyEvent;
+/// struct MyResource(u32);
+///
+/// #[derive(Component)]
+/// struct MyComponent;
+///
+/// // Work directly on the `World`
+/// let mut world = World::new();
+///
+/// // Construct a `SystemState` struct, passing in a tuple of `SystemParam`
+/// // as if you were writing an ordinary system.
+/// // This can be cached and reused for improved performance.
+/// let mut system_state: SystemState<(
+///     EventWriter<MyEvent>,
+///     Option<ResMut<MyResource>>,
+///     Query<&MyComponent>,
+///     )> = SystemState::new(&mut world);
+///
+/// // Use system_state.get_mut(&mut world) and unpack your system parameters into variables!
+/// // You can use system_state.get(&world) instead for read-only versions of your system parameters
+/// let (event_writer, maybe_respource, query) = system_state.get_mut(&mut world);
+/// ```
 pub struct SystemState<Param: SystemParam> {
     meta: SystemMeta,
     param_state: <Param as SystemParam>::Fetch,

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -66,7 +66,6 @@ impl SystemMeta {
 /// For an alternative approach to split mutable access to the world, see [`World::resource_scope`].
 ///
 /// # Warning
-/// This API has more performance overhead than more direct methods: prefer them when possible.
 ///
 /// [`SystemState`] values created can be cached to improve performance,
 /// and *must* be cached and reused in order for system parameters that rely on local state to work correctly.

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -60,7 +60,7 @@ impl SystemMeta {
 /// This is a very powerful and convenient tool for working with exclusive world access,
 /// allowing you to fetch data from the [`World`] as if you were running a [`System`].
 ///
-/// Borrow-checking is handled for you, allowing you to mutably acccess multiple compatible system parameters at once,
+/// Borrow-checking is handled for you, allowing you to mutably access multiple compatible system parameters at once,
 /// and arbitrary system parameters (like [`EventWriter`](crate::event::EventWriter)) can be conveniently fetched.
 ///
 /// For an alternative approach to split mutable access to the world, see [`World::resource_scope`].

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -932,10 +932,9 @@ impl World {
         }
     }
 
-    /// Temporarily removes the requested resource from this [`World`], then re-adds it before
-    /// returning. This enables safe mutable access to a resource while still providing mutable
-    /// world access
+    /// Temporarily removes the requested resource from this [`World`], then re-adds it before returning.
     ///
+    /// This enables safe simultaneous mutable access to both a resource and the rest of the [`World`].
     /// For more complex access patterns, consider using [`SystemState`](crate::system::SystemState).
     ///
     /// # Example

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -34,6 +34,12 @@ pub use identifier::WorldId;
 /// component type. Entity components can be created, updated, removed, and queried using a given
 /// [World].
 ///
+/// For complex access patterns involving [`SystemParam`](crate::system::SystemParam),
+/// consider using [`SystemState`](crate::system::SystemState).
+///
+/// For split mutable access to the [`World`], use [`World::resource_scope`] or
+/// [`SystemState`](crate::system::SystemState).
+///
 /// # Resources
 ///
 /// Worlds can also store *resources*, which are unique instances of a given type that don't
@@ -926,9 +932,13 @@ impl World {
         }
     }
 
-    /// Temporarily removes the requested resource from this [World], then re-adds it before
+    /// Temporarily removes the requested resource from this [`World`], then re-adds it before
     /// returning. This enables safe mutable access to a resource while still providing mutable
     /// world access
+    ///
+    /// For more complex access patterns, consider using [`SystemState`](crate::system::SystemState).
+    ///
+    /// # Example
     /// ```
     /// use bevy_ecs::{component::Component, world::{World, Mut}};
     /// #[derive(Component)]

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -37,8 +37,8 @@ pub use identifier::WorldId;
 /// For complex access patterns involving [`SystemParam`](crate::system::SystemParam),
 /// consider using [`SystemState`](crate::system::SystemState).
 ///
-/// For split mutable access to the [`World`], use [`World::resource_scope`] or
-/// [`SystemState`](crate::system::SystemState).
+/// To mutate different parts of the world simultaneously,
+/// use [`World::resource_scope`] or [`SystemState`](crate::system::SystemState).
 ///
 /// # Resources
 ///


### PR DESCRIPTION
# Objective

- `SystemStates` rock for dealing with exclusive world access, but are hard to figure out how to use.
- Fixes #3341.

## Solution

- Clearly document how to use `SystemState`, and why they're useful as an end-user.