### PR TITLE
[Merged by Bors] - Updated visibility of reflected trait

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/reflect_trait.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/reflect_trait.rs
@@ -26,6 +26,7 @@ pub fn reflect_trait(_args: &TokenStream, input: TokenStream) -> TokenStream {
     let trait_info = parse_macro_input!(input as TraitInfo);
     let item_trait = &trait_info.item_trait;
     let trait_ident = &item_trait.ident;
+    let trait_vis = &item_trait.vis;
     let reflect_trait_ident =
         Ident::new(&format!("Reflect{}", item_trait.ident), Span::call_site());
     let bevy_reflect_path = BevyManifest::default().get_path("bevy_reflect");
@@ -33,17 +34,17 @@ pub fn reflect_trait(_args: &TokenStream, input: TokenStream) -> TokenStream {
         #item_trait
 
         #[derive(Clone)]
-        pub struct #reflect_trait_ident {
+        #trait_vis struct #reflect_trait_ident {
             get_func: fn(&dyn #bevy_reflect_path::Reflect) -> Option<&dyn #trait_ident>,
             get_mut_func: fn(&mut dyn #bevy_reflect_path::Reflect) -> Option<&mut dyn #trait_ident>,
         }
 
         impl #reflect_trait_ident {
-            fn get<'a>(&self, reflect_value: &'a dyn #bevy_reflect_path::Reflect) -> Option<&'a dyn #trait_ident> {
+            pub fn get<'a>(&self, reflect_value: &'a dyn #bevy_reflect_path::Reflect) -> Option<&'a dyn #trait_ident> {
                 (self.get_func)(reflect_value)
             }
 
-            fn get_mut<'a>(&self, reflect_value: &'a mut dyn #bevy_reflect_path::Reflect) -> Option<&'a mut dyn #trait_ident> {
+            pub fn get_mut<'a>(&self, reflect_value: &'a mut dyn #bevy_reflect_path::Reflect) -> Option<&'a mut dyn #trait_ident> {
                 (self.get_mut_func)(reflect_value)
             }
         }


### PR DESCRIPTION
# Objective

The `#[reflect_trait]` macro did not maintain the visibility of its trait. It also did not make its accessor methods public, which made them inaccessible outside the current module.

## Solution

Made the `Reflect***` struct match the visibility of its trait and made both the `get` and `get_mut` methods always public.
