### PR TITLE
[Merged by Bors] - remove unneeded msaa explicit addition from examples

### DIFF
--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -4,7 +4,6 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .run();

--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -4,7 +4,6 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .run();

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -5,7 +5,6 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(rotator_system)

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -26,8 +26,7 @@ pub const FIRST_PASS_DRIVER: &str = "first_pass_driver";
 
 fn main() {
     let mut app = App::new();
-    app.insert_resource(Msaa { samples: 4 }) // Use 4x MSAA
-        .add_plugins(DefaultPlugins)
+    app.add_plugins(DefaultPlugins)
         .add_plugin(CameraTypePlugin::<FirstPassCamera>::default())
         .add_startup_system(setup)
         .add_system(cube_rotator_system)

--- a/examples/3d/shapes.rs
+++ b/examples/3d/shapes.rs
@@ -8,7 +8,6 @@ use bevy::{
 
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(rotate)

--- a/examples/3d/two_passes.rs
+++ b/examples/3d/two_passes.rs
@@ -24,8 +24,7 @@ struct FirstPassCamera;
 
 fn main() {
     let mut app = App::new();
-    app.insert_resource(Msaa { samples: 4 })
-        .add_plugins(DefaultPlugins)
+    app.add_plugins(DefaultPlugins)
         .add_plugin(CameraTypePlugin::<FirstPassCamera>::default())
         .add_startup_system(setup)
         .add_system(cube_rotator_system)

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -5,7 +5,6 @@ use bevy::{prelude::*, scene::InstanceId};
 
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .init_resource::<SceneInstance>()
         .add_startup_system(setup)

--- a/examples/3d/vertex_colors.rs
+++ b/examples/3d/vertex_colors.rs
@@ -4,7 +4,6 @@ use bevy::{prelude::*, render::mesh::VertexAttributeValues};
 
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .run();

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -8,7 +8,6 @@ use bevy::{
 
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 4 })
         .insert_resource(WgpuSettings {
             features: WgpuFeatures::POLYGON_MODE_LINE,
             ..default()

--- a/examples/android/android.rs
+++ b/examples/android/android.rs
@@ -4,7 +4,6 @@ use bevy::prelude::*;
 #[bevy_main]
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 2 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .run();

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -4,7 +4,6 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .run();

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -11,7 +11,6 @@ use std::time::{Duration, Instant};
 
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup_env)
         .add_startup_system(add_assets)

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -10,7 +10,6 @@ const DELTA_TIME: f64 = 0.01;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .insert_resource(AmbientLight {
             brightness: 0.03,

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -11,7 +11,6 @@ enum GameState {
 
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 4 })
         .init_resource::<Game>()
         .add_plugins(DefaultPlugins)
         .add_state(GameState::Playing)

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -9,7 +9,6 @@ fn main() {
             mode: WindowMode::BorderlessFullscreen,
             ..default()
         })
-        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup_scene)
         .add_startup_system(setup_music)


### PR DESCRIPTION
# Objective

- Coming from https://github.com/bevyengine/bevy/pull/4797/files/7a596f1910c97c41f195b12d33025999e81dc0e5#r876310734
- Simplify the examples regarding addition of `Msaa` Resource with default value.

## Solution

- Remove addition of `Msaa` Resource with default value from examples, 