### PR TITLE
Clonable `EventInstance<T>`

### DIFF
--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -43,7 +43,7 @@ impl<T> fmt::Debug for EventId<T> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct EventInstance<T> {
     pub event_id: EventId<T>,
     pub event: T,


### PR DESCRIPTION
# Objective

Allows for manual copying of events, if they implement the `Clone` trait.
This is one step closer to solving #3816 

## Solution

Derived `Clone` for `EventInstance<T>`
