### PR TITLE
Rename texture atlas texture field

### DIFF
--- a/crates/bevy_sprite/src/dynamic_texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/dynamic_texture_atlas_builder.rs
@@ -33,7 +33,7 @@ impl DynamicTextureAtlasBuilder {
             let mut rect: Rect = allocation.rectangle.into();
             rect.max.x -= self.padding as f32;
             rect.max.y -= self.padding as f32;
-            Some(texture_atlas.add_texture(rect))
+            Some(texture_atlas.add_sprite(rect))
         } else {
             None
         }

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -255,7 +255,7 @@ pub fn extract_sprites(
             continue;
         }
         if let Some(texture_atlas) = texture_atlases.get(texture_atlas_handle) {
-            let rect = Some(texture_atlas.textures[atlas_sprite.index as usize]);
+            let rect = Some(texture_atlas.sprites[atlas_sprite.index as usize]);
             extracted_sprites.sprites.alloc().init(ExtractedSprite {
                 color: atlas_sprite.color,
                 transform: *transform,

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -129,7 +129,7 @@ impl TextureAtlas {
     ///
     /// * `rect` - The section of the atlas that contains the texture to be added,
     /// from the top-left corner of the texture to the bottom-right corner
-    pub fn add_texture(&mut self, rect: Rect) -> usize {
+    pub fn add_sprite(&mut self, rect: Rect) -> usize {
         self.sprites.push(rect);
         self.sprites.len() - 1
     }

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -134,7 +134,7 @@ impl TextureAtlas {
         self.sprites.len() - 1
     }
 
-    /// How many textures are in the `TextureAtlas`
+    /// How many sprites are in the `TextureAtlas`
     pub fn len(&self) -> usize {
         self.sprites.len()
     }

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -116,7 +116,7 @@ impl TextureAtlas {
                 ((tile_size.x + x_padding) * columns as f32) - x_padding,
                 ((tile_size.y + y_padding) * rows as f32) - y_padding,
             ),
-            sprites: sprites,
+            sprites,
             texture,
             texture_handles: None,
         }

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -17,7 +17,7 @@ pub struct TextureAtlas {
     // TODO: add support to Uniforms derive to write dimensions and sprites to the same buffer
     pub size: Vec2,
     /// The specific areas of the atlas where each texture can be found
-    pub textures: Vec<Rect>,
+    pub sprites: Vec<Rect>,
     pub texture_handles: Option<HashMap<Handle<Image>, usize>>,
 }
 
@@ -61,7 +61,7 @@ impl TextureAtlas {
             texture,
             size: dimensions,
             texture_handles: None,
-            textures: Vec::new(),
+            sprites: Vec::new(),
         }
     }
 
@@ -116,7 +116,7 @@ impl TextureAtlas {
                 ((tile_size.x + x_padding) * columns as f32) - x_padding,
                 ((tile_size.y + y_padding) * rows as f32) - y_padding,
             ),
-            textures: sprites,
+            sprites: sprites,
             texture,
             texture_handles: None,
         }
@@ -130,17 +130,17 @@ impl TextureAtlas {
     /// * `rect` - The section of the atlas that contains the texture to be added,
     /// from the top-left corner of the texture to the bottom-right corner
     pub fn add_texture(&mut self, rect: Rect) -> usize {
-        self.textures.push(rect);
-        self.textures.len() - 1
+        self.sprites.push(rect);
+        self.sprites.len() - 1
     }
 
     /// How many textures are in the `TextureAtlas`
     pub fn len(&self) -> usize {
-        self.textures.len()
+        self.sprites.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.textures.is_empty()
+        self.sprites.is_empty()
     }
 
     pub fn get_texture_index(&self, texture: &Handle<Image>) -> Option<usize> {

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -134,7 +134,7 @@ impl TextureAtlas {
         self.sprites.len() - 1
     }
 
-    /// How many sprites are in the `TextureAtlas`
+    /// How many sprites are in the [`TextureAtlas`]
     pub fn len(&self) -> usize {
         self.sprites.len()
     }

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -233,7 +233,7 @@ impl TextureAtlasBuilder {
                 atlas_texture.texture_descriptor.size.height as f32,
             ),
             texture: textures.add(atlas_texture),
-            textures: texture_rects,
+            sprites: texture_rects,
             texture_handles: Some(texture_handles),
         })
     }

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -108,7 +108,7 @@ impl GlyphBrush {
                     })?;
 
                 let texture_atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
-                let glyph_rect = texture_atlas.textures[atlas_info.glyph_index as usize];
+                let glyph_rect = texture_atlas.sprites[atlas_info.glyph_index as usize];
                 let size = Vec2::new(glyph_rect.width(), glyph_rect.height());
 
                 let x = bounds.min.x + size.x / 2.0 - min_x;

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -100,7 +100,7 @@ pub fn extract_text2d_sprite(
                     .unwrap();
                 let handle = atlas.texture.clone_weak();
                 let index = text_glyph.atlas_info.glyph_index as usize;
-                let rect = Some(atlas.textures[index]);
+                let rect = Some(atlas.sprites[index]);
 
                 let glyph_transform = Transform::from_translation(
                     alignment_offset * scale_factor + text_glyph.position.extend(0.),

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -200,7 +200,7 @@ pub fn extract_text_uinodes(
                     .unwrap();
                 let texture = atlas.texture.clone_weak();
                 let index = text_glyph.atlas_info.glyph_index as usize;
-                let rect = atlas.textures[index];
+                let rect = atlas.sprites[index];
                 let atlas_size = Some(atlas.size);
 
                 let transform =

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -24,7 +24,7 @@ fn animate_sprite(
         timer.tick(time.delta());
         if timer.just_finished() {
             let texture_atlas = texture_atlases.get(texture_atlas_handle).unwrap();
-            sprite.index = (sprite.index + 1) % texture_atlas.textures.len();
+            sprite.index = (sprite.index + 1) % texture_atlas.sprites.len();
         }
     }
 }


### PR DESCRIPTION
Resolves #268, renaming `textures` field to `sprites` and the method `add_texture` to `add_sprites` in the `TextureAtlas` struct.



