### PR TITLE
[Merged by Bors] - simplified API to get NDC from camera and world position

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -132,6 +132,11 @@ impl Camera {
         let window_size = self.target.get_logical_size(windows, images)?;
 
         if let Some(ndc_space_coords) = self.world_to_ndc(camera_transform, world_position) {
+            // NDC z-values outside of 0 < z < 1 are outside the camera frustum and are thus not in screen space
+            if ndc_space_coords.z < 0.0 || ndc_space_coords.z > 1.0 {
+                return None;
+            }
+
             // Once in NDC space, we can discard the z element and rescale x/y to fit the screen
             let screen_space_coords = (ndc_space_coords.truncate() + Vec2::ONE) / 2.0 * window_size;
             Some(screen_space_coords)
@@ -150,10 +155,6 @@ impl Camera {
         let world_to_ndc: Mat4 =
             self.projection_matrix * camera_transform.compute_matrix().inverse();
         let ndc_space_coords: Vec3 = world_to_ndc.project_point3(world_position);
-        // NDC z-values outside of 0 < z < 1 are outside the camera frustum and are thus not in screen space
-        if ndc_space_coords.z < 0.0 || ndc_space_coords.z > 1.0 {
-            return None;
-        }
 
         if !ndc_space_coords.is_nan() {
             Some(ndc_space_coords)

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -122,6 +122,9 @@ impl Default for DepthCalculation {
 
 impl Camera {
     /// Given a position in world space, use the camera to compute the screen space coordinates.
+    ///
+    /// To get the coordinates in Normalized Device Coordinates, you should use
+    /// [`world_to_ndc`](Self::world_to_ndc).
     pub fn world_to_screen(
         &self,
         windows: &Windows,
@@ -138,14 +141,17 @@ impl Camera {
             }
 
             // Once in NDC space, we can discard the z element and rescale x/y to fit the screen
-            let screen_space_coords = (ndc_space_coords.truncate() + Vec2::ONE) / 2.0 * window_size;
-            Some(screen_space_coords)
+            Some((ndc_space_coords.truncate() + Vec2::ONE) / 2.0 * window_size)
         } else {
             None
         }
     }
 
-    /// Given a position in world space, use the camera to compute the normalized device coordinates.
+    /// Given a position in world space, use the camera to compute the Normalized Device Coordinates.
+    ///
+    /// Values returned will be between -1.0 and 1.0 when the position is in screen space.
+    /// To get the coordinates in the render target dimensions, you should use
+    /// [`world_to_screen`](Self::world_to_screen).
     pub fn world_to_ndc(
         &self,
         camera_transform: &GlobalTransform,

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -139,7 +139,8 @@ impl Camera {
             None
         }
     }
-    /// Given a position in world space, use the camera to compute the screen space coordinates.
+
+    /// Given a position in world space, use the camera to compute the normalized device coordinates.
     pub fn world_to_ndc(
         &self,
         camera_transform: &GlobalTransform,

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -133,18 +133,14 @@ impl Camera {
         world_position: Vec3,
     ) -> Option<Vec2> {
         let window_size = self.target.get_logical_size(windows, images)?;
-
-        if let Some(ndc_space_coords) = self.world_to_ndc(camera_transform, world_position) {
-            // NDC z-values outside of 0 < z < 1 are outside the camera frustum and are thus not in screen space
-            if ndc_space_coords.z < 0.0 || ndc_space_coords.z > 1.0 {
-                return None;
-            }
-
-            // Once in NDC space, we can discard the z element and rescale x/y to fit the screen
-            Some((ndc_space_coords.truncate() + Vec2::ONE) / 2.0 * window_size)
-        } else {
-            None
+        let ndc_space_coords = self.world_to_ndc(camera_transform, world_position)?;
+        // NDC z-values outside of 0 < z < 1 are outside the camera frustum and are thus not in screen space
+        if ndc_space_coords.z < 0.0 || ndc_space_coords.z > 1.0 {
+            return None;
         }
+
+        // Once in NDC space, we can discard the z element and rescale x/y to fit the screen
+        Some((ndc_space_coords.truncate() + Vec2::ONE) / 2.0 * window_size)
     }
 
     /// Given a position in world space, use the camera to compute the Normalized Device Coordinates.


### PR DESCRIPTION
# Objective

- After #3412, `Camera::world_to_screen` got a little bit uglier to use by needing to provide both `Windows` and `Assets<Image>`, even though only one would be needed https://github.com/bevyengine/bevy/blob/b697e73c3d861c209152ccfb140ae00fbc6e9925/crates/bevy_render/src/camera/camera.rs#L117-L123
- Some time, exact coordinates are not needed but normalized device coordinates is enough

## Solution

- Add a function to just get NDC
