### PR TITLE
[Merged by Bors] - Do not crash if RenderDevice doesn't exist

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -88,10 +88,13 @@ impl AssetLoader for GltfLoader {
 
 impl FromWorld for GltfLoader {
     fn from_world(world: &mut World) -> Self {
+        let supported_compressed_formats = match world.get_resource::<RenderDevice>() {
+            Some(render_device) => CompressedImageFormats::from_features(render_device.features()),
+
+            None => CompressedImageFormats::all(),
+        };
         Self {
-            supported_compressed_formats: CompressedImageFormats::from_features(
-                world.resource::<RenderDevice>().features(),
-            ),
+            supported_compressed_formats,
         }
     }
 }

--- a/crates/bevy_render/src/texture/image_texture_loader.rs
+++ b/crates/bevy_render/src/texture/image_texture_loader.rs
@@ -69,10 +69,13 @@ impl AssetLoader for ImageTextureLoader {
 
 impl FromWorld for ImageTextureLoader {
     fn from_world(world: &mut World) -> Self {
+        let supported_compressed_formats = match world.get_resource::<RenderDevice>() {
+            Some(render_device) => CompressedImageFormats::from_features(render_device.features()),
+
+            None => CompressedImageFormats::all(),
+        };
         Self {
-            supported_compressed_formats: CompressedImageFormats::from_features(
-                world.resource::<RenderDevice>().features(),
-            ),
+            supported_compressed_formats,
         }
     }
 }


### PR DESCRIPTION
# Objective

Avoid crashing if `RenderDevice` doesn't exist (required for headless mode).
Fixes #4392.

## Solution

Use `CompressedImageFormats::all()` if there is no `RenderDevice`.