### PR TITLE
Spirv shader bypass

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ render = [
   "bevy_internal/bevy_ui",
 ]
 
+spirv_shader_passthrough = ["bevy_internal/spirv_shader_passthrough" ]
+
 # Optional bevy crates
 bevy_audio = ["bevy_internal/bevy_audio"]
 bevy_core_pipeline = ["bevy_internal/bevy_core_pipeline"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -23,6 +23,7 @@ dds = ["bevy_render/dds"]
 tga = ["bevy_render/tga"]
 jpeg = ["bevy_render/jpeg"]
 bmp = ["bevy_render/bmp"]
+spirv_shader_passthrough = ["bevy_render/spirv_shader_passthrough" ]
 
 # Audio format support (MP3 is enabled by default)
 flac = ["bevy_audio/flac"]

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -19,6 +19,7 @@ trace = []
 wgpu_trace = ["wgpu/trace"]
 ci_limits = []
 webgl = ["wgpu/webgl"]
+spirv_shader_passthrough = []
 
 [dependencies]
 # bevy

--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -40,13 +40,17 @@ impl RenderDevice {
     pub fn create_shader_module(&self, desc: &wgpu::ShaderModuleDescriptor) -> wgpu::ShaderModule {
         #[cfg(feature = "spirv_shader_passthrough")]
         match &desc.source {
-            wgpu::ShaderSource::SpirV(source) if self.features().contains(wgpu::Features::SPIRV_SHADER_PASSTHROUGH) => unsafe {
+            wgpu::ShaderSource::SpirV(source)
+                if self
+                    .features()
+                    .contains(wgpu::Features::SPIRV_SHADER_PASSTHROUGH) =>
+            unsafe {
                 self.device
                     .create_shader_module_spirv(&wgpu::ShaderModuleDescriptorSpirV {
                         label: desc.label,
                         source: source.clone(),
                     })
-            },
+            }
             _ => self.device.create_shader_module(desc),
         }
         #[cfg(not(feature = "spirv_shader_passthrough"))]

--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -50,7 +50,7 @@ impl RenderDevice {
                         label: desc.label,
                         source: source.clone(),
                     })
-            }
+            },
             _ => self.device.create_shader_module(desc),
         }
         #[cfg(not(feature = "spirv_shader_passthrough"))]

--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -40,7 +40,7 @@ impl RenderDevice {
     pub fn create_shader_module(&self, desc: &wgpu::ShaderModuleDescriptor) -> wgpu::ShaderModule {
         #[cfg(feature = "spirv_shader_passthrough")]
         match &desc.source {
-            wgpu::ShaderSource::SpirV(source) => unsafe {
+            self.features().contains(wgpu::Features::SPIRV_SHADER_PASSTHROUGH) && wgpu::ShaderSource::SpirV(source) => unsafe {
                 self.device
                     .create_shader_module_spirv(&wgpu::ShaderModuleDescriptorSpirV {
                         label: desc.label,

--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -38,6 +38,18 @@ impl RenderDevice {
     /// Creates a [`ShaderModule`](wgpu::ShaderModule) from either SPIR-V or WGSL source code.
     #[inline]
     pub fn create_shader_module(&self, desc: &wgpu::ShaderModuleDescriptor) -> wgpu::ShaderModule {
+        #[cfg(feature = "spirv_shader_passthrough")]
+        match &desc.source {
+            wgpu::ShaderSource::SpirV(source) => unsafe {
+                self.device
+                    .create_shader_module_spirv(&wgpu::ShaderModuleDescriptorSpirV {
+                        label: desc.label,
+                        source: source.clone(),
+                    })
+            },
+            _ => self.device.create_shader_module(desc),
+        }
+        #[cfg(not(feature = "spirv_shader_passthrough"))]
         self.device.create_shader_module(desc)
     }
 

--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -40,7 +40,7 @@ impl RenderDevice {
     pub fn create_shader_module(&self, desc: &wgpu::ShaderModuleDescriptor) -> wgpu::ShaderModule {
         #[cfg(feature = "spirv_shader_passthrough")]
         match &desc.source {
-            self.features().contains(wgpu::Features::SPIRV_SHADER_PASSTHROUGH) && wgpu::ShaderSource::SpirV(source) => unsafe {
+            wgpu::ShaderSource::SpirV(source) if self.features().contains(wgpu::Features::SPIRV_SHADER_PASSTHROUGH) => unsafe {
                 self.device
                     .create_shader_module_spirv(&wgpu::ShaderModuleDescriptorSpirV {
                         label: desc.label,

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -59,9 +59,6 @@ impl Default for WgpuSettings {
             limits
         };
 
-        let features = wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
-        #[cfg(feature = "spirv_shader_passthrough")]
-        let features = features | wgpu::Features::SPIRV_SHADER_PASSTHROUGH;
         Self {
             device_label: Default::default(),
             backends,

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -59,12 +59,15 @@ impl Default for WgpuSettings {
             limits
         };
 
+        let features = wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
+        #[cfg(feature = "spirv_shader_passthrough")]
+        let features = features | wgpu::Features::SPIRV_SHADER_PASSTHROUGH;
         Self {
             device_label: Default::default(),
             backends,
             power_preference: PowerPreference::HighPerformance,
             priority,
-            features: wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
+            features,
             disabled_features: None,
             limits,
             constrained_limits: None,

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -64,7 +64,7 @@ impl Default for WgpuSettings {
             backends,
             power_preference: PowerPreference::HighPerformance,
             priority,
-            features,
+            features: wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
             disabled_features: None,
             limits,
             constrained_limits: None,


### PR DESCRIPTION
# Objective

Expose wgpu spirv-shader-passthrough as a bevy feature.
## Solution

add a feature to `bevy_render` and `bevy` itself.

alternative: https://github.com/bevyengine/bevy/pull/3997
More alternative: 
* having a different file extension `passthrough.spv`
* some API to runtime specify if shader is loaded passthrough or not

(But I didn't implement these, because the passthrough is hopefully only temporary, and I don't see why people want some passthrough but some doesn't.)