### PR TITLE
Document `MapEntities` trait.

### DIFF
--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -8,6 +8,32 @@ pub enum MapEntitiesError {
     EntityNotFound(Entity),
 }
 
+/// Operation to map all contained [`Entity`](crate::entity::Entity) fields in
+/// a component to new values.
+/// 
+/// If a component contains [`Entity`](crate::entity::Entity) values
+/// that refer to other entities in the same world and scene functionality
+/// is used to create such components, this trait must be implemented. The
+/// is to replace all [`Entity`](crate::entity::Entity) values in the
+/// component with values looked up from the given [`EntityMap`].
+///
+/// Implementing this trait is pretty straightforward:
+/// 
+/// ```
+/// #[derive(Component)]
+/// struct MyEntityRefs {
+///     a: Entity,
+///     b: Entity,
+/// }
+///
+/// impl MapEntities for MyEntityRefs {
+///     fn map_entities(&mut self, entity_map: &EntityMap) -> Result<(), MapEntitiesError> {
+///         self.a = entity_map.get(self.a)?;
+///         self.b = entity_map.get(self.b)?;
+///         Ok(())
+///     }
+/// }
+/// ```
 pub trait MapEntities {
     fn map_entities(&mut self, entity_map: &EntityMap) -> Result<(), MapEntitiesError>;
 }


### PR DESCRIPTION
# Objective

- `bevy::ecs::entity::MapEntities` trait is undocumented, even though users need to implement it in some cases

## Solution

- Add documentation
