### PR TITLE
[Merged by Bors] - Fix documentation for looking_at/look_at

### DIFF
--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -116,9 +116,9 @@ impl Transform {
         }
     }
 
-    /// Updates and returns this [`Transform`] by rotating it so that its unit vector in the
-    /// local `Z` direction is toward `target` and its unit vector in the local `Y` direction
-    /// is toward `up`.
+    /// Updates and returns this [`Transform`] by rotating it so that its unit
+    /// vector in the local negative `Z` direction is toward `target` and its
+    /// unit vector in the local `Y` direction is toward `up`.
     #[inline]
     #[must_use]
     pub fn looking_at(mut self, target: Vec3, up: Vec3) -> Self {


### PR DESCRIPTION
Bevy's coordinate system is right-handed Y up, so +Z points towards my nose and I'm looking in the -Z direction. Therefore, `Transform::looking_at/look_at` must be pointing towards -Z. Or am I wrong here?