### PR TITLE
[Merged by Bors] - Add benchmarks for schedule dependency resolution

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,6 +11,7 @@ glam = "0.20"
 rand = "0.8"
 rand_chacha = "0.3"
 criterion = { version = "0.3", features = ["html_reports"] }
+bevy_app = { path = "../crates/bevy_app" }
 bevy_ecs = { path = "../crates/bevy_ecs" }
 bevy_reflect = { path = "../crates/bevy_reflect" }
 bevy_tasks = { path = "../crates/bevy_tasks" }
@@ -44,6 +45,11 @@ harness = false
 [[bench]]
 name = "world_get"
 path = "benches/bevy_ecs/world_get.rs"
+harness = false
+
+[[bench]]
+name = "schedule"
+path = "benches/bevy_ecs/schedule.rs"
 harness = false
 
 [[bench]]

--- a/benches/benches/bevy_ecs/schedule.rs
+++ b/benches/benches/bevy_ecs/schedule.rs
@@ -16,7 +16,7 @@ fn build_schedule(criterion: &mut Criterion) {
         group.bench_function(format!("{graph_size}_schedule_noconstraints"), |bencher| {
             bencher.iter(|| {
                 let mut app = App::new();
-                for i in 0..graph_size {
+                for _ in 0..graph_size {
                     // empty system
                     fn sys() {}
                     app.add_system(sys);
@@ -57,7 +57,7 @@ fn build_schedule(criterion: &mut Criterion) {
                             sys.after(OddLabel(a))
                         }
                     }
-                    for b in 0..i {
+                    for b in i + 1..graph_size {
                         sys = if b % 2 == 0 {
                             sys.before(EvenLabel(b))
                         } else {
@@ -66,6 +66,7 @@ fn build_schedule(criterion: &mut Criterion) {
                     }
                     app.add_system(sys);
                 }
+                app.run();
             });
         });
     }

--- a/benches/benches/bevy_ecs/schedule.rs
+++ b/benches/benches/bevy_ecs/schedule.rs
@@ -6,9 +6,24 @@ criterion_group!(benches, build_schedule);
 criterion_main!(benches);
 
 fn build_schedule(criterion: &mut Criterion) {
+    // empty system
+    fn sys() {}
+
+    // Use multiple different kinds of label to ensure that dynamic dispatch
+    // doesn't somehow get optimized away.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemLabel)]
+    struct NumLabel(usize);
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemLabel)]
+    struct DummyLabel;
+
     let mut group = criterion.benchmark_group("build_schedule");
     group.warm_up_time(std::time::Duration::from_millis(500));
     group.measurement_time(std::time::Duration::from_secs(15));
+
+    // Method: generate a set of `graph_size` systems which have a One True Ordering.
+    // Add system to the stage with full constraints. Hopefully this should be maximimally
+    // difficult for bevy to figure out.
+    let labels: Vec<_> = (0..1000).map(NumLabel).collect();
 
     // Benchmark graphs of different sizes.
     for graph_size in [100, 500, 1000] {
@@ -17,52 +32,24 @@ fn build_schedule(criterion: &mut Criterion) {
             bencher.iter(|| {
                 let mut app = App::new();
                 for _ in 0..graph_size {
-                    // empty system
-                    fn sys() {}
                     app.add_system(sys);
                 }
+                app.run();
             });
         });
+
         // Benchmark with constraints.
         group.bench_function(format!("{graph_size}_schedule"), |bencher| {
             bencher.iter(|| {
-                // empty system
-                fn sys() {}
-
-                // Use multiple different kinds of label;
-                #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemLabel)]
-                struct EvenLabel(usize);
-                #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemLabel)]
-                struct OddLabel(usize);
-
-                // unique label
-                #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemLabel)]
-                struct NumLabel(usize);
-
-                // Method: generate a set of `graph_size` systems which have a One True Ordering.
-                // Add system to the stage with full constraints. Hopefully this should be maximimally
-                // difficult for bevy to figure out.
-
                 let mut app = App::new();
+                app.add_system(sys.label(DummyLabel));
                 for i in 0..graph_size {
-                    let mut sys = if i % 2 == 0 {
-                        sys.label(EvenLabel(i))
-                    } else {
-                        sys.label(OddLabel(i))
-                    };
+                    let mut sys = sys.label(labels[i]).before(DummyLabel);
                     for a in 0..i {
-                        sys = if a % 2 == 0 {
-                            sys.after(EvenLabel(a))
-                        } else {
-                            sys.after(OddLabel(a))
-                        }
+                        sys = sys.after(labels[a]);
                     }
                     for b in i + 1..graph_size {
-                        sys = if b % 2 == 0 {
-                            sys.before(EvenLabel(b))
-                        } else {
-                            sys.before(OddLabel(b))
-                        }
+                        sys = sys.before(labels[b]);
                     }
                     app.add_system(sys);
                 }

--- a/benches/benches/bevy_ecs/schedule.rs
+++ b/benches/benches/bevy_ecs/schedule.rs
@@ -1,0 +1,74 @@
+use bevy_app::App;
+use bevy_ecs::prelude::*;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+criterion_group!(benches, build_schedule);
+criterion_main!(benches);
+
+fn build_schedule(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("build_schedule");
+    group.warm_up_time(std::time::Duration::from_millis(500));
+    group.measurement_time(std::time::Duration::from_secs(15));
+
+    // Benchmark graphs of different sizes.
+    for graph_size in [100, 500, 1000, 5000] {
+        // Basic benchmark without constraints.
+        group.bench_function(format!("{graph_size}_schedule_noconstraints"), |bencher| {
+            bencher.iter(|| {
+                let mut app = App::new();
+                for i in 0..graph_size {
+                    // empty system
+                    fn sys() {}
+                    app.add_system(sys);
+                }
+            });
+        });
+        // Benchmark with constraints.
+        group.bench_function(format!("{graph_size}_schedule"), |bencher| {
+            bencher.iter(|| {
+                // empty system
+                fn sys() {}
+
+                // Use multiple different kinds of label;
+                #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemLabel)]
+                struct EvenLabel(usize);
+                #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemLabel)]
+                struct OddLabel(usize);
+
+                // unique label
+                #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemLabel)]
+                struct NumLabel(usize);
+
+                // Method: generate a set of `graph_size` systems which have a One True Ordering.
+                // Add system to the stage with full constraints. Hopefully this should be maximimally
+                // difficult for bevy to figure out.
+
+                let mut app = App::new();
+                for i in 0..graph_size {
+                    let mut sys = if i % 2 == 0 {
+                        sys.label(EvenLabel(i))
+                    } else {
+                        sys.label(OddLabel(i))
+                    };
+                    for a in 0..i {
+                        sys = if a % 2 == 0 {
+                            sys.after(EvenLabel(a))
+                        } else {
+                            sys.after(OddLabel(a))
+                        }
+                    }
+                    for b in 0..i {
+                        sys = if b % 2 == 0 {
+                            sys.before(EvenLabel(b))
+                        } else {
+                            sys.before(OddLabel(b))
+                        }
+                    }
+                    app.add_system(sys);
+                }
+            });
+        });
+    }
+
+    group.finish();
+}

--- a/benches/benches/bevy_ecs/schedule.rs
+++ b/benches/benches/bevy_ecs/schedule.rs
@@ -11,7 +11,7 @@ fn build_schedule(criterion: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(15));
 
     // Benchmark graphs of different sizes.
-    for graph_size in [100, 500, 1000, 5000] {
+    for graph_size in [100, 500, 1000] {
         // Basic benchmark without constraints.
         group.bench_function(format!("{graph_size}_schedule_noconstraints"), |bencher| {
             bencher.iter(|| {

--- a/benches/benches/bevy_ecs/schedule.rs
+++ b/benches/benches/bevy_ecs/schedule.rs
@@ -34,7 +34,7 @@ fn build_schedule(criterion: &mut Criterion) {
                 for _ in 0..graph_size {
                     app.add_system(sys);
                 }
-                app.run();
+                app.update();
             });
         });
 
@@ -53,7 +53,7 @@ fn build_schedule(criterion: &mut Criterion) {
                     }
                     app.add_system(sys);
                 }
-                app.run();
+                app.update();
             });
         });
     }


### PR DESCRIPTION
# Objective

- Add benchmarks to test the performance of `Schedule`'s system dependency resolution.

## Solution

- Do a series of benchmarks while increasing the number of systems in the schedule to see how the run-time scales.
- Split the benchmarks into a group with no dependencies, and a group with many dependencies.