### PR TITLE
[Merged by Bors] - bevy_utils: remove hardcoded log level limit

### DIFF
--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["bevy"]
 [dependencies]
 bevy_derive = { path = "../bevy_derive", version = "0.8.0-dev" }
 ahash = "0.7.0"
-tracing = {version = "0.1", features = ["release_max_level_info"]}
+tracing = { version = "0.1" }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 uuid = { version = "0.8", features = ["v4", "serde"] }
 hashbrown = { version = "0.11", features = ["serde"] }


### PR DESCRIPTION
# Objective

- Debug logs are useful in release builds, but `tracing` logs are hard-capped (`release_max_level_info`) at the `info` level by `bevy_utils`.

## Solution

- This PR simply removes the limit in `bevy_utils` with no further actions.
- If any out-of-the box performance regressions arise, the steps to enable this `tracing` feature should be documented in a user guide in the future.

This PR closes #4069 and closes #1206.

## Alternatives considered

- Instruct the user to build with `debug-assertions` enabled: this is just a workaround, as it obviously enables all `debug-assertions` that affect more than logging itself.
- Re-exporting the feature from `tracing` and enabling it by default: I believe it just adds complexity and confusion, the `tracing` feature can also be re-enabled with one line in userland.

---

## Changelog

### Fixed

- Log level is not hard capped at `info` for release builds anymore.

## Migration Guide

- Maximum log levels for release builds are not enforced by Bevy anymore, to omit "debug" and "trace" level logs entirely from release builds, `tracing` must be added as a dependency with its `release_max_level_info` feature enabled in `Cargo.toml`. (`tracing = { version = "0.1", features = ["release_max_level_info"] }`)