### PR TITLE
[Merged by Bors] - use the default() method in examples instead of Default::default()

### DIFF
--- a/examples/2d/transparency_2d.rs
+++ b/examples/2d/transparency_2d.rs
@@ -17,25 +17,25 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     commands.spawn_bundle(SpriteBundle {
         texture: sprite_handle.clone(),
-        ..Default::default()
+        ..default()
     });
     commands.spawn_bundle(SpriteBundle {
         sprite: Sprite {
             // Alpha channel of the color controls transparency.
             color: Color::rgba(0.0, 0.0, 1.0, 0.7),
-            ..Default::default()
+            ..default()
         },
         texture: sprite_handle.clone(),
         transform: Transform::from_xyz(100.0, 0.0, 0.0),
-        ..Default::default()
+        ..default()
     });
     commands.spawn_bundle(SpriteBundle {
         sprite: Sprite {
             color: Color::rgba(0.0, 1.0, 0.0, 0.3),
-            ..Default::default()
+            ..default()
         },
         texture: sprite_handle,
         transform: Transform::from_xyz(200.0, 0.0, 0.0),
-        ..Default::default()
+        ..default()
     });
 }

--- a/examples/3d/shapes.rs
+++ b/examples/3d/shapes.rs
@@ -55,7 +55,7 @@ fn setup(
                     ),
                     ..default()
                 },
-                ..Default::default()
+                ..default()
             })
             .insert(Shape);
     }
@@ -65,22 +65,22 @@ fn setup(
             intensity: 9000.0,
             range: 100.,
             shadows_enabled: true,
-            ..Default::default()
+            ..default()
         },
         transform: Transform::from_xyz(8.0, 16.0, 8.0),
-        ..Default::default()
+        ..default()
     });
 
     // ground plane
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(shape::Plane { size: 50. }.into()),
         material: materials.add(Color::SILVER.into()),
-        ..Default::default()
+        ..default()
     });
 
     commands.spawn_bundle(Camera3dBundle {
         transform: Transform::from_xyz(0.0, 6., 12.0).looking_at(Vec3::new(0., 1., 0.), Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/3d/transparency_3d.rs
+++ b/examples/3d/transparency_3d.rs
@@ -25,7 +25,7 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Plane { size: 6.0 })),
         material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
-        ..Default::default()
+        ..default()
     });
     // transparent sphere, using alpha_mode: Mask
     commands.spawn_bundle(PbrBundle {
@@ -45,7 +45,7 @@ fn setup(
             ..default()
         }),
         transform: Transform::from_xyz(1.0, 0.5, -1.5),
-        ..Default::default()
+        ..default()
     });
     // transparent cube, using alpha_mode: Blend
     commands.spawn_bundle(PbrBundle {
@@ -55,7 +55,7 @@ fn setup(
         // automatically set to `Blend` if the alpha channel is anything lower than 1.0.
         material: materials.add(Color::rgba(0.5, 0.5, 1.0, 0.0).into()),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
-        ..Default::default()
+        ..default()
     });
     // sphere
     commands.spawn_bundle(PbrBundle {
@@ -65,22 +65,22 @@ fn setup(
         })),
         material: materials.add(Color::rgb(0.7, 0.2, 0.1).into()),
         transform: Transform::from_xyz(0.0, 0.5, -1.5),
-        ..Default::default()
+        ..default()
     });
     // light
     commands.spawn_bundle(PointLightBundle {
         point_light: PointLight {
             intensity: 1500.0,
             shadows_enabled: true,
-            ..Default::default()
+            ..default()
         },
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
-        ..Default::default()
+        ..default()
     });
     // camera
     commands.spawn_bundle(Camera3dBundle {
         transform: Transform::from_xyz(-2.0, 3.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -35,7 +35,7 @@ fn setup(
     commands.spawn_bundle(Camera3dBundle {
         transform: Transform::from_xyz(100.0, 100.0, 150.0)
             .looking_at(Vec3::new(0.0, 20.0, 0.0), Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 
     // Plane

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -18,7 +18,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .insert_resource(AmbientLight {
             brightness: 1.0,
-            ..Default::default()
+            ..default()
         })
         .add_startup_system(setup)
         .add_system(joint_animation)
@@ -152,7 +152,7 @@ fn setup(
                     )
                     .into(),
                 ),
-                ..Default::default()
+                ..default()
             })
             .insert(SkinnedMesh {
                 inverse_bindposes: inverse_bindposes.clone(),

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -10,7 +10,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .insert_resource(AmbientLight {
             brightness: 1.0,
-            ..Default::default()
+            ..default()
         })
         .add_startup_system(setup)
         .add_system(joint_animation)

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -148,7 +148,7 @@ fn setup(
     commands.spawn_bundle(Camera3dBundle {
         transform: Transform::from_translation(translation)
             .looking_at(0.2 * Vec3::new(translation.x, 0.0, translation.z), Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 
     // Plane

--- a/examples/transforms/3d_rotation.rs
+++ b/examples/transforms/3d_rotation.rs
@@ -31,20 +31,20 @@ fn setup(
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::WHITE.into()),
             transform: Transform::from_translation(Vec3::ZERO),
-            ..Default::default()
+            ..default()
         })
         .insert(Rotatable { speed: 0.3 });
 
     // Spawn a camera looking at the entities to show what's happening in this example.
     commands.spawn_bundle(Camera3dBundle {
         transform: Transform::from_xyz(0.0, 10.0, 20.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 
     // Add a light source for better 3d visibility.
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::ONE * 3.0),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/transforms/global_vs_local_translation.rs
+++ b/examples/transforms/global_vs_local_translation.rs
@@ -55,7 +55,7 @@ fn setup(
         .insert_bundle(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::YELLOW.into()),
-            ..Default::default()
+            ..default()
         })
         .insert(ChangeGlobal)
         .insert(Move)
@@ -71,7 +71,7 @@ fn setup(
                 mesh: meshes.add(Mesh::from(shape::Cube { size: 0.5 })),
                 material: materials.add(Color::RED.into()),
                 transform: Transform::from_translation(Vec3::Y - Vec3::Z),
-                ..Default::default()
+                ..default()
             })
             .insert(ChangeGlobal)
             .insert(Move)
@@ -81,7 +81,7 @@ fn setup(
                 mesh: meshes.add(Mesh::from(shape::Cube { size: 0.5 })),
                 material: materials.add(Color::GREEN.into()),
                 transform: Transform::from_translation(Vec3::Y + Vec3::Z),
-                ..Default::default()
+                ..default()
             })
             .insert(ChangeLocal)
             .insert(Move)
@@ -91,13 +91,13 @@ fn setup(
     // Spawn a camera looking at the entities to show what's happening in this example.
     commands.spawn_bundle(Camera3dBundle {
         transform: Transform::from_xyz(0.0, 10.0, 20.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 
     // Add a light source for better 3d visibility.
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::splat(3.0)),
-        ..Default::default()
+        ..default()
     });
 
     // Add text to explain inputs and what is happening.
@@ -115,10 +115,10 @@ The red cube is moved through its GlobalTransform and thus is unaffected by the 
             },
             TextAlignment {
                 horizontal: HorizontalAlign::Left,
-                ..Default::default()
+                ..default()
             },
         ),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/transforms/scale.rs
+++ b/examples/transforms/scale.rs
@@ -46,20 +46,20 @@ fn setup(
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::WHITE.into()),
             transform: Transform::from_rotation(Quat::from_rotation_y(PI / 4.0)),
-            ..Default::default()
+            ..default()
         })
         .insert(Scaling::new());
 
     // Spawn a camera looking at the entities to show what's happening in this example.
     commands.spawn_bundle(Camera3dBundle {
         transform: Transform::from_xyz(0.0, 10.0, 20.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 
     // Add a light source for better 3d visibility.
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::ONE * 3.0),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/transforms/transform.rs
+++ b/examples/transforms/transform.rs
@@ -46,7 +46,7 @@ fn setup(
             })),
             material: materials.add(Color::YELLOW.into()),
             transform: Transform::from_translation(Vec3::ZERO),
-            ..Default::default()
+            ..default()
         })
         .insert(Center {
             max_size: 1.0,
@@ -67,7 +67,7 @@ fn setup(
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::WHITE.into()),
             transform: cube_spawn,
-            ..Default::default()
+            ..default()
         })
         .insert(CubeState {
             start_pos: cube_spawn.translation,
@@ -78,13 +78,13 @@ fn setup(
     // Spawn a camera looking at the entities to show what's happening in this example.
     commands.spawn_bundle(Camera3dBundle {
         transform: Transform::from_xyz(0.0, 10.0, 20.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 
     // Add a light source for better 3d visibility.
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::ONE * 3.0),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/transforms/translation.rs
+++ b/examples/transforms/translation.rs
@@ -43,20 +43,20 @@ fn setup(
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::WHITE.into()),
             transform: Transform::from_translation(entity_spawn),
-            ..Default::default()
+            ..default()
         })
         .insert(Movable::new(entity_spawn));
 
     // Spawn a camera looking at the entities to show what's happening in this example.
     commands.spawn_bundle(Camera3dBundle {
         transform: Transform::from_xyz(0.0, 10.0, 20.0).looking_at(entity_spawn, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 
     // Add a light source for better 3d visibility.
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::ONE * 3.0),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/ui/transparency_ui.rs
+++ b/examples/ui/transparency_ui.rs
@@ -23,10 +23,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 margin: UiRect::all(Val::Auto),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
-                ..Default::default()
+                ..default()
             },
             color: Color::rgb(0.1, 0.5, 0.1).into(),
-            ..Default::default()
+            ..default()
         })
         .with_children(|parent| {
             parent.spawn_bundle(TextBundle {
@@ -40,7 +40,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     },
                     Default::default(),
                 ),
-                ..Default::default()
+                ..default()
             });
         });
 
@@ -53,10 +53,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 margin: UiRect::all(Val::Auto),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
-                ..Default::default()
+                ..default()
             },
             color: Color::rgb(0.5, 0.1, 0.5).into(),
-            ..Default::default()
+            ..default()
         })
         .with_children(|parent| {
             parent.spawn_bundle(TextBundle {
@@ -70,7 +70,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     },
                     Default::default(),
                 ),
-                ..Default::default()
+                ..default()
             });
         });
 }

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -162,7 +162,7 @@ pub(crate) mod test_setup {
         });
         commands.spawn_bundle(Camera3dBundle {
             transform: Transform::from_xyz(-2.0, 2.0, 2.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..Default::default()
+            ..default()
         });
         event.send(RequestRedraw);
         commands
@@ -173,9 +173,9 @@ pub(crate) mod test_setup {
                     position: UiRect {
                         top: Val::Px(5.0),
                         left: Val::Px(5.0),
-                        ..Default::default()
+                        ..default()
                     },
-                    ..Default::default()
+                    ..default()
                 },
                 text: Text {
                     sections: vec![
@@ -214,7 +214,7 @@ pub(crate) mod test_setup {
                     ],
                     alignment: TextAlignment::default(),
                 },
-                ..Default::default()
+                ..default()
             })
             .insert(ModeText);
     }


### PR DESCRIPTION
# Objective

- Use the `..default()` method in examples instead of `..Default::default()`
