### PR TITLE
[Merged by Bors] - Recommend posting new plugins in #crates discord channel

### DIFF
--- a/docs/plugins_guidelines.md
+++ b/docs/plugins_guidelines.md
@@ -113,5 +113,5 @@ Once a crate is published to [crates.io](https://crates.io), there are two badge
 You can promote your plugin in Bevy's [communities](https://github.com/bevyengine/bevy#community):
 
 * Add it as an [Asset on the official website](https://github.com/bevyengine/bevy-assets)
-* Announce it on [Discord](https://discord.gg/bevy), in the `#showcase` channel
+* Announce it on [Discord](https://discord.gg/bevy), in the `#crates` channel
 * Announce it on [Reddit](https://reddit.com/r/bevy)


### PR DESCRIPTION
# Objective

- Guide people to the right discord channel to post about their new plugin. #showcase was split into multiple channels.

## Solution

- recommend posting in #crates