### PR TITLE
[Merged by Bors] - Tidy up the code of events

### DIFF
--- a/benches/benches/bevy_ecs/run_criteria.rs
+++ b/benches/benches/bevy_ecs/run_criteria.rs
@@ -2,7 +2,7 @@ use bevy_ecs::{
     component::Component,
     prelude::{ParallelSystemDescriptorCoercion, Res, RunCriteriaDescriptorCoercion},
     schedule::{ShouldRun, Stage, SystemStage},
-    system::{IntoSystem, Query},
+    system::Query,
     world::World,
 };
 use criterion::{criterion_group, criterion_main, Criterion};

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -131,6 +131,7 @@ struct EventInstance<E: Event> {
 #[derive(Debug)]
 pub struct Events<E: Event> {
     // Holds the oldest still active events
+    // Note that a.start_event_count + a.len() should always === events_b.start_event_count
     events_a: EventSequence<E>,
     // Holds the newer events
     events_b: EventSequence<E>,
@@ -416,6 +417,10 @@ impl<E: Event> Events<E> {
         std::mem::swap(&mut self.events_a, &mut self.events_b);
         self.events_b.clear();
         self.events_b.start_event_count = self.event_count;
+        debug_assert_eq!(
+            self.events_a.start_event_count + self.events_a.len(),
+            self.events_b.start_event_count
+        );
     }
 
     /// A system that calls [`Events::update`] once per frame.


### PR DESCRIPTION
# Objective

- The code in `events.rs` was a bit messy. There was lots of duplication between `EventReader` and `ManualEventReader`, and the state management code is not needed.

## Solution

- Clean it up.

## Future work

Should we remove the type parameter from `ManualEventReader`? 
It doesn't have any meaning outside of its source `Events`. But there's no real reason why it needs to have a type parameter - it's just plain data. I didn't remove it yet to keep the type safety in some of the users of it (primarily related to `&mut World` usage)