### PR TITLE
[Merged by Bors] - WorldQuery derive macro now respects visibility

### DIFF
--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -279,7 +279,6 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
             }
         } else {
             quote! {
-                #[doc(hidden)]
                 #derive_macro_call
                 #visibility struct #item_struct_name #impl_generics #where_clause {
                     #(#(#field_attrs)* #field_visibilities #field_idents: <<#field_types as #path::query::WorldQuery>::#fetch_associated_type as #path::query::Fetch<#world_lifetime, #world_lifetime>>::Item,)*

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -28,6 +28,8 @@ mod field_attr_keywords {
 pub static WORLD_QUERY_ATTRIBUTE_NAME: &str = "world_query";
 
 pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
+    let visibility = ast.vis;
+
     let mut fetch_struct_attributes = FetchStructAttributes::default();
     for attr in &ast.attrs {
         if !attr
@@ -233,7 +235,7 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
                       item_struct_name: Ident| {
         if is_filter {
             quote! {
-                struct #fetch_struct_name #impl_generics #where_clause {
+                #visibility struct #fetch_struct_name #impl_generics #where_clause {
                     #(#field_idents: <#field_types as #path::query::WorldQuery>::#fetch_associated_type,)*
                     #(#ignored_field_idents: #ignored_field_types,)*
                 }
@@ -277,12 +279,12 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
         } else {
             quote! {
                 #derive_macro_call
-                struct #item_struct_name #impl_generics #where_clause {
+                #visibility struct #item_struct_name #impl_generics #where_clause {
                     #(#(#field_attrs)* #field_visibilities #field_idents: <<#field_types as #path::query::WorldQuery>::#fetch_associated_type as #path::query::Fetch<#world_lifetime, #world_lifetime>>::Item,)*
                     #(#(#ignored_field_attrs)* #ignored_field_visibilities #ignored_field_idents: #ignored_field_types,)*
                 }
 
-                struct #fetch_struct_name #impl_generics #where_clause {
+                #visibility struct #fetch_struct_name #impl_generics #where_clause {
                     #(#field_idents: <#field_types as #path::query::WorldQuery>::#fetch_associated_type,)*
                     #(#ignored_field_idents: #ignored_field_types,)*
                 }
@@ -342,7 +344,7 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
     );
 
     let state_impl = quote! {
-        struct #state_struct_name #impl_generics #where_clause {
+        #visibility struct #state_struct_name #impl_generics #where_clause {
             #(#field_idents: <#field_types as #path::query::WorldQuery>::State,)*
             #(#ignored_field_idents: #ignored_field_types,)*
         }

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -235,6 +235,7 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
                       item_struct_name: Ident| {
         if is_filter {
             quote! {
+                #[doc(hidden)]
                 #visibility struct #fetch_struct_name #impl_generics #where_clause {
                     #(#field_idents: <#field_types as #path::query::WorldQuery>::#fetch_associated_type,)*
                     #(#ignored_field_idents: #ignored_field_types,)*
@@ -278,12 +279,14 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
             }
         } else {
             quote! {
+                #[doc(hidden)]
                 #derive_macro_call
                 #visibility struct #item_struct_name #impl_generics #where_clause {
                     #(#(#field_attrs)* #field_visibilities #field_idents: <<#field_types as #path::query::WorldQuery>::#fetch_associated_type as #path::query::Fetch<#world_lifetime, #world_lifetime>>::Item,)*
                     #(#(#ignored_field_attrs)* #ignored_field_visibilities #ignored_field_idents: #ignored_field_types,)*
                 }
 
+                #[doc(hidden)]
                 #visibility struct #fetch_struct_name #impl_generics #where_clause {
                     #(#field_idents: <#field_types as #path::query::WorldQuery>::#fetch_associated_type,)*
                     #(#ignored_field_idents: #ignored_field_types,)*
@@ -344,6 +347,7 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
     );
 
     let state_impl = quote! {
+        #[doc(hidden)]
         #visibility struct #state_struct_name #impl_generics #where_clause {
             #(#field_idents: <#field_types as #path::query::WorldQuery>::State,)*
             #(#ignored_field_idents: #ignored_field_types,)*


### PR DESCRIPTION
## Objective

Fixes #4122.

## Solution

Inherit the visibility of the struct being derived for the `xxItem`, `xxFetch`, `xxState` structs.