### PR TITLE
Add statically available type info for reflected types

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -189,6 +189,12 @@ fn impl_struct(
                 .unwrap_or_else(|| Member::Unnamed(Index::from(*index)))
         })
         .collect::<Vec<_>>();
+    let field_types = active_fields
+        .iter()
+        .map(|(field, _index)| {
+            field.ty.clone()
+        })
+        .collect::<Vec<_>>();
     let field_count = active_fields.len();
     let field_indices = (0..field_count).collect::<Vec<usize>>();
 
@@ -317,6 +323,15 @@ fn impl_struct(
             fn reflect_partial_eq(&self, value: &dyn #bevy_reflect_path::Reflect) -> Option<bool> {
                 #partial_eq_fn
             }
+
+            fn type_info() -> #bevy_reflect_path::TypeInfo where Self: Sized {
+                let name = std::any::type_name::<Self>();
+                let fields: [(&str, &str); #field_count] = [
+                     #((#field_names, std::any::type_name::<#field_types>()),)*
+                ];
+                let info = #bevy_reflect_path::StructInfo::new(name, fields);
+                #bevy_reflect_path::TypeInfo::Struct(info)
+            }
         }
     })
 }
@@ -332,6 +347,12 @@ fn impl_tuple_struct(
     let field_idents = active_fields
         .iter()
         .map(|(_field, index)| Member::Unnamed(Index::from(*index)))
+        .collect::<Vec<_>>();
+    let field_types = active_fields
+        .iter()
+        .map(|(field, _index)| {
+            field.ty.clone()
+        })
         .collect::<Vec<_>>();
     let field_count = active_fields.len();
     let field_indices = (0..field_count).collect::<Vec<usize>>();
@@ -438,6 +459,15 @@ fn impl_tuple_struct(
             fn reflect_partial_eq(&self, value: &dyn #bevy_reflect_path::Reflect) -> Option<bool> {
                 #partial_eq_fn
             }
+
+            fn type_info() -> #bevy_reflect_path::TypeInfo where Self: Sized {
+                let name = std::any::type_name::<Self>();
+                let fields: [&str; #field_count] = [
+                     #(std::any::type_name::<#field_types>(),)*
+                ];
+                let info = #bevy_reflect_path::TupleStructInfo::new(name, fields);
+                #bevy_reflect_path::TypeInfo::TupleStruct(info)
+            }
         }
     })
 }
@@ -513,6 +543,11 @@ fn impl_value(
 
             fn serializable(&self) -> Option<#bevy_reflect_path::serde::Serializable> {
                 #serialize_fn
+            }
+
+            fn type_info() -> #bevy_reflect_path::TypeInfo where Self: Sized {
+                let info = #bevy_reflect_path::ValueInfo::new::<Self>();
+                #bevy_reflect_path::TypeInfo::Value(info)
             }
         }
     })

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -191,9 +191,7 @@ fn impl_struct(
         .collect::<Vec<_>>();
     let field_types = active_fields
         .iter()
-        .map(|(field, _index)| {
-            field.ty.clone()
-        })
+        .map(|(field, _index)| field.ty.clone())
         .collect::<Vec<_>>();
     let field_count = active_fields.len();
     let field_indices = (0..field_count).collect::<Vec<usize>>();
@@ -350,9 +348,7 @@ fn impl_tuple_struct(
         .collect::<Vec<_>>();
     let field_types = active_fields
         .iter()
-        .map(|(field, _index)| {
-            field.ty.clone()
-        })
+        .map(|(field, _index)| field.ty.clone())
         .collect::<Vec<_>>();
     let field_count = active_fields.len();
     let field_indices = (0..field_count).collect::<Vec<usize>>();

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -1,0 +1,53 @@
+use std::borrow::{Borrow, Cow};
+
+/// The named field of a struct
+#[derive(Clone, Debug)]
+pub struct NamedField {
+    name: Cow<'static, str>,
+    type_name: Cow<'static, str>,
+}
+
+impl NamedField {
+    pub fn new<I: Into<String>>(name: I, type_name: I) -> Self {
+        Self {
+            name: Cow::Owned(name.into()),
+            type_name: Cow::Owned(type_name.into()),
+        }
+    }
+
+    /// Returns the name of the field
+    pub fn name(&self) -> &str {
+        self.name.borrow()
+    }
+
+    /// Returns the type of the field
+    pub fn type_name(&self) -> &str {
+        self.type_name.borrow()
+    }
+}
+
+/// The unnamed field of a tuple or tuple struct
+#[derive(Clone, Debug)]
+pub struct UnnamedField {
+    index: usize,
+    type_name: Cow<'static, str>,
+}
+
+impl UnnamedField {
+    pub fn new<I: Into<String>>(index: usize, type_name: I) -> Self {
+        Self {
+            index,
+            type_name: Cow::Owned(type_name.into()),
+        }
+    }
+
+    /// Returns the index of the field
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Returns the type of the field
+    pub fn type_name(&self) -> &str {
+        self.type_name.borrow()
+    }
+}

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -1,7 +1,10 @@
 use smallvec::{Array, SmallVec};
 use std::any::Any;
 
-use crate::{serde::Serializable, FromReflect, List, ListIter, Reflect, ReflectMut, ReflectRef};
+use crate::{
+    serde::Serializable, FromReflect, List, ListInfo, ListIter, Reflect, ReflectMut, ReflectRef,
+    TypeInfo,
+};
 
 impl<T: Array + Send + Sync + 'static> List for SmallVec<T>
 where
@@ -95,6 +98,13 @@ where
 
     fn serializable(&self) -> Option<Serializable> {
         None
+    }
+
+    fn type_info() -> TypeInfo
+    where
+        Self: Sized,
+    {
+        TypeInfo::List(ListInfo::new::<Self, T::Item>(Some(T::size())))
     }
 }
 

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,9 +1,5 @@
 use crate as bevy_reflect;
-use crate::{
-    map_partial_eq, serde::Serializable, DynamicMap, FromReflect, FromType, GetTypeRegistration,
-    List, ListIter, Map, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef,
-    TypeRegistration,
-};
+use crate::{map_partial_eq, serde::Serializable, DynamicMap, FromReflect, FromType, GetTypeRegistration, List, ListInfo, ListIter, Map, MapInfo, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef, TypeInfo, TypeRegistration, ValueInfo};
 
 use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_value};
 use bevy_utils::{Duration, HashMap, HashSet};
@@ -142,6 +138,13 @@ unsafe impl<T: FromReflect> Reflect for Vec<T> {
     fn serializable(&self) -> Option<Serializable> {
         None
     }
+
+    fn type_info() -> TypeInfo
+    where
+        Self: Sized,
+    {
+        TypeInfo::List(ListInfo::new::<Self, T>(None))
+    }
 }
 
 impl<T: FromReflect + for<'de> Deserialize<'de>> GetTypeRegistration for Vec<T> {
@@ -260,6 +263,13 @@ unsafe impl<K: Reflect + Eq + Hash, V: Reflect> Reflect for HashMap<K, V> {
     fn serializable(&self) -> Option<Serializable> {
         None
     }
+
+    fn type_info() -> TypeInfo
+    where
+        Self: Sized,
+    {
+        TypeInfo::Map(MapInfo::new::<Self, K, V>())
+    }
 }
 
 impl<K, V> GetTypeRegistration for HashMap<K, V>
@@ -348,6 +358,10 @@ unsafe impl Reflect for Cow<'static, str> {
 
     fn serializable(&self) -> Option<Serializable> {
         Some(Serializable::Borrowed(self))
+    }
+
+    fn type_info() -> TypeInfo where Self: Sized {
+        TypeInfo::Value(ValueInfo::new::<Self>())
     }
 }
 

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,5 +1,9 @@
 use crate as bevy_reflect;
-use crate::{map_partial_eq, serde::Serializable, DynamicMap, FromReflect, FromType, GetTypeRegistration, List, ListInfo, ListIter, Map, MapInfo, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef, TypeInfo, TypeRegistration, ValueInfo};
+use crate::{
+    map_partial_eq, serde::Serializable, DynamicMap, FromReflect, FromType, GetTypeRegistration,
+    List, ListInfo, ListIter, Map, MapInfo, MapIter, Reflect, ReflectDeserialize, ReflectMut,
+    ReflectRef, TypeInfo, TypeRegistration, ValueInfo,
+};
 
 use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_value};
 use bevy_utils::{Duration, HashMap, HashSet};
@@ -360,7 +364,10 @@ unsafe impl Reflect for Cow<'static, str> {
         Some(Serializable::Borrowed(self))
     }
 
-    fn type_info() -> TypeInfo where Self: Sized {
+    fn type_info() -> TypeInfo
+    where
+        Self: Sized,
+    {
         TypeInfo::Value(ValueInfo::new::<Self>())
     }
 }

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -441,9 +441,15 @@ mod tests {
         let info = MyStruct::type_info();
         if let TypeInfo::Struct(info) = info {
             assert_eq!(std::any::type_name::<MyStruct>(), info.name());
-            assert_eq!(std::any::type_name::<i32>(), info.field("foo").unwrap().type_name());
+            assert_eq!(
+                std::any::type_name::<i32>(),
+                info.field("foo").unwrap().type_name()
+            );
             assert_eq!("foo", info.field("foo").unwrap().name());
-            assert_eq!(std::any::type_name::<usize>(), info.field_at(1).unwrap().type_name());
+            assert_eq!(
+                std::any::type_name::<usize>(),
+                info.field_at(1).unwrap().type_name()
+            );
         } else {
             panic!("Expected `TypeInfo::Struct`");
         }
@@ -455,7 +461,10 @@ mod tests {
         let info = MyTupleStruct::type_info();
         if let TypeInfo::TupleStruct(info) = info {
             assert_eq!(std::any::type_name::<MyTupleStruct>(), info.name());
-            assert_eq!(std::any::type_name::<i32>(), info.field_at(1).unwrap().type_name());
+            assert_eq!(
+                std::any::type_name::<i32>(),
+                info.field_at(1).unwrap().type_name()
+            );
         } else {
             panic!("Expected `TypeInfo::TupleStruct`");
         }
@@ -466,7 +475,10 @@ mod tests {
         let info = MyTuple::type_info();
         if let TypeInfo::Tuple(info) = info {
             assert_eq!(std::any::type_name::<MyTuple>(), info.name());
-            assert_eq!(std::any::type_name::<f32>(), info.field_at(1).unwrap().type_name());
+            assert_eq!(
+                std::any::type_name::<f32>(),
+                info.field_at(1).unwrap().type_name()
+            );
         } else {
             panic!("Expected `TypeInfo::Tuple`");
         }

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 
+mod fields;
 mod list;
 mod map;
 mod path;
@@ -7,6 +8,7 @@ mod reflect;
 mod struct_trait;
 mod tuple;
 mod tuple_struct;
+mod type_info;
 mod type_registry;
 mod type_uuid;
 mod impls {
@@ -24,6 +26,7 @@ mod impls {
 }
 
 pub mod serde;
+
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
@@ -32,6 +35,7 @@ pub mod prelude {
     };
 }
 
+pub use fields::*;
 pub use impls::*;
 pub use list::*;
 pub use map::*;
@@ -40,6 +44,7 @@ pub use reflect::*;
 pub use struct_trait::*;
 pub use tuple::*;
 pub use tuple_struct::*;
+pub use type_info::*;
 pub use type_registry::*;
 pub use type_uuid::*;
 

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -1,7 +1,9 @@
 use std::any::Any;
 use std::borrow::{Borrow, Cow};
 
-use crate::{serde::Serializable, Reflect, ReflectMut, ReflectRef, FromReflect, TypeInfo, DynamicInfo};
+use crate::{
+    serde::Serializable, DynamicInfo, FromReflect, Reflect, ReflectMut, ReflectRef, TypeInfo,
+};
 
 /// An ordered, mutable list of [Reflect] items. This corresponds to types like [`std::vec::Vec`].
 pub trait List: Reflect {
@@ -48,7 +50,7 @@ impl ListInfo {
         Self {
             name: Cow::Owned(std::any::type_name::<T>().to_string()),
             item_type: Cow::Owned(std::any::type_name::<I>().to_string()),
-            capacity
+            capacity,
         }
     }
 
@@ -194,7 +196,10 @@ unsafe impl Reflect for DynamicList {
         None
     }
 
-    fn type_info() -> TypeInfo where Self: Sized {
+    fn type_info() -> TypeInfo
+    where
+        Self: Sized,
+    {
         TypeInfo::Dynamic(DynamicInfo::new::<Self>())
     }
 }

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 
 use bevy_utils::{Entry, HashMap};
 
-use crate::{serde::Serializable, Reflect, ReflectMut, ReflectRef, TypeInfo, DynamicInfo};
+use crate::{serde::Serializable, DynamicInfo, Reflect, ReflectMut, ReflectRef, TypeInfo};
 
 /// An ordered mapping between [`Reflect`] values.
 ///
@@ -224,7 +224,10 @@ unsafe impl Reflect for DynamicMap {
         None
     }
 
-    fn type_info() -> TypeInfo where Self: Sized {
+    fn type_info() -> TypeInfo
+    where
+        Self: Sized,
+    {
         TypeInfo::Dynamic(DynamicInfo::new::<Self>())
     }
 }

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -135,7 +135,9 @@ pub unsafe trait Reflect: Any + Send + Sync {
     fn serializable(&self) -> Option<Serializable>;
 
     /// Returns the compile-time info for the underlying type
-    fn type_info() -> TypeInfo where Self: Sized;
+    fn type_info() -> TypeInfo
+    where
+        Self: Sized;
 }
 
 /// A trait for types which can be constructed from a reflected type.

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -1,4 +1,4 @@
-use crate::{serde::Serializable, List, Map, Struct, Tuple, TupleStruct};
+use crate::{serde::Serializable, List, Map, Struct, Tuple, TupleStruct, TypeInfo};
 use std::{any::Any, fmt::Debug};
 
 pub use bevy_utils::AHasher as ReflectHasher;
@@ -133,6 +133,9 @@ pub unsafe trait Reflect: Any + Send + Sync {
     ///
     /// If the underlying type does not support serialization, returns `None`.
     fn serializable(&self) -> Option<Serializable>;
+
+    /// Returns the compile-time info for the underlying type
+    fn type_info() -> TypeInfo where Self: Sized;
 }
 
 /// A trait for types which can be constructed from a reflected type.

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -116,7 +116,7 @@ impl StructInfo {
 
     /// Get the index of a field with the given name
     pub fn index_of(&self, name: &str) -> Option<usize> {
-        self.field_indices.get(name).map(|index| *index)
+        self.field_indices.get(name).copied()
     }
 
     /// Iterate over the fields of this struct
@@ -125,7 +125,7 @@ impl StructInfo {
     }
 
     /// The total number of fields in this struct
-    pub fn len(&self) -> usize {
+    pub fn field_len(&self) -> usize {
         self.fields.len()
     }
 }

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -1,4 +1,6 @@
-use crate::{serde::Serializable, NamedField, Reflect, ReflectMut, ReflectRef, TypeInfo, DynamicInfo};
+use crate::{
+    serde::Serializable, DynamicInfo, NamedField, Reflect, ReflectMut, ReflectRef, TypeInfo,
+};
 use bevy_utils::{Entry, HashMap};
 use std::borrow::Borrow;
 use std::slice::Iter;
@@ -384,7 +386,10 @@ unsafe impl Reflect for DynamicStruct {
         None
     }
 
-    fn type_info() -> TypeInfo where Self: Sized {
+    fn type_info() -> TypeInfo
+    where
+        Self: Sized,
+    {
         TypeInfo::Dynamic(DynamicInfo::new::<Self>())
     }
 }

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -2,7 +2,10 @@ use std::any::Any;
 use std::borrow::{Borrow, Cow};
 use std::slice::Iter;
 
-use crate::{serde::Serializable, FromReflect, Reflect, ReflectMut, ReflectRef, UnnamedField, TypeInfo, create_tuple_fields, DynamicInfo};
+use crate::{
+    create_tuple_fields, serde::Serializable, DynamicInfo, FromReflect, Reflect, ReflectMut,
+    ReflectRef, TypeInfo, UnnamedField,
+};
 
 /// A reflected Rust tuple.
 ///
@@ -303,7 +306,10 @@ unsafe impl Reflect for DynamicTuple {
         None
     }
 
-    fn type_info() -> TypeInfo where Self: Sized {
+    fn type_info() -> TypeInfo
+    where
+        Self: Sized,
+    {
         TypeInfo::Dynamic(DynamicInfo::new::<Self>())
     }
 }

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -160,7 +160,7 @@ impl TupleInfo {
     }
 
     /// The total number of fields in this tuple
-    pub fn len(&self) -> usize {
+    pub fn field_len(&self) -> usize {
         self.fields.len()
     }
 }

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -1,4 +1,7 @@
-use crate::{create_tuple_fields, serde::Serializable, Reflect, ReflectMut, ReflectRef, UnnamedField, TypeInfo, DynamicInfo};
+use crate::{
+    create_tuple_fields, serde::Serializable, DynamicInfo, Reflect, ReflectMut, ReflectRef,
+    TypeInfo, UnnamedField,
+};
 use std::any::Any;
 use std::borrow::{Borrow, Cow};
 use std::slice::Iter;
@@ -298,7 +301,10 @@ unsafe impl Reflect for DynamicTupleStruct {
         None
     }
 
-    fn type_info() -> TypeInfo where Self: Sized {
+    fn type_info() -> TypeInfo
+    where
+        Self: Sized,
+    {
         TypeInfo::Dynamic(DynamicInfo::new::<Self>())
     }
 }

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -83,7 +83,7 @@ impl TupleStructInfo {
     }
 
     /// The total number of fields in this struct
-    pub fn len(&self) -> usize {
+    pub fn field_len(&self) -> usize {
         self.fields.len()
     }
 }

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -1,5 +1,5 @@
-use std::borrow::{Borrow, Cow};
 use crate::{ListInfo, MapInfo, Reflect, StructInfo, TupleInfo, TupleStructInfo, UnnamedField};
+use std::borrow::{Borrow, Cow};
 
 /// Compile-time type information for various object types
 #[derive(Debug, Clone)]
@@ -19,13 +19,13 @@ pub enum TypeInfo {
 /// A container for compile-time info related to general value types, including primitives
 #[derive(Debug, Clone)]
 pub struct ValueInfo {
-    name: Cow<'static, str>
+    name: Cow<'static, str>,
 }
 
 impl ValueInfo {
     pub fn new<T: Reflect>() -> Self {
         Self {
-            name: Cow::Owned(std::any::type_name::<T>().to_string())
+            name: Cow::Owned(std::any::type_name::<T>().to_string()),
         }
     }
 
@@ -37,13 +37,13 @@ impl ValueInfo {
 
 #[derive(Debug, Clone)]
 pub struct DynamicInfo {
-    name: Cow<'static, str>
+    name: Cow<'static, str>,
 }
 
 impl DynamicInfo {
     pub fn new<T: Reflect>() -> Self {
         Self {
-            name: Cow::Owned(std::any::type_name::<T>().to_string())
+            name: Cow::Owned(std::any::type_name::<T>().to_string()),
         }
     }
 

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -1,0 +1,65 @@
+use std::borrow::{Borrow, Cow};
+use crate::{ListInfo, MapInfo, Reflect, StructInfo, TupleInfo, TupleStructInfo, UnnamedField};
+
+/// Compile-time type information for various object types
+#[derive(Debug, Clone)]
+pub enum TypeInfo {
+    Struct(StructInfo),
+    TupleStruct(TupleStructInfo),
+    Tuple(TupleInfo),
+    List(ListInfo),
+    Map(MapInfo),
+    Value(ValueInfo),
+    /// Type information for "dynamic" types whose metadata can't be known at compile-time
+    ///
+    /// This includes structs like [`DynamicStruct`](crate::DynamicStruct) and [`DynamicList`](crate::DynamicList)
+    Dynamic(DynamicInfo),
+}
+
+/// A container for compile-time info related to general value types, including primitives
+#[derive(Debug, Clone)]
+pub struct ValueInfo {
+    name: Cow<'static, str>
+}
+
+impl ValueInfo {
+    pub fn new<T: Reflect>() -> Self {
+        Self {
+            name: Cow::Owned(std::any::type_name::<T>().to_string())
+        }
+    }
+
+    /// The name of this value
+    pub fn name(&self) -> &str {
+        self.name.borrow()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DynamicInfo {
+    name: Cow<'static, str>
+}
+
+impl DynamicInfo {
+    pub fn new<T: Reflect>() -> Self {
+        Self {
+            name: Cow::Owned(std::any::type_name::<T>().to_string())
+        }
+    }
+
+    /// The name of this value
+    pub fn name(&self) -> &str {
+        self.name.borrow()
+    }
+}
+
+/// Create a collection of unnamed fields from an iterator of field type names
+pub(crate) fn create_tuple_fields<I: Into<String>, F: IntoIterator<Item = I>>(
+    fields: F,
+) -> Vec<UnnamedField> {
+    fields
+        .into_iter()
+        .enumerate()
+        .map(|(index, field)| UnnamedField::new(index, field.into()))
+        .collect()
+}

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -134,7 +134,7 @@ impl TypeRegistry {
     /// If the specified type has not been registered, returns `None`.
     pub fn get_type_info(&self, type_id: TypeId) -> Option<&TypeInfo> {
         self.get(type_id)
-            .and_then(|registration| Some(registration.type_info()))
+            .map(|registration| registration.type_info())
     }
 
     /// Returns an iterator overed the [`TypeRegistration`]s of the registered


### PR DESCRIPTION
# Objective

It can be helpful to have access to type information without requiring an instance of that type. Especially for `Reflect`, a lot of the gathered type information is known at compile-time and should not necessarily require an instance.

## Solution

Created the `TypeInfo` enum which can be accessed one of two ways:

1. By calling `MyType::type_info()`
2. By calling `type_registry.get_type_info(my_type_id)`

We can use Option 1 because of the added method on `Reflect`:

```rust
fn type_info() -> TypeInfo where Self: Sized;
```

> Note: This requires that the reflected type is sized (which I think is generally okay?)

And we can use Option 2 because the `TypeRegistration::of()` method uses Option 1 to store that info on registration.

## Benefits

One major benefit is that this opens the door to other serialization methods. Since we can get all the type info at compile time, we can know how to properly deserialize something like:

```rust
#[derive(Reflect)]
struct MyType {
  foo: usize,
  bar: Vec<String>
}

// RON to be deserialized:
(
  type: "my_crate::MyType", // <- We now know how to deserialize the rest of this object
  value: {
    // "foo" is a value type matching "usize"
    "foo": 123,
    // "bar" is a list type matching "Vec<String>" with item type "String"
    "bar": ["a", "b", "c"]
  }
)
```

Not only is this more compact, but it has better compatibility (we can change the type of `"foo"` to `i32` without having to update our serialized data).

Of course, serialization/deserialization strategies like this may need to be discussed and fully considered before possibly making a change. However, we will be better equipped to do that now that we can access type information right from the registry.

## Discussion

Some items to discuss:

1. Duplication. There's a bit of overlap with the existing traits/structs since they require an instance of the type while the type info structs do not (for example, `Struct::field_at(&self, index: usize)` and `StructInfo::field_at(&self, index: usize)`, though only `StructInfo` is accessible without an instance object). Is this okay, or do we want to handle it in another way?
2. Should `TypeInfo::Dynamic` be removed? Since the dynamic types don't have type information available at runtime, we can consider them `TypeInfo::Value`s (or just even just `TypeInfo::Struct`).
3. General usefulness of this change, including missing/unnecessary parts.
4. Possible changes to the scene format? (One possible issue with changing it like in the example above might be that we'd have to be careful when handling generic types.)