### PR TITLE
[Merged by Bors] - Audio control at start of playback

### DIFF
--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -68,7 +68,10 @@ where
         while i < len {
             let config = queue.pop_front().unwrap();
             if let Some(audio_source) = audio_sources.get(&config.source_handle) {
-                if let Some(sink) = self.play_source(audio_source, config.repeat) {
+                if let Some(sink) = self.play_source(audio_source, config.settings.repeat) {
+                    sink.set_speed(config.settings.speed);
+                    sink.set_volume(config.settings.volume);
+
                     // don't keep the strong handle. there is no way to return it to the user here as it is async
                     let _ = sinks.set(config.sink_handle, AudioSink { sink: Some(sink) });
                 }
@@ -185,5 +188,12 @@ impl AudioSink {
     /// Sinks can be paused and resumed using [`pause`](Self::pause) and [`play`](Self::play).
     pub fn is_paused(&self) -> bool {
         self.sink.as_ref().unwrap().is_paused()
+    }
+
+    /// Stops the sink.
+    ///
+    /// It won't be possible to restart it afterwards.
+    pub fn stop(&self) {
+        self.sink.as_ref().unwrap().stop();
     }
 }

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -35,7 +35,7 @@ mod audio_source;
 #[allow(missing_docs)]
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{Audio, AudioOutput, AudioSource, Decodable};
+    pub use crate::{Audio, AudioOutput, AudioSource, Decodable, PlaybackSettings};
 }
 
 pub use audio::*;


### PR DESCRIPTION
# Objective

- While playing with volume, I noticed that when setting the volume just after playback start, I still get a few milliseconds at normal volume

## Solution

- Replace `play_in_loop` with `play_with_settings` that allows from more controls
- Adds a `PlaybackSettings` to specify the settings from start. Can be used: `PlaybackSettings::LOOP.with_volume(0.75)`