### PR TITLE
Remove unused std_rng dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ bevy_internal = { path = "crates/bevy_internal", version = "0.6.0", default-feat
 
 [dev-dependencies]
 anyhow = "1.0.4"
-rand = "0.8.0"
+rand = { version = "0.8", default-features = false, features = ["std"] }
 ron = "0.7.0"
 serde = { version = "1", features = ["derive"] }
 bytemuck = "1.7"

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = "1.0"
 downcast-rs = "1.2.0"
 notify = { version = "=5.0.0-pre.11", optional = true }
 parking_lot = "0.11.0"
-rand = "0.8.0"
+rand = { version = "0.8", default-features = false, features = ["std"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -28,7 +28,7 @@ serde = "1"
 
 [dev-dependencies]
 parking_lot = "0.11"
-rand = "0.8"
+rand = { version = "0.8", default-features = false, features = ["std"] }
 
 [[example]]
 name = "events"


### PR DESCRIPTION
# Objective

`rand` crate have `std` and `std_rng` as [default features](https://github.com/rust-random/rand/blob/8f372500f05dfadcff6c35e773e81029ab7debad/Cargo.toml#L30). `std_rng` provides [StdRng](https://rust-random.github.io/rand/rand/rngs/struct.StdRng.html) which isn't used by Bevy.

## Solution

I disabled default features for `rand` and enabled only `std`.
