### PR TITLE
[Merged by Bors] - Prevent event from getting registered twice

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -622,8 +622,11 @@ impl App {
     where
         T: Resource,
     {
-        self.init_resource::<Events<T>>()
-            .add_system_to_stage(CoreStage::First, Events::<T>::update_system)
+        if !self.world.contains_resource::<Events<T>>() {
+            self.init_resource::<Events<T>>()
+                .add_system_to_stage(CoreStage::First, Events::<T>::update_system);
+        }
+        self
     }
 
     /// Inserts a resource to the current [App] and overwrites any resource previously added of the same type.


### PR DESCRIPTION
# Objective

As described in  #4257, registering an Event twice would cause some systems to miss events on some starts, since the event buffer is cleared + swapped multiple times.

Fixes #4257

## Solution

A simple check whether the event is already registered is added, making adding an Event a second time a no-op.