### PR TITLE
Shader passthrough alternative 

### DIFF
--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -38,19 +38,22 @@ impl RenderDevice {
     /// Creates a [`ShaderModule`](wgpu::ShaderModule) from either SPIR-V or WGSL source code.
     #[inline]
     pub fn create_shader_module(&self, desc: &wgpu::ShaderModuleDescriptor) -> wgpu::ShaderModule {
-        match &desc.source {
-            wgpu::ShaderSource::SpirV(source)
-                if self
-                    .features()
-                    .contains(wgpu::Features::SPIRV_SHADER_PASSTHROUGH) =>
-            unsafe {
-                self.device
-                    .create_shader_module_spirv(&wgpu::ShaderModuleDescriptorSpirV {
-                        label: desc.label,
-                        source: source.clone(),
-                    })
+        if self
+            .features()
+            .contains(wgpu::Features::SPIRV_SHADER_PASSTHROUGH)
+        {
+            match &desc.source {
+                wgpu::ShaderSource::SpirV(source) => unsafe {
+                    self.device
+                        .create_shader_module_spirv(&wgpu::ShaderModuleDescriptorSpirV {
+                            label: desc.label,
+                            source: source.clone(),
+                        })
+                },
+                _ => self.device.create_shader_module(desc),
             }
-            _ => self.device.create_shader_module(desc),
+        } else {
+            self.device.create_shader_module(desc)
         }
     }
 


### PR DESCRIPTION
# Objective

Enable wgpu spirv-shader-passthrough.

## Solution

if has `wgpu::Features::SPIRV_SHADER_PASSTHROUGH`, always load spirv shaders using the pass through. This is kind of a abuse of wgpu API, but I like it because the change is minimal to bevy, and it doesn't add extra features to bevy. I think this is a sensible default, and I don't want to build elaborate features without people actually finding this sensible default undesirable 

alternative to https://github.com/bevyengine/bevy/pull/3996