### PR TITLE
Switch from &str to String in ReflectPathError

### DIFF
--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -5,11 +5,14 @@ use thiserror::Error;
 
 /// An error returned from a failed path string query.
 #[derive(Debug, PartialEq, Eq, Error)]
-pub enum ReflectPathError<'a> {
+pub enum ReflectPathError {
     #[error("expected an identifier at the given index")]
     ExpectedIdent { index: usize },
     #[error("the current struct doesn't have a field with the given name")]
-    InvalidField { index: usize, field: Cow<'a, str> },
+    InvalidField {
+        index: usize,
+        field: Cow<'static, str>,
+    },
     #[error("the current tuple struct doesn't have a field with the given index")]
     InvalidTupleStructIndex {
         index: usize,
@@ -18,9 +21,15 @@ pub enum ReflectPathError<'a> {
     #[error("the current list doesn't have a value at the given index")]
     InvalidListIndex { index: usize, list_index: usize },
     #[error("encountered an unexpected token")]
-    UnexpectedToken { index: usize, token: Cow<'a, str> },
+    UnexpectedToken {
+        index: usize,
+        token: Cow<'static, str>,
+    },
     #[error("expected a token, but it wasn't there.")]
-    ExpectedToken { index: usize, token: Cow<'a, str> },
+    ExpectedToken {
+        index: usize,
+        token: Cow<'static, str>,
+    },
     #[error("expected a struct, but found a different reflect value")]
     ExpectedStruct { index: usize },
     #[error("expected a list, but found a different reflect value")]
@@ -54,7 +63,7 @@ pub trait GetPath {
     ///
     /// To retrieve a statically typed reference, use
     /// [`get_path`][GetPath::get_path].
-    fn path<'r, 'p>(&'r self, path: &'p str) -> Result<&'r dyn Reflect, ReflectPathError<'p>>;
+    fn path<'r, 'p>(&'r self, path: &'p str) -> Result<&'r dyn Reflect, ReflectPathError>;
 
     /// Returns a mutable reference to the value specified by `path`.
     ///
@@ -63,13 +72,10 @@ pub trait GetPath {
     fn path_mut<'r, 'p>(
         &'r mut self,
         path: &'p str,
-    ) -> Result<&'r mut dyn Reflect, ReflectPathError<'p>>;
+    ) -> Result<&'r mut dyn Reflect, ReflectPathError>;
 
     /// Returns a statically typed reference to the value specified by `path`.
-    fn get_path<'r, 'p, T: Reflect>(
-        &'r self,
-        path: &'p str,
-    ) -> Result<&'r T, ReflectPathError<'p>> {
+    fn get_path<'r, 'p, T: Reflect>(&'r self, path: &'p str) -> Result<&'r T, ReflectPathError> {
         self.path(path).and_then(|p| {
             p.downcast_ref::<T>()
                 .ok_or(ReflectPathError::InvalidDowncast)
@@ -81,7 +87,7 @@ pub trait GetPath {
     fn get_path_mut<'r, 'p, T: Reflect>(
         &'r mut self,
         path: &'p str,
-    ) -> Result<&'r mut T, ReflectPathError<'p>> {
+    ) -> Result<&'r mut T, ReflectPathError> {
         self.path_mut(path).and_then(|p| {
             p.downcast_mut::<T>()
                 .ok_or(ReflectPathError::InvalidDowncast)
@@ -90,20 +96,20 @@ pub trait GetPath {
 }
 
 impl<T: Reflect> GetPath for T {
-    fn path<'r, 'p>(&'r self, path: &'p str) -> Result<&'r dyn Reflect, ReflectPathError<'p>> {
+    fn path<'r, 'p>(&'r self, path: &'p str) -> Result<&'r dyn Reflect, ReflectPathError> {
         (self as &dyn Reflect).path(path)
     }
 
     fn path_mut<'r, 'p>(
         &'r mut self,
         path: &'p str,
-    ) -> Result<&'r mut dyn Reflect, ReflectPathError<'p>> {
+    ) -> Result<&'r mut dyn Reflect, ReflectPathError> {
         (self as &mut dyn Reflect).path_mut(path)
     }
 }
 
 impl GetPath for dyn Reflect {
-    fn path<'r, 'p>(&'r self, path: &'p str) -> Result<&'r dyn Reflect, ReflectPathError<'p>> {
+    fn path<'r, 'p>(&'r self, path: &'p str) -> Result<&'r dyn Reflect, ReflectPathError> {
         let mut index = 0;
         let mut current: &dyn Reflect = self;
         while let Some(token) = next_token(path, &mut index) {
@@ -169,7 +175,7 @@ impl GetPath for dyn Reflect {
     fn path_mut<'r, 'p>(
         &'r mut self,
         path: &'p str,
-    ) -> Result<&'r mut dyn Reflect, ReflectPathError<'p>> {
+    ) -> Result<&'r mut dyn Reflect, ReflectPathError> {
         let mut index = 0;
         let mut current: &mut dyn Reflect = self;
         while let Some(token) = next_token(path, &mut index) {
@@ -237,14 +243,14 @@ fn read_field<'r, 'p>(
     current: &'r dyn Reflect,
     field: &'p str,
     current_index: usize,
-) -> Result<&'r dyn Reflect, ReflectPathError<'p>> {
+) -> Result<&'r dyn Reflect, ReflectPathError> {
     match current.reflect_ref() {
         ReflectRef::Struct(reflect_struct) => {
             Ok(reflect_struct
                 .field(field)
                 .ok_or(ReflectPathError::InvalidField {
                     index: current_index,
-                    field: field.into(),
+                    field: field.to_owned().into(), // possibly removable to_owned() ?
                 })?)
         }
         ReflectRef::TupleStruct(reflect_struct) => {
@@ -266,14 +272,14 @@ fn read_field_mut<'r, 'p>(
     current: &'r mut dyn Reflect,
     field: &'p str,
     current_index: usize,
-) -> Result<&'r mut dyn Reflect, ReflectPathError<'p>> {
+) -> Result<&'r mut dyn Reflect, ReflectPathError> {
     match current.reflect_mut() {
         ReflectMut::Struct(reflect_struct) => {
             Ok(reflect_struct
                 .field_mut(field)
                 .ok_or(ReflectPathError::InvalidField {
                     index: current_index,
-                    field: field.into(),
+                    field: field.to_owned().into(), // possibly removable to_owned() ?
                 })?)
         }
         ReflectMut::TupleStruct(reflect_struct) => {

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -5,11 +5,11 @@ use thiserror::Error;
 
 /// An error returned from a failed path string query.
 #[derive(Debug, PartialEq, Eq, Error)]
-pub enum ReflectPathError<'a> {
+pub enum ReflectPathError {
     #[error("expected an identifier at the given index")]
     ExpectedIdent { index: usize },
     #[error("the current struct doesn't have a field with the given name")]
-    InvalidField { index: usize, field: &'a str },
+    InvalidField { index: usize, field: String },
     #[error("the current tuple struct doesn't have a field with the given index")]
     InvalidTupleStructIndex {
         index: usize,
@@ -18,9 +18,9 @@ pub enum ReflectPathError<'a> {
     #[error("the current list doesn't have a value at the given index")]
     InvalidListIndex { index: usize, list_index: usize },
     #[error("encountered an unexpected token")]
-    UnexpectedToken { index: usize, token: &'a str },
+    UnexpectedToken { index: usize, token: String },
     #[error("expected a token, but it wasn't there.")]
-    ExpectedToken { index: usize, token: &'a str },
+    ExpectedToken { index: usize, token: String },
     #[error("expected a struct, but found a different reflect value")]
     ExpectedStruct { index: usize },
     #[error("expected a list, but found a different reflect value")]
@@ -54,7 +54,7 @@ pub trait GetPath {
     ///
     /// To retrieve a statically typed reference, use
     /// [`get_path`][GetPath::get_path].
-    fn path<'r, 'p>(&'r self, path: &'p str) -> Result<&'r dyn Reflect, ReflectPathError<'p>>;
+    fn path<'r, 'p>(&'r self, path: &'p str) -> Result<&'r dyn Reflect, ReflectPathError>;
 
     /// Returns a mutable reference to the value specified by `path`.
     ///
@@ -63,13 +63,13 @@ pub trait GetPath {
     fn path_mut<'r, 'p>(
         &'r mut self,
         path: &'p str,
-    ) -> Result<&'r mut dyn Reflect, ReflectPathError<'p>>;
+    ) -> Result<&'r mut dyn Reflect, ReflectPathError>;
 
     /// Returns a statically typed reference to the value specified by `path`.
     fn get_path<'r, 'p, T: Reflect>(
         &'r self,
         path: &'p str,
-    ) -> Result<&'r T, ReflectPathError<'p>> {
+    ) -> Result<&'r T, ReflectPathError> {
         self.path(path).and_then(|p| {
             p.downcast_ref::<T>()
                 .ok_or(ReflectPathError::InvalidDowncast)
@@ -81,7 +81,7 @@ pub trait GetPath {
     fn get_path_mut<'r, 'p, T: Reflect>(
         &'r mut self,
         path: &'p str,
-    ) -> Result<&'r mut T, ReflectPathError<'p>> {
+    ) -> Result<&'r mut T, ReflectPathError> {
         self.path_mut(path).and_then(|p| {
             p.downcast_mut::<T>()
                 .ok_or(ReflectPathError::InvalidDowncast)
@@ -90,20 +90,20 @@ pub trait GetPath {
 }
 
 impl<T: Reflect> GetPath for T {
-    fn path<'r, 'p>(&'r self, path: &'p str) -> Result<&'r dyn Reflect, ReflectPathError<'p>> {
+    fn path<'r, 'p>(&'r self, path: &'p str) -> Result<&'r dyn Reflect, ReflectPathError> {
         (self as &dyn Reflect).path(path)
     }
 
     fn path_mut<'r, 'p>(
         &'r mut self,
         path: &'p str,
-    ) -> Result<&'r mut dyn Reflect, ReflectPathError<'p>> {
+    ) -> Result<&'r mut dyn Reflect, ReflectPathError> {
         (self as &mut dyn Reflect).path_mut(path)
     }
 }
 
 impl GetPath for dyn Reflect {
-    fn path<'r, 'p>(&'r self, path: &'p str) -> Result<&'r dyn Reflect, ReflectPathError<'p>> {
+    fn path<'r, 'p>(&'r self, path: &'p str) -> Result<&'r dyn Reflect, ReflectPathError> {
         let mut index = 0;
         let mut current: &dyn Reflect = self;
         while let Some(token) = next_token(path, &mut index) {
@@ -147,14 +147,14 @@ impl GetPath for dyn Reflect {
                     } else {
                         return Err(ReflectPathError::ExpectedToken {
                             index: current_index,
-                            token: "]",
+                            token: "]".to_owned(),
                         });
                     }
                 }
                 Token::CloseBracket => {
                     return Err(ReflectPathError::UnexpectedToken {
                         index: current_index,
-                        token: "]",
+                        token: "]".to_owned(),
                     })
                 }
                 Token::Ident(value) => {
@@ -169,7 +169,7 @@ impl GetPath for dyn Reflect {
     fn path_mut<'r, 'p>(
         &'r mut self,
         path: &'p str,
-    ) -> Result<&'r mut dyn Reflect, ReflectPathError<'p>> {
+    ) -> Result<&'r mut dyn Reflect, ReflectPathError> {
         let mut index = 0;
         let mut current: &mut dyn Reflect = self;
         while let Some(token) = next_token(path, &mut index) {
@@ -213,14 +213,14 @@ impl GetPath for dyn Reflect {
                     } else {
                         return Err(ReflectPathError::ExpectedToken {
                             index: current_index,
-                            token: "]",
+                            token: "]".to_owned(),
                         });
                     }
                 }
                 Token::CloseBracket => {
                     return Err(ReflectPathError::UnexpectedToken {
                         index: current_index,
-                        token: "]",
+                        token: "]".to_owned(),
                     })
                 }
                 Token::Ident(value) => {
@@ -237,14 +237,14 @@ fn read_field<'r, 'p>(
     current: &'r dyn Reflect,
     field: &'p str,
     current_index: usize,
-) -> Result<&'r dyn Reflect, ReflectPathError<'p>> {
+) -> Result<&'r dyn Reflect, ReflectPathError> {
     match current.reflect_ref() {
         ReflectRef::Struct(reflect_struct) => {
             Ok(reflect_struct
                 .field(field)
                 .ok_or(ReflectPathError::InvalidField {
                     index: current_index,
-                    field,
+                    field:field.to_owned(),
                 })?)
         }
         ReflectRef::TupleStruct(reflect_struct) => {
@@ -266,14 +266,14 @@ fn read_field_mut<'r, 'p>(
     current: &'r mut dyn Reflect,
     field: &'p str,
     current_index: usize,
-) -> Result<&'r mut dyn Reflect, ReflectPathError<'p>> {
+) -> Result<&'r mut dyn Reflect, ReflectPathError> {
     match current.reflect_mut() {
         ReflectMut::Struct(reflect_struct) => {
             Ok(reflect_struct
                 .field_mut(field)
                 .ok_or(ReflectPathError::InvalidField {
                     index: current_index,
-                    field,
+                    field:field.to_owned(),
                 })?)
         }
         ReflectMut::TupleStruct(reflect_struct) => {
@@ -391,7 +391,7 @@ mod tests {
             a.path("x.notreal").err().unwrap(),
             ReflectPathError::InvalidField {
                 index: 2,
-                field: "notreal"
+                field: "notreal".to_owned()
             }
         );
 

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -279,7 +279,7 @@ fn read_field_mut<'r, 'p>(
                 .field_mut(field)
                 .ok_or(ReflectPathError::InvalidField {
                     index: current_index,
-                    field: field.to_owned().into(), // possibly removable to_owned() ?
+                    field: field.to_owned().into(),
                 })?)
         }
         ReflectMut::TupleStruct(reflect_struct) => {

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -250,7 +250,7 @@ fn read_field<'r, 'p>(
                 .field(field)
                 .ok_or(ReflectPathError::InvalidField {
                     index: current_index,
-                    field: field.to_owned().into(), // possibly removable to_owned() ?
+                    field: field.to_owned().into(),
                 })?)
         }
         ReflectRef::TupleStruct(reflect_struct) => {

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -66,10 +66,7 @@ pub trait GetPath {
     ) -> Result<&'r mut dyn Reflect, ReflectPathError>;
 
     /// Returns a statically typed reference to the value specified by `path`.
-    fn get_path<'r, 'p, T: Reflect>(
-        &'r self,
-        path: &'p str,
-    ) -> Result<&'r T, ReflectPathError> {
+    fn get_path<'r, 'p, T: Reflect>(&'r self, path: &'p str) -> Result<&'r T, ReflectPathError> {
         self.path(path).and_then(|p| {
             p.downcast_ref::<T>()
                 .ok_or(ReflectPathError::InvalidDowncast)
@@ -244,7 +241,7 @@ fn read_field<'r, 'p>(
                 .field(field)
                 .ok_or(ReflectPathError::InvalidField {
                     index: current_index,
-                    field:field.to_owned(),
+                    field: field.to_owned(),
                 })?)
         }
         ReflectRef::TupleStruct(reflect_struct) => {
@@ -273,7 +270,7 @@ fn read_field_mut<'r, 'p>(
                 .field_mut(field)
                 .ok_or(ReflectPathError::InvalidField {
                     index: current_index,
-                    field:field.to_owned(),
+                    field: field.to_owned(),
                 })?)
         }
         ReflectMut::TupleStruct(reflect_struct) => {

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -1,4 +1,4 @@
-use std::{num::ParseIntError,borrow::Cow};
+use std::{borrow::Cow, num::ParseIntError};
 
 use crate::{Reflect, ReflectMut, ReflectRef};
 use thiserror::Error;
@@ -9,7 +9,7 @@ pub enum ReflectPathError<'a> {
     #[error("expected an identifier at the given index")]
     ExpectedIdent { index: usize },
     #[error("the current struct doesn't have a field with the given name")]
-    InvalidField { index: usize, field: Cow<'a,str> },
+    InvalidField { index: usize, field: Cow<'a, str> },
     #[error("the current tuple struct doesn't have a field with the given index")]
     InvalidTupleStructIndex {
         index: usize,
@@ -18,9 +18,9 @@ pub enum ReflectPathError<'a> {
     #[error("the current list doesn't have a value at the given index")]
     InvalidListIndex { index: usize, list_index: usize },
     #[error("encountered an unexpected token")]
-    UnexpectedToken { index: usize, token: Cow<'a,str> },
+    UnexpectedToken { index: usize, token: Cow<'a, str> },
     #[error("expected a token, but it wasn't there.")]
-    ExpectedToken { index: usize, token: Cow<'a,str> },
+    ExpectedToken { index: usize, token: Cow<'a, str> },
     #[error("expected a struct, but found a different reflect value")]
     ExpectedStruct { index: usize },
     #[error("expected a list, but found a different reflect value")]
@@ -66,7 +66,10 @@ pub trait GetPath {
     ) -> Result<&'r mut dyn Reflect, ReflectPathError<'p>>;
 
     /// Returns a statically typed reference to the value specified by `path`.
-    fn get_path<'r, 'p, T: Reflect>(&'r self, path: &'p str) -> Result<&'r T, ReflectPathError<'p>> {
+    fn get_path<'r, 'p, T: Reflect>(
+        &'r self,
+        path: &'p str,
+    ) -> Result<&'r T, ReflectPathError<'p>> {
         self.path(path).and_then(|p| {
             p.downcast_ref::<T>()
                 .ok_or(ReflectPathError::InvalidDowncast)


### PR DESCRIPTION
# Objective

- ReflectPathError uses non-owned strings, meaning that often when returning errors lifetime issues are encountered.
- Things like the `?` operator need to often be used with `map_err` call to work 

## Solution

- Let the error type own the string, this increases ergonomics at negligible cost.
- I don't think these errors are thrown a lot (at least in my use case)

---

## Migration Guide

- Change type from &str to String in `InvalidField`, `UnexpectedToken` and `ExpectedToken` variants of `bevy_reflect::ReflectPathError`
