### PR TITLE
[Merged by Bors] - add depth_bias to SpecializedMaterial

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -74,6 +74,14 @@ pub trait Material: Asset + RenderAsset {
         &[]
     }
 
+    #[allow(unused_variables)]
+    #[inline]
+    /// Add a bias to the view depth of the mesh which can be used to force a specific render order
+    /// for meshes with equal depth, to avoid z-fighting.
+    fn depth_bias(material: &<Self as RenderAsset>::PreparedAsset) -> f32 {
+        0.0
+    }
+
     /// Customizes the default [`RenderPipelineDescriptor`].
     #[allow(unused_variables)]
     #[inline]
@@ -125,11 +133,15 @@ impl<M: Material> SpecializedMaterial for M {
         <M as Material>::fragment_shader(asset_server)
     }
 
-    #[allow(unused_variables)]
     #[inline]
     fn dynamic_uniform_indices(material: &<Self as RenderAsset>::PreparedAsset) -> &[u32] {
         <M as Material>::dynamic_uniform_indices(material)
     }
+
+    #[inline]
+    fn depth_bias(material: &<Self as RenderAsset>::PreparedAsset) -> f32 {
+        <M as Material>::depth_bias(material)
+    }    
 }
 
 /// Materials are used alongside [`MaterialPlugin`] and [`MaterialMeshBundle`](crate::MaterialMeshBundle)

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -186,6 +186,12 @@ pub trait SpecializedMaterial: Asset + RenderAsset {
     fn dynamic_uniform_indices(material: &<Self as RenderAsset>::PreparedAsset) -> &[u32] {
         &[]
     }
+
+    #[allow(unused_variables)]
+    #[inline]
+    fn depth_bias(material: &<Self as RenderAsset>::PreparedAsset) -> f32 {
+        0.0
+    }
 }
 
 /// Adds the necessary ECS resources and render logic to enable rendering entities using the given [`SpecializedMaterial`]
@@ -375,7 +381,8 @@ pub fn queue_material_meshes<M: SpecializedMaterial>(
 
                         // NOTE: row 2 of the inverse view matrix dotted with column 3 of the model matrix
                         // gives the z component of translation of the mesh in view space
-                        let mesh_z = inverse_view_row_2.dot(mesh_uniform.transform.col(3));
+                        let bias = M::depth_bias(material);
+                        let mesh_z = inverse_view_row_2.dot(mesh_uniform.transform.col(3)) + bias;
                         match alpha_mode {
                             AlphaMode::Opaque => {
                                 opaque_phase.add(Opaque3d {

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -189,6 +189,8 @@ pub trait SpecializedMaterial: Asset + RenderAsset {
 
     #[allow(unused_variables)]
     #[inline]
+    /// Add a bias to the view depth of the mesh which can be used to force a specific render order
+    /// for meshes with equal depth, to avoid z-fighting.
     fn depth_bias(material: &<Self as RenderAsset>::PreparedAsset) -> f32 {
         0.0
     }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -141,7 +141,7 @@ impl<M: Material> SpecializedMaterial for M {
     #[inline]
     fn depth_bias(material: &<Self as RenderAsset>::PreparedAsset) -> f32 {
         <M as Material>::depth_bias(material)
-    }    
+    }
 }
 
 /// Materials are used alongside [`MaterialPlugin`] and [`MaterialMeshBundle`](crate::MaterialMeshBundle)

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -505,5 +505,5 @@ impl SpecializedMaterial for StandardMaterial {
     #[inline]
     fn depth_bias(material: &<Self as RenderAsset>::PreparedAsset) -> f32 {
         material.depth_bias
-    }    
+    }
 }

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -51,6 +51,7 @@ pub struct StandardMaterial {
     pub double_sided: bool,
     pub unlit: bool,
     pub alpha_mode: AlphaMode,
+    pub depth_bias: f32,
 }
 
 impl Default for StandardMaterial {
@@ -79,6 +80,7 @@ impl Default for StandardMaterial {
             double_sided: false,
             unlit: false,
             alpha_mode: AlphaMode::Opaque,
+            depth_bias: 0.0,
         }
     }
 }
@@ -154,6 +156,7 @@ pub struct GpuStandardMaterial {
     pub flags: StandardMaterialFlags,
     pub base_color_texture: Option<Handle<Image>>,
     pub alpha_mode: AlphaMode,
+    pub depth_bias: f32,
 }
 
 impl RenderAsset for StandardMaterial {
@@ -321,6 +324,7 @@ impl RenderAsset for StandardMaterial {
             has_normal_map,
             base_color_texture: material.base_color_texture,
             alpha_mode: material.alpha_mode,
+            depth_bias: material.depth_bias,
         })
     }
 }
@@ -483,4 +487,9 @@ impl SpecializedMaterial for StandardMaterial {
     fn alpha_mode(render_asset: &<Self as RenderAsset>::PreparedAsset) -> AlphaMode {
         render_asset.alpha_mode
     }
+
+    #[inline]
+    fn depth_bias(material: &<Self as RenderAsset>::PreparedAsset) -> f32 {
+        material.depth_bias
+    }    
 }


### PR DESCRIPTION
# Objective

allow meshes with equal z-depth to be rendered in a chosen order / avoid z-fighting

## Solution

add a depth_bias to SpecializedMaterial that is added to the mesh depth used for render-ordering.
