### PR TITLE
[Merged by Bors] - some cleanup for `bevy_ptr`

### DIFF
--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -212,7 +212,7 @@ impl BlobVec {
     #[inline]
     pub unsafe fn get_unchecked(&self, index: usize) -> Ptr<'_> {
         debug_assert!(index < self.len());
-        self.get_ptr().add(index * self.item_layout.size())
+        self.get_ptr().byte_add(index * self.item_layout.size())
     }
 
     /// # Safety
@@ -221,7 +221,7 @@ impl BlobVec {
     pub unsafe fn get_unchecked_mut(&mut self, index: usize) -> PtrMut<'_> {
         debug_assert!(index < self.len());
         let layout_size = self.item_layout.size();
-        self.get_ptr_mut().add(index * layout_size)
+        self.get_ptr_mut().byte_add(index * layout_size)
     }
 
     /// Gets a [`Ptr`] to the start of the vec
@@ -258,7 +258,7 @@ impl BlobVec {
             unsafe {
                 // NOTE: this doesn't use self.get_unchecked(i) because the debug_assert on index
                 // will panic here due to self.len being set to 0
-                let ptr = self.get_ptr_mut().add(i * layout_size).promote();
+                let ptr = self.get_ptr_mut().byte_add(i * layout_size).promote();
                 (drop)(ptr);
             }
         }

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -156,7 +156,7 @@ impl<'a> PtrMut<'a> {
     /// associated lifetime.
     #[inline]
     #[allow(clippy::wrong_self_convention)]
-    pub unsafe fn as_ptr(self) -> *mut u8 {
+    pub unsafe fn as_ptr(&self) -> *mut u8 {
         self.0.as_ptr()
     }
 }
@@ -198,7 +198,7 @@ impl<'a> OwningPtr<'a> {
     /// associated lifetime.
     #[inline]
     #[allow(clippy::wrong_self_convention)]
-    pub unsafe fn as_ptr(self) -> *mut u8 {
+    pub unsafe fn as_ptr(&self) -> *mut u8 {
         self.0.as_ptr()
     }
 }

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -116,13 +116,9 @@ impl<'a> Ptr<'a> {
     ///
     /// If possible, it is strongly encouraged to use [`deref`](Self::deref) over this function,
     /// as it retains the lifetime.
-    ///
-    /// # Safety
-    /// All subsequent operations to the returned pointer must be valid inside the
-    /// associated lifetime.
     #[inline]
     #[allow(clippy::wrong_self_convention)]
-    pub unsafe fn as_ptr(self) -> *mut u8 {
+    pub fn as_ptr(self) -> *mut u8 {
         self.0.as_ptr()
     }
 }
@@ -150,13 +146,9 @@ impl<'a> PtrMut<'a> {
     ///
     /// If possible, it is strongly encouraged to use [`deref_mut`](Self::deref_mut) over
     /// this function, as it retains the lifetime.
-    ///
-    /// # Safety
-    /// All subsequent operations to the returned pointer must be valid inside the
-    /// associated lifetime.
     #[inline]
     #[allow(clippy::wrong_self_convention)]
-    pub unsafe fn as_ptr(&self) -> *mut u8 {
+    pub fn as_ptr(&self) -> *mut u8 {
         self.0.as_ptr()
     }
 }
@@ -192,13 +184,9 @@ impl<'a> OwningPtr<'a> {
     ///
     /// If possible, it is strongly encouraged to use the other more type-safe functions
     /// over this function.
-    ///
-    /// # Safety
-    /// All subsequent operations to the returned pointer must be valid inside the
-    /// associated lifetime.
     #[inline]
     #[allow(clippy::wrong_self_convention)]
-    pub unsafe fn as_ptr(&self) -> *mut u8 {
+    pub fn as_ptr(&self) -> *mut u8 {
         self.0.as_ptr()
     }
 }

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -55,7 +55,7 @@ macro_rules! impl_ptr {
             ///
             /// [ptr_offset]: https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
             #[inline]
-            pub unsafe fn offset(self, count: isize) -> Self {
+            pub unsafe fn byte_offset(self, count: isize) -> Self {
                 Self(
                     NonNull::new_unchecked(self.as_ptr().offset(count)),
                     PhantomData,
@@ -73,7 +73,7 @@ macro_rules! impl_ptr {
             ///
             /// [ptr_add]: https://doc.rust-lang.org/std/primitive.pointer.html#method.add
             #[inline]
-            pub unsafe fn add(self, count: usize) -> Self {
+            pub unsafe fn byte_add(self, count: usize) -> Self {
                 Self(
                     NonNull::new_unchecked(self.as_ptr().add(count)),
                     PhantomData,


### PR DESCRIPTION
1. change `PtrMut::as_ptr(self)` and `OwnedPtr::as_ptr(self)` to take `&self`, otherwise printing the pointer will prevent doing anything else afterwards
2. make all `as_ptr` methods safe. There's nothing unsafe about obtaining a pointer, these kinds of methods are safe in std as well [str::as_ptr](https://doc.rust-lang.org/stable/std/primitive.str.html#method.as_ptr), [Rc::as_ptr](https://doc.rust-lang.org/stable/std/rc/struct.Rc.html#method.as_ptr)
3. rename `offset`/`add` to `byte_offset`/`byte_add`. The unprefixed methods in std add in increments of `std::mem::size_of::<T>`, not in bytes. There's a PR for rust to add these byte_ methods https://github.com/rust-lang/rust/pull/95643 and at the call site it makes it much more clear that you need to do `.byte_add(i * layout_size)` instead of `.add(i)`