### PR TITLE
Replace unwraps with expects in bevy_window, bevy_scene and bevy_diagnostics

### DIFF
--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -87,7 +87,11 @@ impl LogDiagnosticsPlugin {
     ) {
         if state.timer.tick(time.delta()).finished() {
             if let Some(ref filter) = state.filter {
-                for diagnostic in filter.iter().map(|id| diagnostics.get(*id).unwrap()) {
+                for diagnostic in filter.iter().map(|id| {
+                    diagnostics
+                        .get(*id)
+                        .unwrap_or_else(|| panic!("Could not find diagnostic with id {:?}", id))
+                }) {
                     Self::log_diagnostic(diagnostic);
                 }
             } else {
@@ -105,7 +109,11 @@ impl LogDiagnosticsPlugin {
     ) {
         if state.timer.tick(time.delta()).finished() {
             if let Some(ref filter) = state.filter {
-                for diagnostic in filter.iter().map(|id| diagnostics.get(*id).unwrap()) {
+                for diagnostic in filter.iter().map(|id| {
+                    diagnostics
+                        .get(*id)
+                        .unwrap_or_else(|| panic!("Could not find diagnostic with id {:?}", id))
+                }) {
                     debug!("{:#?}\n", diagnostic);
                 }
             } else {

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -107,7 +107,7 @@ impl ComponentInfo {
     }
 
     #[inline]
-    pub fn type_id(&self) -> TypeId {
+    pub fn type_id(&self) -> Option<TypeId> {
         self.descriptor.type_id
     }
 
@@ -171,7 +171,7 @@ pub struct ComponentDescriptor {
     // SAFETY: This must remain private. It must only be set to "true" if this component is
     // actually Send + Sync
     is_send_and_sync: bool,
-    type_id: TypeId,
+    type_id: Option<TypeId>,
     layout: Layout,
     drop: unsafe fn(*mut u8),
 }
@@ -187,7 +187,7 @@ impl ComponentDescriptor {
             name: std::any::type_name::<T>().to_string(),
             storage_type: T::Storage::STORAGE_TYPE,
             is_send_and_sync: true,
-            type_id: TypeId::of::<T>(),
+            type_id: Some(TypeId::of::<T>()),
             layout: Layout::new::<T>(),
             drop: Self::drop_ptr::<T>,
         }
@@ -203,7 +203,7 @@ impl ComponentDescriptor {
             // reasonable choice as `storage_type` for resources.
             storage_type: StorageType::Table,
             is_send_and_sync: true,
-            type_id: TypeId::of::<T>(),
+            type_id: Some(TypeId::of::<T>()),
             layout: Layout::new::<T>(),
             drop: Self::drop_ptr::<T>,
         }
@@ -214,7 +214,7 @@ impl ComponentDescriptor {
             name: std::any::type_name::<T>().to_string(),
             storage_type,
             is_send_and_sync: false,
-            type_id: TypeId::of::<T>(),
+            type_id: Some(TypeId::of::<T>()),
             layout: Layout::new::<T>(),
             drop: Self::drop_ptr::<T>,
         }
@@ -226,7 +226,7 @@ impl ComponentDescriptor {
     }
 
     #[inline]
-    pub fn type_id(&self) -> TypeId {
+    pub fn type_id(&self) -> Option<TypeId> {
         self.type_id
     }
 

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -107,7 +107,7 @@ impl ComponentInfo {
     }
 
     #[inline]
-    pub fn type_id(&self) -> Option<TypeId> {
+    pub fn type_id(&self) -> TypeId {
         self.descriptor.type_id
     }
 
@@ -171,7 +171,7 @@ pub struct ComponentDescriptor {
     // SAFETY: This must remain private. It must only be set to "true" if this component is
     // actually Send + Sync
     is_send_and_sync: bool,
-    type_id: Option<TypeId>,
+    type_id: TypeId,
     layout: Layout,
     drop: unsafe fn(*mut u8),
 }
@@ -187,7 +187,7 @@ impl ComponentDescriptor {
             name: std::any::type_name::<T>().to_string(),
             storage_type: T::Storage::STORAGE_TYPE,
             is_send_and_sync: true,
-            type_id: Some(TypeId::of::<T>()),
+            type_id: TypeId::of::<T>(),
             layout: Layout::new::<T>(),
             drop: Self::drop_ptr::<T>,
         }
@@ -203,7 +203,7 @@ impl ComponentDescriptor {
             // reasonable choice as `storage_type` for resources.
             storage_type: StorageType::Table,
             is_send_and_sync: true,
-            type_id: Some(TypeId::of::<T>()),
+            type_id: TypeId::of::<T>(),
             layout: Layout::new::<T>(),
             drop: Self::drop_ptr::<T>,
         }
@@ -214,7 +214,7 @@ impl ComponentDescriptor {
             name: std::any::type_name::<T>().to_string(),
             storage_type,
             is_send_and_sync: false,
-            type_id: Some(TypeId::of::<T>()),
+            type_id: TypeId::of::<T>(),
             layout: Layout::new::<T>(),
             drop: Self::drop_ptr::<T>,
         }
@@ -226,7 +226,7 @@ impl ComponentDescriptor {
     }
 
     #[inline]
-    pub fn type_id(&self) -> Option<TypeId> {
+    pub fn type_id(&self) -> TypeId {
         self.type_id
     }
 

--- a/crates/bevy_scene/src/command.rs
+++ b/crates/bevy_scene/src/command.rs
@@ -14,7 +14,9 @@ pub struct SpawnScene {
 
 impl Command for SpawnScene {
     fn write(self, world: &mut World) {
-        let mut spawner = world.get_resource_mut::<SceneSpawner>().unwrap();
+        let mut spawner = world
+            .get_resource_mut::<SceneSpawner>()
+            .expect("Could not get `SceneSpawner` resource in the `World`");
         spawner.spawn(self.scene_handle);
     }
 }
@@ -36,7 +38,9 @@ pub struct SpawnSceneAsChild {
 
 impl Command for SpawnSceneAsChild {
     fn write(self, world: &mut World) {
-        let mut spawner = world.get_resource_mut::<SceneSpawner>().unwrap();
+        let mut spawner = world
+            .get_resource_mut::<SceneSpawner>()
+            .expect("Could not get `SceneSpawner` resource from the `World`");
         spawner.spawn_as_child(self.scene_handle, self.parent);
     }
 }

--- a/crates/bevy_scene/src/command.rs
+++ b/crates/bevy_scene/src/command.rs
@@ -16,7 +16,7 @@ impl Command for SpawnScene {
     fn write(self, world: &mut World) {
         let mut spawner = world
             .get_resource_mut::<SceneSpawner>()
-            .expect("Could not get `SceneSpawner` resource in the `World`");
+            .expect("Could not get `SceneSpawner` resource in the `World`.  Did you forget to add `ScenePlugin` to your `App`?");
         spawner.spawn(self.scene_handle);
     }
 }
@@ -40,7 +40,7 @@ impl Command for SpawnSceneAsChild {
     fn write(self, world: &mut World) {
         let mut spawner = world
             .get_resource_mut::<SceneSpawner>()
-            .expect("Could not get `SceneSpawner` resource from the `World`");
+            .expect("Could not get `SceneSpawner` resource from the `World`. Did you forget to add `ScenePlugin` to your `App`?");
         spawner.spawn_as_child(self.scene_handle, self.parent);
     }
 }

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -85,7 +85,7 @@ impl DynamicScene {
     ) -> Result<(), SceneSpawnError> {
         let registry = world
             .get_resource::<TypeRegistryArc>()
-            .expect("Could not get `TypeRegistryArc` resource from the `World`")
+            .expect("Could not get `TypeRegistryArc` resource from the `World`. Did you forget to add `ScenePlugin` to your `App`?")
             .clone();
         let type_registry = registry.read();
 

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -52,7 +52,11 @@ impl DynamicScene {
                 let reflect_component = world
                     .components()
                     .get_info(component_id)
-                    .and_then(|info| type_registry.get(info.type_id()))
+                    .and_then(|info| {
+                        type_registry.get(info.type_id().unwrap_or_else(|| {
+                            panic!("Component {:?} has no `type_id`", info.name())
+                        }))
+                    })
                     .and_then(|registration| registration.data::<ReflectComponent>());
                 if let Some(reflect_component) = reflect_component {
                     for (i, entity) in archetype.entities().iter().enumerate() {

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -52,11 +52,7 @@ impl DynamicScene {
                 let reflect_component = world
                     .components()
                     .get_info(component_id)
-                    .and_then(|info| {
-                        type_registry.get(info.type_id().unwrap_or_else(|| {
-                            panic!("Component {:?} has no `type_id`", info.name())
-                        }))
-                    })
+                    .and_then(|info| type_registry.get(info.type_id()))
                     .and_then(|registration| registration.data::<ReflectComponent>());
                 if let Some(reflect_component) = reflect_component {
                     for (i, entity) in archetype.entities().iter().enumerate() {

--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -13,7 +13,9 @@ pub struct SceneLoader {
 
 impl FromWorld for SceneLoader {
     fn from_world(world: &mut World) -> Self {
-        let type_registry = world.get_resource::<TypeRegistryArc>().unwrap();
+        let type_registry = world
+            .get_resource::<TypeRegistryArc>()
+            .expect("Could not get `TypeRegistryArc` resource from the `World`");
         SceneLoader {
             type_registry: (*type_registry).clone(),
         }

--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -15,7 +15,7 @@ impl FromWorld for SceneLoader {
     fn from_world(world: &mut World) -> Self {
         let type_registry = world
             .get_resource::<TypeRegistryArc>()
-            .expect("Could not get `TypeRegistryArc` resource from the `World`");
+            .expect("Could not get `TypeRegistryArc` resource from the `World`. Did you forget to add `ScenePlugin` to your `App`?");
         SceneLoader {
             type_registry: (*type_registry).clone(),
         }

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -171,9 +171,7 @@ impl SceneSpawner {
                             .expect("component_ids in archetypes should have ComponentInfo");
 
                         let reflect_component = type_registry
-                            .get(component_info.type_id().unwrap_or_else(|| {
-                                panic!("Component {:?} has no `type_id`", component_info.name())
-                            }))
+                            .get(component_info.type_id())
                             .ok_or_else(|| SceneSpawnError::UnregisteredType {
                                 type_name: component_info.name().to_string(),
                             })

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -146,7 +146,7 @@ impl SceneSpawner {
         };
         let type_registry = world
             .get_resource::<TypeRegistryArc>()
-            .expect("Could not get `TypeRegistryArc` from the `World`")
+            .expect("Could not get `TypeRegistryArc` from the `World`. Did you forget to add `ScenePlugin` to your `App`?")
             .clone();
         let type_registry = type_registry.read();
         world.resource_scope(|world, scenes: Mut<Assets<Scene>>| {
@@ -318,7 +318,7 @@ pub fn scene_spawner_system(world: &mut World) {
     world.resource_scope(|world, mut scene_spawner: Mut<SceneSpawner>| {
         let scene_asset_events = world
             .get_resource::<Events<AssetEvent<DynamicScene>>>()
-            .expect("Could not get `Events<AssetEvent<DynamicScene>>` resource from the `World`");
+            .expect("Could not get `Events<AssetEvent<DynamicScene>>` resource from the `World`. Did you forget to add `ScenePlugin` to your `App`?");
 
         let mut updated_spawned_scenes = Vec::new();
         let scene_spawner = &mut *scene_spawner;

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -171,7 +171,9 @@ impl SceneSpawner {
                             .expect("component_ids in archetypes should have ComponentInfo");
 
                         let reflect_component = type_registry
-                            .get(component_info.type_id())
+                            .get(component_info.type_id().unwrap_or_else(|| {
+                                panic!("Component {:?} has no `type_id`", component_info.name())
+                            }))
                             .ok_or_else(|| SceneSpawnError::UnregisteredType {
                                 type_name: component_info.name().to_string(),
                             })

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -63,7 +63,7 @@ impl Plugin for WindowPlugin {
             let mut create_window_event = app
                 .world
                 .get_resource_mut::<Events<CreateWindow>>()
-                .unwrap();
+                .expect("Could not find `Events<CreateWindow>` resource in the `World`.");
             create_window_event.send(CreateWindow {
                 id: WindowId::primary(),
                 descriptor: window_descriptor,


### PR DESCRIPTION
# Objective

- Make bevy's errors more descriptive and easier to understand
- Related: #3913 
- Tracking issue: https://github.com/bevyengine/bevy/issues/3899

## Solution

-  Replace `unwrap` with `expect` in some of the crates  
- ~~[turn ComponentDescriptor::type_id into a TypeId (from Option<TypeId>)](https://github.com/bevyengine/bevy/pull/3975/commits/8e77fbc7d32b6dcb4278b3e5d8c91b5e2a53bdcc)~~