### PR TITLE
Despawn entity rather than removing component

### DIFF
--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -95,8 +95,8 @@ fn handle_tasks(
                 ..default()
             });
 
-            // Task is complete, so remove task component from entity
-            commands.entity(entity).remove::<ComputeTransform>();
+            // Task is complete, so remove the entity
+            commands.entity(entity).despawn();
         }
     }
 }


### PR DESCRIPTION
Removing the component from the entity would leave a dangling entity with no components attached to it, perhaps bevy optimizes this away internally but I think this looks cleaner.

# Objective

- Make example cleaner.


## Solution

- By despawning the entity rather than removing the component.

