### PR TITLE
[Merged by Bors] - bevy_pbr: Fix ClusterConfig::None

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -731,8 +731,10 @@ pub(crate) fn assign_lights_to_clusters(
     {
         let clusters = clusters.into_inner();
 
-        if matches!(config, ClusterConfig::None) && visible_lights.is_some() {
-            commands.entity(view_entity).remove::<VisiblePointLights>();
+        if matches!(config, ClusterConfig::None) {
+            if visible_lights.is_some() {
+                commands.entity(view_entity).remove::<VisiblePointLights>();
+            }
             clusters.clear();
             continue;
         }


### PR DESCRIPTION
# Objective

- Fix `ClusterConfig::None`
- This fix is from @robtfm but they didn't have time to submit it, so I am.

## Solution

- Always clear clusters and skip processing when `ClusterConfig::None`
- Conditionally remove `VisiblePointLights` from the view if it is present