### PR TITLE
[Merged by Bors] - bevy_reflect: Reflect arrays

### DIFF
--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -64,6 +64,7 @@ impl DynamicArray {
     }
 }
 
+// SAFE: any and any_mut both return self
 unsafe impl Reflect for DynamicArray {
     #[inline]
     fn type_name(&self) -> &str {

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -1,4 +1,5 @@
 use crate::{serde::Serializable, Reflect, ReflectMut, ReflectRef};
+use serde::ser::SerializeSeq;
 use std::{
     any::Any,
     hash::{Hash, Hasher},
@@ -126,7 +127,7 @@ unsafe impl Reflect for DynamicArray {
     }
 
     fn serializable(&self) -> Option<Serializable> {
-        None
+        Some(Serializable::Borrowed(self))
     }
 }
 
@@ -190,6 +191,42 @@ impl<'a> Iterator for ArrayIter<'a> {
 }
 
 impl<'a> ExactSizeIterator for ArrayIter<'a> {}
+
+impl<'a> serde::Serialize for dyn Array {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        array_serialize(self, serializer)
+    }
+}
+
+impl serde::Serialize for DynamicArray {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        array_serialize(self, serializer)
+    }
+}
+
+#[inline]
+pub fn array_serialize<A: Array + ?Sized, S>(array: &A, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let mut seq = serializer.serialize_seq(Some(array.len()))?;
+    for element in array.iter() {
+        let serializable = element.serializable().ok_or_else(|| {
+            serde::ser::Error::custom(format!(
+                "Type '{}' does not support `Reflect` serialization",
+                element.type_name()
+            ))
+        })?;
+        seq.serialize_element(serializable.borrow())?;
+    }
+    seq.end()
+}
 
 #[inline]
 pub fn array_hash<A: Array>(array: &A) -> Option<u64> {

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -1,0 +1,214 @@
+use crate::{serde::Serializable, Reflect, ReflectMut, ReflectRef};
+use std::{
+    any::Any,
+    hash::{Hash, Hasher},
+};
+
+/// An ordered, static-sized, mutable array of [`Reflect`] items.
+/// This corresponds to types like `[T; N]` (arrays)
+pub trait Array: Reflect {
+    fn get(&self, index: usize) -> Option<&dyn Reflect>;
+    fn get_mut(&mut self, index: usize) -> Option<&mut dyn Reflect>;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    fn iter(&self) -> ArrayIter;
+    fn clone_dynamic(&self) -> DynamicArray {
+        DynamicArray {
+            name: self.type_name().to_string(),
+            values: self.iter().map(|value| value.clone_value()).collect(),
+        }
+    }
+}
+
+pub struct DynamicArray {
+    name: String,
+    values: Vec<Box<dyn Reflect>>,
+}
+
+impl DynamicArray {
+    #[inline]
+    pub fn new(values: Vec<Box<dyn Reflect>>) -> Self {
+        Self {
+            name: String::default(),
+            values,
+        }
+    }
+
+    #[inline]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[inline]
+    pub fn set_name(&mut self, name: String) {
+        self.name = name;
+    }
+}
+
+unsafe impl Reflect for DynamicArray {
+    #[inline]
+    fn type_name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    #[inline]
+    fn any(&self) -> &dyn Any {
+        self
+    }
+
+    #[inline]
+    fn any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    #[inline]
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    #[inline]
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn apply(&mut self, value: &dyn Reflect) {
+        array_apply(self, value);
+    }
+
+    #[inline]
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+        *self = value.take()?;
+        Ok(())
+    }
+
+    #[inline]
+    fn reflect_ref(&self) -> ReflectRef {
+        ReflectRef::Array(self)
+    }
+
+    #[inline]
+    fn reflect_mut(&mut self) -> ReflectMut {
+        ReflectMut::Array(self)
+    }
+
+    #[inline]
+    fn clone_value(&self) -> Box<dyn Reflect> {
+        Box::new(self.clone_dynamic())
+    }
+
+    #[inline]
+    fn reflect_hash(&self) -> Option<u64> {
+        array_hash(self)
+    }
+
+    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
+        array_partial_eq(self, value)
+    }
+
+    fn serializable(&self) -> Option<Serializable> {
+        None
+    }
+}
+
+impl Array for DynamicArray {
+    #[inline]
+    fn get(&self, index: usize) -> Option<&dyn Reflect> {
+        self.values.get(index).map(|value| &**value)
+    }
+
+    #[inline]
+    fn get_mut(&mut self, index: usize) -> Option<&mut dyn Reflect> {
+        self.values.get_mut(index).map(|value| &mut **value)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    #[inline]
+    fn iter(&self) -> ArrayIter {
+        ArrayIter {
+            array: self,
+            index: 0,
+        }
+    }
+
+    #[inline]
+    fn clone_dynamic(&self) -> DynamicArray {
+        DynamicArray {
+            name: self.name.clone(),
+            values: self
+                .values
+                .iter()
+                .map(|value| value.clone_value())
+                .collect(),
+        }
+    }
+}
+
+pub struct ArrayIter<'a> {
+    pub(crate) array: &'a dyn Array,
+    pub(crate) index: usize,
+}
+
+impl<'a> Iterator for ArrayIter<'a> {
+    type Item = &'a dyn Reflect;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let value = self.array.get(self.index);
+        self.index += 1;
+        value
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = self.array.len();
+        (size, Some(size))
+    }
+}
+
+impl<'a> ExactSizeIterator for ArrayIter<'a> {}
+
+#[inline]
+pub fn array_hash<A: Array>(array: &A) -> Option<u64> {
+    let mut hasher = crate::ReflectHasher::default();
+    std::any::Any::type_id(array).hash(&mut hasher);
+    array.len().hash(&mut hasher);
+    for value in array.iter() {
+        hasher.write_u64(value.reflect_hash()?)
+    }
+    Some(hasher.finish())
+}
+
+#[inline]
+pub fn array_apply<A: Array>(array: &mut A, reflect: &dyn Reflect) {
+    if let ReflectRef::Array(reflect_array) = reflect.reflect_ref() {
+        if array.len() != reflect_array.len() {
+            panic!("Attempted to apply different sized `Array` types.");
+        }
+        for (i, value) in reflect_array.iter().enumerate() {
+            let v = array.get_mut(i).unwrap();
+            v.apply(value);
+        }
+    } else {
+        panic!("Attempted to apply a non-`Array` type to an `Array` type.");
+    }
+}
+
+#[inline]
+pub fn array_partial_eq<A: Array>(array: &A, reflect: &dyn Reflect) -> Option<bool> {
+    match reflect.reflect_ref() {
+        ReflectRef::Array(reflect_array) if reflect_array.len() == array.len() => {
+            for (a, b) in array.iter().zip(reflect_array.iter()) {
+                if let Some(false) | None = a.reflect_partial_eq(b) {
+                    return Some(false);
+                }
+            }
+        }
+        _ => return Some(false),
+    }
+
+    Some(true)
+}

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -7,13 +7,19 @@ use std::{
 /// An ordered, static-sized, mutable array of [`Reflect`] items.
 /// This corresponds to types like `[T; N]` (arrays)
 pub trait Array: Reflect {
+    /// Returns a reference to the element at `index`, or `None` if out of bounds.
     fn get(&self, index: usize) -> Option<&dyn Reflect>;
+    /// Returns a mutable reference to the element at `index`, or `None` if out of bounds.
     fn get_mut(&mut self, index: usize) -> Option<&mut dyn Reflect>;
+    /// Returns the number of elements in the collection.
     fn len(&self) -> usize;
+    /// Returns `true` if the collection contains no elements.
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+    /// Returns an iterator over the collection.
     fn iter(&self) -> ArrayIter;
+
     fn clone_dynamic(&self) -> DynamicArray {
         DynamicArray {
             name: self.type_name().to_string(),
@@ -23,16 +29,27 @@ pub trait Array: Reflect {
 }
 
 pub struct DynamicArray {
-    name: String,
-    values: Vec<Box<dyn Reflect>>,
+    pub(crate) name: String,
+    pub(crate) values: Box<[Box<dyn Reflect>]>,
 }
 
 impl DynamicArray {
     #[inline]
-    pub fn new(values: Vec<Box<dyn Reflect>>) -> Self {
+    pub fn new(values: Box<[Box<dyn Reflect>]>) -> Self {
         Self {
             name: String::default(),
             values,
+        }
+    }
+
+    pub fn from_vec<T: Reflect>(values: Vec<T>) -> Self {
+        Self {
+            name: String::default(),
+            values: values
+                .into_iter()
+                .map(|field| Box::new(field) as Box<dyn Reflect>)
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
         }
     }
 

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -174,12 +174,14 @@ pub struct ArrayIter<'a> {
 impl<'a> Iterator for ArrayIter<'a> {
     type Item = &'a dyn Reflect;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let value = self.array.get(self.index);
         self.index += 1;
         value
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let size = self.array.len();
         (size, Some(size))

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -4,7 +4,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-/// An ordered, static-sized, mutable array of [`Reflect`] items.
+/// A static-sized array of [`Reflect`] items.
 /// This corresponds to types like `[T; N]` (arrays)
 pub trait Array: Reflect {
     /// Returns a reference to the element at `index`, or `None` if out of bounds.

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -1,7 +1,9 @@
 use smallvec::SmallVec;
 use std::any::Any;
 
-use crate::{serde::Serializable, Array, ArrayIter, FromReflect, List, Reflect, ReflectMut, ReflectRef};
+use crate::{
+    serde::Serializable, Array, ArrayIter, FromReflect, List, Reflect, ReflectMut, ReflectRef,
+};
 
 impl<T: smallvec::Array + Send + Sync + 'static> Array for SmallVec<T>
 where

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -1,9 +1,9 @@
-use smallvec::{Array, SmallVec};
+use smallvec::SmallVec;
 use std::any::Any;
 
-use crate::{serde::Serializable, FromReflect, List, ListIter, Reflect, ReflectMut, ReflectRef};
+use crate::{serde::Serializable, Array, ArrayIter, FromReflect, List, Reflect, ReflectMut, ReflectRef};
 
-impl<T: Array + Send + Sync + 'static> List for SmallVec<T>
+impl<T: smallvec::Array + Send + Sync + 'static> Array for SmallVec<T>
 where
     T::Item: FromReflect + Clone,
 {
@@ -27,6 +27,18 @@ where
         <SmallVec<T>>::len(self)
     }
 
+    fn iter(&self) -> ArrayIter {
+        ArrayIter {
+            array: self,
+            index: 0,
+        }
+    }
+}
+
+impl<T: smallvec::Array + Send + Sync + 'static> List for SmallVec<T>
+where
+    T::Item: Reflect + Clone,
+{
     fn push(&mut self, value: Box<dyn Reflect>) {
         let value = value.take::<T::Item>().unwrap_or_else(|value| {
             <T as Array>::Item::from_reflect(&*value).unwrap_or_else(|| {
@@ -38,17 +50,10 @@ where
         });
         SmallVec::push(self, value);
     }
-
-    fn iter(&self) -> ListIter {
-        ListIter {
-            list: self,
-            index: 0,
-        }
-    }
 }
 
 // SAFE: any and any_mut both return self
-unsafe impl<T: Array + Send + Sync + 'static> Reflect for SmallVec<T>
+unsafe impl<T: smallvec::Array + Send + Sync + 'static> Reflect for SmallVec<T>
 where
     T::Item: FromReflect + Clone,
 {

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -37,7 +37,7 @@ where
 
 impl<T: smallvec::Array + Send + Sync + 'static> List for SmallVec<T>
 where
-    T::Item: Reflect + Clone,
+    T::Item: FromReflect + Clone,
 {
     fn push(&mut self, value: Box<dyn Reflect>) {
         let value = value.take::<T::Item>().unwrap_or_else(|value| {
@@ -95,7 +95,7 @@ where
     }
 
     fn clone_value(&self) -> Box<dyn Reflect> {
-        Box::new(self.clone_dynamic())
+        Box::new(List::clone_dynamic(self))
     }
 
     fn reflect_hash(&self) -> Option<u64> {
@@ -111,7 +111,7 @@ where
     }
 }
 
-impl<T: Array + Send + Sync + 'static> FromReflect for SmallVec<T>
+impl<T: smallvec::Array + Send + Sync + 'static> FromReflect for SmallVec<T>
 where
     T::Item: FromReflect + Clone,
 {

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -43,7 +43,7 @@ where
 {
     fn push(&mut self, value: Box<dyn Reflect>) {
         let value = value.take::<T::Item>().unwrap_or_else(|value| {
-            <T as Array>::Item::from_reflect(&*value).unwrap_or_else(|| {
+            <T as smallvec::Array>::Item::from_reflect(&*value).unwrap_or_else(|| {
                 panic!(
                     "Attempted to push invalid value of type {}.",
                     value.type_name()
@@ -121,7 +121,7 @@ where
         if let ReflectRef::List(ref_list) = reflect.reflect_ref() {
             let mut new_list = Self::with_capacity(ref_list.len());
             for field in ref_list.iter() {
-                new_list.push(<T as Array>::Item::from_reflect(field)?);
+                new_list.push(<T as smallvec::Array>::Item::from_reflect(field)?);
             }
             Some(new_list)
         } else {

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,6 +1,6 @@
 use crate as bevy_reflect;
 use crate::{
-    map_partial_eq, serde::Serializable, Array, ArrayIter, DynamicMap, FromType, FromReflect,
+    map_partial_eq, serde::Serializable, Array, ArrayIter, DynamicMap, FromReflect, FromType,
     GetTypeRegistration, List, Map, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef,
     TypeRegistration,
 };
@@ -425,8 +425,8 @@ struct SerializeArrayLike<'a>(&'a dyn Array);
 
 impl<'a> serde::Serialize for SerializeArrayLike<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: serde::Serializer,
+    where
+        S: serde::Serializer,
     {
         crate::array_serialize(self.0, serializer)
     }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -435,7 +435,7 @@ impl<'a> serde::Serialize for SerializeArrayLike<'a> {
 // TODO:
 // `FromType::from_type` requires `Deserialize<'de>` to be implemented for `T`.
 // Currently serde only supports `Deserialize<'de>` for arrays up to size 32.
-// This can be change to used const generics once serde utilized const generics for arrays.
+// This can be changed to use const generics once serde utilizes const generics for arrays.
 // Tracking issue: https://github.com/serde-rs/serde/issues/1937
 macro_rules! impl_array_get_type_registration {
     ($($N:expr)+) => {

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -64,18 +64,22 @@ impl_from_reflect_value!(
 impl_from_reflect_value!(Duration);
 
 impl<T: FromReflect> Array for Vec<T> {
+    #[inline]
     fn get(&self, index: usize) -> Option<&dyn Reflect> {
         <[T]>::get(self, index).map(|value| value as &dyn Reflect)
     }
 
+    #[inline]
     fn get_mut(&mut self, index: usize) -> Option<&mut dyn Reflect> {
         <[T]>::get_mut(self, index).map(|value| value as &mut dyn Reflect)
     }
 
+    #[inline]
     fn len(&self) -> usize {
         <[T]>::len(self)
     }
 
+    #[inline]
     fn iter(&self) -> ArrayIter {
         ArrayIter {
             array: self,

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,8 +1,8 @@
 use crate as bevy_reflect;
 use crate::{
-    map_partial_eq, serde::Serializable, DynamicMap, FromReflect, FromType, GetTypeRegistration,
-    List, ListIter, Map, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef,
-    TypeRegistration,
+    map_partial_eq, serde::Serializable, Array, ArrayIter, DynamicMap, FromReflect, FromType,
+    GetTypeRegistration, List, ListIter, Map, MapIter, Reflect, ReflectDeserialize, ReflectMut,
+    ReflectRef, TypeRegistration,
 };
 
 use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_value};
@@ -304,6 +304,140 @@ impl<K: FromReflect + Eq + Hash, V: FromReflect> FromReflect for HashMap<K, V> {
             None
         }
     }
+}
+
+impl<T: Reflect, const N: usize> Array for [T; N] {
+    #[inline]
+    fn get(&self, index: usize) -> Option<&dyn Reflect> {
+        <[T]>::get(self, index).map(|value| value as &dyn Reflect)
+    }
+
+    #[inline]
+    fn get_mut(&mut self, index: usize) -> Option<&mut dyn Reflect> {
+        <[T]>::get_mut(self, index).map(|value| value as &mut dyn Reflect)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        N
+    }
+
+    #[inline]
+    fn iter(&self) -> ArrayIter {
+        ArrayIter {
+            array: self,
+            index: 0,
+        }
+    }
+}
+
+// SAFE: any and any_mut both return self
+unsafe impl<T: Reflect, const N: usize> Reflect for [T; N] {
+    #[inline]
+    fn type_name(&self) -> &str {
+        std::any::type_name::<Self>()
+    }
+
+    #[inline]
+    fn any(&self) -> &dyn Any {
+        self
+    }
+
+    #[inline]
+    fn any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    #[inline]
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    #[inline]
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    #[inline]
+    fn apply(&mut self, value: &dyn Reflect) {
+        crate::array_apply(self, value);
+    }
+
+    #[inline]
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+        *self = value.take()?;
+        Ok(())
+    }
+
+    #[inline]
+    fn reflect_ref(&self) -> ReflectRef {
+        ReflectRef::Array(self)
+    }
+
+    #[inline]
+    fn reflect_mut(&mut self) -> ReflectMut {
+        ReflectMut::Array(self)
+    }
+
+    #[inline]
+    fn clone_value(&self) -> Box<dyn Reflect> {
+        Box::new(self.clone_dynamic())
+    }
+
+    #[inline]
+    fn reflect_hash(&self) -> Option<u64> {
+        crate::array_hash(self)
+    }
+
+    #[inline]
+    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
+        crate::array_partial_eq(self, value)
+    }
+
+    #[inline]
+    fn serializable(&self) -> Option<Serializable> {
+        None
+    }
+}
+
+impl<T: FromReflect, const N: usize> FromReflect for [T; N] {
+    fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
+        if let ReflectRef::Array(ref_array) = reflect.reflect_ref() {
+            let mut temp_vec = Vec::with_capacity(ref_array.len());
+            for field in ref_array.iter() {
+                temp_vec.push(T::from_reflect(field)?);
+            }
+            temp_vec.try_into().ok()
+        } else {
+            None
+        }
+    }
+}
+
+// TODO:
+// `FromType::from_type` requires `Deserialize<'de>` to be implemented for `T`.
+// Currently serde only supports `Deserialize<'de>` for arrays up to size 32.
+// This can be change to used const generics once serde utilized const generics for arrays.
+// Tracking issue: https://github.com/serde-rs/serde/issues/1937
+macro_rules! impl_array_get_type_registration {
+    ($($N:expr)+) => {
+        $(
+            impl<T: Reflect + for<'de> Deserialize<'de>> GetTypeRegistration for [T; $N] {
+                fn get_type_registration() -> TypeRegistration {
+                    let mut registration = TypeRegistration::of::<[T; $N]>();
+                    registration.insert::<ReflectDeserialize>(FromType::<[T; $N]>::from_type());
+                    registration
+                }
+            }
+        )+
+    };
+}
+
+impl_array_get_type_registration! {
+     0  1  2  3  4  5  6  7  8  9
+    10 11 12 13 14 15 16 17 18 19
+    20 21 22 23 24 25 26 27 28 29
+    30 31 32
 }
 
 // SAFE: any and any_mut both return self

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,8 +1,8 @@
 use crate as bevy_reflect;
 use crate::{
-    map_partial_eq, serde::Serializable, Array, ArrayIter, DynamicMap, FromReflect, FromType,
-    GetTypeRegistration, List, ListIter, Map, MapIter, Reflect, ReflectDeserialize, ReflectMut,
-    ReflectRef, TypeRegistration,
+    map_partial_eq, serde::Serializable, Array, ArrayIter, DynamicMap, FromType, FromReflect,
+    GetTypeRegistration, List, Map, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef,
+    TypeRegistration,
 };
 
 use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_value};
@@ -63,7 +63,7 @@ impl_from_reflect_value!(
 );
 impl_from_reflect_value!(Duration);
 
-impl<T: FromReflect> List for Vec<T> {
+impl<T: FromReflect> Array for Vec<T> {
     fn get(&self, index: usize) -> Option<&dyn Reflect> {
         <[T]>::get(self, index).map(|value| value as &dyn Reflect)
     }
@@ -76,13 +76,15 @@ impl<T: FromReflect> List for Vec<T> {
         <[T]>::len(self)
     }
 
-    fn iter(&self) -> ListIter {
-        ListIter {
-            list: self,
+    fn iter(&self) -> ArrayIter {
+        ArrayIter {
+            array: self,
             index: 0,
         }
     }
+}
 
+impl<T: FromReflect> List for Vec<T> {
     fn push(&mut self, value: Box<dyn Reflect>) {
         let value = value.take::<T>().unwrap_or_else(|value| {
             T::from_reflect(&*value).unwrap_or_else(|| {
@@ -136,7 +138,7 @@ unsafe impl<T: FromReflect> Reflect for Vec<T> {
     }
 
     fn clone_value(&self) -> Box<dyn Reflect> {
-        Box::new(self.clone_dynamic())
+        Box::new(List::clone_dynamic(self))
     }
 
     fn reflect_hash(&self) -> Option<u64> {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 
+mod array;
 mod list;
 mod map;
 mod path;
@@ -35,6 +36,7 @@ pub mod prelude {
     };
 }
 
+pub use array::*;
 pub use impls::*;
 pub use list::*;
 pub use map::*;
@@ -240,6 +242,7 @@ mod tests {
             e: Bar,
             f: (i32, Vec<isize>, Bar),
             g: Vec<(Baz, HashMap<usize, Bar>)>,
+            h: [u32; 2],
         }
 
         #[derive(Reflect, Eq, PartialEq, Clone, Debug, FromReflect)]
@@ -266,6 +269,7 @@ mod tests {
             e: Bar { x: 1 },
             f: (1, vec![1, 2], Bar { x: 1 }),
             g: vec![(Baz("string".to_string()), hash_map_baz)],
+            h: [2; 2],
         };
 
         let mut foo_patch = DynamicStruct::default();
@@ -313,6 +317,9 @@ mod tests {
         });
         foo_patch.insert("g", composite);
 
+        let array = DynamicArray::new(vec![Box::new(2u32), Box::new(2u32)]);
+        foo_patch.insert("h", array);
+
         foo.apply(&foo_patch);
 
         let mut hash_map = HashMap::default();
@@ -330,6 +337,7 @@ mod tests {
             e: Bar { x: 2 },
             f: (2, vec![3, 4, 5], Bar { x: 2 }),
             g: vec![(Baz("new_string".to_string()), hash_map_baz.clone())],
+            h: [2; 2],
         };
 
         assert_eq!(foo, expected_foo);
@@ -348,6 +356,7 @@ mod tests {
             e: Bar { x: 2 },
             f: (2, vec![3, 4, 5], Bar { x: 2 }),
             g: vec![(Baz("new_string".to_string()), hash_map_baz)],
+            h: [2; 2],
         };
 
         assert_eq!(new_foo, expected_new_foo);
@@ -365,6 +374,7 @@ mod tests {
             e: Bar,
             f: String,
             g: (i32, Vec<isize>, Bar),
+            h: [u32; 2],
         }
 
         #[derive(Reflect)]
@@ -383,6 +393,7 @@ mod tests {
             e: Bar { x: 1 },
             f: "hi".to_string(),
             g: (1, vec![1, 2], Bar { x: 1 }),
+            h: [2; 2],
         };
 
         let mut registry = TypeRegistry::default();
@@ -423,6 +434,10 @@ mod tests {
         let list = Vec::<usize>::new();
         let dyn_list = list.clone_dynamic();
         assert_eq!(dyn_list.type_name(), std::any::type_name::<Vec<usize>>());
+
+        let array = [b'0'; 4];
+        let dyn_array = array.clone_dynamic();
+        assert_eq!(dyn_array.type_name(), std::any::type_name::<[u8; 4]>());
 
         let map = HashMap::<usize, String>::default();
         let dyn_map = map.clone_dynamic();

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -280,7 +280,7 @@ mod tests {
         list.push(3isize);
         list.push(4isize);
         list.push(5isize);
-        foo_patch.insert("c", list.clone_dynamic());
+        foo_patch.insert("c", List::clone_dynamic(&list));
 
         let mut map = DynamicMap::default();
         map.insert(2usize, 3i8);
@@ -317,7 +317,7 @@ mod tests {
         });
         foo_patch.insert("g", composite);
 
-        let array = DynamicArray::new(vec![Box::new(2u32), Box::new(2u32)]);
+        let array = DynamicArray::from_vec(vec![2u32, 2u32]);
         foo_patch.insert("h", array);
 
         foo.apply(&foo_patch);
@@ -432,11 +432,11 @@ mod tests {
     #[test]
     fn dynamic_names() {
         let list = Vec::<usize>::new();
-        let dyn_list = list.clone_dynamic();
+        let dyn_list = List::clone_dynamic(&list);
         assert_eq!(dyn_list.type_name(), std::any::type_name::<Vec<usize>>());
 
         let array = [b'0'; 4];
-        let dyn_array = array.clone_dynamic();
+        let dyn_array = Array::clone_dynamic(&array);
         assert_eq!(dyn_array.type_name(), std::any::type_name::<[u8; 4]>());
 
         let map = HashMap::<usize, String>::default();

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -157,7 +157,7 @@ unsafe impl Reflect for DynamicList {
 
     #[inline]
     fn reflect_hash(&self) -> Option<u64> {
-        None
+        crate::array_hash(self)
     }
 
     fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
@@ -165,7 +165,16 @@ unsafe impl Reflect for DynamicList {
     }
 
     fn serializable(&self) -> Option<Serializable> {
-        None
+        Some(Serializable::Borrowed(self))
+    }
+}
+
+impl serde::Serialize for DynamicList {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        crate::array_serialize(self, serializer)
     }
 }
 

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -241,8 +241,8 @@ pub fn list_partial_eq<L: List>(a: &L, b: &dyn Reflect) -> Option<bool> {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_eq;
     use super::DynamicList;
+    use std::assert_eq;
 
     #[test]
     fn test_into_iter() {

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -1,28 +1,14 @@
 use std::any::Any;
 
-use crate::{serde::Serializable, Reflect, ReflectMut, ReflectRef};
+use crate::{serde::Serializable, Array, ArrayIter, DynamicArray, Reflect, ReflectMut, ReflectRef};
 
 /// An ordered, mutable list of [Reflect] items. This corresponds to types like [`std::vec::Vec`].
-pub trait List: Reflect {
-    /// Returns a reference to the element at `index`, or `None` if out of bounds.
-    fn get(&self, index: usize) -> Option<&dyn Reflect>;
-
-    /// Returns a mutable reference to the element at `index`, or `None` if out of bounds.
-    fn get_mut(&mut self, index: usize) -> Option<&mut dyn Reflect>;
-
+///
+/// This is a sub-trait of [`Array`] as it implements a [`push`](List::push) function, allowing
+/// it's internal size to grow.
+pub trait List: Reflect + Array {
     /// Appends an element to the list.
     fn push(&mut self, value: Box<dyn Reflect>);
-
-    /// Returns the number of elements in the list.
-    fn len(&self) -> usize;
-
-    /// Returns `true` if the list contains no elements.
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Returns an iterator over the list.
-    fn iter(&self) -> ListIter;
 
     /// Clones the list, producing a [`DynamicList`].
     fn clone_dynamic(&self) -> DynamicList {
@@ -68,7 +54,7 @@ impl DynamicList {
     }
 }
 
-impl List for DynamicList {
+impl Array for DynamicList {
     fn get(&self, index: usize) -> Option<&dyn Reflect> {
         self.values.get(index).map(|value| &**value)
     }
@@ -81,6 +67,30 @@ impl List for DynamicList {
         self.values.len()
     }
 
+    fn iter(&self) -> ArrayIter {
+        ArrayIter {
+            array: self,
+            index: 0,
+        }
+    }
+
+    fn clone_dynamic(&self) -> DynamicArray {
+        DynamicArray {
+            name: self.name.clone(),
+            values: self
+                .values
+                .iter()
+                .map(|value| value.clone_value())
+                .collect(),
+        }
+    }
+}
+
+impl List for DynamicList {
+    fn push(&mut self, value: Box<dyn Reflect>) {
+        DynamicList::push_box(self, value);
+    }
+
     fn clone_dynamic(&self) -> DynamicList {
         DynamicList {
             name: self.name.clone(),
@@ -90,17 +100,6 @@ impl List for DynamicList {
                 .map(|value| value.clone_value())
                 .collect(),
         }
-    }
-
-    fn iter(&self) -> ListIter {
-        ListIter {
-            list: self,
-            index: 0,
-        }
-    }
-
-    fn push(&mut self, value: Box<dyn Reflect>) {
-        DynamicList::push_box(self, value);
     }
 }
 
@@ -153,7 +152,7 @@ unsafe impl Reflect for DynamicList {
 
     #[inline]
     fn clone_value(&self) -> Box<dyn Reflect> {
-        Box::new(self.clone_dynamic())
+        Box::new(List::clone_dynamic(self))
     }
 
     #[inline]
@@ -170,27 +169,6 @@ unsafe impl Reflect for DynamicList {
     }
 }
 
-/// An iterator over the elements of a [`List`].
-pub struct ListIter<'a> {
-    pub(crate) list: &'a dyn List,
-    pub(crate) index: usize,
-}
-
-impl<'a> Iterator for ListIter<'a> {
-    type Item = &'a dyn Reflect;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let value = self.list.get(self.index);
-        self.index += 1;
-        value
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let size = self.list.len();
-        (size, Some(size))
-    }
-}
-
 impl IntoIterator for DynamicList {
     type Item = Box<dyn Reflect>;
     type IntoIter = std::vec::IntoIter<Self::Item>;
@@ -199,8 +177,6 @@ impl IntoIterator for DynamicList {
         self.values.into_iter()
     }
 }
-
-impl<'a> ExactSizeIterator for ListIter<'a> {}
 
 /// Applies the elements of `b` to the corresponding elements of `a`.
 ///
@@ -256,6 +232,7 @@ pub fn list_partial_eq<L: List>(a: &L, b: &dyn Reflect) -> Option<bool> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_eq;
     use super::DynamicList;
 
     #[test]

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -1,4 +1,4 @@
-use crate::{serde::Serializable, List, Map, Struct, Tuple, TupleStruct};
+use crate::{serde::Serializable, Array, List, Map, Struct, Tuple, TupleStruct};
 use std::{any::Any, fmt::Debug};
 
 pub use bevy_utils::AHasher as ReflectHasher;
@@ -14,6 +14,7 @@ pub enum ReflectRef<'a> {
     TupleStruct(&'a dyn TupleStruct),
     Tuple(&'a dyn Tuple),
     List(&'a dyn List),
+    Array(&'a dyn Array),
     Map(&'a dyn Map),
     Value(&'a dyn Reflect),
 }
@@ -29,6 +30,7 @@ pub enum ReflectMut<'a> {
     TupleStruct(&'a mut dyn TupleStruct),
     Tuple(&'a mut dyn Tuple),
     List(&'a mut dyn List),
+    Array(&'a mut dyn Array),
     Map(&'a mut dyn Map),
     Value(&'a mut dyn Reflect),
 }

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -195,7 +195,7 @@ impl<'a, 'de> Visitor<'de> for ReflectVisitor<'a> {
                     return Ok(Box::new(list));
                 }
                 type_fields::ARRAY => {
-                    let _ = type_name
+                    let _type_name = type_name
                         .take()
                         .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
                     let array = map.next_value_seed(ArrayDeserializer {

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -1,6 +1,6 @@
 use crate::{
-    serde::type_fields, DynamicList, DynamicMap, DynamicStruct, DynamicTuple, DynamicTupleStruct,
-    Reflect, ReflectDeserialize, TypeRegistry,
+    serde::type_fields, DynamicArray, DynamicList, DynamicMap, DynamicStruct, DynamicTuple,
+    DynamicTupleStruct, Reflect, ReflectDeserialize, TypeRegistry,
 };
 use erased_serde::Deserializer;
 use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
@@ -194,6 +194,15 @@ impl<'a, 'de> Visitor<'de> for ReflectVisitor<'a> {
                     })?;
                     return Ok(Box::new(list));
                 }
+                type_fields::ARRAY => {
+                    let _ = type_name
+                        .take()
+                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
+                    let array = map.next_value_seed(ArrayDeserializer {
+                        registry: self.registry,
+                    })?;
+                    return Ok(Box::new(array));
+                }
                 type_fields::VALUE => {
                     let type_name = type_name
                         .take()
@@ -279,6 +288,49 @@ impl<'a, 'de> Visitor<'de> for ListVisitor<'a> {
             list.push_box(value);
         }
         Ok(list)
+    }
+}
+
+struct ArrayDeserializer<'a> {
+    registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> DeserializeSeed<'de> for ArrayDeserializer<'a> {
+    type Value = DynamicArray;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(ArrayVisitor {
+            registry: self.registry,
+        })
+    }
+}
+
+struct ArrayVisitor<'a> {
+    registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> Visitor<'de> for ArrayVisitor<'a> {
+    type Value = DynamicArray;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("array value")
+    }
+
+    fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
+    where
+        V: SeqAccess<'de>,
+    {
+        let mut vec = Vec::with_capacity(seq.size_hint().unwrap_or_default());
+        while let Some(value) = seq.next_element_seed(ReflectDeserializer {
+            registry: self.registry,
+        })? {
+            vec.push(value);
+        }
+
+        Ok(DynamicArray::new(vec))
     }
 }
 

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -330,7 +330,7 @@ impl<'a, 'de> Visitor<'de> for ArrayVisitor<'a> {
             vec.push(value);
         }
 
-        Ok(DynamicArray::new(vec))
+        Ok(DynamicArray::new(Box::from(vec)))
     }
 }
 

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -11,5 +11,6 @@ pub(crate) mod type_fields {
     pub const TUPLE_STRUCT: &str = "tuple_struct";
     pub const TUPLE: &str = "tuple";
     pub const LIST: &str = "list";
+    pub const ARRAY: &str = "array";
     pub const VALUE: &str = "value";
 }

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -1,5 +1,6 @@
 use crate::{
-    serde::type_fields, List, Map, Reflect, ReflectRef, Struct, Tuple, TupleStruct, TypeRegistry,
+    serde::type_fields, Array, List, Map, Reflect, ReflectRef, Struct, Tuple, TupleStruct,
+    TypeRegistry,
 };
 use serde::{
     ser::{SerializeMap, SerializeSeq},
@@ -64,6 +65,11 @@ impl<'a> Serialize for ReflectSerializer<'a> {
             .serialize(serializer),
             ReflectRef::List(value) => ListSerializer {
                 list: value,
+                registry: self.registry,
+            }
+            .serialize(serializer),
+            ReflectRef::Array(value) => ArraySerializer {
+                array: value,
                 registry: self.registry,
             }
             .serialize(serializer),
@@ -308,6 +314,47 @@ impl<'a> Serialize for ListValueSerializer<'a> {
     {
         let mut state = serializer.serialize_seq(Some(self.list.len()))?;
         for value in self.list.iter() {
+            state.serialize_element(&ReflectSerializer::new(value, self.registry))?;
+        }
+        state.end()
+    }
+}
+
+pub struct ArraySerializer<'a> {
+    pub array: &'a dyn Array,
+    pub registry: &'a TypeRegistry,
+}
+
+impl<'a> Serialize for ArraySerializer<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_map(Some(2))?;
+        state.serialize_entry(type_fields::TYPE, self.array.type_name())?;
+        state.serialize_entry(
+            type_fields::ARRAY,
+            &ArrayValueSerializer {
+                array: self.array,
+                registry: self.registry,
+            },
+        )?;
+        state.end()
+    }
+}
+
+pub struct ArrayValueSerializer<'a> {
+    pub array: &'a dyn Array,
+    pub registry: &'a TypeRegistry,
+}
+
+impl<'a> Serialize for ArrayValueSerializer<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_seq(Some(self.array.len()))?;
+        for value in self.array.iter() {
             state.serialize_element(&ReflectSerializer::new(value, self.registry))?;
         }
         state.end()

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -80,8 +80,8 @@ fn setup() {
         // arity 12 or less.
         ReflectRef::Tuple(_) => {}
         // `List` is a special trait that can be manually implemented (instead of deriving Reflect).
-        // This exposes "list" operations on your type, such as indexing and insertion. List
-        // is automatically implemented for relevant core types like Vec<T>
+        // This exposes "list" operations on your type, such as insertion. List is automatically
+        // implemented for relevant core types like Vec<T>
         ReflectRef::List(_) => {}
         // `Array` is a special trait that can be manually implemented (instead of deriving Reflect).
         // This exposes "array" operations on your type, such as indexing. `Array`

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -81,11 +81,11 @@ fn setup() {
         ReflectRef::Tuple(_) => {}
         // `List` is a special trait that can be manually implemented (instead of deriving Reflect).
         // This exposes "list" operations on your type, such as insertion. `List` is automatically
-        // implemented for relevant core types like Vec<T> and [T; 15].
+        // implemented for relevant core types like Vec<T>.
         ReflectRef::List(_) => {}
         // `Array` is a special trait that can be manually implemented (instead of deriving Reflect).
         // This exposes "array" operations on your type, such as indexing. `Array`
-        // is automatically implemented for relevant core types like [T; N]
+        // is automatically implemented for relevant core types like [T; N].
         ReflectRef::Array(_) => {}
         // `Map` is a special trait that can be manually implemented (instead of deriving Reflect).
         // This exposes "map" operations on your type, such as getting / inserting by key.

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -80,8 +80,8 @@ fn setup() {
         // arity 12 or less.
         ReflectRef::Tuple(_) => {}
         // `List` is a special trait that can be manually implemented (instead of deriving Reflect).
-        // This exposes "list" operations on your type, such as insertion. List is automatically
-        // implemented for relevant core types like Vec<T>
+        // This exposes "list" operations on your type, such as insertion. `List` is automatically
+        // implemented for relevant core types like Vec<T> and [T; 15].
         ReflectRef::List(_) => {}
         // `Array` is a special trait that can be manually implemented (instead of deriving Reflect).
         // This exposes "array" operations on your type, such as indexing. `Array`

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -83,6 +83,10 @@ fn setup() {
         // This exposes "list" operations on your type, such as indexing and insertion. List
         // is automatically implemented for relevant core types like Vec<T>
         ReflectRef::List(_) => {}
+        // `Array` is a special trait that can be manually implemented (instead of deriving Reflect).
+        // This exposes "array" operations on your type, such as indexing. `Array`
+        // is automatically implemented for relevant core types like [T; N]
+        ReflectRef::Array(_) => {}
         // `Map` is a special trait that can be manually implemented (instead of deriving Reflect).
         // This exposes "map" operations on your type, such as getting / inserting by key.
         // Map is automatically implemented for relevant core types like HashMap<K, V>


### PR DESCRIPTION
# Objective

> ℹ️ **Note**: This is a rebased version of #2383. A large portion of it has not been touched (only a few minor changes) so that any additional discussion may happen here. All credit should go to @NathanSWard for their work on the original PR.

- Currently reflection is not supported for arrays.
- Fixes #1213

## Solution

* Implement reflection for arrays via the `Array` trait.
* Note, `Array` is different from `List` in the way that you cannot push elements onto an array as they are statically sized.
* Now `List` is defined as a sub-trait of `Array`.

---

## Changelog

* Added the `Array` reflection trait
* Allows arrays up to length 32 to be reflected via the `Array` trait

## Migration Guide

* The `List` trait now has the `Array` supertrait. This means that `clone_dynamic` will need to specify which version to use:
  ```rust
  // Before
  let cloned = my_list.clone_dynamic();
  // After
  let cloned = List::clone_dynamic(&my_list);
  ```
* All implementers of `List` will now need to implement `Array` (this mostly involves moving the existing methods to the `Array` impl)