### PR TITLE
Move import_path definitions into shader source

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -42,13 +42,11 @@ impl Plugin for MeshRenderPlugin {
         );
         shaders.set_untracked(
             MESH_STRUCT_HANDLE,
-            Shader::from_wgsl(include_str!("mesh_struct.wgsl"))
-                .with_import_path("bevy_pbr::mesh_struct"),
+            Shader::from_wgsl(include_str!("mesh_struct.wgsl")),
         );
         shaders.set_untracked(
             MESH_VIEW_BIND_GROUP_HANDLE,
-            Shader::from_wgsl(include_str!("mesh_view_bind_group.wgsl"))
-                .with_import_path("bevy_pbr::mesh_view_bind_group"),
+            Shader::from_wgsl(include_str!("mesh_view_bind_group.wgsl")),
         );
 
         app.add_plugin(UniformComponentPlugin::<MeshUniform>::default());

--- a/crates/bevy_pbr/src/render/mesh_struct.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_struct.wgsl
@@ -1,3 +1,5 @@
+#define_import_path bevy_pbr::mesh_struct
+
 struct Mesh {
     model: mat4x4<f32>;
     inverse_transpose_model: mat4x4<f32>;

--- a/crates/bevy_pbr/src/render/mesh_view_bind_group.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bind_group.wgsl
@@ -1,3 +1,5 @@
+#define_import_path bevy_pbr::mesh_view_bind_group
+
 struct View {
     view_proj: mat4x4<f32>;
     view: mat4x4<f32>;

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -50,13 +50,11 @@ impl Plugin for Mesh2dRenderPlugin {
         );
         shaders.set_untracked(
             MESH2D_STRUCT_HANDLE,
-            Shader::from_wgsl(include_str!("mesh2d_struct.wgsl"))
-                .with_import_path("bevy_sprite::mesh2d_struct"),
+            Shader::from_wgsl(include_str!("mesh2d_struct.wgsl")),
         );
         shaders.set_untracked(
             MESH2D_VIEW_BIND_GROUP_HANDLE,
-            Shader::from_wgsl(include_str!("mesh2d_view_bind_group.wgsl"))
-                .with_import_path("bevy_sprite::mesh2d_view_bind_group"),
+            Shader::from_wgsl(include_str!("mesh2d_view_bind_group.wgsl")),
         );
 
         app.add_plugin(UniformComponentPlugin::<Mesh2dUniform>::default());

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_struct.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_struct.wgsl
@@ -1,3 +1,5 @@
+#define_import_path bevy_sprite::mesh2d_struct
+
 struct Mesh2d {
     model: mat4x4<f32>;
     inverse_transpose_model: mat4x4<f32>;

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_view_bind_group.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_view_bind_group.wgsl
@@ -1,3 +1,5 @@
+#define_import_path bevy_sprite::mesh2d_view_bind_group
+
 struct View {
     view_proj: mat4x4<f32>;
     view: mat4x4<f32>;


### PR DESCRIPTION
This enables shaders to (optionally) define their import path inside their source. This has a number of benefits:

1. enables users to define their own custom paths directly in their assets
2. moves the import path "close" to the asset instead of centralized in the plugin definition, which seems "better" to me. 
3. makes "internal hot shader reloading" way more reasonable (see #3966)
4. logically opens the door to importing "parts" of a shader by defining "import_path blocks".

```rust
#define_import_path bevy_pbr::mesh_struct

struct Mesh {
    model: mat4x4<f32>;
    inverse_transpose_model: mat4x4<f32>;
    // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
    flags: u32;
};

let MESH_FLAGS_SHADOW_RECEIVER_BIT: u32 = 1u;
``` 