### PR TITLE
[Merged by Bors] - Change `Cow<[ComponentId]>` to `Box<[ComponentId]>`

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -8,7 +8,6 @@ use crate::{
     storage::{Column, SparseArray, SparseSet, SparseSetIndex, TableId},
 };
 use std::{
-    borrow::Cow,
     collections::HashMap,
     hash::Hash,
     ops::{Index, IndexMut},
@@ -121,8 +120,8 @@ pub struct Archetype {
     entities: Vec<Entity>,
     edges: Edges,
     table_info: TableInfo,
-    table_components: Cow<'static, [ComponentId]>,
-    sparse_set_components: Cow<'static, [ComponentId]>,
+    table_components: Box<[ComponentId]>,
+    sparse_set_components: Box<[ComponentId]>,
     pub(crate) unique_components: SparseSet<ComponentId, Column>,
     pub(crate) components: SparseSet<ComponentId, ArchetypeComponentInfo>,
 }
@@ -131,8 +130,8 @@ impl Archetype {
     pub fn new(
         id: ArchetypeId,
         table_id: TableId,
-        table_components: Cow<'static, [ComponentId]>,
-        sparse_set_components: Cow<'static, [ComponentId]>,
+        table_components: Box<[ComponentId]>,
+        sparse_set_components: Box<[ComponentId]>,
         table_archetype_components: Vec<ArchetypeComponentId>,
         sparse_set_archetype_components: Vec<ArchetypeComponentId>,
     ) -> Self {
@@ -331,8 +330,8 @@ impl ArchetypeGeneration {
 
 #[derive(Hash, PartialEq, Eq)]
 pub struct ArchetypeIdentity {
-    table_components: Cow<'static, [ComponentId]>,
-    sparse_set_components: Cow<'static, [ComponentId]>,
+    table_components: Box<[ComponentId]>,
+    sparse_set_components: Box<[ComponentId]>,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -381,8 +380,8 @@ impl Default for Archetypes {
         archetypes.archetypes.push(Archetype::new(
             ArchetypeId::RESOURCE,
             TableId::empty(),
-            Cow::Owned(Vec::new()),
-            Cow::Owned(Vec::new()),
+            Box::new([]),
+            Box::new([]),
             Vec::new(),
             Vec::new(),
         ));
@@ -477,8 +476,8 @@ impl Archetypes {
         table_components: Vec<ComponentId>,
         sparse_set_components: Vec<ComponentId>,
     ) -> ArchetypeId {
-        let table_components = Cow::from(table_components);
-        let sparse_set_components = Cow::from(sparse_set_components);
+        let table_components = table_components.into_boxed_slice();
+        let sparse_set_components = sparse_set_components.into_boxed_slice();
         let archetype_identity = ArchetypeIdentity {
             sparse_set_components: sparse_set_components.clone(),
             table_components: table_components.clone(),


### PR DESCRIPTION
`Cow::Borrowed` was never used