### PR TITLE
[Merged by Bors] - Use uniform buffer usage for `SkinnedMeshUniform` instead of all usages

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -715,9 +715,16 @@ pub fn queue_mesh_bind_group(
 // ignoring the rest, whether they're valid for other dynamic offsets or not. This trick may
 // be supported later in encase, and then we should make use of it.
 
-#[derive(Default)]
 pub struct SkinnedMeshUniform {
     pub buffer: BufferVec<Mat4>,
+}
+
+impl Default for SkinnedMeshUniform {
+    fn default() -> Self {
+        Self {
+            buffer: BufferVec::new(BufferUsages::UNIFORM),
+        }
+    }
 }
 
 pub fn prepare_skinned_meshes(

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -14,23 +14,14 @@ pub struct BufferVec<T: Pod> {
     buffer_usage: BufferUsages,
 }
 
-impl<T: Pod> Default for BufferVec<T> {
-    fn default() -> Self {
+impl<T: Pod> BufferVec<T> {
+    pub const fn new(buffer_usage: BufferUsages) -> Self {
         Self {
             values: Vec::new(),
             buffer: None,
             capacity: 0,
-            buffer_usage: BufferUsages::all(),
             item_size: std::mem::size_of::<T>(),
-        }
-    }
-}
-
-impl<T: Pod> BufferVec<T> {
-    pub fn new(buffer_usage: BufferUsages) -> Self {
-        Self {
             buffer_usage,
-            ..Default::default()
         }
     }
 


### PR DESCRIPTION
# Objective

fixes #4811 (caused by #4339 [[exact change](https://github.com/bevyengine/bevy/pull/4339/files#diff-4bf3ed03d4129aad9f5678ba19f9b14ee8e3e61d6f6365e82197b01c74468b10R712-R721)] - where the buffer type has been changed from `UniformVec` to `BufferVec`)

## Solution

Use uniform buffer usage for `SkinnedMeshUniform` instead of all usages due to the `Default` derive.

