### PR TITLE
[Merged by Bors] - Tracy spans around main 3D passes

### DIFF
--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -13,7 +13,6 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = []
 trace = []
 
 [dependencies]

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -12,6 +12,10 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
+[features]
+default = []
+trace = []
+
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }

--- a/crates/bevy_core_pipeline/src/main_pass_3d.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_3d.rs
@@ -59,9 +59,7 @@ impl Node for MainPass3dNode {
             // Run the opaque pass, sorted front-to-back
             // NOTE: Scoped to drop the mutable borrow of render_context
             #[cfg(feature = "trace")]
-            let span = info_span!("main_opaque_pass_3d");
-            #[cfg(feature = "trace")]
-            let _guard = span.enter();
+            let _main_opaque_pass_3d_span = info_span!("main_opaque_pass_3d").entered();
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("main_opaque_pass_3d"),
                 // NOTE: The opaque pass loads the color
@@ -98,9 +96,7 @@ impl Node for MainPass3dNode {
             // Run the alpha mask pass, sorted front-to-back
             // NOTE: Scoped to drop the mutable borrow of render_context
             #[cfg(feature = "trace")]
-            let span = info_span!("main_alpha_mask_pass_3d");
-            #[cfg(feature = "trace")]
-            let _guard = span.enter();
+            let _main_alpha_mask_pass_3d_span = info_span!("main_alpha_mask_pass_3d").entered();
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("main_alpha_mask_pass_3d"),
                 // NOTE: The alpha_mask pass loads the color buffer as well as overwriting it where appropriate.
@@ -136,9 +132,7 @@ impl Node for MainPass3dNode {
             // Run the transparent pass, sorted back-to-front
             // NOTE: Scoped to drop the mutable borrow of render_context
             #[cfg(feature = "trace")]
-            let span = info_span!("main_transparent_pass_3d");
-            #[cfg(feature = "trace")]
-            let _guard = span.enter();
+            let _main_transparent_pass_3d_span = info_span!("main_transparent_pass_3d").entered();
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("main_transparent_pass_3d"),
                 // NOTE: The transparent pass loads the color buffer as well as overwriting it where appropriate.

--- a/crates/bevy_core_pipeline/src/main_pass_3d.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_3d.rs
@@ -7,6 +7,8 @@ use bevy_render::{
     renderer::RenderContext,
     view::{ExtractedView, ViewDepthTexture, ViewTarget},
 };
+#[cfg(feature = "trace")]
+use bevy_utils::tracing::info_span;
 
 pub struct MainPass3dNode {
     query: QueryState<
@@ -56,6 +58,10 @@ impl Node for MainPass3dNode {
         {
             // Run the opaque pass, sorted front-to-back
             // NOTE: Scoped to drop the mutable borrow of render_context
+            #[cfg(feature = "trace")]
+            let span = info_span!("main_opaque_pass_3d");
+            #[cfg(feature = "trace")]
+            let _guard = span.enter();
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("main_opaque_pass_3d"),
                 // NOTE: The opaque pass loads the color
@@ -91,6 +97,10 @@ impl Node for MainPass3dNode {
         {
             // Run the alpha mask pass, sorted front-to-back
             // NOTE: Scoped to drop the mutable borrow of render_context
+            #[cfg(feature = "trace")]
+            let span = info_span!("main_alpha_mask_pass_3d");
+            #[cfg(feature = "trace")]
+            let _guard = span.enter();
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("main_alpha_mask_pass_3d"),
                 // NOTE: The alpha_mask pass loads the color buffer as well as overwriting it where appropriate.
@@ -125,6 +135,10 @@ impl Node for MainPass3dNode {
         {
             // Run the transparent pass, sorted back-to-front
             // NOTE: Scoped to drop the mutable borrow of render_context
+            #[cfg(feature = "trace")]
+            let span = info_span!("main_transparent_pass_3d");
+            #[cfg(feature = "trace")]
+            let _guard = span.enter();
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("main_transparent_pass_3d"),
                 // NOTE: The transparent pass loads the color buffer as well as overwriting it where appropriate.

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 categories = ["game-engines", "graphics", "gui", "rendering"]
 
 [features]
-trace = [ "bevy_app/trace", "bevy_ecs/trace", "bevy_log/trace", "bevy_render/trace" ]
+trace = [ "bevy_app/trace", "bevy_ecs/trace", "bevy_log/trace", "bevy_render/trace", "bevy_core_pipeline/trace" ]
 trace_chrome = [ "bevy_log/tracing-chrome" ]
 trace_tracy = [ "bevy_log/tracing-tracy" ]
 wgpu_trace = ["bevy_render/wgpu_trace"]


### PR DESCRIPTION
# Objective

- Make visible how much time is spent building the Opaque3d, AlphaMask3d, and Transparent3d passes

## Solution

- Add a `trace` feature to `bevy_core_pipeline`
- Add tracy spans around the three passes
- I didn't do this for shadows, sprites, etc as they are only one pass in the node. Perhaps it should be split into 3 nodes to allow insertion of other nodes between...?