### PR TITLE
Make parenting example clearer on parenting rules for newcomers

### DIFF
--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 /// This example illustrates how to create parent->child relationships between entities how parent
 /// transforms are propagated to their descendants.
-/// Any entity with a Transform _and_ a GlobalTransform can be a parent.
+/// Any entity with a `Transform` _and_ a `GlobalTransform` can be a parent.
 fn main() {
     App::new()
         .insert_resource(Msaa { samples: 4 })

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -65,7 +65,7 @@ fn setup(
     commands
         .spawn_bundle(TransformBundle {
             local: Transform::from_xyz(2.0, 0.0, 1.0),
-            global: GlobalTransform::default()
+            global: GlobalTransform::default(),
         })
         .insert(Rotator)
         .with_children(|parent| {

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -63,10 +63,10 @@ fn setup(
         });
     // parent "empty"
     commands
-        .spawn_bundle((
-            Transform::from_xyz(2.0, 0.0, 1.0),
-            GlobalTransform::default(),
-        ))
+        .spawn_bundle(TransformBundle {
+            local: Transform::from_xyz(2.0, 0.0, 1.0),
+            global: GlobalTransform::default()
+        })
         .insert(Rotator)
         .with_children(|parent| {
             // child capsule

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 /// This example illustrates how to create parent->child relationships between entities how parent
 /// transforms are propagated to their descendants.
-/// Any entity with a `Transform` _and_ a `GlobalTransform` can be a parent.
+///  `Transform` can be inherited from any entity with both the `Transform` and `GlobalTransform` components.
 fn main() {
     App::new()
         .insert_resource(Msaa { samples: 4 })

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 /// This example illustrates how to create parent->child relationships between entities how parent
 /// transforms are propagated to their descendants.
-///  `Transform` can be inherited from any entity with both the `Transform` and `GlobalTransform` components.
+/// `Transform` can be inherited from any entity with both the `Transform` and `GlobalTransform` components.
 fn main() {
     App::new()
         .insert_resource(Msaa { samples: 4 })

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -25,7 +25,7 @@ fn rotator_system(time: Res<Time>, mut query: Query<&mut Transform, With<Rotator
 
 /// Set up a simple scene with two hierarchies:
 /// - a "parent" cube and a "child" cube
-/// - a "parent" empty (= invisible entity, just a transform) and a "child" capsule
+/// - an invisible "parent" (that has a transform, but not a mesh) and a "child" capsule
 fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -56,7 +56,7 @@ fn setup(
                 ..default()
             });
         });
-    // parent "empty"
+    // invisible parent
     commands
         .spawn_bundle(TransformBundle {
             local: Transform::from_xyz(2.0, 0.0, 1.0),

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -32,14 +32,9 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let cube_handle = meshes.add(Mesh::from(shape::Cube { size: 2.0 }));
-    let cube_material_handle = materials.add(StandardMaterial {
-        base_color: Color::rgb(0.8, 0.7, 0.6),
-        ..default()
-    });
-
     let capsule_handle = meshes.add(Mesh::from(shape::Capsule::default()));
-    let capsule_material_handle = materials.add(StandardMaterial {
-        base_color: Color::rgb(0.7, 0.8, 0.6),
+    let material_handle = materials.add(StandardMaterial {
+        base_color: Color::BISQUE,
         ..default()
     });
 
@@ -47,7 +42,7 @@ fn setup(
     commands
         .spawn_bundle(PbrBundle {
             mesh: cube_handle.clone(),
-            material: cube_material_handle.clone(),
+            material: material_handle.clone(),
             transform: Transform::from_xyz(-2.0, 0.0, 1.0),
             ..default()
         })
@@ -56,7 +51,7 @@ fn setup(
             // child cube
             parent.spawn_bundle(PbrBundle {
                 mesh: cube_handle,
-                material: cube_material_handle,
+                material: material_handle.clone(),
                 transform: Transform::from_xyz(0.0, 0.0, 3.0),
                 ..default()
             });
@@ -72,7 +67,7 @@ fn setup(
             // child capsule
             parent.spawn_bundle(PbrBundle {
                 mesh: capsule_handle,
-                material: capsule_material_handle,
+                material: material_handle,
                 transform: Transform::from_xyz(0.0, 0.0, 3.0),
                 ..default()
             });


### PR DESCRIPTION
For new users (me included!) coming from engines like Unity, it's easy to not be aware that a parent must also have a GlobalTransform along the obvious Transform.
They then ask themselves why their hierarchy doesn't work properly when using a single Transform instead of a PbrBundle like in the example.

# Objective

- Make parenting basics/rules more obvious to newcomers

## Solution

- Add a rotating object whose parent is an "empty'": a minimal parent entity that's just a transform in the world.
