### PR TITLE
Unify `lib.rs` structure

### DIFF
--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -1,14 +1,20 @@
-#![warn(missing_docs)]
-//! This crate is about everything concerning the highest-level, application layer of a Bevy
+//! This crate is about everything concerning the highest-level, application layer of a `bevy`
 //! app.
 
+#![warn(missing_docs)]
+
 mod app;
+#[cfg(feature = "bevy_ci_testing")]
+mod ci_testing;
 mod plugin;
 mod plugin_group;
 mod schedule_runner;
 
-#[cfg(feature = "bevy_ci_testing")]
-mod ci_testing;
+/// The `bevy_app` prelude.
+pub mod prelude {
+    #[doc(hidden)]
+    pub use crate::{app::App, CoreStage, DynamicPlugin, Plugin, PluginGroup, StartupStage};
+}
 
 pub use app::*;
 pub use bevy_derive::DynamicPlugin;
@@ -16,12 +22,6 @@ pub use bevy_ecs::event::*;
 pub use plugin::*;
 pub use plugin_group::*;
 pub use schedule_runner::*;
-
-#[allow(missing_docs)]
-pub mod prelude {
-    #[doc(hidden)]
-    pub use crate::{app::App, CoreStage, DynamicPlugin, Plugin, PluginGroup, StartupStage};
-}
 
 use bevy_ecs::schedule::StageLabel;
 
@@ -47,6 +47,7 @@ pub enum CoreStage {
     /// Name of app stage that runs after all other app stages
     Last,
 }
+
 /// The names of the default App startup stages
 #[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
 pub enum StartupStage {

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -1,4 +1,4 @@
-//! Audio support for the game engine Bevy
+//! Audio support for the `bevy` game engine.
 //!
 //! ```
 //! # use bevy_ecs::{system::Res, event::EventWriter};
@@ -32,7 +32,7 @@ mod audio;
 mod audio_output;
 mod audio_source;
 
-#[allow(missing_docs)]
+/// The `bevy_audio` prelude.
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{Audio, AudioOutput, AudioSource, Decodable};

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -1,22 +1,23 @@
+//! This crate provides core functionality for the `bevy` game engine.
+
 #![warn(missing_docs)]
-//! This crate provides core functionality for Bevy Engine.
 
 mod float_ord;
 mod name;
 mod task_pool_options;
 mod time;
 
+/// The `bevy_core` prelude.
+pub mod prelude {
+    #[doc(hidden)]
+    pub use crate::{DefaultTaskPoolOptions, Name, Time, Timer};
+}
+
 pub use bytemuck::{bytes_of, cast_slice, Pod, Zeroable};
 pub use float_ord::*;
 pub use name::*;
 pub use task_pool_options::DefaultTaskPoolOptions;
 pub use time::*;
-
-pub mod prelude {
-    //! The Bevy Core Prelude.
-    #[doc(hidden)]
-    pub use crate::{DefaultTaskPoolOptions, Name, Time, Timer};
-}
 
 use bevy_app::prelude::*;
 use bevy_ecs::{
@@ -30,14 +31,6 @@ use std::ops::Range;
 /// Adds core functionality to Apps.
 #[derive(Default)]
 pub struct CorePlugin;
-
-/// A `SystemLabel` enum for ordering systems relative to core Bevy systems.
-#[derive(Debug, PartialEq, Eq, Clone, Hash, SystemLabel)]
-pub enum CoreSystem {
-    /// Updates the elapsed time. Any system that interacts with [Time] component should run after
-    /// this.
-    Time,
-}
 
 impl Plugin for CorePlugin {
     fn build(&self, app: &mut App) {
@@ -66,6 +59,14 @@ impl Plugin for CorePlugin {
         register_rust_types(app);
         register_math_types(app);
     }
+}
+
+/// A `SystemLabel` enum for ordering systems relative to core Bevy systems.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, SystemLabel)]
+pub enum CoreSystem {
+    /// Updates the elapsed time. Any system that interacts with [Time] component should run after
+    /// this.
+    Time,
 }
 
 fn register_rust_types(app: &mut App) {

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -1,58 +1,3 @@
-mod clear_pass;
-mod clear_pass_driver;
-mod main_pass_2d;
-mod main_pass_3d;
-mod main_pass_driver;
-
-pub mod prelude {
-    #[doc(hidden)]
-    pub use crate::ClearColor;
-}
-
-pub use clear_pass::*;
-pub use clear_pass_driver::*;
-pub use main_pass_2d::*;
-pub use main_pass_3d::*;
-pub use main_pass_driver::*;
-
-use std::ops::Range;
-
-use bevy_app::{App, Plugin};
-use bevy_core::FloatOrd;
-use bevy_ecs::prelude::*;
-use bevy_render::{
-    camera::{ActiveCameras, CameraPlugin},
-    color::Color,
-    render_graph::{EmptyNode, RenderGraph, SlotInfo, SlotType},
-    render_phase::{
-        batch_phase_system, sort_phase_system, BatchedPhaseItem, CachedPipelinePhaseItem,
-        DrawFunctionId, DrawFunctions, EntityPhaseItem, PhaseItem, RenderPhase,
-    },
-    render_resource::*,
-    renderer::RenderDevice,
-    texture::TextureCache,
-    view::{ExtractedView, Msaa, ViewDepthTexture},
-    RenderApp, RenderStage, RenderWorld,
-};
-
-/// When used as a resource, sets the color that is used to clear the screen between frames.
-///
-/// This color appears as the "background" color for simple apps, when
-/// there are portions of the screen with nothing rendered.
-#[derive(Clone, Debug)]
-pub struct ClearColor(pub Color);
-
-impl Default for ClearColor {
-    fn default() -> Self {
-        Self(Color::rgb(0.4, 0.4, 0.4))
-    }
-}
-
-// Plugins that contribute to the RenderGraph should use the following label conventions:
-// 1. Graph modules should have a NAME, input module, and node module (where relevant)
-// 2. The "top level" graph is the plugin module root. Just add things like `pub mod node` directly under the plugin module
-// 3. "sub graph" modules should be nested beneath their parent graph module
-
 pub mod node {
     pub const MAIN_PASS_DEPENDENCIES: &str = "main_pass_dependencies";
     pub const MAIN_PASS_DRIVER: &str = "main_pass_driver";
@@ -86,13 +31,50 @@ pub mod clear_graph {
     }
 }
 
+mod clear_pass;
+mod clear_pass_driver;
+mod main_pass_2d;
+mod main_pass_3d;
+mod main_pass_driver;
+
+/// The `bevy_core_pipeline` prelude.
+pub mod prelude {
+    #[doc(hidden)]
+    pub use crate::ClearColor;
+}
+
+pub use clear_pass::*;
+pub use clear_pass_driver::*;
+pub use main_pass_2d::*;
+pub use main_pass_3d::*;
+pub use main_pass_driver::*;
+
+use bevy_app::{App, Plugin};
+use bevy_core::FloatOrd;
+use bevy_ecs::prelude::*;
+use bevy_render::{
+    camera::{ActiveCameras, CameraPlugin},
+    color::Color,
+    render_graph::{EmptyNode, RenderGraph, SlotInfo, SlotType},
+    render_phase::{
+        batch_phase_system, sort_phase_system, BatchedPhaseItem, CachedPipelinePhaseItem,
+        DrawFunctionId, DrawFunctions, EntityPhaseItem, PhaseItem, RenderPhase,
+    },
+    render_resource::*,
+    renderer::RenderDevice,
+    texture::TextureCache,
+    view::{ExtractedView, Msaa, ViewDepthTexture},
+    RenderApp, RenderStage, RenderWorld,
+};
+use std::ops::Range;
+
+// Plugins that contribute to the RenderGraph should use the following label conventions:
+// 1. Graph modules should have a NAME, input module, and node module (where relevant)
+// 2. The "top level" graph is the plugin module root. Just add things like `pub mod node` directly under the plugin module
+// 3. "sub graph" modules should be nested beneath their parent graph module
+
 #[derive(Default)]
 pub struct CorePipelinePlugin;
-
-#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
-pub enum CorePipelineRenderSystems {
-    SortTransparent2d,
-}
 
 impl Plugin for CorePipelinePlugin {
     fn build(&self, app: &mut App) {
@@ -175,6 +157,24 @@ impl Plugin for CorePipelinePlugin {
         graph
             .add_node_edge(node::CLEAR_PASS_DRIVER, node::MAIN_PASS_DRIVER)
             .unwrap();
+    }
+}
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
+pub enum CorePipelineRenderSystems {
+    SortTransparent2d,
+}
+
+/// When used as a resource, sets the color that is used to clear the screen between frames.
+///
+/// This color appears as the "background" color for simple apps, when
+/// there are portions of the screen with nothing rendered.
+#[derive(Clone, Debug)]
+pub struct ClearColor(pub Color);
+
+impl Default for ClearColor {
+    fn default() -> Self {
+        Self(Color::rgb(0.4, 0.4, 0.4))
     }
 }
 

--- a/crates/bevy_crevice/src/lib.rs
+++ b/crates/bevy_crevice/src/lib.rs
@@ -1,3 +1,153 @@
+//! [![GitHub CI Status](https://github.com/LPGhatguy/crevice/workflows/CI/badge.svg)](https://github.com/LPGhatguy/crevice/actions)
+//! [![crevice on crates.io](https://img.shields.io/crates/v/crevice.svg)](https://crates.io/crates/crevice)
+//! [![crevice docs](https://img.shields.io/badge/docs-docs.rs-orange.svg)](https://docs.rs/crevice)
+//!
+//! Crevice creates GLSL-compatible versions of types through the power of derive
+//! macros. Generated structures provide an [`as_bytes`][std140::Std140::as_bytes]
+//! method to allow safely packing data into buffers for uploading.
+//!
+//! Generated structs also implement [`bytemuck::Zeroable`] and
+//! [`bytemuck::Pod`] for use with other libraries.
+//!
+//! Crevice is similar to [`glsl-layout`][glsl-layout], but supports types from many
+//! math crates, can generate GLSL source from structs, and explicitly initializes
+//! padding to remove one source of undefined behavior.
+//!
+//! Crevice has support for many Rust math libraries via feature flags, and most
+//! other math libraries by use of the mint crate. Crevice currently supports:
+//!
+//! * mint 0.5, enabled by default
+//! * cgmath 0.18, using the `cgmath` feature
+//! * nalgebra 0.29, using the `nalgebra` feature
+//! * glam 0.19, using the `glam` feature
+//!
+//! PRs are welcome to add or update math libraries to Crevice.
+//!
+//! If your math library is not supported, it's possible to define structs using the
+//! types from mint and convert your math library's types into mint types. This is
+//! supported by most Rust math libraries.
+//!
+//! Your math library may require you to turn on a feature flag to get mint support.
+//! For example, cgmath requires the "mint" feature to be enabled to allow
+//! conversions to and from mint types.
+//!
+//! ## Examples
+//!
+//! ### Single Value
+//!
+//! Uploading many types can be done by deriving [`AsStd140`][std140::AsStd140] and
+//! using [`as_std140`][std140::AsStd140::as_std140] and
+//! [`as_bytes`][std140::Std140::as_bytes] to turn the result into bytes.
+//!
+//! ```glsl
+//! uniform MAIN {
+//!     mat3 orientation;
+//!     vec3 position;
+//!     float scale;
+//! } main;
+//! ```
+//!
+//! ```rust
+//! use bevy_crevice::std140::{AsStd140, Std140};
+//!
+//! #[derive(AsStd140)]
+//! struct MainUniform {
+//!     orientation: mint::ColumnMatrix3<f32>,
+//!     position: mint::Vector3<f32>,
+//!     scale: f32,
+//! }
+//!
+//! let value = MainUniform {
+//!     orientation: [
+//!         [1.0, 0.0, 0.0],
+//!         [0.0, 1.0, 0.0],
+//!         [0.0, 0.0, 1.0],
+//!     ].into(),
+//!     position: [1.0, 2.0, 3.0].into(),
+//!     scale: 4.0,
+//! };
+//!
+//! let value_std140 = value.as_std140();
+//!
+//! # fn upload_data_to_gpu(_value: &[u8]) {}
+//! upload_data_to_gpu(value_std140.as_bytes());
+//! ```
+//!
+//! ### Sequential Types
+//!
+//! More complicated data can be uploaded using the std140
+//! [`Writer`][std140::Writer] type.
+//!
+//! ```glsl
+//! struct PointLight {
+//!     vec3 position;
+//!     vec3 color;
+//!     float brightness;
+//! };
+//!
+//! buffer POINT_LIGHTS {
+//!     uint len;
+//!     PointLight[] lights;
+//! } point_lights;
+//! ```
+//!
+//! ```rust
+//! use bevy_crevice::std140::{self, AsStd140};
+//!
+//! #[derive(AsStd140)]
+//! struct PointLight {
+//!     position: mint::Vector3<f32>,
+//!     color: mint::Vector3<f32>,
+//!     brightness: f32,
+//! }
+//!
+//! let lights = vec![
+//!     PointLight {
+//!         position: [0.0, 1.0, 0.0].into(),
+//!         color: [1.0, 0.0, 0.0].into(),
+//!         brightness: 0.6,
+//!     },
+//!     PointLight {
+//!         position: [0.0, 4.0, 3.0].into(),
+//!         color: [1.0, 1.0, 1.0].into(),
+//!         brightness: 1.0,
+//!     },
+//! ];
+//!
+//! # fn map_gpu_buffer_for_write() -> &'static mut [u8] {
+//! #     Box::leak(vec![0; 1024].into_boxed_slice())
+//! # }
+//! let target_buffer = map_gpu_buffer_for_write();
+//! let mut writer = std140::Writer::new(target_buffer);
+//!
+//! let light_count = lights.len() as u32;
+//! writer.write(&light_count)?;
+//!
+//! // Crevice will automatically insert the required padding to align the
+//! // PointLight structure correctly. In this case, there will be 12 bytes of
+//! // padding between the length field and the light list.
+//!
+//! writer.write(lights.as_slice())?;
+//!
+//! # fn unmap_gpu_buffer() {}
+//! unmap_gpu_buffer();
+//!
+//! # Ok::<(), std::io::Error>(())
+//! ```
+//!
+//! ## Features
+//!
+//! * `std` (default): Enables [`std::io::Write`]-based structs.
+//! * `cgmath`: Enables support for types from cgmath.
+//! * `nalgebra`: Enables support for types from nalgebra.
+//! * `glam`: Enables support for types from glam.
+//!
+//! ## Minimum Supported Rust Version (MSRV)
+//!
+//! Crevice supports Rust 1.52.1 and newer due to use of new `const fn` features.
+//!
+//! [glsl-layout]: https://github.com/rustgd/glsl-layout
+
 #![allow(
     clippy::new_without_default,
     clippy::needless_update,
@@ -6,169 +156,15 @@
     clippy::all,
     clippy::doc_markdown
 )]
-/*!
-[![GitHub CI Status](https://github.com/LPGhatguy/crevice/workflows/CI/badge.svg)](https://github.com/LPGhatguy/crevice/actions)
-[![crevice on crates.io](https://img.shields.io/crates/v/crevice.svg)](https://crates.io/crates/crevice)
-[![crevice docs](https://img.shields.io/badge/docs-docs.rs-orange.svg)](https://docs.rs/crevice)
-
-Crevice creates GLSL-compatible versions of types through the power of derive
-macros. Generated structures provide an [`as_bytes`][std140::Std140::as_bytes]
-method to allow safely packing data into buffers for uploading.
-
-Generated structs also implement [`bytemuck::Zeroable`] and
-[`bytemuck::Pod`] for use with other libraries.
-
-Crevice is similar to [`glsl-layout`][glsl-layout], but supports types from many
-math crates, can generate GLSL source from structs, and explicitly initializes
-padding to remove one source of undefined behavior.
-
-Crevice has support for many Rust math libraries via feature flags, and most
-other math libraries by use of the mint crate. Crevice currently supports:
-
-* mint 0.5, enabled by default
-* cgmath 0.18, using the `cgmath` feature
-* nalgebra 0.29, using the `nalgebra` feature
-* glam 0.19, using the `glam` feature
-
-PRs are welcome to add or update math libraries to Crevice.
-
-If your math library is not supported, it's possible to define structs using the
-types from mint and convert your math library's types into mint types. This is
-supported by most Rust math libraries.
-
-Your math library may require you to turn on a feature flag to get mint support.
-For example, cgmath requires the "mint" feature to be enabled to allow
-conversions to and from mint types.
-
-## Examples
-
-### Single Value
-
-Uploading many types can be done by deriving [`AsStd140`][std140::AsStd140] and
-using [`as_std140`][std140::AsStd140::as_std140] and
-[`as_bytes`][std140::Std140::as_bytes] to turn the result into bytes.
-
-```glsl
-uniform MAIN {
-    mat3 orientation;
-    vec3 position;
-    float scale;
-} main;
-```
-
-```rust
-use bevy_crevice::std140::{AsStd140, Std140};
-
-#[derive(AsStd140)]
-struct MainUniform {
-    orientation: mint::ColumnMatrix3<f32>,
-    position: mint::Vector3<f32>,
-    scale: f32,
-}
-
-let value = MainUniform {
-    orientation: [
-        [1.0, 0.0, 0.0],
-        [0.0, 1.0, 0.0],
-        [0.0, 0.0, 1.0],
-    ].into(),
-    position: [1.0, 2.0, 3.0].into(),
-    scale: 4.0,
-};
-
-let value_std140 = value.as_std140();
-
-# fn upload_data_to_gpu(_value: &[u8]) {}
-upload_data_to_gpu(value_std140.as_bytes());
-```
-
-### Sequential Types
-
-More complicated data can be uploaded using the std140
-[`Writer`][std140::Writer] type.
-
-```glsl
-struct PointLight {
-    vec3 position;
-    vec3 color;
-    float brightness;
-};
-
-buffer POINT_LIGHTS {
-    uint len;
-    PointLight[] lights;
-} point_lights;
-```
-
-```rust
-use bevy_crevice::std140::{self, AsStd140};
-
-#[derive(AsStd140)]
-struct PointLight {
-    position: mint::Vector3<f32>,
-    color: mint::Vector3<f32>,
-    brightness: f32,
-}
-
-let lights = vec![
-    PointLight {
-        position: [0.0, 1.0, 0.0].into(),
-        color: [1.0, 0.0, 0.0].into(),
-        brightness: 0.6,
-    },
-    PointLight {
-        position: [0.0, 4.0, 3.0].into(),
-        color: [1.0, 1.0, 1.0].into(),
-        brightness: 1.0,
-    },
-];
-
-# fn map_gpu_buffer_for_write() -> &'static mut [u8] {
-#     Box::leak(vec![0; 1024].into_boxed_slice())
-# }
-let target_buffer = map_gpu_buffer_for_write();
-let mut writer = std140::Writer::new(target_buffer);
-
-let light_count = lights.len() as u32;
-writer.write(&light_count)?;
-
-// Crevice will automatically insert the required padding to align the
-// PointLight structure correctly. In this case, there will be 12 bytes of
-// padding between the length field and the light list.
-
-writer.write(lights.as_slice())?;
-
-# fn unmap_gpu_buffer() {}
-unmap_gpu_buffer();
-
-# Ok::<(), std::io::Error>(())
-```
-
-## Features
-
-* `std` (default): Enables [`std::io::Write`]-based structs.
-* `cgmath`: Enables support for types from cgmath.
-* `nalgebra`: Enables support for types from nalgebra.
-* `glam`: Enables support for types from glam.
-
-## Minimum Supported Rust Version (MSRV)
-
-Crevice supports Rust 1.52.1 and newer due to use of new `const fn` features.
-
-[glsl-layout]: https://github.com/rustgd/glsl-layout
-*/
-
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[macro_use]
-mod util;
-
 pub mod glsl;
+#[doc(hidden)]
+pub mod internal;
 pub mod std140;
 pub mod std430;
 
-#[doc(hidden)]
-pub mod internal;
-
+#[macro_use]
+mod util;
 mod imp;

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -2,12 +2,17 @@ mod diagnostic;
 mod entity_count_diagnostics_plugin;
 mod frame_time_diagnostics_plugin;
 mod log_diagnostics_plugin;
+
 pub use diagnostic::*;
 pub use entity_count_diagnostics_plugin::EntityCountDiagnosticsPlugin;
 pub use frame_time_diagnostics_plugin::FrameTimeDiagnosticsPlugin;
 pub use log_diagnostics_plugin::LogDiagnosticsPlugin;
 
 use bevy_app::prelude::*;
+
+/// The width which diagnostic names will be printed as
+/// Plugin names should not be longer than this value
+pub const MAX_DIAGNOSTIC_NAME_WIDTH: usize = 32;
 
 /// Adds core diagnostics resources to an App.
 #[derive(Default)]
@@ -18,7 +23,3 @@ impl Plugin for DiagnosticsPlugin {
         app.init_resource::<Diagnostics>();
     }
 }
-
-/// The width which diagnostic names will be printed as
-/// Plugin names should not be longer than this value
-pub const MAX_DIAGNOSTIC_NAME_WIDTH: usize = 32;

--- a/crates/bevy_dylib/src/lib.rs
+++ b/crates/bevy_dylib/src/lib.rs
@@ -1,7 +1,4 @@
-#![warn(missing_docs)]
-#![allow(clippy::single_component_path_imports)]
-
-//! Forces dynamic linking of Bevy.
+//! Forces dynamic linking of `bevy`.
 //!
 //! Dynamic linking causes Bevy to be built and linked as a dynamic library. This will make
 //! incremental builds compile much faster.
@@ -49,6 +46,9 @@
 //! #[cfg(debug_assertions)] // new
 //! use bevy_dylib;
 //! ```
+
+#![warn(missing_docs)]
+#![allow(clippy::single_component_path_imports)]
 
 // Force linking of the main bevy crate
 #[allow(unused_imports)]

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -14,7 +14,7 @@ pub mod storage;
 pub mod system;
 pub mod world;
 
-/// Most commonly used re-exported types.
+/// The `bevy_ecs` prelude.
 pub mod prelude {
     #[doc(hidden)]
     #[cfg(feature = "bevy_reflect")]

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -1,6 +1,5 @@
-use bevy_utils::HashMap;
-
 mod loader;
+
 pub use loader::*;
 
 use bevy_app::prelude::*;
@@ -9,6 +8,7 @@ use bevy_pbr::StandardMaterial;
 use bevy_reflect::TypeUuid;
 use bevy_render::mesh::Mesh;
 use bevy_scene::Scene;
+use bevy_utils::HashMap;
 
 /// Adds support for glTF file loading to the app.
 #[derive(Default)]

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -1,14 +1,11 @@
-mod axis;
 pub mod gamepad;
-mod input;
 pub mod keyboard;
 pub mod mouse;
 pub mod system;
 pub mod touch;
 
-pub use axis::*;
-use bevy_ecs::schedule::{ParallelSystemDescriptorCoercion, SystemLabel};
-pub use input::*;
+mod axis;
+mod input;
 
 pub mod prelude {
     #[doc(hidden)]
@@ -24,23 +21,23 @@ pub mod prelude {
     };
 }
 
+pub use axis::*;
+pub use input::*;
+
 use bevy_app::prelude::*;
+use bevy_ecs::schedule::{ParallelSystemDescriptorCoercion, SystemLabel};
+use gamepad::{
+    gamepad_connection_system, gamepad_event_system, GamepadAxis, GamepadButton, GamepadEvent,
+    GamepadEventRaw, GamepadSettings,
+};
 use keyboard::{keyboard_input_system, KeyCode, KeyboardInput};
 use mouse::{mouse_button_input_system, MouseButton, MouseButtonInput, MouseMotion, MouseWheel};
 use prelude::Gamepads;
 use touch::{touch_screen_input_system, TouchInput, Touches};
 
-use gamepad::{
-    gamepad_connection_system, gamepad_event_system, GamepadAxis, GamepadButton, GamepadEvent,
-    GamepadEventRaw, GamepadSettings,
-};
-
 /// Adds keyboard and mouse input to an App
 #[derive(Default)]
 pub struct InputPlugin;
-
-#[derive(Debug, PartialEq, Eq, Clone, Hash, SystemLabel)]
-pub struct InputSystem;
 
 impl Plugin for InputPlugin {
     fn build(&self, app: &mut App) {
@@ -86,6 +83,9 @@ impl Plugin for InputPlugin {
             );
     }
 }
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, SystemLabel)]
+pub struct InputSystem;
 
 /// The current "press" state of an element
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -1,11 +1,6 @@
+//! This module is separated into its own crate to enable simple dynamic linking for `bevy`, and should not be used directly.
+
 #![warn(missing_docs)]
-//! This module is separated into its own crate to enable simple dynamic linking for Bevy, and should not be used directly
-
-/// `use bevy::prelude::*;` to import common components, bundles, and plugins.
-pub mod prelude;
-
-mod default_plugins;
-pub use default_plugins::*;
 
 pub mod app {
     //! Build bevy apps, create plugins, and read events.
@@ -17,9 +12,21 @@ pub mod asset {
     pub use bevy_asset::*;
 }
 
+#[cfg(feature = "bevy_audio")]
+pub mod audio {
+    //! Provides types and plugins for audio playback.
+    pub use bevy_audio::*;
+}
+
 pub mod core {
     //! Contains core plugins and utilities for time.
     pub use bevy_core::*;
+}
+
+#[cfg(feature = "bevy_core_pipeline")]
+pub mod core_pipeline {
+    //! Core render pipeline.
+    pub use bevy_core_pipeline::*;
 }
 
 pub mod diagnostic {
@@ -27,9 +34,27 @@ pub mod diagnostic {
     pub use bevy_diagnostic::*;
 }
 
+#[cfg(feature = "bevy_dynamic_plugin")]
+pub mod dynamic_plugin {
+    //! Dynamic linking of plugins
+    pub use bevy_dynamic_plugin::*;
+}
+
 pub mod ecs {
     //! Bevy's entity-component-system.
     pub use bevy_ecs::*;
+}
+
+#[cfg(feature = "bevy_gilrs")]
+pub mod gilrs {
+    //! Bevy interface with `GilRs` - "Game Input Library for Rust" - to handle gamepad inputs.
+    pub use bevy_gilrs::*;
+}
+
+#[cfg(feature = "bevy_gltf")]
+pub mod gltf {
+    //! Support for GLTF file loading.
+    pub use bevy_gltf::*;
 }
 
 pub mod input {
@@ -47,6 +72,12 @@ pub mod math {
     pub use bevy_math::*;
 }
 
+#[cfg(feature = "bevy_pbr")]
+pub mod pbr {
+    //! Physically based rendering.
+    pub use bevy_pbr::*;
+}
+
 pub mod reflect {
     // TODO: remove these renames once TypeRegistryArc is no longer required
     //! Type reflection used for dynamically interacting with rust types.
@@ -55,9 +86,21 @@ pub mod reflect {
     };
 }
 
+#[cfg(feature = "bevy_render")]
+pub mod render {
+    //! Cameras, meshes, textures, shaders, and pipelines.
+    pub use bevy_render::*;
+}
+
 pub mod scene {
     //! Save/load collections of entities and components to/from file.
     pub use bevy_scene::*;
+}
+
+#[cfg(feature = "bevy_sprite")]
+pub mod sprite {
+    //! Items for sprites, rects, texture atlases, etc.
+    pub use bevy_sprite::*;
 }
 
 pub mod tasks {
@@ -65,9 +108,21 @@ pub mod tasks {
     pub use bevy_tasks::*;
 }
 
+#[cfg(feature = "bevy_text")]
+pub mod text {
+    //! Text drawing, styling, and font assets.
+    pub use bevy_text::*;
+}
+
 pub mod transform {
     //! Local and global transforms (e.g. translation, scale, rotation).
     pub use bevy_transform::*;
+}
+
+#[cfg(feature = "bevy_ui")]
+pub mod ui {
+    //! User interface components and widgets.
+    pub use bevy_ui::*;
 }
 
 pub mod utils {
@@ -80,71 +135,17 @@ pub mod window {
     pub use bevy_window::*;
 }
 
-#[cfg(feature = "bevy_audio")]
-pub mod audio {
-    //! Provides types and plugins for audio playback.
-    pub use bevy_audio::*;
-}
-
-#[cfg(feature = "bevy_core_pipeline")]
-pub mod core_pipeline {
-    //! Core render pipeline.
-    pub use bevy_core_pipeline::*;
-}
-
-#[cfg(feature = "bevy_gilrs")]
-pub mod gilrs {
-    //! Bevy interface with `GilRs` - "Game Input Library for Rust" - to handle gamepad inputs.
-    pub use bevy_gilrs::*;
-}
-
-#[cfg(feature = "bevy_gltf")]
-pub mod gltf {
-    //! Support for GLTF file loading.
-    pub use bevy_gltf::*;
-}
-
-#[cfg(feature = "bevy_pbr")]
-pub mod pbr {
-    //! Physically based rendering.
-    pub use bevy_pbr::*;
-}
-
-#[cfg(feature = "bevy_render")]
-pub mod render {
-    //! Cameras, meshes, textures, shaders, and pipelines.
-    pub use bevy_render::*;
-}
-
-#[cfg(feature = "bevy_sprite")]
-pub mod sprite {
-    //! Items for sprites, rects, texture atlases, etc.
-    pub use bevy_sprite::*;
-}
-
-#[cfg(feature = "bevy_text")]
-pub mod text {
-    //! Text drawing, styling, and font assets.
-    pub use bevy_text::*;
-}
-
-#[cfg(feature = "bevy_ui")]
-pub mod ui {
-    //! User interface components and widgets.
-    pub use bevy_ui::*;
-}
-
 #[cfg(feature = "bevy_winit")]
 pub mod winit {
     //! Window creation, configuration, and handling
     pub use bevy_winit::*;
 }
 
-#[cfg(feature = "bevy_dynamic_plugin")]
-pub mod dynamic_plugin {
-    //! Dynamic linking of plugins
-    pub use bevy_dynamic_plugin::*;
-}
+mod default_plugins;
 
+/// The `bevy_internal` prelude.
+pub mod prelude;
+
+pub use default_plugins::*;
 #[cfg(target_os = "android")]
 pub use ndk_glue;

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -1,5 +1,4 @@
-#![warn(missing_docs)]
-//! This crate provides logging functions and configuration for [Bevy](https://bevyengine.org)
+//! This crate provides logging functions and configuration for [`bevy`](https://bevyengine.org)
 //! apps, and automatically configures platform specific log handlers (i.e. WASM or Android).
 //!
 //! The macros provided for logging are reexported from [`tracing`](https://docs.rs/tracing),
@@ -11,16 +10,19 @@
 //! For more fine-tuned control over logging behavior, insert a [`LogSettings`] resource before
 //! adding [`LogPlugin`] or `DefaultPlugins` during app initialization.
 
+#![warn(missing_docs)]
+
 #[cfg(target_os = "android")]
 mod android_tracing;
 
+/// The `bevy_log` prelude.
 pub mod prelude {
-    //! The Bevy Log Prelude.
     #[doc(hidden)]
     pub use bevy_utils::tracing::{
         debug, debug_span, error, error_span, info, info_span, trace, trace_span, warn, warn_span,
     };
 }
+
 pub use bevy_utils::tracing::{
     debug, debug_span, error, error_span, info, info_span, trace, trace_span, warn, warn_span,
     Level,
@@ -83,25 +85,6 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// rerunning the same initialization multiple times will lead to a panic.
 #[derive(Default)]
 pub struct LogPlugin;
-
-/// `LogPlugin` settings
-pub struct LogSettings {
-    /// Filters logs using the [`EnvFilter`] format
-    pub filter: String,
-
-    /// Filters out logs that are "less than" the given level.
-    /// This can be further filtered using the `filter` setting.
-    pub level: Level,
-}
-
-impl Default for LogSettings {
-    fn default() -> Self {
-        Self {
-            filter: "wgpu=error".to_string(),
-            level: Level::INFO,
-        }
-    }
-}
 
 impl Plugin for LogPlugin {
     fn build(&self, app: &mut App) {
@@ -167,6 +150,25 @@ impl Plugin for LogPlugin {
             let subscriber = subscriber.with(android_tracing::AndroidLayer::default());
             bevy_utils::tracing::subscriber::set_global_default(subscriber)
                 .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
+        }
+    }
+}
+
+/// `LogPlugin` settings
+pub struct LogSettings {
+    /// Filters logs using the [`EnvFilter`] format
+    pub filter: String,
+
+    /// Filters out logs that are "less than" the given level.
+    /// This can be further filtered using the `filter` setting.
+    pub level: Level,
+}
+
+impl Default for LogSettings {
+    fn default() -> Self {
+        Self {
+            filter: "wgpu=error".to_string(),
+            level: Level::INFO,
         }
     }
 }

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -5,6 +5,7 @@ pub use face_toward::*;
 pub use geometry::*;
 pub use glam::*;
 
+/// The `bevy_math` prelude.
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -7,13 +7,14 @@ mod material;
 mod pbr_material;
 mod render;
 
-pub use alpha::*;
-pub use bundle::*;
-pub use light::*;
-pub use material::*;
-pub use pbr_material::*;
-pub use render::*;
+pub mod draw_3d_graph {
+    pub mod node {
+        /// Label for the shadow pass node.
+        pub const SHADOW_PASS: &str = "shadow_pass";
+    }
+}
 
+/// The `bevy_pbr` prelude.
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
@@ -25,12 +26,12 @@ pub mod prelude {
     };
 }
 
-pub mod draw_3d_graph {
-    pub mod node {
-        /// Label for the shadow pass node.
-        pub const SHADOW_PASS: &str = "shadow_pass";
-    }
-}
+pub use alpha::*;
+pub use bundle::*;
+pub use light::*;
+pub use material::*;
+pub use pbr_material::*;
+pub use render::*;
 
 use bevy_app::prelude::*;
 use bevy_asset::{Assets, Handle, HandleUntyped};

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!("../README.md")]
 
+pub mod serde;
+
 mod list;
 mod map;
 mod path;
@@ -23,7 +25,7 @@ mod impls {
     pub use self::std::*;
 }
 
-pub mod serde;
+/// The `bevy_reflect` prelude.
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
@@ -32,6 +34,8 @@ pub mod prelude {
     };
 }
 
+pub use bevy_reflect_derive::*;
+pub use erased_serde;
 pub use impls::*;
 pub use list::*;
 pub use map::*;
@@ -42,9 +46,6 @@ pub use tuple::*;
 pub use tuple_struct::*;
 pub use type_registry::*;
 pub use type_uuid::*;
-
-pub use bevy_reflect_derive::*;
-pub use erased_serde;
 
 #[cfg(test)]
 #[allow(clippy::blacklisted_name, clippy::approx_constant)]

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1,22 +1,24 @@
+pub mod serde;
+
 mod command;
 mod dynamic_scene;
 mod scene;
 mod scene_loader;
 mod scene_spawner;
-pub mod serde;
 
-pub use command::*;
-pub use dynamic_scene::*;
-pub use scene::*;
-pub use scene_loader::*;
-pub use scene_spawner::*;
-
+/// The `bevy_scene` prelude.
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
         DynamicScene, Scene, SceneSpawner, SpawnSceneAsChildCommands, SpawnSceneCommands,
     };
 }
+
+pub use command::*;
+pub use dynamic_scene::*;
+pub use scene::*;
+pub use scene_loader::*;
+pub use scene_spawner::*;
 
 use bevy_app::prelude::*;
 use bevy_asset::AddAsset;

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod collide_aabb;
+
 mod bundle;
 mod dynamic_texture_atlas_builder;
 mod mesh2d;
@@ -7,8 +9,7 @@ mod sprite;
 mod texture_atlas;
 mod texture_atlas_builder;
 
-pub mod collide_aabb;
-
+/// The `bevy_sprite` prelude.
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
@@ -39,16 +40,11 @@ use bevy_render::{
     RenderApp, RenderStage,
 };
 
-#[derive(Default)]
-pub struct SpritePlugin;
-
 pub const SPRITE_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 2763343953151597127);
 
-#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
-pub enum SpriteSystem {
-    ExtractSprites,
-}
+#[derive(Default)]
+pub struct SpritePlugin;
 
 impl Plugin for SpritePlugin {
     fn build(&self, app: &mut App) {
@@ -77,4 +73,9 @@ impl Plugin for SpritePlugin {
                 .add_system_to_stage(RenderStage::Queue, queue_sprites);
         };
     }
+}
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
+pub enum SpriteSystem {
+    ExtractSprites,
 }

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -1,32 +1,17 @@
-#![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
-
-mod slice;
-pub use slice::{ParallelSlice, ParallelSliceMut};
-
-mod task;
-pub use task::Task;
-
-#[cfg(not(target_arch = "wasm32"))]
-mod task_pool;
-#[cfg(not(target_arch = "wasm32"))]
-pub use task_pool::{Scope, TaskPool, TaskPoolBuilder};
-
-#[cfg(target_arch = "wasm32")]
-mod single_threaded_task_pool;
-#[cfg(target_arch = "wasm32")]
-pub use single_threaded_task_pool::{Scope, TaskPool, TaskPoolBuilder};
-
-mod usages;
-pub use usages::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool};
+#![warn(missing_docs)]
 
 mod countdown_event;
-pub use countdown_event::CountdownEvent;
-
 mod iter;
-pub use iter::ParallelIterator;
+#[cfg(target_arch = "wasm32")]
+mod single_threaded_task_pool;
+mod slice;
+mod task;
+#[cfg(not(target_arch = "wasm32"))]
+mod task_pool;
+mod usages;
 
-#[allow(missing_docs)]
+/// The `bevy_tasks` prelude.
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
@@ -36,5 +21,14 @@ pub mod prelude {
     };
 }
 
+pub use countdown_event::CountdownEvent;
+pub use iter::ParallelIterator;
 pub use num_cpus::get as logical_core_count;
 pub use num_cpus::get_physical as physical_core_count;
+#[cfg(target_arch = "wasm32")]
+pub use single_threaded_task_pool::{Scope, TaskPool, TaskPoolBuilder};
+pub use slice::{ParallelSlice, ParallelSliceMut};
+pub use task::Task;
+#[cfg(not(target_arch = "wasm32"))]
+pub use task_pool::{Scope, TaskPool, TaskPoolBuilder};
+pub use usages::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool};

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -8,6 +8,14 @@ mod pipeline;
 mod text;
 mod text2d;
 
+pub mod prelude {
+    #[doc(hidden)]
+    pub use crate::{
+        Font, HorizontalAlign, Text, Text2dBundle, TextAlignment, TextError, TextSection,
+        TextStyle, VerticalAlign,
+    };
+}
+
 pub use error::*;
 pub use font::*;
 pub use font_atlas::*;
@@ -17,14 +25,6 @@ pub use glyph_brush::*;
 pub use pipeline::*;
 pub use text::*;
 pub use text2d::*;
-
-pub mod prelude {
-    #[doc(hidden)]
-    pub use crate::{
-        Font, HorizontalAlign, Text, Text2dBundle, TextAlignment, TextError, TextSection,
-        TextStyle, VerticalAlign,
-    };
-}
 
 use bevy_app::prelude::*;
 use bevy_asset::AddAsset;

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -1,5 +1,5 @@
-#![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
+#![warn(missing_docs)]
 
 /// The basic components of the transform crate
 pub mod components;
@@ -8,7 +8,7 @@ pub mod hierarchy;
 /// Propagating transform changes down the transform hierarchy
 pub mod transform_propagate_system;
 
-#[doc(hidden)]
+/// The `bevy_transform` prelude.
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{components::*, hierarchy::*, TransformBundle, TransformPlugin};
@@ -20,6 +20,41 @@ use bevy_ecs::{
     schedule::{ParallelSystemDescriptorCoercion, SystemLabel},
 };
 use prelude::{parent_update_system, Children, GlobalTransform, Parent, PreviousParent, Transform};
+
+/// The base plugin for handling [`Transform`] components.
+#[derive(Default)]
+pub struct TransformPlugin;
+
+impl Plugin for TransformPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_type::<Children>()
+            .register_type::<Parent>()
+            .register_type::<PreviousParent>()
+            .register_type::<Transform>()
+            .register_type::<GlobalTransform>()
+            // add transform systems to startup so the first update is "correct"
+            .add_startup_system_to_stage(
+                StartupStage::PostStartup,
+                parent_update_system.label(TransformSystem::ParentUpdate),
+            )
+            .add_startup_system_to_stage(
+                StartupStage::PostStartup,
+                transform_propagate_system::transform_propagate_system
+                    .label(TransformSystem::TransformPropagate)
+                    .after(TransformSystem::ParentUpdate),
+            )
+            .add_system_to_stage(
+                CoreStage::PostUpdate,
+                parent_update_system.label(TransformSystem::ParentUpdate),
+            )
+            .add_system_to_stage(
+                CoreStage::PostUpdate,
+                transform_propagate_system::transform_propagate_system
+                    .label(TransformSystem::TransformPropagate)
+                    .after(TransformSystem::ParentUpdate),
+            );
+    }
+}
 
 /// A [`Bundle`] of the [`Transform`] and [`GlobalTransform`]
 /// [`Component`](bevy_ecs::component::Component)s, which describe the position of an entity.
@@ -81,10 +116,6 @@ impl From<Transform> for TransformBundle {
         Self::from_transform(transform)
     }
 }
-/// The base plugin for handling [`Transform`] components
-#[derive(Default)]
-pub struct TransformPlugin;
-
 /// Label enum for the types of systems relating to transform
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
 pub enum TransformSystem {
@@ -92,35 +123,4 @@ pub enum TransformSystem {
     TransformPropagate,
     /// Updates [`Parent`] when changes in the hierarchy occur
     ParentUpdate,
-}
-
-impl Plugin for TransformPlugin {
-    fn build(&self, app: &mut App) {
-        app.register_type::<Children>()
-            .register_type::<Parent>()
-            .register_type::<PreviousParent>()
-            .register_type::<Transform>()
-            .register_type::<GlobalTransform>()
-            // add transform systems to startup so the first update is "correct"
-            .add_startup_system_to_stage(
-                StartupStage::PostStartup,
-                parent_update_system.label(TransformSystem::ParentUpdate),
-            )
-            .add_startup_system_to_stage(
-                StartupStage::PostStartup,
-                transform_propagate_system::transform_propagate_system
-                    .label(TransformSystem::TransformPropagate)
-                    .after(TransformSystem::ParentUpdate),
-            )
-            .add_system_to_stage(
-                CoreStage::PostUpdate,
-                parent_update_system.label(TransformSystem::ParentUpdate),
-            )
-            .add_system_to_stage(
-                CoreStage::PostUpdate,
-                transform_propagate_system::transform_propagate_system
-                    .label(TransformSystem::TransformPropagate)
-                    .after(TransformSystem::ParentUpdate),
-            );
-    }
 }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -1,28 +1,29 @@
-//! This crate contains Bevy's UI system, which can be used to create UI for both 2D and 3D games
+//! This crate contains the UI system of `bevy`, which can be used to create UI for both 2D and 3D games.
 //! # Basic usage
 //! Spawn [`entity::UiCameraBundle`] and spawn UI elements with [`entity::ButtonBundle`], [`entity::ImageBundle`], [`entity::TextBundle`] and [`entity::NodeBundle`]
 //! This UI is laid out with the Flexbox paradigm (see <https://cssreference.io/flexbox/> ) except the vertical axis is inverted
+
+pub mod entity;
+pub mod update;
+pub mod widget;
+
 mod flex;
 mod focus;
 mod margins;
 mod render;
 mod ui_node;
 
-pub mod entity;
-pub mod update;
-pub mod widget;
+/// The `bevy_ui` prelude.
+pub mod prelude {
+    #[doc(hidden)]
+    pub use crate::{entity::*, ui_node::*, widget::Button, Interaction, Margins};
+}
 
 pub use flex::*;
 pub use focus::*;
 pub use margins::*;
 pub use render::*;
 pub use ui_node::*;
-
-#[doc(hidden)]
-pub mod prelude {
-    #[doc(hidden)]
-    pub use crate::{entity::*, ui_node::*, widget::Button, Interaction, Margins};
-}
 
 use bevy_app::prelude::*;
 use bevy_ecs::schedule::{ParallelSystemDescriptorCoercion, SystemLabel};
@@ -34,15 +35,6 @@ use update::{ui_z_system, update_clipping_system};
 /// The basic plugin for Bevy UI
 #[derive(Default)]
 pub struct UiPlugin;
-
-/// The label enum labeling the types of systems in the Bevy UI
-#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
-pub enum UiSystem {
-    /// After this label, the ui flex state has been updated
-    Flex,
-    /// After this label, input interactions with UI entities have been updated for this frame
-    Focus,
-}
 
 impl Plugin for UiPlugin {
     fn build(&self, app: &mut App) {
@@ -104,4 +96,13 @@ impl Plugin for UiPlugin {
 
         crate::render::build_ui_render(app);
     }
+}
+
+/// The label enum labeling the types of systems in the Bevy UI
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
+pub enum UiSystem {
+    /// After this label, the ui flex state has been updated
+    Flex,
+    /// After this label, input interactions with UI entities have been updated for this frame
+    Focus,
 }

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -1,5 +1,6 @@
-mod enum_variant_meta;
 pub mod label;
+
+mod enum_variant_meta;
 
 pub use ahash::AHasher;
 pub use enum_variant_meta::*;
@@ -15,22 +16,6 @@ pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 #[cfg(target_arch = "wasm32")]
 pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
-
-/// A hasher builder that will create a fixed hasher.
-#[derive(Debug, Clone, Default)]
-pub struct FixedState;
-
-impl std::hash::BuildHasher for FixedState {
-    type Hasher = AHasher;
-
-    #[inline]
-    fn build_hasher(&self) -> AHasher {
-        AHasher::new_with_keys(
-            0b1001010111101110000001001100010000000011001001101011001001111000,
-            0b1100111101101011011110001011010100000100001111100011010011010101,
-        )
-    }
-}
 
 /// A [`HashMap`][std::collections::HashMap] implementing [`aHash`], a high
 /// speed keyed hashing algorithm intended for use in in-memory hashmaps.
@@ -70,29 +55,6 @@ impl std::hash::BuildHasher for FixedState {
 ///
 /// [`aHash`]: https://github.com/tkaitchuck/aHash
 pub type HashMap<K, V> = std::collections::HashMap<K, V, RandomState>;
-
-pub trait AHashExt {
-    fn with_capacity(capacity: usize) -> Self;
-}
-
-impl<K, V> AHashExt for HashMap<K, V> {
-    /// Creates an empty `HashMap` with the specified capacity with aHash.
-    ///
-    /// The hash map will be able to hold at least `capacity` elements without
-    /// reallocating. If `capacity` is 0, the hash map will not allocate.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bevy_utils::{HashMap, AHashExt};
-    /// let mut map: HashMap<&str, i32> = HashMap::with_capacity(10);
-    /// assert!(map.capacity() >= 10);
-    /// ```
-    #[inline]
-    fn with_capacity(capacity: usize) -> Self {
-        HashMap::with_capacity_and_hasher(capacity, RandomState::default())
-    }
-}
 
 /// A stable std hash map implementing `aHash`, a high speed keyed hashing algorithm
 /// intended for use in in-memory hashmaps.
@@ -205,5 +167,44 @@ impl<K> AHashExt for StableHashSet<K> {
     #[inline]
     fn with_capacity(capacity: usize) -> Self {
         StableHashSet::with_capacity_and_hasher(capacity, FixedState::default())
+    }
+}
+
+pub trait AHashExt {
+    fn with_capacity(capacity: usize) -> Self;
+}
+
+impl<K, V> AHashExt for HashMap<K, V> {
+    /// Creates an empty `HashMap` with the specified capacity with aHash.
+    ///
+    /// The hash map will be able to hold at least `capacity` elements without
+    /// reallocating. If `capacity` is 0, the hash map will not allocate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bevy_utils::{HashMap, AHashExt};
+    /// let mut map: HashMap<&str, i32> = HashMap::with_capacity(10);
+    /// assert!(map.capacity() >= 10);
+    /// ```
+    #[inline]
+    fn with_capacity(capacity: usize) -> Self {
+        HashMap::with_capacity_and_hasher(capacity, RandomState::default())
+    }
+}
+
+/// A hasher builder that will create a fixed hasher.
+#[derive(Debug, Clone, Default)]
+pub struct FixedState;
+
+impl std::hash::BuildHasher for FixedState {
+    type Hasher = AHasher;
+
+    #[inline]
+    fn build_hasher(&self) -> AHasher {
+        AHasher::new_with_keys(
+            0b1001010111101110000001001100010000000011001001101011001001111000,
+            0b1100111101101011011110001011010100000100001111100011010011010101,
+        )
     }
 }

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -5,13 +5,6 @@ mod system;
 mod window;
 mod windows;
 
-pub use crate::raw_window_handle::*;
-pub use cursor::*;
-pub use event::*;
-pub use system::*;
-pub use window::*;
-pub use windows::*;
-
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
@@ -19,6 +12,13 @@ pub mod prelude {
         Window, WindowDescriptor, WindowMoved, Windows,
     };
 }
+
+pub use crate::raw_window_handle::*;
+pub use cursor::*;
+pub use event::*;
+pub use system::*;
+pub use window::*;
+pub use windows::*;
 
 use bevy_app::{prelude::*, Events};
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -2,16 +2,16 @@ mod converters;
 mod winit_config;
 mod winit_windows;
 
-use bevy_input::{
-    keyboard::KeyboardInput,
-    mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
-    touch::TouchInput,
-};
 pub use winit_config::*;
 pub use winit_windows::*;
 
 use bevy_app::{App, AppExit, CoreStage, Events, ManualEventReader, Plugin};
 use bevy_ecs::{system::IntoExclusiveSystem, world::World};
+use bevy_input::{
+    keyboard::KeyboardInput,
+    mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
+    touch::TouchInput,
+};
 use bevy_math::{ivec2, DVec2, Vec2};
 use bevy_utils::tracing::{error, trace, warn};
 use bevy_window::{
@@ -19,13 +19,12 @@ use bevy_window::{
     WindowBackendScaleFactorChanged, WindowCloseRequested, WindowCreated, WindowFocused,
     WindowMoved, WindowResized, WindowScaleFactorChanged, Windows,
 };
+use winit::dpi::LogicalSize;
 use winit::{
     dpi::PhysicalPosition,
     event::{self, DeviceEvent, Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
 };
-
-use winit::dpi::LogicalSize;
 
 #[derive(Default)]
 pub struct WinitPlugin;


### PR DESCRIPTION
# Structure

I updated the order/structure of the `lib.rs` files of every `bevy` crate using the following order. I'd like to discuss if the order is fine with everyone or if there are some things that should be changed/reordered. Ideally I would want to note the elaborated order somewhere. Might be reasonable to add it to the [engine style guide](https://github.com/bevyengine/bevy/blob/main/.github/contributing/engine_style_guide.md).

# Order

1. crate comment `//!`
1. lints
1. `extern crate`
1. `pub mod`s
1. `mod`s
1. `pub mod prelude`
1. `pub use`s
1. `use`s
1. `const`s
1. `pub type`s
1. `type`s
1. `pub trait`s
1. `pub struct XyzPlugin`
1. `impl Plugin for x`
1. `struct`s, `enum`s and so on
1. `mod tests`

# Emptying the `lib.rs` files

I will open a tracking issue for the `lib.rs` files after this PR has been merged, because they are really messy in some crates. I would prefer having pretty much nothing inside of them to make them cleaner, more predictable and unified. So ideally we would have the following things inside of the `lib.rs` files:

1. crate comment `//!`
1. lints
1. `extern crate`
1. `pub mod`s
1. `mod`s
1. `pub mod prelude`
1. `pub use`s
1. `use`s

This would also eliminate a lot of the types mentioned above making the process of structuring the `lib.rs` files way easier.