### PR TITLE
[Merged by Bors] - Update commented vsync code in example to use present_mode

### DIFF
--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -25,7 +25,7 @@ fn main() {
         .insert_resource(ClearColor(Color::BLACK))
         .insert_resource(WindowDescriptor {
             // uncomment for unthrottled FPS
-            // vsync: false,
+            // present_mode: bevy::window::PresentMode::Immediate,
             ..default()
         })
         .add_plugins(DefaultPlugins)


### PR DESCRIPTION
# Objective

- To fix the broken commented code in `examples/shader/compute_shader_game_of_life.rs` for disabling frame throttling

## Solution

- Change the commented code from using the old `WindowDescriptor::vsync` to the new `WindowDescriptor::present_mode`

### Note
I chose to use the fully qualified scope `bevy::window::PresentWindow::Immediate` rather than explicitly including `PresentWindow` to avoid an unused import when the code is commented.