### PR TITLE
Allow PipelineCache to be used in non-render world by opening up API

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -340,7 +340,7 @@ impl PipelineCache {
         id
     }
 
-    fn set_shader(&mut self, handle: &Handle<Shader>, shader: &Shader) {
+    pub fn set_shader(&mut self, handle: &Handle<Shader>, shader: &Shader) {
         let pipelines_to_queue = self.shader_cache.set_shader(handle, shader.clone());
         for cached_pipeline in pipelines_to_queue {
             self.pipelines[cached_pipeline].state = CachedPipelineState::Queued;
@@ -348,7 +348,7 @@ impl PipelineCache {
         }
     }
 
-    fn remove_shader(&mut self, shader: &Handle<Shader>) {
+    pub fn remove_shader(&mut self, shader: &Handle<Shader>) {
         let pipelines_to_queue = self.shader_cache.remove(shader);
         for cached_pipeline in pipelines_to_queue {
             self.pipelines[cached_pipeline].state = CachedPipelineState::Queued;


### PR DESCRIPTION
# Objective

- In my game I use compute shaders in a more general purpose way: It is an intermediate calculation for game logic, I need the result in the ECS world
- Said purpose is for a voxel system: raw voxel data -> compute shader to polygonize with marching cubes -> generate physics mesh (with rapier)
- Key part is I need results of compute shader in the ECS world to generate the physics mesh

## Solution

- Make `set_shader` and `remove_shader` public
- I don't know if I like this approach really, we probably should instead expose the systems that take care of these (`process_pipeline_queue_system`, `extract_shaders`). They will have to be modified slightly to make it work
