### PR TITLE
[Merged by Bors] - fix: remove unneeded filter in check_light_mesh_visibility

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -686,9 +686,7 @@ pub fn update_point_light_frusta(
 }
 
 pub fn check_light_mesh_visibility(
-    // NOTE: VisiblePointLights is an alias for VisibleEntities so the Without<DirectionalLight>
-    // is needed to avoid an unnecessary QuerySet
-    visible_point_lights: Query<&VisiblePointLights, Without<DirectionalLight>>,
+    visible_point_lights: Query<&VisiblePointLights>,
     mut point_lights: Query<(
         &PointLight,
         &GlobalTransform,


### PR DESCRIPTION
# Objective

The query for `VisiblePointLights` in `check_light_mesh_visibility` has a `Without<DirectionalLight>` filter. However, because `VisiblePointLights` is no longer an alias for `VisibleEntities`, the query won't conflict with the query for `DirectionalLight`s and thus the filter is unnecessary.

## Solution

Remove the filter and the outdated comment explaining its purpose.
