### PR TITLE
[Merged by Bors] - Add "depth_load_op" configuration to 3d Cameras

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
@@ -87,6 +87,7 @@ impl Node for MainPass3dNode {
                     view: &depth.view,
                     // NOTE: The opaque main pass loads the depth buffer and possibly overwrites it
                     depth_ops: Some(Operations {
+                        // NOTE: 0.0 is the far plane due to bevy's use of reverse-z projections.
                         load: camera_3d.depth_load_op.clone().into(),
                         store: true,
                     }),

--- a/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
@@ -87,8 +87,7 @@ impl Node for MainPass3dNode {
                     view: &depth.view,
                     // NOTE: The opaque main pass loads the depth buffer and possibly overwrites it
                     depth_ops: Some(Operations {
-                        // NOTE: 0.0 is the far plane due to bevy's use of reverse-z projections
-                        load: LoadOp::Clear(0.0),
+                        load: camera_3d.depth_load_op.clone().into(),
                         store: true,
                     }),
                     stencil_ops: None,

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -95,6 +95,7 @@ fn setup(
         .spawn_bundle(Camera3dBundle {
             camera_3d: Camera3d {
                 clear_color: ClearColorConfig::Custom(Color::WHITE),
+                ..default()
             },
             camera: Camera {
                 // render before the "main pass" camera

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -66,6 +66,7 @@ fn setup(
             camera_3d: Camera3d {
                 // dont clear on the second camera because the first camera already cleared the window
                 clear_color: ClearColorConfig::None,
+                ..default()
             },
             ..default()
         })

--- a/examples/3d/two_passes.rs
+++ b/examples/3d/two_passes.rs
@@ -49,6 +49,7 @@ fn setup(
         transform: Transform::from_xyz(10.0, 10., -5.0).looking_at(Vec3::ZERO, Vec3::Y),
         camera_3d: Camera3d {
             clear_color: ClearColorConfig::None,
+            ..default()
         },
         camera: Camera {
             // renders after / on top of the main camera

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -102,6 +102,7 @@ fn setup(
     commands.spawn_bundle(Camera3dBundle {
         camera_3d: Camera3d {
             clear_color: ClearColorConfig::Custom(Color::WHITE),
+            ..default()
         },
         camera: Camera {
             target: RenderTarget::Image(image_handle.clone()),


### PR DESCRIPTION
# Objective

Users should be able to configure depth load operations on cameras. Currently every camera clears depth when it is rendered. But sometimes later passes need to rely on depth from previous passes.

## Solution

This adds the `Camera3d::depth_load_op` field with a new `Camera3dDepthLoadOp` value. This is a custom type because Camera3d uses "reverse-z depth" and this helps us record and document that in a discoverable way. It also gives us more control over reflection + other trait impls, whereas `LoadOp` is owned by the `wgpu` crate.

```rust
commands.spawn_bundle(Camera3dBundle {
    camera_3d: Camera3d {
        depth_load_op: Camera3dDepthLoadOp::Load,
        ..default()
    },
    ..default()
});
```

### two_passes example with the "second pass" camera configured to the default (clear depth to 0.0)

![image](https://user-images.githubusercontent.com/2694663/171743172-46d4fdd5-5090-46ea-abe4-1fbc519f6ee8.png)


### two_passes example with the "second pass" camera configured to "load" the depth
![image](https://user-images.githubusercontent.com/2694663/171743323-74dd9a1d-9c25-4883-98dd-38ca0bed8c17.png)

---

## Changelog

### Added

* `Camera3d` now has a `depth_load_op` field, which can configure the Camera's main 3d pass depth loading behavior. 
