### PR TITLE
Split up `touch.rs` into smaller chunks

### DIFF
--- a/crates/bevy_input/src/touch/event.rs
+++ b/crates/bevy_input/src/touch/event.rs
@@ -1,0 +1,33 @@
+use crate::touch::{ForceTouch, TouchPhase};
+use bevy_math::Vec2;
+
+/// Represents a touch event
+///
+/// Every time the user touches the screen, a new `Start` event with an unique
+/// identifier for the finger is generated. When the finger is lifted, an `End`
+/// event is generated with the same finger id.
+///
+/// After a `Start` event has been emitted, there may be zero or more `Move`
+/// events when the finger is moved or the touch pressure changes.
+///
+/// The finger id may be reused by the system after an `End` event. The user
+/// should assume that a new `Start` event received with the same id has nothing
+/// to do with the old finger and is a new finger.
+///
+/// A `Cancelled` event is emitted when the system has canceled tracking this
+/// touch, such as when the window loses focus, or on iOS if the user moves the
+/// device against their face.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TouchInput {
+    pub phase: TouchPhase,
+    pub position: Vec2,
+    /// Describes how hard the screen was pressed. May be `None` if the platform
+    /// does not support pressure sensitivity.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - Only available on **iOS** 9.0+ and **Windows** 8+.
+    pub force: Option<ForceTouch>,
+    /// Unique identifier of a finger.
+    pub id: u64,
+}

--- a/crates/bevy_input/src/touch/force.rs
+++ b/crates/bevy_input/src/touch/force.rs
@@ -1,0 +1,32 @@
+/// Describes the force of a touch event
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ForceTouch {
+    /// On iOS, the force is calibrated so that the same number corresponds to
+    /// roughly the same amount of pressure on the screen regardless of the
+    /// device.
+    Calibrated {
+        /// The force of the touch, where a value of 1.0 represents the force of
+        /// an average touch (predetermined by the system, not user-specific).
+        ///
+        /// The force reported by Apple Pencil is measured along the axis of the
+        /// pencil. If you want a force perpendicular to the device, you need to
+        /// calculate this value using the `altitude_angle` value.
+        force: f64,
+        /// The maximum possible force for a touch.
+        ///
+        /// The value of this field is sufficiently high to provide a wide
+        /// dynamic range for values of the `force` field.
+        max_possible_force: f64,
+        /// The altitude (in radians) of the stylus.
+        ///
+        /// A value of 0 radians indicates that the stylus is parallel to the
+        /// surface. The value of this property is Pi/2 when the stylus is
+        /// perpendicular to the surface.
+        altitude_angle: Option<f64>,
+    },
+    /// If the platform reports the force as normalized, we have no way of
+    /// knowing how much pressure 1.0 corresponds to – we know it's the maximum
+    /// amount of force, but as to how much force, you might either have to
+    /// press really really hard, or not hard at all, depending on the device.
+    Normalized(f64),
+}

--- a/crates/bevy_input/src/touch/mod.rs
+++ b/crates/bevy_input/src/touch/mod.rs
@@ -1,0 +1,7 @@
+pub mod event;
+pub mod force;
+pub mod phase;
+pub mod system;
+pub mod touches;
+
+pub use crate::touch::{event::*, force::*, phase::*, system::*, touches::*};

--- a/crates/bevy_input/src/touch/phase.rs
+++ b/crates/bevy_input/src/touch/phase.rs
@@ -1,0 +1,9 @@
+/// Describes touch-screen input state.
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub enum TouchPhase {
+    Started,
+    Moved,
+    Ended,
+    Cancelled,
+}

--- a/crates/bevy_input/src/touch/system.rs
+++ b/crates/bevy_input/src/touch/system.rs
@@ -1,0 +1,14 @@
+use crate::touch::{TouchInput, Touches};
+use bevy_ecs::{event::EventReader, system::ResMut};
+
+/// Updates the `Touches` resource with the latest `TouchInput` events
+pub fn touch_screen_input_system(
+    mut touch_state: ResMut<Touches>,
+    mut touch_input_events: EventReader<TouchInput>,
+) {
+    touch_state.update();
+
+    for event in touch_input_events.iter() {
+        touch_state.process_touch_event(event);
+    }
+}

--- a/crates/bevy_input/src/touch/touches.rs
+++ b/crates/bevy_input/src/touch/touches.rs
@@ -1,81 +1,6 @@
-use bevy_ecs::event::EventReader;
-use bevy_ecs::system::ResMut;
+use crate::touch::{ForceTouch, TouchInput, TouchPhase};
 use bevy_math::Vec2;
 use bevy_utils::HashMap;
-
-/// Represents a touch event
-///
-/// Every time the user touches the screen, a new `Start` event with an unique
-/// identifier for the finger is generated. When the finger is lifted, an `End`
-/// event is generated with the same finger id.
-///
-/// After a `Start` event has been emitted, there may be zero or more `Move`
-/// events when the finger is moved or the touch pressure changes.
-///
-/// The finger id may be reused by the system after an `End` event. The user
-/// should assume that a new `Start` event received with the same id has nothing
-/// to do with the old finger and is a new finger.
-///
-/// A `Cancelled` event is emitted when the system has canceled tracking this
-/// touch, such as when the window loses focus, or on iOS if the user moves the
-/// device against their face.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct TouchInput {
-    pub phase: TouchPhase,
-    pub position: Vec2,
-    /// Describes how hard the screen was pressed. May be `None` if the platform
-    /// does not support pressure sensitivity.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - Only available on **iOS** 9.0+ and **Windows** 8+.
-    pub force: Option<ForceTouch>,
-    /// Unique identifier of a finger.
-    pub id: u64,
-}
-
-/// Describes the force of a touch event
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum ForceTouch {
-    /// On iOS, the force is calibrated so that the same number corresponds to
-    /// roughly the same amount of pressure on the screen regardless of the
-    /// device.
-    Calibrated {
-        /// The force of the touch, where a value of 1.0 represents the force of
-        /// an average touch (predetermined by the system, not user-specific).
-        ///
-        /// The force reported by Apple Pencil is measured along the axis of the
-        /// pencil. If you want a force perpendicular to the device, you need to
-        /// calculate this value using the `altitude_angle` value.
-        force: f64,
-        /// The maximum possible force for a touch.
-        ///
-        /// The value of this field is sufficiently high to provide a wide
-        /// dynamic range for values of the `force` field.
-        max_possible_force: f64,
-        /// The altitude (in radians) of the stylus.
-        ///
-        /// A value of 0 radians indicates that the stylus is parallel to the
-        /// surface. The value of this property is Pi/2 when the stylus is
-        /// perpendicular to the surface.
-        altitude_angle: Option<f64>,
-    },
-    /// If the platform reports the force as normalized, we have no way of
-    /// knowing how much pressure 1.0 corresponds to – we know it's the maximum
-    /// amount of force, but as to how much force, you might either have to
-    /// press really really hard, or not hard at all, depending on the device.
-    Normalized(f64),
-}
-
-/// Describes touch-screen input state.
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-pub enum TouchPhase {
-    Started,
-    Moved,
-    Ended,
-    Cancelled,
-}
 
 #[derive(Debug, Clone, Copy)]
 pub struct Touch {
@@ -187,7 +112,7 @@ impl Touches {
         self.just_cancelled.values()
     }
 
-    fn process_touch_event(&mut self, event: &TouchInput) {
+    pub(crate) fn process_touch_event(&mut self, event: &TouchInput) {
         match event.phase {
             TouchPhase::Started => {
                 self.pressed.insert(event.id, event.into());
@@ -213,22 +138,10 @@ impl Touches {
         };
     }
 
-    fn update(&mut self) {
+    pub(crate) fn update(&mut self) {
         self.just_pressed.clear();
         self.just_released.clear();
         self.just_cancelled.clear();
-    }
-}
-
-/// Updates the `Touches` resource with the latest `TouchInput` events
-pub fn touch_screen_input_system(
-    mut touch_state: ResMut<Touches>,
-    mut touch_input_events: EventReader<TouchInput>,
-) {
-    touch_state.update();
-
-    for event in touch_input_events.iter() {
-        touch_state.process_touch_event(event);
     }
 }
 


### PR DESCRIPTION
# Objective

- Part of the splitting process of #3692.

## Solution

- Split up `touch.rs` into smaller chunks.

## Reasons

- It makes navigating the file structure easier.
- It helps to find particular things faster.
- It's a good practice to not just dump everything into one huge file.
- Discussion in #3692.