### PR TITLE
Fix rendering sprites on 3D models

### DIFF
--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -415,6 +415,7 @@ pub fn prepare_core_views_system(
                                                       * bit depth for better performance */
                 usage: TextureUsages::RENDER_ATTACHMENT,
             },
+            false,
         );
         commands.entity(entity).insert(ViewDepthTexture {
             texture: cached_texture.texture,

--- a/crates/bevy_core_pipeline/src/main_pass_driver.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_driver.rs
@@ -14,17 +14,17 @@ impl Node for MainPassDriverNode {
         _render_context: &mut RenderContext,
         world: &World,
     ) -> Result<(), NodeRunError> {
-        if let Some(camera_2d) = world.resource::<ActiveCamera<Camera2d>>().get() {
-            graph.run_sub_graph(
-                crate::draw_2d_graph::NAME,
-                vec![SlotValue::Entity(camera_2d)],
-            )?;
-        }
-
         if let Some(camera_3d) = world.resource::<ActiveCamera<Camera3d>>().get() {
             graph.run_sub_graph(
                 crate::draw_3d_graph::NAME,
                 vec![SlotValue::Entity(camera_3d)],
+            )?;
+        }
+
+        if let Some(camera_2d) = world.resource::<ActiveCamera<Camera2d>>().get() {
+            graph.run_sub_graph(
+                crate::draw_2d_graph::NAME,
+                vec![SlotValue::Entity(camera_2d)],
             )?;
         }
 

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -770,6 +770,7 @@ pub fn prepare_lights(
                 label: Some("point_light_shadow_map_texture"),
                 usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
             },
+            false,
         );
         let directional_light_depth_texture = texture_cache.get(
             &render_device,
@@ -788,6 +789,7 @@ pub fn prepare_lights(
                 label: Some("directional_light_shadow_map_texture"),
                 usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
             },
+            false,
         );
         let mut view_lights = Vec::new();
 

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -200,6 +200,7 @@ fn prepare_view_targets(
                             format: TextureFormat::bevy_default(),
                             usage: TextureUsages::RENDER_ATTACHMENT,
                         },
+                        true,
                     );
                     Some(sampled_texture.default_view.clone())
                 } else {


### PR DESCRIPTION
# Objective

- Fixes #3902 
- Sprites are not renders on 2D models 
- After changing the render order only the result of the 2d pass is displayed if msaa is in use. Because with msaa the 2d and 3d render passes uses there own sampled_targets which then overrides the complete view. The ui render pass does not use msaa so it is not affected by this issue.

## Solution

- Change order to render 2d after 3d
- Expand TextureCache through shared status
- Use shared sampled_texture so that 2d and 3d render pass use the same sampled_texture 

I don't now if this is the right or best solution.

Result on current main:
![main](https://user-images.githubusercontent.com/688816/162618444-2bcc5d22-b50d-4ae2-9e1f-c546ac5f07ab.png)

Result with order fix:
![order_fix](https://user-images.githubusercontent.com/688816/162618448-3a647b60-b91b-4360-9300-808657d77c13.png)

Result with order fix and shared sampled target:
![shared_texture](https://user-images.githubusercontent.com/688816/162618453-5aa4d25f-f19f-4079-996a-afc798b48eea.png)
