### PR TITLE
Nesting `Task` scopes

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor_parallel.rs
+++ b/crates/bevy_ecs/src/schedule/executor_parallel.rs
@@ -179,7 +179,7 @@ impl ParallelExecutor {
     /// queues systems with no dependencies to run (or skip) at next opportunity.
     fn prepare_systems<'scope>(
         &mut self,
-        scope: &mut Scope<'scope, ()>,
+        scope: &Scope<'scope, ()>,
         systems: &'scope mut [ParallelSystemContainer],
         world: &'scope World,
     ) {

--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -77,7 +77,9 @@ impl TaskPool {
         while executor.try_tick() {}
 
         let result = scope
-            .results.lock().unwrap()
+            .results
+            .lock()
+            .unwrap()
             .iter()
             .map(|result| result.lock().unwrap().take().unwrap())
             .collect();

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -347,10 +347,10 @@ mod tests {
         let outputs = pool.scope(|scope| {
             for _ in 0..10 {
                 let count_clone = count.clone();
-                scope.spawn(async move {
+                scope.spawn_local(async move {
                     for _ in 0..10 {
                         let count_clone_clone = count_clone.clone();
-                        let nested_outputs = scope.spawn(async move {
+                        scope.spawn(async move {
                             if *foo != 42 {
                                 panic!("not 42!?!?")
                             } else {

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -164,7 +164,7 @@ impl TaskPool {
     /// This is similar to `rayon::scope` and `crossbeam::scope`
     pub fn scope<'scope, F, T>(&self, f: F) -> Vec<T>
     where
-        F: FnOnce(&mut Scope<'scope, T>) + 'scope + Send,
+        F: FnOnce(&Scope<'scope, T>) + 'scope + Send,
         T: Send + 'static,
     {
         TaskPool::LOCAL_EXECUTOR.with(|local_executor| {
@@ -278,7 +278,7 @@ impl<'scope, T: Send + 'scope> Scope<'scope, T> {
     /// instead.
     ///
     /// For more information, see [`TaskPool::scope`].
-    pub fn spawn<Fut: Future<Output = T> + 'scope + Send>(&mut self, f: Fut) {
+    pub fn spawn<Fut: Future<Output = T> + 'scope + Send>(&self, f: Fut) {
         let task = self.executor.spawn(f);
         self.spawned.lock().unwrap().push(task);
     }
@@ -289,7 +289,7 @@ impl<'scope, T: Send + 'scope> Scope<'scope, T> {
     /// [`Scope::spawn`] instead, unless the provided future is not `Send`.
     ///
     /// For more information, see [`TaskPool::scope`].
-    pub fn spawn_local<Fut: Future<Output = T> + 'scope>(&mut self, f: Fut) {
+    pub fn spawn_local<Fut: Future<Output = T> + 'scope>(&self, f: Fut) {
         let task = self.local_executor.spawn(f);
         self.spawned.lock().unwrap().push(task);
     }

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -179,7 +179,7 @@ impl TaskPool {
             let mut scope = Scope {
                 executor,
                 local_executor,
-                spawned: Mutex::new(Vec::new()),
+                spawned: Arc::new(Mutex::new(Vec::new())),
             };
 
             f(&mut scope);
@@ -266,7 +266,7 @@ impl Default for TaskPool {
 pub struct Scope<'scope, T> {
     executor: &'scope async_executor::Executor<'scope>,
     local_executor: &'scope async_executor::LocalExecutor<'scope>,
-    spawned: Mutex<Vec<async_executor::Task<T>>>,
+    spawned: Arc<Mutex<Vec<async_executor::Task<T>>>>,
 }
 
 impl<'scope, T: Send + 'scope> Scope<'scope, T> {

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -347,7 +347,7 @@ mod tests {
         let outputs = pool.scope(|scope| {
             for _ in 0..10 {
                 let count_clone = count.clone();
-                scope.spawn_local(async move {
+                scope.spawn(async move {
                     for _ in 0..10 {
                         let count_clone_clone = count_clone.clone();
                         scope.spawn(async move {


### PR DESCRIPTION
# Objective

*attempt to*
Allow for nested task scopes as in #4301.
Possibly not use a scope argument for further nesting.

## Progress

I wrapped `Task`s `results` field in `Arc<Mutex<>>` to make it internally mutable,
then changed functions signatures to no longer use `&mut` but `&`.
Currently stuck on `LocalExecutor` which is `!Send + !Sync`, hence prevents nesting inside `Scope::spawn`.
[full error message](https://github.com/bevyengine/bevy/runs/5709213024?check_suite_focus=true#step:6:352)
(nesting `spawn_local` works, but is stopped by [another problem](https://github.com/bevyengine/bevy/runs/5707064399?check_suite_focus=true#step:6:11), I wanna focus on fixing the original)
