### PR TITLE
[Merged by Bors] - Add "Changelog" and "Migration Guide" to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,3 +6,12 @@
 ## Solution
 
 - Describe the solution used to achieve the objective above.
+
+## Changelog
+
+- List a general overview of the changes made by this PR
+- Try to be concise. If more detail is needed for a particular change, consider adding it to the "Solution" section
+
+## Migration Guide
+
+- If this PR affects the public API, describe how a user might need to migrate their code to support these changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,9 @@
 ## \[ Optional \] Changelog
 
 - What changed as a result of this PR?
+- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
 - Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
-  - If you can't summarize the work your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!
+  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!
 
 ## \[Optional\] Migration Guide
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,14 +9,18 @@
 
 ---
 
-## \[Optional\] Changelog
+## Changelog
 
-- What changed as a result of this PR? If this was a trivial fix, or has no externally-visible impact, feel free to skip this section.
+> This section is optional. If this was a trivial fix, or has no externally-visible impact, feel free to skip this section.
+
+- What changed as a result of this PR?
 - If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
 - Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
   - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!
 
-## \[Optional\] Migration Guide
+## Migration Guide
+
+> This section is optional
 
 - If this PR is a breaking change (relative to the last release of Bevy), describe how a user might need to migrate their code to support these changes
 - Simply adding new functionality is not a breaking change.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,11 +7,12 @@
 
 - Describe the solution used to achieve the objective above.
 
-## Changelog
+## \[ Optional \] Changelog
 
-- List a general overview of the changes made by this PR
-- Try to be concise. If more detail is needed for a particular change, consider adding it to the "Solution" section
+- What changed as a result of this PR?
+- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
+  - If you can't summarize the work your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!
 
-## Migration Guide
+## \[Optional\] Migration Guide
 
 - If this PR affects the public API, describe how a user might need to migrate their code to support these changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 
 ---
 
-## \[ Optional \] Changelog
+## \[Optional\] Changelog
 
 - What changed as a result of this PR? If this was a trivial fix, or has no externally-visible impact, feel free to skip this section.
 - If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings


### PR DESCRIPTION
# Objective

Context: [Discord Discussion](https://discord.com/channels/691052431525675048/745355529777315850/950532143325519902)

Improve the PR template by adding "Changelog" and "Migration Guide" sections. These sections should hopefully help speed up the review/merge process, as well as help make release notes and migration guides.

## Solution

Added the "Changelog" section template which suggests listing out the changes of the PR. This also acts as a sort of tl;dr for reviewers (especially for larger PRs).

Added the "Migration Guide" section template which suggests describing how a user might need to migrate their codebase to account for the changes by the PR. This also helps authors/contributors keep the end-user in mind when adding or changing the API.

Both sections are optional— an author does not _need_ to fill these out. Hopefully they will, though, as it provides a handful of really great benefits.