### PR TITLE
[Merged by Bors] - use elapsed on instant

### DIFF
--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -59,7 +59,7 @@ fn spawn_tasks(mut commands: Commands, thread_pool: Res<AsyncComputeTaskPool>) {
                     let mut rng = rand::thread_rng();
                     let start_time = Instant::now();
                     let duration = Duration::from_secs_f32(rng.gen_range(0.05..0.2));
-                    while Instant::now() - start_time < duration {
+                    while start_time.elapsed() < duration {
                         // Spinning for 'duration', simulating doing hard
                         // compute work generating translation coords!
                     }

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -32,7 +32,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         let mut rng = rand::thread_rng();
         let start_time = Instant::now();
         let duration = Duration::from_secs_f32(rng.gen_range(0.0..0.2));
-        while Instant::now() - start_time < duration {
+        while start_time.elapsed() < duration {
             // Spinning for 'duration', simulating doing hard work!
         }
 


### PR DESCRIPTION
# Objective

- reopen #4497 on main
- Make the example a tiny bit more elegant
