### PR TITLE
[Merged by Bors] - Add view transform to view uniform

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_view_bind_group.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bind_group.wgsl
@@ -1,5 +1,6 @@
 struct View {
     view_proj: mat4x4<f32>;
+    view: mat4x4<f32>;
     inverse_view: mat4x4<f32>;
     projection: mat4x4<f32>;
     world_position: vec3<f32>;

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -73,6 +73,7 @@ pub struct ExtractedView {
 #[derive(Clone, AsStd140)]
 pub struct ViewUniform {
     view_proj: Mat4,
+    view: Mat4,
     inverse_view: Mat4,
     projection: Mat4,
     world_position: Vec3,
@@ -132,10 +133,12 @@ fn prepare_view_uniforms(
     view_uniforms.uniforms.clear();
     for (entity, camera) in views.iter() {
         let projection = camera.projection;
-        let inverse_view = camera.transform.compute_matrix().inverse();
+        let view = camera.transform.compute_matrix();
+        let inverse_view = view.inverse();
         let view_uniforms = ViewUniformOffset {
             offset: view_uniforms.uniforms.push(ViewUniform {
                 view_proj: projection * inverse_view,
+                view,
                 inverse_view,
                 projection,
                 world_position: camera.transform.translation,

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_view_bind_group.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_view_bind_group.wgsl
@@ -1,5 +1,6 @@
 struct View {
     view_proj: mat4x4<f32>;
+    view: mat4x4<f32>;
     inverse_view: mat4x4<f32>;
     projection: mat4x4<f32>;
     world_position: vec3<f32>;


### PR DESCRIPTION
(cherry picked from commit de943381bd2a8b242c94db99e6c7bbd70006d7c3)

# Objective

The view uniform lacks view transform information. The inverse transform is currently provided but this is not sufficient if you do not have access to an `inverse` function (such as in WGSL).

## Solution

Grab the view transform, put it in the view uniform, use the same matrix to compute the inverse as well.
