### PR TITLE
[Merged by Bors] - Some small changes related to run criteria piping

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -29,8 +29,8 @@ pub mod prelude {
         query::{Added, AnyOf, ChangeTrackers, Changed, Or, QueryState, With, Without},
         schedule::{
             AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,
-            RunCriteria, RunCriteriaDescriptorCoercion, RunCriteriaLabel, RunCriteriaPiping,
-            Schedule, Stage, StageLabel, State, SystemLabel, SystemSet, SystemStage,
+            RunCriteria, RunCriteriaDescriptorCoercion, RunCriteriaLabel, Schedule, Stage,
+            StageLabel, State, SystemLabel, SystemSet, SystemStage,
         },
         system::{
             Commands, ConfigurableSystem, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem,

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -950,7 +950,7 @@ mod tests {
             RunCriteria, RunCriteriaDescriptorCoercion, ShouldRun, SingleThreadedExecutor, Stage,
             SystemSet, SystemStage,
         },
-        system::{In, IntoExclusiveSystem, IntoSystem, Local, Query, ResMut},
+        system::{In, IntoExclusiveSystem, Local, Query, ResMut},
         world::World,
     };
 
@@ -1506,24 +1506,25 @@ mod tests {
                 ShouldRun::No
             }
         }
-        let mut stage = SystemStage::parallel()
-            .with_system(make_parallel(0).label("0"))
-            .with_system(
-                make_parallel(1)
-                    .label("1")
-                    .after("0")
-                    .with_run_criteria(every_other_time.label("every other time")),
-            )
-            .with_system(make_parallel(2).label("2").after("1").with_run_criteria(
-                RunCriteria::pipe("every other time", IntoSystem::into_system(eot_piped)),
-            ))
-            .with_system(
-                make_parallel(3).label("3").after("2").with_run_criteria(
-                    RunCriteria::pipe("every other time", IntoSystem::into_system(eot_piped))
-                        .label("piped"),
-                ),
-            )
-            .with_system(make_parallel(4).after("3").with_run_criteria("piped"));
+        let mut stage =
+            SystemStage::parallel()
+                .with_system(make_parallel(0).label("0"))
+                .with_system(
+                    make_parallel(1)
+                        .label("1")
+                        .after("0")
+                        .with_run_criteria(every_other_time.label("every other time")),
+                )
+                .with_system(
+                    make_parallel(2)
+                        .label("2")
+                        .after("1")
+                        .with_run_criteria(RunCriteria::pipe("every other time", eot_piped)),
+                )
+                .with_system(make_parallel(3).label("3").after("2").with_run_criteria(
+                    RunCriteria::pipe("every other time", eot_piped).label("piped"),
+                ))
+                .with_system(make_parallel(4).after("3").with_run_criteria("piped"));
         for _ in 0..4 {
             stage.run(&mut world);
         }

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -947,8 +947,8 @@ mod tests {
         query::{ChangeTrackers, Changed},
         schedule::{
             BoxedSystemLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,
-            RunCriteria, RunCriteriaDescriptorCoercion, RunCriteriaPiping, ShouldRun,
-            SingleThreadedExecutor, Stage, SystemSet, SystemStage,
+            RunCriteria, RunCriteriaDescriptorCoercion, ShouldRun, SingleThreadedExecutor, Stage,
+            SystemSet, SystemStage,
         },
         system::{In, IntoExclusiveSystem, IntoSystem, Local, Query, ResMut},
         world::World,
@@ -1519,8 +1519,7 @@ mod tests {
             ))
             .with_system(
                 make_parallel(3).label("3").after("2").with_run_criteria(
-                    "every other time"
-                        .pipe(IntoSystem::into_system(eot_piped))
+                    RunCriteria::pipe("every other time", IntoSystem::into_system(eot_piped))
                         .label("piped"),
                 ),
             )

--- a/crates/bevy_utils/src/label.rs
+++ b/crates/bevy_utils/src/label.rs
@@ -97,11 +97,5 @@ macro_rules! define_label {
                 Box::new(<&str>::clone(self))
             }
         }
-
-        impl $label_trait_name for Box<dyn $label_trait_name> {
-            fn dyn_clone(&self) -> Box<dyn $label_trait_name> {
-                (&*self).dyn_clone()
-            }
-        }
     };
 }

--- a/crates/bevy_utils/src/label.rs
+++ b/crates/bevy_utils/src/label.rs
@@ -97,5 +97,11 @@ macro_rules! define_label {
                 Box::new(<&str>::clone(self))
             }
         }
+
+        impl $label_trait_name for Box<dyn $label_trait_name> {
+            fn dyn_clone(&self) -> Box<dyn $label_trait_name> {
+                (&*self).dyn_clone()
+            }
+        }
     };
 }

--- a/examples/ecs/system_sets.rs
+++ b/examples/ecs/system_sets.rs
@@ -87,10 +87,7 @@ fn main() {
                 // Here we create a _not done_ criteria by piping the output of
                 // the `is_done` system and inverting the output.
                 // Notice a string literal also works as a label.
-                .with_run_criteria(RunCriteria::pipe(
-                    "is_done_label",
-                    IntoSystem::into_system(inverse),
-                ))
+                .with_run_criteria(RunCriteria::pipe("is_done_label", inverse))
                 // `collision` and `sfx` are not ordered with respect to
                 // each other, and may run in any order
                 .with_system(collision)


### PR DESCRIPTION
Remove the 'chaining' api, as it's peculiar

~~Implement the label traits for `Box<dyn ThatTrait>` (n.b. I'm not confident about this change, but it was the quickest path to not regressing)~~

Remove the need for '`.system`' when using run criteria piping