### PR TITLE
[Merged by Bors] - Remove redundant ComponentId in Column

### DIFF
--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -370,6 +370,14 @@ impl<I: SparseSetIndex, V> SparseSet<I, V> {
     pub fn values_mut(&mut self) -> impl Iterator<Item = &mut V> {
         self.dense.iter_mut()
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&I, &V)> {
+        self.indices.iter().zip(self.dense.iter())
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&I, &mut V)> {
+        self.indices.iter().zip(self.dense.iter_mut())
+    }
 }
 
 pub trait SparseSetIndex: Clone + PartialEq + Eq + Hash {


### PR DESCRIPTION
# Objective
The `ComponentId` in `Column` is redundant as it's stored in parallel in the surrounding `SparseSet` all the time.

## Solution
Remove it. Add `SparseSet::iter(_mut)` to parallel `HashMap::iter(_mut)` to allow iterating pairs of columns and their IDs.

---

## Changelog
Added: `SparseSet::iter` and `SparseSet::iter_mut`.