### PR TITLE
[Merged by Bors] - Split mesh shader files

### DIFF
--- a/assets/shaders/animate_shader.wgsl
+++ b/assets/shaders/animate_shader.wgsl
@@ -1,5 +1,6 @@
-#import bevy_pbr::mesh_view_bind_group
-#import bevy_pbr::mesh_struct
+#import bevy_pbr::mesh_view_types
+#import bevy_pbr::mesh_types
+#import bevy_pbr::mesh_view_bindings
 
 [[group(1), binding(0)]]
 var<uniform> mesh: Mesh;

--- a/assets/shaders/animate_shader.wgsl
+++ b/assets/shaders/animate_shader.wgsl
@@ -1,4 +1,3 @@
-#import bevy_pbr::mesh_view_types
 #import bevy_pbr::mesh_types
 #import bevy_pbr::mesh_view_bindings
 

--- a/assets/shaders/custom_material_screenspace_texture.wgsl
+++ b/assets/shaders/custom_material_screenspace_texture.wgsl
@@ -1,4 +1,3 @@
-#import bevy_pbr::mesh_view_types
 #import bevy_pbr::mesh_view_bindings
 
 [[group(1), binding(0)]]

--- a/assets/shaders/custom_material_screenspace_texture.wgsl
+++ b/assets/shaders/custom_material_screenspace_texture.wgsl
@@ -1,4 +1,5 @@
-#import bevy_pbr::mesh_view_bind_group
+#import bevy_pbr::mesh_view_types
+#import bevy_pbr::mesh_view_bindings
 
 [[group(1), binding(0)]]
 var texture: texture_2d<f32>;

--- a/assets/shaders/custom_vertex_attribute.wgsl
+++ b/assets/shaders/custom_vertex_attribute.wgsl
@@ -1,5 +1,6 @@
-#import bevy_pbr::mesh_view_bind_group
-#import bevy_pbr::mesh_struct
+#import bevy_pbr::mesh_view_types
+#import bevy_pbr::mesh_types
+#import bevy_pbr::mesh_view_bindings
 
 struct Vertex {
     [[location(0)]] position: vec3<f32>;

--- a/assets/shaders/custom_vertex_attribute.wgsl
+++ b/assets/shaders/custom_vertex_attribute.wgsl
@@ -1,6 +1,5 @@
-#import bevy_pbr::mesh_view_types
-#import bevy_pbr::mesh_types
 #import bevy_pbr::mesh_view_bindings
+#import bevy_pbr::mesh_bindings
 
 struct Vertex {
     [[location(0)]] position: vec3<f32>;
@@ -12,9 +11,6 @@ struct CustomMaterial {
 };
 [[group(1), binding(0)]]
 var<uniform> material: CustomMaterial;
-
-[[group(2), binding(0)]]
-var<uniform> mesh: Mesh;
 
 struct VertexOutput {
     [[builtin(position)]] clip_position: vec4<f32>;

--- a/assets/shaders/instancing.wgsl
+++ b/assets/shaders/instancing.wgsl
@@ -1,5 +1,6 @@
-#import bevy_pbr::mesh_view_bind_group
-#import bevy_pbr::mesh_struct
+#import bevy_pbr::mesh_view_types
+#import bevy_pbr::mesh_types
+#import bevy_pbr::mesh_view_bindings
 
 [[group(1), binding(0)]]
 var<uniform> mesh: Mesh;

--- a/assets/shaders/instancing.wgsl
+++ b/assets/shaders/instancing.wgsl
@@ -1,4 +1,3 @@
-#import bevy_pbr::mesh_view_types
 #import bevy_pbr::mesh_types
 #import bevy_pbr::mesh_view_bindings
 

--- a/assets/shaders/shader_defs.wgsl
+++ b/assets/shaders/shader_defs.wgsl
@@ -1,5 +1,6 @@
-#import bevy_pbr::mesh_view_bind_group
-#import bevy_pbr::mesh_struct
+#import bevy_pbr::mesh_view_types
+#import bevy_pbr::mesh_types
+#import bevy_pbr::mesh_view_bindings
 
 [[group(1), binding(0)]]
 var<uniform> mesh: Mesh;
@@ -26,7 +27,7 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 [[stage(fragment)]]
 fn fragment() -> [[location(0)]] vec4<f32> {
     var color = vec4<f32>(0.0, 0.0, 1.0, 1.0);
-# ifdef IS_RED 
+# ifdef IS_RED
     color = vec4<f32>(1.0, 0.0, 0.0, 1.0);
 # endif
     return color;

--- a/assets/shaders/shader_defs.wgsl
+++ b/assets/shaders/shader_defs.wgsl
@@ -1,4 +1,3 @@
-#import bevy_pbr::mesh_view_types
 #import bevy_pbr::mesh_types
 #import bevy_pbr::mesh_view_bindings
 

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -48,6 +48,10 @@ use bevy_render::{
 };
 use bevy_transform::TransformSystem;
 
+pub const PBR_TYPES_SHADER_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 1708015359337029744);
+pub const PBR_BINDINGS_SHADER_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 5635987986427308186);
 pub const PBR_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 4805239651767701046);
 pub const SHADOW_SHADER_HANDLE: HandleUntyped =
@@ -59,6 +63,18 @@ pub struct PbrPlugin;
 
 impl Plugin for PbrPlugin {
     fn build(&self, app: &mut App) {
+        load_internal_asset!(
+            app,
+            PBR_TYPES_SHADER_HANDLE,
+            "render/pbr_types.wgsl",
+            Shader::from_wgsl
+        );
+        load_internal_asset!(
+            app,
+            PBR_BINDINGS_SHADER_HANDLE,
+            "render/pbr_bindings.wgsl",
+            Shader::from_wgsl
+        );
         load_internal_asset!(app, PBR_SHADER_HANDLE, "render/pbr.wgsl", Shader::from_wgsl);
         load_internal_asset!(
             app,

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -116,7 +116,7 @@ impl From<Handle<Image>> for StandardMaterial {
     }
 }
 
-// NOTE: These must match the bit flags in bevy_pbr/src/render/pbr.wgsl!
+// NOTE: These must match the bit flags in bevy_pbr/src/render/pbr_types.wgsl!
 bitflags::bitflags! {
     #[repr(transparent)]
     pub struct StandardMaterialFlags: u32 {

--- a/crates/bevy_pbr/src/render/depth.wgsl
+++ b/crates/bevy_pbr/src/render/depth.wgsl
@@ -1,11 +1,6 @@
-#import bevy_pbr::mesh_struct
+#import bevy_pbr::mesh_view_types
+#import bevy_pbr::mesh_types
 
-// NOTE: Keep in sync with pbr.wgsl
-struct View {
-    view_proj: mat4x4<f32>;
-    projection: mat4x4<f32>;
-    world_position: vec3<f32>;
-};
 [[group(0), binding(0)]]
 var<uniform> view: View;
 

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -41,6 +41,8 @@ pub const MESH_VIEW_BINDINGS_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 9076678235888822571);
 pub const MESH_TYPES_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 2506024101911992377);
+pub const MESH_BINDINGS_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 16831548636314682308);
 pub const MESH_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 3252377289100772450);
 pub const SKINNING_HANDLE: HandleUntyped =
@@ -61,6 +63,12 @@ impl Plugin for MeshRenderPlugin {
             Shader::from_wgsl
         );
         load_internal_asset!(app, MESH_TYPES_HANDLE, "mesh_types.wgsl", Shader::from_wgsl);
+        load_internal_asset!(
+            app,
+            MESH_BINDINGS_HANDLE,
+            "mesh_bindings.wgsl",
+            Shader::from_wgsl
+        );
         load_internal_asset!(app, MESH_SHADER_HANDLE, "mesh.wgsl", Shader::from_wgsl);
         load_internal_asset!(app, SKINNING_HANDLE, "skinning.wgsl", Shader::from_wgsl);
 

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -35,9 +35,11 @@ const MAX_JOINTS: usize = 256;
 const JOINT_SIZE: usize = std::mem::size_of::<Mat4>();
 pub(crate) const JOINT_BUFFER_SIZE: usize = MAX_JOINTS * JOINT_SIZE;
 
-pub const MESH_VIEW_BIND_GROUP_HANDLE: HandleUntyped =
+pub const MESH_VIEW_TYPES_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 8140454348013264787);
+pub const MESH_VIEW_BINDINGS_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 9076678235888822571);
-pub const MESH_STRUCT_HANDLE: HandleUntyped =
+pub const MESH_TYPES_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 2506024101911992377);
 pub const MESH_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 3252377289100772450);
@@ -46,19 +48,20 @@ pub const SKINNING_HANDLE: HandleUntyped =
 
 impl Plugin for MeshRenderPlugin {
     fn build(&self, app: &mut bevy_app::App) {
+        load_internal_asset!(
+            app,
+            MESH_VIEW_TYPES_HANDLE,
+            "mesh_view_types.wgsl",
+            Shader::from_wgsl
+        );
+        load_internal_asset!(
+            app,
+            MESH_VIEW_BINDINGS_HANDLE,
+            "mesh_view_bindings.wgsl",
+            Shader::from_wgsl
+        );
+        load_internal_asset!(app, MESH_TYPES_HANDLE, "mesh_types.wgsl", Shader::from_wgsl);
         load_internal_asset!(app, MESH_SHADER_HANDLE, "mesh.wgsl", Shader::from_wgsl);
-        load_internal_asset!(
-            app,
-            MESH_STRUCT_HANDLE,
-            "mesh_struct.wgsl",
-            Shader::from_wgsl
-        );
-        load_internal_asset!(
-            app,
-            MESH_VIEW_BIND_GROUP_HANDLE,
-            "mesh_view_bind_group.wgsl",
-            Shader::from_wgsl
-        );
         load_internal_asset!(app, SKINNING_HANDLE, "skinning.wgsl", Shader::from_wgsl);
 
         app.add_plugin(UniformComponentPlugin::<MeshUniform>::default());

--- a/crates/bevy_pbr/src/render/mesh.wgsl
+++ b/crates/bevy_pbr/src/render/mesh.wgsl
@@ -1,6 +1,5 @@
-#import bevy_pbr::mesh_view_types
-#import bevy_pbr::mesh_types
 #import bevy_pbr::mesh_view_bindings
+#import bevy_pbr::mesh_bindings
 
 struct Vertex {
     [[location(0)]] position: vec3<f32>;
@@ -30,14 +29,6 @@ struct VertexOutput {
     [[location(4)]] color: vec4<f32>;
 #endif
 };
-
-[[group(2), binding(0)]]
-var<uniform> mesh: Mesh;
-#ifdef SKINNED
-[[group(2), binding(1)]]
-var<uniform> joint_matrices: SkinnedMesh;
-#import bevy_pbr::skinning
-#endif
 
 [[stage(vertex)]]
 fn vertex(vertex: Vertex) -> VertexOutput {

--- a/crates/bevy_pbr/src/render/mesh.wgsl
+++ b/crates/bevy_pbr/src/render/mesh.wgsl
@@ -1,5 +1,6 @@
-#import bevy_pbr::mesh_view_bind_group
-#import bevy_pbr::mesh_struct
+#import bevy_pbr::mesh_view_types
+#import bevy_pbr::mesh_types
+#import bevy_pbr::mesh_view_bindings
 
 struct Vertex {
     [[location(0)]] position: vec3<f32>;
@@ -68,7 +69,7 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 #endif
 #ifdef VERTEX_COLORS
     out.color = vertex.color;
-#endif 
+#endif
 
     out.uv = vertex.uv;
     out.clip_position = view.view_proj * out.world_position;

--- a/crates/bevy_pbr/src/render/mesh_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_bindings.wgsl
@@ -1,0 +1,11 @@
+#define_import_path bevy_pbr::mesh_bindings
+
+#import bevy_pbr::mesh_types
+
+[[group(2), binding(0)]]
+var<uniform> mesh: Mesh;
+#ifdef SKINNED
+[[group(2), binding(1)]]
+var<uniform> joint_matrices: SkinnedMesh;
+#import bevy_pbr::skinning
+#endif

--- a/crates/bevy_pbr/src/render/mesh_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_types.wgsl
@@ -1,4 +1,4 @@
-#define_import_path bevy_pbr::mesh_struct
+#define_import_path bevy_pbr::mesh_types
 
 struct Mesh {
     model: mat4x4<f32>;

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -1,5 +1,7 @@
 #define_import_path bevy_pbr::mesh_view_bindings
 
+#import bevy_pbr::mesh_view_types
+
 [[group(0), binding(0)]]
 var<uniform> view: View;
 [[group(0), binding(1)]]

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -1,0 +1,40 @@
+#define_import_path bevy_pbr::mesh_view_bindings
+
+[[group(0), binding(0)]]
+var<uniform> view: View;
+[[group(0), binding(1)]]
+var<uniform> lights: Lights;
+#ifdef NO_ARRAY_TEXTURES_SUPPORT
+[[group(0), binding(2)]]
+var point_shadow_textures: texture_depth_cube;
+#else
+[[group(0), binding(2)]]
+var point_shadow_textures: texture_depth_cube_array;
+#endif
+[[group(0), binding(3)]]
+var point_shadow_textures_sampler: sampler_comparison;
+#ifdef NO_ARRAY_TEXTURES_SUPPORT
+[[group(0), binding(4)]]
+var directional_shadow_textures: texture_depth_2d;
+#else
+[[group(0), binding(4)]]
+var directional_shadow_textures: texture_depth_2d_array;
+#endif
+[[group(0), binding(5)]]
+var directional_shadow_textures_sampler: sampler_comparison;
+
+#ifdef NO_STORAGE_BUFFERS_SUPPORT
+[[group(0), binding(6)]]
+var<uniform> point_lights: PointLights;
+[[group(0), binding(7)]]
+var<uniform> cluster_light_index_lists: ClusterLightIndexLists;
+[[group(0), binding(8)]]
+var<uniform> cluster_offsets_and_counts: ClusterOffsetsAndCounts;
+#else
+[[group(0), binding(6)]]
+var<storage> point_lights: PointLights;
+[[group(0), binding(7)]]
+var<storage> cluster_light_index_lists: ClusterLightIndexLists;
+[[group(0), binding(8)]]
+var<storage> cluster_offsets_and_counts: ClusterOffsetsAndCounts;
+#endif

--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -1,4 +1,4 @@
-#define_import_path bevy_pbr::mesh_view_bind_group
+#define_import_path bevy_pbr::mesh_view_types
 
 struct View {
     view_proj: mat4x4<f32>;
@@ -78,43 +78,4 @@ struct ClusterLightIndexLists {
 struct ClusterOffsetsAndCounts {
     data: array<vec2<u32>>;
 };
-#endif
-
-[[group(0), binding(0)]]
-var<uniform> view: View;
-[[group(0), binding(1)]]
-var<uniform> lights: Lights;
-#ifdef NO_ARRAY_TEXTURES_SUPPORT
-[[group(0), binding(2)]]
-var point_shadow_textures: texture_depth_cube;
-#else
-[[group(0), binding(2)]]
-var point_shadow_textures: texture_depth_cube_array;
-#endif
-[[group(0), binding(3)]]
-var point_shadow_textures_sampler: sampler_comparison;
-#ifdef NO_ARRAY_TEXTURES_SUPPORT
-[[group(0), binding(4)]]
-var directional_shadow_textures: texture_depth_2d;
-#else
-[[group(0), binding(4)]]
-var directional_shadow_textures: texture_depth_2d_array;
-#endif
-[[group(0), binding(5)]]
-var directional_shadow_textures_sampler: sampler_comparison;
-
-#ifdef NO_STORAGE_BUFFERS_SUPPORT
-[[group(0), binding(6)]]
-var<uniform> point_lights: PointLights;
-[[group(0), binding(7)]]
-var<uniform> cluster_light_index_lists: ClusterLightIndexLists;
-[[group(0), binding(8)]]
-var<uniform> cluster_offsets_and_counts: ClusterOffsetsAndCounts;
-#else
-[[group(0), binding(6)]]
-var<storage> point_lights: PointLights;
-[[group(0), binding(7)]]
-var<storage> cluster_light_index_lists: ClusterLightIndexLists;
-[[group(0), binding(8)]]
-var<storage> cluster_offsets_and_counts: ClusterOffsetsAndCounts;
 #endif

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -32,14 +32,9 @@
 //
 // The above integration needs to be approximated.
 
-#import bevy_pbr::mesh_view_types
-#import bevy_pbr::mesh_types
-#import bevy_pbr::pbr_types
 #import bevy_pbr::mesh_view_bindings
 #import bevy_pbr::pbr_bindings
-
-[[group(2), binding(0)]]
-var<uniform> mesh: Mesh;
+#import bevy_pbr::mesh_bindings
 
 let PI: f32 = 3.141592653589793;
 

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -32,57 +32,14 @@
 //
 // The above integration needs to be approximated.
 
-#import bevy_pbr::mesh_view_bind_group
-#import bevy_pbr::mesh_struct
+#import bevy_pbr::mesh_view_types
+#import bevy_pbr::mesh_types
+#import bevy_pbr::pbr_types
+#import bevy_pbr::mesh_view_bindings
+#import bevy_pbr::pbr_bindings
 
 [[group(2), binding(0)]]
 var<uniform> mesh: Mesh;
-
-struct StandardMaterial {
-    base_color: vec4<f32>;
-    emissive: vec4<f32>;
-    perceptual_roughness: f32;
-    metallic: f32;
-    reflectance: f32;
-    // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
-    flags: u32;
-    alpha_cutoff: f32;
-};
-
-let STANDARD_MATERIAL_FLAGS_BASE_COLOR_TEXTURE_BIT: u32         = 1u;
-let STANDARD_MATERIAL_FLAGS_EMISSIVE_TEXTURE_BIT: u32           = 2u;
-let STANDARD_MATERIAL_FLAGS_METALLIC_ROUGHNESS_TEXTURE_BIT: u32 = 4u;
-let STANDARD_MATERIAL_FLAGS_OCCLUSION_TEXTURE_BIT: u32          = 8u;
-let STANDARD_MATERIAL_FLAGS_DOUBLE_SIDED_BIT: u32               = 16u;
-let STANDARD_MATERIAL_FLAGS_UNLIT_BIT: u32                      = 32u;
-let STANDARD_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE: u32              = 64u;
-let STANDARD_MATERIAL_FLAGS_ALPHA_MODE_MASK: u32                = 128u;
-let STANDARD_MATERIAL_FLAGS_ALPHA_MODE_BLEND: u32               = 256u;
-let STANDARD_MATERIAL_FLAGS_TWO_COMPONENT_NORMAL_MAP: u32       = 512u;
-let STANDARD_MATERIAL_FLAGS_FLIP_NORMAL_MAP_Y: u32              = 1024u;
-
-[[group(1), binding(0)]]
-var<uniform> material: StandardMaterial;
-[[group(1), binding(1)]]
-var base_color_texture: texture_2d<f32>;
-[[group(1), binding(2)]]
-var base_color_sampler: sampler;
-[[group(1), binding(3)]]
-var emissive_texture: texture_2d<f32>;
-[[group(1), binding(4)]]
-var emissive_sampler: sampler;
-[[group(1), binding(5)]]
-var metallic_roughness_texture: texture_2d<f32>;
-[[group(1), binding(6)]]
-var metallic_roughness_sampler: sampler;
-[[group(1), binding(7)]]
-var occlusion_texture: texture_2d<f32>;
-[[group(1), binding(8)]]
-var occlusion_sampler: sampler;
-[[group(1), binding(9)]]
-var normal_map_texture: texture_2d<f32>;
-[[group(1), binding(10)]]
-var normal_map_sampler: sampler;
 
 let PI: f32 = 3.141592653589793;
 
@@ -467,7 +424,7 @@ struct FragmentInput {
 #endif
 #ifdef VERTEX_COLORS
     [[location(4)]] color: vec4<f32>;
-#endif 
+#endif
 };
 
 [[stage(fragment)]]

--- a/crates/bevy_pbr/src/render/pbr_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_bindings.wgsl
@@ -1,5 +1,7 @@
 #define_import_path bevy_pbr::pbr_bindings
 
+#import bevy_pbr::pbr_types
+
 [[group(1), binding(0)]]
 var<uniform> material: StandardMaterial;
 [[group(1), binding(1)]]

--- a/crates/bevy_pbr/src/render/pbr_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_bindings.wgsl
@@ -1,0 +1,24 @@
+#define_import_path bevy_pbr::pbr_bindings
+
+[[group(1), binding(0)]]
+var<uniform> material: StandardMaterial;
+[[group(1), binding(1)]]
+var base_color_texture: texture_2d<f32>;
+[[group(1), binding(2)]]
+var base_color_sampler: sampler;
+[[group(1), binding(3)]]
+var emissive_texture: texture_2d<f32>;
+[[group(1), binding(4)]]
+var emissive_sampler: sampler;
+[[group(1), binding(5)]]
+var metallic_roughness_texture: texture_2d<f32>;
+[[group(1), binding(6)]]
+var metallic_roughness_sampler: sampler;
+[[group(1), binding(7)]]
+var occlusion_texture: texture_2d<f32>;
+[[group(1), binding(8)]]
+var occlusion_sampler: sampler;
+[[group(1), binding(9)]]
+var normal_map_texture: texture_2d<f32>;
+[[group(1), binding(10)]]
+var normal_map_sampler: sampler;

--- a/crates/bevy_pbr/src/render/pbr_types.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_types.wgsl
@@ -1,0 +1,24 @@
+#define_import_path bevy_pbr::pbr_types
+
+struct StandardMaterial {
+    base_color: vec4<f32>;
+    emissive: vec4<f32>;
+    perceptual_roughness: f32;
+    metallic: f32;
+    reflectance: f32;
+    // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
+    flags: u32;
+    alpha_cutoff: f32;
+};
+
+let STANDARD_MATERIAL_FLAGS_BASE_COLOR_TEXTURE_BIT: u32         = 1u;
+let STANDARD_MATERIAL_FLAGS_EMISSIVE_TEXTURE_BIT: u32           = 2u;
+let STANDARD_MATERIAL_FLAGS_METALLIC_ROUGHNESS_TEXTURE_BIT: u32 = 4u;
+let STANDARD_MATERIAL_FLAGS_OCCLUSION_TEXTURE_BIT: u32          = 8u;
+let STANDARD_MATERIAL_FLAGS_DOUBLE_SIDED_BIT: u32               = 16u;
+let STANDARD_MATERIAL_FLAGS_UNLIT_BIT: u32                      = 32u;
+let STANDARD_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE: u32              = 64u;
+let STANDARD_MATERIAL_FLAGS_ALPHA_MODE_MASK: u32                = 128u;
+let STANDARD_MATERIAL_FLAGS_ALPHA_MODE_BLEND: u32               = 256u;
+let STANDARD_MATERIAL_FLAGS_TWO_COMPONENT_NORMAL_MAP: u32       = 512u;
+let STANDARD_MATERIAL_FLAGS_FLIP_NORMAL_MAP_Y: u32              = 1024u;

--- a/crates/bevy_pbr/src/render/wireframe.wgsl
+++ b/crates/bevy_pbr/src/render/wireframe.wgsl
@@ -1,5 +1,6 @@
-#import bevy_pbr::mesh_view_bind_group
-#import bevy_pbr::mesh_struct
+#import bevy_pbr::mesh_view_types
+#import bevy_pbr::mesh_types
+#import bevy_pbr::mesh_view_bindings
 
 struct Vertex {
     [[location(0)]] position: vec3<f32>;

--- a/crates/bevy_pbr/src/render/wireframe.wgsl
+++ b/crates/bevy_pbr/src/render/wireframe.wgsl
@@ -1,4 +1,3 @@
-#import bevy_pbr::mesh_view_types
 #import bevy_pbr::mesh_types
 #import bevy_pbr::mesh_view_bindings
 

--- a/crates/bevy_sprite/src/mesh2d/color_material.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/color_material.wgsl
@@ -1,5 +1,6 @@
-#import bevy_sprite::mesh2d_view_bind_group
-#import bevy_sprite::mesh2d_struct
+#import bevy_sprite::mesh2d_view_types
+#import bevy_sprite::mesh2d_types
+#import bevy_sprite::mesh2d_view_bindings
 
 struct ColorMaterial {
     color: vec4<f32>;
@@ -7,9 +8,6 @@ struct ColorMaterial {
     flags: u32;
 };
 let COLOR_MATERIAL_FLAGS_TEXTURE_BIT: u32 = 1u;
-
-[[group(0), binding(0)]]
-var<uniform> view: View;
 
 [[group(1), binding(0)]]
 var<uniform> material: ColorMaterial;

--- a/crates/bevy_sprite/src/mesh2d/color_material.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/color_material.wgsl
@@ -1,4 +1,3 @@
-#import bevy_sprite::mesh2d_view_types
 #import bevy_sprite::mesh2d_types
 #import bevy_sprite::mesh2d_view_bindings
 

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -35,28 +35,36 @@ impl From<Handle<Mesh>> for Mesh2dHandle {
 #[derive(Default)]
 pub struct Mesh2dRenderPlugin;
 
-pub const MESH2D_VIEW_BIND_GROUP_HANDLE: HandleUntyped =
+pub const MESH2D_VIEW_TYPES_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 12677582416765805110);
+pub const MESH2D_VIEW_BINDINGS_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 6901431444735842434);
-pub const MESH2D_STRUCT_HANDLE: HandleUntyped =
+pub const MESH2D_TYPES_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 8994673400261890424);
 pub const MESH2D_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 2971387252468633715);
 
 impl Plugin for Mesh2dRenderPlugin {
     fn build(&self, app: &mut bevy_app::App) {
+        load_internal_asset!(
+            app,
+            MESH2D_VIEW_TYPES_HANDLE,
+            "mesh2d_view_types.wgsl",
+            Shader::from_wgsl
+        );
+        load_internal_asset!(
+            app,
+            MESH2D_VIEW_BINDINGS_HANDLE,
+            "mesh2d_view_bindings.wgsl",
+            Shader::from_wgsl
+        );
+        load_internal_asset!(
+            app,
+            MESH2D_TYPES_HANDLE,
+            "mesh2d_types.wgsl",
+            Shader::from_wgsl
+        );
         load_internal_asset!(app, MESH2D_SHADER_HANDLE, "mesh2d.wgsl", Shader::from_wgsl);
-        load_internal_asset!(
-            app,
-            MESH2D_STRUCT_HANDLE,
-            "mesh2d_struct.wgsl",
-            Shader::from_wgsl
-        );
-        load_internal_asset!(
-            app,
-            MESH2D_VIEW_BIND_GROUP_HANDLE,
-            "mesh2d_view_bind_group.wgsl",
-            Shader::from_wgsl
-        );
 
         app.add_plugin(UniformComponentPlugin::<Mesh2dUniform>::default());
 

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -41,6 +41,8 @@ pub const MESH2D_VIEW_BINDINGS_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 6901431444735842434);
 pub const MESH2D_TYPES_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 8994673400261890424);
+pub const MESH2D_BINDINGS_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 8983617858458862856);
 pub const MESH2D_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 2971387252468633715);
 
@@ -62,6 +64,12 @@ impl Plugin for Mesh2dRenderPlugin {
             app,
             MESH2D_TYPES_HANDLE,
             "mesh2d_types.wgsl",
+            Shader::from_wgsl
+        );
+        load_internal_asset!(
+            app,
+            MESH2D_BINDINGS_HANDLE,
+            "mesh2d_bindings.wgsl",
             Shader::from_wgsl
         );
         load_internal_asset!(app, MESH2D_SHADER_HANDLE, "mesh2d.wgsl", Shader::from_wgsl);

--- a/crates/bevy_sprite/src/mesh2d/mesh2d.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d.wgsl
@@ -1,5 +1,9 @@
-#import bevy_sprite::mesh2d_view_bind_group
-#import bevy_sprite::mesh2d_struct
+#import bevy_sprite::mesh2d_view_types
+#import bevy_sprite::mesh2d_types
+#import bevy_sprite::mesh2d_view_bindings
+
+[[group(2), binding(0)]]
+var<uniform> mesh: Mesh2d;
 
 struct Vertex {
     [[location(0)]] position: vec3<f32>;
@@ -19,12 +23,6 @@ struct VertexOutput {
     [[location(3)]] world_tangent: vec4<f32>;
 #endif
 };
-
-[[group(0), binding(0)]]
-var<uniform> view: View;
-
-[[group(2), binding(0)]]
-var<uniform> mesh: Mesh2d;
 
 [[stage(vertex)]]
 fn vertex(vertex: Vertex) -> VertexOutput {

--- a/crates/bevy_sprite/src/mesh2d/mesh2d.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d.wgsl
@@ -1,9 +1,5 @@
-#import bevy_sprite::mesh2d_view_types
-#import bevy_sprite::mesh2d_types
 #import bevy_sprite::mesh2d_view_bindings
-
-[[group(2), binding(0)]]
-var<uniform> mesh: Mesh2d;
+#import bevy_sprite::mesh2d_bindings
 
 struct Vertex {
     [[location(0)]] position: vec3<f32>;

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_bindings.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_bindings.wgsl
@@ -1,0 +1,6 @@
+#define_import_path bevy_sprite::mesh2d_bindings
+
+#import bevy_sprite::mesh2d_types
+
+[[group(2), binding(0)]]
+var<uniform> mesh: Mesh2d;

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_types.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_types.wgsl
@@ -1,4 +1,4 @@
-#define_import_path bevy_sprite::mesh2d_struct
+#define_import_path bevy_sprite::mesh2d_types
 
 struct Mesh2d {
     model: mat4x4<f32>;

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_view_bindings.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_view_bindings.wgsl
@@ -1,4 +1,6 @@
 #define_import_path bevy_sprite::mesh2d_view_bindings
 
+#import bevy_sprite::mesh2d_view_types
+
 [[group(0), binding(0)]]
 var<uniform> view: View;

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_view_bindings.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_view_bindings.wgsl
@@ -1,0 +1,4 @@
+#define_import_path bevy_sprite::mesh2d_view_bindings
+
+[[group(0), binding(0)]]
+var<uniform> view: View;

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_view_types.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_view_types.wgsl
@@ -1,4 +1,4 @@
-#define_import_path bevy_sprite::mesh2d_view_bind_group
+#define_import_path bevy_sprite::mesh2d_view_types
 
 struct View {
     view_proj: mat4x4<f32>;

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -209,7 +209,6 @@ type DrawColoredMesh2d = (
 // using `include_str!()`, or loaded like any other asset with `asset_server.load()`.
 const COLORED_MESH2D_SHADER: &str = r"
 // Import the standard 2d mesh uniforms and set their bind groups
-#import bevy_sprite::mesh2d_view_types
 #import bevy_sprite::mesh2d_types
 #import bevy_sprite::mesh2d_view_bindings
 

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -209,10 +209,10 @@ type DrawColoredMesh2d = (
 // using `include_str!()`, or loaded like any other asset with `asset_server.load()`.
 const COLORED_MESH2D_SHADER: &str = r"
 // Import the standard 2d mesh uniforms and set their bind groups
-#import bevy_sprite::mesh2d_view_bind_group
-[[group(0), binding(0)]]
-var<uniform> view: View;
-#import bevy_sprite::mesh2d_struct
+#import bevy_sprite::mesh2d_view_types
+#import bevy_sprite::mesh2d_types
+#import bevy_sprite::mesh2d_view_bindings
+
 [[group(1), binding(0)]]
 var<uniform> mesh: Mesh2d;
 


### PR DESCRIPTION
# Objective

- Split PBR and 2D mesh shaders into types and bindings to prepare the shaders to be more reusable.
- See #3969 for details. I'm doing this in multiple steps to make review easier.

---

## Changelog

- Changed: 2D and PBR mesh shaders are now split into types and bindings, the following shader imports are available: `bevy_pbr::mesh_view_types`, `bevy_pbr::mesh_view_bindings`, `bevy_pbr::mesh_types`, `bevy_pbr::mesh_bindings`, `bevy_sprite::mesh2d_view_types`, `bevy_sprite::mesh2d_view_bindings`, `bevy_sprite::mesh2d_types`, `bevy_sprite::mesh2d_bindings`

## Migration Guide

- In shaders for 3D meshes:
  - `#import bevy_pbr::mesh_view_bind_group` -> `#import bevy_pbr::mesh_view_bindings`
  - `#import bevy_pbr::mesh_struct` -> `#import bevy_pbr::mesh_types`
    - NOTE: If you are using the mesh bind group at bind group index 2, you can remove those binding statements in your shader and just use `#import bevy_pbr::mesh_bindings` which itself imports the mesh types needed for the bindings.
- In shaders for 2D meshes:
  - `#import bevy_sprite::mesh2d_view_bind_group` -> `#import bevy_sprite::mesh2d_view_bindings`
  - `#import bevy_sprite::mesh2d_struct` -> `#import bevy_sprite::mesh2d_types`
    - NOTE: If you are using the mesh2d bind group at bind group index 2, you can remove those binding statements in your shader and just use `#import bevy_sprite::mesh2d_bindings` which itself imports the mesh2d types needed for the bindings.
