### PR TITLE
Use an instanced vertex buffer for Mesh transform matrices instead of a uniform buffer with dynamic offsets

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1,6 +1,5 @@
 use crate::{
-    AlphaMode, DrawMesh, MeshPipeline, MeshPipelineKey, MeshUniform, SetMeshBindGroup,
-    SetMeshViewBindGroup,
+    AlphaMode, DrawMesh, MeshPipeline, MeshPipelineKey, MeshUniform, SetMeshViewBindGroup,
 };
 use bevy_app::{App, Plugin};
 use bevy_asset::{AddAsset, Asset, AssetServer, Handle};
@@ -248,7 +247,6 @@ impl<M: SpecializedMaterial> SpecializedMeshPipeline for MaterialPipeline<M> {
         descriptor.layout = Some(vec![
             self.mesh_pipeline.view_layout.clone(),
             self.material_layout.clone(),
-            self.mesh_pipeline.mesh_layout.clone(),
         ]);
 
         M::specialize(&mut descriptor, key.material_key, layout)?;
@@ -276,7 +274,6 @@ type DrawMaterial<M> = (
     SetItemPipeline,
     SetMeshViewBindGroup<0>,
     SetMaterialBindGroup<M, 1>,
-    SetMeshBindGroup<2>,
     DrawMesh,
 );
 

--- a/crates/bevy_pbr/src/render/depth.wgsl
+++ b/crates/bevy_pbr/src/render/depth.wgsl
@@ -10,30 +10,36 @@ struct View {
 var<uniform> view: View;
 
 struct Vertex {
-    [[location(0)]] i_model_col0: vec4<f32>;
-    [[location(1)]] i_model_col1: vec4<f32>;
-    [[location(2)]] i_model_col2: vec4<f32>;
-    [[location(3)]] i_model_col3: vec4<f32>;
-    [[location(4)]] i_inverse_model_col0: vec4<f32>;
-    [[location(5)]] i_inverse_model_col1: vec4<f32>;
-    [[location(6)]] i_inverse_model_col2: vec4<f32>;
-    [[location(7)]] i_inverse_model_col3: vec4<f32>;
-    [[location(8), interpolate(flat)]] i_mesh_flags: u32;
-    [[location(9)]] position: vec3<f32>;
+    [[location(0)]] i_model_col0: vec3<f32>;
+    [[location(1)]] i_model_col1: vec3<f32>;
+    [[location(2)]] i_model_col2: vec3<f32>;
+    [[location(3)]] i_model_col3: vec3<f32>;
+    [[location(4)]] i_inverse_model_col0: vec3<f32>;
+    [[location(5)]] i_inverse_model_col1: vec3<f32>;
+    [[location(6)]] i_inverse_model_col2: vec3<f32>;
+    [[location(7), interpolate(flat)]] i_mesh_flags: u32;
+    [[location(8)]] position: vec3<f32>;
 };
 
 struct VertexOutput {
     [[builtin(position)]] clip_position: vec4<f32>;
 };
 
-fn vec4_to_mat4x4(c0: vec4<f32>, c1: vec4<f32>, c2: vec4<f32>, c3: vec4<f32>) -> mat4x4<f32> {
-    return mat4x4<f32>(c0, c1, c2, c3);
+fn vec3_to_mat4x4(c0: vec3<f32>, c1: vec3<f32>, c2: vec3<f32>, c3: vec3<f32>) -> mat4x4<f32> {
+    // NOTE: The shader compiler will optimize away multiplications by 0.0 and 1.0 and not use
+    // registers for unused parts of the matrix
+    return mat4x4<f32>(
+        vec4<f32>(c0, 0.0),
+        vec4<f32>(c1, 0.0),
+        vec4<f32>(c2, 0.0),
+        vec4<f32>(c3, 1.0)
+    );
 }
 
 [[stage(vertex)]]
 fn vertex(vertex: Vertex) -> VertexOutput {
     var out: VertexOutput;
-    let model = vec4_to_mat4x4(
+    let model = vec3_to_mat4x4(
         vertex.i_model_col0,
         vertex.i_model_col1,
         vertex.i_model_col2,

--- a/crates/bevy_pbr/src/render/depth.wgsl
+++ b/crates/bevy_pbr/src/render/depth.wgsl
@@ -9,20 +9,36 @@ struct View {
 [[group(0), binding(0)]]
 var<uniform> view: View;
 
-[[group(1), binding(0)]]
-var<uniform> mesh: Mesh;
-
 struct Vertex {
-    [[location(0)]] position: vec3<f32>;
+    [[location(0)]] i_model_col0: vec4<f32>;
+    [[location(1)]] i_model_col1: vec4<f32>;
+    [[location(2)]] i_model_col2: vec4<f32>;
+    [[location(3)]] i_model_col3: vec4<f32>;
+    [[location(4)]] i_inverse_model_col0: vec4<f32>;
+    [[location(5)]] i_inverse_model_col1: vec4<f32>;
+    [[location(6)]] i_inverse_model_col2: vec4<f32>;
+    [[location(7)]] i_inverse_model_col3: vec4<f32>;
+    [[location(8), interpolate(flat)]] i_mesh_flags: u32;
+    [[location(9)]] position: vec3<f32>;
 };
 
 struct VertexOutput {
     [[builtin(position)]] clip_position: vec4<f32>;
 };
 
+fn vec4_to_mat4x4(c0: vec4<f32>, c1: vec4<f32>, c2: vec4<f32>, c3: vec4<f32>) -> mat4x4<f32> {
+    return mat4x4<f32>(c0, c1, c2, c3);
+}
+
 [[stage(vertex)]]
 fn vertex(vertex: Vertex) -> VertexOutput {
     var out: VertexOutput;
-    out.clip_position = view.view_proj * mesh.model * vec4<f32>(vertex.position, 1.0);
+    let model = vec4_to_mat4x4(
+        vertex.i_model_col0,
+        vertex.i_model_col1,
+        vertex.i_model_col2,
+        vertex.i_model_col3
+    );
+    out.clip_position = view.view_proj * model * vec4<f32>(vertex.position, 1.0);
     return out;
 }

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -253,7 +253,7 @@ impl SpecializedMeshPipeline for ShadowPipeline {
         layout: &MeshVertexBufferLayout,
     ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
         let vertex_buffer_layout =
-            layout.get_layout(&[Mesh::ATTRIBUTE_POSITION.at_shader_location(9)])?;
+            layout.get_layout(&[Mesh::ATTRIBUTE_POSITION.at_shader_location(8)])?;
 
         let instance_buffer_layout = MeshInstanceData::get_layout(0);
 

--- a/crates/bevy_pbr/src/render/mesh.wgsl
+++ b/crates/bevy_pbr/src/render/mesh.wgsl
@@ -2,46 +2,71 @@
 #import bevy_pbr::mesh_struct
 
 struct Vertex {
-    [[location(0)]] position: vec3<f32>;
-    [[location(1)]] normal: vec3<f32>;
-    [[location(2)]] uv: vec2<f32>;
+    [[location(0)]] i_model_col0: vec4<f32>;
+    [[location(1)]] i_model_col1: vec4<f32>;
+    [[location(2)]] i_model_col2: vec4<f32>;
+    [[location(3)]] i_model_col3: vec4<f32>;
+    [[location(4)]] i_inverse_model_col0: vec4<f32>;
+    [[location(5)]] i_inverse_model_col1: vec4<f32>;
+    [[location(6)]] i_inverse_model_col2: vec4<f32>;
+    [[location(7)]] i_inverse_model_col3: vec4<f32>;
+    [[location(8), interpolate(flat)]] i_mesh_flags: u32;
+    [[location(9)]] position: vec3<f32>;
+    [[location(10)]] normal: vec3<f32>;
+    [[location(11)]] uv: vec2<f32>;
 #ifdef VERTEX_TANGENTS
-    [[location(3)]] tangent: vec4<f32>;
+    [[location(12)]] tangent: vec4<f32>;
 #endif
 };
 
 struct VertexOutput {
     [[builtin(position)]] clip_position: vec4<f32>;
-    [[location(0)]] world_position: vec4<f32>;
-    [[location(1)]] world_normal: vec3<f32>;
-    [[location(2)]] uv: vec2<f32>;
+    [[location(0)]] mesh_flags: u32;
+    [[location(1)]] world_position: vec4<f32>;
+    [[location(2)]] world_normal: vec3<f32>;
+    [[location(3)]] uv: vec2<f32>;
 #ifdef VERTEX_TANGENTS
-    [[location(3)]] world_tangent: vec4<f32>;
+    [[location(4)]] world_tangent: vec4<f32>;
 #endif
 };
 
-[[group(2), binding(0)]]
-var<uniform> mesh: Mesh;
+fn vec4_to_mat4x4(c0: vec4<f32>, c1: vec4<f32>, c2: vec4<f32>, c3: vec4<f32>) -> mat4x4<f32> {
+    return mat4x4<f32>(c0, c1, c2, c3);
+}
 
 [[stage(vertex)]]
 fn vertex(vertex: Vertex) -> VertexOutput {
-    let world_position = mesh.model * vec4<f32>(vertex.position, 1.0);
+    let model = vec4_to_mat4x4(
+        vertex.i_model_col0,
+        vertex.i_model_col1,
+        vertex.i_model_col2,
+        vertex.i_model_col3
+    );
+    let world_position = model * vec4<f32>(vertex.position, 1.0);
 
     var out: VertexOutput;
+    out.mesh_flags = vertex.i_mesh_flags;
     out.uv = vertex.uv;
     out.world_position = world_position;
     out.clip_position = view.view_proj * world_position;
+
+    let inverse_transpose_model = transpose(vec4_to_mat4x4(
+        vertex.i_inverse_model_col0,
+        vertex.i_inverse_model_col1,
+        vertex.i_inverse_model_col2,
+        vertex.i_inverse_model_col3
+    ));
     out.world_normal = mat3x3<f32>(
-        mesh.inverse_transpose_model[0].xyz,
-        mesh.inverse_transpose_model[1].xyz,
-        mesh.inverse_transpose_model[2].xyz
+        inverse_transpose_model[0].xyz,
+        inverse_transpose_model[1].xyz,
+        inverse_transpose_model[2].xyz
     ) * vertex.normal;
 #ifdef VERTEX_TANGENTS
     out.world_tangent = vec4<f32>(
         mat3x3<f32>(
-            mesh.model[0].xyz,
-            mesh.model[1].xyz,
-            mesh.model[2].xyz
+            model[0].xyz,
+            model[1].xyz,
+            model[2].xyz
         ) * vertex.tangent.xyz,
         vertex.tangent.w
     );
@@ -51,11 +76,12 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 
 struct FragmentInput {
     [[builtin(front_facing)]] is_front: bool;
-    [[location(0)]] world_position: vec4<f32>;
-    [[location(1)]] world_normal: vec3<f32>;
-    [[location(2)]] uv: vec2<f32>;
+    [[location(0)]] mesh_flags: u32;
+    [[location(1)]] world_position: vec4<f32>;
+    [[location(2)]] world_normal: vec3<f32>;
+    [[location(3)]] uv: vec2<f32>;
 #ifdef VERTEX_TANGENTS
-    [[location(3)]] world_tangent: vec4<f32>;
+    [[location(4)]] world_tangent: vec4<f32>;
 #endif
 };
 

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -35,9 +35,6 @@
 #import bevy_pbr::mesh_view_bind_group
 #import bevy_pbr::mesh_struct
 
-[[group(2), binding(0)]]
-var<uniform> mesh: Mesh;
-
 struct StandardMaterial {
     base_color: vec4<f32>;
     emissive: vec4<f32>;
@@ -453,11 +450,12 @@ fn random1D(s: f32) -> f32 {
 struct FragmentInput {
     [[builtin(front_facing)]] is_front: bool;
     [[builtin(position)]] frag_coord: vec4<f32>;
-    [[location(0)]] world_position: vec4<f32>;
-    [[location(1)]] world_normal: vec3<f32>;
-    [[location(2)]] uv: vec2<f32>;
+    [[location(0)]] mesh_flags: u32;
+    [[location(1)]] world_position: vec4<f32>;
+    [[location(2)]] world_normal: vec3<f32>;
+    [[location(3)]] uv: vec2<f32>;
 #ifdef VERTEX_TANGENTS
-    [[location(3)]] world_tangent: vec4<f32>;
+    [[location(4)]] world_tangent: vec4<f32>;
 #endif
 };
 
@@ -582,7 +580,7 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
             let light_id = get_light_id(i);
             let light = point_lights.data[light_id];
             var shadow: f32 = 1.0;
-            if ((mesh.flags & MESH_FLAGS_SHADOW_RECEIVER_BIT) != 0u
+            if ((in.mesh_flags & MESH_FLAGS_SHADOW_RECEIVER_BIT) != 0u
                     && (light.flags & POINT_LIGHT_FLAGS_SHADOWS_ENABLED_BIT) != 0u) {
                 shadow = fetch_point_shadow(light_id, in.world_position, in.world_normal);
             }
@@ -594,7 +592,7 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
         for (var i: u32 = 0u; i < n_directional_lights; i = i + 1u) {
             let light = lights.directional_lights[i];
             var shadow: f32 = 1.0;
-            if ((mesh.flags & MESH_FLAGS_SHADOW_RECEIVER_BIT) != 0u
+            if ((in.mesh_flags & MESH_FLAGS_SHADOW_RECEIVER_BIT) != 0u
                     && (light.flags & DIRECTIONAL_LIGHT_FLAGS_SHADOWS_ENABLED_BIT) != 0u) {
                 shadow = fetch_directional_shadow(i, in.world_position, in.world_normal);
             }

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -1,5 +1,5 @@
 use crate::MeshPipeline;
-use crate::{DrawMesh, MeshPipelineKey, MeshUniform, SetMeshBindGroup, SetMeshViewBindGroup};
+use crate::{DrawMesh, MeshPipelineKey, MeshUniform, SetMeshViewBindGroup};
 use bevy_app::Plugin;
 use bevy_asset::{load_internal_asset, Handle, HandleUntyped};
 use bevy_core_pipeline::Opaque3d;
@@ -160,9 +160,4 @@ fn queue_wireframes(
     }
 }
 
-type DrawWireframes = (
-    SetItemPipeline,
-    SetMeshViewBindGroup<0>,
-    SetMeshBindGroup<1>,
-    DrawMesh,
-);
+type DrawWireframes = (SetItemPipeline, SetMeshViewBindGroup<0>, DrawMesh);

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -80,6 +80,25 @@ impl Mesh {
     pub const ATTRIBUTE_JOINT_INDEX: MeshVertexAttribute =
         MeshVertexAttribute::new("Vertex_JointIndex", 6, VertexFormat::Uint32);
 
+    pub const ATTRIBUTE_MODEL_COL0: MeshVertexAttribute =
+        MeshVertexAttribute::new("Model_Column_0", 7, VertexFormat::Float32x4);
+    pub const ATTRIBUTE_MODEL_COL1: MeshVertexAttribute =
+        MeshVertexAttribute::new("Model_Column_1", 8, VertexFormat::Float32x4);
+    pub const ATTRIBUTE_MODEL_COL2: MeshVertexAttribute =
+        MeshVertexAttribute::new("Model_Column_2", 9, VertexFormat::Float32x4);
+    pub const ATTRIBUTE_MODEL_COL3: MeshVertexAttribute =
+        MeshVertexAttribute::new("Model_Column_3", 10, VertexFormat::Float32x4);
+    pub const ATTRIBUTE_INVERSE_MODEL_COL0: MeshVertexAttribute =
+        MeshVertexAttribute::new("Inverse_Model_Column_0", 11, VertexFormat::Float32x4);
+    pub const ATTRIBUTE_INVERSE_MODEL_COL1: MeshVertexAttribute =
+        MeshVertexAttribute::new("Inverse_Model_Column_1", 12, VertexFormat::Float32x4);
+    pub const ATTRIBUTE_INVERSE_MODEL_COL2: MeshVertexAttribute =
+        MeshVertexAttribute::new("Inverse_Model_Column_2", 13, VertexFormat::Float32x4);
+    pub const ATTRIBUTE_INVERSE_MODEL_COL3: MeshVertexAttribute =
+        MeshVertexAttribute::new("Inverse_Model_Column_3", 14, VertexFormat::Float32x4);
+    pub const ATTRIBUTE_FLAGS: MeshVertexAttribute =
+        MeshVertexAttribute::new("Mesh_Flags", 15, VertexFormat::Uint32);
+
     /// Construct a new mesh. You need to provide a [`PrimitiveTopology`] so that the
     /// renderer knows how to treat the vertex data. Most of the time this will be
     /// [`PrimitiveTopology::TriangleList`].
@@ -222,10 +241,16 @@ impl Mesh {
         let mut vertex_size = 0;
         for attribute_data in self.attributes.values() {
             let vertex_format = attribute_data.attribute.format;
+            // dbg!(attribute_data.attribute.name);
+            // dbg!(vertex_format);
+            // dbg!(vertex_format.get_size());
             vertex_size += vertex_format.get_size() as usize;
         }
 
         let vertex_count = self.count_vertices();
+        // dbg!(vertex_size);
+        // dbg!(vertex_count);
+        // dbg!(vertex_count * vertex_size);
         let mut attributes_interleaved_buffer = vec![0; vertex_count * vertex_size];
         // bundle into interleaved buffers
         let mut attribute_offset = 0;

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -80,25 +80,6 @@ impl Mesh {
     pub const ATTRIBUTE_JOINT_INDEX: MeshVertexAttribute =
         MeshVertexAttribute::new("Vertex_JointIndex", 6, VertexFormat::Uint32);
 
-    pub const ATTRIBUTE_MODEL_COL0: MeshVertexAttribute =
-        MeshVertexAttribute::new("Model_Column_0", 7, VertexFormat::Float32x4);
-    pub const ATTRIBUTE_MODEL_COL1: MeshVertexAttribute =
-        MeshVertexAttribute::new("Model_Column_1", 8, VertexFormat::Float32x4);
-    pub const ATTRIBUTE_MODEL_COL2: MeshVertexAttribute =
-        MeshVertexAttribute::new("Model_Column_2", 9, VertexFormat::Float32x4);
-    pub const ATTRIBUTE_MODEL_COL3: MeshVertexAttribute =
-        MeshVertexAttribute::new("Model_Column_3", 10, VertexFormat::Float32x4);
-    pub const ATTRIBUTE_INVERSE_MODEL_COL0: MeshVertexAttribute =
-        MeshVertexAttribute::new("Inverse_Model_Column_0", 11, VertexFormat::Float32x4);
-    pub const ATTRIBUTE_INVERSE_MODEL_COL1: MeshVertexAttribute =
-        MeshVertexAttribute::new("Inverse_Model_Column_1", 12, VertexFormat::Float32x4);
-    pub const ATTRIBUTE_INVERSE_MODEL_COL2: MeshVertexAttribute =
-        MeshVertexAttribute::new("Inverse_Model_Column_2", 13, VertexFormat::Float32x4);
-    pub const ATTRIBUTE_INVERSE_MODEL_COL3: MeshVertexAttribute =
-        MeshVertexAttribute::new("Inverse_Model_Column_3", 14, VertexFormat::Float32x4);
-    pub const ATTRIBUTE_FLAGS: MeshVertexAttribute =
-        MeshVertexAttribute::new("Mesh_Flags", 15, VertexFormat::Uint32);
-
     /// Construct a new mesh. You need to provide a [`PrimitiveTopology`] so that the
     /// renderer knows how to treat the vertex data. Most of the time this will be
     /// [`PrimitiveTopology::TriangleList`].


### PR DESCRIPTION
# Objective

- Reduce the amount of time spent in preparing Mesh transforms for rendering
- Background in https://github.com/bevyengine/bevy/issues/4288

## Background

### Uniform buffers and dynamic offsets

- Using dynamic offsets into uniform buffers imposes alignment requirements on the offsets
- `crevice` requires 256-byte alignment. `encase` supports configurable alignment. `wgpu` exposes actual alignment requirements. Alignment requirements in practice depend on your GPU / graphics API / graphics driver.
  - Vulkan
    - AMD: 16-byte alignment
    - NVIDIA: 256-byte alignment
    - Intel: 64-byte alignment
  - DirectX 12: 256-byte alignment
  - macOS Metal: 256-byte alignment
  - iOS Metal: 16-byte alignment

### Vertex buffers

- Vertex buffers have no such alignment requirements
- Data can be packed tightly
- Only scalar and vector types supported, no matrices. This is not a problem. Matrices can be reconstructed in the shader.

### Remove redundant data

- There is redundant information in the two Mat4s
- This Twitter thread by Sebastian Aaltonen was the source of information for what I will describe below: https://twitter.com/sebaaltonen/status/1309915006562111489?lang=en
- GlobalTransforms represent so-called affine transforms: scale, rotation, translation, and shear. Affine transforms can be completely represented by a 4x3 matrix. The last row is always 0,0,0,1 and so can be hard-coded in the shader.
  - Hard-coding the 0,0,0,1 in the shader is actually beneficial! Shader compilers can and will optimise-away operations multiplying by 0 or 1. If those values are not used, their registers will not be allocated. So hard-coding these values can actually reduce the number of registers used by a shader, and reduce the number of operations, all while the maths in the shader remains the same as it uses 4x4 matrices.
  - Using two 4x3 matrices reduces the amount of data needed for the 'mesh uniform' data from 132 bytes to 2 * 4 * 3 * 4 + 4 = 100 bytes. A 24% reduction in data!
- The model matrix transforms from the object local coordinates to world coordinates. Its inverse is sometimes needed, for example the transpose of the inverse model matrix is needed to correctly transform vertex normals. The inverse of a 4x3 affine transformation is a 4x3 affine transformation. Vertex normals are directions, and as such, transforming them, their w component must be 0, which then means that the w column of the 4x3 matrix that represents the translation is not needed. This allows us to use 4x3 model and 3x3 inverse model matrix which brings the data down to 4 * 3 * 4 + 3 * 3 * 4 + 4 = 88 bytes, a 33% reduction!

## Solution

- Stop using a uniform buffer with dynamic offsets for MeshUniform data
- Use a 4x3 model matrix and 3x3 inverse model matrix
- Pack the 4x3 model matrix into 3 vec4<f32> and the 3x3 into 2 vec4<f32> and 1 f32 vertex attributes
- Use a `BufferVec` for the tightly-packed vertex buffer
- Calculate the transpose of the inverse model matrix in the shader as tranpose is free on all modern GPUs.

## Results

The median execution time of the prepare_uniform_components system and system commands application, over 1500 frames of `many_cubes -- sphere` drops from 4.39ms + 0.857ms on `main` to 0.443ms + 0.794ms on this PR. That's 4ms per frame saved in this example, and a reduction of 76%! For reference as this also has some impact on shader performance and possibly some other things indirectly, the overall frame time drops from 20.54ms on `main` to 14.14ms on this PR, 6.4ms saved per frame in this example in total, and a reduction of 31%!!

## Open Questions and Reflections

- It feels like we tie a lot of vertex buffer stuff specifically to the Mesh usage of it.
  - I think we will need to allow pipeline specialisation not only based on one vertex buffer, but on a variable number of them.
  - I think we will need to extract the vertex buffer management part of Mesh into its own reusable APIs and build Mesh on top of it. This would be supported by `BufferVec` for serialisation and GPU buffer / binding management.

---

## Changelog

- Changed: Use an instanced vertex buffer for mesh transforms for significant performance improvements with many meshes

## Migration Guide

- Mesh matrices are no longer stored in a uniform buffer binding but rather passed in via vertex attributes in an instanced vertex buffer. Use the helper shader functions to obtain the model or inverse model matrix from the vertex attributes.