### PR TITLE
[Merged by Bors] - Obviate the need for `RunSystem`, and remove it

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -382,7 +382,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
         #[doc(hidden)]
         #fetch_struct_visibility struct #fetch_struct_name<TSystemParamState, #punctuated_generic_idents> {
             state: TSystemParamState,
-            marker: std::marker::PhantomData<(#punctuated_generic_idents)>
+            marker: std::marker::PhantomData<fn()->(#punctuated_generic_idents)>
         }
 
         unsafe impl<TSystemParamState: #path::system::SystemParamState, #punctuated_generics> #path::system::SystemParamState for #fetch_struct_name<TSystemParamState, #punctuated_generic_idents> {

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -4,7 +4,7 @@ use crate::{
     query::{Access, FilteredAccessSet},
     system::{
         check_system_change_tick, ReadOnlySystemParamFetch, System, SystemParam, SystemParamFetch,
-        SystemParamItem, SystemParamState,
+        SystemParamState,
     },
     world::{World, WorldId},
 };
@@ -45,11 +45,6 @@ impl SystemMeta {
     #[inline]
     pub fn set_non_send(&mut self) {
         self.is_send = false;
-    }
-
-    #[inline]
-    pub(crate) fn check_change_tick(&mut self, change_tick: u32) {
-        check_system_change_tick(&mut self.last_change_tick, change_tick, self.name.as_ref());
     }
 }
 
@@ -194,10 +189,6 @@ impl<Param: SystemParam> SystemState<Param> {
         self.world_id == world.id()
     }
 
-    pub(crate) fn new_archetype(&mut self, archetype: &Archetype) {
-        self.param_state.new_archetype(archetype, &mut self.meta);
-    }
-
     fn validate_world_and_update_archetypes(&mut self, world: &World) {
         assert!(self.matches_world(world), "Encountered a mismatched World. A SystemState cannot be used with Worlds other than the one it was created with.");
         let archetypes = world.archetypes();
@@ -233,74 +224,6 @@ impl<Param: SystemParam> SystemState<Param> {
         );
         self.meta.last_change_tick = change_tick;
         param
-    }
-}
-
-/// A trait for defining systems with a [`SystemParam`] associated type.
-///
-/// This facilitates the creation of systems that are generic over some trait
-/// and that use that trait's associated types as `SystemParam`s.
-pub trait RunSystem: Send + Sync + 'static {
-    /// The `SystemParam` type passed to the system when it runs.
-    type Param: SystemParam;
-
-    /// Runs the system.
-    fn run(param: SystemParamItem<Self::Param>);
-
-    /// Creates a concrete instance of the system for the specified `World`.
-    fn system(world: &mut World) -> ParamSystem<Self::Param> {
-        ParamSystem {
-            run: Self::run,
-            state: SystemState::new(world),
-        }
-    }
-}
-
-pub struct ParamSystem<P: SystemParam> {
-    state: SystemState<P>,
-    run: fn(SystemParamItem<P>),
-}
-
-impl<P: SystemParam + 'static> System for ParamSystem<P> {
-    type In = ();
-
-    type Out = ();
-
-    fn name(&self) -> Cow<'static, str> {
-        self.state.meta().name.clone()
-    }
-
-    fn new_archetype(&mut self, archetype: &Archetype) {
-        self.state.new_archetype(archetype);
-    }
-
-    fn component_access(&self) -> &Access<ComponentId> {
-        self.state.meta().component_access_set.combined_access()
-    }
-
-    fn archetype_component_access(&self) -> &Access<ArchetypeComponentId> {
-        &self.state.meta().archetype_component_access
-    }
-
-    fn is_send(&self) -> bool {
-        self.state.meta().is_send()
-    }
-
-    unsafe fn run_unsafe(&mut self, _input: Self::In, world: &World) -> Self::Out {
-        let param = self.state.get_unchecked_manual(world);
-        (self.run)(param);
-    }
-
-    fn apply_buffers(&mut self, world: &mut World) {
-        self.state.apply(world);
-    }
-
-    fn initialize(&mut self, _world: &mut World) {
-        // already initialized by nature of the SystemState being constructed
-    }
-
-    fn check_change_tick(&mut self, change_tick: u32) {
-        self.state.meta.check_change_tick(change_tick);
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1366,15 +1366,10 @@ where
 unsafe impl<'w, 's, S: SystemParamState, P: SystemParam + 'static> SystemParamState
     for StaticSystemParamState<S, P>
 {
-    type Config = S::Config;
-
-    fn init(world: &mut World, system_meta: &mut SystemMeta, config: Self::Config) -> Self {
-        Self(S::init(world, system_meta, config), PhantomData)
+    fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {
+        Self(S::init(world, system_meta), PhantomData)
     }
 
-    fn default_config() -> Self::Config {
-        S::default_config()
-    }
     fn new_archetype(&mut self, archetype: &Archetype, system_meta: &mut SystemMeta) {
         self.0.new_archetype(archetype, system_meta)
     }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1275,7 +1275,7 @@ pub mod lifetimeless {
 /// fn do_thing_generically<T: SystemParam + 'static>(t: StaticSystemParam<T>) {}
 ///
 /// fn check_always_is_system<T: SystemParam + 'static>(){
-///     do_thing_generically::<T>.system();
+///     bevy_ecs::system::assert_is_system(do_thing_generically::<T>);
 /// }
 /// ```
 /// Note that in a real case you'd generally want
@@ -1303,7 +1303,7 @@ pub mod lifetimeless {
 ///     phantom: core::marker::PhantomData<&'w &'s ()>
 /// }
 /// # fn check_always_is_system<T: SystemParam + 'static>(){
-/// #    do_thing_generically::<T>.system();
+/// #    bevy_ecs::system::assert_is_system(do_thing_generically::<T>);
 /// # }
 /// ```
 ///

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -3,7 +3,7 @@ use bevy_app::{App, Plugin};
 use bevy_asset::{Asset, AssetEvent, Assets, Handle};
 use bevy_ecs::{
     prelude::*,
-    system::{lifetimeless::*, RunSystem, SystemParam, SystemParamItem},
+    system::{StaticSystemParam, SystemParam, SystemParamItem},
 };
 use bevy_utils::{HashMap, HashSet};
 use std::marker::PhantomData;
@@ -55,13 +55,12 @@ impl<A: RenderAsset> Default for RenderAssetPlugin<A> {
 impl<A: RenderAsset> Plugin for RenderAssetPlugin<A> {
     fn build(&self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            let prepare_asset_system = PrepareAssetSystem::<A>::system(&mut render_app.world);
             render_app
                 .init_resource::<ExtractedAssets<A>>()
                 .init_resource::<RenderAssets<A>>()
                 .init_resource::<PrepareNextFrameAssets<A>>()
                 .add_system_to_stage(RenderStage::Extract, extract_render_asset::<A>)
-                .add_system_to_stage(RenderStage::Prepare, prepare_asset_system);
+                .add_system_to_stage(RenderStage::Prepare, prepare_assets::<A>);
         }
     }
 }
@@ -122,14 +121,6 @@ fn extract_render_asset<A: RenderAsset>(
     });
 }
 
-/// Specifies all ECS data required by [`PrepareAssetSystem`].
-pub type RenderAssetParams<R> = (
-    SResMut<ExtractedAssets<R>>,
-    SResMut<RenderAssets<R>>,
-    SResMut<PrepareNextFrameAssets<R>>,
-    <R as RenderAsset>::Param,
-);
-
 // TODO: consider storing inside system?
 /// All assets that should be prepared next frame.
 pub struct PrepareNextFrameAssets<A: RenderAsset> {
@@ -146,38 +137,36 @@ impl<A: RenderAsset> Default for PrepareNextFrameAssets<A> {
 
 /// This system prepares all assets of the corresponding [`RenderAsset`] type
 /// which where extracted this frame for the GPU.
-pub struct PrepareAssetSystem<R: RenderAsset>(PhantomData<R>);
-
-impl<R: RenderAsset> RunSystem for PrepareAssetSystem<R> {
-    type Param = RenderAssetParams<R>;
-
-    fn run(
-        (mut extracted_assets, mut render_assets, mut prepare_next_frame, mut param): SystemParamItem<Self::Param>,
-    ) {
-        let mut queued_assets = std::mem::take(&mut prepare_next_frame.assets);
-        for (handle, extracted_asset) in queued_assets.drain(..) {
-            match R::prepare_asset(extracted_asset, &mut param) {
-                Ok(prepared_asset) => {
-                    render_assets.insert(handle, prepared_asset);
-                }
-                Err(PrepareAssetError::RetryNextUpdate(extracted_asset)) => {
-                    prepare_next_frame.assets.push((handle, extracted_asset));
-                }
+fn prepare_assets<R: RenderAsset>(
+    mut extracted_assets: ResMut<ExtractedAssets<R>>,
+    mut render_assets: ResMut<RenderAssets<R>>,
+    mut prepare_next_frame: ResMut<PrepareNextFrameAssets<R>>,
+    param: StaticSystemParam<<R as RenderAsset>::Param>,
+) {
+    let mut param = param.inner();
+    let mut queued_assets = std::mem::take(&mut prepare_next_frame.assets);
+    for (handle, extracted_asset) in queued_assets.drain(..) {
+        match R::prepare_asset(extracted_asset, &mut param) {
+            Ok(prepared_asset) => {
+                render_assets.insert(handle, prepared_asset);
+            }
+            Err(PrepareAssetError::RetryNextUpdate(extracted_asset)) => {
+                prepare_next_frame.assets.push((handle, extracted_asset));
             }
         }
+    }
 
-        for removed in std::mem::take(&mut extracted_assets.removed) {
-            render_assets.remove(&removed);
-        }
+    for removed in std::mem::take(&mut extracted_assets.removed) {
+        render_assets.remove(&removed);
+    }
 
-        for (handle, extracted_asset) in std::mem::take(&mut extracted_assets.extracted) {
-            match R::prepare_asset(extracted_asset, &mut param) {
-                Ok(prepared_asset) => {
-                    render_assets.insert(handle, prepared_asset);
-                }
-                Err(PrepareAssetError::RetryNextUpdate(extracted_asset)) => {
-                    prepare_next_frame.assets.push((handle, extracted_asset));
-                }
+    for (handle, extracted_asset) in std::mem::take(&mut extracted_assets.extracted) {
+        match R::prepare_asset(extracted_asset, &mut param) {
+            Ok(prepared_asset) => {
+                render_assets.insert(handle, prepared_asset);
+            }
+            Err(PrepareAssetError::RetryNextUpdate(extracted_asset)) => {
+                prepare_next_frame.assets.push((handle, extracted_asset));
             }
         }
     }

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -143,7 +143,7 @@ fn prepare_assets<R: RenderAsset>(
     mut prepare_next_frame: ResMut<PrepareNextFrameAssets<R>>,
     param: StaticSystemParam<<R as RenderAsset>::Param>,
 ) {
-    let mut param = param.inner();
+    let mut param = param.into_inner();
     let mut queued_assets = std::mem::take(&mut prepare_next_frame.assets);
     for (handle, extracted_asset) in queued_assets.drain(..) {
         match R::prepare_asset(extracted_asset, &mut param) {


### PR DESCRIPTION
# Objective

- Fixes #3300
- `RunSystem` is messy

## Solution

- Adds the trick theorised in https://github.com/bevyengine/bevy/issues/3300#issuecomment-991791234

P.S. I also want this for an experimental refactoring of `Assets`, to remove the duplication of `Events<AssetEvent<T>>`
