### PR TITLE
[Merged by Bors] - Ensure that the parent is always the expected entity

### DIFF
--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -11,16 +11,21 @@ pub fn transform_propagate_system(
             &Transform,
             Changed<Transform>,
             &mut GlobalTransform,
+            Entity,
         ),
         Without<Parent>,
     >,
-    mut transform_query: Query<
-        (&Transform, Changed<Transform>, &mut GlobalTransform),
-        With<Parent>,
-    >,
+    mut transform_query: Query<(
+        &Transform,
+        Changed<Transform>,
+        &mut GlobalTransform,
+        &Parent,
+    )>,
     children_query: Query<(&Children, Changed<Children>), (With<Parent>, With<GlobalTransform>)>,
 ) {
-    for (children, transform, transform_changed, mut global_transform) in root_query.iter_mut() {
+    for (children, transform, transform_changed, mut global_transform, entity) in
+        root_query.iter_mut()
+    {
         let mut changed = transform_changed;
         if transform_changed {
             *global_transform = GlobalTransform::from(*transform);
@@ -35,6 +40,7 @@ pub fn transform_propagate_system(
                     &mut transform_query,
                     &children_query,
                     *child,
+                    entity,
                     changed,
                 );
             }
@@ -44,19 +50,26 @@ pub fn transform_propagate_system(
 
 fn propagate_recursive(
     parent: &GlobalTransform,
-    transform_query: &mut Query<
-        (&Transform, Changed<Transform>, &mut GlobalTransform),
-        With<Parent>,
-    >,
+    transform_query: &mut Query<(
+        &Transform,
+        Changed<Transform>,
+        &mut GlobalTransform,
+        &Parent,
+    )>,
     children_query: &Query<(&Children, Changed<Children>), (With<Parent>, With<GlobalTransform>)>,
     entity: Entity,
+    expected_parent: Entity,
     mut changed: bool,
     // We use a result here to use the `?` operator. Ideally we'd use a try block instead
 ) -> Result<(), ()> {
     let global_matrix = {
-        let (transform, transform_changed, mut global_transform) =
+        let (transform, transform_changed, mut global_transform, child_parent) =
             transform_query.get_mut(entity).map_err(drop)?;
-
+        // Note that for parallelising, this check cannot occur here, since there is an `&mut GlobalTransform` (in global_transform)
+        assert_eq!(
+            child_parent.0, expected_parent,
+            "Malformed hierarchy, cannot be used"
+        );
         changed |= transform_changed;
         if changed {
             *global_transform = parent.mul_transform(*transform);
@@ -73,6 +86,7 @@ fn propagate_recursive(
             transform_query,
             children_query,
             *child,
+            entity,
             changed,
         );
     }


### PR DESCRIPTION
# Objective

- Transform propogation could stack overflow when there was a cycle.
- I think https://github.com/bevyengine/bevy/pull/4203 would use all available memory.

## Solution

- Make sure that the child entity's `Parent`s are their parents.

This is also required for when parallelising, although as noted in the comment, the naïve solution would be UB.
(The best way to fix this would probably be an `&mut UnsafeCell<T>` `WorldQuery`, or wrapper type with the same effect)