### PR TITLE
bevy_reflect: enforce that type data is only inserted for the correct type

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -719,7 +719,7 @@ fn impl_get_type_registration(
         impl #impl_generics #bevy_reflect_path::GetTypeRegistration for #type_name #ty_generics #where_clause {
             fn get_type_registration() -> #bevy_reflect_path::TypeRegistration {
                 let mut registration = #bevy_reflect_path::TypeRegistration::of::<#type_name #ty_generics>();
-                #(registration.insert::<#registration_data>(#bevy_reflect_path::FromType::<#type_name #ty_generics>::from_type());)*
+                #(registration.insert::<Self, #registration_data>();)*
                 registration
             }
         }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,8 +1,7 @@
 use crate as bevy_reflect;
 use crate::{
-    map_partial_eq, serde::Serializable, DynamicMap, FromReflect, FromType, GetTypeRegistration,
-    List, ListIter, Map, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef,
-    TypeRegistration,
+    map_partial_eq, serde::Serializable, DynamicMap, FromReflect, GetTypeRegistration, List,
+    ListIter, Map, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef, TypeRegistration,
 };
 
 use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_value};
@@ -147,7 +146,7 @@ unsafe impl<T: FromReflect> Reflect for Vec<T> {
 impl<T: FromReflect + for<'de> Deserialize<'de>> GetTypeRegistration for Vec<T> {
     fn get_type_registration() -> TypeRegistration {
         let mut registration = TypeRegistration::of::<Vec<T>>();
-        registration.insert::<ReflectDeserialize>(FromType::<Vec<T>>::from_type());
+        registration.insert::<Self, ReflectDeserialize>();
         registration
     }
 }
@@ -269,7 +268,7 @@ where
 {
     fn get_type_registration() -> TypeRegistration {
         let mut registration = TypeRegistration::of::<Self>();
-        registration.insert::<ReflectDeserialize>(FromType::<Self>::from_type());
+        registration.insert::<Self, ReflectDeserialize>();
         registration
     }
 }
@@ -354,7 +353,7 @@ unsafe impl Reflect for Cow<'static, str> {
 impl GetTypeRegistration for Cow<'static, str> {
     fn get_type_registration() -> TypeRegistration {
         let mut registration = TypeRegistration::of::<Cow<'static, str>>();
-        registration.insert::<ReflectDeserialize>(FromType::<Cow<'static, str>>::from_type());
+        registration.insert::<Self, ReflectDeserialize>();
         registration
     }
 }


### PR DESCRIPTION
# Objective

The `TypeRegistry` in bevy_reflect has a `HashMap<TypeId, TypeRegistration>` where each type registration can contain arbitrary "TypeData", usually created for the type `T` from `<TypeData as FromType<T>>::from_type())`.
This is what `#[reflect(Deserialize, MyTrait, Component)]` expands to.

The problem is that nobody enforces that the data inserted into the `TypeRegistration` of type `T` is actually created using `FromType` for the same `T`.

You could currently do

```rs
let registration = TypeRegistration::of::<f32>();
registration.insert(<ReflectDeserialize as FromType<u128>>::from_type())`;
```
or
```rs
let type_registration = ...;
*type_registration.data_mut::<ReflectDeserialize>() = <ReflectDeserialize as FromType<u128>>::from_type();
```

This is unexpected and may lead to panics, but makes it impossible to do stuff like https://github.com/bevyengine/bevy/pull/4475 that depends on the correct type of the type data for soundness.

## Solution

Change the `insert` method to be used like 
```rs
let registration = TypeRegistration::of::<f32>();
registration.insert::<f32, ReflectDeserialize>();
```
which panics when used with the wrong type.

Also remove the `data_mut` method, I don't know of any use case and if you want to overwrite it you can just `insert` it again to overwrite it.

This *does* remove the ability to insert TypeData not created using `FromType` but as any arbitrary instance, but that's actually a feature IMO since the type data should not depend on any information other than the type `T`. And if there are use cases I'm not thinking of right now we can always add them later.