### PR TITLE
[Merged by Bors] - bevy_ptr works in no_std environments

### DIFF
--- a/crates/bevy_ptr/Cargo.toml
+++ b/crates/bevy_ptr/Cargo.toml
@@ -6,6 +6,6 @@ description = "Utilities for working with untyped pointers in a more safe way"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
-keywords = ["bevy"]
+keywords = ["bevy", "no_std"]
 
 [dependencies]

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc = include_str!("../README.md")]
-use std::{cell::UnsafeCell, marker::PhantomData, mem::MaybeUninit, ptr::NonNull};
+#![no_std]
+#![warn(missing_docs)]
+
+use core::{cell::UnsafeCell, marker::PhantomData, mem::MaybeUninit, ptr::NonNull};
 
 /// Type-erased borrow of some unknown type chosen when constructing this type.
 ///
@@ -239,7 +242,7 @@ impl<'a, T> From<&'a [T]> for ThinSlicePtr<'a, T> {
 }
 
 mod private {
-    use std::cell::UnsafeCell;
+    use core::cell::UnsafeCell;
 
     pub trait SealedUnsafeCell {}
     impl<'a, T> SealedUnsafeCell for &'a UnsafeCell<T> {}


### PR DESCRIPTION
# Objective
`bevy_ptr` works just fine without `std`. Mark it as `no_std`. This should generally be useful for non-bevy use cases, but it also marginally speeds up compilation by allowing the crate to compile without loading the std-lib.

## Solution
Replace `std` with `core`. Added `#![no_std]` to the crate and to the crate's tags.

Also added a missing `#![warn(missing_docs)]` that the other crates have.