### PR TITLE
[Merged by Bors] - scene_viewer: load cameras

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -28,7 +28,7 @@ use bevy_window::{WindowCreated, WindowId, WindowResized, Windows};
 use serde::{Deserialize, Serialize};
 use wgpu::Extent3d;
 
-#[derive(Component, Default, Debug, Reflect)]
+#[derive(Component, Default, Debug, Reflect, Clone)]
 #[reflect(Component)]
 pub struct Camera {
     pub projection_matrix: Mat4,

--- a/examples/tools/scene_viewer.rs
+++ b/examples/tools/scene_viewer.rs
@@ -252,7 +252,7 @@ fn camera_spawn_check(
 
         if !scene_handle.has_camera {
             let bundle = if let Some((transform, camera)) = cameras_3d.iter().next() {
-                let mut transform: Transform = transform.clone().into();
+                let mut transform: Transform = (*transform).into();
                 let (yaw, pitch, _) = transform.rotation.to_euler(EulerRot::YXZ);
                 transform.rotation = Quat::from_euler(EulerRot::YXZ, yaw, pitch, 0.0);
                 PerspectiveCameraBundle {

--- a/examples/tools/scene_viewer.rs
+++ b/examples/tools/scene_viewer.rs
@@ -252,9 +252,12 @@ fn camera_spawn_check(
 
         if !scene_handle.has_camera {
             let bundle = if let Some((transform, camera)) = cameras_3d.iter().next() {
+                let mut transform: Transform = transform.clone().into();
+                let (yaw, pitch, _) = transform.rotation.to_euler(EulerRot::YXZ);
+                transform.rotation = Quat::from_euler(EulerRot::YXZ, yaw, pitch, 0.0);
                 PerspectiveCameraBundle {
                     camera: camera.clone(),
-                    transform: transform.clone().into(),
+                    transform,
                     ..PerspectiveCameraBundle::new_3d()
                 }
             } else {
@@ -435,7 +438,7 @@ fn camera_controller(
 
     if let Ok((mut transform, mut options)) = query.get_single_mut() {
         if !options.initialized {
-            let (_roll, yaw, pitch) = transform.rotation.to_euler(EulerRot::ZYX);
+            let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);
             options.yaw = yaw;
             options.pitch = pitch;
             options.initialized = true;


### PR DESCRIPTION
# Objective

glTF files can contain cameras. Currently the scene viewer example uses _a_ camera defined in the file if possible, otherwise it spawns a new one. It would be nice if instead it could load all the cameras and cycle through them, while also having a separate user-controller camera.

## Solution

- instead of just a camera that is already defined, always spawn a new separate user-controller camera
- maintain a list of loaded cameras and cycle through them (wrapping to the user-controller camera) when pressing `C`

This matches the behavious that https://github.khronos.org/glTF-Sample-Viewer-Release/ has.

## Implementation notes

- The gltf scene asset loader just spawns the cameras into the world, but does not return a mapping of camera index to bevy entity. So instead the scene_viewer example just collects all spawned cameras with a good old `query.iter().collect()`, so the order is unspecified and may change between runs.

## Demo

https://user-images.githubusercontent.com/22177966/161826637-40161482-5b3b-4df5-aae8-1d5e9b918393.mp4


using the virtual city glTF sample file: https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/VC