### PR TITLE
[Merged by Bors] - remove `Serialize` impl for dyn Array and friends

### DIFF
--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -156,7 +156,7 @@ unsafe impl<T: FromReflect> Reflect for Vec<T> {
     }
 
     fn serializable(&self) -> Option<Serializable> {
-        Some(Serializable::Owned(Box::new(SerializeArrayLike(self))))
+        None
     }
 }
 
@@ -396,7 +396,7 @@ unsafe impl<T: Reflect, const N: usize> Reflect for [T; N] {
 
     #[inline]
     fn serializable(&self) -> Option<Serializable> {
-        Some(Serializable::Owned(Box::new(SerializeArrayLike(self))))
+        None
     }
 }
 
@@ -411,18 +411,6 @@ impl<T: FromReflect, const N: usize> FromReflect for [T; N] {
         } else {
             None
         }
-    }
-}
-
-// Supports dynamic serialization for types that implement `Array`.
-struct SerializeArrayLike<'a>(&'a dyn Array);
-
-impl<'a> serde::Serialize for SerializeArrayLike<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        crate::array_serialize(self.0, serializer)
     }
 }
 

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -166,7 +166,7 @@ unsafe impl Reflect for DynamicList {
     }
 
     fn serializable(&self) -> Option<Serializable> {
-        Some(Serializable::Borrowed(self))
+        None
     }
 
     fn debug(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -179,15 +179,6 @@ unsafe impl Reflect for DynamicList {
 impl Debug for DynamicList {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         self.debug(f)
-    }
-}
-
-impl serde::Serialize for DynamicList {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        crate::array_serialize(self, serializer)
     }
 }
 


### PR DESCRIPTION
# Objective

`bevy_reflect` as different kinds of reflected types (each with their own trait), `trait Struct: Reflect`, `trait List: Reflect`, `trait Map: Reflect`, ...
Types that don't fit either of those are called reflect value types, they are opaque and can't be deconstructed further.

`bevy_reflect` can serialize `dyn Reflect` values. Any container types (struct, list, map) get deconstructed and their elements serialized separately, which can all happen without serde being involved ever (happens [here](https://github.com/bevyengine/bevy/blob/main/crates/bevy_reflect/src/serde/ser.rs#L50-L85=)).
 The only point at which we require types to be serde-serializable is for *value types* (happens [here](https://github.com/bevyengine/bevy/blob/main/crates/bevy_reflect/src/serde/ser.rs#L104=)).

So reflect array serializing is solved, since arrays are container types which don't require serde.

#1213 also introduced added the `serialize` method and `Serialize` impls for `dyn Array` and `DynamicArray` which use their element's `Reflect::serializable` function. This is 1. unnecessary, because it is not used for array serialization, and 2. annoying for removing the `Serialize` bound on container types, because these impls don't have access to the `TypeRegistry`, so we can't move the serialization code there.

# Solution

Remove these impls and `fn serialize`. It's not used and annoying for other changes.