### PR TITLE
[Merged by Bors] - Bump Bevy to 0.7.0-dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 categories = ["game-engines", "graphics", "gui", "rendering"]
 description = "A refreshingly simple data-driven game engine and app framework"
@@ -94,11 +94,11 @@ bevy_ci_testing = ["bevy_internal/bevy_ci_testing"]
 debug_asset_server = ["bevy_internal/debug_asset_server"]
 
 [dependencies]
-bevy_dylib = { path = "crates/bevy_dylib", version = "0.6.0", default-features = false, optional = true }
-bevy_internal = { path = "crates/bevy_internal", version = "0.6.0", default-features = false }
+bevy_dylib = { path = "crates/bevy_dylib", version = "0.7.0-dev", default-features = false, optional = true }
+bevy_internal = { path = "crates/bevy_internal", version = "0.7.0-dev", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy_internal = { path = "crates/bevy_internal", version = "0.6.0", default-features = false, features = [
+bevy_internal = { path = "crates/bevy_internal", version = "0.7.0-dev", default-features = false, features = [
   "webgl",
 ] }
 

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_app"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides core App functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -15,10 +15,10 @@ default = ["bevy_reflect"]
 
 [dependencies]
 # bevy
-bevy_derive = { path = "../bevy_derive", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", optional = true }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_derive = { path = "../bevy_derive", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", optional = true }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -31,4 +31,4 @@ web-sys = { version = "0.3", features = [ "Window" ] }
 
 [dev-dependencies]
 # bevy
-bevy_log = { path = "../bevy_log", version = "0.6.0" }
+bevy_log = { path = "../bevy_log", version = "0.7.0-dev" }

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_asset"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides asset functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -15,13 +15,13 @@ debug_asset_server = ["filesystem_watcher"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_log = { path = "../bevy_log", version = "0.6.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", features = ["bevy"] }
-bevy_tasks = { path = "../bevy_tasks", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_log = { path = "../bevy_log", version = "0.7.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", features = ["bevy"] }
+bevy_tasks = { path = "../bevy_tasks", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 
 # other
 serde = { version = "1", features = ["derive"] }
@@ -45,4 +45,4 @@ ndk-glue = { version = "0.5" }
 [dev-dependencies]
 futures-lite = "1.4.0"
 tempfile = "3.2.0"
-bevy_core = { path = "../bevy_core", version = "0.6.0" }
+bevy_core = { path = "../bevy_core", version = "0.7.0-dev" }

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_audio"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides audio functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -10,11 +10,11 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", features = ["bevy"] }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_asset = { path = "../bevy_asset", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", features = ["bevy"] }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 
 # other
 anyhow = "1.0.4"
@@ -26,7 +26,7 @@ rodio = { version = "0.15", default-features = false, features = ["wasm-bindgen"
 
 [dev-dependencies]
 # bevy
-bevy_internal = { path = "../bevy_internal", version = "0.6.0" }
+bevy_internal = { path = "../bevy_internal", version = "0.7.0-dev" }
 
 [features]
 mp3 = ["rodio/mp3"]

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_core"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides core functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -11,13 +11,13 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0", features = ["bevy_reflect"] }
-bevy_derive = { path = "../bevy_derive", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0", features = ["bevy_reflect"] }
-bevy_math = { path = "../bevy_math", version = "0.6.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", features = ["bevy"] }
-bevy_tasks = { path = "../bevy_tasks", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev", features = ["bevy_reflect"] }
+bevy_derive = { path = "../bevy_derive", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev", features = ["bevy_reflect"] }
+bevy_math = { path = "../bevy_math", version = "0.7.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", features = ["bevy"] }
+bevy_tasks = { path = "../bevy_tasks", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 
 # other
 bytemuck = "1.5"

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_core_pipeline"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 authors = [
     "Bevy Contributors <bevyengine@gmail.com>",
@@ -14,10 +14,10 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.6.0" }
-bevy_core = { path = "../bevy_core", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_render = { path = "../bevy_render", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_asset = { path = "../bevy_asset", version = "0.7.0-dev" }
+bevy_core = { path = "../bevy_core", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_render = { path = "../bevy_render", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 

--- a/crates/bevy_crevice/Cargo.toml
+++ b/crates/bevy_crevice/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_crevice"
 description = "Create GLSL-compatible versions of structs with explicitly-initialized padding (Bevy version)"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 authors = ["Lucien Greathouse <me@lpghatguy.com>"]
 documentation = "https://docs.rs/crevice"
@@ -23,7 +23,7 @@ std = []
 # default-members = ["crevice-derive", "crevice-tests"]
 
 [dependencies]
-bevy-crevice-derive = { version = "0.6.0", path = "bevy-crevice-derive" }
+bevy-crevice-derive = { version = "0.7.0-dev", path = "bevy-crevice-derive" }
 
 bytemuck = "1.4.1"
 mint = "0.5.8"

--- a/crates/bevy_crevice/bevy-crevice-derive/Cargo.toml
+++ b/crates/bevy_crevice/bevy-crevice-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy-crevice-derive"
 description = "Derive crate for the 'crevice' crate (Bevy version)"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2018"
 authors = ["Lucien Greathouse <me@lpghatguy.com>"]
 documentation = "https://docs.rs/crevice-derive"
@@ -24,4 +24,4 @@ proc-macro = true
 syn = "1.0.40"
 quote = "1.0.7"
 proc-macro2 = "1.0.21"
-bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.6.0" }
+bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.7.0-dev" }

--- a/crates/bevy_derive/Cargo.toml
+++ b/crates/bevy_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_derive"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides derive implementations for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 proc-macro = true
 
 [dependencies]
-bevy_macro_utils = { path = "../bevy_macro_utils", version = "0.6.0" }
+bevy_macro_utils = { path = "../bevy_macro_utils", version = "0.7.0-dev" }
 
 quote = "1.0"
 syn = "1.0"

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_diagnostic"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides diagnostic functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -11,8 +11,8 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_core = { path = "../bevy_core", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_log = { path = "../bevy_log", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_core = { path = "../bevy_core", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_log = { path = "../bevy_log", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }

--- a/crates/bevy_dylib/Cargo.toml
+++ b/crates/bevy_dylib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_dylib"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Force the Bevy Engine to be dynamically linked for faster linking"
 homepage = "https://bevyengine.org"
@@ -12,4 +12,4 @@ keywords = ["bevy"]
 crate-type = ["dylib"]
 
 [dependencies]
-bevy_internal = { path = "../bevy_internal", version = "0.6.0", default-features = false }
+bevy_internal = { path = "../bevy_internal", version = "0.7.0-dev", default-features = false }

--- a/crates/bevy_dynamic_plugin/Cargo.toml
+++ b/crates/bevy_dynamic_plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_dynamic_plugin"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides dynamic plugin loading capabilities for non-wasm platforms"
 homepage = "https://bevyengine.org"
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
 
 # other
 libloading = { version = "0.7" }

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ecs"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Bevy Engine's entity component system"
 homepage = "https://bevyengine.org"
@@ -14,10 +14,10 @@ trace = []
 default = ["bevy_reflect"]
 
 [dependencies]
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", optional = true }
-bevy_tasks = { path = "../bevy_tasks", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
-bevy_ecs_macros = { path = "macros", version = "0.6.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", optional = true }
+bevy_tasks = { path = "../bevy_tasks", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
+bevy_ecs_macros = { path = "macros", version = "0.7.0-dev" }
 
 async-channel = "1.4"
 fixedbitset = "0.4"

--- a/crates/bevy_ecs/macros/Cargo.toml
+++ b/crates/bevy_ecs/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ecs_macros"
-version = "0.6.0"
+version = "0.7.0-dev"
 description = "Bevy ECS Macros"
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 proc-macro = true
 
 [dependencies]
-bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.6.0" }
+bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.7.0-dev" }
 
 syn = "1.0"
 quote = "1.0"

--- a/crates/bevy_ecs_compile_fail_tests/Cargo.toml
+++ b/crates/bevy_ecs_compile_fail_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ecs_compile_fail_tests"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Compile fail tests for Bevy Engine's entity component system"
 homepage = "https://bevyengine.org"
@@ -9,5 +9,5 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dev-dependencies]
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
 trybuild = "1.0"

--- a/crates/bevy_gilrs/Cargo.toml
+++ b/crates/bevy_gilrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_gilrs"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Gamepad system made using Gilrs for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -10,10 +10,10 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_input = { path = "../bevy_input", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_input = { path = "../bevy_input", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 
 # other
 gilrs = { version = "0.8.0", features = ["wasm-bindgen"] }

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_gltf"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Bevy Engine GLTF loading"
 homepage = "https://bevyengine.org"
@@ -10,19 +10,19 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.6.0" }
-bevy_core = { path = "../bevy_core", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.6.0" }
-bevy_pbr = { path = "../bevy_pbr", version = "0.6.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", features = ["bevy"] }
-bevy_render = { path = "../bevy_render", version = "0.6.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
-bevy_math = { path = "../bevy_math", version = "0.6.0" }
-bevy_scene = { path = "../bevy_scene", version = "0.6.0" }
-bevy_log = { path = "../bevy_log", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_asset = { path = "../bevy_asset", version = "0.7.0-dev" }
+bevy_core = { path = "../bevy_core", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.7.0-dev" }
+bevy_pbr = { path = "../bevy_pbr", version = "0.7.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", features = ["bevy"] }
+bevy_render = { path = "../bevy_render", version = "0.7.0-dev" }
+bevy_transform = { path = "../bevy_transform", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
+bevy_math = { path = "../bevy_math", version = "0.7.0-dev" }
+bevy_scene = { path = "../bevy_scene", version = "0.7.0-dev" }
+bevy_log = { path = "../bevy_log", version = "0.7.0-dev" }
 
 # other
 gltf = { version = "1.0.0", default-features = false, features = [

--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_hierarchy"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides hierarchy functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -10,10 +10,10 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0", features = ["bevy_reflect"] }
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", features = ["bevy"] }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev", features = ["bevy_reflect"] }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", features = ["bevy"] }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 
 # other
 smallvec = { version = "1.6", features = ["serde", "union", "const_generics"] }

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_input"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides input functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -14,10 +14,10 @@ serialize = ["serde"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_math = { path = "../bevy_math", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_math = { path = "../bevy_math", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 
 # other
 serde = { version = "1", features = ["derive"], optional = true }

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_internal"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "An internal Bevy crate used to facilitate optional dynamic linking via the 'dynamic' feature"
 homepage = "https://bevyengine.org"
@@ -50,34 +50,34 @@ bevy_ci_testing = ["bevy_app/bevy_ci_testing", "bevy_render/ci_limits"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.6.0" }
-bevy_core = { path = "../bevy_core", version = "0.6.0" }
-bevy_derive = { path = "../bevy_derive", version = "0.6.0" }
-bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.6.0" }
-bevy_input = { path = "../bevy_input", version = "0.6.0" }
-bevy_log = { path = "../bevy_log", version = "0.6.0" }
-bevy_math = { path = "../bevy_math", version = "0.6.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", features = ["bevy"] }
-bevy_scene = { path = "../bevy_scene", version = "0.6.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
-bevy_window = { path = "../bevy_window", version = "0.6.0" }
-bevy_tasks = { path = "../bevy_tasks", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_asset = { path = "../bevy_asset", version = "0.7.0-dev" }
+bevy_core = { path = "../bevy_core", version = "0.7.0-dev" }
+bevy_derive = { path = "../bevy_derive", version = "0.7.0-dev" }
+bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.7.0-dev" }
+bevy_input = { path = "../bevy_input", version = "0.7.0-dev" }
+bevy_log = { path = "../bevy_log", version = "0.7.0-dev" }
+bevy_math = { path = "../bevy_math", version = "0.7.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", features = ["bevy"] }
+bevy_scene = { path = "../bevy_scene", version = "0.7.0-dev" }
+bevy_transform = { path = "../bevy_transform", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
+bevy_window = { path = "../bevy_window", version = "0.7.0-dev" }
+bevy_tasks = { path = "../bevy_tasks", version = "0.7.0-dev" }
 # bevy (optional)
-bevy_audio = { path = "../bevy_audio", optional = true, version = "0.6.0" }
-bevy_core_pipeline = { path = "../bevy_core_pipeline", optional = true, version = "0.6.0" }
-bevy_gltf = { path = "../bevy_gltf", optional = true, version = "0.6.0" }
-bevy_pbr = { path = "../bevy_pbr", optional = true, version = "0.6.0" }
-bevy_render = { path = "../bevy_render", optional = true, version = "0.6.0" }
-bevy_dynamic_plugin = { path = "../bevy_dynamic_plugin", optional = true, version = "0.6.0" }
-bevy_sprite = { path = "../bevy_sprite", optional = true, version = "0.6.0" }
-bevy_text = { path = "../bevy_text", optional = true, version = "0.6.0" }
-bevy_ui = { path = "../bevy_ui", optional = true, version = "0.6.0" }
-bevy_winit = { path = "../bevy_winit", optional = true, version = "0.6.0" }
-bevy_gilrs = { path = "../bevy_gilrs", optional = true, version = "0.6.0" }
+bevy_audio = { path = "../bevy_audio", optional = true, version = "0.7.0-dev" }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", optional = true, version = "0.7.0-dev" }
+bevy_gltf = { path = "../bevy_gltf", optional = true, version = "0.7.0-dev" }
+bevy_pbr = { path = "../bevy_pbr", optional = true, version = "0.7.0-dev" }
+bevy_render = { path = "../bevy_render", optional = true, version = "0.7.0-dev" }
+bevy_dynamic_plugin = { path = "../bevy_dynamic_plugin", optional = true, version = "0.7.0-dev" }
+bevy_sprite = { path = "../bevy_sprite", optional = true, version = "0.7.0-dev" }
+bevy_text = { path = "../bevy_text", optional = true, version = "0.7.0-dev" }
+bevy_ui = { path = "../bevy_ui", optional = true, version = "0.7.0-dev" }
+bevy_winit = { path = "../bevy_winit", optional = true, version = "0.7.0-dev" }
+bevy_gilrs = { path = "../bevy_gilrs", optional = true, version = "0.7.0-dev" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 ndk-glue = {version = "0.5", features = ["logger"]}

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_log"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides logging for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -12,8 +12,8 @@ keywords = ["bevy"]
 trace = [ "tracing-error" ]
 
 [dependencies]
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 
 tracing-subscriber = {version = "0.3.1", features = ["registry", "env-filter"]}
 tracing-chrome = { version = "0.4.0", optional = true }
@@ -29,4 +29,4 @@ console_error_panic_hook = "0.1.6"
 tracing-wasm = "0.2.1"
 
 [dev-dependencies]
-bevy_internal = { path = "../bevy_internal", version = "0.6.0" }
+bevy_internal = { path = "../bevy_internal", version = "0.7.0-dev" }

--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_macro_utils"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "A collection of utils for Bevy Engine"
 homepage = "https://bevyengine.org"

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_math"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides math functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -10,4 +10,4 @@ keywords = ["bevy"]
 
 [dependencies]
 glam = { version = "0.20.0", features = ["serde", "bytemuck"] }
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", features = ["bevy"] }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", features = ["bevy"] }

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_pbr"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Adds PBR rendering to Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -13,17 +13,17 @@ webgl = []
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.6.0" }
-bevy_core = { path = "../bevy_core", version = "0.6.0" }
-bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_math = { path = "../bevy_math", version = "0.6.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", features = ["bevy"] }
-bevy_render = { path = "../bevy_render", version = "0.6.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
-bevy_window = { path = "../bevy_window", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_asset = { path = "../bevy_asset", version = "0.7.0-dev" }
+bevy_core = { path = "../bevy_core", version = "0.7.0-dev" }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_math = { path = "../bevy_math", version = "0.7.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", features = ["bevy"] }
+bevy_render = { path = "../bevy_render", version = "0.7.0-dev" }
+bevy_transform = { path = "../bevy_transform", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
+bevy_window = { path = "../bevy_window", version = "0.7.0-dev" }
 
 # other
 bitflags = "1.2"

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_reflect"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Dynamically interact with rust types"
 homepage = "https://bevyengine.org"
@@ -14,8 +14,8 @@ bevy = ["glam", "smallvec"]
 
 [dependencies]
 # bevy
-bevy_reflect_derive = { path = "bevy_reflect_derive", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_reflect_derive = { path = "bevy_reflect_derive", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 
 # other
 erased-serde = "0.3"

--- a/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
+++ b/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_reflect_derive"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Derive implementations for bevy_reflect"
 homepage = "https://bevyengine.org"
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 proc-macro = true
 
 [dependencies]
-bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.6.0" }
+bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.7.0-dev" }
 
 syn = "1.0"
 proc-macro2 = "1.0"

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_render"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides rendering functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -22,17 +22,17 @@ webgl = ["wgpu/webgl"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.6.0" }
-bevy_core = { path = "../bevy_core", version = "0.6.0" }
-bevy_crevice = { path = "../bevy_crevice", version = "0.6.0", features = ["glam"] }
-bevy_derive = { path = "../bevy_derive", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_math = { path = "../bevy_math", version = "0.6.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", features = ["bevy"] }
-bevy_transform = { path = "../bevy_transform", version = "0.6.0" }
-bevy_window = { path = "../bevy_window", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_asset = { path = "../bevy_asset", version = "0.7.0-dev" }
+bevy_core = { path = "../bevy_core", version = "0.7.0-dev" }
+bevy_crevice = { path = "../bevy_crevice", version = "0.7.0-dev", features = ["glam"] }
+bevy_derive = { path = "../bevy_derive", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_math = { path = "../bevy_math", version = "0.7.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", features = ["bevy"] }
+bevy_transform = { path = "../bevy_transform", version = "0.7.0-dev" }
+bevy_window = { path = "../bevy_window", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 
 # rendering
 image = { version = "0.23.12", default-features = false }

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_scene"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides scene functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -10,12 +10,12 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", features = ["bevy"] }
-bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_asset = { path = "../bevy_asset", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", features = ["bevy"] }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 
 # other
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_sprite"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides sprite functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -10,19 +10,19 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.6.0" }
-bevy_core = { path = "../bevy_core", version = "0.6.0" }
-bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_log = { path = "../bevy_log", version = "0.6.0" }
-bevy_math = { path = "../bevy_math", version = "0.6.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", features = [
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_asset = { path = "../bevy_asset", version = "0.7.0-dev" }
+bevy_core = { path = "../bevy_core", version = "0.7.0-dev" }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_log = { path = "../bevy_log", version = "0.7.0-dev" }
+bevy_math = { path = "../bevy_math", version = "0.7.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", features = [
     "bevy",
 ] }
-bevy_render = { path = "../bevy_render", version = "0.6.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_render = { path = "../bevy_render", version = "0.7.0-dev" }
+bevy_transform = { path = "../bevy_transform", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 
 # other
 bytemuck = { version = "1.5", features = ["derive"] }

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tasks"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "A task executor for Bevy Engine"
 homepage = "https://bevyengine.org"

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_text"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides text functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -13,17 +13,17 @@ subpixel_glyph_atlas = []
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.6.0" }
-bevy_core = { path = "../bevy_core", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_math = { path = "../bevy_math", version = "0.6.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", features = ["bevy"] }
-bevy_render = { path = "../bevy_render", version = "0.6.0" }
-bevy_sprite = { path = "../bevy_sprite", version = "0.6.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.6.0" }
-bevy_window = { path = "../bevy_window", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_asset = { path = "../bevy_asset", version = "0.7.0-dev" }
+bevy_core = { path = "../bevy_core", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_math = { path = "../bevy_math", version = "0.7.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", features = ["bevy"] }
+bevy_render = { path = "../bevy_render", version = "0.7.0-dev" }
+bevy_sprite = { path = "../bevy_sprite", version = "0.7.0-dev" }
+bevy_transform = { path = "../bevy_transform", version = "0.7.0-dev" }
+bevy_window = { path = "../bevy_window", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 
 # other
 anyhow = "1.0.4"

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_transform"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides transform functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -10,8 +10,8 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0", features = ["bevy_reflect"] }
-bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.6.0"}
-bevy_math = { path = "../bevy_math", version = "0.6.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", features = ["bevy"] }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev", features = ["bevy_reflect"] }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.7.0-dev"}
+bevy_math = { path = "../bevy_math", version = "0.7.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", features = ["bevy"] }

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ui"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "A custom ECS-driven UI framework built specifically for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -10,23 +10,23 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.6.0" }
-bevy_core = { path = "../bevy_core", version = "0.6.0" }
-bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.6.0" }
-bevy_derive = { path = "../bevy_derive", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.6.0" }
-bevy_input = { path = "../bevy_input", version = "0.6.0" }
-bevy_log = { path = "../bevy_log", version = "0.6.0" }
-bevy_math = { path = "../bevy_math", version = "0.6.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.6.0", features = ["bevy"] }
-bevy_render = { path = "../bevy_render", version = "0.6.0" }
-bevy_sprite = { path = "../bevy_sprite", version = "0.6.0" }
-bevy_text = { path = "../bevy_text", version = "0.6.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.6.0" }
-bevy_window = { path = "../bevy_window", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_asset = { path = "../bevy_asset", version = "0.7.0-dev" }
+bevy_core = { path = "../bevy_core", version = "0.7.0-dev" }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.7.0-dev" }
+bevy_derive = { path = "../bevy_derive", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.7.0-dev" }
+bevy_input = { path = "../bevy_input", version = "0.7.0-dev" }
+bevy_log = { path = "../bevy_log", version = "0.7.0-dev" }
+bevy_math = { path = "../bevy_math", version = "0.7.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0-dev", features = ["bevy"] }
+bevy_render = { path = "../bevy_render", version = "0.7.0-dev" }
+bevy_sprite = { path = "../bevy_sprite", version = "0.7.0-dev" }
+bevy_text = { path = "../bevy_text", version = "0.7.0-dev" }
+bevy_transform = { path = "../bevy_transform", version = "0.7.0-dev" }
+bevy_window = { path = "../bevy_window", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 
 # other
 stretch = "0.3.2"

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_utils"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "A collection of utils for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [dependencies]
-bevy_derive = { path = "../bevy_derive", version = "0.6.0" }
+bevy_derive = { path = "../bevy_derive", version = "0.7.0-dev" }
 ahash = "0.7.0"
 tracing = {version = "0.1", features = ["release_max_level_info"]}
 instant = { version = "0.1", features = ["wasm-bindgen"] }

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_window"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "Provides windowing functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -10,10 +10,10 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_math = { path = "../bevy_math", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_math = { path = "../bevy_math", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 raw-window-handle = "0.4.2"
 
 # other

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_winit"
-version = "0.6.0"
+version = "0.7.0-dev"
 edition = "2021"
 description = "A winit window and input backend for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -14,12 +14,12 @@ x11 = ["winit/x11"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.6.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.6.0" }
-bevy_input = { path = "../bevy_input", version = "0.6.0" }
-bevy_math = { path = "../bevy_math", version = "0.6.0" }
-bevy_window = { path = "../bevy_window", version = "0.6.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.6.0" }
+bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0-dev" }
+bevy_input = { path = "../bevy_input", version = "0.7.0-dev" }
+bevy_math = { path = "../bevy_math", version = "0.7.0-dev" }
+bevy_window = { path = "../bevy_window", version = "0.7.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0-dev" }
 
 # other
 winit = { version = "0.26.0", default-features = false }

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -1,5 +1,7 @@
 # Release Checklist
 
+## Pre-release
+
 1. Check regressions tag.
 2. Check appropriate milestone.
 3. Check GitHub Projects page for staleness.
@@ -7,13 +9,22 @@
 5. Create migration guide.
 6. Write blog post.
 7. Update book.
-8. Create tag on GitHub.
-9. Bump `latest` tag to most recent release.
-10. Release on crates.io
-11. Announce on:
+8. Bump version number for all crates.
+9. Create tag on GitHub.
+10. Bump `latest` tag to most recent release.
+
+## Release
+
+1. Release on crates.io
+2. Announce on:
     1. HackerNews
     2. Twitter
     3. Reddit: /r/bevy, /r/rust, /r/rust_gamedev
     4. Discord: Bevy, Game Development in Rust, Rust Programming Language Community
     5. This Month in Rust Game Development newsletter
     6. This Week in Rust newsletter
+
+## Post-release
+
+1. Bump version number for all crates to next versions, as `0.X-dev`, to ensure properly displayed version for [Dev Docs](https://dev-docs.bevyengine.org/bevy/index.html).
+2. Update Bevy version used for Bevy book code validation to latest release.


### PR DESCRIPTION
# Objective

- The [dev docs](https://dev-docs.bevyengine.org/bevy/index.html#) show version 0.6.0, which is actively misleading.

[Image of the problem](https://cdn.discordapp.com/attachments/695741366520512563/953513612943704114/Screenshot_20220316-154100_Firefox-01.jpeg)

Noticed by @ickk, fix proposed by @mockersf.

## Solution

- Bump the version across all Bevy crates to 0.7.0 dev.
- Set a reminder in the Release Checklist to remember to do this each release.
