### PR TITLE
[Merged by Bors] - gltf-loader: disable backface culling if material is double-sided

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -18,7 +18,7 @@ use bevy_render::{
     color::Color,
     mesh::{Indices, Mesh, VertexAttributeValues},
     primitives::{Aabb, Frustum},
-    render_resource::{AddressMode, FilterMode, PrimitiveTopology, SamplerDescriptor},
+    render_resource::{AddressMode, Face, FilterMode, PrimitiveTopology, SamplerDescriptor},
     renderer::RenderDevice,
     texture::{CompressedImageFormats, Image, ImageType, TextureError},
     view::VisibleEntities,
@@ -473,6 +473,11 @@ fn load_material(material: &Material, load_context: &mut LoadContext) -> Handle<
             metallic_roughness_texture,
             normal_map_texture,
             double_sided: material.double_sided(),
+            cull_mode: if material.double_sided() {
+                None
+            } else {
+                Some(Face::Back)
+            },
             occlusion_texture,
             emissive: Color::rgba(emissive[0], emissive[1], emissive[2], 1.0),
             emissive_texture,


### PR DESCRIPTION
# Objective

The  [glTF spec](https://github.com/KhronosGroup/glTF/blob/8e798b02d254cea97659a333cfcb20875b62bdd4/specification/2.0/Specification.adoc#395-double-sided) the `doubleSided` has the following to say about the `doubleSided` boolean:

> When this value is false, back-face culling is enabled, i.e., only front-facing triangles are rendered.
> When this value is true, back-face culling is disabled and double sided lighting is enabled. The back-face MUST have its normals reversed before the lighting equation is evaluated.

## Solution
Disable backface culling when `doubleSided: true`.