### PR TITLE
[Merged by Bors] - bevy_render: Add `attributes` and `attributes_mut` methods to `Mesh`.

### DIFF
--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -142,17 +142,19 @@ impl Mesh {
     }
 
     /// Returns an iterator that yields references to the data of each vertex attribute.
-    pub fn attributes(&self) -> impl Iterator<Item = (&str, &VertexAttributeValues)> {
-        self.attributes
-            .iter()
-            .map(|(name, values)| (name.as_ref(), values))
+    pub fn attributes(
+        &self,
+    ) -> impl Iterator<Item = (MeshVertexAttributeId, &VertexAttributeValues)> {
+        self.attributes.iter().map(|(id, data)| (*id, &data.values))
     }
 
     /// Returns an iterator that yields mutable references to the data of each vertex attribute.
-    pub fn attributes_mut(&mut self) -> impl Iterator<Item = (&str, &mut VertexAttributeValues)> {
+    pub fn attributes_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (MeshVertexAttributeId, &mut VertexAttributeValues)> {
         self.attributes
             .iter_mut()
-            .map(|(name, values)| (name.as_ref(), values))
+            .map(|(id, data)| (*id, &mut data.values))
     }
 
     /// Sets the vertex indices of the mesh. They describe how triangles are constructed out of the

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -142,16 +142,14 @@ impl Mesh {
     }
 
     /// Returns an iterator that yields references to the data of each vertex attribute.
-    pub fn attributes(&self) -> impl Iterator<Item = (&'_ str, &'_ VertexAttributeValues)> + '_ {
+    pub fn attributes(&self) -> impl Iterator<Item = (&str, &VertexAttributeValues)> {
         self.attributes
             .iter()
             .map(|(name, values)| (name.as_ref(), values))
     }
 
     /// Returns an iterator that yields mutable references to the data of each vertex attribute.
-    pub fn attributes_mut(
-        &mut self,
-    ) -> impl Iterator<Item = (&'_ str, &'_ mut VertexAttributeValues)> {
+    pub fn attributes_mut(&mut self) -> impl Iterator<Item = (&str, &mut VertexAttributeValues)> {
         self.attributes
             .iter_mut()
             .map(|(name, values)| (name.as_ref(), values))

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -141,6 +141,22 @@ impl Mesh {
             .map(|data| &mut data.values)
     }
 
+    /// Returns an iterator that yields references to the data of each vertex attribute.
+    pub fn attributes(&self) -> impl Iterator<Item = (&'_ str, &'_ VertexAttributeValues)> + '_ {
+        self.attributes
+            .iter()
+            .map(|(name, values)| (name.as_ref(), values))
+    }
+
+    /// Returns an iterator that yields mutable references to the data of each vertex attribute.
+    pub fn attributes_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (&'_ str, &'_ mut VertexAttributeValues)> {
+        self.attributes
+            .iter_mut()
+            .map(|(name, values)| (name.as_ref(), values))
+    }
+
     /// Sets the vertex indices of the mesh. They describe how triangles are constructed out of the
     /// vertex attributes and are therefore only useful for the [`PrimitiveTopology`] variants
     /// that use triangles.


### PR DESCRIPTION
# Use Case

Seems generally useful, but specifically motivated by my work on the [`bevy_datasize`](https://github.com/BGR360/bevy_datasize) crate.

For that project, I'm implementing "heap size estimators" for all of the Bevy internal types. To do this accurately for `Mesh`, I need to get the lengths of all of the mesh's attribute vectors.

Currently, in order to accomplish this, I am doing the following:

* Checking all of the attributes that are mentioned in the `Mesh` class ([see here](https://github.com/BGR360/bevy_datasize/blob/0531ec2d026085a31e937b12d5ecf4109005e737/src/builtins/render/mesh.rs#L46-L54))

* Providing the user with an option to configure additional attributes to check ([see here](https://github.com/BGR360/bevy_datasize/blob/0531ec2d026085a31e937b12d5ecf4109005e737/src/config.rs#L7-L21))

This is both overly complicated and a bit wasteful (since I have to check every attribute name that I know about in case there are attributes set for it).