### PR TITLE
export TaskPoolThreadAssignmentPolicy

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -9,7 +9,7 @@ mod time;
 pub use bytemuck::{bytes_of, cast_slice, Pod, Zeroable};
 pub use float_ord::*;
 pub use name::*;
-pub use task_pool_options::DefaultTaskPoolOptions;
+pub use task_pool_options::*;
 pub use time::*;
 
 pub mod prelude {


### PR DESCRIPTION
# Objective

- Fix #2163
- Allow configuration of thread pools through `DefaultTaskPoolOptions`

## Solution

- `TaskPoolThreadAssignmentPolicy` was already public but not exported. Export it.
