### PR TITLE
Deferred render init

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -149,67 +149,69 @@ impl Plugin for PbrPlugin {
                 },
             );
 
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
-        };
+        app.add_render_init(move |app| {
+            let render_app = match app.get_sub_app_mut(RenderApp) {
+                Ok(render_app) => render_app,
+                Err(_) => return,
+            };
 
-        render_app
-            .add_system_to_stage(
-                RenderStage::Extract,
-                render::extract_clusters.label(RenderLightSystems::ExtractClusters),
-            )
-            .add_system_to_stage(
-                RenderStage::Extract,
-                render::extract_lights.label(RenderLightSystems::ExtractLights),
-            )
-            .add_system_to_stage(
-                RenderStage::Prepare,
-                // this is added as an exclusive system because it contributes new views. it must run (and have Commands applied)
-                // _before_ the `prepare_views()` system is run. ideally this becomes a normal system when "stageless" features come out
-                render::prepare_lights
-                    .exclusive_system()
-                    .label(RenderLightSystems::PrepareLights),
-            )
-            .add_system_to_stage(
-                RenderStage::Prepare,
-                // NOTE: This needs to run after prepare_lights. As prepare_lights is an exclusive system,
-                // just adding it to the non-exclusive systems in the Prepare stage means it runs after
-                // prepare_lights.
-                render::prepare_clusters.label(RenderLightSystems::PrepareClusters),
-            )
-            .add_system_to_stage(
-                RenderStage::Queue,
-                render::queue_shadows.label(RenderLightSystems::QueueShadows),
-            )
-            .add_system_to_stage(RenderStage::Queue, render::queue_shadow_view_bind_group)
-            .add_system_to_stage(RenderStage::PhaseSort, sort_phase_system::<Shadow>)
-            .init_resource::<ShadowPipeline>()
-            .init_resource::<DrawFunctions<Shadow>>()
-            .init_resource::<LightMeta>()
-            .init_resource::<GlobalLightMeta>()
-            .init_resource::<SpecializedMeshPipelines<ShadowPipeline>>();
+            render_app
+                .add_system_to_stage(
+                    RenderStage::Extract,
+                    render::extract_clusters.label(RenderLightSystems::ExtractClusters),
+                )
+                .add_system_to_stage(
+                    RenderStage::Extract,
+                    render::extract_lights.label(RenderLightSystems::ExtractLights),
+                )
+                .add_system_to_stage(
+                    RenderStage::Prepare,
+                    // this is added as an exclusive system because it contributes new views. it must run (and have Commands applied)
+                    // _before_ the `prepare_views()` system is run. ideally this becomes a normal system when "stageless" features come out
+                    render::prepare_lights
+                        .exclusive_system()
+                        .label(RenderLightSystems::PrepareLights),
+                )
+                .add_system_to_stage(
+                    RenderStage::Prepare,
+                    // NOTE: This needs to run after prepare_lights. As prepare_lights is an exclusive system,
+                    // just adding it to the non-exclusive systems in the Prepare stage means it runs after
+                    // prepare_lights.
+                    render::prepare_clusters.label(RenderLightSystems::PrepareClusters),
+                )
+                .add_system_to_stage(
+                    RenderStage::Queue,
+                    render::queue_shadows.label(RenderLightSystems::QueueShadows),
+                )
+                .add_system_to_stage(RenderStage::Queue, render::queue_shadow_view_bind_group)
+                .add_system_to_stage(RenderStage::PhaseSort, sort_phase_system::<Shadow>)
+                .init_resource::<ShadowPipeline>()
+                .init_resource::<DrawFunctions<Shadow>>()
+                .init_resource::<LightMeta>()
+                .init_resource::<GlobalLightMeta>()
+                .init_resource::<SpecializedMeshPipelines<ShadowPipeline>>();
 
-        let shadow_pass_node = ShadowPassNode::new(&mut render_app.world);
-        render_app.add_render_command::<Shadow, DrawShadowMesh>();
-        let mut graph = render_app.world.resource_mut::<RenderGraph>();
-        let draw_3d_graph = graph
-            .get_sub_graph_mut(bevy_core_pipeline::core_3d::graph::NAME)
-            .unwrap();
-        draw_3d_graph.add_node(draw_3d_graph::node::SHADOW_PASS, shadow_pass_node);
-        draw_3d_graph
-            .add_node_edge(
-                draw_3d_graph::node::SHADOW_PASS,
-                bevy_core_pipeline::core_3d::graph::node::MAIN_PASS,
-            )
-            .unwrap();
-        draw_3d_graph
-            .add_slot_edge(
-                draw_3d_graph.input_node().unwrap().id,
-                bevy_core_pipeline::core_3d::graph::input::VIEW_ENTITY,
-                draw_3d_graph::node::SHADOW_PASS,
-                ShadowPassNode::IN_VIEW,
-            )
-            .unwrap();
+            let shadow_pass_node = ShadowPassNode::new(&mut render_app.world);
+            render_app.add_render_command::<Shadow, DrawShadowMesh>();
+            let mut graph = render_app.world.resource_mut::<RenderGraph>();
+            let draw_3d_graph = graph
+                .get_sub_graph_mut(bevy_core_pipeline::core_3d::graph::NAME)
+                .unwrap();
+            draw_3d_graph.add_node(draw_3d_graph::node::SHADOW_PASS, shadow_pass_node);
+            draw_3d_graph
+                .add_node_edge(
+                    draw_3d_graph::node::SHADOW_PASS,
+                    bevy_core_pipeline::core_3d::graph::node::MAIN_PASS,
+                )
+                .unwrap();
+            draw_3d_graph
+                .add_slot_edge(
+                    draw_3d_graph.input_node().unwrap().id,
+                    bevy_core_pipeline::core_3d::graph::input::VIEW_ENTITY,
+                    draw_3d_graph::node::SHADOW_PASS,
+                    ShadowPassNode::IN_VIEW,
+                )
+                .unwrap();
+        });
     }
 }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -226,15 +226,18 @@ impl<M: SpecializedMaterial> Plugin for MaterialPlugin<M> {
         app.add_asset::<M>()
             .add_plugin(ExtractComponentPlugin::<Handle<M>>::extract_visible())
             .add_plugin(RenderAssetPlugin::<M>::default());
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .add_render_command::<Transparent3d, DrawMaterial<M>>()
-                .add_render_command::<Opaque3d, DrawMaterial<M>>()
-                .add_render_command::<AlphaMask3d, DrawMaterial<M>>()
-                .init_resource::<MaterialPipeline<M>>()
-                .init_resource::<SpecializedMeshPipelines<MaterialPipeline<M>>>()
-                .add_system_to_stage(RenderStage::Queue, queue_material_meshes::<M>);
-        }
+
+        app.add_render_init(move |app| {
+            if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+                render_app
+                    .add_render_command::<Transparent3d, DrawMaterial<M>>()
+                    .add_render_command::<Opaque3d, DrawMaterial<M>>()
+                    .add_render_command::<AlphaMask3d, DrawMaterial<M>>()
+                    .init_resource::<MaterialPipeline<M>>()
+                    .init_resource::<SpecializedMeshPipelines<MaterialPipeline<M>>>()
+                    .add_system_to_stage(RenderStage::Queue, queue_material_meshes::<M>);
+            }
+        });
     }
 }
 

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -74,16 +74,18 @@ impl Plugin for MeshRenderPlugin {
 
         app.add_plugin(UniformComponentPlugin::<MeshUniform>::default());
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<MeshPipeline>()
-                .init_resource::<SkinnedMeshUniform>()
-                .add_system_to_stage(RenderStage::Extract, extract_meshes)
-                .add_system_to_stage(RenderStage::Extract, extract_skinned_meshes)
-                .add_system_to_stage(RenderStage::Prepare, prepare_skinned_meshes)
-                .add_system_to_stage(RenderStage::Queue, queue_mesh_bind_group)
-                .add_system_to_stage(RenderStage::Queue, queue_mesh_view_bind_groups);
-        }
+        app.add_render_init(move |app| {
+            if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+                render_app
+                    .init_resource::<MeshPipeline>()
+                    .init_resource::<SkinnedMeshUniform>()
+                    .add_system_to_stage(RenderStage::Extract, extract_meshes)
+                    .add_system_to_stage(RenderStage::Extract, extract_skinned_meshes)
+                    .add_system_to_stage(RenderStage::Prepare, prepare_skinned_meshes)
+                    .add_system_to_stage(RenderStage::Queue, queue_mesh_bind_group)
+                    .add_system_to_stage(RenderStage::Queue, queue_mesh_view_bind_groups);
+            }
+        });
     }
 }
 

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -38,14 +38,16 @@ impl Plugin for WireframePlugin {
         app.init_resource::<WireframeConfig>()
             .add_plugin(ExtractResourcePlugin::<WireframeConfig>::default());
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .add_render_command::<Opaque3d, DrawWireframes>()
-                .init_resource::<WireframePipeline>()
-                .init_resource::<SpecializedMeshPipelines<WireframePipeline>>()
-                .add_system_to_stage(RenderStage::Extract, extract_wireframes)
-                .add_system_to_stage(RenderStage::Queue, queue_wireframes);
-        }
+        app.add_render_init(move |app| {
+            if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+                render_app
+                    .add_render_command::<Opaque3d, DrawWireframes>()
+                    .init_resource::<WireframePipeline>()
+                    .init_resource::<SpecializedMeshPipelines<WireframePipeline>>()
+                    .add_system_to_stage(RenderStage::Extract, extract_wireframes)
+                    .add_system_to_stage(RenderStage::Queue, queue_wireframes);
+            }
+        });
     }
 }
 

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -33,12 +33,14 @@ impl Plugin for CameraPlugin {
             .add_plugin(CameraProjectionPlugin::<OrthographicProjection>::default())
             .add_plugin(CameraProjectionPlugin::<PerspectiveProjection>::default());
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app.add_system_to_stage(RenderStage::Extract, extract_cameras);
+        app.add_render_init(move |app| {
+            if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+                render_app.add_system_to_stage(RenderStage::Extract, extract_cameras);
 
-            let camera_driver_node = CameraDriverNode::new(&mut render_app.world);
-            let mut render_graph = render_app.world.resource_mut::<RenderGraph>();
-            render_graph.add_node(crate::main_graph::node::CAMERA_DRIVER, camera_driver_node);
-        }
+                let camera_driver_node = CameraDriverNode::new(&mut render_app.world);
+                let mut render_graph = render_app.world.resource_mut::<RenderGraph>();
+                render_graph.add_node(crate::main_graph::node::CAMERA_DRIVER, camera_driver_node);
+            }
+        });
     }
 }

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -60,11 +60,13 @@ impl<C> Default for UniformComponentPlugin<C> {
 
 impl<C: Component + ShaderType + WriteInto + Clone> Plugin for UniformComponentPlugin<C> {
     fn build(&self, app: &mut App) {
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .insert_resource(ComponentUniforms::<C>::default())
-                .add_system_to_stage(RenderStage::Prepare, prepare_uniform_components::<C>);
-        }
+        app.add_render_init(move |app| {
+            if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+                render_app
+                    .insert_resource(ComponentUniforms::<C>::default())
+                    .add_system_to_stage(RenderStage::Prepare, prepare_uniform_components::<C>);
+            }
+        });
     }
 }
 
@@ -157,14 +159,17 @@ impl<C, F> ExtractComponentPlugin<C, F> {
 
 impl<C: ExtractComponent> Plugin for ExtractComponentPlugin<C> {
     fn build(&self, app: &mut App) {
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            if self.only_extract_visible {
-                render_app
-                    .add_system_to_stage(RenderStage::Extract, extract_visible_components::<C>);
-            } else {
-                render_app.add_system_to_stage(RenderStage::Extract, extract_components::<C>);
+        let only_extract_visible = self.only_extract_visible;
+        app.add_render_init(move |app| {
+            if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+                if only_extract_visible {
+                    render_app
+                        .add_system_to_stage(RenderStage::Extract, extract_visible_components::<C>);
+                } else {
+                    render_app.add_system_to_stage(RenderStage::Extract, extract_components::<C>);
+                }
             }
-        }
+        });
     }
 }
 

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -31,9 +31,11 @@ impl<R: ExtractResource> Default for ExtractResourcePlugin<R> {
 
 impl<R: ExtractResource> Plugin for ExtractResourcePlugin<R> {
     fn build(&self, app: &mut App) {
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app.add_system_to_stage(RenderStage::Extract, extract_resource::<R>);
-        }
+        app.add_render_init(move |app| {
+            if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+                render_app.add_system_to_stage(RenderStage::Extract, extract_resource::<R>);
+            }
+        });
     }
 }
 

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -82,26 +82,29 @@ impl<A: RenderAsset> Default for RenderAssetPlugin<A> {
 
 impl<A: RenderAsset> Plugin for RenderAssetPlugin<A> {
     fn build(&self, app: &mut App) {
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            let prepare_asset_system = prepare_assets::<A>.label(self.prepare_asset_label.clone());
+        let label = self.prepare_asset_label.clone();
+        app.add_render_init(move |app| {
+            if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+                let prepare_asset_system = prepare_assets::<A>.label(label.clone());
 
-            let prepare_asset_system = match self.prepare_asset_label {
-                PrepareAssetLabel::PreAssetPrepare => prepare_asset_system,
-                PrepareAssetLabel::AssetPrepare => {
-                    prepare_asset_system.after(PrepareAssetLabel::PreAssetPrepare)
-                }
-                PrepareAssetLabel::PostAssetPrepare => {
-                    prepare_asset_system.after(PrepareAssetLabel::AssetPrepare)
-                }
-            };
+                let prepare_asset_system = match label {
+                    PrepareAssetLabel::PreAssetPrepare => prepare_asset_system,
+                    PrepareAssetLabel::AssetPrepare => {
+                        prepare_asset_system.after(PrepareAssetLabel::PreAssetPrepare)
+                    }
+                    PrepareAssetLabel::PostAssetPrepare => {
+                        prepare_asset_system.after(PrepareAssetLabel::AssetPrepare)
+                    }
+                };
 
-            render_app
-                .init_resource::<ExtractedAssets<A>>()
-                .init_resource::<RenderAssets<A>>()
-                .init_resource::<PrepareNextFrameAssets<A>>()
-                .add_system_to_stage(RenderStage::Extract, extract_render_asset::<A>)
-                .add_system_to_stage(RenderStage::Prepare, prepare_asset_system);
-        }
+                render_app
+                    .init_resource::<ExtractedAssets<A>>()
+                    .init_resource::<RenderAssets<A>>()
+                    .init_resource::<PrepareNextFrameAssets<A>>()
+                    .add_system_to_stage(RenderStage::Extract, extract_render_asset::<A>)
+                    .add_system_to_stage(RenderStage::Prepare, prepare_asset_system);
+            }
+        });
     }
 }
 

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -37,24 +37,6 @@ pub struct ImagePlugin;
 
 impl Plugin for ImagePlugin {
     fn build(&self, app: &mut App) {
-        #[cfg(any(
-            feature = "png",
-            feature = "dds",
-            feature = "tga",
-            feature = "jpeg",
-            feature = "bmp",
-            feature = "basis-universal",
-            feature = "ktx2",
-        ))]
-        {
-            app.init_asset_loader::<ImageTextureLoader>();
-        }
-
-        #[cfg(feature = "hdr")]
-        {
-            app.init_asset_loader::<HdrTextureLoader>();
-        }
-
         app.add_plugin(RenderAssetPlugin::<Image>::with_prepare_asset_label(
             PrepareAssetLabel::PreAssetPrepare,
         ))
@@ -64,6 +46,24 @@ impl Plugin for ImagePlugin {
             .set_untracked(DEFAULT_IMAGE_HANDLE, Image::default());
 
         app.add_render_init(move |app| {
+            #[cfg(any(
+                feature = "png",
+                feature = "dds",
+                feature = "tga",
+                feature = "jpeg",
+                feature = "bmp",
+                feature = "basis-universal",
+                feature = "ktx2",
+            ))]
+            {
+                app.init_asset_loader::<ImageTextureLoader>();
+            }
+
+            #[cfg(feature = "hdr")]
+            {
+                app.init_asset_loader::<HdrTextureLoader>();
+            }
+
             if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
                 render_app
                     .init_resource::<TextureCache>()

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -63,11 +63,13 @@ impl Plugin for ImagePlugin {
             .resource_mut::<Assets<Image>>()
             .set_untracked(DEFAULT_IMAGE_HANDLE, Image::default());
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<TextureCache>()
-                .add_system_to_stage(RenderStage::Cleanup, update_texture_cache_system);
-        }
+        app.add_render_init(move |app| {
+            if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+                render_app
+                    .init_resource::<TextureCache>()
+                    .add_system_to_stage(RenderStage::Cleanup, update_texture_cache_system);
+            }
+        });
     }
 }
 

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -33,15 +33,17 @@ impl Plugin for ViewPlugin {
             .add_plugin(ExtractResourcePlugin::<Msaa>::default())
             .add_plugin(VisibilityPlugin);
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<ViewUniforms>()
-                .add_system_to_stage(RenderStage::Prepare, prepare_view_uniforms)
-                .add_system_to_stage(
-                    RenderStage::Prepare,
-                    prepare_view_targets.after(WindowSystem::Prepare),
-                );
-        }
+        app.add_render_init(move |app| {
+            if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+                render_app
+                    .init_resource::<ViewUniforms>()
+                    .add_system_to_stage(RenderStage::Prepare, prepare_view_uniforms)
+                    .add_system_to_stage(
+                        RenderStage::Prepare,
+                        prepare_view_targets.after(WindowSystem::Prepare),
+                    );
+            }
+        });
     }
 }
 

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -24,17 +24,19 @@ pub enum WindowSystem {
 
 impl Plugin for WindowRenderPlugin {
     fn build(&self, app: &mut App) {
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<ExtractedWindows>()
-                .init_resource::<WindowSurfaces>()
-                .init_resource::<NonSendMarker>()
-                .add_system_to_stage(RenderStage::Extract, extract_windows)
-                .add_system_to_stage(
-                    RenderStage::Prepare,
-                    prepare_windows.label(WindowSystem::Prepare),
-                );
-        }
+        app.add_render_init(move |app| {
+            if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+                render_app
+                    .init_resource::<ExtractedWindows>()
+                    .init_resource::<WindowSurfaces>()
+                    .init_resource::<NonSendMarker>()
+                    .add_system_to_stage(RenderStage::Extract, extract_windows)
+                    .add_system_to_stage(
+                        RenderStage::Prepare,
+                        prepare_windows.label(WindowSystem::Prepare),
+                    );
+            }
+        });
     }
 }
 

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -61,21 +61,23 @@ impl Plugin for SpritePlugin {
             .add_plugin(Mesh2dRenderPlugin)
             .add_plugin(ColorMaterialPlugin);
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<ImageBindGroups>()
-                .init_resource::<SpritePipeline>()
-                .init_resource::<SpecializedRenderPipelines<SpritePipeline>>()
-                .init_resource::<SpriteMeta>()
-                .init_resource::<ExtractedSprites>()
-                .init_resource::<SpriteAssetEvents>()
-                .add_render_command::<Transparent2d, DrawSprite>()
-                .add_system_to_stage(
-                    RenderStage::Extract,
-                    render::extract_sprites.label(SpriteSystem::ExtractSprites),
-                )
-                .add_system_to_stage(RenderStage::Extract, render::extract_sprite_events)
-                .add_system_to_stage(RenderStage::Queue, queue_sprites);
-        };
+        app.add_render_init(move |app| {
+            if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+                render_app
+                    .init_resource::<ImageBindGroups>()
+                    .init_resource::<SpritePipeline>()
+                    .init_resource::<SpecializedRenderPipelines<SpritePipeline>>()
+                    .init_resource::<SpriteMeta>()
+                    .init_resource::<ExtractedSprites>()
+                    .init_resource::<SpriteAssetEvents>()
+                    .add_render_command::<Transparent2d, DrawSprite>()
+                    .add_system_to_stage(
+                        RenderStage::Extract,
+                        render::extract_sprites.label(SpriteSystem::ExtractSprites),
+                    )
+                    .add_system_to_stage(RenderStage::Extract, render::extract_sprite_events)
+                    .add_system_to_stage(RenderStage::Queue, queue_sprites);
+            }
+        });
     }
 }

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -196,13 +196,16 @@ impl<M: SpecializedMaterial2d> Plugin for Material2dPlugin<M> {
         app.add_asset::<M>()
             .add_plugin(ExtractComponentPlugin::<Handle<M>>::extract_visible())
             .add_plugin(RenderAssetPlugin::<M>::default());
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .add_render_command::<Transparent2d, DrawMaterial2d<M>>()
-                .init_resource::<Material2dPipeline<M>>()
-                .init_resource::<SpecializedMeshPipelines<Material2dPipeline<M>>>()
-                .add_system_to_stage(RenderStage::Queue, queue_material2d_meshes::<M>);
-        }
+
+        app.add_render_init(move |app| {
+            if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+                render_app
+                    .add_render_command::<Transparent2d, DrawMaterial2d<M>>()
+                    .init_resource::<Material2dPipeline<M>>()
+                    .init_resource::<SpecializedMeshPipelines<Material2dPipeline<M>>>()
+                    .add_system_to_stage(RenderStage::Queue, queue_material2d_meshes::<M>);
+            }
+        });
     }
 }
 

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -76,14 +76,16 @@ impl Plugin for Mesh2dRenderPlugin {
 
         app.add_plugin(UniformComponentPlugin::<Mesh2dUniform>::default());
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<Mesh2dPipeline>()
-                .init_resource::<SpecializedMeshPipelines<Mesh2dPipeline>>()
-                .add_system_to_stage(RenderStage::Extract, extract_mesh2d)
-                .add_system_to_stage(RenderStage::Queue, queue_mesh2d_bind_group)
-                .add_system_to_stage(RenderStage::Queue, queue_mesh2d_view_bind_groups);
-        }
+        app.add_render_init(move |app| {
+            if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+                render_app
+                    .init_resource::<Mesh2dPipeline>()
+                    .init_resource::<SpecializedMeshPipelines<Mesh2dPipeline>>()
+                    .add_system_to_stage(RenderStage::Extract, extract_mesh2d)
+                    .add_system_to_stage(RenderStage::Queue, queue_mesh2d_bind_group)
+                    .add_system_to_stage(RenderStage::Queue, queue_mesh2d_view_bind_groups);
+            }
+        });
     }
 }
 

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -52,11 +52,13 @@ impl Plugin for TextPlugin {
                 update_text2d_layout.after(ModifiesWindows),
             );
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app.add_system_to_stage(
-                RenderStage::Extract,
-                extract_text2d_sprite.after(SpriteSystem::ExtractSprites),
-            );
-        }
+        app.add_render_init(move |app| {
+            if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+                render_app.add_system_to_stage(
+                    RenderStage::Extract,
+                    extract_text2d_sprite.after(SpriteSystem::ExtractSprites),
+                );
+            }
+        });
     }
 }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -110,6 +110,8 @@ impl Plugin for UiPlugin {
                 update_clipping_system.after(TransformSystem::TransformPropagate),
             );
 
-        crate::render::build_ui_render(app);
+        app.add_render_init(move |app| {
+            crate::render::build_ui_render(app);
+        });
     }
 }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -283,6 +283,7 @@ impl Default for WinitPersistentState {
 struct WinitCreateWindowReader(ManualEventReader<CreateWindow>);
 
 pub fn winit_runner_with(mut app: App) {
+    app.render_init();
     let mut event_loop = app
         .world
         .remove_non_send_resource::<EventLoop<()>>()


### PR DESCRIPTION
# Objective

This work was primarily done as part of an effort to get [Bevy running on Android](https://github.com/bevyengine/bevy/issues/86).

Currently, the biggest barrier to running Bevy apps on Android is that Android apps don't have a SurfaceView when they first start and we have to wait until we get a Winit `Resumed` event before we have a valid SurfaceView that can be used for rendering.

Instead of assuming it's valid to create a native window and graphics context immediately while initializing a Bevy application the aim of this PR is to ring fence the code that handles the initialization of render state so it's possible to control (defer) when it's called.


## Solution

This introduces the idea of `render_init` callbacks for an App that can be registered within plugin `build()` functions and the App runner can decide when it's ready to initialize the render state and call `app.render_init()` which will invoke all the init functions in the same order that they were registered.

It is then a very mechanical change to move all the plugin `build()` code that pertains to initializing render state into an `add_render_init()` callback. In general all code that depends on the `RenderApp` sub app has been moved into a render init callback.

For example plugin `build()` code like this:
```rust
if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
    render_app.add_system_to_stage(
        RenderStage::Extract,
        extract_text2d_sprite.after(SpriteSystem::ExtractSprites),
    );
}
```
becomes:
```rust
app.add_render_init(move |app| {
    if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
        render_app.add_system_to_stage(
            RenderStage::Extract,
            extract_text2d_sprite.after(SpriteSystem::ExtractSprites),
        );
    }
});
```

and `bevy_winit` is updated to call `app.render_init();` when it's ready to initialize all render state.

## Discussion

Due to the fairly large systematic change to wrap the render init code in `add_render_init` callbacks I was quite keen to share this PR early (even though I can't say I have tested it very heavily) in the hope of potentially being able to avoid too much rebasing if we decide this is an acceptable solution for deferred render state initialization. (This is also why I've avoided conflating this PR with other Android specific fixes/changes.)

I also have a branch I can share based on this that gets a minimal Bevy application running on Android (and the same app has also been tested on Windows), so I'm at least confident that this can help with Android enabling.

---

## Changelog

### Added
- Added App render_init functions for deferring render state initialization

## Migration Guide

Any plugin `build()` code that depends on `RenderApp` sub app state should be moved into a render init callback, via `app.add_render_init()`, like:
```rust
app.add_render_init(move |app| {
    if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
        render_app.add_system_to_stage(
            RenderStage::Extract,
            extract_text2d_sprite.after(SpriteSystem::ExtractSprites),
        );
    }
});
```
