### PR TITLE
bevy_reflect: Improve serialization format

### DIFF
--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -1,25 +1,29 @@
 [
-
   (
     entity: 0,
     components: [
       {
-        "type": "bevy_transform::components::transform::Transform",
-        "value": {
-          "translation": (0.0, 0.0, 0.0),
+        "bevy_transform::components::transform::Transform": {
+          "translation": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
           "rotation": (0.0, 0.0, 0.0, 1.0),
-          "scale": (1.0, 1.0, 1.0),
+          "scale": {
+            "x": 1.0,
+            "y": 1.0,
+            "z": 1.0
+          },
         },
       },
       {
-        "type": "scene::ComponentB",
-        "value": {
+        "scene::ComponentB": {
           "value": "hello",
         },
       },
       {
-        "type": "scene::ComponentA",
-        "value": {
+        "scene::ComponentA": {
           "x": 1.0,
           "y": 2.0,
         },
@@ -30,8 +34,7 @@
     entity: 1,
     components: [
       {
-        "type": "scene::ComponentA",
-        "value": {
+        "scene::ComponentA": {
           "x": 3.0,
           "y": 4.0,
         },

--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -1,44 +1,27 @@
 [
+
   (
     entity: 0,
     components: [
       {
         "type": "bevy_transform::components::transform::Transform",
-        "struct": {
-          "translation": {
-            "type": "glam::f32::vec3::Vec3",
-            "value": (0.0, 0.0, 0.0),
-          },
-          "rotation": {
-            "type": "glam::f32::sse2::quat::Quat",
-            "value": (0.0, 0.0, 0.0, 1.0),
-          },
-          "scale": {
-            "type": "glam::f32::vec3::Vec3",
-            "value": (1.0, 1.0, 1.0),
-          },
+        "value": {
+          "translation": (0.0, 0.0, 0.0),
+          "rotation": (0.0, 0.0, 0.0, 1.0),
+          "scale": (1.0, 1.0, 1.0),
         },
       },
       {
         "type": "scene::ComponentB",
-        "struct": {
-          "value": {
-            "type": "alloc::string::String",
-            "value": "hello",
-          },
+        "value": {
+          "value": "hello",
         },
       },
       {
         "type": "scene::ComponentA",
-        "struct": {
-          "x": {
-            "type": "f32",
-            "value": 1.0,
-          },
-          "y": {
-            "type": "f32",
-            "value": 2.0,
-          },
+        "value": {
+          "x": 1.0,
+          "y": 2.0,
         },
       },
     ],
@@ -48,15 +31,9 @@
     components: [
       {
         "type": "scene::ComponentA",
-        "struct": {
-          "x": {
-            "type": "f32",
-            "value": 3.0,
-          },
-          "y": {
-            "type": "f32",
-            "value": 4.0,
-          },
+        "value": {
+          "x": 3.0,
+          "y": 4.0,
         },
       },
     ],

--- a/crates/bevy_reflect/src/impls/glam.rs
+++ b/crates/bevy_reflect/src/impls/glam.rs
@@ -6,14 +6,14 @@ use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_struct, impl_ref
 use glam::*;
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct IVec2 {
         x: i32,
         y: i32,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct IVec3 {
         x: i32,
         y: i32,
@@ -21,7 +21,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct IVec4 {
         x: i32,
         y: i32,
@@ -31,14 +31,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct UVec2 {
         x: u32,
         y: u32,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct UVec3 {
         x: u32,
         y: u32,
@@ -46,7 +46,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct UVec4 {
         x: u32,
         y: u32,
@@ -56,14 +56,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct Vec2 {
         x: f32,
         y: f32,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct Vec3 {
         x: f32,
         y: f32,
@@ -71,7 +71,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct Vec3A {
         x: f32,
         y: f32,
@@ -79,7 +79,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct Vec4 {
         x: f32,
         y: f32,
@@ -114,14 +114,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct DVec2 {
         x: f64,
         y: f64,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct DVec3 {
         x: f64,
         y: f64,
@@ -129,7 +129,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct DVec4 {
         x: f64,
         y: f64,

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -93,7 +93,7 @@ pub mod __macro_exports {
 mod tests {
     #[cfg(feature = "glam")]
     use ::glam::{vec3, Vec3};
-    use ::serde::de::DeserializeSeed;
+    use ::serde::{de::DeserializeSeed, Deserialize, Serialize};
     use bevy_utils::HashMap;
     use ron::{
         ser::{to_string_pretty, PrettyConfig},
@@ -451,7 +451,8 @@ mod tests {
             h: [u32; 2],
         }
 
-        #[derive(Reflect)]
+        #[derive(Reflect, Serialize, Deserialize)]
+        #[reflect(Serialize, Deserialize)]
         struct Bar {
             x: u32,
         }

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -104,7 +104,7 @@ mod tests {
     use super::prelude::*;
     use super::*;
     use crate as bevy_reflect;
-    use crate::serde::{ReflectDeserializer, ReflectSerializer};
+    use crate::serde::{UntypedReflectDeserializer, ReflectSerializer};
 
     #[test]
     fn reflect_struct() {
@@ -489,7 +489,7 @@ mod tests {
         let serialized = to_string_pretty(&serializer, PrettyConfig::default()).unwrap();
 
         let mut deserializer = Deserializer::from_str(&serialized).unwrap();
-        let reflect_deserializer = ReflectDeserializer::new(&registry);
+        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
         let value = reflect_deserializer.deserialize(&mut deserializer).unwrap();
         let dynamic_struct = value.take::<DynamicStruct>().unwrap();
 
@@ -992,7 +992,7 @@ bevy_reflect::tests::should_reflect_debug::Test {
             registry.add_registration(Vec3::get_type_registration());
             registry.add_registration(f32::get_type_registration());
 
-            let de = ReflectDeserializer::new(&registry);
+            let de = UntypedReflectDeserializer::new(&registry);
 
             let mut deserializer =
                 ron::de::Deserializer::from_str(data).expect("Failed to acquire deserializer");

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -958,7 +958,8 @@ bevy_reflect::tests::should_reflect_debug::Test {
 
             let ser = ReflectSerializer::new(&v, &registry);
 
-            let output = to_string_pretty(&ser, Default::default()).unwrap();
+            let config = PrettyConfig::default().new_line(String::from("\n"));
+            let output = to_string_pretty(&ser, config).unwrap();
             let expected = r#"
 {
     "type": "glam::f32::vec3::Vec3",

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -958,7 +958,10 @@ bevy_reflect::tests::should_reflect_debug::Test {
 
             let ser = ReflectSerializer::new(&v, &registry);
 
-            let config = PrettyConfig::default().new_line(String::from("\n"));
+            let config = PrettyConfig::default()
+                .new_line(String::from("\n"))
+                .decimal_floats(true)
+                .indentor(String::from("    "));
             let output = to_string_pretty(&ser, config).unwrap();
             let expected = r#"
 {
@@ -968,10 +971,9 @@ bevy_reflect::tests::should_reflect_debug::Test {
         "y": 3.0,
         "z": -6.9,
     },
-}
-"#;
+}"#;
 
-            assert_eq!(expected, format!("\n{}\n", output));
+            assert_eq!(expected, format!("\n{}", output));
         }
 
         #[test]
@@ -980,12 +982,11 @@ bevy_reflect::tests::should_reflect_debug::Test {
 {
     "type": "glam::f32::vec3::Vec3",
     "value": {
-        "x": 12,
-        "y": 3,
+        "x": 12.0,
+        "y": 3.0,
         "z": -6.9,
     },
-}
-"#;
+}"#;
 
             let mut registry = TypeRegistry::default();
             registry.add_registration(Vec3::get_type_registration());

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -965,8 +965,7 @@ bevy_reflect::tests::should_reflect_debug::Test {
             let output = to_string_pretty(&ser, config).unwrap();
             let expected = r#"
 {
-    "type": "glam::f32::vec3::Vec3",
-    "value": {
+    "glam::f32::vec3::Vec3": {
         "x": 12.0,
         "y": 3.0,
         "z": -6.9,
@@ -980,8 +979,7 @@ bevy_reflect::tests::should_reflect_debug::Test {
         fn vec3_deserialization() {
             let data = r#"
 {
-    "type": "glam::f32::vec3::Vec3",
-    "value": {
+    "glam::f32::vec3::Vec3": {
         "x": 12.0,
         "y": 3.0,
         "z": -6.9,

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -104,7 +104,7 @@ mod tests {
     use super::prelude::*;
     use super::*;
     use crate as bevy_reflect;
-    use crate::serde::{UntypedReflectDeserializer, ReflectSerializer};
+    use crate::serde::{ReflectSerializer, UntypedReflectDeserializer};
 
     #[test]
     fn reflect_struct() {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -472,12 +472,17 @@ mod tests {
 
         let mut registry = TypeRegistry::default();
         registry.register::<u32>();
-        registry.register::<isize>();
-        registry.register::<usize>();
-        registry.register::<Bar>();
-        registry.register::<String>();
         registry.register::<i8>();
         registry.register::<i32>();
+        registry.register::<usize>();
+        registry.register::<isize>();
+        registry.register::<Foo>();
+        registry.register::<Bar>();
+        registry.register::<String>();
+        registry.register::<Vec<isize>>();
+        registry.register::<HashMap<usize, i8>>();
+        registry.register::<(i32, Vec<isize>, Bar)>();
+        registry.register::<[u32; 2]>();
 
         let serializer = ReflectSerializer::new(&foo, &registry);
         let serialized = to_string_pretty(&serializer, PrettyConfig::default()).unwrap();

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -957,17 +957,33 @@ bevy_reflect::tests::should_reflect_debug::Test {
 
             let ser = ReflectSerializer::new(&v, &registry);
 
-            let result = ron::to_string(&ser).expect("Failed to serialize to string");
+            let output = to_string_pretty(&ser, Default::default()).unwrap();
+            let expected = r#"
+{
+    "type": "glam::f32::vec3::Vec3",
+    "value": {
+        "x": 12.0,
+        "y": 3.0,
+        "z": -6.9,
+    },
+}
+"#;
 
-            assert_eq!(
-                result,
-                r#"{"type":"glam::f32::vec3::Vec3","struct":{"x":{"type":"f32","value":12.0},"y":{"type":"f32","value":3.0},"z":{"type":"f32","value":-6.9}}}"#
-            );
+            assert_eq!(expected, format!("\n{}\n", output));
         }
 
         #[test]
         fn vec3_deserialization() {
-            let data = r#"{"type":"glam::vec3::Vec3","struct":{"x":{"type":"f32","value":12},"y":{"type":"f32","value":3},"z":{"type":"f32","value":-6.9}}}"#;
+            let data = r#"
+{
+    "type": "glam::f32::vec3::Vec3",
+    "value": {
+        "x": 12,
+        "y": 3,
+        "z": -6.9,
+    },
+}
+"#;
 
             let mut registry = TypeRegistry::default();
             registry.add_registration(Vec3::get_type_registration());

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -138,10 +138,10 @@ impl<'a, 'de> Visitor<'de> for UntypedReflectDeserializerVisitor<'a> {
         A: MapAccess<'de>,
     {
         let type_name = map
-            .next_key::<&str>()?
+            .next_key::<String>()?
             .ok_or_else(|| Error::invalid_length(0, &"at least one entry"))?;
 
-        let registration = self.registry.get_with_name(type_name).ok_or_else(|| {
+        let registration = self.registry.get_with_name(&type_name).ok_or_else(|| {
             Error::custom(format_args!("No registration found for {}", type_name))
         })?;
         let type_info = registration.type_info();
@@ -512,12 +512,12 @@ impl<'a, 'de> Visitor<'de> for EnumVisitor<'a> {
         V: MapAccess<'de>,
     {
         let variant_name = map
-            .next_key::<&str>()?
+            .next_key::<String>()?
             .ok_or_else(|| Error::missing_field("the variant name of the enum"))?;
 
         let variant_info = self
             .enum_info
-            .variant(variant_name)
+            .variant(&variant_name)
             .ok_or_else(|| Error::custom(format_args!("unknown variant {}", variant_name)))?;
 
         let mut dynamic_enum = DynamicEnum::default();

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -949,6 +949,23 @@ mod tests {
     }
 
     #[test]
+    fn should_deserialize_value() {
+        let input = r#"{
+            "type": "f32",
+            "value": 1.23,
+        }"#;
+
+        let registry = get_registry();
+        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
+        let mut ron_deserializer = ron::de::Deserializer::from_str(input).unwrap();
+        let dynamic_output = reflect_deserializer
+            .deserialize(&mut ron_deserializer)
+            .unwrap();
+        let output = dynamic_output.take::<f32>().expect("underlying type should be f32");
+        assert_eq!(1.23, output);
+    }
+
+    #[test]
     fn should_deserialized_typed() {
         #[derive(Reflect, FromReflect, Debug, PartialEq)]
         struct Foo {

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -758,7 +758,7 @@ mod tests {
         foo: i64,
     }
 
-    /// Implements a custom deserialize using #[reflect(Deserialize)].
+    /// Implements a custom deserialize using `#[reflect(Deserialize)]`.
     ///
     /// For testing purposes, this is just the auto-generated one from deriving.
     #[derive(Reflect, FromReflect, Debug, PartialEq, Deserialize)]

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -293,7 +293,7 @@ struct StructVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for StructVisitor<'a> {
     type Value = DynamicStruct;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
         formatter.write_str("reflected struct value")
     }
 
@@ -313,7 +313,7 @@ struct TupleStructVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for TupleStructVisitor<'a> {
     type Value = DynamicTupleStruct;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
         formatter.write_str("reflected tuple struct value")
     }
 
@@ -365,7 +365,7 @@ struct ListVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for ListVisitor<'a> {
     type Value = DynamicList;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
         formatter.write_str("reflected list value")
     }
 
@@ -397,7 +397,7 @@ struct ArrayVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for ArrayVisitor<'a> {
     type Value = DynamicArray;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
         formatter.write_str("reflected array value")
     }
 
@@ -437,7 +437,7 @@ struct MapVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for MapVisitor<'a> {
     type Value = DynamicMap;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
         formatter.write_str("reflected map value")
     }
 
@@ -479,7 +479,7 @@ struct TupleVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for TupleVisitor<'a> {
     type Value = DynamicTuple;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
         formatter.write_str("reflected tuple value")
     }
 

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -107,7 +107,7 @@ impl<'a, 'de> DeserializeSeed<'de> for ReflectDeserializer<'a> {
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_any(ReflectDeserializerVisitor {
+        deserializer.deserialize_map(ReflectDeserializerVisitor {
             registry: self.registry,
         })
     }

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -199,6 +199,15 @@ pub struct TypedReflectDeserializer<'a> {
     registry: &'a TypeRegistry,
 }
 
+impl<'a> TypedReflectDeserializer<'a> {
+    pub fn new(type_info: &'a TypeInfo, registry: &'a TypeRegistry) -> Self {
+        Self {
+            type_info,
+            registry,
+        }
+    }
+}
+
 impl<'a, 'de> DeserializeSeed<'de> for TypedReflectDeserializer<'a> {
     type Value = Box<dyn Reflect>;
 
@@ -730,13 +739,16 @@ fn get_type_info<'a, E: de::Error>(
 
 #[cfg(test)]
 mod tests {
-    use crate as bevy_reflect;
-    use crate::serde::UntypedReflectDeserializer;
-    use crate::{DynamicEnum, FromReflect, Reflect, ReflectDeserialize, TypeRegistry};
-    use bevy_utils::HashMap;
+    use std::f32::consts::PI;
+
     use serde::de::DeserializeSeed;
     use serde::Deserialize;
-    use std::f32::consts::PI;
+
+    use bevy_utils::HashMap;
+
+    use crate as bevy_reflect;
+    use crate::serde::{TypedReflectDeserializer, UntypedReflectDeserializer};
+    use crate::{DynamicEnum, FromReflect, Reflect, ReflectDeserialize, TypeRegistry, Typed};
 
     #[derive(Reflect, FromReflect, Debug, PartialEq)]
     struct MyStruct {
@@ -933,6 +945,31 @@ mod tests {
             .unwrap();
 
         let output = <MyStruct as FromReflect>::from_reflect(dynamic_output.as_ref()).unwrap();
+        assert_eq!(expected, output);
+    }
+
+    #[test]
+    fn should_deserialized_typed() {
+        #[derive(Reflect, FromReflect, Debug, PartialEq)]
+        struct Foo {
+            bar: i32,
+        }
+
+        let expected = Foo { bar: 123 };
+
+        let input = r#"{
+            "bar": 123
+        }"#;
+
+        let mut registry = get_registry();
+        registry.register::<Foo>();
+        let reflect_deserializer = TypedReflectDeserializer::new(Foo::type_info(), &registry);
+        let mut ron_deserializer = ron::de::Deserializer::from_str(input).unwrap();
+        let dynamic_output = reflect_deserializer
+            .deserialize(&mut ron_deserializer)
+            .unwrap();
+
+        let output = <Foo as FromReflect>::from_reflect(dynamic_output.as_ref()).unwrap();
         assert_eq!(expected, output);
     }
 }

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -853,7 +853,6 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(64, 32);
 
-        // TODO: Add test for standard tuples (requires https://github.com/bevyengine/bevy/pull/4226)
         let expected = MyStruct {
             primitive_value: 123,
             option_value: Some(String::from("Hello world!")),

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -1,8 +1,8 @@
 use crate::{
-    serde::type_fields, ArrayInfo, DynamicArray, DynamicEnum, DynamicList, DynamicMap,
-    DynamicStruct, DynamicTuple, DynamicTupleStruct, EnumInfo, ListInfo, Map, MapInfo, NamedField,
-    Reflect, ReflectDeserialize, StructInfo, StructVariantInfo, Tuple, TupleInfo, TupleStruct,
-    TupleStructInfo, TupleVariantInfo, TypeInfo, TypeRegistry, UnnamedField, VariantInfo,
+    ArrayInfo, DynamicArray, DynamicEnum, DynamicList, DynamicMap, DynamicStruct, DynamicTuple,
+    DynamicTupleStruct, EnumInfo, ListInfo, Map, MapInfo, NamedField, Reflect, ReflectDeserialize,
+    StructInfo, StructVariantInfo, Tuple, TupleInfo, TupleStruct, TupleStructInfo,
+    TupleVariantInfo, TypeInfo, TypeRegistry, UnnamedField, VariantInfo,
 };
 use erased_serde::Deserializer;
 use serde::de::{self, DeserializeSeed, Error, MapAccess, SeqAccess, Visitor};
@@ -137,42 +137,19 @@ impl<'a, 'de> Visitor<'de> for UntypedReflectDeserializerVisitor<'a> {
     where
         A: MapAccess<'de>,
     {
-        let type_name = match map.next_key::<&str>()? {
-            Some(type_fields::TYPE) => map.next_value::<&str>()?,
-            Some(type_fields::VALUE) => {
-                // `type` must come before `value`.
-                return Err(de::Error::missing_field(type_fields::TYPE));
-            }
-            Some(field) => {
-                return Err(de::Error::unknown_field(field, &[type_fields::TYPE]));
-            }
-            None => {
-                return Err(de::Error::invalid_length(
-                    0,
-                    &"two entries: `type` and `value`",
-                ));
-            }
-        };
+        let type_name = map
+            .next_key::<&str>()?
+            .ok_or_else(|| Error::invalid_length(0, &"at least one entry"))?;
 
-        match map.next_key::<&str>()? {
-            Some(type_fields::VALUE) => {
-                let registration = self.registry.get_with_name(type_name).ok_or_else(|| {
-                    de::Error::custom(format_args!("No registration found for {}", type_name))
-                })?;
-                let type_info = registration.type_info();
-                let value = map.next_value_seed(TypedReflectDeserializer {
-                    type_info,
-                    registry: self.registry,
-                })?;
-                Ok(value)
-            }
-            Some(type_fields::TYPE) => Err(de::Error::duplicate_field(type_fields::TYPE)),
-            Some(field) => Err(de::Error::unknown_field(field, &[type_fields::VALUE])),
-            None => Err(de::Error::invalid_length(
-                0,
-                &"two entries: `type` and `value`",
-            )),
-        }
+        let registration = self.registry.get_with_name(type_name).ok_or_else(|| {
+            Error::custom(format_args!("No registration found for {}", type_name))
+        })?;
+        let type_info = registration.type_info();
+        let value = map.next_value_seed(TypedReflectDeserializer {
+            type_info,
+            registry: self.registry,
+        })?;
+        Ok(value)
     }
 }
 
@@ -397,8 +374,8 @@ impl<'a, 'de> Visitor<'de> for TupleVisitor<'a> {
     }
 
     fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
-        where
-            V: SeqAccess<'de>,
+    where
+        V: SeqAccess<'de>,
     {
         visit_tuple(&mut seq, self.tuple_info, self.registry)
     }
@@ -819,8 +796,7 @@ mod tests {
 
         // === Unit Variant === //
         let input = r#"{
-            "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
-            "value": {
+            "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum": {
                 "Unit": (),
             },
         }"#;
@@ -833,8 +809,7 @@ mod tests {
 
         // === NewType Variant === //
         let input = r#"{
-            "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
-            "value": {
+            "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum": {
                 "NewType": (123),
             },
         }"#;
@@ -847,8 +822,7 @@ mod tests {
 
         // === Tuple Variant === //
         let input = r#"{
-            "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
-            "value": {
+            "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum": {
                 "Tuple": (1.23, 3.21),
             },
         }"#;
@@ -861,8 +835,7 @@ mod tests {
 
         // === Struct Variant === //
         let input = r#"{
-            "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
-            "value": {
+            "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum": {
                 "Struct": {
                     "value": "I <3 Enums",
                 },
@@ -899,8 +872,7 @@ mod tests {
         };
 
         let input = r#"{
-            "type": "bevy_reflect::serde::de::tests::MyStruct",
-            "value": {
+            "bevy_reflect::serde::de::tests::MyStruct": {
                 "primitive_value": 123,
                 "option_value": Some("Hello world!"),
                 "tuple_value": (
@@ -951,8 +923,7 @@ mod tests {
     #[test]
     fn should_deserialize_value() {
         let input = r#"{
-            "type": "f32",
-            "value": 1.23,
+            "f32": 1.23,
         }"#;
 
         let registry = get_registry();

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -147,7 +147,7 @@ impl<'a, 'de> Visitor<'de> for ReflectDeserializerVisitor<'a> {
 
         match map.next_key::<&str>()? {
             Some(type_fields::VALUE) => {
-                let registration = self.registry.get_with_name(&type_name).ok_or_else(|| {
+                let registration = self.registry.get_with_name(type_name).ok_or_else(|| {
                     de::Error::custom(format_args!("No registration found for {}", type_name))
                 })?;
                 let type_info = registration.type_info();
@@ -159,12 +159,10 @@ impl<'a, 'de> Visitor<'de> for ReflectDeserializerVisitor<'a> {
             }
             Some(type_fields::TYPE) => Err(de::Error::duplicate_field(type_fields::TYPE)),
             Some(field) => Err(de::Error::unknown_field(field, &[type_fields::VALUE])),
-            None => {
-                return Err(de::Error::invalid_length(
-                    0,
-                    &"two entries: `type` and `value`",
-                ));
-            }
+            None => Err(de::Error::invalid_length(
+                0,
+                &"two entries: `type` and `value`",
+            )),
         }
     }
 }
@@ -720,6 +718,7 @@ mod tests {
     use bevy_utils::HashMap;
     use serde::de::DeserializeSeed;
     use serde::Deserialize;
+    use std::f32::consts::PI;
 
     #[derive(Reflect, FromReflect, Debug, PartialEq)]
     struct MyStruct {
@@ -858,7 +857,7 @@ mod tests {
         let expected = MyStruct {
             primitive_value: 123,
             option_value: Some(String::from("Hello world!")),
-            tuple_value: (3.14, 1337),
+            tuple_value: (PI, 1337),
             list_value: vec![-2, -1, 0, 1, 2],
             array_value: [-2, -1, 0, 1, 2],
             map_value: map,
@@ -876,7 +875,7 @@ mod tests {
                 "primitive_value": 123,
                 "option_value": Some("Hello world!"),
                 "tuple_value": (
-                    3.14,
+                    3.1415927,
                     1337,
                 ),
                 "list_value": [

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -1,9 +1,13 @@
 use crate::{
-    serde::type_fields, DynamicArray, DynamicEnum, DynamicList, DynamicMap, DynamicStruct,
-    DynamicTuple, DynamicTupleStruct, Map, Reflect, ReflectDeserialize, TypeRegistry,
+    serde::type_fields, ArrayInfo, DynamicArray, DynamicEnum, DynamicList, DynamicMap,
+    DynamicStruct, DynamicTuple, DynamicTupleStruct, EnumInfo, ListInfo, Map, MapInfo, NamedField,
+    Reflect, ReflectDeserialize, StructInfo, StructVariantInfo, Tuple, TupleInfo, TupleStruct,
+    TupleStructInfo, TupleVariantInfo, TypeInfo, TypeRegistry, UnnamedField, VariantInfo,
 };
 use erased_serde::Deserializer;
 use serde::de::{self, DeserializeSeed, Error, MapAccess, SeqAccess, Visitor};
+use std::any::TypeId;
+use std::fmt::Formatter;
 
 pub trait DeserializeValue {
     fn deserialize(
@@ -12,6 +16,80 @@ pub trait DeserializeValue {
     ) -> Result<Box<dyn Reflect>, erased_serde::Error>;
 }
 
+trait StructLikeInfo {
+    fn get_name(&self) -> &str;
+    fn get_field(&self, name: &str) -> Option<&NamedField>;
+}
+
+trait TupleLikeInfo {
+    fn get_name(&self) -> &str;
+    fn get_field(&self, index: usize) -> Option<&UnnamedField>;
+    fn get_field_len(&self) -> usize;
+}
+
+impl StructLikeInfo for StructInfo {
+    fn get_name(&self) -> &str {
+        self.type_name()
+    }
+
+    fn get_field(&self, name: &str) -> Option<&NamedField> {
+        self.field(name)
+    }
+}
+
+impl StructLikeInfo for StructVariantInfo {
+    fn get_name(&self) -> &str {
+        self.name()
+    }
+
+    fn get_field(&self, name: &str) -> Option<&NamedField> {
+        self.field(name)
+    }
+}
+
+impl TupleLikeInfo for TupleInfo {
+    fn get_name(&self) -> &str {
+        self.type_name()
+    }
+
+    fn get_field(&self, index: usize) -> Option<&UnnamedField> {
+        self.field_at(index)
+    }
+
+    fn get_field_len(&self) -> usize {
+        self.field_len()
+    }
+}
+
+impl TupleLikeInfo for TupleVariantInfo {
+    fn get_name(&self) -> &str {
+        self.name()
+    }
+
+    fn get_field(&self, index: usize) -> Option<&UnnamedField> {
+        self.field_at(index)
+    }
+
+    fn get_field_len(&self) -> usize {
+        self.field_len()
+    }
+}
+
+/// A general purpose deserializer for reflected types.
+///
+/// For non-value types, this will return the dynamic equivalent. For example, a
+/// deserialized struct will return a [`DynamicStruct`] and a `Vec` will return a
+/// [`DynamicList`].
+///
+/// The serialized data must take the form of a map containing the following entries:
+/// 1. `type`: The _full_ [type name]
+/// 2. `value`: The serialized value of the reflected type
+///
+/// > Note: The ordering is important here. `type` _must_ come before `value`.
+///
+/// [`DynamicStruct`]: crate::DynamicStruct
+/// [`DynamicList`]: crate::DynamicList
+/// [type name]: std::any::type_name
 pub struct ReflectDeserializer<'a> {
     registry: &'a TypeRegistry,
 }
@@ -29,254 +107,260 @@ impl<'a, 'de> DeserializeSeed<'de> for ReflectDeserializer<'a> {
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_any(ReflectVisitor {
+        deserializer.deserialize_any(ReflectDeserializerVisitor {
             registry: self.registry,
         })
     }
 }
 
-struct ReflectVisitor<'a> {
+struct ReflectDeserializerVisitor<'a> {
     registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> Visitor<'de> for ReflectVisitor<'a> {
+impl<'a, 'de> Visitor<'de> for ReflectDeserializerVisitor<'a> {
     type Value = Box<dyn Reflect>;
 
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        formatter.write_str("map containing `type` and `value` entries for the reflected value")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let type_name = match map.next_key::<&str>()? {
+            Some(type_fields::TYPE) => map.next_value::<&str>()?,
+            Some(type_fields::VALUE) => {
+                // `type` must come before `value`.
+                return Err(de::Error::missing_field(type_fields::TYPE));
+            }
+            Some(field) => {
+                return Err(de::Error::unknown_field(field, &[type_fields::TYPE]));
+            }
+            None => {
+                return Err(de::Error::invalid_length(
+                    0,
+                    &"two entries: `type` and `value`",
+                ));
+            }
+        };
+
+        match map.next_key::<&str>()? {
+            Some(type_fields::VALUE) => {
+                let registration = self.registry.get_with_name(&type_name).ok_or_else(|| {
+                    de::Error::custom(format_args!("No registration found for {}", type_name))
+                })?;
+                let type_info = registration.type_info();
+                let value = map.next_value_seed(TypedReflectDeserializer {
+                    type_info,
+                    registry: self.registry,
+                })?;
+                Ok(value)
+            }
+            Some(type_fields::TYPE) => Err(de::Error::duplicate_field(type_fields::TYPE)),
+            Some(field) => Err(de::Error::unknown_field(field, &[type_fields::VALUE])),
+            None => {
+                return Err(de::Error::invalid_length(
+                    0,
+                    &"two entries: `type` and `value`",
+                ));
+            }
+        }
+    }
+}
+
+/// A deserializer for reflected types whose [`TypeInfo`] is known.
+///
+/// For non-value types, this will return the dynamic equivalent. For example, a
+/// deserialized struct will return a [`DynamicStruct`] and a `Vec` will return a
+/// [`DynamicList`].
+///
+/// [`TypeInfo`]: crate::TypeInfo
+/// [`DynamicStruct`]: crate::DynamicStruct
+/// [`DynamicList`]: crate::DynamicList
+pub struct TypedReflectDeserializer<'a> {
+    type_info: &'a TypeInfo,
+    registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> DeserializeSeed<'de> for TypedReflectDeserializer<'a> {
+    type Value = Box<dyn Reflect>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Handle both Value case and types that have a custom `ReflectDeserialize`
+        let type_id = self.type_info.type_id();
+        let type_name = self.type_info.type_name();
+        let registration = self.registry.get(type_id).ok_or_else(|| {
+            de::Error::custom(format_args!("no registration found for {}", type_name))
+        })?;
+
+        if let Some(deserialize_reflect) = registration.data::<ReflectDeserialize>() {
+            let value = deserialize_reflect.deserialize(deserializer)?;
+            return Ok(value);
+        }
+
+        match self.type_info {
+            TypeInfo::Struct(struct_info) => {
+                let mut dynamic_struct = deserializer.deserialize_map(StructVisitor {
+                    struct_info,
+                    registry: self.registry,
+                })?;
+                dynamic_struct.set_name(struct_info.type_name().to_string());
+                Ok(Box::new(dynamic_struct))
+            }
+            TypeInfo::TupleStruct(tuple_struct_info) => {
+                let mut dynamic_tuple_struct = deserializer.deserialize_tuple(
+                    tuple_struct_info.field_len(),
+                    TupleStructVisitor {
+                        tuple_struct_info,
+                        registry: self.registry,
+                    },
+                )?;
+                dynamic_tuple_struct.set_name(tuple_struct_info.type_name().to_string());
+                Ok(Box::new(dynamic_tuple_struct))
+            }
+            TypeInfo::List(list_info) => {
+                let mut dynamic_list = deserializer.deserialize_seq(ListVisitor {
+                    list_info,
+                    registry: self.registry,
+                })?;
+                dynamic_list.set_name(list_info.type_name().to_string());
+                Ok(Box::new(dynamic_list))
+            }
+            TypeInfo::Array(array_info) => {
+                let mut dynamic_array = deserializer.deserialize_tuple(
+                    array_info.capacity(),
+                    ArrayVisitor {
+                        array_info,
+                        registry: self.registry,
+                    },
+                )?;
+                dynamic_array.set_name(array_info.type_name().to_string());
+                Ok(Box::new(dynamic_array))
+            }
+            TypeInfo::Map(map_info) => {
+                let mut dynamic_map = deserializer.deserialize_map(MapVisitor {
+                    map_info,
+                    registry: self.registry,
+                })?;
+                dynamic_map.set_name(map_info.type_name().to_string());
+                Ok(Box::new(dynamic_map))
+            }
+            TypeInfo::Tuple(tuple_info) => {
+                let mut dynamic_tuple = deserializer.deserialize_tuple(
+                    tuple_info.field_len(),
+                    TupleVisitor {
+                        tuple_info,
+                        registry: self.registry,
+                    },
+                )?;
+                dynamic_tuple.set_name(tuple_info.type_name().to_string());
+                Ok(Box::new(dynamic_tuple))
+            }
+            TypeInfo::Enum(enum_info) => {
+                let mut dynamic_enum = deserializer.deserialize_map(EnumVisitor {
+                    enum_info,
+                    registry: self.registry,
+                })?;
+                dynamic_enum.set_name(enum_info.type_name().to_string());
+                Ok(Box::new(dynamic_enum))
+            }
+            TypeInfo::Value(_) => {
+                // This case should already be handled
+                Err(de::Error::custom(format_args!(
+                    "the TypeRegistration for {} doesn't have ReflectDeserialize",
+                    type_name
+                )))
+            }
+            TypeInfo::Dynamic(_) => {
+                // We could potentially allow this but we'd have no idea what the actual types of the
+                // fields are and would rely on the deserializer to determine them (e.g. `i32` vs `i64`)
+                Err(de::Error::custom(format_args!(
+                    "cannot deserialize arbitrary dynamic type {}",
+                    type_name
+                )))
+            }
+        }
+    }
+}
+
+struct StructVisitor<'a> {
+    struct_info: &'a StructInfo,
+    registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> Visitor<'de> for StructVisitor<'a> {
+    type Value = DynamicStruct;
+
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("reflect value")
-    }
-
-    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v.to_string()))
+        formatter.write_str("reflected struct value")
     }
 
     fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
     where
         V: MapAccess<'de>,
     {
-        let mut type_name: Option<String> = None;
-        while let Some(key) = map.next_key::<String>()? {
-            match key.as_str() {
-                type_fields::TYPE => {
-                    type_name = Some(map.next_value()?);
-                }
-                type_fields::MAP => {
-                    let _type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let map = map.next_value_seed(MapDeserializer {
-                        registry: self.registry,
-                    })?;
-                    return Ok(Box::new(map));
-                }
-                type_fields::STRUCT => {
-                    let type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let mut dynamic_struct = map.next_value_seed(StructDeserializer {
-                        registry: self.registry,
-                    })?;
-                    dynamic_struct.set_name(type_name);
-                    return Ok(Box::new(dynamic_struct));
-                }
-                type_fields::TUPLE_STRUCT => {
-                    let type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let mut tuple_struct = map.next_value_seed(TupleStructDeserializer {
-                        registry: self.registry,
-                    })?;
-                    tuple_struct.set_name(type_name);
-                    return Ok(Box::new(tuple_struct));
-                }
-                type_fields::TUPLE => {
-                    let _type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let tuple = map.next_value_seed(TupleDeserializer {
-                        registry: self.registry,
-                    })?;
-                    return Ok(Box::new(tuple));
-                }
-                type_fields::LIST => {
-                    let _type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let list = map.next_value_seed(ListDeserializer {
-                        registry: self.registry,
-                    })?;
-                    return Ok(Box::new(list));
-                }
-                type_fields::ARRAY => {
-                    let _type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let array = map.next_value_seed(ArrayDeserializer {
-                        registry: self.registry,
-                    })?;
-                    return Ok(Box::new(array));
-                }
-                type_fields::ENUM => {
-                    let type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let mut dynamic_enum = map.next_value_seed(EnumDeserializer {
-                        registry: self.registry,
-                    })?;
-                    dynamic_enum.set_name(type_name);
-                    return Ok(Box::new(dynamic_enum));
-                }
-                type_fields::VALUE => {
-                    let type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let registration =
-                        self.registry.get_with_name(&type_name).ok_or_else(|| {
-                            de::Error::custom(format_args!(
-                                "No registration found for {}",
-                                type_name
-                            ))
-                        })?;
-                    let deserialize_reflect =
-                        registration.data::<ReflectDeserialize>().ok_or_else(|| {
-                            de::Error::custom(format_args!(
-                                "The TypeRegistration for {} doesn't have DeserializeReflect",
-                                type_name
-                            ))
-                        })?;
-                    let value = map.next_value_seed(DeserializeReflectDeserializer {
-                        reflect_deserialize: deserialize_reflect,
-                    })?;
-                    return Ok(value);
-                }
-                _ => return Err(de::Error::unknown_field(key.as_str(), &[])),
-            }
-        }
-
-        Err(de::Error::custom("Maps in this location must have the \'type\' field and one of the following fields: \'map\', \'seq\', \'value\'"))
+        visit_struct(&mut map, self.struct_info, self.registry)
     }
 }
 
-struct DeserializeReflectDeserializer<'a> {
-    reflect_deserialize: &'a ReflectDeserialize,
-}
-
-impl<'a, 'de> DeserializeSeed<'de> for DeserializeReflectDeserializer<'a> {
-    type Value = Box<dyn Reflect>;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        self.reflect_deserialize.deserialize(deserializer)
-    }
-}
-
-struct ListDeserializer<'a> {
+struct TupleStructVisitor<'a> {
+    tuple_struct_info: &'a TupleStructInfo,
     registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> DeserializeSeed<'de> for ListDeserializer<'a> {
-    type Value = DynamicList;
+impl<'a, 'de> Visitor<'de> for TupleStructVisitor<'a> {
+    type Value = DynamicTupleStruct;
 
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("reflected tuple struct value")
+    }
+
+    fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
     where
-        D: serde::Deserializer<'de>,
+        V: SeqAccess<'de>,
     {
-        deserializer.deserialize_seq(ListVisitor {
+        let mut index = 0usize;
+        let mut tuple_struct = DynamicTupleStruct::default();
+
+        let get_field_info = |index: usize| -> Result<&'a TypeInfo, V::Error> {
+            let field = self.tuple_struct_info.field_at(index).ok_or_else(|| {
+                de::Error::custom(format_args!(
+                    "no field at index {} on tuple {}",
+                    index,
+                    self.tuple_struct_info.type_name(),
+                ))
+            })?;
+            get_type_info(field.type_id(), field.type_name(), self.registry)
+        };
+
+        while let Some(value) = seq.next_element_seed(TypedReflectDeserializer {
+            type_info: get_field_info(index)?,
             registry: self.registry,
-        })
+        })? {
+            tuple_struct.insert_boxed(value);
+            index += 1;
+            if index >= self.tuple_struct_info.field_len() {
+                break;
+            }
+        }
+
+        if tuple_struct.field_len() != self.tuple_struct_info.field_len() {
+            return Err(Error::invalid_length(
+                tuple_struct.field_len(),
+                &self.tuple_struct_info.field_len().to_string().as_str(),
+            ));
+        }
+
+        Ok(tuple_struct)
     }
 }
 
 struct ListVisitor<'a> {
+    list_info: &'a ListInfo,
     registry: &'a TypeRegistry,
 }
 
@@ -284,7 +368,7 @@ impl<'a, 'de> Visitor<'de> for ListVisitor<'a> {
     type Value = DynamicList;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("list value")
+        formatter.write_str("reflected list value")
     }
 
     fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
@@ -292,7 +376,13 @@ impl<'a, 'de> Visitor<'de> for ListVisitor<'a> {
         V: SeqAccess<'de>,
     {
         let mut list = DynamicList::default();
-        while let Some(value) = seq.next_element_seed(ReflectDeserializer {
+        let type_info = get_type_info(
+            self.list_info.item_type_id(),
+            self.list_info.item_type_name(),
+            self.registry,
+        )?;
+        while let Some(value) = seq.next_element_seed(TypedReflectDeserializer {
+            type_info,
             registry: self.registry,
         })? {
             list.push_box(value);
@@ -301,24 +391,8 @@ impl<'a, 'de> Visitor<'de> for ListVisitor<'a> {
     }
 }
 
-struct ArrayDeserializer<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> DeserializeSeed<'de> for ArrayDeserializer<'a> {
-    type Value = DynamicArray;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_seq(ArrayVisitor {
-            registry: self.registry,
-        })
-    }
-}
-
 struct ArrayVisitor<'a> {
+    array_info: &'a ArrayInfo,
     registry: &'a TypeRegistry,
 }
 
@@ -326,7 +400,7 @@ impl<'a, 'de> Visitor<'de> for ArrayVisitor<'a> {
     type Value = DynamicArray;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("array value")
+        formatter.write_str("reflected array value")
     }
 
     fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
@@ -334,34 +408,31 @@ impl<'a, 'de> Visitor<'de> for ArrayVisitor<'a> {
         V: SeqAccess<'de>,
     {
         let mut vec = Vec::with_capacity(seq.size_hint().unwrap_or_default());
-        while let Some(value) = seq.next_element_seed(ReflectDeserializer {
+        let type_info = get_type_info(
+            self.array_info.item_type_id(),
+            self.array_info.item_type_name(),
+            self.registry,
+        )?;
+        while let Some(value) = seq.next_element_seed(TypedReflectDeserializer {
+            type_info,
             registry: self.registry,
         })? {
             vec.push(value);
         }
 
-        Ok(DynamicArray::new(Box::from(vec)))
-    }
-}
+        if vec.len() != self.array_info.capacity() {
+            return Err(Error::invalid_length(
+                vec.len(),
+                &self.array_info.capacity().to_string().as_str(),
+            ));
+        }
 
-struct MapDeserializer<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> DeserializeSeed<'de> for MapDeserializer<'a> {
-    type Value = DynamicMap;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_map(MapVisitor {
-            registry: self.registry,
-        })
+        Ok(DynamicArray::new(vec.into_boxed_slice()))
     }
 }
 
 struct MapVisitor<'a> {
+    map_info: &'a MapInfo,
     registry: &'a TypeRegistry,
 }
 
@@ -369,7 +440,7 @@ impl<'a, 'de> Visitor<'de> for MapVisitor<'a> {
     type Value = DynamicMap;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("map value")
+        formatter.write_str("reflected map value")
     }
 
     fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
@@ -377,10 +448,22 @@ impl<'a, 'de> Visitor<'de> for MapVisitor<'a> {
         V: MapAccess<'de>,
     {
         let mut dynamic_map = DynamicMap::default();
-        while let Some(key) = map.next_key_seed(ReflectDeserializer {
+        let key_type_info = get_type_info(
+            self.map_info.key_type_id(),
+            self.map_info.key_type_name(),
+            self.registry,
+        )?;
+        let value_type_info = get_type_info(
+            self.map_info.value_type_id(),
+            self.map_info.value_type_name(),
+            self.registry,
+        )?;
+        while let Some(key) = map.next_key_seed(TypedReflectDeserializer {
+            type_info: key_type_info,
             registry: self.registry,
         })? {
-            let value = map.next_value_seed(ReflectDeserializer {
+            let value = map.next_value_seed(TypedReflectDeserializer {
+                type_info: value_type_info,
                 registry: self.registry,
             })?;
             dynamic_map.insert_boxed(key, value);
@@ -390,110 +473,8 @@ impl<'a, 'de> Visitor<'de> for MapVisitor<'a> {
     }
 }
 
-struct StructDeserializer<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> DeserializeSeed<'de> for StructDeserializer<'a> {
-    type Value = DynamicStruct;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_map(StructVisitor {
-            registry: self.registry,
-        })
-    }
-}
-
-struct StructVisitor<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> Visitor<'de> for StructVisitor<'a> {
-    type Value = DynamicStruct;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("struct value")
-    }
-
-    fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
-    where
-        V: MapAccess<'de>,
-    {
-        let mut dynamic_struct = DynamicStruct::default();
-        while let Some(key) = map.next_key::<String>()? {
-            let value = map.next_value_seed(ReflectDeserializer {
-                registry: self.registry,
-            })?;
-            dynamic_struct.insert_boxed(&key, value);
-        }
-
-        Ok(dynamic_struct)
-    }
-}
-
-struct TupleStructDeserializer<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> DeserializeSeed<'de> for TupleStructDeserializer<'a> {
-    type Value = DynamicTupleStruct;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_seq(TupleStructVisitor {
-            registry: self.registry,
-        })
-    }
-}
-
-struct TupleStructVisitor<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> Visitor<'de> for TupleStructVisitor<'a> {
-    type Value = DynamicTupleStruct;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("tuple struct value")
-    }
-
-    fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
-    where
-        V: SeqAccess<'de>,
-    {
-        let mut tuple_struct = DynamicTupleStruct::default();
-        while let Some(value) = seq.next_element_seed(ReflectDeserializer {
-            registry: self.registry,
-        })? {
-            tuple_struct.insert_boxed(value);
-        }
-        Ok(tuple_struct)
-    }
-}
-
-struct TupleDeserializer<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> DeserializeSeed<'de> for TupleDeserializer<'a> {
-    type Value = DynamicTuple;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_seq(TupleVisitor {
-            registry: self.registry,
-        })
-    }
-}
-
 struct TupleVisitor<'a> {
+    tuple_info: &'a TupleInfo,
     registry: &'a TypeRegistry,
 }
 
@@ -501,41 +482,19 @@ impl<'a, 'de> Visitor<'de> for TupleVisitor<'a> {
     type Value = DynamicTuple;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("tuple value")
+        formatter.write_str("reflected tuple value")
     }
 
     fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
     where
         V: SeqAccess<'de>,
     {
-        let mut tuple = DynamicTuple::default();
-        while let Some(value) = seq.next_element_seed(ReflectDeserializer {
-            registry: self.registry,
-        })? {
-            tuple.insert_boxed(value);
-        }
-        Ok(tuple)
-    }
-}
-
-struct EnumDeserializer<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> DeserializeSeed<'de> for EnumDeserializer<'a> {
-    type Value = DynamicEnum;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_map(EnumVisitor {
-            registry: self.registry,
-        })
+        visit_tuple(&mut seq, self.tuple_info, self.registry)
     }
 }
 
 struct EnumVisitor<'a> {
+    enum_info: &'a EnumInfo,
     registry: &'a TypeRegistry,
 }
 
@@ -543,67 +502,276 @@ impl<'a, 'de> Visitor<'de> for EnumVisitor<'a> {
     type Value = DynamicEnum;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("enum value")
+        formatter.write_str("reflected enum value")
     }
 
     fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
     where
         V: MapAccess<'de>,
     {
-        let key = map.next_key::<String>()?;
-        match key.as_deref() {
-            Some(type_fields::VARIANT) => {}
-            Some(key) => return Err(V::Error::unknown_field(key, &[type_fields::VARIANT])),
-            _ => {
-                return Err(V::Error::missing_field(type_fields::VARIANT));
-            }
-        }
+        let variant_name = map
+            .next_key::<&str>()?
+            .ok_or_else(|| Error::missing_field("the variant name of the enum"))?;
 
-        let variant_name = map.next_value::<String>()?;
+        let variant_info = self
+            .enum_info
+            .variant(variant_name)
+            .ok_or_else(|| Error::custom(format_args!("unknown variant {}", variant_name)))?;
 
         let mut dynamic_enum = DynamicEnum::default();
 
-        let key = map.next_key::<String>()?;
-        match key.as_deref() {
-            Some(type_fields::STRUCT) => {
-                let dynamic_struct = map.next_value_seed(StructDeserializer {
+        match variant_info {
+            VariantInfo::Struct(struct_info) => {
+                let dynamic_struct = map.next_value_seed(StructVariantDeserializer {
+                    struct_info,
                     registry: self.registry,
                 })?;
                 dynamic_enum.set_variant(variant_name, dynamic_struct);
             }
-            Some(type_fields::TUPLE) => {
-                let dynamic_tuple = map.next_value_seed(TupleDeserializer {
+            VariantInfo::Tuple(tuple_info) => {
+                let dynamic_tuple = map.next_value_seed(TupleVariantDeserializer {
+                    tuple_info,
                     registry: self.registry,
                 })?;
                 dynamic_enum.set_variant(variant_name, dynamic_tuple);
             }
-            Some(invalid_key) => {
-                return Err(V::Error::unknown_field(
-                    invalid_key,
-                    &[type_fields::STRUCT, type_fields::TUPLE],
-                ));
+            VariantInfo::Unit(..) => {
+                map.next_value::<()>()?;
+                dynamic_enum.set_variant(variant_name, ());
             }
-            None => dynamic_enum.set_variant(variant_name, ()),
         }
 
         Ok(dynamic_enum)
     }
 }
 
+struct StructVariantDeserializer<'a> {
+    struct_info: &'a StructVariantInfo,
+    registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> DeserializeSeed<'de> for StructVariantDeserializer<'a> {
+    type Value = DynamicStruct;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(StructVariantVisitor {
+            struct_info: self.struct_info,
+            registry: self.registry,
+        })
+    }
+}
+
+struct StructVariantVisitor<'a> {
+    struct_info: &'a StructVariantInfo,
+    registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> Visitor<'de> for StructVariantVisitor<'a> {
+    type Value = DynamicStruct;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("reflected struct variant value")
+    }
+
+    fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+    where
+        V: MapAccess<'de>,
+    {
+        visit_struct(&mut map, self.struct_info, self.registry)
+    }
+}
+
+struct TupleVariantDeserializer<'a> {
+    tuple_info: &'a TupleVariantInfo,
+    registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> DeserializeSeed<'de> for TupleVariantDeserializer<'a> {
+    type Value = DynamicTuple;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_tuple(
+            self.tuple_info.field_len(),
+            TupleVariantVisitor {
+                tuple_info: self.tuple_info,
+                registry: self.registry,
+            },
+        )
+    }
+}
+
+struct TupleVariantVisitor<'a> {
+    tuple_info: &'a TupleVariantInfo,
+    registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> Visitor<'de> for TupleVariantVisitor<'a> {
+    type Value = DynamicTuple;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("reflected tuple variant value")
+    }
+
+    fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
+    where
+        V: SeqAccess<'de>,
+    {
+        visit_tuple(&mut seq, self.tuple_info, self.registry)
+    }
+}
+
+fn visit_struct<'de, T, V>(
+    map: &mut V,
+    info: &T,
+    registry: &TypeRegistry,
+) -> Result<DynamicStruct, V::Error>
+where
+    T: StructLikeInfo,
+    V: MapAccess<'de>,
+{
+    let mut dynamic_struct = DynamicStruct::default();
+    while let Some(key) = map.next_key::<String>()? {
+        let field = info.get_field(&key).ok_or_else(|| {
+            Error::custom(format_args!(
+                "no field named {} on struct {}",
+                key,
+                info.get_name(),
+            ))
+        })?;
+        let type_info = get_type_info(field.type_id(), field.type_name(), registry)?;
+        let value = map.next_value_seed(TypedReflectDeserializer {
+            type_info,
+            registry,
+        })?;
+        dynamic_struct.insert_boxed(&key, value);
+    }
+
+    Ok(dynamic_struct)
+}
+
+fn visit_tuple<'de, T, V>(
+    seq: &mut V,
+    info: &T,
+    registry: &TypeRegistry,
+) -> Result<DynamicTuple, V::Error>
+where
+    T: TupleLikeInfo,
+    V: SeqAccess<'de>,
+{
+    let mut tuple = DynamicTuple::default();
+    let mut index = 0usize;
+
+    let get_field_info = |index: usize| -> Result<&TypeInfo, V::Error> {
+        let field = info.get_field(index).ok_or_else(|| {
+            Error::custom(format_args!(
+                "no field at index {} on tuple {}",
+                index,
+                info.get_name(),
+            ))
+        })?;
+        get_type_info(field.type_id(), field.type_name(), registry)
+    };
+
+    while let Some(value) = seq.next_element_seed(TypedReflectDeserializer {
+        type_info: get_field_info(index)?,
+        registry,
+    })? {
+        tuple.insert_boxed(value);
+        index += 1;
+        if index >= info.get_field_len() {
+            break;
+        }
+    }
+
+    let len = info.get_field_len();
+
+    if tuple.field_len() != len {
+        return Err(Error::invalid_length(
+            tuple.field_len(),
+            &len.to_string().as_str(),
+        ));
+    }
+
+    Ok(tuple)
+}
+
+fn get_type_info<'a, E: de::Error>(
+    type_id: TypeId,
+    type_name: &'a str,
+    registry: &'a TypeRegistry,
+) -> Result<&'a TypeInfo, E> {
+    let registration = registry.get(type_id).ok_or_else(|| {
+        de::Error::custom(format_args!("no registration found for type {}", type_name))
+    })?;
+    Ok(registration.type_info())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::ReflectDeserializer;
     use crate as bevy_reflect;
-    use crate::prelude::*;
-    use crate::{DynamicEnum, TypeRegistry};
-    use ::serde::de::DeserializeSeed;
+    use crate::serde::ReflectDeserializer;
+    use crate::{DynamicEnum, FromReflect, Reflect, ReflectDeserialize, TypeRegistry};
+    use bevy_utils::HashMap;
+    use serde::de::DeserializeSeed;
+    use serde::Deserialize;
+
+    #[derive(Reflect, FromReflect, Debug, PartialEq)]
+    struct MyStruct {
+        primitive_value: i8,
+        option_value: Option<String>,
+        tuple_value: (f32, usize),
+        list_value: Vec<i32>,
+        array_value: [i32; 5],
+        map_value: HashMap<u8, usize>,
+        struct_value: SomeStruct,
+        tuple_struct_value: SomeTupleStruct,
+        custom_deserialize: CustomDeserialize,
+    }
+
+    #[derive(Reflect, FromReflect, Debug, PartialEq, Deserialize)]
+    struct SomeStruct {
+        foo: i64,
+    }
+
+    #[derive(Reflect, FromReflect, Debug, PartialEq)]
+    struct SomeTupleStruct(String);
+
+    /// Implements a custom deserialize using #[reflect(Deserialize)].
+    ///
+    /// For testing purposes, this is just the auto-generated one from deriving.
+    #[derive(Reflect, FromReflect, Debug, PartialEq, Deserialize)]
+    #[reflect(Deserialize)]
+    struct CustomDeserialize {
+        value: usize,
+        #[serde(rename = "renamed")]
+        inner_struct: SomeStruct,
+    }
 
     fn get_registry() -> TypeRegistry {
         let mut registry = TypeRegistry::default();
-        registry.register::<usize>();
-        registry.register::<f32>();
+        registry.register::<MyStruct>();
+        registry.register::<SomeStruct>();
+        registry.register::<SomeTupleStruct>();
+        registry.register::<CustomDeserialize>();
+        registry.register::<i8>();
         registry.register::<String>();
-        registry.register::<(f32, f32)>();
+        registry.register::<i64>();
+        registry.register::<f32>();
+        registry.register::<usize>();
+        registry.register::<i32>();
+        registry.register::<u8>();
+        registry.register::<(f32, usize)>();
+        registry.register::<[i32; 5]>();
+        registry.register::<Vec<i32>>();
+        registry.register::<HashMap<u8, usize>>();
+        registry.register::<Option<String>>();
+        registry.register_type_data::<Option<String>, ReflectDeserialize>();
         registry
     }
 
@@ -622,11 +790,11 @@ mod tests {
 
         // === Unit Variant === //
         let input = r#"{
-    "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
-    "enum": {
-        "variant": "Unit",
-    },
-}"#;
+            "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
+            "value": {
+                "Unit": (),
+            },
+        }"#;
         let reflect_deserializer = ReflectDeserializer::new(&registry);
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
@@ -636,17 +804,11 @@ mod tests {
 
         // === NewType Variant === //
         let input = r#"{
-    "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
-    "enum": {
-        "variant": "NewType",
-        "tuple": [
-            {
-                "type": "usize",
-                "value": 123,
+            "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
+            "value": {
+                "NewType": (123),
             },
-        ],
-    },
-}"#;
+        }"#;
         let reflect_deserializer = ReflectDeserializer::new(&registry);
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
@@ -656,21 +818,11 @@ mod tests {
 
         // === Tuple Variant === //
         let input = r#"{
-    "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
-    "enum": {
-        "variant": "Tuple",
-        "tuple": [
-            {
-                "type": "f32",
-                "value": 1.23,
+            "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
+            "value": {
+                "Tuple": (1.23, 3.21),
             },
-            {
-                "type": "f32",
-                "value": 3.21,
-            },
-        ],
-    },
-}"#;
+        }"#;
         let reflect_deserializer = ReflectDeserializer::new(&registry);
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
@@ -680,17 +832,13 @@ mod tests {
 
         // === Struct Variant === //
         let input = r#"{
-    "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
-    "enum": {
-        "variant": "Struct",
-        "struct": {
+            "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
             "value": {
-                "type": "alloc::string::String",
-                "value": "I <3 Enums",
+                "Struct": {
+                    "value": "I <3 Enums",
+                },
             },
-        },
-    },
-}"#;
+        }"#;
         let reflect_deserializer = ReflectDeserializer::new(&registry);
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
@@ -699,5 +847,76 @@ mod tests {
             value: String::from("I <3 Enums"),
         });
         assert!(expected.reflect_partial_eq(output.as_ref()).unwrap());
+    }
+
+    #[test]
+    fn should_deserialize() {
+        let mut map = HashMap::new();
+        map.insert(64, 32);
+
+        // TODO: Add test for standard tuples (requires https://github.com/bevyengine/bevy/pull/4226)
+        let expected = MyStruct {
+            primitive_value: 123,
+            option_value: Some(String::from("Hello world!")),
+            tuple_value: (3.14, 1337),
+            list_value: vec![-2, -1, 0, 1, 2],
+            array_value: [-2, -1, 0, 1, 2],
+            map_value: map,
+            struct_value: SomeStruct { foo: 999999999 },
+            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
+            custom_deserialize: CustomDeserialize {
+                value: 100,
+                inner_struct: SomeStruct { foo: 101 },
+            },
+        };
+
+        let input = r#"{
+            "type": "bevy_reflect::serde::de::tests::MyStruct",
+            "value": {
+                "primitive_value": 123,
+                "option_value": Some("Hello world!"),
+                "tuple_value": (
+                    3.14,
+                    1337,
+                ),
+                "list_value": [
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                ],
+                "array_value": (
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                ),
+                "map_value": {
+                    64: 32,
+                },
+                "struct_value": {
+                    "foo": 999999999,
+                },
+                "tuple_struct_value": ("Tuple Struct"),
+                "custom_deserialize": (
+                    value: 100,
+                    renamed: (
+                        foo: 101,
+                    ),
+                )
+            },
+        }"#;
+
+        let registry = get_registry();
+        let reflect_deserializer = ReflectDeserializer::new(&registry);
+        let mut ron_deserializer = ron::de::Deserializer::from_str(input).unwrap();
+        let dynamic_output = reflect_deserializer
+            .deserialize(&mut ron_deserializer)
+            .unwrap();
+
+        let output = <MyStruct as FromReflect>::from_reflect(dynamic_output.as_ref()).unwrap();
+        assert_eq!(expected, output);
     }
 }

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -116,7 +116,7 @@ impl<'a, 'de> DeserializeSeed<'de> for UntypedReflectDeserializer<'a> {
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_map(UntypedReflectDeserializerVisitor {
+        deserializer.deserialize_any(UntypedReflectDeserializerVisitor {
             registry: self.registry,
         })
     }

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -6,13 +6,5 @@ pub use ser::*;
 
 pub(crate) mod type_fields {
     pub const TYPE: &str = "type";
-    pub const MAP: &str = "map";
-    pub const STRUCT: &str = "struct";
-    pub const TUPLE_STRUCT: &str = "tuple_struct";
-    pub const ENUM: &str = "enum";
-    pub const VARIANT: &str = "variant";
-    pub const TUPLE: &str = "tuple";
-    pub const LIST: &str = "list";
-    pub const ARRAY: &str = "array";
     pub const VALUE: &str = "value";
 }

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -3,8 +3,3 @@ mod ser;
 
 pub use de::*;
 pub use ser::*;
-
-pub(crate) mod type_fields {
-    pub const TYPE: &str = "type";
-    pub const VALUE: &str = "value";
-}

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -435,7 +435,10 @@ mod tests {
         let registry = get_registry();
         let serializer = ReflectSerializer::new(&input, &registry);
 
-        let config = PrettyConfig::default().new_line(String::from("\n"));
+        let config = PrettyConfig::default()
+            .new_line(String::from("\n"))
+            .decimal_floats(true)
+            .indentor(String::from("    "));
 
         let output = ron::ser::to_string_pretty(&serializer, config).unwrap();
         let expected = r#"{

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -1,6 +1,6 @@
 use crate::{
-    serde::type_fields, Array, Enum, List, Map, Reflect, ReflectRef, ReflectSerialize, Struct,
-    Tuple, TupleStruct, TypeRegistry, VariantType,
+    Array, Enum, List, Map, Reflect, ReflectRef, ReflectSerialize, Struct, Tuple, TupleStruct,
+    TypeRegistry, VariantType,
 };
 use serde::ser::SerializeTuple;
 use serde::{
@@ -61,10 +61,9 @@ impl<'a> Serialize for ReflectSerializer<'a> {
     where
         S: serde::Serializer,
     {
-        let mut state = serializer.serialize_map(Some(2))?;
-        state.serialize_entry(type_fields::TYPE, self.value.type_name())?;
+        let mut state = serializer.serialize_map(Some(1))?;
         state.serialize_entry(
-            type_fields::VALUE,
+            self.value.type_name(),
             &TypedReflectSerializer::new(self.value, self.registry),
         )?;
         state.end()
@@ -442,8 +441,7 @@ mod tests {
 
         let output = ron::ser::to_string_pretty(&serializer, config).unwrap();
         let expected = r#"{
-    "type": "bevy_reflect::serde::ser::tests::MyStruct",
-    "value": {
+    "bevy_reflect::serde::ser::tests::MyStruct": {
         "primitive_value": 123,
         "option_value": Some("Hello world!"),
         "tuple_value": (3.1415927, 1337),
@@ -493,8 +491,7 @@ mod tests {
         let serializer = ReflectSerializer::new(&value, &registry);
         let output = ron::ser::to_string_pretty(&serializer, config.clone()).unwrap();
         let expected = r#"{
-    "type": "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum",
-    "value": {
+    "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum": {
         "Unit": (),
     },
 }"#;
@@ -505,8 +502,7 @@ mod tests {
         let serializer = ReflectSerializer::new(&value, &registry);
         let output = ron::ser::to_string_pretty(&serializer, config.clone()).unwrap();
         let expected = r#"{
-    "type": "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum",
-    "value": {
+    "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum": {
         "NewType": (123),
     },
 }"#;
@@ -517,8 +513,7 @@ mod tests {
         let serializer = ReflectSerializer::new(&value, &registry);
         let output = ron::ser::to_string_pretty(&serializer, config.clone()).unwrap();
         let expected = r#"{
-    "type": "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum",
-    "value": {
+    "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum": {
         "Tuple": (1.23, 3.21),
     },
 }"#;
@@ -531,8 +526,7 @@ mod tests {
         let serializer = ReflectSerializer::new(&value, &registry);
         let output = ron::ser::to_string_pretty(&serializer, config).unwrap();
         let expected = r#"{
-    "type": "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum",
-    "value": {
+    "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum": {
         "Struct": {
             "value": "I <3 Enums",
         },

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -366,6 +366,7 @@ mod tests {
     use bevy_utils::HashMap;
     use ron::ser::PrettyConfig;
     use serde::Serialize;
+    use std::f32::consts::PI;
 
     #[derive(Reflect, Debug, PartialEq)]
     struct MyStruct {
@@ -419,7 +420,7 @@ mod tests {
         let input = MyStruct {
             primitive_value: 123,
             option_value: Some(String::from("Hello world!")),
-            tuple_value: (3.14, 1337),
+            tuple_value: (PI, 1337),
             list_value: vec![-2, -1, 0, 1, 2],
             array_value: [-2, -1, 0, 1, 2],
             map_value: map,
@@ -440,7 +441,7 @@ mod tests {
     "value": {
         "primitive_value": 123,
         "option_value": Some("Hello world!"),
-        "tuple_value": (3.14, 1337),
+        "tuple_value": (3.1415927, 1337),
         "list_value": [
             -2,
             -1,

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -388,9 +388,9 @@ mod tests {
     #[derive(Reflect, Debug, PartialEq)]
     struct SomeTupleStruct(String);
 
-    /// Implements a custom serialize using #[reflect(Serialize)].
+    /// Implements a custom serialize using `#[reflect(Serialize)]`.
     ///
-    /// For testing purposes, this is just the auto-generated one from deriving.
+    /// For testing purposes, this just uses the generated one from deriving Serialize.
     #[derive(Reflect, Debug, PartialEq, Serialize)]
     #[reflect(Serialize)]
     struct CustomSerialize {

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -2,7 +2,7 @@ use crate::{
     serde::type_fields, Array, Enum, List, Map, Reflect, ReflectRef, ReflectSerialize, Struct,
     Tuple, TupleStruct, TypeRegistry, VariantType,
 };
-use serde::ser::Error;
+use serde::ser::SerializeTuple;
 use serde::{
     ser::{SerializeMap, SerializeSeq},
     Serialize, Serializer,
@@ -38,6 +38,13 @@ fn get_serializable<'a, E: serde::ser::Error>(
     Ok(reflect_serialize.get_serializable(reflect_value))
 }
 
+/// A general purpose serializer for reflected types.
+///
+/// The serialized data will take the form of a map containing the following entries:
+/// 1. `type`: The _full_ [type name]
+/// 2. `value`: The serialized value of the reflected type
+///
+/// [type name]: std::any::type_name
 pub struct ReflectSerializer<'a> {
     pub value: &'a dyn Reflect,
     pub registry: &'a TypeRegistry,
@@ -54,6 +61,40 @@ impl<'a> Serialize for ReflectSerializer<'a> {
     where
         S: serde::Serializer,
     {
+        let mut state = serializer.serialize_map(Some(2))?;
+        state.serialize_entry(type_fields::TYPE, self.value.type_name())?;
+        state.serialize_entry(
+            type_fields::VALUE,
+            &TypedReflectSerializer::new(self.value, self.registry),
+        )?;
+        state.end()
+    }
+}
+
+/// A serializer for reflected types whose type is known and does not require
+/// serialization to include other metadata about it.
+pub struct TypedReflectSerializer<'a> {
+    pub value: &'a dyn Reflect,
+    pub registry: &'a TypeRegistry,
+}
+
+impl<'a> TypedReflectSerializer<'a> {
+    pub fn new(value: &'a dyn Reflect, registry: &'a TypeRegistry) -> Self {
+        TypedReflectSerializer { value, registry }
+    }
+}
+
+impl<'a> Serialize for TypedReflectSerializer<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // Handle both Value case and types that have a custom `Serialize`
+        let serializable = get_serializable::<S::Error>(self.value, self.registry);
+        if let Ok(serializable) = serializable {
+            return serializable.borrow().serialize(serializer);
+        }
+
         match self.value.reflect_ref() {
             ReflectRef::Struct(value) => StructSerializer {
                 struct_value: value,
@@ -90,11 +131,7 @@ impl<'a> Serialize for ReflectSerializer<'a> {
                 registry: self.registry,
             }
             .serialize(serializer),
-            ReflectRef::Value(value) => ReflectValueSerializer {
-                registry: self.registry,
-                value,
-            }
-            .serialize(serializer),
+            ReflectRef::Value(_) => Err(serializable.err().unwrap()),
         }
     }
 }
@@ -109,13 +146,9 @@ impl<'a> Serialize for ReflectValueSerializer<'a> {
     where
         S: serde::Serializer,
     {
-        let mut state = serializer.serialize_map(Some(2))?;
-        state.serialize_entry(type_fields::TYPE, self.value.type_name())?;
-        state.serialize_entry(
-            type_fields::VALUE,
-            get_serializable::<S::Error>(self.value, self.registry)?.borrow(),
-        )?;
-        state.end()
+        get_serializable::<S::Error>(self.value, self.registry)?
+            .borrow()
+            .serialize(serializer)
     }
 }
 
@@ -129,34 +162,10 @@ impl<'a> Serialize for StructSerializer<'a> {
     where
         S: serde::Serializer,
     {
-        let mut state = serializer.serialize_map(Some(2))?;
-
-        state.serialize_entry(type_fields::TYPE, self.struct_value.type_name())?;
-        state.serialize_entry(
-            type_fields::STRUCT,
-            &StructValueSerializer {
-                struct_value: self.struct_value,
-                registry: self.registry,
-            },
-        )?;
-        state.end()
-    }
-}
-
-pub struct StructValueSerializer<'a> {
-    pub struct_value: &'a dyn Struct,
-    pub registry: &'a TypeRegistry,
-}
-
-impl<'a> Serialize for StructValueSerializer<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
         let mut state = serializer.serialize_map(Some(self.struct_value.field_len()))?;
         for (index, value) in self.struct_value.iter_fields().enumerate() {
             let key = self.struct_value.name_at(index).unwrap();
-            state.serialize_entry(key, &ReflectSerializer::new(value, self.registry))?;
+            state.serialize_entry(key, &TypedReflectSerializer::new(value, self.registry))?;
         }
         state.end()
     }
@@ -172,33 +181,9 @@ impl<'a> Serialize for TupleStructSerializer<'a> {
     where
         S: serde::Serializer,
     {
-        let mut state = serializer.serialize_map(Some(2))?;
-
-        state.serialize_entry(type_fields::TYPE, self.tuple_struct.type_name())?;
-        state.serialize_entry(
-            type_fields::TUPLE_STRUCT,
-            &TupleStructValueSerializer {
-                tuple_struct: self.tuple_struct,
-                registry: self.registry,
-            },
-        )?;
-        state.end()
-    }
-}
-
-pub struct TupleStructValueSerializer<'a> {
-    pub tuple_struct: &'a dyn TupleStruct,
-    pub registry: &'a TypeRegistry,
-}
-
-impl<'a> Serialize for TupleStructValueSerializer<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut state = serializer.serialize_seq(Some(self.tuple_struct.field_len()))?;
+        let mut state = serializer.serialize_tuple(self.tuple_struct.field_len())?;
         for value in self.tuple_struct.iter_fields() {
-            state.serialize_element(&ReflectSerializer::new(value, self.registry))?;
+            state.serialize_element(&TypedReflectSerializer::new(value, self.registry))?;
         }
         state.end()
     }
@@ -214,11 +199,9 @@ impl<'a> Serialize for EnumSerializer<'a> {
     where
         S: serde::Serializer,
     {
-        let mut state = serializer.serialize_map(Some(2))?;
-
-        state.serialize_entry(type_fields::TYPE, self.enum_value.type_name())?;
+        let mut state = serializer.serialize_map(Some(1))?;
         state.serialize_entry(
-            type_fields::ENUM,
+            self.enum_value.variant_name(),
             &EnumValueSerializer {
                 enum_value: self.enum_value,
                 registry: self.registry,
@@ -238,36 +221,26 @@ impl<'a> Serialize for EnumValueSerializer<'a> {
     where
         S: serde::Serializer,
     {
-        let variant_type = self.enum_value.variant_type();
-        let variant_name = self.enum_value.variant_name();
-
-        let mut state = if matches!(variant_type, VariantType::Unit) {
-            serializer.serialize_map(Some(1))?
-        } else {
-            serializer.serialize_map(Some(2))?
-        };
-
-        state.serialize_entry(type_fields::VARIANT, variant_name)?;
-
         match self.enum_value.variant_type() {
             VariantType::Struct => {
-                state.serialize_key(type_fields::STRUCT)?;
-                state.serialize_value(&StructVariantSerializer {
-                    enum_value: self.enum_value,
-                    registry: self.registry,
-                })?;
+                let mut state = serializer.serialize_map(Some(self.enum_value.field_len()))?;
+                for field in self.enum_value.iter_fields() {
+                    let key = field.name().expect("named field");
+                    let value = TypedReflectSerializer::new(field.value(), self.registry);
+                    state.serialize_entry(key, &value)?;
+                }
+                state.end()
             }
             VariantType::Tuple => {
-                state.serialize_key(type_fields::TUPLE)?;
-                state.serialize_value(&TupleVariantSerializer {
-                    enum_value: self.enum_value,
-                    registry: self.registry,
-                })?;
+                let mut state = serializer.serialize_tuple(self.enum_value.field_len())?;
+                for field in self.enum_value.iter_fields() {
+                    let value = TypedReflectSerializer::new(field.value(), self.registry);
+                    state.serialize_element(&value)?;
+                }
+                state.end()
             }
-            _ => {}
+            VariantType::Unit => serializer.serialize_unit(),
         }
-
-        state.end()
     }
 }
 
@@ -281,10 +254,10 @@ impl<'a> Serialize for TupleVariantSerializer<'a> {
     where
         S: Serializer,
     {
-        let field_len = self.enum_value.field_len();
-        let mut state = serializer.serialize_seq(Some(field_len))?;
+        let mut state = serializer.serialize_tuple(self.enum_value.field_len())?;
         for field in self.enum_value.iter_fields() {
-            state.serialize_element(&ReflectSerializer::new(field.value(), self.registry))?;
+            let value = TypedReflectSerializer::new(field.value(), self.registry);
+            state.serialize_element(&value)?;
         }
         state.end()
     }
@@ -300,16 +273,11 @@ impl<'a> Serialize for StructVariantSerializer<'a> {
     where
         S: Serializer,
     {
-        let field_len = self.enum_value.field_len();
-        let mut state = serializer.serialize_map(Some(field_len))?;
-        for (index, field) in self.enum_value.iter_fields().enumerate() {
-            let name = field.name().ok_or_else(|| {
-                S::Error::custom(format_args!(
-                    "struct variant missing name for field at index {}",
-                    index
-                ))
-            })?;
-            state.serialize_entry(name, &ReflectSerializer::new(field.value(), self.registry))?;
+        let mut state = serializer.serialize_map(Some(self.enum_value.field_len()))?;
+        for field in self.enum_value.iter_fields() {
+            let key = field.name().expect("named field");
+            let value = TypedReflectSerializer::new(field.value(), self.registry);
+            state.serialize_entry(key, &value)?;
         }
         state.end()
     }
@@ -325,33 +293,9 @@ impl<'a> Serialize for TupleSerializer<'a> {
     where
         S: serde::Serializer,
     {
-        let mut state = serializer.serialize_map(Some(2))?;
-
-        state.serialize_entry(type_fields::TYPE, self.tuple.type_name())?;
-        state.serialize_entry(
-            type_fields::TUPLE,
-            &TupleValueSerializer {
-                tuple: self.tuple,
-                registry: self.registry,
-            },
-        )?;
-        state.end()
-    }
-}
-
-pub struct TupleValueSerializer<'a> {
-    pub tuple: &'a dyn Tuple,
-    pub registry: &'a TypeRegistry,
-}
-
-impl<'a> Serialize for TupleValueSerializer<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut state = serializer.serialize_seq(Some(self.tuple.field_len()))?;
+        let mut state = serializer.serialize_tuple(self.tuple.field_len())?;
         for value in self.tuple.iter_fields() {
-            state.serialize_element(&ReflectSerializer::new(value, self.registry))?;
+            state.serialize_element(&TypedReflectSerializer::new(value, self.registry))?;
         }
         state.end()
     }
@@ -367,35 +311,11 @@ impl<'a> Serialize for MapSerializer<'a> {
     where
         S: serde::Serializer,
     {
-        let mut state = serializer.serialize_map(Some(2))?;
-
-        state.serialize_entry(type_fields::TYPE, self.map.type_name())?;
-        state.serialize_entry(
-            type_fields::MAP,
-            &MapValueSerializer {
-                map: self.map,
-                registry: self.registry,
-            },
-        )?;
-        state.end()
-    }
-}
-
-pub struct MapValueSerializer<'a> {
-    pub map: &'a dyn Map,
-    pub registry: &'a TypeRegistry,
-}
-
-impl<'a> Serialize for MapValueSerializer<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
         let mut state = serializer.serialize_map(Some(self.map.len()))?;
         for (key, value) in self.map.iter() {
             state.serialize_entry(
-                &ReflectSerializer::new(key, self.registry),
-                &ReflectSerializer::new(value, self.registry),
+                &TypedReflectSerializer::new(key, self.registry),
+                &TypedReflectSerializer::new(value, self.registry),
             )?;
         }
         state.end()
@@ -412,32 +332,9 @@ impl<'a> Serialize for ListSerializer<'a> {
     where
         S: serde::Serializer,
     {
-        let mut state = serializer.serialize_map(Some(2))?;
-        state.serialize_entry(type_fields::TYPE, self.list.type_name())?;
-        state.serialize_entry(
-            type_fields::LIST,
-            &ListValueSerializer {
-                list: self.list,
-                registry: self.registry,
-            },
-        )?;
-        state.end()
-    }
-}
-
-pub struct ListValueSerializer<'a> {
-    pub list: &'a dyn List,
-    pub registry: &'a TypeRegistry,
-}
-
-impl<'a> Serialize for ListValueSerializer<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
         let mut state = serializer.serialize_seq(Some(self.list.len()))?;
         for value in self.list.iter() {
-            state.serialize_element(&ReflectSerializer::new(value, self.registry))?;
+            state.serialize_element(&TypedReflectSerializer::new(value, self.registry))?;
         }
         state.end()
     }
@@ -453,32 +350,9 @@ impl<'a> Serialize for ArraySerializer<'a> {
     where
         S: serde::Serializer,
     {
-        let mut state = serializer.serialize_map(Some(2))?;
-        state.serialize_entry(type_fields::TYPE, self.array.type_name())?;
-        state.serialize_entry(
-            type_fields::ARRAY,
-            &ArrayValueSerializer {
-                array: self.array,
-                registry: self.registry,
-            },
-        )?;
-        state.end()
-    }
-}
-
-pub struct ArrayValueSerializer<'a> {
-    pub array: &'a dyn Array,
-    pub registry: &'a TypeRegistry,
-}
-
-impl<'a> Serialize for ArrayValueSerializer<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut state = serializer.serialize_seq(Some(self.array.len()))?;
+        let mut state = serializer.serialize_tuple(self.array.len())?;
         for value in self.array.iter() {
-            state.serialize_element(&ReflectSerializer::new(value, self.registry))?;
+            state.serialize_element(&TypedReflectSerializer::new(value, self.registry))?;
         }
         state.end()
     }
@@ -486,19 +360,111 @@ impl<'a> Serialize for ArrayValueSerializer<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::ReflectSerializer;
     use crate as bevy_reflect;
-    use crate::prelude::*;
-    use crate::TypeRegistry;
+    use crate::serde::ReflectSerializer;
+    use crate::{Reflect, ReflectSerialize, TypeRegistry};
+    use bevy_utils::HashMap;
     use ron::ser::PrettyConfig;
+    use serde::Serialize;
+
+    #[derive(Reflect, Debug, PartialEq)]
+    struct MyStruct {
+        primitive_value: i8,
+        option_value: Option<String>,
+        tuple_value: (f32, usize),
+        list_value: Vec<i32>,
+        array_value: [i32; 5],
+        map_value: HashMap<u8, usize>,
+        struct_value: SomeStruct,
+        tuple_struct_value: SomeTupleStruct,
+        custom_serialize: CustomSerialize,
+    }
+
+    #[derive(Reflect, Debug, PartialEq, Serialize)]
+    struct SomeStruct {
+        foo: i64,
+    }
+
+    #[derive(Reflect, Debug, PartialEq)]
+    struct SomeTupleStruct(String);
+
+    /// Implements a custom serialize using #[reflect(Serialize)].
+    ///
+    /// For testing purposes, this is just the auto-generated one from deriving.
+    #[derive(Reflect, Debug, PartialEq, Serialize)]
+    #[reflect(Serialize)]
+    struct CustomSerialize {
+        value: usize,
+        #[serde(rename = "renamed")]
+        inner_struct: SomeStruct,
+    }
 
     fn get_registry() -> TypeRegistry {
         let mut registry = TypeRegistry::default();
-        registry.register::<usize>();
-        registry.register::<f32>();
+        registry.register::<MyStruct>();
+        registry.register::<SomeStruct>();
+        registry.register::<SomeTupleStruct>();
+        registry.register::<CustomSerialize>();
         registry.register::<String>();
-        registry.register::<(f32, f32)>();
+        registry.register::<Option<String>>();
+        registry.register_type_data::<Option<String>, ReflectSerialize>();
         registry
+    }
+
+    #[test]
+    fn should_serialize() {
+        let mut map = HashMap::new();
+        map.insert(64, 32);
+
+        let input = MyStruct {
+            primitive_value: 123,
+            option_value: Some(String::from("Hello world!")),
+            tuple_value: (3.14, 1337),
+            list_value: vec![-2, -1, 0, 1, 2],
+            array_value: [-2, -1, 0, 1, 2],
+            map_value: map,
+            struct_value: SomeStruct { foo: 999999999 },
+            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
+            custom_serialize: CustomSerialize {
+                value: 100,
+                inner_struct: SomeStruct { foo: 101 },
+            },
+        };
+
+        let registry = get_registry();
+        let serializer = ReflectSerializer::new(&input, &registry);
+
+        let output = ron::ser::to_string_pretty(&serializer, Default::default()).unwrap();
+        let expected = r#"{
+    "type": "bevy_reflect::serde::ser::tests::MyStruct",
+    "value": {
+        "primitive_value": 123,
+        "option_value": Some("Hello world!"),
+        "tuple_value": (3.14, 1337),
+        "list_value": [
+            -2,
+            -1,
+            0,
+            1,
+            2,
+        ],
+        "array_value": (-2, -1, 0, 1, 2),
+        "map_value": {
+            64: 32,
+        },
+        "struct_value": {
+            "foo": 999999999,
+        },
+        "tuple_struct_value": ("Tuple Struct"),
+        "custom_serialize": (
+            value: 100,
+            renamed: (
+                foo: 101,
+            ),
+        ),
+    },
+}"#;
+        assert_eq!(expected, output);
     }
 
     #[test]
@@ -522,8 +488,8 @@ mod tests {
         let output = ron::ser::to_string_pretty(&serializer, config.clone()).unwrap();
         let expected = r#"{
     "type": "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum",
-    "enum": {
-        "variant": "Unit",
+    "value": {
+        "Unit": (),
     },
 }"#;
         assert_eq!(expected, output);
@@ -534,14 +500,8 @@ mod tests {
         let output = ron::ser::to_string_pretty(&serializer, config.clone()).unwrap();
         let expected = r#"{
     "type": "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum",
-    "enum": {
-        "variant": "NewType",
-        "tuple": [
-            {
-                "type": "usize",
-                "value": 123,
-            },
-        ],
+    "value": {
+        "NewType": (123),
     },
 }"#;
         assert_eq!(expected, output);
@@ -552,18 +512,8 @@ mod tests {
         let output = ron::ser::to_string_pretty(&serializer, config.clone()).unwrap();
         let expected = r#"{
     "type": "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum",
-    "enum": {
-        "variant": "Tuple",
-        "tuple": [
-            {
-                "type": "f32",
-                "value": 1.23,
-            },
-            {
-                "type": "f32",
-                "value": 3.21,
-            },
-        ],
+    "value": {
+        "Tuple": (1.23, 3.21),
     },
 }"#;
         assert_eq!(expected, output);
@@ -576,16 +526,12 @@ mod tests {
         let output = ron::ser::to_string_pretty(&serializer, config).unwrap();
         let expected = r#"{
     "type": "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum",
-    "enum": {
-        "variant": "Struct",
-        "struct": {
-            "value": {
-                "type": "alloc::string::String",
-                "value": "I <3 Enums",
-            },
+    "value": {
+        "Struct": {
+            "value": "I <3 Enums",
         },
     },
 }"#;
-        assert_eq!(expected, output.replace('\r', ""));
+        assert_eq!(expected, output);
     }
 }

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -435,7 +435,9 @@ mod tests {
         let registry = get_registry();
         let serializer = ReflectSerializer::new(&input, &registry);
 
-        let output = ron::ser::to_string_pretty(&serializer, Default::default()).unwrap();
+        let config = PrettyConfig::default().new_line(String::from("\n"));
+
+        let output = ron::ser::to_string_pretty(&serializer, config).unwrap();
         let expected = r#"{
     "type": "bevy_reflect::serde::ser::tests::MyStruct",
     "value": {

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -377,6 +377,10 @@ mod tests {
         map_value: HashMap<u8, usize>,
         struct_value: SomeStruct,
         tuple_struct_value: SomeTupleStruct,
+        unit_enum: SomeEnum,
+        newtype_enum: SomeEnum,
+        tuple_enum: SomeEnum,
+        struct_enum: SomeEnum,
         custom_serialize: CustomSerialize,
     }
 
@@ -387,6 +391,14 @@ mod tests {
 
     #[derive(Reflect, Debug, PartialEq)]
     struct SomeTupleStruct(String);
+
+    #[derive(Reflect, Debug, PartialEq)]
+    enum SomeEnum {
+        Unit,
+        NewType(usize),
+        Tuple(f32, f32),
+        Struct { foo: String },
+    }
 
     /// Implements a custom serialize using `#[reflect(Serialize)]`.
     ///
@@ -425,6 +437,12 @@ mod tests {
             map_value: map,
             struct_value: SomeStruct { foo: 999999999 },
             tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
+            unit_enum: SomeEnum::Unit,
+            newtype_enum: SomeEnum::NewType(123),
+            tuple_enum: SomeEnum::Tuple(1.23, 3.21),
+            struct_enum: SomeEnum::Struct {
+                foo: String::from("Struct variant value"),
+            },
             custom_serialize: CustomSerialize {
                 value: 100,
                 inner_struct: SomeStruct { foo: 101 },
@@ -460,6 +478,20 @@ mod tests {
             "foo": 999999999,
         },
         "tuple_struct_value": ("Tuple Struct"),
+        "unit_enum": {
+            "Unit": (),
+        },
+        "newtype_enum": {
+            "NewType": (123),
+        },
+        "tuple_enum": {
+            "Tuple": (1.23, 3.21),
+        },
+        "struct_enum": {
+            "Struct": {
+                "foo": "Struct variant value",
+            },
+        },
         "custom_serialize": (
             value: 100,
             renamed: (

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -1,7 +1,7 @@
 use crate::{DynamicEntity, DynamicScene};
 use anyhow::Result;
 use bevy_reflect::{
-    serde::{UntypedReflectDeserializer, ReflectSerializer},
+    serde::{ReflectSerializer, UntypedReflectDeserializer},
     Reflect, TypeRegistry, TypeRegistryArc,
 };
 use serde::{
@@ -242,7 +242,9 @@ impl<'a, 'de> Visitor<'de> for ComponentSeqVisitor<'a> {
         A: SeqAccess<'de>,
     {
         let mut dynamic_properties = Vec::new();
-        while let Some(entity) = seq.next_element_seed(UntypedReflectDeserializer::new(self.registry))? {
+        while let Some(entity) =
+            seq.next_element_seed(UntypedReflectDeserializer::new(self.registry))?
+        {
             dynamic_properties.push(entity);
         }
 

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -1,7 +1,7 @@
 use crate::{DynamicEntity, DynamicScene};
 use anyhow::Result;
 use bevy_reflect::{
-    serde::{ReflectDeserializer, ReflectSerializer},
+    serde::{UntypedReflectDeserializer, ReflectSerializer},
     Reflect, TypeRegistry, TypeRegistryArc,
 };
 use serde::{
@@ -242,7 +242,7 @@ impl<'a, 'de> Visitor<'de> for ComponentSeqVisitor<'a> {
         A: SeqAccess<'de>,
     {
         let mut dynamic_properties = Vec::new();
-        while let Some(entity) = seq.next_element_seed(ReflectDeserializer::new(self.registry))? {
+        while let Some(entity) = seq.next_element_seed(UntypedReflectDeserializer::new(self.registry))? {
             dynamic_properties.push(entity);
         }
 

--- a/examples/reflection/reflection.rs
+++ b/examples/reflection/reflection.rs
@@ -7,7 +7,7 @@
 use bevy::{
     prelude::*,
     reflect::{
-        serde::{ReflectDeserializer, ReflectSerializer},
+        serde::{ReflectSerializer, UntypedReflectDeserializer},
         DynamicStruct,
     },
 };
@@ -81,7 +81,7 @@ fn setup(type_registry: Res<AppTypeRegistry>) {
     info!("{}\n", ron_string);
 
     // Dynamic properties can be deserialized
-    let reflect_deserializer = ReflectDeserializer::new(&type_registry);
+    let reflect_deserializer = UntypedReflectDeserializer::new(&type_registry);
     let mut deserializer = ron::de::Deserializer::from_str(&ron_string).unwrap();
     let reflect_value = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 


### PR DESCRIPTION
> Note: See #5723 for an even more improved (but slightly more controversial) format

# Objective

The current serialization format used by `bevy_reflect` is both verbose and error-prone. Taking the following structs[^1] for example:

```rust
// -- src/inventory.rs

#[derive(Reflect)]
struct Inventory {
  id: String,
  max_storage: usize,
  items: Vec<Item>
}

#[derive(Reflect)]
struct Item {
  name: String
}
```

Given an inventory of a single item, this would serialize to something like:

```rust
// -- assets/inventory.ron

{
  "type": "my_game::inventory::Inventory",
  "struct": {
    "id": {
      "type": "alloc::string::String",
      "value": "inv001",
    },
    "max_storage": {
      "type": "usize",
      "value": 10
    },
    "items": {
      "type": "alloc::vec::Vec<alloc::string::String>",
      "list": [
        {
          "type": "my_game::inventory::Item",
          "struct": {
            "name": {
              "type": "alloc::string::String",
              "value": "Pickaxe"
            },
          },
        },
      ],
    },
  },
}
```

Aside from being really long and difficult to read, it also has a few "gotchas" that users need to be aware of if they want to edit the file manually. A major one is the requirement that you use the proper keys for a given type. For structs, you need `"struct"`. For lists, `"list"`. For tuple structs, `"tuple_struct"`. And so on.

It also ***requires*** that the `"type"` entry come before the actual data. Despite being a map— which in programming is almost always orderless by default— the entries need to be in a particular order. Failure to follow the ordering convention results in a failure to deserialize the data.

This makes it very prone to errors and annoyances.

## Solution

Using #4042, we can remove a lot of the boilerplate and metadata needed by this older system. Since we now have static access to type information, we can simplify our serialized data to look like:

```rust
// -- assets/inventory.ron

{
  "my_game::inventory::Inventory": {
    "id": "inv001",
    "max_storage": 10,
    "items": [
      {
        "name": "Pickaxe"
      },
    ],
  },
},
```

This is much more digestible and a lot less error-prone (no more key requirements and no more extra type names).

#### Custom Serialization

Additionally, this PR adds the opt-in ability to specify a custom serde implementation to be used rather than the one created via reflection. For example[^1]:

```rust
// -- src/inventory.rs

#[derive(Reflect, Serialize)]
#[reflect(Serialize)]
struct Item {
  #[serde(alias = "id")]
  name: String
}
```

```rust
// -- assets/inventory.ron

{
  "my_game::inventory::Inventory": {
    "id": "inv001",
    "max_storage": 10,
    "items": [
      (
        id: "Pickaxe"
      )
    ],
  },
},
```

Because we specified a custom `Serialize` implementation with `#[reflect(Serialize)]`, we actually get the RON-style syntax for a struct.

> Note: If we had done this for `Inventory`, it would still define the `type` and continue to serialize the data normally.
> <details>
> <summary><strong>See Example</strong></summary>
>
> ```rust
> // -- assets/inventory.ron
> 
> {
> "my_game::inventory::Inventory": (
>  id: "inv001",
>  max_storage: 10,
>  items: [
>    (
>      name: "Pickaxe"
>    ),
>  ],
> ),
> }
> ```
>
> </details>

By allowing users to define their own serialization methods, we do two things:

1. We give more control over how data is serialized/deserialized to the end user
2. We avoid having to re-define serde's attributes and forcing users to apply both (e.g. we don't need a `#[reflect(alias)]` attribute).

#### Tuples!

Tuples and tuple-likes now use serde's `de/serialize_tuple` method. This provides better semantics— being fixed-size sequences, we should be able to indicate that size at when de/serializing. It also addresses some of serde's own limitations (see sections below).

###### Tuples

Obviously, tuples now use this format. This is better because tuples do have a maximum size according to [serde](https://docs.rs/serde/latest/serde/trait.Serialize.html#impl-Serialize-for-(T0%2C%20T1%2C%20T2%2C%20T3%2C%20T4%2C%20T5%2C%20T6%2C%20T7%2C%20T8%2C%20T9%2C%20T10%2C%20T11%2C%20T12%2C%20T13%2C%20T14%2C%20T15)). I don't think we actually run into this limitation, but it's a good reminder to avoid large tuples in case we want to be compatible with other formats.

```js
{
  "(f32, f32)": (1.0, 1.0)
}
```

<details>
<summary>Old Format</summary>

```js
{
  "type": "(f32, f32)",
  "tuple": [
    {
      "type": "f32",
      "value": 1.0
    },
    {
      "type": "f32",
      "value": 1.0
    }
  ]
}
```

</details>

###### Tuple Structs

This also applies to tuple structs. Though, it should be noted that there _is_ a dedicated `de/serialize_tuple_struct` method in serde. However, it requires a static name, which is not yet provided by `TypeInfo`. Even if it was, we have no way of handling `Dynamic***` types (see https://github.com/bevyengine/rfcs/pull/56).

```js
{
  "my_crate::Bar": ("Hello World!")
}
```

<details>
<summary>Old Format</summary>

```js
{
  "type": "my_crate::Bar",
  "tuple_struct": [
    {
      "type": "alloc::string::String",
      "value": "Hello World!"
    }
  ]
}
```

</details>

###### Arrays

It may be a bit surprising to some, but arrays now also use the tuple format. This is because they essentially _are_ tuples (a sequence of values with a fixed size), but only allow for homogenous types. Additionally, this is how RON handles them and is probably a result of the 32-capacity limit imposed on them (both by [serde](https://docs.rs/serde/latest/serde/trait.Serialize.html#impl-Serialize-for-%5BT%3B%2032%5D) and by [bevy_reflect](https://docs.rs/bevy/latest/bevy/reflect/trait.GetTypeRegistration.html#impl-GetTypeRegistration-for-%5BT%3B%2032%5D)).

```js
{
  "[i32; 3]": (1, 2, 3)
}
```

<details>
<summary>Old Format</summary>

```js
{
  "type": "[i32; 3]",
  "array": [
    {
      "type": "i32",
      "value": 1
    },
    {
      "type": "i32",
      "value": 2
    },
    {
      "type": "i32",
      "value": 3
    }
  ]
}
```

</details>


---

## Changelog

* Re-worked serialization/deserialization for reflected types
* Added `TypedReflectDeserializer` for deserializing data with known `TypeInfo`
* Renamed `ReflectDeserializer` to `UntypedReflectDeserializer` 
* ~~Replaced usages of `deserialize_any` with `deserialize_map` for non-self-describing formats~~ Reverted this change since there are still some issues that need to be sorted out (in a separate PR). By reverting this, crates like `bincode` can throw an error when attempting to deserialize non-self-describing formats (`bincode` results in `DeserializeAnyNotSupported`)
* Tuples, tuple structs, and arrays are now all de/serialized as tuples (similar to RON)

## Migration Guide

* This PR reduces the verbosity of the scene format. Scenes will need to be updated accordingly:

```js
// Old format
{
  "type": "my_game::item::Item",
  "struct": {
    "id": {
      "type": "alloc::string::String",
      "value": "bevycraft:stone",
    },
    "tags": {
      "type": "alloc::vec::Vec<alloc::string::String>",
      "list": [
        {
          "type": "alloc::string::String",
          "value": "material"
        },
      ],
    },
}

// New format
{
  "my_game::item::Item": {
    "id": "bevycraft:stone",
    "tags": ["material"]
  }
}
```

* There are also some smaller changes to how certain types are serialized/deserialized. Tuples, tuple structs, and arrays are all de/serialized as standard tuples now (if using a de/serializer like RON):

```js
// Old format
{
  "type": "my_crate::Foo",
  "tuple": {
    "type": "(f32, f32)",
    "tuple": [
        {
          "type": "f32",
          "value": 1.0
        },
        {
          "type": "f32",
          "value": 1.0
        }
      ]
    },
    "tuple_struct": {
      "type": "my_crate::Bar",
      "tuple_struct": [
        {
          "type": "alloc::string::String",
          "value": "Hello World!"
        }
      ]
    },
    "array": {
      "type": "[i32; 3]",
      "array": [
        {
          "type": "i32",
          "value": 1
        },
        {
          "type": "i32",
          "value": 2
        },
        {
          "type": "i32",
          "value": 3
        }
      ]
    }
  }
}

// New format
{
  "my_crate::Foo": {
    "tuple": (1.0, 1.0),
    "tuple_struct": ("Hello World!"),
    "array": (1, 2, 3),
  }
}
```

> Entering fewer/more than the exact amount of values results in an error when deserializing.

* `ReflectDeserializer` has been renamed to `UntypedReflectDeserializer`



[^1]: Some derives omitted for brevity.