### PR TITLE
merge `matches_archetype` and `matches_table`

### DIFF
--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -279,12 +279,9 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
                 #(self.#field_idents.update_archetype_component_access(_archetype, _access);)*
             }
 
-            fn matches_archetype(&self, _archetype: &#path::archetype::Archetype) -> bool {
-                true #(&& self.#field_idents.matches_archetype(_archetype))*
-            }
+            fn matches_component_set(&self, _component_set: &#path::storage::SparseArray<#path::component::ComponentId, usize>) -> bool {
+                true #(&& self.#field_idents.matches_component_set(_component_set))*
 
-            fn matches_table(&self, _table: &#path::storage::Table) -> bool {
-                true #(&& self.#field_idents.matches_table(_table))*
             }
         }
     };

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -222,6 +222,11 @@ impl Archetype {
     }
 
     #[inline]
+    pub fn component_ids(&self) -> &SparseArray<ComponentId, usize> {
+        self.components.sparse_array()
+    }
+
+    #[inline]
     pub fn edges(&self) -> &Edges {
         &self.edges
     }

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -4,7 +4,7 @@ use crate::{
     component::{Component, ComponentId, ComponentStorage, ComponentTicks, StorageType},
     entity::Entity,
     query::{debug_checked_unreachable, Access, FilteredAccess},
-    storage::{ComponentSparseSet, Table, Tables},
+    storage::{ComponentSparseSet, SparseArray, Table, Tables},
     world::{Mut, World},
 };
 use bevy_ecs_macros::all_tuples;
@@ -431,8 +431,7 @@ pub unsafe trait FetchState: Send + Sync + Sized {
         archetype: &Archetype,
         access: &mut Access<ArchetypeComponentId>,
     );
-    fn matches_archetype(&self, archetype: &Archetype) -> bool;
-    fn matches_table(&self, table: &Table) -> bool;
+    fn matches_component_set(&self, component_set: &SparseArray<ComponentId, usize>) -> bool;
 }
 
 /// A fetch that is read only.
@@ -480,12 +479,7 @@ unsafe impl FetchState for EntityState {
     }
 
     #[inline]
-    fn matches_archetype(&self, _archetype: &Archetype) -> bool {
-        true
-    }
-
-    #[inline]
-    fn matches_table(&self, _table: &Table) -> bool {
+    fn matches_component_set(&self, _component_set: &SparseArray<ComponentId, usize>) -> bool {
         true
     }
 }
@@ -588,12 +582,8 @@ unsafe impl<T: Component> FetchState for ReadState<T> {
         }
     }
 
-    fn matches_archetype(&self, archetype: &Archetype) -> bool {
-        archetype.contains(self.component_id)
-    }
-
-    fn matches_table(&self, table: &Table) -> bool {
-        table.has_column(self.component_id)
+    fn matches_component_set(&self, component_set: &SparseArray<ComponentId, usize>) -> bool {
+        component_set.contains(self.component_id)
     }
 }
 
@@ -825,12 +815,8 @@ unsafe impl<T: Component> FetchState for WriteState<T> {
         }
     }
 
-    fn matches_archetype(&self, archetype: &Archetype) -> bool {
-        archetype.contains(self.component_id)
-    }
-
-    fn matches_table(&self, table: &Table) -> bool {
-        table.has_column(self.component_id)
+    fn matches_component_set(&self, component_set: &SparseArray<ComponentId, usize>) -> bool {
+        component_set.contains(self.component_id)
     }
 }
 
@@ -1105,17 +1091,13 @@ unsafe impl<T: FetchState> FetchState for OptionState<T> {
         archetype: &Archetype,
         access: &mut Access<ArchetypeComponentId>,
     ) {
-        if self.state.matches_archetype(archetype) {
+        if self.state.matches_component_set(archetype.component_ids()) {
             self.state
                 .update_archetype_component_access(archetype, access);
         }
     }
 
-    fn matches_archetype(&self, _archetype: &Archetype) -> bool {
-        true
-    }
-
-    fn matches_table(&self, _table: &Table) -> bool {
+    fn matches_component_set(&self, _component_set: &SparseArray<ComponentId, usize>) -> bool {
         true
     }
 }
@@ -1153,7 +1135,7 @@ impl<'w, T: Fetch<'w>> Fetch<'w> for OptionFetch<T> {
         archetype: &'w Archetype,
         tables: &'w Tables,
     ) {
-        self.matches = state.state.matches_archetype(archetype);
+        self.matches = state.state.matches_component_set(archetype.component_ids());
         if self.matches {
             self.fetch.set_archetype(&state.state, archetype, tables);
         }
@@ -1161,7 +1143,7 @@ impl<'w, T: Fetch<'w>> Fetch<'w> for OptionFetch<T> {
 
     #[inline]
     unsafe fn set_table(&mut self, state: &Self::State, table: &'w Table) {
-        self.matches = state.state.matches_table(table);
+        self.matches = state.state.matches_component_set(table.component_ids());
         if self.matches {
             self.fetch.set_table(&state.state, table);
         }
@@ -1297,12 +1279,8 @@ unsafe impl<T: Component> FetchState for ChangeTrackersState<T> {
         }
     }
 
-    fn matches_archetype(&self, archetype: &Archetype) -> bool {
-        archetype.contains(self.component_id)
-    }
-
-    fn matches_table(&self, table: &Table) -> bool {
-        table.has_column(self.component_id)
+    fn matches_component_set(&self, component_set: &SparseArray<ComponentId, usize>) -> bool {
+        component_set.contains(self.component_id)
     }
 }
 
@@ -1551,14 +1529,9 @@ macro_rules! impl_tuple_fetch {
                 $($name.update_archetype_component_access(_archetype, _access);)*
             }
 
-            fn matches_archetype(&self, _archetype: &Archetype) -> bool {
+            fn matches_component_set(&self, _component_set: &SparseArray<ComponentId, usize>) -> bool {
                 let ($($name,)*) = self;
-                true $(&& $name.matches_archetype(_archetype))*
-            }
-
-            fn matches_table(&self, _table: &Table) -> bool {
-                let ($($name,)*) = self;
-                true $(&& $name.matches_table(_table))*
+                true $(&& $name.matches_component_set(_component_set))*
             }
         }
 
@@ -1618,7 +1591,7 @@ macro_rules! impl_anytuple_fetch {
                 let ($($name,)*) = &mut self.0;
                 let ($($state,)*) = &_state.0;
                 $(
-                    $name.1 = $state.matches_archetype(_archetype);
+                    $name.1 = $state.matches_component_set(_archetype.component_ids());
                     if $name.1 {
                         $name.0.set_archetype($state, _archetype, _tables);
                     }
@@ -1630,7 +1603,7 @@ macro_rules! impl_anytuple_fetch {
                 let ($($name,)*) = &mut self.0;
                 let ($($state,)*) = &_state.0;
                 $(
-                    $name.1 = $state.matches_table(_table);
+                    $name.1 = $state.matches_component_set(_table.component_ids());
                     if $name.1 {
                         $name.0.set_table($state, _table);
                     }
@@ -1699,20 +1672,14 @@ macro_rules! impl_anytuple_fetch {
             fn update_archetype_component_access(&self, _archetype: &Archetype, _access: &mut Access<ArchetypeComponentId>) {
                 let ($($name,)*) = &self.0;
                 $(
-                    if $name.matches_archetype(_archetype) {
+                    if $name.matches_component_set(_archetype.component_ids()) {
                         $name.update_archetype_component_access(_archetype, _access);
                     }
                 )*
             }
-
-            fn matches_archetype(&self, _archetype: &Archetype) -> bool {
+            fn matches_component_set(&self, _component_set: &SparseArray<ComponentId, usize>) -> bool {
                 let ($($name,)*) = &self.0;
-                false $(|| $name.matches_archetype(_archetype))*
-            }
-
-            fn matches_table(&self, _table: &Table) -> bool {
-                let ($($name,)*) = &self.0;
-                false $(|| $name.matches_table(_table))*
+                false $(|| $name.matches_component_set(_component_set))*
             }
         }
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -115,8 +115,12 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
 
     /// Creates a new [`Archetype`].
     pub fn new_archetype(&mut self, archetype: &Archetype) {
-        if self.fetch_state.matches_archetype(archetype)
-            && self.filter_state.matches_archetype(archetype)
+        if self
+            .fetch_state
+            .matches_component_set(archetype.component_ids())
+            && self
+                .filter_state
+                .matches_component_set(archetype.component_ids())
         {
             self.fetch_state
                 .update_archetype_component_access(archetype, &mut self.archetype_component_access);

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -370,6 +370,10 @@ impl<I: SparseSetIndex, V> SparseSet<I, V> {
     pub fn values_mut(&mut self) -> impl Iterator<Item = &mut V> {
         self.dense.iter_mut()
     }
+
+    pub fn sparse_array(&self) -> &SparseArray<I, usize> {
+        &self.sparse
+    }
 }
 
 pub trait SparseSetIndex: Clone + PartialEq + Eq + Hash {

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -405,6 +405,10 @@ impl Table {
             column.clear();
         }
     }
+
+    pub fn component_ids(&self) -> &super::SparseArray<ComponentId, usize> {
+        self.columns.sparse_array()
+    }
 }
 
 /// A collection of [`Table`] storages, indexed by [`TableId`]


### PR DESCRIPTION
# Objective

the code in these fns are always identical so stop having two functions

## Solution

make them the same function

---

## Changelog

change `matches_archetype` and `matches_table` to `fn matches_component_set(&self, &SparseArray<ComponentId, usize>) -> bool` then do extremely boring updating of all `FetchState` impls

## Migration Guide

- move logic of `matches_archetype` and `matches_table` into `matches_component_set` in any manual `FetchState` impls
