### PR TITLE
Add back hot reloading for `Scene`s

### DIFF
--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -74,14 +74,15 @@ impl From<Handle<DynamicScene>> for SceneHandle {
     }
 }
 
+/// Request given to [`SceneSpawner`] for spawning a scene.
 #[derive(Debug, Clone)]
-struct SpawnCommand {
+struct SceneToSpawn {
     scene: SceneHandle,
     instance: InstanceId,
     parent: Option<Entity>,
 }
 
-impl SpawnCommand {
+impl SceneToSpawn {
     fn new(scene: impl Into<SceneHandle>, instance: InstanceId, parent: Option<Entity>) -> Self {
         Self {
             scene: scene.into(),
@@ -95,7 +96,7 @@ pub struct SceneSpawner {
     instances: HashMap<SceneHandle, Vec<InstanceId>>,
     instances_info: HashMap<InstanceId, InstanceInfo>,
     readers: SceneEventReaders,
-    scenes_to_spawn: Vec<SpawnCommand>,
+    scenes_to_spawn: Vec<SceneToSpawn>,
     instances_to_despawn: Vec<InstanceId>,
 }
 
@@ -129,7 +130,7 @@ impl SceneSpawner {
     pub fn spawn(&mut self, scene_handle: Handle<Scene>) -> InstanceId {
         let instance_id = InstanceId::new();
         self.scenes_to_spawn
-            .push(SpawnCommand::new(scene_handle, instance_id, None));
+            .push(SceneToSpawn::new(scene_handle, instance_id, None));
         instance_id
     }
 
@@ -137,7 +138,7 @@ impl SceneSpawner {
     pub fn spawn_dynamic(&mut self, scene_handle: Handle<DynamicScene>) -> InstanceId {
         let instance_id = InstanceId::new();
         self.scenes_to_spawn
-            .push(SpawnCommand::new(scene_handle, instance_id, None));
+            .push(SceneToSpawn::new(scene_handle, instance_id, None));
         instance_id
     }
 
@@ -148,7 +149,7 @@ impl SceneSpawner {
     pub fn spawn_as_child(&mut self, scene_handle: Handle<Scene>, parent: Entity) -> InstanceId {
         let instance_id = InstanceId::new();
         self.scenes_to_spawn
-            .push(SpawnCommand::new(scene_handle, instance_id, Some(parent)));
+            .push(SceneToSpawn::new(scene_handle, instance_id, Some(parent)));
         instance_id
     }
 
@@ -161,7 +162,7 @@ impl SceneSpawner {
     ) -> InstanceId {
         let instance_id = InstanceId::new();
         self.scenes_to_spawn
-            .push(SpawnCommand::new(scene_handle, instance_id, Some(parent)));
+            .push(SceneToSpawn::new(scene_handle, instance_id, Some(parent)));
         instance_id
     }
 
@@ -254,7 +255,7 @@ impl SceneSpawner {
         world: &mut World,
         scene_handle: Handle<Scene>,
     ) -> SpawnResult<InstanceId> {
-        let cmd = SpawnCommand::new(scene_handle, InstanceId::new(), None);
+        let cmd = SceneToSpawn::new(scene_handle, InstanceId::new(), None);
         self.spawn_scene_instance(world, cmd)
     }
 
@@ -265,7 +266,7 @@ impl SceneSpawner {
         world: &mut World,
         scene_handle: Handle<DynamicScene>,
     ) -> SpawnResult<InstanceId> {
-        let cmd = SpawnCommand::new(scene_handle, InstanceId::new(), None);
+        let cmd = SceneToSpawn::new(scene_handle, InstanceId::new(), None);
         self.spawn_scene_instance(world, cmd)
     }
 
@@ -273,11 +274,11 @@ impl SceneSpawner {
     fn spawn_scene_instance(
         &mut self,
         world: &mut World,
-        SpawnCommand {
+        SceneToSpawn {
             scene,
             instance,
             parent,
-        }: SpawnCommand,
+        }: SceneToSpawn,
     ) -> SpawnResult<InstanceId> {
         let mut entity_map = EntityMap::default();
         scene.write_to_world(world, &mut entity_map)?;


### PR DESCRIPTION
# `SceneSpawner` refactor

This PR reworks the `scene_spawner.rs` module in `bevy_scene`. After
hunting for the bug causing #3759, I determined that it was the
culprit. Having difficulties parsing the code myself, I decided
to refactor it.

## Relationship with merging of `Scene` and `DynamicScene`

There has been discussion about getting rid of either `Scene` or
`DynamicScene`, or merging the two.

This PR **does not merge `Scene` and `DynamicScene`** it only limits
itself to refactoring `scene_spawner.rs`. However, the changes
introduced will likely make it easier to transition to an
implementation where only a single `Scene` type exists.

## Improvements

* Merge code in `SceneSpawner` for managing `DynamicScene` and `Scene`.
  * Add back hot reloading for `Scene`s, fixes #3759
* Add documentation to `SceneSpawner` methods.
* Add `write_to_world` method to `Scene` (does the same as `DynamicScene::write_to_world`)

## Tests

The tests would require manipulating `ResMut<Assets<T>>`, which I don't
know how to do. So I left them out.

## Further cleanup

### Removing duplication in API surface

An earlier version of this PR merged the `SceneSpawner::dynamic_foo` and
`SceneSpawner::foo` methods by making them generic over the handle they accept.
However, it was judged too burdensome for the user. It required adding type specification
on existing code, since it doesn't play nice with `asset_server.load()` which introduces
an unbound type variable.

## User migration guide

After the second commit, the migration guide consists of:
* Change all calls to `SceneSpawner::despawn` to `SceneSpawner::despawn_dynamic` (note that you should be using `SceneBundle`s and `remove`ing the `Handle<Scene>` and `Handle<DynamicScene>` component instead in any case)

## Question for reviewers

* Should we revert the `<T: Into<SceneHandle>>` change? Now that scenes are mostly added through `SceneBundle`, there is not as much use of the `SceneSpawner` API with unbound generic types.
