### PR TITLE
[Merged by Bors] - Auto-label function systems with SystemTypeIdLabel

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -35,6 +35,7 @@ pub mod prelude {
         system::{
             Commands, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend,
             NonSendMut, Query, QuerySet, RemovedComponents, Res, ResMut, System,
+            SystemParamFunction,
         },
         world::{FromWorld, Mut, World},
     };

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -1583,15 +1583,25 @@ mod tests {
     fn ambiguity_detection() {
         use super::{find_ambiguities, SystemContainer};
 
-        fn find_ambiguities_first_labels(
+        fn find_ambiguities_first_str_labels(
             systems: &[impl SystemContainer],
         ) -> Vec<(BoxedSystemLabel, BoxedSystemLabel)> {
             find_ambiguities(systems)
                 .drain(..)
                 .map(|(index_a, index_b, _conflicts)| {
                     (
-                        systems[index_a].labels()[0].clone(),
-                        systems[index_b].labels()[0].clone(),
+                        systems[index_a]
+                            .labels()
+                            .iter()
+                            .find(|a| (&***a).type_id() == std::any::TypeId::of::<&str>())
+                            .unwrap()
+                            .clone(),
+                        systems[index_b]
+                            .labels()
+                            .iter()
+                            .find(|a| (&***a).type_id() == std::any::TypeId::of::<&str>())
+                            .unwrap()
+                            .clone(),
                     )
                 })
                 .collect()
@@ -1621,7 +1631,7 @@ mod tests {
             .with_system(component.label("4"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("4")))
                 || ambiguities.contains(&(Box::new("4"), Box::new("1")))
@@ -1636,7 +1646,7 @@ mod tests {
             .with_system(resource.label("4"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("4")))
                 || ambiguities.contains(&(Box::new("4"), Box::new("1")))
@@ -1661,7 +1671,7 @@ mod tests {
             .with_system(resource.label("4"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("0"), Box::new("3")))
                 || ambiguities.contains(&(Box::new("3"), Box::new("0")))
@@ -1680,7 +1690,7 @@ mod tests {
             .with_system(resource.label("4").in_ambiguity_set("a"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("0"), Box::new("3")))
                 || ambiguities.contains(&(Box::new("3"), Box::new("0")))
@@ -1693,7 +1703,7 @@ mod tests {
             .with_system(component.label("2"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("0"), Box::new("1")))
                 || ambiguities.contains(&(Box::new("1"), Box::new("0")))
@@ -1706,7 +1716,7 @@ mod tests {
             .with_system(component.label("2").after("0"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("2")))
                 || ambiguities.contains(&(Box::new("2"), Box::new("1")))
@@ -1720,7 +1730,7 @@ mod tests {
             .with_system(component.label("3").after("1").after("2"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("2")))
                 || ambiguities.contains(&(Box::new("2"), Box::new("1")))
@@ -1734,7 +1744,7 @@ mod tests {
             .with_system(component.label("3").after("1").after("2"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert_eq!(ambiguities.len(), 0);
 
         let mut stage = SystemStage::parallel()
@@ -1744,7 +1754,7 @@ mod tests {
             .with_system(component.label("3").after("1").after("2"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("2")))
                 || ambiguities.contains(&(Box::new("2"), Box::new("1")))
@@ -1774,7 +1784,7 @@ mod tests {
             );
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("2")))
                 || ambiguities.contains(&(Box::new("2"), Box::new("1")))
@@ -1824,7 +1834,7 @@ mod tests {
             );
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert_eq!(ambiguities.len(), 0);
 
         let mut stage = SystemStage::parallel()
@@ -1855,7 +1865,7 @@ mod tests {
             );
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("4")))
                 || ambiguities.contains(&(Box::new("4"), Box::new("1")))
@@ -1889,7 +1899,7 @@ mod tests {
             .with_system(empty.exclusive_system().label("6").after("2").after("5"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.exclusive_at_start);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.exclusive_at_start);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("3")))
                 || ambiguities.contains(&(Box::new("3"), Box::new("1")))
@@ -1926,7 +1936,7 @@ mod tests {
             .with_system(empty.exclusive_system().label("6").after("2").after("5"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.exclusive_at_start);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.exclusive_at_start);
         assert!(
             ambiguities.contains(&(Box::new("2"), Box::new("3")))
                 || ambiguities.contains(&(Box::new("3"), Box::new("2")))
@@ -1952,7 +1962,7 @@ mod tests {
             .with_system(empty.exclusive_system().label("3").in_ambiguity_set("a"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.exclusive_at_start);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.exclusive_at_start);
         assert_eq!(ambiguities.len(), 0);
     }
 

--- a/crates/bevy_ecs/src/schedule/system_descriptor.rs
+++ b/crates/bevy_ecs/src/schedule/system_descriptor.rs
@@ -105,9 +105,9 @@ pub struct ParallelSystemDescriptor {
 
 fn new_parallel_descriptor(system: BoxedSystem<(), ()>) -> ParallelSystemDescriptor {
     ParallelSystemDescriptor {
+        labels: system.default_labels(),
         system,
         run_criteria: None,
-        labels: Vec::new(),
         before: Vec::new(),
         after: Vec::new(),
         ambiguity_sets: Vec::new(),

--- a/crates/bevy_ecs/src/schedule/system_descriptor.rs
+++ b/crates/bevy_ecs/src/schedule/system_descriptor.rs
@@ -3,7 +3,10 @@ use crate::{
         AmbiguitySetLabel, BoxedAmbiguitySetLabel, BoxedSystemLabel, IntoRunCriteria,
         RunCriteriaDescriptorOrLabel, SystemLabel,
     },
-    system::{BoxedSystem, ExclusiveSystem, ExclusiveSystemCoerced, ExclusiveSystemFn, IntoSystem},
+    system::{
+        AsSystemLabel, BoxedSystem, ExclusiveSystem, ExclusiveSystemCoerced, ExclusiveSystemFn,
+        IntoSystem,
+    },
 };
 
 /// Encapsulates a system and information on when it run in a `SystemStage`.
@@ -126,10 +129,10 @@ pub trait ParallelSystemDescriptorCoercion<Params> {
     fn label(self, label: impl SystemLabel) -> ParallelSystemDescriptor;
 
     /// Specifies that the system should run before systems with the given label.
-    fn before(self, label: impl SystemLabel) -> ParallelSystemDescriptor;
+    fn before<Marker>(self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor;
 
     /// Specifies that the system should run after systems with the given label.
-    fn after(self, label: impl SystemLabel) -> ParallelSystemDescriptor;
+    fn after<Marker>(self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor;
 
     /// Specifies that the system is exempt from execution order ambiguity detection
     /// with other systems in this set.
@@ -150,13 +153,13 @@ impl ParallelSystemDescriptorCoercion<()> for ParallelSystemDescriptor {
         self
     }
 
-    fn before(mut self, label: impl SystemLabel) -> ParallelSystemDescriptor {
-        self.before.push(Box::new(label));
+    fn before<Marker>(mut self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor {
+        self.before.push(label.as_system_label());
         self
     }
 
-    fn after(mut self, label: impl SystemLabel) -> ParallelSystemDescriptor {
-        self.after.push(Box::new(label));
+    fn after<Marker>(mut self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor {
+        self.after.push(label.as_system_label());
         self
     }
 
@@ -182,11 +185,11 @@ where
         new_parallel_descriptor(Box::new(IntoSystem::into_system(self))).label(label)
     }
 
-    fn before(self, label: impl SystemLabel) -> ParallelSystemDescriptor {
+    fn before<Marker>(self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor {
         new_parallel_descriptor(Box::new(IntoSystem::into_system(self))).before(label)
     }
 
-    fn after(self, label: impl SystemLabel) -> ParallelSystemDescriptor {
+    fn after<Marker>(self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor {
         new_parallel_descriptor(Box::new(IntoSystem::into_system(self))).after(label)
     }
 
@@ -207,11 +210,11 @@ impl ParallelSystemDescriptorCoercion<()> for BoxedSystem<(), ()> {
         new_parallel_descriptor(self).label(label)
     }
 
-    fn before(self, label: impl SystemLabel) -> ParallelSystemDescriptor {
+    fn before<Marker>(self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor {
         new_parallel_descriptor(self).before(label)
     }
 
-    fn after(self, label: impl SystemLabel) -> ParallelSystemDescriptor {
+    fn after<Marker>(self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor {
         new_parallel_descriptor(self).after(label)
     }
 

--- a/crates/bevy_ecs/src/schedule/system_descriptor.rs
+++ b/crates/bevy_ecs/src/schedule/system_descriptor.rs
@@ -154,12 +154,12 @@ impl ParallelSystemDescriptorCoercion<()> for ParallelSystemDescriptor {
     }
 
     fn before<Marker>(mut self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor {
-        self.before.push(label.as_system_label());
+        self.before.push(Box::new(label.as_system_label()));
         self
     }
 
     fn after<Marker>(mut self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor {
-        self.after.push(label.as_system_label());
+        self.after.push(Box::new(label.as_system_label()));
         self
     }
 

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -432,6 +432,7 @@ where
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Copy, Clone)]
+/// A [`SystemLabel`] that was automatically generated for a system on the basis of its `TypeId`.
 pub struct SystemTypeIdLabel(pub(crate) TypeId);
 
 impl SystemLabel for SystemTypeIdLabel {

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -10,7 +10,7 @@ use crate::{
     world::{World, WorldId},
 };
 use bevy_ecs_macros::all_tuples;
-use std::{any::TypeId, borrow::Cow, fmt::Debug, hash::Hash, marker::PhantomData};
+use std::{borrow::Cow, fmt::Debug, hash::Hash, marker::PhantomData};
 
 /// The metadata of a [`System`].
 pub struct SystemMeta {

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -4,6 +4,7 @@ use crate::{
     archetype::{Archetype, ArchetypeComponentId},
     component::ComponentId,
     query::Access,
+    schedule::SystemLabel,
     world::World,
 };
 use std::borrow::Cow;
@@ -56,6 +57,10 @@ pub trait System: Send + Sync + 'static {
     /// Initialize the system.
     fn initialize(&mut self, _world: &mut World);
     fn check_change_tick(&mut self, change_tick: u32);
+    /// The default labels for the system
+    fn default_labels(&self) -> Vec<Box<dyn SystemLabel>> {
+        Vec::new()
+    }
 }
 
 /// A convenience type alias for a boxed [`System`] trait object.

--- a/examples/ecs/system_sets.rs
+++ b/examples/ecs/system_sets.rs
@@ -57,7 +57,7 @@ fn main() {
                 .with_run_criteria(run_for_a_second)
                 .with_system(update_velocity)
                 // Make movement run after update_velocity
-                .with_system(movement.after(update_velocity.system_label())),
+                .with_system(movement.after(update_velocity)),
         )
         .add_system_set(
             SystemSet::new()

--- a/examples/ecs/system_sets.rs
+++ b/examples/ecs/system_sets.rs
@@ -16,14 +16,6 @@ struct PostPhysics;
 #[derive(Default)]
 struct Done(bool);
 
-/// This is used to show that within a [`SystemSet`], individual systems can also
-/// be labelled, allowing further fine tuning of run ordering.
-#[derive(Clone, Hash, Debug, PartialEq, Eq, SystemLabel)]
-pub enum PhysicsSystem {
-    UpdateVelocity,
-    Movement,
-}
-
 /// This example realizes the following scheme:
 ///
 /// ```none
@@ -63,18 +55,9 @@ fn main() {
                 // This criteria ensures this whole system set only runs when this system's
                 // output says so (ShouldRun::Yes)
                 .with_run_criteria(run_for_a_second)
-                .with_system(
-                    update_velocity
-                        // Only applied to the `update_velocity` system
-                        .label(PhysicsSystem::UpdateVelocity),
-                )
-                .with_system(
-                    movement
-                        // Only applied to the `movement` system
-                        .label(PhysicsSystem::Movement)
-                        // Enforce order within this system by specifying this
-                        .after(PhysicsSystem::UpdateVelocity),
-                ),
+                .with_system(update_velocity)
+                // Make movement run after update_velocity
+                .with_system(movement.after(update_velocity.system_label())),
         )
         .add_system_set(
             SystemSet::new()


### PR DESCRIPTION
This adds the concept of "default labels" for systems (currently scoped to "parallel systems", but this could just as easily be implemented for "exclusive systems"). Function systems now include their function's `SystemTypeIdLabel` by default.

This enables the following patterns:

```rust
// ordering two systems without manually defining labels
app
  .add_system(update_velocity)
  .add_system(movement.after(update_velocity))

// ordering sets of systems without manually defining labels
app
  .add_system(foo)
  .add_system_set(
    SystemSet::new()
      .after(foo)
      .with_system(bar)
      .with_system(baz)
  )
```

Fixes: #4219
Related to: #4220 

Credit to @aevyrie @alice-i-cecile @DJMcNab (and probably others) for proposing (and supporting) this idea about a year ago. I was a big dummy that both shut down this (very good) idea and then forgot I did that. Sorry. You all were right!