### PR TITLE
[Merged by Bors] - shader examples wording coherence

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -241,6 +241,11 @@ Example | File | Description
 
 These examples demonstrate how to implement different shaders in user code.
 
+A shader in its most common usage is a small program that is run by the GPU per-vertex in a mesh (a vertex shader)
+or per-affected-screen-fragment (a fragment shader.) The GPU executes these programs in a highly parallel way.
+
+There are also compute shaders which are used for more general processing leveraging the GPU’s parallelism.
+
 Example | File | Description
 --- | --- | ---
 `animate_shader` | [`shader/animate_shader.rs`](./shader/animate_shader.rs) | A shader that uses dynamic data like the time since startup.

--- a/examples/README.md
+++ b/examples/README.md
@@ -239,16 +239,18 @@ Example | File | Description
 
 ## Shaders
 
+These examples demonstrate how to implement different shaders in user code.
+
 Example | File | Description
 --- | --- | ---
-`animate_shader` | [`shader/animate_shader.rs`](./shader/animate_shader.rs) | Shows how to pass changing data like the time since startup into a shader.
-`compute_shader_game_of_life` | [`shader/compute_shader_game_of_life.rs`](./shader/compute_shader_game_of_life.rs) | A compute shader simulating Conway's Game of Life
-`custom_vertex_attribute` | [`shader/custom_vertex_attribute.rs`](./shader/custom_vertex_attribute.rs) | Illustrates creating a custom shader material that reads a mesh's custom vertex attribute.
-`shader_defs` | [`shader/shader_defs.rs`](./shader/shader_defs.rs) | Demonstrates creating a custom material that uses "shaders defs" (a tool to selectively toggle parts of a shader)
-`shader_instancing` | [`shader/shader_instancing.rs`](./shader/shader_instancing.rs) | A custom shader showing off rendering a mesh multiple times in one draw call.
-`shader_material` | [`shader/shader_material.rs`](./shader/shader_material.rs) | Illustrates creating a custom material and a shader that uses it
-`shader_material_glsl` | [`shader/shader_material_glsl.rs`](./shader/shader_material_glsl.rs) | A custom shader using the GLSL shading language.
-`shader_material_screenspace_texture` | [`shader/shader_material_screenspace_texture.rs`](./shader/shader_material_screenspace_texture.rs) | A custom shader sampling a texture with view-independent UV coordinates.
+`animate_shader` | [`shader/animate_shader.rs`](./shader/animate_shader.rs) | A shader that uses dynamic data like the time since startup.
+`compute_shader_game_of_life` | [`shader/compute_shader_game_of_life.rs`](./shader/compute_shader_game_of_life.rs) | A compute shader that simulates Conway's Game of Life.
+`custom_vertex_attribute` | [`shader/custom_vertex_attribute.rs`](./shader/custom_vertex_attribute.rs) | A shader that reads a mesh's custom vertex attribute.
+`shader_defs` | [`shader/shader_defs.rs`](./shader/shader_defs.rs) | A shader that uses "shaders defs" (a bevy tool to selectively toggle parts of a shader).
+`shader_instancing` | [`shader/shader_instancing.rs`](./shader/shader_instancing.rs) | A shader that renders a mesh multiple times in one draw call.
+`shader_material` | [`shader/shader_material.rs`](./shader/shader_material.rs) | A shader and a material that uses it.
+`shader_material_glsl` | [`shader/shader_material_glsl.rs`](./shader/shader_material_glsl.rs) | A shader that uses the GLSL shading language.
+`shader_material_screenspace_texture` | [`shader/shader_material_screenspace_texture.rs`](./shader/shader_material_screenspace_texture.rs) | A shader that samples a texture with view-independent UV coordinates.
 
 ## Stress Tests
 

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -1,5 +1,6 @@
-//! Shows how to pass changing data like the time since startup into a shader, using a custom
-//! specialized pipeline.
+//! A shader that uses dynamic data like the time since startup.
+//!
+//! This example uses a specialized pipeline.
 
 use bevy::{
     core_pipeline::Transparent3d,

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -1,4 +1,4 @@
-//! A compute shader simulating Conway's Game of Life.
+//! A compute shader that simulates Conway's Game of Life.
 //!
 //! Compute shaders use the GPU for computing arbitrary information, that may be independent of what
 //! is rendered to the screen.

--- a/examples/shader/custom_vertex_attribute.rs
+++ b/examples/shader/custom_vertex_attribute.rs
@@ -1,4 +1,4 @@
-//! Illustrates creating a custom shader material that reads a mesh's custom vertex attribute.
+//! A shader that reads a mesh's custom vertex attribute.
 
 use bevy::{
     ecs::system::{lifetimeless::SRes, SystemParamItem},

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -1,5 +1,4 @@
-//! Demonstrates creating a custom material that uses "shaders defs", a tool that enables
-//! conditional compilation in shaders.
+//! A shader that uses "shaders defs" (a bevy tool to selectively toggle parts of a shader)
 
 use bevy::{
     core_pipeline::Transparent3d,
@@ -15,7 +14,7 @@ use bevy::{
         render_phase::{AddRenderCommand, DrawFunctions, RenderPhase, SetItemPipeline},
         render_resource::{
             PipelineCache, RenderPipelineDescriptor, SpecializedMeshPipeline,
-            SpecializedMeshPipelineError, SpecializedMeshPipelines,
+            SpecializedMeshPipelineError, SpecializedMeshPipelines, VertexState,
         },
         view::ExtractedView,
         RenderApp, RenderStage,

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -14,7 +14,7 @@ use bevy::{
         render_phase::{AddRenderCommand, DrawFunctions, RenderPhase, SetItemPipeline},
         render_resource::{
             PipelineCache, RenderPipelineDescriptor, SpecializedMeshPipeline,
-            SpecializedMeshPipelineError, SpecializedMeshPipelines, VertexState,
+            SpecializedMeshPipelineError, SpecializedMeshPipelines,
         },
         view::ExtractedView,
         RenderApp, RenderStage,

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -1,4 +1,4 @@
-//! A custom shader showing off rendering a mesh multiple times in one draw call.
+//! A shader that renders a mesh multiple times in one draw call.
 
 use bevy::{
     core_pipeline::Transparent3d,

--- a/examples/shader/shader_material.rs
+++ b/examples/shader/shader_material.rs
@@ -1,4 +1,4 @@
-//! Illustrates creating a custom material and a shader that uses it.
+//! A shader and a material that uses it.
 
 use bevy::{
     ecs::system::{lifetimeless::SRes, SystemParamItem},

--- a/examples/shader/shader_material_glsl.rs
+++ b/examples/shader/shader_material_glsl.rs
@@ -1,4 +1,4 @@
-//! A custom shader using the GLSL shading language.
+//! A shader that uses the GLSL shading language.
 
 use bevy::{
     ecs::system::{lifetimeless::SRes, SystemParamItem},

--- a/examples/shader/shader_material_screenspace_texture.rs
+++ b/examples/shader/shader_material_screenspace_texture.rs
@@ -1,4 +1,4 @@
-//! A custom shader sampling a texture with view-independent UV coordinates.
+//! A shader that samples a texture with view-independent UV coordinates.
 
 use bevy::{
     ecs::system::{lifetimeless::SRes, SystemParamItem},


### PR DESCRIPTION
# Objective

I noticed different examples descriptions were not using the same structure:
![different_wordings_examples](https://user-images.githubusercontent.com/2290685/169487055-ab76743e-3400-486f-b672-e8f60455b8e4.png)

This results in sentences that a reader has to read differently each time, which might result in information being hard to find, especially foreign language users.

Original discord discussion: https://discord.com/channels/691052431525675048/976846499889705020

## Solution

- Use less different words, similar structure and being straight to the point.

---

## Changelog

- Examples descriptions more accessible.