### PR TITLE
[Merged by Bors] - fixes complaints about missing docs

### DIFF
--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -280,7 +280,7 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
         } else {
             quote! {
                 #derive_macro_call
-               #[automatically_derived]
+                #[automatically_derived]
                 #visibility struct #item_struct_name #impl_generics #where_clause {
                     #(#(#field_attrs)* #field_visibilities #field_idents: <<#field_types as #path::query::WorldQuery>::#fetch_associated_type as #path::query::Fetch<#world_lifetime, #world_lifetime>>::Item,)*
                     #(#(#ignored_field_attrs)* #ignored_field_visibilities #ignored_field_idents: #ignored_field_types,)*

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -280,7 +280,7 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
         } else {
             quote! {
                 #derive_macro_call
-                #[doc(hidden)]
+                /// An item struct created by the [`WorldQuery`] derive macro
                 #visibility struct #item_struct_name #impl_generics #where_clause {
                     #(#(#field_attrs)* #field_visibilities #field_idents: <<#field_types as #path::query::WorldQuery>::#fetch_associated_type as #path::query::Fetch<#world_lifetime, #world_lifetime>>::Item,)*
                     #(#(#ignored_field_attrs)* #ignored_field_visibilities #ignored_field_idents: #ignored_field_types,)*

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -280,6 +280,7 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
         } else {
             quote! {
                 #derive_macro_call
+                #[doc(hidden)]
                 #visibility struct #item_struct_name #impl_generics #where_clause {
                     #(#(#field_attrs)* #field_visibilities #field_idents: <<#field_types as #path::query::WorldQuery>::#fetch_associated_type as #path::query::Fetch<#world_lifetime, #world_lifetime>>::Item,)*
                     #(#(#ignored_field_attrs)* #ignored_field_visibilities #ignored_field_idents: #ignored_field_types,)*

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -280,7 +280,7 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
         } else {
             quote! {
                 #derive_macro_call
-                /// An item struct created by the [`WorldQuery`] derive macro
+               #[automatically_derived]
                 #visibility struct #item_struct_name #impl_generics #where_clause {
                     #(#(#field_attrs)* #field_visibilities #field_idents: <<#field_types as #path::query::WorldQuery>::#fetch_associated_type as #path::query::Fetch<#world_lifetime, #world_lifetime>>::Item,)*
                     #(#(#ignored_field_attrs)* #ignored_field_visibilities #ignored_field_idents: #ignored_field_types,)*


### PR DESCRIPTION
# Objective

When using `derive(WorldQuery)`, then clippy complains with the following:

```rust
warning: missing documentation for a struct
  --> src\wild_boar_type\marker_vital_status.rs:35:17
   |
35 | #[derive(Debug, WorldQuery)]
   |                 ^^^^^^^^^^
   |
   = note: this warning originates in the derive macro `WorldQuery` (in Nightly builds, run with -Z macro-backtrace for more info)
```

## Solution

* Either `#[doc(hidden)]` or
* Add a generic documentation line to it.

I don't know what is preferred, but I'd gladly add it in here. 

