### PR TITLE
Add AdapterInfo to WgpuOptions

### DIFF
--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -113,6 +113,7 @@ pub mod pbr {
 #[cfg(feature = "bevy_render")]
 pub mod render {
     //! Cameras, meshes, textures, shaders, and pipelines.
+    //! Information about the current renderer can be accessed through the resource [`renderer::RendererInfo`].
     pub use bevy_render::*;
 }
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -134,11 +134,9 @@ impl Plugin for RenderPlugin {
                 compatible_surface: surface.as_ref(),
                 ..Default::default()
             };
-            let (device, queue, info) = futures_lite::future::block_on(renderer::initialize_renderer(
-                &instance,
-                &mut options,
-                &request_adapter_options,
-            ));
+            let (device, queue, info) = futures_lite::future::block_on(
+                renderer::initialize_renderer(&instance, &mut options, &request_adapter_options),
+            );
             debug!("Configured wgpu adapter Limits: {:#?}", &options.limits);
             debug!("Configured wgpu adapter Features: {:#?}", &options.features);
             app.insert_resource(device.clone())

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -134,7 +134,7 @@ impl Plugin for RenderPlugin {
                 compatible_surface: surface.as_ref(),
                 ..Default::default()
             };
-            let (device, queue) = futures_lite::future::block_on(renderer::initialize_renderer(
+            let (device, queue, info) = futures_lite::future::block_on(renderer::initialize_renderer(
                 &instance,
                 &mut options,
                 &request_adapter_options,
@@ -144,6 +144,7 @@ impl Plugin for RenderPlugin {
             app.insert_resource(device.clone())
                 .insert_resource(queue.clone())
                 .insert_resource(options.clone())
+                .insert_resource(info)
                 .init_resource::<ScratchRenderWorld>()
                 .register_type::<Frustum>()
                 .register_type::<CubemapFrusta>();

--- a/crates/bevy_render/src/renderer/info.rs
+++ b/crates/bevy_render/src/renderer/info.rs
@@ -1,0 +1,40 @@
+use wgpu::{
+    AdapterInfo, Backends, Features as WgpuFeatures, Limits as WgpuLimits, PowerPreference,
+};
+
+/// Provides information about the current renderer and the values it was configured with.
+#[derive(Debug, Clone)]
+pub struct RendererInfo {
+    pub(crate) adapter_info: Option<AdapterInfo>,
+    pub(crate) backends: Option<Backends>,
+    pub(crate) power_preference: PowerPreference,
+    pub(crate) features: WgpuFeatures,
+    pub(crate) limits: WgpuLimits,
+}
+
+impl RendererInfo {
+    /// Information about the graphics adapter in use by the current renderer.
+    pub fn adapter_info(&self) -> Option<&AdapterInfo> {
+        self.adapter_info.as_ref()
+    }
+
+    /// The backends the renderer could use, as configured with [`super::WgpuOptions`].
+    pub fn backends(&self) -> Option<&Backends> {
+        self.backends.as_ref()
+    }
+
+    /// The [`PowerPreference`] as configured with [`super::WgpuOptions`].
+    pub fn power_preference(&self) -> &PowerPreference {
+        &self.power_preference
+    }
+
+    /// The [`WgpuFeatures`] supported by the graphics adapter which the current renderer uses.
+    pub fn features(&self) -> &WgpuFeatures {
+        &self.features
+    }
+
+    /// The [`WgpuLimits`] supported by the graphics adapter which the current renderer uses.
+    pub fn limits(&self) -> &WgpuLimits {
+        &self.limits
+    }
+}

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -1,8 +1,10 @@
 mod graph_runner;
+mod info;
 mod render_device;
 
 use bevy_utils::tracing::{info, info_span};
 pub use graph_runner::*;
+pub use info::*;
 pub use render_device::*;
 
 use crate::{
@@ -67,7 +69,7 @@ pub async fn initialize_renderer(
     instance: &Instance,
     options: &mut WgpuOptions,
     request_adapter_options: &RequestAdapterOptions<'_>,
-) -> (RenderDevice, RenderQueue) {
+) -> (RenderDevice, RenderQueue, RendererInfo) {
     let adapter = instance
         .request_adapter(request_adapter_options)
         .await
@@ -113,7 +115,14 @@ pub async fn initialize_renderer(
         .unwrap();
     let device = Arc::new(device);
     let queue = Arc::new(queue);
-    (RenderDevice::from(device), queue)
+    let info = RendererInfo {
+        adapter_info: Some(adapter_info),
+        backends: options.backends,
+        power_preference: options.power_preference,
+        features: options.features,
+        limits: options.limits.clone(),
+    };
+    (RenderDevice::from(device), queue, info)
 }
 
 /// The context with all information required to interact with the GPU.


### PR DESCRIPTION
# Objective
Make it easy to access adapter info in a bevy program. Can be useful to display such information in a dev ui or to send it with an error report.

## Solution
Add `AdapterInfo` to `WgpuOptions` after an adapter is set up. <- chanded this to its own "view" resource `RendererInfo`
