### PR TITLE
gitpod support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,30 @@
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: false
+    addComment: false
+    addBadge: true
+
+tasks:
+  - name: Start web server
+    command: python3 -m http.server --directory examples/wasm
+
+  - name: Install linux dependencies
+    before: |
+      sudo apt-get install --no-install-recommends -yq libasound2-dev libudev-dev
+
+  - name: Install wasm tooling
+    before: |
+      rustup target add wasm32-unknown-unknown
+      cargo install cargo-quickinstall
+      cargo quickinstall wasm-bindgen-cli
+      cargo quickinstall cargo-watch
+    init: |
+      cargo run -p build-wasm-example -- lighting
+
+vscode:
+  extensions:
+    - matklad.rust-analyzer

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -21,6 +21,7 @@ tasks:
 
   - name: Install wasm tooling
     before: |
+      rustup update
       rustup target add wasm32-unknown-unknown
       cargo install cargo-quickinstall
       cargo quickinstall wasm-bindgen-cli

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,9 +12,9 @@ tasks:
   - name: Start web server
     command: python3 -m http.server --directory examples/wasm
 
-  - name: Install linux dependencies
-    before: |
-      sudo apt-get install --no-install-recommends -yq libasound2-dev libudev-dev
+  - name: Setup rust-analyzer for wasm target
+    init: |
+      echo "{\"rust-analyzer.cargo.target\":\"wasm32-unknown-unknown\"}" > .vscode/settings.json
 
   - name: Install wasm tooling
     before: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,6 +14,7 @@ tasks:
 
   - name: Setup rust-analyzer for wasm target
     init: |
+      mkdir .vscode
       echo "{\"rust-analyzer.cargo.target\":\"wasm32-unknown-unknown\"}" > .vscode/settings.json
 
   - name: Install wasm tooling

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,6 +13,8 @@ tasks:
     command: python3 -m http.server --directory examples/wasm
 
   - name: Setup rust-analyzer for wasm target
+    before: |
+      sudo apt-get install --no-install-recommends -yq libasound2-dev libudev-dev
     init: |
       mkdir .vscode
       echo "{\"rust-analyzer.cargo.target\":\"wasm32-unknown-unknown\"}" > .vscode/settings.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/bevyengine/bevy"
 
 [workspace]
 exclude = ["benches", "crates/bevy_ecs_compile_fail_tests"]
-members = ["crates/*", "examples/ios", "tools/*", "errors"]
+members = ["crates/*", "examples/ios", "tools/ci", "tools/spancmp", "tools/build-wasm-example", "errors"]
 
 [features]
 default = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/bevyengine/bevy"
 
 [workspace]
 exclude = ["benches", "crates/bevy_ecs_compile_fail_tests"]
-members = ["crates/*", "examples/ios", "tools/ci", "tools/spancmp", "tools/build-wasm-example", "errors"]
+members = ["crates/*", "examples/ios", "tools/*", "errors"]
 
 [features]
 default = [


### PR DESCRIPTION
# Objective

- Being able to use Bevy in gitpod

## Solution

- Add a gitpod config file. As I want to use it for wasm, it install everything for wasm and run a first build. The environment gets ready in less than a minute, and the first wasm build in 4 minutes.
- If the gitpod integration is fully enabled, it would be much faster, and a button would be added to every PR to open that PR in gitpod

You can try this PR in gitpod at https://gitpod.io/#https://github.com/bevyengine/bevy/pull/4700