### PR TITLE
Add `reparented_to` method to `GlobalTransform`

### DIFF
--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -210,7 +210,11 @@ impl Transform {
     }
 
     /// Multiplies `self` with `transform` component by component, returning the
-    /// resulting [`Transform`]
+    /// resulting [`Transform`].
+    ///
+    /// Note that `self.mul_transform(transform)` is identical to `self * transform`.
+    ///
+    /// To find `X` such as `transform * X = self`, see [`GlobalTransform::reparented_to`].
     #[inline]
     #[must_use]
     pub fn mul_transform(&self, transform: Transform) -> Self {


### PR DESCRIPTION
# Objective

Finding the proper transform to make an entity a child of another
without its global transform changing is tricky and error prone. It
requires some knowledge of how bevy computes and propagates
`GlobalTransform` through the hierarchy.

## Solution

This introduces a way to find such a transform. The method is only
implemented on `GlobalTransform` since we expect it to be the most
common use-case.

## Changelog

- Add `reparented_to` method to `GlobalTransform`
