### PR TITLE
examples: Use ECS entities for individual instances in shader_instancing

### DIFF
--- a/assets/shaders/instancing.wgsl
+++ b/assets/shaders/instancing.wgsl
@@ -21,7 +21,7 @@ struct VertexOutput {
 [[stage(vertex)]]
 fn vertex(vertex: Vertex) -> VertexOutput {
     let position = vertex.position * vertex.i_pos_scale.w + vertex.i_pos_scale.xyz;
-    let world_position = mesh.model * vec4<f32>(position, 1.0);
+    let world_position = vec4<f32>(position, 1.0);
 
     var out: VertexOutput;
     out.clip_position = view.view_proj * world_position;


### PR DESCRIPTION
# Objective

- The `shader_instancing` example uses a component representing many instances stored on one entity, which is perhaps surprising given users will generally think about an instance as an entity. Make instances be represented by separate ECS entities.

## Solution

- Identify instances by a `ColorMaterialInstanced` component that contains the colour of the instance
- Use the translation and scale (x-component of scale only) from the entity transform as the instance position and scale.
- When preparing instances, do it per-view and create an `InstanceBuffer` that contains a `BufferVec<InstanceData>`. For each instance entity, push the appropriate `InstanceData` onto the `BufferVec` and store the instance index that is returned in a `InstanceIndex` on the instance entity. Finally store the `InstanceBuffer` on the view entity
- Draw each instance with a separate draw command using the `InstanceIndex` component

---

## Possible extension

- I was thinking we could maybe add a toggle to switch between drawing each instance with a separate draw command using the instance index, and drawing the whole batch using one command based simply on the number of instances. Alternatively we could actually try to implement batching properly for this, or a separate example.