### PR TITLE
Add option to create headless windows

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -266,7 +266,7 @@ impl Window {
             cursor_locked: window_descriptor.cursor_locked,
             cursor_icon: CursorIcon::Default,
             physical_cursor_position: None,
-            raw_window_handle: raw_window_handle.map(|handle| RawWindowHandleWrapper::new(handle)),
+            raw_window_handle: raw_window_handle.map(RawWindowHandleWrapper::new),
             focused: true,
             mode: window_descriptor.mode,
             #[cfg(target_arch = "wasm32")]

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -143,6 +143,9 @@ impl WindowResizeConstraints {
 /// requested size due to operating system limits on the window size, or the
 /// quantization of the logical size when converting the physical size to the
 /// logical size through the scaling factor.
+///
+/// ## Headless Testing
+/// To run tests without needing to create an actual window, set `raw_window_handle` to `None`.
 #[derive(Debug)]
 pub struct Window {
     id: WindowId,
@@ -162,7 +165,7 @@ pub struct Window {
     cursor_visible: bool,
     cursor_locked: bool,
     physical_cursor_position: Option<DVec2>,
-    raw_window_handle: RawWindowHandleWrapper,
+    raw_window_handle: Option<RawWindowHandleWrapper>,
     focused: bool,
     mode: WindowMode,
     #[cfg(target_arch = "wasm32")]
@@ -243,7 +246,7 @@ impl Window {
         physical_height: u32,
         scale_factor: f64,
         position: Option<IVec2>,
-        raw_window_handle: RawWindowHandle,
+        raw_window_handle: Option<RawWindowHandle>,
     ) -> Self {
         Window {
             id,
@@ -263,7 +266,7 @@ impl Window {
             cursor_locked: window_descriptor.cursor_locked,
             cursor_icon: CursorIcon::Default,
             physical_cursor_position: None,
-            raw_window_handle: RawWindowHandleWrapper::new(raw_window_handle),
+            raw_window_handle: raw_window_handle.map(|handle| RawWindowHandleWrapper::new(handle)),
             focused: true,
             mode: window_descriptor.mode,
             #[cfg(target_arch = "wasm32")]
@@ -581,7 +584,7 @@ impl Window {
         self.focused
     }
 
-    pub fn raw_window_handle(&self) -> RawWindowHandleWrapper {
+    pub fn raw_window_handle(&self) -> Option<RawWindowHandleWrapper> {
         self.raw_window_handle.clone()
     }
 }

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -168,7 +168,7 @@ impl WinitWindows {
             inner_size.height,
             scale_factor,
             position,
-            raw_window_handle,
+            Some(raw_window_handle),
         )
     }
 

--- a/tests/how_to_test_ui.rs
+++ b/tests/how_to_test_ui.rs
@@ -1,0 +1,91 @@
+use bevy::prelude::*;
+use bevy_internal::asset::AssetPlugin;
+use bevy_internal::core_pipeline::CorePipelinePlugin;
+use bevy_internal::input::InputPlugin;
+use bevy_internal::render::options::WgpuOptions;
+use bevy_internal::render::RenderPlugin;
+use bevy_internal::sprite::SpritePlugin;
+use bevy_internal::text::TextPlugin;
+use bevy_internal::ui::UiPlugin;
+use bevy_internal::window::{WindowId, WindowPlugin};
+
+const WINDOW_WIDTH: u32 = 200;
+const WINDOW_HEIGHT: u32 = 100;
+
+struct HeadlessUiPlugin;
+
+impl Plugin for HeadlessUiPlugin {
+    fn build(&self, app: &mut App) {
+        // These tests are meant to be ran on systems without gpu, or display.
+        // To make this work, we tell bevy not to look for any rendering backends.
+        app.insert_resource(WgpuOptions {
+            backends: None,
+            ..Default::default()
+        })
+        // To test the positioning of UI elements,
+        // we first need a window to position these elements in.
+        .insert_resource({
+            let mut windows = Windows::default();
+            windows.add(Window::new(
+                // At the moment, all ui elements are placed in the primary window.
+                WindowId::primary(),
+                &WindowDescriptor::default(),
+                WINDOW_WIDTH,
+                WINDOW_HEIGHT,
+                1.0,
+                None,
+                // Because this test is running without a real window, we pass `None` here.
+                None,
+            ));
+            windows
+        })
+        .add_plugins(MinimalPlugins)
+        .add_plugin(TransformPlugin)
+        .add_plugin(WindowPlugin::default())
+        .add_plugin(InputPlugin)
+        .add_plugin(AssetPlugin)
+        .add_plugin(RenderPlugin)
+        .add_plugin(CorePipelinePlugin)
+        .add_plugin(SpritePlugin)
+        .add_plugin(TextPlugin)
+        .add_plugin(UiPlugin);
+    }
+}
+
+#[test]
+fn test_button_translation() {
+    let mut app = App::new();
+    app.add_plugin(HeadlessUiPlugin)
+        .add_startup_system(setup_button_test);
+
+    // First call to `update` also runs the startup systems.
+    app.update();
+
+    let mut query = app.world.query_filtered::<Entity, With<Button>>();
+    let button = *query.iter(&app.world).collect::<Vec<_>>().first().unwrap();
+
+    // The button's translation got updated because the UI system had a window to place it in.
+    // If we hadn't added a window, the button's translation would at this point be all zero's.
+    let button_transform = app.world.entity(button).get::<Transform>().unwrap();
+    assert_eq!(
+        button_transform.translation.x.floor() as u32,
+        WINDOW_WIDTH / 2
+    );
+    assert_eq!(
+        button_transform.translation.y.floor() as u32,
+        WINDOW_HEIGHT / 2
+    );
+}
+
+fn setup_button_test(mut commands: Commands) {
+    commands.spawn_bundle(UiCameraBundle::default());
+    commands.spawn_bundle(ButtonBundle {
+        style: Style {
+            size: Size::new(Val::Px(150.0), Val::Px(65.0)),
+            // Center this button in the middle of the window.
+            margin: Rect::all(Val::Auto),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+}

--- a/tests/how_to_test_ui.rs
+++ b/tests/how_to_test_ui.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use bevy_internal::asset::AssetPlugin;
 use bevy_internal::core_pipeline::CorePipelinePlugin;
 use bevy_internal::input::InputPlugin;
-use bevy_internal::render::options::WgpuOptions;
+use bevy_internal::render::settings::WgpuSettings;
 use bevy_internal::render::RenderPlugin;
 use bevy_internal::sprite::SpritePlugin;
 use bevy_internal::text::TextPlugin;
@@ -18,7 +18,7 @@ impl Plugin for HeadlessUiPlugin {
     fn build(&self, app: &mut App) {
         // These tests are meant to be ran on systems without gpu, or display.
         // To make this work, we tell bevy not to look for any rendering backends.
-        app.insert_resource(WgpuOptions {
+        app.insert_resource(WgpuSettings {
             backends: None,
             ..Default::default()
         })
@@ -65,7 +65,7 @@ fn test_button_translation() {
     let button = *query.iter(&app.world).collect::<Vec<_>>().first().unwrap();
 
     // The button's translation got updated because the UI system had a window to place it in.
-    // If we hadn't added a window, the button's translation would at this point be all zero's.
+    // If we hadn't added a window, the button's translation would at this point be all zeros.
     let button_transform = app.world.entity(button).get::<Transform>().unwrap();
     assert_eq!(
         button_transform.translation.x.floor() as u32,


### PR DESCRIPTION
This adds the ability to pass `None` to a `Window`'s `raw_window_handle` field.
Includes a test to demonstrate how this allows for headless testing of UI related stuff which requires windows. In this case: the positioning of a button.

Closes #3754
