### PR TITLE
Windows as Entities

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -215,6 +215,20 @@ impl<'w, 's> Commands<'w, 's> {
         }
     }
 
+
+    pub fn window<'a>(&'a mut self, entity: Entity) -> WindowCommands<'w, 's, 'a> {
+        assert!(
+            self.entities.contains(entity),
+            "Attempting to create an EntityCommands for entity {:?}, which doesn't exist.",
+            entity
+        );
+
+        WindowCommands { 
+            entity, 
+            commands: self
+        }
+    }
+
     /// Spawns entities to the [`World`] according to the given iterator (or a type that can
     /// be converted to it).
     ///
@@ -592,6 +606,18 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     }
 }
 
+
+/// A list of commmands that will be run to modify a window
+pub struct WindowCommands<'w, 's, 'a> {
+    entity: Entity,
+    commands: &'a mut Commands<'w, 's>,
+}
+
+impl<'w, 's, 'a> WindowCommands <'w, 's, 'a> {
+
+
+}
+
 impl<F> Command for F
 where
     F: FnOnce(&mut World) + Send + Sync + 'static,
@@ -790,6 +816,9 @@ impl<R: Resource> Command for RemoveResource<R> {
         world.remove_resource::<R>();
     }
 }
+
+
+
 
 #[cfg(test)]
 #[allow(clippy::float_cmp, clippy::approx_constant)]


### PR DESCRIPTION
# Objective

Windows as Entities

## Solution

What solution would you like?

- [ ] `WindowId` is now `Entity`
- [ ] Extend `Commands` with a `window` method returns `WindowCommands` similar to how the entity method returns `EntityCommands,` 
- [ ] `WindowCommandQueued` will implement `Command` and on `write` send itself as an event that window backends like `bevy_winit` will process.
- [ ] `Window` should be separated into different components:
  - [x]  `WindowCursor` 
  - [x] `WindowCursorPosition`
  - [x] `WindowHandle` 
  - [x] `WindowPosition`
  - [x] `WindowResizeConstraints`
  - [x] `WindowResolution`
  - [x] `WindowTitle` 
  - [x] WindowPresentation
  - [x] WindowModeComponent
  - [x] `WindowCurrentlyFocused` (marker) (WindowFocused is taken by a window event)
  - [x] `WindowDecorated` (marker)
  - [x] `WindowResizable` (marker)
  - [ ] A world query struct containing all these components and markers should be publicly exposed
- [ ] Windows should be spawned like an entity in Commands with a WindowDescriptor component
- [ ] Window backends should query Added<WindowDescriptor> and create the windows for them
- [ ] while also applying a `Window` marker confirming they have been created, query Added<Window> or use a `WindowCreated` event to get newly created windows.
- [ ] Despawning windows should be done just as entities (as they are now entities), window backends should close/destroy windows their internal component has been dropped, e.g. WinitWindow (wrapper around winit's Window that destroys itself on drop)
- [ ] A resource called `PrimaryWindow` contains the entity id of initial window created by `WindowPlugin,` this replaces `Windows::primary`
- [ ] Insert `PrimaryWindow` resource when primary window has been created
- [ ] `PrimaryWindow` when add_primary_window is false?
- [ ] `WindowPlugin` should change exit_on_close into a enum called `ExitCondition` with the values `OnPrimaryClosed` (when primary window is closed), `OnAllClosed` (when all windows are closed), `DontExit` (keep app headless)

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- What changed as a result of this PR?
- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!

## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- If this PR is a breaking change (relative to the last release of Bevy), describe how a user might need to migrate their code to support these changes
- Simply adding new functionality is not a breaking change.
- Fixing behavior that was definitely a bug, rather than a questionable design choice is not a breaking change.
