### PR TITLE
[Merged by Bors] - Fix call with features in docs/profiling.md

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -6,7 +6,7 @@ Bevy has built-in [tracing](https://github.com/tokio-rs/tracing) spans to make i
 
 ### Backend: trace_chrome
 
-`cargo run --release --features trace_chrome`
+`cargo run --release --features bevy/trace_chrome`
 
 After running your app a `json` file in the "chrome tracing format" will be produced. You can open this file in your browser using <https://ui.perfetto.dev>. It will look something like this (make sure you expand `Process 1`):
 


### PR DESCRIPTION
Features must be called with the crate, otherwise the following error is thrown:

> error: none of the selected packages contains these features: trace_chrome