### PR TITLE
reduce how many colors are possible by limiting channels to what an u8 can hold

### DIFF
--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -738,10 +738,10 @@ impl From<Color> for wgpu::Color {
         } = color.as_rgba_linear()
         {
             wgpu::Color {
-                r: red as f64,
-                g: green as f64,
-                b: blue as f64,
-                a: alpha as f64,
+                r: ((red * 255.0) as u8) as f64 / 255.0,
+                g: ((green * 255.0) as u8) as f64 / 255.0,
+                b: ((blue * 255.0) as u8) as f64 / 255.0,
+                a: ((alpha * 255.0) as u8) as f64 / 255.0,
             }
         } else {
             unreachable!()


### PR DESCRIPTION
# Objective

- Fix #4356 

## Solution

- Limit conversion of colors to wgpu colors to what an `u8` can hold instead of directly as a `f64`

This is not an ideal fix as it reduces what is possible to do, but having color channels in `u8` is what is used in a lot of places