### PR TITLE
[Merged by Bors] - Fix HDR asset support

### DIFF
--- a/crates/bevy_render/src/texture/image_texture_loader.rs
+++ b/crates/bevy_render/src/texture/image_texture_loader.rs
@@ -9,7 +9,20 @@ use crate::texture::{Image, ImageType, TextureError};
 #[derive(Clone, Default)]
 pub struct ImageTextureLoader;
 
-const FILE_EXTENSIONS: &[&str] = &["png", "dds", "tga", "jpg", "jpeg", "bmp"];
+const FILE_EXTENSIONS: &[&str] = &[
+    #[cfg(feature = "png")]
+    "png",
+    #[cfg(feature = "dds")]
+    "dds",
+    #[cfg(feature = "tga")]
+    "tga",
+    #[cfg(feature = "jpeg")]
+    "jpg",
+    #[cfg(feature = "jpeg")]
+    "jpeg",
+    #[cfg(feature = "bmp")]
+    "bmp",
+];
 
 impl AssetLoader for ImageTextureLoader {
     fn load<'a>(

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -37,7 +37,7 @@ impl Plugin for ImagePlugin {
 
         #[cfg(feature = "hdr")]
         {
-            app.init_asset_loader::<HdrTextureLoader>()
+            app.init_asset_loader::<HdrTextureLoader>();
         }
 
         app.add_plugin(RenderAssetPlugin::<Image>::default())

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod image_texture_conversion;
 pub use self::image::*;
 #[cfg(feature = "hdr")]
 pub use hdr_texture_loader::*;
+
 pub use image_texture_loader::*;
 pub use texture_cache::*;
 
@@ -23,9 +24,20 @@ pub struct ImagePlugin;
 
 impl Plugin for ImagePlugin {
     fn build(&self, app: &mut App) {
-        #[cfg(feature = "png")]
+        #[cfg(any(
+            feature = "png",
+            feature = "dds",
+            feature = "tga",
+            feature = "jpeg",
+            feature = "bmp"
+        ))]
         {
             app.init_asset_loader::<ImageTextureLoader>();
+        }
+
+        #[cfg(feature = "hdr")]
+        {
+            app.init_asset_loader::<HdrTextureLoader>()
         }
 
         app.add_plugin(RenderAssetPlugin::<Image>::default())


### PR DESCRIPTION
The HDR texture loader was never added to the app, this PR makes sure it is added when the relevant feature is enabled.