### PR TITLE
[Merged by Bors] - remove external_type_uuid macro

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -732,11 +732,6 @@ pub fn type_uuid_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStre
     type_uuid::type_uuid_derive(input)
 }
 
-#[proc_macro]
-pub fn external_type_uuid(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    type_uuid::external_type_uuid(tokens)
-}
-
 #[proc_macro_attribute]
 pub fn reflect_trait(args: TokenStream, input: TokenStream) -> TokenStream {
     reflect_trait::reflect_trait(&args, input)

--- a/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
@@ -2,7 +2,7 @@ extern crate proc_macro;
 
 use bevy_macro_utils::BevyManifest;
 use quote::{quote, ToTokens};
-use syn::{parse::*, *};
+use syn::*;
 use uuid::Uuid;
 
 pub fn type_uuid_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -59,41 +59,6 @@ pub fn type_uuid_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStre
     let gen = quote! {
         impl #bevy_reflect_path::TypeUuid for #name {
             const TYPE_UUID: #bevy_reflect_path::Uuid = #bevy_reflect_path::Uuid::from_bytes([
-                #( #bytes ),*
-            ]);
-        }
-    };
-    gen.into()
-}
-
-struct ExternalDeriveInput {
-    path: ExprPath,
-    uuid_str: LitStr,
-}
-
-impl Parse for ExternalDeriveInput {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let path = input.parse()?;
-        input.parse::<Token![,]>()?;
-        let uuid_str = input.parse()?;
-        Ok(Self { path, uuid_str })
-    }
-}
-
-pub fn external_type_uuid(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let ExternalDeriveInput { path, uuid_str } = parse_macro_input!(tokens as ExternalDeriveInput);
-
-    let uuid = Uuid::parse_str(&uuid_str.value()).expect("Value was not a valid UUID.");
-
-    let bytes = uuid
-        .as_bytes()
-        .iter()
-        .map(|byte| format!("{:#X}", byte))
-        .map(|byte_str| syn::parse_str::<LitInt>(&byte_str).unwrap());
-
-    let gen = quote! {
-        impl crate::TypeUuid for #path {
-            const TYPE_UUID: Uuid = uuid::Uuid::from_bytes([
                 #( #bytes ),*
             ]);
         }


### PR DESCRIPTION
# Objective

- Macro `external_type_uuid` seems unused
- https://docs.rs/bevy/latest/bevy/reflect/macro.external_type_uuid.html

## Solution

- Remove it and see if it was? There is a derive for the same trait that is used everywhere (`#[derive(TypeUuid)]`) and is a better api
