### PR TITLE
[Merged by Bors] - Change default `ColorMaterial` color to white

### DIFF
--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -57,7 +57,7 @@ pub struct ColorMaterial {
 impl Default for ColorMaterial {
     fn default() -> Self {
         ColorMaterial {
-            color: Color::rgb(1.0, 0.0, 1.0),
+            color: Color::WHITE,
             texture: None,
         }
     }
@@ -76,7 +76,7 @@ impl From<Handle<Image>> for ColorMaterial {
     fn from(texture: Handle<Image>) -> Self {
         ColorMaterial {
             texture: Some(texture),
-            color: Color::WHITE,
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
# Context

I wanted to add a `texture` to my `ColorMaterial` without explicitly adding a `color`. To do this I used `..Default::default()` which in turn gave me unexpected results. I was expecting that my texture would render without any color modifications, but to my surprise it got rendered in a purple tint (`Color::rgb(1.0, 0.0, 1.0)`). To fix this I had to explicitly define the `color` using `color: Color::WHITE`.

## What I wanted to use

```rust
commands
    .spawn_bundle(MaterialMesh2dBundle {
        mesh: mesh_handle.clone().into(),
        transform: Transform::default().with_scale(Vec3::splat(8.)),
        material: materials.add(ColorMaterial {
            texture: Some(texture_handle.clone()),
            ..Default::default() // here
        }),
        ..Default::default()
    })
```

![image](https://user-images.githubusercontent.com/75334794/154765141-4a8161ce-4ec8-4687-b7d5-18ddf1b58660.png)

## What I had to use instead

```rust
commands
    .spawn_bundle(MaterialMesh2dBundle {
        mesh: mesh_handle.clone().into(),
        transform: Transform::default().with_scale(Vec3::splat(8.)),
        material: materials.add(ColorMaterial {
            texture: Some(texture_handle.clone()),
            color: Color::WHITE, // here
        }),
        ..Default::default()
    })
```

![image](https://user-images.githubusercontent.com/75334794/154765225-f1508b41-9d5b-4f0c-af7b-e89c1a82d85b.png)
