### PR TITLE
[Merged by Bors] - add informative panic message when adding render commands to a DrawFunctions that does not exist

### DIFF
--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -315,7 +315,16 @@ impl AddRenderCommand for App {
         <C::Param as SystemParam>::Fetch: ReadOnlySystemParamFetch,
     {
         let draw_function = RenderCommandState::<P, C>::new(&mut self.world);
-        let draw_functions = self.world.get_resource::<DrawFunctions<P>>().unwrap();
+        let draw_functions = self
+            .world
+            .get_resource::<DrawFunctions<P>>()
+            .unwrap_or_else(|| {
+                panic!(
+                    "DrawFunctions<{}> must be added to the world as a resource \
+                     before adding render commands to it",
+                    std::any::type_name::<P>(),
+                );
+            });
         draw_functions.write().add_with::<C, _>(draw_function);
         self
     }


### PR DESCRIPTION
# Objective

If a user attempts to `.add_render_command::<P, C>()` on a world that does not contain `DrawFunctions<P>`, the engine panics with a generic `Option::unwrap` message:

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /[redacted]/bevy/crates/bevy_render/src/render_phase/draw.rs:318:76
```

## Solution

This PR adds a panic message describing the problem:

```
thread 'main' panicked at 'DrawFunctions<outline::MeshStencil> must be added to the world as a resource before adding render commands to it', /[redacted]/bevy/crates/bevy_render/src/render_phase/draw.rs:322:17
```
