### PR TITLE
[Merged by Bors] - Improve docs and naming for RawWindowHandle functionality

### DIFF
--- a/crates/bevy_window/src/raw_window_handle.rs
+++ b/crates/bevy_window/src/raw_window_handle.rs
@@ -10,12 +10,13 @@ impl RawWindowHandleWrapper {
         Self(handle)
     }
 
+    /// Returns a [`HasRawWindowHandle`] impl, which exposes [`RawWindowHandle`]
+    ///
     /// # Safety
-    /// This returns a [`HasRawWindowHandle`] impl, which exposes [`RawWindowHandle`]. Some platforms
-    /// have constraints on where/how this handle can be used. For example, some platforms don't support doing window
+    /// Some platforms have constraints on where/how this handle can be used. For example, some platforms don't support doing window
     /// operations off of the main thread. The caller must ensure the [`RawWindowHandle`] is only used in valid contexts.
-    pub unsafe fn get_handle(&self) -> HasRawWindowHandleWrapper {
-        HasRawWindowHandleWrapper(self.0)
+    pub unsafe fn get_handle(&self) -> ThreadLockedRawWindowHandleWrapper {
+        ThreadLockedRawWindowHandleWrapper(self.0)
     }
 }
 
@@ -27,10 +28,18 @@ impl RawWindowHandleWrapper {
 unsafe impl Send for RawWindowHandleWrapper {}
 unsafe impl Sync for RawWindowHandleWrapper {}
 
-pub struct HasRawWindowHandleWrapper(RawWindowHandle);
+/// A [`RawWindowHandleWrapper`]that cannot be sent across threads,
+///
+/// This safely exposes a [`RawWindowHandle`], but care must be taken to ensure that the construction itself is correct.
+///
+/// This can only be constructed via the [`RawWindowHandleWrapper::get_handle()`] method;
+/// be sure to read the safety docs there about platform-specific limitations.
+/// In many cases, this should only be constructed on the main thread.
+pub struct ThreadLockedRawWindowHandleWrapper(RawWindowHandle);
 
 // SAFE: the caller has validated that this is a valid context to get RawWindowHandle
-unsafe impl HasRawWindowHandle for HasRawWindowHandleWrapper {
+// as otherwise an instance of this type could not have been constructed
+unsafe impl HasRawWindowHandle for ThreadLockedRawWindowHandleWrapper {
     fn raw_window_handle(&self) -> RawWindowHandle {
         self.0
     }

--- a/crates/bevy_window/src/raw_window_handle.rs
+++ b/crates/bevy_window/src/raw_window_handle.rs
@@ -32,7 +32,7 @@ impl RawWindowHandleWrapper {
 unsafe impl Send for RawWindowHandleWrapper {}
 unsafe impl Sync for RawWindowHandleWrapper {}
 
-/// A [`RawWindowHandleWrapper`]that cannot be sent across threads,
+/// A [`RawWindowHandleWrapper`] that cannot be sent across threads
 ///
 /// This safely exposes a [`RawWindowHandle`], but care must be taken to ensure that the construction itself is correct.
 ///

--- a/crates/bevy_window/src/raw_window_handle.rs
+++ b/crates/bevy_window/src/raw_window_handle.rs
@@ -3,7 +3,7 @@ use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 /// A wrapper over [`RawWindowHandle`] that allows us to safely pass it across threads.
 ///
 /// Depending on the platform, the underlying pointer-containing handle cannot be used on all threads,
-/// and so we cannot simply make it (or any type that has a safe opration to get a [`RawWindowHandle`])
+/// and so we cannot simply make it (or any type that has a safe operation to get a [`RawWindowHandle`])
 /// thread-safe.
 #[derive(Debug, Clone)]
 pub struct RawWindowHandleWrapper(RawWindowHandle);
@@ -13,7 +13,7 @@ impl RawWindowHandleWrapper {
         Self(handle)
     }
 
-    /// Returns a [`HasRawWindowHandle`] impl, which exposes [`RawWindowHandle`]
+    /// Returns a [`HasRawWindowHandle`] impl, which exposes [`RawWindowHandle`].
     ///
     /// # Safety
     ///
@@ -32,7 +32,7 @@ impl RawWindowHandleWrapper {
 unsafe impl Send for RawWindowHandleWrapper {}
 unsafe impl Sync for RawWindowHandleWrapper {}
 
-/// A [`RawWindowHandleWrapper`] that cannot be sent across threads
+/// A [`RawWindowHandleWrapper`] that cannot be sent across threads.
 ///
 /// This safely exposes a [`RawWindowHandle`], but care must be taken to ensure that the construction itself is correct.
 ///


### PR DESCRIPTION
# Objective

- As noticed in #4333 by @x-52, the exact purpose and logic of `HasRawWIndowHandleWrapper` is unclear
- Unfortunately, there are rather good reasons why this design is needed (and why we can't just `impl HasRawWindowHandle for RawWindowHandleWrapper` 

## Solution

- Rename `HasRawWindowHandleWrapper` to `ThreadLockedRawWindowHandleWrapper`, reflecting the primary distinction
- Document how this design is intended to be used
- Leave comments explaining why this design must exist


## Migration Guide

- renamed `HasRawWindowHandleWrapper` to `ThreadLockedRawWindowHandleWrapper`
