### PR TITLE
[Merged by Bors] - perf: only recalculate frusta of changed lights

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -702,12 +702,15 @@ pub(crate) fn assign_lights_to_clusters(
 }
 
 pub fn update_directional_light_frusta(
-    mut views: Query<(
-        &GlobalTransform,
-        &DirectionalLight,
-        &mut Frustum,
-        &Visibility,
-    )>,
+    mut views: Query<
+        (
+            &GlobalTransform,
+            &DirectionalLight,
+            &mut Frustum,
+            &Visibility,
+        ),
+        Or<(Changed<GlobalTransform>, Changed<DirectionalLight>)>,
+    >,
 ) {
     for (transform, directional_light, mut frustum, visibility) in views.iter_mut() {
         // The frustum is used for culling meshes to the light for shadow mapping
@@ -731,7 +734,10 @@ pub fn update_directional_light_frusta(
 // NOTE: Run this after assign_lights_to_clusters!
 pub fn update_point_light_frusta(
     global_lights: Res<VisiblePointLights>,
-    mut views: Query<(Entity, &GlobalTransform, &PointLight, &mut CubemapFrusta)>,
+    mut views: Query<
+        (Entity, &GlobalTransform, &PointLight, &mut CubemapFrusta),
+        Or<(Changed<GlobalTransform>, Changed<PointLight>)>,
+    >,
 ) {
     let projection =
         Mat4::perspective_infinite_reverse_rh(std::f32::consts::FRAC_PI_2, 1.0, POINT_LIGHT_NEAR_Z);


### PR DESCRIPTION
## Objective

Currently, all directional and point lights have their viewing frusta recalculated every frame, even if they have not moved or been disabled/enabled.

## Solution

The relevant systems now make use of change detection to only update those lights whose viewing frusta may have changed.
