### PR TITLE
[Merged by Bors] - Derive thiserror::Error for HexColorError (again)

### DIFF
--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -7,6 +7,7 @@ use bevy_math::{Vec3, Vec4};
 use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize};
 use serde::{Deserialize, Serialize};
 use std::ops::{Add, AddAssign, Mul, MulAssign};
+use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]
 #[reflect(PartialEq, Serialize, Deserialize)]
@@ -1170,10 +1171,12 @@ impl MulAssign<[f32; 3]> for Color {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum HexColorError {
+    #[error("Unexpected length of hex string")]
     Length,
-    Hex(hex::FromHexError),
+    #[error("Error parsing hex value")]
+    Hex(#[from] hex::FromHexError),
 }
 
 fn decode_rgb(data: &[u8]) -> Result<Color, HexColorError> {


### PR DESCRIPTION
This was first done in 7b4e3a5, but was then reverted when the new
renderer for 0.6 was merged (ffecb05).

I'm assuming it was simply a mistake when merging.

# Objective

- Same as #2740, I think it was reverted by mistake when merging.

> # Objective
>
> - Make it easy to use HexColorError with `thiserror`, i.e. converting it into other error types.
> 
> Makes this possible:
> 
> ```rust
> #[derive(Debug, thiserror::Error)]
> pub enum LdtkError {
>     #[error("An error occured while deserializing")]
>     Json(#[from] serde_json::Error),
>     #[error("An error occured while parsing a color")]
>     HexColor(#[from] bevy::render::color::HexColorError),
> }
> ```
> 
> ## Solution
> 
> - Derive thiserror::Error the same way we do elsewhere (see query.rs for instance)
