### PR TITLE
[Merged by Bors] - Add missing audio/ogg file extensions: .oga, .spx

### DIFF
--- a/crates/bevy_audio/src/audio_source.rs
+++ b/crates/bevy_audio/src/audio_source.rs
@@ -46,7 +46,11 @@ impl AssetLoader for AudioLoader {
             #[cfg(feature = "wav")]
             "wav",
             #[cfg(feature = "vorbis")]
+            "oga",
+            #[cfg(feature = "vorbis")]
             "ogg",
+            #[cfg(feature = "vorbis")]
+            "spx",
         ]
     }
 }


### PR DESCRIPTION
# Objective

- Add two missing ogg vorbis audio extensions. 

## Solution

- Add the two missing extensions to the list
  - The file format is the same, there are simply two other possible extensions files can use. 
  - This can be easily (manually) tested by renaming the extension of `assets/sounds/Windless Slopes.ogg` to end in either `.oga` or `.spx` (in both the filesystem and in `examples/audio/audio.rs`) and then running `cargo run --example audio` and observing that the music still plays.

## More info

From the [wikipedia article for Ogg](https://en.wikipedia.org/wiki/Ogg):

> Ogg audio media is registered as [IANA](https://en.wikipedia.org/wiki/Internet_Assigned_Numbers_Authority) [media type](https://en.wikipedia.org/wiki/Media_type) audio/ogg with file extensions .oga, .ogg, and [.spx](https://en.wikipedia.org/wiki/Speex).

The current workaround is to rename any files ending in `.oga` or `.spx` to end in `.ogg` instead, which complicates tracking assets procured from other organizations.

See also [a corresponding change to bevy_kira_audio](https://github.com/NiklasEi/bevy_kira_audio/pull/8)


---

## Changelog

### Added
- Vorbis audio files may now use the `.oga` and `.spx` filename extensions in addition to the more common `.ogg` filename extension.
