### PR TITLE
Clonable `Events<T>` resource

### DIFF
--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -122,7 +122,7 @@ enum State {
 /// This complicates consumption and risks ever-expanding memory usage if not cleaned up,
 /// but can be done by adding your event as a resource instead of using
 /// [`add_event`](https://docs.rs/bevy/*/bevy/app/struct.App.html#method.add_event).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Events<T> {
     events_a: Vec<EventInstance<T>>,
     events_b: Vec<EventInstance<T>>,

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -586,18 +586,4 @@ mod tests {
         events.update();
         assert!(events.is_empty());
     }
-
-    #[test]
-    fn test_events_clone() {
-        let mut events = Events::<TestEvent>::default();
-        events.send(TestEvent { i: 0 });
-        events.update();
-        events.send(TestEvent { i: 1 });
-
-        let events_dupe = events.clone();
-        let mut reader = events_dupe.get_reader();
-        assert!(reader
-            .iter(&events_dupe)
-            .eq([TestEvent { i: 0 }, TestEvent { i: 1 }].iter()));
-    }
 }

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -43,13 +43,13 @@ impl<T> fmt::Debug for EventId<T> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct EventInstance<T> {
     pub event_id: EventId<T>,
     pub event: T,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum State {
     A,
     B,
@@ -585,5 +585,19 @@ mod tests {
         // due to double buffering.
         events.update();
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_events_clone() {
+        let mut events = Events::<TestEvent>::default();
+        events.send(TestEvent { i: 0 });
+        events.update();
+        events.send(TestEvent { i: 1 });
+
+        let events_dupe = events.clone();
+        let mut reader = events_dupe.get_reader();
+        assert!(reader
+            .iter(&events_dupe)
+            .eq([TestEvent { i: 0 }, TestEvent { i: 1 }].iter()));
     }
 }


### PR DESCRIPTION
# Objective

- Add `Clone` to `Events<T>` to share it to another `World`.
- Fixes #3816 

## Solution

I added `Clone` derives to necessary objects.
