### PR TITLE
[Merged by Bors] - Make AnimationClip::duration return value instead of reference

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -74,8 +74,9 @@ impl AnimationClip {
     }
 
     /// Duration of the clip, represented in seconds
-    pub fn duration(&self) -> &f32 {
-        &self.duration
+    #[inline]
+    pub fn duration(&self) -> f32 {
+        self.duration
     }
 
     /// Add a [`VariableCurve`] to an [`EntityPath`].


### PR DESCRIPTION
Tiny follow-up to https://github.com/bevyengine/bevy/pull/4615 as discussed on Discord here: https://discord.com/channels/691052431525675048/692572690833473578/968945307767414855

Since f32 is `Copy` and smaller than a reference on most systems (or at least not larger), there's no reason not to copy it, which should be more convenient to use.