### PR TITLE
Make sprites and text2d work with RenderLayers (add ComputedVisibility)

### DIFF
--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -5,6 +5,7 @@ use crate::{
 use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
 use bevy_render::{
+    prelude::ComputedVisibility,
     texture::{Image, DEFAULT_IMAGE_HANDLE},
     view::Visibility,
 };
@@ -18,6 +19,7 @@ pub struct SpriteBundle {
     pub texture: Handle<Image>,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
+    pub computed_visibility: ComputedVisibility,
 }
 
 impl Default for SpriteBundle {
@@ -28,6 +30,7 @@ impl Default for SpriteBundle {
             global_transform: Default::default(),
             texture: DEFAULT_IMAGE_HANDLE.typed(),
             visibility: Default::default(),
+            computed_visibility: Default::default(),
         }
     }
 }

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -399,7 +399,6 @@ pub fn queue_sprites(
         let mut index = 0;
         let mut colored_index = 0;
 
-        // FIXME: VisibleEntities is ignored
         for (visible_entities, mut transparent_phase) in views.iter_mut() {
             let extracted_sprites = &mut extracted_sprites.sprites;
             let image_bind_groups = &mut *image_bind_groups;

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -27,7 +27,7 @@ use bevy_render::{
 };
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::FloatOrd;
-use bevy_utils::HashMap;
+use bevy_utils::{HashMap, HashSet};
 use bytemuck::{Pod, Zeroable};
 use copyless::VecHelper;
 
@@ -404,6 +404,8 @@ pub fn queue_sprites(
             let extracted_sprites = &mut extracted_sprites.sprites;
             let image_bind_groups = &mut *image_bind_groups;
 
+            let visible_entities = HashSet::from_iter(visible_entities.iter().cloned());
+
             transparent_phase.items.reserve(extracted_sprites.len());
 
             // Sort sprites by z for correct transparency and then by handle to improve batching
@@ -432,11 +434,9 @@ pub fn queue_sprites(
             // Batches are merged later (in `batch_phase_system()`), so that they can be interrupted
             // by any other phase item (and they can interrupt other items from batching).
             for extracted_sprite in extracted_sprites.iter() {
-                // TODO: this is probably super-inefficient
-                if !visible_entities.entities.contains(&extracted_sprite.entity) {
+                if !visible_entities.contains(&extracted_sprite.entity) {
                     continue;
                 }
-                // &visible_entities.entities
                 let new_batch = SpriteBatch {
                     image_handle_id: extracted_sprite.image_handle_id,
                     colored: extracted_sprite.color != Color::WHITE,

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -359,6 +359,7 @@ pub fn queue_sprites(
     mut extracted_sprites: ResMut<ExtractedSprites>,
     mut views: Query<(&VisibleEntities, &mut RenderPhase<Transparent2d>)>,
     events: Res<SpriteAssetEvents>,
+    mut visible_entities_map: Local<HashSet<Entity>>,
 ) {
     // If an image has changed, the GpuImage has (probably) changed
     for event in &events.images {
@@ -403,7 +404,8 @@ pub fn queue_sprites(
             let extracted_sprites = &mut extracted_sprites.sprites;
             let image_bind_groups = &mut *image_bind_groups;
 
-            let visible_entities = HashSet::from_iter(visible_entities.iter().cloned());
+            visible_entities_map.clear();
+            visible_entities_map.extend(visible_entities.iter().copied());
 
             transparent_phase.items.reserve(extracted_sprites.len());
 
@@ -433,7 +435,7 @@ pub fn queue_sprites(
             // Batches are merged later (in `batch_phase_system()`), so that they can be interrupted
             // by any other phase item (and they can interrupt other items from batching).
             for extracted_sprite in extracted_sprites.iter() {
-                if !visible_entities.contains(&extracted_sprite.entity) {
+                if !visible_entities_map.contains(&extracted_sprite.entity) {
                     continue;
                 }
                 let new_batch = SpriteBatch {

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -10,7 +10,7 @@ use bevy_ecs::{
 };
 use bevy_math::{Vec2, Vec3};
 use bevy_reflect::Reflect;
-use bevy_render::{texture::Image, view::Visibility, RenderWorld};
+use bevy_render::{prelude::ComputedVisibility, texture::Image, view::Visibility, RenderWorld};
 use bevy_sprite::{Anchor, ExtractedSprite, ExtractedSprites, TextureAtlas};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 use bevy_utils::HashSet;
@@ -58,6 +58,7 @@ pub struct Text2dBundle {
     pub text_2d_size: Text2dSize,
     pub text_2d_bounds: Text2dBounds,
     pub visibility: Visibility,
+    pub computed_visibility: ComputedVisibility,
 }
 
 pub fn extract_text2d_sprite(
@@ -111,6 +112,7 @@ pub fn extract_text2d_sprite(
                 let transform = text_transform.mul_transform(glyph_transform);
 
                 extracted_sprites.sprites.push(ExtractedSprite {
+                    entity,
                     transform,
                     color,
                     rect,


### PR DESCRIPTION
# Objective

- Make sprites and text2d work with RenderLayers, so a subset of sprites could be rendered with one camera.

## Solution

- Add ComputedVisibility to SpriteBundle and Text2DBundle
- Extract the entity handle as well when extracting sprites
- Create a hash map out of VisibleEntities per view.
- Check if extracted sprites are present in the hashmap

Maybe there are more efficient ways of doing this than recreating hashmaps all the time?

Anyways, I didn't see any drop in performance when running the `bevymark` example, so perhaps it's ok.

EDIT: It's a ~17% decline in performance with many_sprites, but no change in bevymark. bevymark is perhaps a bit contrived? Isn't it better to be correct than performant? Most of the performance hit seems to be caused by sampling the hashmap.