### PR TITLE
[Merged by Bors] - Avoid windows with a physical size of zero

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -723,11 +723,15 @@ pub(crate) fn assign_lights_to_clusters(
         }
 
         let clusters = clusters.into_inner();
-        let screen_size = camera.target.get_physical_size(&windows, &images);
+        let screen_size =
+            if let Some(screen_size) = camera.target.get_physical_size(&windows, &images) {
+                screen_size
+            } else {
+                continue;
+            };
 
         clusters.lights.clear();
 
-        let screen_size = screen_size.unwrap_or_default();
         let mut requested_cluster_dimensions = config.dimensions_for_screen_size(screen_size);
 
         let view_transform = camera_transform.compute_matrix();
@@ -856,10 +860,6 @@ pub(crate) fn assign_lights_to_clusters(
             (clusters.dimensions.x * clusters.dimensions.y * clusters.dimensions.z) as usize,
             VisiblePointLights::default,
         );
-
-        if screen_size.x == 0 || screen_size.y == 0 {
-            continue;
-        }
 
         // Calculate the x/y/z cluster frustum planes in view space
         let mut x_planes = Vec::with_capacity(clusters.dimensions.x as usize + 1);

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -79,6 +79,7 @@ impl RenderTarget {
                 UVec2::new(width, height)
             }),
         }
+        .filter(|size| size.x > 0 && size.y > 0)
     }
     pub fn get_logical_size(&self, windows: &Windows, images: &Assets<Image>) -> Option<Vec2> {
         match self {
@@ -312,8 +313,8 @@ pub fn extract_cameras<M: Component + Default>(
                     ExtractedView {
                         projection: camera.projection_matrix,
                         transform: *transform,
-                        width: size.x.max(1),
-                        height: size.y.max(1),
+                        width: size.x,
+                        height: size.y,
                         near: camera.near,
                         far: camera.far,
                     },


### PR DESCRIPTION
# Objective

Fix #4097

## Solution

Return `None` from `RenderTarget::get_physical_size` if either dimension is zero.
