### PR TITLE
Rename Color::as_hlsa_f32 to Color::as_hsla_f32

### DIFF
--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -491,8 +491,8 @@ impl Color {
         }
     }
 
-    /// Converts a `Color` to a `[f32; 4]` from HLS colorspace
-    pub fn as_hlsa_f32(self: Color) -> [f32; 4] {
+    /// Converts a `Color` to a `[f32; 4]` from HSL colorspace
+    pub fn as_hsla_f32(self: Color) -> [f32; 4] {
         match self {
             Color::Rgba {
                 red,


### PR DESCRIPTION
# Objective

Make the function consistent with returned values and `as_hsla` method

Fixes #4826 

## Solution

- Rename the method


## Migration Guide

- Rename the method
