### PR TITLE
[Merged by Bors] - register `Camera{2,3}d` components for reflection

### DIFF
--- a/crates/bevy_render/src/camera/bundle.rs
+++ b/crates/bevy_render/src/camera/bundle.rs
@@ -1,18 +1,21 @@
+use super::{CameraProjection, ScalingMode};
 use crate::{
     camera::{Camera, DepthCalculation, OrthographicProjection, PerspectiveProjection},
     primitives::Frustum,
     view::VisibleEntities,
 };
+use bevy_ecs::reflect::ReflectComponent;
 use bevy_ecs::{bundle::Bundle, prelude::Component};
 use bevy_math::Vec3;
+use bevy_reflect::Reflect;
 use bevy_transform::components::{GlobalTransform, Transform};
 
-use super::{CameraProjection, ScalingMode};
-
-#[derive(Component, Default)]
+#[derive(Component, Default, Reflect)]
+#[reflect(Component)]
 pub struct Camera3d;
 
-#[derive(Component, Default)]
+#[derive(Component, Default, Reflect)]
+#[reflect(Component)]
 pub struct Camera2d;
 
 /// Component bundle for camera entities with perspective projection

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -37,6 +37,8 @@ impl Plugin for CameraPlugin {
                 crate::camera::camera_system::<PerspectiveProjection>,
             )
             .add_plugin(CameraTypePlugin::<Camera3d>::default())
-            .add_plugin(CameraTypePlugin::<Camera2d>::default());
+            .add_plugin(CameraTypePlugin::<Camera2d>::default())
+            .register_type::<Camera3d>()
+            .register_type::<Camera2d>();
     }
 }

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -28,6 +28,8 @@ impl Plugin for CameraPlugin {
             .register_type::<ScalingMode>()
             .register_type::<DepthCalculation>()
             .register_type::<Aabb>()
+            .register_type::<Camera3d>()
+            .register_type::<Camera2d>()
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 crate::camera::camera_system::<OrthographicProjection>,
@@ -37,8 +39,6 @@ impl Plugin for CameraPlugin {
                 crate::camera::camera_system::<PerspectiveProjection>,
             )
             .add_plugin(CameraTypePlugin::<Camera3d>::default())
-            .add_plugin(CameraTypePlugin::<Camera2d>::default())
-            .register_type::<Camera3d>()
-            .register_type::<Camera2d>();
+            .add_plugin(CameraTypePlugin::<Camera2d>::default());
     }
 }


### PR DESCRIPTION
# Objective

When loading a gltf scene with a camera, bevy will panic at ``thread 'main' panicked at 'scene contains the unregistered type `bevy_render::camera::bundle::Camera3d`. consider registering the type using `app.register_type::<T>()`', /home/jakob/dev/rust/contrib/bevy/bevy/crates/bevy_scene/src/scene_spawner.rs:332:35``.

## Solution

Register the camera types to fix the panic.