### PR TITLE
Avoid unnecessary copying with BufferVec::swap

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -741,7 +741,7 @@ impl Default for SkinnedMeshUniform {
 pub fn prepare_skinned_meshes(
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
-    extracted_joints: Res<ExtractedJoints>,
+    mut extracted_joints: ResMut<ExtractedJoints>,
     mut skinned_mesh_uniform: ResMut<SkinnedMeshUniform>,
 ) {
     if extracted_joints.buffer.is_empty() {
@@ -752,9 +752,7 @@ pub fn prepare_skinned_meshes(
     skinned_mesh_uniform
         .buffer
         .reserve(extracted_joints.buffer.len(), &render_device);
-    for joint in &extracted_joints.buffer {
-        skinned_mesh_uniform.buffer.push(*joint);
-    }
+    skinned_mesh_uniform.buffer.swap(&mut extracted_joints.buffer);
     skinned_mesh_uniform
         .buffer
         .write_buffer(&render_device, &render_queue);

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -752,7 +752,10 @@ pub fn prepare_skinned_meshes(
     skinned_mesh_uniform
         .buffer
         .reserve(extracted_joints.buffer.len(), &render_device);
-    skinned_mesh_uniform.buffer.swap(&mut extracted_joints.buffer);
+    skinned_mesh_uniform
+        .buffer
+        .swap(&mut extracted_joints.buffer);
+    extracted_joints.buffer.clear();
     skinned_mesh_uniform
         .buffer
         .write_buffer(&render_device, &render_queue);

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -5,6 +5,8 @@ use crate::{
 use bevy_core::{cast_slice, Pod};
 use copyless::VecHelper;
 use wgpu::BufferUsages;
+#[cfg(feature="trace")]
+use bevy_utils::tracing::info_span;
 
 pub struct BufferVec<T: Pod> {
     values: Vec<T>,
@@ -51,6 +53,11 @@ impl<T: Pod> BufferVec<T> {
         index
     }
 
+    /// Swaps the internal [`Vec`] with another of the same type.
+    pub fn swap(&mut self, other: &mut Vec<T>) {
+        std::mem::swap(&mut self.values, other)
+    }
+
     pub fn reserve(&mut self, capacity: usize, device: &RenderDevice) {
         if capacity > self.capacity {
             self.capacity = capacity;
@@ -72,6 +79,8 @@ impl<T: Pod> BufferVec<T> {
         if let Some(buffer) = &self.buffer {
             let range = 0..self.item_size * self.values.len();
             let bytes: &[u8] = cast_slice(&self.values);
+            #[cfg(feature="trace")]
+            let _span = info_span!("BufferVec: write buffer").entered();
             queue.write_buffer(buffer, 0, &bytes[range]);
         }
     }

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -3,10 +3,10 @@ use crate::{
     renderer::{RenderDevice, RenderQueue},
 };
 use bevy_core::{cast_slice, Pod};
+#[cfg(feature = "trace")]
+use bevy_utils::tracing::info_span;
 use copyless::VecHelper;
 use wgpu::BufferUsages;
-#[cfg(feature="trace")]
-use bevy_utils::tracing::info_span;
 
 pub struct BufferVec<T: Pod> {
     values: Vec<T>,
@@ -79,7 +79,7 @@ impl<T: Pod> BufferVec<T> {
         if let Some(buffer) = &self.buffer {
             let range = 0..self.item_size * self.values.len();
             let bytes: &[u8] = cast_slice(&self.values);
-            #[cfg(feature="trace")]
+            #[cfg(feature = "trace")]
             let _span = info_span!("BufferVec: write buffer").entered();
             queue.write_buffer(buffer, 0, &bytes[range]);
         }

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -55,7 +55,7 @@ impl<T: Pod> BufferVec<T> {
 
     /// Swaps the internal [`Vec`] with another of the same type.
     pub fn swap(&mut self, other: &mut Vec<T>) {
-        std::mem::swap(&mut self.values, other)
+        std::mem::swap(&mut self.values, other);
     }
 
     pub fn reserve(&mut self, capacity: usize, device: &RenderDevice) {

--- a/crates/bevy_render/src/render_resource/storage_buffer.rs
+++ b/crates/bevy_render/src/render_resource/storage_buffer.rs
@@ -1,12 +1,12 @@
 use super::Buffer;
 use crate::renderer::{RenderDevice, RenderQueue};
+#[cfg(feature = "trace")]
+use bevy_utils::tracing::info_span;
 use encase::{
     internal::WriteInto, DynamicStorageBuffer as DynamicStorageBufferWrapper, ShaderType,
     StorageBuffer as StorageBufferWrapper,
 };
 use wgpu::{util::BufferInitDescriptor, BindingResource, BufferBinding, BufferUsages};
-#[cfg(feature="trace")]
-use bevy_utils::tracing::info_span;
 
 pub struct StorageBuffer<T: ShaderType> {
     value: T,
@@ -75,7 +75,7 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
             }));
             self.capacity = size;
         } else if let Some(buffer) = &self.buffer {
-            #[cfg(feature="trace")]
+            #[cfg(feature = "trace")]
             let _span = info_span!("StorageBuffer: write buffer").entered();
             queue.write_buffer(buffer, 0, self.scratch.as_ref());
         }
@@ -144,7 +144,7 @@ impl<T: ShaderType + WriteInto> DynamicStorageBuffer<T> {
             }));
             self.capacity = size;
         } else if let Some(buffer) = &self.buffer {
-            #[cfg(feature="trace")]
+            #[cfg(feature = "trace")]
             let _span = info_span!("DynamicStorageBuffer: write buffer").entered();
             queue.write_buffer(buffer, 0, self.scratch.as_ref());
         }

--- a/crates/bevy_render/src/render_resource/storage_buffer.rs
+++ b/crates/bevy_render/src/render_resource/storage_buffer.rs
@@ -5,6 +5,8 @@ use encase::{
     StorageBuffer as StorageBufferWrapper,
 };
 use wgpu::{util::BufferInitDescriptor, BindingResource, BufferBinding, BufferUsages};
+#[cfg(feature="trace")]
+use bevy_utils::tracing::info_span;
 
 pub struct StorageBuffer<T: ShaderType> {
     value: T,
@@ -73,6 +75,8 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
             }));
             self.capacity = size;
         } else if let Some(buffer) = &self.buffer {
+            #[cfg(feature="trace")]
+            let _span = info_span!("StorageBuffer: write buffer").entered();
             queue.write_buffer(buffer, 0, self.scratch.as_ref());
         }
     }
@@ -140,6 +144,8 @@ impl<T: ShaderType + WriteInto> DynamicStorageBuffer<T> {
             }));
             self.capacity = size;
         } else if let Some(buffer) = &self.buffer {
+            #[cfg(feature="trace")]
+            let _span = info_span!("DynamicStorageBuffer: write buffer").entered();
             queue.write_buffer(buffer, 0, self.scratch.as_ref());
         }
     }

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -2,13 +2,13 @@ use crate::{
     render_resource::Buffer,
     renderer::{RenderDevice, RenderQueue},
 };
+#[cfg(feature = "trace")]
+use bevy_utils::tracing::info_span;
 use encase::{
     internal::WriteInto, DynamicUniformBuffer as DynamicUniformBufferWrapper, ShaderType,
     UniformBuffer as UniformBufferWrapper,
 };
 use wgpu::{util::BufferInitDescriptor, BindingResource, BufferBinding, BufferUsages};
-#[cfg(feature="trace")]
-use bevy_utils::tracing::info_span;
 
 pub struct UniformBuffer<T: ShaderType> {
     value: T,
@@ -66,10 +66,10 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
 
         match &self.buffer {
             Some(buffer) => {
-                #[cfg(feature="trace")]
+                #[cfg(feature = "trace")]
                 let _span = info_span!("UniformBuffer: write buffer").entered();
                 queue.write_buffer(buffer, 0, self.scratch.as_ref())
-            },
+            }
             None => {
                 self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {
                     label: None,
@@ -143,7 +143,7 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
             }));
             self.capacity = size;
         } else if let Some(buffer) = &self.buffer {
-            #[cfg(feature="trace")]
+            #[cfg(feature = "trace")]
             let _span = info_span!("DynamicUniformBuffer: write buffer").entered();
             queue.write_buffer(buffer, 0, self.scratch.as_ref());
         }

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -68,7 +68,7 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
             Some(buffer) => {
                 #[cfg(feature = "trace")]
                 let _span = info_span!("UniformBuffer: write buffer").entered();
-                queue.write_buffer(buffer, 0, self.scratch.as_ref())
+                queue.write_buffer(buffer, 0, self.scratch.as_ref());
             }
             None => {
                 self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {


### PR DESCRIPTION
# Objective
`prepare_skinned_meshes` is repeatedly copying values from `ExtractedJoints` when both end up identical to each other and cleared every frame.

## Solution

 - Add spans for measuring the time spent writing out buffers to the GPU.
 - Add `BufferVec::swap` to directly replace the backing `Vec` with a pre-prepared one. Avoid the copy.
 
## Performance
On `many_foxes` ,this halves the time spent in `prepare_skinned_meshes`:

![image](https://user-images.githubusercontent.com/3137680/171674565-3b51d9c0-b80d-4d39-930a-51cf6988ad41.png)

Almost all of the time spent in the system is now spent writing the buffer out.

![image](https://user-images.githubusercontent.com/3137680/171674786-04422e4b-1b26-41e7-a678-65e6fe474e66.png)

---

# Changelog
Added: `BufferVec::swap`.