### PR TITLE
[Merged by Bors] - Add a clear() method to the EventReader that consumes the iterator

### DIFF
--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -392,32 +392,17 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
     /// Determines if no events are available to be read without consuming any.
     /// If you need to consume the iterator you can use [`EventReader::clear`].
     ///
+    /// ## Example usage with .clear()
     /// ```
-    /// use bevy_ecs::prelude::*;
-    /// use bevy_ecs::event::Events;
-    ///
-    /// struct MyEvent;
-    ///
-    /// let mut world = World::new();
-    /// let mut events = Events::<MyEvent>::default();
-    /// events.send(MyEvent);
-    /// world.insert_resource(events);
-    ///
-    /// let mut reader = IntoSystem::into_system(|events: EventReader<MyEvent>| -> bool {
-    ///     if !events.is_empty() {
+    /// # use bevy_ecs::prelude::*;
+    /// #
+    /// # struct MyEvent;
+    /// fn event_reader(events: EventReader<MyEvent>) {
+    ///      if !events.is_empty() {
     ///         events.clear();
-    ///         false
-    ///     } else {
-    ///         true
     ///     }
-    /// });
-    /// reader.initialize(&mut world);
-    ///
-    /// let is_empty = reader.run((), &mut world);
-    /// assert!(!is_empty, "EventReader should not be empty");
-    ///
-    /// let is_empty = reader.run((), &mut world);
-    /// assert!(is_empty, "EventReader should be empty");
+    /// }
+    /// # bevy_ecs::system::assert_is_system(event_reader);
     /// ```
     pub fn is_empty(&self) -> bool {
         self.len() == 0
@@ -817,8 +802,10 @@ mod tests {
         });
         reader.initialize(&mut world);
 
-        assert!(!reader.run((), &mut world));
-        assert!(reader.run((), &mut world));
+        let is_empty = reader.run((), &mut world);
+        assert!(!is_empty, "EventReader should not be empty");
+        let is_empty = reader.run((), &mut world);
+        assert!(is_empty, "EventReader should be empty");
     }
 
     #[derive(Clone, PartialEq, Debug, Default)]

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -396,9 +396,10 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
     /// ```
     /// # use bevy_ecs::prelude::*;
     /// #
-    /// # struct MyEvent;
+    /// struct MyEvent;
+    ///
     /// fn event_reader(events: EventReader<MyEvent>) {
-    ///      if !events.is_empty() {
+    ///     if !events.is_empty() {
     ///         events.clear();
     ///     }
     /// }

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -777,13 +777,13 @@ mod tests {
                 events.clear();
                 return false;
             } else {
-                return true;
+                true
             }
         });
         reader.initialize(&mut world);
 
-        assert_eq!(reader.run((), &mut world), false);
-        assert_eq!(reader.run((), &mut world), true);
+        assert!(!reader.run((), &mut world));
+        assert!(reader.run((), &mut world));
     }
 
     #[derive(Clone, PartialEq, Debug, Default)]

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -396,14 +396,15 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
     /// ```
     /// # use bevy_ecs::prelude::*;
     /// #
-    /// struct MyEvent;
+    /// struct CollisionEvent;
     ///
-    /// fn event_reader(events: EventReader<MyEvent>) {
+    /// fn play_collision_sound(events: EventReader<CollisionEvent>) {
     ///     if !events.is_empty() {
     ///         events.clear();
+    ///         // Play a sound
     ///     }
     /// }
-    /// # bevy_ecs::system::assert_is_system(event_reader);
+    /// # bevy_ecs::system::assert_is_system(play_collision_sound);
     /// ```
     pub fn is_empty(&self) -> bool {
         self.len() == 0

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -394,13 +394,16 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
     ///
     /// ```
     /// use bevy_ecs::prelude::*;
+    /// use bevy_ecs::event::Events;
+    ///
+    /// struct MyEvent;
     ///
     /// let mut world = World::new();
-    /// let mut events = Events::<TestEvent>::default();
-    /// events.send(TestEvent { i: 0 });
+    /// let mut events = Events::<MyEvent>::default();
+    /// events.send(MyEvent);
     /// world.insert_resource(events);
     ///
-    /// let mut reader = IntoSystem::into_system(|events: EventReader<TestEvent>| -> bool {
+    /// let mut reader = IntoSystem::into_system(|events: EventReader<MyEvent>| -> bool {
     ///     if !events.is_empty() {
     ///         events.clear();
     ///         false

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -392,7 +392,11 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
     /// Determines if no events are available to be read without consuming any.
     /// If you need to consume the iterator you can use [`EventReader::clear`].
     ///
-    /// ## Example usage with .clear()
+    /// # Example
+    /// 
+    /// The following example shows a common pattern of this function in conjunction with `clear`
+    /// to avoid leaking events to the next schedule iteration while also checking if it was emitted.
+    /// 
     /// ```
     /// # use bevy_ecs::prelude::*;
     /// #

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -775,7 +775,7 @@ mod tests {
         let mut reader = IntoSystem::into_system(|events: EventReader<TestEvent>| -> bool {
             if !events.is_empty() {
                 events.clear();
-                return false;
+                false
             } else {
                 true
             }

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -390,11 +390,14 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
     }
 
     /// Determines if there are any events available to be read without consuming any.
+    /// If you need to consume the iterator you can use [`EventReader::any`]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Determines if there are any events available to be read and consumes all events.
+    /// If you don't need to consume the iterator you can use [`EventReader::is_empty`]
+    /// WARNING: `events.any()` is not the same as doing `!events.is_empty()`
     pub fn any(&mut self) -> bool {
         self.iter().last().is_some()
     }

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -391,6 +391,7 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
 
     /// Determines if there are any events available to be read without consuming any.
     /// If you need to consume the iterator you can use [`EventReader::any`]
+    /// WARNING: `events.is_empty()` is not the same as doing `!events.any()`
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -390,12 +390,44 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
     }
 
     /// Determines if no events are available to be read without consuming any.
-    /// If you need to consume the iterator you can use [`EventReader::clear`]
+    /// If you need to consume the iterator you can use [`EventReader::clear`].
+    ///
+    /// ```
+    /// use bevy_ecs::prelude::*;
+    ///
+    /// let mut world = World::new();
+    /// let mut events = Events::<TestEvent>::default();
+    /// events.send(TestEvent { i: 0 });
+    /// world.insert_resource(events);
+    ///
+    /// let mut reader = IntoSystem::into_system(|events: EventReader<TestEvent>| -> bool {
+    ///     if !events.is_empty() {
+    ///         events.clear();
+    ///         false
+    ///     } else {
+    ///         true
+    ///     }
+    /// });
+    /// reader.initialize(&mut world);
+    ///
+    /// let is_empty = reader.run((), &mut world);
+    /// assert!(!is_empty, "EventReader should not be empty");
+    ///
+    /// let is_empty = reader.run((), &mut world);
+    /// assert!(is_empty, "EventReader should be empty");
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    /// Consumes the iterator. This means all currently available events will be removed before the next frame.
+    /// Consumes the iterator.
+    ///
+    /// This means all currently available events will be removed before the next frame.
+    /// This is useful when multiple events are sent in a single frame and you want
+    /// to react to one or more events without needing to know how many were sent.
+    /// In those situations you generally want to consume those events to make sure they don't appear in the next frame.
+    ///
+    /// For more information see [`EventReader::is_empty()`].
     pub fn clear(mut self) {
         self.iter().last();
     }

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -389,7 +389,7 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
         internal_event_reader(&mut self.last_event_count.0.clone(), &self.events).len()
     }
 
-    /// Determines if there are any events available to be read without consuming any.
+    /// Determines if no events are available to be read without consuming any.
     /// If you need to consume the iterator you can use [`EventReader::any`]
     /// WARNING: `events.is_empty()` is not the same as doing `!events.any()`
     pub fn is_empty(&self) -> bool {

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -411,13 +411,14 @@ fn check_for_collisions(
 }
 
 fn play_collision_sound(
-    mut collision_events: EventReader<CollisionEvent>,
+    collision_events: EventReader<CollisionEvent>,
     audio: Res<Audio>,
     sound: Res<CollisionSound>,
 ) {
-    // Play a sound once per frame if a collision occurred. `count` consumes the
-    // events, preventing them from triggering a sound on the next frame.
-    if collision_events.iter().count() > 0 {
+    // Play a sound once per frame if a collision occurred.
+    if !collision_events.is_empty() {
+        // This prevents events staying active on the next frame.
+        collision_events.clear();
         audio.play(sound.0.clone());
     }
 }


### PR DESCRIPTION
# Objective

- It's pretty common to want to check if an EventReader has received one or multiple events while also needing to consume the iterator to "clear" the EventReader.
- The current approach is to do something like `events.iter().count() > 0` or `events.iter().last().is_some()`. It's not immediately obvious that the purpose of that is to consume the events and check if there were any events. My solution doesn't really solve that part, but it encapsulates the pattern.

## Solution

- Add a `.clear()` method that consumes the iterator.
	- It takes the EventReader by value to make sure it isn't used again after it has been called.

---

## Migration Guide

Not a breaking change, but if you ever found yourself in a situation where you needed to consume the EventReader and check if there was any events you can now use

```rust
fn system(events: EventReader<MyEvent>) {
	if !events.is_empty {
		events.clear();
		// Process the fact that one or more event was received
	}
}
```
