### PR TITLE
Support non srgb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,9 @@ tga = ["bevy_internal/tga"]
 jpeg = ["bevy_internal/jpeg"]
 bmp = ["bevy_internal/bmp"]
 
+# Disable sRGB (needed for certain physical devices)
+no_srgb = ["bevy_internal/no_srgb"]
+
 # Audio format support (MP3 is enabled by default)
 flac = ["bevy_internal/flac"]
 mp3 = ["bevy_internal/mp3"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -24,7 +24,7 @@ jpeg = ["bevy_render/jpeg"]
 bmp = ["bevy_render/bmp"]
 
 # Disable sRGB (needed for certain physical devices)
-no_srgb = ["bevy_render/no_srgb", "bevy_pbr/no_srgb"]
+no_srgb = ["bevy_render/no_srgb", "bevy_pbr/no_srgb", "bevy_sprite/no_srgb"]
 
 # Audio format support (MP3 is enabled by default)
 flac = ["bevy_audio/flac"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -23,6 +23,9 @@ tga = ["bevy_render/tga"]
 jpeg = ["bevy_render/jpeg"]
 bmp = ["bevy_render/bmp"]
 
+# Disable sRGB (needed for certain physical devices)
+no_srgb = ["bevy_render/no_srgb"]
+
 # Audio format support (MP3 is enabled by default)
 flac = ["bevy_audio/flac"]
 mp3 = ["bevy_audio/mp3"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -24,7 +24,7 @@ jpeg = ["bevy_render/jpeg"]
 bmp = ["bevy_render/bmp"]
 
 # Disable sRGB (needed for certain physical devices)
-no_srgb = ["bevy_render/no_srgb"]
+no_srgb = ["bevy_render/no_srgb", "bevy_pbr/no_srgb"]
 
 # Audio format support (MP3 is enabled by default)
 flac = ["bevy_audio/flac"]

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["bevy"]
 
 [features]
 webgl = []
+no_srgb = []
 
 [dependencies]
 # bevy

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -63,7 +63,7 @@ impl Plugin for PbrPlugin {
             #[cfg(not(feature = "no_srgb"))]
             Shader::from_wgsl(include_str!("render/pbr.wgsl")),
             #[cfg(feature = "no_srgb")]
-            Shader::from_wgsl("#define ENABLE_GAMMA_CORRECTION\n".to_owned() + include_str!("render/pbr.wgsl")),
+            Shader::from_wgsl("#define ENABLE_GAMMA_CORRECTION;\n".to_owned() + include_str!("render/pbr.wgsl")),
         );
         shaders.set_untracked(
             SHADOW_SHADER_HANDLE,

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -60,9 +60,9 @@ impl Plugin for PbrPlugin {
         let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
         shaders.set_untracked(
             PBR_SHADER_HANDLE,
-            //#[cfg(not(feature = "no_srgb"))]
-            //Shader::from_wgsl(include_str!("render/pbr.wgsl")),
-            //#[cfg(feature = "no_srgb")]
+            #[cfg(not(feature = "no_srgb"))]
+            Shader::from_wgsl(include_str!("render/pbr.wgsl")),
+            #[cfg(feature = "no_srgb")]
             Shader::from_wgsl("#define ENABLE_GAMMA_CORRECTION\n".to_owned() + include_str!("render/pbr.wgsl")),
         );
         shaders.set_untracked(

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -60,10 +60,10 @@ impl Plugin for PbrPlugin {
         let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
         shaders.set_untracked(
             PBR_SHADER_HANDLE,
-            //#[cfg(not(feature = "no_srgb"))]
-            //Shader::from_wgsl(include_str!("render/pbr.wgsl")),
-            //#[cfg(feature = "no_srgb")]
+            #[cfg(not(feature = "no_srgb"))]
             Shader::from_wgsl(include_str!("render/pbr.wgsl")),
+            #[cfg(feature = "no_srgb")]
+            Shader::from_wgsl("#define ENABLE_GAMMA_CORRECTION\n".to_owned() + include_str!("render/pbr.wgsl")),
         );
         shaders.set_untracked(
             SHADOW_SHADER_HANDLE,

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -60,10 +60,10 @@ impl Plugin for PbrPlugin {
         let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
         shaders.set_untracked(
             PBR_SHADER_HANDLE,
-            #[cfg(not(feature = "no_srgb"))]
+            //#[cfg(not(feature = "no_srgb"))]
+            //Shader::from_wgsl(include_str!("render/pbr.wgsl")),
+            //#[cfg(feature = "no_srgb")]
             Shader::from_wgsl(include_str!("render/pbr.wgsl")),
-            #[cfg(feature = "no_srgb")]
-            Shader::from_wgsl("#define ENABLE_GAMMA_CORRECTION\n".to_owned() + include_str!("render/pbr.wgsl")),
         );
         shaders.set_untracked(
             SHADOW_SHADER_HANDLE,

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -60,7 +60,10 @@ impl Plugin for PbrPlugin {
         let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
         shaders.set_untracked(
             PBR_SHADER_HANDLE,
-            Shader::from_wgsl(include_str!("render/pbr.wgsl")),
+            //#[cfg(not(feature = "no_srgb"))]
+            //Shader::from_wgsl(include_str!("render/pbr.wgsl")),
+            //#[cfg(feature = "no_srgb")]
+            Shader::from_wgsl("#define ENABLE_GAMMA_CORRECTION\n".to_owned() + include_str!("render/pbr.wgsl")),
         );
         shaders.set_untracked(
             SHADOW_SHADER_HANDLE,

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -61,9 +61,9 @@ impl Plugin for PbrPlugin {
         shaders.set_untracked(
             PBR_SHADER_HANDLE,
             #[cfg(not(feature = "no_srgb"))]
-            Shader::from_wgsl("let ENABLE_GAMMA_CORRECTION: u32 = 0u;\n".to_owned() + include_str!("render/pbr.wgsl")),
+            Shader::from_wgsl("let ENABLE_GAMMA_CORRECTION: bool = false;\n".to_owned() + include_str!("render/pbr.wgsl")),
             #[cfg(feature = "no_srgb")]
-            Shader::from_wgsl("let ENABLE_GAMMA_CORRECTION: u32 = 1u;\n".to_owned() + include_str!("render/pbr.wgsl")),
+            Shader::from_wgsl("let ENABLE_GAMMA_CORRECTION: bool = true;\n".to_owned() + include_str!("render/pbr.wgsl")),
         );
         shaders.set_untracked(
             SHADOW_SHADER_HANDLE,

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -61,9 +61,9 @@ impl Plugin for PbrPlugin {
         shaders.set_untracked(
             PBR_SHADER_HANDLE,
             #[cfg(not(feature = "no_srgb"))]
-            Shader::from_wgsl(include_str!("render/pbr.wgsl")),
+            Shader::from_wgsl("let ENABLE_GAMMA_CORRECTION: u32 = 0u;\n".to_owned() + include_str!("render/pbr.wgsl")),
             #[cfg(feature = "no_srgb")]
-            Shader::from_wgsl("#define ENABLE_GAMMA_CORRECTION;\n".to_owned() + include_str!("render/pbr.wgsl")),
+            Shader::from_wgsl("let ENABLE_GAMMA_CORRECTION: u32 = 1u;\n".to_owned() + include_str!("render/pbr.wgsl")),
         );
         shaders.set_untracked(
             SHADOW_SHADER_HANDLE,

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -638,7 +638,7 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
         output_color = vec4<f32>(reinhard_luminance(output_color.rgb), output_color.a);
         // Gamma correction.
         // Not needed with sRGB buffer, but needed if sRGB is disabled
-        if (ENABLE_GAMMA_CORRECTION == 1u) {
+        if (ENABLE_GAMMA_CORRECTION) {
             output_color.rgb = pow(output_color.rgb, vec3(1.0 / 2.2));
         }
     }

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -638,9 +638,9 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
         output_color = vec4<f32>(reinhard_luminance(output_color.rgb), output_color.a);
         // Gamma correction.
         // Not needed with sRGB buffer, but needed if sRGB is disabled
-#ifdef ENABLE_GAMMA_CORRECTION
-        output_color.rgb = pow(output_color.rgb, vec3(1.0 / 2.2));
-#endif // ENABLE_GAMMA_CORRECTION
+        if (ENABLE_GAMMA_CORRECTION == 1u) {
+            output_color.rgb = pow(output_color.rgb, vec3(1.0 / 2.2));
+        }
     }
 
     return output_color;

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -639,7 +639,7 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
         // Gamma correction.
         // Not needed with sRGB buffer, but needed if sRGB is disabled
         if (ENABLE_GAMMA_CORRECTION) {
-            output_color.rgb = pow(output_color.rgb, vec3(1.0 / 2.2));
+            *output_color.rgb = pow(output_color.rgb, vec3(1.0 / 2.2));
         }
     }
 

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -639,7 +639,7 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
         // Gamma correction.
         // Not needed with sRGB buffer, but needed if sRGB is disabled
         if (ENABLE_GAMMA_CORRECTION) {
-            return vec4<f32>(pow(output_color.rgb, vec3<f32>(1.0 / 2.2)), output_color.a);
+            output_color = vec4<f32>(pow(output_color.rgb, vec3<f32>(1.0 / 2.2)), output_color.a);
         }
     }
 

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -639,7 +639,7 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
         // Gamma correction.
         // Not needed with sRGB buffer, but needed if sRGB is disabled
         if (ENABLE_GAMMA_CORRECTION) {
-            return pow(output_color.rgb, vec3<f32>(1.0 / 2.2));
+            return vec4<f32>(pow(output_color.rgb, vec3<f32>(1.0 / 2.2)), output_color.a);
         }
     }
 

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -637,8 +637,10 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
         // tone_mapping
         output_color = vec4<f32>(reinhard_luminance(output_color.rgb), output_color.a);
         // Gamma correction.
-        // Not needed with sRGB buffer
-        // output_color.rgb = pow(output_color.rgb, vec3(1.0 / 2.2));
+        // Not needed with sRGB buffer, but needed if sRGB is disabled
+#ifdef ENABLE_GAMMA_CORRECTION
+        output_color.rgb = pow(output_color.rgb, vec3(1.0 / 2.2));
+#endif // ENABLE_GAMMA_CORRECTION
     }
 
     return output_color;

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -639,7 +639,7 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
         // Gamma correction.
         // Not needed with sRGB buffer, but needed if sRGB is disabled
         if (ENABLE_GAMMA_CORRECTION) {
-            *output_color.rgb = pow(output_color.rgb, vec3(1.0 / 2.2));
+            return pow(output_color.rgb, vec3(1.0 / 2.2));
         }
     }
 

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -639,7 +639,7 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
         // Gamma correction.
         // Not needed with sRGB buffer, but needed if sRGB is disabled
         if (ENABLE_GAMMA_CORRECTION) {
-            return pow(output_color.rgb, vec3(1.0 / 2.2));
+            return pow(output_color.rgb, vec3<f32>(1.0 / 2.2));
         }
     }
 

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -1,3 +1,4 @@
+#define ENABLE_GAMMA_CORRECTION
 // From the Filament design doc
 // https://google.github.io/filament/Filament.html#table_symbols
 // Symbol Definition

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -1,4 +1,3 @@
-//#define ENABLE_GAMMA_CORRECTION
 // From the Filament design doc
 // https://google.github.io/filament/Filament.html#table_symbols
 // Symbol Definition
@@ -639,9 +638,9 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
         output_color = vec4<f32>(reinhard_luminance(output_color.rgb), output_color.a);
         // Gamma correction.
         // Not needed with sRGB buffer, but needed if sRGB is disabled
-//#ifdef ENABLE_GAMMA_CORRECTION
+#ifdef ENABLE_GAMMA_CORRECTION
         output_color.rgb = pow(output_color.rgb, vec3(1.0 / 2.2));
-//#endif // ENABLE_GAMMA_CORRECTION
+#endif // ENABLE_GAMMA_CORRECTION
     }
 
     return output_color;

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -1,4 +1,4 @@
-#define ENABLE_GAMMA_CORRECTION
+//#define ENABLE_GAMMA_CORRECTION
 // From the Filament design doc
 // https://google.github.io/filament/Filament.html#table_symbols
 // Symbol Definition
@@ -639,9 +639,9 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
         output_color = vec4<f32>(reinhard_luminance(output_color.rgb), output_color.a);
         // Gamma correction.
         // Not needed with sRGB buffer, but needed if sRGB is disabled
-#ifdef ENABLE_GAMMA_CORRECTION
+//#ifdef ENABLE_GAMMA_CORRECTION
         output_color.rgb = pow(output_color.rgb, vec3(1.0 / 2.2));
-#endif // ENABLE_GAMMA_CORRECTION
+//#endif // ENABLE_GAMMA_CORRECTION
     }
 
     return output_color;

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -19,6 +19,7 @@ trace = []
 wgpu_trace = ["wgpu/trace"]
 ci_limits = []
 webgl = ["wgpu/webgl"]
+no_srgb = []
 
 [dependencies]
 # bevy

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -59,6 +59,7 @@ pub trait BevyDefault {
     fn bevy_default() -> Self;
 }
 
+#[cfg(not(feature = "no_srgb"))]
 impl BevyDefault for wgpu::TextureFormat {
     fn bevy_default() -> Self {
         if cfg!(target_os = "android") || cfg!(target_arch = "wasm32") {
@@ -66,6 +67,18 @@ impl BevyDefault for wgpu::TextureFormat {
             wgpu::TextureFormat::Rgba8UnormSrgb
         } else {
             wgpu::TextureFormat::Bgra8UnormSrgb
+        }
+    }
+}
+
+#[cfg(feature = "no_srgb")]
+impl BevyDefault for wgpu::TextureFormat {
+    fn bevy_default() -> Self {
+        if cfg!(target_os = "android") || cfg!(target_arch = "wasm32") {
+            // Bgra8UnormSrgb texture missing on some Android devices
+            wgpu::TextureFormat::Rgba8Unorm
+        } else {
+            wgpu::TextureFormat::Bgra8Unorm
         }
     }
 }

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -32,3 +32,6 @@ rectangle-pack = "0.4"
 serde = { version = "1", features = ["derive"] }
 bitflags = "1.2"
 copyless = "0.1.5"
+
+[features]
+no_srgb = []

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -54,9 +54,9 @@ impl Plugin for SpritePlugin {
     fn build(&self, app: &mut App) {
         let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
         #[cfg(not(feature = "no_srgb"))]
-        let sprite_shader = Shader::from_wgsl("let ENABLE_GAMMA_CORRECTION: u32 = 0u;\n".to_owned() + include_str!("render/sprite.wgsl"));
+        let sprite_shader = Shader::from_wgsl("let ENABLE_GAMMA_CORRECTION: bool = false;\n".to_owned() + include_str!("render/sprite.wgsl"));
         #[cfg(feature = "no_srgb")]
-        let sprite_shader = Shader::from_wgsl("let ENABLE_GAMMA_CORRECTION: u32 = 1u;\n".to_owned() + include_str!("render/sprite.wgsl"));
+        let sprite_shader = Shader::from_wgsl("let ENABLE_GAMMA_CORRECTION: bool = true;\n".to_owned() + include_str!("render/sprite.wgsl"));
         shaders.set_untracked(SPRITE_SHADER_HANDLE, sprite_shader);
         app.add_asset::<TextureAtlas>()
             .register_type::<Sprite>()

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -53,7 +53,10 @@ pub enum SpriteSystem {
 impl Plugin for SpritePlugin {
     fn build(&self, app: &mut App) {
         let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
+        #[cfg(not(feature = "no_srgb"))]
         let sprite_shader = Shader::from_wgsl(include_str!("render/sprite.wgsl"));
+        #[cfg(feature = "no_srgb")]
+        let sprite_shader = Shader::from_wgsl("#define ENABLE_GAMMA_CORRECTION\n".to_owned() + include_str!("render/sprite.wgsl"));
         shaders.set_untracked(SPRITE_SHADER_HANDLE, sprite_shader);
         app.add_asset::<TextureAtlas>()
             .register_type::<Sprite>()

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -56,7 +56,7 @@ impl Plugin for SpritePlugin {
         #[cfg(not(feature = "no_srgb"))]
         let sprite_shader = Shader::from_wgsl(include_str!("render/sprite.wgsl"));
         #[cfg(feature = "no_srgb")]
-        let sprite_shader = Shader::from_wgsl("#define ENABLE_GAMMA_CORRECTION\n".to_owned() + include_str!("render/sprite.wgsl"));
+        let sprite_shader = Shader::from_wgsl("#define ENABLE_GAMMA_CORRECTION;\n".to_owned() + include_str!("render/sprite.wgsl"));
         shaders.set_untracked(SPRITE_SHADER_HANDLE, sprite_shader);
         app.add_asset::<TextureAtlas>()
             .register_type::<Sprite>()

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -54,9 +54,9 @@ impl Plugin for SpritePlugin {
     fn build(&self, app: &mut App) {
         let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
         #[cfg(not(feature = "no_srgb"))]
-        let sprite_shader = Shader::from_wgsl(include_str!("render/sprite.wgsl"));
+        let sprite_shader = Shader::from_wgsl("let ENABLE_GAMMA_CORRECTION: u32 = 0u;\n".to_owned() + include_str!("render/sprite.wgsl"));
         #[cfg(feature = "no_srgb")]
-        let sprite_shader = Shader::from_wgsl("#define ENABLE_GAMMA_CORRECTION;\n".to_owned() + include_str!("render/sprite.wgsl"));
+        let sprite_shader = Shader::from_wgsl("let ENABLE_GAMMA_CORRECTION: u32 = 1u;\n".to_owned() + include_str!("render/sprite.wgsl"));
         shaders.set_untracked(SPRITE_SHADER_HANDLE, sprite_shader);
         app.add_asset::<TextureAtlas>()
             .register_type::<Sprite>()

--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -42,7 +42,7 @@ fn fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     color = in.color * color;
 #endif
     if (ENABLE_GAMMA_CORRECTION) {
-        return vec4<f32>(pow(output_color.rgb, vec3<f32>(1.0 / 2.2)), output_color.a);
+        color = vec4<f32>(pow(output_color.rgb, vec3<f32>(1.0 / 2.2)), color.a);
     }
     return color;
 }

--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -42,7 +42,7 @@ fn fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     color = in.color * color;
 #endif
     if (ENABLE_GAMMA_CORRECTION) {
-        color = vec4<f32>(pow(output_color.rgb, vec3<f32>(1.0 / 2.2)), color.a);
+        color = vec4<f32>(pow(color.rgb, vec3<f32>(1.0 / 2.2)), color.a);
     }
     return color;
 }

--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -41,8 +41,8 @@ fn fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
 #ifdef COLORED
     color = in.color * color;
 #endif
-#ifdef ENABLE_GAMMA_CORRECTION
+    if (ENABLE_GAMMA_CORRECTION == 1u) {
     color.rgb = pow(color.rgb, vec3(1.0 / 2.2));
-#endif
+    }
     return color;
 }

--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -41,5 +41,8 @@ fn fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
 #ifdef COLORED
     color = in.color * color;
 #endif
+#ifdef ENABLE_GAMMA_CORRECTION
+    color.rgb = pow(color.rgb, vec3(1.0 / 2.2));
+#endif
     return color;
 }

--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -42,7 +42,7 @@ fn fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     color = in.color * color;
 #endif
     if (ENABLE_GAMMA_CORRECTION) {
-        color.rgb = pow(color.rgb, vec3(1.0 / 2.2));
+        *color.rgb = pow(color.rgb, vec3(1.0 / 2.2));
     }
     return color;
 }

--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -42,7 +42,7 @@ fn fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     color = in.color * color;
 #endif
     if (ENABLE_GAMMA_CORRECTION) {
-        return pow(color.rgb, vec3<f32>(1.0 / 2.2));
+        return vec4<f32>(pow(output_color.rgb, vec3<f32>(1.0 / 2.2)), output_color.a);
     }
     return color;
 }

--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -42,7 +42,7 @@ fn fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     color = in.color * color;
 #endif
     if (ENABLE_GAMMA_CORRECTION) {
-        return pow(color.rgb, vec3(1.0 / 2.2));
+        return pow(color.rgb, vec3<f32>(1.0 / 2.2));
     }
     return color;
 }

--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -42,7 +42,7 @@ fn fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     color = in.color * color;
 #endif
     if (ENABLE_GAMMA_CORRECTION) {
-        *color.rgb = pow(color.rgb, vec3(1.0 / 2.2));
+        return pow(color.rgb, vec3(1.0 / 2.2));
     }
     return color;
 }

--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -41,8 +41,8 @@ fn fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
 #ifdef COLORED
     color = in.color * color;
 #endif
-    if (ENABLE_GAMMA_CORRECTION == 1u) {
-    color.rgb = pow(color.rgb, vec3(1.0 / 2.2));
+    if (ENABLE_GAMMA_CORRECTION) {
+        color.rgb = pow(color.rgb, vec3(1.0 / 2.2));
     }
     return color;
 }


### PR DESCRIPTION
# Objective

Enables a workaround for #3897 by setting a `no_srgb` feature. Should allow native Wayland support on systems that may not support sRGB directly e.g. (some video cards) Nvidia on Wayland presently.

## Solution

Gamma correction is enabled conditionally based on whether the feature is enabled.