### PR TITLE
change system name of `RunSystem` to system type name, not param type name

### DIFF
--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -182,6 +182,7 @@ pub trait RunSystem: Send + Sync + 'static {
     /// Creates a concrete instance of the system for the specified `World`.
     fn system(world: &mut World) -> ParamSystem<Self::Param> {
         ParamSystem {
+            name: std::any::type_name::<Self>(),
             run: Self::run,
             state: SystemState::new(world),
         }
@@ -189,6 +190,7 @@ pub trait RunSystem: Send + Sync + 'static {
 }
 
 pub struct ParamSystem<P: SystemParam> {
+    name: &'static str,
     state: SystemState<P>,
     run: fn(SystemParamItem<P>),
 }
@@ -199,7 +201,7 @@ impl<P: SystemParam + 'static> System for ParamSystem<P> {
     type Out = ();
 
     fn name(&self) -> Cow<'static, str> {
-        self.state.meta().name.clone()
+        Cow::Borrowed(self.name)
     }
 
     fn new_archetype(&mut self, archetype: &Archetype) {


### PR DESCRIPTION
Tools like [bevy_mod_debugdump](https://github.com/jakobhellermann/bevy_mod_debugdump/) use the system name to visualize the schedule.

Previously, the system name of `RunSystem`s would have the type name of their system param as their system name, so for example the `PrepareAssetSystem<StandardMaterial>` was called `(ResMut<ExtractedAssets<StandardMaterial>>, ResMut<HashMap<Handle<StandardMaterial>, GpuStandardMaterial, RandomState>>, ResMut<PrepareNextFrameAssets<StandardMaterial>>, (Res<RenderDevice>, Res<MaterialPipeline<StandardMaterial>>, Res<HashMap<Handle<Image>, GpuImage, RandomState>>))`.

This PR uses the name of the type implementing `RunSystem` as system name, so the new name is `PrepareAssetSystem<StandardMaterial>`.

<br>

Before:
![prepare schedule before](https://user-images.githubusercontent.com/22177966/153765923-c0265a2f-b2eb-4f03-9ae4-d5c03dcb4de8.png)
After:
![prepare schedule after](https://user-images.githubusercontent.com/22177966/153765941-5e44c150-7c9c-4a91-975a-42c76905e6d3.png)
