### PR TITLE
[Merged by Bors] - Add FocusPolicy to NodeBundle and ImageBundle

### DIFF
--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -23,6 +23,8 @@ pub struct NodeBundle {
     pub color: UiColor,
     /// Describes the image of the node
     pub image: UiImage,
+    /// Whether this node should block interaction with lower nodes
+    pub focus_policy: FocusPolicy,
     /// The transform of the node
     pub transform: Transform,
     /// The global transform of the node
@@ -46,6 +48,8 @@ pub struct ImageBundle {
     pub color: UiColor,
     /// The image of the node
     pub image: UiImage,
+    /// Whether this node should block interaction with lower nodes
+    pub focus_policy: FocusPolicy,
     /// The transform of the node
     pub transform: Transform,
     /// The global transform of the node


### PR DESCRIPTION
# Objective
`FocusPolicy` allows tracking `Interaction` of a parent node when a player hovers/clicks at the child node, and I see no reason why it shouldn't exist in these 2 nodes.

Resolves #2488

## Solution
Add it!

In the tracking system it's used as `Option`: https://github.com/bevyengine/bevy/blob/e749ee786c3a3ca11718b08f0545aa90e4b5aae6/crates/bevy_ui/src/focus.rs#L71 and then it treats it as `Block` if it's not present: https://github.com/bevyengine/bevy/blob/e749ee786c3a3ca11718b08f0545aa90e4b5aae6/crates/bevy_ui/src/focus.rs#L162 and the default value is https://github.com/bevyengine/bevy/blob/e749ee786c3a3ca11718b08f0545aa90e4b5aae6/crates/bevy_ui/src/focus.rs#L47-L51 so it should be compatible with all existing UIs that use `..Default::default()`
