### PR TITLE
[Merged by Bors] - GitHub Actions: don't depend on patch versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v3
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -50,7 +50,7 @@ jobs:
           touch target/doc/.nojekyll
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4.3.0
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: target/doc


### PR DESCRIPTION
# Objective

- don't depend on patch versions in GitHub Actions to avoid dependant frequent updates (like #4641, #4584)
