### PR TITLE
Fedora Silverblue setup

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -54,6 +54,7 @@ Add your arch to the end of the package to remove the linker error. For example:
 ```bash
 sudo dnf install alsa-lib-devel.x86_64
 ```
+
 ## Fedora / Silverblue
 
 ```bash

--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -54,6 +54,13 @@ Add your arch to the end of the package to remove the linker error. For example:
 ```bash
 sudo dnf install alsa-lib-devel.x86_64
 ```
+## Fedora / Silverblue
+
+```bash
+toolbox enter
+sudo dnf install gcc-c++ libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel rust-alsa-sys-devel.noarch
+exit
+```
 
 ## Arch / Manjaro
 

--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -59,7 +59,15 @@ sudo dnf install alsa-lib-devel.x86_64
 
 ```bash
 toolbox enter
-sudo dnf install gcc-c++ libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel rust-alsa-sys-devel.noarch
+sudo dnf install gcc-c++ libX11-devel alsa-lib-devel systemd-devel wayland-devel libxkbcommon-devel
+exit
+```
+
+In the future, run cargo inside toolbox. For example:
+
+```bash
+toolbox enter
+cargo run --features bevy/dynamic
 exit
 ```
 


### PR DESCRIPTION
*Edit rust-alsa-sys-devel.noarch doesn't seam to be needed: please read: https://github.com/bevyengine/bevy/pull/4506#issuecomment-1100916043*

Silverblue requires installing rust-alsa-sys-devel.noarch (and install installs from inside cli: toolbox).

# Objective
Setup instructions do not work for Fedora Silverblue and potentially other OSTree Flatpak OSes.
Fixing: error: could not find system library 'alsa' required by the 'alsa-sys' crate

## Solution

Add instructions to documentation.

## Request

Can someone else try these instructions in Silverblue to make sure it works in general and not just my machine. Some of these packages may already be installed in base Silverblue and could be removed from Silverblue's dnf install command.