### PR TITLE
More ergonomic labels

### DIFF
--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -1,4 +1,5 @@
 use bevy_ecs::prelude::*;
+use bevy_ecs_macros::system_label;
 use rand::Rng;
 use std::ops::Deref;
 
@@ -52,7 +53,7 @@ struct Age {
 }
 
 // System labels to enforce a run order of our systems
-#[derive(SystemLabel, Debug, Clone, PartialEq, Eq, Hash)]
+#[system_label]
 enum SimulationSystem {
     Spawn,
     Age,

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -450,11 +450,10 @@ pub fn system_label(_attr: TokenStream, input: TokenStream) -> TokenStream {
     trait_path
         .segments
         .push(format_ident!("SystemLabel").into());
-    (quote! {
+    TokenStream::from(quote! {
         #[derive(#trait_path, Clone, Hash, Eq, PartialEq, Debug)]
         #input
     })
-    .into()
 }
 
 #[proc_macro_derive(StageLabel)]

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -442,6 +442,21 @@ pub fn derive_system_label(input: TokenStream) -> TokenStream {
     derive_label(input, &trait_path)
 }
 
+#[proc_macro_attribute]
+pub fn system_label(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as syn::Item);
+    let mut trait_path = bevy_ecs_path();
+    trait_path.segments.push(format_ident!("schedule").into());
+    trait_path
+        .segments
+        .push(format_ident!("SystemLabel").into());
+    (quote! {
+        #[derive(#trait_path, Clone, Hash, Eq, PartialEq, Debug)]
+        #input
+    })
+    .into()
+}
+
 #[proc_macro_derive(StageLabel)]
 pub fn derive_stage_label(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);


### PR DESCRIPTION
# Objective

Creating new labels involves boilerplate along the lines of:

```rs
#[derive(SystemLabel, Debug, Clone, PartialEq, Eq, Hash)]
struct MyLabel;
```

This is a little bit annoying to type and could be simplified.

## Solution

The boilerplate is replaced with a `system_label` proc macro:

```rs
#[system_label]
struct MyLabel;
```
---

This PR could be expanded to also include stage labels, ambiguity set labels and run criteria labels. Perhaps a different syntax could be considered to include all of these labels, and potential future label types, under the same syntax.