### PR TITLE
[Merged by Bors] - Rename rg3d to Fyrox in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Plugins are very welcome to extend Bevy's features. [Guidelines][plugin_guidelin
 
 ## Thanks and Alternatives
 
-Additionally, we would like to thank the [Amethyst](https://github.com/amethyst/amethyst), [macroquad](https://github.com/not-fl3/macroquad), [coffee](https://github.com/hecrj/coffee), [ggez](https://github.com/ggez/ggez), [rg3d](https://github.com/mrDIMAS/rg3d), and [Piston](https://github.com/PistonDevelopers/piston) projects for providing solid examples of game engine development in Rust. If you are looking for a Rust game engine, it is worth considering all of your options. Each engine has different design goals, and some will likely resonate with you more than others.
+Additionally, we would like to thank the [Amethyst](https://github.com/amethyst/amethyst), [macroquad](https://github.com/not-fl3/macroquad), [coffee](https://github.com/hecrj/coffee), [ggez](https://github.com/ggez/ggez), [Fyrox](https://github.com/FyroxEngine/Fyrox), and [Piston](https://github.com/PistonDevelopers/piston) projects for providing solid examples of game engine development in Rust. If you are looking for a Rust game engine, it is worth considering all of your options. Each engine has different design goals, and some will likely resonate with you more than others.
 
 ## License
 


### PR DESCRIPTION
# Objective

 rg3d has been renamed to Fyrox for a little while now and we should reflect that. It's not particularly urgent since the old link redirects to Fyrox.

## Solution

Rename rg3d to Fyrox in the README
