### PR TITLE
2d frustum culling

### DIFF
--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -6,7 +6,7 @@ use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
 use bevy_render::{
     texture::{Image, DEFAULT_IMAGE_HANDLE},
-    view::Visibility,
+    view::{ComputedVisibility, Visibility},
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 
@@ -18,6 +18,8 @@ pub struct SpriteBundle {
     pub texture: Handle<Image>,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
+    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    pub computed_visibility: ComputedVisibility,
 }
 
 impl Default for SpriteBundle {
@@ -28,6 +30,7 @@ impl Default for SpriteBundle {
             global_transform: Default::default(),
             texture: DEFAULT_IMAGE_HANDLE.typed(),
             visibility: Default::default(),
+            computed_visibility: Default::default(),
         }
     }
 }

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -34,6 +34,7 @@ impl Default for SpriteBundle {
         }
     }
 }
+
 /// A Bundle of components for drawing a single sprite from a sprite sheet (also referred
 /// to as a `TextureAtlas`)
 #[derive(Bundle, Clone, Default)]
@@ -47,4 +48,6 @@ pub struct SpriteSheetBundle {
     pub global_transform: GlobalTransform,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
+    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    pub computed_visibility: ComputedVisibility,
 }

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -36,6 +36,7 @@ use bevy_reflect::TypeUuid;
 use bevy_render::{
     render_phase::AddRenderCommand,
     render_resource::{Shader, SpecializedPipelines},
+    view::VisibilitySystems,
     RenderApp, RenderStage,
 };
 
@@ -58,7 +59,11 @@ impl Plugin for SpritePlugin {
         app.add_asset::<TextureAtlas>()
             .register_type::<Sprite>()
             .add_plugin(Mesh2dRenderPlugin)
-            .add_plugin(ColorMaterialPlugin);
+            .add_plugin(ColorMaterialPlugin)
+            .add_system_to_stage(
+                CoreStage::PostUpdate,
+                render::calculate_bounds.label(VisibilitySystems::CalculateBounds),
+            );
 
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app


### PR DESCRIPTION
# Objective

Enable frustum culling for 2D, to be more precise, for `Mesh2d`, `Sprite` and `TextureAtlasSprite`.

## Solution

- `Mesh2d` is essentially only a regular `Mesh` with its handle wrapped by `Mesh2dHandle`, which enables it to be drawn by the 2d pipeline. As such it already has the `compute_aabb()` function, which i used for frustum culling the same way it is done for the regular `Mesh`.
- `Sprite` has an image/texture, which provides a size, or a user specified `custom_size`. I've added `ComputedVisibility` to the `SpriteBundle` and use the size to create an `Aabb` and insert it as a component. The visibility is computed by the already existing `check_visibility` system.
- For `TextureAtlasSprite` i use the user specified `custom_size`, or a size computed from the sprite's `Rect` as specified in the `TextureAtlas`. I've added `ComputedVisibility` to the `SpriteSheetBundle` too and the rest is the same as with what i have done for the `Sprite`.

### Benchmarks
**System:** Windows 10, AMD Ryzen 5 5600XT, AMD Radeon RX 570

|                 | Bevymark              | many_sprites       |
|-----------------|-----------------------|--------------------|
| without culling | ~32-33 fps / CPU  ~9% | ~52 fps / CPU ~19% |
| with culling    | ~32-33 fps / CPU ~10% | ~60 fps / CPU  ~6% |

#### Commands
`cargo run --release --example bevymark -- 13 10000`  
`cargo run --release --example many_sprites`
