### PR TITLE
[Merged by Bors] - bevy_render: Fix KTX2 UASTC format mapping

### DIFF
--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -338,11 +338,11 @@ impl Image {
 
 #[derive(Clone, Copy, Debug)]
 pub enum DataFormat {
-    R8,
-    Rg8,
-    Rgb8,
-    Rgba8,
-    Rgba16Float,
+    Rgb,
+    Rgba,
+    Rrr,
+    Rrrg,
+    Rg,
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
# Objective

- KTX2 UASTC format mapping was incorrect. For some reason I had written it to map to a set of data formats based on the count of KTX2 sample information blocks, but the mapping should be done based on the channel type in the sample information.
- This is a valid change pulled out from #4514 as the attempt to fix the array textures there was incorrect

## Solution

- Fix the KTX2 UASTC `DataFormat` enum to contain the correct formats based on the channel types in section 3.10.2 of https://github.khronos.org/KTX-Specification/ (search for "Basis Universal UASTC Format")
- Correctly map from the sample information channel type to `DataFormat`
- Correctly configure transcoding and the resulting texture format based on the `DataFormat`

---

## Changelog

- Fixed: KTX2 UASTC format handling