### PR TITLE
[Merged by Bors] - Remind users to initialize their systems before running them

### DIFF
--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -378,7 +378,7 @@ where
         let change_tick = world.increment_change_tick();
         let out = self.func.run(
             input,
-            self.param_state.as_mut().unwrap(),
+            self.param_state.as_mut().expect("System's param_state was not found. Did you forget to initialize this system before running it?"),
             &self.system_meta,
             world,
             change_tick,
@@ -389,7 +389,7 @@ where
 
     #[inline]
     fn apply_buffers(&mut self, world: &mut World) {
-        let param_state = self.param_state.as_mut().unwrap();
+        let param_state = self.param_state.as_mut().expect("System's param_state was not found. Did you forget to initialize this system before running it?");
         param_state.apply(world);
     }
 

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -305,6 +305,8 @@ pub struct InputMarker;
 /// You get this by calling [`IntoSystem::into_system`]  on a function that only accepts
 /// [`SystemParam`]s. The output of the system becomes the functions return type, while the input
 /// becomes the functions [`In`] tagged parameter or `()` if no such parameter exists.
+///
+/// [`FunctionSystem`] must be `.initialized` before they can be run.
 pub struct FunctionSystem<In, Out, Param, Marker, F>
 where
     Param: SystemParam,


### PR DESCRIPTION
# Objective

- Manually running systems is a somewhat obscure process: systems must be initialized before they are run
- The unwrap is rather hard to debug.

## Solution

- Replace unwraps in `FunctionSystem` methods with expects (progress towards #3892).
- Briefly document this requirement.