### PR TITLE
[Merged by Bors] - default() shorthand

### DIFF
--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -2,7 +2,7 @@
 pub use crate::{
     app::prelude::*, asset::prelude::*, core::prelude::*, ecs::prelude::*, input::prelude::*,
     log::prelude::*, math::prelude::*, reflect::prelude::*, scene::prelude::*,
-    transform::prelude::*, window::prelude::*, DefaultPlugins, MinimalPlugins,
+    transform::prelude::*, utils::prelude::*, window::prelude::*, DefaultPlugins, MinimalPlugins,
 };
 
 pub use bevy_derive::bevy_main;

--- a/crates/bevy_utils/src/default.rs
+++ b/crates/bevy_utils/src/default.rs
@@ -1,4 +1,4 @@
-/// Used to make initializing structs with defaults easier:
+/// An ergonomic abbreviation for [`Default::default()`] to make initializing structs easier
 /// ```
 /// use bevy_utils::default;
 ///

--- a/crates/bevy_utils/src/default.rs
+++ b/crates/bevy_utils/src/default.rs
@@ -1,25 +1,30 @@
-/// An ergonomic abbreviation for [`Default::default()`] to make initializing structs easier
+/// An ergonomic abbreviation for [`Default::default()`] to make initializing structs easier.
+/// This is especially helpful when combined with ["struct update syntax"](https://doc.rust-lang.org/book/ch05-01-defining-structs.html#creating-instances-from-other-instances-with-struct-update-syntax).
 /// ```
 /// use bevy_utils::default;
 ///
 /// #[derive(Default)]
 /// struct Foo {
-///   bar: usize,
-///   baz: usize,
+///   a: usize,
+///   b: usize,
+///   c: usize,
 /// }
 ///
-/// // Normally you would do this:
+/// // Normally you would initialize a struct with defaults using "struct update syntax"
+/// // combined with `Default::default()`. This example sets `Foo::bar` to 10 and the remaining
+/// // values to their defaults.
 /// let foo = Foo {
-///   bar: 10,
+///   a: 10,
 ///   ..Default::default()
 /// };
 ///
-/// // But now you can do this:
+/// // But now you can do this, which is equivalent:
 /// let foo = Foo {
-///   bar: 10,
+///   a: 10,
 ///   ..default()
 /// };
 /// ```
+#[inline]
 pub fn default<T: Default>() -> T {
     std::default::Default::default()
 }

--- a/crates/bevy_utils/src/default.rs
+++ b/crates/bevy_utils/src/default.rs
@@ -1,0 +1,25 @@
+/// Used to make initializing structs with defaults easier:
+/// ```
+/// use bevy_utils::default;
+///
+/// #[derive(Default)]
+/// struct Foo {
+///   bar: usize,
+///   baz: usize,
+/// }
+///
+/// // Normally you would do this:
+/// let foo = Foo {
+///   bar: 10,
+///   ..Default::default()
+/// };
+///
+/// // But now you can do this:
+/// let foo = Foo {
+///   bar: 10,
+///   ..default()
+/// };
+/// ```
+pub fn default<T: Default>() -> T {
+    std::default::Default::default()
+}

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -1,16 +1,22 @@
-mod enum_variant_meta;
+pub mod prelude {
+    pub use crate::default;
+}
+
 pub mod label;
 
+mod default;
+mod enum_variant_meta;
+
 pub use ahash::AHasher;
+pub use default::default;
 pub use enum_variant_meta::*;
-pub type Entry<'a, K, V> = hashbrown::hash_map::Entry<'a, K, V, RandomState>;
 pub use hashbrown;
-use hashbrown::hash_map::RawEntryMut;
 pub use instant::{Duration, Instant};
 pub use tracing;
 pub use uuid::Uuid;
 
 use ahash::RandomState;
+use hashbrown::hash_map::RawEntryMut;
 use std::{
     fmt::Debug,
     future::Future,
@@ -25,6 +31,8 @@ pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 #[cfg(target_arch = "wasm32")]
 pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+
+pub type Entry<'a, K, V> = hashbrown::hash_map::Entry<'a, K, V, RandomState>;
 
 /// A hasher builder that will create a fixed hasher.
 #[derive(Debug, Clone, Default)]

--- a/examples/2d/contributors.rs
+++ b/examples/2d/contributors.rs
@@ -100,11 +100,11 @@ fn setup_contributor_selection(mut commands: Commands, asset_server: Res<AssetSe
                     custom_size: Some(Vec2::new(1.0, 1.0) * SPRITE_SIZE),
                     color: Color::hsla(hue, SATURATION_DESELECTED, LIGHTNESS_DESELECTED, ALPHA),
                     flip_x: flipped,
-                    ..Default::default()
+                    ..default()
                 },
                 texture: texture_handle.clone(),
                 transform,
-                ..Default::default()
+                ..default()
             })
             .id();
 
@@ -126,7 +126,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .insert_bundle(TextBundle {
             style: Style {
                 align_self: AlignSelf::FlexEnd,
-                ..Default::default()
+                ..default()
             },
             text: Text {
                 sections: vec![
@@ -147,9 +147,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         },
                     },
                 ],
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         });
 }
 

--- a/examples/2d/many_sprites.rs
+++ b/examples/2d/many_sprites.rs
@@ -57,9 +57,9 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
                 },
                 sprite: Sprite {
                     custom_size: Some(tile_size),
-                    ..Default::default()
+                    ..default()
                 },
-                ..Default::default()
+                ..default()
             });
         }
     }

--- a/examples/2d/mesh2d.rs
+++ b/examples/2d/mesh2d.rs
@@ -17,6 +17,6 @@ fn setup(
         mesh: meshes.add(Mesh::from(shape::Quad::default())).into(),
         transform: Transform::default().with_scale(Vec3::splat(128.)),
         material: materials.add(ColorMaterial::from(Color::PURPLE)),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/2d/move_sprite.rs
+++ b/examples/2d/move_sprite.rs
@@ -20,7 +20,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn_bundle(SpriteBundle {
             texture: asset_server.load("branding/icon.png"),
             transform: Transform::from_xyz(100., 0., 0.),
-            ..Default::default()
+            ..default()
         })
         .insert(Direction::Up);
 }

--- a/examples/2d/rect.rs
+++ b/examples/2d/rect.rs
@@ -13,8 +13,8 @@ fn setup(mut commands: Commands) {
         sprite: Sprite {
             color: Color::rgb(0.25, 0.25, 0.75),
             custom_size: Some(Vec2::new(50.0, 50.0)),
-            ..Default::default()
+            ..default()
         },
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/2d/rotation.rs
+++ b/examples/2d/rotation.rs
@@ -66,7 +66,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn_bundle(SpriteBundle {
             texture: ship_handle,
-            ..Default::default()
+            ..default()
         })
         .insert(Player {
             movement_speed: 500.0,                  // metres per second
@@ -78,14 +78,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn_bundle(SpriteBundle {
             texture: enemy_a_handle.clone(),
             transform: Transform::from_xyz(0.0 - horizontal_margin, 0.0, 0.0),
-            ..Default::default()
+            ..default()
         })
         .insert(SnapToPlayer);
     commands
         .spawn_bundle(SpriteBundle {
             texture: enemy_a_handle,
             transform: Transform::from_xyz(0.0, 0.0 - vertical_margin, 0.0),
-            ..Default::default()
+            ..default()
         })
         .insert(SnapToPlayer);
 
@@ -94,7 +94,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn_bundle(SpriteBundle {
             texture: enemy_b_handle.clone(),
             transform: Transform::from_xyz(0.0 + horizontal_margin, 0.0, 0.0),
-            ..Default::default()
+            ..default()
         })
         .insert(RotateToPlayer {
             rotation_speed: f32::to_radians(45.0), // degrees per second
@@ -103,7 +103,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn_bundle(SpriteBundle {
             texture: enemy_b_handle,
             transform: Transform::from_xyz(0.0, 0.0 + vertical_margin, 0.0),
-            ..Default::default()
+            ..default()
         })
         .insert(RotateToPlayer {
             rotation_speed: f32::to_radians(90.0), // degrees per second

--- a/examples/2d/sprite.rs
+++ b/examples/2d/sprite.rs
@@ -11,6 +11,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
     commands.spawn_bundle(SpriteBundle {
         texture: asset_server.load("branding/icon.png"),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/2d/sprite_flipping.rs
+++ b/examples/2d/sprite_flipping.rs
@@ -16,8 +16,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             flip_x: true,
             // And don't flip it upside-down ( the default )
             flip_y: false,
-            ..Default::default()
+            ..default()
         },
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -42,7 +42,7 @@ fn setup(
         .spawn_bundle(SpriteSheetBundle {
             texture_atlas: texture_atlas_handle,
             transform: Transform::from_scale(Vec3::splat(6.0)),
-            ..Default::default()
+            ..default()
         })
         .insert(AnimationTimer(Timer::from_seconds(0.1, true)));
 }

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -34,21 +34,21 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn_bundle(Text2dBundle {
             text: Text::with_section("translation", text_style.clone(), text_alignment),
-            ..Default::default()
+            ..default()
         })
         .insert(AnimateTranslation);
     // Demonstrate changing rotation
     commands
         .spawn_bundle(Text2dBundle {
             text: Text::with_section("rotation", text_style.clone(), text_alignment),
-            ..Default::default()
+            ..default()
         })
         .insert(AnimateRotation);
     // Demonstrate changing scale
     commands
         .spawn_bundle(Text2dBundle {
             text: Text::with_section("scale", text_style, text_alignment),
-            ..Default::default()
+            ..default()
         })
         .insert(AnimateScale);
 }

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -66,16 +66,16 @@ fn setup(
         transform: Transform {
             translation: Vec3::new(150.0, 0.0, 0.0),
             scale: Vec3::splat(4.0),
-            ..Default::default()
+            ..default()
         },
         sprite: TextureAtlasSprite::new(vendor_index),
         texture_atlas: atlas_handle,
-        ..Default::default()
+        ..default()
     });
     // draw the atlas itself
     commands.spawn_bundle(SpriteBundle {
         texture: texture_atlas_texture,
         transform: Transform::from_xyz(-300.0, 0.0, 0.0),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -18,28 +18,28 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
         material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
-        ..Default::default()
+        ..default()
     });
     // cube
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
-        ..Default::default()
+        ..default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
         point_light: PointLight {
             intensity: 1500.0,
             shadows_enabled: true,
-            ..Default::default()
+            ..default()
         },
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
-        ..Default::default()
+        ..default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -24,9 +24,9 @@ fn setup(
         material: materials.add(StandardMaterial {
             base_color: Color::WHITE,
             perceptual_roughness: 1.0,
-            ..Default::default()
+            ..default()
         }),
-        ..Default::default()
+        ..default()
     });
 
     // left wall
@@ -38,9 +38,9 @@ fn setup(
         material: materials.add(StandardMaterial {
             base_color: Color::INDIGO,
             perceptual_roughness: 1.0,
-            ..Default::default()
+            ..default()
         }),
-        ..Default::default()
+        ..default()
     });
     // back (right) wall
     let mut transform = Transform::from_xyz(0.0, 2.5, -2.5);
@@ -51,9 +51,9 @@ fn setup(
         material: materials.add(StandardMaterial {
             base_color: Color::INDIGO,
             perceptual_roughness: 1.0,
-            ..Default::default()
+            ..default()
         }),
-        ..Default::default()
+        ..default()
     });
 
     // cube
@@ -62,10 +62,10 @@ fn setup(
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(StandardMaterial {
                 base_color: Color::PINK,
-                ..Default::default()
+                ..default()
             }),
             transform: Transform::from_xyz(0.0, 0.5, 0.0),
-            ..Default::default()
+            ..default()
         })
         .insert(Movable);
     // sphere
@@ -73,14 +73,14 @@ fn setup(
         .spawn_bundle(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::UVSphere {
                 radius: 0.5,
-                ..Default::default()
+                ..default()
             })),
             material: materials.add(StandardMaterial {
                 base_color: Color::LIME_GREEN,
-                ..Default::default()
+                ..default()
             }),
             transform: Transform::from_xyz(1.5, 1.0, 1.5),
-            ..Default::default()
+            ..default()
         })
         .insert(Movable);
 
@@ -99,22 +99,22 @@ fn setup(
                 intensity: 1600.0, // lumens - roughly a 100W non-halogen incandescent bulb
                 color: Color::RED,
                 shadows_enabled: true,
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         })
         .with_children(|builder| {
             builder.spawn_bundle(PbrBundle {
                 mesh: meshes.add(Mesh::from(shape::UVSphere {
                     radius: 0.1,
-                    ..Default::default()
+                    ..default()
                 })),
                 material: materials.add(StandardMaterial {
                     base_color: Color::RED,
                     emissive: Color::rgba_linear(100.0, 0.0, 0.0, 0.0),
-                    ..Default::default()
+                    ..default()
                 }),
-                ..Default::default()
+                ..default()
             });
         });
 
@@ -127,22 +127,22 @@ fn setup(
                 intensity: 1600.0, // lumens - roughly a 100W non-halogen incandescent bulb
                 color: Color::GREEN,
                 shadows_enabled: true,
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         })
         .with_children(|builder| {
             builder.spawn_bundle(PbrBundle {
                 mesh: meshes.add(Mesh::from(shape::UVSphere {
                     radius: 0.1,
-                    ..Default::default()
+                    ..default()
                 })),
                 material: materials.add(StandardMaterial {
                     base_color: Color::GREEN,
                     emissive: Color::rgba_linear(0.0, 100.0, 0.0, 0.0),
-                    ..Default::default()
+                    ..default()
                 }),
-                ..Default::default()
+                ..default()
             });
         });
 
@@ -155,22 +155,22 @@ fn setup(
                 intensity: 1600.0, // lumens - roughly a 100W non-halogen incandescent bulb
                 color: Color::BLUE,
                 shadows_enabled: true,
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         })
         .with_children(|builder| {
             builder.spawn_bundle(PbrBundle {
                 mesh: meshes.add(Mesh::from(shape::UVSphere {
                     radius: 0.1,
-                    ..Default::default()
+                    ..default()
                 })),
                 material: materials.add(StandardMaterial {
                     base_color: Color::BLUE,
                     emissive: Color::rgba_linear(0.0, 0.0, 100.0, 0.0),
-                    ..Default::default()
+                    ..default()
                 }),
-                ..Default::default()
+                ..default()
             });
         });
 
@@ -186,23 +186,23 @@ fn setup(
                 top: HALF_SIZE,
                 near: -10.0 * HALF_SIZE,
                 far: 10.0 * HALF_SIZE,
-                ..Default::default()
+                ..default()
             },
             shadows_enabled: true,
-            ..Default::default()
+            ..default()
         },
         transform: Transform {
             translation: Vec3::new(0.0, 2.0, 0.0),
             rotation: Quat::from_rotation_x(-std::f32::consts::FRAC_PI_4),
-            ..Default::default()
+            ..default()
         },
-        ..Default::default()
+        ..default()
     });
 
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -16,7 +16,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_scene(asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0"));
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(0.7, 0.7, 1.0).looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
-        ..Default::default()
+        ..default()
     });
     const HALF_SIZE: f32 = 1.0;
     commands.spawn_bundle(DirectionalLightBundle {
@@ -28,12 +28,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 top: HALF_SIZE,
                 near: -10.0 * HALF_SIZE,
                 far: 10.0 * HALF_SIZE,
-                ..Default::default()
+                ..default()
             },
             shadows_enabled: true,
-            ..Default::default()
+            ..default()
         },
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/3d/many_cubes.rs
+++ b/examples/3d/many_cubes.rs
@@ -22,7 +22,7 @@ fn setup(
     let mesh = meshes.add(Mesh::from(shape::Cube { size: 1.0 }));
     let material = materials.add(StandardMaterial {
         base_color: Color::PINK,
-        ..Default::default()
+        ..default()
     });
     for x in 0..WIDTH {
         for y in 0..HEIGHT {
@@ -31,7 +31,7 @@ fn setup(
                 mesh: mesh.clone(),
                 material: material.clone(),
                 transform: Transform::from_xyz((x as f32) * 2.0, (y as f32) * 2.0, 0.0),
-                ..Default::default()
+                ..default()
             });
         }
     }
@@ -39,6 +39,6 @@ fn setup(
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(80.0, 80.0, 300.0),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -29,17 +29,17 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 2.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-        ..Default::default()
+        ..default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
-        ..Default::default()
+        ..default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(-3.0, 3.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -26,36 +26,36 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
         material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
-        ..Default::default()
+        ..default()
     });
     // cubes
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
         transform: Transform::from_xyz(1.5, 0.5, 1.5),
-        ..Default::default()
+        ..default()
     });
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
         transform: Transform::from_xyz(1.5, 0.5, -1.5),
-        ..Default::default()
+        ..default()
     });
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
         transform: Transform::from_xyz(-1.5, 0.5, 1.5),
-        ..Default::default()
+        ..default()
     });
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
         transform: Transform::from_xyz(-1.5, 0.5, -1.5),
-        ..Default::default()
+        ..default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(3.0, 8.0, 5.0),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -31,7 +31,7 @@ fn setup(
     let cube_handle = meshes.add(Mesh::from(shape::Cube { size: 2.0 }));
     let cube_material_handle = materials.add(StandardMaterial {
         base_color: Color::rgb(0.8, 0.7, 0.6),
-        ..Default::default()
+        ..default()
     });
 
     // parent cube
@@ -40,7 +40,7 @@ fn setup(
             mesh: cube_handle.clone(),
             material: cube_material_handle.clone(),
             transform: Transform::from_xyz(0.0, 0.0, 1.0),
-            ..Default::default()
+            ..default()
         })
         .insert(Rotator)
         .with_children(|parent| {
@@ -49,17 +49,17 @@ fn setup(
                 mesh: cube_handle,
                 material: cube_material_handle,
                 transform: Transform::from_xyz(0.0, 0.0, 3.0),
-                ..Default::default()
+                ..default()
             });
         });
     // light
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(4.0, 5.0, -4.0),
-        ..Default::default()
+        ..default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(5.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -30,10 +30,10 @@ fn setup(
                     // vary key PBR parameters on a grid of spheres to show the effect
                     metallic: y01,
                     perceptual_roughness: x01,
-                    ..Default::default()
+                    ..default()
                 }),
                 transform: Transform::from_xyz(x as f32, y as f32 + 0.5, 0.0),
-                ..Default::default()
+                ..default()
             });
         }
     }
@@ -47,10 +47,10 @@ fn setup(
             base_color: Color::hex("ffd891").unwrap(),
             // vary key PBR parameters on a grid of spheres to show the effect
             unlit: true,
-            ..Default::default()
+            ..default()
         }),
         transform: Transform::from_xyz(-5.0, -2.5, 0.0),
-        ..Default::default()
+        ..default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
@@ -58,16 +58,16 @@ fn setup(
         point_light: PointLight {
             intensity: 600000.,
             range: 100.,
-            ..Default::default()
+            ..default()
         },
-        ..Default::default()
+        ..default()
     });
     // camera
     commands.spawn_bundle(OrthographicCameraBundle {
         transform: Transform::from_xyz(0.0, 0.0, 8.0).looking_at(Vec3::default(), Vec3::Y),
         orthographic_projection: OrthographicProjection {
             scale: 0.01,
-            ..Default::default()
+            ..default()
         },
         ..OrthographicCameraBundle::new_3d()
     });

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -109,7 +109,7 @@ fn setup(
     let size = Extent3d {
         width: 512,
         height: 512,
-        ..Default::default()
+        ..default()
     };
 
     // This is the texture that will be rendered to.
@@ -125,7 +125,7 @@ fn setup(
                 | TextureUsages::COPY_DST
                 | TextureUsages::RENDER_ATTACHMENT,
         },
-        ..Default::default()
+        ..default()
     };
 
     // fill image.data with zeroes
@@ -138,7 +138,7 @@ fn setup(
         base_color: Color::rgb(0.8, 0.7, 0.6),
         reflectance: 0.02,
         unlit: false,
-        ..Default::default()
+        ..default()
     });
 
     // This specifies the layer used for the first pass, which will be attached to the first pass camera and cube.
@@ -150,7 +150,7 @@ fn setup(
             mesh: cube_handle,
             material: cube_material_handle,
             transform: Transform::from_translation(Vec3::new(0.0, 0.0, 1.0)),
-            ..Default::default()
+            ..default()
         })
         .insert(FirstPassCube)
         .insert(first_pass_layer);
@@ -159,7 +159,7 @@ fn setup(
     // NOTE: Currently lights are shared between passes - see https://github.com/bevyengine/bevy/issues/3462
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
-        ..Default::default()
+        ..default()
     });
 
     // First pass camera
@@ -171,11 +171,11 @@ fn setup(
             camera: Camera {
                 name: Some(FIRST_PASS_CAMERA.to_string()),
                 target: render_target,
-                ..Default::default()
+                ..default()
             },
             transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
                 .looking_at(Vec3::default(), Vec3::Y),
-            ..Default::default()
+            ..default()
         })
         .insert(first_pass_layer);
     // NOTE: omitting the RenderLayers component for this camera may cause a validation error:
@@ -200,7 +200,7 @@ fn setup(
         base_color_texture: Some(RENDER_IMAGE_HANDLE.typed()),
         reflectance: 0.02,
         unlit: false,
-        ..Default::default()
+        ..default()
     });
 
     // Main pass cube, with material containing the rendered first pass texture.
@@ -211,9 +211,9 @@ fn setup(
             transform: Transform {
                 translation: Vec3::new(0.0, 0.0, 1.5),
                 rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         })
         .insert(MainPassCube);
 
@@ -221,7 +221,7 @@ fn setup(
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
             .looking_at(Vec3::default(), Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -36,11 +36,11 @@ fn setup(
     let white_handle = materials.add(StandardMaterial {
         base_color: Color::WHITE,
         perceptual_roughness: 1.0,
-        ..Default::default()
+        ..default()
     });
     let sphere_handle = meshes.add(Mesh::from(shape::Icosphere {
         radius: sphere_radius,
-        ..Default::default()
+        ..default()
     }));
 
     println!("Using DirectionalLight");
@@ -54,9 +54,9 @@ fn setup(
             shadow_depth_bias: 0.0,
             shadow_normal_bias: 0.0,
             shadows_enabled: true,
-            ..Default::default()
+            ..default()
         },
-        ..Default::default()
+        ..default()
     });
 
     let theta = std::f32::consts::FRAC_PI_4;
@@ -71,15 +71,15 @@ fn setup(
                 top: 5.0,
                 near: -5.0,
                 far: 5.0,
-                ..Default::default()
+                ..default()
             },
             shadow_depth_bias: 0.0,
             shadow_normal_bias: 0.0,
             shadows_enabled: true,
-            ..Default::default()
+            ..default()
         },
         transform: Transform::from_matrix(light_transform),
-        ..Default::default()
+        ..default()
     });
 
     // camera
@@ -87,7 +87,7 @@ fn setup(
         .spawn_bundle(PerspectiveCameraBundle {
             transform: Transform::from_xyz(-1.0, 1.0, 1.0)
                 .looking_at(Vec3::new(-1.0, 1.0, 0.0), Vec3::Y),
-            ..Default::default()
+            ..default()
         })
         .insert(CameraController::default());
 
@@ -96,7 +96,7 @@ fn setup(
             mesh: sphere_handle.clone(),
             material: white_handle.clone(),
             transform: Transform::from_xyz(0.0, spawn_height, z_i32 as f32),
-            ..Default::default()
+            ..default()
         });
     }
 
@@ -106,7 +106,7 @@ fn setup(
             size: 2.0 * spawn_plane_depth,
         })),
         material: white_handle,
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/3d/shadow_caster_receiver.rs
+++ b/examples/3d/shadow_caster_receiver.rs
@@ -31,11 +31,11 @@ fn setup(
     let white_handle = materials.add(StandardMaterial {
         base_color: Color::WHITE,
         perceptual_roughness: 1.0,
-        ..Default::default()
+        ..default()
     });
     let sphere_handle = meshes.add(Mesh::from(shape::Icosphere {
         radius: sphere_radius,
-        ..Default::default()
+        ..default()
     }));
 
     // sphere - initially a caster
@@ -43,7 +43,7 @@ fn setup(
         mesh: sphere_handle.clone(),
         material: materials.add(Color::RED.into()),
         transform: Transform::from_xyz(-1.0, spawn_height, 0.0),
-        ..Default::default()
+        ..default()
     });
 
     // sphere - initially not a caster
@@ -52,7 +52,7 @@ fn setup(
             mesh: sphere_handle,
             material: materials.add(Color::BLUE.into()),
             transform: Transform::from_xyz(1.0, spawn_height, 0.0),
-            ..Default::default()
+            ..default()
         })
         .insert(NotShadowCaster);
 
@@ -62,7 +62,7 @@ fn setup(
             mesh: meshes.add(Mesh::from(shape::Plane { size: 20.0 })),
             material: materials.add(Color::GREEN.into()),
             transform: Transform::from_xyz(0.0, 1.0, -10.0),
-            ..Default::default()
+            ..default()
         })
         .insert_bundle((NotShadowCaster, NotShadowReceiver));
 
@@ -70,7 +70,7 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Plane { size: 20.0 })),
         material: white_handle,
-        ..Default::default()
+        ..default()
     });
 
     println!("Using DirectionalLight");
@@ -82,9 +82,9 @@ fn setup(
             range: spawn_plane_depth,
             color: Color::WHITE,
             shadows_enabled: true,
-            ..Default::default()
+            ..default()
         },
-        ..Default::default()
+        ..default()
     });
 
     let theta = std::f32::consts::FRAC_PI_4;
@@ -99,20 +99,20 @@ fn setup(
                 top: 10.0,
                 near: -50.0,
                 far: 50.0,
-                ..Default::default()
+                ..default()
             },
             shadows_enabled: true,
-            ..Default::default()
+            ..default()
         },
         transform: Transform::from_matrix(light_transform),
-        ..Default::default()
+        ..default()
     });
 
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(-5.0, 5.0, 5.0)
             .looking_at(Vec3::new(-1.0, 1.0, 0.0), Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/3d/spherical_area_lights.rs
+++ b/examples/3d/spherical_area_lights.rs
@@ -16,7 +16,7 @@ fn setup(
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(1.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 
     // plane
@@ -25,9 +25,9 @@ fn setup(
         material: materials.add(StandardMaterial {
             base_color: Color::rgb(0.2, 0.2, 0.2),
             perceptual_roughness: 0.08,
-            ..Default::default()
+            ..default()
         }),
-        ..Default::default()
+        ..default()
     });
 
     const COUNT: usize = 6;
@@ -38,7 +38,7 @@ fn setup(
     let mesh = meshes.add(Mesh::from(shape::UVSphere {
         sectors: 128,
         stacks: 64,
-        ..Default::default()
+        ..default()
     }));
 
     for i in 0..COUNT {
@@ -52,11 +52,11 @@ fn setup(
                 material: materials.add(StandardMaterial {
                     base_color: Color::rgb(0.5, 0.5, 1.0),
                     unlit: true,
-                    ..Default::default()
+                    ..default()
                 }),
                 transform: Transform::from_xyz(position_range.start + percent * pos_len, 0.6, 0.0)
                     .with_scale(Vec3::splat(radius)),
-                ..Default::default()
+                ..default()
             })
             .with_children(|children| {
                 children.spawn_bundle(PointLightBundle {
@@ -64,9 +64,9 @@ fn setup(
                         intensity: 1500.0,
                         radius,
                         color: Color::rgb(0.2, 0.2, 1.0),
-                        ..Default::default()
+                        ..default()
                     },
-                    ..Default::default()
+                    ..default()
                 });
             });
     }

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -31,7 +31,7 @@ fn setup(
         base_color_texture: Some(texture_handle.clone()),
         alpha_mode: AlphaMode::Blend,
         unlit: true,
-        ..Default::default()
+        ..default()
     });
 
     // this material modulates the texture to make it red (and slightly transparent)
@@ -40,7 +40,7 @@ fn setup(
         base_color_texture: Some(texture_handle.clone()),
         alpha_mode: AlphaMode::Blend,
         unlit: true,
-        ..Default::default()
+        ..default()
     });
 
     // and lets make this one blue! (and also slightly transparent)
@@ -49,7 +49,7 @@ fn setup(
         base_color_texture: Some(texture_handle),
         alpha_mode: AlphaMode::Blend,
         unlit: true,
-        ..Default::default()
+        ..default()
     });
 
     // textured quad - normal
@@ -59,9 +59,9 @@ fn setup(
         transform: Transform {
             translation: Vec3::new(0.0, 0.0, 1.5),
             rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
-            ..Default::default()
+            ..default()
         },
-        ..Default::default()
+        ..default()
     });
     // textured quad - modulated
     commands.spawn_bundle(PbrBundle {
@@ -70,9 +70,9 @@ fn setup(
         transform: Transform {
             translation: Vec3::new(0.0, 0.0, 0.0),
             rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
-            ..Default::default()
+            ..default()
         },
-        ..Default::default()
+        ..default()
     });
     // textured quad - modulated
     commands.spawn_bundle(PbrBundle {
@@ -81,13 +81,13 @@ fn setup(
         transform: Transform {
             translation: Vec3::new(0.0, 0.0, -1.5),
             rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
-            ..Default::default()
+            ..default()
         },
-        ..Default::default()
+        ..default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(3.0, 5.0, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -27,12 +27,12 @@ fn setup(
 ) {
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(4.0, 5.0, 4.0),
-        ..Default::default()
+        ..default()
     });
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(1.05, 0.9, 1.5)
             .looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 
     // Spawn the scene as a child of another entity. This first scene will be translated backward

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -9,7 +9,7 @@ fn main() {
         .insert_resource(Msaa { samples: 4 })
         .insert_resource(WgpuSettings {
             features: WgpuFeatures::POLYGON_MODE_LINE,
-            ..Default::default()
+            ..default()
         })
         .add_plugins(DefaultPlugins)
         .add_plugin(WireframePlugin)
@@ -30,7 +30,7 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
         material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
-        ..Default::default()
+        ..default()
     });
     // cube
     commands
@@ -38,18 +38,18 @@ fn setup(
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
             transform: Transform::from_xyz(0.0, 0.5, 0.0),
-            ..Default::default()
+            ..default()
         })
         // This enables wireframe drawing on this entity
         .insert(Wireframe);
     // light
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
-        ..Default::default()
+        ..default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/android/android.rs
+++ b/examples/android/android.rs
@@ -20,23 +20,23 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
         material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
-        ..Default::default()
+        ..default()
     });
     // cube
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
-        ..Default::default()
+        ..default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
-        ..Default::default()
+        ..default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/app/headless_defaults.rs
+++ b/examples/app/headless_defaults.rs
@@ -4,7 +4,7 @@ fn main() {
     App::new()
         .insert_resource(WgpuSettings {
             backends: None,
-            ..Default::default()
+            ..default()
         })
         .add_plugins(DefaultPlugins)
         .run();

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -46,7 +46,7 @@ fn setup(
     // You can also add assets directly to their Assets<T> storage:
     let material_handle = materials.add(StandardMaterial {
         base_color: Color::rgb(0.8, 0.7, 0.6),
-        ..Default::default()
+        ..default()
     });
 
     // monkey
@@ -54,30 +54,30 @@ fn setup(
         mesh: monkey_handle,
         material: material_handle.clone(),
         transform: Transform::from_xyz(-3.0, 0.0, 0.0),
-        ..Default::default()
+        ..default()
     });
     // cube
     commands.spawn_bundle(PbrBundle {
         mesh: cube_handle,
         material: material_handle.clone(),
         transform: Transform::from_xyz(0.0, 0.0, 0.0),
-        ..Default::default()
+        ..default()
     });
     // sphere
     commands.spawn_bundle(PbrBundle {
         mesh: sphere_handle,
         material: material_handle,
         transform: Transform::from_xyz(3.0, 0.0, 0.0),
-        ..Default::default()
+        ..default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(4.0, 5.0, 4.0),
-        ..Default::default()
+        ..default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(0.0, 3.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/asset/custom_asset_io.rs
+++ b/examples/asset/custom_asset_io.rs
@@ -88,6 +88,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
     commands.spawn_bundle(SpriteBundle {
         texture: asset_server.load("branding/icon.png"),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -8,7 +8,7 @@ fn main() {
         // Tell the asset server to watch for asset changes on disk:
         .insert_resource(AssetServerSettings {
             watch_for_changes: true,
-            ..Default::default()
+            ..default()
         })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
@@ -27,11 +27,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // light
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(4.0, 5.0, 4.0),
-        ..Default::default()
+        ..default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(2.0, 2.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -87,7 +87,7 @@ fn handle_tasks(
                 mesh: box_mesh_handle.0.clone(),
                 material: box_material_handle.0.clone(),
                 transform,
-                ..Default::default()
+                ..default()
             });
 
             // Task is complete, so remove task component from entity
@@ -108,13 +108,13 @@ fn setup_env(mut commands: Commands) {
     // lights
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(4.0, 12.0, 15.0),
-        ..Default::default()
+        ..default()
     });
 
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(offset, offset, 15.0)
             .looking_at(Vec3::new(offset, offset, 0.0), Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -70,7 +70,7 @@ fn spawn_text(
                 300.0,
                 0.0,
             ),
-            ..Default::default()
+            ..default()
         });
     }
 }

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -17,7 +17,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn_bundle(SpriteBundle {
             transform: Transform::from_scale(Vec3::splat(0.75)),
             texture: texture.clone(),
-            ..Default::default()
+            ..default()
         })
         // With that entity as a parent, run a lambda that spawns its children
         .with_children(|parent| {
@@ -26,14 +26,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 transform: Transform {
                     translation: Vec3::new(250.0, 0.0, 0.0),
                     scale: Vec3::splat(0.75),
-                    ..Default::default()
+                    ..default()
                 },
                 texture: texture.clone(),
                 sprite: Sprite {
                     color: Color::BLUE,
-                    ..Default::default()
+                    ..default()
                 },
-                ..Default::default()
+                ..default()
             });
         })
         // Store parent entity for next sections
@@ -48,14 +48,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             transform: Transform {
                 translation: Vec3::new(-250.0, 0.0, 0.0),
                 scale: Vec3::splat(0.75),
-                ..Default::default()
+                ..default()
             },
             texture: texture.clone(),
             sprite: Sprite {
                 color: Color::RED,
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         })
         // Using the entity from the previous section as the parent:
         .insert(Parent(parent));
@@ -67,14 +67,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             transform: Transform {
                 translation: Vec3::new(0.0, 250.0, 0.0),
                 scale: Vec3::splat(0.75),
-                ..Default::default()
+                ..default()
             },
             texture,
             sprite: Sprite {
                 color: Color::GREEN,
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         })
         .id();
 

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -12,7 +12,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .insert_resource(AmbientLight {
             brightness: 0.03,
-            ..Default::default()
+            ..default()
         })
         .add_startup_system(generate_bodies)
         .add_stage_after(
@@ -81,7 +81,7 @@ fn generate_bodies(
                 transform: Transform {
                     translation: position,
                     scale: Vec3::splat(radius),
-                    ..Default::default()
+                    ..default()
                 },
                 mesh: mesh.clone(),
                 material: materials.add(
@@ -92,7 +92,7 @@ fn generate_bodies(
                     )
                     .into(),
                 ),
-                ..Default::default()
+                ..default()
             },
             mass: Mass(mass_value),
             acceleration: Acceleration(Vec3::ZERO),
@@ -120,12 +120,12 @@ fn generate_bodies(
                 material: materials.add(StandardMaterial {
                     base_color: Color::ORANGE_RED,
                     emissive: (Color::ORANGE_RED * 2.),
-                    ..Default::default()
+                    ..default()
                 }),
-                ..Default::default()
+                ..default()
             },
             mass: Mass(500.0),
-            ..Default::default()
+            ..default()
         })
         .insert(Star)
         .with_children(|p| {
@@ -135,14 +135,14 @@ fn generate_bodies(
                     intensity: 400.0,
                     range: 100.0,
                     radius: star_radius,
-                    ..Default::default()
+                    ..default()
                 },
-                ..Default::default()
+                ..default()
             });
         });
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(0.0, 10.5, -30.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -12,7 +12,7 @@ fn spawn_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             .spawn_bundle(SpriteBundle {
                 texture: texture.clone(),
                 transform: Transform::from_scale(Vec3::splat(0.1)),
-                ..Default::default()
+                ..default()
             })
             .insert(Velocity(
                 20.0 * Vec2::new(random::<f32>() - 0.5, random::<f32>() - 0.5),

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -31,7 +31,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn_bundle(SpriteBundle {
             texture: asset_server.load("branding/icon.png"),
-            ..Default::default()
+            ..default()
         })
         .insert(MyComponent); // Add the `Component`.
 }

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -45,10 +45,10 @@ fn setup_menu(mut commands: Commands, asset_server: Res<AssetServer>) {
                 justify_content: JustifyContent::Center,
                 // vertically center child text
                 align_items: AlignItems::Center,
-                ..Default::default()
+                ..default()
             },
             color: NORMAL_BUTTON.into(),
-            ..Default::default()
+            ..default()
         })
         .with_children(|parent| {
             parent.spawn_bundle(TextBundle {
@@ -61,7 +61,7 @@ fn setup_menu(mut commands: Commands, asset_server: Res<AssetServer>) {
                     },
                     Default::default(),
                 ),
-                ..Default::default()
+                ..default()
             });
         })
         .id();
@@ -99,7 +99,7 @@ fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
     commands.spawn_bundle(SpriteBundle {
         texture: asset_server.load("branding/icon.png"),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/game/alien_cake_addict.rs
+++ b/examples/game/alien_cake_addict.rs
@@ -87,7 +87,7 @@ fn setup_cameras(mut commands: Commands, mut game: ResMut<Game>) {
             BOARD_SIZE_J as f32 / 2.0 - 0.5,
         )
         .looking_at(game.camera_is_focus, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
     commands.spawn_bundle(UiCameraBundle::default());
 }
@@ -106,9 +106,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
             intensity: 3000.0,
             shadows_enabled: true,
             range: 30.0,
-            ..Default::default()
+            ..default()
         },
-        ..Default::default()
+        ..default()
     });
 
     // spawn the game board
@@ -143,7 +143,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
                     game.player.j as f32,
                 ),
                 rotation: Quat::from_rotation_y(-std::f32::consts::FRAC_PI_2),
-                ..Default::default()
+                ..default()
             }))
             .with_children(|cell| {
                 cell.spawn_scene(asset_server.load("models/AlienCake/alien.glb#Scene0"));
@@ -170,11 +170,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
             position: Rect {
                 top: Val::Px(5.0),
                 left: Val::Px(5.0),
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         },
-        ..Default::default()
+        ..default()
     });
 }
 
@@ -236,7 +236,7 @@ fn move_player(
                     game.player.j as f32,
                 ),
                 rotation: Quat::from_rotation_y(rotation),
-                ..Default::default()
+                ..default()
             };
         }
     }
@@ -340,10 +340,10 @@ fn spawn_bonus(
                         color: Color::rgb(1.0, 1.0, 0.0),
                         intensity: 1000.0,
                         range: 10.0,
-                        ..Default::default()
+                        ..default()
                     },
                     transform: Transform::from_xyz(0.0, 2.0, 0.0),
-                    ..Default::default()
+                    ..default()
                 });
                 children.spawn_scene(game.bonus.handle.clone());
             })
@@ -384,10 +384,10 @@ fn display_score(mut commands: Commands, asset_server: Res<AssetServer>, game: R
                 margin: Rect::all(Val::Auto),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
-                ..Default::default()
+                ..default()
             },
             color: Color::NONE.into(),
-            ..Default::default()
+            ..default()
         })
         .with_children(|parent| {
             parent.spawn_bundle(TextBundle {
@@ -400,7 +400,7 @@ fn display_score(mut commands: Commands, asset_server: Res<AssetServer>, game: R
                     },
                     Default::default(),
                 ),
-                ..Default::default()
+                ..default()
             });
         });
 }

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -57,13 +57,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             transform: Transform {
                 translation: Vec3::new(0.0, -215.0, 0.0),
                 scale: Vec3::new(120.0, 30.0, 0.0),
-                ..Default::default()
+                ..default()
             },
             sprite: Sprite {
                 color: Color::rgb(0.5, 0.5, 1.0),
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         })
         .insert(Paddle { speed: 500.0 })
         .insert(Collider::Paddle);
@@ -73,13 +73,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             transform: Transform {
                 scale: Vec3::new(30.0, 30.0, 0.0),
                 translation: Vec3::new(0.0, -50.0, 1.0),
-                ..Default::default()
+                ..default()
             },
             sprite: Sprite {
                 color: Color::rgb(1.0, 0.5, 0.5),
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         })
         .insert(Ball {
             velocity: 400.0 * Vec3::new(0.5, -0.5, 0.0).normalize(),
@@ -105,18 +105,18 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     },
                 },
             ],
-            ..Default::default()
+            ..default()
         },
         style: Style {
             position_type: PositionType::Absolute,
             position: Rect {
                 top: Val::Px(5.0),
                 left: Val::Px(5.0),
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         },
-        ..Default::default()
+        ..default()
     });
 
     // Add walls
@@ -130,13 +130,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             transform: Transform {
                 translation: Vec3::new(-bounds.x / 2.0, 0.0, 0.0),
                 scale: Vec3::new(wall_thickness, bounds.y + wall_thickness, 1.0),
-                ..Default::default()
+                ..default()
             },
             sprite: Sprite {
                 color: wall_color,
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         })
         .insert(Collider::Solid);
     // right
@@ -145,13 +145,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             transform: Transform {
                 translation: Vec3::new(bounds.x / 2.0, 0.0, 0.0),
                 scale: Vec3::new(wall_thickness, bounds.y + wall_thickness, 1.0),
-                ..Default::default()
+                ..default()
             },
             sprite: Sprite {
                 color: wall_color,
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         })
         .insert(Collider::Solid);
     // bottom
@@ -160,13 +160,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             transform: Transform {
                 translation: Vec3::new(0.0, -bounds.y / 2.0, 0.0),
                 scale: Vec3::new(bounds.x + wall_thickness, wall_thickness, 1.0),
-                ..Default::default()
+                ..default()
             },
             sprite: Sprite {
                 color: wall_color,
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         })
         .insert(Collider::Solid);
     // top
@@ -175,13 +175,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             transform: Transform {
                 translation: Vec3::new(0.0, bounds.y / 2.0, 0.0),
                 scale: Vec3::new(bounds.x + wall_thickness, wall_thickness, 1.0),
-                ..Default::default()
+                ..default()
             },
             sprite: Sprite {
                 color: wall_color,
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         })
         .insert(Collider::Solid);
 
@@ -207,14 +207,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 .spawn_bundle(SpriteBundle {
                     sprite: Sprite {
                         color: brick_color,
-                        ..Default::default()
+                        ..default()
                     },
                     transform: Transform {
                         translation: brick_position,
                         scale: brick_size,
-                        ..Default::default()
+                        ..default()
                     },
-                    ..Default::default()
+                    ..default()
                 })
                 .insert(Collider::Scorable);
         }

--- a/examples/game/game_menu.rs
+++ b/examples/game/game_menu.rs
@@ -88,10 +88,10 @@ mod splash {
                     margin: Rect::all(Val::Auto),
                     // This will set the logo to be 200px wide, and auto adjust its height
                     size: Size::new(Val::Px(200.0), Val::Auto),
-                    ..Default::default()
+                    ..default()
                 },
                 image: UiImage(icon),
-                ..Default::default()
+                ..default()
             })
             .insert(OnSplashScreen);
         // Insert the timer as a resource
@@ -156,10 +156,10 @@ mod game {
                     // vertical (column), so the cross axis is horizontal. This will center the
                     // children
                     align_items: AlignItems::Center,
-                    ..Default::default()
+                    ..default()
                 },
                 color: Color::BLACK.into(),
-                ..Default::default()
+                ..default()
             })
             .insert(OnGameScreen)
             .with_children(|parent| {
@@ -167,7 +167,7 @@ mod game {
                 parent.spawn_bundle(TextBundle {
                     style: Style {
                         margin: Rect::all(Val::Px(50.0)),
-                        ..Default::default()
+                        ..default()
                     },
                     text: Text::with_section(
                         "Will be back to the menu shortly...",
@@ -178,12 +178,12 @@ mod game {
                         },
                         Default::default(),
                     ),
-                    ..Default::default()
+                    ..default()
                 });
                 parent.spawn_bundle(TextBundle {
                     style: Style {
                         margin: Rect::all(Val::Px(50.0)),
-                        ..Default::default()
+                        ..default()
                     },
                     text: Text {
                         sections: vec![
@@ -212,9 +212,9 @@ mod game {
                                 },
                             },
                         ],
-                        ..Default::default()
+                        ..default()
                     },
-                    ..Default::default()
+                    ..default()
                 });
             });
         // Spawn a 5 seconds timer to trigger going back to the menu
@@ -397,7 +397,7 @@ mod menu {
             margin: Rect::all(Val::Px(20.0)),
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
-            ..Default::default()
+            ..default()
         };
         let button_icon_style = Style {
             size: Size::new(Val::Px(30.0), Val::Auto),
@@ -410,7 +410,7 @@ mod menu {
                 top: Val::Auto,
                 bottom: Val::Auto,
             },
-            ..Default::default()
+            ..default()
         };
         let button_text_style = TextStyle {
             font: font.clone(),
@@ -424,10 +424,10 @@ mod menu {
                     margin: Rect::all(Val::Auto),
                     flex_direction: FlexDirection::ColumnReverse,
                     align_items: AlignItems::Center,
-                    ..Default::default()
+                    ..default()
                 },
                 color: Color::CRIMSON.into(),
-                ..Default::default()
+                ..default()
             })
             .insert(OnMainMenuScreen)
             .with_children(|parent| {
@@ -435,7 +435,7 @@ mod menu {
                 parent.spawn_bundle(TextBundle {
                     style: Style {
                         margin: Rect::all(Val::Px(50.0)),
-                        ..Default::default()
+                        ..default()
                     },
                     text: Text::with_section(
                         "Bevy Game Menu UI",
@@ -446,7 +446,7 @@ mod menu {
                         },
                         Default::default(),
                     ),
-                    ..Default::default()
+                    ..default()
                 });
 
                 // Display three buttons for each action available from the main menu:
@@ -457,7 +457,7 @@ mod menu {
                     .spawn_bundle(ButtonBundle {
                         style: button_style.clone(),
                         color: NORMAL_BUTTON.into(),
-                        ..Default::default()
+                        ..default()
                     })
                     .insert(MenuButtonAction::Play)
                     .with_children(|parent| {
@@ -465,7 +465,7 @@ mod menu {
                         parent.spawn_bundle(ImageBundle {
                             style: button_icon_style.clone(),
                             image: UiImage(icon),
-                            ..Default::default()
+                            ..default()
                         });
                         parent.spawn_bundle(TextBundle {
                             text: Text::with_section(
@@ -473,14 +473,14 @@ mod menu {
                                 button_text_style.clone(),
                                 Default::default(),
                             ),
-                            ..Default::default()
+                            ..default()
                         });
                     });
                 parent
                     .spawn_bundle(ButtonBundle {
                         style: button_style.clone(),
                         color: NORMAL_BUTTON.into(),
-                        ..Default::default()
+                        ..default()
                     })
                     .insert(MenuButtonAction::Settings)
                     .with_children(|parent| {
@@ -488,7 +488,7 @@ mod menu {
                         parent.spawn_bundle(ImageBundle {
                             style: button_icon_style.clone(),
                             image: UiImage(icon),
-                            ..Default::default()
+                            ..default()
                         });
                         parent.spawn_bundle(TextBundle {
                             text: Text::with_section(
@@ -496,14 +496,14 @@ mod menu {
                                 button_text_style.clone(),
                                 Default::default(),
                             ),
-                            ..Default::default()
+                            ..default()
                         });
                     });
                 parent
                     .spawn_bundle(ButtonBundle {
                         style: button_style,
                         color: NORMAL_BUTTON.into(),
-                        ..Default::default()
+                        ..default()
                     })
                     .insert(MenuButtonAction::Quit)
                     .with_children(|parent| {
@@ -511,11 +511,11 @@ mod menu {
                         parent.spawn_bundle(ImageBundle {
                             style: button_icon_style,
                             image: UiImage(icon),
-                            ..Default::default()
+                            ..default()
                         });
                         parent.spawn_bundle(TextBundle {
                             text: Text::with_section("Quit", button_text_style, Default::default()),
-                            ..Default::default()
+                            ..default()
                         });
                     });
             });
@@ -527,7 +527,7 @@ mod menu {
             margin: Rect::all(Val::Px(20.0)),
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
-            ..Default::default()
+            ..default()
         };
         let button_text_style = TextStyle {
             font: asset_server.load("fonts/FiraSans-Bold.ttf"),
@@ -541,10 +541,10 @@ mod menu {
                     margin: Rect::all(Val::Auto),
                     flex_direction: FlexDirection::ColumnReverse,
                     align_items: AlignItems::Center,
-                    ..Default::default()
+                    ..default()
                 },
                 color: Color::CRIMSON.into(),
-                ..Default::default()
+                ..default()
             })
             .insert(OnSettingsMenuScreen)
             .with_children(|parent| {
@@ -553,7 +553,7 @@ mod menu {
                     .spawn_bundle(ButtonBundle {
                         style: button_style.clone(),
                         color: NORMAL_BUTTON.into(),
-                        ..Default::default()
+                        ..default()
                     })
                     .insert(MenuButtonAction::SettingsDisplay)
                     .with_children(|parent| {
@@ -563,14 +563,14 @@ mod menu {
                                 button_text_style.clone(),
                                 Default::default(),
                             ),
-                            ..Default::default()
+                            ..default()
                         });
                     });
                 parent
                     .spawn_bundle(ButtonBundle {
                         style: button_style.clone(),
                         color: NORMAL_BUTTON.into(),
-                        ..Default::default()
+                        ..default()
                     })
                     .insert(MenuButtonAction::SettingsSound)
                     .with_children(|parent| {
@@ -580,7 +580,7 @@ mod menu {
                                 button_text_style.clone(),
                                 Default::default(),
                             ),
-                            ..Default::default()
+                            ..default()
                         });
                     });
                 // Display the back button to return to the main menu screen
@@ -588,13 +588,13 @@ mod menu {
                     .spawn_bundle(ButtonBundle {
                         style: button_style,
                         color: NORMAL_BUTTON.into(),
-                        ..Default::default()
+                        ..default()
                     })
                     .insert(MenuButtonAction::BackToMainMenu)
                     .with_children(|parent| {
                         parent.spawn_bundle(TextBundle {
                             text: Text::with_section("Back", button_text_style, Default::default()),
-                            ..Default::default()
+                            ..default()
                         });
                     });
             });
@@ -610,7 +610,7 @@ mod menu {
             margin: Rect::all(Val::Px(20.0)),
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
-            ..Default::default()
+            ..default()
         };
         let button_text_style = TextStyle {
             font: asset_server.load("fonts/FiraSans-Bold.ttf"),
@@ -624,10 +624,10 @@ mod menu {
                     margin: Rect::all(Val::Auto),
                     flex_direction: FlexDirection::ColumnReverse,
                     align_items: AlignItems::Center,
-                    ..Default::default()
+                    ..default()
                 },
                 color: Color::CRIMSON.into(),
-                ..Default::default()
+                ..default()
             })
             .insert(OnDisplaySettingsMenuScreen)
             .with_children(|parent| {
@@ -637,10 +637,10 @@ mod menu {
                     .spawn_bundle(NodeBundle {
                         style: Style {
                             align_items: AlignItems::Center,
-                            ..Default::default()
+                            ..default()
                         },
                         color: Color::CRIMSON.into(),
-                        ..Default::default()
+                        ..default()
                     })
                     .with_children(|parent| {
                         // Display a label for the current setting
@@ -650,7 +650,7 @@ mod menu {
                                 button_text_style.clone(),
                                 Default::default(),
                             ),
-                            ..Default::default()
+                            ..default()
                         });
                         // Display a button for each possible value
                         for quality_setting in [
@@ -664,7 +664,7 @@ mod menu {
                                     ..button_style.clone()
                                 },
                                 color: NORMAL_BUTTON.into(),
-                                ..Default::default()
+                                ..default()
                             });
                             entity.insert(quality_setting).with_children(|parent| {
                                 parent.spawn_bundle(TextBundle {
@@ -673,7 +673,7 @@ mod menu {
                                         button_text_style.clone(),
                                         Default::default(),
                                     ),
-                                    ..Default::default()
+                                    ..default()
                                 });
                             });
                             if *display_quality == quality_setting {
@@ -686,13 +686,13 @@ mod menu {
                     .spawn_bundle(ButtonBundle {
                         style: button_style,
                         color: NORMAL_BUTTON.into(),
-                        ..Default::default()
+                        ..default()
                     })
                     .insert(MenuButtonAction::BackToSettings)
                     .with_children(|parent| {
                         parent.spawn_bundle(TextBundle {
                             text: Text::with_section("Back", button_text_style, Default::default()),
-                            ..Default::default()
+                            ..default()
                         });
                     });
             });
@@ -708,7 +708,7 @@ mod menu {
             margin: Rect::all(Val::Px(20.0)),
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
-            ..Default::default()
+            ..default()
         };
         let button_text_style = TextStyle {
             font: asset_server.load("fonts/FiraSans-Bold.ttf"),
@@ -722,10 +722,10 @@ mod menu {
                     margin: Rect::all(Val::Auto),
                     flex_direction: FlexDirection::ColumnReverse,
                     align_items: AlignItems::Center,
-                    ..Default::default()
+                    ..default()
                 },
                 color: Color::CRIMSON.into(),
-                ..Default::default()
+                ..default()
             })
             .insert(OnSoundSettingsMenuScreen)
             .with_children(|parent| {
@@ -733,10 +733,10 @@ mod menu {
                     .spawn_bundle(NodeBundle {
                         style: Style {
                             align_items: AlignItems::Center,
-                            ..Default::default()
+                            ..default()
                         },
                         color: Color::CRIMSON.into(),
-                        ..Default::default()
+                        ..default()
                     })
                     .with_children(|parent| {
                         parent.spawn_bundle(TextBundle {
@@ -745,7 +745,7 @@ mod menu {
                                 button_text_style.clone(),
                                 Default::default(),
                             ),
-                            ..Default::default()
+                            ..default()
                         });
                         for volume_setting in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] {
                             let mut entity = parent.spawn_bundle(ButtonBundle {
@@ -754,7 +754,7 @@ mod menu {
                                     ..button_style.clone()
                                 },
                                 color: NORMAL_BUTTON.into(),
-                                ..Default::default()
+                                ..default()
                             });
                             entity.insert(Volume(volume_setting));
                             if *volume == Volume(volume_setting) {
@@ -766,13 +766,13 @@ mod menu {
                     .spawn_bundle(ButtonBundle {
                         style: button_style,
                         color: NORMAL_BUTTON.into(),
-                        ..Default::default()
+                        ..default()
                     })
                     .insert(MenuButtonAction::BackToSettings)
                     .with_children(|parent| {
                         parent.spawn_bundle(TextBundle {
                             text: Text::with_section("Back", button_text_style, Default::default()),
-                            ..Default::default()
+                            ..default()
                         });
                     });
             });

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -7,7 +7,7 @@ fn main() {
         .insert_resource(WindowDescriptor {
             resizable: false,
             mode: WindowMode::BorderlessFullscreen,
-            ..Default::default()
+            ..default()
         })
         .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
@@ -53,14 +53,14 @@ fn setup_scene(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
         material: materials.add(Color::rgb(0.1, 0.2, 0.1).into()),
-        ..Default::default()
+        ..default()
     });
     // cube
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.5, 0.4, 0.3).into()),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
-        ..Default::default()
+        ..default()
     });
     // sphere
     commands.spawn_bundle(PbrBundle {
@@ -70,7 +70,7 @@ fn setup_scene(
         })),
         material: materials.add(Color::rgb(0.1, 0.4, 0.8).into()),
         transform: Transform::from_xyz(1.5, 1.5, 1.5),
-        ..Default::default()
+        ..default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
@@ -78,14 +78,14 @@ fn setup_scene(
         point_light: PointLight {
             intensity: 5000.0,
             shadows_enabled: true,
-            ..Default::default()
+            ..default()
         },
-        ..Default::default()
+        ..default()
     });
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -107,7 +107,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(TextBundle {
         style: Style {
             align_self: AlignSelf::FlexEnd,
-            ..Default::default()
+            ..default()
         },
         text: Text::with_section(
             "Nothing to see in this window! Check the console output!",
@@ -118,6 +118,6 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
             Default::default(),
         ),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -42,7 +42,7 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -20,7 +20,7 @@ fn main() {
         .insert_resource(WindowDescriptor {
             // uncomment for unthrottled FPS
             // vsync: false,
-            ..Default::default()
+            ..default()
         })
         .add_plugins(DefaultPlugins)
         .add_plugin(GameOfLifeComputePlugin)
@@ -46,10 +46,10 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
     commands.spawn_bundle(SpriteBundle {
         sprite: Sprite {
             custom_size: Some(Vec2::new(SIZE.0 as f32, SIZE.1 as f32)),
-            ..Default::default()
+            ..default()
         },
         texture: image.clone(),
-        ..Default::default()
+        ..default()
     });
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
 

--- a/examples/shader/custom_vertex_attribute.rs
+++ b/examples/shader/custom_vertex_attribute.rs
@@ -50,13 +50,13 @@ fn setup(
         material: materials.add(CustomMaterial {
             color: Color::WHITE,
         }),
-        ..Default::default()
+        ..default()
     });
 
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -78,7 +78,7 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -58,7 +58,7 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(0.0, 0.0, 15.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/shader/shader_material.rs
+++ b/examples/shader/shader_material.rs
@@ -36,13 +36,13 @@ fn setup(
         material: materials.add(CustomMaterial {
             color: Color::GREEN,
         }),
-        ..Default::default()
+        ..default()
     });
 
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/shader/shader_material_glsl.rs
+++ b/examples/shader/shader_material_glsl.rs
@@ -35,13 +35,13 @@ fn setup(
         material: materials.add(CustomMaterial {
             color: Color::GREEN,
         }),
-        ..Default::default()
+        ..default()
     });
 
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/shader/shader_material_screenspace_texture.rs
+++ b/examples/shader/shader_material_screenspace_texture.rs
@@ -36,15 +36,15 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
         material: standard_materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
-        ..Default::default()
+        ..default()
     });
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
-        ..Default::default()
+        ..default()
     });
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(0.0, 2.5, 1.0).looking_at(Vec3::default(), Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 
     commands.spawn().insert_bundle(MaterialMeshBundle {
@@ -55,14 +55,14 @@ fn setup(
                 "models/FlightHelmet/FlightHelmet_Materials_LensesMat_OcclusionRoughMetal.png",
             ),
         }),
-        ..Default::default()
+        ..default()
     });
 
     // camera
     commands
         .spawn_bundle(PerspectiveCameraBundle {
             transform: Transform::from_xyz(4.0, 2.5, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
+            ..default()
         })
         .insert(MainCamera);
 }

--- a/examples/tools/bevymark.rs
+++ b/examples/tools/bevymark.rs
@@ -33,7 +33,7 @@ fn main() {
             height: 600.,
             present_mode: PresentMode::Immediate,
             resizable: true,
-            ..Default::default()
+            ..default()
         })
         .add_plugins(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
@@ -129,18 +129,18 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         },
                     },
                 ],
-                ..Default::default()
+                ..default()
             },
             style: Style {
                 position_type: PositionType::Absolute,
                 position: Rect {
                     top: Val::Px(5.0),
                     left: Val::Px(5.0),
-                    ..Default::default()
+                    ..default()
                 },
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         })
         .insert(StatsText);
 
@@ -202,13 +202,13 @@ fn spawn_birds(
                 transform: Transform {
                     translation: Vec3::new(bird_x, bird_y, bird_z),
                     scale: Vec3::splat(BIRD_SCALE),
-                    ..Default::default()
+                    ..default()
                 },
                 sprite: Sprite {
                     color: counter.color,
-                    ..Default::default()
+                    ..default()
                 },
-                ..Default::default()
+                ..default()
             })
             .insert(Bird {
                 velocity: Vec3::new(

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -53,10 +53,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 justify_content: JustifyContent::Center,
                 // vertically center child text
                 align_items: AlignItems::Center,
-                ..Default::default()
+                ..default()
             },
             color: NORMAL_BUTTON.into(),
-            ..Default::default()
+            ..default()
         })
         .with_children(|parent| {
             parent.spawn_bundle(TextBundle {
@@ -69,7 +69,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     },
                     Default::default(),
                 ),
-                ..Default::default()
+                ..default()
             });
         });
 }

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -53,11 +53,11 @@ fn atlas_render_system(
                     position: Rect {
                         top: Val::Px(0.0),
                         left: Val::Px(512.0 * x_offset),
-                        ..Default::default()
+                        ..default()
                     },
-                    ..Default::default()
+                    ..default()
                 },
-                ..Default::default()
+                ..default()
             });
         }
     }
@@ -90,6 +90,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut state: ResM
             },
             Default::default(),
         ),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -36,9 +36,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 position: Rect {
                     bottom: Val::Px(5.0),
                     right: Val::Px(15.0),
-                    ..Default::default()
+                    ..default()
                 },
-                ..Default::default()
+                ..default()
             },
             // Use the `Text::with_section` constructor
             text: Text::with_section(
@@ -52,10 +52,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 // Note: You can use `Default::default()` in place of the `TextAlignment`
                 TextAlignment {
                     horizontal: HorizontalAlign::Center,
-                    ..Default::default()
+                    ..default()
                 },
             ),
-            ..Default::default()
+            ..default()
         })
         .insert(ColorText);
     // Rich text with multiple sections
@@ -63,7 +63,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn_bundle(TextBundle {
             style: Style {
                 align_self: AlignSelf::FlexEnd,
-                ..Default::default()
+                ..default()
             },
             // Use `Text` directly
             text: Text {
@@ -86,9 +86,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         },
                     },
                 ],
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         })
         .insert(FpsText);
 }

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -9,7 +9,7 @@ fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
             present_mode: PresentMode::Immediate,
-            ..Default::default()
+            ..default()
         })
         .add_plugins(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin)
@@ -31,9 +31,9 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             position: Rect {
                 top: Val::Px(5.0),
                 left: Val::Px(15.0),
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         },
         text: Text::with_section(
             "This is\ntext with\nline breaks\nin the top left",
@@ -44,7 +44,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
             Default::default(),
         ),
-        ..Default::default()
+        ..default()
     });
     commands.spawn_bundle(TextBundle {
         style: Style {
@@ -53,13 +53,13 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             position: Rect {
                 top: Val::Px(5.0),
                 right: Val::Px(15.0),
-                ..Default::default()
+                ..default()
             },
             max_size: Size {
                 width: Val::Px(400.),
                 height: Val::Undefined,
             },
-            ..Default::default()
+            ..default()
         },
         text: Text::with_section(
                     "This text is very long, has a limited width, is centred, is positioned in the top right and is also coloured pink.",
@@ -73,7 +73,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 vertical: VerticalAlign::Center,
             },
         ),
-        ..Default::default()
+        ..default()
     });
     commands
         .spawn_bundle(TextBundle {
@@ -83,9 +83,9 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 position: Rect {
                     bottom: Val::Px(5.0),
                     right: Val::Px(15.0),
-                    ..Default::default()
+                    ..default()
                 },
-                ..Default::default()
+                ..default()
             },
             text: Text {
                 sections: vec![
@@ -140,7 +140,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ],
                 alignment: Default::default(),
             },
-            ..Default::default()
+            ..default()
         })
         .insert(TextChanges);
     commands.spawn_bundle(TextBundle {
@@ -150,13 +150,13 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             position: Rect {
                 bottom: Val::Px(5.0),
                 left: Val::Px(15.0),
-                ..Default::default()
+                ..default()
             },
             size: Size {
                 width: Val::Px(200.0),
-                ..Default::default()
+                ..default()
             },
-            ..Default::default()
+            ..default()
         },
         text: Text::with_section(
             "This\ntext has\nline breaks and also a set width in the bottom left".to_string(),
@@ -167,7 +167,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
             Default::default(),
         ),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -22,10 +22,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             style: Style {
                 size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                 justify_content: JustifyContent::SpaceBetween,
-                ..Default::default()
+                ..default()
             },
             color: Color::NONE.into(),
-            ..Default::default()
+            ..default()
         })
         .with_children(|parent| {
             // left vertical fill (border)
@@ -34,10 +34,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: Style {
                         size: Size::new(Val::Px(200.0), Val::Percent(100.0)),
                         border: Rect::all(Val::Px(2.0)),
-                        ..Default::default()
+                        ..default()
                     },
                     color: Color::rgb(0.65, 0.65, 0.65).into(),
-                    ..Default::default()
+                    ..default()
                 })
                 .with_children(|parent| {
                     // left vertical fill (content)
@@ -46,17 +46,17 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             style: Style {
                                 size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                                 align_items: AlignItems::FlexEnd,
-                                ..Default::default()
+                                ..default()
                             },
                             color: Color::rgb(0.15, 0.15, 0.15).into(),
-                            ..Default::default()
+                            ..default()
                         })
                         .with_children(|parent| {
                             // text
                             parent.spawn_bundle(TextBundle {
                                 style: Style {
                                     margin: Rect::all(Val::Px(5.0)),
-                                    ..Default::default()
+                                    ..default()
                                 },
                                 text: Text::with_section(
                                     "Text Example",
@@ -67,7 +67,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     },
                                     Default::default(),
                                 ),
-                                ..Default::default()
+                                ..default()
                             });
                         });
                 });
@@ -78,10 +78,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         flex_direction: FlexDirection::ColumnReverse,
                         justify_content: JustifyContent::Center,
                         size: Size::new(Val::Px(200.0), Val::Percent(100.0)),
-                        ..Default::default()
+                        ..default()
                     },
                     color: Color::rgb(0.15, 0.15, 0.15).into(),
-                    ..Default::default()
+                    ..default()
                 })
                 .with_children(|parent| {
                     // Title
@@ -91,9 +91,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             margin: Rect {
                                 left: Val::Auto,
                                 right: Val::Auto,
-                                ..Default::default()
+                                ..default()
                             },
-                            ..Default::default()
+                            ..default()
                         },
                         text: Text::with_section(
                             "Scrolling list",
@@ -104,7 +104,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             },
                             Default::default(),
                         ),
-                        ..Default::default()
+                        ..default()
                     });
                     // List with hidden overflow
                     parent
@@ -114,10 +114,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 align_self: AlignSelf::Center,
                                 size: Size::new(Val::Percent(100.0), Val::Percent(50.0)),
                                 overflow: Overflow::Hidden,
-                                ..Default::default()
+                                ..default()
                             },
                             color: Color::rgb(0.10, 0.10, 0.10).into(),
-                            ..Default::default()
+                            ..default()
                         })
                         .with_children(|parent| {
                             // Moving panel
@@ -127,10 +127,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                         flex_direction: FlexDirection::ColumnReverse,
                                         flex_grow: 1.0,
                                         max_size: Size::new(Val::Undefined, Val::Undefined),
-                                        ..Default::default()
+                                        ..default()
                                     },
                                     color: Color::NONE.into(),
-                                    ..Default::default()
+                                    ..default()
                                 })
                                 .insert(ScrollingList::default())
                                 .with_children(|parent| {
@@ -143,9 +143,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                                 margin: Rect {
                                                     left: Val::Auto,
                                                     right: Val::Auto,
-                                                    ..Default::default()
+                                                    ..default()
                                                 },
-                                                ..Default::default()
+                                                ..default()
                                             },
                                             text: Text::with_section(
                                                 format!("Item {}", i),
@@ -157,7 +157,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                                 },
                                                 Default::default(),
                                             ),
-                                            ..Default::default()
+                                            ..default()
                                         });
                                     }
                                 });
@@ -172,22 +172,22 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         position: Rect {
                             left: Val::Px(210.0),
                             bottom: Val::Px(10.0),
-                            ..Default::default()
+                            ..default()
                         },
                         border: Rect::all(Val::Px(20.0)),
-                        ..Default::default()
+                        ..default()
                     },
                     color: Color::rgb(0.4, 0.4, 1.0).into(),
-                    ..Default::default()
+                    ..default()
                 })
                 .with_children(|parent| {
                     parent.spawn_bundle(NodeBundle {
                         style: Style {
                             size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
-                            ..Default::default()
+                            ..default()
                         },
                         color: Color::rgb(0.8, 0.8, 1.0).into(),
-                        ..Default::default()
+                        ..default()
                     });
                 });
             // render order test: reddest in the back, whitest in the front (flex center)
@@ -198,20 +198,20 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         position_type: PositionType::Absolute,
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
-                        ..Default::default()
+                        ..default()
                     },
                     color: Color::NONE.into(),
-                    ..Default::default()
+                    ..default()
                 })
                 .with_children(|parent| {
                     parent
                         .spawn_bundle(NodeBundle {
                             style: Style {
                                 size: Size::new(Val::Px(100.0), Val::Px(100.0)),
-                                ..Default::default()
+                                ..default()
                             },
                             color: Color::rgb(1.0, 0.0, 0.0).into(),
-                            ..Default::default()
+                            ..default()
                         })
                         .with_children(|parent| {
                             parent.spawn_bundle(NodeBundle {
@@ -221,12 +221,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     position: Rect {
                                         left: Val::Px(20.0),
                                         bottom: Val::Px(20.0),
-                                        ..Default::default()
+                                        ..default()
                                     },
-                                    ..Default::default()
+                                    ..default()
                                 },
                                 color: Color::rgb(1.0, 0.3, 0.3).into(),
-                                ..Default::default()
+                                ..default()
                             });
                             parent.spawn_bundle(NodeBundle {
                                 style: Style {
@@ -235,12 +235,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     position: Rect {
                                         left: Val::Px(40.0),
                                         bottom: Val::Px(40.0),
-                                        ..Default::default()
+                                        ..default()
                                     },
-                                    ..Default::default()
+                                    ..default()
                                 },
                                 color: Color::rgb(1.0, 0.5, 0.5).into(),
-                                ..Default::default()
+                                ..default()
                             });
                             parent.spawn_bundle(NodeBundle {
                                 style: Style {
@@ -249,12 +249,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     position: Rect {
                                         left: Val::Px(60.0),
                                         bottom: Val::Px(60.0),
-                                        ..Default::default()
+                                        ..default()
                                     },
-                                    ..Default::default()
+                                    ..default()
                                 },
                                 color: Color::rgb(1.0, 0.7, 0.7).into(),
-                                ..Default::default()
+                                ..default()
                             });
                             // alpha test
                             parent.spawn_bundle(NodeBundle {
@@ -264,12 +264,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     position: Rect {
                                         left: Val::Px(80.0),
                                         bottom: Val::Px(80.0),
-                                        ..Default::default()
+                                        ..default()
                                     },
-                                    ..Default::default()
+                                    ..default()
                                 },
                                 color: Color::rgba(1.0, 0.9, 0.9, 0.4).into(),
-                                ..Default::default()
+                                ..default()
                             });
                         });
                 });
@@ -281,20 +281,20 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         position_type: PositionType::Absolute,
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::FlexEnd,
-                        ..Default::default()
+                        ..default()
                     },
                     color: Color::NONE.into(),
-                    ..Default::default()
+                    ..default()
                 })
                 .with_children(|parent| {
                     // bevy logo (image)
                     parent.spawn_bundle(ImageBundle {
                         style: Style {
                             size: Size::new(Val::Px(500.0), Val::Auto),
-                            ..Default::default()
+                            ..default()
                         },
                         image: asset_server.load("branding/bevy_logo_dark_big.png").into(),
-                        ..Default::default()
+                        ..default()
                     });
                 });
         });

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -59,7 +59,7 @@ fn create_new_window(
             height: 600.,
             present_mode: PresentMode::Immediate,
             title: "Second window".to_string(),
-            ..Default::default()
+            ..default()
         },
     });
     // second window camera
@@ -67,10 +67,10 @@ fn create_new_window(
         camera: Camera {
             target: RenderTarget::Window(window_id),
             name: Some(SECONDARY_CAMERA_NAME.into()),
-            ..Default::default()
+            ..default()
         },
         transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 
     active_cameras.add(SECONDARY_CAMERA_NAME);
@@ -101,11 +101,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // light
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(4.0, 5.0, 4.0),
-        ..Default::default()
+        ..default()
     });
     // main camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(0.0, 0.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -6,7 +6,7 @@ fn main() {
         .insert_resource(WindowDescriptor {
             width: 500.,
             height: 300.,
-            ..Default::default()
+            ..default()
         })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
@@ -24,10 +24,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             style: Style {
                 size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                 justify_content: JustifyContent::SpaceBetween,
-                ..Default::default()
+                ..default()
             },
             color: Color::NONE.into(),
-            ..Default::default()
+            ..default()
         })
         .with_children(|parent| {
             // left vertical fill (border)
@@ -36,16 +36,16 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: Style {
                         size: Size::new(Val::Px(200.0), Val::Percent(100.0)),
                         border: Rect::all(Val::Px(2.0)),
-                        ..Default::default()
+                        ..default()
                     },
                     color: Color::rgb(0.65, 0.65, 0.65).into(),
-                    ..Default::default()
+                    ..default()
                 })
                 .with_children(|parent| {
                     parent.spawn_bundle(TextBundle {
                         style: Style {
                             align_self: AlignSelf::FlexEnd,
-                            ..Default::default()
+                            ..default()
                         },
                         text: Text::with_section(
                             "Example text",
@@ -56,7 +56,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             },
                             Default::default(),
                         ),
-                        ..Default::default()
+                        ..default()
                     });
                 });
         });

--- a/examples/window/transparent_window.rs
+++ b/examples/window/transparent_window.rs
@@ -11,7 +11,7 @@ fn main() {
             transparent: true,
             // Disabling window decorations to make it feel more like a widget than a window
             decorations: false,
-            ..Default::default()
+            ..default()
         })
         .add_startup_system(setup)
         .add_plugins(DefaultPlugins)
@@ -22,6 +22,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
     commands.spawn_bundle(SpriteBundle {
         texture: asset_server.load("branding/icon.png"),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -8,7 +8,7 @@ fn main() {
             width: 500.,
             height: 300.,
             present_mode: PresentMode::Fifo,
-            ..Default::default()
+            ..default()
         })
         .add_plugins(DefaultPlugins)
         .add_system(change_title)


### PR DESCRIPTION
Adds a `default()` shorthand for `Default::default()` ... because life is too short to constantly type `Default::default()`.

```rust
use bevy::prelude::*;

#[derive(Default)]
struct Foo {
  bar: usize,
  baz: usize,
}

// Normally you would do this:
let foo = Foo {
  bar: 10,
  ..Default::default()
};

// But now you can do this:
let foo = Foo {
  bar: 10,
  ..default()
};
```

The examples have been adapted to use `..default()`. I've left internal crates as-is for now because they don't pull in the bevy prelude, and the ergonomics of each case should be considered individually.