### PR TITLE
update time in render stage

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -53,13 +53,14 @@ impl Plugin for CorePlugin {
             .register_type::<Entity>()
             .register_type::<Name>()
             .register_type::<Range<f32>>()
-            .register_type::<Timer>()
-            // time system is added as an "exclusive system" to ensure it runs before other systems
-            // in CoreStage::First
-            .add_system_to_stage(
-                CoreStage::First,
-                time_system.exclusive_system().label(CoreSystem::Time),
-            );
+            .register_type::<Timer>();
+        // TODO: figure out how to add this when we don't have a render sub app
+        // time system is added as an "exclusive system" to ensure it runs before other systems
+        // in CoreStage::First
+        // .add_system_to_stage(
+        //     CoreStage::First,
+        //     time_system.exclusive_system().label(CoreSystem::Time),
+        // );
 
         register_rust_types(app);
         register_math_types(app);

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -19,6 +19,7 @@ trace = []
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.8.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.8.0-dev" }
+bevy_core = { path = "../bevy_core", version = "0.8.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.8.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.8.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -1,6 +1,7 @@
 mod graph_runner;
 mod render_device;
 
+use bevy_core::Time;
 use bevy_utils::tracing::{error, info, info_span};
 pub use graph_runner::*;
 pub use render_device::*;
@@ -72,6 +73,11 @@ pub fn render_system(world: &mut World) {
             message = "finished frame",
             tracy.frame_mark = true
         );
+    }
+
+    // update time after presenting frames
+    if let Some(mut time) = world.get_resource_mut::<Time>() {
+        time.update();
     }
 }
 


### PR DESCRIPTION
# Objective

- Reduce variability of Time resource
- Alternative to #4728. See that PR for more detail on what causes most of the variation. This PR should be closer to what we want to do when we have pipelined rendering.

## Solution

- Move time updates into the render system. This puts the time update as close in time to frame presentation as possible.
- Add a second extract stage after the render cleanup stage. This is required to move the time from the render world into the app world. Once we have pipelined rendering the two extract stages can be combined.

## Histograms of the different approaches

- main branch has 10x the standard deviation of the 2 PRs.  The 2 PRs are very similar in terms of median and standard deviation, but the distributions are a little different. Not sure what effect the difference in distributions would have.

![image](https://user-images.githubusercontent.com/2180432/168164389-6edf6f3a-6ac7-4a4e-b66b-608d6c0bbe12.png)

## TODO
- [ ] Figure out how to update the time when there is not a render sub app
- [ ] Changelog
- [ ] Migration Guide