### PR TITLE
Replace unwraps with expects in bevy_asset

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -506,9 +506,12 @@ impl AssetServer {
     // triggered unless the `Assets` collection is actually updated.
     pub(crate) fn update_asset_storage<T: Asset>(&self, mut assets: ResMut<Assets<T>>) {
         let asset_lifecycles = self.server.asset_lifecycles.read();
-        let asset_lifecycle = asset_lifecycles
-            .get(&T::TYPE_UUID)
-            .expect("Could not find an asset of the appropriate type UUID.");
+        let asset_lifecycle = asset_lifecycles.get(&T::TYPE_UUID).expect_or_else(|| {
+            format!(
+                "Could not find an asset of the appropriate type UUID={}.",
+                T::TYPE_UUID
+            )
+        });
         let mut asset_sources_guard = None;
         let channel = asset_lifecycle
             .downcast_ref::<AssetLifecycleChannel<T>>()

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -506,8 +506,8 @@ impl AssetServer {
     // triggered unless the `Assets` collection is actually updated.
     pub(crate) fn update_asset_storage<T: Asset>(&self, mut assets: ResMut<Assets<T>>) {
         let asset_lifecycles = self.server.asset_lifecycles.read();
-        let asset_lifecycle = asset_lifecycles.get(&T::TYPE_UUID).expect_or_else(|| {
-            format!(
+        let asset_lifecycle = asset_lifecycles.get(&T::TYPE_UUID).unwrap_or_else(|| {
+            panic!(
                 "Could not find an asset of the appropriate type UUID={}.",
                 T::TYPE_UUID
             )

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -281,7 +281,9 @@ impl AddAsset for App {
             return self;
         }
         let assets = {
-            let asset_server = self.world.get_resource::<AssetServer>().unwrap();
+            let asset_server = self.world.get_resource::<AssetServer>().expect(
+                "Could not find `AssetServer` resource in the `World`. Did you forget to add it?",
+            );
             asset_server.register_asset_type::<T>()
         };
 

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -132,7 +132,9 @@ impl Debug for HandleType {
 
 impl<T: Asset> Handle<T> {
     pub(crate) fn strong(id: HandleId, ref_change_sender: Sender<RefChange>) -> Self {
-        ref_change_sender.send(RefChange::Increment(id)).unwrap();
+        ref_change_sender
+            .send(RefChange::Increment(id))
+            .expect("Could not increment reference count when creating a strong handle.");
         Self {
             id,
             handle_type: HandleType::Strong(ref_change_sender),
@@ -174,7 +176,9 @@ impl<T: Asset> Handle<T> {
             return;
         }
         let sender = assets.ref_change_sender.clone();
-        sender.send(RefChange::Increment(self.id)).unwrap();
+        sender.send(RefChange::Increment(self.id)).expect(
+            "Could not increment reference count when converting a weak handle a strong handle.",
+        );
         self.handle_type = HandleType::Strong(sender);
     }
 
@@ -278,7 +282,10 @@ impl<T: Asset> Default for Handle<T> {
 
 impl<T: Asset> Debug for Handle<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        let name = std::any::type_name::<T>().split("::").last().unwrap();
+        let name = std::any::type_name::<T>()
+            .split("::")
+            .last()
+            .expect("Could not split type name correctly.");
         write!(f, "{:?}Handle<{}>({:?})", self.handle_type, name, self.id)
     }
 }
@@ -313,7 +320,9 @@ impl HandleUntyped {
     }
 
     pub(crate) fn strong(id: HandleId, ref_change_sender: Sender<RefChange>) -> Self {
-        ref_change_sender.send(RefChange::Increment(id)).unwrap();
+        ref_change_sender
+            .send(RefChange::Increment(id))
+            .expect("Could not increment reference count when creating a strong handle.");
         Self {
             id,
             handle_type: HandleType::Strong(ref_change_sender),

--- a/crates/bevy_asset/src/io/android_asset_io.rs
+++ b/crates/bevy_asset/src/io/android_asset_io.rs
@@ -23,7 +23,7 @@ impl AssetIo for AndroidAssetIo {
         Box::pin(async move {
             let asset_manager = ndk_glue::native_activity().asset_manager();
             let mut opened_asset = asset_manager
-                .open(&CString::new(path.to_str().unwrap()).unwrap())
+                .open(&CString::new(path.to_str().expect("Could not convert path to string")).expect("Could not open file"))
                 .ok_or(AssetIoError::NotFound(path.to_path_buf()))?;
             let bytes = opened_asset.get_buffer()?;
             Ok(bytes.to_vec())

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -44,7 +44,9 @@ impl FileAssetIo {
                 wasm32 / android targets"
             );
             #[cfg(feature = "filesystem_watcher")]
-            file_asset_io.watch_for_changes().unwrap();
+            file_asset_io
+                .watch_for_changes()
+                .expect("Could not watch for changes.");
         }
         file_asset_io
     }
@@ -57,9 +59,9 @@ impl FileAssetIo {
                 .map(|path| {
                     path.parent()
                         .map(|exe_parent_path| exe_parent_path.to_owned())
-                        .unwrap()
+                        .expect("Path does not have a parent.")
                 })
-                .unwrap()
+                .expect("Acquiring the path to the current executable failed.")
         }
     }
 }
@@ -92,8 +94,10 @@ impl AssetIo for FileAssetIo {
         let root_path = self.root_path.to_owned();
         Ok(Box::new(fs::read_dir(root_path.join(path))?.map(
             move |entry| {
-                let path = entry.unwrap().path();
-                path.strip_prefix(&root_path).unwrap().to_owned()
+                let path = entry.expect("Could not read entry in folder.").path();
+                path.strip_prefix(&root_path)
+                    .expect("Could not strip prefix from path.")
+                    .to_owned()
             },
         )))
     }
@@ -157,7 +161,9 @@ pub fn filesystem_watcher_system(asset_server: Res<AssetServer>) {
             {
                 for path in paths.iter() {
                     if !changed.contains(path) {
-                        let relative_path = path.strip_prefix(&asset_io.root_path).unwrap();
+                        let relative_path = path
+                            .strip_prefix(&asset_io.root_path)
+                            .expect("Could not strip prefix from path.");
                         let _ = asset_server.load_untracked(relative_path.into(), true);
                     }
                 }

--- a/crates/bevy_asset/src/io/wasm_asset_io.rs
+++ b/crates/bevy_asset/src/io/wasm_asset_io.rs
@@ -23,8 +23,8 @@ impl AssetIo for WasmAssetIo {
     fn load_path<'a>(&'a self, path: &'a Path) -> BoxedFuture<'a, Result<Vec<u8>, AssetIoError>> {
         Box::pin(async move {
             let path = self.root_path.join(path);
-            let window = web_sys::window().unwrap();
-            let resp_value = JsFuture::from(window.fetch_with_str(path.to_str().unwrap()))
+            let window = web_sys::window().expect("Could not get window.");
+            let resp_value = JsFuture::from(window.fetch_with_str(path.to_str().expect("Could not convert path to string")))
                 .await
                 .unwrap();
             let resp: Response = resp_value.dyn_into().unwrap();

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -136,7 +136,11 @@ impl<'a> LoadContext<'a> {
             asset_metas.push(AssetMeta {
                 dependencies: asset.dependencies.clone(),
                 label: label.clone(),
-                type_uuid: asset.value.as_ref().unwrap().type_uuid(),
+                type_uuid: asset
+                    .value
+                    .as_ref()
+                    .expect("No value was found for BoxedLoadedAsset")
+                    .type_uuid(),
             });
         }
         asset_metas
@@ -182,7 +186,7 @@ impl<T: AssetDynamic> AssetLifecycle for AssetLifecycleChannel<T> {
                     id,
                     version,
                 }))
-                .unwrap()
+                .expect("Could not send an AssetLifecycleEvent::Create correctly.")
         } else {
             panic!(
                 "Failed to downcast asset to {}.",
@@ -192,7 +196,9 @@ impl<T: AssetDynamic> AssetLifecycle for AssetLifecycleChannel<T> {
     }
 
     fn free_asset(&self, id: HandleId) {
-        self.sender.send(AssetLifecycleEvent::Free(id)).unwrap();
+        self.sender
+            .send(AssetLifecycleEvent::Free(id))
+            .expect("Could not send an AssetLifecycleEvent::Free correctly.");
     }
 }
 


### PR DESCRIPTION
# Objective

- Panics in bevy_asset are often particularly frustrating and obtuse.

## Solution

- Provide somewhat more helpful error messages by replacing expects with unwraps.

## Meta

This is a very basic, mechanical pass to improve error handling.

I don't currently have a deep understanding of the internals (and they're likely to change), so the error messages provided are very localized. It would be nice to capture more information about the state in these expect messages as well before merging.

There are a few wasm-specific unwraps left in `wasm_asset_io.rs` that I didn't feel comfortable tackling. There are also some expects in test code left, which I felt were fine to keep.

Like always, improvements are very welcome.