### PR TITLE
Support calculating normals for indexed meshes

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -291,18 +291,8 @@ async fn load_gltf<'a, 'b>(
             if mesh.attribute(Mesh::ATTRIBUTE_NORMAL).is_none()
                 && matches!(mesh.primitive_topology(), PrimitiveTopology::TriangleList)
             {
-                let vertex_count_before = mesh.count_vertices();
-                mesh.duplicate_vertices();
-                mesh.compute_flat_normals();
-                let vertex_count_after = mesh.count_vertices();
-
-                if vertex_count_before != vertex_count_after {
-                    bevy_log::debug!("Missing vertex normals in indexed geometry, computing them as flat. Vertex count increased from {} to {}", vertex_count_before, vertex_count_after);
-                } else {
-                    bevy_log::debug!(
-                        "Missing vertex normals in indexed geometry, computing them as flat."
-                    );
-                }
+                bevy_log::debug!("Automatically calculating missing vertex normals for geometry.");
+                mesh.compute_normals();
             }
 
             if let Some(vertex_attribute) = reader

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -302,15 +302,16 @@ impl Mesh {
     /// Calculates the [`Mesh::ATTRIBUTE_NORMAL`] of a mesh.
     ///
     /// # Panics
-    /// Panics if [`Indices`] are set or [`Mesh::ATTRIBUTE_POSITION`] is not of type `float3` or
-    /// if the mesh has any other topology than [`PrimitiveTopology::TriangleList`].
-    /// Consider calling [`Mesh::duplicate_vertices`] or export your mesh with normal attributes.
-    pub fn compute_flat_normals(&mut self) {
-        assert!(self.indices().is_none(), "`compute_flat_normals` can't work on indexed geometry. Consider calling `Mesh::duplicate_vertices`.");
-
+    /// Panics if [`Mesh::ATTRIBUTE_POSITION`] is not of type `float3`.
+    /// Panics if the mesh has any other topology than [`PrimitiveTopology::TriangleList`].
+    ///
+    /// FIXME: The should handle more cases since this is called as a part of gltf
+    /// mesh loading where we can't really blame users for loading meshes that might
+    /// not conform to the limitations here!
+    pub fn compute_normals(&mut self) {
         assert!(
             matches!(self.primitive_topology, PrimitiveTopology::TriangleList),
-            "`compute_flat_normals` can only work on `TriangleList`s"
+            "`compute_normals` can only work on `TriangleList`s"
         );
 
         let positions = self
@@ -319,13 +320,51 @@ impl Mesh {
             .as_float3()
             .expect("`Mesh::ATTRIBUTE_POSITION` vertex attributes should be of type `float3`");
 
-        let normals: Vec<_> = positions
-            .chunks_exact(3)
-            .map(|p| face_normal(p[0], p[1], p[2]))
-            .flat_map(|normal| [normal; 3])
-            .collect();
+        match self.indices() {
+            Some(indices) => {
+                let mut count: usize = 0;
+                let mut corners = [0_usize; 3];
+                let mut normals = vec![[0.0f32; 3]; positions.len()];
+                let mut adjacency_counts = vec![0_usize; positions.len()];
 
-        self.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+                for i in indices.iter() {
+                    corners[count % 3] = i;
+                    count += 1;
+                    if count % 3 == 0 {
+                        let normal = face_normal(
+                            positions[corners[0]],
+                            positions[corners[1]],
+                            positions[corners[2]],
+                        );
+                        for corner in corners {
+                            normals[corner] =
+                                (Vec3::from(normal) + Vec3::from(normals[corner])).into();
+                            adjacency_counts[corner] += 1;
+                        }
+                    }
+                }
+
+                // average (smooth) normals for shared vertices...
+                // TODO: support different methods of weighting the average
+                for i in 0..normals.len() {
+                    let count = adjacency_counts[i];
+                    if count > 0 {
+                        normals[i] = (Vec3::from(normals[i]) / (count as f32)).normalize().into();
+                    }
+                }
+
+                self.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+            }
+            None => {
+                let normals: Vec<_> = positions
+                    .chunks_exact(3)
+                    .map(|p| face_normal(p[0], p[1], p[2]))
+                    .flat_map(|normal| [normal; 3])
+                    .collect();
+
+                self.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+            }
+        }
     }
 
     /// Generate tangents for the mesh using the `mikktspace` algorithm.


### PR DESCRIPTION
Currently the PBR renderer requires every mesh to have a normals
attribute, and in case normals are missing there was a
`compute_flat_normals()` utility.

This utility was documented to panic in case a mesh was based on indices
and so to avoid that there is also a utility to expand a mesh into one
that doesn't depend on an index buffer.

To avoid needing to expand meshes to avoid index buffers, this updates
the utility to be able to calculate normals even for indexed geometry.

Note: this still has the other notable limitations that it assumes a
triangle list topology and will panic for triangle strips or meshes that
don't have vec3 float32 position attributes.

The api was renamed to `compute_normals()` since they can't be assumed to
be flat in the case that indexed vertices may be shared by multiple
faces. The calculated normals are (naively) averaged without any weighting,
such as by the angle or area of each adjacent face.

The gltf loader has been updated to no longer expand an indexed mesh
via `duplicate_vertices` before generating missing normals.

Ideally in the future there will be some kind of separation of how
assets like meshes are imported into bevy where there will be
a natural place to configure exactly how missing normals should be
calculated, including choosing what weighting to use for averaging.
