### PR TITLE
[Merged by Bors] - Public access for AnimationClip.duration

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -73,6 +73,11 @@ impl AnimationClip {
         &self.curves
     }
 
+    /// Duration of the clip, represented in seconds
+    pub fn duration(&self) -> &f32 {
+        &self.duration
+    }
+    
     /// Add a [`VariableCurve`] to an [`EntityPath`].
     pub fn add_curve_to_path(&mut self, path: EntityPath, curve: VariableCurve) {
         // Update the duration of the animation by this curve duration if it's longer

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -77,7 +77,7 @@ impl AnimationClip {
     pub fn duration(&self) -> &f32 {
         &self.duration
     }
-    
+
     /// Add a [`VariableCurve`] to an [`EntityPath`].
     pub fn add_curve_to_path(&mut self, path: EntityPath, curve: VariableCurve) {
         // Update the duration of the animation by this curve duration if it's longer


### PR DESCRIPTION
# Objective

- Small change that better facilitates custom animation systems

## Solution

- Added a public access function to `bevy::animation::AnimationClip`, making duration publicly readable

---