### PR TITLE
[Merged by Bors] - Fix KTX2 R8_SRGB, R8_UNORM, R8G8_SRGB, R8G8_UNORM, R8G8B8_SRGB, R8G8B8_UNORM support

### DIFF
--- a/crates/bevy_render/src/color/colorspace.rs
+++ b/crates/bevy_render/src/color/colorspace.rs
@@ -31,6 +31,18 @@ impl SrgbColorSpace for f32 {
     }
 }
 
+impl SrgbColorSpace for u8 {
+    #[inline]
+    fn linear_to_nonlinear_srgb(self) -> Self {
+        ((self as f32 / u8::MAX as f32).linear_to_nonlinear_srgb() * u8::MAX as f32) as u8
+    }
+
+    #[inline]
+    fn nonlinear_to_linear_srgb(self) -> Self {
+        ((self as f32 / u8::MAX as f32).nonlinear_to_linear_srgb() * u8::MAX as f32) as u8
+    }
+}
+
 pub struct HslRepresentation;
 impl HslRepresentation {
     /// converts a color in HLS space to sRGB space

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -2,7 +2,6 @@ mod colorspace;
 
 pub use colorspace::*;
 
-use crate::color::{HslRepresentation, SrgbColorSpace};
 use bevy_math::{Vec3, Vec4};
 use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize};
 use serde::{Deserialize, Serialize};

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -406,9 +406,13 @@ pub enum DataFormat {
 #[derive(Clone, Copy, Debug)]
 pub enum TranscodeFormat {
     Etc1s,
+    Uastc(DataFormat),
+    // Has to be transcoded to R8Unorm for use with `wgpu`
+    R8UnormSrgb,
+    // Has to be transcoded to R8G8Unorm for use with `wgpu`
+    Rg8UnormSrgb,
     // Has to be transcoded to Rgba8 for use with `wgpu`
     Rgb8,
-    Uastc(DataFormat),
 }
 
 /// An error that occurs when loading a texture

--- a/crates/bevy_render/src/texture/ktx2.rs
+++ b/crates/bevy_render/src/texture/ktx2.rs
@@ -90,7 +90,7 @@ pub fn ktx2_buffer_to_image(
                 TranscodeFormat::R8UnormSrgb => {
                     let (mut original_width, mut original_height) = (width, height);
 
-                    for level_data in levels.iter() {
+                    for level_data in &levels {
                         transcoded.push(
                             level_data
                                 .iter()
@@ -109,7 +109,7 @@ pub fn ktx2_buffer_to_image(
                 TranscodeFormat::Rg8UnormSrgb => {
                     let (mut original_width, mut original_height) = (width, height);
 
-                    for level_data in levels.iter() {
+                    for level_data in &levels {
                         transcoded.push(
                             level_data
                                 .iter()

--- a/crates/bevy_render/src/texture/ktx2.rs
+++ b/crates/bevy_render/src/texture/ktx2.rs
@@ -1222,6 +1222,11 @@ pub fn ktx2_format_to_texture_format(
         ktx2::Format::R8G8_SNORM => TextureFormat::Rg8Snorm,
         ktx2::Format::R8G8_UINT => TextureFormat::Rg8Uint,
         ktx2::Format::R8G8_SINT => TextureFormat::Rg8Sint,
+        ktx2::Format::R8G8B8_UNORM | ktx2::Format::R8G8B8_SRGB => {
+            return Err(TextureError::FormatRequiresTranscodingError(
+                TranscodeFormat::Rgb8,
+            ));
+        }
         ktx2::Format::R8G8B8A8_UNORM | ktx2::Format::R8G8B8A8_SRGB => {
             if is_srgb {
                 TextureFormat::Rgba8UnormSrgb


### PR DESCRIPTION
# Objective

- Fixes #4592

## Solution

- Implement `SrgbColorSpace` for `u8` via `f32`
- Convert KTX2 R8 and R8G8 non-linear sRGB to wgpu `R8Unorm` and `Rg8Unorm` as non-linear sRGB are not supported by wgpu for these formats
- Convert KTX2 R8G8B8 formats to `Rgba8Unorm` and `Rgba8UnormSrgb` by adding an alpha channel as the Rgb variants don't exist in wgpu

---

## Changelog

- Added: Support for KTX2 `R8_SRGB`, `R8_UNORM`, `R8G8_SRGB`, `R8G8_UNORM`, `R8G8B8_SRGB`, `R8G8B8_UNORM` formats by converting to supported wgpu formats as appropriate