### PR TITLE
[Merged by Bors] - Fix type parameter name conflicts of derive(Bundle)

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -156,9 +156,9 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
             }
 
             #[allow(unused_variables, unused_mut, non_snake_case)]
-            unsafe fn from_components<T, F>(ctx: &mut T, mut func: F) -> Self
+            unsafe fn from_components<__T, __F>(ctx: &mut __T, mut func: __F) -> Self
             where
-                F: FnMut(&mut T) -> #ecs_path::ptr::OwningPtr<'_>
+                __F: FnMut(&mut __T) -> #ecs_path::ptr::OwningPtr<'_>
             {
                 Self {
                     #(#field_from_components)*


### PR DESCRIPTION
# Objective

This code currently fails to compile with error ``the name `T` is already used for a generic parameter in this item's generic parameters``, because `T` is also used in code generated by `derive(Bundle)`.

```rust
#[derive(Bundle)]
struct MyBundle<T: Component> {
    component: T,
}
```

## Solution

Add double underscores to type parameter names in `derive(Bundle)`.