### PR TITLE
[Merged by Bors] - Add methods for querying lists of entities.

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -31,7 +31,7 @@ pub mod prelude {
         component::Component,
         entity::Entity,
         event::{EventReader, EventWriter},
-        query::{Added, AnyOf, ChangeTrackers, Changed, Or, QueryState, With, WithQuery, Without},
+        query::{Added, AnyOf, ChangeTrackers, Changed, Or, QueryState, With, Without},
         schedule::{
             AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,
             RunCriteria, RunCriteriaDescriptorCoercion, RunCriteriaLabel, Schedule, Stage,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -31,7 +31,7 @@ pub mod prelude {
         component::Component,
         entity::Entity,
         event::{EventReader, EventWriter},
-        query::{Added, AnyOf, ChangeTrackers, Changed, Or, QueryState, With, Without},
+        query::{Added, AnyOf, ChangeTrackers, Changed, Or, QueryState, With, WithQuery, Without},
         schedule::{
             AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,
             RunCriteria, RunCriteriaDescriptorCoercion, RunCriteriaLabel, Schedule, Stage,

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -74,8 +74,7 @@ where
 
 /// An [`Iterator`] over query results of a [`Query`](crate::system::Query).
 ///
-/// This struct is created by the [`Query::many_iter`](crate::system::Query::many_iter) and
-/// [`Query::many_iter_mut`](crate::system::Query::many_iter_mut) methods.
+/// This struct is created by the [`Query::iter_many`](crate::system::Query::iter_many) method.
 pub struct QueryManyIter<
     'w,
     's,
@@ -143,13 +142,13 @@ where
 {
     type Item = QF::Item;
 
+    #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
             for entity in self.entity_iter.by_ref() {
-                let location = if let Some(location) = self.entities.get(*entity.borrow()) {
-                    location
-                } else {
-                    continue;
+                let location = match self.entities.get(*entity.borrow()) {
+                    Some(location) => location,
+                    None => continue,
                 };
 
                 if !self

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -82,9 +82,10 @@ pub struct QueryManyIter<
     Q: WorldQuery,
     QF: Fetch<'w, State = Q::State>,
     F: WorldQuery,
-    E: Borrow<Entity>,
-    I: Iterator<Item = E>,
-> {
+    I: Iterator,
+> where
+    I::Item: Borrow<Entity>,
+{
     entity_iter: I,
     world: &'w World,
     fetch: QF,
@@ -92,15 +93,10 @@ pub struct QueryManyIter<
     query_state: &'s QueryState<Q, F>,
 }
 
-impl<
-        'w,
-        's,
-        Q: WorldQuery,
-        QF: Fetch<'w, State = Q::State>,
-        F: WorldQuery,
-        E: Borrow<Entity>,
-        I: Iterator<Item = E>,
-    > QueryManyIter<'w, 's, Q, QF, F, E, I>
+impl<'w, 's, Q: WorldQuery, QF: Fetch<'w, State = Q::State>, F: WorldQuery, I: Iterator>
+    QueryManyIter<'w, 's, Q, QF, F, I>
+where
+    I::Item: Borrow<Entity>,
 {
     /// # Safety
     /// This does not check for mutable query correctness. To be safe, make sure mutable queries
@@ -113,7 +109,7 @@ impl<
         entity_list: EntityList,
         last_change_tick: u32,
         change_tick: u32,
-    ) -> QueryManyIter<'w, 's, Q, QF, F, E, I> {
+    ) -> QueryManyIter<'w, 's, Q, QF, F, I> {
         let fetch = QF::init(
             world,
             &query_state.fetch_state,
@@ -136,15 +132,10 @@ impl<
     }
 }
 
-impl<
-        'w,
-        's,
-        Q: WorldQuery,
-        QF: Fetch<'w, State = Q::State>,
-        F: WorldQuery,
-        E: Borrow<Entity>,
-        I: Iterator<Item = E>,
-    > Iterator for QueryManyIter<'w, 'w, Q, QF, F, E, I>
+impl<'w, 's, Q: WorldQuery, QF: Fetch<'w, State = Q::State>, F: WorldQuery, I: Iterator> Iterator
+    for QueryManyIter<'w, 'w, Q, QF, F, I>
+where
+    I::Item: Borrow<Entity>,
 {
     type Item = QF::Item;
 

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -519,7 +519,7 @@ mod tests {
     }
 
     #[test]
-    fn many_iter() {
+    fn many_entities() {
         let mut world = World::new();
         world.spawn().insert_bundle((A(0), B(0)));
         world.spawn().insert_bundle((A(0), B(0)));
@@ -527,7 +527,7 @@ mod tests {
         world.spawn().insert(B(0));
         {
             fn system(has_a: Query<Entity, With<A>>, has_a_and_b: Query<(&A, &B)>) {
-                assert_eq!(has_a_and_b.many_iter(&has_a).count(), 2);
+                assert_eq!(has_a_and_b.iter_many(&has_a).count(), 2);
             }
             let mut system = IntoSystem::into_system(system);
             system.initialize(&mut world);
@@ -535,9 +535,9 @@ mod tests {
         }
         {
             fn system(has_a: Query<Entity, With<A>>, mut b_query: Query<&mut B>) {
-                for mut b in b_query.many_iter_mut(&has_a) {
+                b_query.many_for_each_mut(&has_a, |mut b| {
                     b.0 = 1;
-                }
+                });
             }
             let mut system = IntoSystem::into_system(system);
             system.initialize(&mut world);

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -519,21 +519,12 @@ mod tests {
     }
 
     #[test]
-    fn many() {
+    fn many_iter() {
         let mut world = World::new();
         world.spawn().insert_bundle((A(0), B(0)));
         world.spawn().insert_bundle((A(0), B(0)));
-        world.spawn().insert_bundle((A(0),));
-        world.spawn().insert_bundle((B(0),));
-
-        {
-            fn system(query: Query<Entity>, b_query: Query<&B>) {
-                for _b in b_query.many_iter(&query) {}
-            }
-            let mut system = IntoSystem::into_system(system);
-            system.initialize(&mut world);
-            system.run((), &mut world);
-        }
+        world.spawn().insert(A(0));
+        world.spawn().insert(B(0));
         {
             fn system(has_a: Query<Entity, With<A>>, has_a_and_b: Query<(&A, &B)>) {
                 assert_eq!(has_a_and_b.many_iter(&has_a).count(), 2);
@@ -544,9 +535,9 @@ mod tests {
         }
         {
             fn system(has_a: Query<Entity, With<A>>, mut b_query: Query<&mut B>) {
-                b_query.many_for_each_mut(&has_a, |mut b| {
+                for mut b in b_query.many_iter_mut(&has_a) {
                     b.0 = 1;
-                });
+                }
             }
             let mut system = IntoSystem::into_system(system);
             system.initialize(&mut world);

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -978,7 +978,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
             fetch.set_archetype(&self.fetch_state, archetype, tables);
             filter.set_archetype(&self.filter_state, archetype, tables);
             if filter.archetype_filter_fetch(location.index) {
-                func(fetch.archetype_fetch(location.index))
+                func(fetch.archetype_fetch(location.index));
             }
         }
     }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -556,6 +556,32 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         }
     }
 
+    /// Returns an [`Iterator`] over the query results of a list of [`Entity`]'s.
+    ///
+    /// This can only return immutable data (mutable data will be cast to an immutable form).
+    /// See [`Self::many_for_each_mut`] for queries that contain at least one mutable component.
+    ///
+    #[inline]
+    pub fn iter_many<'w, 's, EntityList: IntoIterator>(
+        &'s mut self,
+        world: &'w World,
+        entities: EntityList,
+    ) -> QueryManyIter<'w, 's, Q, ROQueryFetch<'w, Q>, F, EntityList::IntoIter>
+    where
+        EntityList::Item: Borrow<Entity>,
+    {
+        // SAFETY: query is read only
+        unsafe {
+            self.update_archetypes(world);
+            self.iter_many_unchecked_manual(
+                entities,
+                world,
+                world.last_change_tick(),
+                world.read_change_tick(),
+            )
+        }
+    }
+
     /// Returns an [`Iterator`] over the query results for the given [`World`].
     ///
     /// # Safety
@@ -804,6 +830,29 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         );
     }
 
+    /// Runs `func` on each query result where the entities match.
+    #[inline]
+    pub fn many_for_each_mut<EntityList: IntoIterator>(
+        &mut self,
+        world: &mut World,
+        entities: EntityList,
+        func: impl FnMut(QueryItem<'_, Q>),
+    ) where
+        EntityList::Item: Borrow<Entity>,
+    {
+        // SAFETY: query has unique world access
+        unsafe {
+            self.update_archetypes(world);
+            self.many_for_each_unchecked_manual(
+                world,
+                entities,
+                func,
+                world.last_change_tick(),
+                world.read_change_tick(),
+            );
+        };
+    }
+
     /// Runs `func` on each query result for the given [`World`], where the last change and
     /// the current change tick are given. This is faster than the equivalent
     /// iter() method, but cannot be chained like a normal [`Iterator`].
@@ -1008,23 +1057,20 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     /// have unique access to the components they query.
     /// This does not validate that `world.id()` matches `self.world_id`. Calling this on a `world`
     /// with a mismatched [`WorldId`] is unsound.
-    pub(crate) unsafe fn many_for_each_unchecked_manual<
-        'w,
-        QF: Fetch<'w, State = Q::State>,
-        E: Borrow<Entity>,
-        EntityList: IntoIterator<Item = E>,
-        FN: FnMut(QF::Item),
-    >(
+    pub(crate) unsafe fn many_for_each_unchecked_manual<EntityList: IntoIterator>(
         &self,
-        world: &'w World,
+        world: &World,
         entity_list: EntityList,
-        mut func: FN,
+        mut func: impl FnMut(QueryItem<'_, Q>),
         last_change_tick: u32,
         change_tick: u32,
-    ) {
+    ) where
+        EntityList::Item: Borrow<Entity>,
+    {
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
         // QueryIter, QueryIterationCursor, QueryState::for_each_unchecked_manual, QueryState::many_for_each_unchecked_manual, QueryState::par_for_each_unchecked_manual
-        let mut fetch = QF::init(world, &self.fetch_state, last_change_tick, change_tick);
+        let mut fetch =
+            <QueryFetch<Q> as Fetch>::init(world, &self.fetch_state, last_change_tick, change_tick);
         let mut filter = <QueryFetch<F> as Fetch>::init(
             world,
             &self.filter_state,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -625,16 +625,17 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         'w,
         's,
         QF: Fetch<'w, State = Q::State>,
-        E: Borrow<Entity>,
-        I: Iterator<Item = E>,
-        EntityList: IntoIterator<IntoIter = I>,
+        EntityList: IntoIterator,
     >(
         &'s self,
         entities: EntityList,
         world: &'w World,
         last_change_tick: u32,
         change_tick: u32,
-    ) -> QueryManyIter<'w, 's, Q, QF, F, E, I> {
+    ) -> QueryManyIter<'w, 's, Q, QF, F, EntityList::IntoIter>
+    where
+        EntityList::Item: Borrow<Entity>,
+    {
         QueryManyIter::new(world, self, entities, last_change_tick, change_tick)
     }
 

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1156,11 +1156,11 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
-    pub fn many_iter<I, II, E>(&self, entities: II) -> QueryManyIter<'_, '_, I, Q, F, E>
+    pub fn many_iter<I, EntityList, E>(&self, entities: EntityList) -> QueryManyIter<'_, '_, I, Q, F, E>
     where
         E: Borrow<Entity>,
         I: Iterator<Item = E>,
-        II: IntoIterator<IntoIter = I>,
+        EntityList: IntoIterator<IntoIter = I>,
     {
         QueryManyIter {
             entities: entities.into_iter(),
@@ -1195,10 +1195,10 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
-    pub fn many_for_each<II, E>(&self, entities: II, f: impl Fn(ROQueryItem<'_, Q>))
+    pub fn many_for_each<EntityList, E>(&self, entities: EntityList, f: impl Fn(ROQueryItem<'_, Q>))
     where
         E: Borrow<Entity>,
-        II: IntoIterator<Item = E>,
+        EntityList: IntoIterator<Item = E>,
     {
         entities.into_iter().map(|e| *e.borrow()).for_each(|input| {
             if let Ok(item) = self.get(input) {
@@ -1235,10 +1235,10 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
-    pub fn many_for_each_mut<II, E>(&mut self, entities: II, mut f: impl FnMut(QueryItem<'_, Q>))
+    pub fn many_for_each_mut<EntityList, E>(&mut self, entities: EntityList, mut f: impl FnMut(QueryItem<'_, Q>))
     where
         E: Borrow<Entity>,
-        II: IntoIterator<Item = E>,
+        EntityList: IntoIterator<Item = E>,
     {
         entities.into_iter().map(|e| *e.borrow()).for_each(|entity| {
             if let Ok(item) = self.get_mut(entity) {

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -418,6 +418,7 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
+    #[inline]
     pub fn iter_many<EntityList: IntoIterator>(
         &self,
         entities: EntityList,
@@ -666,22 +667,24 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
-    pub fn many_for_each_mut<E: Borrow<Entity>, EntityList: IntoIterator<Item = E>>(
+    #[inline]
+    pub fn many_for_each_mut<EntityList: IntoIterator>(
         &mut self,
         entities: EntityList,
         f: impl FnMut(QueryItem<'_, Q>),
-    ) {
+    ) where
+        EntityList::Item: Borrow<Entity>,
+    {
         // SAFE: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict
         unsafe {
-            self.state
-                .many_for_each_unchecked_manual::<QueryFetch<Q>, E, EntityList, _>(
-                    self.world,
-                    entities,
-                    f,
-                    self.last_change_tick,
-                    self.change_tick,
-                );
+            self.state.many_for_each_unchecked_manual(
+                self.world,
+                entities,
+                f,
+                self.last_change_tick,
+                self.change_tick,
+            );
         };
     }
 

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1156,10 +1156,10 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
-    pub fn many_iter<I, II, T>(&self, entities: II) -> QueryManyIter<'_, '_, I, Q, F, T>
+    pub fn many_iter<I, II, E>(&self, entities: II) -> QueryManyIter<'_, '_, I, Q, F, E>
     where
-        T: Borrow<Entity>,
-        I: Iterator<Item = T>,
+        E: Borrow<Entity>,
+        I: Iterator<Item = E>,
         II: IntoIterator<IntoIter = I>,
     {
         QueryManyIter {
@@ -1195,14 +1195,14 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
-    pub fn many_for_each<II, T>(&self, input: II, cb: impl Fn(ROQueryItem<'_, Q>))
+    pub fn many_for_each<II, E>(&self, entities: II, f: impl Fn(ROQueryItem<'_, Q>))
     where
-        T: Borrow<Entity>,
-        II: IntoIterator<Item = T>,
+        E: Borrow<Entity>,
+        II: IntoIterator<Item = E>,
     {
-        input.into_iter().map(|e| *e.borrow()).for_each(|input| {
+        entities.into_iter().map(|e| *e.borrow()).for_each(|input| {
             if let Ok(item) = self.get(input) {
-                cb(item);
+                f(item);
             }
         });
     }
@@ -1235,14 +1235,14 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
-    pub fn many_for_each_mut<II, T>(&mut self, input: II, mut cb: impl FnMut(QueryItem<'_, Q>))
+    pub fn many_for_each_mut<II, E>(&mut self, entities: II, mut f: impl FnMut(QueryItem<'_, Q>))
     where
-        T: Borrow<Entity>,
-        II: IntoIterator<Item = T>,
+        E: Borrow<Entity>,
+        II: IntoIterator<Item = E>,
     {
-        input.into_iter().map(|e| *e.borrow()).for_each(|entity| {
+        entities.into_iter().map(|e| *e.borrow()).for_each(|entity| {
             if let Ok(item) = self.get_mut(entity) {
-                cb(item);
+                f(item);
             }
         });
     }

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1159,14 +1159,13 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
-    pub fn many_iter<
-        E: Borrow<Entity>,
-        I: Iterator<Item = E>,
-        EntityList: IntoIterator<IntoIter = I>,
-    >(
+    pub fn many_iter<EntityList: IntoIterator>(
         &self,
         entities: EntityList,
-    ) -> QueryManyIter<'_, '_, Q, ROQueryFetch<'_, Q>, F, E, I> {
+    ) -> QueryManyIter<'_, '_, Q, ROQueryFetch<'_, Q>, F, EntityList::IntoIter>
+    where
+        EntityList::Item: Borrow<Entity>,
+    {
         // SAFETY: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict
         unsafe {
@@ -1204,14 +1203,13 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     ///     }
     /// }
     /// ```
-    pub fn many_iter_mut<
-        E: Borrow<Entity>,
-        I: Iterator<Item = E>,
-        EntityList: IntoIterator<IntoIter = I>,
-    >(
+    pub fn many_iter_mut<EntityList: IntoIterator>(
         &mut self,
         entities: EntityList,
-    ) -> QueryManyIter<'_, '_, Q, QueryFetch<'_, Q>, F, E, I> {
+    ) -> QueryManyIter<'_, '_, Q, QueryFetch<'_, Q>, F, EntityList::IntoIter>
+    where
+        EntityList::Item: Borrow<Entity>,
+    {
         // SAFETY: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict
         unsafe {

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -471,9 +471,9 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     }
 
     /// Returns an [`Iterator`] over the query results of a list of [`Entity`]'s.
-    /// 
+    ///
     /// If you want safe mutable access to query results of a list of [`Entity`]'s. See [`Self::many_for_each_mut`].
-    /// 
+    ///
     /// # Safety
     /// This allows aliased mutability and does not check for entity uniqueness.
     /// You must make sure this call does not result in multiple mutable references to the same component.

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1129,7 +1129,10 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
         }
     }
 
-    /// Iterate over this [`Query`] where the entities match.
+    /// Returns an [`Iterator`] over the query results of a list of [`Entity`]'s.
+    ///
+    /// This can only return immutable data (mutable data will be cast to an immutable form).
+    /// See [`Self::many_iter_mut`] for queries that contain at least one mutable component.
     ///
     /// # Examples
     /// ```
@@ -1163,14 +1166,20 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     >(
         &self,
         entities: EntityList,
-    ) -> QueryManyIter<'_, '_, I, Q, F, E> {
-        QueryManyIter {
-            entities: entities.into_iter(),
-            query: self,
+    ) -> QueryManyIter<'_, '_, Q, ROQueryFetch<'_, Q>, F, E, I> {
+        // SAFETY: system runs without conflicts with other systems.
+        // same-system queries have runtime borrow checks when they conflict
+        unsafe {
+            self.state.iter_many_unchecked_manual(
+                entities,
+                self.world,
+                self.last_change_tick,
+                self.change_tick,
+            )
         }
     }
 
-    /// Calls a closure on each result of [`Query`] where the entities match.
+    /// Returns an [`Iterator`] over the query results of a list of [`Entity`]'s.
     ///
     /// # Examples
     /// ```
@@ -1179,88 +1188,40 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     /// struct Counter {
     ///     value: i32
     /// }
-    ///
     /// #[derive(Component)]
     /// struct Friends {
     ///     list: Vec<Entity>,
     /// }
-    ///
-    /// fn system(
-    ///     friends_query: Query<&Friends>,
-    ///     counter_query: Query<&Counter>,
-    /// ) {
-    ///     for friends in &friends_query {
-    ///         counter_query.many_for_each(&friends.list, |counter| {
-    ///             println!("Friend's counter: {:?}", counter.value);
-    ///         });
-    ///     }
-    /// }
-    /// # bevy_ecs::system::assert_is_system(system);
-    /// ```
-    pub fn many_for_each<E: Borrow<Entity>, EntityList: IntoIterator<Item = E>>(
-        &self,
-        entities: EntityList,
-        f: impl Fn(ROQueryItem<'_, Q>),
-    ) {
-        // SAFE: system runs without conflicts with other systems.
-        // same-system queries have runtime borrow checks when they conflict
-        unsafe {
-            self.state
-                .many_for_each_unchecked_manual::<ROQueryFetch<Q>, E, EntityList, _>(
-                    self.world,
-                    entities,
-                    f,
-                    self.last_change_tick,
-                    self.change_tick,
-                );
-        };
-    }
-
-    /// Calls a closure on each result of [`Query`] where the entities match.
-    /// # Examples
-    ///
-    /// ```
-    /// # use bevy_ecs::prelude::*;
-    /// #[derive(Component)]
-    /// struct Counter {
-    ///     value: i32
-    /// }
-    ///
-    /// #[derive(Component)]
-    /// struct Friends {
-    ///     list: Vec<Entity>,
-    /// }
-    ///
     /// fn system(
     ///     friends_query: Query<&Friends>,
     ///     mut counter_query: Query<&mut Counter>,
     /// ) {
     ///     for friends in &friends_query {
-    ///         counter_query.many_for_each_mut(&friends.list, |mut counter| {
+    ///         for mut counter in counter_query.many_iter_mut(&friends.list) {
     ///             println!("Friend's counter: {:?}", counter.value);
     ///             counter.value += 1;
-    ///         });
+    ///         }
     ///     }
     /// }
-    /// # bevy_ecs::system::assert_is_system(system);
     /// ```
-    pub fn many_for_each_mut<E: Borrow<Entity>, EntityList: IntoIterator<Item = E>>(
+    pub fn many_iter_mut<
+        E: Borrow<Entity>,
+        I: Iterator<Item = E>,
+        EntityList: IntoIterator<IntoIter = I>,
+    >(
         &mut self,
         entities: EntityList,
-        f: impl FnMut(QueryItem<'_, Q>),
-    ) {
-        // SAFE: system runs without conflicts with other systems.
+    ) -> QueryManyIter<'_, '_, Q, QueryFetch<'_, Q>, F, E, I> {
+        // SAFETY: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict
         unsafe {
-            self.state
-                .many_for_each_unchecked_manual::<QueryFetch<Q>, E, EntityList, _>(
-                    self.world,
-                    entities,
-                    f,
-                    self.last_change_tick,
-                    self.change_tick,
-                );
-        };
+            self.state.iter_many_unchecked_manual(
+                entities,
+                self.world,
+                self.last_change_tick,
+                self.change_tick,
+            )
+        }
     }
 }
 

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -421,6 +421,29 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
         )
     }
 
+    /// Returns an [`Iterator`] over the query results of a list of [`Entity`]'s.
+    /// 
+    /// If you want safe mutable access to query results of a list of [`Entity`]'s. See [`Self::many_for_each_mut`].
+    /// 
+    /// # Safety
+    /// This does not check for entity uniqueness and thus allows aliased mutability.
+    /// You must make sure this call does not result in multiple mutable references to the same component.
+    /// Particular care must be taken when collecting the data (rather than iterating over it one item at a time) such as via `[Iterator::collect()]`.
+    pub unsafe fn many_iter_unsafe<EntityList: IntoIterator>(
+        &mut self,
+        entities: EntityList,
+    ) -> QueryManyIter<'_, '_, Q, QueryFetch<'_, Q>, F, EntityList::IntoIter>
+    where
+        EntityList::Item: Borrow<Entity>,
+    {
+        self.state.iter_many_unchecked_manual(
+            entities,
+            self.world,
+            self.last_change_tick,
+            self.change_tick,
+        )
+    }
+
     /// Runs `f` on each query result. This is faster than the equivalent iter() method, but cannot
     /// be chained like a normal [`Iterator`].
     ///

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_many_for_each_mut_lifetime_safety.rs
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_many_for_each_mut_lifetime_safety.rs
@@ -1,0 +1,14 @@
+use bevy_ecs::prelude::*;
+
+#[derive(Component)]
+struct A(usize);
+
+fn system(mut query: Query<&mut A>, e: Res<Entity>) {
+    let mut results = Vec::new();
+    query.many_for_each_mut(vec![*e, *e], |a| {
+        // this should fail to compile
+        results.push(a);
+    });
+}
+
+fn main() {}

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_many_for_each_mut_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_many_for_each_mut_lifetime_safety.stderr
@@ -1,0 +1,10 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/system_query_many_for_each_mut_lifetime_safety.rs:10:9
+   |
+7  |     let mut results = Vec::new();
+   |         ----------- `results` declared here, outside of the closure body
+8  |     query.many_for_each_mut(vec![*e, *e], |a| {
+   |                                            - `a` is a reference that is only valid in the closure body
+9  |         // this should fail to compile
+10 |         results.push(a);
+   |         ^^^^^^^^^^^^^^^ `a` escapes the closure body here

--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -4,6 +4,7 @@ use bevy_ecs::{
     reflect::{ReflectComponent, ReflectMapEntities},
 };
 use bevy_reflect::Reflect;
+use core::slice;
 use smallvec::SmallVec;
 use std::ops::Deref;
 
@@ -39,5 +40,15 @@ impl Deref for Children {
 
     fn deref(&self) -> &Self::Target {
         &self.0[..]
+    }
+}
+
+impl<'a> IntoIterator for &'a Children {
+    type Item = <Self::IntoIter as Iterator>::Item;
+
+    type IntoIter = slice::Iter<'a, Entity>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
     }
 }


### PR DESCRIPTION
# Objective
Improve querying ergonomics around collections and iterators of entities.

Example how queries over Children might be done currently. 
```rust
fn system(foo_query: Query<(&Foo, &Children)>, bar_query: Query<(&Bar, &Children)>) {
    for (foo, children) in &foo_query {
        for child in children.iter() {
            if let Ok((bar, children)) = bar_query.get(*child) {
                for child in children.iter() {
                    if let Ok((foo, children)) = foo_query.get(*child) {
                        // D:
                    }
                }
            }
        }
    }
}
```
Answers #4868
Partially addresses #4864
Fixes #1470
## Solution
Based on the great work by @deontologician in #2563 

Added `iter_many` and `many_for_each_mut` to `Query`.
These take a list of entities (Anything that implements `IntoIterator<Item: Borrow<Entity>>`).

`iter_many` returns a `QueryManyIter` iterator over immutable results of a query (mutable data will be cast to an immutable form).

`many_for_each_mut` calls a closure for every result of the query, ensuring not aliased mutability. 
This iterator goes over the list of entities in order and returns the result from the query for it. Skipping over any entities that don't match the query.

Also added `unsafe fn iter_many_unsafe`.

### Examples
```rust
#[derive(Component)]
struct Counter {
    value: i32
}

#[derive(Component)]
struct Friends {
    list: Vec<Entity>,
}

fn system(
    friends_query: Query<&Friends>,
    mut counter_query: Query<&mut Counter>,
) {
    for friends in &friends_query {
        for counter in counter_query.iter_many(&friends.list) {
            println!("Friend's counter: {:?}", counter.value);
        }
        
        counter_query.many_for_each_mut(&friends.list, |mut counter| {
            counter.value += 1;
            println!("Friend's counter: {:?}", counter.value);
        });
    }
}

```

Here's how example in the Objective section can be written with this PR.
```rust
fn system(foo_query: Query<(&Foo, &Children)>, bar_query: Query<(&Bar, &Children)>) {
    for (foo, children) in &foo_query {
        for (bar, children) in bar_query.iter_many(children) {
            for (foo, children) in foo_query.iter_many(children) {
                // :D
            }
        }
    }
}
```
## Additional changes
Implemented `IntoIterator` for `&Children` because why not.
## Todo
- Bikeshed!

Co-authored-by: deontologician <deontologician@gmail.com>