### PR TITLE
Implement `Component` for WASM `FakeTask`

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -63,6 +63,15 @@ where
     type Storage = TableStorage;
 }
 
+#[cfg(target_arch = "wasm32")]
+// ECS dependencies cannot derive Component, so we must implement it manually for relevant structs.
+impl<T> Component for bevy_tasks::single_threaded_task_pool::FakeTask<T>
+where
+    Self: Send + Sync + 'static,
+{
+    type Storage = TableStorage;
+}
+
 /// The storage used for a specific component type.
 ///
 /// # Examples

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -65,7 +65,7 @@ where
 
 #[cfg(target_arch = "wasm32")]
 // ECS dependencies cannot derive Component, so we must implement it manually for relevant structs.
-impl<T> Component for bevy_tasks::FakeTask<T>
+impl Component for bevy_tasks::FakeTask
 where
     Self: Send + Sync + 'static,
 {

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -65,7 +65,7 @@ where
 
 #[cfg(target_arch = "wasm32")]
 // ECS dependencies cannot derive Component, so we must implement it manually for relevant structs.
-impl<T> Component for bevy_tasks::single_threaded_task_pool::FakeTask<T>
+impl<T> Component for bevy_tasks::FakeTask<T>
 where
     Self: Send + Sync + 'static,
 {

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -15,7 +15,7 @@ pub use task_pool::{Scope, TaskPool, TaskPoolBuilder};
 #[cfg(target_arch = "wasm32")]
 mod single_threaded_task_pool;
 #[cfg(target_arch = "wasm32")]
-pub use single_threaded_task_pool::{Scope, TaskPool, TaskPoolBuilder};
+pub use single_threaded_task_pool::{FakeTask, Scope, TaskPool, TaskPoolBuilder};
 
 mod usages;
 pub use usages::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool};


### PR DESCRIPTION
# Objective

- WASM users cannot place async task futures into a component for detaching.
- This example does not work for WASM due to this issue: https://github.com/bevyengine/bevy/blob/latest/examples/async_tasks/async_compute.rs
Although in the WASM case, there is no result in the task future's output. Instead, it provides a `detach()` function.
- See: https://discord.com/channels/691052431525675048/937158127491633152/947323394515410946
- ...with the CI error here: https://github.com/Earthmark/nothing_moves/runs/5346983870?check_suite_focus=true

## Solution

- Like `Task`, implement `Component` for `FakeTask` on the wasm32 target.
