### PR TITLE
`bevy_input`: Fix gamepad connection system ordering

### DIFF
--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -75,7 +75,7 @@ impl Plugin for InputPlugin {
             )
             .add_system_to_stage(
                 CoreStage::PreUpdate,
-                gamepad_connection_system.label(InputSystem),
+                gamepad_connection_system.after(InputSystem),
             )
             // touch
             .add_event::<TouchInput>()


### PR DESCRIPTION
# Objective

- Part of the splitting process of #3692.

## Solution

- Change the `gamepad_connection_system` to run after the `InputSystem` label.

## Reasons

I changed the `gamepad_connection_system` to run after the `InputSystem` instead of in parallel, because this system checks the `GamepadEvent`s which get send inside of the `gamepad_event_system`. This means that the `gamepad_connection_system` could respond to the events one frame later, instead of instantly resulting in one frame lag.

Old possible case:
1. `gamepad_connection_system` (reacts to the `GamepadEvent`s too early)
2. `gamepad_event_system` (sends the `GamepadEvent`s)

New fixed ordering:
1. `gamepad_event_system` (sends the `GamepadEvent`s)
2. `gamepad_connection_system` (reacts to the `GamepadEvent`s)