### PR TITLE
[Merged by Bors] - input clear should not clear pressed

### DIFF
--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -120,7 +120,6 @@ where
     pub fn clear(&mut self) {
         self.just_pressed.clear();
         self.just_released.clear();
-        self.pressed.clear();
     }
 
     /// List all inputs that are pressed.

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -116,7 +116,7 @@ where
         self.just_released.remove(&input);
     }
 
-    /// Clear pressed, just pressed and just released information.
+    /// Clear just pressed and just released information.
     pub fn clear(&mut self) {
         self.just_pressed.clear();
         self.just_released.clear();
@@ -166,23 +166,20 @@ mod test {
         assert!(input.pressed(DummyInput::Input1));
         assert!(input.pressed(DummyInput::Input2));
 
-        // Clear the `input`, removing pressed, just pressed and just released
+        // Clear the `input`, removing just pressed and just released
         input.clear();
+
+        // After calling clear, inputs should still be pressed but not be just_pressed
 
         // Check if they're marked "just pressed"
         assert!(!input.just_pressed(DummyInput::Input1));
         assert!(!input.just_pressed(DummyInput::Input2));
 
         // Check if they're marked as pressed
-        assert!(!input.pressed(DummyInput::Input1));
-        assert!(!input.pressed(DummyInput::Input2));
-
-        // Test pressing
-        input.press(DummyInput::Input1);
-        input.press(DummyInput::Input2);
+        assert!(input.pressed(DummyInput::Input1));
+        assert!(input.pressed(DummyInput::Input2));
 
         // Release the inputs and check state
-
         input.release(DummyInput::Input1);
         input.release(DummyInput::Input2);
 


### PR DESCRIPTION
# Objective

- Revert #4410 
- `Input<T>.clear()` is the method call at the end of each frame for inputs. Clearing `pressed` in it mean that checking if a key is pressed will always return false
