### PR TITLE
[Merged by Bors] - Clean up duplicated color conversion code

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -498,12 +498,9 @@ pub fn queue_sprites(
 
                 // Store the vertex data and add the item to the render phase
                 if current_batch.colored {
-                    let color = extracted_sprite.color.as_linear_rgba_f32();
                     // encode color as a single u32 to save space
-                    let color = (color[0] * 255.0) as u32
-                        | ((color[1] * 255.0) as u32) << 8
-                        | ((color[2] * 255.0) as u32) << 16
-                        | ((color[3] * 255.0) as u32) << 24;
+                    let color = extracted_sprite.color.as_linear_rgba_u32();
+
                     for i in QUAD_INDICES.iter() {
                         sprite_meta.colored_vertices.push(ColoredSpriteVertex {
                             position: positions[*i],

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -360,12 +360,8 @@ pub fn prepare_uinodes(
         ]
         .map(|pos| pos / atlas_extent);
 
-        let color = extracted_uinode.color.as_linear_rgba_f32();
         // encode color as a single u32 to save space
-        let color = (color[0] * 255.0) as u32
-            | ((color[1] * 255.0) as u32) << 8
-            | ((color[2] * 255.0) as u32) << 16
-            | ((color[3] * 255.0) as u32) << 24;
+        let color = extracted_uinode.color.as_linear_rgba_u32();
 
         for i in QUAD_INDICES {
             ui_meta.vertices.push(UiVertex {


### PR DESCRIPTION
# Objective

Cleans up some duplicated color -> u32 conversion code in `bevy_sprite` and `bevy_ui`

## Solution

Use `as_linear_rgba_u32` which was added recently by #4088


