### PR TITLE
[Merged by Bors] - Revert ndk-glue to 0.5 to synchronize with winit

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -40,7 +40,7 @@ wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = { version = "0.5", features = ["logger"]}
+ndk-glue = { version = "0.5"}
 
 [dev-dependencies]
 futures-lite = "1.4.0"

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -40,7 +40,7 @@ wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = { version = "0.5"}
+ndk-glue = { version = "0.5" }
 
 [dev-dependencies]
 futures-lite = "1.4.0"

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -40,7 +40,7 @@ wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = { version = "0.6" }
+ndk-glue = { version = "0.5", features = ["logger"]}
 
 [dev-dependencies]
 futures-lite = "1.4.0"

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -98,4 +98,4 @@ bevy_winit = { path = "../bevy_winit", optional = true, version = "0.8.0-dev" }
 bevy_gilrs = { path = "../bevy_gilrs", optional = true, version = "0.8.0-dev" }
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = {version = "0.6", features = ["logger"]}
+ndk-glue = {version = "0.5", features = ["logger"]}

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -98,4 +98,6 @@ bevy_winit = { path = "../bevy_winit", optional = true, version = "0.8.0-dev" }
 bevy_gilrs = { path = "../bevy_gilrs", optional = true, version = "0.8.0-dev" }
 
 [target.'cfg(target_os = "android")'.dependencies]
+# This version *must* be the same as the version used by winit,
+# or Android will break: https://github.com/rust-windowing/winit#android
 ndk-glue = {version = "0.5", features = ["logger"]}


### PR DESCRIPTION
# Objective

- Upgrading ndk-glue (our Android interop layer) desynchronized us from winit
- This further broke Android builds, see #4905 (oops...)
- Reverting to 0.5 should help with this, until the new `winit` version releases
- Fixes #4774 and closes #4529