### PR TITLE
Add `remove_attribute` function to `Mesh`

### DIFF
--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -108,6 +108,14 @@ impl Mesh {
         self.attributes.get_mut(&name.into())
     }
 
+    /// Removes the data for a vertex attribute with the specified `name`, returning its value.
+    pub fn remove_attribute(
+        &mut self,
+        name: impl Into<Cow<'static, str>>,
+    ) -> Option<VertexAttributeValues> {
+        self.attributes.remove(&name.into())
+    }
+
     /// Sets the vertex indices of the mesh. They describe how triangles are constructed out of the
     /// vertex attributes and are therefore only useful for the [`PrimitiveTopology`] variants
     /// that use triangles.


### PR DESCRIPTION
# Objective

When modifying meshes in a system, it is convenient to be able to edit multiple `VertexAttributeValues` attributes at the same time (e.g modify a vertex, its normal and uv at the same time). Using `Mesh::attribute_mut` is only possible to get mutable access to one attribute at a time. 

One (expensive) solution is to make a copy of the attributes. To avoid the copy (and memory allocation), one could get the attribute, `std::mem:swap` with an empty `Vec`, modify it and set it back. Instead of setting attribute to empty vecs, it would be more ergonomic if the vertex attributes could be moved out of the mesh.

## Solution

Add a new function `Mesh::remove_attribute` which removes the data for a vertex attribute, returning its value.
