### PR TITLE
[Merged by Bors] - Ignore duplicate wasi crate in dependency tree

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -48,7 +48,7 @@ skip = [
     { name = "ndk-glue", version = "0.5" },             # from winit v0.26.1
     { name = "ndk-sys", version = "0.2" },              # from winit v0.26.1
     { name = "stdweb", version = "0.1" },               # from rodio v0.15.0
-    { name = "wasi",  version = "0.11"},                # from winit v0.26.1
+    { name = "wasi",  version = "0.10"},                # from ahash v0.7.6
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -48,6 +48,7 @@ skip = [
     { name = "ndk-glue", version = "0.5" },             # from winit v0.26.1
     { name = "ndk-sys", version = "0.2" },              # from winit v0.26.1
     { name = "stdweb", version = "0.1" },               # from rodio v0.15.0
+    { name = "wasi",  version = "0.11"},                # from winit v0.26.1
 ]
 
 [sources]


### PR DESCRIPTION
# Objective

- CI is giving a warning about duplicate dependency because of a differing versions between `winit` and `ahash` of https://github.com/bytecodealliance/wasi
- PRs that are mergeable look like they're not.

## Solution

- Add this crate to the list of ignored duplicates