### PR TITLE
use handleid in renderer instead of a weak handle

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -7,8 +7,9 @@ use crate::{
 use anyhow::Result;
 use bevy_ecs::system::{Res, ResMut};
 use bevy_log::warn;
+use bevy_reflect::UniqueAssetId;
 use bevy_tasks::TaskPool;
-use bevy_utils::{Entry, HashMap, Uuid};
+use bevy_utils::{Entry, HashMap};
 use crossbeam_channel::TryRecvError;
 use parking_lot::{Mutex, RwLock};
 use std::{path::Path, sync::Arc};
@@ -52,7 +53,7 @@ pub struct AssetServerInternal {
     pub(crate) asset_io: Box<dyn AssetIo>,
     pub(crate) asset_ref_counter: AssetRefCounter,
     pub(crate) asset_sources: Arc<RwLock<HashMap<SourcePathId, SourceInfo>>>,
-    pub(crate) asset_lifecycles: Arc<RwLock<HashMap<Uuid, Box<dyn AssetLifecycle>>>>,
+    pub(crate) asset_lifecycles: Arc<RwLock<HashMap<UniqueAssetId, Box<dyn AssetLifecycle>>>>,
     loaders: RwLock<Vec<Arc<dyn AssetLoader>>>,
     extension_to_loader_index: RwLock<HashMap<String, usize>>,
     handle_to_path: Arc<RwLock<HashMap<HandleId, AssetPath<'static>>>>,
@@ -880,7 +881,7 @@ mod test {
         assert!(server.get_handle_path(&handle).is_none());
 
         // invalid HandleId
-        let invalid_id = HandleId::new(Uuid::new_v4(), 42);
+        let invalid_id = HandleId::new(0, 42);
         assert!(server.get_handle_path(invalid_id).is_none());
 
         // invalid AssetPath

--- a/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
+++ b/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
@@ -2,6 +2,7 @@ use crate::{Asset, Assets};
 use bevy_app::prelude::*;
 use bevy_diagnostic::{Diagnostic, DiagnosticId, Diagnostics, MAX_DIAGNOSTIC_NAME_WIDTH};
 use bevy_ecs::system::{Res, ResMut};
+use bevy_reflect::Uuid;
 
 /// Adds "asset count" diagnostic to an App
 pub struct AssetCountDiagnosticsPlugin<T: Asset> {
@@ -25,7 +26,7 @@ impl<T: Asset> Plugin for AssetCountDiagnosticsPlugin<T> {
 
 impl<T: Asset> AssetCountDiagnosticsPlugin<T> {
     pub fn diagnostic_id() -> DiagnosticId {
-        DiagnosticId(T::TYPE_UUID)
+        DiagnosticId(Uuid::from_u128(T::TYPE_UUID as u128))
     }
 
     pub fn setup_system(mut diagnostics: ResMut<Diagnostics>) {

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -10,8 +10,7 @@ use crate::{
     Asset, Assets,
 };
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
-use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize};
-use bevy_utils::Uuid;
+use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize, UniqueAssetId};
 use crossbeam_channel::{Receiver, Sender};
 use serde::{Deserialize, Serialize};
 
@@ -32,7 +31,7 @@ use serde::{Deserialize, Serialize};
 )]
 #[reflect_value(Serialize, Deserialize, PartialEq, Hash)]
 pub enum HandleId {
-    Id(Uuid, u64),
+    Id(UniqueAssetId, u64),
     AssetPathId(AssetPathId),
 }
 
@@ -60,7 +59,7 @@ impl HandleId {
     }
 
     #[inline]
-    pub const fn new(type_uuid: Uuid, id: u64) -> Self {
+    pub const fn new(type_uuid: UniqueAssetId, id: u64) -> Self {
         HandleId::Id(type_uuid, id)
     }
 }
@@ -306,7 +305,7 @@ pub struct HandleUntyped {
 }
 
 impl HandleUntyped {
-    pub const fn weak_from_u64(uuid: Uuid, id: u64) -> Self {
+    pub const fn weak_from_u64(uuid: UniqueAssetId, id: u64) -> Self {
         Self {
             id: HandleId::new(uuid, id),
             handle_type: HandleType::Weak,

--- a/crates/bevy_asset/src/info.rs
+++ b/crates/bevy_asset/src/info.rs
@@ -1,5 +1,6 @@
 use crate::{path::AssetPath, LabelId};
-use bevy_utils::{HashMap, HashSet, Uuid};
+use bevy_reflect::UniqueAssetId;
+use bevy_utils::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -12,7 +13,7 @@ pub struct SourceMeta {
 pub struct AssetMeta {
     pub label: Option<String>,
     pub dependencies: Vec<AssetPath<'static>>,
-    pub type_uuid: Uuid,
+    pub type_uuid: UniqueAssetId,
 }
 
 /// Info about a specific asset, such as its path and its current load state
@@ -20,7 +21,7 @@ pub struct AssetMeta {
 pub struct SourceInfo {
     pub meta: Option<SourceMeta>,
     pub path: PathBuf,
-    pub asset_types: HashMap<LabelId, Uuid>,
+    pub asset_types: HashMap<LabelId, UniqueAssetId>,
     pub load_state: LoadState,
     pub committed_assets: HashSet<LabelId>,
     pub version: usize,
@@ -33,7 +34,7 @@ impl SourceInfo {
         })
     }
 
-    pub fn get_asset_type(&self, label_id: LabelId) -> Option<Uuid> {
+    pub fn get_asset_type(&self, label_id: LabelId) -> Option<UniqueAssetId> {
         self.asset_types.get(&label_id).cloned()
     }
 }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -290,7 +290,7 @@ impl<M: SpecializedMaterial, const I: usize> EntityRenderCommand for SetMaterial
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let material_handle = query.get(item).unwrap();
-        let material = materials.into_inner().get(material_handle).unwrap();
+        let material = materials.into_inner().get(&material_handle.id).unwrap();
         pass.set_bind_group(
             I,
             M::bind_group(material),
@@ -344,8 +344,8 @@ pub fn queue_material_meshes<M: SpecializedMaterial>(
             if let Ok((material_handle, mesh_handle, mesh_uniform)) =
                 material_meshes.get(*visible_entity)
             {
-                if let Some(material) = render_materials.get(material_handle) {
-                    if let Some(mesh) = render_meshes.get(mesh_handle) {
+                if let Some(material) = render_materials.get(&material_handle.id) {
+                    if let Some(mesh) = render_meshes.get(&mesh_handle.id) {
                         let mut mesh_key =
                             MeshPipelineKey::from_primitive_topology(mesh.primitive_topology)
                                 | msaa_key;

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1070,7 +1070,7 @@ pub fn queue_shadows(
             // so no meshes will be queued
             for entity in visible_entities.iter().copied() {
                 if let Ok(mesh_handle) = casting_meshes.get(entity) {
-                    if let Some(mesh) = render_meshes.get(mesh_handle) {
+                    if let Some(mesh) = render_meshes.get(&mesh_handle.id) {
                         let key =
                             ShadowPipelineKey::from_primitive_topology(mesh.primitive_topology);
                         let pipeline_id = pipelines.specialize(

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -349,7 +349,7 @@ impl MeshPipeline {
         handle_option: &Option<Handle<Image>>,
     ) -> Option<(&'a TextureView, &'a Sampler)> {
         if let Some(handle) = handle_option {
-            let gpu_image = gpu_images.get(handle)?;
+            let gpu_image = gpu_images.get(&handle.id)?;
             Some((&gpu_image.texture_view, &gpu_image.sampler))
         } else {
             Some((
@@ -669,7 +669,7 @@ impl EntityRenderCommand for DrawMesh {
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let mesh_handle = mesh_query.get(item).unwrap();
-        if let Some(gpu_mesh) = meshes.into_inner().get(mesh_handle) {
+        if let Some(gpu_mesh) = meshes.into_inner().get(&mesh_handle.id) {
             pass.set_vertex_buffer(0, gpu_mesh.vertex_buffer.slice(..));
             match &gpu_mesh.buffer_info {
                 GpuBufferInfo::Indexed {

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -129,7 +129,7 @@ fn queue_wireframes(
 
         let add_render_phase =
             |(entity, mesh_handle, mesh_uniform): (Entity, &Handle<Mesh>, &MeshUniform)| {
-                if let Some(mesh) = render_meshes.get(mesh_handle) {
+                if let Some(mesh) = render_meshes.get(&mesh_handle.id) {
                     let key = msaa_key
                         | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
                     let pipeline_id = specialized_pipelines.specialize(

--- a/crates/bevy_reflect/src/type_uuid.rs
+++ b/crates/bevy_reflect/src/type_uuid.rs
@@ -1,14 +1,16 @@
 pub use bevy_reflect_derive::TypeUuid;
 pub use bevy_utils::Uuid;
 
+pub type UniqueAssetId = u64;
+
 /// A trait for types with a statically associated UUID.
 pub trait TypeUuid {
-    const TYPE_UUID: Uuid;
+    const TYPE_UUID: UniqueAssetId;
 }
 
 /// A trait for types with an associated UUID.
 pub trait TypeUuidDynamic {
-    fn type_uuid(&self) -> Uuid;
+    fn type_uuid(&self) -> UniqueAssetId;
     fn type_name(&self) -> &'static str;
 }
 
@@ -17,7 +19,7 @@ where
     T: TypeUuid,
 {
     /// Returns the UUID associated with this value's type.
-    fn type_uuid(&self) -> Uuid {
+    fn type_uuid(&self) -> UniqueAssetId {
         Self::TYPE_UUID
     }
 

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -57,9 +57,9 @@ impl RenderTarget {
             RenderTarget::Window(window_id) => windows
                 .get(window_id)
                 .and_then(|window| window.swap_chain_texture.as_ref()),
-            RenderTarget::Image(image_handle) => {
-                images.get(image_handle).map(|image| &image.texture_view)
-            }
+            RenderTarget::Image(image_handle) => images
+                .get(&image_handle.id)
+                .map(|image| &image.texture_view),
         }
     }
     pub fn get_physical_size(&self, windows: &Windows, images: &Assets<Image>) -> Option<UVec2> {

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -276,7 +276,7 @@ impl<M: SpecializedMaterial2d, const I: usize> EntityRenderCommand
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let material2d_handle = query.get(item).unwrap();
-        let material2d = materials.into_inner().get(material2d_handle).unwrap();
+        let material2d = materials.into_inner().get(&material2d_handle.id).unwrap();
         pass.set_bind_group(
             I,
             M::bind_group(material2d),
@@ -313,8 +313,8 @@ pub fn queue_material2d_meshes<M: SpecializedMaterial2d>(
             if let Ok((material2d_handle, mesh2d_handle, mesh2d_uniform)) =
                 material2d_meshes.get(*visible_entity)
             {
-                if let Some(material2d) = render_materials.get(material2d_handle) {
-                    if let Some(mesh) = render_meshes.get(&mesh2d_handle.0) {
+                if let Some(material2d) = render_materials.get(&material2d_handle.id) {
+                    if let Some(mesh) = render_meshes.get(&mesh2d_handle.0.id) {
                         let mesh_key = msaa_key
                             | Mesh2dPipelineKey::from_primitive_topology(mesh.primitive_topology);
 

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -214,7 +214,7 @@ impl Mesh2dPipeline {
         handle_option: &Option<Handle<Image>>,
     ) -> Option<(&'a TextureView, &'a Sampler)> {
         if let Some(handle) = handle_option {
-            let gpu_image = gpu_images.get(handle)?;
+            let gpu_image = gpu_images.get(&handle.id)?;
             Some((&gpu_image.texture_view, &gpu_image.sampler))
         } else {
             Some((
@@ -441,7 +441,7 @@ impl EntityRenderCommand for DrawMesh2d {
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let mesh_handle = &mesh2d_query.get(item).unwrap().0;
-        if let Some(gpu_mesh) = meshes.into_inner().get(mesh_handle) {
+        if let Some(gpu_mesh) = meshes.into_inner().get(&mesh_handle.id) {
             pass.set_vertex_buffer(0, gpu_mesh.vertex_buffer.slice(..));
             match &gpu_mesh.buffer_info {
                 GpuBufferInfo::Indexed {

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -12,7 +12,6 @@ use bevy_ecs::{
     system::{lifetimeless::*, SystemParamItem},
 };
 use bevy_math::{const_vec2, Vec2};
-use bevy_reflect::Uuid;
 use bevy_render::{
     color::Color,
     render_asset::RenderAssets,
@@ -409,7 +408,7 @@ pub fn queue_sprites(
 
             // Impossible starting values that will be replaced on the first iteration
             let mut current_batch = SpriteBatch {
-                image_handle_id: HandleId::Id(Uuid::nil(), u64::MAX),
+                image_handle_id: HandleId::Id(u64::MAX, u64::MAX),
                 colored: false,
             };
             let mut current_batch_entity = Entity::from_raw(u32::MAX);

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -426,9 +426,7 @@ pub fn queue_sprites(
                 };
                 if new_batch != current_batch {
                     // Set-up a new possible batch
-                    if let Some(gpu_image) =
-                        gpu_images.get(&Handle::weak(new_batch.image_handle_id))
-                    {
+                    if let Some(gpu_image) = gpu_images.get(&new_batch.image_handle_id) {
                         current_batch = new_batch;
                         current_image_size = Vec2::new(gpu_image.size.width, gpu_image.size.height);
                         current_batch_entity = commands.spawn_bundle((current_batch,)).id();

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -448,7 +448,7 @@ pub fn queue_uinodes(
                     .values
                     .entry(batch.image.clone_weak())
                     .or_insert_with(|| {
-                        let gpu_image = gpu_images.get(&batch.image).unwrap();
+                        let gpu_image = gpu_images.get(&batch.image.id).unwrap();
                         render_device.create_bind_group(&BindGroupDescriptor {
                             entries: &[
                                 BindGroupEntry {

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -333,7 +333,7 @@ pub fn queue_colored_mesh2d(
             if let Ok((mesh2d_handle, mesh2d_uniform)) = colored_mesh2d.get(*visible_entity) {
                 // Get our specialized pipeline
                 let mut mesh2d_key = mesh_key;
-                if let Some(mesh) = render_meshes.get(&mesh2d_handle.0) {
+                if let Some(mesh) = render_meshes.get(&mesh2d_handle.0.id) {
                     mesh2d_key |=
                         Mesh2dPipelineKey::from_primitive_topology(mesh.primitive_topology);
                 }

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -115,7 +115,7 @@ fn queue_custom(
         let view_matrix = view.transform.compute_matrix();
         let view_row_2 = view_matrix.row(2);
         for (entity, mesh_uniform, mesh_handle) in material_meshes.iter() {
-            if let Some(mesh) = render_meshes.get(mesh_handle) {
+            if let Some(mesh) = render_meshes.get(&mesh_handle.id) {
                 let pipeline = pipelines
                     .specialize(&mut pipeline_cache, &custom_pipeline, key, &mesh.layout)
                     .unwrap();

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -87,7 +87,7 @@ fn queue_bind_group(
     game_of_life_image: Res<GameOfLifeImage>,
     render_device: Res<RenderDevice>,
 ) {
-    let view = &gpu_images[&game_of_life_image.0];
+    let view = &gpu_images[&game_of_life_image.0.id];
     let bind_group = render_device.create_bind_group(&BindGroupDescriptor {
         label: None,
         layout: &pipeline.texture_bind_group_layout,

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -152,7 +152,7 @@ fn queue_custom(
         let view_matrix = view.transform.compute_matrix();
         let view_row_2 = view_matrix.row(2);
         for (entity, mesh_handle, mesh_uniform, is_red) in material_meshes.iter() {
-            if let Some(mesh) = render_meshes.get(mesh_handle) {
+            if let Some(mesh) = render_meshes.get(&mesh_handle.id) {
                 let key =
                     msaa_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
                 let pipeline = pipelines

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -242,7 +242,7 @@ impl EntityRenderCommand for DrawMeshInstanced {
         let mesh_handle = mesh_query.get(item).unwrap();
         let instance_buffer = instance_buffer_query.get(item).unwrap();
 
-        let gpu_mesh = match meshes.into_inner().get(mesh_handle) {
+        let gpu_mesh = match meshes.into_inner().get(&mesh_handle.id) {
             Some(gpu_mesh) => gpu_mesh,
             None => return RenderCommandResult::Failure,
         };

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -120,7 +120,7 @@ fn queue_custom(
         let view_matrix = view.transform.compute_matrix();
         let view_row_2 = view_matrix.row(2);
         for (entity, mesh_uniform, mesh_handle) in material_meshes.iter() {
-            if let Some(mesh) = meshes.get(mesh_handle) {
+            if let Some(mesh) = meshes.get(&mesh_handle.id) {
                 let key =
                     msaa_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
                 let pipeline = pipelines


### PR DESCRIPTION
- The renderer only need a weak handle, so it can work with the HandleId
- Tiny perf improvement
- This was already done for the sprites

next question would be to replace the type uuid by a smaller unique id: uuid is backed by a u128, but a u64 would be largely enough to have a unique id for asset types, and make the `HandleId` enum the same size for both variants
