### PR TITLE
add TaskPool::spawn_pollable so that the consumer does not need a blo…

### DIFF
--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -9,6 +9,8 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [dependencies]
+bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+
 futures-lite = "1.4.0"
 event-listener = "2.5.2"
 async-executor = "1.3.0"

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [dependencies]
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 
 futures-lite = "1.4.0"
 event-listener = "2.5.2"

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -7,6 +7,9 @@ pub use slice::{ParallelSlice, ParallelSliceMut};
 mod task;
 pub use task::Task;
 
+mod pollable_task;
+pub use pollable_task::PollableTask;
+
 #[cfg(not(target_arch = "wasm32"))]
 mod task_pool;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/bevy_tasks/src/pollable_task.rs
+++ b/crates/bevy_tasks/src/pollable_task.rs
@@ -1,0 +1,33 @@
+use crate::Task;
+use async_channel::{Receiver, TryRecvError};
+
+/// A pollable task whose result readiness can be checked in system functions
+/// on every frame update without blocking on a future
+#[derive(Debug)]
+pub struct PollableTask<T> {
+    receiver: Receiver<T>,
+    // this is to keep the task alive
+    _task: Task<()>,
+}
+
+impl<T> PollableTask<T> {
+    pub(crate) fn new(receiver: Receiver<T>, task: Task<()>) -> Self {
+        Self {
+            receiver,
+            _task: task,
+        }
+    }
+
+    /// poll to see whether the task finished
+    pub fn poll(&self) -> Option<T> {
+        match self.receiver.try_recv() {
+            Ok(value) => Some(value),
+            Err(try_error) => match try_error {
+                TryRecvError::Empty => None,
+                TryRecvError::Closed => {
+                    panic!("Polling on the task failed because the connection was already closed.")
+                }
+            },
+        }
+    }
+}


### PR DESCRIPTION
# Objective

add TaskPool::spawn_pollable so that the consumer does not need a block_on method

## Solution

add TaskPool::spawn_pollable that uses a receiver to get the result of the async task.


This is basically a rework of PR #2691 with the review comments incorporated. In PR #4062 this was considered the better option.
Also see #2677 and #4045.