### PR TITLE
Make system chaining use a normal system

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -38,9 +38,8 @@ pub mod prelude {
             StageLabel, State, SystemLabel, SystemSet, SystemStage,
         },
         system::{
-            Commands, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend,
-            NonSendMut, ParamSet, Query, RemovedComponents, Res, ResMut, System,
-            SystemParamFunction,
+            chain, Commands, In, IntoExclusiveSystem, IntoSystem, Local, NonSend, NonSendMut,
+            ParamSet, Query, RemovedComponents, Res, ResMut, System, SystemParamFunction,
         },
         world::{FromWorld, Mut, World},
     };

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -522,10 +522,12 @@ impl<T> SystemLabel for SystemTypeIdLabel<T> {
 /// {
 ///     // The type of `params` is inferred based on the return of this function above
 ///     move |In(input), mut params| {
-///         let shared = system.run(input, params.p0())
+///         system.run(input, params.p0())
 ///     }
 /// }
 ///
+/// # bevy_ecs::system::assert_is_system(identity(|| ()));
+/// # bevy_ecs::system::assert_is_system(identity(|_: In<u32>| ()));
 /// ```
 ///
 /// [`chain`]: crate::system::chain

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -85,9 +85,9 @@ pub use system_param::*;
 
 /// Ensure that a given function is a system
 ///
-/// This should be used when writing doc examples,
-/// to confirm that systems used in an example are
-/// valid systems
+/// This should be used when writing doc examples, such as for
+/// custom [`SystemParam`]s, to confirm that systems used in an
+/// example are valid systems
 pub fn assert_is_system<In, Out, Params, S: IntoSystem<In, Out, Params>>(sys: S) {
     if false {
         // Check it can be converted into a system

--- a/crates/bevy_ecs/src/system/system_chaining.rs
+++ b/crates/bevy_ecs/src/system/system_chaining.rs
@@ -1,21 +1,13 @@
-use crate::{
-    archetype::ArchetypeComponentId,
-    component::ComponentId,
-    query::Access,
-    system::{IntoSystem, System},
-    world::World,
-};
-use std::borrow::Cow;
+use super::{In, SystemParam, SystemParamFunction, SystemParamItem};
 
-/// A [`System`] that chains two systems together, creating a new system that routes the output of
+/// A [`System`](crate::system::System) that chains two systems together, creating a new system that routes the output of
 /// the first system into the input of the second system, yielding the output of the second system.
 ///
-/// Given two systems A and B, A may be chained with B as `A.chain(B)` if the output type of A is
+/// Given two systems A and B, A may be chained with B as `chain(A, B)` if the return type of A is
 /// equal to the input type of B.
 ///
-/// Note that for [`FunctionSystem`](crate::system::FunctionSystem)s the output is the return value
-/// of the function and the input is the first [`SystemParam`](crate::system::SystemParam) if it is
-/// tagged with [`In`](crate::system::In) or `()` if the function has no designated input parameter.
+/// Note that the input to a system is the [`In`] parameter, which must be the first parameter to the
+/// system function. If the function has no designated input parameter, the input type is [`()`](unit)
 ///
 /// # Examples
 ///
@@ -29,7 +21,7 @@ use std::borrow::Cow;
 ///     world.insert_resource(Message("42".to_string()));
 ///
 ///     // chain the `parse_message_system`'s output into the `filter_system`s input
-///     let mut chained_system = parse_message_system.chain(filter_system);
+///     let mut chained_system = IntoSystem::into_system(chain(parse_message_system, filter_system));
 ///     chained_system.initialize(&mut world);
 ///     assert_eq!(chained_system.run((), &mut world), Some(42));
 /// }
@@ -44,100 +36,20 @@ use std::borrow::Cow;
 ///     result.ok().filter(|&n| n < 100)
 /// }
 /// ```
-pub struct ChainSystem<SystemA, SystemB> {
-    system_a: SystemA,
-    system_b: SystemB,
-    name: Cow<'static, str>,
-    component_access: Access<ComponentId>,
-    archetype_component_access: Access<ArchetypeComponentId>,
-}
-
-impl<SystemA: System, SystemB: System<In = SystemA::Out>> System for ChainSystem<SystemA, SystemB> {
-    type In = SystemA::In;
-    type Out = SystemB::Out;
-
-    fn name(&self) -> Cow<'static, str> {
-        self.name.clone()
-    }
-
-    fn archetype_component_access(&self) -> &Access<ArchetypeComponentId> {
-        &self.archetype_component_access
-    }
-
-    fn component_access(&self) -> &Access<ComponentId> {
-        &self.component_access
-    }
-
-    fn is_send(&self) -> bool {
-        self.system_a.is_send() && self.system_b.is_send()
-    }
-
-    unsafe fn run_unsafe(&mut self, input: Self::In, world: &World) -> Self::Out {
-        let out = self.system_a.run_unsafe(input, world);
-        self.system_b.run_unsafe(out, world)
-    }
-
-    fn apply_buffers(&mut self, world: &mut World) {
-        self.system_a.apply_buffers(world);
-        self.system_b.apply_buffers(world);
-    }
-
-    fn initialize(&mut self, world: &mut World) {
-        self.system_a.initialize(world);
-        self.system_b.initialize(world);
-        self.component_access
-            .extend(self.system_a.component_access());
-        self.component_access
-            .extend(self.system_b.component_access());
-    }
-
-    fn update_archetype_component_access(&mut self, world: &World) {
-        self.system_a.update_archetype_component_access(world);
-        self.system_b.update_archetype_component_access(world);
-
-        self.archetype_component_access
-            .extend(self.system_a.archetype_component_access());
-        self.archetype_component_access
-            .extend(self.system_b.archetype_component_access());
-    }
-
-    fn check_change_tick(&mut self, change_tick: u32) {
-        self.system_a.check_change_tick(change_tick);
-        self.system_b.check_change_tick(change_tick);
-    }
-}
-
-/// An extension trait providing the [`IntoChainSystem::chain`] method for convenient [`System`]
-/// chaining.
 ///
-/// This trait is blanket implemented for all system pairs that fulfill the chaining requirement.
-///
-/// See [`ChainSystem`].
-pub trait IntoChainSystem<ParamA, Payload, SystemB, ParamB, Out>:
-    IntoSystem<(), Payload, ParamA> + Sized
+/// [`In`]: crate::system::In
+pub fn chain<AIn, Shared, BOut, A, AParam, AMarker, B, BParam, BMarker>(
+    mut a: A,
+    mut b: B,
+) -> impl FnMut(In<AIn>, SystemParamItem<AParam>, SystemParamItem<BParam>) -> BOut
 where
-    SystemB: IntoSystem<Payload, Out, ParamB>,
+    A: SystemParamFunction<AIn, Shared, AParam, AMarker>,
+    B: SystemParamFunction<Shared, BOut, BParam, BMarker>,
+    AParam: SystemParam,
+    BParam: SystemParam,
 {
-    /// Chain this system `A` with another system `B` creating a new system that feeds system A's
-    /// output into system `B`, returning the output of system `B`.
-    fn chain(self, system: SystemB) -> ChainSystem<Self::System, SystemB::System>;
-}
-
-impl<SystemA, ParamA, Payload, SystemB, ParamB, Out>
-    IntoChainSystem<ParamA, Payload, SystemB, ParamB, Out> for SystemA
-where
-    SystemA: IntoSystem<(), Payload, ParamA>,
-    SystemB: IntoSystem<Payload, Out, ParamB>,
-{
-    fn chain(self, system: SystemB) -> ChainSystem<SystemA::System, SystemB::System> {
-        let system_a = IntoSystem::into_system(self);
-        let system_b = IntoSystem::into_system(system);
-        ChainSystem {
-            name: Cow::Owned(format!("Chain({}, {})", system_a.name(), system_b.name())),
-            system_a,
-            system_b,
-            archetype_component_access: Default::default(),
-            component_access: Default::default(),
-        }
+    move |In(a_in), a_params, b_params| {
+        let shared = a.run(a_in, a_params);
+        b.run(shared, b_params)
     }
 }

--- a/crates/bevy_ecs/src/system/system_chaining.rs
+++ b/crates/bevy_ecs/src/system/system_chaining.rs
@@ -1,4 +1,4 @@
-use super::{In, SystemParam, SystemParamFunction, SystemParamItem};
+use super::{In, ParamSet, SystemParam, SystemParamFunction, SystemParamItem};
 
 /// A [`System`](crate::system::System) that chains two systems together, creating a new system that routes the output of
 /// the first system into the input of the second system, yielding the output of the second system.
@@ -41,15 +41,15 @@ use super::{In, SystemParam, SystemParamFunction, SystemParamItem};
 pub fn chain<AIn, Shared, BOut, A, AParam, AMarker, B, BParam, BMarker>(
     mut a: A,
     mut b: B,
-) -> impl FnMut(In<AIn>, SystemParamItem<AParam>, SystemParamItem<BParam>) -> BOut
+) -> impl FnMut(In<AIn>, ParamSet<(SystemParamItem<AParam>, SystemParamItem<BParam>)>) -> BOut
 where
     A: SystemParamFunction<AIn, Shared, AParam, AMarker>,
     B: SystemParamFunction<Shared, BOut, BParam, BMarker>,
     AParam: SystemParam,
     BParam: SystemParam,
 {
-    move |In(a_in), a_params, b_params| {
-        let shared = a.run(a_in, a_params);
-        b.run(shared, b_params)
+    move |In(a_in), mut params| {
+        let shared = a.run(a_in, params.p0());
+        b.run(shared, params.p1())
     }
 }

--- a/examples/ecs/system_chaining.rs
+++ b/examples/ecs/system_chaining.rs
@@ -7,7 +7,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .insert_resource(Message("42".to_string()))
-        .add_system(parse_message_system.chain(handler_system))
+        .add_system(chain(parse_message_system, handler_system))
         .run();
 }
 


### PR DESCRIPTION
# Objective

- The API for our system abstraction is functions, not the `System` trait.
- Demonstrate that this can be used for higher order systems
- Allow it to be used for higher order systems

## Solution

- Change `SystemParamFunction` to allow higher-order systems to be created in terms of functions rather than Systems.
- Migrate `ChainSystem` to this.

Please note, that without GATs, as far as I know, we cannot have `chain` remain as a method. However, GATs are on the path to stabilisation, hopefully in a form sufficiently powerful for this case.

## Open questions

Is `chain` the correct name? I think it's probably a fine name, but the idiomatic style is for functions which return systems to have the `_system` suffix. Do we make an exception for `chain` due to the old name or higher-order nature?

## Changelog

### Changed

The `chain` method on system functions has been removed. Use the `bevy_ecs::system::chain` function instead (which is in the `bevy_ecs` prelude).

## Migration Guide

The `chain` method on system functions has been removed. Use the `bevy_ecs::system::chain` function instead (which is in the `bevy_ecs` prelude). If previously you used chain as:
```rust
do_thing.chain(handler)
```
you should instead use:
```rust
chain(do_thing, handler)
```