### PR TITLE
Update to hashbrown 0.12

### DIFF
--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -13,7 +13,7 @@ ahash = "0.7.0"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 uuid = { version = "0.8", features = ["v4", "serde"] }
-hashbrown = { version = "0.11", features = ["serde"] }
+hashbrown = { version = "0.12", features = ["serde"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = {version = "0.2.0", features = ["js"]}


### PR DESCRIPTION
# Objective

- A new version of the `hashbrown` crate that we use for `HashSet` and `HashMap` is available
- This has some nice new toys, like [get_many_mut](https://docs.rs/hashbrown/latest/hashbrown/struct.HashMap.html#method.get_many_mut)

## Solution

- Bump our version number

## Context

Here's [hashbrown's changelog](https://github.com/rust-lang/hashbrown/blob/master/CHANGELOG.md).