### PR TITLE
Scale sprite z level by their scale

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -174,7 +174,7 @@ impl SpecializedPipeline for SpritePipeline {
 /// Extracted informations about a [`Sprite`] used to render it.
 #[derive(Component, Clone, Copy)]
 pub struct ExtractedSprite {
-    /// 2d extracted transform from the sprite [`bevy_transform::GlobalTransform`]
+    /// 2d extracted transform from the sprite [`GlobalTransform`]
     pub transform: Extracted2dTransform,
     /// Z layer at which the sprite should be shown
     pub z_layer: f32,
@@ -193,7 +193,7 @@ pub struct ExtractedSprite {
     pub flip_y: bool,
 }
 
-/// A 2d representation of a [`bevy_transform::GlobalTransform`] for an [`ExtractedSprite`]
+/// A 2d representation of a [`GlobalTransform`] for an [`ExtractedSprite`]
 #[derive(Clone, Copy)]
 pub struct Extracted2dTransform {
     /// The 2d position

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -195,6 +195,7 @@ pub struct Transform2d {
 }
 
 impl Transform2d {
+    #[inline]
     fn mul_vec2(&self, value: Vec2) -> Vec2 {
         (self.rotation * (self.scale * value).extend(0.0)).truncate() + self.translation
     }

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -171,10 +171,14 @@ impl SpecializedPipeline for SpritePipeline {
     }
 }
 
+/// Extracted informations about a [`Sprite`] used to render it.
 #[derive(Component, Clone, Copy)]
 pub struct ExtractedSprite {
-    pub transform: Transform2d,
+    /// 2d extracted transform from the sprite [`bevy_transform::GlobalTransform`]
+    pub transform: Extracted2dTransform,
+    /// Z layer at which the sprite should be shown
     pub z_layer: f32,
+    /// Color of the sprite
     pub color: Color,
     /// Select an area of the texture
     pub rect: Option<Rect>,
@@ -183,18 +187,24 @@ pub struct ExtractedSprite {
     /// Handle to the `Image` of this sprite
     /// PERF: storing a `HandleId` instead of `Handle<Image>` enables some optimizations (`ExtractedSprite` becomes `Copy` and doesn't need to be dropped)
     pub image_handle_id: HandleId,
+    /// Is it flipped along the X axis
     pub flip_x: bool,
+    /// Is it flipped along the Y axis
     pub flip_y: bool,
 }
 
+/// A 2d representation of a [`bevy_transform::GlobalTransform`] for an [`ExtractedSprite`]
 #[derive(Clone, Copy)]
-pub struct Transform2d {
+pub struct Extracted2dTransform {
+    /// The 2d position
     pub translation: Vec2,
+    /// The 2d scale
     pub scale: Vec2,
+    /// The rotation
     pub rotation: Quat,
 }
 
-impl Transform2d {
+impl Extracted2dTransform {
     #[inline]
     fn mul_vec2(&self, value: Vec2) -> Vec2 {
         (self.rotation * (self.scale * value).extend(0.0)).truncate() + self.translation
@@ -255,7 +265,7 @@ pub fn extract_sprites(
         // PERF: we don't check in this function that the `Image` asset is ready, since it should be in most cases and hashing the handle is expensive
         extracted_sprites.sprites.alloc().init(ExtractedSprite {
             color: sprite.color,
-            transform: Transform2d {
+            transform: Extracted2dTransform {
                 translation: transform.translation.truncate(),
                 scale: transform.scale.truncate(),
                 rotation: transform.rotation,
@@ -278,7 +288,7 @@ pub fn extract_sprites(
             let rect = Some(texture_atlas.textures[atlas_sprite.index as usize]);
             extracted_sprites.sprites.alloc().init(ExtractedSprite {
                 color: atlas_sprite.color,
-                transform: Transform2d {
+                transform: Extracted2dTransform {
                     translation: transform.translation.truncate(),
                     scale: transform.scale.truncate(),
                     rotation: transform.rotation,

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -195,11 +195,8 @@ pub struct Transform2d {
 }
 
 impl Transform2d {
-    fn mul_vec2(&self, mut value: Vec2) -> Vec2 {
-        value = self.scale * value;
-        value = (self.rotation * value.extend(0.0)).truncate();
-        value += self.translation;
-        value
+    fn mul_vec2(&self, value: Vec2) -> Vec2 {
+        (self.rotation * (self.scale * value).extend(0.0)).truncate() + self.translation
     }
 }
 

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
 };
 use bevy_math::{Size, Vec3};
 use bevy_render::{texture::Image, view::Visibility, RenderWorld};
-use bevy_sprite::{ExtractedSprite, ExtractedSprites, TextureAtlas};
+use bevy_sprite::{ExtractedSprite, ExtractedSprites, TextureAtlas, Transform2d};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 use bevy_window::{WindowId, Windows};
 
@@ -92,7 +92,12 @@ pub fn extract_text2d_sprite(
                 let transform = text_transform.mul_transform(glyph_transform);
 
                 extracted_sprites.sprites.push(ExtractedSprite {
-                    transform,
+                    transform: Transform2d {
+                        translation: transform.translation.truncate(),
+                        scale: transform.scale.truncate(),
+                        rotation: transform.rotation,
+                    },
+                    z_layer: transform.translation.z * transform.scale.z,
                     color,
                     rect,
                     custom_size: None,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
 };
 use bevy_math::{Size, Vec3};
 use bevy_render::{texture::Image, view::Visibility, RenderWorld};
-use bevy_sprite::{ExtractedSprite, ExtractedSprites, TextureAtlas, Transform2d};
+use bevy_sprite::{Extracted2dTransform, ExtractedSprite, ExtractedSprites, TextureAtlas};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 use bevy_window::{WindowId, Windows};
 
@@ -92,7 +92,7 @@ pub fn extract_text2d_sprite(
                 let transform = text_transform.mul_transform(glyph_transform);
 
                 extracted_sprites.sprites.push(ExtractedSprite {
-                    transform: Transform2d {
+                    transform: Extracted2dTransform {
                         translation: transform.translation.truncate(),
                         scale: transform.scale.truncate(),
                         rotation: transform.rotation,

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -212,11 +212,8 @@ impl GlobalTransform {
 
     /// Returns a [`Vec3`] of this [`Transform`] applied to `value`.
     #[inline]
-    pub fn mul_vec3(&self, mut value: Vec3) -> Vec3 {
-        value = self.scale * value;
-        value = self.rotation * value;
-        value += self.translation;
-        value
+    pub fn mul_vec3(&self, value: Vec3) -> Vec3 {
+        self.rotation * self.scale * value + self.translation
     }
 
     #[doc(hidden)]

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -213,7 +213,7 @@ impl GlobalTransform {
     /// Returns a [`Vec3`] of this [`Transform`] applied to `value`.
     #[inline]
     pub fn mul_vec3(&self, value: Vec3) -> Vec3 {
-        self.rotation * self.scale * value + self.translation
+        self.rotation * (self.scale * value) + self.translation
     }
 
     #[doc(hidden)]

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -223,7 +223,7 @@ impl Transform {
     /// Returns a [`Vec3`] of this [`Transform`] applied to `value`.
     #[inline]
     pub fn mul_vec3(&self, value: Vec3) -> Vec3 {
-        self.rotation * self.scale * value + self.translation
+        self.rotation * (self.scale * value) + self.translation
     }
 
     /// Changes the `scale` of this [`Transform`], multiplying the current `scale` by

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -222,11 +222,8 @@ impl Transform {
 
     /// Returns a [`Vec3`] of this [`Transform`] applied to `value`.
     #[inline]
-    pub fn mul_vec3(&self, mut value: Vec3) -> Vec3 {
-        value = self.scale * value;
-        value = self.rotation * value;
-        value += self.translation;
-        value
+    pub fn mul_vec3(&self, value: Vec3) -> Vec3 {
+        self.rotation * self.scale * value + self.translation
     }
 
     /// Changes the `scale` of this [`Transform`], multiplying the current `scale` by


### PR DESCRIPTION
# Objective

- Fix #4149 
- Apply the sprite own scale on the z axis
  - the scale was already applied to other axis
  - the scale on z axis of parents was already applied
  - => only the z axis scale of a sprite own transform was not used

## Solution

- scale the sprite z axis by its scale.
  - as the multiplication was done several times, I factored it in its own parameter to do it only once
  - after extracting it, keeping the transform in 3d isn't as useful, so I changed it to a 2d transform
  - changing the new `mul_vec2` to a single line has an impact, so I also changed `mul_vec3` on transforms



|fps|before|after|
|-|-|-|
|`many_sprites`|68~69|77~79|
|`bevymark 1300 100`|49~50|52|
|`bevymark 10000 100`|7|8~10|
