### PR TITLE
Refactor bevy_mikktspace into idiomatic Rust

### DIFF
--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["bevy", "3D", "graphics", "algorithm", "tangent"]
 glam = "0.20.0"
 id-arena = "2.2.1"
 smallvec = { version = "1.6", features = ["union"] }
-
+bitflags = "1.3.2"
 
 [[example]]
 name = "generate"

--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -2,7 +2,11 @@
 name = "bevy_mikktspace"
 version = "0.8.0-dev"
 edition = "2021"
-authors = ["Benjamin Wasty <benny.wasty@gmail.com>", "David Harvey-Macaulay <alteous@outlook.com>", "Layl Bongers <LaylConway@users.noreply.github.com>"]
+authors = [
+    "Benjamin Wasty <benny.wasty@gmail.com>",
+    "David Harvey-Macaulay <alteous@outlook.com>",
+    "Layl Bongers <LaylConway@users.noreply.github.com>",
+]
 description = "Mikkelsen tangent space algorithm"
 documentation = "https://docs.rs/bevy"
 homepage = "https://bevyengine.org"
@@ -12,6 +16,9 @@ keywords = ["bevy", "3D", "graphics", "algorithm", "tangent"]
 
 [dependencies]
 glam = "0.20.0"
+id-arena = "2.2.1"
+smallvec = { version = "1.6", features = ["union"] }
+
 
 [[example]]
 name = "generate"

--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -16,9 +16,9 @@ keywords = ["bevy", "3D", "graphics", "algorithm", "tangent"]
 
 [dependencies]
 glam = "0.20.0"
-id-arena = "2.2.1"
-smallvec = { version = "1.6", features = ["union"] }
 bitflags = "1.3.2"
+# id-arena = "2.2.1"
+# smallvec = { version = "1.6", features = ["union"] }
 
 [[example]]
 name = "generate"

--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -19,6 +19,7 @@ glam = "0.20.0"
 bitflags = "1.3.2"
 # id-arena = "2.2.1"
 # smallvec = { version = "1.6", features = ["union"] }
+ordered-float = "3.0.0"
 
 [[example]]
 name = "generate"

--- a/crates/bevy_mikktspace/examples/generate.rs
+++ b/crates/bevy_mikktspace/examples/generate.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::bool_assert_comparison, clippy::useless_conversion)]
 
+use bevy_mikktspace::FaceKind;
 use glam::{Vec2, Vec3};
 
 pub type Face = [u32; 3];
@@ -26,8 +27,8 @@ impl bevy_mikktspace::Geometry for Mesh {
         self.faces.len()
     }
 
-    fn num_vertices_of_face(&self, _face: usize) -> usize {
-        3
+    fn num_vertices_of_face(&self, _face: usize) -> FaceKind {
+        FaceKind::Triangle
     }
 
     fn position(&self, face: usize, vert: usize) -> [f32; 3] {

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -44,7 +44,6 @@
     non_snake_case,
     non_upper_case_globals,
     unused_mut,
-    unused_assignments,
     unused_variables
 )]
 
@@ -163,7 +162,7 @@ impl SGroup {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct SSubGroup {
     pub iNrFaces: i32,
     pub pTriMembers: Vec<i32>,
@@ -178,15 +177,16 @@ impl SSubGroup {
     }
 }
 
-#[derive(Copy, Clone)]
-pub union SEdge {
-    pub unnamed: unnamed,
-    pub array: [i32; 3],
+#[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SEdge {
+    pub i0: i32,
+    pub i1: i32,
+    pub f: i32,
 }
 
 impl SEdge {
     fn zero() -> Self {
-        Self { array: [0, 0, 0] }
+        Self::default()
     }
 }
 
@@ -1452,11 +1452,8 @@ unsafe fn GenerateInitialVerticesIndexList(
     iNrTrianglesIn: usize,
 ) -> usize {
     let mut iTSpacesOffs: usize = 0;
-    let mut f = 0;
-    let mut t: usize = 0;
     let mut iDstTriIndex = 0;
-    f = 0;
-    while f < geometry.num_faces() {
+    for f in 0..geometry.num_faces() {
         let verts = geometry.num_vertices_of_face(f);
 
         pTriInfos[iDstTriIndex].iOrgFaceNumber = f as i32;
@@ -1483,7 +1480,7 @@ unsafe fn GenerateInitialVerticesIndexList(
             let T3 = get_tex_coord(geometry, i3);
             let distSQ_02: f32 = (T2 - T0).length_squared();
             let distSQ_13: f32 = (T3 - T1).length_squared();
-            let mut bQuadDiagIs_02: bool = false;
+            let bQuadDiagIs_02: bool;
             if distSQ_02 < distSQ_13 {
                 bQuadDiagIs_02 = true
             } else if distSQ_13 < distSQ_02 {
@@ -1540,13 +1537,10 @@ unsafe fn GenerateInitialVerticesIndexList(
             }
         }
         iTSpacesOffs += verts.num_vertices();
-
-        f += 1
     }
-    t = 0;
-    while t < iNrTrianglesIn {
+
+    for t in 0..iNrTrianglesIn {
         pTriInfos[t].iFlag = TriangleFlags::empty();
-        t += 1
     }
     return iTSpacesOffs;
 }

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -300,18 +300,18 @@ pub unsafe fn genTangSpace(geometry: &mut impl Geometry, fAngularThreshold: f32)
         iNrTrianglesIn as i32,
         iTotTris as i32,
     );
+
+    // Output generated triangles
     let mut index = 0;
     for f in 0..iNrFaces {
         let verts_0 = geometry.num_vertices_of_face(f);
         for i in 0..verts_0.num_vertices() {
-            let mut pTSpace: *const STSpace = &mut psTspace[index] as *mut STSpace;
-            let mut tang = Vec3::new((*pTSpace).vOs.x, (*pTSpace).vOs.y, (*pTSpace).vOs.z);
-            let mut bitang = Vec3::new((*pTSpace).vOt.x, (*pTSpace).vOt.y, (*pTSpace).vOt.z);
+            let mut pTSpace = &psTspace[index];
             geometry.set_tangent(
-                tang.into(),
-                bitang.into(),
-                (*pTSpace).fMagS,
-                (*pTSpace).fMagT,
+                pTSpace.vOs.into(),
+                pTSpace.vOt.into(),
+                pTSpace.fMagS,
+                pTSpace.fMagT,
                 (*pTSpace).bOrient,
                 f,
                 i,

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -209,9 +209,8 @@ impl STmpVert {
     }
 }
 
-pub unsafe fn genTangSpace<I: Geometry>(geometry: &mut I, fAngularThreshold: f32) -> bool {
+pub unsafe fn genTangSpace(geometry: &mut impl Geometry, fAngularThreshold: f32) -> bool {
     let iNrFaces = geometry.num_faces();
-    let mut bRes: bool = false;
     let fThresCos = (fAngularThreshold.to_radians()).cos();
 
     let mut iNrTrianglesIn = 0;
@@ -224,6 +223,7 @@ pub unsafe fn genTangSpace<I: Geometry>(geometry: &mut I, fAngularThreshold: f32
     }
 
     if iNrTrianglesIn <= 0 {
+        // Easier if we can assume there's at least one face
         return false;
     }
     let iNrTrianglesIn = iNrTrianglesIn;
@@ -332,11 +332,11 @@ pub unsafe fn genTangSpace<I: Geometry>(geometry: &mut I, fAngularThreshold: f32
 
     return true;
 }
-unsafe fn DegenEpilogue<I: Geometry>(
+unsafe fn DegenEpilogue(
     mut psTspace: *mut STSpace,
     mut pTriInfos: *mut STriInfo,
     mut piTriListIn: *mut i32,
-    geometry: &mut I,
+    geometry: &impl Geometry,
     iNrTrianglesIn: i32,
     iTotTris: i32,
 ) {
@@ -426,14 +426,14 @@ unsafe fn DegenEpilogue<I: Geometry>(
     }
 }
 
-unsafe fn GenerateTSpaces<I: Geometry>(
+unsafe fn GenerateTSpaces(
     psTspace: &mut [STSpace],
     mut pTriInfos: *const STriInfo,
     mut pGroups: *const SGroup,
     iNrActiveGroups: i32,
     mut piTriListIn: *const i32,
     fThresCos: f32,
-    geometry: &mut I,
+    geometry: &impl Geometry,
 ) -> bool {
     let mut iMaxNrFaces: usize = 0;
     let mut iUniqueTspaces = 0;
@@ -619,12 +619,12 @@ unsafe fn NotZero(fX: f32) -> bool {
     fX.abs() > 1.17549435e-38f32
 }
 
-unsafe fn EvalTspace<I: Geometry>(
+unsafe fn EvalTspace(
     mut face_indices: *mut i32,
     iFaces: i32,
     mut piTriListIn: *const i32,
     mut pTriInfos: *const STriInfo,
-    geometry: &mut I,
+    geometry: &impl Geometry,
     iVertexRepresentitive: i32,
 ) -> STSpace {
     let mut res: STSpace = STSpace {
@@ -939,10 +939,10 @@ unsafe fn AddTriToGroup(mut pGroup: *mut SGroup, iTriIndex: i32) {
     *(*pGroup).pFaceIndices.offset((*pGroup).iNrFaces as isize) = iTriIndex;
     (*pGroup).iNrFaces += 1;
 }
-unsafe fn InitTriInfo<I: Geometry>(
+unsafe fn InitTriInfo(
     mut pTriInfos: *mut STriInfo,
     mut piTriListIn: *const i32,
-    geometry: &mut I,
+    geometry: &impl Geometry,
     iNrTrianglesIn: usize,
 ) {
     let mut f = 0;
@@ -1297,7 +1297,7 @@ unsafe fn QuickSortEdges(
 }
 
 // returns the texture area times 2
-unsafe fn CalcTexArea<I: Geometry>(geometry: &mut I, mut indices: *const i32) -> f32 {
+unsafe fn CalcTexArea(geometry: &impl Geometry, mut indices: *const i32) -> f32 {
     let t1 = get_tex_coord(geometry, *indices.offset(0isize) as usize);
     let t2 = get_tex_coord(geometry, *indices.offset(1isize) as usize);
     let t3 = get_tex_coord(geometry, *indices.offset(2isize) as usize);
@@ -1399,9 +1399,9 @@ unsafe fn DegenPrologue(
         }
     }
 }
-unsafe fn GenerateSharedVerticesIndexList<I: Geometry>(
+unsafe fn GenerateSharedVerticesIndexList(
     mut piTriList_in_and_out: *mut i32,
-    geometry: &mut I,
+    geometry: &impl Geometry,
     iNrTrianglesIn: usize,
 ) {
     let mut i = 0;
@@ -1537,10 +1537,10 @@ unsafe fn GenerateSharedVerticesIndexList<I: Geometry>(
     }
 }
 
-unsafe fn MergeVertsFast<I: Geometry>(
+unsafe fn MergeVertsFast(
     mut piTriList_in_and_out: *mut i32,
     mut pTmpVert: *mut STmpVert,
-    geometry: &mut I,
+    geometry: &impl Geometry,
     iL_in: i32,
     iR_in: i32,
 ) {
@@ -1686,10 +1686,10 @@ unsafe fn FindGridCell(fMin: f32, fMax: f32, fVal: f32) -> usize {
     };
 }
 
-unsafe fn GenerateInitialVerticesIndexList<I: Geometry>(
+unsafe fn GenerateInitialVerticesIndexList(
     pTriInfos: &mut [STriInfo],
     piTriList_out: &mut [i32],
-    geometry: &mut I,
+    geometry: &mut impl Geometry,
     iNrTrianglesIn: usize,
 ) -> usize {
     let mut iTSpacesOffs: usize = 0;

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -103,10 +103,10 @@ impl STSpace {
 
 bitflags! {
     pub struct TriangleFlags: u8 {
-        const DEGENERATE = 0b0000_0001;
-        const QUAD_ONE_DEGENERATE_TRI = 0b0000_0010;
-        const GROUP_WITH_ANY = 0b0000_0100;
-        const ORIENT_PRESERVING = 0b0000_1000;
+        const DEGENERATE = 1;
+        const QUAD_ONE_DEGENERATE_TRI = 2;
+        const GROUP_WITH_ANY = 4;
+        const ORIENT_PRESERVING = 8;
     }
 }
 
@@ -1000,7 +1000,7 @@ unsafe fn InitTriInfo<I: Geometry>(
             let fAbsArea: f32 = fSignedAreaSTx2.abs();
             let fLenOs: f32 = vOs.length();
             let fLenOt: f32 = vOt.length();
-            let fS: f32 = if (*pTriInfos.offset(f as isize))
+            let fS: f32 = if !(*pTriInfos.offset(f as isize))
                 .iFlag
                 .contains(TriangleFlags::ORIENT_PRESERVING)
             {

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -211,6 +211,7 @@ impl STmpVert {
 
 pub unsafe fn genTangSpace(geometry: &mut impl Geometry, fAngularThreshold: f32) -> bool {
     let iNrFaces = geometry.num_faces();
+    // TODO: Accept in radians by default here?
     let fThresCos = (fAngularThreshold.to_radians()).cos();
 
     let mut iNrTrianglesIn = 0;

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -621,48 +621,21 @@ unsafe fn EvalTspace(
     geometry: &impl Geometry,
     iVertexRepresentitive: i32,
 ) -> STSpace {
-    let mut res: STSpace = STSpace {
-        vOs: Vec3::new(0.0, 0.0, 0.0),
-        fMagS: 0.,
-        vOt: Vec3::new(0.0, 0.0, 0.0),
-        fMagT: 0.,
-        iCounter: 0,
-        bOrient: false,
-    };
+    let mut res: STSpace = STSpace::zero();
     let mut fAngleSum: f32 = 0i32 as f32;
-    let mut face: i32 = 0i32;
-    res.vOs.x = 0.0f32;
-    res.vOs.y = 0.0f32;
-    res.vOs.z = 0.0f32;
-    res.vOt.x = 0.0f32;
-    res.vOt.y = 0.0f32;
-    res.vOt.z = 0.0f32;
-    res.fMagS = 0i32 as f32;
-    res.fMagT = 0i32 as f32;
-    face = 0i32;
-    while face < iFaces {
+
+    for face in 0..iFaces {
         let f: i32 = *face_indices.offset(face as isize);
         if !(*pTriInfos.offset(f as isize))
             .iFlag
             .contains(TriangleFlags::GROUP_WITH_ANY)
         {
-            let mut n = Vec3::new(0.0, 0.0, 0.0);
             let mut vOs = Vec3::new(0.0, 0.0, 0.0);
             let mut vOt = Vec3::new(0.0, 0.0, 0.0);
-            let mut p0 = Vec3::new(0.0, 0.0, 0.0);
-            let mut p1 = Vec3::new(0.0, 0.0, 0.0);
-            let mut p2 = Vec3::new(0.0, 0.0, 0.0);
-            let mut v1 = Vec3::new(0.0, 0.0, 0.0);
-            let mut v2 = Vec3::new(0.0, 0.0, 0.0);
+
             let mut fCos: f32 = 0.;
-            let mut fAngle: f32 = 0.;
-            let mut fMagS: f32 = 0.;
-            let mut fMagT: f32 = 0.;
             let mut i: i32 = -1i32;
-            let mut index: i32 = -1i32;
-            let mut i0: i32 = -1i32;
-            let mut i1: i32 = -1i32;
-            let mut i2: i32 = -1i32;
+
             if *piTriListIn.offset((3i32 * f + 0i32) as isize) == iVertexRepresentitive {
                 i = 0i32
             } else if *piTriListIn.offset((3i32 * f + 1i32) as isize) == iVertexRepresentitive {
@@ -670,8 +643,8 @@ unsafe fn EvalTspace(
             } else if *piTriListIn.offset((3i32 * f + 2i32) as isize) == iVertexRepresentitive {
                 i = 2i32
             }
-            index = *piTriListIn.offset((3i32 * f + i) as isize);
-            n = get_normal(geometry, index as usize);
+            let index = *piTriListIn.offset((3i32 * f + i) as isize);
+            let n = get_normal(geometry, index as usize);
             let mut vOs = (*pTriInfos.offset(f as isize)).vOs
                 - (n.dot((*pTriInfos.offset(f as isize)).vOs) * n);
             let mut vOt = (*pTriInfos.offset(f as isize)).vOt
@@ -682,14 +655,16 @@ unsafe fn EvalTspace(
             if VNotZero(vOt) {
                 vOt = Normalize(vOt)
             }
-            i2 = *piTriListIn.offset((3i32 * f + if i < 2i32 { i + 1i32 } else { 0i32 }) as isize);
-            i1 = *piTriListIn.offset((3i32 * f + i) as isize);
-            i0 = *piTriListIn.offset((3i32 * f + if i > 0i32 { i - 1i32 } else { 2i32 }) as isize);
-            p0 = get_position(geometry, i0 as usize);
-            p1 = get_position(geometry, i1 as usize);
-            p2 = get_position(geometry, i2 as usize);
-            v1 = p0 - p1;
-            v2 = p2 - p1;
+            let i2 =
+                *piTriListIn.offset((3i32 * f + if i < 2i32 { i + 1i32 } else { 0i32 }) as isize);
+            let i1 = *piTriListIn.offset((3i32 * f + i) as isize);
+            let i0 =
+                *piTriListIn.offset((3i32 * f + if i > 0i32 { i - 1i32 } else { 2i32 }) as isize);
+            let p0 = get_position(geometry, i0 as usize);
+            let p1 = get_position(geometry, i1 as usize);
+            let p2 = get_position(geometry, i2 as usize);
+            let v1 = p0 - p1;
+            let v2 = p2 - p1;
             let mut v1 = v1 - (n.dot(v1) * n);
             if VNotZero(v1) {
                 v1 = Normalize(v1)
@@ -707,16 +682,15 @@ unsafe fn EvalTspace(
             } else {
                 fCos
             };
-            fAngle = (fCos as f64).acos() as f32;
-            fMagS = (*pTriInfos.offset(f as isize)).fMagS;
-            fMagT = (*pTriInfos.offset(f as isize)).fMagT;
+            let fAngle = (fCos as f64).acos() as f32;
+            let fMagS = (*pTriInfos.offset(f as isize)).fMagS;
+            let fMagT = (*pTriInfos.offset(f as isize)).fMagT;
             res.vOs = res.vOs + (fAngle * vOs);
             res.vOt = res.vOt + (fAngle * vOt);
             res.fMagS += fAngle * fMagS;
             res.fMagT += fAngle * fMagT;
             fAngleSum += fAngle
         }
-        face += 1
     }
     if VNotZero(res.vOs) {
         res.vOs = Normalize(res.vOs)

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -243,8 +243,8 @@ pub unsafe fn genTangSpace(geometry: &mut impl Geometry, fAngularThreshold: f32)
     // C: put the degenerate triangles last.
     // Note: A quad can have degenerate triangles if two vertices are in the same location
     degenerate::DegenPrologue(
-        pTriInfos.as_mut_ptr(),
-        piTriListIn.as_mut_ptr(),
+        &mut pTriInfos,
+        &mut piTriListIn,
         iNrTrianglesIn as i32,
         iTotTris as i32,
     );

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -843,13 +843,8 @@ unsafe fn InitTriInfo(
     geometry: &impl Geometry,
     iNrTrianglesIn: usize,
 ) {
-    let mut f = 0;
-    let mut i = 0;
-    let mut t = 0;
-    f = 0;
-    while f < iNrTrianglesIn {
-        i = 0i32;
-        while i < 3i32 {
+    for f in 0..iNrTrianglesIn {
+        for i in 0..3i32 {
             (*pTriInfos.offset(f as isize)).FaceNeighbors[i as usize] = -1i32;
             let ref mut fresh4 = (*pTriInfos.offset(f as isize)).AssignedGroup[i as usize];
             *fresh4 = 0 as *mut SGroup;
@@ -864,12 +859,9 @@ unsafe fn InitTriInfo(
             (*pTriInfos.offset(f as isize))
                 .iFlag
                 .insert(TriangleFlags::GROUP_WITH_ANY);
-            i += 1
         }
-        f += 1
     }
-    f = 0;
-    while f < iNrTrianglesIn {
+    for f in 0..iNrTrianglesIn {
         let v1 = get_position(geometry, *piTriListIn.offset((f * 3 + 0) as isize) as usize);
         let v2 = get_position(geometry, *piTriListIn.offset((f * 3 + 1) as isize) as usize);
         let v3 = get_position(geometry, *piTriListIn.offset((f * 3 + 2) as isize) as usize);
@@ -918,8 +910,8 @@ unsafe fn InitTriInfo(
                     .remove(TriangleFlags::GROUP_WITH_ANY);
             }
         }
-        f += 1
     }
+    let mut t = 0;
     while t < iNrTrianglesIn - 1 {
         let iFO_a: i32 = (*pTriInfos.offset(t as isize)).iOrgFaceNumber;
         let iFO_b: i32 = (*pTriInfos.offset((t + 1) as isize)).iOrgFaceNumber;

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -288,9 +288,9 @@ pub unsafe fn genTangSpace(geometry: &mut impl Geometry, fAngularThreshold: f32)
         return false;
     }
     degenerate::DegenEpilogue(
-        psTspace.as_mut_ptr(),
-        pTriInfos.as_mut_ptr(),
-        piTriListIn.as_mut_ptr(),
+        &mut psTspace,
+        &mut pTriInfos,
+        &mut piTriListIn,
         geometry,
         iNrTrianglesIn as i32,
         iTotTris as i32,

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -489,12 +489,9 @@ unsafe fn GenerateTSpaces(
                 - (n.dot((*pTriInfos.offset(f as isize)).vOs) * n);
             let mut vOt = (*pTriInfos.offset(f as isize)).vOt
                 - (n.dot((*pTriInfos.offset(f as isize)).vOt) * n);
-            if VNotZero(vOs) {
-                vOs = vOs.normalize()
-            }
-            if VNotZero(vOt) {
-                vOt = vOt.normalize()
-            }
+            vOs = vOs.normalize_or_zero();
+            vOt = vOt.normalize_or_zero();
+
             let iOF_1 = (*pTriInfos.offset(f as isize)).iOrgFaceNumber;
             let mut iMembers = 0;
 
@@ -505,12 +502,9 @@ unsafe fn GenerateTSpaces(
                     - (n.dot((*pTriInfos.offset(t as isize)).vOs) * n);
                 let mut vOt2 = (*pTriInfos.offset(t as isize)).vOt
                     - (n.dot((*pTriInfos.offset(t as isize)).vOt) * n);
-                if VNotZero(vOs2) {
-                    vOs2 = vOs2.normalize()
-                }
-                if VNotZero(vOt2) {
-                    vOt2 = vOt2.normalize()
-                }
+                vOs2 = vOs2.normalize_or_zero();
+                vOt2 = vOt2.normalize_or_zero();
+
                 let bAny: bool = ((*pTriInfos.offset(f as isize)).iFlag
                     | (*pTriInfos.offset(t as isize)).iFlag)
                     .contains(TriangleFlags::GROUP_WITH_ANY);
@@ -603,18 +597,10 @@ unsafe fn AvgTSpace(mut pTS0: *const STSpace, mut pTS1: *const STSpace) -> STSpa
         ts_res.fMagT = 0.5f32 * ((*pTS0).fMagT + (*pTS1).fMagT);
         ts_res.vOs = (*pTS0).vOs + (*pTS1).vOs;
         ts_res.vOt = (*pTS0).vOt + (*pTS1).vOt;
-        if VNotZero(ts_res.vOs) {
-            ts_res.vOs = ts_res.vOs.normalize();
-        }
-        if VNotZero(ts_res.vOt) {
-            ts_res.vOt = ts_res.vOt.normalize();
-        }
+        ts_res.vOs = ts_res.vOs.normalize_or_zero();
+        ts_res.vOt = ts_res.vOt.normalize_or_zero();
     }
     return ts_res;
-}
-
-fn VNotZero(v: Vec3) -> bool {
-    NotZero(v.x) || NotZero(v.y) || NotZero(v.z)
 }
 
 fn NotZero(fX: f32) -> bool {
@@ -654,12 +640,9 @@ unsafe fn EvalTspace(
                 - (n.dot((*pTriInfos.offset(f as isize)).vOs) * n);
             let mut vOt = (*pTriInfos.offset(f as isize)).vOt
                 - (n.dot((*pTriInfos.offset(f as isize)).vOt) * n);
-            if VNotZero(vOs) {
-                vOs = vOs.normalize();
-            }
-            if VNotZero(vOt) {
-                vOt = vOt.normalize()
-            }
+            vOs = vOs.normalize_or_zero();
+            vOt = vOt.normalize_or_zero();
+
             let i2 =
                 *piTriListIn.offset((3i32 * f + if i < 2i32 { i + 1i32 } else { 0i32 }) as isize);
             let i1 = *piTriListIn.offset((3i32 * f + i) as isize);
@@ -671,22 +654,12 @@ unsafe fn EvalTspace(
             let v1 = p0 - p1;
             let v2 = p2 - p1;
             let mut v1 = v1 - (n.dot(v1) * n);
-            if VNotZero(v1) {
-                v1 = v1.normalize()
-            }
-            let mut v2 = v2 - (n.dot(v2) * n);
-            if VNotZero(v2) {
-                v2 = v2.normalize()
-            }
-            let fCos = v1.dot(v2);
+            v1 = v1.normalize_or_zero();
 
-            let fCos = if fCos > 1i32 as f32 {
-                1i32 as f32
-            } else if fCos < -1i32 as f32 {
-                -1i32 as f32
-            } else {
-                fCos
-            };
+            let mut v2 = v2 - (n.dot(v2) * n);
+            v2 = v2.normalize_or_zero();
+            let fCos = v1.dot(v2).clamp(-1., 1.);
+
             let fAngle = (fCos as f64).acos() as f32;
             let fMagS = (*pTriInfos.offset(f as isize)).fMagS;
             let fMagT = (*pTriInfos.offset(f as isize)).fMagT;
@@ -697,12 +670,9 @@ unsafe fn EvalTspace(
             fAngleSum += fAngle
         }
     }
-    if VNotZero(res.vOs) {
-        res.vOs = res.vOs.normalize()
-    }
-    if VNotZero(res.vOt) {
-        res.vOt = res.vOt.normalize()
-    }
+    res.vOs = res.vOs.normalize_or_zero();
+    res.vOt = res.vOt.normalize_or_zero();
+
     if fAngleSum > 0i32 as f32 {
         res.fMagS /= fAngleSum;
         res.fMagT /= fAngleSum

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -1215,6 +1215,8 @@ unsafe fn GenerateSharedVerticesIndexList(
         let vP = get_position(geometry, index as usize);
         let vN = get_normal(geometry, index as usize);
         let vT = get_tex_coord(geometry, index as usize);
+        // Technically, these unwraps aren't ideal, but the original puts absolutely no thought into its handling of
+        // NaN and infinity, so it's probably *fine*
         let vP = FiniteVec3::new(vP).unwrap();
         let vN = FiniteVec3::new(vN).unwrap();
         let vT = FiniteVec3::new(vT).unwrap();

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -178,8 +178,11 @@ impl SSubGroup {
 
 #[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SEdge {
+    // The first vertex's (global) index. This is the minimum index
     pub i0: i32,
+    // The second vertex's (global) index
     pub i1: i32,
+    // The face this edge is associated with
     pub f: i32,
 }
 

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -64,7 +64,6 @@ use crate::{
 
 #[derive(Copy, Clone)]
 pub struct STSpace {
-    // Normalised f
     pub vOs: Vec3,
     pub fMagS: f32,
     pub vOt: Vec3,
@@ -221,6 +220,16 @@ impl STmpVert {
             index: 0,
         }
     }
+}
+
+/// Stores a map of 'internal' triangle vertices to real 'faces' and vertices
+/// This is used to deduplicate vertices with identical faces
+struct TriangleMap {
+    /// Packed face/vertex index of each triangle
+    /// Note that this is an index to the first vertex
+    /// with the given properties, rather than necessarily
+    /// (Not impressed with this data layout)
+    triangles: Vec<[u32; 3]>,
 }
 
 pub unsafe fn genTangSpace(geometry: &mut impl Geometry, fAngularThreshold: f32) -> bool {

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -1315,47 +1315,37 @@ unsafe fn MergeVertsFast(
     iR_in: i32,
 ) {
     // make bbox
-    let mut c: i32 = 0i32;
-    let mut l: i32 = 0i32;
-    let mut channel: i32 = 0i32;
     let mut fvMin: [f32; 3] = [0.; 3];
     let mut fvMax: [f32; 3] = [0.; 3];
-    let mut dx: f32 = 0i32 as f32;
-    let mut dy: f32 = 0i32 as f32;
-    let mut dz: f32 = 0i32 as f32;
-    let mut fSep: f32 = 0i32 as f32;
-    c = 0i32;
-    while c < 3i32 {
+
+    for c in 0..3i32 {
         fvMin[c as usize] = (*pTmpVert.offset(iL_in as isize)).vert[c as usize];
         fvMax[c as usize] = fvMin[c as usize];
-        c += 1
     }
-    l = iL_in + 1i32;
-    while l <= iR_in {
-        c = 0i32;
-        while c < 3i32 {
+
+    for l in (iL_in + 1i32)..=iR_in {
+        for c in 0..3i32 {
             if fvMin[c as usize] > (*pTmpVert.offset(l as isize)).vert[c as usize] {
                 fvMin[c as usize] = (*pTmpVert.offset(l as isize)).vert[c as usize]
             } else if fvMax[c as usize] < (*pTmpVert.offset(l as isize)).vert[c as usize] {
                 fvMax[c as usize] = (*pTmpVert.offset(l as isize)).vert[c as usize]
             }
-            c += 1
         }
-        l += 1
     }
-    dx = fvMax[0usize] - fvMin[0usize];
-    dy = fvMax[1usize] - fvMin[1usize];
-    dz = fvMax[2usize] - fvMin[2usize];
-    channel = 0i32;
+    let dx = fvMax[0usize] - fvMin[0usize];
+    let dy = fvMax[1usize] - fvMin[1usize];
+    let dz = fvMax[2usize] - fvMin[2usize];
+    let channel;
     if dy > dx && dy > dz {
         channel = 1i32
     } else if dz > dx {
         channel = 2i32
+    } else {
+        channel = 0i32
     }
-    fSep = 0.5f32 * (fvMax[channel as usize] + fvMin[channel as usize]);
+    let fSep = 0.5f32 * (fvMax[channel as usize] + fvMin[channel as usize]);
     if fSep >= fvMax[channel as usize] || fSep <= fvMin[channel as usize] {
-        l = iL_in;
-        while l <= iR_in {
+        for l in iL_in..=iR_in {
             let mut i: i32 = (*pTmpVert.offset(l as isize)).index;
             let index: i32 = *piTriList_in_and_out.offset(i as isize);
             let vP = get_position(geometry, index as usize);
@@ -1390,7 +1380,6 @@ unsafe fn MergeVertsFast(
                 *piTriList_in_and_out.offset(i as isize) =
                     *piTriList_in_and_out.offset(i2rec as isize)
             }
-            l += 1
         }
     } else {
         let mut iL: i32 = iL_in;

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -345,7 +345,7 @@ fn GenerateTSpaces(
             vOt = vOt.normalize_or_zero();
 
             let iOF_1 = pTriInfos[f as usize].iOrgFaceNumber;
-            let iMembers = 0;
+            let mut iMembers = 0;
 
             for j in 0..pGroup.iNrFaces {
                 let t: i32 = piGroupTrianglesBuffer[pGroup.pFaceIndices + j as usize];
@@ -363,7 +363,8 @@ fn GenerateTSpaces(
                 let fCosT: f32 = vOt.dot(vOt2);
                 debug_assert!(f != t || bSameOrgFace); // sanity check
                 if bAny || bSameOrgFace || fCosS > fThresCos && fCosT > fThresCos {
-                    pTmpMembers[iMembers + 1] = t;
+                    pTmpMembers[iMembers] = t;
+                    iMembers += 1;
                 }
             }
             if iMembers > 1 {

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -44,15 +44,14 @@
     unused_mut
 )]
 
-use std::{collections::BTreeMap, ptr::null_mut};
+mod setup;
+
+use std::ptr::null_mut;
 
 use bitflags::bitflags;
 use glam::Vec3;
 
-use crate::{
-    face_vert_to_index, get_normal, get_position, get_tex_coord, ordered_vec::FiniteVec3, FaceKind,
-    Geometry,
-};
+use crate::{face_vert_to_index, get_normal, get_position, get_tex_coord, FaceKind, Geometry};
 
 #[derive(Copy, Clone)]
 pub struct STSpace {
@@ -211,14 +210,14 @@ pub unsafe fn genTangSpace(geometry: &mut impl Geometry, fAngularThreshold: f32)
     // This also handles quads
     // TODO: Make this return triangle_info and tri_face_map
     // probably in a single structure.
-    let iNrTSPaces = GenerateInitialVerticesIndexList(
+    let iNrTSPaces = setup::GenerateInitialVerticesIndexList(
         &mut pTriInfos,
         &mut piTriListIn,
         geometry,
         iNrTrianglesIn,
     );
     // C: Make a welded index list of identical positions and attributes (pos, norm, texc)
-    GenerateSharedVerticesIndexList(&mut piTriListIn, geometry);
+    setup::GenerateSharedVerticesIndexList(&mut piTriListIn, geometry);
 
     let iTotTris = iNrTrianglesIn;
     let mut iDegenTriangles = 0;
@@ -1088,133 +1087,4 @@ unsafe fn DegenPrologue(
     }
     debug_assert!(iNrTrianglesIn == t);
     debug_assert!(bStillFindingGoodOnes);
-}
-fn GenerateSharedVerticesIndexList(
-    // The input vertex index->face/vert mappings
-    // Identical face/verts will have each vertex index
-    // point to the same (arbitrary?) face/vert
-    // TODO: This seems overly complicated - storing vertex properties in a
-    // side channel seems much easier.
-    // Hopefully implementation can be changed to just use a btreemap or
-    // something too.
-    mut piTriList_in_and_out: &mut [i32],
-    geometry: &impl Geometry,
-) {
-    let mut map = BTreeMap::new();
-    for vertex_index in piTriList_in_and_out {
-        let index = *vertex_index as usize;
-        let vertex_properties = [
-            get_position(geometry, index),
-            get_normal(geometry, index),
-            get_tex_coord(geometry, index),
-        ]
-        // We need to make the vertex properties finite to be able to use them in a btreemap
-        // Technically, these unwraps aren't ideal, but the original puts absolutely no thought into its handling of
-        // NaN and infinity, so it's probably *fine*. (I strongly suspect that infinity or NaN would have
-        //  lead to UB somewhere)
-        .map(|prop| FiniteVec3::new(prop).unwrap());
-
-        *vertex_index = *(map.entry(vertex_properties).or_insert(*vertex_index));
-    }
-}
-
-fn GenerateInitialVerticesIndexList(
-    pTriInfos: &mut [STriInfo],
-    piTriList_out: &mut [i32],
-    geometry: &impl Geometry,
-    iNrTrianglesIn: usize,
-) -> usize {
-    let mut iTSpacesOffs: usize = 0;
-    let mut iDstTriIndex = 0;
-    for f in 0..geometry.num_faces() {
-        let verts = geometry.num_vertices_of_face(f);
-
-        pTriInfos[iDstTriIndex].iOrgFaceNumber = f as i32;
-        pTriInfos[iDstTriIndex].iTSpacesOffs = iTSpacesOffs as i32;
-        if let FaceKind::Triangle = verts {
-            let mut pVerts = &mut pTriInfos[iDstTriIndex].vert_num;
-            pVerts[0] = 0;
-            pVerts[1] = 1;
-            pVerts[2] = 2;
-            piTriList_out[iDstTriIndex * 3 + 0] = face_vert_to_index(f, 0) as i32;
-            piTriList_out[iDstTriIndex * 3 + 1] = face_vert_to_index(f, 1) as i32;
-            piTriList_out[iDstTriIndex * 3 + 2] = face_vert_to_index(f, 2) as i32;
-            iDstTriIndex += 1
-        } else {
-            pTriInfos[iDstTriIndex + 1].iOrgFaceNumber = f as i32;
-            pTriInfos[iDstTriIndex + 1].iTSpacesOffs = iTSpacesOffs as i32;
-            let i0 = face_vert_to_index(f, 0);
-            let i1 = face_vert_to_index(f, 1);
-            let i2 = face_vert_to_index(f, 2);
-            let i3 = face_vert_to_index(f, 3);
-            let T0 = get_tex_coord(geometry, i0);
-            let T1 = get_tex_coord(geometry, i1);
-            let T2 = get_tex_coord(geometry, i2);
-            let T3 = get_tex_coord(geometry, i3);
-            let distSQ_02: f32 = (T2 - T0).length_squared();
-            let distSQ_13: f32 = (T3 - T1).length_squared();
-            let bQuadDiagIs_02: bool;
-            if distSQ_02 < distSQ_13 {
-                bQuadDiagIs_02 = true
-            } else if distSQ_13 < distSQ_02 {
-                bQuadDiagIs_02 = false
-            } else {
-                let P0 = get_position(geometry, i0);
-                let P1 = get_position(geometry, i1);
-                let P2 = get_position(geometry, i2);
-                let P3 = get_position(geometry, i3);
-                let distSQ_02_0: f32 = (P2 - P0).length_squared();
-                let distSQ_13_0: f32 = (P3 - P1).length_squared();
-                bQuadDiagIs_02 = if distSQ_13_0 < distSQ_02_0 {
-                    false
-                } else {
-                    true
-                }
-            }
-            if bQuadDiagIs_02 {
-                let mut pVerts_A = &mut pTriInfos[iDstTriIndex].vert_num;
-                pVerts_A[0] = 0;
-                pVerts_A[1] = 1;
-                pVerts_A[2] = 2;
-                piTriList_out[iDstTriIndex * 3 + 0] = i0 as i32;
-                piTriList_out[iDstTriIndex * 3 + 1] = i1 as i32;
-                piTriList_out[iDstTriIndex * 3 + 2] = i2 as i32;
-                iDstTriIndex += 1;
-
-                let mut pVerts_B = &mut pTriInfos[iDstTriIndex].vert_num;
-                pVerts_B[0] = 0;
-                pVerts_B[1] = 2;
-                pVerts_B[2] = 3;
-                piTriList_out[iDstTriIndex * 3 + 0] = i0 as i32;
-                piTriList_out[iDstTriIndex * 3 + 1] = i2 as i32;
-                piTriList_out[iDstTriIndex * 3 + 2] = i3 as i32;
-                iDstTriIndex += 1
-            } else {
-                let mut pVerts_A_0 = &mut pTriInfos[iDstTriIndex].vert_num;
-                pVerts_A_0[0] = 0;
-                pVerts_A_0[1] = 1;
-                pVerts_A_0[2] = 3;
-                piTriList_out[iDstTriIndex * 3 + 0] = i0 as i32;
-                piTriList_out[iDstTriIndex * 3 + 1] = i1 as i32;
-                piTriList_out[iDstTriIndex * 3 + 2] = i3 as i32;
-                iDstTriIndex += 1;
-
-                let mut pVerts_B_0 = &mut pTriInfos[iDstTriIndex].vert_num;
-                pVerts_B_0[0] = 1;
-                pVerts_B_0[1] = 2;
-                pVerts_B_0[2] = 3;
-                piTriList_out[iDstTriIndex * 3 + 0] = i1 as i32;
-                piTriList_out[iDstTriIndex * 3 + 1] = i2 as i32;
-                piTriList_out[iDstTriIndex * 3 + 2] = i3 as i32;
-                iDstTriIndex += 1
-            }
-        }
-        iTSpacesOffs += verts.num_vertices();
-        assert!(iDstTriIndex <= iNrTrianglesIn);
-    }
-
-    for t in 0..iNrTrianglesIn {
-        pTriInfos[t].iFlag = TriangleFlags::empty();
-    }
-    return iTSpacesOffs;
 }

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -1097,8 +1097,6 @@ unsafe fn DegenPrologue(
     iNrTrianglesIn: i32,
     iTotTris: i32,
 ) {
-    let mut iNextGoodTriangleSearchIndex: i32 = -1i32;
-    let mut bStillFindingGoodOnes: bool = false;
     // locate quads with only one good triangle
     let mut t: i32 = 0i32;
     while t < iTotTris - 1i32 {
@@ -1135,9 +1133,9 @@ unsafe fn DegenPrologue(
     // but good enough and safe.
     // TODO: Consider using `sort_by_key` on Vec instead (which is stable) - it might be
     // technically slower, but it's much easier to reason about
-    iNextGoodTriangleSearchIndex = 1i32;
+    let mut iNextGoodTriangleSearchIndex = 1i32;
     t = 0i32;
-    bStillFindingGoodOnes = true;
+    let mut bStillFindingGoodOnes = true;
     while t < iNrTrianglesIn && bStillFindingGoodOnes {
         let bIsGood: bool = !(*pTriInfos.offset(t as isize))
             .iFlag
@@ -1147,8 +1145,6 @@ unsafe fn DegenPrologue(
                 iNextGoodTriangleSearchIndex = t + 2i32
             }
         } else {
-            let mut t0: i32 = 0;
-            let mut t1: i32 = 0;
             let mut bJustADegenerate: bool = true;
             while bJustADegenerate && iNextGoodTriangleSearchIndex < iTotTris {
                 let bIsGood_0: bool = !(*pTriInfos.offset(iNextGoodTriangleSearchIndex as isize))
@@ -1160,19 +1156,16 @@ unsafe fn DegenPrologue(
                     iNextGoodTriangleSearchIndex += 1
                 }
             }
-            t0 = t;
-            t1 = iNextGoodTriangleSearchIndex;
+            let t0 = t;
+            let t1 = iNextGoodTriangleSearchIndex;
             iNextGoodTriangleSearchIndex += 1;
             // Swap t0 and t1
             if !bJustADegenerate {
-                let mut i: i32 = 0i32;
-                i = 0i32;
-                while i < 3i32 {
+                for i in 0..3i32 {
                     let index: i32 = *piTriList_out.offset((t0 * 3i32 + i) as isize);
                     *piTriList_out.offset((t0 * 3i32 + i) as isize) =
                         *piTriList_out.offset((t1 * 3i32 + i) as isize);
                     *piTriList_out.offset((t1 * 3i32 + i) as isize) = index;
-                    i += 1
                 }
                 let tri_info: STriInfo = *pTriInfos.offset(t0 as isize);
                 *pTriInfos.offset(t0 as isize) = *pTriInfos.offset(t1 as isize);

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -199,48 +199,40 @@ impl STmpVert {
 }
 
 pub unsafe fn genTangSpace<I: Geometry>(geometry: &mut I, fAngularThreshold: f32) -> bool {
-    let mut iNrTrianglesIn = 0;
-    let mut f = 0;
-    let mut t = 0;
-    let mut i = 0;
-    let mut iNrTSPaces = 0;
-    let mut iTotTris = 0;
-    let mut iDegenTriangles = 0;
-    let mut iNrMaxGroups = 0;
-    let mut iNrActiveGroups: i32 = 0i32;
-    let mut index = 0;
     let iNrFaces = geometry.num_faces();
     let mut bRes: bool = false;
-    let fThresCos: f32 =
-        ((fAngularThreshold * 3.14159265358979323846f64 as f32 / 180.0f32) as f64).cos() as f32;
-    f = 0;
-    while f < iNrFaces {
+    let fThresCos = (fAngularThreshold.to_radians()).cos();
+
+    let mut iNrTrianglesIn = 0;
+    // The number of triangles here is
+    for f in 0..iNrFaces {
         let verts = geometry.num_vertices_of_face(f);
         if verts == 3 {
             iNrTrianglesIn += 1
         } else if verts == 4 {
             iNrTrianglesIn += 2
         }
-        f += 1
     }
+
     if iNrTrianglesIn <= 0 {
         return false;
     }
-
+    let iNrTrianglesIn = iNrTrianglesIn;
     let mut piTriListIn = vec![0i32; 3 * iNrTrianglesIn];
     let mut pTriInfos = vec![STriInfo::zero(); iNrTrianglesIn];
 
-    iNrTSPaces = GenerateInitialVerticesIndexList(
+    // Make an initial triangle --> face index list
+    // This also produces
+    let iNrTSPaces = GenerateInitialVerticesIndexList(
         &mut pTriInfos,
         &mut piTriListIn,
         geometry,
         iNrTrianglesIn,
     );
     GenerateSharedVerticesIndexList(piTriListIn.as_mut_ptr(), geometry, iNrTrianglesIn);
-    iTotTris = iNrTrianglesIn;
-    iDegenTriangles = 0;
-    t = 0;
-    while t < iTotTris as usize {
+    let iTotTris = iNrTrianglesIn;
+    let mut iDegenTriangles = 0;
+    for t in 0..(iTotTris as usize) {
         let i0 = piTriListIn[t * 3 + 0];
         let i1 = piTriListIn[t * 3 + 1];
         let i2 = piTriListIn[t * 3 + 2];
@@ -253,7 +245,7 @@ pub unsafe fn genTangSpace<I: Geometry>(geometry: &mut I, fAngularThreshold: f32
         }
         t += 1
     }
-    iNrTrianglesIn = iTotTris - iDegenTriangles;
+    let iNrTrianglesIn = iTotTris - iDegenTriangles;
     DegenPrologue(
         pTriInfos.as_mut_ptr(),
         piTriListIn.as_mut_ptr(),
@@ -266,12 +258,12 @@ pub unsafe fn genTangSpace<I: Geometry>(geometry: &mut I, fAngularThreshold: f32
         geometry,
         iNrTrianglesIn,
     );
-    iNrMaxGroups = iNrTrianglesIn * 3;
+    let iNrMaxGroups = iNrTrianglesIn * 3;
 
     let mut pGroups = vec![SGroup::zero(); iNrMaxGroups];
     let mut piGroupTrianglesBuffer = vec![0; iNrTrianglesIn * 3];
 
-    iNrActiveGroups = Build4RuleGroups(
+    let iNrActiveGroups = Build4RuleGroups(
         pTriInfos.as_mut_ptr(),
         pGroups.as_mut_ptr(),
         piGroupTrianglesBuffer.as_mut_ptr(),
@@ -290,7 +282,7 @@ pub unsafe fn genTangSpace<I: Geometry>(geometry: &mut I, fAngularThreshold: f32
         iNrTSPaces
     ];
 
-    bRes = GenerateTSpaces(
+    let bRes = GenerateTSpaces(
         &mut psTspace,
         pTriInfos.as_ptr(),
         pGroups.as_ptr(),
@@ -310,13 +302,11 @@ pub unsafe fn genTangSpace<I: Geometry>(geometry: &mut I, fAngularThreshold: f32
         iNrTrianglesIn as i32,
         iTotTris as i32,
     );
-    index = 0;
-    f = 0;
-    while f < iNrFaces {
+    let mut index = 0;
+    for f in 0..iNrFaces {
         let verts_0 = geometry.num_vertices_of_face(f);
         if !(verts_0 != 3 && verts_0 != 4) {
-            i = 0;
-            while i < verts_0 {
+            for i in 0..verts_0 {
                 let mut pTSpace: *const STSpace = &mut psTspace[index] as *mut STSpace;
                 let mut tang = Vec3::new((*pTSpace).vOs.x, (*pTSpace).vOs.y, (*pTSpace).vOs.z);
                 let mut bitang = Vec3::new((*pTSpace).vOt.x, (*pTSpace).vOt.y, (*pTSpace).vOt.z);
@@ -330,10 +320,8 @@ pub unsafe fn genTangSpace<I: Geometry>(geometry: &mut I, fAngularThreshold: f32
                     i,
                 );
                 index += 1;
-                i += 1
             }
         }
-        f += 1
     }
 
     return true;

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -115,7 +115,7 @@ pub struct STriInfo {
 impl STriInfo {
     fn zero() -> Self {
         Self {
-            FaceNeighbors: [0, 0, 0],
+            FaceNeighbors: [-1, -1, -1],
             AssignedGroup: [null_mut(), null_mut(), null_mut()],
             vOs: Default::default(),
             vOt: Default::default(),
@@ -249,12 +249,7 @@ pub unsafe fn genTangSpace(geometry: &mut impl Geometry, fAngularThreshold: f32)
         iTotTris as i32,
     );
     // C: Evaluate triangle level attributes and neighbor list
-    setup::InitTriInfo(
-        pTriInfos.as_mut_ptr(),
-        piTriListIn.as_ptr(),
-        geometry,
-        iNrTrianglesIn,
-    );
+    setup::InitTriInfo(&mut pTriInfos, &piTriListIn, geometry, iNrTrianglesIn);
     //C: Based on the 4 rules, identify groups based on connectivity
     let iNrMaxGroups = iNrTrianglesIn * 3;
 

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -30,7 +30,7 @@
 // Comments starting with `C:` are copied as-is from the original
 // Note that some comments may originate from the original but not be marked as such
 
-#![allow(dead_code, non_camel_case_types, non_snake_case, unused_mut)]
+#![allow(non_camel_case_types, non_snake_case)]
 
 mod degenerate;
 mod setup;
@@ -160,16 +160,6 @@ pub struct SEdge {
     pub f: i32,
 }
 
-/// Stores a map of 'internal' triangle vertices to real 'faces' and vertices
-/// This is used to deduplicate vertices with identical faces
-struct TriangleMap {
-    /// Packed face/vertex index of each triangle
-    /// Note that this is an index to the first vertex
-    /// with the given properties, rather than necessarily
-    /// (Not impressed with this data layout)
-    triangles: Vec<[u32; 3]>,
-}
-
 // Entry point
 pub fn genTangSpace(geometry: &mut impl Geometry, fAngularThreshold: f32) -> bool {
     // TODO: Accept in radians by default here?
@@ -289,7 +279,7 @@ pub fn genTangSpace(geometry: &mut impl Geometry, fAngularThreshold: f32) -> boo
     for f in 0..iNrFaces {
         let verts_0 = geometry.num_vertices_of_face(f);
         for i in 0..verts_0.num_vertices() {
-            let mut pTSpace = &psTspace[index];
+            let pTSpace = &psTspace[index];
             geometry.set_tangent(
                 pTSpace.vOs.into(),
                 pTSpace.vOt.into(),
@@ -308,15 +298,15 @@ pub fn genTangSpace(geometry: &mut impl Geometry, fAngularThreshold: f32) -> boo
 
 fn GenerateTSpaces(
     psTspace: &mut [STSpace],
-    mut pTriInfos: &[STriInfo],
-    mut pGroups: &[SGroup],
+    pTriInfos: &[STriInfo],
+    pGroups: &[SGroup],
     iNrActiveGroups: i32,
-    mut piTriListIn: &[i32],
+    piTriListIn: &[i32],
     fThresCos: f32,
     geometry: &impl Geometry,
     piGroupTrianglesBuffer: &[i32],
 ) -> bool {
-    let mut iMaxNrFaces = pGroups[..iNrActiveGroups as usize]
+    let iMaxNrFaces = pGroups[..iNrActiveGroups as usize]
         .iter()
         .map(|it| it.iNrFaces)
         .max();
@@ -331,7 +321,7 @@ fn GenerateTSpaces(
     let mut pTmpMembers = vec![0i32; iMaxNrFaces];
 
     for g in 0..iNrActiveGroups {
-        let mut pGroup: &SGroup = &pGroups[g as usize];
+        let pGroup: &SGroup = &pGroups[g as usize];
         let mut iUniqueSubGroups = 0;
 
         for i in 0..pGroup.iNrFaces {
@@ -355,7 +345,7 @@ fn GenerateTSpaces(
             vOt = vOt.normalize_or_zero();
 
             let iOF_1 = pTriInfos[f as usize].iOrgFaceNumber;
-            let mut iMembers = 0;
+            let iMembers = 0;
 
             for j in 0..pGroup.iNrFaces {
                 let t: i32 = piGroupTrianglesBuffer[pGroup.pFaceIndices + j as usize];
@@ -433,7 +423,7 @@ fn GenerateTSpaces(
     }
     true
 }
-fn AvgTSpace(mut pTS0: &STSpace, mut pTS1: &STSpace) -> STSpace {
+fn AvgTSpace(pTS0: &STSpace, pTS1: &STSpace) -> STSpace {
     let mut ts_res: STSpace = STSpace {
         vOs: Vec3::new(0.0, 0.0, 0.0),
         fMagS: 0.,
@@ -463,10 +453,10 @@ fn AvgTSpace(mut pTS0: &STSpace, mut pTS1: &STSpace) -> STSpace {
 }
 
 fn EvalTspace(
-    mut face_indices: &mut [i32],
+    face_indices: &mut [i32],
     iFaces: i32,
-    mut piTriListIn: &[i32],
-    mut pTriInfos: &[STriInfo],
+    piTriListIn: &[i32],
+    pTriInfos: &[STriInfo],
     geometry: &impl Geometry,
     iVertexRepresentitive: i32,
 ) -> STSpace {
@@ -532,9 +522,9 @@ fn EvalTspace(
 
 fn Build4RuleGroups(
     mut pTriInfos: &mut [STriInfo],
-    mut pGroups: &mut [SGroup],
-    mut piGroupTrianglesBuffer: &mut [i32],
-    mut piTriListIn: &[i32],
+    pGroups: &mut [SGroup],
+    piGroupTrianglesBuffer: &mut [i32],
+    piTriListIn: &[i32],
     iNrTrianglesIn: i32,
 ) -> i32 {
     let mut iNrActiveGroups: i32 = 0i32;
@@ -563,8 +553,8 @@ fn Build4RuleGroups(
                 let bOrPre = pTriInfos[f as usize]
                     .iFlag
                     .contains(TriangleFlags::ORIENT_PRESERVING);
-                let mut neigh_indexL = pTriInfos[f as usize].FaceNeighbors[i as usize];
-                let mut neigh_indexR = pTriInfos[f as usize].FaceNeighbors[((i + 2) % 3) as usize];
+                let neigh_indexL = pTriInfos[f as usize].FaceNeighbors[i as usize];
+                let neigh_indexR = pTriInfos[f as usize].FaceNeighbors[((i + 2) % 3) as usize];
                 if neigh_indexL >= 0i32 {
                     let index = pTriInfos[f as usize].AssignedGroup[i as usize];
                     let bAnswer: bool = AssignRecur(
@@ -620,7 +610,7 @@ fn AssignRecur(
     let mut pMyTriInfo = &mut psTriInfos[iMyTriIndex as usize];
     // track down vertex
     let iVertRep: i32 = pGroup.iVertexRepresentitive;
-    let mut pVerts = &piTriListIn[3 * iMyTriIndex as usize..][..3];
+    let pVerts = &piTriListIn[3 * iMyTriIndex as usize..][..3];
     let i = pVerts.iter().position(|&it| it == iVertRep).unwrap();
     if pMyTriInfo.AssignedGroup[i as usize] == group_idx {
         return true;

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -603,10 +603,6 @@ unsafe fn AvgTSpace(mut pTS0: *const STSpace, mut pTS1: *const STSpace) -> STSpa
     return ts_res;
 }
 
-fn NotZero(fX: f32) -> bool {
-    fX.is_normal()
-}
-
 unsafe fn EvalTspace(
     mut face_indices: *mut i32,
     iFaces: i32,
@@ -865,7 +861,7 @@ unsafe fn InitTriInfo(
                 .iFlag
                 .insert(TriangleFlags::ORIENT_PRESERVING);
         }
-        if NotZero(fSignedAreaSTx2) {
+        if fSignedAreaSTx2.is_normal() {
             let fAbsArea: f32 = fSignedAreaSTx2.abs();
             let fLenOs: f32 = vOs.length();
             let fLenOt: f32 = vOt.length();
@@ -877,16 +873,16 @@ unsafe fn InitTriInfo(
             } else {
                 1.0f32
             };
-            if NotZero(fLenOs) {
+            if fLenOs.is_normal() {
                 (*pTriInfos.offset(f as isize)).vOs = (fS / fLenOs) * vOs
             }
-            if NotZero(fLenOt) {
+            if fLenOt.is_normal() {
                 (*pTriInfos.offset(f as isize)).vOt = (fS / fLenOt) * vOt
             }
             (*pTriInfos.offset(f as isize)).fMagS = fLenOs / fAbsArea;
             (*pTriInfos.offset(f as isize)).fMagT = fLenOt / fAbsArea;
-            if NotZero((*pTriInfos.offset(f as isize)).fMagS)
-                && NotZero((*pTriInfos.offset(f as isize)).fMagT)
+            if ((*pTriInfos.offset(f as isize)).fMagS.is_normal())
+                && (*pTriInfos.offset(f as isize)).fMagT.is_normal()
             {
                 (*pTriInfos.offset(f as isize))
                     .iFlag

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -985,6 +985,8 @@ unsafe fn BuildNeighborsFast(
     }
     pEdges.sort();
 
+    let iEntries = iNrTrianglesIn * 3i32;
+
     for i in 0..iEntries {
         let edge = pEdges[i as usize];
         let i0_0: i32 = edge.i0;

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -1127,10 +1127,10 @@ unsafe fn GenerateSharedVerticesIndexList(
     }
 }
 
-unsafe fn GenerateInitialVerticesIndexList(
+fn GenerateInitialVerticesIndexList(
     pTriInfos: &mut [STriInfo],
     piTriList_out: &mut [i32],
-    geometry: &mut impl Geometry,
+    geometry: &impl Geometry,
     iNrTrianglesIn: usize,
 ) -> usize {
     let mut iTSpacesOffs: usize = 0;

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -243,7 +243,6 @@ pub unsafe fn genTangSpace<I: Geometry>(geometry: &mut I, fAngularThreshold: f32
             pTriInfos[t].iFlag |= 1i32;
             iDegenTriangles += 1
         }
-        t += 1
     }
     let iNrTrianglesIn = iTotTris - iDegenTriangles;
     DegenPrologue(

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -44,6 +44,7 @@
     unused_mut
 )]
 
+mod degenerate;
 mod setup;
 
 use std::ptr::null_mut;
@@ -51,7 +52,7 @@ use std::ptr::null_mut;
 use bitflags::bitflags;
 use glam::Vec3;
 
-use crate::{face_vert_to_index, get_normal, get_position, get_tex_coord, FaceKind, Geometry};
+use crate::{get_normal, get_position, FaceKind, Geometry};
 
 #[derive(Copy, Clone)]
 pub struct STSpace {
@@ -241,14 +242,14 @@ pub unsafe fn genTangSpace(geometry: &mut impl Geometry, fAngularThreshold: f32)
     // C: pTriInfos[] and piTriListIn[] without changing order and
     // C: put the degenerate triangles last.
     // Note: A quad can have degenerate triangles if two vertices are in the same location
-    DegenPrologue(
+    degenerate::DegenPrologue(
         pTriInfos.as_mut_ptr(),
         piTriListIn.as_mut_ptr(),
         iNrTrianglesIn as i32,
         iTotTris as i32,
     );
     // C: Evaluate triangle level attributes and neighbor list
-    InitTriInfo(
+    setup::InitTriInfo(
         pTriInfos.as_mut_ptr(),
         piTriListIn.as_ptr(),
         geometry,
@@ -291,7 +292,7 @@ pub unsafe fn genTangSpace(geometry: &mut impl Geometry, fAngularThreshold: f32)
     if !bRes {
         return false;
     }
-    DegenEpilogue(
+    degenerate::DegenEpilogue(
         psTspace.as_mut_ptr(),
         pTriInfos.as_mut_ptr(),
         piTriListIn.as_mut_ptr(),
@@ -320,87 +321,6 @@ pub unsafe fn genTangSpace(geometry: &mut impl Geometry, fAngularThreshold: f32)
     }
 
     return true;
-}
-
-unsafe fn DegenEpilogue(
-    mut psTspace: *mut STSpace,
-    mut pTriInfos: *mut STriInfo,
-    mut piTriListIn: *mut i32,
-    geometry: &impl Geometry,
-    iNrTrianglesIn: i32,
-    iTotTris: i32,
-) {
-    // For all degenerate triangles
-    for t in iNrTrianglesIn..iTotTris {
-        let bSkip: bool = (*pTriInfos.offset(t as isize))
-            .iFlag
-            .contains(TriangleFlags::QUAD_ONE_DEGENERATE_TRI);
-        if !bSkip {
-            for i in 0..3i32 {
-                // For all vertices on that triangle
-                let index1: i32 = *piTriListIn.offset((t * 3i32 + i) as isize);
-                for j in 0..(3i32 * iNrTrianglesIn) {
-                    let index2: i32 = *piTriListIn.offset(j as isize);
-                    // If the vertex properties are the same as another non-degenerate vertex
-                    if index1 == index2 {
-                        let iTri: i32 = j / 3i32;
-                        let iVert: i32 = j % 3i32;
-                        let iSrcVert: i32 =
-                            (*pTriInfos.offset(iTri as isize)).vert_num[iVert as usize] as i32;
-                        let iSrcOffs: i32 = (*pTriInfos.offset(iTri as isize)).iTSpacesOffs;
-                        let iDstVert: i32 =
-                            (*pTriInfos.offset(t as isize)).vert_num[i as usize] as i32;
-                        let iDstOffs: i32 = (*pTriInfos.offset(t as isize)).iTSpacesOffs;
-                        // Set the tangent space of this vertex to the tangent space of that vertex
-                        // TODO: This is absurd - doing a linear search through all vertices for each
-                        // degenerate triangle?
-                        *psTspace.offset((iDstOffs + iDstVert) as isize) =
-                            *psTspace.offset((iSrcOffs + iSrcVert) as isize);
-                        break;
-                    }
-                }
-            }
-        }
-    }
-    for t in 0..iNrTrianglesIn {
-        // Handle quads with a single degenerate triangle by
-        if (*pTriInfos.offset(t as isize))
-            .iFlag
-            .contains(TriangleFlags::QUAD_ONE_DEGENERATE_TRI)
-        {
-            let mut pV: *mut u8 = (*pTriInfos.offset(t as isize)).vert_num.as_mut_ptr();
-            let mut iFlag: i32 = 1i32 << *pV.offset(0isize) as i32
-                | 1i32 << *pV.offset(1isize) as i32
-                | 1i32 << *pV.offset(2isize) as i32;
-            let mut iMissingIndex: i32 = 0i32;
-            if iFlag & 2i32 == 0i32 {
-                iMissingIndex = 1i32
-            } else if iFlag & 4i32 == 0i32 {
-                iMissingIndex = 2i32
-            } else if iFlag & 8i32 == 0i32 {
-                iMissingIndex = 3i32
-            }
-            let iOrgF = (*pTriInfos.offset(t as isize)).iOrgFaceNumber;
-            let vDstP = get_position(
-                geometry,
-                face_vert_to_index(iOrgF as usize, iMissingIndex as usize),
-            );
-
-            for i_0 in 0..3i32 {
-                let iVert_0: i32 = *pV.offset(i_0 as isize) as i32;
-                let vSrcP = get_position(
-                    geometry,
-                    face_vert_to_index(iOrgF as usize, iVert_0 as usize),
-                );
-                if vSrcP == vDstP {
-                    let iOffs: i32 = (*pTriInfos.offset(t as isize)).iTSpacesOffs;
-                    *psTspace.offset((iOffs + iMissingIndex) as isize) =
-                        *psTspace.offset((iOffs + iVert_0) as isize);
-                    break;
-                }
-            }
-        }
-    }
 }
 
 unsafe fn GenerateTSpaces(
@@ -782,309 +702,4 @@ unsafe fn AssignRecur(
 unsafe fn AddTriToGroup(mut pGroup: *mut SGroup, iTriIndex: i32) {
     *(*pGroup).pFaceIndices.offset((*pGroup).iNrFaces as isize) = iTriIndex;
     (*pGroup).iNrFaces += 1;
-}
-unsafe fn InitTriInfo(
-    mut pTriInfos: *mut STriInfo,
-    mut piTriListIn: *const i32,
-    geometry: &impl Geometry,
-    iNrTrianglesIn: usize,
-) {
-    for f in 0..iNrTrianglesIn {
-        for i in 0..3i32 {
-            (*pTriInfos.offset(f as isize)).FaceNeighbors[i as usize] = -1i32;
-            let ref mut fresh4 = (*pTriInfos.offset(f as isize)).AssignedGroup[i as usize];
-            *fresh4 = 0 as *mut SGroup;
-            (*pTriInfos.offset(f as isize)).vOs.x = 0.0f32;
-            (*pTriInfos.offset(f as isize)).vOs.y = 0.0f32;
-            (*pTriInfos.offset(f as isize)).vOs.z = 0.0f32;
-            (*pTriInfos.offset(f as isize)).vOt.x = 0.0f32;
-            (*pTriInfos.offset(f as isize)).vOt.y = 0.0f32;
-            (*pTriInfos.offset(f as isize)).vOt.z = 0.0f32;
-            (*pTriInfos.offset(f as isize)).fMagS = 0i32 as f32;
-            (*pTriInfos.offset(f as isize)).fMagT = 0i32 as f32;
-            // C: assumed bad
-            (*pTriInfos.offset(f as isize))
-                .iFlag
-                .insert(TriangleFlags::GROUP_WITH_ANY);
-        }
-    }
-    for f in 0..iNrTrianglesIn {
-        let v1 = get_position(geometry, *piTriListIn.offset((f * 3 + 0) as isize) as usize);
-        let v2 = get_position(geometry, *piTriListIn.offset((f * 3 + 1) as isize) as usize);
-        let v3 = get_position(geometry, *piTriListIn.offset((f * 3 + 2) as isize) as usize);
-        let t1 = get_tex_coord(geometry, *piTriListIn.offset((f * 3 + 0) as isize) as usize);
-        let t2 = get_tex_coord(geometry, *piTriListIn.offset((f * 3 + 1) as isize) as usize);
-        let t3 = get_tex_coord(geometry, *piTriListIn.offset((f * 3 + 2) as isize) as usize);
-        let t21x: f32 = t2.x - t1.x;
-        let t21y: f32 = t2.y - t1.y;
-        let t31x: f32 = t3.x - t1.x;
-        let t31y: f32 = t3.y - t1.y;
-        let d1 = v2 - v1;
-        let d2 = v3 - v1;
-        let fSignedAreaSTx2: f32 = t21x * t31y - t21y * t31x;
-        let mut vOs = (t31y * d1) - (t21y * d2);
-        let mut vOt = (-t31x * d1) + (t21x * d2);
-        if fSignedAreaSTx2 > 0.0 {
-            (*pTriInfos.offset(f as isize))
-                .iFlag
-                .insert(TriangleFlags::ORIENT_PRESERVING);
-        }
-        if fSignedAreaSTx2.is_normal() {
-            let fAbsArea: f32 = fSignedAreaSTx2.abs();
-            let fLenOs: f32 = vOs.length();
-            let fLenOt: f32 = vOt.length();
-            let fS: f32 = if !(*pTriInfos.offset(f as isize))
-                .iFlag
-                .contains(TriangleFlags::ORIENT_PRESERVING)
-            {
-                -1.0f32
-            } else {
-                1.0f32
-            };
-            if fLenOs.is_normal() {
-                (*pTriInfos.offset(f as isize)).vOs = (fS / fLenOs) * vOs
-            }
-            if fLenOt.is_normal() {
-                (*pTriInfos.offset(f as isize)).vOt = (fS / fLenOt) * vOt
-            }
-            (*pTriInfos.offset(f as isize)).fMagS = fLenOs / fAbsArea;
-            (*pTriInfos.offset(f as isize)).fMagT = fLenOt / fAbsArea;
-            if ((*pTriInfos.offset(f as isize)).fMagS.is_normal())
-                && (*pTriInfos.offset(f as isize)).fMagT.is_normal()
-            {
-                (*pTriInfos.offset(f as isize))
-                    .iFlag
-                    .remove(TriangleFlags::GROUP_WITH_ANY);
-            }
-        }
-    }
-    let mut t = 0;
-    while t < iNrTrianglesIn - 1 {
-        let iFO_a: i32 = (*pTriInfos.offset(t as isize)).iOrgFaceNumber;
-        let iFO_b: i32 = (*pTriInfos.offset((t + 1) as isize)).iOrgFaceNumber;
-        if iFO_a == iFO_b {
-            let bIsDeg_a: bool = (*pTriInfos.offset(t as isize))
-                .iFlag
-                .contains(TriangleFlags::DEGENERATE);
-            let bIsDeg_b: bool = (*pTriInfos.offset((t + 1) as isize))
-                .iFlag
-                .contains(TriangleFlags::DEGENERATE);
-            if !(bIsDeg_a || bIsDeg_b) {
-                let bOrientA: bool = (*pTriInfos.offset(t as isize))
-                    .iFlag
-                    .contains(TriangleFlags::ORIENT_PRESERVING);
-                let bOrientB: bool = (*pTriInfos.offset((t + 1) as isize))
-                    .iFlag
-                    .contains(TriangleFlags::ORIENT_PRESERVING);
-                if bOrientA != bOrientB {
-                    let mut bChooseOrientFirstTri: bool = false;
-                    if (*pTriInfos.offset((t + 1) as isize))
-                        .iFlag
-                        .contains(TriangleFlags::GROUP_WITH_ANY)
-                    {
-                        bChooseOrientFirstTri = true
-                    } else if CalcTexArea(geometry, &*piTriListIn.offset((t * 3 + 0) as isize))
-                        >= CalcTexArea(geometry, &*piTriListIn.offset(((t + 1) * 3 + 0) as isize))
-                    {
-                        bChooseOrientFirstTri = true
-                    }
-                    let t0 = if bChooseOrientFirstTri { t } else { t + 1 };
-                    let t1_0 = if bChooseOrientFirstTri { t + 1 } else { t };
-                    (*pTriInfos.offset(t1_0 as isize)).iFlag.set(
-                        TriangleFlags::ORIENT_PRESERVING,
-                        (*pTriInfos.offset(t0 as isize))
-                            .iFlag
-                            .contains(TriangleFlags::ORIENT_PRESERVING),
-                    );
-                }
-            }
-            t += 2
-        } else {
-            t += 1
-        }
-    }
-
-    BuildNeighborsFast(pTriInfos, piTriListIn, iNrTrianglesIn as i32);
-}
-
-unsafe fn BuildNeighborsFast(
-    mut pTriInfos: *mut STriInfo,
-    mut piTriListIn: *const i32,
-    iNrTrianglesIn: i32,
-) {
-    let mut pEdges = Vec::with_capacity((iNrTrianglesIn * 3) as usize);
-    // build array of edges
-    for f in 0..iNrTrianglesIn {
-        for i in 0..3i32 {
-            let i0: i32 = *piTriListIn.offset((f * 3i32 + i) as isize);
-            let i1: i32 = *piTriListIn.offset((f * 3i32 + (i + 1) % 3) as isize);
-            // Ensure that the indices have a consistent order by making i0 the smaller
-            pEdges.push(SEdge {
-                i0: i0.min(i1),
-                i1: i0.max(i1),
-                f,
-            });
-        }
-    }
-    pEdges.sort();
-
-    let iEntries = iNrTrianglesIn * 3i32;
-
-    for i in 0..iEntries {
-        let edge = pEdges[i as usize];
-        let i0_0: i32 = edge.i0;
-        let i1_0: i32 = edge.i1;
-        let f_0: i32 = edge.f;
-
-        let (i0_A, i1_A, edgenum_A) =
-            GetEdge(&*piTriListIn.offset((f_0 * 3i32) as isize), i0_0, i1_0);
-        let bUnassigned_A =
-            (*pTriInfos.offset(f_0 as isize)).FaceNeighbors[edgenum_A as usize] == -1i32;
-        if bUnassigned_A {
-            let mut j: i32 = i + 1i32;
-
-            while j < iEntries && i0_0 == pEdges[j as usize].i0 && i1_0 == pEdges[j as usize].i1 {
-                let t = pEdges[j as usize].f;
-                // C: Flip i1 and i0
-                let (i1_B, i0_B, edgenum_B) = GetEdge(
-                    &*piTriListIn.offset((t * 3i32) as isize),
-                    pEdges[j as usize].i0,
-                    pEdges[j as usize].i1,
-                );
-                let bUnassigned_B =
-                    (*pTriInfos.offset(t as isize)).FaceNeighbors[edgenum_B as usize] == -1i32;
-                if i0_A == i0_B && i1_A == i1_B && bUnassigned_B {
-                    let mut t_0: i32 = pEdges[j as usize].f;
-                    (*pTriInfos.offset(f_0 as isize)).FaceNeighbors[edgenum_A as usize] = t_0;
-                    (*pTriInfos.offset(t_0 as isize)).FaceNeighbors[edgenum_B as usize] = f_0;
-                    break;
-                } else {
-                    j += 1
-                }
-            }
-        }
-    }
-}
-unsafe fn GetEdge(mut indices: *const i32, i0_in: i32, i1_in: i32) -> (i32, i32, i32) {
-    if *indices.offset(0isize) == i0_in || *indices.offset(0isize) == i1_in {
-        if *indices.offset(1isize) == i0_in || *indices.offset(1isize) == i1_in {
-            (*indices.offset(0isize), *indices.offset(1isize), 0)
-        } else {
-            (*indices.offset(2isize), *indices.offset(0isize), 2)
-        }
-    } else {
-        (*indices.offset(1isize), *indices.offset(2isize), 1)
-    }
-}
-// ///////////////////////////////////////////////////////////////////////////////////////////
-/////////////////////////////////////////////////////////////////////////////////////////////
-
-// returns the texture area times 2
-unsafe fn CalcTexArea(geometry: &impl Geometry, mut indices: *const i32) -> f32 {
-    let t1 = get_tex_coord(geometry, *indices.offset(0isize) as usize);
-    let t2 = get_tex_coord(geometry, *indices.offset(1isize) as usize);
-    let t3 = get_tex_coord(geometry, *indices.offset(2isize) as usize);
-    let t21x: f32 = t2.x - t1.x;
-    let t21y: f32 = t2.y - t1.y;
-    let t31x: f32 = t3.x - t1.x;
-    let t31y: f32 = t3.y - t1.y;
-    let fSignedAreaSTx2: f32 = t21x * t31y - t21y * t31x;
-    return if fSignedAreaSTx2 < 0i32 as f32 {
-        -fSignedAreaSTx2
-    } else {
-        fSignedAreaSTx2
-    };
-}
-
-// degen triangles
-unsafe fn DegenPrologue(
-    mut pTriInfos: *mut STriInfo,
-    mut piTriList_out: *mut i32,
-    iNrTrianglesIn: i32,
-    iTotTris: i32,
-) {
-    // locate quads with only one good triangle
-    let mut t: i32 = 0i32;
-    while t < iTotTris - 1i32 {
-        let iFO_a: i32 = (*pTriInfos.offset(t as isize)).iOrgFaceNumber;
-        let iFO_b: i32 = (*pTriInfos.offset((t + 1i32) as isize)).iOrgFaceNumber;
-        if iFO_a == iFO_b {
-            let bIsDeg_a: bool = (*pTriInfos.offset(t as isize))
-                .iFlag
-                .contains(TriangleFlags::DEGENERATE);
-            let bIsDeg_b: bool = (*pTriInfos.offset((t + 1i32) as isize))
-                .iFlag
-                .contains(TriangleFlags::DEGENERATE);
-            // If exactly one is degenerate, mark both as QUAD_ONE_DEGENERATE_TRI, i.e. that the other triangle
-            // (If both are degenerate, this)
-            if bIsDeg_a ^ bIsDeg_b {
-                (*pTriInfos.offset(t as isize))
-                    .iFlag
-                    .insert(TriangleFlags::QUAD_ONE_DEGENERATE_TRI);
-                (*pTriInfos.offset((t + 1i32) as isize))
-                    .iFlag
-                    .insert(TriangleFlags::QUAD_ONE_DEGENERATE_TRI);
-            }
-            t += 2i32
-        } else {
-            t += 1
-        }
-    }
-
-    // reorder list so all degen triangles are moved to the back
-    // without reordering the good triangles
-    // That is, a semi-stable partition, e.g. as described at
-    // https://dlang.org/library/std/algorithm/sorting/partition.html
-    // TODO: Use `Vec::retain` with a second vec here - not perfect,
-    // but good enough and safe.
-    // TODO: Consider using `sort_by_key` on Vec instead (which is stable) - it might be
-    // technically slower, but it's much easier to reason about
-    let mut iNextGoodTriangleSearchIndex = 1i32;
-    t = 0i32;
-    let mut bStillFindingGoodOnes = true;
-    while t < iNrTrianglesIn && bStillFindingGoodOnes {
-        let bIsGood: bool = !(*pTriInfos.offset(t as isize))
-            .iFlag
-            .contains(TriangleFlags::DEGENERATE);
-        if bIsGood {
-            if iNextGoodTriangleSearchIndex < t + 2i32 {
-                iNextGoodTriangleSearchIndex = t + 2i32
-            }
-        } else {
-            let mut bJustADegenerate: bool = true;
-            while bJustADegenerate && iNextGoodTriangleSearchIndex < iTotTris {
-                let bIsGood_0: bool = !(*pTriInfos.offset(iNextGoodTriangleSearchIndex as isize))
-                    .iFlag
-                    .contains(TriangleFlags::DEGENERATE);
-                if bIsGood_0 {
-                    bJustADegenerate = false
-                } else {
-                    iNextGoodTriangleSearchIndex += 1
-                }
-            }
-            let t0 = t;
-            let t1 = iNextGoodTriangleSearchIndex;
-            iNextGoodTriangleSearchIndex += 1;
-            debug_assert!(iNextGoodTriangleSearchIndex > (t + 1));
-            // Swap t0 and t1
-            if !bJustADegenerate {
-                for i in 0..3i32 {
-                    let index: i32 = *piTriList_out.offset((t0 * 3i32 + i) as isize);
-                    *piTriList_out.offset((t0 * 3i32 + i) as isize) =
-                        *piTriList_out.offset((t1 * 3i32 + i) as isize);
-                    *piTriList_out.offset((t1 * 3i32 + i) as isize) = index;
-                }
-                let tri_info: STriInfo = *pTriInfos.offset(t0 as isize);
-                *pTriInfos.offset(t0 as isize) = *pTriInfos.offset(t1 as isize);
-                *pTriInfos.offset(t1 as isize) = tri_info
-            } else {
-                bStillFindingGoodOnes = false
-            }
-        }
-        if bStillFindingGoodOnes {
-            t += 1
-        }
-    }
-    debug_assert!(iNrTrianglesIn == t);
-    debug_assert!(bStillFindingGoodOnes);
 }

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -39,10 +39,8 @@
     clippy::explicit_iter_loop,
     clippy::map_flatten,
     dead_code,
-    mutable_transmutes,
     non_camel_case_types,
     non_snake_case,
-    non_upper_case_globals,
     unused_mut
 )]
 
@@ -192,19 +190,6 @@ pub struct SEdge {
     // The second vertex's (global) index
     pub i1: i32,
     // The face this edge is associated with
-    pub f: i32,
-}
-
-impl SEdge {
-    fn zero() -> Self {
-        Self::default()
-    }
-}
-
-#[derive(Copy, Clone)]
-pub struct unnamed {
-    pub i0: i32,
-    pub i1: i32,
     pub f: i32,
 }
 

--- a/crates/bevy_mikktspace/src/generated/degenerate.rs
+++ b/crates/bevy_mikktspace/src/generated/degenerate.rs
@@ -7,8 +7,8 @@ use super::STriInfo;
 use super::TriangleFlags;
 
 pub(crate) fn DegenPrologue(
-    mut pTriInfos: &mut [STriInfo],
-    mut piTriList_out: &mut [i32],
+    pTriInfos: &mut [STriInfo],
+    piTriList_out: &mut [i32],
     iNrTrianglesIn: i32,
     iTotTris: i32,
 ) {
@@ -87,9 +87,9 @@ pub(crate) fn DegenPrologue(
 }
 
 pub(crate) fn DegenEpilogue(
-    mut psTspace: &mut [STSpace],
-    mut pTriInfos: &mut [STriInfo],
-    mut piTriListIn: &mut [i32],
+    psTspace: &mut [STSpace],
+    pTriInfos: &mut [STriInfo],
+    piTriListIn: &mut [i32],
     geometry: &impl Geometry,
     iNrTrianglesIn: i32,
     iTotTris: i32,
@@ -131,8 +131,8 @@ pub(crate) fn DegenEpilogue(
             .iFlag
             .contains(TriangleFlags::QUAD_ONE_DEGENERATE_TRI)
         {
-            let mut pV = &mut pTriInfos[t as usize].vert_num;
-            let mut iFlag: i32 = 1i32 << pV[0] as i32 | 1i32 << pV[1] as i32 | 1i32 << pV[2] as i32;
+            let pV = &mut pTriInfos[t as usize].vert_num;
+            let iFlag: i32 = 1i32 << pV[0] as i32 | 1i32 << pV[1] as i32 | 1i32 << pV[2] as i32;
             let mut iMissingIndex: i32 = 0i32;
             if iFlag & 2i32 == 0i32 {
                 iMissingIndex = 1i32;

--- a/crates/bevy_mikktspace/src/generated/degenerate.rs
+++ b/crates/bevy_mikktspace/src/generated/degenerate.rs
@@ -50,7 +50,7 @@ pub(crate) fn DegenPrologue(
         let bIsGood: bool = !pTriInfos[t].iFlag.contains(TriangleFlags::DEGENERATE);
         if bIsGood {
             if iNextGoodTriangleSearchIndex < t + 2 {
-                iNextGoodTriangleSearchIndex = t + 2
+                iNextGoodTriangleSearchIndex = t + 2;
             }
         } else {
             let mut bJustADegenerate: bool = true;
@@ -59,9 +59,9 @@ pub(crate) fn DegenPrologue(
                     .iFlag
                     .contains(TriangleFlags::DEGENERATE);
                 if bIsGood_0 {
-                    bJustADegenerate = false
+                    bJustADegenerate = false;
                 } else {
-                    iNextGoodTriangleSearchIndex += 1
+                    iNextGoodTriangleSearchIndex += 1;
                 }
             }
             let t0 = t;
@@ -75,11 +75,11 @@ pub(crate) fn DegenPrologue(
                 start[t0 * 3..t0 * 3 + 3].swap_with_slice(&mut end[0..3]);
                 pTriInfos.swap(t0, t1);
             } else {
-                bStillFindingGoodOnes = false
+                bStillFindingGoodOnes = false;
             }
         }
         if bStillFindingGoodOnes {
-            t += 1
+            t += 1;
         }
     }
     debug_assert!(iNrTrianglesIn as usize == t);
@@ -135,11 +135,11 @@ pub(crate) fn DegenEpilogue(
             let mut iFlag: i32 = 1i32 << pV[0] as i32 | 1i32 << pV[1] as i32 | 1i32 << pV[2] as i32;
             let mut iMissingIndex: i32 = 0i32;
             if iFlag & 2i32 == 0i32 {
-                iMissingIndex = 1i32
+                iMissingIndex = 1i32;
             } else if iFlag & 4i32 == 0i32 {
-                iMissingIndex = 2i32
+                iMissingIndex = 2i32;
             } else if iFlag & 8i32 == 0i32 {
-                iMissingIndex = 3i32
+                iMissingIndex = 3i32;
             }
             let iOrgF = pTriInfos[t as usize].iOrgFaceNumber;
             let vDstP = get_position(
@@ -147,8 +147,7 @@ pub(crate) fn DegenEpilogue(
                 face_vert_to_index(iOrgF as usize, iMissingIndex as usize),
             );
 
-            for i_0 in 0..3 {
-                let iVert_0 = pV[i_0];
+            for &iVert_0 in pV.iter().take(3) {
                 let vSrcP = get_position(
                     geometry,
                     face_vert_to_index(iOrgF as usize, iVert_0 as usize),

--- a/crates/bevy_mikktspace/src/generated/degenerate.rs
+++ b/crates/bevy_mikktspace/src/generated/degenerate.rs
@@ -1,0 +1,180 @@
+use crate::face_vert_to_index;
+use crate::get_position;
+use crate::Geometry;
+
+use super::STSpace;
+use super::STriInfo;
+use super::TriangleFlags;
+
+pub(crate) unsafe fn DegenPrologue(
+    mut pTriInfos: *mut STriInfo,
+    mut piTriList_out: *mut i32,
+    iNrTrianglesIn: i32,
+    iTotTris: i32,
+) {
+    // locate quads with only one good triangle
+    let mut t: i32 = 0i32;
+    while t < iTotTris - 1i32 {
+        let iFO_a: i32 = (*pTriInfos.offset(t as isize)).iOrgFaceNumber;
+        let iFO_b: i32 = (*pTriInfos.offset((t + 1i32) as isize)).iOrgFaceNumber;
+        if iFO_a == iFO_b {
+            let bIsDeg_a: bool = (*pTriInfos.offset(t as isize))
+                .iFlag
+                .contains(TriangleFlags::DEGENERATE);
+            let bIsDeg_b: bool = (*pTriInfos.offset((t + 1i32) as isize))
+                .iFlag
+                .contains(TriangleFlags::DEGENERATE);
+            // If exactly one is degenerate, mark both as QUAD_ONE_DEGENERATE_TRI, i.e. that the other triangle
+            // (If both are degenerate, this)
+            if bIsDeg_a ^ bIsDeg_b {
+                (*pTriInfos.offset(t as isize))
+                    .iFlag
+                    .insert(TriangleFlags::QUAD_ONE_DEGENERATE_TRI);
+                (*pTriInfos.offset((t + 1i32) as isize))
+                    .iFlag
+                    .insert(TriangleFlags::QUAD_ONE_DEGENERATE_TRI);
+            }
+            t += 2i32
+        } else {
+            t += 1
+        }
+    }
+
+    // reorder list so all degen triangles are moved to the back
+    // without reordering the good triangles
+    // That is, a semi-stable partition, e.g. as described at
+    // https://dlang.org/library/std/algorithm/sorting/partition.html
+    // TODO: Use `Vec::retain` with a second vec here - not perfect,
+    // but good enough and safe.
+    // TODO: Consider using `sort_by_key` on Vec instead (which is stable) - it might be
+    // technically slower, but it's much easier to reason about
+    let mut iNextGoodTriangleSearchIndex = 1i32;
+    t = 0i32;
+    let mut bStillFindingGoodOnes = true;
+    while t < iNrTrianglesIn && bStillFindingGoodOnes {
+        let bIsGood: bool = !(*pTriInfos.offset(t as isize))
+            .iFlag
+            .contains(TriangleFlags::DEGENERATE);
+        if bIsGood {
+            if iNextGoodTriangleSearchIndex < t + 2i32 {
+                iNextGoodTriangleSearchIndex = t + 2i32
+            }
+        } else {
+            let mut bJustADegenerate: bool = true;
+            while bJustADegenerate && iNextGoodTriangleSearchIndex < iTotTris {
+                let bIsGood_0: bool = !(*pTriInfos.offset(iNextGoodTriangleSearchIndex as isize))
+                    .iFlag
+                    .contains(TriangleFlags::DEGENERATE);
+                if bIsGood_0 {
+                    bJustADegenerate = false
+                } else {
+                    iNextGoodTriangleSearchIndex += 1
+                }
+            }
+            let t0 = t;
+            let t1 = iNextGoodTriangleSearchIndex;
+            iNextGoodTriangleSearchIndex += 1;
+            debug_assert!(iNextGoodTriangleSearchIndex > (t + 1));
+            // Swap t0 and t1
+            if !bJustADegenerate {
+                for i in 0..3i32 {
+                    let index: i32 = *piTriList_out.offset((t0 * 3i32 + i) as isize);
+                    *piTriList_out.offset((t0 * 3i32 + i) as isize) =
+                        *piTriList_out.offset((t1 * 3i32 + i) as isize);
+                    *piTriList_out.offset((t1 * 3i32 + i) as isize) = index;
+                }
+                let tri_info: STriInfo = *pTriInfos.offset(t0 as isize);
+                *pTriInfos.offset(t0 as isize) = *pTriInfos.offset(t1 as isize);
+                *pTriInfos.offset(t1 as isize) = tri_info
+            } else {
+                bStillFindingGoodOnes = false
+            }
+        }
+        if bStillFindingGoodOnes {
+            t += 1
+        }
+    }
+    debug_assert!(iNrTrianglesIn == t);
+    debug_assert!(bStillFindingGoodOnes);
+}
+
+pub(crate) unsafe fn DegenEpilogue(
+    mut psTspace: *mut STSpace,
+    mut pTriInfos: *mut STriInfo,
+    mut piTriListIn: *mut i32,
+    geometry: &impl Geometry,
+    iNrTrianglesIn: i32,
+    iTotTris: i32,
+) {
+    // For all degenerate triangles
+    for t in iNrTrianglesIn..iTotTris {
+        let bSkip: bool = (*pTriInfos.offset(t as isize))
+            .iFlag
+            .contains(TriangleFlags::QUAD_ONE_DEGENERATE_TRI);
+        if !bSkip {
+            for i in 0..3i32 {
+                // For all vertices on that triangle
+                let index1: i32 = *piTriListIn.offset((t * 3i32 + i) as isize);
+                for j in 0..(3i32 * iNrTrianglesIn) {
+                    let index2: i32 = *piTriListIn.offset(j as isize);
+                    // If the vertex properties are the same as another non-degenerate vertex
+                    if index1 == index2 {
+                        let iTri: i32 = j / 3i32;
+                        let iVert: i32 = j % 3i32;
+                        let iSrcVert: i32 =
+                            (*pTriInfos.offset(iTri as isize)).vert_num[iVert as usize] as i32;
+                        let iSrcOffs: i32 = (*pTriInfos.offset(iTri as isize)).iTSpacesOffs;
+                        let iDstVert: i32 =
+                            (*pTriInfos.offset(t as isize)).vert_num[i as usize] as i32;
+                        let iDstOffs: i32 = (*pTriInfos.offset(t as isize)).iTSpacesOffs;
+                        // Set the tangent space of this vertex to the tangent space of that vertex
+                        // TODO: This is absurd - doing a linear search through all vertices for each
+                        // degenerate triangle?
+                        *psTspace.offset((iDstOffs + iDstVert) as isize) =
+                            *psTspace.offset((iSrcOffs + iSrcVert) as isize);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    for t in 0..iNrTrianglesIn {
+        // Handle quads with a single degenerate triangle by
+        if (*pTriInfos.offset(t as isize))
+            .iFlag
+            .contains(TriangleFlags::QUAD_ONE_DEGENERATE_TRI)
+        {
+            let mut pV: *mut u8 = (*pTriInfos.offset(t as isize)).vert_num.as_mut_ptr();
+            let mut iFlag: i32 = 1i32 << *pV.offset(0isize) as i32
+                | 1i32 << *pV.offset(1isize) as i32
+                | 1i32 << *pV.offset(2isize) as i32;
+            let mut iMissingIndex: i32 = 0i32;
+            if iFlag & 2i32 == 0i32 {
+                iMissingIndex = 1i32
+            } else if iFlag & 4i32 == 0i32 {
+                iMissingIndex = 2i32
+            } else if iFlag & 8i32 == 0i32 {
+                iMissingIndex = 3i32
+            }
+            let iOrgF = (*pTriInfos.offset(t as isize)).iOrgFaceNumber;
+            let vDstP = get_position(
+                geometry,
+                face_vert_to_index(iOrgF as usize, iMissingIndex as usize),
+            );
+
+            for i_0 in 0..3i32 {
+                let iVert_0: i32 = *pV.offset(i_0 as isize) as i32;
+                let vSrcP = get_position(
+                    geometry,
+                    face_vert_to_index(iOrgF as usize, iVert_0 as usize),
+                );
+                if vSrcP == vDstP {
+                    let iOffs: i32 = (*pTriInfos.offset(t as isize)).iTSpacesOffs;
+                    *psTspace.offset((iOffs + iMissingIndex) as isize) =
+                        *psTspace.offset((iOffs + iVert_0) as isize);
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/crates/bevy_mikktspace/src/generated/setup.rs
+++ b/crates/bevy_mikktspace/src/generated/setup.rs
@@ -1,0 +1,143 @@
+use super::STriInfo;
+use super::TriangleFlags;
+
+use crate::face_vert_to_index;
+use crate::ordered_vec::FiniteVec3;
+use crate::FaceKind;
+
+use std::collections::BTreeMap;
+
+use crate::get_normal;
+use crate::get_position;
+use crate::get_tex_coord;
+use crate::Geometry;
+
+pub(crate) fn GenerateSharedVerticesIndexList(
+    // The input vertex index->face/vert mappings
+    // Identical face/verts will have each vertex index
+    // point to the same (arbitrary?) face/vert
+    // TODO: This seems overly complicated - storing vertex properties in a
+    // side channel seems much easier.
+    // Hopefully implementation can be changed to just use a btreemap or
+    // something too.
+    mut piTriList_in_and_out: &mut [i32],
+    geometry: &impl Geometry,
+) {
+    let mut map = BTreeMap::new();
+    for vertex_index in piTriList_in_and_out {
+        let index = *vertex_index as usize;
+        let vertex_properties = [
+            get_position(geometry, index),
+            get_normal(geometry, index),
+            get_tex_coord(geometry, index),
+        ]
+        // We need to make the vertex properties finite to be able to use them in a btreemap
+        // Technically, these unwraps aren't ideal, but the original puts absolutely no thought into its handling of
+        // NaN and infinity, so it's probably *fine*. (I strongly suspect that infinity or NaN would have
+        //  lead to UB somewhere)
+        .map(|prop| FiniteVec3::new(prop).unwrap());
+
+        *vertex_index = *(map.entry(vertex_properties).or_insert(*vertex_index));
+    }
+}
+
+pub(crate) fn GenerateInitialVerticesIndexList(
+    pTriInfos: &mut [STriInfo],
+    piTriList_out: &mut [i32],
+    geometry: &impl Geometry,
+    iNrTrianglesIn: usize,
+) -> usize {
+    let mut iTSpacesOffs: usize = 0;
+    let mut iDstTriIndex = 0;
+    for f in 0..geometry.num_faces() {
+        let verts = geometry.num_vertices_of_face(f);
+
+        pTriInfos[iDstTriIndex].iOrgFaceNumber = f as i32;
+        pTriInfos[iDstTriIndex].iTSpacesOffs = iTSpacesOffs as i32;
+        if let FaceKind::Triangle = verts {
+            let mut pVerts = &mut pTriInfos[iDstTriIndex].vert_num;
+            pVerts[0] = 0;
+            pVerts[1] = 1;
+            pVerts[2] = 2;
+            piTriList_out[iDstTriIndex * 3 + 0] = face_vert_to_index(f, 0) as i32;
+            piTriList_out[iDstTriIndex * 3 + 1] = face_vert_to_index(f, 1) as i32;
+            piTriList_out[iDstTriIndex * 3 + 2] = face_vert_to_index(f, 2) as i32;
+            iDstTriIndex += 1
+        } else {
+            pTriInfos[iDstTriIndex + 1].iOrgFaceNumber = f as i32;
+            pTriInfos[iDstTriIndex + 1].iTSpacesOffs = iTSpacesOffs as i32;
+            let i0 = face_vert_to_index(f, 0);
+            let i1 = face_vert_to_index(f, 1);
+            let i2 = face_vert_to_index(f, 2);
+            let i3 = face_vert_to_index(f, 3);
+            let T0 = get_tex_coord(geometry, i0);
+            let T1 = get_tex_coord(geometry, i1);
+            let T2 = get_tex_coord(geometry, i2);
+            let T3 = get_tex_coord(geometry, i3);
+            let distSQ_02: f32 = (T2 - T0).length_squared();
+            let distSQ_13: f32 = (T3 - T1).length_squared();
+            let bQuadDiagIs_02: bool;
+            if distSQ_02 < distSQ_13 {
+                bQuadDiagIs_02 = true
+            } else if distSQ_13 < distSQ_02 {
+                bQuadDiagIs_02 = false
+            } else {
+                let P0 = get_position(geometry, i0);
+                let P1 = get_position(geometry, i1);
+                let P2 = get_position(geometry, i2);
+                let P3 = get_position(geometry, i3);
+                let distSQ_02_0: f32 = (P2 - P0).length_squared();
+                let distSQ_13_0: f32 = (P3 - P1).length_squared();
+                bQuadDiagIs_02 = if distSQ_13_0 < distSQ_02_0 {
+                    false
+                } else {
+                    true
+                }
+            }
+            if bQuadDiagIs_02 {
+                let mut pVerts_A = &mut pTriInfos[iDstTriIndex].vert_num;
+                pVerts_A[0] = 0;
+                pVerts_A[1] = 1;
+                pVerts_A[2] = 2;
+                piTriList_out[iDstTriIndex * 3 + 0] = i0 as i32;
+                piTriList_out[iDstTriIndex * 3 + 1] = i1 as i32;
+                piTriList_out[iDstTriIndex * 3 + 2] = i2 as i32;
+                iDstTriIndex += 1;
+
+                let mut pVerts_B = &mut pTriInfos[iDstTriIndex].vert_num;
+                pVerts_B[0] = 0;
+                pVerts_B[1] = 2;
+                pVerts_B[2] = 3;
+                piTriList_out[iDstTriIndex * 3 + 0] = i0 as i32;
+                piTriList_out[iDstTriIndex * 3 + 1] = i2 as i32;
+                piTriList_out[iDstTriIndex * 3 + 2] = i3 as i32;
+                iDstTriIndex += 1
+            } else {
+                let mut pVerts_A_0 = &mut pTriInfos[iDstTriIndex].vert_num;
+                pVerts_A_0[0] = 0;
+                pVerts_A_0[1] = 1;
+                pVerts_A_0[2] = 3;
+                piTriList_out[iDstTriIndex * 3 + 0] = i0 as i32;
+                piTriList_out[iDstTriIndex * 3 + 1] = i1 as i32;
+                piTriList_out[iDstTriIndex * 3 + 2] = i3 as i32;
+                iDstTriIndex += 1;
+
+                let mut pVerts_B_0 = &mut pTriInfos[iDstTriIndex].vert_num;
+                pVerts_B_0[0] = 1;
+                pVerts_B_0[1] = 2;
+                pVerts_B_0[2] = 3;
+                piTriList_out[iDstTriIndex * 3 + 0] = i1 as i32;
+                piTriList_out[iDstTriIndex * 3 + 1] = i2 as i32;
+                piTriList_out[iDstTriIndex * 3 + 2] = i3 as i32;
+                iDstTriIndex += 1
+            }
+        }
+        iTSpacesOffs += verts.num_vertices();
+        assert!(iDstTriIndex <= iNrTrianglesIn);
+    }
+
+    for t in 0..iNrTrianglesIn {
+        pTriInfos[t].iFlag = TriangleFlags::empty();
+    }
+    return iTSpacesOffs;
+}

--- a/crates/bevy_mikktspace/src/generated/setup.rs
+++ b/crates/bevy_mikktspace/src/generated/setup.rs
@@ -1,3 +1,5 @@
+use super::SEdge;
+use super::SGroup;
 use super::STriInfo;
 use super::TriangleFlags;
 
@@ -140,4 +142,215 @@ pub(crate) fn GenerateInitialVerticesIndexList(
         pTriInfos[t].iFlag = TriangleFlags::empty();
     }
     return iTSpacesOffs;
+}
+
+pub(crate) unsafe fn InitTriInfo(
+    mut pTriInfos: *mut STriInfo,
+    mut piTriListIn: *const i32,
+    geometry: &impl Geometry,
+    iNrTrianglesIn: usize,
+) {
+    for f in 0..iNrTrianglesIn {
+        for i in 0..3i32 {
+            (*pTriInfos.offset(f as isize)).FaceNeighbors[i as usize] = -1i32;
+            let ref mut fresh4 = (*pTriInfos.offset(f as isize)).AssignedGroup[i as usize];
+            *fresh4 = 0 as *mut SGroup;
+            (*pTriInfos.offset(f as isize)).vOs.x = 0.0f32;
+            (*pTriInfos.offset(f as isize)).vOs.y = 0.0f32;
+            (*pTriInfos.offset(f as isize)).vOs.z = 0.0f32;
+            (*pTriInfos.offset(f as isize)).vOt.x = 0.0f32;
+            (*pTriInfos.offset(f as isize)).vOt.y = 0.0f32;
+            (*pTriInfos.offset(f as isize)).vOt.z = 0.0f32;
+            (*pTriInfos.offset(f as isize)).fMagS = 0i32 as f32;
+            (*pTriInfos.offset(f as isize)).fMagT = 0i32 as f32;
+            // C: assumed bad
+            (*pTriInfos.offset(f as isize))
+                .iFlag
+                .insert(TriangleFlags::GROUP_WITH_ANY);
+        }
+    }
+    for f in 0..iNrTrianglesIn {
+        let v1 = get_position(geometry, *piTriListIn.offset((f * 3 + 0) as isize) as usize);
+        let v2 = get_position(geometry, *piTriListIn.offset((f * 3 + 1) as isize) as usize);
+        let v3 = get_position(geometry, *piTriListIn.offset((f * 3 + 2) as isize) as usize);
+        let t1 = get_tex_coord(geometry, *piTriListIn.offset((f * 3 + 0) as isize) as usize);
+        let t2 = get_tex_coord(geometry, *piTriListIn.offset((f * 3 + 1) as isize) as usize);
+        let t3 = get_tex_coord(geometry, *piTriListIn.offset((f * 3 + 2) as isize) as usize);
+        let t21x: f32 = t2.x - t1.x;
+        let t21y: f32 = t2.y - t1.y;
+        let t31x: f32 = t3.x - t1.x;
+        let t31y: f32 = t3.y - t1.y;
+        let d1 = v2 - v1;
+        let d2 = v3 - v1;
+        let fSignedAreaSTx2: f32 = t21x * t31y - t21y * t31x;
+        let mut vOs = (t31y * d1) - (t21y * d2);
+        let mut vOt = (-t31x * d1) + (t21x * d2);
+        if fSignedAreaSTx2 > 0.0 {
+            (*pTriInfos.offset(f as isize))
+                .iFlag
+                .insert(TriangleFlags::ORIENT_PRESERVING);
+        }
+        if fSignedAreaSTx2.is_normal() {
+            let fAbsArea: f32 = fSignedAreaSTx2.abs();
+            let fLenOs: f32 = vOs.length();
+            let fLenOt: f32 = vOt.length();
+            let fS: f32 = if !(*pTriInfos.offset(f as isize))
+                .iFlag
+                .contains(TriangleFlags::ORIENT_PRESERVING)
+            {
+                -1.0f32
+            } else {
+                1.0f32
+            };
+            if fLenOs.is_normal() {
+                (*pTriInfos.offset(f as isize)).vOs = (fS / fLenOs) * vOs
+            }
+            if fLenOt.is_normal() {
+                (*pTriInfos.offset(f as isize)).vOt = (fS / fLenOt) * vOt
+            }
+            (*pTriInfos.offset(f as isize)).fMagS = fLenOs / fAbsArea;
+            (*pTriInfos.offset(f as isize)).fMagT = fLenOt / fAbsArea;
+            if ((*pTriInfos.offset(f as isize)).fMagS.is_normal())
+                && (*pTriInfos.offset(f as isize)).fMagT.is_normal()
+            {
+                (*pTriInfos.offset(f as isize))
+                    .iFlag
+                    .remove(TriangleFlags::GROUP_WITH_ANY);
+            }
+        }
+    }
+    let mut t = 0;
+    while t < iNrTrianglesIn - 1 {
+        let iFO_a: i32 = (*pTriInfos.offset(t as isize)).iOrgFaceNumber;
+        let iFO_b: i32 = (*pTriInfos.offset((t + 1) as isize)).iOrgFaceNumber;
+        if iFO_a == iFO_b {
+            let bIsDeg_a: bool = (*pTriInfos.offset(t as isize))
+                .iFlag
+                .contains(TriangleFlags::DEGENERATE);
+            let bIsDeg_b: bool = (*pTriInfos.offset((t + 1) as isize))
+                .iFlag
+                .contains(TriangleFlags::DEGENERATE);
+            if !(bIsDeg_a || bIsDeg_b) {
+                let bOrientA: bool = (*pTriInfos.offset(t as isize))
+                    .iFlag
+                    .contains(TriangleFlags::ORIENT_PRESERVING);
+                let bOrientB: bool = (*pTriInfos.offset((t + 1) as isize))
+                    .iFlag
+                    .contains(TriangleFlags::ORIENT_PRESERVING);
+                if bOrientA != bOrientB {
+                    let mut bChooseOrientFirstTri: bool = false;
+                    if (*pTriInfos.offset((t + 1) as isize))
+                        .iFlag
+                        .contains(TriangleFlags::GROUP_WITH_ANY)
+                    {
+                        bChooseOrientFirstTri = true
+                    } else if CalcTexArea(geometry, &*piTriListIn.offset((t * 3 + 0) as isize))
+                        >= CalcTexArea(geometry, &*piTriListIn.offset(((t + 1) * 3 + 0) as isize))
+                    {
+                        bChooseOrientFirstTri = true
+                    }
+                    let t0 = if bChooseOrientFirstTri { t } else { t + 1 };
+                    let t1_0 = if bChooseOrientFirstTri { t + 1 } else { t };
+                    (*pTriInfos.offset(t1_0 as isize)).iFlag.set(
+                        TriangleFlags::ORIENT_PRESERVING,
+                        (*pTriInfos.offset(t0 as isize))
+                            .iFlag
+                            .contains(TriangleFlags::ORIENT_PRESERVING),
+                    );
+                }
+            }
+            t += 2
+        } else {
+            t += 1
+        }
+    }
+
+    BuildNeighborsFast(pTriInfos, piTriListIn, iNrTrianglesIn as i32);
+}
+
+pub(crate) unsafe fn BuildNeighborsFast(
+    mut pTriInfos: *mut STriInfo,
+    mut piTriListIn: *const i32,
+    iNrTrianglesIn: i32,
+) {
+    let mut pEdges = Vec::with_capacity((iNrTrianglesIn * 3) as usize);
+    // build array of edges
+    for f in 0..iNrTrianglesIn {
+        for i in 0..3i32 {
+            let i0: i32 = *piTriListIn.offset((f * 3i32 + i) as isize);
+            let i1: i32 = *piTriListIn.offset((f * 3i32 + (i + 1) % 3) as isize);
+            // Ensure that the indices have a consistent order by making i0 the smaller
+            pEdges.push(SEdge {
+                i0: i0.min(i1),
+                i1: i0.max(i1),
+                f,
+            });
+        }
+    }
+    pEdges.sort();
+
+    let iEntries = iNrTrianglesIn * 3i32;
+
+    for i in 0..iEntries {
+        let edge = pEdges[i as usize];
+        let i0_0: i32 = edge.i0;
+        let i1_0: i32 = edge.i1;
+        let f_0: i32 = edge.f;
+
+        let (i0_A, i1_A, edgenum_A) =
+            GetEdge(&*piTriListIn.offset((f_0 * 3i32) as isize), i0_0, i1_0);
+        let bUnassigned_A =
+            (*pTriInfos.offset(f_0 as isize)).FaceNeighbors[edgenum_A as usize] == -1i32;
+        if bUnassigned_A {
+            let mut j: i32 = i + 1i32;
+
+            while j < iEntries && i0_0 == pEdges[j as usize].i0 && i1_0 == pEdges[j as usize].i1 {
+                let t = pEdges[j as usize].f;
+                // C: Flip i1 and i0
+                let (i1_B, i0_B, edgenum_B) = GetEdge(
+                    &*piTriListIn.offset((t * 3i32) as isize),
+                    pEdges[j as usize].i0,
+                    pEdges[j as usize].i1,
+                );
+                let bUnassigned_B =
+                    (*pTriInfos.offset(t as isize)).FaceNeighbors[edgenum_B as usize] == -1i32;
+                if i0_A == i0_B && i1_A == i1_B && bUnassigned_B {
+                    let mut t_0: i32 = pEdges[j as usize].f;
+                    (*pTriInfos.offset(f_0 as isize)).FaceNeighbors[edgenum_A as usize] = t_0;
+                    (*pTriInfos.offset(t_0 as isize)).FaceNeighbors[edgenum_B as usize] = f_0;
+                    break;
+                } else {
+                    j += 1
+                }
+            }
+        }
+    }
+}
+
+pub(crate) unsafe fn GetEdge(mut indices: *const i32, i0_in: i32, i1_in: i32) -> (i32, i32, i32) {
+    if *indices.offset(0isize) == i0_in || *indices.offset(0isize) == i1_in {
+        if *indices.offset(1isize) == i0_in || *indices.offset(1isize) == i1_in {
+            (*indices.offset(0isize), *indices.offset(1isize), 0)
+        } else {
+            (*indices.offset(2isize), *indices.offset(0isize), 2)
+        }
+    } else {
+        (*indices.offset(1isize), *indices.offset(2isize), 1)
+    }
+}
+// returns the texture area times 2
+unsafe fn CalcTexArea(geometry: &impl Geometry, mut indices: *const i32) -> f32 {
+    let t1 = get_tex_coord(geometry, *indices.offset(0isize) as usize);
+    let t2 = get_tex_coord(geometry, *indices.offset(1isize) as usize);
+    let t3 = get_tex_coord(geometry, *indices.offset(2isize) as usize);
+    let t21x: f32 = t2.x - t1.x;
+    let t21y: f32 = t2.y - t1.y;
+    let t31x: f32 = t3.x - t1.x;
+    let t31y: f32 = t3.y - t1.y;
+    let fSignedAreaSTx2: f32 = t21x * t31y - t21y * t31x;
+    return if fSignedAreaSTx2 < 0i32 as f32 {
+        -fSignedAreaSTx2
+    } else {
+        fSignedAreaSTx2
+    };
 }

--- a/crates/bevy_mikktspace/src/generated/setup.rs
+++ b/crates/bevy_mikktspace/src/generated/setup.rs
@@ -21,7 +21,7 @@ pub(crate) fn GenerateSharedVerticesIndexList(
     // side channel seems much easier.
     // Hopefully implementation can be changed to just use a btreemap or
     // something too.
-    mut piTriList_in_and_out: &mut [i32],
+    piTriList_in_and_out: &mut [i32],
     geometry: &impl Geometry,
 ) {
     let mut map = BTreeMap::new();
@@ -56,7 +56,7 @@ pub(crate) fn GenerateInitialVerticesIndexList(
         pTriInfos[iDstTriIndex].iOrgFaceNumber = f as i32;
         pTriInfos[iDstTriIndex].iTSpacesOffs = iTSpacesOffs as i32;
         if let FaceKind::Triangle = verts {
-            let mut pVerts = &mut pTriInfos[iDstTriIndex].vert_num;
+            let pVerts = &mut pTriInfos[iDstTriIndex].vert_num;
             pVerts[0] = 0;
             pVerts[1] = 1;
             pVerts[2] = 2;
@@ -92,7 +92,7 @@ pub(crate) fn GenerateInitialVerticesIndexList(
                 bQuadDiagIs_02 = distSQ_13_0 > distSQ_02_0;
             }
             if bQuadDiagIs_02 {
-                let mut pVerts_A = &mut pTriInfos[iDstTriIndex].vert_num;
+                let pVerts_A = &mut pTriInfos[iDstTriIndex].vert_num;
                 pVerts_A[0] = 0;
                 pVerts_A[1] = 1;
                 pVerts_A[2] = 2;
@@ -101,7 +101,7 @@ pub(crate) fn GenerateInitialVerticesIndexList(
                 piTriList_out[iDstTriIndex * 3 + 2] = i2 as i32;
                 iDstTriIndex += 1;
 
-                let mut pVerts_B = &mut pTriInfos[iDstTriIndex].vert_num;
+                let pVerts_B = &mut pTriInfos[iDstTriIndex].vert_num;
                 pVerts_B[0] = 0;
                 pVerts_B[1] = 2;
                 pVerts_B[2] = 3;
@@ -110,7 +110,7 @@ pub(crate) fn GenerateInitialVerticesIndexList(
                 piTriList_out[iDstTriIndex * 3 + 2] = i3 as i32;
                 iDstTriIndex += 1;
             } else {
-                let mut pVerts_A_0 = &mut pTriInfos[iDstTriIndex].vert_num;
+                let pVerts_A_0 = &mut pTriInfos[iDstTriIndex].vert_num;
                 pVerts_A_0[0] = 0;
                 pVerts_A_0[1] = 1;
                 pVerts_A_0[2] = 3;
@@ -119,7 +119,7 @@ pub(crate) fn GenerateInitialVerticesIndexList(
                 piTriList_out[iDstTriIndex * 3 + 2] = i3 as i32;
                 iDstTriIndex += 1;
 
-                let mut pVerts_B_0 = &mut pTriInfos[iDstTriIndex].vert_num;
+                let pVerts_B_0 = &mut pTriInfos[iDstTriIndex].vert_num;
                 pVerts_B_0[0] = 1;
                 pVerts_B_0[1] = 2;
                 pVerts_B_0[2] = 3;
@@ -141,7 +141,7 @@ pub(crate) fn GenerateInitialVerticesIndexList(
 
 pub(crate) fn InitTriInfo(
     mut pTriInfos: &mut [STriInfo],
-    mut piTriListIn: &[i32],
+    piTriListIn: &[i32],
     geometry: &impl Geometry,
     iNrTrianglesIn: usize,
 ) {
@@ -164,8 +164,8 @@ pub(crate) fn InitTriInfo(
         let d1 = v2 - v1;
         let d2 = v3 - v1;
         let fSignedAreaSTx2: f32 = t21x * t31y - t21y * t31x;
-        let mut vOs = (t31y * d1) - (t21y * d2);
-        let mut vOt = (-t31x * d1) + (t21x * d2);
+        let vOs = (t31y * d1) - (t21y * d2);
+        let vOt = (-t31x * d1) + (t21x * d2);
         if fSignedAreaSTx2 > 0.0 {
             pTriInfos[f].iFlag.insert(TriangleFlags::ORIENT_PRESERVING);
         }
@@ -235,7 +235,7 @@ pub(crate) fn InitTriInfo(
 
 pub(crate) fn BuildNeighborsFast(
     mut pTriInfos: &mut [STriInfo],
-    mut piTriListIn: &[i32],
+    piTriListIn: &[i32],
     iNrTrianglesIn: i32,
 ) {
     let mut pEdges = Vec::with_capacity((iNrTrianglesIn * 3) as usize);
@@ -278,7 +278,7 @@ pub(crate) fn BuildNeighborsFast(
                 let bUnassigned_B =
                     pTriInfos[t as usize].FaceNeighbors[edgenum_B as usize] == -1i32;
                 if i0_A == i0_B && i1_A == i1_B && bUnassigned_B {
-                    let mut t_0: i32 = pEdges[j as usize].f;
+                    let t_0: i32 = pEdges[j as usize].f;
                     pTriInfos[f_0 as usize].FaceNeighbors[edgenum_A as usize] = t_0;
                     pTriInfos[t_0 as usize].FaceNeighbors[edgenum_B as usize] = f_0;
                     break;
@@ -302,7 +302,7 @@ pub(crate) fn GetEdge(indices: &[i32], i0_in: i32, i1_in: i32) -> (i32, i32, i32
     }
 }
 // returns the texture area times 2
-fn CalcTexArea(geometry: &impl Geometry, mut indices: &[i32]) -> f32 {
+fn CalcTexArea(geometry: &impl Geometry, indices: &[i32]) -> f32 {
     let t1 = get_tex_coord(geometry, indices[0] as usize);
     let t2 = get_tex_coord(geometry, indices[1] as usize);
     let t3 = get_tex_coord(geometry, indices[2] as usize);

--- a/crates/bevy_mikktspace/src/generated/setup.rs
+++ b/crates/bevy_mikktspace/src/generated/setup.rs
@@ -89,7 +89,7 @@ pub(crate) fn GenerateInitialVerticesIndexList(
                 let P3 = get_position(geometry, i3);
                 let distSQ_02_0: f32 = (P2 - P0).length_squared();
                 let distSQ_13_0: f32 = (P3 - P1).length_squared();
-                bQuadDiagIs_02 = distSQ_13_0 > distSQ_02_0;
+                bQuadDiagIs_02 = distSQ_13_0 >= distSQ_02_0;
             }
             if bQuadDiagIs_02 {
                 let pVerts_A = &mut pTriInfos[iDstTriIndex].vert_num;

--- a/crates/bevy_mikktspace/src/generated/setup.rs
+++ b/crates/bevy_mikktspace/src/generated/setup.rs
@@ -60,10 +60,10 @@ pub(crate) fn GenerateInitialVerticesIndexList(
             pVerts[0] = 0;
             pVerts[1] = 1;
             pVerts[2] = 2;
-            piTriList_out[iDstTriIndex * 3 + 0] = face_vert_to_index(f, 0) as i32;
+            piTriList_out[iDstTriIndex * 3] = face_vert_to_index(f, 0) as i32;
             piTriList_out[iDstTriIndex * 3 + 1] = face_vert_to_index(f, 1) as i32;
             piTriList_out[iDstTriIndex * 3 + 2] = face_vert_to_index(f, 2) as i32;
-            iDstTriIndex += 1
+            iDstTriIndex += 1;
         } else {
             pTriInfos[iDstTriIndex + 1].iOrgFaceNumber = f as i32;
             pTriInfos[iDstTriIndex + 1].iTSpacesOffs = iTSpacesOffs as i32;
@@ -79,9 +79,9 @@ pub(crate) fn GenerateInitialVerticesIndexList(
             let distSQ_13: f32 = (T3 - T1).length_squared();
             let bQuadDiagIs_02: bool;
             if distSQ_02 < distSQ_13 {
-                bQuadDiagIs_02 = true
+                bQuadDiagIs_02 = true;
             } else if distSQ_13 < distSQ_02 {
-                bQuadDiagIs_02 = false
+                bQuadDiagIs_02 = false;
             } else {
                 let P0 = get_position(geometry, i0);
                 let P1 = get_position(geometry, i1);
@@ -89,18 +89,14 @@ pub(crate) fn GenerateInitialVerticesIndexList(
                 let P3 = get_position(geometry, i3);
                 let distSQ_02_0: f32 = (P2 - P0).length_squared();
                 let distSQ_13_0: f32 = (P3 - P1).length_squared();
-                bQuadDiagIs_02 = if distSQ_13_0 < distSQ_02_0 {
-                    false
-                } else {
-                    true
-                }
+                bQuadDiagIs_02 = distSQ_13_0 > distSQ_02_0;
             }
             if bQuadDiagIs_02 {
                 let mut pVerts_A = &mut pTriInfos[iDstTriIndex].vert_num;
                 pVerts_A[0] = 0;
                 pVerts_A[1] = 1;
                 pVerts_A[2] = 2;
-                piTriList_out[iDstTriIndex * 3 + 0] = i0 as i32;
+                piTriList_out[iDstTriIndex * 3] = i0 as i32;
                 piTriList_out[iDstTriIndex * 3 + 1] = i1 as i32;
                 piTriList_out[iDstTriIndex * 3 + 2] = i2 as i32;
                 iDstTriIndex += 1;
@@ -109,16 +105,16 @@ pub(crate) fn GenerateInitialVerticesIndexList(
                 pVerts_B[0] = 0;
                 pVerts_B[1] = 2;
                 pVerts_B[2] = 3;
-                piTriList_out[iDstTriIndex * 3 + 0] = i0 as i32;
+                piTriList_out[iDstTriIndex * 3] = i0 as i32;
                 piTriList_out[iDstTriIndex * 3 + 1] = i2 as i32;
                 piTriList_out[iDstTriIndex * 3 + 2] = i3 as i32;
-                iDstTriIndex += 1
+                iDstTriIndex += 1;
             } else {
                 let mut pVerts_A_0 = &mut pTriInfos[iDstTriIndex].vert_num;
                 pVerts_A_0[0] = 0;
                 pVerts_A_0[1] = 1;
                 pVerts_A_0[2] = 3;
-                piTriList_out[iDstTriIndex * 3 + 0] = i0 as i32;
+                piTriList_out[iDstTriIndex * 3] = i0 as i32;
                 piTriList_out[iDstTriIndex * 3 + 1] = i1 as i32;
                 piTriList_out[iDstTriIndex * 3 + 2] = i3 as i32;
                 iDstTriIndex += 1;
@@ -127,20 +123,20 @@ pub(crate) fn GenerateInitialVerticesIndexList(
                 pVerts_B_0[0] = 1;
                 pVerts_B_0[1] = 2;
                 pVerts_B_0[2] = 3;
-                piTriList_out[iDstTriIndex * 3 + 0] = i1 as i32;
+                piTriList_out[iDstTriIndex * 3] = i1 as i32;
                 piTriList_out[iDstTriIndex * 3 + 1] = i2 as i32;
                 piTriList_out[iDstTriIndex * 3 + 2] = i3 as i32;
-                iDstTriIndex += 1
+                iDstTriIndex += 1;
             }
         }
         iTSpacesOffs += verts.num_vertices();
         assert!(iDstTriIndex <= iNrTrianglesIn);
     }
 
-    for t in 0..iNrTrianglesIn {
-        pTriInfos[t].iFlag = TriangleFlags::empty();
+    for triangle in pTriInfos.iter_mut().take(iNrTrianglesIn) {
+        triangle.iFlag = TriangleFlags::empty();
     }
-    return iTSpacesOffs;
+    iTSpacesOffs
 }
 
 pub(crate) fn InitTriInfo(
@@ -149,16 +145,16 @@ pub(crate) fn InitTriInfo(
     geometry: &impl Geometry,
     iNrTrianglesIn: usize,
 ) {
-    for f in 0..iNrTrianglesIn {
+    for triangle in pTriInfos.iter_mut().take(iNrTrianglesIn) {
         // C: assumed bad
-        pTriInfos[f].iFlag.insert(TriangleFlags::GROUP_WITH_ANY);
+        triangle.iFlag.insert(TriangleFlags::GROUP_WITH_ANY);
     }
 
     for f in 0..iNrTrianglesIn {
-        let v1 = get_position(geometry, piTriListIn[(f * 3 + 0)] as usize);
+        let v1 = get_position(geometry, piTriListIn[f * 3] as usize);
         let v2 = get_position(geometry, piTriListIn[f * 3 + 1] as usize);
         let v3 = get_position(geometry, piTriListIn[f * 3 + 2] as usize);
-        let t1 = get_tex_coord(geometry, piTriListIn[f * 3 + 0] as usize);
+        let t1 = get_tex_coord(geometry, piTriListIn[f * 3] as usize);
         let t2 = get_tex_coord(geometry, piTriListIn[f * 3 + 1] as usize);
         let t3 = get_tex_coord(geometry, piTriListIn[f * 3 + 2] as usize);
         let t21x: f32 = t2.x - t1.x;
@@ -186,10 +182,10 @@ pub(crate) fn InitTriInfo(
                 1.0f32
             };
             if fLenOs.is_normal() {
-                pTriInfos[f].vOs = (fS / fLenOs) * vOs
+                pTriInfos[f].vOs = (fS / fLenOs) * vOs;
             }
             if fLenOt.is_normal() {
-                pTriInfos[f].vOt = (fS / fLenOt) * vOt
+                pTriInfos[f].vOt = (fS / fLenOt) * vOt;
             }
             pTriInfos[f].fMagS = fLenOs / fAbsArea;
             pTriInfos[f].fMagT = fLenOt / fAbsArea;
@@ -213,17 +209,11 @@ pub(crate) fn InitTriInfo(
                     .iFlag
                     .contains(TriangleFlags::ORIENT_PRESERVING);
                 if bOrientA != bOrientB {
-                    let mut bChooseOrientFirstTri: bool = false;
-                    if pTriInfos[t + 1]
+                    let bChooseOrientFirstTri = pTriInfos[t + 1]
                         .iFlag
                         .contains(TriangleFlags::GROUP_WITH_ANY)
-                    {
-                        bChooseOrientFirstTri = true
-                    } else if CalcTexArea(geometry, &piTriListIn[(t * 3)..])
-                        >= CalcTexArea(geometry, &piTriListIn[((t + 1) * 3)..])
-                    {
-                        bChooseOrientFirstTri = true
-                    }
+                        || (CalcTexArea(geometry, &piTriListIn[(t * 3)..])
+                            >= CalcTexArea(geometry, &piTriListIn[((t + 1) * 3)..]));
                     let t0 = if bChooseOrientFirstTri { t } else { t + 1 };
                     let t1_0 = if bChooseOrientFirstTri { t + 1 } else { t };
                     pTriInfos[t1_0].iFlag.set(
@@ -234,9 +224,9 @@ pub(crate) fn InitTriInfo(
                     );
                 }
             }
-            t += 2
+            t += 2;
         } else {
-            t += 1
+            t += 1;
         }
     }
 
@@ -292,9 +282,8 @@ pub(crate) fn BuildNeighborsFast(
                     pTriInfos[f_0 as usize].FaceNeighbors[edgenum_A as usize] = t_0;
                     pTriInfos[t_0 as usize].FaceNeighbors[edgenum_B as usize] = f_0;
                     break;
-                } else {
-                    j += 1
                 }
+                j += 1;
             }
         }
     }
@@ -322,9 +311,9 @@ fn CalcTexArea(geometry: &impl Geometry, mut indices: &[i32]) -> f32 {
     let t31x: f32 = t3.x - t1.x;
     let t31y: f32 = t3.y - t1.y;
     let fSignedAreaSTx2: f32 = t21x * t31y - t21y * t31x;
-    return if fSignedAreaSTx2 < 0i32 as f32 {
+    if fSignedAreaSTx2 < 0i32 as f32 {
         -fSignedAreaSTx2
     } else {
         fSignedAreaSTx2
-    };
+    }
 }

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -70,23 +70,23 @@ pub trait Geometry {
 ///
 /// Returns `false` if the geometry is unsuitable for tangent generation including,
 /// but not limited to, lack of vertices.
-pub fn generate_tangents<I: Geometry>(geometry: &mut I) -> bool {
+pub fn generate_tangents(geometry: &mut impl Geometry) -> bool {
     unsafe { generated::genTangSpace(geometry, 180.0) }
 }
 
-fn get_position<I: Geometry>(geometry: &mut I, index: usize) -> Vec3 {
+fn get_position(geometry: &impl Geometry, index: usize) -> Vec3 {
     let (face, vert) = index_to_face_vert(index);
     geometry.position(face, vert).into()
 }
 
-fn get_tex_coord<I: Geometry>(geometry: &mut I, index: usize) -> Vec3 {
+fn get_tex_coord(geometry: &impl Geometry, index: usize) -> Vec3 {
     let (face, vert) = index_to_face_vert(index);
     let tex_coord: Vec2 = geometry.tex_coord(face, vert).into();
     let val = tex_coord.extend(1.0);
     val
 }
 
-fn get_normal<I: Geometry>(geometry: &mut I, index: usize) -> Vec3 {
+fn get_normal(geometry: &impl Geometry, index: usize) -> Vec3 {
     let (face, vert) = index_to_face_vert(index);
     geometry.normal(face, vert).into()
 }

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -72,7 +72,7 @@ pub trait Geometry {
 /// Returns `false` if the geometry is unsuitable for tangent generation including,
 /// but not limited to, lack of vertices.
 pub fn generate_tangents(geometry: &mut impl Geometry) -> bool {
-    unsafe { generated::genTangSpace(geometry, 180.0) }
+    generated::genTangSpace(geometry, 180.0)
 }
 
 fn get_position(geometry: &impl Geometry, index: usize) -> Vec3 {

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -1,4 +1,5 @@
-#![allow(clippy::all)]
+#![forbid(unsafe_code)]
+#![allow(clippy::too_many_arguments)]
 
 use glam::{Vec2, Vec3};
 
@@ -83,8 +84,7 @@ fn get_position(geometry: &impl Geometry, index: usize) -> Vec3 {
 fn get_tex_coord(geometry: &impl Geometry, index: usize) -> Vec3 {
     let (face, vert) = index_to_face_vert(index);
     let tex_coord: Vec2 = geometry.tex_coord(face, vert).into();
-    let val = tex_coord.extend(1.0);
-    val
+    tex_coord.extend(1.0)
 }
 
 fn get_normal(geometry: &impl Geometry, index: usize) -> Vec3 {

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -4,13 +4,28 @@ use glam::{Vec2, Vec3};
 
 mod generated;
 
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum FaceKind {
+    Triangle,
+    Quad,
+}
+
+impl FaceKind {
+    fn num_vertices(&self) -> usize {
+        match self {
+            FaceKind::Triangle => 3,
+            FaceKind::Quad => 4,
+        }
+    }
+}
+
 /// The interface by which mikktspace interacts with your geometry.
 pub trait Geometry {
     /// Returns the number of faces.
     fn num_faces(&self) -> usize;
 
     /// Returns the number of vertices of a face.
-    fn num_vertices_of_face(&self, face: usize) -> usize;
+    fn num_vertices_of_face(&self, face: usize) -> FaceKind;
 
     /// Returns the position of a vertex.
     fn position(&self, face: usize, vert: usize) -> [f32; 3];

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -96,5 +96,6 @@ fn index_to_face_vert(index: usize) -> (usize, usize) {
 }
 
 fn face_vert_to_index(face: usize, vert: usize) -> usize {
+    assert!(vert < 4);
     face << 2 | vert & 0x3
 }

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -3,6 +3,7 @@
 use glam::{Vec2, Vec3};
 
 mod generated;
+pub(crate) mod ordered_vec;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum FaceKind {

--- a/crates/bevy_mikktspace/src/ordered_vec.rs
+++ b/crates/bevy_mikktspace/src/ordered_vec.rs
@@ -1,0 +1,28 @@
+use glam::Vec3;
+use ordered_float::NotNan;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+pub struct FiniteVec3 {
+    x: NotNan<f32>,
+    y: NotNan<f32>,
+    z: NotNan<f32>,
+}
+
+impl FiniteVec3 {
+    pub fn new(val: Vec3) -> Result<FiniteVec3, NotFinite> {
+        if val.is_finite() {
+            Ok(Self {
+                // Unwrapping here is fine, because is_finite guarantees that
+                // the values are not `Nan`
+                x: NotNan::new(val.x).unwrap(),
+                y: NotNan::new(val.y).unwrap(),
+                z: NotNan::new(val.z).unwrap(),
+            })
+        } else {
+            Err(NotFinite)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct NotFinite;

--- a/crates/bevy_mikktspace/src/refactored.rs
+++ b/crates/bevy_mikktspace/src/refactored.rs
@@ -24,14 +24,57 @@
 //!
 //! 3. This notice may not be removed or altered from any source distribution.
 
+/// The interface by which mikktspace interacts with your geometry.
+pub trait Geometry {
+    // For simplicity's sake, we intentionall eschew the quad handling of mikktspace.
+    // You should ensure that the mesh passed here is triangulated
+
+    /// Returns the number of faces.
+    fn num_faces(&self) -> usize;
+
+    /// Returns the position of a vertex.
+    fn position(&self, face: usize, vert: usize) -> Vec3;
+
+    /// Returns the normal of a vertex.
+    fn normal(&self, face: usize, vert: usize) -> Vec3;
+
+    /// Returns the texture coordinate of a vertex.
+    fn tex_coord(&self, face: usize, vert: usize) -> Vec2;
+
+    /// Sets the generated tangent for a vertex.
+    /// Leave this function unimplemented if you are implementing
+    /// `set_tangent_encoded`.
+    fn set_tangent(
+        &mut self,
+        tangent: [f32; 3],
+        _bi_tangent: [f32; 3],
+        _f_mag_s: f32,
+        _f_mag_t: f32,
+        bi_tangent_preserves_orientation: bool,
+        face: usize,
+        vert: usize,
+    ) {
+        let sign = if bi_tangent_preserves_orientation {
+            1.0
+        } else {
+            -1.0
+        };
+        self.set_tangent_encoded([tangent[0], tangent[1], tangent[2], sign], face, vert);
+    }
+
+    /// Sets the generated tangent for a vertex with its bi-tangent encoded as the 'W' (4th)
+    /// component in the tangent. The 'W' component marks if the bi-tangent is flipped. This
+    /// is called by the default implementation of `set_tangent`; therefore, this function will
+    /// not be called by the crate unless `set_tangent` is unimplemented.
+    fn set_tangent_encoded(&mut self, _tangent: [f32; 4], _face: usize, _vert: usize) {}
+}
+
 use std::{
     cmp::Ordering,
     collections::{btree_map::Entry, BTreeMap},
 };
 
 use glam::{Vec2, Vec3};
-
-use crate::Geometry;
 
 pub fn generate_tangents(geometry: &mut impl Geometry) {
     let triangle_count = geometry.num_faces();

--- a/crates/bevy_mikktspace/src/refactored.rs
+++ b/crates/bevy_mikktspace/src/refactored.rs
@@ -1,0 +1,100 @@
+//! The contents of this file are a combination of transpilation and human
+//! modification to Morten S. Mikkelsen's original tangent space algorithm
+//! implementation written in C. The original source code can be found at
+//! <https://archive.blender.org/wiki/index.php/Dev:Shading/Tangent_Space_Normal_Maps>
+//! and includes the following licence:
+//!
+//! Copyright (C) 2011 by Morten S. Mikkelsen
+//!
+//! This software is provided 'as-is', without any express or implied
+//! warranty.  In no event will the authors be held liable for any damages
+//! arising from the use of this software.
+//!
+//! Permission is granted to anyone to use this software for any purpose,
+//! including commercial applications, and to alter it and redistribute it
+//! freely, subject to the following restrictions:
+//!
+//! 1. The origin of this software must not be misrepresented; you must not
+//! claim that you wrote the original software. If you use this software
+//! in a product, an acknowledgment in the product documentation would be
+//! appreciated but is not required.
+//!
+//! 2. Altered source versions must be plainly marked as such, and must not be
+//! misrepresented as being the original software.
+//!
+//! 3. This notice may not be removed or altered from any source distribution.
+
+use std::{
+    cmp::Ordering,
+    collections::{btree_map::Entry, BTreeMap},
+};
+
+use glam::{Vec2, Vec3};
+
+use crate::Geometry;
+
+pub fn generate_tangents(geometry: &mut impl Geometry) {
+    let triangle_count = geometry.num_faces();
+    if triangle_count == 0 {
+        // Nothing to do - further steps can now assume at least one face exists.
+        return;
+    }
+    let vertex_indices = find_shared_vertices(geometry);
+    // Ignore degenerate triangles for now
+}
+
+fn find_shared_vertices(geometry: &impl Geometry) -> Vec<usize> {
+    let mut vertex_indices = BTreeMap::<VertexInfo, usize>::new();
+    let mut vertices = Vec::<usize>::new();
+    for face in 0..geometry.num_faces() {
+        for vert in 0..3 {
+            let info = VertexInfo {
+                position: geometry.position(face, vert),
+                normal: geometry.normal(face, vert),
+                tex_coord: geometry.tex_coord(face, vert),
+            };
+            match vertex_indices.entry(info) {
+                Entry::Vacant(vacant) => {
+                    let new_idx = vertices.len();
+                    vacant.insert(new_idx);
+                    vertices.push(new_idx);
+                }
+                Entry::Occupied(o) => vertices.push(*o.get()),
+            }
+        }
+    }
+    vertices
+}
+
+fn build_groups() {}
+
+fn build_neighbours() {}
+
+#[derive(PartialEq, Clone, Copy)]
+struct VertexInfo {
+    position: Vec3,
+    normal: Vec3,
+    tex_coord: Vec2,
+}
+
+impl Eq for VertexInfo {}
+
+impl Ord for VertexInfo {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap_or(Ordering::Less)
+    }
+}
+
+impl PartialOrd for VertexInfo {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match self.position.partial_cmp(&other.position) {
+            Some(Ordering::Equal) => {}
+            ord => return ord,
+        }
+        match self.normal.partial_cmp(&other.normal) {
+            Some(Ordering::Equal) => {}
+            ord => return ord,
+        }
+        self.tex_coord.partial_cmp(&other.tex_coord)
+    }
+}

--- a/crates/bevy_mikktspace/tests/regression_test.rs
+++ b/crates/bevy_mikktspace/tests/regression_test.rs
@@ -8,7 +8,7 @@
     clippy::map_flatten
 )]
 
-use bevy_mikktspace::{generate_tangents, Geometry};
+use bevy_mikktspace::{generate_tangents, FaceKind, Geometry};
 use glam::{Vec2, Vec3};
 
 pub type Face = [u32; 3];
@@ -73,8 +73,9 @@ impl Geometry for Context {
         self.mesh.faces.len()
     }
 
-    fn num_vertices_of_face(&self, _face: usize) -> usize {
-        3
+    fn num_vertices_of_face(&self, _face: usize) -> FaceKind {
+        // We don't currently support Quads
+        FaceKind::Triangle
     }
 
     fn position(&self, face: usize, vert: usize) -> [f32; 3] {

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -1,5 +1,6 @@
 mod conversions;
 pub mod skinning;
+use bevy_mikktspace::FaceKind;
 pub use wgpu::PrimitiveTopology;
 
 use crate::{
@@ -883,8 +884,8 @@ impl bevy_mikktspace::Geometry for MikktspaceGeometryHelper<'_> {
         self.indices.len() / 3
     }
 
-    fn num_vertices_of_face(&self, _: usize) -> usize {
-        3
+    fn num_vertices_of_face(&self, _: usize) -> FaceKind {
+        FaceKind::Triangle
     }
 
     fn position(&self, face: usize, vert: usize) -> [f32; 3] {


### PR DESCRIPTION
# Objective

- `bevy_mikktspace`'s use of unsafe is concerning.
- Eventually, we want this to be `#[forbid(unsafe_code)]`
- The refactor needs to maintain the same behaviour.

## Solution

- [x] Do small refactoring on the unsafe version (e.g. moving variables down to their declarations, adding comments)
- [x] Chip away at the unsafe code
- [x] Refactor some of the gnarlier parts to use standard facilities