### PR TITLE
[Merged by Bors] - Clean up Breakout logic

### DIFF
--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -81,11 +81,11 @@ struct Brick;
 // This bundle is a collection of the components that define a "wall" in our game
 #[derive(Bundle)]
 struct WallBundle {
-    collider: Collider,
     // You can nest bundles inside of other bundles like this
     // Allowing you to compose their functionality
     #[bundle]
     sprite_bundle: SpriteBundle,
+    collider: Collider,
 }
 
 /// Which side of the arena is this wall located on?

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -141,7 +141,7 @@ impl WallBundle {
                     // This is used to determine the order of our sprites
                     translation: location.position().extend(0.0),
                     // The z-scale of 2D objects must always be 1.0,
-                    // or their ordering will be affected in surpirising ways.
+                    // or their ordering will be affected in surprising ways.
                     // See https://github.com/bevyengine/bevy/issues/4149
                     scale: location.size().extend(1.0),
                     ..default()

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -13,8 +13,8 @@ const TIME_STEP: f32 = 1.0 / 60.0;
 // These constants are defined in `Transform` units.
 // Using the default 2D camera they correspond 1:1 with screen pixels.
 // The `const_vec3!` macros are needed as functions that operate on floats cannot be constant in Rust.
-const PADDLE_SIZE: Vec3 = const_vec3!([120.0, 30.0, 0.0]);
-const GAP_BETWEEN_PADDLE_AND_FLOOR: f32 = 100.0;
+const PADDLE_SIZE: Vec3 = const_vec3!([120.0, 20.0, 0.0]);
+const GAP_BETWEEN_PADDLE_AND_FLOOR: f32 = 60.0;
 const PADDLE_SPEED: f32 = 500.0;
 // How close can the paddle get to the wall
 const PADDLE_PADDING: f32 = 10.0;
@@ -35,17 +35,17 @@ const TOP_WALL: f32 = 300.;
 
 const BRICK_SIZE: Vec2 = const_vec2!([100., 30.]);
 // These values are exact
-const GAP_BETWEEN_PADDLE_AND_BRICKS: f32 = 120.0;
+const GAP_BETWEEN_PADDLE_AND_BRICKS: f32 = 270.0;
 const GAP_BETWEEN_BRICKS: f32 = 5.0;
 // These values are lower bounds, as the number of bricks is computed
-const GAP_BETWEEN_BRICKS_AND_CEILING: f32 = 50.0;
+const GAP_BETWEEN_BRICKS_AND_CEILING: f32 = 20.0;
 const GAP_BETWEEN_BRICKS_AND_SIDES: f32 = 20.0;
 
 const SCOREBOARD_FONT_SIZE: f32 = 40.0;
 const SCOREBOARD_TEXT_PADDING: Val = Val::Px(5.0);
 
 const BACKGROUND_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);
-const PADDLE_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
+const PADDLE_COLOR: Color = Color::rgb(0.3, 0.3, 0.7);
 const BALL_COLOR: Color = Color::rgb(1.0, 0.5, 0.5);
 const BRICK_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
 const WALL_COLOR: Color = Color::rgb(0.8, 0.8, 0.8);

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -229,9 +229,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(WallBundle::new(WallLocation::Top));
 
     // Add bricks
-    let bricks_width = BRICK_COLUMNS as f32 * (BRICK_SIZE.x + BRICK_SPACING) - BRICK_SPACING;
+    let brick_width = BRICK_COLUMNS as f32 * (BRICK_SIZE.x + BRICK_SPACING) - BRICK_SPACING;
     // center the bricks and move them up a bit
-    let bricks_offset = Vec3::new(-(bricks_width - BRICK_SIZE.x) / 2.0, BRICK_Y_OFFSET, 0.0);
+    let brick_offset = Vec3::new((BRICK_SIZE.x - brick_width) / 2.0, BRICK_Y_OFFSET, 0.0);
+
     for row in 0..BRICK_ROWS {
         let y_position = row as f32 * (BRICK_SIZE.y + BRICK_SPACING);
         for column in 0..BRICK_COLUMNS {
@@ -239,7 +240,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 column as f32 * (BRICK_SIZE.x + BRICK_SPACING),
                 y_position,
                 0.0,
-            ) + bricks_offset;
+            ) + brick_offset;
+
             // brick
             commands
                 .spawn()

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -13,8 +13,8 @@ const TIME_STEP: f32 = 1.0 / 60.0;
 // These constants are defined in `Transform` units.
 // Using the default 2D camera they correspond 1:1 with screen pixels.
 // The `const_vec3!` macros are needed as functions that operate on floats cannot be constant in Rust.
-const PADDLE_HEIGHT: f32 = -215.0;
 const PADDLE_SIZE: Vec3 = const_vec3!([120.0, 30.0, 0.0]);
+const PADDLE_Y_OFFSET: f32 = -215.0;
 const PADDLE_SPEED: f32 = 500.0;
 const PADDLE_BOUNDS: f32 = 380.0;
 
@@ -30,7 +30,7 @@ const WALL_THICKNESS: f32 = 10.0;
 const BRICK_ROWS: u8 = 4;
 const BRICK_COLUMNS: u8 = 5;
 const BRICK_SPACING: f32 = 20.0;
-const BRICK_HEIGHT: f32 = 100.0;
+const BRICK_Y_OFFSET: f32 = 100.0;
 const BRICK_SIZE: Vec3 = const_vec3!([150.0, 30.0, 1.0]);
 
 const SCOREBOARD_FONT_SIZE: f32 = 40.0;
@@ -155,7 +155,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .insert(Paddle)
         .insert_bundle(SpriteBundle {
             transform: Transform {
-                translation: Vec3::new(0.0, PADDLE_HEIGHT, 0.0),
+                translation: Vec3::new(0.0, PADDLE_Y_OFFSET, 0.0),
                 scale: PADDLE_SIZE,
                 ..default()
             },
@@ -231,7 +231,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Add bricks
     let bricks_width = BRICK_COLUMNS as f32 * (BRICK_SIZE.x + BRICK_SPACING) - BRICK_SPACING;
     // center the bricks and move them up a bit
-    let bricks_offset = Vec3::new(-(bricks_width - BRICK_SIZE.x) / 2.0, BRICK_HEIGHT, 0.0);
+    let bricks_offset = Vec3::new(-(bricks_width - BRICK_SIZE.x) / 2.0, BRICK_Y_OFFSET, 0.0);
     for row in 0..BRICK_ROWS {
         let y_position = row as f32 * (BRICK_SIZE.y + BRICK_SPACING);
         for column in 0..BRICK_COLUMNS {

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -103,28 +103,30 @@ impl WallBundle {
         // This allows us to just use `Left`, rather than `WallOrientation::Left` everywhere
         use WallLocation::*;
 
-        let translation = match orientation {
+        let position = match orientation {
             Left => Vec2::new(-PLAY_AREA_BOUNDS.x / 2.0, 0.0),
             Right => Vec2::new(PLAY_AREA_BOUNDS.x / 2.0, 0.0),
             Bottom => Vec2::new(0.0, -PLAY_AREA_BOUNDS.y / 2.0),
             Top => Vec2::new(0.0, PLAY_AREA_BOUNDS.y / 2.0),
-        }
-        // We need to convert our Vec2 into a Vec3, by giving it a z-coordinate
-        .extend(0.0);
+        };
 
-        let scale = match orientation {
+        let size = match orientation {
             Left => Vec2::new(WALL_THICKNESS, PLAY_AREA_BOUNDS.y + WALL_THICKNESS),
             Right => Vec2::new(WALL_THICKNESS, PLAY_AREA_BOUNDS.y + WALL_THICKNESS),
             Bottom => Vec2::new(PLAY_AREA_BOUNDS.x + WALL_THICKNESS, WALL_THICKNESS),
             Top => Vec2::new(PLAY_AREA_BOUNDS.x + WALL_THICKNESS, WALL_THICKNESS),
-        }
-        .extend(1.0);
+        };
 
         WallBundle {
             sprite_bundle: SpriteBundle {
                 transform: Transform {
-                    translation,
-                    scale,
+                    // We need to convert our Vec2 into a Vec3, by giving it a z-coordinate
+                    // This is used to determine the order of our sprites
+                    translation: position.extend(0.0),
+                    // The z-scale of 2D objects must always be 1.0,
+                    // or their ordering will be affected in surpirising ways.
+                    // See https://github.com/bevyengine/bevy/issues/4149
+                    scale: size.extend(1.0),
                     ..default()
                 },
                 sprite: Sprite {

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -30,6 +30,7 @@ const WALL_THICKNESS: f32 = 10.0;
 const BRICK_ROWS: u8 = 4;
 const BRICK_COLUMNS: u8 = 5;
 const BRICK_SPACING: f32 = 20.0;
+const BRICK_HEIGHT: f32 = 100.0;
 const BRICK_SIZE: Vec3 = const_vec3!([150.0, 30.0, 1.0]);
 
 const SCOREBOARD_FONT_SIZE: f32 = 40.0;
@@ -230,7 +231,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Add bricks
     let bricks_width = BRICK_COLUMNS as f32 * (BRICK_SIZE.x + BRICK_SPACING) - BRICK_SPACING;
     // center the bricks and move them up a bit
-    let bricks_offset = Vec3::new(-(bricks_width - BRICK_SIZE.x) / 2.0, 100.0, 0.0);
+    let bricks_offset = Vec3::new(-(bricks_width - BRICK_SIZE.x) / 2.0, BRICK_HEIGHT, 0.0);
     for row in 0..BRICK_ROWS {
         let y_position = row as f32 * (BRICK_SIZE.y + BRICK_SPACING);
         for column in 0..BRICK_COLUMNS {

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -142,14 +142,13 @@ struct Scoreboard {
     score: usize,
 }
 
+// Add the game's entities to our world
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    // Add the game's entities to our world
-
-    // cameras
+    // Cameras
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
     commands.spawn_bundle(UiCameraBundle::default());
 
-    // paddle
+    // Paddle
     commands
         .spawn()
         .insert(Paddle)
@@ -167,7 +166,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         })
         .insert(Collider);
 
-    // ball
+    // Ball
     let ball_velocity = INITIAL_BALL_DIRECTION.normalize() * BALL_SPEED;
 
     commands
@@ -187,7 +186,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         })
         .insert(Velocity(ball_velocity));
 
-    // scoreboard
+    // Scoreboard
     commands.spawn_bundle(TextBundle {
         text: Text {
             sections: vec![
@@ -222,13 +221,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         ..default()
     });
 
-    // walls
+    // Walls
     commands.spawn_bundle(WallBundle::new(WallLocation::Left));
     commands.spawn_bundle(WallBundle::new(WallLocation::Right));
     commands.spawn_bundle(WallBundle::new(WallLocation::Bottom));
     commands.spawn_bundle(WallBundle::new(WallLocation::Top));
 
-    // Add bricks
+    // Bricks
     let brick_width = BRICK_COLUMNS as f32 * (BRICK_SIZE.x + BRICK_SPACING) - BRICK_SPACING;
     // center the bricks and move them up a bit
     let brick_offset = Vec3::new((BRICK_SIZE.x - brick_width) / 2.0, BRICK_Y_OFFSET, 0.0);

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -61,9 +61,9 @@ fn main() {
         .add_system_set(
             SystemSet::new()
                 .with_run_criteria(FixedTimestep::step(TIME_STEP as f64))
-                .with_system(move_paddle)
                 .with_system(check_for_collisions)
-                .with_system(apply_velocity),
+                .with_system(move_paddle.before(check_for_collisions))
+                .with_system(apply_velocity.before(check_for_collisions)),
         )
         .add_system(update_scoreboard)
         .add_system(bevy::input::system::exit_on_esc_system)

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -114,12 +114,11 @@ impl WallLocation {
     }
 
     fn size(&self) -> Vec2 {
-        // Make sure we haven't messed up our left and right
-        assert!(LEFT_WALL < RIGHT_WALL);
-        assert!(BOTTOM_WALL < TOP_WALL);
-
         let arena_height = TOP_WALL - BOTTOM_WALL;
         let arena_width = RIGHT_WALL - LEFT_WALL;
+        // Make sure we haven't messed up our constants
+        assert!(arena_height > 0.0);
+        assert!(arena_width > 0.0);
 
         match self {
             WallLocation::Left => Vec2::new(WALL_THICKNESS, arena_height + WALL_THICKNESS),

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -167,8 +167,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .insert(Collider);
 
     // Ball
-    let ball_velocity = INITIAL_BALL_DIRECTION.normalize() * BALL_SPEED;
-
     commands
         .spawn()
         .insert(Ball)
@@ -184,7 +182,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
             ..default()
         })
-        .insert(Velocity(ball_velocity));
+        .insert(Velocity(INITIAL_BALL_DIRECTION.normalize() * BALL_SPEED));
 
     // Scoreboard
     commands.spawn_bundle(TextBundle {

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -276,17 +276,16 @@ fn move_paddle(
         direction += 1.0;
     }
 
-    // Move the paddle horizontally
-    paddle_transform.translation.x += direction * PADDLE_SPEED * TIME_STEP;
-
-    // Bound the paddle within the walls
-    // This is maximum x value that the paddle's transform can have without leaving the play area
+    // This is the maximum x value that the paddle's transform can have without leaving the play area
     let paddle_bounds =
         (PLAY_AREA_BOUNDS.x - WALL_THICKNESS - PADDLE_SIZE.x) / 2.0 - PADDLE_PADDING;
-    paddle_transform.translation.x = paddle_transform
-        .translation
-        .x
-        .clamp(-paddle_bounds, paddle_bounds);
+
+    // Calculate the new horizontal paddle position based on player input
+    let new_paddle_position = paddle_transform.translation.x + direction * PADDLE_SPEED * TIME_STEP;
+
+    // Update the paddle position,
+    // making sure it doesn't cause the paddle to leave the arena
+    paddle_transform.translation.x = new_paddle_position.clamp(-paddle_bounds, paddle_bounds);
 }
 
 fn apply_velocity(mut query: Query<(&mut Transform, &Velocity)>) {

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -33,13 +33,13 @@ const RIGHT_WALL: f32 = 450.;
 const BOTTOM_WALL: f32 = -300.;
 const TOP_WALL: f32 = 300.;
 
-const BRICK_SIZE: Vec2 = const_vec2!([80., 40.]);
+const BRICK_SIZE: Vec2 = const_vec2!([100., 30.]);
 // These values are exact
 const GAP_BETWEEN_PADDLE_AND_BRICKS: f32 = 120.0;
-const GAP_BETWEEN_BRICKS: f32 = 40.0;
+const GAP_BETWEEN_BRICKS: f32 = 5.0;
 // These values are lower bounds, as the number of bricks is computed
 const GAP_BETWEEN_BRICKS_AND_CEILING: f32 = 50.0;
-const GAP_BETWEEN_BRICKS_AND_SIDES: f32 = 50.0;
+const GAP_BETWEEN_BRICKS_AND_SIDES: f32 = 20.0;
 
 const SCOREBOARD_FONT_SIZE: f32 = 40.0;
 const SCOREBOARD_TEXT_PADDING: Val = Val::Px(5.0);

--- a/examples/game/breakout.rs
+++ b/examples/game/breakout.rs
@@ -233,14 +233,17 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     let width_available_for_bricks =
         total_width_of_bricks - (BRICK_COLUMNS - 1) as f32 * BRICK_SPACING_X;
-    // Negative scales result in flipped sprites / meshes,
-    // which is not what we want here
-    let brick_width = (width_available_for_bricks / BRICK_COLUMNS as f32).max(0.0);
+    let brick_width = (width_available_for_bricks / BRICK_COLUMNS as f32);
 
     let total_height_of_bricks = PLAY_AREA_BOUNDS.y / 2.0 - BRICK_Y_OFFSET - 2. * BRICK_SPACING_X;
     let height_available_for_bricks =
         total_height_of_bricks - (BRICK_ROWS - 1) as f32 * BRICK_SPACING_Y;
-    let brick_height = (height_available_for_bricks / BRICK_COLUMNS as f32).max(0.0);
+    let brick_height = (height_available_for_bricks / BRICK_COLUMNS as f32);
+
+    // Negative scales result in flipped sprites / meshes,
+    // which is definitely not what we want here
+    assert!(brick_width > 0.0);
+    assert!(brick_height > 0.0);
 
     // Center the bricks and move them up a bit
     let brick_offset = Vec2::new(-(total_width_of_bricks - brick_width) / 2.0, BRICK_Y_OFFSET);


### PR DESCRIPTION
# Objective

1. Spawning walls in the Breakout example was hard to follow and error-prone.
2. The strategy used in `paddle_movement_system` was somewhat convoluted.
3. Correctly modifying the size of the arena was hard, due to implicit coupling between the bounds and the bounds that the paddle can move in.

## Solution

1. Refactor this to use a WallBundle struct with a builder; neatly demonstrating some essential patterns along the way.
2. Use clamp and avoid using weird &mut strategies.
3. Refactor logic to allow users to tweak the brick size, and automatically adjust the number of rows and columns to match.
4. Make the brick layout more like classic breakout!

![image](https://user-images.githubusercontent.com/3579909/160028924-993f3fa2-b264-4eca-94e1-e5985d8b9379.png)