### PR TITLE
[Merged by Bors] - fix: only init_resource() once for AmbientLight

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -75,7 +75,6 @@ impl Plugin for PbrPlugin {
             .init_resource::<AmbientLight>()
             .init_resource::<DirectionalLightShadowMap>()
             .init_resource::<PointLightShadowMap>()
-            .init_resource::<AmbientLight>()
             .init_resource::<VisiblePointLights>()
             .add_system_to_stage(
                 CoreStage::PostUpdate,


### PR DESCRIPTION
# Objective

`PbrPlugin` calls `app.init_resource::<AmbientLight>()` twice. The second call won't do anything.

## Solution

Remove the second call.
