### PR TITLE
[Merged by Bors] - fix scene_viewer example on wasm

### DIFF
--- a/examples/tools/scene_viewer.rs
+++ b/examples/tools/scene_viewer.rs
@@ -40,7 +40,10 @@ Controls:
             brightness: 1.0 / 5.0f32,
         })
         .insert_resource(AssetServerSettings {
+            #[cfg(not(target_family = "wasm"))]
             asset_folder: std::env::var("CARGO_MANIFEST_DIR").unwrap(),
+            #[cfg(target_family = "wasm")]
+            asset_folder: ".".into(),
             watch_for_changes: true,
         })
         .insert_resource(WindowDescriptor {

--- a/examples/tools/scene_viewer.rs
+++ b/examples/tools/scene_viewer.rs
@@ -40,10 +40,7 @@ Controls:
             brightness: 1.0 / 5.0f32,
         })
         .insert_resource(AssetServerSettings {
-            #[cfg(not(target_family = "wasm"))]
-            asset_folder: std::env::var("CARGO_MANIFEST_DIR").unwrap(),
-            #[cfg(target_family = "wasm")]
-            asset_folder: ".".into(),
+            asset_folder: std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string()),
             watch_for_changes: true,
         })
         .insert_resource(WindowDescriptor {


### PR DESCRIPTION
The scene viewer example doesn't run on wasm because it sets the asset folder to `std::env::var("CARGO_MANIFEST_DIR").unwrap()`, which isn't supported on the web.

Solution: set the asset folder to `"."` instead.