### PR TITLE
[Merged by Bors] - Add alsa-lib-devel to OpenSUSE dependencies

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -101,7 +101,7 @@ Note that this template doesn't add Rust to the environment because there are ma
 ## Opensuse Tumbleweed
 
 ```bash
-   sudo zypper install libudev-devel gcc-c++
+   sudo zypper install libudev-devel gcc-c++ alsa-lib-devel
 ```
 
 ## Gentoo


### PR DESCRIPTION
Needed for compilation, tumbleweed. This PR adds the needed alsa package for OpenSUSE to the documentation.