### PR TITLE
Remove `rand` crate from dependency tree

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -29,9 +29,9 @@ crossbeam-channel = "0.5.0"
 anyhow = "1.0.4"
 thiserror = "1.0"
 downcast-rs = "1.2.0"
+fastrand = "1.7.0"
 notify = { version = "=5.0.0-pre.11", optional = true }
 parking_lot = "0.11.0"
-rand = "0.8.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -51,7 +51,7 @@ impl<'a> From<AssetPath<'a>> for HandleId {
 impl HandleId {
     #[inline]
     pub fn random<T: Asset>() -> Self {
-        HandleId::Id(T::TYPE_UUID, rand::random())
+        HandleId::Id(T::TYPE_UUID, fastrand::u64(..))
     }
 
     #[inline]


### PR DESCRIPTION
This replaces `rand` with `fastrand` as the source of randomness for `HandleId::new()` in `bevy_asset`. This was the only crate with a dependency on `rand`, and now the dependency exists only as a dev-dependency.

`fastrand` was already in the dependency tree, thanks to `futures-lite`, `async-executor`, and `tempfile` to name a few.

## Changelog

Removed `rand` from dependencies in `bevy_asset` in favor of existing in-tree `fast-rand`
