### PR TITLE
can only add a plugin once

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -754,7 +754,7 @@ impl App {
     where
         T: Plugin,
     {
-        self.plugins.contains_key(&std::any::TypeId::of::<T>())
+        self.plugins.contains_key(&TypeId::of::<T>())
     }
 
     /// Adds a single [`Plugin`].

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -4,13 +4,21 @@ use std::any::Any;
 /// A collection of Bevy app logic and configuration.
 ///
 /// Plugins configure an [`App`]. When an [`App`] registers a plugin,
-/// the plugin's [`Plugin::build`] function is run.
+/// the plugin's [`Plugin::build`] function is run. By default, a plugin
+/// can only be added once to an [`App`]. If the plugin may need to be
+/// added twice or more, the function [`is_unique`](Plugin::is_unique)
+/// should be overriden to return `false`.
 pub trait Plugin: Any + Send + Sync {
     /// Configures the [`App`] to which this plugin is added.
     fn build(&self, app: &mut App);
     /// Configures a name for the [`Plugin`] which is primarily used for debugging.
     fn name(&self) -> &str {
         std::any::type_name::<Self>()
+    }
+    /// If the plugin can be instantiated several times in an [`App`](crate::App), override this
+    /// method to return `false`.
+    fn is_unique(&self) -> bool {
+        true
     }
 }
 

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -15,8 +15,8 @@ pub trait Plugin: Any + Send + Sync {
     fn name(&self) -> &str {
         std::any::type_name::<Self>()
     }
-    /// If the plugin can be instantiated several times in an [`App`](crate::App), override this
-    /// method to return `false`.
+    /// If the plugin can be meaningfully instantiated several times in an [`App`](crate::App),
+    /// override this method to return `false`.
     fn is_unique(&self) -> bool {
         true
     }


### PR DESCRIPTION
- a plugin group can only be added once
- unless specified by the plugin author, a plugin can only be added once
- add a method on app to check if a plugin has been added

split from #2988 