### PR TITLE
[Merged by Bors] - Bugfix `State::set` transition condition infinite loop

### DIFF
--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -289,14 +289,14 @@ where
     }
 
     /// Schedule a state change that replaces the full stack with the given state.
-    /// This will fail if there is a scheduled operation, or if the given `state` matches the
-    /// current state
+    /// This will fail if there is a scheduled operation, pending transition, or if the given
+    /// `state` matches the current state
     pub fn replace(&mut self, state: T) -> Result<(), StateError> {
         if self.stack.last().unwrap() == &state {
             return Err(StateError::AlreadyInState);
         }
 
-        if self.scheduled.is_some() {
+        if self.scheduled.is_some() || self.transition.is_some() {
             return Err(StateError::StateAlreadyQueued);
         }
 
@@ -321,7 +321,7 @@ where
             return Err(StateError::AlreadyInState);
         }
 
-        if self.scheduled.is_some() {
+        if self.scheduled.is_some() || self.transition.is_some() {
             return Err(StateError::StateAlreadyQueued);
         }
 
@@ -342,7 +342,7 @@ where
 
     /// Same as [`Self::set`], but does a pop operation instead of a set operation
     pub fn pop(&mut self) -> Result<(), StateError> {
-        if self.scheduled.is_some() {
+        if self.scheduled.is_some() || self.transition.is_some() {
             return Err(StateError::StateAlreadyQueued);
         }
 
@@ -365,9 +365,9 @@ where
     }
 
     /// Schedule a state change that restarts the active state.
-    /// This will fail if there is a scheduled operation
+    /// This will fail if there is a scheduled operation or a pending transition
     pub fn restart(&mut self) -> Result<(), StateError> {
-        if self.scheduled.is_some() {
+        if self.scheduled.is_some() || self.transition.is_some() {
             return Err(StateError::StateAlreadyQueued);
         }
 

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -269,7 +269,7 @@ where
             return Err(StateError::AlreadyInState);
         }
 
-        if self.scheduled.is_some() {
+        if self.scheduled.is_some() || self.transition.is_some() {
             return Err(StateError::StateAlreadyQueued);
         }
 

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -262,8 +262,8 @@ where
     }
 
     /// Schedule a state change that replaces the active state with the given state.
-    /// This will fail if there is a scheduled operation, or if the given `state` matches the
-    /// current state
+    /// This will fail if there is a scheduled operation, pending transition, or if the given
+    /// `state` matches the current state
     pub fn set(&mut self, state: T) -> Result<(), StateError> {
         if self.stack.last().unwrap() == &state {
             return Err(StateError::AlreadyInState);


### PR DESCRIPTION
# Objective

- Fixes #4271

## Solution

- Check for a pending transition in addition to a scheduled operation.
- I don't see a valid reason for updating the state unless both `scheduled` and `transition` are empty.