### PR TITLE
[Merged by Bors] - Make `RunOnce` a non-manual `System` impl

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -4,8 +4,8 @@ use bevy_ecs::{
     event::Events,
     prelude::{FromWorld, IntoExclusiveSystem},
     schedule::{
-        run_once_criteria, IntoSystemDescriptor, Schedule, Stage, StageLabel, State, StateData,
-        SystemSet, SystemStage,
+        IntoSystemDescriptor, Schedule, ShouldRun, Stage, StageLabel, State, StateData, SystemSet,
+        SystemStage,
     },
     system::Resource,
     world::World,
@@ -591,7 +591,7 @@ impl App {
             .add_stage(
                 StartupSchedule,
                 Schedule::default()
-                    .with_run_criteria(run_once_criteria())
+                    .with_run_criteria(ShouldRun::once)
                     .with_stage(StartupStage::PreStartup, SystemStage::parallel())
                     .with_stage(StartupStage::Startup, SystemStage::parallel())
                     .with_stage(StartupStage::PostStartup, SystemStage::parallel()),

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -4,8 +4,8 @@ use bevy_ecs::{
     event::Events,
     prelude::{FromWorld, IntoExclusiveSystem},
     schedule::{
-        IntoSystemDescriptor, RunOnce, Schedule, Stage, StageLabel, State, StateData, SystemSet,
-        SystemStage,
+        run_once_criteria, IntoSystemDescriptor, Schedule, Stage, StageLabel, State, StateData,
+        SystemSet, SystemStage,
     },
     system::Resource,
     world::World,
@@ -591,7 +591,7 @@ impl App {
             .add_stage(
                 StartupSchedule,
                 Schedule::default()
-                    .with_run_criteria(RunOnce::default())
+                    .with_run_criteria(run_once_criteria())
                     .with_stage(StartupStage::PreStartup, SystemStage::parallel())
                     .with_stage(StartupStage::Startup, SystemStage::parallel())
                     .with_stage(StartupStage::PostStartup, SystemStage::parallel()),

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -27,7 +27,7 @@ pub use system_set::*;
 
 use std::fmt::Debug;
 
-use crate::{system::System, world::World};
+use crate::{system::IntoSystem, world::World};
 use bevy_utils::HashMap;
 
 /// A container of [`Stage`]s set to be run in a linear order.
@@ -76,7 +76,7 @@ impl Schedule {
     }
 
     #[must_use]
-    pub fn with_run_criteria<S: System<In = (), Out = ShouldRun>>(mut self, system: S) -> Self {
+    pub fn with_run_criteria<S: IntoSystem<(), ShouldRun, P>, P>(mut self, system: S) -> Self {
         self.set_run_criteria(system);
         self
     }
@@ -92,11 +92,9 @@ impl Schedule {
         self
     }
 
-    pub fn set_run_criteria<S: System<In = (), Out = ShouldRun>>(
-        &mut self,
-        system: S,
-    ) -> &mut Self {
-        self.run_criteria.set(Box::new(system));
+    pub fn set_run_criteria<S: IntoSystem<(), ShouldRun, P>, P>(&mut self, system: S) -> &mut Self {
+        self.run_criteria
+            .set(Box::new(IntoSystem::into_system(system)));
         self
     }
 

--- a/crates/bevy_ecs/src/schedule/run_criteria.rs
+++ b/crates/bevy_ecs/src/schedule/run_criteria.rs
@@ -1,9 +1,6 @@
 use crate::{
-    archetype::ArchetypeComponentId,
-    component::ComponentId,
-    query::Access,
     schedule::{BoxedRunCriteriaLabel, GraphNode, RunCriteriaLabel},
-    system::{BoxedSystem, IntoSystem, System},
+    system::{BoxedSystem, IntoSystem},
     world::World,
 };
 use std::borrow::Cow;
@@ -325,47 +322,14 @@ impl RunCriteria {
     }
 }
 
-#[derive(Default)]
-pub struct RunOnce {
-    ran: bool,
-    archetype_component_access: Access<ArchetypeComponentId>,
-    component_access: Access<ComponentId>,
-}
-
-impl System for RunOnce {
-    type In = ();
-    type Out = ShouldRun;
-
-    fn name(&self) -> Cow<'static, str> {
-        Cow::Borrowed(std::any::type_name::<RunOnce>())
-    }
-
-    fn component_access(&self) -> &Access<ComponentId> {
-        &self.component_access
-    }
-
-    fn archetype_component_access(&self) -> &Access<ArchetypeComponentId> {
-        &self.archetype_component_access
-    }
-
-    fn is_send(&self) -> bool {
-        true
-    }
-
-    unsafe fn run_unsafe(&mut self, _input: (), _world: &World) -> ShouldRun {
-        if self.ran {
+pub fn run_once_criteria() -> impl FnMut() -> ShouldRun {
+    let mut ran = false;
+    move || {
+        if ran {
             ShouldRun::No
         } else {
-            self.ran = true;
+            ran = true;
             ShouldRun::Yes
         }
     }
-
-    fn apply_buffers(&mut self, _world: &mut World) {}
-
-    fn initialize(&mut self, _world: &mut World) {}
-
-    fn update_archetype_component_access(&mut self, _world: &World) {}
-
-    fn check_change_tick(&mut self, _change_tick: u32) {}
 }

--- a/crates/bevy_ecs/src/schedule/run_criteria.rs
+++ b/crates/bevy_ecs/src/schedule/run_criteria.rs
@@ -1,6 +1,6 @@
 use crate::{
     schedule::{BoxedRunCriteriaLabel, GraphNode, RunCriteriaLabel},
-    system::{BoxedSystem, IntoSystem},
+    system::{BoxedSystem, IntoSystem, Local},
     world::World,
 };
 use std::borrow::Cow;
@@ -39,6 +39,17 @@ pub enum ShouldRun {
     /// criteria should be checked again. This will cause the stage to loop over the remaining
     /// systems and criteria this tick until they no longer need to be checked.
     NoAndCheckAgain,
+}
+
+impl ShouldRun {
+    pub fn once(mut ran: Local<bool>) -> ShouldRun {
+        if *ran {
+            ShouldRun::No
+        } else {
+            *ran = true;
+            ShouldRun::Yes
+        }
+    }
 }
 
 #[derive(Default)]
@@ -318,18 +329,6 @@ impl RunCriteria {
             duplicate_label_strategy: DuplicateLabelStrategy::Panic,
             before: vec![],
             after: vec![Box::new(label)],
-        }
-    }
-}
-
-pub fn run_once_criteria() -> impl FnMut() -> ShouldRun {
-    let mut ran = false;
-    move || {
-        if ran {
-            ShouldRun::No
-        } else {
-            ran = true;
-            ShouldRun::Yes
         }
     }
 }

--- a/crates/bevy_ecs/src/schedule/run_criteria.rs
+++ b/crates/bevy_ecs/src/schedule/run_criteria.rs
@@ -42,6 +42,10 @@ pub enum ShouldRun {
 }
 
 impl ShouldRun {
+    /// A run criterion which returns [`ShouldRun::Yes`] exactly once.
+    ///
+    /// This leads to the systems controlled by it only being
+    /// executed one time only.
     pub fn once(mut ran: Local<bool>) -> ShouldRun {
         if *ran {
             ShouldRun::No


### PR DESCRIPTION
# Objective

- `RunOnce` was a manual `System` implementation.
- Adding run criteria to stages was yet to be systemyoten

## Solution

- Make it a normal function
- yeet

##  Changelog

- Replaced `RunOnce` with `ShouldRun::once`

## Migration guide

The run criterion `RunOnce`, which would make the controlled systems run only once, has been replaced with a new run criterion function `ShouldRun::once`. Replace all instances of `RunOnce` with `ShouldRun::once`.