### PR TITLE
Move Name from bevy_core to bevy_ecs

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -6,10 +6,10 @@ use std::ops::Deref;
 
 use bevy_app::{App, CoreStage, Plugin};
 use bevy_asset::{AddAsset, Assets, Handle};
-use bevy_core::{Name, Time};
+use bevy_core::Time;
 use bevy_ecs::{
     change_detection::DetectChanges,
-    entity::Entity,
+    entity::{Entity, Name},
     prelude::Component,
     reflect::ReflectComponent,
     schedule::ParallelSystemDescriptorCoercion,

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -1,24 +1,22 @@
 #![warn(missing_docs)]
 //! This crate provides core functionality for Bevy Engine.
 
-mod name;
 mod task_pool_options;
 mod time;
 
 pub use bytemuck::{bytes_of, cast_slice, Pod, Zeroable};
-pub use name::*;
 pub use task_pool_options::*;
 pub use time::*;
 
 pub mod prelude {
     //! The Bevy Core Prelude.
     #[doc(hidden)]
-    pub use crate::{DefaultTaskPoolOptions, Name, Time, Timer};
+    pub use crate::{DefaultTaskPoolOptions, Time, Timer};
 }
 
 use bevy_app::prelude::*;
 use bevy_ecs::{
-    entity::Entity,
+    entity::{Entity, Name},
     schedule::{ExclusiveSystemDescriptorCoercion, SystemLabel},
     system::IntoExclusiveSystem,
 };

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -23,8 +23,10 @@
 //! - **Removing a component to an entity:** use
 //!   [`EntityCommands::remove`](crate::system::EntityCommands::remove).
 mod map_entities;
+mod name;
 mod serde;
 
+pub use self::name::Name;
 pub use self::serde::*;
 pub use map_entities::*;
 

--- a/crates/bevy_ecs/src/entity/name.rs
+++ b/crates/bevy_ecs/src/entity/name.rs
@@ -1,4 +1,4 @@
-use bevy_ecs::{component::Component, reflect::ReflectComponent};
+use crate::{component::Component, reflect::ReflectComponent};
 use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::Reflect;
 use bevy_utils::AHasher;

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -3,6 +3,9 @@
 #[cfg(target_pointer_width = "16")]
 compile_error!("bevy_ecs cannot safely compile for a 16-bit platform.");
 
+// for #[derive(Component)]
+extern crate self as bevy_ecs;
+
 pub mod archetype;
 pub mod bundle;
 pub mod change_detection;
@@ -29,7 +32,7 @@ pub mod prelude {
         bundle::Bundle,
         change_detection::DetectChanges,
         component::Component,
-        entity::Entity,
+        entity::{Entity, Name},
         event::{EventReader, EventWriter},
         query::{Added, AnyOf, ChangeTrackers, Changed, Or, QueryState, With, Without},
         schedule::{

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["bevy"]
 bevy_animation = { path = "../bevy_animation", version = "0.8.0-dev", optional = true }
 bevy_app = { path = "../bevy_app", version = "0.8.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.8.0-dev" }
-bevy_core = { path = "../bevy_core", version = "0.8.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.8.0-dev" }
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.8.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.8.0-dev" }

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -2,8 +2,11 @@ use anyhow::Result;
 use bevy_asset::{
     AssetIoError, AssetLoader, AssetPath, BoxedFuture, Handle, LoadContext, LoadedAsset,
 };
-use bevy_core::Name;
-use bevy_ecs::{entity::Entity, prelude::FromWorld, world::World};
+use bevy_ecs::{
+    entity::{Entity, Name},
+    prelude::FromWorld,
+    world::World,
+};
 use bevy_hierarchy::{BuildWorldChildren, WorldChildBuilder};
 use bevy_log::warn;
 use bevy_math::{Mat4, Vec3};


### PR DESCRIPTION
# Objective

- Part of [breaking bevy_core up](https://github.com/bevyengine/bevy/issues/2931) into more specific locations.
- `Name` is universally applicable to ecs consumers, so should be available in bevy_ecs.

## Solution

- Move `Name` from `bevy_core` to `bevy_ecs`.
- `Name` utilizes `#[derive(Component)]`; use `extern crate self as bevy_ecs` to make the expected name available.

---

## Changelog

### Changed

- The `Name` struct moved from `bevy::core` to `bevy::ecs`.

## Migration Guide

- If you're using a `bevy::prelude` import, no migration is necessary.
- If you aren't, replace uses of `bevy::core::Name` with `bevy::ecs::Name`.
