### PR TITLE
Allow UIPlugin to be used without rendering

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -657,7 +657,7 @@ impl App {
             .remove(&std::any::TypeId::of::<T>());
         self.world
             .remove_resource::<Init<T>>()
-            .map(|startup| startup.0)
+            .map(|initialization| initialization.0)
     }
 
     /// Check that all initialization resources have been consumed, panicking otherwise.

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -666,7 +666,7 @@ impl App {
             .values()
             .for_each(|v| error!("Initialization resource \"{}\" has not been consumed", v));
         if !self.initialization_resources.is_empty() {
-            panic!("All initialization resources have not been consumed. This can happen if you inserted a initialization resource after the plugin consuming it.")
+            panic!("All initialization resources have not been consumed. This can happen if you inserted an initialization resource after the plugin consuming it.")
         }
     }
 

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -817,7 +817,7 @@ impl App {
     where
         T: Plugin,
     {
-        debug!("added plugin: {}", plugin.name());
+        debug!("added plugin {}", plugin.name());
         if plugin.is_unique() {
             self.register_plugin(&std::any::TypeId::of::<T>(), plugin.name(), None);
         }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1018,3 +1018,49 @@ fn run_once(mut app: App) {
 /// An event that indicates the app should exit. This will fully exit the app process.
 #[derive(Debug, Clone)]
 pub struct AppExit;
+
+#[cfg(test)]
+mod tests {
+    use crate::{App, Plugin};
+
+    struct PluginA;
+    impl Plugin for PluginA {
+        fn build(&self, _app: &mut crate::App) {}
+    }
+    struct PluginB;
+    impl Plugin for PluginB {
+        fn build(&self, _app: &mut crate::App) {}
+    }
+    struct PluginC<T>(T);
+    impl<T: Send + Sync + 'static> Plugin for PluginC<T> {
+        fn build(&self, _app: &mut crate::App) {}
+    }
+    struct PluginD;
+    impl Plugin for PluginD {
+        fn build(&self, _app: &mut crate::App) {}
+        fn is_unique(&self) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn can_add_two_plugins() {
+        App::new().add_plugin(PluginA).add_plugin(PluginB);
+    }
+
+    #[test]
+    #[should_panic]
+    fn cant_add_twice_the_same_plugin() {
+        App::new().add_plugin(PluginA).add_plugin(PluginA);
+    }
+
+    #[test]
+    fn can_add_twice_the_same_plugin_with_different_type_param() {
+        App::new().add_plugin(PluginC(0)).add_plugin(PluginC(true));
+    }
+
+    #[test]
+    fn can_add_twice_the_same_plugin_not_unique() {
+        App::new().add_plugin(PluginD).add_plugin(PluginD);
+    }
+}

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -802,6 +802,14 @@ impl App {
         self
     }
 
+    /// Check that a plugin has already been added to the app.
+    pub fn is_plugin_added<T>(&self) -> bool
+    where
+        T: Plugin,
+    {
+        self.plugins.contains_key(&std::any::TypeId::of::<T>())
+    }
+
     /// Adds a single plugin
     ///
     /// One of Bevy's core principles is modularity. All Bevy engine features are implemented

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -647,7 +647,7 @@ impl App {
         self
     }
 
-    /// Consumes a startup resource, and removes it from the current [App] so that a plugin
+    /// Consumes an initialization resource, and removes it from the current [App] so that a plugin
     /// can use it for its configuration.
     pub fn consume_initialization_resource<T>(&mut self) -> Option<T>
     where

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -666,7 +666,7 @@ impl App {
             .values()
             .for_each(|v| error!("Initialization resource \"{}\" has not been consumed", v));
         if !self.initialization_resources.is_empty() {
-            panic!("All initialization resources have not been consumed. This can happen if you inserted an initialization resource after the plugin consuming it.")
+            panic!("Not all initialization resources have been consumed. This can happen if you inserted an initialization resource after the plugin consuming it.")
         }
     }
 

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -19,8 +19,8 @@ use std::{any::TypeId, fmt::Debug};
 use bevy_utils::tracing::info_span;
 bevy_utils::define_label!(AppLabel);
 
-/// Wrapper struct for setting startup resource aside
-struct Startup<T>(T);
+/// Wrapper struct for setting initialization resources aside
+struct Init<T>(T);
 
 #[allow(clippy::needless_doctest_main)]
 /// Containers of app logic and data
@@ -62,7 +62,7 @@ pub struct App {
     pub schedule: Schedule,
     sub_apps: HashMap<Box<dyn AppLabel>, SubApp>,
     plugins: HashMap<std::any::TypeId, Option<&'static str>>,
-    startup_resources: HashMap<std::any::TypeId, &'static str>,
+    initialization_resources: HashMap<std::any::TypeId, &'static str>,
 }
 
 /// Each [`SubApp`] has its own [`Schedule`] and [`World`], enabling a separation of concerns.
@@ -107,7 +107,7 @@ impl App {
             runner: Box::new(run_once),
             sub_apps: HashMap::default(),
             plugins: Default::default(),
-            startup_resources: Default::default(),
+            initialization_resources: Default::default(),
         }
     }
 
@@ -137,7 +137,7 @@ impl App {
         #[cfg(feature = "trace")]
         let _bevy_app_run_guard = bevy_app_run_span.enter();
 
-        self.check_all_startup_resources_consumed();
+        self.check_all_initialization_resources_consumed();
 
         let mut app = std::mem::replace(self, App::empty());
         let runner = std::mem::replace(&mut app.runner, Box::new(run_once));
@@ -631,40 +631,42 @@ impl App {
             .add_system_to_stage(CoreStage::First, Events::<T>::update_system)
     }
 
-    /// Inserts a startup resource to the current [App] and overwrites any resource previously
-    /// added of the same type.
+    /// Inserts an initialization resource to the current [App] and overwrites any resource
+    /// previously added of the same type.
     ///
-    /// A startup resource is used at startup for plugin initialisation and configuration. All
-    /// startup resources inserted must be consumed before the application is ran.
-    pub fn insert_startup_resource<T>(&mut self, resource: T) -> &mut Self
+    /// An initialization resource is used at startup for plugin initialisation and configuration.
+    /// All initialization resources inserted must be consumed by a plugin and removed before the
+    /// application is ran.
+    pub fn insert_initialization_resource<T>(&mut self, resource: T) -> &mut Self
     where
         T: Resource,
     {
-        self.startup_resources
+        self.initialization_resources
             .insert(std::any::TypeId::of::<T>(), std::any::type_name::<T>());
-        self.insert_resource(Startup(resource));
+        self.insert_resource(Init(resource));
         self
     }
 
     /// Consumes a startup resource, and removes it from the current [App] so that a plugin
     /// can use it for its configuration.
-    pub fn consume_startup_resource<T>(&mut self) -> Option<T>
+    pub fn consume_initialization_resource<T>(&mut self) -> Option<T>
     where
         T: Resource,
     {
-        self.startup_resources.remove(&std::any::TypeId::of::<T>());
+        self.initialization_resources
+            .remove(&std::any::TypeId::of::<T>());
         self.world
-            .remove_resource::<Startup<T>>()
+            .remove_resource::<Init<T>>()
             .map(|startup| startup.0)
     }
 
-    /// Check that all startup resources have been consumed, panicing otherwise.
-    fn check_all_startup_resources_consumed(&self) {
-        self.startup_resources
+    /// Check that all initialization resources have been consumed, panicking otherwise.
+    fn check_all_initialization_resources_consumed(&self) {
+        self.initialization_resources
             .values()
-            .for_each(|v| error!("Startup resource \"{}\" has not been consumed", v));
-        if !self.startup_resources.is_empty() {
-            panic!("All startup resources have not been consumed. This can happen if you inserted a startup resource after the plugin consuming it.")
+            .for_each(|v| error!("Initialization resource \"{}\" has not been consumed", v));
+        if !self.initialization_resources.is_empty() {
+            panic!("All initialization resources have not been consumed. This can happen if you inserted a initialization resource after the plugin consuming it.")
         }
     }
 

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -382,6 +382,9 @@ impl App {
         stage_label: impl StageLabel,
         system: impl IntoSystemDescriptor<Params>,
     ) -> &mut Self {
+        if stage_label.type_id() == TypeId::of::<StartupStage>() {
+            panic!("add systems to a startup stage using App::add_startup_system_to_stage");
+        }
         self.schedule.add_system_to_stage(stage_label, system);
         self
     }
@@ -412,6 +415,9 @@ impl App {
         stage_label: impl StageLabel,
         system_set: SystemSet,
     ) -> &mut Self {
+        if stage_label.type_id() == TypeId::of::<StartupStage>() {
+            panic!("add system sets to a startup stage using App::add_startup_system_set_to_stage");
+        }
         self.schedule
             .add_system_set_to_stage(stage_label, system_set);
         self

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -818,7 +818,9 @@ impl App {
         T: Plugin,
     {
         debug!("added plugin: {}", plugin.name());
-        self.register_plugin(&std::any::TypeId::of::<T>(), plugin.name(), None);
+        if plugin.is_unique() {
+            self.register_plugin(&std::any::TypeId::of::<T>(), plugin.name(), None);
+        }
         plugin.build(self);
         self
     }

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -12,6 +12,11 @@ pub trait Plugin: Any + Send + Sync {
     fn name(&self) -> &str {
         std::any::type_name::<Self>()
     }
+    /// If the plugin can be instantiated several times in an [`App`](crate::App), override this
+    /// method to return `false`.
+    fn is_unique(&self) -> bool {
+        true
+    }
 }
 
 /// Type representing an unsafe function that returns a mutable pointer to a [`Plugin`].

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -4,7 +4,10 @@ use std::any::Any;
 /// A collection of Bevy App logic and configuration
 ///
 /// Plugins configure an [`App`](crate::App). When an [`App`](crate::App) registers
-/// a plugin, the plugin's [`Plugin::build`] function is run.
+/// a plugin, the plugin's [`Plugin::build`] function is run. By default, a plugin
+/// can only be added once to an [`App`](crate::App). If the plugin may need to be
+/// added twice or more, the function [`is_unique`](Plugin::is_unique) should be
+/// overriden to return `false`.
 pub trait Plugin: Any + Send + Sync {
     /// Configures the [`App`] to which this plugin is added.
     fn build(&self, app: &mut App);

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -114,7 +114,11 @@ impl PluginGroupBuilder {
         for ty in self.order.iter() {
             if let Some(entry) = self.plugins.get(ty) {
                 if entry.enabled {
-                    debug!("added plugin from group: {}", entry.plugin.name());
+                    debug!(
+                        "added plugin {} from group {}",
+                        entry.plugin.name(),
+                        std::any::type_name::<T>()
+                    );
                     if entry.plugin.is_unique() {
                         app.register_plugin(
                             ty,

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -115,7 +115,13 @@ impl PluginGroupBuilder {
             if let Some(entry) = self.plugins.get(ty) {
                 if entry.enabled {
                     debug!("added plugin from group: {}", entry.plugin.name());
-                    app.register_plugin(ty, entry.plugin.name(), Some(std::any::type_name::<T>()));
+                    if entry.plugin.is_unique() {
+                        app.register_plugin(
+                            ty,
+                            entry.plugin.name(),
+                            Some(std::any::type_name::<T>()),
+                        );
+                    }
                     entry.plugin.build(app);
                 }
             }

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -3,7 +3,7 @@ use bevy_utils::{tracing::debug, HashMap};
 use std::any::TypeId;
 
 /// Combines multiple [`Plugin`]s into a single unit.
-pub trait PluginGroup {
+pub trait PluginGroup: 'static {
     /// Configures the [`Plugin`]s that are to be added.
     fn build(&mut self, group: &mut PluginGroupBuilder);
 }
@@ -110,11 +110,12 @@ impl PluginGroupBuilder {
     }
 
     /// Consumes the [`PluginGroupBuilder`] and [builds](Plugin::build) the contained [`Plugin`]s.
-    pub fn finish(self, app: &mut App) {
+    pub fn finish<T: PluginGroup>(self, app: &mut App) {
         for ty in self.order.iter() {
             if let Some(entry) = self.plugins.get(ty) {
                 if entry.enabled {
-                    debug!("added plugin: {}", entry.plugin.name());
+                    debug!("added plugin from group: {}", entry.plugin.name());
+                    app.register_plugin(ty, entry.plugin.name(), Some(std::any::type_name::<T>()));
                     entry.plugin.build(app);
                 }
             }

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -60,8 +60,8 @@ impl Default for AssetServerSettings {
 /// delegate to the default `AssetIo` for the platform.
 pub fn create_platform_default_asset_io(app: &mut App) -> Box<dyn AssetIo> {
     let settings = app
-        .world
-        .get_resource_or_insert_with(AssetServerSettings::default);
+        .consume_initialization_resource::<AssetServerSettings>()
+        .unwrap_or_default();
 
     #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
     let source = FileAssetIo::new(&settings.asset_folder);

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -60,7 +60,7 @@ impl Default for AssetServerSettings {
 /// delegate to the default `AssetIo` for the platform.
 pub fn create_platform_default_asset_io(app: &mut App) -> Box<dyn AssetIo> {
     let settings = app
-        .consume_initialization_resource::<AssetServerSettings>()
+        .consume_setup_resource::<AssetServerSettings>()
         .unwrap_or_default();
 
     #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -42,7 +42,7 @@ pub enum CoreSystem {
 impl Plugin for CorePlugin {
     fn build(&self, app: &mut App) {
         // Setup the default bevy task pools
-        app.consume_initialization_resource::<DefaultTaskPoolOptions>()
+        app.consume_setup_resource::<DefaultTaskPoolOptions>()
             .unwrap_or_default()
             .create_default_pools(&mut app.world);
 

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -42,9 +42,7 @@ pub enum CoreSystem {
 impl Plugin for CorePlugin {
     fn build(&self, app: &mut App) {
         // Setup the default bevy task pools
-        app.world
-            .get_resource::<DefaultTaskPoolOptions>()
-            .cloned()
+        app.consume_initialization_resource::<DefaultTaskPoolOptions>()
             .unwrap_or_default()
             .create_default_pools(&mut app.world);
 

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -41,7 +41,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// * Using [`tracing-wasm`](https://crates.io/crates/tracing-wasm) in WASM, logging
 /// to the browser console.
 ///
-/// You can configure this plugin using the initialization resource [`LogSettings`].
+/// You can configure this plugin using the setup resource [`LogSettings`].
 /// ```no_run
 /// # use bevy_internal::DefaultPlugins;
 /// # use bevy_app::App;
@@ -49,7 +49,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// # use bevy_utils::tracing::Level;
 /// fn main() {
 ///     App::new()
-///         .insert_initialization_resource(LogSettings {
+///         .insert_setup_resource(LogSettings {
 ///             level: Level::DEBUG,
 ///             filter: "wgpu=error,bevy_render=info".to_string(),
 ///         })
@@ -107,7 +107,7 @@ impl Plugin for LogPlugin {
     fn build(&self, app: &mut App) {
         let default_filter = {
             let settings = app
-                .consume_initialization_resource::<LogSettings>()
+                .consume_setup_resource::<LogSettings>()
                 .unwrap_or_default();
             format!("{},{}", settings.level, settings.filter)
         };

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -49,7 +49,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// # use bevy_utils::tracing::Level;
 /// fn main() {
 ///     App::new()
-///         .insert_startup_resource(LogSettings {
+///         .insert_initialization_resource(LogSettings {
 ///             level: Level::DEBUG,
 ///             filter: "wgpu=error,bevy_render=info".to_string(),
 ///         })
@@ -107,7 +107,7 @@ impl Plugin for LogPlugin {
     fn build(&self, app: &mut App) {
         let default_filter = {
             let settings = app
-                .consume_startup_resource::<LogSettings>()
+                .consume_initialization_resource::<LogSettings>()
                 .unwrap_or_default();
             format!("{},{}", settings.level, settings.filter)
         };

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -41,7 +41,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// * Using [`tracing-wasm`](https://crates.io/crates/tracing-wasm) in WASM, logging
 /// to the browser console.
 ///
-/// You can configure this plugin using the startup resource [`LogSettings`].
+/// You can configure this plugin using the initialization resource [`LogSettings`].
 /// ```no_run
 /// # use bevy_internal::DefaultPlugins;
 /// # use bevy_app::App;

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -41,7 +41,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// * Using [`tracing-wasm`](https://crates.io/crates/tracing-wasm) in WASM, logging
 /// to the browser console.
 ///
-/// You can configure this plugin using the resource [`LogSettings`].
+/// You can configure this plugin using the startup resource [`LogSettings`].
 /// ```no_run
 /// # use bevy_internal::DefaultPlugins;
 /// # use bevy_app::App;
@@ -49,7 +49,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// # use bevy_utils::tracing::Level;
 /// fn main() {
 ///     App::new()
-///         .insert_resource(LogSettings {
+///         .insert_startup_resource(LogSettings {
 ///             level: Level::DEBUG,
 ///             filter: "wgpu=error,bevy_render=info".to_string(),
 ///         })
@@ -106,7 +106,9 @@ impl Default for LogSettings {
 impl Plugin for LogPlugin {
     fn build(&self, app: &mut App) {
         let default_filter = {
-            let settings = app.world.get_resource_or_insert_with(LogSettings::default);
+            let settings = app
+                .consume_startup_resource::<LogSettings>()
+                .unwrap_or_default();
             format!("{},{}", settings.level, settings.filter)
         };
         LogTracer::init().unwrap();

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -110,9 +110,7 @@ impl Plugin for RenderPlugin {
     /// Initializes the renderer, sets up the [`RenderStage`](RenderStage) and creates the rendering sub-app.
     fn build(&self, app: &mut App) {
         let mut options = app
-            .world
-            .get_resource::<options::WgpuOptions>()
-            .cloned()
+            .consume_initialization_resource::<options::WgpuOptions>()
             .unwrap_or_default();
 
         app.add_asset::<Shader>()

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -110,7 +110,7 @@ impl Plugin for RenderPlugin {
     /// Initializes the renderer, sets up the [`RenderStage`](RenderStage) and creates the rendering sub-app.
     fn build(&self, app: &mut App) {
         let mut options = app
-            .consume_initialization_resource::<options::WgpuOptions>()
+            .consume_setup_resource::<options::WgpuOptions>()
             .unwrap_or_default();
 
         app.add_asset::<Shader>()

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -40,7 +40,7 @@ impl Plugin for WindowRenderPlugin {
 
 pub struct ExtractedWindow {
     pub id: WindowId,
-    pub handle: RawWindowHandleWrapper,
+    pub handle: Option<RawWindowHandleWrapper>,
     pub physical_width: u32,
     pub physical_height: u32,
     pub vsync: bool,
@@ -125,42 +125,44 @@ pub fn prepare_windows(
 ) {
     let window_surfaces = window_surfaces.deref_mut();
     for window in windows.windows.values_mut() {
-        let surface = window_surfaces
-            .surfaces
-            .entry(window.id)
-            .or_insert_with(|| unsafe {
-                // NOTE: On some OSes this MUST be called from the main thread.
-                render_instance.create_surface(&window.handle.get_handle())
-            });
+        if let Some(window_handle_wrapper) = &window.handle {
+            let surface = window_surfaces
+                .surfaces
+                .entry(window.id)
+                .or_insert_with(|| unsafe {
+                    // NOTE: On some OSes this MUST be called from the main thread.
+                    render_instance.create_surface(&window_handle_wrapper.get_handle())
+                });
 
-        let swap_chain_descriptor = wgpu::SurfaceConfiguration {
-            format: TextureFormat::bevy_default(),
-            width: window.physical_width,
-            height: window.physical_height,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            present_mode: if window.vsync {
-                wgpu::PresentMode::Fifo
-            } else {
-                wgpu::PresentMode::Immediate
-            },
-        };
+            let swap_chain_descriptor = wgpu::SurfaceConfiguration {
+                format: TextureFormat::bevy_default(),
+                width: window.physical_width,
+                height: window.physical_height,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                present_mode: if window.vsync {
+                    wgpu::PresentMode::Fifo
+                } else {
+                    wgpu::PresentMode::Immediate
+                },
+            };
 
-        // Do the initial surface configuration if it hasn't been configured yet
-        if window_surfaces.configured_windows.insert(window.id) || window.size_changed {
-            render_device.configure_surface(surface, &swap_chain_descriptor);
-        }
-
-        let frame = match surface.get_current_texture() {
-            Ok(swap_chain_frame) => swap_chain_frame,
-            Err(wgpu::SurfaceError::Outdated) => {
+            // Do the initial surface configuration if it hasn't been configured yet
+            if window_surfaces.configured_windows.insert(window.id) || window.size_changed {
                 render_device.configure_surface(surface, &swap_chain_descriptor);
-                surface
-                    .get_current_texture()
-                    .expect("Error reconfiguring surface")
             }
-            err => err.expect("Failed to acquire next swap chain texture!"),
-        };
 
-        window.swap_chain_texture = Some(TextureView::from(frame));
+            let frame = match surface.get_current_texture() {
+                Ok(swap_chain_frame) => swap_chain_frame,
+                Err(wgpu::SurfaceError::Outdated) => {
+                    render_device.configure_surface(surface, &swap_chain_descriptor);
+                    surface
+                        .get_current_texture()
+                        .expect("Error reconfiguring surface")
+                }
+                err => err.expect("Failed to acquire next swap chain texture!"),
+            };
+
+            window.swap_chain_texture = Some(TextureView::from(frame));
+        }
     }
 }

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{WindowId, WindowInitializationDescriptor};
+use super::{WindowId, WindowSetupDescriptor};
 use bevy_math::{IVec2, Vec2};
 
 /// A window event that is sent whenever a windows logical size has changed
@@ -17,7 +17,7 @@ pub struct WindowResized {
 #[derive(Debug, Clone)]
 pub struct CreateWindow {
     pub id: WindowId,
-    pub descriptor: WindowInitializationDescriptor,
+    pub descriptor: WindowSetupDescriptor,
 }
 
 /// An event that indicates a window should be closed.

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{WindowDescriptor, WindowId};
+use super::{WindowId, WindowInitializationDescriptor};
 use bevy_math::{IVec2, Vec2};
 
 /// A window event that is sent whenever a windows logical size has changed
@@ -17,7 +17,7 @@ pub struct WindowResized {
 #[derive(Debug, Clone)]
 pub struct CreateWindow {
     pub id: WindowId,
-    pub descriptor: WindowDescriptor,
+    pub descriptor: WindowInitializationDescriptor,
 }
 
 /// An event that indicates a window should be closed.

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -16,7 +16,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
         CursorEntered, CursorIcon, CursorLeft, CursorMoved, FileDragAndDrop, ReceivedCharacter,
-        Window, WindowInitializationDescriptor, WindowMoved, Windows,
+        Window, WindowMoved, WindowSetupDescriptor, Windows,
     };
 }
 
@@ -56,7 +56,7 @@ impl Plugin for WindowPlugin {
 
         if self.add_primary_window {
             let window_descriptor = app
-                .consume_initialization_resource::<WindowInitializationDescriptor>()
+                .consume_setup_resource::<WindowSetupDescriptor>()
                 .unwrap_or_default();
             let mut create_window_event = app
                 .world

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -56,7 +56,7 @@ impl Plugin for WindowPlugin {
 
         if self.add_primary_window {
             let window_descriptor = app
-                .consume_startup_resource::<WindowInitializationDescriptor>()
+                .consume_initialization_resource::<WindowInitializationDescriptor>()
                 .unwrap_or_default();
             let mut create_window_event = app
                 .world

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -16,7 +16,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
         CursorEntered, CursorIcon, CursorLeft, CursorMoved, FileDragAndDrop, ReceivedCharacter,
-        Window, WindowDescriptor, WindowMoved, Windows,
+        Window, WindowInitializationDescriptor, WindowMoved, Windows,
     };
 }
 
@@ -56,9 +56,7 @@ impl Plugin for WindowPlugin {
 
         if self.add_primary_window {
             let window_descriptor = app
-                .world
-                .get_resource::<WindowDescriptor>()
-                .map(|descriptor| (*descriptor).clone())
+                .consume_startup_resource::<WindowInitializationDescriptor>()
                 .unwrap_or_default();
             let mut create_window_event = app
                 .world

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -5,6 +5,40 @@ use raw_window_handle::RawWindowHandle;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct WindowId(Uuid);
 
+/// Presentation mode for a window.
+///
+/// The presentation mode specifies when a frame is presented to the window. The `Fifo`
+/// option corresponds to a traditional `VSync`, where the framerate is capped by the
+/// display refresh rate. Both `Immediate` and `Mailbox` are low-latency and are not
+/// capped by the refresh rate, but may not be available on all platforms. Tearing
+/// may be observed with `Immediate` mode, but will not be observed with `Mailbox` or
+/// `Fifo`.
+///
+/// `Immediate` or `Mailbox` will gracefully fallback to `Fifo` when unavailable.
+///
+/// The presentation mode may be declared in the
+/// [`WindowSetupDescriptor`](WindowSetupDescriptor::present_mode) or updated on a
+/// [`Window`](Window::set_present_mode).
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[doc(alias = "vsync")]
+pub enum PresentMode {
+    /// The presentation engine does **not** wait for a vertical blanking period and
+    /// the request is presented immediately. This is a low-latency presentation mode,
+    /// but visible tearing may be observed. Will fallback to `Fifo` if unavailable on the
+    /// selected platform and backend. Not optimal for mobile.
+    Immediate = 0,
+    /// The presentation engine waits for the next vertical blanking period to update
+    /// the current image, but frames may be submitted without delay. This is a low-latency
+    /// presentation mode and visible tearing will **not** be observed. Will fallback to `Fifo`
+    /// if unavailable on the selected platform and backend. Not optimal for mobile.
+    Mailbox = 1,
+    /// The presentation engine waits for the next vertical blanking period to update
+    /// the current image. The framerate will be capped at the display refresh rate,
+    /// corresponding to the `VSync`. Tearing cannot be observed. Optimal for mobile.
+    Fifo = 2, // NOTE: The explicit ordinal values mirror wgpu and the vulkan spec.
+}
+
 impl WindowId {
     pub fn new() -> Self {
         WindowId(Uuid::new_v4())

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -207,7 +207,7 @@ pub enum WindowMode {
 impl Window {
     pub fn new(
         id: WindowId,
-        window_descriptor: &WindowInitializationDescriptor,
+        window_descriptor: &WindowSetupDescriptor,
         physical_width: u32,
         physical_height: u32,
         scale_factor: f64,
@@ -553,7 +553,7 @@ impl Window {
 }
 
 #[derive(Debug, Clone)]
-pub struct WindowInitializationDescriptor {
+pub struct WindowSetupDescriptor {
     pub width: f32,
     pub height: f32,
     pub position: Option<Vec2>,
@@ -578,9 +578,9 @@ pub struct WindowInitializationDescriptor {
     pub canvas: Option<String>,
 }
 
-impl Default for WindowInitializationDescriptor {
+impl Default for WindowSetupDescriptor {
     fn default() -> Self {
-        WindowInitializationDescriptor {
+        WindowSetupDescriptor {
             title: "app".to_string(),
             width: 1280.,
             height: 720.,

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -207,7 +207,7 @@ pub enum WindowMode {
 impl Window {
     pub fn new(
         id: WindowId,
-        window_descriptor: &WindowDescriptor,
+        window_descriptor: &WindowInitializationDescriptor,
         physical_width: u32,
         physical_height: u32,
         scale_factor: f64,
@@ -553,7 +553,7 @@ impl Window {
 }
 
 #[derive(Debug, Clone)]
-pub struct WindowDescriptor {
+pub struct WindowInitializationDescriptor {
     pub width: f32,
     pub height: f32,
     pub position: Option<Vec2>,
@@ -578,10 +578,10 @@ pub struct WindowDescriptor {
     pub canvas: Option<String>,
 }
 
-impl Default for WindowDescriptor {
+impl Default for WindowInitializationDescriptor {
     fn default() -> Self {
-        WindowDescriptor {
-            title: "bevy".to_string(),
+        WindowInitializationDescriptor {
+            title: "app".to_string(),
             width: 1280.,
             height: 720.,
             position: None,

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -232,7 +232,7 @@ impl Window {
             cursor_locked: window_descriptor.cursor_locked,
             cursor_icon: CursorIcon::Default,
             physical_cursor_position: None,
-            raw_window_handle: raw_window_handle.map(|handle| RawWindowHandleWrapper::new(handle)),
+            raw_window_handle: raw_window_handle.map(RawWindowHandleWrapper::new),
             focused: true,
             mode: window_descriptor.mode,
             #[cfg(target_arch = "wasm32")]

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -109,6 +109,9 @@ impl WindowResizeConstraints {
 /// requested size due to operating system limits on the window size, or the
 /// quantization of the logical size when converting the physical size to the
 /// logical size through the scaling factor.
+///
+/// ## Headless Testing
+/// To run tests without needing to create an actual window, set `raw_window_handle` to `None`.
 #[derive(Debug)]
 pub struct Window {
     id: WindowId,
@@ -128,7 +131,7 @@ pub struct Window {
     cursor_visible: bool,
     cursor_locked: bool,
     physical_cursor_position: Option<DVec2>,
-    raw_window_handle: RawWindowHandleWrapper,
+    raw_window_handle: Option<RawWindowHandleWrapper>,
     focused: bool,
     mode: WindowMode,
     #[cfg(target_arch = "wasm32")]
@@ -209,7 +212,7 @@ impl Window {
         physical_height: u32,
         scale_factor: f64,
         position: Option<IVec2>,
-        raw_window_handle: RawWindowHandle,
+        raw_window_handle: Option<RawWindowHandle>,
     ) -> Self {
         Window {
             id,
@@ -229,7 +232,7 @@ impl Window {
             cursor_locked: window_descriptor.cursor_locked,
             cursor_icon: CursorIcon::Default,
             physical_cursor_position: None,
-            raw_window_handle: RawWindowHandleWrapper::new(raw_window_handle),
+            raw_window_handle: raw_window_handle.map(|handle| RawWindowHandleWrapper::new(handle)),
             focused: true,
             mode: window_descriptor.mode,
             #[cfg(target_arch = "wasm32")]
@@ -544,7 +547,7 @@ impl Window {
         self.focused
     }
 
-    pub fn raw_window_handle(&self) -> RawWindowHandleWrapper {
+    pub fn raw_window_handle(&self) -> Option<RawWindowHandleWrapper> {
         self.raw_window_handle.clone()
     }
 }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -231,8 +231,7 @@ pub fn winit_runner_with(mut app: App) {
     trace!("Entering winit event loop");
 
     let should_return_from_run = app
-        .world
-        .get_resource::<WinitConfig>()
+        .consume_initialization_resource::<WinitConfig>()
         .map_or(false, |config| config.return_from_run);
 
     let mut active = true;

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -231,7 +231,7 @@ pub fn winit_runner_with(mut app: App) {
     trace!("Entering winit event loop");
 
     let should_return_from_run = app
-        .consume_initialization_resource::<WinitConfig>()
+        .consume_setup_resource::<WinitConfig>()
         .map_or(false, |config| config.return_from_run);
 
     let mut active = true;

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -1,6 +1,6 @@
 use bevy_math::IVec2;
 use bevy_utils::HashMap;
-use bevy_window::{Window, WindowDescriptor, WindowId, WindowMode};
+use bevy_window::{Window, WindowId, WindowInitializationDescriptor, WindowMode};
 use raw_window_handle::HasRawWindowHandle;
 use winit::dpi::LogicalSize;
 
@@ -16,7 +16,7 @@ impl WinitWindows {
         &mut self,
         event_loop: &winit::event_loop::EventLoopWindowTarget<()>,
         window_id: WindowId,
-        window_descriptor: &WindowDescriptor,
+        window_descriptor: &WindowInitializationDescriptor,
     ) -> Window {
         #[cfg(target_os = "windows")]
         let mut winit_window_builder = {
@@ -44,7 +44,7 @@ impl WinitWindows {
                 )),
             )),
             _ => {
-                let WindowDescriptor {
+                let WindowInitializationDescriptor {
                     width,
                     height,
                     position,

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -1,6 +1,6 @@
 use bevy_math::IVec2;
 use bevy_utils::HashMap;
-use bevy_window::{Window, WindowId, WindowInitializationDescriptor, WindowMode};
+use bevy_window::{Window, WindowId, WindowMode, WindowSetupDescriptor};
 use raw_window_handle::HasRawWindowHandle;
 use winit::dpi::LogicalSize;
 
@@ -16,7 +16,7 @@ impl WinitWindows {
         &mut self,
         event_loop: &winit::event_loop::EventLoopWindowTarget<()>,
         window_id: WindowId,
-        window_descriptor: &WindowInitializationDescriptor,
+        window_descriptor: &WindowSetupDescriptor,
     ) -> Window {
         #[cfg(target_os = "windows")]
         let mut winit_window_builder = {
@@ -44,7 +44,7 @@ impl WinitWindows {
                 )),
             )),
             _ => {
-                let WindowInitializationDescriptor {
+                let WindowSetupDescriptor {
                     width,
                     height,
                     position,

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -171,7 +171,7 @@ impl WinitWindows {
             inner_size.height,
             scale_factor,
             position,
-            raw_window_handle,
+            Some(raw_window_handle),
         )
     }
 

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -7,7 +7,7 @@ use bevy::{
 fn main() {
     App::new()
         .insert_resource(Msaa { samples: 4 })
-        .insert_initialization_resource(WgpuOptions {
+        .insert_setup_resource(WgpuOptions {
             features: WgpuFeatures::POLYGON_MODE_LINE,
             ..Default::default()
         })

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -7,7 +7,7 @@ use bevy::{
 fn main() {
     App::new()
         .insert_resource(Msaa { samples: 4 })
-        .insert_resource(WgpuOptions {
+        .insert_initialization_resource(WgpuOptions {
             features: WgpuFeatures::POLYGON_MODE_LINE,
             ..Default::default()
         })

--- a/examples/app/headless_defaults.rs
+++ b/examples/app/headless_defaults.rs
@@ -2,7 +2,7 @@ use bevy::{prelude::*, render::options::WgpuOptions};
 
 fn main() {
     App::new()
-        .insert_initialization_resource(WgpuOptions {
+        .insert_setup_resource(WgpuOptions {
             backends: None,
             ..Default::default()
         })

--- a/examples/app/headless_defaults.rs
+++ b/examples/app/headless_defaults.rs
@@ -2,7 +2,7 @@ use bevy::{prelude::*, render::options::WgpuOptions};
 
 fn main() {
     App::new()
-        .insert_resource(WgpuOptions {
+        .insert_initialization_resource(WgpuOptions {
             backends: None,
             ..Default::default()
         })

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -23,7 +23,7 @@ fn log_system() {
     error!("something failed");
 
     // by default, trace and debug logs are ignored because they are "noisy"
-    // you can control what level is logged by adding the LogSettings startup resource
+    // you can control what level is logged by adding the LogSettings initialization resource
     // alternatively you can set the log level via the RUST_LOG=LEVEL environment variable
     // ex: RUST_LOG=trace, RUST_LOG=info,bevy_ecs=warn
     // the format used here is super flexible. check out this documentation for more info:

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         // Uncomment this to override the default log settings:
-        // .insert_startup_resource(bevy::log::LogSettings {
+        // .insert_initialization_resource(bevy::log::LogSettings {
         //     level: bevy::log::Level::TRACE,
         //     filter: "wgpu=warn,bevy_ecs=info".to_string(),
         // })

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         // Uncomment this to override the default log settings:
-        // .insert_resource(bevy::log::LogSettings {
+        // .insert_startup_resource(bevy::log::LogSettings {
         //     level: bevy::log::Level::TRACE,
         //     filter: "wgpu=warn,bevy_ecs=info".to_string(),
         // })
@@ -23,7 +23,7 @@ fn log_system() {
     error!("something failed");
 
     // by default, trace and debug logs are ignored because they are "noisy"
-    // you can control what level is logged by adding the LogSettings resource
+    // you can control what level is logged by adding the LogSettings startup resource
     // alternatively you can set the log level via the RUST_LOG=LEVEL environment variable
     // ex: RUST_LOG=trace, RUST_LOG=info,bevy_ecs=warn
     // the format used here is super flexible. check out this documentation for more info:

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         // Uncomment this to override the default log settings:
-        // .insert_initialization_resource(bevy::log::LogSettings {
+        // .insert_setup_resource(bevy::log::LogSettings {
         //     level: bevy::log::Level::TRACE,
         //     filter: "wgpu=warn,bevy_ecs=info".to_string(),
         // })
@@ -23,7 +23,7 @@ fn log_system() {
     error!("something failed");
 
     // by default, trace and debug logs are ignored because they are "noisy"
-    // you can control what level is logged by adding the LogSettings initialization resource
+    // you can control what level is logged by adding the LogSettings setup resource
     // alternatively you can set the log level via the RUST_LOG=LEVEL environment variable
     // ex: RUST_LOG=trace, RUST_LOG=info,bevy_ecs=warn
     // the format used here is super flexible. check out this documentation for more info:

--- a/examples/app/return_after_run.rs
+++ b/examples/app/return_after_run.rs
@@ -3,7 +3,7 @@ use bevy::{prelude::*, winit::WinitConfig};
 fn main() {
     println!("Running first App.");
     App::new()
-        .insert_initialization_resource(WinitConfig {
+        .insert_setup_resource(WinitConfig {
             return_from_run: true,
         })
         .insert_resource(ClearColor(Color::rgb(0.2, 0.2, 0.8)))
@@ -12,7 +12,7 @@ fn main() {
         .run();
     println!("Running another App.");
     App::new()
-        .insert_initialization_resource(WinitConfig {
+        .insert_setup_resource(WinitConfig {
             return_from_run: true,
         })
         .insert_resource(ClearColor(Color::rgb(0.2, 0.8, 0.2)))

--- a/examples/app/return_after_run.rs
+++ b/examples/app/return_after_run.rs
@@ -3,7 +3,7 @@ use bevy::{prelude::*, winit::WinitConfig};
 fn main() {
     println!("Running first App.");
     App::new()
-        .insert_resource(WinitConfig {
+        .insert_initialization_resource(WinitConfig {
             return_from_run: true,
         })
         .insert_resource(ClearColor(Color::rgb(0.2, 0.2, 0.8)))
@@ -12,7 +12,7 @@ fn main() {
         .run();
     println!("Running another App.");
     App::new()
-        .insert_resource(WinitConfig {
+        .insert_initialization_resource(WinitConfig {
             return_from_run: true,
         })
         .insert_resource(ClearColor(Color::rgb(0.2, 0.8, 0.2)))

--- a/examples/app/thread_pool_resources.rs
+++ b/examples/app/thread_pool_resources.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 /// certain number of threads).
 fn main() {
     App::new()
-        .insert_initialization_resource(DefaultTaskPoolOptions::with_num_threads(4))
+        .insert_setup_resource(DefaultTaskPoolOptions::with_num_threads(4))
         .add_plugins(DefaultPlugins)
         .run();
 }

--- a/examples/app/thread_pool_resources.rs
+++ b/examples/app/thread_pool_resources.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 /// certain number of threads).
 fn main() {
     App::new()
-        .insert_resource(DefaultTaskPoolOptions::with_num_threads(4))
+        .insert_initialization_resource(DefaultTaskPoolOptions::with_num_threads(4))
         .add_plugins(DefaultPlugins)
         .run();
 }

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -4,7 +4,7 @@ use bevy::{input::touch::TouchPhase, prelude::*, window::WindowMode};
 #[bevy_main]
 fn main() {
     App::new()
-        .insert_initialization_resource(WindowInitializationDescriptor {
+        .insert_setup_resource(WindowSetupDescriptor {
             resizable: false,
             mode: WindowMode::BorderlessFullscreen,
             ..Default::default()

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -4,7 +4,7 @@ use bevy::{input::touch::TouchPhase, prelude::*, window::WindowMode};
 #[bevy_main]
 fn main() {
     App::new()
-        .insert_startup_resource(WindowInitializationDescriptor {
+        .insert_initialization_resource(WindowInitializationDescriptor {
             resizable: false,
             mode: WindowMode::BorderlessFullscreen,
             ..Default::default()

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -4,8 +4,7 @@ use bevy::{input::touch::TouchPhase, prelude::*, window::WindowMode};
 #[bevy_main]
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
-            vsync: true,
+        .insert_startup_resource(WindowInitializationDescriptor {
             resizable: false,
             mode: WindowMode::BorderlessFullscreen,
             ..Default::default()

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -8,7 +8,7 @@ use bevy::{
         renderer::{RenderContext, RenderDevice},
         RenderApp, RenderStage,
     },
-    window::WindowDescriptor,
+    window::WindowInitializationDescriptor,
 };
 
 const SIZE: (u32, u32) = (1280, 720);
@@ -17,7 +17,7 @@ const WORKGROUP_SIZE: u32 = 8;
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
-        .insert_resource(WindowDescriptor {
+        .insert_initialization_resource(WindowInitializationDescriptor {
             // uncomment for unthrottled FPS
             // vsync: false,
             ..Default::default()

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -8,7 +8,7 @@ use bevy::{
         renderer::{RenderContext, RenderDevice},
         RenderApp, RenderStage,
     },
-    window::WindowInitializationDescriptor,
+    window::WindowSetupDescriptor,
 };
 
 const SIZE: (u32, u32) = (1280, 720);
@@ -17,7 +17,7 @@ const WORKGROUP_SIZE: u32 = 8;
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
-        .insert_initialization_resource(WindowInitializationDescriptor {
+        .insert_setup_resource(WindowSetupDescriptor {
             // uncomment for unthrottled FPS
             // vsync: false,
             ..Default::default()

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -24,7 +24,7 @@ struct Bird {
 
 fn main() {
     App::new()
-        .insert_startup_resource(WindowInitializationDescriptor {
+        .insert_initialization_resource(WindowInitializationDescriptor {
             title: "BevyMark".to_string(),
             width: 800.,
             height: 600.,

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -24,7 +24,7 @@ struct Bird {
 
 fn main() {
     App::new()
-        .insert_initialization_resource(WindowInitializationDescriptor {
+        .insert_setup_resource(WindowSetupDescriptor {
             title: "BevyMark".to_string(),
             width: 800.,
             height: 600.,

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -24,7 +24,7 @@ struct Bird {
 
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
+        .insert_startup_resource(WindowInitializationDescriptor {
             title: "BevyMark".to_string(),
             width: 800.,
             height: 600.,

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -6,8 +6,8 @@ use bevy::{
 /// This example is for debugging text layout
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
-            vsync: false,
+        .insert_startup_resource(WindowInitializationDescriptor {
+            present_mode: PresentMode::Immediate,
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -6,7 +6,7 @@ use bevy::{
 /// This example is for debugging text layout
 fn main() {
     App::new()
-        .insert_startup_resource(WindowInitializationDescriptor {
+        .insert_initialization_resource(WindowInitializationDescriptor {
             present_mode: PresentMode::Immediate,
             ..Default::default()
         })

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -6,7 +6,7 @@ use bevy::{
 /// This example is for debugging text layout
 fn main() {
     App::new()
-        .insert_initialization_resource(WindowInitializationDescriptor {
+        .insert_setup_resource(WindowSetupDescriptor {
             present_mode: PresentMode::Immediate,
             ..Default::default()
         })

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -54,7 +54,7 @@ fn create_new_window(
     // sends out a "CreateWindow" event, which will be received by the windowing backend
     create_window_events.send(CreateWindow {
         id: window_id,
-        descriptor: WindowInitializationDescriptor {
+        descriptor: WindowSetupDescriptor {
             width: 800.,
             height: 600.,
             vsync: false,

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -54,7 +54,7 @@ fn create_new_window(
     // sends out a "CreateWindow" event, which will be received by the windowing backend
     create_window_events.send(CreateWindow {
         id: window_id,
-        descriptor: WindowDescriptor {
+        descriptor: WindowInitializationDescriptor {
             width: 800.,
             height: 600.,
             vsync: false,

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 /// This example illustrates how to customize the default window settings
 fn main() {
     App::new()
-        .insert_initialization_resource(WindowInitializationDescriptor {
+        .insert_setup_resource(WindowSetupDescriptor {
             width: 500.,
             height: 300.,
             ..Default::default()

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 /// This example illustrates how to customize the default window settings
 fn main() {
     App::new()
-        .insert_startup_resource(WindowInitializationDescriptor {
+        .insert_initialization_resource(WindowInitializationDescriptor {
             width: 500.,
             height: 300.,
             ..Default::default()

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 /// This example illustrates how to customize the default window settings
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
+        .insert_startup_resource(WindowInitializationDescriptor {
             width: 500.,
             height: 300.,
             ..Default::default()

--- a/examples/window/transparent_window.rs
+++ b/examples/window/transparent_window.rs
@@ -1,12 +1,12 @@
 /// An example of how to display a window in transparent mode
 /// [Documentation & Platform support.](https://docs.rs/bevy/latest/bevy/prelude/struct.WindowDescriptor.html#structfield.transparent)
-use bevy::{prelude::*, window::WindowInitializationDescriptor};
+use bevy::{prelude::*, window::WindowSetupDescriptor};
 
 fn main() {
     App::new()
         // ClearColor must have 0 alpha, otherwise some color will bleed through
         .insert_resource(ClearColor(Color::NONE))
-        .insert_initialization_resource(WindowInitializationDescriptor {
+        .insert_setup_resource(WindowSetupDescriptor {
             // Setting `transparent` allows the `ClearColor`'s alpha value to take effect
             transparent: true,
             // Disabling window decorations to make it feel more like a widget than a window

--- a/examples/window/transparent_window.rs
+++ b/examples/window/transparent_window.rs
@@ -1,12 +1,12 @@
 /// An example of how to display a window in transparent mode
 /// [Documentation & Platform support.](https://docs.rs/bevy/latest/bevy/prelude/struct.WindowDescriptor.html#structfield.transparent)
-use bevy::{prelude::*, window::WindowDescriptor};
+use bevy::{prelude::*, window::WindowInitializationDescriptor};
 
 fn main() {
     App::new()
         // ClearColor must have 0 alpha, otherwise some color will bleed through
         .insert_resource(ClearColor(Color::NONE))
-        .insert_resource(WindowDescriptor {
+        .insert_initialization_resource(WindowInitializationDescriptor {
             // Setting `transparent` allows the `ClearColor`'s alpha value to take effect
             transparent: true,
             // Disabling window decorations to make it feel more like a widget than a window

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 /// This example illustrates how to customize the default window settings
 fn main() {
     App::new()
-        .insert_startup_resource(WindowInitializationDescriptor {
+        .insert_initialization_resource(WindowInitializationDescriptor {
             title: "I am a window!".to_string(),
             width: 500.,
             height: 300.,

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 /// This example illustrates how to customize the default window settings
 fn main() {
     App::new()
-        .insert_initialization_resource(WindowInitializationDescriptor {
+        .insert_setup_resource(WindowSetupDescriptor {
             title: "I am a window!".to_string(),
             width: 500.,
             height: 300.,

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 /// This example illustrates how to customize the default window settings
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
+        .insert_startup_resource(WindowInitializationDescriptor {
             title: "I am a window!".to_string(),
             width: 500.,
             height: 300.,

--- a/tests/how_to_test_ui.rs
+++ b/tests/how_to_test_ui.rs
@@ -1,0 +1,91 @@
+use bevy::prelude::*;
+use bevy_internal::asset::AssetPlugin;
+use bevy_internal::core_pipeline::CorePipelinePlugin;
+use bevy_internal::input::InputPlugin;
+use bevy_internal::render::options::WgpuOptions;
+use bevy_internal::render::RenderPlugin;
+use bevy_internal::sprite::SpritePlugin;
+use bevy_internal::text::TextPlugin;
+use bevy_internal::ui::UiPlugin;
+use bevy_internal::window::{WindowId, WindowPlugin};
+
+const WINDOW_WIDTH: u32 = 200;
+const WINDOW_HEIGHT: u32 = 100;
+
+struct HeadlessUiPlugin;
+
+impl Plugin for HeadlessUiPlugin {
+    fn build(&self, app: &mut App) {
+        // These tests are meant to be ran on systems without gpu, or display.
+        // To make this work, we tell bevy not to look for any rendering backends.
+        app.insert_resource(WgpuOptions {
+            backends: None,
+            ..Default::default()
+        })
+        // To test the positioning of UI elements,
+        // we first need a window to position these elements in.
+        .insert_resource({
+            let mut windows = Windows::default();
+            windows.add(Window::new(
+                // At the moment, all ui elements are placed in the primary window.
+                WindowId::primary(),
+                &WindowDescriptor::default(),
+                WINDOW_WIDTH,
+                WINDOW_HEIGHT,
+                1.0,
+                None,
+                // Because this test is running without a real window, we pass `None` here.
+                None,
+            ));
+            windows
+        })
+        .add_plugins(MinimalPlugins)
+        .add_plugin(TransformPlugin)
+        .add_plugin(WindowPlugin::default())
+        .add_plugin(InputPlugin)
+        .add_plugin(AssetPlugin)
+        .add_plugin(RenderPlugin)
+        .add_plugin(CorePipelinePlugin)
+        .add_plugin(SpritePlugin)
+        .add_plugin(TextPlugin)
+        .add_plugin(UiPlugin);
+    }
+}
+
+#[test]
+fn test_button_translation() {
+    let mut app = App::new();
+    app.add_plugin(HeadlessUiPlugin)
+        .add_startup_system(setup_button_test);
+
+    // First call to `update` also runs the startup systems.
+    app.update();
+
+    let mut query = app.world.query_filtered::<Entity, With<Button>>();
+    let button = *query.iter(&app.world).collect::<Vec<_>>().first().unwrap();
+
+    // The button's translation got updated because the UI system had a window to place it in.
+    // If we hadn't added a window, the button's translation would at this point be all zero's.
+    let button_transform = app.world.entity(button).get::<Transform>().unwrap();
+    assert_eq!(
+        button_transform.translation.x.floor() as u32,
+        WINDOW_WIDTH / 2
+    );
+    assert_eq!(
+        button_transform.translation.y.floor() as u32,
+        WINDOW_HEIGHT / 2
+    );
+}
+
+fn setup_button_test(mut commands: Commands) {
+    commands.spawn_bundle(UiCameraBundle::default());
+    commands.spawn_bundle(ButtonBundle {
+        style: Style {
+            size: Size::new(Val::Px(150.0), Val::Px(65.0)),
+            // Center this button in the middle of the window.
+            margin: Rect::all(Val::Auto),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+}

--- a/tests/how_to_test_ui.rs
+++ b/tests/how_to_test_ui.rs
@@ -65,7 +65,7 @@ fn test_button_translation() {
     let button = *query.iter(&app.world).collect::<Vec<_>>().first().unwrap();
 
     // The button's translation got updated because the UI system had a window to place it in.
-    // If we hadn't added a window, the button's translation would at this point be all zero's.
+    // If we hadn't added a window, the button's translation would at this point be all zeros.
     let button_transform = app.world.entity(button).get::<Transform>().unwrap();
     assert_eq!(
         button_transform.translation.x.floor() as u32,


### PR DESCRIPTION
# Objective

- Fixes #3815

## Solution

- Make `UIPlugin` add rendering-dependent systems only when `RenderPlugin` is enabled

### Dependencies

- #2988 
- #3835

## Notes

As stated by cart on Discord regarding #3835:

> Lets wait. I'm hesitant to decouple windows from "actual windows" conceptually. If the goal is to test UI, I think we should consider other options (such as render targets or "null" targets). We'll need to decouple UI from windows anyway because we want to enable rendering ui to textures.

this PR might become obsolete as Bevy's UI in general needs an engineering overhaul.