### PR TITLE
[Merged by Bors] - Remove nonexistent `WgpuResourceDiagnosticsPlugin`

### DIFF
--- a/examples/diagnostics/log_diagnostics.rs
+++ b/examples/diagnostics/log_diagnostics.rs
@@ -11,8 +11,6 @@ fn main() {
         // Adds a system that prints diagnostics to the console
         .add_plugin(LogDiagnosticsPlugin::default())
         // Any plugin can register diagnostics
-        // Uncomment this to add some render resource diagnostics:
-        // .add_plugin(bevy::wgpu::diagnostic::WgpuResourceDiagnosticsPlugin::default())
         // Uncomment this to add an entity count diagnostics:
         // .add_plugin(bevy::diagnostic::EntityCountDiagnosticsPlugin::default())
         // Uncomment this to add an asset count diagnostics:


### PR DESCRIPTION
# Objective

Uncommenting the following results in a compile error: https://github.com/bevyengine/bevy/blob/7557f4db83b8e9d3049f242bd4b58f8546bb1510/examples/diagnostics/log_diagnostics.rs#L14-L15

## Solution

Remove the commented line.