### PR TITLE
bevy_render: Batch insertion for prepare_uniform_components

### DIFF
--- a/crates/bevy_render/src/render_component.rs
+++ b/crates/bevy_render/src/render_component.rs
@@ -107,18 +107,23 @@ fn prepare_uniform_components<C: Component>(
     render_queue: Res<RenderQueue>,
     mut component_uniforms: ResMut<ComponentUniforms<C>>,
     components: Query<(Entity, &C)>,
+    mut prev_len: Local<usize>,
 ) where
     C: AsStd140 + Clone,
 {
     component_uniforms.uniforms.clear();
+    let mut entities = Vec::with_capacity(*prev_len);
     for (entity, component) in components.iter() {
-        commands
-            .get_or_spawn(entity)
-            .insert(DynamicUniformIndex::<C> {
+        entities.push((
+            entity,
+            (DynamicUniformIndex::<C> {
                 index: component_uniforms.uniforms.push(component.clone()),
                 marker: PhantomData,
-            });
+            },),
+        ));
     }
+    *prev_len = entities.len();
+    commands.insert_or_spawn_batch(entities);
 
     component_uniforms
         .uniforms


### PR DESCRIPTION
# Objective

- Make insertion of uniform components faster

## Solution

- Use batch insertion in the prepare_uniform_components system
- Improves `many_cubes -- sphere` from ~42fps to ~43fps
