### PR TITLE
[Merged by Bors] - insert the gltf mesh name on the entity if there is one

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -801,6 +801,9 @@ fn load_node(
                         value: extras.get().to_string(),
                     });
                 }
+                if let Some(name) = mesh.name() {
+                    mesh_entity.insert(Name::new(name.to_string()));
+                }
                 // Mark for adding skinned mesh
                 if let Some(skin) = gltf_node.skin() {
                     entity_to_skin_index_map.insert(mesh_entity.id(), skin.index());


### PR DESCRIPTION
# Objective

- In glTF, mesh can be named. This named is used to be able to reference the mesh, but not as a component on the entity
- Bevy only added the node name to the parent node.


## Solution

- Also adds the name on the mesh entity if there is one.

Limitation: In glTF, it's possible to have one mesh (which can be named) corresponding to several primitives (which can't, but are the actual mesh). I added the mesh name to the entity with the `PbrBundle` matching the primitives, which means that a mesh with several primitives would all have the same name. I think this is acceptable...

