### PR TITLE
[Merged by Bors] - Clean up advice on glob imports in style guide

### DIFF
--- a/.github/contributing/engine_style_guide.md
+++ b/.github/contributing/engine_style_guide.md
@@ -6,7 +6,7 @@ For more advice on contributing to the engine, see the [relevant section](../../
 
 ## General guidelines
 
-1. Prefer granular imports over glob imports of `bevy::prelude::*` and `bevy::sub_crate::*`.
+1. Prefer granular imports over glob imports like `bevy::ecs::prelude::*`.
 2. Use a consistent comment style:
    1. `///` doc comments belong above `#[derive(Trait)]` invocations.
    2. `//` comments should generally go above the line in question, rather than in-line.

--- a/.github/contributing/engine_style_guide.md
+++ b/.github/contributing/engine_style_guide.md
@@ -6,7 +6,7 @@ For more advice on contributing to the engine, see the [relevant section](../../
 
 ## General guidelines
 
-1. Prefer granular imports over glob imports like `bevy::ecs::prelude::*`.
+1. Prefer granular imports over glob imports like `bevy_ecs::prelude::*`.
 2. Use a consistent comment style:
    1. `///` doc comments belong above `#[derive(Trait)]` invocations.
    2. `//` comments should generally go above the line in question, rather than in-line.


### PR DESCRIPTION
# Objective

- Example was misleading, as we never import `bevy` itself in the engine (except in integration tests).

## Solution

- Clean up wording.

## Context

Noticed by @mockersf in #4608.