### PR TITLE
[Merged by Bors] - Fix SetSpriteTextureBindGroup to use index

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -601,7 +601,7 @@ impl<const I: usize> EntityRenderCommand for SetSpriteTextureBindGroup<I> {
         let image_bind_groups = image_bind_groups.into_inner();
 
         pass.set_bind_group(
-            1,
+            I,
             image_bind_groups
                 .values
                 .get(&Handle::weak(sprite_batch.image_handle_id))


### PR DESCRIPTION
# Objective

Fix `SetSpriteTextureBindGroup` to use index instead of hard coded 1.
Fixes #3895 

## Solution

1 -> I
