### PR TITLE
[Merged by Bors] - Move primitive type registration into bevy_reflect

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -32,11 +32,7 @@ impl Plugin for CorePlugin {
             .unwrap_or_default()
             .create_default_pools(&mut app.world);
 
-        app.register_type::<HashSet<String>>()
-            .register_type::<Option<String>>()
-            .register_type::<Entity>()
-            .register_type::<Name>()
-            .register_type::<Range<f32>>();
+        app.register_type::<Entity>().register_type::<Name>();
 
         register_rust_types(app);
         register_math_types(app);
@@ -44,22 +40,9 @@ impl Plugin for CorePlugin {
 }
 
 fn register_rust_types(app: &mut App) {
-    app.register_type::<bool>()
-        .register_type::<u8>()
-        .register_type::<u16>()
-        .register_type::<u32>()
-        .register_type::<u64>()
-        .register_type::<u128>()
-        .register_type::<usize>()
-        .register_type::<i8>()
-        .register_type::<i16>()
-        .register_type::<i32>()
-        .register_type::<i64>()
-        .register_type::<i128>()
-        .register_type::<isize>()
-        .register_type::<f32>()
-        .register_type::<f64>()
+    app.register_type::<Range<f32>>()
         .register_type::<String>()
+        .register_type::<HashSet<String>>()
         .register_type::<Option<String>>();
 }
 

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -6,7 +6,6 @@ use serde::Deserialize;
 use std::{any::TypeId, fmt::Debug, sync::Arc};
 
 /// A registry of reflected types.
-#[derive(Default)]
 pub struct TypeRegistry {
     registrations: HashMap<TypeId, TypeRegistration>,
     short_name_to_id: HashMap<String, TypeId>,
@@ -35,7 +34,44 @@ pub trait GetTypeRegistration {
     fn get_type_registration() -> TypeRegistration;
 }
 
+impl Default for TypeRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TypeRegistry {
+    /// Create a type registry with *no* registered types.
+    pub fn empty() -> Self {
+        Self {
+            registrations: Default::default(),
+            short_name_to_id: Default::default(),
+            full_name_to_id: Default::default(),
+            ambiguous_names: Default::default(),
+        }
+    }
+
+    /// Create a type registry with default registrations for primitive types.
+    pub fn new() -> Self {
+        let mut registry = Self::empty();
+        registry.register::<bool>();
+        registry.register::<u8>();
+        registry.register::<u16>();
+        registry.register::<u32>();
+        registry.register::<u64>();
+        registry.register::<u128>();
+        registry.register::<usize>();
+        registry.register::<i8>();
+        registry.register::<i16>();
+        registry.register::<i32>();
+        registry.register::<i64>();
+        registry.register::<i128>();
+        registry.register::<isize>();
+        registry.register::<f32>();
+        registry.register::<f64>();
+        registry
+    }
+
     /// Registers the type `T`.
     pub fn register<T>(&mut self)
     where


### PR DESCRIPTION
# Objective

- Users of bevy_reflect probably always want primitive types registered.

## Solution

- Register them by default.

---

This is a minor incremental change along the path of [removing catch-all functionality from bevy_core](https://github.com/bevyengine/bevy/issues/2931).
