### PR TITLE
[Merged by Bors] - Filter material handles on extraction

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -226,7 +226,7 @@ fn extract_materials<M: SpecializedMaterial>(
     let mut materials = Vec::with_capacity(*prev_len);
     for (entity, computed_visibility, material) in query.iter() {
         if computed_visibility.is_visible {
-            materials.push((entity, (material.clone(),)));
+            materials.push((entity, (material.clone_weak(),)));
         }
     }
     *prev_len = materials.len();

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -10,14 +10,14 @@ use bevy_ecs::{
     prelude::World,
     system::{
         lifetimeless::{Read, SQuery, SRes},
-        Query, Res, ResMut, SystemParamItem,
+        Commands, Local, Query, Res, ResMut, SystemParamItem,
     },
     world::FromWorld,
 };
 use bevy_render::{
     mesh::{Mesh, MeshVertexBufferLayout},
+    prelude::ComputedVisibility,
     render_asset::{RenderAsset, RenderAssetPlugin, RenderAssets},
-    render_component::ExtractComponentPlugin,
     render_phase::{
         AddRenderCommand, DrawFunctions, EntityRenderCommand, RenderCommandResult, RenderPhase,
         SetItemPipeline, TrackedRenderPass,
@@ -204,7 +204,6 @@ impl<M: SpecializedMaterial> Default for MaterialPlugin<M> {
 impl<M: SpecializedMaterial> Plugin for MaterialPlugin<M> {
     fn build(&self, app: &mut App) {
         app.add_asset::<M>()
-            .add_plugin(ExtractComponentPlugin::<Handle<M>>::default())
             .add_plugin(RenderAssetPlugin::<M>::default());
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
@@ -213,9 +212,25 @@ impl<M: SpecializedMaterial> Plugin for MaterialPlugin<M> {
                 .add_render_command::<AlphaMask3d, DrawMaterial<M>>()
                 .init_resource::<MaterialPipeline<M>>()
                 .init_resource::<SpecializedMeshPipelines<MaterialPipeline<M>>>()
+                .add_system_to_stage(RenderStage::Extract, extract_materials::<M>)
                 .add_system_to_stage(RenderStage::Queue, queue_material_meshes::<M>);
         }
     }
+}
+
+fn extract_materials<M: SpecializedMaterial>(
+    mut commands: Commands,
+    query: Query<(Entity, &ComputedVisibility, &Handle<M>)>,
+    mut prev_len: Local<usize>,
+) {
+    let mut materials = Vec::with_capacity(*prev_len);
+    for (entity, computed_visibility, material) in query.iter() {
+        if computed_visibility.is_visible {
+            materials.push((entity, (material.clone(),)));
+        }
+    }
+    *prev_len = materials.len();
+    commands.insert_or_spawn_batch(materials);
 }
 
 #[derive(Eq, PartialEq, Clone, Hash)]

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -194,7 +194,7 @@ impl<M: SpecializedMaterial2d> Default for Material2dPlugin<M> {
 impl<M: SpecializedMaterial2d> Plugin for Material2dPlugin<M> {
     fn build(&self, app: &mut App) {
         app.add_asset::<M>()
-            .add_plugin(ExtractComponentPlugin::<Handle<M>>::default())
+            .add_plugin(ExtractComponentPlugin::<Handle<M>>::extract_visible())
             .add_plugin(RenderAssetPlugin::<M>::default());
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app


### PR DESCRIPTION
# Objective

- While optimising many_cubes, I noticed that all material handles are extracted regardless of whether the entity to which the handle belongs is visible or not. As such >100k handles are extracted when only <20k are visible.

## Solution

- Only extract material handles of visible entities.
- This improves `many_cubes -- sphere` from ~42fps to ~48fps. It reduces not only the extraction time but also system commands time. `Handle<StandardMaterial>` extraction and its system commands went from 0.522ms + 3.710ms respectively, to 0.267ms + 0.227ms an 88% reduction for this system for this case. It's very view dependent but...