### PR TITLE
[Merged by Bors] - Copy TaskPool resoures to subapps

### DIFF
--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -19,6 +19,7 @@ bevy_derive = { path = "../bevy_derive", version = "0.8.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.8.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.8.0-dev", optional = true }
 bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
+bevy_tasks = { path = "../bevy_tasks", version = "0.8.0-dev" }
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -10,6 +10,7 @@ use bevy_ecs::{
     system::Resource,
     world::World,
 };
+use bevy_tasks::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool};
 use bevy_utils::{tracing::debug, HashMap};
 use std::fmt::Debug;
 
@@ -862,9 +863,18 @@ impl App {
     pub fn add_sub_app(
         &mut self,
         label: impl AppLabel,
-        app: App,
+        mut app: App,
         sub_app_runner: impl Fn(&mut World, &mut App) + 'static,
     ) -> &mut Self {
+        if let Some(pool) = self.world.get_resource::<ComputeTaskPool>() {
+            app.world.insert_resource(pool.clone());
+        }
+        if let Some(pool) = self.world.get_resource::<AsyncComputeTaskPool>() {
+            app.world.insert_resource(pool.clone());
+        }
+        if let Some(pool) = self.world.get_resource::<IoTaskPool>() {
+            app.world.insert_resource(pool.clone());
+        }
         self.sub_apps.insert(
             Box::new(label),
             SubApp {


### PR DESCRIPTION
# Objective
Fixes #4791. `ParallelExecutor` inserts a default `CompteTaskPool` if there isn't one stored as a resource, including when it runs on a different world. When spawning the render sub-app, the main world's `ComputeTaskPool` is not cloned and inserted into the render app's, which causes a second `ComputeTaskPool` with the default configuration to be spawned. This results in an excess number of threads being spawned.

## Solution
Copy the task pools from the main world to the subapps upon creating them.

## Alternative
An alternative to this would be to make the task pools global, as seen in #2250 or bevyengine/rfcs#54.