### PR TITLE
[Merged by Bors] - Make change lifespan deterministic and update docs

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -5,11 +5,19 @@ use crate::{component::ComponentTicks, system::Resource};
 use bevy_reflect::Reflect;
 use std::ops::{Deref, DerefMut};
 
-/// The minimum number of tick increments between consecutive `check_tick` scans.
-pub const CHANGE_DETECTION_CHECK_THRESHOLD: u32 = u32::MAX / 2048;
+/// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
+/// 
+/// Change ticks can only be scanned when systems aren't running. Thus, if the threshold is `N`, 
+/// the maximum is `2 * N - 1` (i.e. world ticks `N - 1` times, then `N` times).
+/// 
+/// If a change is older than `u32::MAX - (2 * N - 1)`, the difference that calculates its age
+/// might overflow and wraparound before the next scan, causing false positives.
+pub const CHECK_TICK_THRESHOLD: u32 = 10_000_000;
 
-/// The maximum change tick difference that we can guarantee won't overflow before the next scan.
-pub const CHANGE_DETECTION_MAX_DELTA: u32 = u32::MAX - (2 * CHANGE_DETECTION_CHECK_THRESHOLD - 1);
+/// The maximum change tick difference that won't overflow before the next `check_tick` scan.
+/// 
+/// Changes stop being detected once they become this old.
+pub const MAX_TICK_DELTA: u32 = u32::MAX - (2 * CHECK_TICK_THRESHOLD - 1);
 
 /// Types that implement reliable change detection.
 ///

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -5,6 +5,12 @@ use crate::{component::ComponentTicks, system::Resource};
 use bevy_reflect::Reflect;
 use std::ops::{Deref, DerefMut};
 
+/// The minimum number of tick increments between consecutive check tick scans. The maximum is twice this number.
+pub const CHANGE_DETECTION_CHECK_THRESHOLD: u32 = u32::MAX / 2048;
+
+/// The maximum change tick difference that won't overflow before the next check.
+pub const CHANGE_DETECTION_MAX_DELTA: u32 = u32::MAX - (2 * CHANGE_DETECTION_CHECK_THRESHOLD);
+
 /// Types that implement reliable change detection.
 ///
 /// ## Example

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -5,11 +5,11 @@ use crate::{component::ComponentTicks, system::Resource};
 use bevy_reflect::Reflect;
 use std::ops::{Deref, DerefMut};
 
-/// The minimum number of tick increments between consecutive check tick scans. The maximum is twice this number.
+/// The minimum number of tick increments between consecutive `check_tick` scans.
 pub const CHANGE_DETECTION_CHECK_THRESHOLD: u32 = u32::MAX / 2048;
 
-/// The maximum change tick difference that won't overflow before the next check.
-pub const CHANGE_DETECTION_MAX_DELTA: u32 = u32::MAX - (2 * CHANGE_DETECTION_CHECK_THRESHOLD);
+/// The maximum change tick difference that we can guarantee won't overflow before the next scan.
+pub const CHANGE_DETECTION_MAX_DELTA: u32 = u32::MAX - (2 * CHANGE_DETECTION_CHECK_THRESHOLD - 1);
 
 /// Types that implement reliable change detection.
 ///

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -12,7 +12,8 @@ use std::ops::{Deref, DerefMut};
 /// 
 /// If no change is older than `u32::MAX - (2 * N - 1)` following a scan, none of their ages can
 /// overflow and cause false positives.
-pub const CHECK_TICK_THRESHOLD: u32 = 10_000_000;
+// (518,400,000 = 1000 ticks per frame * 144 frames per second * 3600 seconds per hour)
+pub const CHECK_TICK_THRESHOLD: u32 = 518_400_000;
 
 /// The maximum change tick difference that won't overflow before the next `check_tick` scan.
 /// 

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -18,7 +18,7 @@ pub const CHECK_TICK_THRESHOLD: u32 = 518_400_000;
 /// The maximum change tick difference that won't overflow before the next `check_tick` scan.
 /// 
 /// Changes stop being detected once they become this old.
-pub const MAX_TICK_DELTA: u32 = u32::MAX - (2 * CHECK_TICK_THRESHOLD - 1);
+pub const MAX_CHANGE_AGE: u32 = u32::MAX - (2 * CHECK_TICK_THRESHOLD - 1);
 
 /// Types that implement reliable change detection.
 ///

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -8,10 +8,10 @@ use std::ops::{Deref, DerefMut};
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
 /// 
 /// Change ticks can only be scanned when systems aren't running. Thus, if the threshold is `N`, 
-/// the maximum is `2 * N - 1` (i.e. world ticks `N - 1` times, then `N` times).
+/// the maximum is `2 * N - 1` (i.e. the world ticks `N - 1` times, then `N` times).
 /// 
-/// If a change is older than `u32::MAX - (2 * N - 1)`, the difference that calculates its age
-/// might overflow and wraparound before the next scan, causing false positives.
+/// If no change is older than `u32::MAX - (2 * N - 1)` following a scan, none of their ages can
+/// overflow and cause false positives.
 pub const CHECK_TICK_THRESHOLD: u32 = 10_000_000;
 
 /// The maximum change tick difference that won't overflow before the next `check_tick` scan.

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -43,19 +43,18 @@ pub const MAX_CHANGE_AGE: u32 = u32::MAX - (2 * CHECK_TICK_THRESHOLD - 1);
 /// ```
 ///
 pub trait DetectChanges {
-    /// Returns true if (and only if) this value been added since the last execution of this
-    /// system.
+    /// Returns `true` if this value was added after the system last ran, `false` otherwise.
     fn is_added(&self) -> bool;
 
-    /// Returns true if (and only if) this value been changed since the last execution of this
-    /// system.
+    /// Returns `true` if this value was added or mutably dereferenced after the system last ran, `false` otherwise.
     fn is_changed(&self) -> bool;
 
-    /// Manually flags this value as having been changed. This normally isn't
-    /// required because accessing this pointer mutably automatically flags this
-    /// value as "changed".
+    /// Flags this value as having been changed.
+    /// 
+    /// Mutably accessing this smart pointer will automatically flag this value as having been changed.
+    /// However, mutation through interior mutability requires manual reporting.
     ///
-    /// **Note**: This operation is irreversible.
+    /// **Note**: This operation cannot be undone.
     fn set_changed(&mut self);
 
     /// Returns the change tick recording the previous time this component (or resource) was changed.

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -228,3 +228,105 @@ pub struct ReflectMut<'a> {
 change_detection_impl!(ReflectMut<'a>, dyn Reflect,);
 #[cfg(feature = "bevy_reflect")]
 impl_into_inner!(ReflectMut<'a>, dyn Reflect,);
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        self as bevy_ecs,
+        change_detection::{CHECK_TICK_THRESHOLD, MAX_CHANGE_AGE},
+        component::Component,
+        query::ChangeTrackers,
+        system::{IntoSystem, Query, System},
+        world::World,
+    };
+
+    #[derive(Component)]
+    struct C;
+
+    #[test]
+    fn change_expiration() {         
+        fn change_detected(query: Query<ChangeTrackers<C>>) -> bool {
+            query.single().is_changed()
+        }
+    
+        fn change_expired(query: Query<ChangeTrackers<C>>) -> bool {
+            query.single().is_changed()
+        }
+            
+        let mut world = World::new();
+
+        // component added: 1, changed: 1
+        world.spawn().insert(C);
+        
+        let mut change_detected_system = IntoSystem::into_system(change_detected);
+        let mut change_expired_system = IntoSystem::into_system(change_expired);
+        change_detected_system.initialize(&mut world);
+        change_expired_system.initialize(&mut world);
+    
+        // world: 1, system last ran: 0, component changed: 1
+        // The spawn will be detected since it happened after the system "last ran".
+        assert_eq!(change_detected_system.run((), &mut world), true);
+    
+        // world: 1 + MAX_CHANGE_AGE
+        let change_tick = world.change_tick.get_mut();
+        *change_tick = change_tick.wrapping_add(MAX_CHANGE_AGE);
+    
+        // Both the system and component appeared `MAX_CHANGE_AGE` ticks ago.
+        // Since we clamp things to `MAX_CHANGE_AGE` for determinism,
+        // `ComponentTicks::is_changed` will now see `MAX_CHANGE_AGE > MAX_CHANGE_AGE`
+        // and return `false`.
+        assert_eq!(change_expired_system.run((), &mut world), false);
+    }
+    
+    #[test]
+    fn change_tick_wraparound() {       
+        fn change_detected(query: Query<ChangeTrackers<C>>) -> bool {
+            query.single().is_changed()
+        }
+    
+        let mut world = World::new();
+        world.last_change_tick = u32::MAX;
+        *world.change_tick.get_mut() = 0;
+        
+        // component added: 0, changed: 0
+        world.spawn().insert(C);
+        
+        // system last ran: u32::MAX
+        let mut change_detected_system = IntoSystem::into_system(change_detected);
+        change_detected_system.initialize(&mut world);
+        
+        // Since the world is always ahead, as long as changes can't get older than `u32::MAX` (which we ensure),
+        // the wrapping difference will always be positive, so wraparound doesn't matter.
+        assert_eq!(change_detected_system.run((), &mut world), true);
+    }
+
+    #[test]
+    fn change_tick_scan() {
+        let mut world = World::new();
+
+        // component added: 0, changed: 0
+        world.spawn().insert(C);
+
+        // a bunch of stuff happens, the component is now older than `MAX_CHANGE_AGE`
+        *world.change_tick.get_mut() += MAX_CHANGE_AGE + CHECK_TICK_THRESHOLD;
+        let change_tick = world.change_tick();
+
+        let mut query = world.query::<ChangeTrackers<C>>();
+        for tracker in query.iter(&world) {
+            let ticks_since_insert = change_tick.wrapping_sub(tracker.component_ticks.added);
+            let ticks_since_change = change_tick.wrapping_sub(tracker.component_ticks.changed);
+            assert!(ticks_since_insert > MAX_CHANGE_AGE);
+            assert!(ticks_since_change > MAX_CHANGE_AGE);
+        }
+
+        // scan change ticks and clamp those at risk of overflow
+        world.check_change_ticks();
+
+        for tracker in query.iter(&world) {
+            let ticks_since_insert = change_tick.wrapping_sub(tracker.component_ticks.added);
+            let ticks_since_change = change_tick.wrapping_sub(tracker.component_ticks.changed);
+            assert!(ticks_since_insert == MAX_CHANGE_AGE);
+            assert!(ticks_since_change == MAX_CHANGE_AGE);
+        }
+    }
+}

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -304,7 +304,7 @@ mod tests {
     fn change_tick_scan() {
         let mut world = World::new();
 
-        // component added: 0, changed: 0
+        // component added: 1, changed: 1
         world.spawn().insert(C);
 
         // a bunch of stuff happens, the component is now older than `MAX_CHANGE_AGE`

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -265,7 +265,7 @@ mod tests {
 
         // world: 1, system last ran: 0, component changed: 1
         // The spawn will be detected since it happened after the system "last ran".
-        assert_eq!(change_detected_system.run((), &mut world), true);
+        assert!(change_detected_system.run((), &mut world));
 
         // world: 1 + MAX_CHANGE_AGE
         let change_tick = world.change_tick.get_mut();
@@ -275,7 +275,7 @@ mod tests {
         // Since we clamp things to `MAX_CHANGE_AGE` for determinism,
         // `ComponentTicks::is_changed` will now see `MAX_CHANGE_AGE > MAX_CHANGE_AGE`
         // and return `false`.
-        assert_eq!(change_expired_system.run((), &mut world), false);
+        assert!(!change_expired_system.run((), &mut world));
     }
 
     #[test]
@@ -297,7 +297,7 @@ mod tests {
 
         // Since the world is always ahead, as long as changes can't get older than `u32::MAX` (which we ensure),
         // the wrapping difference will always be positive, so wraparound doesn't matter.
-        assert_eq!(change_detected_system.run((), &mut world), true);
+        assert!(change_detected_system.run((), &mut world));
     }
 
     #[test]

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -50,7 +50,7 @@ pub trait DetectChanges {
     fn is_changed(&self) -> bool;
 
     /// Flags this value as having been changed.
-    /// 
+    ///
     /// Mutably accessing this smart pointer will automatically flag this value as having been changed.
     /// However, mutation through interior mutability requires manual reporting.
     ///

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -43,10 +43,10 @@ pub const MAX_CHANGE_AGE: u32 = u32::MAX - (2 * CHECK_TICK_THRESHOLD - 1);
 /// ```
 ///
 pub trait DetectChanges {
-    /// Returns `true` if this value was added after the system last ran, `false` otherwise.
+    /// Returns `true` if this value was added after the system last ran.
     fn is_added(&self) -> bool;
 
-    /// Returns `true` if this value was added or mutably dereferenced after the system last ran, `false` otherwise.
+    /// Returns `true` if this value was added or mutably dereferenced after the system last ran.
     fn is_changed(&self) -> bool;
 
     /// Flags this value as having been changed.

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -355,7 +355,7 @@ pub struct ComponentTicks {
 
 impl ComponentTicks {
     #[inline]
-    /// Returns `true` if the component was added after the system last ran, `false` otherwise.
+    /// Returns `true` if the component was added after the system last ran.
     pub fn is_added(&self, last_change_tick: u32, change_tick: u32) -> bool {
         // This works even with wraparound because the world tick (`change_tick`) is always "newer" than
         // `last_change_tick` and `self.added`, and we scan periodically to clamp `ComponentTicks` values
@@ -371,7 +371,7 @@ impl ComponentTicks {
     }
 
     #[inline]
-    /// Returns `true` if the component was added or mutably dereferenced after the system last ran, `false` otherwise.
+    /// Returns `true` if the component was added or mutably dereferenced after the system last ran.
     pub fn is_changed(&self, last_change_tick: u32, change_tick: u32) -> bool {
         // This works even with wraparound because the world tick (`change_tick`) is always "newer" than
         // `last_change_tick` and `self.changed`, and we scan periodically to clamp `ComponentTicks` values

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -413,7 +413,7 @@ impl ComponentTicks {
 fn check_tick(last_change_tick: &mut u32, change_tick: u32) {
     let delta = change_tick.wrapping_sub(*last_change_tick);
     // This comparison assumes that `delta` has not overflowed `u32::MAX` before, which will be true
-    // so long as this check runs always runs before that can happen.
+    // so long as this check always runs before that can happen.
     if delta > MAX_TICK_DELTA {
         *last_change_tick = change_tick.wrapping_sub(MAX_TICK_DELTA);
     }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -358,13 +358,11 @@ impl ComponentTicks {
     /// Returns `true` if the component was added after the system last ran, `false` otherwise.
     pub fn is_added(&self, last_change_tick: u32, change_tick: u32) -> bool {
         // This works even with wraparound because the world tick (`change_tick`) is always "newer" than
-        // `last_change_tick` and `self.added`, and we scan periodically to clamp `ComponentTicks` values 
+        // `last_change_tick` and `self.added`, and we scan periodically to clamp `ComponentTicks` values
         // so they never get older than `u32::MAX` (the difference would overflow).
-        // 
+        //
         // The clamp here ensures determinism (since scans could differ between app runs).
-        let ticks_since_insert = change_tick
-            .wrapping_sub(self.added)
-            .min(MAX_CHANGE_AGE);
+        let ticks_since_insert = change_tick.wrapping_sub(self.added).min(MAX_CHANGE_AGE);
         let ticks_since_system = change_tick
             .wrapping_sub(last_change_tick)
             .min(MAX_CHANGE_AGE);
@@ -376,13 +374,11 @@ impl ComponentTicks {
     /// Returns `true` if the component was added or mutably-dereferenced after the system last ran, `false` otherwise.
     pub fn is_changed(&self, last_change_tick: u32, change_tick: u32) -> bool {
         // This works even with wraparound because the world tick (`change_tick`) is always "newer" than
-        // `last_change_tick` and `self.changed`, and we scan periodically to clamp `ComponentTicks` values 
+        // `last_change_tick` and `self.changed`, and we scan periodically to clamp `ComponentTicks` values
         // so they never get older than `u32::MAX` (the difference would overflow).
-        // 
+        //
         // The clamp here ensures determinism (since scans could differ between app runs).
-        let ticks_since_change = change_tick
-            .wrapping_sub(self.changed)
-            .min(MAX_CHANGE_AGE);
+        let ticks_since_change = change_tick.wrapping_sub(self.changed).min(MAX_CHANGE_AGE);
         let ticks_since_system = change_tick
             .wrapping_sub(last_change_tick)
             .min(MAX_CHANGE_AGE);

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1,7 +1,7 @@
 //! Types for declaring and storing [`Component`]s.
 
 use crate::{
-    change_detection::CHANGE_DETECTION_MAX_DELTA,
+    change_detection::MAX_TICK_DELTA,
     storage::{SparseSetIndex, Storages},
     system::Resource,
 };
@@ -360,10 +360,10 @@ impl ComponentTicks {
         // maximum delta to `u32::MAX / 2` because of wraparound.
         let ticks_since_insert = change_tick
             .wrapping_sub(self.added)
-            .min(CHANGE_DETECTION_MAX_DELTA);
+            .min(MAX_TICK_DELTA);
         let ticks_since_system = change_tick
             .wrapping_sub(last_change_tick)
-            .min(CHANGE_DETECTION_MAX_DELTA);
+            .min(MAX_TICK_DELTA);
 
         ticks_since_system > ticks_since_insert
     }
@@ -372,10 +372,10 @@ impl ComponentTicks {
     pub fn is_changed(&self, last_change_tick: u32, change_tick: u32) -> bool {
         let ticks_since_change = change_tick
             .wrapping_sub(self.changed)
-            .min(CHANGE_DETECTION_MAX_DELTA);
+            .min(MAX_TICK_DELTA);
         let ticks_since_system = change_tick
             .wrapping_sub(last_change_tick)
-            .min(CHANGE_DETECTION_MAX_DELTA);
+            .min(MAX_TICK_DELTA);
 
         ticks_since_system > ticks_since_change
     }
@@ -413,8 +413,8 @@ impl ComponentTicks {
 fn check_tick(last_change_tick: &mut u32, change_tick: u32) {
     let delta = change_tick.wrapping_sub(*last_change_tick);
     // This comparison assumes that `delta` has not overflowed `u32::MAX` before, which will be true
-    // so long as a check runs at least every 2 * `CHANGE_DETECTION_CHECK_THRESHOLD` ticks.
-    if delta > CHANGE_DETECTION_MAX_DELTA {
-        *last_change_tick = change_tick.wrapping_sub(CHANGE_DETECTION_MAX_DELTA);
+    // so long as this check runs always runs before that can happen.
+    if delta > MAX_TICK_DELTA {
+        *last_change_tick = change_tick.wrapping_sub(MAX_TICK_DELTA);
     }
 }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -355,7 +355,7 @@ pub struct ComponentTicks {
 
 impl ComponentTicks {
     #[inline]
-    /// Returns `true` if the component was added since the system last ran, `false` otherwise.
+    /// Returns `true` if the component was added after the system last ran, `false` otherwise.
     pub fn is_added(&self, last_change_tick: u32, change_tick: u32) -> bool {
         // The comparison is relative to the world tick (`change_tick`) so that we can use
         // the full `u32` range. Comparing the system and component ticks directly would limit the
@@ -371,7 +371,7 @@ impl ComponentTicks {
     }
 
     #[inline]
-    /// Returns `true` if the component was added or mutably-dereferenced since the system last ran, `false` otherwise.
+    /// Returns `true` if the component was added or mutably-dereferenced after the system last ran, `false` otherwise.
     pub fn is_changed(&self, last_change_tick: u32, change_tick: u32) -> bool {
         let ticks_since_change = change_tick
             .wrapping_sub(self.changed)

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -346,7 +346,7 @@ impl Components {
     }
 }
 
-/// Stores two [`World`](crate::world::World) "ticks" denoting when the component was added and when it was last changed (added or mutably-deferenced).
+/// Records when a component was added and when it was last mutably dereferenced (or added).
 #[derive(Copy, Clone, Debug)]
 pub struct ComponentTicks {
     pub(crate) added: u32,
@@ -371,7 +371,7 @@ impl ComponentTicks {
     }
 
     #[inline]
-    /// Returns `true` if the component was added or mutably-dereferenced after the system last ran, `false` otherwise.
+    /// Returns `true` if the component was added or mutably dereferenced after the system last ran, `false` otherwise.
     pub fn is_changed(&self, last_change_tick: u32, change_tick: u32) -> bool {
         // This works even with wraparound because the world tick (`change_tick`) is always "newer" than
         // `last_change_tick` and `self.changed`, and we scan periodically to clamp `ComponentTicks` values

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -357,9 +357,11 @@ impl ComponentTicks {
     #[inline]
     /// Returns `true` if the component was added after the system last ran, `false` otherwise.
     pub fn is_added(&self, last_change_tick: u32, change_tick: u32) -> bool {
-        // The comparison is relative to the world tick (`change_tick`) so that we can use
-        // the full `u32` range. Comparing the system and component ticks directly would limit the
-        // maximum difference to `u32::MAX / 2` because of wraparound.
+        // This works even with wraparound because the world tick (`change_tick`) is always "newer" than
+        // `last_change_tick` and `self.added`, and we scan periodically to clamp `ComponentTicks` values 
+        // so they never get older than `u32::MAX` (the difference would overflow).
+        // 
+        // The clamp here ensures determinism (since scans could differ between app runs).
         let ticks_since_insert = change_tick
             .wrapping_sub(self.added)
             .min(MAX_CHANGE_AGE);
@@ -373,6 +375,11 @@ impl ComponentTicks {
     #[inline]
     /// Returns `true` if the component was added or mutably-dereferenced after the system last ran, `false` otherwise.
     pub fn is_changed(&self, last_change_tick: u32, change_tick: u32) -> bool {
+        // This works even with wraparound because the world tick (`change_tick`) is always "newer" than
+        // `last_change_tick` and `self.changed`, and we scan periodically to clamp `ComponentTicks` values 
+        // so they never get older than `u32::MAX` (the difference would overflow).
+        // 
+        // The clamp here ensures determinism (since scans could differ between app runs).
         let ticks_since_change = change_tick
             .wrapping_sub(self.changed)
             .min(MAX_CHANGE_AGE);

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -401,7 +401,7 @@ impl ComponentTicks {
     /// Manually sets the change tick.
     ///
     /// This is normally done automatically via the [`DerefMut`](std::ops::DerefMut) implementation
-    /// on [`Mut<T>`](crate::world::Mut), [`ResMut<T>`](crate::system::ResMut), etc.
+    /// on [`Mut<T>`](crate::change_detection::Mut), [`ResMut<T>`](crate::change_detection::ResMut), etc.
     /// However, components and resources that make use of interior mutability might require manual updates.
     ///
     /// # Example

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -650,17 +650,12 @@ macro_rules! impl_tick_filter {
 }
 
 impl_tick_filter!(
-    /// Filter that retrieves components of type `T` that have been added since the last execution
-    /// of this system.
+    /// A filter on a component that only retains results added after the system last ran.
     ///
-    /// This filter is useful to do one-time post-processing on components.
+    /// A common use for this filter is one-time initialization.
     ///
-    /// Because the ordering of systems can change and this filter is only effective on changes
-    /// before the query executes you need to use explicit dependency ordering or ordered stages to
-    /// avoid frame delays.
-    ///
-    /// If instead behavior is meant to change on whether the component changed or not
-    /// [`ChangeTrackers`](crate::query::ChangeTrackers) may be used.
+    /// To retain all results without filtering but still check whether they were added after the
+    /// system last ran, use [`ChangeTrackers<T>`](crate::query::ChangeTrackers).
     ///
     /// # Examples
     ///
@@ -690,18 +685,15 @@ impl_tick_filter!(
 );
 
 impl_tick_filter!(
-    /// Filter that retrieves components of type `T` that have been changed since the last
-    /// execution of this system.
+    /// A filter on a component that only retains results added or mutably dereferenced after the system last ran.
+    ///  
+    /// A common use for this filter is avoiding redundant work when values have not changed.
     ///
-    /// This filter is useful for synchronizing components, and as a performance optimization as it
-    /// means that the query contains fewer items for a system to iterate over.
+    /// **Note** that simply *mutably dereferencing* a component is considered a change ([`DerefMut`](std::ops::DerefMut)).
+    /// Bevy does not compare components to their previous values.
     ///
-    /// Because the ordering of systems can change and this filter is only effective on changes
-    /// before the query executes you need to use explicit dependency ordering or ordered
-    /// stages to avoid frame delays.
-    ///
-    /// If instead behavior is meant to change on whether the component changed or not
-    /// [`ChangeTrackers`](crate::query::ChangeTrackers) may be used.
+    /// To retain all results without filtering but still check whether they were changed after the
+    /// system last ran, use [`ChangeTrackers<T>`](crate::query::ChangeTrackers).
     ///
     /// # Examples
     ///

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -572,7 +572,7 @@ impl SystemStage {
         let change_tick = world.change_tick();
         let ticks_since_last_check = change_tick.wrapping_sub(self.last_tick_check);
 
-        if ticks_since_last_check > CHECK_TICK_THRESHOLD {
+        if ticks_since_last_check >= CHECK_TICK_THRESHOLD {
             // Check all system change ticks.
             for exclusive_system in &mut self.exclusive_at_start {
                 exclusive_system.system_mut().check_change_tick(change_tick);

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -564,7 +564,7 @@ impl SystemStage {
 
     /// All system and component change ticks are scanned for risk of delta overflow once the world
     /// counter has incremented at least [`CHECK_TICK_THRESHOLD`](crate::change_detection::CHECK_TICK_THRESHOLD)
-    /// times since the previous `check_tick` scan. 
+    /// times since the previous `check_tick` scan.
     ///
     /// During each scan, any change ticks older than [`MAX_CHANGE_AGE`](crate::change_detection::MAX_CHANGE_AGE)
     /// are clamped to that difference, preventing potential false positives due to overflow.

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -567,7 +567,7 @@ impl SystemStage {
     /// times since the previous `check_tick` scan. 
     ///
     /// During each scan, any change ticks older than [`MAX_TICK_DELTA`](crate::change_detection::MAX_TICK_DELTA)
-    /// are clamped to that difference, potential false positives due to overflow.
+    /// are clamped to that difference, preventing potential false positives due to overflow.
     fn check_change_ticks(&mut self, world: &mut World) {
         let change_tick = world.change_tick();
         let ticks_since_last_check = change_tick.wrapping_sub(self.last_tick_check);

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -562,12 +562,12 @@ impl SystemStage {
         }
     }
 
-    /// All system and component change ticks are scanned for risk of delta overflow once the world
-    /// counter has incremented at least [`CHECK_TICK_THRESHOLD`](crate::change_detection::CHECK_TICK_THRESHOLD)
+    /// All system and component change ticks are scanned once the world counter has incremented
+    /// at least [`CHECK_TICK_THRESHOLD`](crate::change_detection::CHECK_TICK_THRESHOLD)
     /// times since the previous `check_tick` scan.
     ///
     /// During each scan, any change ticks older than [`MAX_CHANGE_AGE`](crate::change_detection::MAX_CHANGE_AGE)
-    /// are clamped to that difference, preventing potential false positives due to overflow.
+    /// are clamped to that age. This prevents false positives from appearing due to overflow.
     fn check_change_ticks(&mut self, world: &mut World) {
         let change_tick = world.change_tick();
         let ticks_since_last_check = change_tick.wrapping_sub(self.last_tick_check);

--- a/crates/bevy_ecs/src/system/exclusive_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system.rs
@@ -1,4 +1,5 @@
 use crate::{
+    change_detection::MAX_CHANGE_AGE,
     system::{check_system_change_tick, BoxedSystem, IntoSystem},
     world::World,
 };
@@ -43,7 +44,9 @@ where
         world.last_change_tick = saved_last_tick;
     }
 
-    fn initialize(&mut self, _: &mut World) {}
+    fn initialize(&mut self, world: &mut World) {
+        self.last_change_tick = world.change_tick().wrapping_sub(MAX_CHANGE_AGE);
+    }
 
     fn check_change_tick(&mut self, change_tick: u32) {
         check_system_change_tick(&mut self.last_change_tick, change_tick, self.name.as_ref());

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -1,5 +1,6 @@
 use crate::{
     archetype::{ArchetypeComponentId, ArchetypeGeneration, ArchetypeId},
+    change_detection::MAX_CHANGE_AGE,
     component::ComponentId,
     prelude::FromWorld,
     query::{Access, FilteredAccessSet},
@@ -8,7 +9,7 @@ use crate::{
         check_system_change_tick, ReadOnlySystemParamFetch, System, SystemParam, SystemParamFetch,
         SystemParamState,
     },
-    world::{World, WorldId}, change_detection::MAX_CHANGE_AGE,
+    world::{World, WorldId},
 };
 use bevy_ecs_macros::all_tuples;
 use std::{borrow::Cow, fmt::Debug, hash::Hash, marker::PhantomData};

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -140,6 +140,7 @@ pub struct SystemState<Param: SystemParam> {
 impl<Param: SystemParam> SystemState<Param> {
     pub fn new(world: &mut World) -> Self {
         let mut meta = SystemMeta::new::<Param>();
+        meta.last_change_tick = world.last_change_tick;
         let param_state = <Param::Fetch as SystemParamState>::init(world, &mut meta);
         Self {
             meta,
@@ -398,6 +399,7 @@ where
     #[inline]
     fn initialize(&mut self, world: &mut World) {
         self.world_id = Some(world.id());
+        self.system_meta.last_change_tick = world.last_change_tick;
         self.param_state = Some(<Param::Fetch as SystemParamState>::init(
             world,
             &mut self.system_meta,

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -8,7 +8,7 @@ use crate::{
         check_system_change_tick, ReadOnlySystemParamFetch, System, SystemParam, SystemParamFetch,
         SystemParamState,
     },
-    world::{World, WorldId},
+    world::{World, WorldId}, change_detection::MAX_CHANGE_AGE,
 };
 use bevy_ecs_macros::all_tuples;
 use std::{borrow::Cow, fmt::Debug, hash::Hash, marker::PhantomData};
@@ -140,7 +140,7 @@ pub struct SystemState<Param: SystemParam> {
 impl<Param: SystemParam> SystemState<Param> {
     pub fn new(world: &mut World) -> Self {
         let mut meta = SystemMeta::new::<Param>();
-        meta.last_change_tick = world.last_change_tick;
+        meta.last_change_tick = world.change_tick().wrapping_sub(MAX_CHANGE_AGE);
         let param_state = <Param::Fetch as SystemParamState>::init(world, &mut meta);
         Self {
             meta,
@@ -399,7 +399,7 @@ where
     #[inline]
     fn initialize(&mut self, world: &mut World) {
         self.world_id = Some(world.id());
-        self.system_meta.last_change_tick = world.last_change_tick;
+        self.system_meta.last_change_tick = world.change_tick().wrapping_sub(MAX_CHANGE_AGE);
         self.param_state = Some(<Param::Fetch as SystemParamState>::init(
             world,
             &mut self.system_meta,

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -73,7 +73,6 @@ pub(crate) fn check_system_change_tick(
     // This comparison assumes that `delta` has not overflowed `u32::MAX` before, which will be true
     // so long as this check always runs before that can happen.
     if delta > MAX_TICK_DELTA {
-        // TODO: Don't spam this warning over and over for the same system.
         warn!(
             "System '{}' has not run for {} ticks. \
             Changes older than {} ticks will not be detected.",

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -71,7 +71,7 @@ pub(crate) fn check_system_change_tick(
 ) {
     let delta = change_tick.wrapping_sub(*last_change_tick);
     // This comparison assumes that `delta` has not overflowed `u32::MAX` before, which will be true
-    // so long as this check runs always runs before that can happen.
+    // so long as this check always runs before that can happen.
     if delta > MAX_TICK_DELTA {
         // TODO: Don't spam this warning over and over for the same system.
         warn!(

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -76,7 +76,7 @@ pub(crate) fn check_system_change_tick(
         warn!(
             "{} intervening systems have run since system '{}' last ran. \
             Systems cannot detect changes older than {}.",
-            delta, system_name, CHANGE_DETECTION_MAX_DELTA,
+            delta, system_name, CHANGE_DETECTION_MAX_DELTA - 1,
         );
         *last_change_tick = change_tick.wrapping_sub(CHANGE_DETECTION_MAX_DELTA);
     }

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -71,13 +71,14 @@ pub(crate) fn check_system_change_tick(
 ) {
     let delta = change_tick.wrapping_sub(*last_change_tick);
     // This comparison assumes that `delta` has not overflowed `u32::MAX` before, which will be true
-    // so long as a check runs at least every 2 * `CHANGE_DETECTION_CHECK_THRESHOLD` ticks.
-    if delta > CHANGE_DETECTION_MAX_DELTA {
+    // so long as this check runs always runs before that can happen.
+    if delta > MAX_TICK_DELTA {
+        // TODO: Don't spam this warning over and over for the same system.
         warn!(
-            "{} intervening systems have run since system '{}' last ran. \
-            Systems cannot detect changes older than {}.",
-            delta, system_name, CHANGE_DETECTION_MAX_DELTA - 1,
+            "System '{}' has not run for {} ticks. \
+            Changes older than {} ticks will not be detected.",
+            system_name, delta, MAX_TICK_DELTA - 1,
         );
-        *last_change_tick = change_tick.wrapping_sub(CHANGE_DETECTION_MAX_DELTA);
+        *last_change_tick = change_tick.wrapping_sub(MAX_TICK_DELTA);
     }
 }

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -1,8 +1,8 @@
 use bevy_utils::tracing::warn;
 
 use crate::{
-    archetype::ArchetypeComponentId, change_detection::CHANGE_DETECTION_MAX_DELTA,
-    component::ComponentId, query::Access, schedule::SystemLabel, world::World,
+    archetype::ArchetypeComponentId, change_detection::MAX_CHANGE_AGE, component::ComponentId,
+    query::Access, schedule::SystemLabel, world::World,
 };
 use std::borrow::Cow;
 
@@ -69,15 +69,17 @@ pub(crate) fn check_system_change_tick(
     change_tick: u32,
     system_name: &str,
 ) {
-    let delta = change_tick.wrapping_sub(*last_change_tick);
-    // This comparison assumes that `delta` has not overflowed `u32::MAX` before, which will be true
+    let age = change_tick.wrapping_sub(*last_change_tick);
+    // This comparison assumes that `age` has not overflowed `u32::MAX` before, which will be true
     // so long as this check always runs before that can happen.
-    if delta > MAX_TICK_DELTA {
+    if age > MAX_CHANGE_AGE {
         warn!(
             "System '{}' has not run for {} ticks. \
             Changes older than {} ticks will not be detected.",
-            system_name, delta, MAX_TICK_DELTA - 1,
+            system_name,
+            age,
+            MAX_CHANGE_AGE - 1,
         );
-        *last_change_tick = change_tick.wrapping_sub(MAX_TICK_DELTA);
+        *last_change_tick = change_tick.wrapping_sub(MAX_CHANGE_AGE);
     }
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -213,14 +213,12 @@ where
 }
 
 impl<'w, T: Resource> Res<'w, T> {
-    /// Returns true if (and only if) this resource been added since the last execution of this
-    /// system.
+    /// Returns `true` if the resource was added since the system last ran, `false` otherwise.
     pub fn is_added(&self) -> bool {
         self.ticks.is_added(self.last_change_tick, self.change_tick)
     }
 
-    /// Returns true if (and only if) this resource been changed since the last execution of this
-    /// system.
+    /// Returns `true` if the resource was added or mutably-dereferenced since the system last ran, `false` otherwise.
     pub fn is_changed(&self) -> bool {
         self.ticks
             .is_changed(self.last_change_tick, self.change_tick)
@@ -779,14 +777,12 @@ where
 }
 
 impl<'w, T: 'static> NonSend<'w, T> {
-    /// Returns true if (and only if) this resource been added since the last execution of this
-    /// system.
+    /// Returns `true` if the resource was added since the system last ran, `false` otherwise.
     pub fn is_added(&self) -> bool {
         self.ticks.is_added(self.last_change_tick, self.change_tick)
     }
 
-    /// Returns true if (and only if) this resource been changed since the last execution of this
-    /// system.
+    /// Returns `true` if the resource was added or mutably-dereferenced since the system last ran, `false` otherwise.
     pub fn is_changed(&self) -> bool {
         self.ticks
             .is_changed(self.last_change_tick, self.change_tick)

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -213,12 +213,12 @@ where
 }
 
 impl<'w, T: Resource> Res<'w, T> {
-    /// Returns `true` if the resource was added since the system last ran, `false` otherwise.
+    /// Returns `true` if the resource was added after the system last ran, `false` otherwise.
     pub fn is_added(&self) -> bool {
         self.ticks.is_added(self.last_change_tick, self.change_tick)
     }
 
-    /// Returns `true` if the resource was added or mutably-dereferenced since the system last ran, `false` otherwise.
+    /// Returns `true` if the resource was added or mutably-dereferenced after the system last ran, `false` otherwise.
     pub fn is_changed(&self) -> bool {
         self.ticks
             .is_changed(self.last_change_tick, self.change_tick)
@@ -777,12 +777,12 @@ where
 }
 
 impl<'w, T: 'static> NonSend<'w, T> {
-    /// Returns `true` if the resource was added since the system last ran, `false` otherwise.
+    /// Returns `true` if the resource was added after the system last ran, `false` otherwise.
     pub fn is_added(&self) -> bool {
         self.ticks.is_added(self.last_change_tick, self.change_tick)
     }
 
-    /// Returns `true` if the resource was added or mutably-dereferenced since the system last ran, `false` otherwise.
+    /// Returns `true` if the resource was added or mutably-dereferenced after the system last ran, `false` otherwise.
     pub fn is_changed(&self) -> bool {
         self.ticks
             .is_changed(self.last_change_tick, self.change_tick)

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -218,7 +218,7 @@ impl<'w, T: Resource> Res<'w, T> {
         self.ticks.is_added(self.last_change_tick, self.change_tick)
     }
 
-    /// Returns `true` if the resource was added or mutably-dereferenced after the system last ran, `false` otherwise.
+    /// Returns `true` if the resource was added or mutably dereferenced after the system last ran, `false` otherwise.
     pub fn is_changed(&self) -> bool {
         self.ticks
             .is_changed(self.last_change_tick, self.change_tick)
@@ -782,7 +782,7 @@ impl<'w, T: 'static> NonSend<'w, T> {
         self.ticks.is_added(self.last_change_tick, self.change_tick)
     }
 
-    /// Returns `true` if the resource was added or mutably-dereferenced after the system last ran, `false` otherwise.
+    /// Returns `true` if the resource was added or mutably dereferenced after the system last ran, `false` otherwise.
     pub fn is_changed(&self) -> bool {
         self.ticks
             .is_changed(self.last_change_tick, self.change_tick)

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -213,12 +213,12 @@ where
 }
 
 impl<'w, T: Resource> Res<'w, T> {
-    /// Returns `true` if the resource was added after the system last ran, `false` otherwise.
+    /// Returns `true` if the resource was added after the system last ran.
     pub fn is_added(&self) -> bool {
         self.ticks.is_added(self.last_change_tick, self.change_tick)
     }
 
-    /// Returns `true` if the resource was added or mutably dereferenced after the system last ran, `false` otherwise.
+    /// Returns `true` if the resource was added or mutably dereferenced after the system last ran.
     pub fn is_changed(&self) -> bool {
         self.ticks
             .is_changed(self.last_change_tick, self.change_tick)
@@ -777,12 +777,12 @@ where
 }
 
 impl<'w, T: 'static> NonSend<'w, T> {
-    /// Returns `true` if the resource was added after the system last ran, `false` otherwise.
+    /// Returns `true` if the resource was added after the system last ran.
     pub fn is_added(&self) -> bool {
         self.ticks.is_added(self.last_change_tick, self.change_tick)
     }
 
-    /// Returns `true` if the resource was added or mutably dereferenced after the system last ran, `false` otherwise.
+    /// Returns `true` if the resource was added or mutably dereferenced after the system last ran.
     pub fn is_changed(&self) -> bool {
         self.ticks
             .is_changed(self.last_change_tick, self.change_tick)


### PR DESCRIPTION
## Objective

- ~~Make absurdly long-lived changes stay detectable for even longer (without leveling up to `u64`).~~
- Give all changes a consistent maximum lifespan.
- Improve code clarity.

## Solution

- ~~Increase the frequency of `check_tick` scans to increase the oldest reliably-detectable change.~~
(Deferred until we can benchmark the cost of a scan.)
- Ignore changes older than the maximum reliably-detectable age.
- General refactoring—name the constants, use them everywhere, and update the docs.
- Update test cases to check for the specified behavior.

## Related

This PR addresses (at least partially) the concerns raised in:

- #3071
- #3082 (and associated PR #3084)

## Background

- #1471

Given the minimum interval between `check_ticks` scans, `N`, the oldest reliably-detectable change is `u32::MAX - (2 * N - 1)` (or `MAX_CHANGE_AGE`). Reducing `N` from ~530 million (current value) to something like ~2 million would extend the lifetime of changes by a billion.

| minimum `check_ticks` interval | oldest reliably-detectable change  | usable % of `u32::MAX` |
| --- | --- | --- |
| `u32::MAX / 8`  (536,870,911) | `(u32::MAX / 4) * 3` | 75.0% |
| `2_000_000` | `u32::MAX - 3_999_999` | 99.9% |

Similarly, changes are still allowed to be between `MAX_CHANGE_AGE`-old and `u32::MAX`-old in the interim between `check_tick` scans. While we prevent their age from overflowing, the test to detect changes still compares raw values. This makes failure ultimately unreliable, since when ancient changes stop being detected varies depending on when the next scan occurs.

## Open Question

Currently, systems and system states are incorrectly initialized with their `last_change_tick` set to `0`, which doesn't handle wraparound correctly.

For consistent behavior, they should either be initialized to the world's `last_change_tick` (and detect no changes) or to `MAX_CHANGE_AGE` behind the world's current `change_tick` (and detect everything as a change). I've currently gone with the latter since that was closer to the existing behavior.

## Follow-up Work

(Edited: entire section)

We haven't actually profiled how long a `check_ticks` scan takes on a "large" `World` , so we don't know if it's safe to increase their frequency. However, we are currently relying on play sessions not lasting long enough to trigger a scan and apps not having enough entities/archetypes for it to be "expensive" (our assumption). That isn't a real solution. (Either scanning never costs enough to impact frame times or we provide an option to use `u64` change ticks. Nobody will accept random hiccups.)

To further extend the lifetime of changes, we actually only need to increment the world tick if a system has `Fetch: !ReadOnlySystemParamFetch`. The behavior will be identical because all writes are sequenced, but I'm not sure how to implement that in a way that the compiler can optimize the branch out.

Also, since having no false positives depends on a `check_ticks` scan running at least every `2 * N - 1` ticks, a `last_check_tick` should also be stored in the `World` so that any lull in system execution (like a command flush) could trigger a scan if needed. To be completely robust, all the systems initialized on the world should be scanned, not just those in the current stage.