### PR TITLE
Make ComputedVisibility a bitset resource

### DIFF
--- a/crates/bevy_pbr/src/bundle.rs
+++ b/crates/bevy_pbr/src/bundle.rs
@@ -5,7 +5,7 @@ use bevy_reflect::Reflect;
 use bevy_render::{
     mesh::Mesh,
     primitives::{CubemapFrusta, Frustum},
-    view::{ComputedVisibility, Visibility, VisibleEntities},
+    view::{Visibility, VisibleEntities},
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 
@@ -21,8 +21,6 @@ pub struct MaterialMeshBundle<M: SpecializedMaterial> {
     pub global_transform: GlobalTransform,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
-    pub computed_visibility: ComputedVisibility,
 }
 
 impl<M: SpecializedMaterial> Default for MaterialMeshBundle<M> {
@@ -33,7 +31,6 @@ impl<M: SpecializedMaterial> Default for MaterialMeshBundle<M> {
             transform: Default::default(),
             global_transform: Default::default(),
             visibility: Default::default(),
-            computed_visibility: Default::default(),
         }
     }
 }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -67,3 +67,4 @@ flate2 = { version = "1.0.22", optional = true }
 ruzstd = { version = "0.2.4", optional = true }
 # For transcoding of UASTC/ETC1S universal formats, and for .basis file support
 basis-universal = { version = "0.2.0", optional = true }
+fixedbitset = "0.4"

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -22,7 +22,6 @@ impl Plugin for CameraPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Camera>()
             .register_type::<Visibility>()
-            .register_type::<ComputedVisibility>()
             .register_type::<OrthographicProjection>()
             .register_type::<PerspectiveProjection>()
             .register_type::<VisibleEntities>()
@@ -32,6 +31,7 @@ impl Plugin for CameraPlugin {
             .register_type::<Aabb>()
             .register_type::<Camera3d>()
             .register_type::<Camera2d>()
+            .init_resource::<ComputedVisibility>()
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 crate::camera::camera_system::<OrthographicProjection>.after(ModifiesWindows),

--- a/crates/bevy_render/src/render_component.rs
+++ b/crates/bevy_render/src/render_component.rs
@@ -194,13 +194,14 @@ fn extract_components<C: ExtractComponent>(
 
 /// This system extracts all visible components of the corresponding [`ExtractComponent`] type.
 fn extract_visible_components<C: ExtractComponent>(
+    computed_visibility: Res<ComputedVisibility>,
     mut commands: Commands,
     mut previous_len: Local<usize>,
-    mut query: StaticSystemParam<Query<(Entity, Read<ComputedVisibility>, C::Query), C::Filter>>,
+    mut query: StaticSystemParam<Query<(Entity, C::Query), C::Filter>>,
 ) {
     let mut values = Vec::with_capacity(*previous_len);
-    for (entity, computed_visibility, query_item) in query.iter_mut() {
-        if computed_visibility.is_visible {
+    for (entity, query_item) in query.iter_mut() {
+        if computed_visibility.is_visible(entity) {
             values.push((entity, (C::extract_component(query_item),)));
         }
     }

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -51,7 +51,7 @@ impl ComputedVisibility {
 
     #[inline]
     pub fn reserve(&mut self, entities: &Entities) {
-        self.entities.grow(entities.len() as usize);
+        self.entities.grow(entities.meta_len() as usize);
     }
 
     #[inline]

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -24,7 +24,7 @@ use bevy_render::{
         SpecializedMeshPipeline, SpecializedMeshPipelineError, SpecializedMeshPipelines,
     },
     renderer::RenderDevice,
-    view::{ComputedVisibility, Msaa, Visibility, VisibleEntities},
+    view::{Msaa, Visibility, VisibleEntities},
     RenderApp, RenderStage,
 };
 use bevy_transform::components::{GlobalTransform, Transform};
@@ -375,8 +375,6 @@ pub struct MaterialMesh2dBundle<M: SpecializedMaterial2d> {
     pub global_transform: GlobalTransform,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
-    pub computed_visibility: ComputedVisibility,
 }
 
 impl<M: SpecializedMaterial2d> Default for MaterialMesh2dBundle<M> {
@@ -387,7 +385,6 @@ impl<M: SpecializedMaterial2d> Default for MaterialMesh2dBundle<M> {
             transform: Default::default(),
             global_transform: Default::default(),
             visibility: Default::default(),
-            computed_visibility: Default::default(),
         }
     }
 }

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -88,13 +88,14 @@ bitflags::bitflags! {
 }
 
 pub fn extract_mesh2d(
+    computed_visibility: Res<ComputedVisibility>,
     mut commands: Commands,
     mut previous_len: Local<usize>,
-    query: Query<(Entity, &ComputedVisibility, &GlobalTransform, &Mesh2dHandle)>,
+    query: Query<(Entity, &GlobalTransform, &Mesh2dHandle)>,
 ) {
     let mut values = Vec::with_capacity(*previous_len);
-    for (entity, computed_visibility, transform, handle) in query.iter() {
-        if !computed_visibility.is_visible {
+    for (entity, transform, handle) in query.iter() {
+        if !computed_visibility.is_visible(entity) {
             continue;
         }
         let transform = transform.compute_matrix();

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -99,7 +99,6 @@ fn star(
         Transform::default(),
         GlobalTransform::default(),
         Visibility::default(),
-        ComputedVisibility::default(),
     ));
     commands
         // And use an orthographic projection
@@ -277,13 +276,14 @@ impl Plugin for ColoredMesh2dPlugin {
 
 /// Extract the [`ColoredMesh2d`] marker component into the render app
 pub fn extract_colored_mesh2d(
+    computed_visibility: Res<ComputedVisibility>,
     mut commands: Commands,
     mut previous_len: Local<usize>,
-    query: Query<(Entity, &ComputedVisibility), With<ColoredMesh2d>>,
+    query: Query<Entity, (With<Visibility>, With<ColoredMesh2d>)>,
 ) {
     let mut values = Vec::with_capacity(*previous_len);
-    for (entity, computed_visibility) in query.iter() {
-        if !computed_visibility.is_visible {
+    for entity in query.iter() {
+        if !computed_visibility.is_visible(entity) {
             continue;
         }
         values.push((entity, (ColoredMesh2d,)));

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -15,7 +15,7 @@ use bevy::{
         },
         render_resource::*,
         renderer::{RenderDevice, RenderQueue},
-        view::{ComputedVisibility, ExtractedView, Msaa, Visibility},
+        view::{ExtractedView, Msaa, Visibility},
         RenderApp, RenderStage,
     },
 };
@@ -36,7 +36,6 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
         GlobalTransform::default(),
         CustomMaterial,
         Visibility::default(),
-        ComputedVisibility::default(),
     ));
 
     // camera

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -62,7 +62,6 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
         Transform::from_xyz(-1.0, 0.5, 0.0),
         GlobalTransform::default(),
         Visibility::default(),
-        ComputedVisibility::default(),
     ));
 
     // blue cube
@@ -72,7 +71,6 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
         Transform::from_xyz(1.0, 0.5, 0.0),
         GlobalTransform::default(),
         Visibility::default(),
-        ComputedVisibility::default(),
     ));
 
     // camera

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -14,7 +14,7 @@ use bevy::{
         },
         render_resource::*,
         renderer::RenderDevice,
-        view::{ComputedVisibility, ExtractedView, Msaa, NoFrustumCulling, Visibility},
+        view::{ExtractedView, Msaa, NoFrustumCulling, Visibility},
         RenderApp, RenderStage,
     },
 };
@@ -44,7 +44,6 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
                 .collect(),
         ),
         Visibility::default(),
-        ComputedVisibility::default(),
         // NOTE: Frustum culling is done based on the Aabb of the Mesh and the GlobalTransform.
         // As the cube is at the origin, if its Aabb moves outside the view frustum, all the
         // instanced cubes will be culled.

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -141,9 +141,10 @@ fn move_camera(time: Res<Time>, mut camera_query: Query<&mut Transform, With<Cam
 
 // System for printing the number of meshes on every tick of the timer
 fn print_mesh_count(
+    computed_visibility: Res<ComputedVisibility>,
     time: Res<Time>,
     mut timer: Local<PrintingTimer>,
-    sprites: Query<(&Handle<Mesh>, &ComputedVisibility)>,
+    sprites: Query<(Entity, &Handle<Mesh>)>,
 ) {
     timer.tick(time.delta());
 
@@ -151,7 +152,10 @@ fn print_mesh_count(
         info!(
             "Meshes: {} - Visible Meshes {}",
             sprites.iter().len(),
-            sprites.iter().filter(|(_, cv)| cv.is_visible).count(),
+            sprites
+                .iter()
+                .filter(|(entity, _)| computed_visibility.is_visible(*entity))
+                .count(),
         );
     }
 }


### PR DESCRIPTION
# Objective
Fixes #4661. 

## Solution
 - Make `ComputedVisibility` a resource wrapping a `FixedBitset`.
 - Remove `ComputedVisibility` as a component.

This adds a one-bit overhead to every entity in the app world. For a game with 100,000 entities, this is 12.5KB of memory. This is still small enough to fit entirely in most L1 caches. Also removes the need for a per-Entity change detection tick. This reduces the memory footprint of ComputedVisibility 72x.

The decreased memory usage and less fragmented memory locality should provide significant performance benefits. 

Clearing visible entities should be significantly faster than before:
 
 - Setting one `u32` to 0 clears 32 entities per cycle.
 - No archetype fragmentation to contend with.
 - Change detection is applied to the resource, so there is no per-Entity update tick requirement.

The side benefit of this design is that it removes one more "computed component" from userspace.  Though accessing the values within it are now less ergonomic.

TODO: Benchmark.

---

## Changelog

- Changed: For performance reasons, `ComputedVisibility` is now a resource and is no longer usable as a component. Only `Visibility` is now required for entities that require rendering.

## Migration Guide

ComputedVisibility is no longer a component, but a resource. Instead of checking `computed_visibility.is_visible`, use a `Res<ComputedVisibility>` resource parameter and use `computed_visibility.is_visible(entity)` to check if the entity is visible. 