### PR TITLE
[Merged by Bors] - fix feature location from #3851

### DIFF
--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
+[features]
+trace = []
+
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -16,7 +16,7 @@ trace = [
     "bevy_ecs/trace",
     "bevy_log/trace",
     "bevy_render/trace",
-    "bevy_transform/trace"
+    "bevy_hierarchy/trace"
 ]
 trace_chrome = [ "bevy_log/tracing-chrome" ]
 trace_tracy = ["bevy_render/tracing-tracy", "bevy_log/tracing-tracy" ]

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -8,9 +8,6 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
-[features]
-trace = []
-
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.7.0-dev" }


### PR DESCRIPTION
# Objective

- in #3851, a feature for tracing was added to bevy_transform
- usage of that feature was moved to bevy_hierarchy, but the feature was not updated

## Solution

- add the feature to bevy_hierarchy, remove it from bevy_transform
