### PR TITLE
[Merged by Bors] - Fix UI node Transform change detection

### DIFF
--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -285,14 +285,17 @@ pub fn flex_node_system(
         if node.size != new_size {
             node.size = new_size;
         }
-        let position = &mut transform.translation;
-        position.x = to_logical(layout.location.x + layout.size.width / 2.0);
-        position.y = to_logical(layout.location.y + layout.size.height / 2.0);
+        let mut new_position = transform.translation;
+        new_position.x = to_logical(layout.location.x + layout.size.width / 2.0);
+        new_position.y = to_logical(layout.location.y + layout.size.height / 2.0);
         if let Some(parent) = parent {
             if let Ok(parent_layout) = flex_surface.get_layout(parent.0) {
-                position.x -= to_logical(parent_layout.size.width / 2.0);
-                position.y -= to_logical(parent_layout.size.height / 2.0);
+                new_position.x -= to_logical(parent_layout.size.width / 2.0);
+                new_position.y -= to_logical(parent_layout.size.height / 2.0);
             }
+        }
+        if transform.translation != new_position {
+            transform.translation = new_position;
         }
     }
 }

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -282,6 +282,7 @@ pub fn flex_node_system(
             to_logical(layout.size.width),
             to_logical(layout.size.height),
         );
+        // only trigger change detection when the new value is different
         if node.size != new_size {
             node.size = new_size;
         }
@@ -294,6 +295,7 @@ pub fn flex_node_system(
                 new_position.y -= to_logical(parent_layout.size.height / 2.0);
             }
         }
+        // only trigger change detection when the new value is different
         if transform.translation != new_position {
             transform.translation = new_position;
         }

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -45,7 +45,10 @@ fn update_hierarchy(
 ) -> f32 {
     current_global_z += UI_Z_STEP;
     if let Ok(mut transform) = node_query.get_mut(entity) {
-        transform.translation.z = current_global_z - parent_global_z;
+        let new_z = current_global_z - parent_global_z;
+        if transform.translation.z != new_z {
+            transform.translation.z = new_z;
+        }
     }
     if let Ok(children) = children_query.get(entity) {
         let current_parent_global_z = current_global_z;

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -46,6 +46,7 @@ fn update_hierarchy(
     current_global_z += UI_Z_STEP;
     if let Ok(mut transform) = node_query.get_mut(entity) {
         let new_z = current_global_z - parent_global_z;
+        // only trigger change detection when the new value is different
         if transform.translation.z != new_z {
             transform.translation.z = new_z;
         }


### PR DESCRIPTION
# Objective

Fixes #4133 

## Solution

Add comparisons to make sure we don't dereference `Mut<>` in the two places where `Transform` is being mutated. `GlobalTransform` implementation already works properly so fixing Transform automatically fixed that as well.