### PR TITLE
[Merged by Bors] - update system test example to include using events

### DIFF
--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -169,9 +169,6 @@ fn update_score_on_event() {
     // Run systems
     app.update();
 
-    // Run systems again to let the event be processed
-    app.update();
-
     // Check resulting changes
     assert_eq!(app.world.resource::<Score>().0, 3);
 }

--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -105,8 +105,16 @@ fn did_despawn_enemy() {
     // Run systems
     app.update();
 
-    // Check resulting changes
+    // Check enemy was despawned
     assert!(app.world.get::<Enemy>(enemy_id).is_none());
+
+    // Get `EnemyDied` event reader
+    let enemy_died_events = app.world.resource::<Events<EnemyDied>>();
+    let mut enemy_died_reader = enemy_died_events.get_reader();
+    let enemy_died = enemy_died_reader.iter(enemy_died_events).next().unwrap();
+
+    // Check the event has been sent
+    assert_eq!(enemy_died.0, 1);
 }
 
 #[test]
@@ -160,14 +168,6 @@ fn update_score_on_event() {
 
     // Run systems
     app.update();
-
-    // Get `EnemyDied` event reader
-    let enemy_died_events = app.world.resource::<Events<EnemyDied>>();
-    let mut enemy_died_reader = enemy_died_events.get_reader();
-    let enemy_died = enemy_died_reader.iter(enemy_died_events).next().unwrap();
-
-    // Check the event has been sent
-    assert_eq!(enemy_died.0, 3);
 
     // Run systems again to let the event be processed
     app.update();

--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -74,6 +74,7 @@ fn did_hurt_enemy() {
 
     // Check resulting changes
     assert!(app.world.get::<Enemy>(enemy_id).is_some());
+    assert_eq!(app.world.get::<Enemy>(enemy_id).unwrap().hit_points, 4);
 }
 
 #[test]
@@ -105,7 +106,6 @@ fn did_despawn_enemy() {
     app.update();
 
     // Check resulting changes
-    assert!(app.world.get::<Enemy>(enemy_id).is_none());
     assert!(app.world.get::<Enemy>(enemy_id).is_none());
 }
 

--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -164,12 +164,12 @@ fn update_score_on_event() {
     // Get `EnemyDied` event reader
     let enemy_died_events = app.world.resource::<Events<EnemyDied>>();
     let mut enemy_died_reader = enemy_died_events.get_reader();
-    let enemy_died = enemy_died_reader.iter(&enemy_died_events).next().unwrap();
+    let enemy_died = enemy_died_reader.iter(enemy_died_events).next().unwrap();
 
     // Check the event has been sent
     assert_eq!(enemy_died.0, 3);
 
-    // Run to let the event be processed
+    // Run systems again to let the event be processed
     app.update();
 
     // Check resulting changes

--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -1,14 +1,30 @@
-use bevy::prelude::*;
+use bevy::{ecs::event::Events, prelude::*};
 
 #[derive(Component, Default)]
 struct Enemy {
     hit_points: u32,
+    score_value: u32,
 }
 
-fn despawn_dead_enemies(mut commands: Commands, enemies: Query<(Entity, &Enemy)>) {
+struct EnemyDied(u32);
+
+struct Score(u32);
+
+fn update_score(mut dead_enemies: EventReader<EnemyDied>, mut score: ResMut<Score>) {
+    for value in dead_enemies.iter() {
+        score.0 += value.0;
+    }
+}
+
+fn despawn_dead_enemies(
+    mut commands: Commands,
+    mut dead_enemies: EventWriter<EnemyDied>,
+    enemies: Query<(Entity, &Enemy)>,
+) {
     for (entity, enemy) in enemies.iter() {
         if enemy.hit_points == 0 {
             commands.entity(entity).despawn_recursive();
+            dead_enemies.send(EnemyDied(enemy.score_value));
         }
     }
 }
@@ -21,49 +37,76 @@ fn hurt_enemies(mut enemies: Query<&mut Enemy>) {
 
 fn spawn_enemy(mut commands: Commands, keyboard_input: Res<Input<KeyCode>>) {
     if keyboard_input.just_pressed(KeyCode::Space) {
-        commands.spawn().insert(Enemy { hit_points: 5 });
+        commands.spawn().insert(Enemy {
+            hit_points: 5,
+            score_value: 3,
+        });
     }
 }
 
 #[test]
 fn did_hurt_enemy() {
-    // Setup world
-    let mut world = World::default();
+    // Setup app
+    let mut app = App::new();
 
-    // Setup stage with our two systems
-    let mut update_stage = SystemStage::parallel();
-    update_stage.add_system(hurt_enemies.before(despawn_dead_enemies));
-    update_stage.add_system(despawn_dead_enemies);
+    // Add Score resource
+    app.insert_resource(Score(0));
+
+    // Add `EnemyDied` event
+    app.add_event::<EnemyDied>();
+
+    // Add our two systems
+    app.add_system(hurt_enemies.before(despawn_dead_enemies));
+    app.add_system(despawn_dead_enemies);
 
     // Setup test entities
-    let enemy_id = world.spawn().insert(Enemy { hit_points: 5 }).id();
+    let enemy_id = app
+        .world
+        .spawn()
+        .insert(Enemy {
+            hit_points: 5,
+            score_value: 3,
+        })
+        .id();
 
     // Run systems
-    update_stage.run(&mut world);
+    app.update();
 
     // Check resulting changes
-    assert!(world.get::<Enemy>(enemy_id).is_some());
-    assert_eq!(world.get::<Enemy>(enemy_id).unwrap().hit_points, 4);
+    assert!(app.world.get::<Enemy>(enemy_id).is_some());
 }
 
 #[test]
 fn did_despawn_enemy() {
-    // Setup world
-    let mut world = World::default();
+    // Setup app
+    let mut app = App::new();
 
-    // Setup stage with our two systems
-    let mut update_stage = SystemStage::parallel();
-    update_stage.add_system(hurt_enemies.before(despawn_dead_enemies));
-    update_stage.add_system(despawn_dead_enemies);
+    // Add Score resource
+    app.insert_resource(Score(0));
+
+    // Add `EnemyDied` event
+    app.add_event::<EnemyDied>();
+
+    // Add our two systems
+    app.add_system(hurt_enemies.before(despawn_dead_enemies));
+    app.add_system(despawn_dead_enemies);
 
     // Setup test entities
-    let enemy_id = world.spawn().insert(Enemy { hit_points: 1 }).id();
+    let enemy_id = app
+        .world
+        .spawn()
+        .insert(Enemy {
+            hit_points: 1,
+            score_value: 1,
+        })
+        .id();
 
     // Run systems
-    update_stage.run(&mut world);
+    app.update();
 
     // Check resulting changes
-    assert!(world.get::<Enemy>(enemy_id).is_none());
+    assert!(app.world.get::<Enemy>(enemy_id).is_none());
+    assert!(app.world.get::<Enemy>(enemy_id).is_none());
 }
 
 #[test]
@@ -94,4 +137,41 @@ fn spawn_enemy_using_input_resource() {
 
     // Check resulting changes, no new entity has been spawned
     assert_eq!(world.query::<&Enemy>().iter(&world).len(), 1);
+}
+
+#[test]
+fn update_score_on_event() {
+    // Setup app
+    let mut app = App::new();
+
+    // Add Score resource
+    app.insert_resource(Score(0));
+
+    // Add `EnemyDied` event
+    app.add_event::<EnemyDied>();
+
+    // Add our systems
+    app.add_system(update_score);
+
+    // Send an `EnemyDied` event
+    app.world
+        .resource_mut::<Events<EnemyDied>>()
+        .send(EnemyDied(3));
+
+    // Run systems
+    app.update();
+
+    // Get `EnemyDied` event reader
+    let enemy_died_events = app.world.resource::<Events<EnemyDied>>();
+    let mut enemy_died_reader = enemy_died_events.get_reader();
+    let enemy_died = enemy_died_reader.iter(&enemy_died_events).next().unwrap();
+
+    // Check the event has been sent
+    assert_eq!(enemy_died.0, 3);
+
+    // Run to let the event be processed
+    app.update();
+
+    // Check resulting changes
+    assert_eq!(app.world.resource::<Score>().0, 3);
 }

--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -119,32 +119,31 @@ fn did_despawn_enemy() {
 
 #[test]
 fn spawn_enemy_using_input_resource() {
-    // Setup world
-    let mut world = World::default();
+    // Setup app
+    let mut app = App::new();
 
-    // Setup stage with a system
-    let mut update_stage = SystemStage::parallel();
-    update_stage.add_system(spawn_enemy);
+    // Add our systems
+    app.add_system(spawn_enemy);
 
     // Setup test resource
     let mut input = Input::<KeyCode>::default();
     input.press(KeyCode::Space);
-    world.insert_resource(input);
+    app.insert_resource(input);
 
     // Run systems
-    update_stage.run(&mut world);
+    app.update();
 
     // Check resulting changes, one entity has been spawned with `Enemy` component
-    assert_eq!(world.query::<&Enemy>().iter(&world).len(), 1);
+    assert_eq!(app.world.query::<&Enemy>().iter(&app.world).len(), 1);
 
     // Clear the `just_pressed` status for all `KeyCode`s
-    world.resource_mut::<Input<KeyCode>>().clear();
+    app.world.resource_mut::<Input<KeyCode>>().clear();
 
     // Run systems
-    update_stage.run(&mut world);
+    app.update();
 
     // Check resulting changes, no new entity has been spawned
-    assert_eq!(world.query::<&Enemy>().iter(&world).len(), 1);
+    assert_eq!(app.world.query::<&Enemy>().iter(&app.world).len(), 1);
 }
 
 #[test]


### PR DESCRIPTION
# Objective

- Adds an example of testing systems that handle events. I had a hard time figuring out how to do it a couple days ago so figured an official example could be useful.
- Fixes #4936

## Solution

- Adds a `Score` resource and an `EnemyDied` event. An `update_score` system updates the score when a new event comes through. I'm not sure the example is great, as this probably isn't how you'd do it in a real game, but I didn't want to change the existing example too much.
