### PR TITLE
[Merged by Bors] - Misc dependency improvements

### DIFF
--- a/crates/bevy_derive/Cargo.toml
+++ b/crates/bevy_derive/Cargo.toml
@@ -15,4 +15,4 @@ proc-macro = true
 bevy_macro_utils = { path = "../bevy_macro_utils", version = "0.8.0-dev" }
 
 quote = "1.0"
-syn = "1.0"
+syn = { version = "1.0", features = ["full"] }

--- a/crates/bevy_macro_utils/src/attrs.rs
+++ b/crates/bevy_macro_utils/src/attrs.rs
@@ -1,23 +1,6 @@
 use syn::DeriveInput;
 
-use crate::Symbol;
-
-pub fn get_attr_meta_items(
-    attr: &syn::Attribute,
-    attr_name: &'static str,
-) -> syn::Result<Vec<syn::NestedMeta>> {
-    if !attr.path.is_ident(attr_name) {
-        return Ok(Vec::new());
-    }
-
-    match attr.parse_meta()? {
-        syn::Meta::List(meta) => Ok(meta.nested.into_iter().collect()),
-        other => Err(syn::Error::new_spanned(
-            other,
-            format!("expected #[{}(...)]", attr_name),
-        )),
-    }
-}
+use crate::symbol::Symbol;
 
 pub fn parse_attrs(ast: &DeriveInput, attr_name: Symbol) -> syn::Result<Vec<syn::NestedMeta>> {
     let mut list = Vec::new();

--- a/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
+++ b/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 [dependencies]
 bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.8.0-dev" }
 
-syn = "1.0"
+syn = { version = "1.0", features = ["full"] }
 proc-macro2 = "1.0"
 quote = "1.0"
 uuid = { version = "0.8", features = ["v4", "serde"] }


### PR DESCRIPTION
A couple more uncontroversial changes extracted from #3886.

* Enable full feature of syn
  
   It is necessary for the ItemFn and ItemTrait type. Currently it is indirectly
   enabled through the tracing dependency of bevy_utils, but this may no
   longer be the case in the future.
* Remove unused function from bevy_macro_utils