### PR TITLE
Only insert or remove input if needed

### DIFF
--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -53,9 +53,8 @@ where
     pub fn press(&mut self, input: T) {
         if !self.pressed(input) {
             self.just_pressed.insert(input);
+            self.pressed.insert(input);
         }
-
-        self.pressed.insert(input);
     }
 
     /// Check if `input` has been pressed.
@@ -71,10 +70,9 @@ where
     /// Register a release for input `input`.
     pub fn release(&mut self, input: T) {
         if self.pressed(input) {
+            self.pressed.remove(&input);
             self.just_released.insert(input);
         }
-
-        self.pressed.remove(&input);
     }
 
     /// Check if `input` has been just pressed.


### PR DESCRIPTION
# Objective

We are currently inserting an `input` into `pressed` even if it is already pressed. This also applies to releasing an input. This is not a big deal, but since we are already checking if the `input` is pressed or not we might as well remove the cost of an additional check inside of the `pressed.insert` method.

Related to #4209

## Solution

Only insert or remove input if needed.