### PR TITLE
[Merged by Bors] - set alpha_mode based on alpha value

### DIFF
--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -100,7 +100,7 @@ impl From<Color> for StandardMaterial {
     fn from(color: Color) -> Self {
         StandardMaterial {
             base_color: color,
-            alpha_mode: if color.a() != 1.0 {
+            alpha_mode: if color.a() < 1.0 {
                 AlphaMode::Blend
             } else {
                 AlphaMode::Opaque

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -100,6 +100,11 @@ impl From<Color> for StandardMaterial {
     fn from(color: Color) -> Self {
         StandardMaterial {
             base_color: color,
+            alpha_mode: if color.a() != 1.0 {
+                AlphaMode::Blend
+            } else {
+                AlphaMode::Opaque
+            },
             ..Default::default()
         }
     }


### PR DESCRIPTION
# Objective

- When spawning a sprite the alpha is used for transparency, but when using the `Color::into()` implementation to spawn a `StandardMaterial`, the alpha is ignored.
- Pretty much everytime I want to make something transparent I started with a `Color::rgb().into()` and I'm always surprised that it doesn't work when changing it to  `Color::rgba().into()`
- It's possible there's an issue with this approach I am not thinking of, but I'm not sure what's the point of setting an alpha value without the goal of making a color transparent.

## Solution

- Set the alpha_mode to AlphaMode::Blend when the alpha is not the default value.

---

## Migration Guide

This is not a breaking change, but it can easily be migrated to reduce boilerplate

```rust
commands.spawn_bundle(PbrBundle {
    mesh: meshes.add(shape::Cube::default().into()),
    material: materials.add(StandardMaterial {
        base_color: Color::rgba(1.0, 0.0, 0.0, 0.75),
        alpha_mode: AlphaMode::Blend,
        ..default()
    }),
    ..default()
});

// becomes

commands.spawn_bundle(PbrBundle {
    mesh: meshes.add(shape::Cube::default().into()),
    material: materials.add(Color::rgba(1.0, 0.0, 0.0, 0.75).into()),
    ..default()
});
```
