### PR TITLE
offer a convenience function to poll on tasks

### DIFF
--- a/crates/bevy_tasks/src/task.rs
+++ b/crates/bevy_tasks/src/task.rs
@@ -1,3 +1,4 @@
+use futures_lite::future::{block_on, poll_once};
 use std::{
     future::Future,
     pin::Pin,
@@ -39,6 +40,13 @@ impl<T> Task<T> {
     /// See `async_executor::Task::cancel`
     pub async fn cancel(self) -> Option<T> {
         self.0.cancel().await
+    }
+
+    /// Poll once and check whether the task finished.
+    ///
+    /// After the task finished, polling again will panic because the task was already cancelled.
+    pub fn check_on_result(&mut self) -> Option<T> {
+        block_on(poll_once(self))
     }
 }
 

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -2,7 +2,6 @@ use bevy::{
     prelude::*,
     tasks::{AsyncComputeTaskPool, Task},
 };
-use futures_lite::future;
 use rand::Rng;
 use std::time::{Duration, Instant};
 
@@ -81,7 +80,7 @@ fn handle_tasks(
     box_material_handle: Res<BoxMaterialHandle>,
 ) {
     for (entity, mut task) in transform_tasks.iter_mut() {
-        if let Some(transform) = future::block_on(future::poll_once(&mut *task)) {
+        if let Some(transform) = task.check_on_result() {
             // Add our new PbrBundle of components to our tagged entity
             commands.entity(entity).insert_bundle(PbrBundle {
                 mesh: box_mesh_handle.0.clone(),


### PR DESCRIPTION
# Objective

Offer a convenience function to poll on tasks to provide some more abstraction. See #4045.

## Solution

futures_lite is present in bevy already anyway, so don't also let the consumer require it. -> Basically reexport the idiomatic way to use tasks in systems in bevy.
