### PR TITLE
Add rumble support to bevy_gilrs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -390,6 +390,10 @@ name = "gamepad_input_events"
 path = "examples/input/gamepad_input_events.rs"
 
 [[example]]
+name = "gamepad_rumble"
+path = "examples/input/gamepad_rumble.rs"
+
+[[example]]
 name = "keyboard_input"
 path = "examples/input/keyboard_input.rs"
 

--- a/crates/bevy_gilrs/Cargo.toml
+++ b/crates/bevy_gilrs/Cargo.toml
@@ -11,8 +11,10 @@ keywords = ["bevy"]
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.6.0" }
+bevy_core = { path = "../bevy_core", version = "0.6.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
 bevy_input = { path = "../bevy_input", version = "0.6.0" }
+bevy_log = { path = "../bevy_log", version = "0.6.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
 
 # other

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -1,12 +1,15 @@
 mod converter;
 mod gilrs_system;
+mod rumble;
 
 use bevy_app::{App, CoreStage, Plugin, StartupStage};
 use bevy_ecs::schedule::ParallelSystemDescriptorCoercion;
 use bevy_input::InputSystem;
 use bevy_utils::tracing::error;
+pub use gilrs::ff;
 use gilrs::GilrsBuilder;
 use gilrs_system::{gilrs_event_startup_system, gilrs_event_system};
+pub use rumble::{RumbleIntensity, RumbleRequest};
 
 #[derive(Default)]
 pub struct GilrsPlugin;
@@ -20,10 +23,13 @@ impl Plugin for GilrsPlugin {
         {
             Ok(gilrs) => {
                 app.insert_non_send_resource(gilrs)
+                    .add_event::<RumbleRequest>()
+                    .init_non_send_resource::<rumble::RumblesManager>()
                     .add_startup_system_to_stage(
                         StartupStage::PreStartup,
                         gilrs_event_startup_system,
                     )
+                    .add_system_to_stage(CoreStage::PostUpdate, rumble::gilrs_rumble_system)
                     .add_system_to_stage(
                         CoreStage::PreUpdate,
                         gilrs_event_system.before(InputSystem),

--- a/crates/bevy_gilrs/src/rumble.rs
+++ b/crates/bevy_gilrs/src/rumble.rs
@@ -1,0 +1,155 @@
+//! Handle user specified Rumble request events.
+use crate::converter::convert_gamepad_id;
+use bevy_app::EventReader;
+use bevy_core::Time;
+use bevy_ecs::{prelude::Res, system::NonSendMut};
+use bevy_input::gamepad::Gamepad;
+use bevy_log as log;
+use bevy_utils::HashMap;
+use gilrs::{ff, GamepadId, Gilrs};
+
+pub enum RumbleIntensity {
+    Strong,
+    Medium,
+    Weak,
+}
+impl RumbleIntensity {
+    fn effect_type(&self) -> ff::BaseEffectType {
+        use RumbleIntensity::*;
+        match self {
+            Strong => ff::BaseEffectType::Strong { magnitude: 63_000 },
+            Medium => ff::BaseEffectType::Strong { magnitude: 40_000 },
+            Weak => ff::BaseEffectType::Weak { magnitude: 40_000 },
+        }
+    }
+}
+
+/// Request `pad` rumble in `gilrs_effect` pattern for `duration_seconds`
+///
+/// # Notes
+///
+/// * Does nothing if `pad` does not support rumble
+/// * If a new `RumbleRequest` is sent while another one is still executing, it
+///   replaces the old one.
+///
+/// # Example
+///
+/// ```
+/// # use bevy_gilrs::{RumbleRequest, RumbleIntensity};
+/// # use bevy_input::gamepad::Gamepad;
+/// # use bevy_app::EventWriter;
+/// fn rumble_pad_system(mut rumble_requests: EventWriter<RumbleRequest>) {
+///     let request = RumbleRequest::with_intensity(
+///         RumbleIntensity::Strong,
+///         10.0,
+///         Gamepad(0),
+///     );
+///     rumble_requests.send(request);
+/// }
+/// ```
+#[derive(Clone)]
+pub struct RumbleRequest {
+    /// The duration in seconds of the rumble
+    pub duration_seconds: f32,
+    /// The gilrs descriptor, use [`RumbleRequest::with_intensity`] if you want
+    /// a simpler API.
+    pub gilrs_effect: ff::EffectBuilder,
+    /// The gamepad to rumble
+    pub pad: Gamepad,
+}
+impl RumbleRequest {
+    /// Causes `pad` to rumble for `duration_seconds` at given `intensity`.
+    pub fn with_intensity(intensity: RumbleIntensity, duration_seconds: f32, pad: Gamepad) -> Self {
+        let kind = intensity.effect_type();
+        let effect = ff::BaseEffect {
+            kind,
+            ..Default::default()
+        };
+        let mut gilrs_effect = ff::EffectBuilder::new();
+        gilrs_effect.add_effect(effect);
+        RumbleRequest {
+            duration_seconds,
+            gilrs_effect,
+            pad,
+        }
+    }
+    /// Stops provided `pad` rumbling.
+    pub fn stop(pad: Gamepad) -> Self {
+        RumbleRequest {
+            duration_seconds: 0.0,
+            gilrs_effect: ff::EffectBuilder::new(),
+            pad,
+        }
+    }
+}
+
+struct RunningRumble {
+    deadline: f32,
+    // We use `effect.drop()` to interact with this, but rustc can't know
+    // gilrs uses Drop as an API feature.
+    #[allow(dead_code)]
+    effect: ff::Effect,
+}
+
+#[derive(Default)]
+pub(crate) struct RumblesManager {
+    rumbles: HashMap<GamepadId, RunningRumble>,
+}
+
+pub(crate) fn gilrs_rumble_system(
+    time: Res<Time>,
+    mut gilrs: NonSendMut<Gilrs>,
+    mut requests: EventReader<RumbleRequest>,
+    mut manager: NonSendMut<RumblesManager>,
+) {
+    let current_time = time.seconds_since_startup() as f32;
+    // Remove outdated rumble effects.
+    if !manager.rumbles.is_empty() {
+        let mut to_remove = Vec::new();
+        for (id, RunningRumble { deadline, .. }) in manager.rumbles.iter() {
+            if *deadline < current_time {
+                to_remove.push(*id);
+            }
+        }
+        for id in &to_remove {
+            // `ff::Effect` uses RAII, dropping = deactivating
+            manager.rumbles.remove(id);
+        }
+    }
+    // Add new effects.
+    for mut rumble in requests.iter().cloned() {
+        let gilrs_pad = gilrs
+            .gamepads()
+            .find(|(pad_id, _)| convert_gamepad_id(*pad_id) == rumble.pad);
+        if let Some((pad_id, _)) = gilrs_pad {
+            let current_time = time.seconds_since_startup() as f32;
+            let deadline = current_time + rumble.duration_seconds;
+            let effect = rumble.gilrs_effect.gamepads(&[pad_id]).finish(&mut gilrs);
+            match effect {
+                Ok(effect) => {
+                    if let Err(err) = effect.play() {
+                        log::error!(
+                            "Tried to rumble {:?} but an error occurred: {err}",
+                            rumble.pad
+                        );
+                        continue;
+                    };
+                    manager
+                        .rumbles
+                        .insert(pad_id, RunningRumble { deadline, effect });
+                }
+                Err(err) => {
+                    log::debug!(
+                        "Tried to rumble {:?} but an error occurred: {err}",
+                        rumble.pad
+                    );
+                }
+            }
+        } else {
+            log::warn!(
+                "Tried to trigger rumble on gamepad {:?}, but that gamepad doesn't exist",
+                rumble.pad,
+            );
+        }
+    }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -194,6 +194,7 @@ Example | File | Description
 `char_input_events` | [`input/char_input_events.rs`](./input/char_input_events.rs) | Prints out all chars as they are inputted.
 `gamepad_input` | [`input/gamepad_input.rs`](./input/gamepad_input.rs) | Shows handling of gamepad input, connections, and disconnections
 `gamepad_input_events` | [`input/gamepad_input_events.rs`](./input/gamepad_input_events.rs) | Iterates and prints gamepad input and connection events
+`gamepad_rumble` | [`input/gamepad_rumble.rs`](./input/gamepad_rumble.rs) | Make a controller rumble
 `keyboard_input` | [`input/keyboard_input.rs`](./input/keyboard_input.rs) | Demonstrates handling a key press/release
 `keyboard_input_events` | [`input/keyboard_input_events.rs`](./input/keyboard_input_events.rs) | Prints out all keyboard events
 `keyboard_modifiers` | [`input/keyboard_modifiers.rs`](./input/keyboard_modifiers.rs) | Demonstrates using key modifiers (ctrl, shift)

--- a/examples/input/gamepad_rumble.rs
+++ b/examples/input/gamepad_rumble.rs
@@ -1,0 +1,70 @@
+use bevy::{
+    gilrs::{ff, RumbleIntensity, RumbleRequest},
+    prelude::*,
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_system(gamepad_system)
+        .run();
+}
+
+fn gamepad_system(
+    gamepads: Res<Gamepads>,
+    button_inputs: Res<Input<GamepadButton>>,
+    mut rumble_requests: EventWriter<RumbleRequest>,
+) {
+    for gamepad in gamepads.iter().cloned() {
+        let button_pressed = |button| button_inputs.just_pressed(GamepadButton(gamepad, button));
+        if button_pressed(GamepadButtonType::South) {
+            info!("(S) South face button: weak rumble for 3 second");
+            // Use the simplified API provided by bevy
+            rumble_requests.send(RumbleRequest::with_intensity(
+                RumbleIntensity::Weak,
+                3.0,
+                gamepad,
+            ));
+        } else if button_pressed(GamepadButtonType::West) {
+            info!("(W) West face button: strong rumble for 10 second");
+            rumble_requests.send(RumbleRequest::with_intensity(
+                RumbleIntensity::Strong,
+                10.0,
+                gamepad,
+            ));
+        } else if button_pressed(GamepadButtonType::East) {
+            info!("(E) East face button: alternating for 5 seconds");
+            // Use the gilrs::ff more complex but feature-complete effect
+            let duration = ff::Ticks::from_ms(800);
+            let mut effect = ff::EffectBuilder::new();
+            effect
+                .add_effect(ff::BaseEffect {
+                    kind: ff::BaseEffectType::Strong { magnitude: 60_000 },
+                    scheduling: ff::Replay {
+                        play_for: duration,
+                        with_delay: duration * 3,
+                        ..Default::default()
+                    },
+                    envelope: Default::default(),
+                })
+                .add_effect(ff::BaseEffect {
+                    kind: ff::BaseEffectType::Weak { magnitude: 60_000 },
+                    scheduling: ff::Replay {
+                        after: duration * 2,
+                        play_for: duration,
+                        with_delay: duration * 3,
+                    },
+                    ..Default::default()
+                });
+            let request = RumbleRequest {
+                pad: gamepad,
+                gilrs_effect: effect,
+                duration_seconds: 5.0,
+            };
+            rumble_requests.send(request);
+        } else if button_pressed(GamepadButtonType::North) {
+            info!("(N) North face button: Interupt the current rumble");
+            rumble_requests.send(RumbleRequest::stop(gamepad));
+        }
+    }
+}


### PR DESCRIPTION
This adds the `RumbleRequest` event and a system to read them and rumble
controllers accordingly.

It gives users two ways of controlling controller rumble:
1. A very primitive API with `RumbleIntensity` that is easy to
   understand and use.
2. A direct access to the girls `ff::Effect` system for complete
   fine-grained control over how the gamepad rumbles.

