### PR TITLE
Draft puffin_tracing support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ bevy_winit = ["bevy_internal/bevy_winit"]
 trace_chrome = ["trace", "bevy_internal/trace_chrome"]
 trace_tracy = ["trace", "bevy_internal/trace_tracy"]
 trace = ["bevy_internal/trace"]
+puffin_tracing = ["bevy_internal/puffin_tracing"]
 wgpu_trace = ["bevy_internal/wgpu_trace"]
 
 # Image format support for texture loading (PNG and HDR are enabled by default)

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -18,8 +18,9 @@ trace = [
     "bevy_render/trace",
     "bevy_hierarchy/trace"
 ]
-trace_chrome = [ "bevy_log/tracing-chrome" ]
+trace_chrome = ["bevy_log/tracing-chrome" ]
 trace_tracy = ["bevy_render/tracing-tracy", "bevy_log/tracing-tracy" ]
+puffin_tracing = ["bevy_log/puffin_tracing"]
 wgpu_trace = ["bevy_render/wgpu_trace"]
 debug_asset_server = ["bevy_asset/debug_asset_server"]
 

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-trace = [ "tracing-error" ]
+trace = [ "tracing-error"]
 
 [dependencies]
 bevy_app = { path = "../bevy_app", version = "0.8.0-dev" }
@@ -20,6 +20,7 @@ tracing-chrome = { version = "0.4.0", optional = true }
 tracing-tracy = { version = "0.8.0", optional = true }
 tracing-log = "0.1.2"
 tracing-error = { version = "0.2.0", optional = true }
+puffin_tracing = { version = "0.1", optional = true, git = "https://github.com/mvlabat/puffin.git", branch = "tracing" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_log-sys = "0.2.0"

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -162,6 +162,9 @@ impl Plugin for LogPlugin {
             #[cfg(feature = "tracing-tracy")]
             let tracy_layer = tracing_tracy::TracyLayer::new();
 
+            #[cfg(feature = "puffin_tracing")]
+            let puffin_layer = puffin_tracing::PuffinLayer::new();
+
             let fmt_layer = tracing_subscriber::fmt::Layer::default();
             #[cfg(feature = "tracing-tracy")]
             let fmt_layer = fmt_layer.with_filter(
@@ -174,6 +177,8 @@ impl Plugin for LogPlugin {
             let subscriber = subscriber.with(chrome_layer);
             #[cfg(feature = "tracing-tracy")]
             let subscriber = subscriber.with(tracy_layer);
+            #[cfg(feature = "puffin_tracing")]
+            let subscriber = subscriber.with(puffin_layer);
 
             bevy_utils::tracing::subscriber::set_global_default(subscriber)
                 .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");


### PR DESCRIPTION
# Objective

The purpose of this PR is to demonstrate how puffin support can be integrated into Bevy. Currently, this PR is based on my fork of the `puffin` library which implements a tracing layer for puffin: https://github.com/EmbarkStudios/puffin/pull/79. But regardless of whether the `tracing` support lands into `puffin` itself or it'll be an independent crate, it's possible for Bevy to integrate `puffin` as a `tracing` layer without replacing `tracing` with an alternative crate such as `profiling` or `puffin` itself (but it might still be worth to discuss those as well).

## Solution

The current approach is to add the `puffin_tracing` crate (which isn't published atm) as an optional dependency and introduce a feature which passes `PuffinLayer` as a `tracing-subscriber` layer. This implies that users will have to add `puffin`, `bevy_egui`, `puffin_egui` crates to their apps themselves so that Bevy can avoid depending on those directly.

It would be fair to note that such integration can also exist outside of Bevy as a plugin (today, I also published one: https://github.com/mvlabat/bevy_puffin). ~~But it doesn't offer an ideal UX, as it's incompatible with Bevy's `LogPlugin`, which renders it impossible to use the `DefaultPlugins` plugin group and makes users add those plugins manually.~~

Alternatively, we can also allow users to customize `LogPlugin` by passing their own layers.

## To discuss

I noted that this change doesn't make Bevy depend on `puffin` itself (only on `puffin_tracing`, which still transitively depends on `puffin` though), but there still might be a valid reason to do that. For example, we can add a system which would call `puffin::GlobalProfiler::lock().new_frame();`. As a counter-argument, users may want to control marking a new frame themselves, but I can't imagine the use-cases for that yet.