### PR TITLE
[Merged by Bors] - Fix crash when using Duration::MAX

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -591,7 +591,11 @@ pub fn winit_runner_with(mut app: App) {
                     *control_flow = match winit_config.update_mode(focused) {
                         Continuous => ControlFlow::Poll,
                         Reactive { max_wait } | ReactiveLowPower { max_wait } => {
-                            ControlFlow::WaitUntil(now + *max_wait)
+                            if let Some(instant) = now.checked_add(*max_wait) {
+                                ControlFlow::WaitUntil(instant)
+                            } else {
+                                ControlFlow::Wait
+                            }
                         }
                     };
                 }

--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -68,7 +68,11 @@ pub enum UpdateMode {
     /// Once the app has executed all bevy systems and reaches the end of the event loop, there is
     /// no way to force the app to wake and update again, unless a `winit` event (such as user
     /// input, or the window being resized) is received or the time limit is reached.
-    Reactive { max_wait: Duration },
+    Reactive {
+        /// The maximum time to wait before the event loop runs again. Note that if the duration is
+        /// too high, Bevy will wait indefinitely.
+        max_wait: Duration,
+    },
     /// The event loop will only update if there is a winit event from direct interaction with the
     /// window (e.g. mouseover), a redraw is requested, or the maximum wait time has elapsed.
     ///
@@ -85,5 +89,9 @@ pub enum UpdateMode {
     /// window is not focused, to only re-draw your bevy app when the cursor is over the window, but
     /// not when the mouse moves somewhere else on the screen. This helps to significantly reduce
     /// power consumption by only updated the app when absolutely necessary.
-    ReactiveLowPower { max_wait: Duration },
+    ReactiveLowPower {
+        /// The maximum time to wait before the event loop runs again. Note that if the duration is
+        /// too high, Bevy will wait indefinitely.
+        max_wait: Duration,
+    },
 }

--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -69,8 +69,9 @@ pub enum UpdateMode {
     /// no way to force the app to wake and update again, unless a `winit` event (such as user
     /// input, or the window being resized) is received or the time limit is reached.
     Reactive {
-        /// The maximum time to wait before the event loop runs again. Note that if the duration is
-        /// too high, Bevy will wait indefinitely.
+        /// The maximum time to wait before the event loop runs again.
+        ///
+        /// Note that Bevy will wait indefinitely if the duration is too high (such as [`Duration::MAX`]).
         max_wait: Duration,
     },
     /// The event loop will only update if there is a winit event from direct interaction with the
@@ -90,8 +91,9 @@ pub enum UpdateMode {
     /// not when the mouse moves somewhere else on the screen. This helps to significantly reduce
     /// power consumption by only updated the app when absolutely necessary.
     ReactiveLowPower {
-        /// The maximum time to wait before the event loop runs again. Note that if the duration is
-        /// too high, Bevy will wait indefinitely.
+        /// The maximum time to wait before the event loop runs again.
+        ///
+        /// Note that Bevy will wait indefinitely if the duration is too high (such as [`Duration::MAX`]).
         max_wait: Duration,
     },
 }


### PR DESCRIPTION
# Objective

If you set the `ReactiveLowPower` max wait to `Duration::MAX`, stuff panics. Fix that.

## Solution

Wait forever if addition failed.