### PR TITLE
[Merged by Bors] - CI runs `cargo miri test -p bevy_ecs`

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -13,6 +13,7 @@ status = [
     "check-missing-examples-in-docs",
     "check-unused-dependencies",
     "ci",
+    "miri",
     "check-benches",
 ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           # -Zmiri-ignore-leaks is needed because running bevy_ecs tests finds a memory leak but its impossible
           # to track down because allocids are nondeterministic.
           # -Zmiri-tag-raw-pointers is not strictly "necessary" but enables a lot of extra UB checks relating
-          # to raw pointer aliasing rules that we should be tryign to uphold.
+          # to raw pointer aliasing rules that we should be trying to uphold.
           MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-tag-raw-pointers
 
   check-benches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,13 @@ jobs:
       - name: CI job
         run: cargo miri test -p bevy_ecs
         env:
+          # -Zrandomize-layout makes sure we dont rely on the layout of anything that might change
           RUSTFLAGS: -Zrandomize-layout
+          # -Zmiri-disable-isolation is needed because our executor uses `fastrand` which accesses system time.
+          # -Zmiri-ignore-leaks is needed because running bevy_ecs tests finds a memory leak but its impossible
+          # to track down because allocids are nondeterministic.
+          # -Zmiri-tag-raw-pointers is not strictly "necessary" but enables a lot of extra UB checks relating
+          # to raw pointer aliasing rules that we should be tryign to uphold.
           MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-tag-raw-pointers
 
   check-benches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,32 @@ jobs:
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- nonlocal
 
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-ci-${{ hashFiles('**/Cargo.toml') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: miri
+          override: true
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+      - name: CI job
+        run: cargo miri test -p bevy_ecs
+        env:
+          RUSTFLAGS: -Zrandomize-layout
+          MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-tag-raw-pointers
+
   check-benches:
     runs-on: ubuntu-latest
     needs: ci

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -637,16 +637,16 @@ mod tests {
     #[test]
     fn table_add_remove_many() {
         let mut world = World::default();
-      #[cfg(miri)]
-      let (mut entities, to) = {
-          let to = 10;
-          (Vec::with_capacity(to), to)
-      };
-      #[cfg(not(miri))]
-      let (mut entities, to) = {
-          let to = 10_000;
-          (Vec::with_capacity(to), to)
-      };
+        #[cfg(miri)]
+        let (mut entities, to) = {
+            let to = 10;
+            (Vec::with_capacity(to), to)
+        };
+        #[cfg(not(miri))]
+        let (mut entities, to) = {
+            let to = 10_000;
+            (Vec::with_capacity(to), to)
+        };
 
         for _ in 0..to {
             entities.push(world.spawn().insert(B(0)).id());

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1614,3 +1614,11 @@ mod tests {
         );
     }
 }
+
+#[test]
+fn ub() {
+    #[allow(deref_nullptr)]
+    unsafe {
+        *std::ptr::null::<u8>()
+    };
+}

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -637,20 +637,16 @@ mod tests {
     #[test]
     fn table_add_remove_many() {
         let mut world = World::default();
-        #[cfg(miri)]
-        let mut entities = Vec::with_capacity(10);
-        #[cfg(not(miri))]
-        let mut entities = Vec::with_capacity(1_000);
-
-        let to;
-        #[cfg(miri)]
-        {
-            to = 10;
-        }
-        #[cfg(not(miri))]
-        {
-            to = 1000;
-        }
+      #[cfg(miri)]
+      let (mut entities, to) = {
+          let to = 10;
+          (Vec::with_capacity(to), to)
+      };
+      #[cfg(not(miri))]
+      let (mut entities, to) = {
+          let to = 10_000;
+          (Vec::with_capacity(to), to)
+      };
 
         for _ in 0..to {
             entities.push(world.spawn().insert(B(0)).id());

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1614,11 +1614,3 @@ mod tests {
         );
     }
 }
-
-#[test]
-fn ub() {
-    #[allow(deref_nullptr)]
-    unsafe {
-        *std::ptr::null::<u8>()
-    };
-}

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -637,8 +637,22 @@ mod tests {
     #[test]
     fn table_add_remove_many() {
         let mut world = World::default();
-        let mut entities = Vec::with_capacity(10_000);
-        for _ in 0..1000 {
+        #[cfg(miri)]
+        let mut entities = Vec::with_capacity(10);
+        #[cfg(not(miri))]
+        let mut entities = Vec::with_capacity(1_000);
+
+        let to;
+        #[cfg(miri)]
+        {
+            to = 10;
+        }
+        #[cfg(not(miri))]
+        {
+            to = 1000;
+        }
+
+        for _ in 0..to {
             entities.push(world.spawn().insert(B(0)).id());
         }
 

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["bevy"]
 
 [dependencies]
 futures-lite = "1.4.0"
-event-listener = "2.4.0"
+event-listener = "2.5.2"
 async-executor = "1.3.0"
 async-channel = "1.4.2"
 num_cpus = "1.0.1"

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -132,7 +132,8 @@ impl TaskPool {
                 #[cfg(miri)]
                 let _ = thread_name;
 
-                // miri does not support setting thread names `https://github.com/rust-lang/miri/issues/1717`
+                // miri does not support setting thread names
+                // TODO: change back when https://github.com/rust-lang/miri/issues/1717 is fixed
                 #[cfg(not(miri))]
                 let mut thread_builder = thread::Builder::new().name(thread_name);
                 #[cfg(miri)]

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -121,13 +121,22 @@ impl TaskPool {
                 let ex = Arc::clone(&executor);
                 let shutdown_rx = shutdown_rx.clone();
 
+                #[cfg(not(miri))]
                 let thread_name = if let Some(thread_name) = thread_name {
                     format!("{} ({})", thread_name, i)
                 } else {
                     format!("TaskPool ({})", i)
                 };
+                #[cfg(miri)]
+                let _ = i;
+                #[cfg(miri)]
+                let _ = thread_name;
 
+                // miri does not support setting thread names `https://github.com/rust-lang/miri/issues/1717`
+                #[cfg(not(miri))]
                 let mut thread_builder = thread::Builder::new().name(thread_name);
+                #[cfg(miri)]
+                let mut thread_builder = thread::Builder::new();
 
                 if let Some(stack_size) = stack_size {
                     thread_builder = thread_builder.stack_size(stack_size);

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -121,23 +121,23 @@ impl TaskPool {
                 let ex = Arc::clone(&executor);
                 let shutdown_rx = shutdown_rx.clone();
 
-                #[cfg(not(miri))]
-                let thread_name = if let Some(thread_name) = thread_name {
-                    format!("{} ({})", thread_name, i)
-                } else {
-                    format!("TaskPool ({})", i)
-                };
-                #[cfg(miri)]
-                let _ = i;
-                #[cfg(miri)]
-                let _ = thread_name;
-
                 // miri does not support setting thread names
                 // TODO: change back when https://github.com/rust-lang/miri/issues/1717 is fixed
                 #[cfg(not(miri))]
-                let mut thread_builder = thread::Builder::new().name(thread_name);
+                let mut thread_builder = {
+                    let thread_name = if let Some(thread_name) = thread_name {
+                        format!("{} ({})", thread_name, i)
+                    } else {
+                        format!("TaskPool ({})", i)
+                    };
+                    thread::Builder::new().name(thread_name)
+                };
                 #[cfg(miri)]
-                let mut thread_builder = thread::Builder::new();
+                let mut thread_builder = {
+                    let _ = i;
+                    let _ = thread_name;
+                    thread::Builder::new()
+                };
 
                 if let Some(stack_size) = stack_size {
                     thread_builder = thread_builder.stack_size(stack_size);


### PR DESCRIPTION
# Objective

Fixes #1529
Run bevy_ecs in miri

## Solution

- Don't set thread names when running in miri rust-lang/miri/issues/1717
- Update `event-listener` to `2.5.2` as previous versions have UB that is detected by miri: [event-listener commit](https://github.com/smol-rs/event-listener/commit/1fa31c553e37003cb116d9ed7bc40f36845ac8b5)
- Ignore memory leaks when running in miri as they are impossible to track down rust-lang/miri/issues/1481
- Make `table_add_remove_many` test less "many" because miri is really quite slow :)
- Make CI run `RUSTFLAGS="-Zrandomize-layout" MIRIFLAGS="-Zmiri-ignore-leaks -Zmiri-tag-raw-pointers -Zmiri-disable-isolation" cargo +nightly miri test -p bevy_ecs`
