### PR TITLE
Make the entity that was the previous parent public

### DIFF
--- a/crates/bevy_transform/src/components/parent.rs
+++ b/crates/bevy_transform/src/components/parent.rs
@@ -47,7 +47,7 @@ impl DerefMut for Parent {
 /// Component that holds the [`Parent`] this entity had previously
 #[derive(Component, Debug, Copy, Clone, Eq, PartialEq, Reflect)]
 #[reflect(Component, MapEntities, PartialEq)]
-pub struct PreviousParent(pub(crate) Entity);
+pub struct PreviousParent(pub Entity);
 
 impl MapEntities for PreviousParent {
     fn map_entities(&mut self, entity_map: &EntityMap) -> Result<(), MapEntitiesError> {

--- a/crates/bevy_transform/src/components/parent.rs
+++ b/crates/bevy_transform/src/components/parent.rs
@@ -51,7 +51,7 @@ pub struct PreviousParent(pub(crate) Entity);
 
 impl PreviousParent {
     /// Gets the [`Entity`] that was the [`Parent`] this entity had
-    /// previous.
+    /// previously.
     pub fn entity(&self) -> Entity {
         self.0
     }

--- a/crates/bevy_transform/src/components/parent.rs
+++ b/crates/bevy_transform/src/components/parent.rs
@@ -47,7 +47,15 @@ impl DerefMut for Parent {
 /// Component that holds the [`Parent`] this entity had previously
 #[derive(Component, Debug, Copy, Clone, Eq, PartialEq, Reflect)]
 #[reflect(Component, MapEntities, PartialEq)]
-pub struct PreviousParent(pub Entity);
+pub struct PreviousParent(pub(crate) Entity);
+
+impl PreviousParent {
+    /// Gets the [`Entity`] that was the [`Parent`] this entity had
+    /// previous.
+    pub fn entity(&self) -> Entity {
+        self.0
+    }
+}
 
 impl MapEntities for PreviousParent {
     fn map_entities(&mut self, entity_map: &EntityMap) -> Result<(), MapEntitiesError> {


### PR DESCRIPTION
# Objective
When dirtying hierarchy bound structures, like when binding bones for animation, knowing what the previous parent was is needed to propagate upwards both the current and previous hierarchies. This is currently inaccessible due to the `pub(crate)` access modifier on the field. For both bevy crates and external users, there should be a read-only API for accessing the entity within.

## Solution
Make a read-only function to get the entity stored within.
