### PR TITLE
Use type aliases for Query item types in Query and QueryState methods

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -309,7 +309,15 @@ pub trait WorldQuery {
         + ReadOnlyFetch;
 }
 
+/// The item type returned when you iterate a [`Query`](crate::system::Query) or [`QueryState`](crate::query::QueryState)
+///
+/// Unlike [`ReadOnlyQueryItem`], this type may allow mutable access to the component data.
 pub type QueryItem<'w, 's, Q> = <<Q as WorldQuery>::Fetch as Fetch<'w, 's>>::Item;
+
+/// The item type returned when you iterate a [`Query`](crate::system::Query) or [`QueryState`](crate::query::QueryState)
+///
+/// Unlike [`QueryItem`], this type only permits immutable access to the component data.
+pub type ReadOnlyQueryItem<'w, 's, Q> = <<Q as WorldQuery>::ReadOnlyFetch as Fetch<'w, 's>>::Item;
 
 /// Types that implement this trait are responsible for fetching query items from tables or
 /// archetypes.

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -467,8 +467,6 @@ where
     /// Runs `func` on each query result for the given [`World`]. This is faster than the equivalent
     /// iter() method, but cannot be chained like a normal [`Iterator`].
     ///
-    /// This can only be called for read-only queries.
-    ///
     /// # Safety
     ///
     /// This does not check for mutable query correctness. To be safe, make sure mutable queries

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -4,7 +4,7 @@ use crate::{
     entity::Entity,
     query::{
         Access, Fetch, FetchState, FilterFetch, FilteredAccess, NopFetch, QueryCombinationIter,
-        QueryIter, WorldQuery,
+        QueryItem, QueryIter, ReadOnlyQueryItem, WorldQuery,
     },
     storage::TableId,
     world::{World, WorldId},
@@ -140,7 +140,7 @@ where
         &'s mut self,
         world: &'w World,
         entity: Entity,
-    ) -> Result<<Q::ReadOnlyFetch as Fetch<'w, 's>>::Item, QueryEntityError> {
+    ) -> Result<ReadOnlyQueryItem<'w, 's, Q>, QueryEntityError> {
         self.update_archetypes(world);
         // SAFETY: query is read only
         unsafe {
@@ -159,7 +159,7 @@ where
         &'s mut self,
         world: &'w mut World,
         entity: Entity,
-    ) -> Result<<Q::Fetch as Fetch<'w, 's>>::Item, QueryEntityError> {
+    ) -> Result<QueryItem<'w, 's, Q>, QueryEntityError> {
         self.update_archetypes(world);
         // SAFETY: query has unique world access
         unsafe {
@@ -177,7 +177,7 @@ where
         &'s self,
         world: &'w World,
         entity: Entity,
-    ) -> Result<<Q::ReadOnlyFetch as Fetch<'w, 's>>::Item, QueryEntityError> {
+    ) -> Result<ReadOnlyQueryItem<'w, 's, Q>, QueryEntityError> {
         self.validate_world(world);
         // SAFETY: query is read only and world is validated
         unsafe {
@@ -201,7 +201,7 @@ where
         &'s mut self,
         world: &'w World,
         entity: Entity,
-    ) -> Result<<Q::Fetch as Fetch<'w, 's>>::Item, QueryEntityError> {
+    ) -> Result<QueryItem<'w, 's, Q>, QueryEntityError> {
         self.update_archetypes(world);
         self.get_unchecked_manual::<Q::Fetch>(
             world,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -427,7 +427,7 @@ where
     ///
     /// This can only be called for read-only queries, see [`Self::for_each_mut`] for write-queries.
     #[inline]
-    pub fn for_each<'w, 's, FN: FnMut(<Q::ReadOnlyFetch as Fetch<'w, 's>>::Item)>(
+    pub fn for_each<'w, 's, FN: FnMut(ReadOnlyQueryItem<'w, 's, Q>)>(
         &'s mut self,
         world: &'w World,
         func: FN,
@@ -447,7 +447,7 @@ where
     /// Runs `func` on each query result for the given [`World`]. This is faster than the equivalent
     /// `iter_mut()` method, but cannot be chained like a normal [`Iterator`].
     #[inline]
-    pub fn for_each_mut<'w, 's, FN: FnMut(<Q::Fetch as Fetch<'w, 's>>::Item)>(
+    pub fn for_each_mut<'w, 's, FN: FnMut(QueryItem<'w, 's, Q>)>(
         &'s mut self,
         world: &'w mut World,
         func: FN,
@@ -474,7 +474,7 @@ where
     /// This does not check for mutable query correctness. To be safe, make sure mutable queries
     /// have unique access to the components they query.
     #[inline]
-    pub unsafe fn for_each_unchecked<'w, 's, FN: FnMut(<Q::Fetch as Fetch<'w, 's>>::Item)>(
+    pub unsafe fn for_each_unchecked<'w, 's, FN: FnMut(QueryItem<'w, 's, Q>)>(
         &'s mut self,
         world: &'w World,
         func: FN,
@@ -493,11 +493,7 @@ where
     /// This can only be called for read-only queries, see [`Self::par_for_each_mut`] for
     /// write-queries.
     #[inline]
-    pub fn par_for_each<
-        'w,
-        's,
-        FN: Fn(<Q::ReadOnlyFetch as Fetch<'w, 's>>::Item) + Send + Sync + Clone,
-    >(
+    pub fn par_for_each<'w, 's, FN: Fn(ReadOnlyQueryItem<'w, 's, Q>) + Send + Sync + Clone>(
         &'s mut self,
         world: &'w World,
         task_pool: &TaskPool,
@@ -520,11 +516,7 @@ where
 
     /// Runs `func` on each query result in parallel using the given `task_pool`.
     #[inline]
-    pub fn par_for_each_mut<
-        'w,
-        's,
-        FN: Fn(<Q::Fetch as Fetch<'w, 's>>::Item) + Send + Sync + Clone,
-    >(
+    pub fn par_for_each_mut<'w, 's, FN: Fn(QueryItem<'w, 's, Q>) + Send + Sync + Clone>(
         &'s mut self,
         world: &'w mut World,
         task_pool: &TaskPool,
@@ -557,7 +549,7 @@ where
     pub unsafe fn par_for_each_unchecked<
         'w,
         's,
-        FN: Fn(<Q::Fetch as Fetch<'w, 's>>::Item) + Send + Sync + Clone,
+        FN: Fn(QueryItem<'w, 's, Q>) + Send + Sync + Clone,
     >(
         &'s mut self,
         world: &'w World,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -2,7 +2,7 @@ use crate::{
     component::Component,
     entity::Entity,
     query::{
-        Fetch, FilterFetch, NopFetch, QueryCombinationIter, QueryEntityError, QueryItem, QueryIter,
+        FilterFetch, NopFetch, QueryCombinationIter, QueryEntityError, QueryItem, QueryIter,
         QueryState, ReadOnlyFetch, ReadOnlyQueryItem, WorldQuery,
     },
     world::{Mut, World},
@@ -454,10 +454,7 @@ where
     /// # bevy_ecs::system::assert_is_system(report_names_system);
     /// ```
     #[inline]
-    pub fn for_each<'this>(
-        &'this self,
-        f: impl FnMut(<Q::ReadOnlyFetch as Fetch<'this, 's>>::Item),
-    ) {
+    pub fn for_each<'this>(&'this self, f: impl FnMut(ReadOnlyQueryItem<'this, 's, Q>)) {
         // SAFE: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict
         unsafe {
@@ -492,7 +489,7 @@ where
     /// # bevy_ecs::system::assert_is_system(gravity_system);
     /// ```
     #[inline]
-    pub fn for_each_mut<'a, FN: FnMut(<Q::Fetch as Fetch<'a, 'a>>::Item)>(&'a mut self, f: FN) {
+    pub fn for_each_mut<'a, FN: FnMut(QueryItem<'a, 'a, Q>)>(&'a mut self, f: FN) {
         // SAFE: system runs without conflicts with other systems. same-system queries have runtime
         // borrow checks when they conflict
         unsafe {
@@ -530,7 +527,7 @@ where
         &'this self,
         task_pool: &TaskPool,
         batch_size: usize,
-        f: impl Fn(<Q::ReadOnlyFetch as Fetch<'this, 's>>::Item) + Send + Sync + Clone,
+        f: impl Fn(ReadOnlyQueryItem<'this, 's, Q>) + Send + Sync + Clone,
     ) {
         // SAFE: system runs without conflicts with other systems. same-system queries have runtime
         // borrow checks when they conflict
@@ -550,7 +547,7 @@ where
     /// Runs `f` on each query result in parallel using the given [`TaskPool`].
     /// See [`Self::par_for_each`] for more details.
     #[inline]
-    pub fn par_for_each_mut<'a, FN: Fn(<Q::Fetch as Fetch<'a, 'a>>::Item) + Send + Sync + Clone>(
+    pub fn par_for_each_mut<'a, FN: Fn(QueryItem<'a, 'a, Q>) + Send + Sync + Clone>(
         &'a mut self,
         task_pool: &TaskPool,
         batch_size: usize,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -2,8 +2,8 @@ use crate::{
     component::Component,
     entity::Entity,
     query::{
-        Fetch, FilterFetch, NopFetch, QueryCombinationIter, QueryEntityError, QueryIter,
-        QueryState, ReadOnlyFetch, WorldQuery,
+        Fetch, FilterFetch, NopFetch, QueryCombinationIter, QueryEntityError, QueryItem, QueryIter,
+        QueryState, ReadOnlyFetch, ReadOnlyQueryItem, WorldQuery,
     },
     world::{Mut, World},
 };
@@ -602,10 +602,7 @@ where
     /// # bevy_ecs::system::assert_is_system(print_selected_character_name_system);
     /// ```
     #[inline]
-    pub fn get(
-        &self,
-        entity: Entity,
-    ) -> Result<<Q::ReadOnlyFetch as Fetch<'_, 's>>::Item, QueryEntityError> {
+    pub fn get(&self, entity: Entity) -> Result<ReadOnlyQueryItem<Q>, QueryEntityError> {
         // SAFE: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict
         unsafe {
@@ -643,10 +640,7 @@ where
     /// # bevy_ecs::system::assert_is_system(poison_system);
     /// ```
     #[inline]
-    pub fn get_mut(
-        &mut self,
-        entity: Entity,
-    ) -> Result<<Q::Fetch as Fetch>::Item, QueryEntityError> {
+    pub fn get_mut(&mut self, entity: Entity) -> Result<QueryItem<Q>, QueryEntityError> {
         // SAFE: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict
         unsafe {
@@ -672,7 +666,7 @@ where
     pub unsafe fn get_unchecked(
         &'s self,
         entity: Entity,
-    ) -> Result<<Q::Fetch as Fetch<'w, 's>>::Item, QueryEntityError> {
+    ) -> Result<QueryItem<Q>, QueryEntityError> {
         // SEMI-SAFE: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict
         self.state.get_unchecked_manual::<Q::Fetch>(
@@ -836,7 +830,7 @@ where
     /// Panics if the number of query results is not exactly one. Use
     /// [`get_single`](Self::get_single) to return a `Result` instead of panicking.
     #[track_caller]
-    pub fn single(&self) -> <Q::ReadOnlyFetch as Fetch<'_, 's>>::Item {
+    pub fn single(&self) -> ReadOnlyQueryItem<Q> {
         self.get_single().unwrap()
     }
 
@@ -871,9 +865,7 @@ where
     /// }
     /// # bevy_ecs::system::assert_is_system(player_scoring_system);
     /// ```
-    pub fn get_single(
-        &self,
-    ) -> Result<<Q::ReadOnlyFetch as Fetch<'_, 's>>::Item, QuerySingleError> {
+    pub fn get_single(&self) -> Result<ReadOnlyQueryItem<Q>, QuerySingleError> {
         let mut query = self.iter();
         let first = query.next();
         let extra = query.next().is_some();
@@ -912,7 +904,7 @@ where
     /// Panics if the number of query results is not exactly one. Use
     /// [`get_single_mut`](Self::get_single_mut) to return a `Result` instead of panicking.
     #[track_caller]
-    pub fn single_mut(&mut self) -> <Q::Fetch as Fetch<'_, '_>>::Item {
+    pub fn single_mut(&mut self) -> QueryItem<Q> {
         self.get_single_mut().unwrap()
     }
 
@@ -938,9 +930,7 @@ where
     /// }
     /// # bevy_ecs::system::assert_is_system(regenerate_player_health_system);
     /// ```
-    pub fn get_single_mut(
-        &mut self,
-    ) -> Result<<Q::Fetch as Fetch<'_, '_>>::Item, QuerySingleError> {
+    pub fn get_single_mut(&mut self) -> Result<QueryItem<Q>, QuerySingleError> {
         let mut query = self.iter_mut();
         let first = query.next();
         let extra = query.next().is_some();
@@ -1081,7 +1071,7 @@ where
     pub fn get_inner(
         &'s self,
         entity: Entity,
-    ) -> Result<<Q::ReadOnlyFetch as Fetch<'w, 's>>::Item, QueryEntityError> {
+    ) -> Result<ReadOnlyQueryItem<'w, 's, Q>, QueryEntityError> {
         // SAFE: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict
         unsafe {


### PR DESCRIPTION
# Objective

- The `Query` and `QueryState` methods have a large number of `<<Q as WorldQuery>::ReadOnlyFetch as Fetch<'w, 's>>::Item`  return types
- The unaliased types are mysterious and hard to read, especially for beginners

## Solution

- Use the `QueryItem` type alias and a parallel `ReadOnlyQueryItem` alias to make this code easier to read and write.

## Future Work

I think we should consider refactoring `QueryIter` to have an `Item` associated type and use these aliases there too. I'd prefer to keep this minimal though, so we can merge it ASAP and make #3333 easier.