### PR TITLE
[Merged by Bors] - Fix custom material glsl example using incorrect CameraViewProj

### DIFF
--- a/assets/shaders/custom_material.vert
+++ b/assets/shaders/custom_material.vert
@@ -6,6 +6,7 @@ layout(location = 2) in vec2 Vertex_Uv;
 
 layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
+    mat4 View;
     mat4 InverseView;
     mat4 Projection;
     vec3 WorldPosition;


### PR DESCRIPTION
# Objective

The `custom_material.vert` shader used by the `shader_material_glsl` example is missing a `mat4 View` in `CameraViewProj` (added in [#3885](https://github.com/bevyengine/bevy/pull/3885))

## Solution

Update the definition of `CameraViewProj`
