### PR TITLE
[Merged by Bors] - Support returning data out of with_children

### DIFF
--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -170,8 +170,10 @@ pub trait BuildChildren {
     fn with_children(&mut self, f: impl FnOnce(&mut ChildBuilder)) -> &mut Self;
     /// Creates a [`ChildBuilder`] with the given children built in the given closure
     ///
-    /// Compared to [`with_children`][BuildChildren::with_children], this method lets you
-    /// return data out of the closure like so:
+    /// Compared to [`with_children`][BuildChildren::with_children], this method returns the
+    /// the value returned from the closure, but doesn't  allow chaining.
+    /// 
+    /// ## Example
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -169,6 +169,32 @@ pub trait BuildChildren {
     /// Creates a [`ChildBuilder`] with the given children built in the given closure
     fn with_children(&mut self, f: impl FnOnce(&mut ChildBuilder)) -> &mut Self;
     /// Creates a [`ChildBuilder`] with the given children built in the given closure
+    ///
+    /// Compared to [`with_children`][BuildChildren::with_children], this method lets you
+    /// return data out of the closure like so:
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// # use bevy_hierarchy::*;
+    /// #
+    /// # #[derive(Component)]
+    /// # struct SomethingElse;
+    /// #
+    /// # #[derive(Component)]
+    /// # struct MoreStuff;
+    /// #
+    /// # fn foo(mut commands: Commands) {
+    ///     let mut parent_commands = commands.spawn();
+    ///     let child_id = parent_commands.add_children(|parent| {
+    ///         parent.spawn().id()
+    ///     });
+    ///
+    ///     parent_commands.insert(SomethingElse);
+    ///     commands.entity(child_id).with_children(|parent| {
+    ///         parent.spawn().insert(MoreStuff);
+    ///     });
+    /// # }
+    /// ```
     fn add_children<T>(&mut self, f: impl FnOnce(&mut ChildBuilder) -> T) -> T;
     /// Pushes children to the back of the builder's children
     fn push_children(&mut self, children: &[Entity]) -> &mut Self;

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -167,6 +167,9 @@ impl<'w, 's, 'a> ChildBuilder<'w, 's, 'a> {
 /// Trait defining how to build children
 pub trait BuildChildren {
     /// Creates a [`ChildBuilder`] with the given children built in the given closure
+    ///
+    /// Compared to [`add_children`][BuildChildren::add_children], this method returns self
+    /// to allow chaining.
     fn with_children(&mut self, f: impl FnOnce(&mut ChildBuilder)) -> &mut Self;
     /// Creates a [`ChildBuilder`] with the given children built in the given closure
     ///

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -186,7 +186,7 @@ pub trait BuildChildren<'w, 's, 'a> {
 /// Result of a [BuildChildren::with_children] call that provides access to the underlying commands
 /// and the closure's output.
 pub struct WithChildren<'w, 's, 'a, T> {
-    /// The output of the [BuildChildren::with_children] closure.
+    /// The output of the [`BuildChildren::with_children`] closure.
     pub out: T,
     commands: &'a mut EntityCommands<'w, 's, 'a>,
 }

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -183,7 +183,7 @@ pub trait BuildChildren<'w, 's, 'a> {
     fn add_child(&mut self, child: Entity) -> &mut Self;
 }
 
-/// Result of a [BuildChildren::with_children] call that provides access to the underlying commands
+/// Result of a [`BuildChildren::with_children`] call that provides access to the underlying commands
 /// and the closure's output.
 pub struct WithChildren<'w, 's, 'a, T> {
     /// The output of the [`BuildChildren::with_children`] closure.


### PR DESCRIPTION
# Objective

Support returning data out of with_children to enable the use case of changing the parent commands with data created inside the child builder.

## Solution

Change the with_children closure to return T.

Closes https://github.com/bevyengine/bevy/pull/2817.

---

## Changelog

`BuildChildren::add_children` was added with the ability to return data to use outside the closure (for spawning a new child builder on a returned entity for example).