### PR TITLE
[Merged by Bors] - allow Entity to be deserialized with serde_json

### DIFF
--- a/crates/bevy_ecs/src/entity/serde.rs
+++ b/crates/bevy_ecs/src/entity/serde.rs
@@ -25,7 +25,7 @@ impl<'de> Visitor<'de> for EntityVisitor {
     type Value = Entity;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("expected Entity")
+        formatter.write_str("Entity")
     }
 
     fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
@@ -33,5 +33,12 @@ impl<'de> Visitor<'de> for EntityVisitor {
         E: serde::de::Error,
     {
         Ok(Entity::from_raw(v))
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(Entity::from_raw(v as u32))
     }
 }


### PR DESCRIPTION
# Objective

- `serde_json` assumes that numbers being deserialized are either u64 or i64.
- `Entity` serializes and deserializes as a u32.
- Deserializing an `Entity` with `serde_json` fails with: `Error("invalid type: integer 10947, expected expected Entity"`

## Solution

- Implemented a visitor for u64 that allows an `Entity` to be deserialized in this case.
- While I was here, also fixed the redundant "expected expected Entity" in the error message
- Tested the change in a local project which now correctly deserializes `Entity` structs with `serde_json` when it couldn't before