### PR TITLE
State Reloading

### DIFF
--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -649,7 +649,6 @@ mod test {
             .add_system_set(SystemSet::on_enter(TestState).with_system(
                 |mut r: ResMut<Vec<&'static str>>, mut s: ResMut<State<TestState>>| {
                     r.push("enter");
-                    println!("{:#?}", r);
                     if r.len() == 1 {
                         s.push(TestState).unwrap();
                     } else if r.len() == 3 {


### PR DESCRIPTION
# Objective

Current state scheduling prevents same-state transitions, aka state reloading.
The state reloading can be very useful to reset levels or boards for example

## Solution

- I removed the same state error and verification
- Every state `overwrite_` method is no longer faillible (**breaking change**)
- I added a test for state reloading