### PR TITLE
Fix filter query derive when missing generic arguments

### DIFF
--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -218,7 +218,11 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
 
     // Replace lifetime `'world` with `'fetch`. See `replace_lifetime_for_type` for more details.
     let mut fetch_generics = ast.generics.clone();
-    *fetch_generics.params.first_mut().unwrap() = fetch_lifetime_param;
+    if let Some(first_fetch_lifetime) = fetch_generics.params.first_mut() {
+        if *first_fetch_lifetime == world_lifetime_param {
+            *first_fetch_lifetime = fetch_lifetime_param;
+        }
+    }
 
     let fetch_ty_generics = if fetch_struct_attributes.is_filter {
         ty_generics.clone()

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -287,9 +287,15 @@ use std::{
 ///
 /// #[derive(WorldQuery)]
 /// #[world_query(filter)]
-/// struct MyFilter<T: Component, P: Component> {
+/// struct FooBarFilter {
 ///     _foo: With<Foo>,
 ///     _bar: With<Bar>,
+/// }
+///
+/// #[derive(WorldQuery)]
+/// #[world_query(filter)]
+/// struct MyFilter<T: Component, P: Component> {
+///     _foobar: FooBarFilter,
 ///     _or: Or<(With<Baz>, Changed<Foo>, Added<Bar>)>,
 ///     _generic_tuple: (With<T>, Without<P>),
 ///     #[world_query(ignore)]


### PR DESCRIPTION
# Objective

Fixes #4533 

## Solution

The solution is to employ the hack with replacing the world lifetime with the fetch one only when the world lifetime exists.

This will become irrelevant with these changes: https://github.com/TheRawMeatball/bevy/pull/40. But it might be a good candidate for the patch release.