### PR TITLE
bevy_render: Support overriding wgpu features and limits

### DIFF
--- a/crates/bevy_render/src/options.rs
+++ b/crates/bevy_render/src/options.rs
@@ -15,8 +15,16 @@ pub struct WgpuOptions {
     pub backends: Option<Backends>,
     pub power_preference: PowerPreference,
     pub priority: WgpuOptionsPriority,
+    /// The enabled features. Setting features will require them to be enabled when initializing
+    /// the renderer.
     pub features: WgpuFeatures,
+    /// The features to ensure are disabled regardless of what the adapter/backend supports
+    pub disabled_features: Option<WgpuFeatures>,
+    /// The imposed limits. Updated based on adapter/backend limits when initializing the renderer
+    /// if using WgpuOptionsPriority::Functionality
     pub limits: WgpuLimits,
+    /// The constraints on limits allowed regardless of what the adapter/backend supports
+    pub constrained_limits: Option<WgpuLimits>,
 }
 
 impl Default for WgpuOptions {
@@ -50,7 +58,9 @@ impl Default for WgpuOptions {
             power_preference: PowerPreference::HighPerformance,
             priority,
             features: wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
+            disabled_features: None,
             limits,
+            constrained_limits: None,
         }
     }
 }


### PR DESCRIPTION
# Objective

- Support overriding wgpu features and limits that were calculated from default values or queried from the adapter/backend.
- Fixes #3686

## Solution

- Add `disabled_features: Option<wgpu::Features>` to `WgpuOptions`
- Add `constrained_limits: Option<wgpu::Limits>` to `WgpuOptions`
- After maybe obtaining updated features and limits from the adapter/backend in the case of `WgpuOptionsPriority::Functionality`, enable the `WgpuOptions` `features`, disable the `disabled_features`, and constrain the `limits` by `constrained_limits`.
  - Note that constraining the limits means for `wgpu::Limits` members named `max_.*` we take the minimum of that which was configured/queried for the backend/adapter and the specified constrained limit value. This means the configured/queried value is used if the constrained limit is larger as that is as much as the device/API supports, or the constrained limit value is used if it is smaller as we are imposing an artificial constraint. For members named `min_.*` we take the maximum instead. For example, a minimum stride might be 256 but we set constrained limit value of 1024, then 1024 is the more conservative value. If the constrained limit value were 16, then 256 would be the more conservative.