### PR TITLE
CloneWeak trait, and impl on tuples, Option and Vec of handles

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -438,6 +438,12 @@ impl CloneWeak for HandleUntyped {
     }
 }
 
+impl<H: CloneWeak> CloneWeak for Option<H> {
+    fn clone_weak(&self) -> Self {
+        self.as_ref().map(|h| h.clone_weak())
+    }
+}
+
 impl<H: CloneWeak> CloneWeak for Vec<H> {
     fn clone_weak(&self) -> Self {
         self.iter().map(|h| h.clone_weak()).collect()


### PR DESCRIPTION
# Objective

- Lately I'm weak cloning a lot of things, which can be a pain as the default `clone` impl on things will just clone

## Solution

- Add a new trait `CloneWeak` with just a `clone_weak` function
- Impl it for `Handle<T>` and `HandleUntyped`
- Impl it for `Option<H: CloneWeak>`, `Vec<H: CloneWeak>` and tuples
- if someone else find that interesting, I would love to have a derive macro `#[derive(CloneWeak)]` that would clone_weak things when possible, or simply clone otherwise (not completely sure it's possible without specialisation though...)
