### PR TITLE
[Merged by Bors] - doc: remove mention of void return type in entry_point docs

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -110,8 +110,8 @@ pub struct VertexState {
     /// The compiled shader module for this stage.
     pub shader: Handle<Shader>,
     pub shader_defs: Vec<String>,
-    /// The name of the entry point in the compiled shader. There must be a function that returns
-    /// void with this name in the shader.
+    /// The name of the entry point in the compiled shader. There must be a
+    /// function with this name in the shader.
     pub entry_point: Cow<'static, str>,
     /// The format of any vertex buffers used with this pipeline.
     pub buffers: Vec<VertexBufferLayout>,
@@ -134,8 +134,8 @@ pub struct FragmentState {
     /// The compiled shader module for this stage.
     pub shader: Handle<Shader>,
     pub shader_defs: Vec<String>,
-    /// The name of the entry point in the compiled shader. There must be a function that returns
-    /// void with this name in the shader.
+    /// The name of the entry point in the compiled shader. There must be a
+    /// function with this name in the shader.
     pub entry_point: Cow<'static, str>,
     /// The color state of the render targets.
     pub targets: Vec<ColorTargetState>,


### PR DESCRIPTION
# Objective

The docs for `{VertexState, FragmentState}::entry_point` stipulate that the entry point function in the shader must return void. This seems to be specific to GLSL; WGSL has no `void` type and its entry point functions return values that describe their output.

## Solution

Remove the mention of the `void` return type.
