### PR TITLE
[Merged by Bors] - Update gilrs to v0.9

### DIFF
--- a/crates/bevy_gilrs/Cargo.toml
+++ b/crates/bevy_gilrs/Cargo.toml
@@ -16,4 +16,4 @@ bevy_input = { path = "../bevy_input", version = "0.8.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 
 # other
-gilrs = { version = "0.8.0", features = ["wasm-bindgen"] }
+gilrs = "0.9.0"

--- a/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
+++ b/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
@@ -17,4 +17,4 @@ bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.8.0-dev" }
 syn = { version = "1.0", features = ["full"] }
 proc-macro2 = "1.0"
 quote = "1.0"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.1", features = ["v4"] }

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -20,6 +20,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 # other
 serde = { version = "1.0", features = ["derive"] }
 ron = "0.7.0"
-uuid = { version = "0.8", features = ["v4", "serde"] }
+uuid = { version = "1.1", features = ["v4", "serde"] }
 anyhow = "1.0.4"
 thiserror = "1.0"

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -12,9 +12,8 @@ keywords = ["bevy"]
 ahash = "0.7.0"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
-uuid = { version = "0.8", features = ["v4", "serde"] }
+uuid = { version = "1.1", features = ["v4", "serde"] }
 hashbrown = { version = "0.11", features = ["serde"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = {version = "0.2.0", features = ["js"]}
-uuid = { version = "0.8", features = ["wasm-bindgen"] }

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -59,7 +59,7 @@ use crate::raw_window_handle::RawWindowHandleWrapper;
 
 impl fmt::Display for WindowId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.to_simple().fmt(f)
+        self.0.as_simple().fmt(f)
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -50,7 +50,6 @@ skip = [
     { name = "stdweb", version = "0.1" },               # from rodio v0.15.0
     { name = "wasi",  version = "0.10"},                # from ahash v0.7.6
     { name = "nix", version = "0.23.1" },               # from alsa v0.6.0
-    { name = "nix", version = "0.24.1" },               # from gilrs-core v0.4.0
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -49,6 +49,8 @@ skip = [
     { name = "ndk-sys", version = "0.2" },              # from winit v0.26.1
     { name = "stdweb", version = "0.1" },               # from rodio v0.15.0
     { name = "wasi",  version = "0.10"},                # from ahash v0.7.6
+    { name = "nix", version = "0.23.1" },               # from alsa v0.6.0
+    { name = "nix", version = "0.24.1" },               # from gilrs-core v0.4.0
 ]
 
 [sources]


### PR DESCRIPTION
# Objective
Fixes #4353. Fixes #4431. Picks up fixes for a panic for `gilrs` when `getGamepads()` is not available. 

## Solution
Update the `gilrs` to `v0.9.0`. Changelog can be seen here: https://gitlab.com/gilrs-project/gilrs/-/commit/dba36f91869c823fb66f8633d2b650b430682f80

EDIT: Updated `uuid` to 1.1 to avoid duplicate dependencies. Added `nix`'s two dependencies as exceptions until `rodio` updates their deps.