### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Post-release version bump
 
 # how to trigger: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
 on:
@@ -16,29 +16,32 @@ jobs:
       - name: Install cargo-release
         run: cargo install cargo-release
 
-      - name: Setup release
+      - name: Setup post-release version bump
         run: |
           # Set the commit author to the github-actions bot. See discussion here for more information:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212
           # https://github.community/t/github-actions-bot-email-address/17204/6
           git config user.name 'Bevy Auto Releaser'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          # release: remove the dev suffix, like going from 0.X.0-dev to 0.X.0
-          # --workspace: updating all crates in the workspace
-          # --no-publish: do not publish to crates.io
-          # --execute: not a dry run
-          # --no-tag: do not push tag for each new version
-          # --no-push: do not push the update commits
-          # --dependent-version upgrade: change 0.X.0-dev in internal dependencies to 0.X.0
-          # --exclude: ignore those packages
-          cargo release release \
+          # Read the current version from Cargo.toml
+          current_version=$(cargo metadata --format-version 1 --no-deps | \
+            jq --raw-output '.packages | .[] | select(.name == "bevy").version')
+          # Sanity check: current version should be 0.X.Y
+          if ! grep -q '^0\.[0-9]\+\.[0-9]\+$' <<< "${current_version}"; then
+            echo "Invalid version (not in 0.X.Y format): ${current_version}"
+            exit 1
+          fi
+          minor_version=$(sed 's/^0\.\([0-9]\+\).*/\1/' <<< "${current_version}")
+          next_version=0.$((minor_version + 1)).0-dev
+          echo "Bumping version to ${next_version}"
+          # See release.yml for meaning of these arguments
+          cargo release "${next_version}" \
             --workspace \
             --no-publish \
             --execute \
             --no-tag \
             --no-confirm \
             --no-push \
-            --dependent-version upgrade \
             --exclude ci \
             --exclude errors \
             --exclude bevy-ios-example \
@@ -50,7 +53,7 @@ jobs:
         with:
           delete-branch: true
           base: "main"
-          title: "Preparing Next Release"
+          title: "Bump Version after Release"
           body: |
-            Preparing next release
+            Bump version after release
             This PR has been auto-generated

--- a/crates/bevy_ecs_compile_fail_tests/Cargo.toml
+++ b/crates/bevy_ecs_compile_fail_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ecs_compile_fail_tests"
-version = "0.8.0-dev"
+version = "0.1.0"
 edition = "2021"
 description = "Compile fail tests for Bevy Engine's entity component system"
 homepage = "https://bevyengine.org"
@@ -9,5 +9,5 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dev-dependencies]
-bevy_ecs = { path = "../bevy_ecs", version = "0.8.0-dev" }
+bevy_ecs = { path = "../bevy_ecs" }
 trybuild = "1.0"

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -9,7 +9,7 @@
 5. Create migration guide.
 6. Write blog post.
 7. Update book.
-8. Bump version number for all crates.
+8. Bump version number for all crates, using the "Release" workflow.
 9. Create tag on GitHub.
 10. Bump `latest` tag to most recent release.
 
@@ -26,5 +26,5 @@
 
 ## Post-release
 
-1. Bump version number for all crates to next versions, as `0.X-dev`, to ensure properly displayed version for [Dev Docs](https://dev-docs.bevyengine.org/bevy/index.html).
+1. Bump version number for all crates to next versions, as `0.X-dev`, using the "Post-release version bump" workflow, to ensure properly displayed version for [Dev Docs](https://dev-docs.bevyengine.org/bevy/index.html).
 2. Update Bevy version used for Bevy book code validation to latest release.


### PR DESCRIPTION
# Objective

While playing with the code, I found some problems in the recently merged version-bumping workflow:
- Most importantly, now that we are using `0.8.0-dev` in development, the workflow will try to bump it to `0.9.0` :sob: 
- The crate filter is outdated now that we have more crates in `tools`.
- We are using `bevy@users.noreply.github.com`, but according to [Github help](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#about-commit-email-addresses), that email address means "old no-reply email format for the user `bevy`". It is currently not associated with any account, but I feel this is still not appropriate here.

## Solution

- Create a new workflow, `Post-release version bump`, that should be run after a release and bumps version from `0.X.0` to `0.X+1.0-dev`. Unfortunately, cargo-release doesn't have a builtin way to do this, so we need to parse and increment the version manually.
- Add the new crates in `tools` to exclusion list. Also removes the dependency version specifier from `bevy_ecs_compile_fail_tests`. It is not in the workspace so the dependency version will not get automatically updated by cargo-release.
- Change the author email to `41898282+github-actions[bot]@users.noreply.github.com`. According to the discussion [here](https://github.com/actions/checkout/issues/13#issuecomment-724415212) and [here](https://github.community/t/github-actions-bot-email-address/17204/6), this is the email address associated with the github-actions bot account.
- Also add the workflows to our release checklist.

See infmagic2047#5 and infmagic2047#6 for examples of release and post-release PRs.