### PR TITLE
Fix prepare ordering between images & view targets

### DIFF
--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -5,6 +5,7 @@ use bevy_ecs::{
     prelude::*,
     system::{StaticSystemParam, SystemParam, SystemParamItem},
 };
+use bevy_reflect::Uuid;
 use bevy_utils::{HashMap, HashSet};
 use std::marker::PhantomData;
 
@@ -52,6 +53,9 @@ impl<A: RenderAsset> Default for RenderAssetPlugin<A> {
     }
 }
 
+#[derive(Clone, Hash, Debug, PartialEq, Eq, SystemLabel)]
+pub struct PrepareAssetSystemLabel(pub Uuid);
+
 impl<A: RenderAsset> Plugin for RenderAssetPlugin<A> {
     fn build(&self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
@@ -60,7 +64,10 @@ impl<A: RenderAsset> Plugin for RenderAssetPlugin<A> {
                 .init_resource::<RenderAssets<A>>()
                 .init_resource::<PrepareNextFrameAssets<A>>()
                 .add_system_to_stage(RenderStage::Extract, extract_render_asset::<A>)
-                .add_system_to_stage(RenderStage::Prepare, prepare_assets::<A>);
+                .add_system_to_stage(
+                    RenderStage::Prepare,
+                    prepare_assets::<A>.label(PrepareAssetSystemLabel(A::TYPE_UUID)),
+                );
         }
     }
 }

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -1,6 +1,7 @@
 pub mod visibility;
 pub mod window;
 
+use bevy_reflect::TypeUuid;
 pub use visibility::*;
 use wgpu::{
     Color, Extent3d, Operations, RenderPassColorAttachment, TextureDescriptor, TextureDimension,
@@ -11,7 +12,7 @@ pub use window::*;
 use crate::{
     camera::ExtractedCamera,
     prelude::Image,
-    render_asset::RenderAssets,
+    render_asset::{PrepareAssetSystemLabel, RenderAssets},
     render_resource::{std140::AsStd140, DynamicUniformVec, Texture, TextureView},
     renderer::{RenderDevice, RenderQueue},
     texture::{BevyDefault, TextureCache},
@@ -35,7 +36,9 @@ impl Plugin for ViewPlugin {
                 .add_system_to_stage(RenderStage::Prepare, prepare_view_uniforms)
                 .add_system_to_stage(
                     RenderStage::Prepare,
-                    prepare_view_targets.after(WindowSystem::Prepare),
+                    prepare_view_targets
+                        .after(WindowSystem::Prepare)
+                        .after(PrepareAssetSystemLabel(Image::TYPE_UUID)),
                 );
         }
     }


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/4087
- View targets can be images, but right now the prepare order is undefined between those so random crashes occur when using them.

## Solution

- Added AssetPrepareSystemLabel assigned to all asset prepare systems, identified by the Uuid of their Asset.
- Add a dependency between view target and image prepare systems.

## Additional info

It looks like https://github.com/bevyengine/bevy/pull/3917 might be a step toward this, but it looks like there's still some design decisions to be made for it to go forward.
As the release of 0.7 is getting close, I propose this simple fix.