### PR TITLE
Garbage collect event memory

### DIFF
--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -59,6 +59,7 @@ struct EventInstance<E: Event> {
 
 /// Settings for controlling the general behavior of [`Events<T>`].
 pub struct EventSettings<T> {
+    /// Controls how and when the memory allocated for events will be freed
     pub garbage_collection: EventGarbageCollection,
     marker_: PhantomData<fn() -> T>,
 }

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -117,7 +117,7 @@ impl Default for EventGarbageCollection {
 ///
 /// # Example
 /// ```
-/// use bevy_ecs::event::Events;
+/// use bevy_ecs::event::*;
 ///
 /// struct MyEvent {
 ///     value: usize
@@ -126,9 +126,10 @@ impl Default for EventGarbageCollection {
 /// // setup
 /// let mut events = Events::<MyEvent>::default();
 /// let mut reader = events.get_reader();
+/// let settings = EventSettings::<MyEvent>::default();
 ///
 /// // run this once per update/frame
-/// events.update();
+/// events.update(&settings);
 ///
 /// // somewhere else: send an event
 /// events.send(MyEvent { value: 1 });
@@ -647,7 +648,7 @@ mod tests {
             "reader_a receives next unread event"
         );
 
-        events.update();
+        events.update(&Default::default());
 
         let mut reader_d = events.get_reader();
 
@@ -669,7 +670,7 @@ mod tests {
             "reader_d receives all events created before and after update"
         );
 
-        events.update();
+        events.update(&Default::default());
 
         assert_eq!(
             get_events(&events, &mut reader_missed),
@@ -703,7 +704,7 @@ mod tests {
         assert!(reader.iter(&events).next().is_none());
 
         events.send(E(2));
-        events.update();
+        events.update(&Default::default());
         events.send(E(3));
 
         assert!(reader.iter(&events).eq([E(2), E(3)].iter()));
@@ -740,12 +741,12 @@ mod tests {
         events.send(TestEvent { i: 0 });
         assert!(!events.is_empty());
 
-        events.update();
+        events.update(&Default::default());
         assert!(!events.is_empty());
 
         // events are only empty after the second call to update
         // due to double buffering.
-        events.update();
+        events.update(&Default::default());
         assert!(events.is_empty());
     }
 
@@ -799,12 +800,12 @@ mod tests {
         events.send(TestEvent { i: 0 });
         let reader = events.get_reader();
         assert_eq!(reader.len(&events), 2);
-        events.update();
+        events.update(&Default::default());
         events.send(TestEvent { i: 0 });
         assert_eq!(reader.len(&events), 3);
-        events.update();
+        events.update(&Default::default());
         assert_eq!(reader.len(&events), 1);
-        events.update();
+        events.update(&Default::default());
         assert!(reader.is_empty(&events));
     }
 

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -439,7 +439,10 @@ impl<E: Event> Events<E> {
     /// called once per frame/update.
     pub fn update(&mut self) {
         std::mem::swap(&mut self.events_a, &mut self.events_b);
+        // Garbage collect unused event space. Shrink after clear to avoid a copy.
+        let new_capacity = self.events_b.len().max(self.events_b.capacity() / 2);
         self.events_b.clear();
+        self.events_b.shrink_to(new_capacity);
         self.events_b.start_event_count = self.event_count;
         debug_assert_eq!(
             self.events_a.start_event_count + self.events_a.len(),


### PR DESCRIPTION
# Objective
As mentioned briefly in discussions in https://github.com/bevyengine/rfcs/pull/53, the memory used for events is never garbage collected despite the data being stored transiently. Bevy should release that memory when possible to avoid said memory from being held for too long.

## Solution
Use `Vec::shrink_to` to halve the capacity of the the backing `Vec` for events after clearing during updates.