### PR TITLE
[Merged by Bors] - animations: don't ignore curves with one keyframe

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -218,6 +218,18 @@ pub fn animation_player(
                 }
                 if let Ok(mut transform) = transforms.get_mut(current_entity) {
                     for curve in curves {
+                        // Some curves have only one keyframe used to set a transform
+                        if curve.keyframe_timestamps.len() == 1 {
+                            match &curve.keyframes {
+                                Keyframes::Rotation(keyframes) => transform.rotation = keyframes[0],
+                                Keyframes::Translation(keyframes) => {
+                                    transform.translation = keyframes[0]
+                                }
+                                Keyframes::Scale(keyframes) => transform.scale = keyframes[0],
+                            }
+                            continue;
+                        }
+
                         // Find the current keyframe
                         // PERF: finding the current keyframe can be optimised
                         let step_start = match curve


### PR DESCRIPTION
# Objective

- While playing with animated models, I noticed some were a little off

## Solution

- Some animations curves only have one keyframe, they are used to set a transform to a given value
- Those were ignored as we're never exactly at the ts 0.0 of an animation. going there explicitly (`.set_elapsed(0.0).pause()`) would crash
- Special case this as there isn't much to animate in this case
