### PR TITLE
Make gamepad registration methods public

### DIFF
--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -35,12 +35,12 @@ impl Gamepads {
     }
 
     /// Registers [Gamepad].
-    fn register(&mut self, gamepad: Gamepad) {
+    pub fn register(&mut self, gamepad: Gamepad) {
         self.gamepads.insert(gamepad);
     }
 
     /// Deregisters [Gamepad.
-    fn deregister(&mut self, gamepad: &Gamepad) {
+    pub fn deregister(&mut self, gamepad: &Gamepad) {
         self.gamepads.remove(gamepad);
     }
 }

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -26,8 +26,8 @@ pub struct Gamepads {
 
 impl Gamepads {
     /// Returns true if the [`Gamepads`] contains the provided [`Gamepad`].
-    pub fn contains(&self, gamepad: &Gamepad) -> bool {
-        self.gamepads.contains(gamepad)
+    pub fn contains(&self, gamepad: Gamepad) -> bool {
+        self.gamepads.contains(&gamepad)
     }
 
     /// Iterates over registered [`Gamepad`]s
@@ -40,9 +40,9 @@ impl Gamepads {
         self.gamepads.insert(gamepad);
     }
 
-    /// Deregisters [`Gamepad`].
-    pub fn deregister(&mut self, gamepad: &Gamepad) {
-        self.gamepads.remove(gamepad);
+    /// Deregisters the provided [`Gamepad`].
+    pub fn deregister(&mut self, gamepad: Gamepad) {
+        self.gamepads.remove(&gamepad);
     }
 }
 
@@ -311,7 +311,7 @@ pub fn gamepad_connection_system(
                 info!("{:?} Connected", event.gamepad);
             }
             GamepadEventType::Disconnected => {
-                gamepads.deregister(&event.gamepad);
+                gamepads.deregister(event.gamepad);
                 info!("{:?} Disconnected", event.gamepad);
             }
             _ => (),

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -30,7 +30,7 @@ impl Gamepads {
         self.gamepads.contains(&gamepad)
     }
 
-    /// Iterates over registered [`Gamepad`]s
+    /// Iterates over the set of currently registered [`Gamepad`]s
     pub fn iter(&self) -> impl Iterator<Item = &Gamepad> + '_ {
         self.gamepads.iter()
     }

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -16,30 +16,31 @@ impl Gamepad {
 }
 
 #[derive(Default)]
-/// Container of unique connected [`Gamepad`]s
+/// Resource that stores the set of connected [`Gamepad`]s
 ///
-/// [`Gamepad`]s are registered and deregistered in [`gamepad_connection_system`]
+/// [`Gamepad`]s are registered and deregistered in [`gamepad_connection_system`],
+/// based on the [`GamepadEvent`]s provided by the system.
 pub struct Gamepads {
     gamepads: HashSet<Gamepad>,
 }
 
 impl Gamepads {
-    /// Returns true if the [Gamepads] contains a [Gamepad].
+    /// Returns true if the [`Gamepads`] contains the provided [`Gamepad`].
     pub fn contains(&self, gamepad: &Gamepad) -> bool {
         self.gamepads.contains(gamepad)
     }
 
-    /// Iterates over registered [Gamepad]s
+    /// Iterates over registered [`Gamepad`]s
     pub fn iter(&self) -> impl Iterator<Item = &Gamepad> + '_ {
         self.gamepads.iter()
     }
 
-    /// Registers [Gamepad].
+    /// Registers the provided [`Gamepad`].
     pub fn register(&mut self, gamepad: Gamepad) {
         self.gamepads.insert(gamepad);
     }
 
-    /// Deregisters [Gamepad.
+    /// Deregisters [`Gamepad`].
     pub fn deregister(&mut self, gamepad: &Gamepad) {
         self.gamepads.remove(gamepad);
     }


### PR DESCRIPTION
# Objective

- Gamepads could not be (easily) manually registered or deregistered, making testing hard.
  - Fixes #4911 and fixes #3808

## Solution

- make `register` and `deregister` public
- while I'm here:
  - make the APIs more consistent / correct
  - improve the docs a bit

## Changelog

Users can now directly manually register and deregister gamepads. This functionality is primarily useful for testing.