### PR TITLE
mesh2d_manual: Use unpack4x8unorm to unpack a u32 linear rgba to a vec4<f32>

### DIFF
--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -231,7 +231,7 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     // Project the world position of the mesh into screen position
     out.clip_position = view.view_proj * mesh.model * vec4<f32>(vertex.position, 1.0);
     // Unpack the `u32` from the vertex buffer into the `vec4<f32>` used by the fragment shader
-    out.color = vec4<f32>((vec4<u32>(vertex.color) >> vec4<u32>(0u, 8u, 16u, 24u)) & vec4<u32>(255u)) / 255.0;
+    out.color = unpack4x8unorm(vertex.color);
     return out;
 }
 


### PR DESCRIPTION
# Objective

- WGSL built-in unpacking functions should be used for much simpler code where appropriate

## Solution

- Use the `unpack4x8unorm` built-in WGSL function for unpacking a linear rgba u32 to a vec4<f32> for use in the `mesh2d_manual` example's shader