### PR TITLE
[Merged by Bors] - Fix clicked UI nodes getting reset when hovering child nodes

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -170,10 +170,8 @@ pub fn ui_focus_system(
     for (_entity, _focus_policy, interaction, _) in moused_over_z_sorted_nodes {
         if let Some(mut interaction) = interaction {
             // don't reset clicked nodes because they're handled separately
-            if *interaction != Interaction::Clicked {
-                if *interaction != Interaction::None {
-                    *interaction = Interaction::None;
-                }
+            if *interaction != Interaction::Clicked && *interaction != Interaction::None {
+                *interaction = Interaction::None;
             }
         }
     }

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -166,11 +166,14 @@ pub fn ui_focus_system(
             FocusPolicy::Pass => { /* allow the next node to be hovered/clicked */ }
         }
     }
-    // reset lower nodes to None, except if they're clicked
+    // reset lower nodes to None
     for (_entity, _focus_policy, interaction, _) in moused_over_z_sorted_nodes {
         if let Some(mut interaction) = interaction {
-            if *interaction != Interaction::None && *interaction != Interaction::Clicked {
-                *interaction = Interaction::None;
+            // don't reset clicked nodes because they're handled separately
+            if *interaction != Interaction::Clicked {
+                if *interaction != Interaction::None {
+                    *interaction = Interaction::None;
+                }
             }
         }
     }

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -166,10 +166,10 @@ pub fn ui_focus_system(
             FocusPolicy::Pass => { /* allow the next node to be hovered/clicked */ }
         }
     }
-    // reset lower nodes to None
+    // reset lower nodes to None, except if they're clicked
     for (_entity, _focus_policy, interaction, _) in moused_over_z_sorted_nodes {
         if let Some(mut interaction) = interaction {
-            if *interaction != Interaction::None {
+            if *interaction != Interaction::None && *interaction != Interaction::Clicked {
                 *interaction = Interaction::None;
             }
         }


### PR DESCRIPTION
# Objective

Fixes #4193

## Solution

When resetting a node's `Interaction` to `None`, ignore any `Clicked` node because that should be handled by the mouse release check exclusively.