### PR TITLE
[Merged by Bors] - Fix glTF perspective camera projection

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -515,6 +515,8 @@ fn load_node(
                 node.insert(Camera {
                     name: Some(CameraPlugin::CAMERA_3D.to_owned()),
                     projection_matrix: perspective_projection.get_projection_matrix(),
+                    near: perspective_projection.near,
+                    far: perspective_projection.far,
                     ..Default::default()
                 });
                 node.insert(perspective_projection);


### PR DESCRIPTION
# Objective

- Fixes #4005 

## Solution

- Include the `near` and `far` clipping values from the perspective projection in the `Camera` struct; before that, they were both being defaulted to 0.