### PR TITLE
[Merged by Bors] - fix timer test to be less reliant on float precision

### DIFF
--- a/crates/bevy_core/src/time/timer.rs
+++ b/crates/bevy_core/src/time/timer.rs
@@ -469,15 +469,18 @@ mod tests {
     #[test]
     fn times_finished_precise() {
         let mut t = Timer::from_seconds(0.01, true);
-        let duration = Duration::from_secs_f64(1.0 / 3.0);
+        let duration = Duration::from_secs_f64(0.333);
 
+        // total duration: 0.333 => 33 times finished
         t.tick(duration);
         assert_eq!(t.times_finished(), 33);
+        // total duration: 0.666 => 33 times finished
         t.tick(duration);
         assert_eq!(t.times_finished(), 33);
+        // total duration: 0.999 => 33 times finished
         t.tick(duration);
         assert_eq!(t.times_finished(), 33);
-        // It has one additional tick this time to compensate for missing 100th tick
+        // total duration: 1.332 => 34 times finished
         t.tick(duration);
         assert_eq!(t.times_finished(), 34);
     }


### PR DESCRIPTION
# Objective

- Test is failing on nightly after the merge of https://github.com/rust-lang/rust/pull/90247
- It was relying on the precision of the duration of `1.0 / 3.0`

## Solution

- Fix the test to be less reliant on float precision to have the same result
