### PR TITLE
[Merged by Bors] - bevy_reflect: Add `as_reflect` and `as_reflect_mut`

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -274,6 +274,17 @@ fn impl_struct(
             fn any_mut(&mut self) -> &mut dyn std::any::Any {
                 self
             }
+
+            #[inline]
+            fn as_reflect(&self) -> &dyn #bevy_reflect_path::Reflect {
+                self
+            }
+
+            #[inline]
+            fn as_reflect_mut(&mut self) -> &mut dyn #bevy_reflect_path::Reflect {
+                self
+            }
+
             #[inline]
             fn clone_value(&self) -> Box<dyn #bevy_reflect_path::Reflect> {
                 use #bevy_reflect_path::Struct;
@@ -396,6 +407,17 @@ fn impl_tuple_struct(
             fn any_mut(&mut self) -> &mut dyn std::any::Any {
                 self
             }
+
+            #[inline]
+            fn as_reflect(&self) -> &dyn #bevy_reflect_path::Reflect {
+                self
+            }
+
+            #[inline]
+            fn as_reflect_mut(&mut self) -> &mut dyn #bevy_reflect_path::Reflect {
+                self
+            }
+
             #[inline]
             fn clone_value(&self) -> Box<dyn #bevy_reflect_path::Reflect> {
                 use #bevy_reflect_path::TupleStruct;
@@ -471,6 +493,16 @@ fn impl_value(
 
             #[inline]
             fn any_mut(&mut self) -> &mut dyn std::any::Any {
+                self
+            }
+
+            #[inline]
+            fn as_reflect(&self) -> &dyn #bevy_reflect_path::Reflect {
+                self
+            }
+
+            #[inline]
+            fn as_reflect_mut(&mut self) -> &mut dyn #bevy_reflect_path::Reflect {
                 self
             }
 

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -64,6 +64,14 @@ where
         self
     }
 
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
     fn apply(&mut self, value: &dyn Reflect) {
         crate::list_apply(self, value);
     }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -110,6 +110,14 @@ unsafe impl<T: FromReflect> Reflect for Vec<T> {
         self
     }
 
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
     fn apply(&mut self, value: &dyn Reflect) {
         crate::list_apply(self, value);
     }
@@ -220,6 +228,14 @@ unsafe impl<K: Reflect + Eq + Hash, V: Reflect> Reflect for HashMap<K, V> {
         self
     }
 
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
     fn apply(&mut self, value: &dyn Reflect) {
         if let ReflectRef::Map(map_value) = value.reflect_ref() {
             for (key, value) in map_value.iter() {
@@ -301,6 +317,14 @@ unsafe impl Reflect for Cow<'static, str> {
     }
 
     fn any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
         self
     }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -423,4 +423,19 @@ mod tests {
             std::any::type_name::<TestTupleStruct>()
         );
     }
+
+    #[test]
+    fn as_reflect() {
+        trait TestTrait: Reflect {}
+
+        #[derive(Reflect)]
+        struct TestStruct;
+
+        impl TestTrait for TestStruct {}
+
+        let trait_object: Box<dyn TestTrait> = Box::new(TestStruct);
+
+        // Should compile:
+        let _ = trait_object.as_reflect();
+    }
 }

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -121,6 +121,16 @@ unsafe impl Reflect for DynamicList {
         self
     }
 
+    #[inline]
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    #[inline]
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
     fn apply(&mut self, value: &dyn Reflect) {
         list_apply(self, value);
     }

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -147,6 +147,16 @@ unsafe impl Reflect for DynamicMap {
         self
     }
 
+    #[inline]
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    #[inline]
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
     fn apply(&mut self, value: &dyn Reflect) {
         if let ReflectRef::Map(map_value) = value.reflect_ref() {
             for (key, value) in map_value.iter() {

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -57,6 +57,12 @@ pub unsafe trait Reflect: Any + Send + Sync {
     /// Returns the value as a [`&mut dyn Any`][std::any::Any].
     fn any_mut(&mut self) -> &mut dyn Any;
 
+    /// Casts this type to a reflected value
+    fn as_reflect(&self) -> &dyn Reflect;
+
+    /// Casts this type to a mutable reflected value
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect;
+
     /// Applies a reflected value to this value.
     ///
     /// If a type implements a subtrait of `Reflect`, then the semantics of this

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -270,6 +270,16 @@ unsafe impl Reflect for DynamicStruct {
     }
 
     #[inline]
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    #[inline]
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    #[inline]
     fn clone_value(&self) -> Box<dyn Reflect> {
         Box::new(self.clone_dynamic())
     }

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -223,6 +223,16 @@ unsafe impl Reflect for DynamicTuple {
     }
 
     #[inline]
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    #[inline]
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    #[inline]
     fn clone_value(&self) -> Box<dyn Reflect> {
         Box::new(self.clone_dynamic())
     }
@@ -363,6 +373,14 @@ macro_rules! impl_reflect_tuple {
             }
 
             fn any_mut(&mut self) -> &mut dyn Any {
+                self
+            }
+
+            fn as_reflect(&self) -> &dyn Reflect {
+                self
+            }
+
+            fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
                 self
             }
 

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -210,6 +210,16 @@ unsafe impl Reflect for DynamicTupleStruct {
     }
 
     #[inline]
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    #[inline]
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    #[inline]
     fn clone_value(&self) -> Box<dyn Reflect> {
         Box::new(self.clone_dynamic())
     }


### PR DESCRIPTION
# Objective

Trait objects that have `Reflect` as a supertrait cannot be upcast to a `dyn Reflect`.

Attempting something like:

```rust
trait MyTrait: Reflect {
  // ...
}

fn foo(value: &dyn MyTrait) {
  let reflected = value as &dyn Reflect; // Error!
  // ...
}
```

Results in `error[E0658]: trait upcasting coercion is experimental`.

The reason this is important is that a lot of `bevy_reflect` methods require a `&dyn Reflect`. This is trivial with concrete types, but if we don't know the concrete type (we only have the trait object), we can't use these methods. For example, we couldn't create a `ReflectSerializer` for the type since it expects a `&dyn Reflect` value— even though we should be able to.

## Solution

Add `as_reflect` and `as_reflect_mut` to `Reflect` to allow upcasting to a `dyn Reflect`:

```rust
trait MyTrait: Reflect {
  // ...
}

fn foo(value: &dyn MyTrait) {
  let reflected = value.as_reflect();
  // ...
}
```

## Alternatives

We could defer this type of logic to the crate/user. They can add these methods to their trait in the same exact way we do here. The main benefit of doing it ourselves is it makes things convenient for them (especially when using the derive macro).

We could also create an `AsReflect` trait with a blanket impl over all reflected types, however, I could not get that to work for trait objects since they aren't sized.

---

## Changelog

- Added trait method `Reflect::as_reflect(&self)`
- Added trait method `Reflect::as_reflect_mut(&mut self)`

## Migration Guide

- Manual implementors of `Reflect` will need to add implementations for the methods above (this should be pretty easy as most cases just need to return `self`)