### PR TITLE
[Merged by Bors] - Fix type mismatch error with latest winit

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -188,7 +188,7 @@ where
     F: FnMut(Event<'_, ()>, &EventLoopWindowTarget<()>, &mut ControlFlow),
 {
     use winit::platform::run_return::EventLoopExtRunReturn;
-    event_loop.run_return(event_handler)
+    event_loop.run_return(event_handler);
 }
 
 #[cfg(not(any(


### PR DESCRIPTION
# Objective

When I use the latest winit with bevy main, I got this error.
```
error[E0308]: mismatched types
   --> /Users/ryo/.cargo/git/checkouts/bevy-f7ffde730c324c74/b13f238/crates/bevy_winit/src/lib.rs:191:5
    |
191 |     event_loop.run_return(event_handler)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `i32`
    |
help: consider using a semicolon here
    |
191 |     event_loop.run_return(event_handler);
    |                                         +
help: try adding a return type
    |
187 | -> i32 where
    | ++++++
```

In [this commit](https://github.com/rust-windowing/winit/commit/a52f755ce8dfffe53329163364908937c780057d), the signature of `run_return` was changed in winit.

## Solution

This tiny PR does not add support for exit code, but makes compilation successful.