### PR TITLE
[Merged by Bors] - fix tracy frame marker placement (after preseting *all* windows)

### DIFF
--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -63,15 +63,15 @@ pub fn render_system(world: &mut World) {
                 if let Some(surface_texture) = texture_view.take_surface_texture() {
                     surface_texture.present();
                 }
-
-                #[cfg(feature = "tracing-tracy")]
-                bevy_utils::tracing::event!(
-                    bevy_utils::tracing::Level::INFO,
-                    message = "finished frame",
-                    tracy.frame_mark = true
-                );
             }
         }
+
+        #[cfg(feature = "tracing-tracy")]
+        bevy_utils::tracing::event!(
+            bevy_utils::tracing::Level::INFO,
+            message = "finished frame",
+            tracy.frame_mark = true
+        );
     }
 }
 


### PR DESCRIPTION
# Objective

The frame marker event was emitted in the loop of presenting all the windows. This would mark the frame as finished multiple times if more than one window is used.

## Solution

Move the frame marker to after the `for`-loop, so that it gets executed only once.