### PR TITLE
[Merged by Bors] - A hack to work around minimising still being broken

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -391,7 +391,7 @@ impl Clusters {
     }
     fn clear(&mut self) {
         self.tile_size = UVec2::ONE;
-        self.dimensions = UVec3::ONE;
+        self.dimensions = UVec3::ZERO;
         self.near = 0.0;
         self.far = 0.0;
         self.lights.clear();


### PR DESCRIPTION
# Objective

- https://github.com/bevyengine/bevy/pull/4098 still hasn't fixed minimisation on Windows.
- `Clusters.lights` is assumed to have the number of items given by the product of `Clusters.dimensions`'s axes.

## Solution

- Make that true in `clear`.