### PR TITLE
Split up `keyboard.rs` into smaller chunks

### DIFF
--- a/crates/bevy_input/src/keyboard/event.rs
+++ b/crates/bevy_input/src/keyboard/event.rs
@@ -1,0 +1,10 @@
+use crate::keyboard::KeyCode;
+use crate::ElementState;
+
+/// A key input event from a keyboard device
+#[derive(Debug, Clone)]
+pub struct KeyboardInput {
+    pub scan_code: u32,
+    pub key_code: Option<KeyCode>,
+    pub state: ElementState,
+}

--- a/crates/bevy_input/src/keyboard/key_code.rs
+++ b/crates/bevy_input/src/keyboard/key_code.rs
@@ -1,36 +1,3 @@
-use crate::{ElementState, Input};
-use bevy_ecs::event::EventReader;
-use bevy_ecs::system::ResMut;
-
-/// A key input event from a keyboard device
-#[derive(Debug, Clone)]
-pub struct KeyboardInput {
-    pub scan_code: u32,
-    pub key_code: Option<KeyCode>,
-    pub state: ElementState,
-}
-
-/// Updates the `Input<KeyCode>` resource with the latest `KeyboardInput` events
-pub fn keyboard_input_system(
-    mut keyboard_input: ResMut<Input<KeyCode>>,
-    mut keyboard_input_events: EventReader<KeyboardInput>,
-) {
-    keyboard_input.clear();
-    for event in keyboard_input_events.iter() {
-        if let KeyboardInput {
-            key_code: Some(key_code),
-            state,
-            ..
-        } = event
-        {
-            match state {
-                ElementState::Pressed => keyboard_input.press(*key_code),
-                ElementState::Released => keyboard_input.release(*key_code),
-            }
-        }
-    }
-}
-
 /// The key code of a keyboard input.
 #[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/bevy_input/src/keyboard/mod.rs
+++ b/crates/bevy_input/src/keyboard/mod.rs
@@ -1,0 +1,5 @@
+pub mod event;
+pub mod key_code;
+pub mod system;
+
+pub use crate::keyboard::{event::*, key_code::*, system::*};

--- a/crates/bevy_input/src/keyboard/system.rs
+++ b/crates/bevy_input/src/keyboard/system.rs
@@ -1,0 +1,26 @@
+use crate::{
+    keyboard::{KeyCode, KeyboardInput},
+    ElementState, Input,
+};
+use bevy_ecs::{event::EventReader, system::ResMut};
+
+/// Updates the `Input<KeyCode>` resource with the latest `KeyboardInput` events
+pub fn keyboard_input_system(
+    mut keyboard_input: ResMut<Input<KeyCode>>,
+    mut keyboard_input_events: EventReader<KeyboardInput>,
+) {
+    keyboard_input.clear();
+    for event in keyboard_input_events.iter() {
+        if let KeyboardInput {
+            key_code: Some(key_code),
+            state,
+            ..
+        } = event
+        {
+            match state {
+                ElementState::Pressed => keyboard_input.press(*key_code),
+                ElementState::Released => keyboard_input.release(*key_code),
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Objective

- Part of the splitting process of #3692.

## Solution

- Split up `keyboard.rs` into smaller chunks.

## Reasons

- It makes navigating the file structure easier.
- It helps to find particular things faster.
- It's a good practice to not just dump everything into one huge file.
- Discussion in #3692.