### PR TITLE
[Merged by Bors] - add NO_STORAGE_BUFFERS_SUPPORT shaderdef when needed

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -212,6 +212,7 @@ pub struct ShadowPipeline {
     pub skinned_mesh_layout: BindGroupLayout,
     pub point_light_sampler: Sampler,
     pub directional_light_sampler: Sampler,
+    pub clustered_forward_buffer_binding_type: BufferBindingType,
 }
 
 // TODO: this pattern for initializing the shaders / pipeline isn't ideal. this should be handled by the asset system
@@ -219,6 +220,9 @@ impl FromWorld for ShadowPipeline {
     fn from_world(world: &mut World) -> Self {
         let world = world.cell();
         let render_device = world.resource::<RenderDevice>();
+
+        let clustered_forward_buffer_binding_type = render_device
+            .get_supported_read_only_binding_type(CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT);
 
         let view_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
             entries: &[
@@ -264,6 +268,7 @@ impl FromWorld for ShadowPipeline {
                 compare: Some(CompareFunction::GreaterEqual),
                 ..Default::default()
             }),
+            clustered_forward_buffer_binding_type,
         }
     }
 }
@@ -323,6 +328,13 @@ impl SpecializedMeshPipeline for ShadowPipeline {
             bind_group_layout.push(self.skinned_mesh_layout.clone());
         } else {
             bind_group_layout.push(self.mesh_layout.clone());
+        }
+
+        if !matches!(
+            self.clustered_forward_buffer_binding_type,
+            BufferBindingType::Storage { .. }
+        ) {
+            shader_defs.push(String::from("NO_STORAGE_BUFFERS_SUPPORT"));
         }
 
         let vertex_buffer_layout = layout.get_layout(&vertex_attributes)?;


### PR DESCRIPTION
# Objective

- fix #4946 
- fix running 3d in wasm

## Solution

- since #4867, the imports are splitter differently, and this shader def was not always set correctly depending on the shader used
- add it when needed

