### PR TITLE
Visibility as a marker component

### DIFF
--- a/crates/bevy_pbr/src/bundle.rs
+++ b/crates/bevy_pbr/src/bundle.rs
@@ -5,7 +5,7 @@ use bevy_reflect::Reflect;
 use bevy_render::{
     mesh::Mesh,
     primitives::{CubemapFrusta, Frustum},
-    view::{ComputedVisibility, Visibility, VisibleEntities},
+    view::{ComputedVisibility, Visible, VisibleEntities},
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 
@@ -20,7 +20,7 @@ pub struct MaterialMeshBundle<M: SpecializedMaterial> {
     pub transform: Transform,
     pub global_transform: GlobalTransform,
     /// User indication of whether an entity is visible
-    pub visibility: Visibility,
+    pub visible: Visible,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub computed_visibility: ComputedVisibility,
 }
@@ -32,7 +32,7 @@ impl<M: SpecializedMaterial> Default for MaterialMeshBundle<M> {
             material: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),
-            visibility: Default::default(),
+            visible: Default::default(),
             computed_visibility: Default::default(),
         }
     }

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -7,7 +7,7 @@ use bevy_render::{
     camera::{Camera, CameraProjection, OrthographicProjection},
     color::Color,
     primitives::{Aabb, CubemapFrusta, Frustum, Sphere},
-    view::{ComputedVisibility, RenderLayers, Visibility, VisibleEntities},
+    view::{ComputedVisibility, RenderLayers, Visible, VisibleEntities},
 };
 use bevy_transform::components::GlobalTransform;
 use bevy_window::Windows;
@@ -705,13 +705,12 @@ pub fn check_light_mesh_visibility(
     mut visible_entity_query: Query<
         (
             Entity,
-            &Visibility,
             &mut ComputedVisibility,
             Option<&RenderLayers>,
             Option<&Aabb>,
             Option<&GlobalTransform>,
         ),
-        Without<NotShadowCaster>,
+        (Without<NotShadowCaster>, With<Visible>),
     >,
 ) {
     // Directonal lights
@@ -727,19 +726,9 @@ pub fn check_light_mesh_visibility(
 
         let view_mask = maybe_view_mask.copied().unwrap_or_default();
 
-        for (
-            entity,
-            visibility,
-            mut computed_visibility,
-            maybe_entity_mask,
-            maybe_aabb,
-            maybe_transform,
-        ) in visible_entity_query.iter_mut()
+        for (entity, mut computed_visibility, maybe_entity_mask, maybe_aabb, maybe_transform) in
+            visible_entity_query.iter_mut()
         {
-            if !visibility.is_visible {
-                continue;
-            }
-
             let entity_mask = maybe_entity_mask.copied().unwrap_or_default();
             if !view_mask.intersects(&entity_mask) {
                 continue;
@@ -788,17 +777,12 @@ pub fn check_light_mesh_visibility(
 
                 for (
                     entity,
-                    visibility,
                     mut computed_visibility,
                     maybe_entity_mask,
                     maybe_aabb,
                     maybe_transform,
                 ) in visible_entity_query.iter_mut()
                 {
-                    if !visibility.is_visible {
-                        continue;
-                    }
-
                     let entity_mask = maybe_entity_mask.copied().unwrap_or_default();
                     if !view_mask.intersects(&entity_mask) {
                         continue;

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -14,7 +14,7 @@ pub use projection::*;
 
 use crate::{
     primitives::Aabb,
-    view::{ComputedVisibility, ExtractedView, Visibility, VisibleEntities},
+    view::{ComputedVisibility, ExtractedView, Visible, VisibleEntities},
     RenderApp, RenderStage,
 };
 use bevy_app::{App, CoreStage, Plugin};
@@ -34,7 +34,7 @@ impl Plugin for CameraPlugin {
         active_cameras.add(Self::CAMERA_2D);
         active_cameras.add(Self::CAMERA_3D);
         app.register_type::<Camera>()
-            .register_type::<Visibility>()
+            .register_type::<Visible>()
             .register_type::<ComputedVisibility>()
             .register_type::<OrthographicProjection>()
             .register_type::<PerspectiveProjection>()

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -23,7 +23,7 @@ pub mod prelude {
         mesh::{shape, Mesh},
         render_resource::Shader,
         texture::Image,
-        view::{ComputedVisibility, Msaa, Visibility},
+        view::{ComputedVisibility, Msaa, Visible},
     };
 }
 

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -6,7 +6,7 @@ use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
 use bevy_render::{
     texture::{Image, DEFAULT_IMAGE_HANDLE},
-    view::Visibility,
+    view::Visible,
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 
@@ -17,7 +17,7 @@ pub struct SpriteBundle {
     pub global_transform: GlobalTransform,
     pub texture: Handle<Image>,
     /// User indication of whether an entity is visible
-    pub visibility: Visibility,
+    pub visible: Visible,
 }
 
 impl Default for SpriteBundle {
@@ -27,7 +27,7 @@ impl Default for SpriteBundle {
             transform: Default::default(),
             global_transform: Default::default(),
             texture: DEFAULT_IMAGE_HANDLE.typed(),
-            visibility: Default::default(),
+            visible: Default::default(),
         }
     }
 }
@@ -43,5 +43,5 @@ pub struct SpriteSheetBundle {
     pub transform: Transform,
     pub global_transform: GlobalTransform,
     /// User indication of whether an entity is visible
-    pub visibility: Visibility,
+    pub visible: Visible,
 }

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -24,7 +24,7 @@ use bevy_render::{
         SpecializedPipeline, SpecializedPipelines,
     },
     renderer::RenderDevice,
-    view::{ComputedVisibility, Msaa, Visibility, VisibleEntities},
+    view::{ComputedVisibility, Msaa, Visible, VisibleEntities},
     RenderApp, RenderStage,
 };
 use bevy_transform::components::{GlobalTransform, Transform};
@@ -326,7 +326,7 @@ pub struct MaterialMesh2dBundle<M: SpecializedMaterial2d> {
     pub transform: Transform,
     pub global_transform: GlobalTransform,
     /// User indication of whether an entity is visible
-    pub visibility: Visibility,
+    pub visible: Visible,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub computed_visibility: ComputedVisibility,
 }
@@ -338,7 +338,7 @@ impl<M: SpecializedMaterial2d> Default for MaterialMesh2dBundle<M> {
             material: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),
-            visibility: Default::default(),
+            visible: Default::default(),
             computed_visibility: Default::default(),
         }
     }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
     system::{Local, Query, QuerySet, Res, ResMut},
 };
 use bevy_math::{Size, Vec3};
-use bevy_render::{texture::Image, view::Visibility, RenderWorld};
+use bevy_render::{texture::Image, view::Visible, RenderWorld};
 use bevy_sprite::{ExtractedSprite, ExtractedSprites, TextureAtlas};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 use bevy_window::Windows;
@@ -24,7 +24,7 @@ pub struct Text2dBundle {
     pub transform: Transform,
     pub global_transform: GlobalTransform,
     pub text_2d_size: Text2dSize,
-    pub visibility: Visibility,
+    pub visible: Visible,
 }
 
 impl Default for Text2dBundle {
@@ -36,7 +36,7 @@ impl Default for Text2dBundle {
             text_2d_size: Text2dSize {
                 size: Size::default(),
             },
-            visibility: Default::default(),
+            visible: Default::default(),
         }
     }
 }
@@ -46,7 +46,7 @@ pub fn extract_text2d_sprite(
     texture_atlases: Res<Assets<TextureAtlas>>,
     text_pipeline: Res<DefaultTextPipeline>,
     windows: Res<Windows>,
-    text2d_query: Query<(Entity, &Visibility, &Text, &GlobalTransform, &Text2dSize)>,
+    text2d_query: Query<(Entity, &Text, &GlobalTransform, &Text2dSize), With<Visible>>,
 ) {
     let mut extracted_sprites = render_world.get_resource_mut::<ExtractedSprites>().unwrap();
 
@@ -56,10 +56,7 @@ pub fn extract_text2d_sprite(
         1.
     };
 
-    for (entity, visibility, text, transform, calculated_size) in text2d_query.iter() {
-        if !visibility.is_visible {
-            continue;
-        }
+    for (entity, text, transform, calculated_size) in text2d_query.iter() {
         let (width, height) = (calculated_size.size.width, calculated_size.size.height);
 
         if let Some(text_layout) = text_pipeline.get_glyphs(&entity) {

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -7,7 +7,7 @@ use crate::{
 use bevy_ecs::bundle::Bundle;
 use bevy_render::{
     camera::{Camera, DepthCalculation, OrthographicProjection, WindowOrigin},
-    view::{Visibility, VisibleEntities},
+    view::{Visible, VisibleEntities},
 };
 use bevy_text::Text;
 use bevy_transform::prelude::{GlobalTransform, Transform};
@@ -28,7 +28,7 @@ pub struct NodeBundle {
     /// The global transform of the node
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
-    pub visibility: Visibility,
+    pub visible: Visible,
 }
 
 /// A UI node that is an image
@@ -51,7 +51,7 @@ pub struct ImageBundle {
     /// The global transform of the node
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
-    pub visibility: Visibility,
+    pub visible: Visible,
 }
 
 /// A UI node that is text
@@ -72,7 +72,7 @@ pub struct TextBundle {
     /// The global transform of the node
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
-    pub visibility: Visibility,
+    pub visible: Visible,
 }
 
 impl Default for TextBundle {
@@ -85,7 +85,7 @@ impl Default for TextBundle {
             style: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),
-            visibility: Default::default(),
+            visible: Default::default(),
         }
     }
 }
@@ -112,7 +112,7 @@ pub struct ButtonBundle {
     /// The global transform of the node
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
-    pub visibility: Visibility,
+    pub visible: Visible,
 }
 
 impl Default for ButtonBundle {
@@ -127,7 +127,7 @@ impl Default for ButtonBundle {
             image: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),
-            visibility: Default::default(),
+            visible: Default::default(),
         }
     }
 }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -23,7 +23,7 @@ use bevy_render::{
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
     texture::Image,
-    view::{ViewUniforms, Visibility},
+    view::{ViewUniforms, Visible},
     RenderApp, RenderStage, RenderWorld,
 };
 use bevy_sprite::{Rect, SpriteAssetEvents, TextureAtlas};
@@ -138,21 +138,20 @@ pub struct ExtractedUiNodes {
 pub fn extract_uinodes(
     mut render_world: ResMut<RenderWorld>,
     images: Res<Assets<Image>>,
-    uinode_query: Query<(
-        &Node,
-        &GlobalTransform,
-        &UiColor,
-        &UiImage,
-        &Visibility,
-        Option<&CalculatedClip>,
-    )>,
+    uinode_query: Query<
+        (
+            &Node,
+            &GlobalTransform,
+            &UiColor,
+            &UiImage,
+            Option<&CalculatedClip>,
+        ),
+        With<Visible>,
+    >,
 ) {
     let mut extracted_uinodes = render_world.get_resource_mut::<ExtractedUiNodes>().unwrap();
     extracted_uinodes.uinodes.clear();
-    for (uinode, transform, color, image, visibility, clip) in uinode_query.iter() {
-        if !visibility.is_visible {
-            continue;
-        }
+    for (uinode, transform, color, image, clip) in uinode_query.iter() {
         let image = image.0.clone_weak();
         // Skip loading images
         if !images.contains(image.clone_weak()) {
@@ -177,14 +176,16 @@ pub fn extract_text_uinodes(
     texture_atlases: Res<Assets<TextureAtlas>>,
     text_pipeline: Res<DefaultTextPipeline>,
     windows: Res<Windows>,
-    uinode_query: Query<(
-        Entity,
-        &Node,
-        &GlobalTransform,
-        &Text,
-        &Visibility,
-        Option<&CalculatedClip>,
-    )>,
+    uinode_query: Query<
+        (
+            Entity,
+            &Node,
+            &GlobalTransform,
+            &Text,
+            Option<&CalculatedClip>,
+        ),
+        With<Visible>,
+    >,
 ) {
     let mut extracted_uinodes = render_world.get_resource_mut::<ExtractedUiNodes>().unwrap();
 
@@ -194,10 +195,7 @@ pub fn extract_text_uinodes(
         1.
     };
 
-    for (entity, uinode, transform, text, visibility, clip) in uinode_query.iter() {
-        if !visibility.is_visible {
-            continue;
-        }
+    for (entity, uinode, transform, text, clip) in uinode_query.iter() {
         // Skip if size is set to zero (e.g. when a parent is set to `Display::None`)
         if uinode.size == Vec2::ZERO {
             continue;

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -98,7 +98,7 @@ fn star(
         // These other components are needed for 2d meshes to be rendered
         Transform::default(),
         GlobalTransform::default(),
-        Visibility::default(),
+        Visible::default(),
         ComputedVisibility::default(),
     ));
     commands

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -13,7 +13,7 @@ use bevy::{
         },
         render_resource::*,
         renderer::{RenderDevice, RenderQueue},
-        view::{ComputedVisibility, ExtractedView, Msaa, Visibility},
+        view::{ComputedVisibility, ExtractedView, Msaa, Visible},
         RenderApp, RenderStage,
     },
 };
@@ -33,7 +33,7 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
         Transform::from_xyz(0.0, 0.5, 0.0),
         GlobalTransform::default(),
         CustomMaterial,
-        Visibility::default(),
+        Visible::default(),
         ComputedVisibility::default(),
     ));
 

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -60,7 +60,7 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
         IsRed(true),
         Transform::from_xyz(-1.0, 0.5, 0.0),
         GlobalTransform::default(),
-        Visibility::default(),
+        Visible::default(),
         ComputedVisibility::default(),
     ));
 
@@ -70,7 +70,7 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
         IsRed(false),
         Transform::from_xyz(1.0, 0.5, 0.0),
         GlobalTransform::default(),
-        Visibility::default(),
+        Visible::default(),
         ComputedVisibility::default(),
     ));
 

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -14,7 +14,7 @@ use bevy::{
         },
         render_resource::*,
         renderer::RenderDevice,
-        view::{ComputedVisibility, ExtractedView, Msaa, NoFrustumCulling, Visibility},
+        view::{ComputedVisibility, ExtractedView, Msaa, NoFrustumCulling, Visible},
         RenderApp, RenderStage,
     },
 };
@@ -43,7 +43,7 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
                 })
                 .collect(),
         ),
-        Visibility::default(),
+        Visible::default(),
         ComputedVisibility::default(),
         // NOTE: Frustum culling is done based on the Aabb of the Mesh and the GlobalTransform.
         // As the cube is at the origin, if its Aabb moves outside the view frustum, all the


### PR DESCRIPTION
# Objective

The `Visibility` component could be a marker component allowing simpler and probably faster querying

## Solution

I changed the `Visibility` component to a marker struct `Visible` and adapted the queries.

This is a breaking change that could be expanded to `ComputedVisibility`

Associated discussion: #3833 
