### PR TITLE
Change plugin to consume self

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -762,7 +762,7 @@ impl App {
         T: Plugin,
     {
         debug!("added plugin: {}", plugin.name());
-        plugin.build(self);
+        Box::new(plugin).build(self);
         self
     }
 
@@ -814,7 +814,7 @@ impl App {
     /// #
     /// # struct MyOwnPlugin;
     /// # impl Plugin for MyOwnPlugin {
-    /// #     fn build(&self, app: &mut App){;}
+    /// #     fn build(self: Box<Self>, app: &mut App){;}
     /// # }
     /// #
     /// App::new()

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -7,7 +7,7 @@ use std::any::Any;
 /// a plugin, the plugin's [`Plugin::build`] function is run.
 pub trait Plugin: Any + Send + Sync {
     /// Configures the [`App`] to which this plugin is added.
-    fn build(&self, app: &mut App);
+    fn build(self: Box<Self>, app: &mut App);
     /// Configures a name for the [`Plugin`]. Primarily for debugging.
     fn name(&self) -> &str {
         std::any::type_name::<Self>()

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -110,9 +110,9 @@ impl PluginGroupBuilder {
     }
 
     /// Consumes the [`PluginGroupBuilder`] and [builds](Plugin::build) the contained [`Plugin`]s.
-    pub fn finish(self, app: &mut App) {
+    pub fn finish(mut self, app: &mut App) {
         for ty in self.order.iter() {
-            if let Some(entry) = self.plugins.get(ty) {
+            if let Some(entry) = self.plugins.remove(ty) {
                 if entry.enabled {
                     debug!("added plugin: {}", entry.plugin.name());
                     entry.plugin.build(app);

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -60,7 +60,7 @@ impl ScheduleRunnerSettings {
 pub struct ScheduleRunnerPlugin;
 
 impl Plugin for ScheduleRunnerPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         let settings = app
             .world
             .get_resource_or_insert_with(ScheduleRunnerSettings::default)

--- a/crates/bevy_asset/src/debug_asset_server.rs
+++ b/crates/bevy_asset/src/debug_asset_server.rs
@@ -57,7 +57,7 @@ impl<T: Asset> Default for HandleMap<T> {
 }
 
 impl Plugin for DebugAssetServerPlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(self: Box<Self>, app: &mut bevy_app::App) {
         let mut debug_asset_app = App::new();
         debug_asset_app
             .insert_resource(IoTaskPool(

--- a/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
+++ b/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
@@ -17,7 +17,7 @@ impl<T: Asset> Default for AssetCountDiagnosticsPlugin<T> {
 }
 
 impl<T: Asset> Plugin for AssetCountDiagnosticsPlugin<T> {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.add_startup_system(Self::setup_system)
             .add_system(Self::diagnostic_system);
     }

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -80,7 +80,7 @@ pub fn create_platform_default_asset_io(app: &mut App) -> Box<dyn AssetIo> {
 }
 
 impl Plugin for AssetPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         if !app.world.contains_resource::<AssetServer>() {
             let task_pool = app.world.resource::<IoTaskPool>().0.clone();
 

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -53,7 +53,7 @@ use bevy_ecs::system::IntoExclusiveSystem;
 pub struct AudioPlugin;
 
 impl Plugin for AudioPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.init_non_send_resource::<AudioOutput<AudioSource>>()
             .add_asset::<AudioSource>()
             .add_asset::<AudioSink>()

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -40,7 +40,7 @@ pub enum CoreSystem {
 }
 
 impl Plugin for CorePlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         // Setup the default bevy task pools
         app.world
             .get_resource::<DefaultTaskPoolOptions>()

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -111,7 +111,7 @@ pub enum CorePipelineRenderSystems {
 }
 
 impl Plugin for CorePipelinePlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.init_resource::<ClearColor>()
             .init_resource::<RenderTargetClearColors>();
 

--- a/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
@@ -11,7 +11,7 @@ use crate::{Diagnostic, DiagnosticId, Diagnostics};
 pub struct EntityCountDiagnosticsPlugin;
 
 impl Plugin for EntityCountDiagnosticsPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.add_startup_system(Self::setup_system)
             .add_system(Self::diagnostic_system.exclusive_system());
     }

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -12,7 +12,7 @@ pub struct FrameTimeDiagnosticsState {
 }
 
 impl Plugin for FrameTimeDiagnosticsPlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(self: Box<Self>, app: &mut bevy_app::App) {
         app.add_startup_system(Self::setup_system)
             .insert_resource(FrameTimeDiagnosticsState { frame_count: 0.0 })
             .add_system(Self::diagnostic_system);

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -14,7 +14,7 @@ use bevy_app::prelude::*;
 pub struct DiagnosticsPlugin;
 
 impl Plugin for DiagnosticsPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.init_resource::<Diagnostics>();
     }
 }

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -29,7 +29,7 @@ impl Default for LogDiagnosticsPlugin {
 }
 
 impl Plugin for LogDiagnosticsPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.insert_resource(LogDiagnosticsState {
             timer: Timer::new(self.wait_duration, true),
             filter: self.filter.clone(),

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -12,7 +12,7 @@ use gilrs_system::{gilrs_event_startup_system, gilrs_event_system};
 pub struct GilrsPlugin;
 
 impl Plugin for GilrsPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         match GilrsBuilder::new()
             .with_default_filters(false)
             .set_update_state(false)

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -15,7 +15,7 @@ use bevy_scene::Scene;
 pub struct GltfPlugin;
 
 impl Plugin for GltfPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.init_asset_loader::<GltfLoader>()
             .add_asset::<Gltf>()
             .add_asset::<GltfNode>()

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -37,7 +37,7 @@ pub enum HierarchySystem {
 }
 
 impl Plugin for HierarchyPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.register_type::<Children>()
             .register_type::<Parent>()
             .register_type::<PreviousParent>()

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -43,7 +43,7 @@ pub struct InputPlugin;
 pub struct InputSystem;
 
 impl Plugin for InputPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app
             // keyboard
             .add_event::<KeyboardInput>()

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -110,7 +110,7 @@ impl Default for LogSettings {
 }
 
 impl Plugin for LogPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         #[cfg(feature = "trace")]
         {
             let old_handler = panic::take_hook();

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -56,7 +56,7 @@ pub const SHADOW_SHADER_HANDLE: HandleUntyped =
 pub struct PbrPlugin;
 
 impl Plugin for PbrPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         load_internal_asset!(app, PBR_SHADER_HANDLE, "render/pbr.wgsl", Shader::from_wgsl);
         load_internal_asset!(
             app,

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -199,7 +199,7 @@ impl<M: SpecializedMaterial> Default for MaterialPlugin<M> {
 }
 
 impl<M: SpecializedMaterial> Plugin for MaterialPlugin<M> {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.add_asset::<M>()
             .add_plugin(ExtractComponentPlugin::<Handle<M>>::default())
             .add_plugin(RenderAssetPlugin::<M>::default());

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -34,7 +34,7 @@ pub const MESH_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 3252377289100772450);
 
 impl Plugin for MeshRenderPlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(self: Box<Self>, app: &mut bevy_app::App) {
         load_internal_asset!(app, MESH_SHADER_HANDLE, "mesh.wgsl", Shader::from_wgsl);
         load_internal_asset!(
             app,

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -27,7 +27,7 @@ pub const WIREFRAME_SHADER_HANDLE: HandleUntyped =
 pub struct WireframePlugin;
 
 impl Plugin for WireframePlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(self: Box<Self>, app: &mut bevy_app::App) {
         load_internal_asset!(
             app,
             WIREFRAME_SHADER_HANDLE,

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -219,7 +219,7 @@ impl<T: Component + Default> Default for CameraTypePlugin<T> {
 }
 
 impl<T: Component + Default> Plugin for CameraTypePlugin<T> {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.init_resource::<ActiveCamera<T>>()
             .add_startup_system_to_stage(StartupStage::PostStartup, set_active_camera::<T>)
             .add_system_to_stage(CoreStage::PostUpdate, set_active_camera::<T>);

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -17,7 +17,7 @@ use bevy_app::{App, CoreStage, Plugin};
 pub struct CameraPlugin;
 
 impl Plugin for CameraPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.register_type::<Camera>()
             .register_type::<Visibility>()
             .register_type::<ComputedVisibility>()

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -107,7 +107,7 @@ struct ScratchRenderWorld(World);
 
 impl Plugin for RenderPlugin {
     /// Initializes the renderer, sets up the [`RenderStage`](RenderStage) and creates the rendering sub-app.
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         let options = app
             .world
             .get_resource::<settings::WgpuSettings>()

--- a/crates/bevy_render/src/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mod.rs
@@ -13,7 +13,7 @@ use bevy_asset::AddAsset;
 pub struct MeshPlugin;
 
 impl Plugin for MeshPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.add_asset::<Mesh>()
             .add_plugin(RenderAssetPlugin::<Mesh>::default());
     }

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -53,7 +53,7 @@ impl<A: RenderAsset> Default for RenderAssetPlugin<A> {
 }
 
 impl<A: RenderAsset> Plugin for RenderAssetPlugin<A> {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .init_resource::<ExtractedAssets<A>>()

--- a/crates/bevy_render/src/render_component.rs
+++ b/crates/bevy_render/src/render_component.rs
@@ -58,7 +58,7 @@ impl<C> Default for UniformComponentPlugin<C> {
 }
 
 impl<C: Component + AsStd140 + Clone> Plugin for UniformComponentPlugin<C> {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .insert_resource(ComponentUniforms::<C>::default())
@@ -143,7 +143,7 @@ impl<C: ExtractComponent> Plugin for ExtractComponentPlugin<C>
 where
     <C::Filter as WorldQuery>::Fetch: FilterFetch,
 {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.add_system_to_stage(RenderStage::Extract, extract_components::<C>);
         }

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -23,7 +23,7 @@ use bevy_asset::{AddAsset, Assets};
 pub struct ImagePlugin;
 
 impl Plugin for ImagePlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         #[cfg(any(
             feature = "png",
             feature = "dds",

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -25,7 +25,7 @@ use bevy_transform::components::GlobalTransform;
 pub struct ViewPlugin;
 
 impl Plugin for ViewPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.init_resource::<Msaa>().add_plugin(VisibilityPlugin);
 
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -77,7 +77,7 @@ pub enum VisibilitySystems {
 pub struct VisibilityPlugin;
 
 impl Plugin for VisibilityPlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(self: Box<Self>, app: &mut bevy_app::App) {
         use VisibilitySystems::*;
 
         app.add_system_to_stage(

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -23,7 +23,7 @@ pub enum WindowSystem {
 }
 
 impl Plugin for WindowRenderPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .init_resource::<ExtractedWindows>()

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -26,7 +26,7 @@ use bevy_ecs::{schedule::ExclusiveSystemDescriptorCoercion, system::IntoExclusiv
 pub struct ScenePlugin;
 
 impl Plugin for ScenePlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.add_asset::<DynamicScene>()
             .add_asset::<Scene>()
             .init_asset_loader::<SceneLoader>()

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -51,7 +51,7 @@ pub enum SpriteSystem {
 }
 
 impl Plugin for SpritePlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         let mut shaders = app.world.resource_mut::<Assets<Shader>>();
         let sprite_shader = Shader::from_wgsl(include_str!("render/sprite.wgsl"));
         shaders.set_untracked(SPRITE_SHADER_HANDLE, sprite_shader);

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -24,7 +24,7 @@ pub const COLOR_MATERIAL_SHADER_HANDLE: HandleUntyped =
 pub struct ColorMaterialPlugin;
 
 impl Plugin for ColorMaterialPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         load_internal_asset!(
             app,
             COLOR_MATERIAL_SHADER_HANDLE,

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -185,7 +185,7 @@ impl<M: SpecializedMaterial2d> Default for Material2dPlugin<M> {
 }
 
 impl<M: SpecializedMaterial2d> Plugin for Material2dPlugin<M> {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.add_asset::<M>()
             .add_plugin(ExtractComponentPlugin::<Handle<M>>::default())
             .add_plugin(RenderAssetPlugin::<M>::default());

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -42,7 +42,7 @@ pub const MESH2D_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 2971387252468633715);
 
 impl Plugin for Mesh2dRenderPlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(self: Box<Self>, app: &mut bevy_app::App) {
         load_internal_asset!(app, MESH2D_SHADER_HANDLE, "mesh2d.wgsl", Shader::from_wgsl);
         load_internal_asset!(
             app,

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -38,7 +38,7 @@ pub type DefaultTextPipeline = TextPipeline<Entity>;
 pub struct TextPlugin;
 
 impl Plugin for TextPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.add_asset::<Font>()
             .add_asset::<FontAtlasSet>()
             .register_type::<Text>()

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -89,7 +89,7 @@ pub enum TransformSystem {
 pub struct TransformPlugin;
 
 impl Plugin for TransformPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.register_type::<Transform>()
             .register_type::<GlobalTransform>()
             // Adding these to startup ensures the first update is "correct"

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -48,7 +48,7 @@ pub enum UiSystem {
 }
 
 impl Plugin for UiPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.add_plugin(CameraTypePlugin::<CameraUi>::default())
             .init_resource::<FlexSurface>()
             .register_type::<AlignContent>()

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -38,7 +38,7 @@ impl Default for WindowPlugin {
 }
 
 impl Plugin for WindowPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.add_event::<WindowResized>()
             .add_event::<CreateWindow>()
             .add_event::<WindowCreated>()

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -38,7 +38,7 @@ use winit::dpi::LogicalSize;
 pub struct WinitPlugin;
 
 impl Plugin for WinitPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.init_non_send_resource::<WinitWindows>()
             .init_resource::<WinitSettings>()
             .set_runner(winit_runner)

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -256,7 +256,7 @@ pub const COLORED_MESH2D_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 13828845428412094821);
 
 impl Plugin for ColoredMesh2dPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         // Load our custom shader
         let mut shaders = app.world.resource_mut::<Assets<Shader>>();
         shaders.set_untracked(

--- a/examples/app/plugin.rs
+++ b/examples/app/plugin.rs
@@ -23,7 +23,7 @@ pub struct PrintMessagePlugin {
 
 impl Plugin for PrintMessagePlugin {
     // this is where we set up our plugin
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         let state = PrintMessageState {
             message: self.message.clone(),
             timer: Timer::new(self.wait_duration, true),

--- a/examples/app/plugin_group.rs
+++ b/examples/app/plugin_group.rs
@@ -28,7 +28,7 @@ impl PluginGroup for HelloWorldPlugins {
 pub struct PrintHelloPlugin;
 
 impl Plugin for PrintHelloPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.add_system(print_hello_system);
     }
 }
@@ -40,7 +40,7 @@ fn print_hello_system() {
 pub struct PrintWorldPlugin;
 
 impl Plugin for PrintWorldPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.add_system(print_world_system);
     }
 }

--- a/examples/asset/custom_asset_io.rs
+++ b/examples/asset/custom_asset_io.rs
@@ -46,7 +46,7 @@ impl AssetIo for CustomAssetIo {
 struct CustomAssetIoPlugin;
 
 impl Plugin for CustomAssetIoPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         // must get a hold of the task pool in order to create the asset server
 
         let task_pool = app.world.resource::<bevy::tasks::IoTaskPool>().0.clone();

--- a/examples/game/game_menu.rs
+++ b/examples/game/game_menu.rs
@@ -56,7 +56,7 @@ mod splash {
     pub struct SplashPlugin;
 
     impl Plugin for SplashPlugin {
-        fn build(&self, app: &mut App) {
+        fn build(self: Box<Self>, app: &mut App) {
             // As this plugin is managing the splash screen, it will focus on the state `GameState::Splash`
             app
                 // When entering the state, spawn everything needed for this screen
@@ -120,7 +120,7 @@ mod game {
     pub struct GamePlugin;
 
     impl Plugin for GamePlugin {
-        fn build(&self, app: &mut App) {
+        fn build(self: Box<Self>, app: &mut App) {
             app.add_system_set(SystemSet::on_enter(GameState::Game).with_system(game_setup))
                 .add_system_set(SystemSet::on_update(GameState::Game).with_system(game))
                 .add_system_set(
@@ -245,7 +245,7 @@ mod menu {
     pub struct MenuPlugin;
 
     impl Plugin for MenuPlugin {
-        fn build(&self, app: &mut App) {
+        fn build(self: Box<Self>, app: &mut App) {
             app
                 // At start, the menu is not enabled. This will be changed in `menu_setup` when
                 // entering the `GameState::Menu` state.

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -52,7 +52,7 @@ struct CustomMaterial;
 pub struct CustomMaterialPlugin;
 
 impl Plugin for CustomMaterialPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         let render_device = app.world.resource::<RenderDevice>();
         let buffer = render_device.create_buffer(&BufferDescriptor {
             label: Some("time uniform buffer"),

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -59,7 +59,7 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
 pub struct GameOfLifeComputePlugin;
 
 impl Plugin for GameOfLifeComputePlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         let render_app = app.sub_app_mut(RenderApp);
         render_app
             .init_resource::<GameOfLifePipeline>()

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -22,7 +22,7 @@ use bevy::{
 pub struct IsRedPlugin;
 
 impl Plugin for IsRedPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.add_plugin(ExtractComponentPlugin::<IsRed>::default());
         app.sub_app_mut(RenderApp)
             .add_render_command::<Transparent3d, DrawIsRed>()

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -76,7 +76,7 @@ impl ExtractComponent for InstanceMaterialData {
 pub struct CustomMaterialPlugin;
 
 impl Plugin for CustomMaterialPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(self: Box<Self>, app: &mut App) {
         app.add_plugin(ExtractComponentPlugin::<InstanceMaterialData>::default());
         app.sub_app_mut(RenderApp)
             .add_render_command::<Transparent3d, DrawCustom>()


### PR DESCRIPTION
## Objective

- When building a plugin I wanted to be able to temporarily store some stuff that is not clone on the Plugin for initialization, but then move it into a resource when the build function is called. In my specific case this was a `Schedule`.

## Solution

- This changes the build function from &Self to Box<Self> and so consumes the Plugin type on `build`. It needs to be boxed because internally `App` stores the plugin as a `dyn Plugin` and this is not sized so cannot be moved.  So changing `build` to use a `Box<Self>` allows it to be moved into the function.

```rust

pub struct AltSchedule(pub Schedule);

pub struct AltSchedulePlugin {
    schedule: AltSchedule
}

impl Plugin for AltSchedulePlugin {
    fn build(self: Box<Self>, app: &mut App) {
        app.insert_resource(self.schedule)
    }
}
```

## Question
- Is it weird to have `Box<Self>` in a common public API?
