### PR TITLE
[Merged by Bors] - Run tests (including doc tests) in `cargo run -p ci` command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci nonlocal
+        run: cargo run -p ci -- nonlocal
 
   check-benches:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci
+        run: cargo run -p ci nonlocal
 
   check-benches:
     runs-on: ubuntu-latest

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -17,16 +17,6 @@ fn main() {
         .run()
         .expect("Please fix clippy errors in output above.");
 
-    // Run tests
-    cmd!("cargo test --workspace")
-        .run()
-        .expect("Please fix failing tests in output above.");
-
-    // Run doc tests: these are ignored by `cargo test`
-    cmd!("cargo test --doc --workspace")
-        .run()
-        .expect("Please fix failing doc-tests in output above.");
-
     // Run UI tests (they do not get executed with the workspace tests)
     // - See crates/bevy_ecs_compile_fail_tests/README.md
     {
@@ -35,5 +25,21 @@ fn main() {
         cmd!("cargo test")
             .run()
             .expect("Compiler errors of the ECS compile fail tests seem to be different than expected! Check locally and compare rust versions.");
+    }
+
+    // These tests are already run on the CI
+    // Using a double-negative here allows end-users to have a nicer experience
+    // as we can pass in the extra argument to the CI script
+    let args: Vec<String> = std::env::args().collect();
+    if args.get(0) != Some(&"nonlocal".to_string()) {
+        // Run tests
+        cmd!("cargo test --workspace")
+            .run()
+            .expect("Please fix failing tests in output above.");
+
+        // Run doc tests: these are ignored by `cargo test`
+        cmd!("cargo test --doc --workspace")
+            .run()
+            .expect("Please fix failing doc-tests in output above.");
     }
 }

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -17,6 +17,16 @@ fn main() {
         .run()
         .expect("Please fix clippy errors in output above.");
 
+    // Run tests
+    cmd!("cargo test")
+        .run()
+        .expect("Please fix failing tests in output above.");
+
+    // Run doc tests: these are ignored by `cargo test`
+    cmd!("cargo test --doc --workspace")
+        .run()
+        .expect("Please fix failing doc-tests in output above.");
+
     // Run UI tests (they do not get executed with the workspace tests)
     // - See crates/bevy_ecs_compile_fail_tests/README.md
     {

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
     // Using a double-negative here allows end-users to have a nicer experience
     // as we can pass in the extra argument to the CI script
     let args: Vec<String> = std::env::args().collect();
-    if args.get(0) != Some(&"nonlocal".to_string()) {
+    if args.get(1) != Some(&"nonlocal".to_string()) {
         // Run tests
         cmd!("cargo test --workspace")
             .run()

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
         .expect("Please fix clippy errors in output above.");
 
     // Run tests
-    cmd!("cargo test")
+    cmd!("cargo test --workspace")
         .run()
         .expect("Please fix failing tests in output above.");
 


### PR DESCRIPTION
# Objective

- Using the `cargo run -p ci` command locally is unreliable, as it does not run tests.
- This is particularly unreliable for doc tests, as they are not run as part of `cargo test`.

## Solution

- add more steps to the appropriate Rust file.

## Known Problems

This duplicates work done to run tests when run on Github. @mockersf, suggestions on if we care / how we can mitigate it?