### PR TITLE
[Merged by Bors] - Remove `.system()`

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -284,10 +284,10 @@ impl<'w, 's> Commands<'w, 's> {
     /// #     high_score: u32,
     /// # }
     /// #
-    /// # fn system(mut commands: Commands) {
+    /// # fn initialise_scoreboard(mut commands: Commands) {
     /// commands.init_resource::<Scoreboard>();
     /// # }
-    /// # system.system();
+    /// # bevy_ecs::system::assert_is_system(initialise_scoreboard);
     /// ```
     pub fn init_resource<R: Resource + FromWorld>(&mut self) {
         self.queue.push(InitResource::<R> {

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -249,7 +249,7 @@ impl<Param: SystemParam> FromWorld for SystemState<Param> {
 ///
 /// fn my_system_function(an_usize_resource: Res<usize>) {}
 ///
-/// let system = IntoSystem::system(my_system_function);
+/// let system = IntoSystem::into_system(my_system_function);
 /// ```
 // This trait has to be generic because we have potentially overlapping impls, in particular
 // because Rust thinks a type could impl multiple different `FnMut` combinations
@@ -302,7 +302,7 @@ pub struct InputMarker;
 
 /// The [`System`] counter part of an ordinary function.
 ///
-/// You get this by calling [`IntoSystem::system`]  on a function that only accepts
+/// You get this by calling [`IntoSystem::into_system`]  on a function that only accepts
 /// [`SystemParam`]s. The output of the system becomes the functions return type, while the input
 /// becomes the functions [`In`] tagged parameter or `()` if no such parameter exists.
 pub struct FunctionSystem<In, Out, Param, Marker, F>

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -257,26 +257,6 @@ impl<Param: SystemParam> FromWorld for SystemState<Param> {
 pub trait IntoSystem<In, Out, Params>: Sized {
     type System: System<In = In, Out = Out>;
     /// Turns this value into its corresponding [`System`].
-    ///
-    /// Use of this method was formerly required whenever adding a `system` to an `App`.
-    /// or other cases where a system is required.
-    /// However, since [#2398](https://github.com/bevyengine/bevy/pull/2398),
-    /// this is no longer required.
-    ///
-    /// In future, this method will be removed.
-    ///
-    /// One use of this method is to assert that a given function is a valid system.
-    /// For this case, use [`bevy_ecs::system::assert_is_system`] instead.
-    ///
-    /// [`bevy_ecs::system::assert_is_system`]: [`crate::system::assert_is_system`]:
-    #[deprecated(
-        since = "0.7.0",
-        note = "`.system()` is no longer needed, as methods which accept systems will convert functions into a system automatically"
-    )]
-    fn system(self) -> Self::System {
-        IntoSystem::into_system(self)
-    }
-    /// Turns this value into its corresponding [`System`].
     fn into_system(this: Self) -> Self::System;
 }
 

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1125,7 +1125,6 @@ where
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::
     /// #
     /// # #[derive(Component)]
     /// # struct InRange;

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1125,6 +1125,7 @@ where
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::
     /// #
     /// # #[derive(Component)]
     /// # struct InRange;
@@ -1138,7 +1139,7 @@ where
     ///         println!("Bam!")
     ///     }
     /// }
-    /// # targeting_system.system();
+    /// # bevy_ecs::system::assert_is_system(targeting_system);
     /// ```
     #[inline]
     pub fn contains(&self, entity: Entity) -> bool {


### PR DESCRIPTION
Free at last!

# Objective

- Using `.system()` is no longer needed anywhere, and anyone using it will have already gotten a deprecation warning.
- https://github.com/bevyengine/bevy/pull/3302 was a super special case for `.system()`, since it was so prevelant. However, that's no reason.
- Despite it being deprecated, another couple of uses of it have already landed, including in the deprecating PR.
   - These have all been because of doc examples having warnings not breaking CI - 🎟️?

## Solution

- Remove it.
- It's gone

---

## Changelog

- You can no longer use `.system()`

## Migration Guide

- You can no longer use `.system()`. It was deprecated in 0.7.0, and you should have followed the deprecation warning then. You can just remove the method call.

![image](https://user-images.githubusercontent.com/36049421/163688197-3e774a04-6f8f-40a6-b7a4-1330e0b7acf0.png)

- Thanks to the @TheRawMeatball  for producing