### PR TITLE
Rename `reads_and_writes` field of `Access` to `reads`

### DIFF
--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -16,7 +16,7 @@ pub struct Access<T: SparseSetIndex> {
     reads: FixedBitSet,
     /// The values that can be written to
     writes: FixedBitSet,
-    marker: PhantomData<T>,
+    _marker: PhantomData<T>,
 }
 
 impl<T: SparseSetIndex> Default for Access<T> {
@@ -25,7 +25,7 @@ impl<T: SparseSetIndex> Default for Access<T> {
             reads_all: false,
             reads: Default::default(),
             writes: Default::default(),
-            marker: PhantomData,
+            _marker: PhantomData,
         }
     }
 }

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -7,9 +7,14 @@ use std::marker::PhantomData;
 /// This is used for ensuring systems are executed soundly.
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct Access<T: SparseSetIndex> {
+    /// Does this access require reading from all values?
     reads_all: bool,
-    /// A combined set of T read and write accesses.
+    /// The values that can be read from
+    ///
+    /// Note that the ability to write to data implies the ability to read from it,
+    /// and so this must always be a superset of `writes`.
     reads: FixedBitSet,
+    /// The values that can be written to
     writes: FixedBitSet,
     marker: PhantomData<T>,
 }
@@ -93,8 +98,7 @@ impl<T: SparseSetIndex> Access<T> {
         } else if other.reads_all {
             0 == self.writes.count_ones(..)
         } else {
-            self.writes.is_disjoint(&other.reads)
-                && self.reads.is_disjoint(&other.writes)
+            self.writes.is_disjoint(&other.reads) && self.reads.is_disjoint(&other.writes)
         }
     }
 


### PR DESCRIPTION
# Objective

- this field is confusingly named, as the ability to write to a field necessarily implies the ability to read
  - for an example of this friction, see https://github.com/bevyengine/bevy/pull/4166#discussion_r833616995 
- the logic here is `reads | writes == reads`, not `reads & writes`

## Solution

- rename field
- improve doc comments

## Additional Context

In an ideal world, this would look something like 

```rust
enum AccessLevel {
   Nothing,
   Reads,
   Writes,
}
```

Unfortunately, this is perf-critical code, so we're using a bitset to allow for quick comparisons.

If and when we want to extend `Access` to support more exotic access types (like `presence`  for the existence of a component type or `forge` for the ability to add components of that type), the name makes even less sense.

