### PR TITLE
Naive garbage collection

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -306,6 +306,13 @@ impl Archetype {
             .map(|info| info.archetype_component_id)
     }
 
+    pub fn shrink_to_fit(&mut self) {
+        self.entities.shrink_to_fit();
+        for component in self.unique_components.values_mut() {
+            component.shrink_to_fit();
+        }
+    }
+
     pub(crate) fn clear_entities(&mut self) {
         self.entities.clear();
         self.table_info.entity_rows.clear();
@@ -511,6 +518,13 @@ impl Archetypes {
                 ));
                 id
             })
+    }
+
+    pub fn shrink_to_fit(&mut self) {
+        self.archetypes.shrink_to_fit();
+        for archetype in self.archetypes.iter_mut() {
+            archetype.shrink_to_fit();
+        }
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/storage/mod.rs
+++ b/crates/bevy_ecs/src/storage/mod.rs
@@ -14,3 +14,10 @@ pub struct Storages {
     pub sparse_sets: SparseSets,
     pub tables: Tables,
 }
+
+impl Storages {
+    pub fn shrink_to_fit(&mut self) {
+        self.tables.shrink_to_fit();
+        self.sparse_sets.shrink_to_fit();
+    }
+}

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -220,6 +220,12 @@ impl ComponentSparseSet {
         }
     }
 
+    pub fn shrink_to_fit(&mut self) {
+        self.dense.shrink_to_fit();
+        self.ticks.shrink_to_fit();
+        self.entities.shrink_to_fit();
+    }
+
     pub(crate) fn check_change_ticks(&mut self, change_tick: u32) {
         for component_ticks in &mut self.ticks {
             component_ticks.get_mut().check_ticks(change_tick);
@@ -424,6 +430,12 @@ impl SparseSets {
     pub fn clear(&mut self) {
         for set in self.sets.values_mut() {
             set.clear();
+        }
+    }
+
+    pub fn shrink_to_fit(&mut self) {
+        for sparse_set in self.sets.values_mut() {
+            sparse_set.shrink_to_fit();
         }
     }
 

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -180,6 +180,14 @@ impl Column {
         self.ticks.clear();
     }
 
+    /// Shrinks the backing storage for the [`Column`] such that the `len == capacity`.
+    ///
+    /// This runs in `O(n)` time and may require reallocating the backing buffers.
+    pub fn shrink_to_fit(&mut self) {
+        self.data.shrink_to_fit();
+        self.ticks.shrink_to_fit();
+    }
+
     #[inline]
     pub(crate) fn check_change_ticks(&mut self, change_tick: u32) {
         for component_ticks in &mut self.ticks {
@@ -399,6 +407,16 @@ impl Table {
         self.columns.values()
     }
 
+    /// Shrinks the backing storage for the [`Table`] such that the `len == capacity`.
+    ///
+    /// This runs in `O(n)` time and may require reallocating the backing buffers.
+    pub fn shrink_to_fit(&mut self) {
+        self.entities.shrink_to_fit();
+        for column in self.columns.values_mut() {
+            column.shrink_to_fit();
+        }
+    }
+
     pub fn clear(&mut self) {
         self.entities.clear();
         for column in self.columns.values_mut() {
@@ -497,6 +515,13 @@ impl Tables {
     pub fn clear(&mut self) {
         for table in &mut self.tables {
             table.clear();
+        }
+    }
+
+    pub fn shrink_to_fit(&mut self) {
+        self.tables.shrink_to_fit();
+        for table in &mut self.tables {
+            table.shrink_to_fit();
         }
     }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1280,6 +1280,18 @@ impl World {
         self.archetypes.clear_entities();
         self.entities.clear();
     }
+
+    /// Shrinks the backing storage for the [`World`].
+    ///
+    /// This can be a very expensive operation on large worlds. Runs in `O(n)` time in both
+    /// the number of archetypes, tables, and entities stored in the world.
+    pub fn shrink_to_fit(&mut self) {
+        self.archetypes.shrink_to_fit();
+        self.storages.shrink_to_fit();
+        for components in self.removed_components.values_mut() {
+            components.shrink_to_fit();
+        }
+    }
 }
 
 impl fmt::Debug for World {


### PR DESCRIPTION
# Objective
Right now, it's not possible to reclaim used memory from a `World`. Memory allocated to any `BlobVec` is only released after it grows beyond it's current capacity.

## Solution
Implement `BlobVec::shrink_to_fit` and work the way up to `World`. `World::shrink_to_fit` can be quite expensive to use, so it's not automatically used anywhere. Users can use this in an exclusive system periodically or at opportune moments (i.e. a loading screen) to release the memory used in ECS storage.

---

## Changelog
Added: `World::shrink_to_fit` to allow users to release any unused memory not currently used by the World's ECS storage.