### PR TITLE
[Merged by Bors] - Let contributors know it's okay to delete optional template sections

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@
 
 ## Changelog
 
-> This section is optional. If this was a trivial fix, or has no externally-visible impact, feel free to skip this section.
+> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.
 
 - What changed as a result of this PR?
 - If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
@@ -20,7 +20,7 @@
 
 ## Migration Guide
 
-> This section is optional
+> This section is optional. If there are no breaking changes, you can delete this section.
 
 - If this PR is a breaking change (relative to the last release of Bevy), describe how a user might need to migrate their code to support these changes
 - Simply adding new functionality is not a breaking change.


### PR DESCRIPTION
# Objective

We are currently asking contributors to "skip" optional sections, which is a bit confusing. "Skip" can be taken to mean that you should "leave that section alone" and result in these bits of template being left in the PR description.

## Solution

Let contributors know that it's okay to delete the section if it's not needed.