### PR TITLE
Fix typo in documentation of bevy_crevice/std430

### DIFF
--- a/crates/bevy_crevice/src/std430.rs
+++ b/crates/bevy_crevice/src/std430.rs
@@ -1,4 +1,4 @@
-//! Defines traits and types for working with data adhering to GLSL's `std140`
+//! Defines traits and types for working with data adhering to GLSL's `std430`
 //! layout specification.
 
 mod primitives;


### PR DESCRIPTION
# Objective

Fix typo in documentation of bevy_crevice/std430

## Solution

Correct information in documentation