### PR TITLE
[Merged by Bors] - fix "unused" warnings when compiling with `render` feature but without `animation`

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -1,6 +1,4 @@
 use anyhow::Result;
-#[cfg(feature = "bevy_animation")]
-use bevy_animation::{AnimationClip, AnimationPlayer, EntityPath, Keyframes, VariableCurve};
 use bevy_asset::{
     AssetIoError, AssetLoader, AssetPath, BoxedFuture, Handle, LoadContext, LoadedAsset,
 };
@@ -8,7 +6,7 @@ use bevy_core::Name;
 use bevy_ecs::{entity::Entity, prelude::FromWorld, world::World};
 use bevy_hierarchy::{BuildWorldChildren, WorldChildBuilder};
 use bevy_log::warn;
-use bevy_math::{Mat4, Quat, Vec3};
+use bevy_math::{Mat4, Vec3};
 use bevy_pbr::{
     AlphaMode, DirectionalLight, DirectionalLightBundle, PbrBundle, PointLight, PointLightBundle,
     StandardMaterial,
@@ -40,6 +38,11 @@ use gltf::{
 };
 use std::{collections::VecDeque, path::Path};
 use thiserror::Error;
+
+#[cfg(feature = "bevy_animation")]
+use bevy_animation::{AnimationClip, AnimationPlayer, EntityPath, Keyframes, VariableCurve};
+#[cfg(feature = "bevy_animation")]
+use bevy_math::Quat;
 
 use crate::{Gltf, GltfNode};
 
@@ -539,6 +542,7 @@ fn node_name(node: &Node) -> Name {
     Name::new(name)
 }
 
+#[cfg(feature = "bevy_animation")]
 fn paths_recur(
     node: Node,
     current_path: &[Name],


### PR DESCRIPTION
# Objective
When running `cargo check --no-default-features --features render` I get
```rust
warning: unused import: `Quat`
  --> crates/bevy_gltf/src/loader.rs:11:23
   |
11 | use bevy_math::{Mat4, Quat, Vec3};
   |                       ^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: function is never used: `paths_recur`
   --> crates/bevy_gltf/src/loader.rs:542:4
    |
542 | fn paths_recur(
    |    ^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
```

## Solution

Put these items behind `#[cfg(feature = "animation")]`.