### PR TITLE
[Merged by Bors] - Make public macros more robust with $crate

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -356,8 +356,8 @@ macro_rules! load_internal_asset {
         {
             let mut debug_app = $app
                 .world
-                .non_send_resource_mut::<bevy_asset::debug_asset_server::DebugAssetApp>();
-            bevy_asset::debug_asset_server::register_handle_with_loader(
+                .non_send_resource_mut::<$crate::debug_asset_server::DebugAssetApp>();
+            $crate::debug_asset_server::register_handle_with_loader(
                 $loader,
                 &mut debug_app,
                 $handle,
@@ -365,7 +365,7 @@ macro_rules! load_internal_asset {
                 $path_str,
             );
         }
-        let mut assets = $app.world.resource_mut::<bevy_asset::Assets<_>>();
+        let mut assets = $app.world.resource_mut::<$crate::Assets<_>>();
         assets.set_untracked($handle, ($loader)(include_str!($path_str)));
     }};
 }
@@ -374,7 +374,7 @@ macro_rules! load_internal_asset {
 #[macro_export]
 macro_rules! load_internal_asset {
     ($app: ident, $handle: ident, $path_str: expr, $loader: expr) => {{
-        let mut assets = $app.world.resource_mut::<bevy_asset::Assets<_>>();
+        let mut assets = $app.world.resource_mut::<$crate::Assets<_>>();
         assets.set_untracked($handle, ($loader)(include_str!($path_str)));
     }};
 }

--- a/crates/bevy_utils/src/label.rs
+++ b/crates/bevy_utils/src/label.rs
@@ -60,7 +60,7 @@ macro_rules! define_label {
     ($label_trait_name:ident) => {
         /// Defines a set of strongly-typed labels for a class of objects
         pub trait $label_trait_name:
-            ::bevy_utils::label::DynHash + ::std::fmt::Debug + Send + Sync + 'static
+            $crate::label::DynHash + ::std::fmt::Debug + Send + Sync + 'static
         {
             #[doc(hidden)]
             fn dyn_clone(&self) -> Box<dyn $label_trait_name>;


### PR DESCRIPTION
# Objective

We have some macros that are public but only used internally for now. They fail on user's code due to the use of crate names like `bevy_utils`, while the user only has `bevy::utils`. There are two affected macros.

- `bevy_utils::define_label`: it may be useful in user's code for defining custom kinds of label traits (this is why I made this PR).
- `bevy_asset::load_internal_asset`: not useful currently due to limitations of the debug asset server, but this may change in the future.

## Solution

We can make them work by using `$crate` instead of names of their own crates, which can refer to the macro's defining crate regardless of the user's setup. Even though our objective is rather low-priority here, the solution adds no maintenance cost so it is still worthwhile.