### PR TITLE
[Merged by Bors] - Rename "2d rotation" example name to "rotation"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ name = "move_sprite"
 path = "examples/2d/move_sprite.rs"
 
 [[example]]
-name = "2d_rotation"
+name = "rotation"
 path = "examples/2d/rotation.rs"
 
 [[example]]


### PR DESCRIPTION
All other examples dont have "2d" prefix in their names (even though they are in 2d folder) and reading README makes user think that example is named "rotation" not "2d_rotation" hence rename PR

# Objective

- Remove discrepancy between example name in documentation and in cargo

## Solution

- Rename example in cargo file
