### PR TITLE
[Merged by Bors] - Mesh vertex buffer layouts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -445,6 +445,10 @@ path = "examples/scene/scene.rs"
 
 # Shaders
 [[example]]
+name = "custom_vertex_attribute"
+path = "examples/shader/custom_vertex_attribute.rs"
+
+[[example]]
 name = "shader_defs"
 path = "examples/shader/shader_defs.rs"
 

--- a/assets/shaders/custom_vertex_attribute.wgsl
+++ b/assets/shaders/custom_vertex_attribute.wgsl
@@ -1,0 +1,40 @@
+#import bevy_pbr::mesh_view_bind_group
+#import bevy_pbr::mesh_struct
+
+struct Vertex {
+    [[location(0)]] position: vec3<f32>;
+    [[location(1)]] blend_color: vec4<f32>;
+};
+
+struct CustomMaterial {
+    color: vec4<f32>;
+};
+[[group(1), binding(0)]]
+var<uniform> material: CustomMaterial;
+
+[[group(2), binding(0)]]
+var<uniform> mesh: Mesh;
+
+struct VertexOutput {
+    [[builtin(position)]] clip_position: vec4<f32>;
+    [[location(0)]] blend_color: vec4<f32>;
+};
+
+[[stage(vertex)]]
+fn vertex(vertex: Vertex) -> VertexOutput {
+    let world_position = mesh.model * vec4<f32>(vertex.position, 1.0);
+
+    var out: VertexOutput;
+    out.clip_position = view.view_proj * world_position;
+    out.blend_color = vertex.blend_color;
+    return out;
+}
+
+struct FragmentInput {
+    [[location(0)]] blend_color: vec4<f32>;
+};
+
+[[stage(fragment)]]
+fn fragment(input: FragmentInput) -> [[location(0)]] vec4<f32> {
+    return material.color * input.blend_color;
+}

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -158,7 +158,7 @@ async fn load_gltf<'a, 'b>(
             //     .read_colors(0)
             //     .map(|v| VertexAttributeValues::Float32x4(v.into_rgba_f32().collect()))
             // {
-            //     mesh.set_attribute(Mesh::ATTRIBUTE_COLOR, vertex_attribute);
+            //     mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, vertex_attribute);
             // }
 
             if let Some(indices) = reader.read_indices() {

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -125,33 +125,33 @@ async fn load_gltf<'a, 'b>(
                 .read_positions()
                 .map(|v| VertexAttributeValues::Float32x3(v.collect()))
             {
-                mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, vertex_attribute);
+                mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertex_attribute);
             }
 
             if let Some(vertex_attribute) = reader
                 .read_normals()
                 .map(|v| VertexAttributeValues::Float32x3(v.collect()))
             {
-                mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, vertex_attribute);
+                mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, vertex_attribute);
             }
 
             if let Some(vertex_attribute) = reader
                 .read_tangents()
                 .map(|v| VertexAttributeValues::Float32x4(v.collect()))
             {
-                mesh.set_attribute(Mesh::ATTRIBUTE_TANGENT, vertex_attribute);
+                mesh.insert_attribute(Mesh::ATTRIBUTE_TANGENT, vertex_attribute);
             }
 
             if let Some(vertex_attribute) = reader
                 .read_tex_coords(0)
                 .map(|v| VertexAttributeValues::Float32x2(v.into_f32().collect()))
             {
-                mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, vertex_attribute);
+                mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vertex_attribute);
             } else {
                 let len = mesh.count_vertices();
                 let uvs = vec![[0.0, 0.0]; len];
                 bevy_log::debug!("missing `TEXCOORD_0` vertex attribute, loading zeroed out UVs");
-                mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+                mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
             }
 
             // if let Some(vertex_attribute) = reader

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -40,7 +40,7 @@ use bevy_render::{
     prelude::Color,
     render_graph::RenderGraph,
     render_phase::{sort_phase_system, AddRenderCommand, DrawFunctions},
-    render_resource::{Shader, SpecializedPipelines},
+    render_resource::{Shader, SpecializedMeshPipelines},
     view::VisibilitySystems,
     RenderApp, RenderStage,
 };
@@ -178,7 +178,7 @@ impl Plugin for PbrPlugin {
             .init_resource::<DrawFunctions<Shadow>>()
             .init_resource::<LightMeta>()
             .init_resource::<GlobalLightMeta>()
-            .init_resource::<SpecializedPipelines<ShadowPipeline>>();
+            .init_resource::<SpecializedMeshPipelines<ShadowPipeline>>();
 
         let shadow_pass_node = ShadowPassNode::new(&mut render_app.world);
         render_app.add_render_command::<Shadow, DrawShadowMesh>();

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -93,11 +93,11 @@ impl<M: Material> SpecializedMaterial for M {
 
     #[inline]
     fn specialize(
-        _descriptor: &mut RenderPipelineDescriptor,
+        descriptor: &mut RenderPipelineDescriptor,
         _key: Self::Key,
-        _layout: &MeshVertexBufferLayout,
+        layout: &MeshVertexBufferLayout,
     ) -> Result<(), SpecializedMeshPipelineError> {
-        <M as Material>::specialize(_descriptor, _layout)
+        <M as Material>::specialize(descriptor, layout)
     }
 
     #[inline]

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -343,7 +343,7 @@ impl SpecializedMaterial for StandardMaterial {
         descriptor: &mut RenderPipelineDescriptor,
         key: Self::Key,
         _layout: &MeshVertexBufferLayout,
-    ) {
+    ) -> Result<(), SpecializedMeshPipelineError> {
         if key.normal_map {
             descriptor
                 .fragment
@@ -355,6 +355,7 @@ impl SpecializedMaterial for StandardMaterial {
         if let Some(label) = &mut descriptor.label {
             *label = format!("pbr_{}", *label).into();
         }
+        Ok(())
     }
 
     fn fragment_shader(_asset_server: &AssetServer) -> Option<Handle<Shader>> {

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -5,6 +5,7 @@ use bevy_math::Vec4;
 use bevy_reflect::TypeUuid;
 use bevy_render::{
     color::Color,
+    mesh::MeshVertexBufferLayout,
     prelude::Shader,
     render_asset::{PrepareAssetError, RenderAsset, RenderAssets},
     render_resource::{
@@ -338,7 +339,11 @@ impl SpecializedMaterial for StandardMaterial {
         }
     }
 
-    fn specialize(key: Self::Key, descriptor: &mut RenderPipelineDescriptor) {
+    fn specialize(
+        descriptor: &mut RenderPipelineDescriptor,
+        key: Self::Key,
+        _layout: &MeshVertexBufferLayout,
+    ) {
         if key.normal_map {
             descriptor
                 .fragment

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -262,7 +262,7 @@ impl SpecializedMeshPipeline for ShadowPipeline {
                 shader: SHADOW_SHADER_HANDLE.typed::<Shader>(),
                 entry_point: "vertex".into(),
                 shader_defs: vec![],
-                buffers: vec![vertex_buffer_layout.clone()],
+                buffers: vec![vertex_buffer_layout],
             },
             fragment: None,
             layout: Some(vec![self.view_layout.clone(), self.mesh_layout.clone()]),

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -14,7 +14,7 @@ use bevy_math::{const_vec3, Mat4, UVec3, UVec4, Vec2, Vec3, Vec4, Vec4Swizzles};
 use bevy_render::{
     camera::{Camera, CameraProjection},
     color::Color,
-    mesh::Mesh,
+    mesh::{Mesh, MeshVertexBufferLayout},
     render_asset::RenderAssets,
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
     render_phase::{
@@ -214,7 +214,6 @@ bitflags::bitflags! {
     #[repr(transparent)]
     pub struct ShadowPipelineKey: u32 {
         const NONE               = 0;
-        const VERTEX_TANGENTS    = (1 << 0);
         const PRIMITIVE_TOPOLOGY_RESERVED_BITS = ShadowPipelineKey::PRIMITIVE_TOPOLOGY_MASK_BITS << ShadowPipelineKey::PRIMITIVE_TOPOLOGY_SHIFT_BITS;
     }
 }
@@ -244,76 +243,24 @@ impl ShadowPipelineKey {
     }
 }
 
-impl SpecializedPipeline for ShadowPipeline {
+impl SpecializedMeshPipeline for ShadowPipeline {
     type Key = ShadowPipelineKey;
 
-    fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
-        let (vertex_array_stride, vertex_attributes) =
-            if key.contains(ShadowPipelineKey::VERTEX_TANGENTS) {
-                (
-                    48,
-                    vec![
-                        // Position (GOTCHA! Vertex_Position isn't first in the buffer due to how Mesh sorts attributes (alphabetically))
-                        VertexAttribute {
-                            format: VertexFormat::Float32x3,
-                            offset: 12,
-                            shader_location: 0,
-                        },
-                        // Normal
-                        VertexAttribute {
-                            format: VertexFormat::Float32x3,
-                            offset: 0,
-                            shader_location: 1,
-                        },
-                        // Uv (GOTCHA! uv is no longer third in the buffer due to how Mesh sorts attributes (alphabetically))
-                        VertexAttribute {
-                            format: VertexFormat::Float32x2,
-                            offset: 40,
-                            shader_location: 2,
-                        },
-                        // Tangent
-                        VertexAttribute {
-                            format: VertexFormat::Float32x4,
-                            offset: 24,
-                            shader_location: 3,
-                        },
-                    ],
-                )
-            } else {
-                (
-                    32,
-                    vec![
-                        // Position (GOTCHA! Vertex_Position isn't first in the buffer due to how Mesh sorts attributes (alphabetically))
-                        VertexAttribute {
-                            format: VertexFormat::Float32x3,
-                            offset: 12,
-                            shader_location: 0,
-                        },
-                        // Normal
-                        VertexAttribute {
-                            format: VertexFormat::Float32x3,
-                            offset: 0,
-                            shader_location: 1,
-                        },
-                        // Uv
-                        VertexAttribute {
-                            format: VertexFormat::Float32x2,
-                            offset: 24,
-                            shader_location: 2,
-                        },
-                    ],
-                )
-            };
+    fn specialize(
+        &self,
+        key: Self::Key,
+        layout: &MeshVertexBufferLayout,
+    ) -> RenderPipelineDescriptor {
+        let vertex_buffer_layout = layout
+            .get_layout(&[Mesh::ATTRIBUTE_POSITION.at_shader_location(0)])
+            .expect("Mesh is missing a vertex attribute");
+
         RenderPipelineDescriptor {
             vertex: VertexState {
                 shader: SHADOW_SHADER_HANDLE.typed::<Shader>(),
                 entry_point: "vertex".into(),
                 shader_defs: vec![],
-                buffers: vec![VertexBufferLayout {
-                    array_stride: vertex_array_stride,
-                    step_mode: VertexStepMode::Vertex,
-                    attributes: vertex_attributes,
-                }],
+                buffers: vec![vertex_buffer_layout.clone()],
             },
             fragment: None,
             layout: Some(vec![self.view_layout.clone(), self.mesh_layout.clone()]),
@@ -1090,7 +1037,7 @@ pub fn queue_shadows(
     shadow_pipeline: Res<ShadowPipeline>,
     casting_meshes: Query<&Handle<Mesh>, Without<NotShadowCaster>>,
     render_meshes: Res<RenderAssets<Mesh>>,
-    mut pipelines: ResMut<SpecializedPipelines<ShadowPipeline>>,
+    mut pipelines: ResMut<SpecializedMeshPipelines<ShadowPipeline>>,
     mut pipeline_cache: ResMut<RenderPipelineCache>,
     view_lights: Query<&ViewLightEntities>,
     mut view_light_shadow_phases: Query<(&LightEntity, &mut RenderPhase<Shadow>)>,
@@ -1120,23 +1067,24 @@ pub fn queue_shadows(
             // NOTE: Lights with shadow mapping disabled will have no visible entities
             // so no meshes will be queued
             for entity in visible_entities.iter().copied() {
-                let mut key = ShadowPipelineKey::empty();
                 if let Ok(mesh_handle) = casting_meshes.get(entity) {
                     if let Some(mesh) = render_meshes.get(mesh_handle) {
-                        if mesh.has_tangents {
-                            key |= ShadowPipelineKey::VERTEX_TANGENTS;
-                        }
-                        key |= ShadowPipelineKey::from_primitive_topology(mesh.primitive_topology);
-                    }
-                    let pipeline_id =
-                        pipelines.specialize(&mut pipeline_cache, &shadow_pipeline, key);
+                        let key =
+                            ShadowPipelineKey::from_primitive_topology(mesh.primitive_topology);
+                        let pipeline_id = pipelines.specialize(
+                            &mut pipeline_cache,
+                            &shadow_pipeline,
+                            key,
+                            &mesh.layout,
+                        );
 
-                    shadow_phase.add(Shadow {
-                        draw_function: draw_shadow_mesh,
-                        pipeline: pipeline_id,
-                        entity,
-                        distance: 0.0, // TODO: sort back-to-front
-                    });
+                        shadow_phase.add(Shadow {
+                            draw_function: draw_shadow_mesh,
+                            pipeline: pipeline_id,
+                            entity,
+                            distance: 0.0, // TODO: sort back-to-front
+                        });
+                    }
                 }
             }
         }

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -417,7 +417,7 @@ impl SpecializedMeshPipeline for MeshPipeline {
         &self,
         key: Self::Key,
         layout: &MeshVertexBufferLayout,
-    ) -> RenderPipelineDescriptor {
+    ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
         let mut vertex_attributes = vec![
             Mesh::ATTRIBUTE_POSITION.at_shader_location(0),
             Mesh::ATTRIBUTE_NORMAL.at_shader_location(1),
@@ -430,9 +430,7 @@ impl SpecializedMeshPipeline for MeshPipeline {
             vertex_attributes.push(Mesh::ATTRIBUTE_TANGENT.at_shader_location(3));
         }
 
-        let vertex_buffer_layout = layout
-            .get_layout(&vertex_attributes)
-            .expect("Mesh is missing a vertex attribute");
+        let vertex_buffer_layout = layout.get_layout(&vertex_attributes)?;
 
         let (label, blend, depth_write_enabled);
         if key.contains(MeshPipelineKey::TRANSPARENT_MAIN_PASS) {
@@ -453,7 +451,7 @@ impl SpecializedMeshPipeline for MeshPipeline {
         #[cfg(feature = "webgl")]
         shader_defs.push(String::from("NO_ARRAY_TEXTURES_SUPPORT"));
 
-        RenderPipelineDescriptor {
+        Ok(RenderPipelineDescriptor {
             vertex: VertexState {
                 shader: MESH_SHADER_HANDLE.typed::<Shader>(),
                 entry_point: "vertex".into(),
@@ -502,7 +500,7 @@ impl SpecializedMeshPipeline for MeshPipeline {
                 alpha_to_coverage_enabled: false,
             },
             label: Some(label),
-        }
+        })
     }
 }
 

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -456,7 +456,7 @@ impl SpecializedMeshPipeline for MeshPipeline {
                 shader: MESH_SHADER_HANDLE.typed::<Shader>(),
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
-                buffers: vec![vertex_buffer_layout.clone()],
+                buffers: vec![vertex_buffer_layout],
             },
             fragment: Some(FragmentState {
                 shader: MESH_SHADER_HANDLE.typed::<Shader>(),

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -11,7 +11,7 @@ use bevy_ecs::{
 use bevy_math::{Mat4, Size};
 use bevy_reflect::TypeUuid;
 use bevy_render::{
-    mesh::{GpuBufferInfo, Mesh},
+    mesh::{GpuBufferInfo, Mesh, MeshVertexBufferLayout},
     render_asset::RenderAssets,
     render_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
     render_phase::{EntityRenderCommand, RenderCommandResult, TrackedRenderPass},
@@ -368,8 +368,7 @@ bitflags::bitflags! {
     /// MSAA uses the highest 6 bits for the MSAA sample count - 1 to support up to 64x MSAA.
     pub struct MeshPipelineKey: u32 {
         const NONE                        = 0;
-        const VERTEX_TANGENTS             = (1 << 0);
-        const TRANSPARENT_MAIN_PASS       = (1 << 1);
+        const TRANSPARENT_MAIN_PASS       = (1 << 0);
         const MSAA_RESERVED_BITS          = MeshPipelineKey::MSAA_MASK_BITS << MeshPipelineKey::MSAA_SHIFT_BITS;
         const PRIMITIVE_TOPOLOGY_RESERVED_BITS = MeshPipelineKey::PRIMITIVE_TOPOLOGY_MASK_BITS << MeshPipelineKey::PRIMITIVE_TOPOLOGY_SHIFT_BITS;
     }
@@ -411,70 +410,29 @@ impl MeshPipelineKey {
     }
 }
 
-impl SpecializedPipeline for MeshPipeline {
+impl SpecializedMeshPipeline for MeshPipeline {
     type Key = MeshPipelineKey;
 
-    fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
-        let (vertex_array_stride, vertex_attributes) =
-            if key.contains(MeshPipelineKey::VERTEX_TANGENTS) {
-                (
-                    48,
-                    vec![
-                        // Position (GOTCHA! Vertex_Position isn't first in the buffer due to how Mesh sorts attributes (alphabetically))
-                        VertexAttribute {
-                            format: VertexFormat::Float32x3,
-                            offset: 12,
-                            shader_location: 0,
-                        },
-                        // Normal
-                        VertexAttribute {
-                            format: VertexFormat::Float32x3,
-                            offset: 0,
-                            shader_location: 1,
-                        },
-                        // Uv (GOTCHA! uv is no longer third in the buffer due to how Mesh sorts attributes (alphabetically))
-                        VertexAttribute {
-                            format: VertexFormat::Float32x2,
-                            offset: 40,
-                            shader_location: 2,
-                        },
-                        // Tangent
-                        VertexAttribute {
-                            format: VertexFormat::Float32x4,
-                            offset: 24,
-                            shader_location: 3,
-                        },
-                    ],
-                )
-            } else {
-                (
-                    32,
-                    vec![
-                        // Position (GOTCHA! Vertex_Position isn't first in the buffer due to how Mesh sorts attributes (alphabetically))
-                        VertexAttribute {
-                            format: VertexFormat::Float32x3,
-                            offset: 12,
-                            shader_location: 0,
-                        },
-                        // Normal
-                        VertexAttribute {
-                            format: VertexFormat::Float32x3,
-                            offset: 0,
-                            shader_location: 1,
-                        },
-                        // Uv
-                        VertexAttribute {
-                            format: VertexFormat::Float32x2,
-                            offset: 24,
-                            shader_location: 2,
-                        },
-                    ],
-                )
-            };
+    fn specialize(
+        &self,
+        key: Self::Key,
+        layout: &MeshVertexBufferLayout,
+    ) -> RenderPipelineDescriptor {
+        let mut vertex_attributes = vec![
+            Mesh::ATTRIBUTE_POSITION.at_shader_location(0),
+            Mesh::ATTRIBUTE_NORMAL.at_shader_location(1),
+            Mesh::ATTRIBUTE_UV_0.at_shader_location(2),
+        ];
+
         let mut shader_defs = Vec::new();
-        if key.contains(MeshPipelineKey::VERTEX_TANGENTS) {
+        if layout.contains(Mesh::ATTRIBUTE_TANGENT) {
             shader_defs.push(String::from("VERTEX_TANGENTS"));
+            vertex_attributes.push(Mesh::ATTRIBUTE_TANGENT.at_shader_location(3));
         }
+
+        let vertex_buffer_layout = layout
+            .get_layout(&vertex_attributes)
+            .expect("Mesh is missing a vertex attribute");
 
         let (label, blend, depth_write_enabled);
         if key.contains(MeshPipelineKey::TRANSPARENT_MAIN_PASS) {
@@ -500,11 +458,7 @@ impl SpecializedPipeline for MeshPipeline {
                 shader: MESH_SHADER_HANDLE.typed::<Shader>(),
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
-                buffers: vec![VertexBufferLayout {
-                    array_stride: vertex_array_stride,
-                    step_mode: VertexStepMode::Vertex,
-                    attributes: vertex_attributes,
-                }],
+                buffers: vec![vertex_buffer_layout.clone()],
             },
             fragment: Some(FragmentState {
                 shader: MESH_SHADER_HANDLE.typed::<Shader>(),

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -402,7 +402,6 @@ impl InnerMeshVertexBufferLayout {
         self.attribute_ids.contains(&attribute_id.into())
     }
 
-    // TODO: maybe these should be hidden to ensure specializers can only use this type to generate VertexBufferLayouts?
     #[inline]
     pub fn attribute_ids(&self) -> &[MeshVertexAttributeId] {
         &self.attribute_ids

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -46,22 +46,22 @@ pub struct Mesh {
 /// # use bevy_render::render_resource::PrimitiveTopology;
 /// fn create_triangle() -> Mesh {
 ///     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-///     mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, vec![[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0]]);
+///     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vec![[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0]]);
 ///     mesh.set_indices(Some(Indices::U32(vec![0,1,2])));
 ///     mesh
 /// }
 /// ```
 impl Mesh {
-    /// Where the vertex is located in space. Use in conjunction with [`Mesh::set_attribute`]
+    /// Where the vertex is located in space. Use in conjunction with [`Mesh::insert_attribute`]
     pub const ATTRIBUTE_POSITION: MeshVertexAttribute =
         MeshVertexAttribute::new("Vertex_Position", 0, VertexFormat::Float32x3);
 
     /// The direction the vertex normal is facing in.
-    /// Use in conjunction with [`Mesh::set_attribute`]
+    /// Use in conjunction with [`Mesh::insert_attribute`]
     pub const ATTRIBUTE_NORMAL: MeshVertexAttribute =
         MeshVertexAttribute::new("Vertex_Normal", 1, VertexFormat::Float32x3);
 
-    /// Texture coordinates for the vertex. Use in conjunction with [`Mesh::set_attribute`]
+    /// Texture coordinates for the vertex. Use in conjunction with [`Mesh::insert_attribute`]
     pub const ATTRIBUTE_UV_0: MeshVertexAttribute =
         MeshVertexAttribute::new("Vertex_Uv", 2, VertexFormat::Float32x2);
 
@@ -69,14 +69,14 @@ impl Mesh {
     pub const ATTRIBUTE_TANGENT: MeshVertexAttribute =
         MeshVertexAttribute::new("Vertex_Tangent", 3, VertexFormat::Float32x4);
 
-    /// Per vertex coloring. Use in conjunction with [`Mesh::set_attribute`]
+    /// Per vertex coloring. Use in conjunction with [`Mesh::insert_attribute`]
     pub const ATTRIBUTE_COLOR: MeshVertexAttribute =
         MeshVertexAttribute::new("Vertex_Color", 4, VertexFormat::Uint32);
 
-    /// Per vertex joint transform matrix weight. Use in conjunction with [`Mesh::set_attribute`]
+    /// Per vertex joint transform matrix weight. Use in conjunction with [`Mesh::insert_attribute`]
     pub const ATTRIBUTE_JOINT_WEIGHT: MeshVertexAttribute =
         MeshVertexAttribute::new("Vertex_JointWeight", 5, VertexFormat::Float32x4);
-    /// Per vertex joint transform matrix index. Use in conjunction with [`Mesh::set_attribute`]
+    /// Per vertex joint transform matrix index. Use in conjunction with [`Mesh::insert_attribute`]
     pub const ATTRIBUTE_JOINT_INDEX: MeshVertexAttribute =
         MeshVertexAttribute::new("Vertex_JointIndex", 6, VertexFormat::Uint32);
 

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -3,17 +3,18 @@ mod conversions;
 use crate::{
     primitives::Aabb,
     render_asset::{PrepareAssetError, RenderAsset},
-    render_resource::Buffer,
+    render_resource::{Buffer, VertexBufferLayout},
     renderer::RenderDevice,
 };
 use bevy_core::cast_slice;
 use bevy_ecs::system::{lifetimeless::SRes, SystemParamItem};
 use bevy_math::*;
 use bevy_reflect::TypeUuid;
-use bevy_utils::EnumVariantMeta;
-use std::{borrow::Cow, collections::BTreeMap};
+use bevy_utils::{EnumVariantMeta, Hashed};
+use std::{collections::BTreeMap, hash::Hash};
 use wgpu::{
-    util::BufferInitDescriptor, BufferUsages, IndexFormat, PrimitiveTopology, VertexFormat,
+    util::BufferInitDescriptor, BufferUsages, IndexFormat, PrimitiveTopology, VertexAttribute,
+    VertexFormat, VertexStepMode,
 };
 
 pub const INDEX_BUFFER_ASSET_INDEX: u64 = 0;
@@ -25,10 +26,10 @@ pub const VERTEX_ATTRIBUTE_BUFFER_ID: u64 = 10;
 pub struct Mesh {
     primitive_topology: PrimitiveTopology,
     /// `std::collections::BTreeMap` with all defined vertex attributes (Positions, Normals, ...)
-    /// for this mesh. Attribute name maps to attribute values.
+    /// for this mesh. Attribute ids to attribute values.
     /// Uses a BTreeMap because, unlike HashMap, it has a defined iteration order,
     /// which allows easy stable VertexBuffers (i.e. same buffer order)
-    attributes: BTreeMap<Cow<'static, str>, VertexAttributeValues>,
+    attributes: BTreeMap<MeshVertexAttributeId, MeshAttributeData>,
     indices: Option<Indices>,
 }
 
@@ -50,23 +51,33 @@ pub struct Mesh {
 /// }
 /// ```
 impl Mesh {
-    /// Per vertex coloring. Use in conjunction with [`Mesh::set_attribute`]
-    pub const ATTRIBUTE_COLOR: &'static str = "Vertex_Color";
+    /// Where the vertex is located in space. Use in conjunction with [`Mesh::set_attribute`]
+    pub const ATTRIBUTE_POSITION: MeshVertexAttribute =
+        MeshVertexAttribute::new("Vertex_Position", 0, VertexFormat::Float32x3);
+
     /// The direction the vertex normal is facing in.
     /// Use in conjunction with [`Mesh::set_attribute`]
-    pub const ATTRIBUTE_NORMAL: &'static str = "Vertex_Normal";
-    /// The direction of the vertex tangent. Used for normal mapping
-    pub const ATTRIBUTE_TANGENT: &'static str = "Vertex_Tangent";
+    pub const ATTRIBUTE_NORMAL: MeshVertexAttribute =
+        MeshVertexAttribute::new("Vertex_Normal", 1, VertexFormat::Float32x3);
 
-    /// Where the vertex is located in space. Use in conjunction with [`Mesh::set_attribute`]
-    pub const ATTRIBUTE_POSITION: &'static str = "Vertex_Position";
     /// Texture coordinates for the vertex. Use in conjunction with [`Mesh::set_attribute`]
-    pub const ATTRIBUTE_UV_0: &'static str = "Vertex_Uv";
+    pub const ATTRIBUTE_UV_0: MeshVertexAttribute =
+        MeshVertexAttribute::new("Vertex_Uv", 2, VertexFormat::Float32x2);
+
+    /// The direction of the vertex tangent. Used for normal mapping
+    pub const ATTRIBUTE_TANGENT: MeshVertexAttribute =
+        MeshVertexAttribute::new("Vertex_Tangent", 3, VertexFormat::Float32x4);
+
+    /// Per vertex coloring. Use in conjunction with [`Mesh::set_attribute`]
+    pub const ATTRIBUTE_COLOR: MeshVertexAttribute =
+        MeshVertexAttribute::new("Vertex_Color", 4, VertexFormat::Uint32);
 
     /// Per vertex joint transform matrix weight. Use in conjunction with [`Mesh::set_attribute`]
-    pub const ATTRIBUTE_JOINT_WEIGHT: &'static str = "Vertex_JointWeight";
+    pub const ATTRIBUTE_JOINT_WEIGHT: MeshVertexAttribute =
+        MeshVertexAttribute::new("Vertex_JointWeight", 5, VertexFormat::Float32x4);
     /// Per vertex joint transform matrix index. Use in conjunction with [`Mesh::set_attribute`]
-    pub const ATTRIBUTE_JOINT_INDEX: &'static str = "Vertex_JointIndex";
+    pub const ATTRIBUTE_JOINT_INDEX: MeshVertexAttribute =
+        MeshVertexAttribute::new("Vertex_JointIndex", 6, VertexFormat::Uint32);
 
     /// Construct a new mesh. You need to provide a [`PrimitiveTopology`] so that the
     /// renderer knows how to treat the vertex data. Most of the time this will be
@@ -86,41 +97,62 @@ impl Mesh {
 
     /// Sets the data for a vertex attribute (position, normal etc.). The name will
     /// often be one of the associated constants such as [`Mesh::ATTRIBUTE_POSITION`].
-    pub fn set_attribute(
+    #[inline]
+    pub fn insert_attribute(
         &mut self,
-        name: impl Into<Cow<'static, str>>,
+        attribute: MeshVertexAttribute,
         values: impl Into<VertexAttributeValues>,
     ) {
-        let values: VertexAttributeValues = values.into();
-        self.attributes.insert(name.into(), values);
+        self.attributes.insert(
+            attribute.id,
+            MeshAttributeData {
+                attribute,
+                values: values.into(),
+            },
+        );
+    }
+
+    #[inline]
+    pub fn contains_attribute(&self, id: impl Into<MeshVertexAttributeId>) -> bool {
+        self.attributes.contains_key(&id.into())
     }
 
     /// Retrieves the data currently set to the vertex attribute with the specified `name`.
-    pub fn attribute(&self, name: impl Into<Cow<'static, str>>) -> Option<&VertexAttributeValues> {
-        self.attributes.get(&name.into())
+    #[inline]
+    pub fn attribute(
+        &self,
+        id: impl Into<MeshVertexAttributeId>,
+    ) -> Option<&VertexAttributeValues> {
+        self.attributes.get(&id.into()).map(|data| &data.values)
     }
 
     /// Retrieves the data currently set to the vertex attribute with the specified `name` mutably.
+    #[inline]
     pub fn attribute_mut(
         &mut self,
-        name: impl Into<Cow<'static, str>>,
+        id: impl Into<MeshVertexAttributeId>,
     ) -> Option<&mut VertexAttributeValues> {
-        self.attributes.get_mut(&name.into())
+        self.attributes
+            .get_mut(&id.into())
+            .map(|data| &mut data.values)
     }
 
     /// Sets the vertex indices of the mesh. They describe how triangles are constructed out of the
     /// vertex attributes and are therefore only useful for the [`PrimitiveTopology`] variants
     /// that use triangles.
+    #[inline]
     pub fn set_indices(&mut self, indices: Option<Indices>) {
         self.indices = indices;
     }
 
     /// Retrieves the vertex `indices` of the mesh.
+    #[inline]
     pub fn indices(&self) -> Option<&Indices> {
         self.indices.as_ref()
     }
 
     /// Retrieves the vertex `indices` of the mesh mutably.
+    #[inline]
     pub fn indices_mut(&mut self) -> Option<&mut Indices> {
         self.indices.as_mut()
     }
@@ -134,27 +166,32 @@ impl Mesh {
         })
     }
 
-    // pub fn get_vertex_buffer_layout(&self) -> VertexBufferLayout {
-    //     let mut attributes = Vec::new();
-    //     let mut accumulated_offset = 0;
-    //     for (attribute_name, attribute_values) in self.attributes.iter() {
-    //         let vertex_format = VertexFormat::from(attribute_values);
-    //         attributes.push(VertexAttribute {
-    //             name: attribute_name.clone(),
-    //             offset: accumulated_offset,
-    //             format: vertex_format,
-    //             shader_location: 0,
-    //         });
-    //         accumulated_offset += vertex_format.get_size();
-    //     }
+    /// For a given `descriptor` returns a [`VertexBufferLayout`] compatible with this mesh. If this
+    /// mesh is not compatible with the given `descriptor` (ex: it is missing vertex attributes), [`None`] will
+    /// be returned.
+    pub fn get_mesh_vertex_buffer_layout(&self) -> MeshVertexBufferLayout {
+        let mut attributes = Vec::with_capacity(self.attributes.len());
+        let mut attribute_ids = Vec::with_capacity(self.attributes.len());
+        let mut accumulated_offset = 0;
+        for (index, data) in self.attributes.values().enumerate() {
+            attribute_ids.push(data.attribute.id);
+            attributes.push(VertexAttribute {
+                offset: accumulated_offset,
+                format: data.attribute.format,
+                shader_location: index as u32,
+            });
+            accumulated_offset += data.attribute.format.get_size();
+        }
 
-    //     VertexBufferLayout {
-    //         name: Default::default(),
-    //         stride: accumulated_offset,
-    //         step_mode: InputStepMode::Vertex,
-    //         attributes,
-    //     }
-    // }
+        MeshVertexBufferLayout::new(InnerMeshVertexBufferLayout {
+            layout: VertexBufferLayout {
+                array_stride: accumulated_offset,
+                step_mode: VertexStepMode::Vertex,
+                attributes,
+            },
+            attribute_ids,
+        })
+    }
 
     /// Counts all vertices of the mesh.
     ///
@@ -162,11 +199,11 @@ impl Mesh {
     /// Panics if the attributes have different vertex counts.
     pub fn count_vertices(&self) -> usize {
         let mut vertex_count: Option<usize> = None;
-        for (attribute_name, attribute_data) in &self.attributes {
-            let attribute_len = attribute_data.len();
+        for (attribute_id, attribute_data) in self.attributes.iter() {
+            let attribute_len = attribute_data.values.len();
             if let Some(previous_vertex_count) = vertex_count {
                 assert_eq!(previous_vertex_count, attribute_len,
-                        "Attribute {} has a different vertex count ({}) than other attributes ({}) in this mesh.", attribute_name, attribute_len, previous_vertex_count);
+                        "{:?} has a different vertex count ({}) than other attributes ({}) in this mesh.", attribute_id, attribute_len, previous_vertex_count);
             }
             vertex_count = Some(attribute_len);
         }
@@ -182,8 +219,8 @@ impl Mesh {
     /// Panics if the attributes have different vertex counts.
     pub fn get_vertex_buffer_data(&self) -> Vec<u8> {
         let mut vertex_size = 0;
-        for attribute_values in self.attributes.values() {
-            let vertex_format = VertexFormat::from(attribute_values);
+        for attribute_data in self.attributes.values() {
+            let vertex_format = attribute_data.attribute.format;
             vertex_size += vertex_format.get_size() as usize;
         }
 
@@ -191,10 +228,9 @@ impl Mesh {
         let mut attributes_interleaved_buffer = vec![0; vertex_count * vertex_size];
         // bundle into interleaved buffers
         let mut attribute_offset = 0;
-        for attribute_values in self.attributes.values() {
-            let vertex_format = VertexFormat::from(attribute_values);
-            let attribute_size = vertex_format.get_size() as usize;
-            let attributes_bytes = attribute_values.get_bytes();
+        for attribute_data in self.attributes.values() {
+            let attribute_size = attribute_data.attribute.format.get_size() as usize;
+            let attributes_bytes = attribute_data.values.get_bytes();
             for (vertex_index, attribute_bytes) in
                 attributes_bytes.chunks_exact(attribute_size).enumerate()
             {
@@ -232,7 +268,7 @@ impl Mesh {
         };
         for attributes in self.attributes.values_mut() {
             let indices = indices.iter();
-            match attributes {
+            match &mut attributes.values {
                 VertexAttributeValues::Float32(vec) => *vec = duplicate(vec, indices),
                 VertexAttributeValues::Sint32(vec) => *vec = duplicate(vec, indices),
                 VertexAttributeValues::Uint32(vec) => *vec = duplicate(vec, indices),
@@ -285,7 +321,7 @@ impl Mesh {
             .flat_map(|normal| [normal; 3])
             .collect();
 
-        self.set_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+        self.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
     }
 
     /// Compute the Axis-Aligned Bounding Box of the mesh vertices in model space
@@ -312,6 +348,118 @@ impl Mesh {
 
         None
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct MeshVertexAttribute {
+    /// The friendly name of the vertex attribute
+    pub name: &'static str,
+
+    /// The _unique_ id of the vertex attribute. This will also determine sort ordering
+    /// when generating vertex buffers. Built-in / standard attributes will use "close to zero"
+    /// indices. When in doubt, use a random / very large usize to avoid conflicts.
+    pub id: MeshVertexAttributeId,
+
+    /// The format of the vertex attribute.
+    pub format: VertexFormat,
+}
+
+impl MeshVertexAttribute {
+    pub const fn new(name: &'static str, id: usize, format: VertexFormat) -> Self {
+        Self {
+            name,
+            id: MeshVertexAttributeId(id),
+            format,
+        }
+    }
+
+    pub const fn at_shader_location(&self, shader_location: u32) -> VertexAttributeDescriptor {
+        VertexAttributeDescriptor::new(shader_location, self.id)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub struct MeshVertexAttributeId(usize);
+
+impl From<MeshVertexAttribute> for MeshVertexAttributeId {
+    fn from(attribute: MeshVertexAttribute) -> Self {
+        attribute.id
+    }
+}
+
+pub type MeshVertexBufferLayout = Hashed<InnerMeshVertexBufferLayout>;
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct InnerMeshVertexBufferLayout {
+    attribute_ids: Vec<MeshVertexAttributeId>,
+    layout: VertexBufferLayout,
+}
+
+impl InnerMeshVertexBufferLayout {
+    #[inline]
+    pub fn contains(&self, attribute_id: impl Into<MeshVertexAttributeId>) -> bool {
+        self.attribute_ids.contains(&attribute_id.into())
+    }
+
+    // TODO: maybe these should be hidden to ensure specializers can only use this type to generate VertexBufferLayouts?
+    #[inline]
+    pub fn attribute_ids(&self) -> &[MeshVertexAttributeId] {
+        &self.attribute_ids
+    }
+
+    #[inline]
+    pub fn layout(&self) -> &VertexBufferLayout {
+        &self.layout
+    }
+
+    pub fn get_layout(
+        &self,
+        attribute_descriptors: &[VertexAttributeDescriptor],
+    ) -> Option<VertexBufferLayout> {
+        let mut attributes = Vec::with_capacity(attribute_descriptors.len());
+        for attribute_descriptor in attribute_descriptors.iter() {
+            if let Some(index) = self
+                .attribute_ids
+                .iter()
+                .position(|id| *id == attribute_descriptor.id)
+            {
+                let layout_attribute = &self.layout.attributes[index];
+                attributes.push(VertexAttribute {
+                    format: layout_attribute.format,
+                    offset: layout_attribute.offset,
+                    shader_location: attribute_descriptor.shader_location,
+                })
+            } else {
+                return None;
+            }
+        }
+
+        Some(VertexBufferLayout {
+            array_stride: self.layout.array_stride,
+            step_mode: self.layout.step_mode,
+            attributes,
+        })
+    }
+}
+
+pub struct VertexAttributeDescriptor {
+    pub shader_location: u32,
+    pub id: MeshVertexAttributeId,
+}
+
+impl VertexAttributeDescriptor {
+    pub const fn new(shader_location: u32, id: MeshVertexAttributeId) -> Self {
+        Self {
+            shader_location,
+            id,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MeshAttributeData {
+    attribute: MeshVertexAttribute,
+    values: VertexAttributeValues,
 }
 
 const VEC3_MIN: Vec3 = const_vec3!([std::f32::MIN, std::f32::MIN, std::f32::MIN]);
@@ -521,7 +669,6 @@ impl From<&VertexAttributeValues> for VertexFormat {
         }
     }
 }
-
 /// An array of indices into the [`VertexAttributeValues`] for a mesh.
 ///
 /// It describes the order in which the vertex attributes should be joined into faces.
@@ -590,8 +737,8 @@ pub struct GpuMesh {
     /// Contains all attribute data for each vertex.
     pub vertex_buffer: Buffer,
     pub buffer_info: GpuBufferInfo,
-    pub has_tangents: bool,
     pub primitive_topology: PrimitiveTopology,
+    pub layout: MeshVertexBufferLayout,
 }
 
 /// The index/vertex buffer info of a [`GpuMesh`].
@@ -645,11 +792,13 @@ impl RenderAsset for Mesh {
             },
         );
 
+        let mesh_vertex_buffer_layout = mesh.get_mesh_vertex_buffer_layout();
+
         Ok(GpuMesh {
             vertex_buffer,
             buffer_info,
-            has_tangents: mesh.attributes.contains_key(Mesh::ATTRIBUTE_TANGENT),
             primitive_topology: mesh.primitive_topology(),
+            layout: mesh_vertex_buffer_layout,
         })
     }
 }

--- a/crates/bevy_render/src/mesh/shape/capsule.rs
+++ b/crates/bevy_render/src/mesh/shape/capsule.rs
@@ -370,9 +370,9 @@ impl From<Capsule> for Mesh {
         assert_eq!(tris.len(), fs_len);
 
         let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-        mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, vs);
-        mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, vns);
-        mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, vts);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vs);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, vns);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vts);
         mesh.set_indices(Some(Indices::U32(tris)));
         mesh
     }

--- a/crates/bevy_render/src/mesh/shape/icosphere.rs
+++ b/crates/bevy_render/src/mesh/shape/icosphere.rs
@@ -95,9 +95,9 @@ impl From<Icosphere> for Mesh {
 
         let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
         mesh.set_indices(Some(indices));
-        mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, points);
-        mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
-        mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, points);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
         mesh
     }
 }

--- a/crates/bevy_render/src/mesh/shape/mod.rs
+++ b/crates/bevy_render/src/mesh/shape/mod.rs
@@ -112,9 +112,9 @@ impl From<Box> for Mesh {
         ]);
 
         let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-        mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, positions);
-        mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
-        mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
         mesh.set_indices(Some(indices));
         mesh
     }
@@ -171,9 +171,9 @@ impl From<Quad> for Mesh {
 
         let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
         mesh.set_indices(Some(indices));
-        mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, positions);
-        mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
-        mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
         mesh
     }
 }
@@ -215,9 +215,9 @@ impl From<Plane> for Mesh {
 
         let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
         mesh.set_indices(Some(indices));
-        mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, positions);
-        mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
-        mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
         mesh
     }
 }

--- a/crates/bevy_render/src/mesh/shape/torus.rs
+++ b/crates/bevy_render/src/mesh/shape/torus.rs
@@ -90,9 +90,9 @@ impl From<Torus> for Mesh {
 
         let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
         mesh.set_indices(Some(Indices::U32(indices)));
-        mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, positions);
-        mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
-        mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
         mesh
     }
 }

--- a/crates/bevy_render/src/mesh/shape/uvsphere.rs
+++ b/crates/bevy_render/src/mesh/shape/uvsphere.rs
@@ -82,9 +82,9 @@ impl From<UVSphere> for Mesh {
 
         let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
         mesh.set_indices(Some(Indices::U32(indices)));
-        mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
-        mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
-        mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
         mesh
     }
 }

--- a/crates/bevy_render/src/render_resource/bind_group_layout.rs
+++ b/crates/bevy_render/src/render_resource/bind_group_layout.rs
@@ -10,6 +10,12 @@ pub struct BindGroupLayout {
     value: Arc<wgpu::BindGroupLayout>,
 }
 
+impl PartialEq for BindGroupLayout {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
 impl BindGroupLayout {
     #[inline]
     pub fn id(&self) -> BindGroupLayoutId {

--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -137,19 +137,19 @@ impl VertexBufferLayout {
         step_mode: VertexStepMode,
         vertex_formats: T,
     ) -> Self {
-        let mut array_stride = 0;
+        let mut offset = 0;
         let mut attributes = Vec::new();
         for (shader_location, format) in vertex_formats.into_iter().enumerate() {
             attributes.push(VertexAttribute {
                 format,
-                offset: array_stride,
+                offset,
                 shader_location: shader_location as u32,
             });
-            array_stride += format.size();
+            offset += format.size();
         }
 
         VertexBufferLayout {
-            array_stride,
+            array_stride: offset,
             step_mode,
             attributes,
         }

--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -87,7 +87,7 @@ impl Deref for ComputePipeline {
 }
 
 /// Describes a render (graphics) pipeline.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct RenderPipelineDescriptor {
     /// Debug label of the pipeline. This will show up in graphics debuggers for easy identification.
     pub label: Option<Cow<'static, str>>,
@@ -105,7 +105,7 @@ pub struct RenderPipelineDescriptor {
     pub fragment: Option<FragmentState>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VertexState {
     /// The compiled shader module for this stage.
     pub shader: Handle<Shader>,
@@ -157,7 +157,7 @@ impl VertexBufferLayout {
 }
 
 /// Describes the fragment process in a render pipeline.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct FragmentState {
     /// The compiled shader module for this stage.
     pub shader: Handle<Shader>,

--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -130,9 +130,9 @@ pub struct VertexBufferLayout {
 
 impl VertexBufferLayout {
     /// Creates a new densely packed [`VertexBufferLayout`] from an iterator of vertex formats.
-    /// Iteration order determines the `shader_location` and `offset` of the VertexAttributes.
+    /// Iteration order determines the `shader_location` and `offset` of the [`VertexAttributes`](VertexAttribute).
     /// The first iterated item will have a `shader_location` and `offset` of zero.
-    /// The `array_stride` is the sum of the size of the iterated VertexFormats (in bytes).
+    /// The `array_stride` is the sum of the size of the iterated [`VertexFormats`](VertexFormat) (in bytes).
     pub fn from_vertex_formats<T: IntoIterator<Item = VertexFormat>>(
         step_mode: VertexStepMode,
         vertex_formats: T,

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -245,6 +245,11 @@ impl RenderPipelineCache {
     }
 
     #[inline]
+    pub fn get_descriptor(&self, id: CachedPipelineId) -> &RenderPipelineDescriptor {
+        &self.pipelines[id.0].descriptor
+    }
+
+    #[inline]
     pub fn get(&self, id: CachedPipelineId) -> Option<&RenderPipeline> {
         if let CachedPipelineState::Ok(pipeline) = &self.pipelines[id.0].state {
             Some(pipeline)

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -13,7 +13,7 @@ use bevy_ecs::system::{Res, ResMut};
 use bevy_utils::{tracing::error, Entry, HashMap, HashSet};
 use std::{hash::Hash, ops::Deref, sync::Arc};
 use thiserror::Error;
-use wgpu::{PipelineLayoutDescriptor, ShaderModule, VertexBufferLayout};
+use wgpu::{PipelineLayoutDescriptor, ShaderModule, VertexBufferLayout as RawVertexBufferLayout};
 
 use super::ProcessedShader;
 
@@ -345,7 +345,7 @@ impl RenderPipelineCache {
                 .vertex
                 .buffers
                 .iter()
-                .map(|layout| VertexBufferLayout {
+                .map(|layout| RawVertexBufferLayout {
                     array_stride: layout.array_stride,
                     attributes: &layout.attributes,
                     step_mode: layout.step_mode,

--- a/crates/bevy_render/src/render_resource/pipeline_specializer.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_specializer.rs
@@ -1,5 +1,12 @@
-use crate::render_resource::{CachedPipelineId, RenderPipelineCache, RenderPipelineDescriptor};
-use bevy_utils::HashMap;
+use crate::{
+    mesh::{InnerMeshVertexBufferLayout, MeshVertexBufferLayout},
+    render_resource::{
+        CachedPipelineId, RenderPipelineCache, RenderPipelineDescriptor, VertexBufferLayout,
+    },
+};
+use bevy_utils::{
+    hashbrown::hash_map::RawEntryMut, Entry, HashMap, Hashed, PreHashMap, PreHashMapExt,
+};
 use std::hash::Hash;
 
 pub struct SpecializedPipelines<S: SpecializedPipeline> {
@@ -31,4 +38,63 @@ impl<S: SpecializedPipeline> SpecializedPipelines<S> {
 pub trait SpecializedPipeline {
     type Key: Clone + Hash + PartialEq + Eq;
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor;
+}
+
+pub struct SpecializedMeshPipelines<S: SpecializedMeshPipeline> {
+    mesh_layout_cache: PreHashMap<InnerMeshVertexBufferLayout, HashMap<S::Key, CachedPipelineId>>,
+    vertex_layout_cache: HashMap<VertexBufferLayout, HashMap<S::Key, CachedPipelineId>>,
+}
+
+impl<S: SpecializedMeshPipeline> Default for SpecializedMeshPipelines<S> {
+    fn default() -> Self {
+        Self {
+            mesh_layout_cache: Default::default(),
+            vertex_layout_cache: Default::default(),
+        }
+    }
+}
+
+impl<S: SpecializedMeshPipeline> SpecializedMeshPipelines<S> {
+    #[inline]
+    pub fn specialize(
+        &mut self,
+        cache: &mut RenderPipelineCache,
+        specialize_pipeline: &S,
+        key: S::Key,
+        layout: &MeshVertexBufferLayout,
+    ) -> CachedPipelineId {
+        let map = self
+            .mesh_layout_cache
+            .get_or_insert_with(layout, Default::default);
+        *map.entry(key.clone()).or_insert_with(|| {
+            let descriptor = specialize_pipeline.specialize(key.clone(), layout);
+            // Different MeshVertexBufferLayouts can produce the same final VertexBufferLayout
+            // We want compatible vertex buffer layouts to use the same pipelines, so we must "deduplicate" them
+            let layout_map = match self
+                .vertex_layout_cache
+                .raw_entry_mut()
+                .from_key(&descriptor.vertex.buffers[0])
+            {
+                RawEntryMut::Occupied(entry) => entry.into_mut(),
+                RawEntryMut::Vacant(entry) => {
+                    entry
+                        .insert(descriptor.vertex.buffers[0].clone(), Default::default())
+                        .1
+                }
+            };
+            match layout_map.entry(key) {
+                Entry::Occupied(entry) => *entry.into_mut(),
+                Entry::Vacant(entry) => *entry.insert(cache.queue(descriptor)),
+            }
+        })
+    }
+}
+
+pub trait SpecializedMeshPipeline {
+    type Key: Clone + Hash + PartialEq + Eq;
+    fn specialize(
+        &self,
+        key: Self::Key,
+        layout: &MeshVertexBufferLayout,
+    ) -> RenderPipelineDescriptor;
 }

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -70,6 +70,16 @@ pub trait Material2d: Asset + RenderAsset {
     fn dynamic_uniform_indices(material: &<Self as RenderAsset>::PreparedAsset) -> &[u32] {
         &[]
     }
+
+    /// Customizes the default [`RenderPipelineDescriptor`].
+    #[allow(unused_variables)]
+    #[inline]
+    fn specialize(
+        descriptor: &mut RenderPipelineDescriptor,
+        layout: &MeshVertexBufferLayout,
+    ) -> Result<(), SpecializedMeshPipelineError> {
+        Ok(())
+    }
 }
 
 impl<M: Material2d> SpecializedMaterial2d for M {
@@ -83,7 +93,8 @@ impl<M: Material2d> SpecializedMaterial2d for M {
         _key: Self::Key,
         _descriptor: &mut RenderPipelineDescriptor,
         _layout: &MeshVertexBufferLayout,
-    ) {
+    ) -> Result<(), SpecializedMeshPipelineError> {
+        <M as Material2d>::specialize(_descriptor, _layout)
     }
 
     #[inline]
@@ -132,7 +143,7 @@ pub trait SpecializedMaterial2d: Asset + RenderAsset {
         key: Self::Key,
         descriptor: &mut RenderPipelineDescriptor,
         layout: &MeshVertexBufferLayout,
-    );
+    ) -> Result<(), SpecializedMeshPipelineError>;
 
     /// Returns this material's [`BindGroup`]. This should match the layout returned by [`SpecializedMaterial2d::bind_group_layout`].
     fn bind_group(material: &<Self as RenderAsset>::PreparedAsset) -> &BindGroup;
@@ -218,7 +229,7 @@ impl<M: SpecializedMaterial2d> SpecializedMeshPipeline for Material2dPipeline<M>
             self.mesh2d_pipeline.mesh_layout.clone(),
         ]);
 
-        M::specialize(key.1, &mut descriptor, layout);
+        M::specialize(key.1, &mut descriptor, layout)?;
         Ok(descriptor)
     }
 }

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -91,10 +91,10 @@ impl<M: Material2d> SpecializedMaterial2d for M {
     #[inline]
     fn specialize(
         _key: Self::Key,
-        _descriptor: &mut RenderPipelineDescriptor,
-        _layout: &MeshVertexBufferLayout,
+        descriptor: &mut RenderPipelineDescriptor,
+        layout: &MeshVertexBufferLayout,
     ) -> Result<(), SpecializedMeshPipelineError> {
-        <M as Material2d>::specialize(_descriptor, _layout)
+        <M as Material2d>::specialize(descriptor, layout)
     }
 
     #[inline]

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -282,7 +282,7 @@ impl SpecializedMeshPipeline for Mesh2dPipeline {
         &self,
         key: Self::Key,
         layout: &MeshVertexBufferLayout,
-    ) -> RenderPipelineDescriptor {
+    ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
         let mut vertex_attributes = vec![
             Mesh::ATTRIBUTE_POSITION.at_shader_location(0),
             Mesh::ATTRIBUTE_NORMAL.at_shader_location(1),
@@ -298,11 +298,9 @@ impl SpecializedMeshPipeline for Mesh2dPipeline {
         #[cfg(feature = "webgl")]
         shader_defs.push(String::from("NO_ARRAY_TEXTURES_SUPPORT"));
 
-        let vertex_buffer_layout = layout
-            .get_layout(&vertex_attributes)
-            .expect("Mesh is missing a vertex attribute");
+        let vertex_buffer_layout = layout.get_layout(&vertex_attributes)?;
 
-        RenderPipelineDescriptor {
+        Ok(RenderPipelineDescriptor {
             vertex: VertexState {
                 shader: MESH2D_SHADER_HANDLE.typed::<Shader>(),
                 entry_point: "vertex".into(),
@@ -336,7 +334,7 @@ impl SpecializedMeshPipeline for Mesh2dPipeline {
                 alpha_to_coverage_enabled: false,
             },
             label: Some("transparent_mesh2d_pipeline".into()),
-        }
+        })
     }
 }
 

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
 use bevy_math::{Mat4, Size};
 use bevy_reflect::TypeUuid;
 use bevy_render::{
-    mesh::{GpuBufferInfo, Mesh},
+    mesh::{GpuBufferInfo, Mesh, MeshVertexBufferLayout},
     render_asset::RenderAssets,
     render_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
     render_phase::{EntityRenderCommand, RenderCommandResult, TrackedRenderPass},
@@ -64,7 +64,7 @@ impl Plugin for Mesh2dRenderPlugin {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .init_resource::<Mesh2dPipeline>()
-                .init_resource::<SpecializedPipelines<Mesh2dPipeline>>()
+                .init_resource::<SpecializedMeshPipelines<Mesh2dPipeline>>()
                 .add_system_to_stage(RenderStage::Extract, extract_mesh2d)
                 .add_system_to_stage(RenderStage::Queue, queue_mesh2d_bind_group)
                 .add_system_to_stage(RenderStage::Queue, queue_mesh2d_view_bind_groups);
@@ -234,7 +234,6 @@ bitflags::bitflags! {
     // FIXME: make normals optional?
     pub struct Mesh2dPipelineKey: u32 {
         const NONE                        = 0;
-        const VERTEX_TANGENTS             = (1 << 0);
         const MSAA_RESERVED_BITS          = Mesh2dPipelineKey::MSAA_MASK_BITS << Mesh2dPipelineKey::MSAA_SHIFT_BITS;
         const PRIMITIVE_TOPOLOGY_RESERVED_BITS = Mesh2dPipelineKey::PRIMITIVE_TOPOLOGY_MASK_BITS << Mesh2dPipelineKey::PRIMITIVE_TOPOLOGY_SHIFT_BITS;
     }
@@ -276,84 +275,39 @@ impl Mesh2dPipelineKey {
     }
 }
 
-impl SpecializedPipeline for Mesh2dPipeline {
+impl SpecializedMeshPipeline for Mesh2dPipeline {
     type Key = Mesh2dPipelineKey;
 
-    fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
-        let (vertex_array_stride, vertex_attributes) =
-            if key.contains(Mesh2dPipelineKey::VERTEX_TANGENTS) {
-                (
-                    48,
-                    vec![
-                        // Position (GOTCHA! Vertex_Position isn't first in the buffer due to how Mesh sorts attributes (alphabetically))
-                        VertexAttribute {
-                            format: VertexFormat::Float32x3,
-                            offset: 12,
-                            shader_location: 0,
-                        },
-                        // Normal
-                        VertexAttribute {
-                            format: VertexFormat::Float32x3,
-                            offset: 0,
-                            shader_location: 1,
-                        },
-                        // Uv (GOTCHA! uv is no longer third in the buffer due to how Mesh sorts attributes (alphabetically))
-                        VertexAttribute {
-                            format: VertexFormat::Float32x2,
-                            offset: 40,
-                            shader_location: 2,
-                        },
-                        // Tangent
-                        VertexAttribute {
-                            format: VertexFormat::Float32x4,
-                            offset: 24,
-                            shader_location: 3,
-                        },
-                    ],
-                )
-            } else {
-                (
-                    32,
-                    vec![
-                        // Position (GOTCHA! Vertex_Position isn't first in the buffer due to how Mesh sorts attributes (alphabetically))
-                        VertexAttribute {
-                            format: VertexFormat::Float32x3,
-                            offset: 12,
-                            shader_location: 0,
-                        },
-                        // Normal
-                        VertexAttribute {
-                            format: VertexFormat::Float32x3,
-                            offset: 0,
-                            shader_location: 1,
-                        },
-                        // Uv
-                        VertexAttribute {
-                            format: VertexFormat::Float32x2,
-                            offset: 24,
-                            shader_location: 2,
-                        },
-                    ],
-                )
-            };
+    fn specialize(
+        &self,
+        key: Self::Key,
+        layout: &MeshVertexBufferLayout,
+    ) -> RenderPipelineDescriptor {
+        let mut vertex_attributes = vec![
+            Mesh::ATTRIBUTE_POSITION.at_shader_location(0),
+            Mesh::ATTRIBUTE_NORMAL.at_shader_location(1),
+            Mesh::ATTRIBUTE_UV_0.at_shader_location(2),
+        ];
+
         let mut shader_defs = Vec::new();
-        if key.contains(Mesh2dPipelineKey::VERTEX_TANGENTS) {
+        if layout.contains(Mesh::ATTRIBUTE_TANGENT) {
             shader_defs.push(String::from("VERTEX_TANGENTS"));
+            vertex_attributes.push(Mesh::ATTRIBUTE_TANGENT.at_shader_location(3));
         }
 
         #[cfg(feature = "webgl")]
         shader_defs.push(String::from("NO_ARRAY_TEXTURES_SUPPORT"));
+
+        let vertex_buffer_layout = layout
+            .get_layout(&vertex_attributes)
+            .expect("Mesh is missing a vertex attribute");
 
         RenderPipelineDescriptor {
             vertex: VertexState {
                 shader: MESH2D_SHADER_HANDLE.typed::<Shader>(),
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
-                buffers: vec![VertexBufferLayout {
-                    array_stride: vertex_array_stride,
-                    step_mode: VertexStepMode::Vertex,
-                    attributes: vertex_attributes,
-                }],
+                buffers: vec![vertex_buffer_layout],
             },
             fragment: Some(FragmentState {
                 shader: MESH2D_SHADER_HANDLE.typed::<Shader>(),

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -138,7 +138,7 @@ impl SpecializedPipeline for SpritePipeline {
                 shader: SPRITE_SHADER_HANDLE.typed::<Shader>(),
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
-                buffers: vec![vertex_layout.clone()],
+                buffers: vec![vertex_layout],
             },
             fragment: Some(FragmentState {
                 shader: SPRITE_SHADER_HANDLE.typed::<Shader>(),

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -113,31 +113,24 @@ impl SpecializedPipeline for SpritePipeline {
     type Key = SpritePipelineKey;
 
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
-        let mut vertex_buffer_layout = VertexBufferLayout {
-            array_stride: 20,
-            step_mode: VertexStepMode::Vertex,
-            attributes: vec![
-                VertexAttribute {
-                    format: VertexFormat::Float32x3,
-                    offset: 0,
-                    shader_location: 0,
-                },
-                VertexAttribute {
-                    format: VertexFormat::Float32x2,
-                    offset: 12,
-                    shader_location: 1,
-                },
-            ],
-        };
+        let mut formats = vec![
+            // position
+            VertexFormat::Float32x3,
+            // uv
+            VertexFormat::Float32x2,
+        ];
+
+        if key.contains(SpritePipelineKey::COLORED) {
+            // color
+            formats.push(VertexFormat::Uint32);
+        }
+
+        let vertex_layout =
+            VertexBufferLayout::from_vertex_formats(VertexStepMode::Vertex, formats);
+
         let mut shader_defs = Vec::new();
         if key.contains(SpritePipelineKey::COLORED) {
             shader_defs.push("COLORED".to_string());
-            vertex_buffer_layout.attributes.push(VertexAttribute {
-                format: VertexFormat::Uint32,
-                offset: 20,
-                shader_location: 2,
-            });
-            vertex_buffer_layout.array_stride += 4;
         }
 
         RenderPipelineDescriptor {
@@ -145,7 +138,7 @@ impl SpecializedPipeline for SpritePipeline {
                 shader: SPRITE_SHADER_HANDLE.typed::<Shader>(),
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
-                buffers: vec![vertex_buffer_layout],
+                buffers: vec![vertex_layout.clone()],
             },
             fragment: Some(FragmentState {
                 shader: SPRITE_SHADER_HANDLE.typed::<Shader>(),

--- a/crates/bevy_ui/src/render/pipeline.rs
+++ b/crates/bevy_ui/src/render/pipeline.rs
@@ -84,7 +84,7 @@ impl SpecializedPipeline for UiPipeline {
                 shader: super::UI_SHADER_HANDLE.typed::<Shader>(),
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
-                buffers: vec![vertex_layout.clone()],
+                buffers: vec![vertex_layout],
             },
             fragment: Some(FragmentState {
                 shader: super::UI_SHADER_HANDLE.typed::<Shader>(),

--- a/crates/bevy_ui/src/render/pipeline.rs
+++ b/crates/bevy_ui/src/render/pipeline.rs
@@ -66,29 +66,17 @@ impl SpecializedPipeline for UiPipeline {
     type Key = UiPipelineKey;
     /// FIXME: there are no specialization for now, should this be removed?
     fn specialize(&self, _key: Self::Key) -> RenderPipelineDescriptor {
-        let vertex_buffer_layout = VertexBufferLayout {
-            array_stride: 24,
-            step_mode: VertexStepMode::Vertex,
-            attributes: vec![
-                // Position
-                VertexAttribute {
-                    format: VertexFormat::Float32x3,
-                    offset: 0,
-                    shader_location: 0,
-                },
-                // UV
-                VertexAttribute {
-                    format: VertexFormat::Float32x2,
-                    offset: 12,
-                    shader_location: 1,
-                },
-                VertexAttribute {
-                    format: VertexFormat::Uint32,
-                    offset: 20,
-                    shader_location: 2,
-                },
+        let vertex_layout = VertexBufferLayout::from_vertex_formats(
+            VertexStepMode::Vertex,
+            vec![
+                // position
+                VertexFormat::Float32x3,
+                // uv
+                VertexFormat::Float32x2,
+                // color
+                VertexFormat::Uint32,
             ],
-        };
+        );
         let shader_defs = Vec::new();
 
         RenderPipelineDescriptor {
@@ -96,7 +84,7 @@ impl SpecializedPipeline for UiPipeline {
                 shader: super::UI_SHADER_HANDLE.typed::<Shader>(),
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
-                buffers: vec![vertex_buffer_layout],
+                buffers: vec![vertex_layout.clone()],
             },
             fragment: Some(FragmentState {
                 shader: super::UI_SHADER_HANDLE.typed::<Shader>(),

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -68,11 +68,11 @@ fn star(
         v_pos.push([r * a.cos(), r * a.sin(), 0.0]);
     }
     // Set the position attribute
-    star.set_attribute(Mesh::ATTRIBUTE_POSITION, v_pos);
+    star.insert_attribute(Mesh::ATTRIBUTE_POSITION, v_pos);
     // And a RGB color attribute as well
     let mut v_color = vec![[0.0, 0.0, 0.0, 1.0]];
     v_color.extend_from_slice(&[[1.0, 1.0, 0.0, 1.0]; 10]);
-    star.set_attribute(Mesh::ATTRIBUTE_COLOR, v_color);
+    star.insert_attribute(Mesh::ATTRIBUTE_COLOR, v_color);
 
     // Now, we specify the indices of the vertex that are going to compose the
     // triangles in our star. Vertices in triangles have to be specified in CCW

--- a/examples/README.md
+++ b/examples/README.md
@@ -222,6 +222,7 @@ Example | File | Description
 
 Example | File | Description
 --- | --- | ---
+`custom_vertex_attribute` | [`shader/custom_vertex_attribute.rs`](./shader/custom_vertex_attribute.rs) | Illustrates creating a custom shader material that reads a mesh's custom vertex attribute.
 `shader_material` | [`shader/shader_material.rs`](./shader/shader_material.rs) | Illustrates creating a custom material and a shader that uses it
 `shader_material_glsl` | [`shader/shader_material_glsl.rs`](./shader/shader_material_glsl.rs) | A custom shader using the GLSL shading language.
 `shader_instancing` | [`shader/shader_instancing.rs`](./shader/shader_instancing.rs) | A custom shader showing off rendering a mesh multiple times in one draw call.

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -92,6 +92,7 @@ fn extract_custom_material(
 }
 
 // add each entity with a mesh and a `CustomMaterial` to every view's `Transparent3d` render phase using the `CustomPipeline`
+#[allow(clippy::too_many_arguments)]
 fn queue_custom(
     transparent_3d_draw_functions: Res<DrawFunctions<Transparent3d>>,
     custom_pipeline: Res<CustomPipeline>,

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -115,8 +115,9 @@ fn queue_custom(
         let view_row_2 = view_matrix.row(2);
         for (entity, mesh_uniform, mesh_handle) in material_meshes.iter() {
             if let Some(mesh) = render_meshes.get(mesh_handle) {
-                let pipeline =
-                    pipelines.specialize(&mut pipeline_cache, &custom_pipeline, key, &mesh.layout);
+                let pipeline = pipelines
+                    .specialize(&mut pipeline_cache, &custom_pipeline, key, &mesh.layout)
+                    .unwrap();
                 transparent_phase.add(Transparent3d {
                     entity,
                     pipeline,
@@ -220,8 +221,8 @@ impl SpecializedMeshPipeline for CustomPipeline {
         &self,
         key: Self::Key,
         layout: &MeshVertexBufferLayout,
-    ) -> RenderPipelineDescriptor {
-        let mut descriptor = self.mesh_pipeline.specialize(key, layout);
+    ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
+        let mut descriptor = self.mesh_pipeline.specialize(key, layout)?;
         descriptor.vertex.shader = self.shader.clone();
         descriptor.fragment.as_mut().unwrap().shader = self.shader.clone();
         descriptor.layout = Some(vec![
@@ -229,7 +230,7 @@ impl SpecializedMeshPipeline for CustomPipeline {
             self.mesh_pipeline.mesh_layout.clone(),
             self.time_bind_group_layout.clone(),
         ]);
-        descriptor
+        Ok(descriptor)
     }
 }
 

--- a/examples/shader/custom_vertex_attribute.rs
+++ b/examples/shader/custom_vertex_attribute.rs
@@ -1,14 +1,17 @@
 use bevy::{
     ecs::system::{lifetimeless::SRes, SystemParamItem},
-    pbr::{MaterialPipeline, SpecializedMaterial},
+    pbr::MaterialPipeline,
     prelude::*,
     reflect::TypeUuid,
     render::{
-        mesh::MeshVertexBufferLayout,
+        mesh::{MeshVertexAttribute, MeshVertexBufferLayout},
         render_asset::{PrepareAssetError, RenderAsset},
         render_resource::{
             std140::{AsStd140, Std140},
-            *,
+            BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayout,
+            BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingType, Buffer,
+            BufferBindingType, BufferInitDescriptor, BufferSize, BufferUsages,
+            RenderPipelineDescriptor, ShaderStages, SpecializedMeshPipelineError, VertexFormat,
         },
         renderer::RenderDevice,
     },
@@ -22,18 +25,30 @@ fn main() {
         .run();
 }
 
+const ATTRIBUTE_BLEND_COLOR: MeshVertexAttribute =
+    MeshVertexAttribute::new("BlendColor", 988540917, VertexFormat::Float32x4);
+
 /// set up a simple 3D scene
 fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<CustomMaterial>>,
 ) {
+    // A "high" random id should be used for custom attributes to ensure proper sorting and avoid collisions with other attributes.
+    // See the MeshVertexAttribute docs for more info.
+    let mut mesh = Mesh::from(shape::Cube { size: 1.0 });
+    mesh.insert_attribute(
+        ATTRIBUTE_BLEND_COLOR,
+        // The cube mesh has 24 vertices (6 faces, 4 vertices per face), so we insert one BlendColor for each
+        vec![[1.0, 0.0, 0.0, 1.0]; 24],
+    );
+
     // cube
     commands.spawn().insert_bundle(MaterialMeshBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(mesh),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         material: materials.add(CustomMaterial {
-            color: Color::GREEN,
+            color: Color::WHITE,
         }),
         ..Default::default()
     });
@@ -45,8 +60,9 @@ fn setup(
     });
 }
 
+// This is the struct that will be passed to your shader
 #[derive(Debug, Clone, TypeUuid)]
-#[uuid = "4ee9c363-1124-4113-890e-199d81b00281"]
+#[uuid = "f690fdae-d598-45ab-8225-97e2a3f056e0"]
 pub struct CustomMaterial {
     color: Color,
 }
@@ -57,6 +73,7 @@ pub struct GpuCustomMaterial {
     bind_group: BindGroup,
 }
 
+// The implementation of [`Material`] needs this impl to work properly.
 impl RenderAsset for CustomMaterial {
     type ExtractedAsset = CustomMaterial;
     type PreparedAsset = GpuCustomMaterial;
@@ -91,27 +108,12 @@ impl RenderAsset for CustomMaterial {
     }
 }
 
-impl SpecializedMaterial for CustomMaterial {
-    type Key = ();
-
-    fn key(_: &<CustomMaterial as RenderAsset>::PreparedAsset) -> Self::Key {}
-
-    fn specialize(
-        descriptor: &mut RenderPipelineDescriptor,
-        _: Self::Key,
-        _layout: &MeshVertexBufferLayout,
-    ) -> Result<(), SpecializedMeshPipelineError> {
-        descriptor.vertex.entry_point = "main".into();
-        descriptor.fragment.as_mut().unwrap().entry_point = "main".into();
-        Ok(())
-    }
-
+impl Material for CustomMaterial {
     fn vertex_shader(asset_server: &AssetServer) -> Option<Handle<Shader>> {
-        Some(asset_server.load("shaders/custom_material.vert"))
+        Some(asset_server.load("shaders/custom_vertex_attribute.wgsl"))
     }
-
     fn fragment_shader(asset_server: &AssetServer) -> Option<Handle<Shader>> {
-        Some(asset_server.load("shaders/custom_material.frag"))
+        Some(asset_server.load("shaders/custom_vertex_attribute.wgsl"))
     }
 
     fn bind_group(render_asset: &<Self as RenderAsset>::PreparedAsset) -> &BindGroup {
@@ -132,5 +134,17 @@ impl SpecializedMaterial for CustomMaterial {
             }],
             label: None,
         })
+    }
+
+    fn specialize(
+        descriptor: &mut RenderPipelineDescriptor,
+        layout: &MeshVertexBufferLayout,
+    ) -> Result<(), SpecializedMeshPipelineError> {
+        let vertex_layout = layout.get_layout(&[
+            Mesh::ATTRIBUTE_POSITION.at_shader_location(0),
+            ATTRIBUTE_BLEND_COLOR.at_shader_location(1),
+        ])?;
+        descriptor.vertex.buffers = vec![vertex_layout];
+        Ok(())
     }
 }

--- a/examples/shader/custom_vertex_attribute.rs
+++ b/examples/shader/custom_vertex_attribute.rs
@@ -25,6 +25,8 @@ fn main() {
         .run();
 }
 
+// A "high" random id should be used for custom attributes to ensure consistent sorting and avoid collisions with other attributes.
+// See the MeshVertexAttribute docs for more info.
 const ATTRIBUTE_BLEND_COLOR: MeshVertexAttribute =
     MeshVertexAttribute::new("BlendColor", 988540917, VertexFormat::Float32x4);
 
@@ -34,8 +36,6 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<CustomMaterial>>,
 ) {
-    // A "high" random id should be used for custom attributes to ensure proper sorting and avoid collisions with other attributes.
-    // See the MeshVertexAttribute docs for more info.
     let mut mesh = Mesh::from(shape::Cube { size: 1.0 });
     mesh.insert_attribute(
         ATTRIBUTE_BLEND_COLOR,

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -6,12 +6,13 @@ use bevy::{
     },
     prelude::*,
     render::{
+        mesh::MeshVertexBufferLayout,
         render_asset::RenderAssets,
         render_component::{ExtractComponent, ExtractComponentPlugin},
         render_phase::{AddRenderCommand, DrawFunctions, RenderPhase, SetItemPipeline},
         render_resource::{
-            RenderPipelineCache, RenderPipelineDescriptor, SpecializedPipeline,
-            SpecializedPipelines,
+            RenderPipelineCache, RenderPipelineDescriptor, SpecializedMeshPipeline,
+            SpecializedMeshPipelines,
         },
         view::ExtractedView,
         RenderApp, RenderStage,
@@ -26,7 +27,7 @@ impl Plugin for IsRedPlugin {
         app.sub_app_mut(RenderApp)
             .add_render_command::<Transparent3d, DrawIsRed>()
             .init_resource::<IsRedPipeline>()
-            .init_resource::<SpecializedPipelines<IsRedPipeline>>()
+            .init_resource::<SpecializedMeshPipelines<IsRedPipeline>>()
             .add_system_to_stage(RenderStage::Queue, queue_custom);
     }
 }
@@ -98,15 +99,19 @@ impl FromWorld for IsRedPipeline {
     }
 }
 
-impl SpecializedPipeline for IsRedPipeline {
+impl SpecializedMeshPipeline for IsRedPipeline {
     type Key = (IsRed, MeshPipelineKey);
 
-    fn specialize(&self, (is_red, pbr_pipeline_key): Self::Key) -> RenderPipelineDescriptor {
+    fn specialize(
+        &self,
+        (is_red, pbr_pipeline_key): Self::Key,
+        layout: &MeshVertexBufferLayout,
+    ) -> RenderPipelineDescriptor {
         let mut shader_defs = Vec::new();
         if is_red.0 {
             shader_defs.push("IS_RED".to_string());
         }
-        let mut descriptor = self.mesh_pipeline.specialize(pbr_pipeline_key);
+        let mut descriptor = self.mesh_pipeline.specialize(pbr_pipeline_key, layout);
         descriptor.vertex.shader = self.shader.clone();
         descriptor.vertex.shader_defs = shader_defs.clone();
         let fragment = descriptor.fragment.as_mut().unwrap();
@@ -133,7 +138,7 @@ fn queue_custom(
     render_meshes: Res<RenderAssets<Mesh>>,
     custom_pipeline: Res<IsRedPipeline>,
     msaa: Res<Msaa>,
-    mut pipelines: ResMut<SpecializedPipelines<IsRedPipeline>>,
+    mut pipelines: ResMut<SpecializedMeshPipelines<IsRedPipeline>>,
     mut pipeline_cache: ResMut<RenderPipelineCache>,
     material_meshes: Query<(Entity, &Handle<Mesh>, &MeshUniform, &IsRed)>,
     mut views: Query<(&ExtractedView, &mut RenderPhase<Transparent3d>)>,
@@ -142,15 +147,20 @@ fn queue_custom(
         .read()
         .get_id::<DrawIsRed>()
         .unwrap();
-    let key = MeshPipelineKey::from_msaa_samples(msaa.samples);
+    let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples);
     for (view, mut transparent_phase) in views.iter_mut() {
         let view_matrix = view.transform.compute_matrix();
         let view_row_2 = view_matrix.row(2);
         for (entity, mesh_handle, mesh_uniform, is_red) in material_meshes.iter() {
             if let Some(mesh) = render_meshes.get(mesh_handle) {
-                let key = key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
-                let pipeline =
-                    pipelines.specialize(&mut pipeline_cache, &custom_pipeline, (*is_red, key));
+                let key =
+                    msaa_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
+                let pipeline = pipelines.specialize(
+                    &mut pipeline_cache,
+                    &custom_pipeline,
+                    (*is_red, key),
+                    &mesh.layout,
+                );
                 transparent_phase.add(Transparent3d {
                     entity,
                     pipeline,

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -122,8 +122,9 @@ fn queue_custom(
             if let Some(mesh) = meshes.get(mesh_handle) {
                 let key =
                     msaa_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
-                let pipeline =
-                    pipelines.specialize(&mut pipeline_cache, &custom_pipeline, key, &mesh.layout);
+                let pipeline = pipelines
+                    .specialize(&mut pipeline_cache, &custom_pipeline, key, &mesh.layout)
+                    .unwrap();
                 transparent_phase.add(Transparent3d {
                     entity,
                     pipeline,
@@ -187,8 +188,8 @@ impl SpecializedMeshPipeline for CustomPipeline {
         &self,
         key: Self::Key,
         layout: &MeshVertexBufferLayout,
-    ) -> RenderPipelineDescriptor {
-        let mut descriptor = self.mesh_pipeline.specialize(key, layout);
+    ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
+        let mut descriptor = self.mesh_pipeline.specialize(key, layout)?;
         descriptor.vertex.shader = self.shader.clone();
         descriptor.vertex.buffers.push(VertexBufferLayout {
             array_stride: std::mem::size_of::<InstanceData>() as u64,
@@ -212,7 +213,7 @@ impl SpecializedMeshPipeline for CustomPipeline {
             self.mesh_pipeline.mesh_layout.clone(),
         ]);
 
-        descriptor
+        Ok(descriptor)
     }
 }
 

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -95,6 +95,7 @@ struct InstanceData {
     color: [f32; 4],
 }
 
+#[allow(clippy::too_many_arguments)]
 fn queue_custom(
     transparent_3d_draw_functions: Res<DrawFunctions<Transparent3d>>,
     custom_pipeline: Res<CustomPipeline>,

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -5,7 +5,7 @@ use bevy::{
     pbr::{MeshPipeline, MeshPipelineKey, MeshUniform, SetMeshBindGroup, SetMeshViewBindGroup},
     prelude::*,
     render::{
-        mesh::GpuBufferInfo,
+        mesh::{GpuBufferInfo, MeshVertexBufferLayout},
         render_asset::RenderAssets,
         render_component::{ExtractComponent, ExtractComponentPlugin},
         render_phase::{
@@ -81,7 +81,7 @@ impl Plugin for CustomMaterialPlugin {
         app.sub_app_mut(RenderApp)
             .add_render_command::<Transparent3d, DrawCustom>()
             .init_resource::<CustomPipeline>()
-            .init_resource::<SpecializedPipelines<CustomPipeline>>()
+            .init_resource::<SpecializedMeshPipelines<CustomPipeline>>()
             .add_system_to_stage(RenderStage::Queue, queue_custom)
             .add_system_to_stage(RenderStage::Prepare, prepare_instance_buffers);
     }
@@ -99,10 +99,11 @@ fn queue_custom(
     transparent_3d_draw_functions: Res<DrawFunctions<Transparent3d>>,
     custom_pipeline: Res<CustomPipeline>,
     msaa: Res<Msaa>,
-    mut pipelines: ResMut<SpecializedPipelines<CustomPipeline>>,
+    mut pipelines: ResMut<SpecializedMeshPipelines<CustomPipeline>>,
     mut pipeline_cache: ResMut<RenderPipelineCache>,
+    meshes: Res<RenderAssets<Mesh>>,
     material_meshes: Query<
-        (Entity, &MeshUniform),
+        (Entity, &MeshUniform, &Handle<Mesh>),
         (With<Handle<Mesh>>, With<InstanceMaterialData>),
     >,
     mut views: Query<(&ExtractedView, &mut RenderPhase<Transparent3d>)>,
@@ -112,20 +113,24 @@ fn queue_custom(
         .get_id::<DrawCustom>()
         .unwrap();
 
-    let key = MeshPipelineKey::from_msaa_samples(msaa.samples)
-        | MeshPipelineKey::from_primitive_topology(PrimitiveTopology::TriangleList);
-    let pipeline = pipelines.specialize(&mut pipeline_cache, &custom_pipeline, key);
+    let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples);
 
     for (view, mut transparent_phase) in views.iter_mut() {
         let view_matrix = view.transform.compute_matrix();
         let view_row_2 = view_matrix.row(2);
-        for (entity, mesh_uniform) in material_meshes.iter() {
-            transparent_phase.add(Transparent3d {
-                entity,
-                pipeline,
-                draw_function: draw_custom,
-                distance: view_row_2.dot(mesh_uniform.transform.col(3)),
-            });
+        for (entity, mesh_uniform, mesh_handle) in material_meshes.iter() {
+            if let Some(mesh) = meshes.get(mesh_handle) {
+                let key =
+                    msaa_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
+                let pipeline =
+                    pipelines.specialize(&mut pipeline_cache, &custom_pipeline, key, &mesh.layout);
+                transparent_phase.add(Transparent3d {
+                    entity,
+                    pipeline,
+                    draw_function: draw_custom,
+                    distance: view_row_2.dot(mesh_uniform.transform.col(3)),
+                });
+            }
         }
     }
 }
@@ -175,11 +180,15 @@ impl FromWorld for CustomPipeline {
     }
 }
 
-impl SpecializedPipeline for CustomPipeline {
+impl SpecializedMeshPipeline for CustomPipeline {
     type Key = MeshPipelineKey;
 
-    fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
-        let mut descriptor = self.mesh_pipeline.specialize(key);
+    fn specialize(
+        &self,
+        key: Self::Key,
+        layout: &MeshVertexBufferLayout,
+    ) -> RenderPipelineDescriptor {
+        let mut descriptor = self.mesh_pipeline.specialize(key, layout);
         descriptor.vertex.shader = self.shader.clone();
         descriptor.vertex.buffers.push(VertexBufferLayout {
             array_stride: std::mem::size_of::<InstanceData>() as u64,

--- a/examples/shader/shader_material_glsl.rs
+++ b/examples/shader/shader_material_glsl.rs
@@ -4,6 +4,7 @@ use bevy::{
     prelude::*,
     reflect::TypeUuid,
     render::{
+        mesh::MeshVertexBufferLayout,
         render_asset::{PrepareAssetError, RenderAsset},
         render_resource::{
             std140::{AsStd140, Std140},
@@ -95,7 +96,11 @@ impl SpecializedMaterial for CustomMaterial {
 
     fn key(_: &<CustomMaterial as RenderAsset>::PreparedAsset) -> Self::Key {}
 
-    fn specialize(_: Self::Key, descriptor: &mut RenderPipelineDescriptor) {
+    fn specialize(
+        descriptor: &mut RenderPipelineDescriptor,
+        _: Self::Key,
+        _layout: &MeshVertexBufferLayout,
+    ) {
         descriptor.vertex.entry_point = "main".into();
         descriptor.fragment.as_mut().unwrap().entry_point = "main".into();
     }


### PR DESCRIPTION
This PR makes a number of changes to how meshes and vertex attributes are handled, which the goal of enabling easy and flexible custom vertex attributes:
* Reworks the `Mesh` type to use the newly added `VertexAttribute` internally
  * `VertexAttribute` defines the name, a unique `VertexAttributeId`, and a `VertexFormat`
  *  `VertexAttributeId` is used to produce consistent sort orders for vertex buffer generation, replacing the more expensive and often surprising "name based sorting"  
  * Meshes can be used to generate a `MeshVertexBufferLayout`, which defines the layout of the gpu buffer produced by the mesh. `MeshVertexBufferLayouts` can then be used to generate actual `VertexBufferLayouts` according to the requirements of a specific pipeline. This decoupling of "mesh layout" vs "pipeline vertex buffer layout" is what enables custom attributes. We don't need to standardize _mesh layouts_ or contort meshes to meet the needs of a specific pipeline. As long as the mesh has what the pipeline needs, it will work transparently. 
* Mesh-based pipelines now specialize on `&MeshVertexBufferLayout` via the new `SpecializedMeshPipeline` trait (which behaves like `SpecializedPipeline`, but adds `&MeshVertexBufferLayout`). The integrity of the pipeline cache is maintained because the `MeshVertexBufferLayout` is treated as part of the key (which is fully abstracted from implementers of the trait ... no need to add any additional info to the specialization key).    
* Hashing `MeshVertexBufferLayout` is too expensive to do for every entity, every frame. To make this scalable, I added a generalized "pre-hashing" solution to `bevy_utils`: `Hashed<T>` keys and `PreHashMap<K, V>` (which uses `Hashed<T>` internally) . Why didn't I just do the quick and dirty in-place "pre-compute hash and use that u64 as a key in a hashmap" that we've done in the past? Because its wrong! Hashes by themselves aren't enough because two different values can produce the same hash. Re-hashing a hash is even worse! I decided to build a generalized solution because this pattern has come up in the past and we've chosen to do the wrong thing. Now we can do the right thing! This did unfortunately require pulling in `hashbrown` and using that in `bevy_utils`, because avoiding re-hashes requires the `raw_entry_mut` api, which isn't stabilized yet (and may never be ... `entry_ref` has favor now, but also isn't available yet). If std's HashMap ever provides the tools we need, we can move back to that. Note that adding `hashbrown` doesn't increase our dependency count because it was already in our tree. I will probably break these changes out into their own PR.
* Specializing on `MeshVertexBufferLayout` has one non-obvious behavior: it can produce identical pipelines for two different MeshVertexBufferLayouts. To optimize the number of active pipelines / reduce re-binds while drawing, I de-duplicate pipelines post-specialization using the final `VertexBufferLayout` as the key.  For example, consider a pipeline that needs the layout `(position, normal)` and is specialized using two meshes: `(position, normal, uv)` and `(position, normal, other_vec2)`. If both of these meshes result in `(position, normal)` specializations, we can use the same pipeline! Now we do. Cool!

To briefly illustrate, this is what the relevant section of `MeshPipeline`'s specialization code looks like now:

```rust
impl SpecializedMeshPipeline for MeshPipeline {
    type Key = MeshPipelineKey;

    fn specialize(
        &self,
        key: Self::Key,
        layout: &MeshVertexBufferLayout,
    ) -> RenderPipelineDescriptor {
        let mut vertex_attributes = vec![
            Mesh::ATTRIBUTE_POSITION.at_shader_location(0),
            Mesh::ATTRIBUTE_NORMAL.at_shader_location(1),
            Mesh::ATTRIBUTE_UV_0.at_shader_location(2),
        ];

        let mut shader_defs = Vec::new();
        if layout.contains(Mesh::ATTRIBUTE_TANGENT) {
            shader_defs.push(String::from("VERTEX_TANGENTS"));
            vertex_attributes.push(Mesh::ATTRIBUTE_TANGENT.at_shader_location(3));
        }

        let vertex_buffer_layout = layout
            .get_layout(&vertex_attributes)
            .expect("Mesh is missing a vertex attribute");
```

Notice that this is _much_ simpler than it was before. And now any mesh with any layout can be used with this pipeline, provided it has vertex postions, normals, and uvs. We even got to remove `HAS_TANGENTS` from MeshPipelineKey and `has_tangents` from `GpuMesh`, because that information is redundant with `MeshVertexBufferLayout`.

This is still a draft because I still need to:

* Add more docs
* Experiment with adding error handling to mesh pipeline specialization (which would print errors at runtime when a mesh is missing a vertex attribute required by a pipeline). If it doesn't tank perf, we'll keep it.
* Consider breaking out the PreHash / hashbrown changes into a separate PR.
* Add an example illustrating this change
* Verify that the "mesh-specialized pipeline de-duplication code" works properly

Please dont yell at me for not doing these things yet :) Just trying to get this in peoples' hands asap.

Alternative to #3120
Fixes #3030
