### PR TITLE
[Merged by Bors] - Fix hardcoded texture bind group index in bevy_ui

### DIFF
--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -174,7 +174,7 @@ impl<const I: usize> EntityRenderCommand for SetUiTextureBindGroup<I> {
         let batch = query_batch.get(item).unwrap();
         let image_bind_groups = image_bind_groups.into_inner();
 
-        pass.set_bind_group(1, image_bind_groups.values.get(&batch.image).unwrap(), &[]);
+        pass.set_bind_group(I, image_bind_groups.values.get(&batch.image).unwrap(), &[]);
         RenderCommandResult::Success
     }
 }


### PR DESCRIPTION
# Objective

While looking at #3896, I noticed the same error in the equivalent location in `bevy_ui`.

## Solution

Fix it in the same way.
