### PR TITLE
[Merged by Bors] - Improve the `set_active_camera` system

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -270,12 +270,20 @@ pub fn set_active_camera<T: Component>(
     mut active_camera: ResMut<ActiveCamera<T>>,
     cameras: Query<Entity, With<T>>,
 ) {
-    if active_camera.get().is_some() {
-        return;
+    // Check if there is already an active camera set and
+    // that it has not been deleted on the previous frame
+    if let Some(camera) = active_camera.get() {
+        if cameras.contains(camera) {
+            return;
+        }
     }
 
+    // If the previous active camera ceised to exist -
+    // fallback to another camera of the same type T
     if let Some(camera) = cameras.iter().next() {
         active_camera.camera = Some(camera);
+    } else {
+        active_camera.camera = None;
     }
 }
 

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -268,7 +268,7 @@ impl<T: Component> ActiveCamera<T> {
 
 pub fn set_active_camera<T: Component>(
     mut active_camera: ResMut<ActiveCamera<T>>,
-    cameras: Query<Entity, With<T>>,
+    cameras: Query<Entity, (With<Camera>, With<T>)>,
 ) {
     // Check if there is already an active camera set and
     // that it has not been deleted on the previous frame
@@ -278,7 +278,7 @@ pub fn set_active_camera<T: Component>(
         }
     }
 
-    // If the previous active camera ceised to exist -
+    // If the previous active camera ceased to exist
     // fallback to another camera of the same type T
     if let Some(camera) = cameras.iter().next() {
         active_camera.camera = Some(camera);


### PR DESCRIPTION
# Objective

- Make `set_active_camera` system correctly respond to camera deletion, while preserving its correct behavior on first ever frame and any consequent frame, and with multiple cameras of the same type available in the world.
- Fixes #4227

## Solution

- Add a check that the entity referred to by `ActiveCamera` still exists in the world.