### PR TITLE
[Merged by Bors] - Check an `Input`'s `pressed` set before adding to `just_released`.

### DIFF
--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -70,8 +70,11 @@ where
 
     /// Register a release for input `input`.
     pub fn release(&mut self, input: T) {
+        if self.pressed(input) {
+            self.just_released.insert(input);
+        }
+
         self.pressed.remove(&input);
-        self.just_released.insert(input);
     }
 
     /// Check if `input` has been just pressed.


### PR DESCRIPTION
# Objective

- Fixes #4208

## Solution

- Adds a check before inserting into an `Input`'s `just_released` set, in the same way that one exists for adding into the `just_pressed` set.
