### PR TITLE
[Merged by Bors] - Make MaterialPipelineKey<T> fields public

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -220,8 +220,8 @@ impl<M: SpecializedMaterial> Plugin for MaterialPlugin<M> {
 
 #[derive(Eq, PartialEq, Clone, Hash)]
 pub struct MaterialPipelineKey<T> {
-    mesh_key: MeshPipelineKey,
-    material_key: T,
+    pub mesh_key: MeshPipelineKey,
+    pub material_key: T,
 }
 
 pub struct MaterialPipeline<M: SpecializedMaterial> {


### PR DESCRIPTION
# Objective

Fixes #4507. This comment provides a very good explanation: https://github.com/bevyengine/bevy/issues/4507#issuecomment-1100905685.

## Solution

Make `MaterialPipelineKey` fields public.