### PR TITLE
[Merged by Bors] - Tidy up PluginGroupBuilder by moving Plugin index retrieval to it's own function

### DIFF
--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -28,9 +28,7 @@ impl PluginGroupBuilder {
         let index = self
             .order
             .iter()
-            .enumerate()
-            .find(|(_i, ty)| **ty == TypeId::of::<Target>())
-            .map(|(i, _)| i);
+            .position(|&ty| ty == TypeId::of::<Target>());
 
         match index {
             Some(i) => i,

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -33,7 +33,7 @@ impl PluginGroupBuilder {
         match index {
             Some(i) => i,
             None => panic!(
-                "Plugin does not exist: {}.",
+                "Plugin does not exist in group: {}.",
                 std::any::type_name::<Target>()
             ),
         }

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -23,6 +23,20 @@ pub struct PluginGroupBuilder {
 }
 
 impl PluginGroupBuilder {
+	/// Finds the index of a target [`Plugin`]. Panics if the target's ['TypeId'] is not found.
+	fn index_of<Target: Plugin>(&mut self) -> usize {
+		let index = self.order
+			.iter()
+			.enumerate()
+			.find(|(_i, ty)| **ty == TypeId::of::<Target>())
+            .map(|(i, _)| i);
+
+		match index {
+			Some(i) => return i,
+			None => panic!("Plugin does not exist: {}.",std::any::type_name::<Target>())
+		};
+	}
+
     /// Appends a [`Plugin`] to the [`PluginGroupBuilder`].
     pub fn add<T: Plugin>(&mut self, plugin: T) -> &mut Self {
         self.order.push(TypeId::of::<T>());
@@ -38,18 +52,7 @@ impl PluginGroupBuilder {
 
     /// Configures a [`Plugin`] to be built before another plugin.
     pub fn add_before<Target: Plugin, T: Plugin>(&mut self, plugin: T) -> &mut Self {
-        let target_index = self
-            .order
-            .iter()
-            .enumerate()
-            .find(|(_i, ty)| **ty == TypeId::of::<Target>())
-            .map(|(i, _)| i)
-            .unwrap_or_else(|| {
-                panic!(
-                    "Plugin does not exist: {}.",
-                    std::any::type_name::<Target>()
-                )
-            });
+        let target_index = self.index_of::<Target>();
         self.order.insert(target_index, TypeId::of::<T>());
         self.plugins.insert(
             TypeId::of::<T>(),
@@ -63,18 +66,7 @@ impl PluginGroupBuilder {
 
     /// Configures a [`Plugin`] to be built after another plugin.
     pub fn add_after<Target: Plugin, T: Plugin>(&mut self, plugin: T) -> &mut Self {
-        let target_index = self
-            .order
-            .iter()
-            .enumerate()
-            .find(|(_i, ty)| **ty == TypeId::of::<Target>())
-            .map(|(i, _)| i)
-            .unwrap_or_else(|| {
-                panic!(
-                    "Plugin does not exist: {}.",
-                    std::any::type_name::<Target>()
-                )
-            });
+        let target_index = self.index_of::<Target>();
         self.order.insert(target_index + 1, TypeId::of::<T>());
         self.plugins.insert(
             TypeId::of::<T>(),

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -23,19 +23,23 @@ pub struct PluginGroupBuilder {
 }
 
 impl PluginGroupBuilder {
-	/// Finds the index of a target [`Plugin`]. Panics if the target's ['TypeId'] is not found.
-	fn index_of<Target: Plugin>(&mut self) -> usize {
-		let index = self.order
-			.iter()
-			.enumerate()
-			.find(|(_i, ty)| **ty == TypeId::of::<Target>())
-			.map(|(i, _)| i);
+    /// Finds the index of a target [`Plugin`]. Panics if the target's ['TypeId'] is not found.
+    fn index_of<Target: Plugin>(&mut self) -> usize {
+        let index = self
+            .order
+            .iter()
+            .enumerate()
+            .find(|(_i, ty)| **ty == TypeId::of::<Target>())
+            .map(|(i, _)| i);
 
-		match index {
-			Some(i) => return i,
-			None => panic!("Plugin does not exist: {}.",std::any::type_name::<Target>())
-		};
-	}
+        match index {
+            Some(i) => return i,
+            None => panic!(
+                "Plugin does not exist: {}.",
+                std::any::type_name::<Target>()
+            ),
+        };
+    }
 
     /// Appends a [`Plugin`] to the [`PluginGroupBuilder`].
     pub fn add<T: Plugin>(&mut self, plugin: T) -> &mut Self {

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -33,12 +33,12 @@ impl PluginGroupBuilder {
             .map(|(i, _)| i);
 
         match index {
-            Some(i) => return i,
+            Some(i) => i,
             None => panic!(
                 "Plugin does not exist: {}.",
                 std::any::type_name::<Target>()
             ),
-        };
+        }
     }
 
     /// Appends a [`Plugin`] to the [`PluginGroupBuilder`].

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -29,7 +29,7 @@ impl PluginGroupBuilder {
 			.iter()
 			.enumerate()
 			.find(|(_i, ty)| **ty == TypeId::of::<Target>())
-            .map(|(i, _)| i);
+			.map(|(i, _)| i);
 
 		match index {
 			Some(i) => return i,

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -23,7 +23,7 @@ pub struct PluginGroupBuilder {
 }
 
 impl PluginGroupBuilder {
-    /// Finds the index of a target [`Plugin`]. Panics if the target's ['TypeId'] is not found.
+    /// Finds the index of a target [`Plugin`]. Panics if the target's [`TypeId`] is not found.
     fn index_of<Target: Plugin>(&mut self) -> usize {
         let index = self
             .order


### PR DESCRIPTION
# Objective

- Clean up duplicate code in the add_before/add_after functions in PluginGroupBuilder.

## Solution

- moved index retrieval code to a private function index_of() for the PluginGroupBuilder.
- change is just tidying up. No real change to functionality.


