### PR TITLE
[Merged by Bors] - do not check links on docs.github.com

### DIFF
--- a/.github/linters/markdown-link-check.json
+++ b/.github/linters/markdown-link-check.json
@@ -4,6 +4,9 @@
       "pattern": "^https?://github\\.com/"
     },
     {
+      "pattern": "^https?://docs\\.github\\.com/"
+    },
+    {
       "pattern": "^https?://reddit\\.com/"
     }
   ],


### PR DESCRIPTION
# Objective

- related to #4575, but not a complete fix
- links to GitHub.com can't be checked from inside a GitHub Actions as GitHub is protecting itself from being flooded by an action execution
- it seems they added that protection to GitHub doc site

## Solution

- Ignore links to docs.github.com
