### PR TITLE
[Merged by Bors] - Make `Transform` propagation correct in the presence of updated children

### DIFF
--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -62,6 +62,3 @@ impl FromWorld for PreviousParent {
         PreviousParent(Entity::from_raw(u32::MAX))
     }
 }
-
-#[derive(Component, Debug, Copy, Clone, Eq, PartialEq, Reflect)]
-pub struct DirtyParent;

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -62,3 +62,6 @@ impl FromWorld for PreviousParent {
         PreviousParent(Entity::from_raw(u32::MAX))
     }
 }
+
+#[derive(Component, Debug, Copy, Clone, Eq, PartialEq, Reflect)]
+pub struct DirtyParent;

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -1,5 +1,5 @@
 use crate::components::{GlobalTransform, Transform};
-use bevy_ecs::prelude::*;
+use bevy_ecs::prelude::{Changed, Entity, Query, With, Without};
 use bevy_hierarchy::{Children, Parent};
 
 /// Update [`GlobalTransform`] component of entities based on entity hierarchy and


### PR DESCRIPTION
Supercedes https://github.com/bevyengine/bevy/pull/3340, and absorbs the test from there.

# Objective

- Fixes #3329

## Solution

- If the `Children` component has changed, we currently do not have a way to know how it has changed.
- Therefore, we must update the hierarchy downwards  from that point to be correct.