### PR TITLE
Added boxable commands

### DIFF
--- a/crates/bevy_ecs/src/system/commands/command_queue.rs
+++ b/crates/bevy_ecs/src/system/commands/command_queue.rs
@@ -96,7 +96,7 @@ impl CommandQueue {
             // original commands memory.
             unsafe {
                 std::ptr::copy_nonoverlapping(
-                    command_ptr.clone(),
+                    command_ptr,
                     self.bytes.as_mut_ptr().add(old_len),
                     size,
                 );

--- a/crates/bevy_ecs/src/system/commands/command_queue.rs
+++ b/crates/bevy_ecs/src/system/commands/command_queue.rs
@@ -34,7 +34,7 @@ impl CommandQueue {
     where
         C: Command,
     {
-        /// SAFE: This function is only every called when the `command` bytes is the associated
+        /// SAFE: This function is only ever called when the `command` bytes is the associated
         /// [`Commands`] `T` type. Also this only reads the data via `read_unaligned` so unaligned
         /// accesses are safe.
         unsafe fn write_command<T: Command>(command: *mut u8, world: &mut World) {

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -410,8 +410,8 @@ impl<'w, 's> Commands<'w, 's> {
     /// #     defense: Defense,
     /// # }
     /// // Make sure this is in scope!
-    /// use crate::bevy_ecs::system::BoxableCommand; 
-    /// 
+    /// use crate::bevy_ecs::system::BoxableCommand;
+    ///
     /// fn add_combat_stats_system(mut commands: Commands, player: Res<PlayerEntity>) {
     ///     let boxed_insert = InsertBundle {
     ///         entity: player.entity,

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -388,7 +388,7 @@ impl<'w, 's> Commands<'w, 's> {
     }
 
     /// Adds a [`BoxedCommand`] directly to the command list.
-    /// This is currently helpful for sending commands from non_system/async sources.
+    /// This is currently helpful for sending commands from non_system or async sources.
     pub fn add_boxed(&mut self, command: BoxedCommand) {
         self.queue.push_boxed(command);
     }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -426,7 +426,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///     // once we box them!
     ///     bullets.par_for_each(&task_pool, 5, |(entity, bullet)| {
     ///         // Despawn the bullet
-    ///         commands_tx.try_send(Despawn{entity}.box_command()).unwrap();
+    ///         commands_tx.try_send(Despawn{ entity }.box_command()).unwrap();
     ///         // Spawn the explosion
     ///         commands_tx.try_send(Spawn{bundle: ExplosionBundle::default()}.box_command()).unwrap();
     ///         // send commands to main thread

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -832,7 +832,7 @@ pub trait BoxableCommand {
     fn box_command(self) -> BoxedCommand;
 }
 
-impl<T: Sized + Command> BoxableCommand for T {
+impl<T: Command> BoxableCommand for T {
     fn box_command(self) -> BoxedCommand {
         /// SAFE: This function is only every called when the `command` bytes is the associated
         /// [`Commands`] `T` type. Also this only reads the data via `read_unaligned` so unaligned

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -388,56 +388,7 @@ impl<'w, 's> Commands<'w, 's> {
     }
 
     /// Adds a [`BoxedCommand`] directly to the command list.
-    /// This is currently helpful for sending commands across
-    /// threads or parallel loops.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use bevy_ecs::prelude::*;
-    /// use bevy_ecs::system::{Despawn, Spawn};
-    /// use bevy_tasks::TaskPool;
-    /// use async_channel::unbounded;
-    /// #
-    /// # #[derive(Bundle, Default)]
-    /// # struct ExplosionBundle{
-    ///     size: Size,
-    ///     shape: Shape,
-    /// };
-    /// #
-    /// # #[derive(Component)]
-    /// # struct Bullet;
-    /// # #[derive(Component)]
-    /// # struct BulletCollision;
-    /// # #[derive(Component, Default)]
-    /// # struct Size;
-    /// # #[derive(Component, Default)]
-    /// # struct Shape;
-    ///
-    /// // Make sure this is in scope!
-    /// use crate::bevy_ecs::system::BoxableCommand;
-    ///
-    /// fn explode_bullets(mut commands: Commands, task_pool: Res<TaskPool>, bullets: Query<(Entity, &Bullet), With<BulletCollision>>) {
-    ///     
-    ///     // Create a channel to send commands from par for each, back to main
-    ///     let (commands_tx, commands_rx) = unbounded();
-    ///
-    ///     // We can send different typed commands in the same channel
-    ///     // once we box them!
-    ///     bullets.par_for_each(&task_pool, 5, |(entity, bullet)| {
-    ///         // Despawn the bullet
-    ///         commands_tx.try_send(Despawn{ entity }.box_command()).unwrap();
-    ///         // Spawn the explosion
-    ///         commands_tx.try_send(Spawn{ bundle: ExplosionBundle::default() }.box_command()).unwrap();
-    ///         // send commands to main thread
-    ///     });
-    ///     
-    ///     while let Ok(command) = commands_rx.try_recv(){
-    ///         commands.add_boxed(command);
-    ///     }
-    /// }
-    /// # bevy_ecs::system::assert_is_system(explode_bullets);
-    /// ```
+    /// This is currently helpful for sending commands from non_system/async sources.
     pub fn add_boxed(&mut self, command: BoxedCommand) {
         self.queue.push_boxed(command);
     }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -388,42 +388,55 @@ impl<'w, 's> Commands<'w, 's> {
     }
 
     /// Adds a [`BoxedCommand`] directly to the command list.
+    /// This is currently helpful for sending commands across
+    /// threads or parallel loops.
     ///
     /// # Example
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// use bevy_ecs::system::InsertBundle;
+    /// use bevy_ecs::system::{Despawn, Spawn};
+    /// use bevy_tasks::TaskPool;
+    /// use async_channel::unbounded;
     /// #
-    /// # struct PlayerEntity { entity: Entity }
-    /// # #[derive(Component)]
-    /// # struct Health(u32);
-    /// # #[derive(Component)]
-    /// # struct Strength(u32);
-    /// # #[derive(Component)]
-    /// # struct Defense(u32);
+    /// # #[derive(Bundle, Default)]
+    /// # struct ExplosionBundle{
+    ///     size: Size,
+    ///     shape: Shape,
+    /// };
     /// #
-    /// # #[derive(Bundle)]
-    /// # struct CombatBundle {
-    /// #     health: Health,
-    /// #     strength: Strength,
-    /// #     defense: Defense,
-    /// # }
+    /// # #[derive(Component)]
+    /// # struct Bullet;
+    /// # #[derive(Component)]
+    /// # struct BulletCollision;
+    /// # #[derive(Component, Default)]
+    /// # struct Size;
+    /// # #[derive(Component, Default)]
+    /// # struct Shape;
+    /// 
     /// // Make sure this is in scope!
     /// use crate::bevy_ecs::system::BoxableCommand;
     ///
-    /// fn add_combat_stats_system(mut commands: Commands, player: Res<PlayerEntity>) {
-    ///     let boxed_insert = InsertBundle {
-    ///         entity: player.entity,
-    ///         bundle: CombatBundle {
-    ///             health: Health(100),
-    ///             strength: Strength(40),
-    ///             defense: Defense(20),
-    ///         },
-    ///     }.box_command();
-    ///     commands.add_boxed(boxed_insert);
+    /// fn explode_bullets(mut commands: Commands, task_pool: Res<TaskPool>, bullets: Query<(Entity, &Bullet), With<BulletCollision>>) {
+    ///     
+    ///     // Create a channel to send commands from par for each, back to main
+    ///     let (commands_tx, commands_rx) = unbounded();
+    /// 
+    ///     // We can send different typed commands in the same channel
+    ///     // once we box them!
+    ///     bullets.par_for_each(&task_pool, 5, |(entity, bullet)| {
+    ///         // Despawn the bullet
+    ///         commands_tx.try_send(Despawn{entity}.box_command()).unwrap();
+    ///         // Spawn the explosion
+    ///         commands_tx.try_send(Spawn{bundle: ExplosionBundle::default()}.box_command()).unwrap();
+    ///         // send commands to main thread
+    ///     });
+    ///     
+    ///     while let Ok(command) = commands_rx.try_recv(){
+    ///         commands.add_boxed(command);
+    ///     }
     /// }
-    /// # bevy_ecs::system::assert_is_system(add_combat_stats_system);
+    /// # bevy_ecs::system::assert_is_system(explode_bullets);
     /// ```
     pub fn add_boxed(&mut self, command: BoxedCommand) {
         self.queue.push_boxed(command);

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -428,7 +428,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///         // Despawn the bullet
     ///         commands_tx.try_send(Despawn{ entity }.box_command()).unwrap();
     ///         // Spawn the explosion
-    ///         commands_tx.try_send(Spawn{bundle: ExplosionBundle::default()}.box_command()).unwrap();
+    ///         commands_tx.try_send(Spawn{ bundle: ExplosionBundle::default() }.box_command()).unwrap();
     ///         // send commands to main thread
     ///     });
     ///     

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -847,7 +847,7 @@ pub trait BoxableCommand {
 
 impl<T: Command> BoxableCommand for T {
     fn box_command(self) -> BoxedCommand {
-        /// SAFE: This function is only every called when the `command` bytes is the associated
+        /// SAFE: This function is only ever called when the `command` bytes is the associated
         /// [`Commands`] `T` type. Also this only reads the data via `read_unaligned` so unaligned
         /// accesses are safe.
         unsafe fn write_command<T: Command>(command: *mut u8, world: &mut World) {

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -388,7 +388,7 @@ impl<'w, 's> Commands<'w, 's> {
     }
 
     /// Adds a [`BoxedCommand`] directly to the command list.
-    /// This is currently helpful for sending commands from non_system or async sources.
+    /// This is currently helpful for sending commands from external or async sources.
     pub fn add_boxed(&mut self, command: BoxedCommand) {
         self.queue.push_boxed(command);
     }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -413,7 +413,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// # struct Size;
     /// # #[derive(Component, Default)]
     /// # struct Shape;
-    /// 
+    ///
     /// // Make sure this is in scope!
     /// use crate::bevy_ecs::system::BoxableCommand;
     ///
@@ -421,7 +421,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///     
     ///     // Create a channel to send commands from par for each, back to main
     ///     let (commands_tx, commands_rx) = unbounded();
-    /// 
+    ///
     ///     // We can send different typed commands in the same channel
     ///     // once we box them!
     ///     bullets.par_for_each(&task_pool, 5, |(entity, bullet)| {


### PR DESCRIPTION
# Objective

Create a simple method of adding boxed commands to Commands.  The cleanest method of adding Box<dyn Command> currently isn't possible (adding Box<dyn Commands> directly), but we can do something close.

The end goal is to allow a performant method of adding commands to the CommandQueue across threads (mainly for sharing some form of Commands in a par_for_each loop).

## Solution

By essentially creating and storing the CommandMetas write function alongside the Box<dyn Command> in a specialized type, we can copy the data from the box into the CommandQueue, and move it's write function into the new CommandMeta object.  
