### PR TITLE
[Merged by Bors] - Remove outdated perf comments

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -605,9 +605,6 @@ impl World {
     /// and those default values will be here instead.
     #[inline]
     pub fn init_resource<R: Resource + FromWorld>(&mut self) {
-        // PERF: We could avoid double hashing here, since the `from_world` call is guaranteed
-        // not to modify the map. However, we would need to be borrowing resources both
-        // mutably and immutably, so we would need to be extremely certain this is correct
         if !self.contains_resource::<R>() {
             let resource = R::from_world(self);
             self.insert_resource(resource);
@@ -635,9 +632,6 @@ impl World {
     /// and those default values will be here instead.
     #[inline]
     pub fn init_non_send_resource<R: 'static + FromWorld>(&mut self) {
-        // PERF: We could avoid double hashing here, since the `from_world` call is guaranteed
-        // not to modify the map. However, we would need to be borrowing resources both
-        // mutably and immutably, so we would need to be extremely certain this is correct
         if !self.contains_resource::<R>() {
             let resource = R::from_world(self);
             self.insert_non_send_resource(resource);


### PR DESCRIPTION
# Objective

- The perf comments, added (by me) in https://github.com/bevyengine/bevy/pull/1349, became outdated once the initialisation call started to take an exclusive reference, (presumably in https://github.com/bevyengine/bevy/pull/1525).
- They have been naïvely transferred along ever since

## Solution

- Remove them