### PR TITLE
[Merged by Bors] - Remove unnecessary system labels

### DIFF
--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -21,8 +21,8 @@ fn main() {
 
     // Add systems sending and receiving events to a "second" Stage
     let mut second = SystemStage::parallel();
-    second.add_system(sending_system.label(EventSystem::Sending));
-    second.add_system(receiving_system.after(EventSystem::Sending));
+    second.add_system(sending_system);
+    second.add_system(receiving_system.after(sending_system));
 
     // Run the "second" Stage after the "first" Stage, so our Events always get updated before we use them
     schedule.add_stage_after("first", "second", second);
@@ -32,12 +32,6 @@ fn main() {
         println!("Simulating frame {}/10", iteration);
         schedule.run(&mut world);
     }
-}
-
-// System label to enforce a run order of our systems
-#[derive(SystemLabel, Debug, Clone, PartialEq, Eq, Hash)]
-enum EventSystem {
-    Sending,
 }
 
 // This is our event that we will send and receive in systems

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -16,8 +16,8 @@ fn main() {
     let mut update = SystemStage::parallel();
 
     // Add systems to increase the counter and to print out the current value
-    update.add_system(increase_counter.label(CounterSystem::Increase));
-    update.add_system(print_counter.after(CounterSystem::Increase));
+    update.add_system(increase_counter);
+    update.add_system(print_counter.after(increase_counter));
     schedule.add_stage("update", update);
 
     for iteration in 1..=10 {
@@ -30,12 +30,6 @@ fn main() {
 #[derive(Debug)]
 struct Counter {
     pub value: i32,
-}
-
-// System label to enforce a run order of our systems
-#[derive(SystemLabel, Debug, Clone, PartialEq, Eq, Hash)]
-enum CounterSystem {
-    Increase,
 }
 
 fn increase_counter(mut counter: ResMut<Counter>) {

--- a/examples/2d/many_sprites.rs
+++ b/examples/2d/many_sprites.rs
@@ -17,8 +17,8 @@ fn main() {
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(print_sprite_count.label("Tick"))
-        .add_system(move_camera.after("Tick"))
+        .add_system(print_sprite_count)
+        .add_system(move_camera.after(print_sprite_count))
         .run();
 }
 

--- a/examples/ecs/custom_query_param.rs
+++ b/examples/ecs/custom_query_param.rs
@@ -20,18 +20,10 @@ use std::{fmt::Debug, marker::PhantomData};
 fn main() {
     App::new()
         .add_startup_system(spawn)
-        .add_system(print_components_read_only.label("print_components_read_only"))
-        .add_system(
-            print_components_iter_mut
-                .label("print_components_iter_mut")
-                .after("print_components_read_only"),
-        )
-        .add_system(
-            print_components_iter
-                .label("print_components_iter")
-                .after("print_components_iter_mut"),
-        )
-        .add_system(print_components_tuple.after("print_components_iter"))
+        .add_system(print_components_read_only)
+        .add_system(print_components_iter_mut.after(print_components_read_only))
+        .add_system(print_components_iter.after(print_components_iter_mut))
+        .add_system(print_components_tuple.after(print_components_iter))
         .run();
 }
 

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -331,22 +331,18 @@ fn main() {
         .add_system_to_stage(MyStage::BeforeRound, new_player_system)
         .add_system_to_stage(
             MyStage::BeforeRound,
+            // Systems which take `&mut World` as an argument must call `.exclusive_system()`.
+            // The following will not compile.
+            //.add_system_to_stage(MyStage::BeforeRound, exclusive_player_system)
             exclusive_player_system.exclusive_system(),
         )
-        // Systems which take `&mut World` as an argument must call `.exclusive_system()`.
-        // The following will not compile.
-        //.add_system_to_stage(MyStage::BeforeRound, exclusive_player_system)
-        //
-        // We can ensure that game_over system runs after score_check_system using explicit ordering
-        // constraints First, we label the system we want to refer to using `.label`
-        // Then, we use either `.before` or `.after` to describe the order we want the relationship
+        .add_system_to_stage(MyStage::AfterRound, score_check_system)
         .add_system_to_stage(
+            // We can ensure that `game_over_system` runs after `score_check_system` using explicit ordering
+            // To do this we use either `.before` or `.after` to describe the order we want the relationship
+            // Since we are using `after`, `game_over_system` runs after `score_check_system`
             MyStage::AfterRound,
-            score_check_system.label(MyLabels::ScoreCheck),
-        )
-        .add_system_to_stage(
-            MyStage::AfterRound,
-            game_over_system.after(MyLabels::ScoreCheck),
+            game_over_system.after(score_check_system),
         )
         // We can check our systems for execution order ambiguities by examining the output produced
         // in the console by using the `LogPlugin` and adding the following Resource to our App :)

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -255,11 +255,6 @@ enum MyStage {
     AfterRound,
 }
 
-#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
-enum MyLabels {
-    ScoreCheck,
-}
-
 // Our Bevy app's entry point
 fn main() {
     // Bevy apps are created using the builder pattern. We use the builder to add systems,

--- a/examples/tools/scene_viewer.rs
+++ b/examples/tools/scene_viewer.rs
@@ -45,9 +45,9 @@ Controls:
         .add_startup_system(setup)
         .add_system_to_stage(CoreStage::PreUpdate, scene_load_check)
         .add_system_to_stage(CoreStage::PreUpdate, camera_spawn_check)
-        .add_system(camera_controller_check.label(CameraControllerCheckSystem))
+        .add_system(check_camera_controller)
         .add_system(update_lights)
-        .add_system(camera_controller.after(CameraControllerCheckSystem))
+        .add_system(camera_controller.after(check_camera_controller))
         .run();
 }
 
@@ -221,7 +221,7 @@ fn camera_spawn_check(
     }
 }
 
-fn camera_controller_check(
+fn check_camera_controller(
     mut commands: Commands,
     camera: Query<Entity, (With<Camera>, Without<CameraController>)>,
     mut found_camera: Local<bool>,

--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -32,8 +32,8 @@ fn did_hurt_enemy() {
 
     // Setup stage with our two systems
     let mut update_stage = SystemStage::parallel();
-    update_stage.add_system(hurt_enemies.before("death"));
-    update_stage.add_system(despawn_dead_enemies.label("death"));
+    update_stage.add_system(hurt_enemies.before(despawn_dead_enemies));
+    update_stage.add_system(despawn_dead_enemies);
 
     // Setup test entities
     let enemy_id = world.spawn().insert(Enemy { hit_points: 5 }).id();
@@ -53,8 +53,8 @@ fn did_despawn_enemy() {
 
     // Setup stage with our two systems
     let mut update_stage = SystemStage::parallel();
-    update_stage.add_system(hurt_enemies.before("death"));
-    update_stage.add_system(despawn_dead_enemies.label("death"));
+    update_stage.add_system(hurt_enemies.before(despawn_dead_enemies));
+    update_stage.add_system(despawn_dead_enemies);
 
     // Setup test entities
     let enemy_id = world.spawn().insert(Enemy { hit_points: 1 }).id();


### PR DESCRIPTION
# Objective

- Since #4224, using labels which only refer to one system doesn't make sense.

## Solution

- Remove some of those.

## Future work

- We should remove the ability to use strings as system labels entirely. I haven't in this PR because there are tests which use this, and that's a lot of code to change.
   - The only use cases for labels are either intra-crate, which use #4224, or inter-crate, which should either use #4224 or explicit types. Neither of those should use strings.