### PR TITLE
[Merged by Bors] - Fixed Android example icon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -673,8 +673,10 @@ path = "examples/android/android.rs"
 [package.metadata.android]
 apk_label = "Bevy Example"
 assets = "assets"
-res = "assets/android-res"
-icon = "@mipmap/ic_launcher"
+resources = "assets/android-res"
 build_targets = ["aarch64-linux-android", "armv7-linux-androideabi"]
 min_sdk_version = 16
 target_sdk_version = 29
+
+[package.metadata.android.application]
+icon = "@mipmap/ic_launcher"


### PR DESCRIPTION
# Objective

- The android example icon doesn't show up

## Solution

- I fixed the android metadata to match `cargo-apk` manifest
