### PR TITLE
Implement push constants for pipeline cache

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -344,6 +344,7 @@ impl SpecializedMeshPipeline for ShadowPipeline {
             },
             fragment: None,
             layout: Some(bind_group_layout),
+            push_constant_ranges: None,
             primitive: PrimitiveState {
                 topology: key.primitive_topology(),
                 strip_index_format: None,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -642,6 +642,7 @@ impl SpecializedMeshPipeline for MeshPipeline {
                 })],
             }),
             layout: Some(bind_group_layout),
+            push_constant_ranges: None,
             primitive: PrimitiveState {
                 front_face: FrontFace::Ccw,
                 cull_mode: Some(Face::Back),

--- a/crates/bevy_render/src/render_resource/mod.rs
+++ b/crates/bevy_render/src/render_resource/mod.rs
@@ -34,14 +34,14 @@ pub use wgpu::{
     FrontFace, ImageCopyBuffer, ImageCopyBufferBase, ImageCopyTexture, ImageCopyTextureBase,
     ImageDataLayout, ImageSubresourceRange, IndexFormat, Limits as WgpuLimits, LoadOp, MapMode,
     MultisampleState, Operations, Origin3d, PipelineLayout, PipelineLayoutDescriptor, PolygonMode,
-    PrimitiveState, PrimitiveTopology, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
-    RenderPassDescriptor, RenderPipelineDescriptor as RawRenderPipelineDescriptor,
-    SamplerBindingType, SamplerDescriptor, ShaderModule, ShaderModuleDescriptor, ShaderSource,
-    ShaderStages, StencilFaceState, StencilOperation, StencilState, StorageTextureAccess,
-    TextureAspect, TextureDescriptor, TextureDimension, TextureFormat, TextureSampleType,
-    TextureUsages, TextureViewDescriptor, TextureViewDimension, VertexAttribute,
-    VertexBufferLayout as RawVertexBufferLayout, VertexFormat, VertexState as RawVertexState,
-    VertexStepMode,
+    PrimitiveState, PrimitiveTopology, PushConstantRange, RenderPassColorAttachment,
+    RenderPassDepthStencilAttachment, RenderPassDescriptor,
+    RenderPipelineDescriptor as RawRenderPipelineDescriptor, SamplerBindingType, SamplerDescriptor,
+    ShaderModule, ShaderModuleDescriptor, ShaderSource, ShaderStages, StencilFaceState,
+    StencilOperation, StencilState, StorageTextureAccess, TextureAspect, TextureDescriptor,
+    TextureDimension, TextureFormat, TextureSampleType, TextureUsages, TextureViewDescriptor,
+    TextureViewDimension, VertexAttribute, VertexBufferLayout as RawVertexBufferLayout,
+    VertexFormat, VertexState as RawVertexState, VertexStepMode,
 };
 
 pub mod encase {

--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -4,7 +4,7 @@ use bevy_reflect::Uuid;
 use std::{borrow::Cow, ops::Deref, sync::Arc};
 use wgpu::{
     BufferAddress, ColorTargetState, DepthStencilState, MultisampleState, PrimitiveState,
-    VertexAttribute, VertexFormat, VertexStepMode,
+    PushConstantRange, VertexAttribute, VertexFormat, VertexStepMode,
 };
 
 /// A [`RenderPipeline`] identifier.
@@ -93,6 +93,8 @@ pub struct RenderPipelineDescriptor {
     pub label: Option<Cow<'static, str>>,
     /// The layout of bind groups for this pipeline.
     pub layout: Option<Vec<BindGroupLayout>>,
+    /// The push constant ranges for this pipeline.
+    pub push_constant_ranges: Option<Vec<PushConstantRange>>,
     /// The compiled vertex stage, its entry point, and the input buffers layout.
     pub vertex: VertexState,
     /// The properties of the pipeline at the primitive assembly and rasterization level.
@@ -174,6 +176,7 @@ pub struct FragmentState {
 pub struct ComputePipelineDescriptor {
     pub label: Option<Cow<'static, str>>,
     pub layout: Option<Vec<BindGroupLayout>>,
+    pub push_constant_ranges: Option<Vec<PushConstantRange>>,
     /// The compiled shader module for this stage.
     pub shader: Handle<Shader>,
     pub shader_defs: Vec<String>,

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -384,6 +384,7 @@ impl SpecializedMeshPipeline for Mesh2dPipeline {
                 })],
             }),
             layout: Some(vec![self.view_layout.clone(), self.mesh_layout.clone()]),
+            push_constant_ranges: None,
             primitive: PrimitiveState {
                 front_face: FrontFace::Ccw,
                 cull_mode: Some(Face::Back),

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -209,6 +209,7 @@ impl SpecializedRenderPipeline for SpritePipeline {
                 })],
             }),
             layout: Some(vec![self.view_layout.clone(), self.material_layout.clone()]),
+            push_constant_ranges: None,
             primitive: PrimitiveState {
                 front_face: FrontFace::Ccw,
                 cull_mode: None,

--- a/crates/bevy_ui/src/render/pipeline.rs
+++ b/crates/bevy_ui/src/render/pipeline.rs
@@ -153,6 +153,7 @@ impl SpecializedRenderPipeline for UiPipeline {
                 })],
             }),
             layout: Some(vec![self.view_layout.clone(), self.image_layout.clone()]),
+            push_constant_ranges: None,
             primitive: PrimitiveState {
                 front_face: FrontFace::Ccw,
                 cull_mode: None,

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -173,6 +173,7 @@ impl SpecializedRenderPipeline for ColoredMesh2dPipeline {
                 // Bind group 1 is the mesh uniform
                 self.mesh2d_pipeline.mesh_layout.clone(),
             ]),
+            push_constant_ranges: None,
             primitive: PrimitiveState {
                 front_face: FrontFace::Ccw,
                 cull_mode: Some(Face::Back),

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -141,6 +141,7 @@ impl FromWorld for GameOfLifePipeline {
         let init_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
             label: None,
             layout: Some(vec![texture_bind_group_layout.clone()]),
+            push_constant_ranges: None,
             shader: shader.clone(),
             shader_defs: vec![],
             entry_point: Cow::from("init"),
@@ -148,6 +149,7 @@ impl FromWorld for GameOfLifePipeline {
         let update_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
             label: None,
             layout: Some(vec![texture_bind_group_layout.clone()]),
+            push_constant_ranges: None,
             shader,
             shader_defs: vec![],
             entry_point: Cow::from("update"),


### PR DESCRIPTION
# Objective

Allow for creating pipelines that use push constants. To be able to use push constants this depends on #4824. Fixes #4825.

## Solution

Add a field `push_constant_ranges` to `RenderPipelineDescriptor` and `ComputePipelineDescriptor`

---

## Changelog

* Add a field `push_constant_ranges` to `RenderPipelineDescriptor` and `ComputePipelineDescriptor`
* Update `bevy_sprite`, `bevy_ui` and `bevy_pbr` to declare the new field

## Migration Guide

* Add `push_constant_ranges: None` to every `RenderPipelineDescriptor` and `ComputePipelineDescriptor`
