### PR TITLE
[Merged by Bors] - Profile par_for_each(_mut) tasks

### DIFF
--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -847,7 +847,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         change_tick: u32,
     ) {
         #[cfg(feature = "trace")]
-        let span = bevy_utils::tracing::span::Span::current();
+        let span = bevy_utils::info_span!("par_for_each");
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
         // QueryIter, QueryIterationCursor, QueryState::for_each_unchecked_manual, QueryState::par_for_each_unchecked_manual
         task_pool.scope(|scope| {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -846,6 +846,8 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         last_change_tick: u32,
         change_tick: u32,
     ) {
+        #[cfg(feature = "trace")]
+        let span = bevy_utils::tracing::span::Span::current();
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
         // QueryIter, QueryIterationCursor, QueryState::for_each_unchecked_manual, QueryState::par_for_each_unchecked_manual
         task_pool.scope(|scope| {
@@ -856,7 +858,12 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
                     let mut offset = 0;
                     while offset < table.len() {
                         let func = func.clone();
+                        #[cfg(feature = "trace")]
+                        let subspan = span.clone();
                         scope.spawn(async move {
+                            #[cfg(feature = "trace")]
+                            let _span_guard = subspan.enter();
+
                             let mut fetch =
                                 QF::init(world, &self.fetch_state, last_change_tick, change_tick);
                             let mut filter = <QueryFetch<F> as Fetch>::init(
@@ -888,7 +895,12 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
                     let archetype = &archetypes[*archetype_id];
                     while offset < archetype.len() {
                         let func = func.clone();
+                        #[cfg(feature = "trace")]
+                        let subspan = span.clone();
                         scope.spawn(async move {
+                            #[cfg(feature = "trace")]
+                            let _span_guard = subspan.enter();
+
                             let mut fetch =
                                 QF::init(world, &self.fetch_state, last_change_tick, change_tick);
                             let mut filter = <QueryFetch<F> as Fetch>::init(

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -863,7 +863,8 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
                                 query = std::any::type_name::<Q>(),
                                 filter = std::any::type_name::<F>(),
                                 count = len,
-                            ).entered();
+                            )
+                            .entered();
 
                             let mut fetch =
                                 QF::init(world, &self.fetch_state, last_change_tick, change_tick);
@@ -903,7 +904,8 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
                                 query = std::any::type_name::<Q>(),
                                 filter = std::any::type_name::<F>(),
                                 count = len,
-                            ).entered();
+                            )
+                            .entered();
 
                             let mut fetch =
                                 QF::init(world, &self.fetch_state, last_change_tick, change_tick);

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -846,12 +846,6 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         last_change_tick: u32,
         change_tick: u32,
     ) {
-        #[cfg(feature = "trace")]
-        let span = bevy_utils::tracing::info_span!(
-            "par_for_each",
-            query = std::any::type_name::<Q>(),
-            filter = std::any::type_name::<F>(),
-        );
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
         // QueryIter, QueryIterationCursor, QueryState::for_each_unchecked_manual, QueryState::par_for_each_unchecked_manual
         task_pool.scope(|scope| {
@@ -862,11 +856,14 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
                     let mut offset = 0;
                     while offset < table.len() {
                         let func = func.clone();
-                        #[cfg(feature = "trace")]
-                        let subspan = span.clone();
                         scope.spawn(async move {
                             #[cfg(feature = "trace")]
-                            let _span_guard = subspan.enter();
+                            let _span_guard = bevy_utils::tracing::info_span!(
+                                "par_for_each",
+                                query = std::any::type_name::<Q>(),
+                                filter = std::any::type_name::<F>(),
+                                count = len,
+                            ).entered();
 
                             let mut fetch =
                                 QF::init(world, &self.fetch_state, last_change_tick, change_tick);

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -896,11 +896,14 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
                     let archetype = &archetypes[*archetype_id];
                     while offset < archetype.len() {
                         let func = func.clone();
-                        #[cfg(feature = "trace")]
-                        let subspan = span.clone();
                         scope.spawn(async move {
                             #[cfg(feature = "trace")]
-                            let _span_guard = subspan.enter();
+                            let _span_guard = bevy_utils::tracing::info_span!(
+                                "par_for_each",
+                                query = std::any::type_name::<Q>(),
+                                filter = std::any::type_name::<F>(),
+                                count = len,
+                            ).entered();
 
                             let mut fetch =
                                 QF::init(world, &self.fetch_state, last_change_tick, change_tick);

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -847,7 +847,11 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         change_tick: u32,
     ) {
         #[cfg(feature = "trace")]
-        let span = bevy_utils::info_span!("par_for_each");
+        let span = bevy_utils::tracing::info_span!(
+            "par_for_each",
+            query = std::any::type_name::<Q>(),
+            filter = std::any::type_name::<F>(),
+        );
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
         // QueryIter, QueryIterationCursor, QueryState::for_each_unchecked_manual, QueryState::par_for_each_unchecked_manual
         task_pool.scope(|scope| {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -11,6 +11,8 @@ use crate::{
     world::{World, WorldId},
 };
 use bevy_tasks::TaskPool;
+#[cfg(feature = "trace")]
+use bevy_utils::tracing::Instrument;
 use fixedbitset::FixedBitSet;
 use std::fmt;
 
@@ -856,16 +858,8 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
                     let mut offset = 0;
                     while offset < table.len() {
                         let func = func.clone();
-                        scope.spawn(async move {
-                            #[cfg(feature = "trace")]
-                            let _span_guard = bevy_utils::tracing::info_span!(
-                                "par_for_each",
-                                query = std::any::type_name::<Q>(),
-                                filter = std::any::type_name::<F>(),
-                                count = len,
-                            )
-                            .entered();
-
+                        let len = batch_size.min(table.len() - offset);
+                        let task = async move {
                             let mut fetch =
                                 QF::init(world, &self.fetch_state, last_change_tick, change_tick);
                             let mut filter = <QueryFetch<F> as Fetch>::init(
@@ -878,7 +872,6 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
                             let table = &tables[*table_id];
                             fetch.set_table(&self.fetch_state, table);
                             filter.set_table(&self.filter_state, table);
-                            let len = batch_size.min(table.len() - offset);
                             for table_index in offset..offset + len {
                                 if !filter.table_filter_fetch(table_index) {
                                     continue;
@@ -886,7 +879,17 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
                                 let item = fetch.table_fetch(table_index);
                                 func(item);
                             }
-                        });
+                        };
+                        #[cfg(feature = "trace")]
+                        let span = bevy_utils::tracing::info_span!(
+                            "par_for_each",
+                            query = std::any::type_name::<Q>(),
+                            filter = std::any::type_name::<F>(),
+                            count = len,
+                        );
+                        #[cfg(feature = "trace")]
+                        let task = task.instrument(span);
+                        scope.spawn(task);
                         offset += batch_size;
                     }
                 }
@@ -897,16 +900,8 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
                     let archetype = &archetypes[*archetype_id];
                     while offset < archetype.len() {
                         let func = func.clone();
-                        scope.spawn(async move {
-                            #[cfg(feature = "trace")]
-                            let _span_guard = bevy_utils::tracing::info_span!(
-                                "par_for_each",
-                                query = std::any::type_name::<Q>(),
-                                filter = std::any::type_name::<F>(),
-                                count = len,
-                            )
-                            .entered();
-
+                        let len = batch_size.min(archetype.len() - offset);
+                        let task = async move {
                             let mut fetch =
                                 QF::init(world, &self.fetch_state, last_change_tick, change_tick);
                             let mut filter = <QueryFetch<F> as Fetch>::init(
@@ -920,14 +915,25 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
                             fetch.set_archetype(&self.fetch_state, archetype, tables);
                             filter.set_archetype(&self.filter_state, archetype, tables);
 
-                            let len = batch_size.min(archetype.len() - offset);
                             for archetype_index in offset..offset + len {
                                 if !filter.archetype_filter_fetch(archetype_index) {
                                     continue;
                                 }
                                 func(fetch.archetype_fetch(archetype_index));
                             }
-                        });
+                        };
+
+                        #[cfg(feature = "trace")]
+                        let span = bevy_utils::tracing::info_span!(
+                            "par_for_each",
+                            query = std::any::type_name::<Q>(),
+                            filter = std::any::type_name::<F>(),
+                            count = len,
+                        );
+                        #[cfg(feature = "trace")]
+                        let task = task.instrument(span);
+
+                        scope.spawn(task);
                         offset += batch_size;
                     }
                 }


### PR DESCRIPTION
# Objective
`Query::par_for_each` and it's variants do not show up when profiling using `tracy` or other profilers. Failing to show the impact of changing batch size, the overhead of scheduling tasks, overall thread utilization, etc. other than the effect on the surrounding system.

## Solution
Add a child span that is entered on every spawned task.

Example view of the results in `tracy` using a modified `parallel_query`: 
![image](https://user-images.githubusercontent.com/3137680/167560036-626bd091-344b-4664-b323-b692f4f16084.png)

---

## Changelog
Added: `tracing` spans for `Query::par_for_each` and its variants. Spans should now be visible for all 