### PR TITLE
[Merged by Bors] - helper tool to build examples in wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/bevyengine/bevy"
 
 [workspace]
 exclude = ["benches", "crates/bevy_ecs_compile_fail_tests"]
-members = ["crates/*", "examples/ios", "tools/ci", "tools/spancmp", "errors"]
+members = ["crates/*", "examples/ios", "tools/ci", "tools/spancmp", "tools/build-wasm-example", "errors"]
 
 [features]
 default = [

--- a/examples/README.md
+++ b/examples/README.md
@@ -422,7 +422,13 @@ cargo install wasm-bindgen-cli
 ### Build & Run
 
 Following is an example for `lighting`. For other examples, change the `lighting` in the
-following commands.
+following command.
+
+```sh
+cargo run -p build-wasm-example -- lighting
+```
+
+This is the same as running
 
 ```sh
 cargo build --release --example lighting --target wasm32-unknown-unknown

--- a/tools/build-wasm-example/Cargo.toml
+++ b/tools/build-wasm-example/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "build-wasm-example"
+version = "0.1.0"
+edition = "2021"
+description = "Build an example for wasm"
+publish = false
+license = "MIT OR Apache-2.0"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+xshell = "0.2"

--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -1,0 +1,18 @@
+use xshell::{cmd, Shell};
+
+fn main() {
+    let example = std::env::args().nth(1).expect("abbb");
+    let sh = Shell::new().unwrap();
+    cmd!(
+        sh,
+        "cargo build --release --target wasm32-unknown-unknown --example {example}"
+    )
+    .run()
+    .expect("Error building example");
+    cmd!(
+        sh,
+        "wasm-bindgen --out-dir examples/wasm/target --out-name wasm_example --target web target/wasm32-unknown-unknown/release/examples/{example}.wasm"
+    )
+    .run()
+    .expect("Error creating wasm binding");
+}


### PR DESCRIPTION
# Objective

- add an helper to build examples in wasm (from #4700)

## Solution

- `cargo run -p build-wasm-example -- lighting`
