### PR TITLE
[Merged by Bors] - Improve soundness of `CommandQueue`

### DIFF
--- a/crates/bevy_ecs/src/system/commands/command_queue.rs
+++ b/crates/bevy_ecs/src/system/commands/command_queue.rs
@@ -226,4 +226,17 @@ mod test {
     fn test_command_is_send() {
         assert_is_send(SpawnCommand);
     }
+
+    struct CommandWithPadding(u8, u16);
+    impl Command for CommandWithPadding {
+        fn write(self, _: &mut World) {}
+    }
+
+    #[cfg(miri)]
+    #[test]
+    fn test_uninit_bytes() {
+        let mut queue = CommandQueue::default();
+        queue.push(CommandWithPadding(0, 0));
+        let _ = format!("{:?}", queue.bytes);
+    }
 }

--- a/crates/bevy_ecs/src/system/commands/command_queue.rs
+++ b/crates/bevy_ecs/src/system/commands/command_queue.rs
@@ -85,27 +85,11 @@ impl CommandQueue {
         // unnecessary allocations.
         unsafe { self.bytes.set_len(0) };
 
-        let byte_ptr = if self.bytes.as_mut_ptr().is_null() {
-            // SAFE: If the vector's buffer pointer is `null` this mean nothing has been pushed to its bytes.
-            // This means either that:
-            //
-            // 1) There are no commands so this pointer will never be read/written from/to.
-            //
-            // 2) There are only zero-sized commands pushed.
-            //    According to https://doc.rust-lang.org/std/ptr/index.html
-            //    "The canonical way to obtain a pointer that is valid for zero-sized accesses is NonNull::dangling"
-            //    therefore it is safe to call `read_unaligned` on a pointer produced from `NonNull::dangling` for
-            //    zero-sized commands.
-            unsafe { std::ptr::NonNull::dangling().as_mut() }
-        } else {
-            self.bytes.as_mut_ptr()
-        };
-
         for meta in self.metas.drain(..) {
             // SAFE: The implementation of `write_command` is safe for the according Command type.
             // The bytes are safely cast to their original type, safely read, and then dropped.
             unsafe {
-                (meta.func)(byte_ptr.add(meta.offset), world);
+                (meta.func)(self.bytes.as_mut_ptr().add(meta.offset), world);
             }
         }
     }


### PR DESCRIPTION
# Objective

This PR aims to improve the soundness of `CommandQueue`. In particular it aims to:
- make it sound to store commands that contain padding or uninitialized bytes;
- avoid uses of commands after moving them in the queue's buffer (`std::mem::forget` is technically a use of its argument);
- remove useless checks: `self.bytes.as_mut_ptr().is_null()` is always `false` because even `Vec`s that haven't allocated use a dangling pointer. Moreover the same pointer was used to write the command, so it ought to be valid for reads if it was for writes.

## Solution

- To soundly store padding or uninitialized bytes `CommandQueue` was changed to contain a `Vec<MaybeUninit<u8>>` instead of `Vec<u8>`;
- To avoid uses of the command through `std::mem::forget`, `ManuallyDrop` was used.
 
## Other observations

While writing this PR I noticed that `CommandQueue` doesn't seem to drop the commands that weren't applied. While this is a pretty niche case (you would have to be manually using `CommandQueue`/`std::mem::swap`ping one), I wonder if it should be documented anyway.