### PR TITLE
Rename get_multiple APIs to get_many

### DIFF
--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -623,17 +623,17 @@ where
     /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is
     /// returned instead.
     ///
-    /// Note that the unlike [`Query::get_multiple_mut`], the entities passed in do not need to be unique.
+    /// Note that the unlike [`Query::get_many_mut`], the entities passed in do not need to be unique.
     ///
     /// See [`Query::multiple`] for the infallible equivalent.
     #[inline]
-    pub fn get_multiple<const N: usize>(
+    pub fn get_many<const N: usize>(
         &self,
         entities: [Entity; N],
     ) -> Result<[<Q::ReadOnlyFetch as Fetch<'_, 's>>::Item; N], QueryEntityError> {
         // SAFE: it is the scheduler's responsibility to ensure that `Query` is never handed out on the wrong `World`.
         unsafe {
-            self.state.get_multiple_read_only_manual(
+            self.state.get_many_read_only_manual(
                 self.world,
                 entities,
                 self.last_change_tick,
@@ -644,7 +644,7 @@ where
 
     /// Returns the read-only query items for the provided array of [`Entity`]
     ///
-    /// See [`Query::get_multiple`] for the [`Result`]-returning equivalent.
+    /// See [`Query::get_many`] for the [`Result`]-returning equivalent.
     ///
     /// # Examples
     /// ```rust, no_run
@@ -682,7 +682,7 @@ where
         &self,
         entities: [Entity; N],
     ) -> [<Q::ReadOnlyFetch as Fetch<'_, 's>>::Item; N] {
-        self.get_multiple(entities).unwrap()
+        self.get_many(entities).unwrap()
     }
 
     /// Returns the query result for the given [`Entity`].
@@ -733,13 +733,13 @@ where
     ///
     /// See [`Query::multiple_mut`] for the infallible equivalent.
     #[inline]
-    pub fn get_multiple_mut<const N: usize>(
+    pub fn get_many_mut<const N: usize>(
         &mut self,
         entities: [Entity; N],
     ) -> Result<[<Q::Fetch as Fetch<'_, 's>>::Item; N], QueryEntityError> {
         // SAFE: scheduler ensures safe Query world access
         unsafe {
-            self.state.get_multiple_unchecked_manual(
+            self.state.get_many_unchecked_manual(
                 self.world,
                 entities,
                 self.last_change_tick,
@@ -750,7 +750,7 @@ where
 
     /// Returns the query items for the provided array of [`Entity`]
     ///
-    /// See [`Query::get_multiple_mut`] for the [`Result`]-returning equivalent.
+    /// See [`Query::get_many_mut`] for the [`Result`]-returning equivalent.
     ///
     /// # Examples
     ///
@@ -794,7 +794,7 @@ where
         &mut self,
         entities: [Entity; N],
     ) -> [<Q::Fetch as Fetch<'_, 's>>::Item; N] {
-        self.get_multiple_mut(entities).unwrap()
+        self.get_many_mut(entities).unwrap()
     }
 
     /// Returns the query result for the given [`Entity`].

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_lifetime_safety.rs
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_lifetime_safety.rs
@@ -4,7 +4,7 @@ use bevy_ecs::prelude::*;
 struct A(usize);
 
 fn system(mut query: Query<&mut A>, e: Res<Entity>) {
-    let a1 = query.get_multiple([*e, *e]).unwrap();
+    let a1 = query.get_many([*e, *e]).unwrap();
     let a2 = query.get_mut(*e).unwrap();
     // this should fail to compile
     println!("{} {}", a1[0].0, a2.0);

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_lifetime_safety.stderr
@@ -1,7 +1,7 @@
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
-  --> tests/ui/system_query_get_multiple_lifetime_safety.rs:8:14
+  --> tests/ui/system_query_get_many_lifetime_safety.rs:8:14
    |
-7  |     let a1 = query.get_multiple([*e, *e]).unwrap();
+7  |     let a1 = query.get_many([*e, *e]).unwrap();
    |              ---------------------------- immutable borrow occurs here
 8  |     let a2 = query.get_mut(*e).unwrap();
    |              ^^^^^^^^^^^^^^^^^ mutable borrow occurs here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_mut_lifetime_safety.rs
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_mut_lifetime_safety.rs
@@ -4,7 +4,7 @@ use bevy_ecs::prelude::*;
 struct A(usize);
 
 fn system(mut query: Query<&mut A>, e: Res<Entity>) {
-    let a1 = query.get_multiple_mut([*e, *e]).unwrap();
+    let a1 = query.get_many_mut([*e, *e]).unwrap();
     let a2 = query.get_mut(*e).unwrap();
     // this should fail to compile
     println!("{} {}", a1[0].0, a2.0);

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_mut_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_multiple_mut_lifetime_safety.stderr
@@ -1,7 +1,7 @@
 error[E0499]: cannot borrow `query` as mutable more than once at a time
-  --> tests/ui/system_query_get_multiple_mut_lifetime_safety.rs:8:14
+  --> tests/ui/system_query_get_many_mut_lifetime_safety.rs:8:14
    |
-7  |     let a1 = query.get_multiple_mut([*e, *e]).unwrap();
+7  |     let a1 = query.get_many_mut([*e, *e]).unwrap();
    |              -------------------------------- first mutable borrow occurs here
 8  |     let a2 = query.get_mut(*e).unwrap();
    |              ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here


### PR DESCRIPTION

# Objective

-  std's new APIs do the same thing as `Query::get_multiple_mut`, but are called `get_many`: https://github.com/rust-lang/rust/pull/83608

## Solution

- Find and replace `get_multiple` with `get_many`