### PR TITLE
[Merged by Bors] - Documenting `BufferVec`.

### DIFF
--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -107,10 +107,10 @@ impl<T: Pod> BufferVec<T> {
         }
     }
 
-    /// Queues writing of memory from the host to [`RenderDevice`](crate::renderer::RenderDevice) using
-    /// the provided [`RenderQueue`](crate::renderer::RenderQueue).
+    /// Queues writing of data from system RAM to VRAM using the [`RenderDevice`](crate::renderer::RenderDevice)
+    /// and the provided [`RenderQueue`](crate::renderer::RenderQueue).
     ///
-    /// Before queueing the write, a [`reserve`](crate::render_resource::BufferVec::reserve) operation
+    /// Before queuing the write, a [`reserve`](crate::render_resource::BufferVec::reserve) operation
     /// is executed.
     pub fn write_buffer(&mut self, device: &RenderDevice, queue: &RenderQueue) {
         if self.values.is_empty() {

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -7,7 +7,7 @@ use copyless::VecHelper;
 use wgpu::BufferUsages;
 
 /// A structure for storing raw bytes that have already been properly formatted
-/// for the [`RenderDevice`](crate::renderer::RenderDevice).
+/// for use by the GPU.
 ///
 /// "Properly formatted" means data that is [`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-representation), [`Pod`]
 /// and `Zeroable`. Unlike the [`DynamicUniformVec`](crate::render_resource::DynamicUniformVec),

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -9,7 +9,7 @@ use wgpu::BufferUsages;
 /// A structure for storing raw bytes that have already been properly formatted
 /// for use by the GPU.
 ///
-/// "Properly formatted" means data that item data already meets the alignment and padding
+/// "Properly formatted" means that item data already meets the alignment and padding
 /// requirements for how it will be used on the GPU.
 /// 
 /// Index, vertex, and instance-rate vertex buffers have no alignment nor padding requirements and

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -11,7 +11,7 @@ use wgpu::BufferUsages;
 ///
 /// "Properly formatted" means that item data already meets the alignment and padding
 /// requirements for how it will be used on the GPU.
-/// 
+///
 /// Index, vertex, and instance-rate vertex buffers have no alignment nor padding requirements and
 /// so this helper type is a good choice for them. Uniform buffers must adhere to std140
 /// alignment/padding requirements, and storage buffers to std430. There are helper types for such
@@ -22,7 +22,7 @@ use wgpu::BufferUsages;
 /// - Storage buffers
 ///   - Plain: [`StorageBuffer`](crate::render_resource::StorageBuffer)
 ///   - Dynamic offsets: [`DynamicStorageBuffer`](crate::render_resource::DynamicStorageBuffer)
-/// 
+///
 /// The item type must implement [`Pod`] for its data representation to be directly copyable.
 ///
 /// The contained data is stored in system RAM. Calling [`reserve`](crate::render_resource::BufferVec::reserve)

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -9,15 +9,26 @@ use wgpu::BufferUsages;
 /// A structure for storing raw bytes that have already been properly formatted
 /// for use by the GPU.
 ///
-/// "Properly formatted" means data that is [`#[repr(C)]`](https://doc.rust-lang.org/reference/type-layout.html#the-c-representation), [`Pod`]
-/// and `Zeroable`. Unlike the [`DynamicUniformVec`](crate::render_resource::DynamicUniformVec),
-/// [`UniformVec`](crate::render_resource::UniformVec) and [`StorageBuffer`](crate::render_resource::StorageBuffer) structures,
-/// `BufferVec` does not provide padding or alignment between items, or within items.
+/// "Properly formatted" means data that item data already meets the alignment and padding
+/// requirements for how it will be used on the GPU.
+/// 
+/// Index, vertex, and instance-rate vertex buffers have no alignment nor padding requirements and
+/// so this helper type is a good choice for them. Uniform buffers must adhere to std140
+/// alignment/padding requirements, and storage buffers to std430. There are helper types for such
+/// buffers:
+/// - Uniform buffers
+///   - Plain: [`UniformBuffer`](crate::render_resource::UniformBuffer)
+///   - Dynamic offsets: [`DynamicUniformBuffer`](crate::render_resource::DynamicUniformBuffer)
+/// - Storage buffers
+///   - Plain: [`StorageBuffer`](crate::render_resource::StorageBuffer)
+///   - Dynamic offsets: [`DynamicStorageBuffer`](crate::render_resource::DynamicStorageBuffer)
+/// 
+/// The item type must implement [`Pod`] for its data representation to be directly copyable.
 ///
-/// The data is stored on the host, calling [`reserve`](crate::render_resource::BufferVec::reserve)
-/// allocates memory on the [`RenderDevice`](crate::renderer::RenderDevice).
+/// The contained data is stored in system RAM. Calling [`reserve`](crate::render_resource::BufferVec::reserve)
+/// allocates VRAM from the [`RenderDevice`](crate::renderer::RenderDevice).
 /// [`write_buffer`](crate::render_resource::BufferVec::write_buffer) queues copying of the data
-/// from the host to the [`RenderDevice`](crate::renderer::RenderDevice).
+/// from system RAM to VRAM.
 pub struct BufferVec<T: Pod> {
     values: Vec<T>,
     buffer: Option<Buffer>,


### PR DESCRIPTION
# Objective

Documents the `BufferVec` render resource.

`BufferVec` is a fairly low level object, that will likely be managed by a higher level API (e.g. through [`encase`](https://github.com/bevyengine/bevy/issues/4272)) in the future. For now, since it is still used by some simple 
example crates (e.g. [bevy-vertex-pulling](https://github.com/superdump/bevy-vertex-pulling)), it will be helpful
to provide some simple documentation on what `BufferVec` does.  

## Solution

I looked through Discord discussion on `BufferVec`, and found [a comment](https://discord.com/channels/691052431525675048/953222550568173580/956596218857918464 ) by @superdump to be particularly helpful, in the general discussion around `encase`. 

I have taken care to clarify where the data is stored (host-side), when the device-side buffer is created (through calls to `reserve`), and when data writes from host to device are scheduled (using `write_buffer` calls). 

---

## Changelog

- Added doc string for `BufferVec` and two of its methods: `reserve` and `write_buffer`. 
