### PR TITLE
[Merged by Bors] - depend on dioxus(and bevy)-maintained fork of stretch (taffy)

### DIFF
--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -29,7 +29,7 @@ bevy_window = { path = "../bevy_window", version = "0.8.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 
 # other
-stretch2 = "0.4.2"
+stretch2 = { git = "https://github.com/mockersf/stretch/", branch = "remove_round_layout_changes" }
 serde = { version = "1", features = ["derive"] }
 smallvec = { version = "1.6", features = ["union", "const_generics"] }
 bytemuck = { version = "1.5", features = ["derive"] }

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -29,7 +29,7 @@ bevy_window = { path = "../bevy_window", version = "0.8.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 
 # other
-sprawl = { git = "https://github.com/colepoirier/sprawl.git" }
+sprawl = { git = "https://github.com/colepoirier/sprawl.git", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 smallvec = { version = "1.6", features = ["union", "const_generics"] }
 bytemuck = { version = "1.5", features = ["derive"] }

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -18,7 +18,9 @@ bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.8.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.8.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.8.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.8.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.8.0-dev", features = ["bevy"] }
+bevy_reflect = { path = "../bevy_reflect", version = "0.8.0-dev", features = [
+    "bevy",
+] }
 bevy_render = { path = "../bevy_render", version = "0.8.0-dev" }
 bevy_sprite = { path = "../bevy_sprite", version = "0.8.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.8.0-dev" }
@@ -27,7 +29,7 @@ bevy_window = { path = "../bevy_window", version = "0.8.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 
 # other
-stretch = "0.3.2"
+stretch2 = "0.4.2"
 serde = { version = "1", features = ["derive"] }
 smallvec = { version = "1.6", features = ["union", "const_generics"] }
 bytemuck = { version = "1.5", features = ["derive"] }

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -29,7 +29,7 @@ bevy_window = { path = "../bevy_window", version = "0.8.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 
 # other
-stretch2 = "0.4.3"
+sprawl = { git = "https://github.com/DioxusLabs/sprawl.git" }
 serde = { version = "1", features = ["derive"] }
 smallvec = { version = "1.6", features = ["union", "const_generics"] }
 bytemuck = { version = "1.5", features = ["derive"] }

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -29,7 +29,7 @@ bevy_window = { path = "../bevy_window", version = "0.8.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 
 # other
-stretch2 = { git = "https://github.com/mockersf/stretch/", branch = "remove_round_layout_changes" }
+stretch2 = "0.4.3"
 serde = { version = "1", features = ["derive"] }
 smallvec = { version = "1.6", features = ["union", "const_generics"] }
 bytemuck = { version = "1.5", features = ["derive"] }

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -29,7 +29,7 @@ bevy_window = { path = "../bevy_window", version = "0.8.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 
 # other
-sprawl = { git = "https://github.com/DioxusLabs/sprawl.git" }
+sprawl = { git = "https://github.com/colepoirier/sprawl.git" }
 serde = { version = "1", features = ["derive"] }
 smallvec = { version = "1.6", features = ["union", "const_generics"] }
 bytemuck = { version = "1.5", features = ["derive"] }

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -29,7 +29,7 @@ bevy_window = { path = "../bevy_window", version = "0.8.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 
 # other
-sprawl = { git = "https://github.com/colepoirier/sprawl.git", version = "0.1.0" }
+taffy = "0.1.0"
 serde = { version = "1", features = ["derive"] }
 smallvec = { version = "1.6", features = ["union", "const_generics"] }
 bytemuck = { version = "1.5", features = ["derive"] }

--- a/crates/bevy_ui/src/flex/convert.rs
+++ b/crates/bevy_ui/src/flex/convert.rs
@@ -6,8 +6,8 @@ use crate::{
 pub fn from_rect(
     scale_factor: f64,
     rect: UiRect<Val>,
-) -> stretch::geometry::Rect<stretch::style::Dimension> {
-    stretch::geometry::Rect {
+) -> stretch2::geometry::Rect<stretch2::style::Dimension> {
+    stretch2::geometry::Rect {
         start: from_val(scale_factor, rect.left),
         end: from_val(scale_factor, rect.right),
         // NOTE: top and bottom are intentionally flipped. stretch has a flipped y-axis
@@ -16,8 +16,8 @@ pub fn from_rect(
     }
 }
 
-pub fn from_f32_size(scale_factor: f64, size: Size<f32>) -> stretch::geometry::Size<f32> {
-    stretch::geometry::Size {
+pub fn from_f32_size(scale_factor: f64, size: Size<f32>) -> stretch2::geometry::Size<f32> {
+    stretch2::geometry::Size {
         width: (scale_factor * size.width as f64) as f32,
         height: (scale_factor * size.height as f64) as f32,
     }
@@ -26,16 +26,16 @@ pub fn from_f32_size(scale_factor: f64, size: Size<f32>) -> stretch::geometry::S
 pub fn from_val_size(
     scale_factor: f64,
     size: Size<Val>,
-) -> stretch::geometry::Size<stretch::style::Dimension> {
-    stretch::geometry::Size {
+) -> stretch2::geometry::Size<stretch2::style::Dimension> {
+    stretch2::geometry::Size {
         width: from_val(scale_factor, size.width),
         height: from_val(scale_factor, size.height),
     }
 }
 
-pub fn from_style(scale_factor: f64, value: &Style) -> stretch::style::Style {
-    stretch::style::Style {
-        overflow: stretch::style::Overflow::Visible,
+pub fn from_style(scale_factor: f64, value: &Style) -> stretch2::style::Style {
+    stretch2::style::Style {
+        overflow: stretch2::style::Overflow::Visible,
         display: value.display.into(),
         position_type: value.position_type.into(),
         direction: value.direction.into(),
@@ -56,117 +56,117 @@ pub fn from_style(scale_factor: f64, value: &Style) -> stretch::style::Style {
         min_size: from_val_size(scale_factor, value.min_size),
         max_size: from_val_size(scale_factor, value.max_size),
         aspect_ratio: match value.aspect_ratio {
-            Some(value) => stretch::number::Number::Defined(value),
-            None => stretch::number::Number::Undefined,
+            Some(value) => stretch2::number::Number::Defined(value),
+            None => stretch2::number::Number::Undefined,
         },
     }
 }
 
-pub fn from_val(scale_factor: f64, val: Val) -> stretch::style::Dimension {
+pub fn from_val(scale_factor: f64, val: Val) -> stretch2::style::Dimension {
     match val {
-        Val::Auto => stretch::style::Dimension::Auto,
-        Val::Percent(value) => stretch::style::Dimension::Percent(value / 100.0),
-        Val::Px(value) => stretch::style::Dimension::Points((scale_factor * value as f64) as f32),
-        Val::Undefined => stretch::style::Dimension::Undefined,
+        Val::Auto => stretch2::style::Dimension::Auto,
+        Val::Percent(value) => stretch2::style::Dimension::Percent(value / 100.0),
+        Val::Px(value) => stretch2::style::Dimension::Points((scale_factor * value as f64) as f32),
+        Val::Undefined => stretch2::style::Dimension::Undefined,
     }
 }
 
-impl From<AlignItems> for stretch::style::AlignItems {
+impl From<AlignItems> for stretch2::style::AlignItems {
     fn from(value: AlignItems) -> Self {
         match value {
-            AlignItems::FlexStart => stretch::style::AlignItems::FlexStart,
-            AlignItems::FlexEnd => stretch::style::AlignItems::FlexEnd,
-            AlignItems::Center => stretch::style::AlignItems::Center,
-            AlignItems::Baseline => stretch::style::AlignItems::Baseline,
-            AlignItems::Stretch => stretch::style::AlignItems::Stretch,
+            AlignItems::FlexStart => stretch2::style::AlignItems::FlexStart,
+            AlignItems::FlexEnd => stretch2::style::AlignItems::FlexEnd,
+            AlignItems::Center => stretch2::style::AlignItems::Center,
+            AlignItems::Baseline => stretch2::style::AlignItems::Baseline,
+            AlignItems::Stretch => stretch2::style::AlignItems::Stretch,
         }
     }
 }
 
-impl From<AlignSelf> for stretch::style::AlignSelf {
+impl From<AlignSelf> for stretch2::style::AlignSelf {
     fn from(value: AlignSelf) -> Self {
         match value {
-            AlignSelf::Auto => stretch::style::AlignSelf::Auto,
-            AlignSelf::FlexStart => stretch::style::AlignSelf::FlexStart,
-            AlignSelf::FlexEnd => stretch::style::AlignSelf::FlexEnd,
-            AlignSelf::Center => stretch::style::AlignSelf::Center,
-            AlignSelf::Baseline => stretch::style::AlignSelf::Baseline,
-            AlignSelf::Stretch => stretch::style::AlignSelf::Stretch,
+            AlignSelf::Auto => stretch2::style::AlignSelf::Auto,
+            AlignSelf::FlexStart => stretch2::style::AlignSelf::FlexStart,
+            AlignSelf::FlexEnd => stretch2::style::AlignSelf::FlexEnd,
+            AlignSelf::Center => stretch2::style::AlignSelf::Center,
+            AlignSelf::Baseline => stretch2::style::AlignSelf::Baseline,
+            AlignSelf::Stretch => stretch2::style::AlignSelf::Stretch,
         }
     }
 }
 
-impl From<AlignContent> for stretch::style::AlignContent {
+impl From<AlignContent> for stretch2::style::AlignContent {
     fn from(value: AlignContent) -> Self {
         match value {
-            AlignContent::FlexStart => stretch::style::AlignContent::FlexStart,
-            AlignContent::FlexEnd => stretch::style::AlignContent::FlexEnd,
-            AlignContent::Center => stretch::style::AlignContent::Center,
-            AlignContent::Stretch => stretch::style::AlignContent::Stretch,
-            AlignContent::SpaceBetween => stretch::style::AlignContent::SpaceBetween,
-            AlignContent::SpaceAround => stretch::style::AlignContent::SpaceAround,
+            AlignContent::FlexStart => stretch2::style::AlignContent::FlexStart,
+            AlignContent::FlexEnd => stretch2::style::AlignContent::FlexEnd,
+            AlignContent::Center => stretch2::style::AlignContent::Center,
+            AlignContent::Stretch => stretch2::style::AlignContent::Stretch,
+            AlignContent::SpaceBetween => stretch2::style::AlignContent::SpaceBetween,
+            AlignContent::SpaceAround => stretch2::style::AlignContent::SpaceAround,
         }
     }
 }
 
-impl From<Direction> for stretch::style::Direction {
+impl From<Direction> for stretch2::style::Direction {
     fn from(value: Direction) -> Self {
         match value {
-            Direction::Inherit => stretch::style::Direction::Inherit,
-            Direction::LeftToRight => stretch::style::Direction::LTR,
-            Direction::RightToLeft => stretch::style::Direction::RTL,
+            Direction::Inherit => stretch2::style::Direction::Inherit,
+            Direction::LeftToRight => stretch2::style::Direction::LTR,
+            Direction::RightToLeft => stretch2::style::Direction::RTL,
         }
     }
 }
 
-impl From<Display> for stretch::style::Display {
+impl From<Display> for stretch2::style::Display {
     fn from(value: Display) -> Self {
         match value {
-            Display::Flex => stretch::style::Display::Flex,
-            Display::None => stretch::style::Display::None,
+            Display::Flex => stretch2::style::Display::Flex,
+            Display::None => stretch2::style::Display::None,
         }
     }
 }
 
-impl From<FlexDirection> for stretch::style::FlexDirection {
+impl From<FlexDirection> for stretch2::style::FlexDirection {
     fn from(value: FlexDirection) -> Self {
         match value {
-            FlexDirection::Row => stretch::style::FlexDirection::Row,
-            FlexDirection::Column => stretch::style::FlexDirection::Column,
-            FlexDirection::RowReverse => stretch::style::FlexDirection::RowReverse,
-            FlexDirection::ColumnReverse => stretch::style::FlexDirection::ColumnReverse,
+            FlexDirection::Row => stretch2::style::FlexDirection::Row,
+            FlexDirection::Column => stretch2::style::FlexDirection::Column,
+            FlexDirection::RowReverse => stretch2::style::FlexDirection::RowReverse,
+            FlexDirection::ColumnReverse => stretch2::style::FlexDirection::ColumnReverse,
         }
     }
 }
 
-impl From<JustifyContent> for stretch::style::JustifyContent {
+impl From<JustifyContent> for stretch2::style::JustifyContent {
     fn from(value: JustifyContent) -> Self {
         match value {
-            JustifyContent::FlexStart => stretch::style::JustifyContent::FlexStart,
-            JustifyContent::FlexEnd => stretch::style::JustifyContent::FlexEnd,
-            JustifyContent::Center => stretch::style::JustifyContent::Center,
-            JustifyContent::SpaceBetween => stretch::style::JustifyContent::SpaceBetween,
-            JustifyContent::SpaceAround => stretch::style::JustifyContent::SpaceAround,
-            JustifyContent::SpaceEvenly => stretch::style::JustifyContent::SpaceEvenly,
+            JustifyContent::FlexStart => stretch2::style::JustifyContent::FlexStart,
+            JustifyContent::FlexEnd => stretch2::style::JustifyContent::FlexEnd,
+            JustifyContent::Center => stretch2::style::JustifyContent::Center,
+            JustifyContent::SpaceBetween => stretch2::style::JustifyContent::SpaceBetween,
+            JustifyContent::SpaceAround => stretch2::style::JustifyContent::SpaceAround,
+            JustifyContent::SpaceEvenly => stretch2::style::JustifyContent::SpaceEvenly,
         }
     }
 }
 
-impl From<PositionType> for stretch::style::PositionType {
+impl From<PositionType> for stretch2::style::PositionType {
     fn from(value: PositionType) -> Self {
         match value {
-            PositionType::Relative => stretch::style::PositionType::Relative,
-            PositionType::Absolute => stretch::style::PositionType::Absolute,
+            PositionType::Relative => stretch2::style::PositionType::Relative,
+            PositionType::Absolute => stretch2::style::PositionType::Absolute,
         }
     }
 }
 
-impl From<FlexWrap> for stretch::style::FlexWrap {
+impl From<FlexWrap> for stretch2::style::FlexWrap {
     fn from(value: FlexWrap) -> Self {
         match value {
-            FlexWrap::NoWrap => stretch::style::FlexWrap::NoWrap,
-            FlexWrap::Wrap => stretch::style::FlexWrap::Wrap,
-            FlexWrap::WrapReverse => stretch::style::FlexWrap::WrapReverse,
+            FlexWrap::NoWrap => stretch2::style::FlexWrap::NoWrap,
+            FlexWrap::Wrap => stretch2::style::FlexWrap::Wrap,
+            FlexWrap::WrapReverse => stretch2::style::FlexWrap::WrapReverse,
         }
     }
 }

--- a/crates/bevy_ui/src/flex/convert.rs
+++ b/crates/bevy_ui/src/flex/convert.rs
@@ -6,8 +6,8 @@ use crate::{
 pub fn from_rect(
     scale_factor: f64,
     rect: UiRect<Val>,
-) -> stretch2::geometry::Rect<stretch2::style::Dimension> {
-    stretch2::geometry::Rect {
+) -> sprawl::geometry::Rect<sprawl::style::Dimension> {
+    sprawl::geometry::Rect {
         start: from_val(scale_factor, rect.left),
         end: from_val(scale_factor, rect.right),
         // NOTE: top and bottom are intentionally flipped. stretch has a flipped y-axis
@@ -16,8 +16,8 @@ pub fn from_rect(
     }
 }
 
-pub fn from_f32_size(scale_factor: f64, size: Size<f32>) -> stretch2::geometry::Size<f32> {
-    stretch2::geometry::Size {
+pub fn from_f32_size(scale_factor: f64, size: Size<f32>) -> sprawl::geometry::Size<f32> {
+    sprawl::geometry::Size {
         width: (scale_factor * size.width as f64) as f32,
         height: (scale_factor * size.height as f64) as f32,
     }
@@ -26,16 +26,16 @@ pub fn from_f32_size(scale_factor: f64, size: Size<f32>) -> stretch2::geometry::
 pub fn from_val_size(
     scale_factor: f64,
     size: Size<Val>,
-) -> stretch2::geometry::Size<stretch2::style::Dimension> {
-    stretch2::geometry::Size {
+) -> sprawl::geometry::Size<sprawl::style::Dimension> {
+    sprawl::geometry::Size {
         width: from_val(scale_factor, size.width),
         height: from_val(scale_factor, size.height),
     }
 }
 
-pub fn from_style(scale_factor: f64, value: &Style) -> stretch2::style::Style {
-    stretch2::style::Style {
-        overflow: stretch2::style::Overflow::Visible,
+pub fn from_style(scale_factor: f64, value: &Style) -> sprawl::style::Style {
+    sprawl::style::Style {
+        overflow: sprawl::style::Overflow::Visible,
         display: value.display.into(),
         position_type: value.position_type.into(),
         direction: value.direction.into(),
@@ -56,117 +56,117 @@ pub fn from_style(scale_factor: f64, value: &Style) -> stretch2::style::Style {
         min_size: from_val_size(scale_factor, value.min_size),
         max_size: from_val_size(scale_factor, value.max_size),
         aspect_ratio: match value.aspect_ratio {
-            Some(value) => stretch2::number::Number::Defined(value),
-            None => stretch2::number::Number::Undefined,
+            Some(value) => sprawl::number::Number::Defined(value),
+            None => sprawl::number::Number::Undefined,
         },
     }
 }
 
-pub fn from_val(scale_factor: f64, val: Val) -> stretch2::style::Dimension {
+pub fn from_val(scale_factor: f64, val: Val) -> sprawl::style::Dimension {
     match val {
-        Val::Auto => stretch2::style::Dimension::Auto,
-        Val::Percent(value) => stretch2::style::Dimension::Percent(value / 100.0),
-        Val::Px(value) => stretch2::style::Dimension::Points((scale_factor * value as f64) as f32),
-        Val::Undefined => stretch2::style::Dimension::Undefined,
+        Val::Auto => sprawl::style::Dimension::Auto,
+        Val::Percent(value) => sprawl::style::Dimension::Percent(value / 100.0),
+        Val::Px(value) => sprawl::style::Dimension::Points((scale_factor * value as f64) as f32),
+        Val::Undefined => sprawl::style::Dimension::Undefined,
     }
 }
 
-impl From<AlignItems> for stretch2::style::AlignItems {
+impl From<AlignItems> for sprawl::style::AlignItems {
     fn from(value: AlignItems) -> Self {
         match value {
-            AlignItems::FlexStart => stretch2::style::AlignItems::FlexStart,
-            AlignItems::FlexEnd => stretch2::style::AlignItems::FlexEnd,
-            AlignItems::Center => stretch2::style::AlignItems::Center,
-            AlignItems::Baseline => stretch2::style::AlignItems::Baseline,
-            AlignItems::Stretch => stretch2::style::AlignItems::Stretch,
+            AlignItems::FlexStart => sprawl::style::AlignItems::FlexStart,
+            AlignItems::FlexEnd => sprawl::style::AlignItems::FlexEnd,
+            AlignItems::Center => sprawl::style::AlignItems::Center,
+            AlignItems::Baseline => sprawl::style::AlignItems::Baseline,
+            AlignItems::Stretch => sprawl::style::AlignItems::Stretch,
         }
     }
 }
 
-impl From<AlignSelf> for stretch2::style::AlignSelf {
+impl From<AlignSelf> for sprawl::style::AlignSelf {
     fn from(value: AlignSelf) -> Self {
         match value {
-            AlignSelf::Auto => stretch2::style::AlignSelf::Auto,
-            AlignSelf::FlexStart => stretch2::style::AlignSelf::FlexStart,
-            AlignSelf::FlexEnd => stretch2::style::AlignSelf::FlexEnd,
-            AlignSelf::Center => stretch2::style::AlignSelf::Center,
-            AlignSelf::Baseline => stretch2::style::AlignSelf::Baseline,
-            AlignSelf::Stretch => stretch2::style::AlignSelf::Stretch,
+            AlignSelf::Auto => sprawl::style::AlignSelf::Auto,
+            AlignSelf::FlexStart => sprawl::style::AlignSelf::FlexStart,
+            AlignSelf::FlexEnd => sprawl::style::AlignSelf::FlexEnd,
+            AlignSelf::Center => sprawl::style::AlignSelf::Center,
+            AlignSelf::Baseline => sprawl::style::AlignSelf::Baseline,
+            AlignSelf::Stretch => sprawl::style::AlignSelf::Stretch,
         }
     }
 }
 
-impl From<AlignContent> for stretch2::style::AlignContent {
+impl From<AlignContent> for sprawl::style::AlignContent {
     fn from(value: AlignContent) -> Self {
         match value {
-            AlignContent::FlexStart => stretch2::style::AlignContent::FlexStart,
-            AlignContent::FlexEnd => stretch2::style::AlignContent::FlexEnd,
-            AlignContent::Center => stretch2::style::AlignContent::Center,
-            AlignContent::Stretch => stretch2::style::AlignContent::Stretch,
-            AlignContent::SpaceBetween => stretch2::style::AlignContent::SpaceBetween,
-            AlignContent::SpaceAround => stretch2::style::AlignContent::SpaceAround,
+            AlignContent::FlexStart => sprawl::style::AlignContent::FlexStart,
+            AlignContent::FlexEnd => sprawl::style::AlignContent::FlexEnd,
+            AlignContent::Center => sprawl::style::AlignContent::Center,
+            AlignContent::Stretch => sprawl::style::AlignContent::Stretch,
+            AlignContent::SpaceBetween => sprawl::style::AlignContent::SpaceBetween,
+            AlignContent::SpaceAround => sprawl::style::AlignContent::SpaceAround,
         }
     }
 }
 
-impl From<Direction> for stretch2::style::Direction {
+impl From<Direction> for sprawl::style::Direction {
     fn from(value: Direction) -> Self {
         match value {
-            Direction::Inherit => stretch2::style::Direction::Inherit,
-            Direction::LeftToRight => stretch2::style::Direction::LTR,
-            Direction::RightToLeft => stretch2::style::Direction::RTL,
+            Direction::Inherit => sprawl::style::Direction::Inherit,
+            Direction::LeftToRight => sprawl::style::Direction::LTR,
+            Direction::RightToLeft => sprawl::style::Direction::RTL,
         }
     }
 }
 
-impl From<Display> for stretch2::style::Display {
+impl From<Display> for sprawl::style::Display {
     fn from(value: Display) -> Self {
         match value {
-            Display::Flex => stretch2::style::Display::Flex,
-            Display::None => stretch2::style::Display::None,
+            Display::Flex => sprawl::style::Display::Flex,
+            Display::None => sprawl::style::Display::None,
         }
     }
 }
 
-impl From<FlexDirection> for stretch2::style::FlexDirection {
+impl From<FlexDirection> for sprawl::style::FlexDirection {
     fn from(value: FlexDirection) -> Self {
         match value {
-            FlexDirection::Row => stretch2::style::FlexDirection::Row,
-            FlexDirection::Column => stretch2::style::FlexDirection::Column,
-            FlexDirection::RowReverse => stretch2::style::FlexDirection::RowReverse,
-            FlexDirection::ColumnReverse => stretch2::style::FlexDirection::ColumnReverse,
+            FlexDirection::Row => sprawl::style::FlexDirection::Row,
+            FlexDirection::Column => sprawl::style::FlexDirection::Column,
+            FlexDirection::RowReverse => sprawl::style::FlexDirection::RowReverse,
+            FlexDirection::ColumnReverse => sprawl::style::FlexDirection::ColumnReverse,
         }
     }
 }
 
-impl From<JustifyContent> for stretch2::style::JustifyContent {
+impl From<JustifyContent> for sprawl::style::JustifyContent {
     fn from(value: JustifyContent) -> Self {
         match value {
-            JustifyContent::FlexStart => stretch2::style::JustifyContent::FlexStart,
-            JustifyContent::FlexEnd => stretch2::style::JustifyContent::FlexEnd,
-            JustifyContent::Center => stretch2::style::JustifyContent::Center,
-            JustifyContent::SpaceBetween => stretch2::style::JustifyContent::SpaceBetween,
-            JustifyContent::SpaceAround => stretch2::style::JustifyContent::SpaceAround,
-            JustifyContent::SpaceEvenly => stretch2::style::JustifyContent::SpaceEvenly,
+            JustifyContent::FlexStart => sprawl::style::JustifyContent::FlexStart,
+            JustifyContent::FlexEnd => sprawl::style::JustifyContent::FlexEnd,
+            JustifyContent::Center => sprawl::style::JustifyContent::Center,
+            JustifyContent::SpaceBetween => sprawl::style::JustifyContent::SpaceBetween,
+            JustifyContent::SpaceAround => sprawl::style::JustifyContent::SpaceAround,
+            JustifyContent::SpaceEvenly => sprawl::style::JustifyContent::SpaceEvenly,
         }
     }
 }
 
-impl From<PositionType> for stretch2::style::PositionType {
+impl From<PositionType> for sprawl::style::PositionType {
     fn from(value: PositionType) -> Self {
         match value {
-            PositionType::Relative => stretch2::style::PositionType::Relative,
-            PositionType::Absolute => stretch2::style::PositionType::Absolute,
+            PositionType::Relative => sprawl::style::PositionType::Relative,
+            PositionType::Absolute => sprawl::style::PositionType::Absolute,
         }
     }
 }
 
-impl From<FlexWrap> for stretch2::style::FlexWrap {
+impl From<FlexWrap> for sprawl::style::FlexWrap {
     fn from(value: FlexWrap) -> Self {
         match value {
-            FlexWrap::NoWrap => stretch2::style::FlexWrap::NoWrap,
-            FlexWrap::Wrap => stretch2::style::FlexWrap::Wrap,
-            FlexWrap::WrapReverse => stretch2::style::FlexWrap::WrapReverse,
+            FlexWrap::NoWrap => sprawl::style::FlexWrap::NoWrap,
+            FlexWrap::Wrap => sprawl::style::FlexWrap::Wrap,
+            FlexWrap::WrapReverse => sprawl::style::FlexWrap::WrapReverse,
         }
     }
 }

--- a/crates/bevy_ui/src/flex/convert.rs
+++ b/crates/bevy_ui/src/flex/convert.rs
@@ -6,8 +6,8 @@ use crate::{
 pub fn from_rect(
     scale_factor: f64,
     rect: UiRect<Val>,
-) -> sprawl::geometry::Rect<sprawl::style::Dimension> {
-    sprawl::geometry::Rect {
+) -> taffy::geometry::Rect<taffy::style::Dimension> {
+    taffy::geometry::Rect {
         start: from_val(scale_factor, rect.left),
         end: from_val(scale_factor, rect.right),
         // NOTE: top and bottom are intentionally flipped. stretch has a flipped y-axis
@@ -16,8 +16,8 @@ pub fn from_rect(
     }
 }
 
-pub fn from_f32_size(scale_factor: f64, size: Size<f32>) -> sprawl::geometry::Size<f32> {
-    sprawl::geometry::Size {
+pub fn from_f32_size(scale_factor: f64, size: Size<f32>) -> taffy::geometry::Size<f32> {
+    taffy::geometry::Size {
         width: (scale_factor * size.width as f64) as f32,
         height: (scale_factor * size.height as f64) as f32,
     }
@@ -26,19 +26,17 @@ pub fn from_f32_size(scale_factor: f64, size: Size<f32>) -> sprawl::geometry::Si
 pub fn from_val_size(
     scale_factor: f64,
     size: Size<Val>,
-) -> sprawl::geometry::Size<sprawl::style::Dimension> {
-    sprawl::geometry::Size {
+) -> taffy::geometry::Size<taffy::style::Dimension> {
+    taffy::geometry::Size {
         width: from_val(scale_factor, size.width),
         height: from_val(scale_factor, size.height),
     }
 }
 
-pub fn from_style(scale_factor: f64, value: &Style) -> sprawl::style::Style {
-    sprawl::style::Style {
-        overflow: sprawl::style::Overflow::Visible,
+pub fn from_style(scale_factor: f64, value: &Style) -> taffy::style::Style {
+    taffy::style::Style {
         display: value.display.into(),
         position_type: value.position_type.into(),
-        direction: value.direction.into(),
         flex_direction: value.flex_direction.into(),
         flex_wrap: value.flex_wrap.into(),
         align_items: value.align_items.into(),
@@ -56,117 +54,107 @@ pub fn from_style(scale_factor: f64, value: &Style) -> sprawl::style::Style {
         min_size: from_val_size(scale_factor, value.min_size),
         max_size: from_val_size(scale_factor, value.max_size),
         aspect_ratio: match value.aspect_ratio {
-            Some(value) => sprawl::number::Number::Defined(value),
-            None => sprawl::number::Number::Undefined,
+            Some(value) => taffy::number::Number::Defined(value),
+            None => taffy::number::Number::Undefined,
         },
     }
 }
 
-pub fn from_val(scale_factor: f64, val: Val) -> sprawl::style::Dimension {
+pub fn from_val(scale_factor: f64, val: Val) -> taffy::style::Dimension {
     match val {
-        Val::Auto => sprawl::style::Dimension::Auto,
-        Val::Percent(value) => sprawl::style::Dimension::Percent(value / 100.0),
-        Val::Px(value) => sprawl::style::Dimension::Points((scale_factor * value as f64) as f32),
-        Val::Undefined => sprawl::style::Dimension::Undefined,
+        Val::Auto => taffy::style::Dimension::Auto,
+        Val::Percent(value) => taffy::style::Dimension::Percent(value / 100.0),
+        Val::Px(value) => taffy::style::Dimension::Points((scale_factor * value as f64) as f32),
+        Val::Undefined => taffy::style::Dimension::Undefined,
     }
 }
 
-impl From<AlignItems> for sprawl::style::AlignItems {
+impl From<AlignItems> for taffy::style::AlignItems {
     fn from(value: AlignItems) -> Self {
         match value {
-            AlignItems::FlexStart => sprawl::style::AlignItems::FlexStart,
-            AlignItems::FlexEnd => sprawl::style::AlignItems::FlexEnd,
-            AlignItems::Center => sprawl::style::AlignItems::Center,
-            AlignItems::Baseline => sprawl::style::AlignItems::Baseline,
-            AlignItems::Stretch => sprawl::style::AlignItems::Stretch,
+            AlignItems::FlexStart => taffy::style::AlignItems::FlexStart,
+            AlignItems::FlexEnd => taffy::style::AlignItems::FlexEnd,
+            AlignItems::Center => taffy::style::AlignItems::Center,
+            AlignItems::Baseline => taffy::style::AlignItems::Baseline,
+            AlignItems::Stretch => taffy::style::AlignItems::Stretch,
         }
     }
 }
 
-impl From<AlignSelf> for sprawl::style::AlignSelf {
+impl From<AlignSelf> for taffy::style::AlignSelf {
     fn from(value: AlignSelf) -> Self {
         match value {
-            AlignSelf::Auto => sprawl::style::AlignSelf::Auto,
-            AlignSelf::FlexStart => sprawl::style::AlignSelf::FlexStart,
-            AlignSelf::FlexEnd => sprawl::style::AlignSelf::FlexEnd,
-            AlignSelf::Center => sprawl::style::AlignSelf::Center,
-            AlignSelf::Baseline => sprawl::style::AlignSelf::Baseline,
-            AlignSelf::Stretch => sprawl::style::AlignSelf::Stretch,
+            AlignSelf::Auto => taffy::style::AlignSelf::Auto,
+            AlignSelf::FlexStart => taffy::style::AlignSelf::FlexStart,
+            AlignSelf::FlexEnd => taffy::style::AlignSelf::FlexEnd,
+            AlignSelf::Center => taffy::style::AlignSelf::Center,
+            AlignSelf::Baseline => taffy::style::AlignSelf::Baseline,
+            AlignSelf::Stretch => taffy::style::AlignSelf::Stretch,
         }
     }
 }
 
-impl From<AlignContent> for sprawl::style::AlignContent {
+impl From<AlignContent> for taffy::style::AlignContent {
     fn from(value: AlignContent) -> Self {
         match value {
-            AlignContent::FlexStart => sprawl::style::AlignContent::FlexStart,
-            AlignContent::FlexEnd => sprawl::style::AlignContent::FlexEnd,
-            AlignContent::Center => sprawl::style::AlignContent::Center,
-            AlignContent::Stretch => sprawl::style::AlignContent::Stretch,
-            AlignContent::SpaceBetween => sprawl::style::AlignContent::SpaceBetween,
-            AlignContent::SpaceAround => sprawl::style::AlignContent::SpaceAround,
+            AlignContent::FlexStart => taffy::style::AlignContent::FlexStart,
+            AlignContent::FlexEnd => taffy::style::AlignContent::FlexEnd,
+            AlignContent::Center => taffy::style::AlignContent::Center,
+            AlignContent::Stretch => taffy::style::AlignContent::Stretch,
+            AlignContent::SpaceBetween => taffy::style::AlignContent::SpaceBetween,
+            AlignContent::SpaceAround => taffy::style::AlignContent::SpaceAround,
         }
     }
 }
 
-impl From<Direction> for sprawl::style::Direction {
-    fn from(value: Direction) -> Self {
-        match value {
-            Direction::Inherit => sprawl::style::Direction::Inherit,
-            Direction::LeftToRight => sprawl::style::Direction::LTR,
-            Direction::RightToLeft => sprawl::style::Direction::RTL,
-        }
-    }
-}
-
-impl From<Display> for sprawl::style::Display {
+impl From<Display> for taffy::style::Display {
     fn from(value: Display) -> Self {
         match value {
-            Display::Flex => sprawl::style::Display::Flex,
-            Display::None => sprawl::style::Display::None,
+            Display::Flex => taffy::style::Display::Flex,
+            Display::None => taffy::style::Display::None,
         }
     }
 }
 
-impl From<FlexDirection> for sprawl::style::FlexDirection {
+impl From<FlexDirection> for taffy::style::FlexDirection {
     fn from(value: FlexDirection) -> Self {
         match value {
-            FlexDirection::Row => sprawl::style::FlexDirection::Row,
-            FlexDirection::Column => sprawl::style::FlexDirection::Column,
-            FlexDirection::RowReverse => sprawl::style::FlexDirection::RowReverse,
-            FlexDirection::ColumnReverse => sprawl::style::FlexDirection::ColumnReverse,
+            FlexDirection::Row => taffy::style::FlexDirection::Row,
+            FlexDirection::Column => taffy::style::FlexDirection::Column,
+            FlexDirection::RowReverse => taffy::style::FlexDirection::RowReverse,
+            FlexDirection::ColumnReverse => taffy::style::FlexDirection::ColumnReverse,
         }
     }
 }
 
-impl From<JustifyContent> for sprawl::style::JustifyContent {
+impl From<JustifyContent> for taffy::style::JustifyContent {
     fn from(value: JustifyContent) -> Self {
         match value {
-            JustifyContent::FlexStart => sprawl::style::JustifyContent::FlexStart,
-            JustifyContent::FlexEnd => sprawl::style::JustifyContent::FlexEnd,
-            JustifyContent::Center => sprawl::style::JustifyContent::Center,
-            JustifyContent::SpaceBetween => sprawl::style::JustifyContent::SpaceBetween,
-            JustifyContent::SpaceAround => sprawl::style::JustifyContent::SpaceAround,
-            JustifyContent::SpaceEvenly => sprawl::style::JustifyContent::SpaceEvenly,
+            JustifyContent::FlexStart => taffy::style::JustifyContent::FlexStart,
+            JustifyContent::FlexEnd => taffy::style::JustifyContent::FlexEnd,
+            JustifyContent::Center => taffy::style::JustifyContent::Center,
+            JustifyContent::SpaceBetween => taffy::style::JustifyContent::SpaceBetween,
+            JustifyContent::SpaceAround => taffy::style::JustifyContent::SpaceAround,
+            JustifyContent::SpaceEvenly => taffy::style::JustifyContent::SpaceEvenly,
         }
     }
 }
 
-impl From<PositionType> for sprawl::style::PositionType {
+impl From<PositionType> for taffy::style::PositionType {
     fn from(value: PositionType) -> Self {
         match value {
-            PositionType::Relative => sprawl::style::PositionType::Relative,
-            PositionType::Absolute => sprawl::style::PositionType::Absolute,
+            PositionType::Relative => taffy::style::PositionType::Relative,
+            PositionType::Absolute => taffy::style::PositionType::Absolute,
         }
     }
 }
 
-impl From<FlexWrap> for sprawl::style::FlexWrap {
+impl From<FlexWrap> for taffy::style::FlexWrap {
     fn from(value: FlexWrap) -> Self {
         match value {
-            FlexWrap::NoWrap => sprawl::style::FlexWrap::NoWrap,
-            FlexWrap::Wrap => sprawl::style::FlexWrap::Wrap,
-            FlexWrap::WrapReverse => sprawl::style::FlexWrap::WrapReverse,
+            FlexWrap::NoWrap => taffy::style::FlexWrap::NoWrap,
+            FlexWrap::Wrap => taffy::style::FlexWrap::Wrap,
+            FlexWrap::WrapReverse => taffy::style::FlexWrap::WrapReverse,
         }
     }
 }

--- a/crates/bevy_ui/src/flex/convert.rs
+++ b/crates/bevy_ui/src/flex/convert.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AlignContent, AlignItems, AlignSelf, Direction, Display, FlexDirection, FlexWrap,
-    JustifyContent, PositionType, Size, Style, UiRect, Val,
+    AlignContent, AlignItems, AlignSelf, Display, FlexDirection, FlexWrap, JustifyContent,
+    PositionType, Size, Style, UiRect, Val,
 };
 
 pub fn from_rect(

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -33,7 +33,7 @@ fn _assert_send_sync_flex_surface_impl_safe() {
     _assert_send_sync::<HashMap<Entity, taffy::node::Node>>();
     _assert_send_sync::<HashMap<WindowId, taffy::node::Node>>();
     // FIXME https://github.com/vislyhq/taffy/issues/69
-    // _assert_send_sync::<taffy>();
+    // _assert_send_sync::<Taffy>();
 }
 
 impl fmt::Debug for FlexSurface {

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -175,7 +175,7 @@ without UI components as a child of an entity with UI components, results may be
         }
     }
 
-    pub fn get_layout(&self, entity: Entity) -> Result<&sprawl::result::Layout, FlexError> {
+    pub fn get_layout(&self, entity: Entity) -> Result<&sprawl::layout::Layout, FlexError> {
         if let Some(sprawl_node) = self.entity_to_sprawl.get(&entity) {
             self.sprawl
                 .layout(*sprawl_node)

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -22,7 +22,7 @@ pub struct FlexSurface {
     taffy: Taffy,
 }
 
-// SAFE: as long as MeasureFunc is Send + Sync. https://github.com/vislyhq/stretch/issues/69
+// SAFE: as long as MeasureFunc is Send + Sync. https://github.com/DioxusLabs/taffy/issues/146
 // TODO: remove allow on lint - https://github.com/bevyengine/bevy/issues/3666
 #[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl Send for FlexSurface {}
@@ -32,7 +32,7 @@ fn _assert_send_sync_flex_surface_impl_safe() {
     fn _assert_send_sync<T: Send + Sync>() {}
     _assert_send_sync::<HashMap<Entity, taffy::node::Node>>();
     _assert_send_sync::<HashMap<WindowId, taffy::node::Node>>();
-    // FIXME https://github.com/vislyhq/stretch/issues/69
+    // FIXME https://github.com/DioxusLabs/taffy/issues/146
     // _assert_send_sync::<Taffy>();
 }
 

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -32,7 +32,7 @@ fn _assert_send_sync_flex_surface_impl_safe() {
     fn _assert_send_sync<T: Send + Sync>() {}
     _assert_send_sync::<HashMap<Entity, taffy::node::Node>>();
     _assert_send_sync::<HashMap<WindowId, taffy::node::Node>>();
-    // FIXME https://github.com/vislyhq/taffy/issues/69
+    // FIXME https://github.com/vislyhq/stretch/issues/69
     // _assert_send_sync::<Taffy>();
 }
 

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -22,7 +22,7 @@ pub struct FlexSurface {
     taffy: Taffy,
 }
 
-// SAFE: as long as MeasureFunc is Send + Sync. https://github.com/vislyhq/taffy/issues/69
+// SAFE: as long as MeasureFunc is Send + Sync. https://github.com/vislyhq/stretch/issues/69
 // TODO: remove allow on lint - https://github.com/bevyengine/bevy/issues/3666
 #[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl Send for FlexSurface {}

--- a/deny.toml
+++ b/deny.toml
@@ -25,11 +25,6 @@ allow = [
 ]
 default = "deny"
 
-[[licenses.clarify]]
-name = "stretch"
-expression = "MIT"
-license-files = []
-
 [bans]
 multiple-versions = "deny"
 wildcards = "deny"


### PR DESCRIPTION
# Objective

DioxusLabs and Bevy have taken over maintaining what was our abandoned ui layout dependency [stretch](https://github.com/vislyhq/stretch). Dioxus' fork has had a lot of work done on it by @alice-i-cecile, @Weibye , @jkelleyrtp, @mockersf, @HackerFoo, @TimJentzsch and a dozen other contributors and now is in much better shape than stretch was. The updated crate is called taffy and is available on github [here](https://github.com/DioxusLabs/taffy) ([taffy](https://crates.io/crates/taffy) on crates.io). The goal of this PR is to replace stretch v0.3.2 with taffy v0.1.0.

## Solution

I changed the bevy_ui Cargo.toml to depend on taffy instead of stretch and fixed all the errors rustc complained about.

---

## Changelog

Changed bevy_ui layout dependency from stretch to taffy (the maintained fork of stretch).

fixes #677

## Migration Guide

The public api of taffy is different from that of stretch so please advise me on what to do here @alice-i-cecile.
