### PR TITLE
Make gamepads register and deregister methods public

### DIFF
--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -27,12 +27,12 @@ impl Gamepads {
     }
 
     /// Registers [Gamepad].
-    fn register(&mut self, gamepad: Gamepad) {
+    pub fn register(&mut self, gamepad: Gamepad) {
         self.gamepads.insert(gamepad);
     }
 
-    /// Deregisters [Gamepad.
-    fn deregister(&mut self, gamepad: &Gamepad) {
+    /// Deregisters [Gamepad].
+    pub fn deregister(&mut self, gamepad: &Gamepad) {
         self.gamepads.remove(gamepad);
     }
 }


### PR DESCRIPTION
# Objective

- Expose `Gamepads` `register` and `deregister` methods - allows for external use, e.g for libraries that customise input.
- Closes #3808.

## Solution

- Marked methods `pub`.
