### PR TITLE
[Merged by Bors] - bevy_reflect: Add `GetTypeRegistration` impl for reflected tuples

### DIFF
--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -1,6 +1,9 @@
+use crate::{
+    serde::Serializable, FromReflect, FromType, GetTypeRegistration, Reflect, ReflectDeserialize,
+    ReflectMut, ReflectRef, TypeRegistration,
+};
+use serde::Deserialize;
 use std::any::Any;
-
-use crate::{serde::Serializable, FromReflect, Reflect, ReflectMut, ReflectRef};
 
 /// A reflected Rust tuple.
 ///
@@ -415,6 +418,14 @@ macro_rules! impl_reflect_tuple {
 
             fn serializable(&self) -> Option<Serializable> {
                 None
+            }
+        }
+
+        impl<$($name: Reflect + for<'de> Deserialize<'de>),*> GetTypeRegistration for ($($name,)*) {
+            fn get_type_registration() -> TypeRegistration {
+                let mut registration = TypeRegistration::of::<($($name,)*)>();
+                registration.insert::<ReflectDeserialize>(FromType::<($($name,)*)>::from_type());
+                registration
             }
         }
 


### PR DESCRIPTION
# Objective

Reflected tuples do not implement `GetTypeRegistration`, preventing us from registering our tuples, like:

```rust
app.register_type::<(i32, i32)>();
```

This is especially important for things like using #4042 to improve the scene format or implementing #4154 to recursively register fields.

## Solution

Added an implementation to the tuple macro:

```rust
impl<$($name: Reflect + for<'de> Deserialize<'de>),*> GetTypeRegistration for ($($name,)*) {
  fn get_type_registration() -> TypeRegistration {
    let mut registration = TypeRegistration::of::<($($name,)*)>();
    registration.insert::<ReflectDeserialize>(FromType::<($($name,)*)>::from_type());
    registration
  }
}
```

This requires that the tuple's types implement `Deserialize`. This is exactly how `Vec` and `HashMap` handle it:

```rust
impl<T: FromReflect + for<'de> Deserialize<'de>> GetTypeRegistration for Vec<T> {
  fn get_type_registration() -> TypeRegistration {
    let mut registration = TypeRegistration::of::<Vec<T>>();
    registration.insert::<ReflectDeserialize>(FromType::<Vec<T>>::from_type());
    registration
  }
}
```