### PR TITLE
[Merged by Bors] - Fix animation: shadow and wireframe support

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -261,7 +261,7 @@ impl SpecializedMeshPipeline for ShadowPipeline {
     ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
         let mut vertex_attributes = vec![Mesh::ATTRIBUTE_POSITION.at_shader_location(0)];
 
-        let mut bind_group_layout = vec![self.view_layout.clone(), self.mesh_layout.clone()];
+        let mut bind_group_layout = vec![self.view_layout.clone()];
         let mut shader_defs = Vec::new();
 
         if layout.contains(Mesh::ATTRIBUTE_JOINT_INDEX)
@@ -271,6 +271,8 @@ impl SpecializedMeshPipeline for ShadowPipeline {
             vertex_attributes.push(Mesh::ATTRIBUTE_JOINT_INDEX.at_shader_location(4));
             vertex_attributes.push(Mesh::ATTRIBUTE_JOINT_WEIGHT.at_shader_location(5));
             bind_group_layout.push(self.skinned_mesh_layout.clone());
+        } else {
+            bind_group_layout.push(self.mesh_layout.clone());
         }
 
         let vertex_buffer_layout = layout.get_layout(&vertex_attributes)?;

--- a/crates/bevy_pbr/src/render/wireframe.wgsl
+++ b/crates/bevy_pbr/src/render/wireframe.wgsl
@@ -17,7 +17,7 @@ struct VertexOutput {
 };
 
 #ifdef SKINNED
-[[group(2), binding(0)]]
+[[group(1), binding(1)]]
 var<uniform> joint_matrices: SkinnedMesh;
 #import bevy_pbr::skinning
 #endif


### PR DESCRIPTION
# Objective

Animation with shadows crashes with:
```
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_render_pipeline
      note: label = `shadow_pipeline`
    error matching VERTEX shader requirements against the pipeline
    shader global ResourceBinding { group: 1, binding: 1 } is not available in the layout pipeline layout
    visibility flags don't include the shader stage
```


Animation with wireframe crashes with:
```
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_render_pipeline
      note: label = `opaque_mesh_pipeline`
    error matching VERTEX shader requirements against the pipeline
    shader global ResourceBinding { group: 2, binding: 0 } is not available in the layout pipeline layout
    binding is missing from the pipeline layout
```

## Solution

- Fix the bindings
