### PR TITLE
Add a pre-parsed FieldPath for faster repeated uses of GetPath calls

### DIFF
--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -207,24 +207,24 @@ impl fmt::Display for FieldPath {
             match access {
                 Access::Field(field) => {
                     if idx != 0 {
-                        f.write_str(".")?;
+                        Token::DOT.fmt(f)?;
                     }
                     f.write_str(field.as_str())?;
                 }
                 Access::FieldIndex(index) => {
-                    f.write_str("#")?;
+                    Token::CROSSHATCH.fmt(f)?;
                     index.fmt(f)?;
                 }
                 Access::TupleIndex(index) => {
                     if idx != 0 {
-                        f.write_str(".")?;
+                        Token::DOT.fmt(f)?;
                     }
                     index.fmt(f)?;
                 }
                 Access::ListIndex(index) => {
-                    f.write_str("[")?;
+                    Token::OPEN_BRACKET.fmt(f)?;
                     index.fmt(f)?;
-                    f.write_str("]")?;
+                    Token::CLOSE_BRACKET.fmt(f)?;
                 }
             }
         }

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -130,7 +130,7 @@ impl GetPath for dyn Reflect {
 pub struct FieldPath(Box<[(Access, usize)]>);
 
 impl FieldPath {
-    pub fn parse<'a>(string: &'a str) -> Result<Self, ReflectPathError<'a>> {
+    pub fn parse(string: &str) -> Result<Self, ReflectPathError<'_>> {
         let mut parts = Vec::new();
         for (access, idx) in PathParser::new(string) {
             parts.push((access?.to_owned(), idx));
@@ -171,7 +171,7 @@ enum Access {
 impl Access {
     fn to_ref(&self) -> AccessRef<'_> {
         match self {
-            Self::Field(value) => AccessRef::Field(&value),
+            Self::Field(value) => AccessRef::Field(value),
             Self::TupleIndex(value) => AccessRef::TupleIndex(*value),
             Self::ListIndex(value) => AccessRef::ListIndex(*value),
         }

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -42,8 +42,8 @@ pub enum ReflectPathError<'a> {
 /// - [`List`] items are accessed with brackets: `[0]`
 /// - Field indexes within [`Struct`] can also be optionally used instead: `#0` for
 ///   the first field. This can speed up fetches at runtime (no string matching)
-///   but can be much more fragile to keeping code and string paths in sync. Storing
-///   these paths in persistent storage (i.e. game assets) is strongly discouraged.
+///   but can be much more fragile to keeping code and string paths in sync since
+///   the order of fields could be easily changed. Storing these paths in persistent ///   storage (i.e. game assets) is strongly discouraged.
 ///
 /// If the initial path element is a field of a struct, tuple struct, or tuple,
 /// the initial '.' may be omitted.

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -45,6 +45,9 @@ pub enum ReflectPathError<'a> {
 /// 2-tuples (like a `Vec<(T, U)>`), the path string `foo[3].0` would access tuple
 /// element 0 of element 3 of `foo`.
 ///
+/// Using these functions repeatedly with the same string requires parsing the
+/// string every time. To avoid this cost, construct a [`FieldPath`] instead.
+///
 /// [`Struct`]: crate::Struct
 /// [`TupleStruct`]: crate::TupleStruct
 /// [`Tuple`]: crate::Tuple
@@ -106,12 +109,7 @@ impl GetPath for dyn Reflect {
     fn path<'r, 'p>(&'r self, path: &'p str) -> Result<&'r dyn Reflect, ReflectPathError<'p>> {
         let mut current: &dyn Reflect = self;
         for (access, current_index) in PathParser::new(path) {
-            match access {
-                Ok(access) => {
-                    current = access.read_field(current, current_index)?;
-                }
-                Err(err) => return Err(err),
-            }
+            current = access?.read_field(current, current_index)?;
         }
         Ok(current)
     }
@@ -122,25 +120,80 @@ impl GetPath for dyn Reflect {
     ) -> Result<&'r mut dyn Reflect, ReflectPathError<'p>> {
         let mut current: &mut dyn Reflect = self;
         for (access, current_index) in PathParser::new(path) {
-            match access {
-                Ok(access) => {
-                    current = access.read_field_mut(current, current_index)?;
-                }
-                Err(err) => return Err(err),
-            }
+            current = access?.read_field_mut(current, current_index)?;
         }
         Ok(current)
     }
 }
 
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub struct FieldPath(Box<[(Access, usize)]>);
+
+impl FieldPath {
+    pub fn parse<'a>(string: &'a str) -> Result<Self, ReflectPathError<'a>> {
+        let mut parts = Vec::new();
+        for (access, idx) in PathParser::new(string) {
+            parts.push((access?.to_owned(), idx));
+        }
+        Ok(Self(parts.into_boxed_slice()))
+    }
+
+    pub fn field<'r, 'p>(
+        &'p self,
+        root: &'r impl Reflect,
+    ) -> Result<&'r dyn Reflect, ReflectPathError<'p>> {
+        let mut current: &dyn Reflect = root;
+        for (access, current_index) in self.0.iter() {
+            current = access.to_ref().read_field(current, *current_index)?;
+        }
+        Ok(current)
+    }
+
+    pub fn field_mut<'r, 'p>(
+        &'p mut self,
+        root: &'r mut impl Reflect,
+    ) -> Result<&'r mut dyn Reflect, ReflectPathError<'p>> {
+        let mut current: &mut dyn Reflect = root;
+        for (access, current_index) in self.0.iter() {
+            current = access.to_ref().read_field_mut(current, *current_index)?;
+        }
+        Ok(current)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+enum Access {
+    Field(String),
+    TupleIndex(usize),
+    ListIndex(usize),
+}
+
+impl Access {
+    fn to_ref(&self) -> AccessRef<'_> {
+        match self {
+            Self::Field(value) => AccessRef::Field(&value),
+            Self::TupleIndex(value) => AccessRef::TupleIndex(*value),
+            Self::ListIndex(value) => AccessRef::ListIndex(*value),
+        }
+    }
+}
+
 #[derive(Debug)]
-enum Access<'a> {
+enum AccessRef<'a> {
     Field(&'a str),
     TupleIndex(usize),
     ListIndex(usize),
 }
 
-impl<'a> Access<'a> {
+impl<'a> AccessRef<'a> {
+    fn to_owned(&self) -> Access {
+        match self {
+            Self::Field(value) => Access::Field(value.to_string()),
+            Self::TupleIndex(value) => Access::TupleIndex(*value),
+            Self::ListIndex(value) => Access::ListIndex(*value),
+        }
+    }
+
     fn read_field<'r>(
         &self,
         current: &'r dyn Reflect,
@@ -260,15 +313,15 @@ impl<'a> PathParser<'a> {
         Some(ident)
     }
 
-    fn token_to_access(&mut self, token: Token<'a>) -> Result<Access<'a>, ReflectPathError<'a>> {
+    fn token_to_access(&mut self, token: Token<'a>) -> Result<AccessRef<'a>, ReflectPathError<'a>> {
         let current_index = self.index;
         match token {
             Token::Dot => {
                 if let Some(Token::Ident(value)) = self.next_token() {
                     if let Ok(tuple_index) = value.parse::<usize>() {
-                        Ok(Access::TupleIndex(tuple_index))
+                        Ok(AccessRef::TupleIndex(tuple_index))
                     } else {
-                        Ok(Access::Field(value))
+                        Ok(AccessRef::Field(value))
                     }
                 } else {
                     Err(ReflectPathError::ExpectedIdent {
@@ -278,7 +331,7 @@ impl<'a> PathParser<'a> {
             }
             Token::OpenBracket => {
                 let access = if let Some(Token::Ident(value)) = self.next_token() {
-                    Access::ListIndex(value.parse::<usize>()?)
+                    AccessRef::ListIndex(value.parse::<usize>()?)
                 } else {
                     return Err(ReflectPathError::ExpectedIdent {
                         index: current_index,
@@ -300,9 +353,9 @@ impl<'a> PathParser<'a> {
             }),
             Token::Ident(value) => {
                 if let Ok(tuple_index) = value.parse::<usize>() {
-                    Ok(Access::TupleIndex(tuple_index))
+                    Ok(AccessRef::TupleIndex(tuple_index))
                 } else {
-                    Ok(Access::Field(value))
+                    Ok(AccessRef::Field(value))
                 }
             }
         }
@@ -310,7 +363,7 @@ impl<'a> PathParser<'a> {
 }
 
 impl<'a> Iterator for PathParser<'a> {
-    type Item = (Result<Access<'a>, ReflectPathError<'a>>, usize);
+    type Item = (Result<AccessRef<'a>, ReflectPathError<'a>>, usize);
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(token) = self.next_token() {

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -43,7 +43,8 @@ pub enum ReflectPathError<'a> {
 /// - Field indexes within [`Struct`] can also be optionally used instead: `#0` for
 ///   the first field. This can speed up fetches at runtime (no string matching)
 ///   but can be much more fragile as code and string paths must be kept in sync since
-///   the order of fields could be easily changed. Storing these paths in persistent ///   storage (i.e. game assets) is strongly discouraged.
+///   the order of fields could be easily changed. Storing these paths in persistent
+///   storage (i.e. game assets) is strongly discouraged.
 ///
 /// If the initial path element is a field of a struct, tuple struct, or tuple,
 /// the initial '.' may be omitted.

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -369,12 +369,9 @@ impl<'a> Iterator for PathParser<'a> {
     type Item = (Result<AccessRef<'a>, ReflectPathError<'a>>, usize);
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(token) = self.next_token() {
-            let index = self.index;
-            Some((self.token_to_access(token), index))
-        } else {
-            None
-        }
+        let token = self.next_token()?;
+        let index = self.index;
+        Some((self.token_to_access(token), index))
     }
 }
 

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -462,6 +462,8 @@ mod tests {
         assert_eq!(*a.get_path::<f32>("x.bar.baz").unwrap(), 3.14);
         assert_eq!(*a.get_path::<f32>("y[1].baz").unwrap(), 2.0);
         assert_eq!(*a.get_path::<usize>("z.0.1").unwrap(), 42);
+        assert_eq!(*a.get_path::<usize>("x#0").unwrap(), 10);
+        assert_eq!(*a.get_path::<f32>("x#1#0").unwrap(), 3.14);
 
         *a.get_path_mut::<f32>("y[1].baz").unwrap() = 3.0;
         assert_eq!(a.y[1].baz, 3.0);

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -40,6 +40,10 @@ pub enum ReflectPathError<'a> {
 /// - [`Struct`] items are accessed with a dot and a field name: `.field_name`
 /// - [`TupleStruct`] and [`Tuple`] items are accessed with a dot and a number: `.0`
 /// - [`List`] items are accessed with brackets: `[0]`
+/// - Field indexes within [`Struct`] can also be optionally used instead: `#0` for
+///   the first field. This can speed up fetches at runtime (no string matching)
+///   but can be much more fragile to keeping code and string paths in sync. Storing
+///   these paths in persistent storage (i.e. game assets) is strongly discouraged.
 ///
 /// If the initial path element is a field of a struct, tuple struct, or tuple,
 /// the initial '.' may be omitted.

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -150,7 +150,8 @@ impl FieldPath {
         Ok(Self(parts.into_boxed_slice()))
     }
 
-    /// Gets a read-only reference of given field.
+    /// Gets a read-only reference to a given field.
+    ///
     /// Returns an error if the path is invalid for the provided type.
     pub fn field<'r, 'p>(
         &'p self,

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -153,9 +153,9 @@ impl FieldPath {
     /// Returns an error if the path is invalid for the provided type.
     pub fn field<'r, 'p>(
         &'p self,
-        root: &'r impl Reflect,
+        root: &'r dyn Reflect,
     ) -> Result<&'r dyn Reflect, ReflectPathError<'p>> {
-        let mut current: &dyn Reflect = root;
+        let mut current = root;
         for (access, current_index) in self.0.iter() {
             current = access.to_ref().read_field(current, *current_index)?;
         }
@@ -166,9 +166,9 @@ impl FieldPath {
     /// Returns an error if the path is invalid for the provided type.
     pub fn field_mut<'r, 'p>(
         &'p mut self,
-        root: &'r mut impl Reflect,
+        root: &'r mut dyn Reflect,
     ) -> Result<&'r mut dyn Reflect, ReflectPathError<'p>> {
-        let mut current: &mut dyn Reflect = root;
+        let mut current = root;
         for (access, current_index) in self.0.iter() {
             current = access.to_ref().read_field_mut(current, *current_index)?;
         }

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -327,7 +327,7 @@ impl<'a> PathParser<'a> {
                 if let Some(Token::Ident(value)) = self.next_token() {
                     value
                         .parse::<usize>()
-                        .map(|idx| AccessRef::TupleIndex(idx))
+                        .map(AccessRef::TupleIndex)
                         .or(Ok(AccessRef::Field(value)))
                 } else {
                     Err(ReflectPathError::ExpectedIdent {
@@ -359,7 +359,7 @@ impl<'a> PathParser<'a> {
             }),
             Token::Ident(value) => value
                 .parse::<usize>()
-                .map(|idx| AccessRef::TupleIndex(idx))
+                .map(AccessRef::TupleIndex)
                 .or(Ok(AccessRef::Field(value))),
         }
     }

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -366,19 +366,19 @@ impl<'a> PathParser<'a> {
         }
 
         match self.path[self.index..].chars().next().unwrap() {
-            '.' => {
+            Token::DOT => {
                 self.index += 1;
                 return Some(Token::Dot);
             }
-            '#' => {
+            Token::CROSSHATCH => {
                 self.index += 1;
                 return Some(Token::CrossHatch);
             }
-            '[' => {
+            Token::OPEN_BRACKET => {
                 self.index += 1;
                 return Some(Token::OpenBracket);
             }
-            ']' => {
+            Token::CLOSE_BRACKET => {
                 self.index += 1;
                 return Some(Token::CloseBracket);
             }
@@ -388,7 +388,7 @@ impl<'a> PathParser<'a> {
         // we can assume we are parsing an ident now
         for (char_index, character) in self.path[self.index..].chars().enumerate() {
             match character {
-                '.' | '#' | '[' | ']' => {
+                Token::DOT | Token::CROSSHATCH | Token::OPEN_BRACKET | Token::CLOSE_BRACKET => {
                     let ident = Token::Ident(&self.path[self.index..self.index + char_index]);
                     self.index += char_index;
                     return Some(ident);
@@ -437,7 +437,7 @@ impl<'a> PathParser<'a> {
                 if !matches!(self.next_token(), Some(Token::CloseBracket)) {
                     return Err(ReflectPathError::ExpectedToken {
                         index: current_index,
-                        token: "]",
+                        token: Token::OPEN_BRACKET_STR,
                     });
                 }
 
@@ -445,7 +445,7 @@ impl<'a> PathParser<'a> {
             }
             Token::CloseBracket => Err(ReflectPathError::UnexpectedToken {
                 index: current_index,
-                token: "]",
+                token: Token::CLOSE_BRACKET_STR,
             }),
             Token::Ident(value) => value
                 .parse::<usize>()
@@ -471,6 +471,15 @@ enum Token<'a> {
     OpenBracket,
     CloseBracket,
     Ident(&'a str),
+}
+
+impl<'a> Token<'a> {
+    const DOT: char = '.';
+    const CROSSHATCH: char = '#';
+    const OPEN_BRACKET: char = '[';
+    const CLOSE_BRACKET: char = ']';
+    const OPEN_BRACKET_STR: &'static str = "[";
+    const CLOSE_BRACKET_STR: &'static str = "]";
 }
 
 #[cfg(test)]

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::num::ParseIntError;
 
 use crate::{Reflect, ReflectMut, ReflectRef};
@@ -168,6 +169,37 @@ impl FieldPath {
             current = access.to_ref().read_field_mut(current, *current_index)?;
         }
         Ok(current)
+    }
+}
+
+impl fmt::Display for FieldPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (idx, (access, _)) in self.0.iter().enumerate() {
+            match access {
+                Access::Field(field) => {
+                    if idx != 0 {
+                        f.write_str(".")?;
+                    }
+                    f.write_str(field.as_str())?;
+                }
+                Access::FieldIndex(index) => {
+                    f.write_str("#")?;
+                    index.fmt(f)?;
+                }
+                Access::TupleIndex(index) => {
+                    if idx != 0 {
+                        f.write_str(".")?;
+                    }
+                    index.fmt(f)?;
+                }
+                Access::ListIndex(index) => {
+                    f.write_str("[")?;
+                    index.fmt(f)?;
+                    f.write_str("]")?;
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -42,7 +42,7 @@ pub enum ReflectPathError<'a> {
 /// - [`List`] items are accessed with brackets: `[0]`
 /// - Field indexes within [`Struct`] can also be optionally used instead: `#0` for
 ///   the first field. This can speed up fetches at runtime (no string matching)
-///   but can be much more fragile to keeping code and string paths in sync since
+///   but can be much more fragile as code and string paths must be kept in sync since
 ///   the order of fields could be easily changed. Storing these paths in persistent ///   storage (i.e. game assets) is strongly discouraged.
 ///
 /// If the initial path element is a field of a struct, tuple struct, or tuple,

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -164,7 +164,8 @@ impl FieldPath {
         Ok(current)
     }
 
-    /// Gets a mutable reference of given field.
+    /// Gets a mutable reference to a given field.
+    ///
     /// Returns an error if the path is invalid for the provided type.
     pub fn field_mut<'r, 'p>(
         &'p mut self,

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -199,7 +199,6 @@ impl<'a> AccessRef<'a> {
         current: &'r dyn Reflect,
         current_index: usize,
     ) -> Result<&'r dyn Reflect, ReflectPathError<'a>> {
-        println!("{:?}", self);
         match (self, current.reflect_ref()) {
             (Self::Field(field), ReflectRef::Struct(reflect_struct)) => Ok(reflect_struct
                 .field(field)

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -134,6 +134,8 @@ impl GetPath for dyn Reflect {
     }
 }
 
+// This stores an access and a start index for the identity. The index is only really
+// used for errors.
 /// A path to a field within a type. Can be used like [`GetPath`] functions to get
 /// references to the inner fields of a type.
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
@@ -230,6 +232,10 @@ impl fmt::Display for FieldPath {
     }
 }
 
+/// A singular owned field access within a path. Can be applied
+/// to a `dyn Reflect` to get a reference to the targetted field.
+/// 
+/// A path is composed of multiple accesses in sequence.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 enum Access {
     Field(String),
@@ -249,6 +255,11 @@ impl Access {
     }
 }
 
+/// A singular borrowed field access within a path. Can be applied
+/// to a `dyn Reflect` to get a reference to the targetted field.
+/// 
+/// Does not own the backing store it's sourced from. For an owned
+/// version, you can convert one to an [`Access`].
 #[derive(Debug)]
 enum AccessRef<'a> {
     Field(&'a str),


### PR DESCRIPTION
# Objective
Fixes #4080. Implement a pre-parsed version of `GetPath` functions.

## Solution
Implement `FieldPath` a struct that parses a field path ahead of time and caches the sequence of field accesses to avoid string parsing when fetching a field. Added a few additional changes:

 - Clean up some of the duplicated code in that file.
 - Extended the string format to allow for specifying normal struct field indexes instead of normal names. This can be faster to use for `FieldPath` lookups, but it can be much more fragile when serialized to assets. Can be used to transform string lookups into index lookups static type information.

## Future Directions
If we get non-reference bound type information, we can further optimize this by looking up field indexes during parsing using a TypeRegistry.