### PR TITLE
[Merged by Bors] - Add get_multiple and get_multiple_mut APIs for Query and QueryState

### DIFF
--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -265,8 +265,10 @@ where
         entities: [Entity; N],
     ) -> Result<[<Q::Fetch as Fetch<'w, 's>>::Item; N], QueryEntityError> {
         self.update_archetypes(world);
+        self.validate_world(world);
 
         // SAFE: method requires exclusive world access
+        // and world has been validated
         unsafe {
             self.get_multiple_unchecked_manual(
                 world,
@@ -323,6 +325,9 @@ where
     ///
     /// This does not check for mutable query correctness. To be safe, make sure mutable queries
     /// have unique access to the components they query.
+    ///
+    /// This must be called on the same `World` that the `Query` was generated from:
+    /// use `QueryState::validate_world` to verify this.
     pub(crate) unsafe fn get_unchecked_manual<'w, 's, QF: Fetch<'w, 's, State = Q::State>>(
         &'s self,
         world: &'w World,
@@ -397,6 +402,9 @@ where
     ///
     /// This does not check for unique access to subsets of the entity-component data.
     /// To be safe, make sure mutable queries have unique access to the components they query.
+    ///
+    /// This must be called on the same `World` that the `Query` was generated from:
+    /// use `QueryState::validate_world` to verify this.
     pub(crate) unsafe fn get_multiple_unchecked_manual<'s, 'w, const N: usize>(
         &'s self,
         world: &'w World,
@@ -404,8 +412,6 @@ where
         last_change_tick: u32,
         change_tick: u32,
     ) -> Result<[<Q::Fetch as Fetch<'w, 's>>::Item; N], QueryEntityError> {
-        self.validate_world(world);
-
         // Verify that all entities are unique
         for i in 0..N {
             for j in 0..i {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -198,27 +198,15 @@ where
     ) -> Result<[<Q::ReadOnlyFetch as Fetch<'w, 's>>::Item; N], QueryEntityError> {
         self.update_archetypes(world);
 
-        let array_of_results = entities.map(|entity| {
-            // SAFETY: query is read only
-            unsafe {
-                self.get_unchecked_manual::<Q::ReadOnlyFetch>(
-                    world,
-                    entity,
-                    world.last_change_tick(),
-                    world.read_change_tick(),
-                )
-            }
-        });
-
-        // If any of the entities were not present, return an error
-        for result in &array_of_results {
-            if let Err(QueryEntityError::NoSuchEntity(entity)) = result {
-                return Err(QueryEntityError::NoSuchEntity(*entity));
-            }
+        // SAFE: query is read-only
+        unsafe {
+            self.get_multiple_unchecked_manual::<Q::ReadOnlyFetch, N>(
+                world,
+                entities,
+                world.last_change_tick(),
+                world.read_change_tick(),
+            )
         }
-
-        // Since we have verified that all entities are present, we can safely unwrap
-        Ok(array_of_results.map(|result| result.unwrap()))
     }
 
     /// Gets the query result for the given [`World`] and [`Entity`].
@@ -288,35 +276,17 @@ where
     ) -> Result<[<Q::Fetch as Fetch<'w, 's>>::Item; N], QueryEntityError> {
         self.update_archetypes(world);
 
-        for i in 0..N {
-            for j in 0..i {
-                if entities[i] == entities[j] {
-                    return Err(QueryEntityError::AliasedMutability(entities[i]));
-                }
-            }
+        verify_entities_unique(entities)?;
+
+        // SAFE: method requires exclusive world access, and entities are checked for uniqueness
+        unsafe {
+            self.get_multiple_unchecked_manual::<Q::Fetch, N>(
+                world,
+                entities,
+                world.last_change_tick(),
+                world.read_change_tick(),
+            )
         }
-
-        let array_of_results = entities.map(|entity| {
-            // SAFETY: entity list is checked for uniqueness, and we require exclusive access to the World
-            unsafe {
-                self.get_unchecked_manual::<Q::Fetch>(
-                    world,
-                    entity,
-                    world.last_change_tick(),
-                    world.read_change_tick(),
-                )
-            }
-        });
-
-        // If any of the entities were not present, return an error
-        for result in &array_of_results {
-            if let Err(QueryEntityError::NoSuchEntity(entity)) = result {
-                return Err(QueryEntityError::NoSuchEntity(*entity));
-            }
-        }
-
-        // Since we have verified that all entities are present, we can safely unwrap
-        Ok(array_of_results.map(|result| result.unwrap()))
     }
 
     #[inline]
@@ -394,6 +364,42 @@ where
         } else {
             Err(QueryEntityError::QueryDoesNotMatch)
         }
+    }
+
+    /// Gets the query results for the given [`World`] and array of [`Entity`], where the last change and
+    /// the current change tick are given.
+    ///
+    /// # Safety
+    /// This does not check for mutable query correctness. To be safe, make sure mutable queries
+    /// have unique access to the components they query.
+    ///
+    /// If you are calling this method with a mutable query, you must verify that `entities` is free of duplicates:
+    /// use [`verify_entities_unique`] to do so efficiently for small `N`.
+    pub(crate) unsafe fn get_multiple_unchecked_manual<
+        's,
+        'w,
+        QF: Fetch<'w, 's, State = Q::State>,
+        const N: usize,
+    >(
+        &'s self,
+        world: &'w World,
+        entities: [Entity; N],
+        last_change_tick: u32,
+        change_tick: u32,
+    ) -> Result<[<QF as Fetch<'w, 's>>::Item; N], QueryEntityError> {
+        let array_of_results = entities.map(|entity| {
+            self.get_unchecked_manual::<QF>(world, entity, last_change_tick, change_tick)
+        });
+
+        // If any of the entities were not present, return an error
+        for result in &array_of_results {
+            if let Err(QueryEntityError::NoSuchEntity(entity)) = result {
+                return Err(QueryEntityError::NoSuchEntity(*entity));
+            }
+        }
+
+        // Since we have verified that all entities are present, we can safely unwrap
+        Ok(array_of_results.map(|result| result.unwrap()))
     }
 
     /// Returns an [`Iterator`] over the query results for the given [`World`].
@@ -889,4 +895,18 @@ pub enum QueryEntityError {
     NoSuchEntity(Entity),
     #[error("The entity was requested mutably more than once.")]
     AliasedMutability(Entity),
+}
+
+#[inline]
+pub(crate) fn verify_entities_unique<const N: usize>(
+    entities: [Entity; N],
+) -> Result<(), QueryEntityError> {
+    for i in 0..N {
+        for j in 0..i {
+            if entities[i] == entities[j] {
+                return Err(QueryEntityError::AliasedMutability(entities[i]));
+            }
+        }
+    }
+    Ok(())
 }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -175,8 +175,8 @@ where
 
         // If any of the entities were not present, return an error
         for result in &array_of_results {
-            if result.is_err() {
-                return Err(QueryEntityError::NoSuchEntity);
+            if let Err(QueryEntityError::NoSuchEntity(entity)) = result {
+                return Err(QueryEntityError::NoSuchEntity(*entity));
             }
         }
 
@@ -214,7 +214,7 @@ where
         for i in 0..N {
             for j in 0..i {
                 if entities[i] == entities[j] {
-                    return Err(QueryEntityError::AliasedMutability);
+                    return Err(QueryEntityError::AliasedMutability(entities[i]));
                 }
             }
         }
@@ -233,8 +233,8 @@ where
 
         // If any of the entities were not present, return an error
         for result in &array_of_results {
-            if result.is_err() {
-                return Err(QueryEntityError::NoSuchEntity);
+            if let Err(QueryEntityError::NoSuchEntity(entity)) = result {
+                return Err(QueryEntityError::NoSuchEntity(*entity));
             }
         }
 
@@ -298,7 +298,7 @@ where
         let location = world
             .entities
             .get(entity)
-            .ok_or(QueryEntityError::NoSuchEntity)?;
+            .ok_or(QueryEntityError::NoSuchEntity(entity))?;
         if !self
             .matched_archetypes
             .contains(location.archetype_id.index())
@@ -803,13 +803,13 @@ where
 }
 
 /// An error that occurs when retrieving a specific [`Entity`]'s query result.
-// TODO: return the TypeID or invalid Entity as part of this error
+// TODO: return the type_name as part of this error
 #[derive(Error, Debug)]
 pub enum QueryEntityError {
     #[error("The given entity does not have the requested component.")]
     QueryDoesNotMatch,
     #[error("The requested entity does not exist.")]
-    NoSuchEntity,
+    NoSuchEntity(Entity),
     #[error("The entity was requested mutably more than once.")]
-    AliasedMutability,
+    AliasedMutability(Entity),
 }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -370,6 +370,8 @@ where
         last_change_tick: u32,
         change_tick: u32,
     ) -> Result<[<Q::ReadOnlyFetch as Fetch<'w, 's>>::Item; N], QueryEntityError> {
+        self.validate_world(world);
+
         // SAFE: fetch is read-only
         let array_of_results = unsafe {
             entities.map(|entity| {
@@ -408,6 +410,8 @@ where
         last_change_tick: u32,
         change_tick: u32,
     ) -> Result<[<Q::Fetch as Fetch<'w, 's>>::Item; N], QueryEntityError> {
+        self.validate_world(world);
+
         // Verify that all entities are unique
         for i in 0..N {
             for j in 0..i {
@@ -998,5 +1002,35 @@ mod tests {
             },
             QueryEntityError::AliasedMutability(entities[9])
         );
+    }
+
+    #[test]
+    #[should_panic]
+    fn right_world_get() {
+        let mut world_1 = World::new();
+        let world_2 = World::new();
+
+        let mut query_state = world_1.query::<Entity>();
+        let _panics = query_state.get(&world_2, Entity::from_raw(0));
+    }
+
+    #[test]
+    #[should_panic]
+    fn right_world_get_multiple() {
+        let mut world_1 = World::new();
+        let world_2 = World::new();
+
+        let mut query_state = world_1.query::<Entity>();
+        let _panics = query_state.get_multiple(&world_2, []);
+    }
+
+    #[test]
+    #[should_panic]
+    fn right_world_get_multiple_mut() {
+        let mut world_1 = World::new();
+        let mut world_2 = World::new();
+
+        let mut query_state = world_1.query::<Entity>();
+        let _panics = query_state.get_multiple_mut(&mut world_2, []);
     }
 }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -375,7 +375,6 @@ where
         last_change_tick: u32,
         change_tick: u32,
     ) -> Result<[<Q::ReadOnlyFetch as Fetch<'w, 's>>::Item; N], QueryEntityError> {
-        self.validate_world(world);
 
         // SAFE: fetch is read-only
         // and world must be validated

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -375,7 +375,6 @@ where
         last_change_tick: u32,
         change_tick: u32,
     ) -> Result<[<Q::ReadOnlyFetch as Fetch<'w, 's>>::Item; N], QueryEntityError> {
-
         // SAFE: fetch is read-only
         // and world must be validated
         let array_of_results = entities.map(|entity| {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -164,6 +164,7 @@ where
     ///
     /// ```rust
     /// use bevy_ecs::prelude::*;
+    /// use bevy_ecs::query::QueryEntityError;
     ///
     /// #[derive(Component, PartialEq, Debug)]
     /// struct A(usize);
@@ -183,7 +184,11 @@ where
     ///
     /// let component_values = query_state.get_multiple(&world, entities).unwrap();
     ///
-    /// assert_eq!(component_values, [&A(0), &A(1), &A(2)])
+    /// assert_eq!(component_values, [&A(0), &A(1), &A(2)]);
+    ///
+    /// let wrong_entity = Entity::from_raw(365);
+    ///
+    /// assert_eq!(query_state.get_multiple(&world, [wrong_entity]), Err(QueryEntityError::NoSuchEntity(wrong_entity)));
     /// ```
     #[inline]
     pub fn get_multiple<'w, 's, const N: usize>(
@@ -242,6 +247,7 @@ where
     ///
     /// ```rust
     /// use bevy_ecs::prelude::*;
+    /// use bevy_ecs::query::QueryEntityError;
     ///
     /// #[derive(Component, PartialEq, Debug)]
     /// struct A(usize);
@@ -267,7 +273,12 @@ where
     ///
     /// let component_values = query_state.get_multiple(&world, entities).unwrap();
     ///
-    /// assert_eq!(component_values, [&A(5), &A(6), &A(7)])
+    /// assert_eq!(component_values, [&A(5), &A(6), &A(7)]);
+    ///
+    /// let wrong_entity = Entity::from_raw(365);
+    ///
+    /// assert_eq!(query_state.get_multiple_mut(&mut world, [wrong_entity]), Err(QueryEntityError::NoSuchEntity(wrong_entity)));
+    /// assert_eq!(query_state.get_multiple_mut(&mut world, [entities[0], entities[0]]), Err(QueryEntityError::AliasedMutability(entities[0])));
     /// ```
     #[inline]
     pub fn get_multiple_mut<'w, 's, const N: usize>(
@@ -870,7 +881,7 @@ where
 
 /// An error that occurs when retrieving a specific [`Entity`]'s query result.
 // TODO: return the type_name as part of this error
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Clone, Copy)]
 pub enum QueryEntityError {
     #[error("The given entity does not have the requested component.")]
     QueryDoesNotMatch,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -170,13 +170,8 @@ where
     /// struct A(usize);
     ///
     /// let mut world = World::new();
-    /// let mut entities: [Entity; 3] = [Entity::from_raw(0); 3];
-    ///
-    /// world.spawn().insert(A(42));
-    ///
-    /// for i in 0..3 {
-    ///     entities[i] = world.spawn().insert(A(i)).id();
-    /// }
+    /// let entity_vec: Vec<Entity> = (0..3).map(|i|world.spawn().insert(A(i)).id()).collect();
+    /// let entities: [Entity; 3] = entity_vec.try_into().unwrap();
     ///
     /// world.spawn().insert(A(73));
     ///
@@ -238,13 +233,9 @@ where
     /// struct A(usize);
     ///
     /// let mut world = World::new();
-    /// let mut entities: [Entity; 3] = [Entity::from_raw(0); 3];
     ///
-    /// world.spawn().insert(A(42));
-    ///
-    /// for i in 0..3 {
-    ///     entities[i] = world.spawn().insert(A(i)).id();
-    /// }
+    /// let entities: Vec<Entity> = (0..3).map(|i|world.spawn().insert(A(i)).id()).collect();
+    /// let entities: [Entity; 3] = entities.try_into().unwrap();
     ///
     /// world.spawn().insert(A(73));
     ///
@@ -260,7 +251,7 @@ where
     ///
     /// assert_eq!(component_values, [&A(5), &A(6), &A(7)]);
     ///
-    /// let wrong_entity = Entity::from_raw(365);
+    /// let wrong_entity = world.spawn().id();
     ///
     /// assert_eq!(query_state.get_multiple_mut(&mut world, [wrong_entity]).unwrap_err(), QueryEntityError::NoSuchEntity(wrong_entity));
     /// assert_eq!(query_state.get_multiple_mut(&mut world, [entities[0], entities[0]]).unwrap_err(), QueryEntityError::AliasedMutability(entities[0]));

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -159,6 +159,32 @@ where
     /// returned instead.
     ///
     /// Note that the unlike [`QueryState::get_multiple_mut`], the entities passed in do not need to be unique.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bevy_ecs::prelude::*;
+    ///
+    /// #[derive(Component, PartialEq, Debug)]
+    /// struct A(usize);
+    ///
+    /// let mut world = World::new();
+    /// let mut entities: [Entity; 3] = [Entity::from_raw(0); 3];
+    ///
+    /// world.spawn().insert(A(42));
+    ///
+    /// for i in 0..3 {
+    ///     entities[i] = world.spawn().insert(A(i)).id();
+    /// }
+    ///
+    /// world.spawn().insert(A(73));
+    ///
+    /// let mut query_state = world.query::<&A>();
+    ///
+    /// let component_values = query_state.get_multiple(&world, entities).unwrap();
+    ///
+    /// assert_eq!(component_values, [&A(0), &A(1), &A(2)])
+    /// ```
     #[inline]
     pub fn get_multiple<'w, 's, const N: usize>(
         &'s mut self,
@@ -213,6 +239,36 @@ where
     ///
     /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is
     /// returned instead.
+    ///
+    /// ```rust
+    /// use bevy_ecs::prelude::*;
+    ///
+    /// #[derive(Component, PartialEq, Debug)]
+    /// struct A(usize);
+    ///
+    /// let mut world = World::new();
+    /// let mut entities: [Entity; 3] = [Entity::from_raw(0); 3];
+    ///
+    /// world.spawn().insert(A(42));
+    ///
+    /// for i in 0..3 {
+    ///     entities[i] = world.spawn().insert(A(i)).id();
+    /// }
+    ///
+    /// world.spawn().insert(A(73));
+    ///
+    /// let mut query_state = world.query::<&mut A>();
+    ///
+    /// let mut mutable_component_values = query_state.get_multiple_mut(&mut world, entities).unwrap();
+    ///
+    /// for mut a in mutable_component_values.iter_mut(){
+    ///     a.0 += 5;
+    /// }
+    ///
+    /// let component_values = query_state.get_multiple(&world, entities).unwrap();
+    ///
+    /// assert_eq!(component_values, [&A(5), &A(6), &A(7)])
+    /// ```
     #[inline]
     pub fn get_multiple_mut<'w, 's, const N: usize>(
         &'s mut self,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -153,6 +153,12 @@ where
         }
     }
 
+    /// Returns the read-only query results for the given array of [`Entity`].
+    ///
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is
+    /// returned instead.
+    ///
+    /// Note that the unlike [`QueryState::get_multiple_mut`], the entities passed in do not need to be unique.
     #[inline]
     pub fn get_multiple<'w, 's, const N: usize>(
         &'s mut self,
@@ -203,6 +209,10 @@ where
         }
     }
 
+    /// Returns the query results for the given array of [`Entity`].
+    ///
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is
+    /// returned instead.
     #[inline]
     pub fn get_multiple_mut<'w, 's, const N: usize>(
         &'s mut self,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -751,10 +751,13 @@ where
 }
 
 /// An error that occurs when retrieving a specific [`Entity`]'s query result.
+// TODO: return the TypeID or invalid Entity as part of this error
 #[derive(Error, Debug)]
 pub enum QueryEntityError {
     #[error("The given entity does not have the requested component.")]
     QueryDoesNotMatch,
     #[error("The requested entity does not exist.")]
     NoSuchEntity,
+    #[error("The entity was requested mutably more than once.")]
+    AliasedMutability,
 }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -275,7 +275,7 @@ where
 
         // SAFE: method requires exclusive world access
         unsafe {
-            self.get_multiple_unchecked_manual::<Q::Fetch, N>(
+            self.get_multiple_unchecked_manual(
                 world,
                 entities,
                 world.last_change_tick(),
@@ -400,18 +400,13 @@ where
     ///
     /// This does not check for unique access to subsets of the entity-component data.
     /// To be safe, make sure mutable queries have unique access to the components they query.
-    pub(crate) unsafe fn get_multiple_unchecked_manual<
-        's,
-        'w,
-        QF: Fetch<'w, 's, State = Q::State>,
-        const N: usize,
-    >(
+    pub(crate) unsafe fn get_multiple_unchecked_manual<'s, 'w, const N: usize>(
         &'s self,
         world: &'w World,
         entities: [Entity; N],
         last_change_tick: u32,
         change_tick: u32,
-    ) -> Result<[<QF as Fetch<'w, 's>>::Item; N], QueryEntityError> {
+    ) -> Result<[<Q::Fetch as Fetch<'w, 's>>::Item; N], QueryEntityError> {
         // Verify that all entities are unique
         for i in 0..N {
             for j in 0..i {
@@ -422,7 +417,7 @@ where
         }
 
         let array_of_results = entities.map(|entity| {
-            self.get_unchecked_manual::<QF>(world, entity, last_change_tick, change_tick)
+            self.get_unchecked_manual::<Q::Fetch>(world, entity, last_change_tick, change_tick)
         });
 
         // If any of the entities were not present, return an error

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -251,11 +251,11 @@ where
     ///
     /// assert_eq!(component_values, [&A(5), &A(6), &A(7)]);
     ///
-    /// let wrong_entity = World::from_raw(57);
+    /// let wrong_entity = Entity::from_raw(57);
     /// let invalid_entity = world.spawn().id();
     ///
     /// assert_eq!(query_state.get_multiple_mut(&mut world, [wrong_entity]).unwrap_err(), QueryEntityError::NoSuchEntity(wrong_entity));
-    /// assert_eq!(query_state.get_multiple_mut(&mut world, [invalid_entity]).unwrap_err(), QueryEntityError::QueryDoesNotMatch);
+    /// assert_eq!(query_state.get_multiple_mut(&mut world, [invalid_entity]).unwrap_err(), QueryEntityError::QueryDoesNotMatch(invalid_entity));
     /// assert_eq!(query_state.get_multiple_mut(&mut world, [entities[0], entities[0]]).unwrap_err(), QueryEntityError::AliasedMutability(entities[0]));
     /// ```
     #[inline]

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -153,6 +153,15 @@ where
         }
     }
 
+    #[inline]
+    pub fn get_multiple<'w, 's, const N: usize>(
+        &'s mut self,
+        world: &'w World,
+        entities: [Entity; N],
+    ) -> Result<[<Q::ReadOnlyFetch as Fetch<'w, 's>>::Item; N], QueryEntityError> {
+        todo!()
+    }
+
     /// Gets the query result for the given [`World`] and [`Entity`].
     #[inline]
     pub fn get_mut<'w, 's>(
@@ -170,6 +179,15 @@ where
                 world.read_change_tick(),
             )
         }
+    }
+
+    #[inline]
+    pub fn get_multiple_mut<'w, 's, const N: usize>(
+        &'s mut self,
+        world: &'w mut World,
+        entities: [Entity; N],
+    ) -> Result<[<Q::ReadOnlyFetch as Fetch<'w, 's>>::Item; N], QueryEntityError> {
+        todo!()
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -265,10 +265,9 @@ where
         entities: [Entity; N],
     ) -> Result<[<Q::Fetch as Fetch<'w, 's>>::Item; N], QueryEntityError> {
         self.update_archetypes(world);
-        self.validate_world(world);
 
         // SAFE: method requires exclusive world access
-        // and world has been validated
+        // and world has been validated via update_archetypes
         unsafe {
             self.get_multiple_unchecked_manual(
                 world,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -277,8 +277,8 @@ where
     ///
     /// let wrong_entity = Entity::from_raw(365);
     ///
-    /// assert_eq!(query_state.get_multiple_mut(&mut world, [wrong_entity]), Err(QueryEntityError::NoSuchEntity(wrong_entity)));
-    /// assert_eq!(query_state.get_multiple_mut(&mut world, [entities[0], entities[0]]), Err(QueryEntityError::AliasedMutability(entities[0])));
+    /// assert_eq!(query_state.get_multiple_mut(&mut world, [wrong_entity]).unwrap_err(), QueryEntityError::NoSuchEntity(wrong_entity));
+    /// assert_eq!(query_state.get_multiple_mut(&mut world, [entities[0], entities[0]]).unwrap_err(), QueryEntityError::AliasedMutability(entities[0]));
     /// ```
     #[inline]
     pub fn get_multiple_mut<'w, 's, const N: usize>(

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -376,10 +376,11 @@ where
         };
 
         // TODO: Replace with TryMap once https://github.com/rust-lang/rust/issues/79711 is stabilized
-        // If any of the entities were not present, return an error
+        // If any of the get calls failed, bubble up the error
         for result in &array_of_results {
-            if let Err(QueryEntityError::NoSuchEntity(entity)) = result {
-                return Err(QueryEntityError::NoSuchEntity(*entity));
+            match result {
+                Ok(_) => (),
+                Err(error) => return Err(*error),
             }
         }
 
@@ -416,10 +417,11 @@ where
             self.get_unchecked_manual::<Q::Fetch>(world, entity, last_change_tick, change_tick)
         });
 
-        // If any of the entities were not present, return an error
+        // If any of the get calls failed, bubble up the error
         for result in &array_of_results {
-            if let Err(QueryEntityError::NoSuchEntity(entity)) = result {
-                return Err(QueryEntityError::NoSuchEntity(*entity));
+            match result {
+                Ok(_) => (),
+                Err(error) => return Err(*error),
             }
         }
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -382,6 +382,7 @@ where
             })
         };
 
+        // TODO: Replace with TryMap once https://github.com/rust-lang/rust/issues/79711 is stabilized
         // If any of the entities were not present, return an error
         for result in &array_of_results {
             if let Err(QueryEntityError::NoSuchEntity(entity)) = result {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -338,7 +338,7 @@ where
             .matched_archetypes
             .contains(location.archetype_id.index())
         {
-            return Err(QueryEntityError::QueryDoesNotMatch);
+            return Err(QueryEntityError::QueryDoesNotMatch(entity));
         }
         let archetype = &world.archetypes[location.archetype_id];
         let mut fetch = QF::init(world, &self.fetch_state, last_change_tick, change_tick);
@@ -350,7 +350,7 @@ where
         if filter.archetype_filter_fetch(location.index) {
             Ok(fetch.archetype_fetch(location.index))
         } else {
-            Err(QueryEntityError::QueryDoesNotMatch)
+            Err(QueryEntityError::QueryDoesNotMatch(entity))
         }
     }
 
@@ -919,7 +919,7 @@ where
 #[derive(Error, Debug, PartialEq, Clone, Copy)]
 pub enum QueryEntityError {
     #[error("The given entity does not have the requested component.")]
-    QueryDoesNotMatch,
+    QueryDoesNotMatch(Entity),
     #[error("The requested entity does not exist.")]
     NoSuchEntity(Entity),
     #[error("The entity was requested mutably more than once.")]

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -251,9 +251,11 @@ where
     ///
     /// assert_eq!(component_values, [&A(5), &A(6), &A(7)]);
     ///
-    /// let wrong_entity = world.spawn().id();
+    /// let wrong_entity = World::from_raw(57);
+    /// let invalid_entity = world.spawn().id();
     ///
     /// assert_eq!(query_state.get_multiple_mut(&mut world, [wrong_entity]).unwrap_err(), QueryEntityError::NoSuchEntity(wrong_entity));
+    /// assert_eq!(query_state.get_multiple_mut(&mut world, [invalid_entity]).unwrap_err(), QueryEntityError::QueryDoesNotMatch);
     /// assert_eq!(query_state.get_multiple_mut(&mut world, [entities[0], entities[0]]).unwrap_err(), QueryEntityError::AliasedMutability(entities[0]));
     /// ```
     #[inline]

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -637,8 +637,8 @@ where
 
         // If any of the entities were not present, return an error
         for result in &array_of_results {
-            if result.is_err() {
-                return Err(QueryEntityError::NoSuchEntity);
+            if let Err(QueryEntityError::NoSuchEntity(entity)) = result {
+                return Err(QueryEntityError::NoSuchEntity(*entity));
             }
         }
 
@@ -703,7 +703,7 @@ where
         for i in 0..N {
             for j in 0..i {
                 if entities[i] == entities[j] {
-                    return Err(QueryEntityError::AliasedMutability);
+                    return Err(QueryEntityError::AliasedMutability(entities[i]));
                 }
             }
         }
@@ -724,8 +724,8 @@ where
 
         // If any of the entities were not present, return an error
         for result in &array_of_results {
-            if result.is_err() {
-                return Err(QueryEntityError::NoSuchEntity);
+            if let Err(QueryEntityError::NoSuchEntity(entity)) = result {
+                return Err(QueryEntityError::NoSuchEntity(*entity));
             }
         }
 

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -646,6 +646,14 @@ where
         Ok(array_of_results.map(|result| result.unwrap()))
     }
 
+    #[inline]
+    pub fn multiple<const N: usize>(
+        &'s self,
+        entities: [Entity; N],
+    ) -> [<Q::ReadOnlyFetch as Fetch<'_, 's>>::Item; N] {
+        self.get_multiple(entities).unwrap()
+    }
+
     /// Returns the query result for the given [`Entity`].
     ///
     /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is
@@ -721,6 +729,14 @@ where
 
         // Since we have verified that all entities are present, we can safely unwrap
         Ok(array_of_results.map(|result| result.unwrap()))
+    }
+
+    #[inline]
+    pub fn multiple_mut<const N: usize>(
+        &'s mut self,
+        entities: [Entity; N],
+    ) -> [<Q::Fetch as Fetch<'_, 's>>::Item; N] {
+        self.get_multiple_mut(entities).unwrap()
     }
 
     /// Returns the query result for the given [`Entity`].

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -709,7 +709,9 @@ where
         }
 
         let array_of_results = entities.map(|entity| {
-            // SAFETY: query is read only
+            // SAFETY: Entities are checked for uniqueness above,
+            // the scheduler ensure that we do not have conflicting world access,
+            // and we require &mut self to avoid any other simultaneous operations on this Query
             unsafe {
                 self.state.get_unchecked_manual::<Q::Fetch>(
                     self.world,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -736,7 +736,7 @@ where
     ) -> Result<[<Q::Fetch as Fetch<'_, 's>>::Item; N], QueryEntityError> {
         // SAFE: scheduler ensures safe Query world access
         unsafe {
-            self.state.get_multiple_unchecked_manual::<Q::Fetch, N>(
+            self.state.get_multiple_unchecked_manual(
                 self.world,
                 entities,
                 self.last_change_tick,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -618,6 +618,14 @@ where
         }
     }
 
+    #[inline]
+    pub fn get_multiple<const N: usize>(
+        &'s self,
+        entities: [Entity; N],
+    ) -> Result<[<Q::ReadOnlyFetch as Fetch<'_, 's>>::Item; N], QueryEntityError> {
+        todo!()
+    }
+
     /// Returns the query result for the given [`Entity`].
     ///
     /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is
@@ -657,6 +665,14 @@ where
                 self.change_tick,
             )
         }
+    }
+
+    #[inline]
+    pub fn get_multiple_mut<const N: usize>(
+        &'s mut self,
+        entities: [Entity; N],
+    ) -> Result<[<Q::Fetch as Fetch>::Item; N], QueryEntityError> {
+        todo!()
     }
 
     /// Returns the query result for the given [`Entity`].

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -624,6 +624,8 @@ where
     /// returned instead.
     ///
     /// Note that the unlike [`Query::get_multiple_mut`], the entities passed in do not need to be unique.
+    ///
+    /// See [`Query::multiple`] for the infallible equivalent.
     #[inline]
     pub fn get_multiple<const N: usize>(
         &'s self,
@@ -653,6 +655,40 @@ where
     }
 
     /// Returns the read-only query items for the provided array of [`Entity`]
+    ///
+    /// See [`Query::get_multiple`] for the [`Result`]-returning equivalent.
+    ///
+    /// # Examples
+    /// ```rust, no_run
+    /// use bevy_ecs::prelude::*;
+    ///
+    /// #[derive(Component)]
+    /// struct Targets([Entity; 3]);
+    ///
+    /// #[derive(Component)]
+    /// struct Position{
+    ///     x: i8,
+    ///     y: i8
+    /// };
+    ///
+    /// impl Position {
+    ///     fn distance(&self, other: &Position) -> i8 {
+    ///         // Manhattan distance is way easier to compute!
+    ///         (self.x - other.x).abs() + (self.y - other.y).abs()
+    ///     }
+    /// }
+    ///
+    /// fn check_all_targets_in_range(targeting_query: Query<(Entity, &Targets, &Position)>, targets_query: Query<&Position>){
+    ///     for (targeting_entity, targets, origin) in targeting_query.iter(){
+    ///         // We can use "destructuring" to unpack the results nicely
+    ///         let [target_1, target_2, target_3] = targets_query.multiple(targets.0);
+    ///         
+    ///         assert!(target_1.distance(origin) <= 5);
+    ///         assert!(target_2.distance(origin) <= 5);
+    ///         assert!(target_3.distance(origin) <= 5);
+    ///     }
+    /// }
+    /// ```
     #[inline]
     pub fn multiple<const N: usize>(
         &'s self,
@@ -706,6 +742,8 @@ where
     ///
     /// In case of a nonexisting entity, duplicate entities or mismatched component, a [`QueryEntityError`] is
     /// returned instead.
+    ///
+    /// See [`Query::multiple_mut`] for the infallible equivalent.
     #[inline]
     pub fn get_multiple_mut<const N: usize>(
         &'s mut self,
@@ -745,6 +783,46 @@ where
     }
 
     /// Returns the query items for the provided array of [`Entity`]
+    ///
+    /// See [`Query::get_multiple_mut`] for the [`Result`]-returning equivalent.
+    ///
+    /// # Examples
+    ///
+    /// ```rust, no_run
+    /// use bevy_ecs::prelude::*;
+    ///
+    /// #[derive(Component)]
+    /// struct Spring{
+    ///     connected_entities: [Entity; 2],
+    ///     strength: f32,
+    /// }
+    ///
+    /// #[derive(Component)]
+    /// struct Position {
+    ///     x: f32,
+    ///     y: f32,
+    /// }
+    ///
+    /// #[derive(Component)]
+    /// struct Force {
+    ///     x: f32,
+    ///     y: f32,
+    /// }
+    ///
+    /// fn spring_forces(spring_query: Query<&Spring>, mut mass_query: Query<(&Position, &mut Force)>){
+    ///     for spring in spring_query.iter(){
+    ///          // We can use "destructuring" to unpack our query items nicely
+    ///          let [(position_1, mut force_1), (position_2, mut force_2)] = mass_query.multiple_mut(spring.connected_entities);
+    ///             
+    ///          force_1.x += spring.strength * (position_1.x - position_2.x);
+    ///          force_1.y += spring.strength * (position_1.y - position_2.y);
+    ///          
+    ///          // Silence borrow-checker: I have split your mutable borrow!
+    ///          force_2.x += spring.strength * (position_2.x - position_1.x);
+    ///          force_2.y += spring.strength * (position_2.y - position_1.y);
+    ///     }
+    /// }
+    /// ```
     #[inline]
     pub fn multiple_mut<const N: usize>(
         &'s mut self,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -618,6 +618,12 @@ where
         }
     }
 
+    /// Returns the read-only query results for the given array of [`Entity`].
+    ///
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is
+    /// returned instead.
+    ///
+    /// Note that the unlike [`Query::get_multiple_mut`], the entities passed in do not need to be unique.
     #[inline]
     pub fn get_multiple<const N: usize>(
         &'s self,
@@ -646,6 +652,7 @@ where
         Ok(array_of_results.map(|result| result.unwrap()))
     }
 
+    /// Returns the read-only query items for the provided array of [`Entity`]
     #[inline]
     pub fn multiple<const N: usize>(
         &'s self,
@@ -695,6 +702,10 @@ where
         }
     }
 
+    /// Returns the query results for the given array of [`Entity`].
+    ///
+    /// In case of a nonexisting entity, duplicate entities or mismatched component, a [`QueryEntityError`] is
+    /// returned instead.
     #[inline]
     pub fn get_multiple_mut<const N: usize>(
         &'s mut self,
@@ -733,6 +744,7 @@ where
         Ok(array_of_results.map(|result| result.unwrap()))
     }
 
+    /// Returns the query items for the provided array of [`Entity`]
     #[inline]
     pub fn multiple_mut<const N: usize>(
         &'s mut self,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -631,12 +631,15 @@ where
         &self,
         entities: [Entity; N],
     ) -> Result<[<Q::ReadOnlyFetch as Fetch<'_, 's>>::Item; N], QueryEntityError> {
-        self.state.get_multiple_read_only_manual(
-            self.world,
-            entities,
-            self.last_change_tick,
-            self.change_tick,
-        )
+        // SAFE: it is the scheduler's responsibility to ensure that `Query` is never handed out on the wrong `World`.
+        unsafe {
+            self.state.get_multiple_read_only_manual(
+                self.world,
+                entities,
+                self.last_change_tick,
+                self.change_tick,
+            )
+        }
     }
 
     /// Returns the read-only query items for the provided array of [`Entity`]

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -628,7 +628,7 @@ where
     /// See [`Query::multiple`] for the infallible equivalent.
     #[inline]
     pub fn get_multiple<const N: usize>(
-        &'s self,
+        &self,
         entities: [Entity; N],
     ) -> Result<[<Q::ReadOnlyFetch as Fetch<'_, 's>>::Item; N], QueryEntityError> {
         let array_of_results = entities.map(|entity| {
@@ -691,7 +691,7 @@ where
     /// ```
     #[inline]
     pub fn multiple<const N: usize>(
-        &'s self,
+        &self,
         entities: [Entity; N],
     ) -> [<Q::ReadOnlyFetch as Fetch<'_, 's>>::Item; N] {
         self.get_multiple(entities).unwrap()
@@ -746,9 +746,9 @@ where
     /// See [`Query::multiple_mut`] for the infallible equivalent.
     #[inline]
     pub fn get_multiple_mut<const N: usize>(
-        &'s mut self,
+        &mut self,
         entities: [Entity; N],
-    ) -> Result<[<Q::Fetch as Fetch>::Item; N], QueryEntityError> {
+    ) -> Result<[<Q::Fetch as Fetch<'_, 's>>::Item; N], QueryEntityError> {
         for i in 0..N {
             for j in 0..i {
                 if entities[i] == entities[j] {
@@ -825,7 +825,7 @@ where
     /// ```
     #[inline]
     pub fn multiple_mut<const N: usize>(
-        &'s mut self,
+        &mut self,
         entities: [Entity; N],
     ) -> [<Q::Fetch as Fetch<'_, 's>>::Item; N] {
         self.get_multiple_mut(entities).unwrap()

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_lifetime_safety.rs
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_lifetime_safety.rs
@@ -1,0 +1,13 @@
+use bevy_ecs::prelude::*;
+
+#[derive(Component)]
+struct A(usize);
+
+fn system(mut query: Query<&mut A>, e: Res<Entity>) {
+    let a1 = query.get_multiple([*e, *e]).unwrap();
+    let a2 = query.get_mut(*e).unwrap();
+    // this should fail to compile
+    println!("{} {}", a1[0].0, a2.0);
+}
+
+fn main() {}

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_lifetime_safety.stderr
@@ -1,0 +1,10 @@
+error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
+  --> tests/ui/system_query_get_multiple_lifetime_safety.rs:8:14
+   |
+7  |     let a1 = query.get_multiple([*e, *e]).unwrap();
+   |              ---------------------------- immutable borrow occurs here
+8  |     let a2 = query.get_mut(*e).unwrap();
+   |              ^^^^^^^^^^^^^^^^^ mutable borrow occurs here
+9  |     // this should fail to compile
+10 |     println!("{} {}", a1[0].0, a2.0);
+   |                       ----- immutable borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_mut_lifetime_safety.rs
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_mut_lifetime_safety.rs
@@ -7,7 +7,7 @@ fn system(mut query: Query<&mut A>, e: Res<Entity>) {
     let a1 = query.get_multiple_mut([*e, *e]).unwrap();
     let a2 = query.get_mut(*e).unwrap();
     // this should fail to compile
-    println!("{} {}", a1.0, a2.0);
+    println!("{} {}", a1[0].0, a2.0);
 }
 
 fn main() {}

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_mut_lifetime_safety.rs
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_mut_lifetime_safety.rs
@@ -1,0 +1,13 @@
+use bevy_ecs::prelude::*;
+
+#[derive(Component)]
+struct A(usize);
+
+fn system(mut query: Query<&mut A>, e: Res<Entity>) {
+    let a1 = query.get_multiple_mut([*e, *e]).unwrap();
+    let a2 = query.get_mut(*e).unwrap();
+    // this should fail to compile
+    println!("{} {}", a1.0, a2.0);
+}
+
+fn main() {}

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_mut_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_mut_lifetime_safety.stderr
@@ -1,0 +1,10 @@
+error[E0499]: cannot borrow `query` as mutable more than once at a time
+  --> tests/ui/system_query_get_multiple_mut_lifetime_safety.rs:8:14
+   |
+7  |     let a1 = query.get_multiple_mut([*e, *e]).unwrap();
+   |              ----------------- first mutable borrow occurs here
+8  |     let a2 = query.get_mut(*e).unwrap();
+   |              ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+9  |     // this should fail to compile
+10 |     println!("{} {}", a1.0, a2.0);
+   |                       -- first borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_mut_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_mut_lifetime_safety.stderr
@@ -2,9 +2,9 @@ error[E0499]: cannot borrow `query` as mutable more than once at a time
   --> tests/ui/system_query_get_multiple_mut_lifetime_safety.rs:8:14
    |
 7  |     let a1 = query.get_multiple_mut([*e, *e]).unwrap();
-   |              ----------------- first mutable borrow occurs here
+   |              -------------------------------- first mutable borrow occurs here
 8  |     let a2 = query.get_mut(*e).unwrap();
    |              ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
 9  |     // this should fail to compile
-10 |     println!("{} {}", a1.0, a2.0);
-   |                       -- first borrow later used here
+10 |     println!("{} {}", a1[0].0, a2.0);
+   |                       ----- first borrow later used here


### PR DESCRIPTION
# Objective

- The inability to have multiple active mutable borrows into a query is a common source of borrow-checker pain for users.
- This is a pointless restriction if and only if we can guarantee that the entities they are accessing are unique.
- This could already by bypassed with get_unchecked, but that is an extremely unsafe API.
- Closes https://github.com/bevyengine/bevy/issues/2042.

## Solution

- Add `get_multiple`, `get_multiple_mut` and their unchecked equivalents (`multiple` and `multiple_mut`) to `Query` and `QueryState`.
- Improve the `QueryEntityError` type to provide more useful error information.

## Changelog

- Added `get_multiple`, `get_multiple_mut` and their unchecked equivalents (`multiple` and `multiple_mut`) to Query and QueryState.

## Migration Guide

- The `QueryEntityError` enum now has a `AliasedMutability variant, and returns the offending entity.

## Context

This is a fresh attempt at #3333; rebasing was behaving very badly and it was important to rebase on top of the recent query soundness fixes. Many thanks to all the reviewers in that thread, especially @BoxyUwU for the help with lifetimes.

## To-do

- [x] Add compile fail tests
- [x] Successfully deduplicate code
- [x] Decide what to do about failing doc tests
- [x] Get some reviews for lifetime soundness