### PR TITLE
Update VSync option

### DIFF
--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -8,7 +8,7 @@ use bevy::{
         renderer::{RenderContext, RenderDevice},
         RenderApp, RenderStage,
     },
-    window::{WindowDescriptor, PresentMode},
+    window::{PresentMode, WindowDescriptor},
 };
 use std::borrow::Cow;
 

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -8,7 +8,7 @@ use bevy::{
         renderer::{RenderContext, RenderDevice},
         RenderApp, RenderStage,
     },
-    window::WindowDescriptor,
+    window::{WindowDescriptor, PresentMode},
 };
 use std::borrow::Cow;
 
@@ -19,8 +19,10 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
         .insert_resource(WindowDescriptor {
-            // uncomment for unthrottled FPS
-            // vsync: false,
+            // uncomment one for unthrottled FPS
+            // if it doesn't work try the other one
+            //present_mode: PresentMode::Mailbox,
+            //present_mode: PresentMode::Immediate,
             ..default()
         })
         .add_plugins(DefaultPlugins)


### PR DESCRIPTION
Update VSync option to work with latest version. I didn't submit an issue report, but this PR fixes the issue where uncommenting the vsync line as instructed causes a compile-time error.

## Solution

Updated to use the members of the new `PresentMode` enum.