### PR TITLE
[Merged by Bors] - examples: add screenspace texture shader example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -468,6 +468,10 @@ name = "shader_material"
 path = "examples/shader/shader_material.rs"
 
 [[example]]
+name = "shader_material_screenspace_texture"
+path = "examples/shader/shader_material_screenspace_texture.rs"
+
+[[example]]
 name = "shader_material_glsl"
 path = "examples/shader/shader_material_glsl.rs"
 

--- a/assets/shaders/custom_material_screenspace_texture.wgsl
+++ b/assets/shaders/custom_material_screenspace_texture.wgsl
@@ -1,0 +1,13 @@
+#import bevy_pbr::mesh_view_bind_group
+
+[[group(1), binding(0)]]
+var texture: texture_2d<f32>;
+[[group(1), binding(1)]]
+var texture_sampler: sampler;
+
+[[stage(fragment)]]
+fn fragment([[builtin(position)]] position: vec4<f32>) -> [[location(0)]] vec4<f32> {
+    let uv = position.xy / vec2<f32>(view.width, view.height);
+    let color = textureSample(texture, texture_sampler, uv);
+    return color;
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -226,6 +226,7 @@ Example | File | Description
 --- | --- | ---
 `custom_vertex_attribute` | [`shader/custom_vertex_attribute.rs`](./shader/custom_vertex_attribute.rs) | Illustrates creating a custom shader material that reads a mesh's custom vertex attribute.
 `shader_material` | [`shader/shader_material.rs`](./shader/shader_material.rs) | Illustrates creating a custom material and a shader that uses it
+`shader_material_screenspace_uv` | [`shader/shader_material_screenspace_uv.rs`](./shader/shader_material_screenspace_uv.rs) | A custom shader sampling a texture with view-indepdenant UV coordinates
 `shader_material_glsl` | [`shader/shader_material_glsl.rs`](./shader/shader_material_glsl.rs) | A custom shader using the GLSL shading language.
 `shader_instancing` | [`shader/shader_instancing.rs`](./shader/shader_instancing.rs) | A custom shader showing off rendering a mesh multiple times in one draw call.
 `animate_shader` | [`shader/animate_shader.rs`](./shader/animate_shader.rs) | Shows how to pass changing data like the time since startup into a shader.

--- a/examples/README.md
+++ b/examples/README.md
@@ -226,7 +226,7 @@ Example | File | Description
 --- | --- | ---
 `custom_vertex_attribute` | [`shader/custom_vertex_attribute.rs`](./shader/custom_vertex_attribute.rs) | Illustrates creating a custom shader material that reads a mesh's custom vertex attribute.
 `shader_material` | [`shader/shader_material.rs`](./shader/shader_material.rs) | Illustrates creating a custom material and a shader that uses it
-`shader_material_screenspace_uv` | [`shader/shader_material_screenspace_uv.rs`](./shader/shader_material_screenspace_uv.rs) | A custom shader sampling a texture with view-indepdenant UV coordinates
+`shader_material_screenspace_uv` | [`shader/shader_material_screenspace_uv.rs`](./shader/shader_material_screenspace_uv.rs) | A custom shader sampling a texture with view-independent UV coordinates
 `shader_material_glsl` | [`shader/shader_material_glsl.rs`](./shader/shader_material_glsl.rs) | A custom shader using the GLSL shading language.
 `shader_instancing` | [`shader/shader_instancing.rs`](./shader/shader_instancing.rs) | A custom shader showing off rendering a mesh multiple times in one draw call.
 `animate_shader` | [`shader/animate_shader.rs`](./shader/animate_shader.rs) | Shows how to pass changing data like the time since startup into a shader.

--- a/examples/README.md
+++ b/examples/README.md
@@ -226,7 +226,7 @@ Example | File | Description
 --- | --- | ---
 `custom_vertex_attribute` | [`shader/custom_vertex_attribute.rs`](./shader/custom_vertex_attribute.rs) | Illustrates creating a custom shader material that reads a mesh's custom vertex attribute.
 `shader_material` | [`shader/shader_material.rs`](./shader/shader_material.rs) | Illustrates creating a custom material and a shader that uses it
-`shader_material_screenspace_uv` | [`shader/shader_material_screenspace_uv.rs`](./shader/shader_material_screenspace_uv.rs) | A custom shader sampling a texture with view-independent UV coordinates
+`shader_material_screenspace_texture` | [`shader/shader_material_screenspace_texture.rs`](./shader/shader_material_screenspace_texture.rs) | A custom shader sampling a texture with view-independent UV coordinates
 `shader_material_glsl` | [`shader/shader_material_glsl.rs`](./shader/shader_material_glsl.rs) | A custom shader using the GLSL shading language.
 `shader_instancing` | [`shader/shader_instancing.rs`](./shader/shader_instancing.rs) | A custom shader showing off rendering a mesh multiple times in one draw call.
 `animate_shader` | [`shader/animate_shader.rs`](./shader/animate_shader.rs) | Shows how to pass changing data like the time since startup into a shader.

--- a/examples/shader/shader_material_screenspace_texture.rs
+++ b/examples/shader/shader_material_screenspace_texture.rs
@@ -1,0 +1,164 @@
+use bevy::{
+    ecs::system::{lifetimeless::SRes, SystemParamItem},
+    pbr::MaterialPipeline,
+    prelude::*,
+    reflect::TypeUuid,
+    render::{
+        render_asset::{PrepareAssetError, RenderAsset, RenderAssets},
+        render_resource::{
+            BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayout,
+            BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingResource, BindingType,
+            SamplerBindingType, ShaderStages, TextureSampleType, TextureViewDimension,
+        },
+        renderer::RenderDevice,
+    },
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(MaterialPlugin::<CustomMaterial>::default())
+        .add_startup_system(setup)
+        .add_system(rotate_camera)
+        .run();
+}
+
+#[derive(Component)]
+struct MainCamera;
+
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut custom_materials: ResMut<Assets<CustomMaterial>>,
+    mut standard_materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
+        material: standard_materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        ..Default::default()
+    });
+    commands.spawn_bundle(PointLightBundle {
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..Default::default()
+    });
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(0.0, 2.5, 1.0).looking_at(Vec3::default(), Vec3::Y),
+        ..Default::default()
+    });
+
+    commands.spawn().insert_bundle(MaterialMeshBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        material: custom_materials.add(CustomMaterial {
+            texture: asset_server.load(
+                "models/FlightHelmet/FlightHelmet_Materials_LensesMat_OcclusionRoughMetal.png",
+            ),
+        }),
+        ..Default::default()
+    });
+
+    // camera
+    commands
+        .spawn_bundle(PerspectiveCameraBundle {
+            transform: Transform::from_xyz(4.0, 2.5, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..Default::default()
+        })
+        .insert(MainCamera);
+}
+
+fn rotate_camera(mut camera: Query<&mut Transform, With<MainCamera>>, time: Res<Time>) {
+    let cam_transform = camera.single_mut().into_inner();
+
+    cam_transform.rotate_around(
+        Vec3::ZERO,
+        Quat::from_axis_angle(Vec3::Y, 45f32.to_radians() * time.delta_seconds()),
+    );
+    cam_transform.look_at(Vec3::ZERO, Vec3::Y);
+}
+
+#[derive(Debug, Clone, TypeUuid)]
+#[uuid = "b62bb455-a72c-4b56-87bb-81e0554e234f"]
+pub struct CustomMaterial {
+    texture: Handle<Image>,
+}
+
+#[derive(Clone)]
+pub struct GpuCustomMaterial {
+    bind_group: BindGroup,
+}
+
+impl RenderAsset for CustomMaterial {
+    type ExtractedAsset = CustomMaterial;
+    type PreparedAsset = GpuCustomMaterial;
+    type Param = (
+        SRes<RenderDevice>,
+        SRes<RenderAssets<Image>>,
+        SRes<MaterialPipeline<Self>>,
+    );
+    fn extract_asset(&self) -> Self::ExtractedAsset {
+        self.clone()
+    }
+
+    fn prepare_asset(
+        extracted_asset: Self::ExtractedAsset,
+        (render_device, gpu_images, material_pipeline): &mut SystemParamItem<Self::Param>,
+    ) -> Result<Self::PreparedAsset, PrepareAssetError<Self::ExtractedAsset>> {
+        let gpu_image = match gpu_images.get(&extracted_asset.texture) {
+            Some(gpu_image) => gpu_image,
+            // if the image isn't loaded yet, try next frame
+            None => return Err(PrepareAssetError::RetryNextUpdate(extracted_asset)),
+        };
+
+        let bind_group = render_device.create_bind_group(&BindGroupDescriptor {
+            entries: &[
+                BindGroupEntry {
+                    binding: 0,
+                    resource: BindingResource::TextureView(&gpu_image.texture_view),
+                },
+                BindGroupEntry {
+                    binding: 1,
+                    resource: BindingResource::Sampler(&gpu_image.sampler),
+                },
+            ],
+            label: None,
+            layout: &material_pipeline.material_layout,
+        });
+
+        Ok(GpuCustomMaterial { bind_group })
+    }
+}
+
+impl Material for CustomMaterial {
+    fn fragment_shader(asset_server: &AssetServer) -> Option<Handle<Shader>> {
+        Some(asset_server.load("shaders/custom_material_screenspace_texture.wgsl"))
+    }
+
+    fn bind_group(render_asset: &<Self as RenderAsset>::PreparedAsset) -> &BindGroup {
+        &render_asset.bind_group
+    }
+
+    fn bind_group_layout(render_device: &RenderDevice) -> BindGroupLayout {
+        render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            entries: &[
+                BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Texture {
+                        sample_type: TextureSampleType::Float { filterable: true },
+                        view_dimension: TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Sampler(SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+            label: None,
+        })
+    }
+}


### PR DESCRIPTION
Adds a new shader example showing how to sample a texture with screenspace coordinates, similar to the end [portal in minecraft](https://bugs.mojang.com/secure/attachment/163759/portal_frame_112.gif).

https://user-images.githubusercontent.com/22177966/156031195-33d14ed8-733f-4d9e-b1da-0fc807c994a5.mp4

I just used the already existent `models/FlightHelmet/FlightHelmet_Materials_LensesMat_OcclusionRoughMetal.png` texture but maybe we should use a dedicated texture for the example. Suggestions welcome.