### PR TITLE
Missing `Debug`  Implementation for bevy_ecs

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -33,17 +33,19 @@ impl ArchetypeId {
     }
 }
 
+#[derive(Debug)]
 pub enum ComponentStatus {
     Added,
     Mutated,
 }
 
+#[derive(Debug)]
 pub struct AddBundle {
     pub archetype_id: ArchetypeId,
     pub bundle_status: Vec<ComponentStatus>,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Edges {
     pub add_bundle: SparseArray<BundleId, AddBundle>,
     pub remove_bundle: SparseArray<BundleId, Option<ArchetypeId>>,
@@ -101,6 +103,7 @@ impl Edges {
     }
 }
 
+#[derive(Debug)]
 struct TableInfo {
     id: TableId,
     entity_rows: Vec<usize>,
@@ -111,11 +114,13 @@ pub(crate) struct ArchetypeSwapRemoveResult {
     pub(crate) table_row: usize,
 }
 
+#[derive(Debug)]
 pub(crate) struct ArchetypeComponentInfo {
     pub(crate) storage_type: StorageType,
     pub(crate) archetype_component_id: ArchetypeComponentId,
 }
 
+#[derive(Debug)]
 pub struct Archetype {
     id: ArchetypeId,
     entities: Vec<Entity>,
@@ -329,7 +334,7 @@ impl ArchetypeGeneration {
     }
 }
 
-#[derive(Hash, PartialEq, Eq)]
+#[derive(Debug, Hash, PartialEq, Eq)]
 pub struct ArchetypeIdentity {
     table_components: Cow<'static, [ComponentId]>,
     sparse_set_components: Cow<'static, [ComponentId]>,
@@ -361,6 +366,7 @@ impl SparseSetIndex for ArchetypeComponentId {
     }
 }
 
+#[derive(Debug)]
 pub struct Archetypes {
     pub(crate) archetypes: Vec<Archetype>,
     pub(crate) archetype_component_count: usize,

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -149,6 +149,7 @@ impl SparseSetIndex for BundleId {
     }
 }
 
+#[derive(Debug)]
 pub struct BundleInfo {
     pub(crate) id: BundleId,
     pub(crate) component_ids: Vec<ComponentId>,
@@ -522,6 +523,7 @@ impl<'a, 'b> BundleInserter<'a, 'b> {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct BundleSpawner<'a, 'b> {
     pub(crate) archetype: &'a mut Archetype,
     pub(crate) entities: &'a mut Entities,
@@ -572,7 +574,7 @@ impl<'a, 'b> BundleSpawner<'a, 'b> {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Bundles {
     bundle_infos: Vec<BundleInfo>,
     bundle_ids: HashMap<TypeId, BundleId>,

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -131,6 +131,7 @@ macro_rules! impl_debug {
     };
 }
 
+#[derive(Debug)]
 pub(crate) struct Ticks<'a> {
     pub(crate) component_ticks: &'a mut ComponentTicks,
     pub(crate) last_change_tick: u32,
@@ -190,6 +191,7 @@ impl_debug!(Mut<'a, T>,);
 
 /// Unique mutable borrow of a Reflected component
 #[cfg(feature = "bevy_reflect")]
+#[derive(Debug)]
 pub struct ReflectMut<'a> {
     pub(crate) value: &'a mut dyn Reflect,
     pub(crate) ticks: Ticks<'a>,

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -34,7 +34,9 @@ pub trait Component: Send + Sync + 'static {
     type Storage: ComponentStorage;
 }
 
+#[derive(Debug)]
 pub struct TableStorage;
+#[derive(Debug)]
 pub struct SparseStorage;
 
 pub trait ComponentStorage: sealed::Sealed {

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -50,6 +50,7 @@ pub struct Entity {
     pub(crate) id: u32,
 }
 
+#[derive(Debug)]
 pub enum AllocAtWithoutReplacement {
     Exists(EntityLocation),
     DidNotExist,

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -158,14 +158,14 @@ fn map_instance_event<T>(event_instance: &EventInstance<T>) -> &T {
 }
 
 /// Reads events of type `T` in order and tracks which events have already been read.
-#[derive(SystemParam)]
+#[derive(Debug, SystemParam)]
 pub struct EventReader<'w, 's, T: Resource> {
     last_event_count: Local<'s, (usize, PhantomData<T>)>,
     events: Res<'w, Events<T>>,
 }
 
 /// Sends events of type `T`.
-#[derive(SystemParam)]
+#[derive(Debug, SystemParam)]
 pub struct EventWriter<'w, 's, T: Resource> {
     events: ResMut<'w, Events<T>>,
     #[system_param(ignore)]
@@ -192,6 +192,7 @@ impl<'w, 's, T: Resource> EventWriter<'w, 's, T> {
     }
 }
 
+#[derive(Debug)]
 pub struct ManualEventReader<T> {
     last_event_count: usize,
     _marker: PhantomData<T>,

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -129,7 +129,7 @@ impl<T: SparseSetIndex> Access<T> {
     }
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FilteredAccess<T: SparseSetIndex> {
     access: Access<T>,
     with: FixedBitSet,
@@ -192,6 +192,7 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
     }
 }
 
+#[derive(Debug)]
 pub struct FilteredAccessSet<T: SparseSetIndex> {
     combined_access: Access<T>,
     filtered_accesses: Vec<FilteredAccess<T>>,

--- a/crates/bevy_ecs/src/schedule/run_criteria.rs
+++ b/crates/bevy_ecs/src/schedule/run_criteria.rs
@@ -399,7 +399,7 @@ where
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct RunOnce {
     ran: bool,
     archetype_component_access: Access<ArchetypeComponentId>,

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -46,6 +46,7 @@ impl_downcast!(Stage);
 ///
 /// The checker may report a system more times than the amount of constraints it would actually need
 /// to have unambiguous order with regards to a group of already-constrained systems.
+#[derive(Debug)]
 pub struct ReportExecutionOrderAmbiguities;
 
 /// Stores and executes systems. Execution order is not defined unless explicitly specified;

--- a/crates/bevy_ecs/src/storage/mod.rs
+++ b/crates/bevy_ecs/src/storage/mod.rs
@@ -9,7 +9,7 @@ pub use sparse_set::*;
 pub use table::*;
 
 /// The raw data stores of a [World](crate::world::World)
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Storages {
     pub sparse_sets: SparseSets,
     pub tables: Tables,

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -400,7 +400,7 @@ impl_sparse_set_index!(u8, u16, u32, u64, usize);
 /// A collection of [`ComponentSparseSet`] storages, indexed by [`ComponentId`]
 ///
 /// Can be accessed via [`Storages`](crate::storage::Storages)
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SparseSets {
     sets: SparseSet<ComponentId, ComponentSparseSet>,
 }

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -30,6 +30,7 @@ impl TableId {
     }
 }
 
+#[derive(Debug)]
 pub struct Column {
     pub(crate) component_id: ComponentId,
     pub(crate) data: BlobVec,
@@ -191,6 +192,7 @@ impl Column {
     }
 }
 
+#[derive(Debug)]
 pub struct Table {
     columns: SparseSet<ComponentId, Column>,
     entities: Vec<Entity>,
@@ -412,6 +414,7 @@ impl Table {
 /// A collection of [`Table`] storages, indexed by [`TableId`]
 ///
 /// Can be accessed via [`Storages`](crate::storage::Storages)
+#[derive(Debug)]
 pub struct Tables {
     tables: Vec<Table>,
     table_ids: HashMap<Vec<ComponentId>, TableId>,
@@ -427,6 +430,7 @@ impl Default for Tables {
     }
 }
 
+#[derive(Debug)]
 pub struct TableMoveResult {
     pub swapped_entity: Option<Entity>,
     pub new_row: usize,

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -613,6 +613,7 @@ impl Command for GetOrSpawn {
     }
 }
 
+#[derive(Debug)]
 pub struct SpawnBatch<I>
 where
     I: IntoIterator,
@@ -631,6 +632,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct InsertOrSpawnBatch<I, B>
 where
     I: IntoIterator + Send + Sync + 'static,
@@ -672,6 +674,7 @@ impl Command for Despawn {
     }
 }
 
+#[derive(Debug)]
 pub struct InsertBundle<T> {
     pub entity: Entity,
     pub bundle: T,
@@ -749,6 +752,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct InitResource<R: Resource + FromWorld> {
     _phantom: PhantomData<R>,
 }
@@ -759,6 +763,7 @@ impl<R: Resource + FromWorld> Command for InitResource<R> {
     }
 }
 
+#[derive(Debug)]
 pub struct InsertResource<R: Resource> {
     pub resource: R,
 }
@@ -769,6 +774,7 @@ impl<R: Resource> Command for InsertResource<R> {
     }
 }
 
+#[derive(Debug)]
 pub struct RemoveResource<R: Resource> {
     pub phantom: PhantomData<R>,
 }

--- a/crates/bevy_ecs/src/system/exclusive_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system.rs
@@ -15,6 +15,7 @@ pub trait ExclusiveSystem: Send + Sync + 'static {
     fn check_change_tick(&mut self, change_tick: u32);
 }
 
+#[derive(Debug)]
 pub struct ExclusiveSystemFn<F> {
     func: F,
     name: Cow<'static, str>,

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -12,6 +12,7 @@ use bevy_ecs_macros::all_tuples;
 use std::{borrow::Cow, marker::PhantomData};
 
 /// The metadata of a [`System`].
+#[derive(Debug)]
 pub struct SystemMeta {
     pub(crate) name: Cow<'static, str>,
     pub(crate) component_access_set: FilteredAccessSet<ComponentId>,
@@ -348,6 +349,7 @@ pub trait IntoSystem<In, Out, Params>: Sized {
     fn into_system(this: Self) -> Self::System;
 }
 
+#[derive(Debug)]
 pub struct AlreadyWasSystem;
 
 // Systems implicitly implement IntoSystem
@@ -385,6 +387,7 @@ impl<In, Out, Sys: System<In = In, Out = Out>> IntoSystem<In, Out, AlreadyWasSys
 /// }
 /// ```
 pub struct In<In>(pub In);
+#[derive(Debug)]
 pub struct InputMarker;
 
 /// The [`System`] counter part of an ordinary function.
@@ -392,6 +395,7 @@ pub struct InputMarker;
 /// You get this by calling [`IntoSystem::system`]  on a function that only accepts
 /// [`SystemParam`]s. The output of the system becomes the functions return type, while the input
 /// becomes the functions [`In`] tagged parameter or `()` if no such parameter exists.
+#[derive(Debug)]
 pub struct FunctionSystem<In, Out, Param, Marker, F>
 where
     Param: SystemParam,
@@ -404,6 +408,7 @@ where
     marker: PhantomData<fn() -> (In, Out, Marker)>,
 }
 
+#[derive(Debug)]
 pub struct IsFunctionSystem;
 
 impl<In, Out, Param, Marker, F> IntoSystem<In, Out, (IsFunctionSystem, Param, Marker)> for F

--- a/crates/bevy_ecs/src/system/system_chaining.rs
+++ b/crates/bevy_ecs/src/system/system_chaining.rs
@@ -44,6 +44,7 @@ use std::borrow::Cow;
 ///     result.ok().filter(|&n| n < 100)
 /// }
 /// ```
+#[derive(Debug)]
 pub struct ChainSystem<SystemA, SystemB> {
     system_a: SystemA,
     system_b: SystemB,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -174,6 +174,7 @@ fn assert_component_access_compatibility(
            query_type, filter_type, system_name, accesses);
 }
 
+#[derive(Debug)]
 pub struct QuerySet<'w, 's, T> {
     query_states: &'s T,
     world: &'w World,
@@ -181,6 +182,7 @@ pub struct QuerySet<'w, 's, T> {
     change_tick: u32,
 }
 
+#[derive(Debug)]
 pub struct QuerySetState<T>(T);
 
 impl_query_set!();
@@ -265,6 +267,7 @@ impl<'w, T: Resource> From<ResMut<'w, T>> for Res<'w, T> {
 }
 
 /// The [`SystemParamState`] of [`Res<T>`].
+#[derive(Debug)]
 pub struct ResState<T> {
     component_id: ComponentId,
     marker: PhantomData<T>,
@@ -332,6 +335,7 @@ impl<'w, 's, T: Resource> SystemParamFetch<'w, 's> for ResState<T> {
 
 /// The [`SystemParamState`] of [`Option<Res<T>>`].
 /// See: [`Res<T>`]
+#[derive(Debug)]
 pub struct OptionResState<T>(ResState<T>);
 
 impl<'a, T: Resource> SystemParam for Option<Res<'a, T>> {
@@ -369,6 +373,7 @@ impl<'w, 's, T: Resource> SystemParamFetch<'w, 's> for OptionResState<T> {
 }
 
 /// The [`SystemParamState`] of [`ResMut<T>`].
+#[derive(Debug)]
 pub struct ResMutState<T> {
     component_id: ComponentId,
     marker: PhantomData<T>,
@@ -441,6 +446,7 @@ impl<'w, 's, T: Resource> SystemParamFetch<'w, 's> for ResMutState<T> {
 
 /// The [`SystemParamState`] of [`Option<ResMut<T>>`].
 /// See: [`ResMut<T>`]
+#[derive(Debug)]
 pub struct OptionResMutState<T>(ResMutState<T>);
 
 impl<'a, T: Resource> SystemParam for Option<ResMut<'a, T>> {
@@ -512,6 +518,7 @@ impl<'w, 's> SystemParamFetch<'w, 's> for CommandQueue {
 unsafe impl ReadOnlySystemParamFetch for WorldState {}
 
 /// The [`SystemParamState`] of [`&World`](crate::world::World).
+#[derive(Debug)]
 pub struct WorldState;
 
 impl<'w, 's> SystemParam for &'w World {
@@ -631,6 +638,7 @@ impl<'a, T: Resource> DerefMut for Local<'a, T> {
 }
 
 /// The [`SystemParamState`] of [`Local<T>`].
+#[derive(Debug)]
 pub struct LocalState<T: Resource>(T);
 
 impl<'a, T: Resource + FromWorld> SystemParam for Local<'a, T> {
@@ -690,6 +698,7 @@ impl<'w, 's, T: Resource + FromWorld> SystemParamFetch<'w, 's> for LocalState<T>
 ///
 /// # bevy_ecs::system::assert_is_system(react_on_removal);
 /// ```
+#[derive(Debug)]
 pub struct RemovedComponents<'a, T: Component> {
     world: &'a World,
     component_id: ComponentId,
@@ -707,6 +716,7 @@ impl<'a, T: Component> RemovedComponents<'a, T> {
 unsafe impl<T: Component> ReadOnlySystemParamFetch for RemovedComponentsState<T> {}
 
 /// The [`SystemParamState`] of [`RemovedComponents<T>`].
+#[derive(Debug)]
 pub struct RemovedComponentsState<T> {
     component_id: ComponentId,
     marker: PhantomData<T>,
@@ -810,6 +820,7 @@ impl<'a, T> From<NonSendMut<'a, T>> for NonSend<'a, T> {
 }
 
 /// The [`SystemParamState`] of [`NonSend<T>`].
+#[derive(Debug)]
 pub struct NonSendState<T> {
     component_id: ComponentId,
     marker: PhantomData<fn() -> T>,
@@ -881,6 +892,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendState<T> {
 
 /// The [`SystemParamState`] of [`Option<NonSend<T>>`].
 /// See: [`NonSend<T>`]
+#[derive(Debug)]
 pub struct OptionNonSendState<T>(NonSendState<T>);
 
 impl<'w, T: 'static> SystemParam for Option<NonSend<'w, T>> {
@@ -919,6 +931,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for OptionNonSendState<T> {
 }
 
 /// The [`SystemParamState`] of [`NonSendMut<T>`].
+#[derive(Debug)]
 pub struct NonSendMutState<T> {
     component_id: ComponentId,
     marker: PhantomData<fn() -> T>,
@@ -994,6 +1007,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendMutState<T> {
 
 /// The [`SystemParamState`] of [`Option<NonSendMut<T>>`].
 /// See: [`NonSendMut<T>`]
+#[derive(Debug)]
 pub struct OptionNonSendMutState<T>(NonSendMutState<T>);
 
 impl<'a, T: 'static> SystemParam for Option<NonSendMut<'a, T>> {
@@ -1038,6 +1052,7 @@ impl<'a> SystemParam for &'a Archetypes {
 unsafe impl ReadOnlySystemParamFetch for ArchetypesState {}
 
 /// The [`SystemParamState`] of [`Archetypes`].
+#[derive(Debug)]
 pub struct ArchetypesState;
 
 // SAFE: no component value access
@@ -1069,6 +1084,7 @@ impl<'a> SystemParam for &'a Components {
 unsafe impl ReadOnlySystemParamFetch for ComponentsState {}
 
 /// The [`SystemParamState`] of [`Components`].
+#[derive(Debug)]
 pub struct ComponentsState;
 
 // SAFE: no component value access
@@ -1100,6 +1116,7 @@ impl<'a> SystemParam for &'a Entities {
 unsafe impl ReadOnlySystemParamFetch for EntitiesState {}
 
 /// The [`SystemParamState`] of [`Entities`].
+#[derive(Debug)]
 pub struct EntitiesState;
 
 // SAFE: no component value access
@@ -1131,6 +1148,7 @@ impl<'a> SystemParam for &'a Bundles {
 unsafe impl ReadOnlySystemParamFetch for BundlesState {}
 
 /// The [`SystemParamState`] of [`Bundles`].
+#[derive(Debug)]
 pub struct BundlesState;
 
 // SAFE: no component value access
@@ -1168,6 +1186,7 @@ impl SystemParam for SystemChangeTick {
 }
 
 /// The [`SystemParamState`] of [`SystemChangeTick`].
+#[derive(Debug)]
 pub struct SystemChangeTickState {}
 
 unsafe impl SystemParamState for SystemChangeTickState {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use std::any::TypeId;
 
+#[derive(Debug)]
 pub struct EntityRef<'w> {
     world: &'w World,
     entity: Entity,
@@ -91,6 +92,7 @@ impl<'w> EntityRef<'w> {
     }
 }
 
+#[derive(Debug)]
 pub struct EntityMut<'w> {
     world: &'w mut World,
     entity: Entity,

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -4,6 +4,7 @@ use crate::{
     world::World,
 };
 
+#[derive(Debug)]
 pub struct SpawnBatchIter<'w, I>
 where
     I: Iterator,

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -13,11 +13,13 @@ use std::{
 
 /// Exposes safe mutable access to multiple resources at a time in a World. Attempting to access
 /// World in a way that violates Rust's mutability rules will panic thanks to runtime checks.
+#[derive(Debug)]
 pub struct WorldCell<'w> {
     pub(crate) world: &'w mut World,
     pub(crate) access: Rc<RefCell<ArchetypeComponentAccess>>,
 }
 
+#[derive(Debug)]
 pub(crate) struct ArchetypeComponentAccess {
     access: SparseSet<ArchetypeComponentId, usize>,
 }
@@ -78,6 +80,7 @@ impl<'w> Drop for WorldCell<'w> {
     }
 }
 
+#[derive(Debug)]
 pub struct WorldBorrow<'w, T> {
     value: &'w T,
     archetype_component_id: ArchetypeComponentId,
@@ -119,6 +122,7 @@ impl<'w, T> Drop for WorldBorrow<'w, T> {
     }
 }
 
+#[derive(Debug)]
 pub struct WorldBorrowMut<'w, T> {
     value: Mut<'w, T>,
     archetype_component_id: ArchetypeComponentId,


### PR DESCRIPTION
# Objective

Making sure we have `Debug` implementations for `bevy_ecs`  crate.
-  Progress towards #4089 

## Solution

- adding `#[derive(Debug)]` where possible

## Notes

As discussed in the issue, some parts need manual implementations and these will need to be discussed to find the best way for handling them. The reason being is that some struct have multiple levels of nested structures that all need implementation.

Here's a list of the parts that I think will need to be implemented manually:
- [ ] `crates/bevy_ecs/src/system/query.rs`
- [ ] crates/bevy_ecs/src/system/function_system.rs
- [ ] crates/bevy_ecs/src/system/exclusive_system.rs
- [ ] crates/bevy_ecs/src/system/commands/mod.rs
- [ ] crates/bevy_ecs/src/system/commands/command_queue.rs
- [ ] crates/bevy_ecs/src/schedule/mod.rs
- [ ] crates/bevy_ecs/src/schedule/system_set.rs
- [ ] crates/bevy_ecs/src/schedule/system_descriptor.rs
- [ ] crates/bevy_ecs/src/schedule/system_container.rs
- [ ] crates/bevy_ecs/src/schedule/stage.rs
- [ ] crates/bevy_ecs/src/schedule/run_criteria.rs
- [ ] crates/bevy_ecs/src/schedule/executor_parallel.rs
- [ ] crates/bevy_ecs/src/schedule/executor.rs
- [ ] crates/bevy_ecs/src/reflect.rs
- [ ]  crates/bevy_ecs/src/query/state.rs
- [ ] crates/bevy_ecs/src/query/iter.rs
- [ ] crates/bevy_ecs/src/query/filter.rs
- [ ] crates/bevy_ecs/src/query/fetch.rs

