### PR TITLE
Fix view z calculation for 'distance' used as sort key

### DIFF
--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -20,6 +20,7 @@ trace = []
 bevy_app = { path = "../bevy_app", version = "0.8.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.8.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.8.0-dev" }
+bevy_math = { path = "../bevy_math", version = "0.8.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.8.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -762,6 +762,9 @@ pub(crate) fn assign_lights_to_clusters(
                 lights
                     .iter()
                     .map(|light| {
+                        // NOTE: row 2 of the inverse view matrix dotted with the world space
+                        // translation gives the z component of translation of the mesh in view
+                        // space
                         -inverse_view_row_2.dot(light.translation.extend(1.0)) + light.range
                     })
                     .reduce(f32::max)

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -124,7 +124,6 @@ fn queue_wireframes(
     let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples);
     for (view, visible_entities, mut opaque_phase) in views.iter_mut() {
         let inverse_view_matrix = view.transform.compute_matrix().inverse();
-        let inverse_view_row_2 = inverse_view_matrix.row(2);
 
         let add_render_phase =
             |(entity, mesh_handle, mesh_uniform): (Entity, &Handle<Mesh>, &MeshUniform)| {
@@ -144,14 +143,13 @@ fn queue_wireframes(
                             return;
                         }
                     };
-                    opaque_phase.add(Opaque3d {
+                    opaque_phase.add(Opaque3d::from_mesh_transform(
                         entity,
-                        pipeline: pipeline_id,
-                        draw_function: draw_custom,
-                        // NOTE: row 2 of the inverse view matrix dotted with column 3 of the model matrix
-                        // gives the z component of translation of the mesh in view space
-                        distance: inverse_view_row_2.dot(mesh_uniform.transform.col(3)),
-                    });
+                        pipeline_id,
+                        draw_custom,
+                        &inverse_view_matrix,
+                        &mesh_uniform.transform,
+                    ));
                 }
             };
 

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -123,8 +123,8 @@ fn queue_wireframes(
         .unwrap();
     let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples);
     for (view, visible_entities, mut opaque_phase) in views.iter_mut() {
-        let view_matrix = view.transform.compute_matrix();
-        let view_row_2 = view_matrix.row(2);
+        let inverse_view_matrix = view.transform.compute_matrix().inverse();
+        let inverse_view_row_2 = inverse_view_matrix.row(2);
 
         let add_render_phase =
             |(entity, mesh_handle, mesh_uniform): (Entity, &Handle<Mesh>, &MeshUniform)| {
@@ -148,7 +148,9 @@ fn queue_wireframes(
                         entity,
                         pipeline: pipeline_id,
                         draw_function: draw_custom,
-                        distance: view_row_2.dot(mesh_uniform.transform.col(3)),
+                        // NOTE: row 2 of the inverse view matrix dotted with column 3 of the model matrix
+                        // gives the z component of translation of the mesh in view space
+                        distance: inverse_view_row_2.dot(mesh_uniform.transform.col(3)),
                     });
                 }
             };

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -28,7 +28,6 @@ use bevy_render::{
     RenderApp, RenderStage,
 };
 use bevy_transform::components::{GlobalTransform, Transform};
-use bevy_utils::FloatOrd;
 use std::hash::Hash;
 use std::marker::PhantomData;
 

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -347,18 +347,13 @@ pub fn queue_material2d_meshes<M: SpecializedMaterial2d>(
                         };
 
                         let mesh_z = mesh2d_uniform.transform.w_axis.z;
-                        transparent_phase.add(Transparent2d {
-                            entity: *visible_entity,
-                            draw_function: draw_transparent_pbr,
-                            pipeline: pipeline_id,
-                            // NOTE: Back-to-front ordering for transparent with ascending sort means far should have the
-                            // lowest sort key and getting closer should increase. As we have
-                            // -z in front of the camera, the largest distance is -far with values increasing toward the
-                            // camera. As such we can just use mesh_z as the distance
-                            sort_key: FloatOrd(mesh_z),
-                            // This material is not batched
-                            batch_range: None,
-                        });
+                        transparent_phase.add(Transparent2d::new(
+                            *visible_entity,
+                            pipeline_id,
+                            draw_transparent_pbr,
+                            mesh_z,
+                            None,
+                        ));
                     }
                 }
             }

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -26,7 +26,6 @@ use bevy_render::{
     RenderWorld,
 };
 use bevy_transform::components::GlobalTransform;
-use bevy_utils::FloatOrd;
 use bevy_utils::HashMap;
 use bytemuck::{Pod, Zeroable};
 use copyless::VecHelper;

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -497,7 +497,7 @@ pub fn queue_sprites(
                 });
 
                 // These items will be sorted by depth with other phase items
-                let sort_key = FloatOrd(extracted_sprite.transform.translation.z);
+                let sort_key = extracted_sprite.transform.translation.z;
 
                 // Store the vertex data and add the item to the render phase
                 if current_batch.colored {
@@ -512,13 +512,13 @@ pub fn queue_sprites(
                     colored_index += QUAD_INDICES.len() as u32;
                     let item_end = colored_index;
 
-                    transparent_phase.add(Transparent2d {
-                        draw_function: draw_sprite_function,
-                        pipeline: colored_pipeline,
-                        entity: current_batch_entity,
+                    transparent_phase.add(Transparent2d::new(
+                        current_batch_entity,
+                        colored_pipeline,
+                        draw_sprite_function,
                         sort_key,
-                        batch_range: Some(item_start..item_end),
-                    });
+                        Some(item_start..item_end),
+                    ));
                 } else {
                     for i in QUAD_INDICES.iter() {
                         sprite_meta.vertices.push(SpriteVertex {
@@ -530,13 +530,13 @@ pub fn queue_sprites(
                     index += QUAD_INDICES.len() as u32;
                     let item_end = index;
 
-                    transparent_phase.add(Transparent2d {
-                        draw_function: draw_sprite_function,
+                    transparent_phase.add(Transparent2d::new(
+                        current_batch_entity,
                         pipeline,
-                        entity: current_batch_entity,
+                        draw_sprite_function,
                         sort_key,
-                        batch_range: Some(item_start..item_end),
-                    });
+                        Some(item_start..item_end),
+                    ));
                 }
             }
         }

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -330,16 +330,16 @@ pub fn queue_colored_mesh2d(
                     pipelines.specialize(&mut pipeline_cache, &colored_mesh2d_pipeline, mesh2d_key);
 
                 let mesh_z = mesh2d_uniform.transform.w_axis.z;
-                transparent_phase.add(Transparent2d {
-                    entity: *visible_entity,
-                    draw_function: draw_colored_mesh2d,
-                    pipeline: pipeline_id,
+                transparent_phase.add(Transparent2d::new(
+                    *visible_entity,
+                    pipeline_id,
+                    draw_colored_mesh2d,
                     // The 2d render items are sorted according to their z value before rendering,
                     // in order to get correct transparency
-                    sort_key: FloatOrd(mesh_z),
+                    mesh_z,
                     // This material is not batched
-                    batch_range: None,
-                });
+                    None,
+                ));
             }
         }
     }

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -20,7 +20,6 @@ use bevy::{
         DrawMesh2d, Mesh2dHandle, Mesh2dPipeline, Mesh2dPipelineKey, Mesh2dUniform,
         SetMesh2dBindGroup, SetMesh2dViewBindGroup,
     },
-    utils::FloatOrd,
 };
 
 /// This example shows how to manually render 2d items using "mid level render apis" with a custom pipeline for 2d meshes

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -113,24 +113,18 @@ fn queue_custom(
 
     for (view, mut transparent_phase) in views.iter_mut() {
         let inverse_view_matrix = view.transform.compute_matrix().inverse();
-        let inverse_view_row_2 = inverse_view_matrix.row(2);
         for (entity, mesh_uniform, mesh_handle) in material_meshes.iter() {
             if let Some(mesh) = render_meshes.get(mesh_handle) {
                 let pipeline = pipelines
                     .specialize(&mut pipeline_cache, &custom_pipeline, key, &mesh.layout)
                     .unwrap();
-                transparent_phase.add(Transparent3d {
+                transparent_phase.add(Transparent3d::from_mesh_transform(
                     entity,
                     pipeline,
-                    draw_function: draw_custom,
-                    // NOTE: row 2 of the inverse view matrix dotted with column 3 of the model matrix
-                    // gives the z component of translation of the mesh in view space.
-                    // NOTE: Back-to-front ordering for transparent with ascending sort means far should have the
-                    // lowest sort key and getting closer should increase. As we have
-                    // -z in front of the camera, the largest distance is -far with values increasing toward the
-                    // camera. As such we can just use the dot product value.
-                    distance: inverse_view_row_2.dot(mesh_uniform.transform.col(3)),
-                });
+                    draw_custom,
+                    &inverse_view_matrix,
+                    &mesh_uniform.transform,
+                ));
             }
         }
     }

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -149,8 +149,8 @@ fn queue_custom(
         .unwrap();
     let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples);
     for (view, mut transparent_phase) in views.iter_mut() {
-        let view_matrix = view.transform.compute_matrix();
-        let view_row_2 = view_matrix.row(2);
+        let inverse_view_matrix = view.transform.compute_matrix().inverse();
+        let inverse_view_row_2 = inverse_view_matrix.row(2);
         for (entity, mesh_handle, mesh_uniform, is_red) in material_meshes.iter() {
             if let Some(mesh) = render_meshes.get(mesh_handle) {
                 let key =
@@ -167,7 +167,13 @@ fn queue_custom(
                     entity,
                     pipeline,
                     draw_function: draw_custom,
-                    distance: view_row_2.dot(mesh_uniform.transform.col(3)),
+                    // NOTE: row 2 of the inverse view matrix dotted with column 3 of the model matrix
+                    // gives the z component of translation of the mesh in view space.
+                    // NOTE: Back-to-front ordering for transparent with ascending sort means far should have the
+                    // lowest sort key and getting closer should increase. As we have
+                    // -z in front of the camera, the largest distance is -far with values increasing toward the
+                    // camera. As such we can just use the dot product value.
+                    distance: inverse_view_row_2.dot(mesh_uniform.transform.col(3)),
                 });
             }
         }

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -117,8 +117,8 @@ fn queue_custom(
     let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples);
 
     for (view, mut transparent_phase) in views.iter_mut() {
-        let view_matrix = view.transform.compute_matrix();
-        let view_row_2 = view_matrix.row(2);
+        let inverse_view_matrix = view.transform.compute_matrix().inverse();
+        let inverse_view_row_2 = inverse_view_matrix.row(2);
         for (entity, mesh_uniform, mesh_handle) in material_meshes.iter() {
             if let Some(mesh) = meshes.get(mesh_handle) {
                 let key =
@@ -130,7 +130,13 @@ fn queue_custom(
                     entity,
                     pipeline,
                     draw_function: draw_custom,
-                    distance: view_row_2.dot(mesh_uniform.transform.col(3)),
+                    // NOTE: row 2 of the inverse view matrix dotted with column 3 of the model matrix
+                    // gives the z component of translation of the mesh in view space.
+                    // NOTE: Back-to-front ordering for transparent with ascending sort means far should have the
+                    // lowest sort key and getting closer should increase. As we have
+                    // -z in front of the camera, the largest distance is -far with values increasing toward the
+                    // camera. As such we can just use the dot product value.
+                    distance: inverse_view_row_2.dot(mesh_uniform.transform.col(3)),
                 });
             }
         }

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -118,7 +118,6 @@ fn queue_custom(
 
     for (view, mut transparent_phase) in views.iter_mut() {
         let inverse_view_matrix = view.transform.compute_matrix().inverse();
-        let inverse_view_row_2 = inverse_view_matrix.row(2);
         for (entity, mesh_uniform, mesh_handle) in material_meshes.iter() {
             if let Some(mesh) = meshes.get(mesh_handle) {
                 let key =
@@ -126,18 +125,13 @@ fn queue_custom(
                 let pipeline = pipelines
                     .specialize(&mut pipeline_cache, &custom_pipeline, key, &mesh.layout)
                     .unwrap();
-                transparent_phase.add(Transparent3d {
+                transparent_phase.add(Transparent3d::from_mesh_transform(
                     entity,
                     pipeline,
-                    draw_function: draw_custom,
-                    // NOTE: row 2 of the inverse view matrix dotted with column 3 of the model matrix
-                    // gives the z component of translation of the mesh in view space.
-                    // NOTE: Back-to-front ordering for transparent with ascending sort means far should have the
-                    // lowest sort key and getting closer should increase. As we have
-                    // -z in front of the camera, the largest distance is -far with values increasing toward the
-                    // camera. As such we can just use the dot product value.
-                    distance: inverse_view_row_2.dot(mesh_uniform.transform.col(3)),
-                });
+                    draw_custom,
+                    &inverse_view_matrix,
+                    &mesh_uniform.transform,
+                ));
             }
         }
     }


### PR DESCRIPTION
# Objective

- Fix incorrect mesh sorting in wireframe and examples that use custom sorts

## Solution

- The model translation must be transformed by the inverse view transform. If you consider an object directly in front of you and you turn your head to the left you're now looking to the left of the object. The way rendering works is that you instead consider that your head remains stationary, and you rotate everything else in the opposite direction to how you want to turn your head. So, you transform the model by the inverse view transform.
- To get the view space z of the object, we can calculate the dot product of row 2 of the inverse view matrix and the object's translation, which is stored in column 3 of the object transform.
- Add constructors for `Opaque3d`,  `AlphaMask3d`,  `Transparent3d`,  `Transparent2d` in order to correctly calculate the sort key using the inverse view transform and mesh transform
- Make phase item struct members private to encourage use of the constructors

---

## Changelog

- Fixed: Sort order of wireframe meshes
- Changed: Add constructors for `Opaque3d`,  `AlphaMask3d`,  `Transparent3d`,  `Transparent2d` in order to correctly calculate the sort key using the inverse view transform and mesh transform, and make phase item struct members private to encourage use of the constructors