### PR TITLE
[Merged by Bors] - Document that AppExit can be read by Bevy apps

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -921,5 +921,9 @@ fn run_once(mut app: App) {
 }
 
 /// An event that indicates the [`App`] should exit. This will fully exit the app process.
+///
+/// You can also use this event to detect that an exit was requested. In order to receive it, systems
+/// subscribing to this event should run before [`CoreStage::Last`], which is when the app exiting
+/// actually occurs.
 #[derive(Debug, Clone, Default)]
 pub struct AppExit;

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -920,10 +920,11 @@ fn run_once(mut app: App) {
     app.update();
 }
 
-/// An event that indicates the [`App`] should exit. This will fully exit the app process.
+/// An event that indicates the [`App`] should exit. This will fully exit the app process at the
+/// start of the next tick of the schedule.
 ///
 /// You can also use this event to detect that an exit was requested. In order to receive it, systems
-/// subscribing to this event should run before [`CoreStage::Last`], which is when the app exiting
-/// actually occurs.
+/// subscribing to this event should run after it was emitted and before the schedule of the same
+/// frame is over.
 #[derive(Debug, Clone, Default)]
 pub struct AppExit;


### PR DESCRIPTION
Explain it's safe to subscribe to this event to detect an exit before it happens. For instance, to clean-up and release system resources.