### PR TITLE
[Merged by Bors] - Fix typos in `Time::last_update` and `Time::time_since_startup` documentation

### DIFF
--- a/crates/bevy_core/src/time/time.rs
+++ b/crates/bevy_core/src/time/time.rs
@@ -75,13 +75,13 @@ impl Time {
         self.startup
     }
 
-    /// The ['Instant'] when [`Time::update`] was last called, if it exists
+    /// The [`Instant`] when [`Time::update`] was last called, if it exists
     #[inline]
     pub fn last_update(&self) -> Option<Instant> {
         self.last_update
     }
 
-    /// The ['Duration'] from startup to the last update
+    /// The [`Duration`] from startup to the last update
     #[inline]
     pub fn time_since_startup(&self) -> Duration {
         self.time_since_startup


### PR DESCRIPTION
# Objective

The documentation of the `Time::last_update` and `Time::time_since_startup` methods contains typos. It uses apostrophe instead of backtick characters around `Instant` and `Duration`, so that these words are not recognized as identifiers in the generated API documentation. This should be fixed.

## Solution

Fix the typos.