### PR TITLE
[Merged by Bors] - Parallel Frustum Culling

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -28,21 +28,22 @@ webgl = ["wgpu/webgl"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.8.0-dev" }
-bevy_asset = { path = "../bevy_asset", version = "0.8.0-dev" }
-bevy_core = { path = "../bevy_core", version = "0.8.0-dev" }
-bevy_derive = { path = "../bevy_derive", version = "0.8.0-dev" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.8.0-dev" }
-bevy_encase_derive = { path = "../bevy_encase_derive", version = "0.8.0-dev" }
-bevy_math = { path = "../bevy_math", version = "0.8.0-dev" }
-bevy_mikktspace = { path = "../bevy_mikktspace", version = "0.8.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.8.0-dev", features = [
+bevy_app = { path = "../bevy_app", version = "0.7.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.7.0" }
+bevy_core = { path = "../bevy_core", version = "0.7.0" }
+bevy_crevice = { path = "../bevy_crevice", version = "0.7.0", features = [
+    "glam",
+] }
+bevy_derive = { path = "../bevy_derive", version = "0.7.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.7.0" }
+bevy_math = { path = "../bevy_math", version = "0.7.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.7.0", features = [
     "bevy",
 ] }
-bevy_render_macros = { path = "macros", version = "0.8.0-dev" }
-bevy_transform = { path = "../bevy_transform", version = "0.8.0-dev" }
-bevy_window = { path = "../bevy_window", version = "0.8.0-dev" }
-bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
+bevy_tasks = { path = "../bevy_tasks", version = "0.7.0" }
+bevy_transform = { path = "../bevy_transform", version = "0.7.0" }
+bevy_window = { path = "../bevy_window", version = "0.7.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.7.0" }
 
 # rendering
 image = { version = "0.24", default-features = false }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -36,7 +36,9 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.8.0-dev" }
 bevy_encase_derive = { path = "../bevy_encase_derive", version = "0.8.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.8.0-dev" }
 bevy_mikktspace = { path = "../bevy_mikktspace", version = "0.8.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.8.0-dev", features = ["bevy"] }
+bevy_reflect = { path = "../bevy_reflect", version = "0.8.0-dev", features = [
+    "bevy",
+] }
 bevy_render_macros = { path = "macros", version = "0.8.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.8.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.8.0-dev" }
@@ -48,7 +50,13 @@ image = { version = "0.24", default-features = false }
 # misc
 wgpu = { version = "0.12.0", features = ["spirv"] }
 codespan-reporting = "0.11.0"
-naga = { version = "0.8.0", features = ["glsl-in", "spv-in", "spv-out", "wgsl-in", "wgsl-out"] }
+naga = { version = "0.8.0", features = [
+    "glsl-in",
+    "spv-in",
+    "spv-out",
+    "wgsl-in",
+    "wgsl-out",
+] }
 serde = { version = "1", features = ["derive"] }
 bitflags = "1.2.1"
 smallvec = { version = "1.6", features = ["union", "const_generics"] }
@@ -56,6 +64,7 @@ once_cell = "1.4.1" # TODO: replace once_cell with std equivalent if/when this l
 downcast-rs = "1.2.0"
 thiserror = "1.0"
 futures-lite = "1.4.0"
+crossbeam-channel = "0.5.0"
 anyhow = "1.0"
 hex = "0.4.2"
 hexasphere = "7.0.0"

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -28,22 +28,19 @@ webgl = ["wgpu/webgl"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.7.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.7.0" }
-bevy_core = { path = "../bevy_core", version = "0.7.0" }
-bevy_crevice = { path = "../bevy_crevice", version = "0.7.0", features = [
-    "glam",
-] }
-bevy_derive = { path = "../bevy_derive", version = "0.7.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.7.0" }
-bevy_math = { path = "../bevy_math", version = "0.7.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.7.0", features = [
-    "bevy",
-] }
-bevy_tasks = { path = "../bevy_tasks", version = "0.7.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.7.0" }
-bevy_window = { path = "../bevy_window", version = "0.7.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.7.0" }
+bevy_app = { path = "../bevy_app", version = "0.8.0-dev" }
+bevy_asset = { path = "../bevy_asset", version = "0.8.0-dev" }
+bevy_core = { path = "../bevy_core", version = "0.8.0-dev" }
+bevy_derive = { path = "../bevy_derive", version = "0.8.0-dev" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.8.0-dev" }
+bevy_encase_derive = { path = "../bevy_encase_derive", version = "0.8.0-dev" }
+bevy_math = { path = "../bevy_math", version = "0.8.0-dev" }
+bevy_mikktspace = { path = "../bevy_mikktspace", version = "0.8.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.8.0-dev", features = ["bevy"] }
+bevy_render_macros = { path = "macros", version = "0.8.0-dev" }
+bevy_transform = { path = "../bevy_transform", version = "0.8.0-dev" }
+bevy_window = { path = "../bevy_window", version = "0.8.0-dev" }
+bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 
 # rendering
 image = { version = "0.24", default-features = false }
@@ -51,13 +48,7 @@ image = { version = "0.24", default-features = false }
 # misc
 wgpu = { version = "0.12.0", features = ["spirv"] }
 codespan-reporting = "0.11.0"
-naga = { version = "0.8.0", features = [
-    "glsl-in",
-    "spv-in",
-    "spv-out",
-    "wgsl-in",
-    "wgsl-out",
-] }
+naga = { version = "0.8.0", features = ["glsl-in", "spv-in", "spv-out", "wgsl-in", "wgsl-out"] }
 serde = { version = "1", features = ["derive"] }
 bitflags = "1.2.1"
 smallvec = { version = "1.6", features = ["union", "const_generics"] }

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -170,7 +170,7 @@ pub fn check_visibility(
 
         visible_entity_query.par_for_each_mut(
             &thread_pool,
-            10000,
+            1024,
             |(
                 entity,
                 visibility,

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -1,8 +1,4 @@
 mod render_layers;
-
-use bevy_math::Vec3A;
-use crossbeam_channel::unbounded;
-
 pub use render_layers::*;
 
 use bevy_app::{CoreStage, Plugin};
@@ -166,7 +162,7 @@ pub fn check_visibility(
         visible_entities.entities.clear();
         let view_mask = maybe_view_mask.copied().unwrap_or_default();
 
-        let (visible_entity_sender, visible_entity_receiver) = unbounded();
+        let (visible_entity_sender, visible_entity_receiver) = crossbeam_channel::unbounded();
 
         visible_entity_query.par_for_each_mut(
             &thread_pool,

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -1,10 +1,12 @@
 mod render_layers;
+
+use bevy_math::Vec3A;
 pub use render_layers::*;
 
 use bevy_app::{CoreStage, Plugin};
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::prelude::*;
-use bevy_math::Vec3A;
+use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::Reflect;
 use bevy_transform::components::GlobalTransform;
 use bevy_transform::TransformSystem;
@@ -146,7 +148,6 @@ pub fn update_frusta<T: Component + CameraProjection + Send + Sync + 'static>(
 }
 
 pub fn check_visibility(
-    thread_pool: Res<bevy_tasks::prelude::ComputeTaskPool>,
     mut view_query: Query<(&mut VisibleEntities, &Frustum, Option<&RenderLayers>), With<Camera>>,
     mut visible_entity_query: Query<(
         Entity,
@@ -163,7 +164,6 @@ pub fn check_visibility(
         let (visible_entity_sender, visible_entity_receiver) = crossbeam_channel::unbounded();
 
         visible_entity_query.par_for_each_mut(
-            &thread_pool,
             1024,
             |(
                 entity,

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -159,9 +159,7 @@ pub fn check_visibility(
     )>,
 ) {
     for (mut visible_entities, frustum, maybe_view_mask) in view_query.iter_mut() {
-        visible_entities.entities.clear();
         let view_mask = maybe_view_mask.copied().unwrap_or_default();
-
         let (visible_entity_sender, visible_entity_receiver) = crossbeam_channel::unbounded();
 
         visible_entity_query.par_for_each_mut(
@@ -182,7 +180,6 @@ pub fn check_visibility(
                 if !visibility.is_visible {
                     return;
                 }
-
                 let entity_mask = maybe_entity_mask.copied().unwrap_or_default();
                 if !view_mask.intersects(&entity_mask) {
                     return;
@@ -211,7 +208,6 @@ pub fn check_visibility(
                 visible_entity_sender.send(entity).ok();
             },
         );
-
         visible_entities.entities = visible_entity_receiver.try_iter().collect();
     }
 }

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -218,7 +218,7 @@ pub fn check_visibility(
         );
 
         visible_entities.entities = Arc::try_unwrap(visible_entity_pointer)
-            .expect("wtf")
+            .expect("Unable to unwrap visible entity Arc pointer.")
             .into_inner()
             .to_vec();
     }

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -150,7 +150,7 @@ pub fn update_frusta<T: Component + CameraProjection + Send + Sync + 'static>(
 }
 
 pub fn check_visibility(
-    pool: Res<bevy_tasks::prelude::ComputeTaskPool>,
+    thread_pool: Res<bevy_tasks::prelude::ComputeTaskPool>,
     mut view_query: Query<(&mut VisibleEntities, &Frustum, Option<&RenderLayers>), With<Camera>>,
     mut visible_entity_query: Query<(
         Entity,
@@ -169,8 +169,8 @@ pub fn check_visibility(
         let (visible_entity_sender, visible_entity_receiver) = unbounded();
 
         visible_entity_query.par_for_each_mut(
-            &pool,
-            32,
+            &thread_pool,
+            10000,
             |(
                 entity,
                 visibility,

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -1,4 +1,8 @@
 mod render_layers;
+
+use bevy_math::Vec3A;
+use crossbeam_channel::unbounded;
+
 pub use render_layers::*;
 
 use bevy_app::{CoreStage, Plugin};
@@ -162,7 +166,7 @@ pub fn check_visibility(
         visible_entities.entities.clear();
         let view_mask = maybe_view_mask.copied().unwrap_or_default();
 
-        let (visible_entity_sender, visible_entity_receiver) = crossbeam_channel::unbounded();
+        let (visible_entity_sender, visible_entity_receiver) = unbounded();
 
         visible_entity_query.par_for_each_mut(
             &thread_pool,

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -1,14 +1,10 @@
 mod render_layers;
-
-use bevy_math::Vec3A;
-use crossbeam_channel::unbounded;
-
 pub use render_layers::*;
 
 use bevy_app::{CoreStage, Plugin};
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::prelude::*;
-use bevy_reflect::std_traits::ReflectDefault;
+use bevy_math::Vec3A;
 use bevy_reflect::Reflect;
 use bevy_transform::components::GlobalTransform;
 use bevy_transform::TransformSystem;
@@ -166,7 +162,7 @@ pub fn check_visibility(
         visible_entities.entities.clear();
         let view_mask = maybe_view_mask.copied().unwrap_or_default();
 
-        let (visible_entity_sender, visible_entity_receiver) = unbounded();
+        let (visible_entity_sender, visible_entity_receiver) = crossbeam_channel::unbounded();
 
         visible_entity_query.par_for_each_mut(
             &thread_pool,

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -170,7 +170,7 @@ pub fn check_visibility(
 
         visible_entity_query.par_for_each_mut(
             &thread_pool,
-            1024,
+            10000,
             |(
                 entity,
                 visibility,


### PR DESCRIPTION
# Objective

Working with a large number of entities with `Aabbs`, rendered with an instanced shader, I found the bottleneck became the frustum culling system. The goal of this PR is to significantly improve culling performance without any major changes. We should consider constructing a BVH for more substantial improvements.

## Solution

- Convert the inner entity query to a parallel iterator with `par_for_each_mut` using a batch size of 1,024. 
- This outperforms single threaded culling when there are more than 1,000 entities. 
  - Below this they are approximately equal, with <= 10 microseconds of multithreading overhead.
  - Above this, the multithreaded version is significantly faster, scaling linearly with core count.
- In my million-entity-workload, this PR improves my framerate by 200% - 300%.

## log-log of `check_visibility` time vs. entities for single/multithreaded
![image](https://user-images.githubusercontent.com/2632925/163709007-7eab4437-e9f9-4c06-bac0-250073885110.png)

---

## Changelog

Frustum culling is now run with a parallel query. When culling more than a thousand entities, this is faster than the previous method, scaling proportionally with the number of available cores.