### PR TITLE
[Merged by Bors] - add more logs when despawning entities

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -17,13 +17,13 @@ use crate::{
     storage::{Column, SparseSet, Storages},
     system::Resource,
 };
+use bevy_utils::tracing::debug;
 use std::{
     any::TypeId,
     fmt,
     mem::ManuallyDrop,
     sync::atomic::{AtomicU32, Ordering},
 };
-
 mod identifier;
 
 pub use identifier::WorldId;
@@ -464,6 +464,7 @@ impl World {
     /// ```
     #[inline]
     pub fn despawn(&mut self, entity: Entity) -> bool {
+        debug!("Despawning entity {:?}", entity);
         self.get_entity_mut(entity)
             .map(|e| {
                 e.despawn();

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -56,12 +56,28 @@ fn despawn_children(world: &mut World, entity: Entity) {
 
 impl Command for DespawnRecursive {
     fn write(self, world: &mut World) {
+        #[cfg(feature = "trace")]
+        let span = bevy_utils::tracing::info_span!(
+            "command",
+            name = "DespawnRecursive",
+            entity = bevy_utils::tracing::field::debug(self.entity)
+        );
+        #[cfg(feature = "trace")]
+        let _guard = span.enter();
         despawn_with_children_recursive(world, self.entity);
     }
 }
 
 impl Command for DespawnChildrenRecursive {
     fn write(self, world: &mut World) {
+        #[cfg(feature = "trace")]
+        let span = bevy_utils::tracing::info_span!(
+            "command",
+            name = "DespawnChildrenRecursive",
+            entity = bevy_utils::tracing::field::debug(self.entity)
+        );
+        #[cfg(feature = "trace")]
+        let _guard = span.enter();
         despawn_children(world, self.entity);
     }
 }
@@ -92,6 +108,15 @@ impl<'w> DespawnRecursiveExt for EntityMut<'w> {
     /// Despawns the provided entity and its children.
     fn despawn_recursive(mut self) {
         let entity = self.id();
+
+        #[cfg(feature = "trace")]
+        let span = bevy_utils::tracing::info_span!(
+            "despawn_recursive",
+            entity = bevy_utils::tracing::field::debug(entity)
+        );
+        #[cfg(feature = "trace")]
+        let _guard = span.enter();
+
         // SAFE: EntityMut is consumed so even though the location is no longer
         // valid, it cannot be accessed again with the invalid location.
         unsafe {
@@ -101,6 +126,15 @@ impl<'w> DespawnRecursiveExt for EntityMut<'w> {
 
     fn despawn_descendants(&mut self) {
         let entity = self.id();
+
+        #[cfg(feature = "trace")]
+        let span = bevy_utils::tracing::info_span!(
+            "despawn_descendants",
+            entity = bevy_utils::tracing::field::debug(entity)
+        );
+        #[cfg(feature = "trace")]
+        let _guard = span.enter();
+
         // SAFE: The location is updated.
         unsafe {
             despawn_children(self.world_mut(), entity);

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -57,13 +57,12 @@ fn despawn_children(world: &mut World, entity: Entity) {
 impl Command for DespawnRecursive {
     fn write(self, world: &mut World) {
         #[cfg(feature = "trace")]
-        let span = bevy_utils::tracing::info_span!(
+        let _span = bevy_utils::tracing::info_span!(
             "command",
             name = "DespawnRecursive",
             entity = bevy_utils::tracing::field::debug(self.entity)
-        );
-        #[cfg(feature = "trace")]
-        let _guard = span.enter();
+        )
+        .entered();
         despawn_with_children_recursive(world, self.entity);
     }
 }
@@ -71,13 +70,12 @@ impl Command for DespawnRecursive {
 impl Command for DespawnChildrenRecursive {
     fn write(self, world: &mut World) {
         #[cfg(feature = "trace")]
-        let span = bevy_utils::tracing::info_span!(
+        let _span = bevy_utils::tracing::info_span!(
             "command",
             name = "DespawnChildrenRecursive",
             entity = bevy_utils::tracing::field::debug(self.entity)
-        );
-        #[cfg(feature = "trace")]
-        let _guard = span.enter();
+        )
+        .entered();
         despawn_children(world, self.entity);
     }
 }
@@ -110,12 +108,11 @@ impl<'w> DespawnRecursiveExt for EntityMut<'w> {
         let entity = self.id();
 
         #[cfg(feature = "trace")]
-        let span = bevy_utils::tracing::info_span!(
+        let _span = bevy_utils::tracing::info_span!(
             "despawn_recursive",
             entity = bevy_utils::tracing::field::debug(entity)
-        );
-        #[cfg(feature = "trace")]
-        let _guard = span.enter();
+        )
+        .entered();
 
         // SAFE: EntityMut is consumed so even though the location is no longer
         // valid, it cannot be accessed again with the invalid location.
@@ -128,12 +125,11 @@ impl<'w> DespawnRecursiveExt for EntityMut<'w> {
         let entity = self.id();
 
         #[cfg(feature = "trace")]
-        let span = bevy_utils::tracing::info_span!(
+        let _span = bevy_utils::tracing::info_span!(
             "despawn_descendants",
             entity = bevy_utils::tracing::field::debug(entity)
-        );
-        #[cfg(feature = "trace")]
-        let _guard = span.enter();
+        )
+        .entered();
 
         // SAFE: The location is updated.
         unsafe {

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -9,17 +9,19 @@ use bevy_utils::tracing::debug;
 /// Despawns the given entity and all its children recursively
 #[derive(Debug)]
 pub struct DespawnRecursive {
-    entity: Entity,
+    /// Target entity
+    pub entity: Entity,
 }
 
 /// Despawns the given entity's children recursively
 #[derive(Debug)]
 pub struct DespawnChildrenRecursive {
-    entity: Entity,
+    /// Target entity
+    pub entity: Entity,
 }
 
 /// Function for despawning an entity and all its children
-pub fn despawn_with_children_recursive(world: &mut World, entity: Entity) {
+fn despawn_with_children_recursive(world: &mut World, entity: Entity) {
     // first, make the entity's own parent forget about it
     if let Some(parent) = world.get::<Parent>(entity).map(|parent| parent.0) {
         if let Some(mut children) = world.get_mut::<Children>(parent) {

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -21,7 +21,7 @@ pub struct DespawnChildrenRecursive {
 }
 
 /// Function for despawning an entity and all its children
-fn despawn_with_children_recursive(world: &mut World, entity: Entity) {
+pub fn despawn_with_children_recursive(world: &mut World, entity: Entity) {
     // first, make the entity's own parent forget about it
     if let Some(parent) = world.get::<Parent>(entity).map(|parent| parent.0) {
         if let Some(mut children) = world.get_mut::<Children>(parent) {

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -10,7 +10,14 @@ keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 categories = ["game-engines", "graphics", "gui", "rendering"]
 
 [features]
-trace = [ "bevy_app/trace", "bevy_ecs/trace", "bevy_log/trace", "bevy_render/trace", "bevy_core_pipeline/trace" ]
+trace = [
+    "bevy_app/trace",
+    "bevy_core_pipeline/trace",
+    "bevy_ecs/trace",
+    "bevy_log/trace",
+    "bevy_render/trace",
+    "bevy_transform/trace"
+]
 trace_chrome = [ "bevy_log/tracing-chrome" ]
 trace_tracy = [ "bevy_log/tracing-tracy" ]
 wgpu_trace = ["bevy_render/wgpu_trace"]

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
+[features]
+trace = []
+
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }


### PR DESCRIPTION
# Objective

- Provide more information when despawning an entity

## Solution

- Add a debug log when despawning an entity
- Add spans to the recursive ways of despawning an entity

```sh
RUST_LOG=debug cargo run --example panic --features trace
# RUST_LOG=debug needed to show debug logs from bevy_ecs
# --features trace needed to have the extra spans
...

DEBUG bevy_app:frame:stage{name=Update}:system_commands{name="panic::despawn_parent"}:command{name="DespawnRecursive" entity=0v0}: bevy_ecs::world: Despawning entity 1v0
DEBUG bevy_app:frame:stage{name=Update}:system_commands{name="panic::despawn_parent"}:command{name="DespawnRecursive" entity=0v0}: bevy_ecs::world: Despawning entity 0v0
```
