### PR TITLE
[Merged by Bors] - SystemSet::before and after: take AsSystemLabel

### DIFF
--- a/crates/bevy_ecs/src/schedule/system_set.rs
+++ b/crates/bevy_ecs/src/schedule/system_set.rs
@@ -1,9 +1,9 @@
 use crate::schedule::{
     AmbiguitySetLabel, BoxedAmbiguitySetLabel, BoxedSystemLabel, IntoRunCriteria,
-    RunCriteriaDescriptorOrLabel, State, StateData, SystemDescriptor, SystemLabel,
+    IntoSystemDescriptor, RunCriteriaDescriptorOrLabel, State, StateData, SystemDescriptor,
+    SystemLabel,
 };
-
-use super::IntoSystemDescriptor;
+use crate::system::AsSystemLabel;
 
 /// A builder for describing several systems at the same time.
 #[derive(Default)]
@@ -95,14 +95,14 @@ impl SystemSet {
     }
 
     #[must_use]
-    pub fn before(mut self, label: impl SystemLabel) -> Self {
-        self.before.push(Box::new(label));
+    pub fn before<Marker>(mut self, label: impl AsSystemLabel<Marker>) -> Self {
+        self.before.push(Box::new(label.as_system_label()));
         self
     }
 
     #[must_use]
-    pub fn after(mut self, label: impl SystemLabel) -> Self {
-        self.after.push(Box::new(label));
+    pub fn after<Marker>(mut self, label: impl AsSystemLabel<Marker>) -> Self {
+        self.after.push(Box::new(label.as_system_label()));
         self
     }
 


### PR DESCRIPTION
# Objective

`AsSystemLabel` has been introduced on system descriptors to make ordering systems more convenient, but `SystemSet::before` and `SystemSet::after` still take `SystemLabels` directly:

    use bevy::ecs::system::AsSystemLabel;
    /*…*/ SystemSet::new().before(foo.as_system_label()) /*…*/

is currently necessary instead of

    /*…*/ SystemSet::new().before(foo) /*…*/

## Solution

Use `AsSystemLabel` for `SystemSet`