### PR TITLE
[Merged by Bors] - Do not create nor execute render passes which have no phase items to draw

### DIFF
--- a/crates/bevy_core_pipeline/src/main_pass_2d.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_2d.rs
@@ -44,6 +44,10 @@ impl Node for MainPass2dNode {
             .get_manual(world, view_entity)
             .expect("view entity should exist");
 
+        if transparent_phase.items.is_empty() {
+            return Ok(());
+        }
+
         let pass_descriptor = RenderPassDescriptor {
             label: Some("main_pass_2d"),
             color_attachments: &[target.get_color_attachment(Operations {

--- a/crates/bevy_core_pipeline/src/main_pass_3d.rs
+++ b/crates/bevy_core_pipeline/src/main_pass_3d.rs
@@ -55,7 +55,7 @@ impl Node for MainPass3dNode {
                 Err(_) => return Ok(()), // No window
             };
 
-        {
+        if !opaque_phase.items.is_empty() {
             // Run the opaque pass, sorted front-to-back
             // NOTE: Scoped to drop the mutable borrow of render_context
             #[cfg(feature = "trace")]
@@ -92,7 +92,7 @@ impl Node for MainPass3dNode {
             }
         }
 
-        {
+        if !alpha_mask_phase.items.is_empty() {
             // Run the alpha mask pass, sorted front-to-back
             // NOTE: Scoped to drop the mutable borrow of render_context
             #[cfg(feature = "trace")]
@@ -128,7 +128,7 @@ impl Node for MainPass3dNode {
             }
         }
 
-        {
+        if !transparent_phase.items.is_empty() {
             // Run the transparent pass, sorted back-to-front
             // NOTE: Scoped to drop the mutable borrow of render_context
             #[cfg(feature = "trace")]

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1439,6 +1439,11 @@ impl Node for ShadowPassNode {
                     .view_light_query
                     .get_manual(world, view_light_entity)
                     .unwrap();
+
+                if shadow_phase.items.is_empty() {
+                    continue;
+                }
+
                 let pass_descriptor = RenderPassDescriptor {
                     label: Some(&view_light.pass_name),
                     color_attachments: &[],

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -70,6 +70,11 @@ impl Node for UiPassNode {
             .query
             .get_manual(world, view_entity)
             .expect("view entity should exist");
+
+        if transparent_phase.items.is_empty() {
+            return Ok(());
+        }
+
         let pass_descriptor = RenderPassDescriptor {
             label: Some("ui_pass"),
             color_attachments: &[RenderPassColorAttachment {


### PR DESCRIPTION
# Objective

- Creating and executing render passes has GPU overhead. If there are no phase items in the render phase to draw, then this overhead should not be incurred as it has no benefit.

## Solution

- Check if there are no phase items to draw, and if not, do not construct not execute the render pass

---

## Changelog

- Changed: Do not create nor execute empty render passes