### PR TITLE
[Merged by Bors] - Break out Breakout components into a more sensible organization

### DIFF
--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -62,9 +62,7 @@ fn main() {
 }
 
 #[derive(Component)]
-struct Paddle {
-    speed: f32,
-}
+struct Paddle;
 
 #[derive(Component)]
 struct Ball;
@@ -106,9 +104,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
             ..default()
         })
-        .insert(Paddle {
-            speed: PADDLE_SPEED,
-        })
+        .insert(Paddle)
         .insert(Collider::Paddle);
     // ball
     let ball_velocity = BALL_SPEED * INITIAL_BALL_DIRECTION.extend(0.0).normalize();
@@ -260,9 +256,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 fn paddle_movement_system(
     keyboard_input: Res<Input<KeyCode>>,
-    mut query: Query<(&Paddle, &mut Transform)>,
+    mut query: Query<&mut Transform, With<Paddle>>,
 ) {
-    let (paddle, mut transform) = query.single_mut();
+    let mut transform = query.single_mut();
     let mut direction = 0.0;
     if keyboard_input.pressed(KeyCode::Left) {
         direction -= 1.0;
@@ -274,7 +270,7 @@ fn paddle_movement_system(
 
     let translation = &mut transform.translation;
     // move the paddle horizontally
-    translation.x += direction * paddle.speed * TIME_STEP;
+    translation.x += direction * 400.0 * TIME_STEP;
     // bound the paddle within the walls
     translation.x = translation.x.min(PADDLE_BOUNDS).max(-PADDLE_BOUNDS);
 }

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -107,7 +107,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .insert(Paddle)
         .insert(Collider);
     // ball
-    let ball_velocity = BALL_SPEED * INITIAL_BALL_DIRECTION.extend(0.0).normalize();
+    let ball_velocity = INITIAL_BALL_DIRECTION.normalize() * BALL_SPEED;
 
     commands
         .spawn_bundle(SpriteBundle {

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -92,7 +92,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(UiCameraBundle::default());
     // paddle
     commands
-        .spawn_bundle(SpriteBundle {
+        .spawn()
+        .insert(Paddle)
+        .insert_bundle(SpriteBundle {
             transform: Transform {
                 translation: Vec3::new(0.0, PADDLE_HEIGHT, 0.0),
                 scale: PADDLE_SIZE,
@@ -104,13 +106,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
             ..default()
         })
-        .insert(Paddle)
         .insert(Collider);
     // ball
     let ball_velocity = INITIAL_BALL_DIRECTION.normalize() * BALL_SPEED;
 
     commands
-        .spawn_bundle(SpriteBundle {
+        .spawn()
+        .insert(Ball)
+        .insert_bundle(SpriteBundle {
             transform: Transform {
                 scale: BALL_SIZE,
                 translation: BALL_STARTING_POSITION,
@@ -122,7 +125,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
             ..default()
         })
-        .insert(Ball)
         .insert(Velocity {
             x: ball_velocity.x,
             y: ball_velocity.y,
@@ -237,7 +239,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             ) + bricks_offset;
             // brick
             commands
-                .spawn_bundle(SpriteBundle {
+                .spawn()
+                .insert(Brick)
+                .insert_bundle(SpriteBundle {
                     sprite: Sprite {
                         color: BRICK_COLOR,
                         ..default()
@@ -249,8 +253,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     },
                     ..default()
                 })
-                .insert(Collider)
-                .insert(Brick);
+                .insert(Collider);
         }
     }
 }

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -68,10 +68,7 @@ struct Paddle;
 struct Ball;
 
 #[derive(Component)]
-struct Velocity {
-    x: f32,
-    y: f32,
-}
+struct Velocity(Vec2);
 
 #[derive(Component)]
 struct Collider;
@@ -125,10 +122,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
             ..default()
         })
-        .insert(Velocity {
-            x: ball_velocity.x,
-            y: ball_velocity.y,
-        });
+        .insert(Velocity(ball_velocity));
     // scoreboard
     commands.spawn_bundle(TextBundle {
         text: Text {
@@ -281,8 +275,8 @@ fn paddle_movement_system(
 
 fn apply_velocity_system(mut query: Query<(&mut Transform, &Velocity)>) {
     for (mut transform, velocity) in query.iter_mut() {
-        transform.translation.x += velocity.x * TIME_STEP;
-        transform.translation.y += velocity.y * TIME_STEP;
+        transform.translation.x += velocity.0.x * TIME_STEP;
+        transform.translation.y += velocity.0.y * TIME_STEP;
     }
 }
 
@@ -322,21 +316,21 @@ fn ball_collision_system(
             // only reflect if the ball's velocity is going in the opposite direction of the
             // collision
             match collision {
-                Collision::Left => reflect_x = ball_velocity.x > 0.0,
-                Collision::Right => reflect_x = ball_velocity.x < 0.0,
-                Collision::Top => reflect_y = ball_velocity.y < 0.0,
-                Collision::Bottom => reflect_y = ball_velocity.y > 0.0,
+                Collision::Left => reflect_x = ball_velocity.0.x > 0.0,
+                Collision::Right => reflect_x = ball_velocity.0.x < 0.0,
+                Collision::Top => reflect_y = ball_velocity.0.y < 0.0,
+                Collision::Bottom => reflect_y = ball_velocity.0.y > 0.0,
                 Collision::Inside => { /* do nothing */ }
             }
 
             // reflect velocity on the x-axis if we hit something on the x-axis
             if reflect_x {
-                ball_velocity.x = -ball_velocity.x;
+                ball_velocity.0.x = -ball_velocity.0.x;
             }
 
             // reflect velocity on the y-axis if we hit something on the y-axis
             if reflect_y {
-                ball_velocity.y = -ball_velocity.y;
+                ball_velocity.0.y = -ball_velocity.0.y;
             }
         }
     }

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -79,6 +79,7 @@ struct Collider;
 #[derive(Component)]
 struct Brick;
 
+// This resource tracks the game's score
 struct Scoreboard {
     score: usize,
 }
@@ -270,7 +271,7 @@ fn paddle_movement_system(
 
     let translation = &mut transform.translation;
     // move the paddle horizontally
-    translation.x += direction * 400.0 * TIME_STEP;
+    translation.x += direction * PADDLE_SPEED * TIME_STEP;
     // bound the paddle within the walls
     translation.x = translation.x.min(PADDLE_BOUNDS).max(-PADDLE_BOUNDS);
 }


### PR DESCRIPTION
# Objective

- The components in the Breakout game are defined in a strange fashion.
   - Components should decouple behavior wherever possible.
   - Systems should be as general as possible, to make extending behavior easier.
   - Marker components are idiomatic and useful, but marker components and query filters were not used.
- The existing design makes it challenging for beginners to extend the example into a high-quality game.

## Solution

- Refactor component definitions in the Breakout example to reflect principles above.

## Context

A small portion of the changes made in #2094. Interacts with changes in #4255; merge conflicts will have to be resolved.