### PR TITLE
[Merged by Bors] - `transparency_3d` example tweaks

### DIFF
--- a/examples/3d/transparency_3d.rs
+++ b/examples/3d/transparency_3d.rs
@@ -18,13 +18,13 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    // Opaque plane
+    // opaque plane, uses `alpha_mode: Opaque` by default
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Plane { size: 6.0 })),
         material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
         ..default()
     });
-    // transparent sphere, using alpha_mode: Mask
+    // transparent sphere, uses `alpha_mode: Mask(f32)`
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Icosphere {
             radius: 0.5,
@@ -44,7 +44,7 @@ fn setup(
         transform: Transform::from_xyz(1.0, 0.5, -1.5),
         ..default()
     });
-    // transparent cube, using alpha_mode: Blend
+    // transparent cube, uses `alpha_mode: Blend`
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         // Notice how there is no need to set the `alpha_mode` explicitly here.
@@ -54,7 +54,7 @@ fn setup(
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });
-    // sphere
+    // opaque sphere
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Icosphere {
             radius: 0.5,

--- a/examples/3d/transparency_3d.rs
+++ b/examples/3d/transparency_3d.rs
@@ -87,10 +87,7 @@ fn setup(
 /// - `Mask(f32)`: Object appears when the alpha value goes above the mask's threshold, disappears
 ///                when the alpha value goes back below the threshold.
 /// - `Blend`: Object fades in and out smoothly.
-pub fn fade_transparency(
-    time: Res<Time>,
-    mut materials: ResMut<Assets<StandardMaterial>>
-) {
+pub fn fade_transparency(time: Res<Time>, mut materials: ResMut<Assets<StandardMaterial>>) {
     let alpha = (time.time_since_startup().as_secs_f32().sin() / 2.0) + 0.5;
     for (_, material) in materials.iter_mut() {
         material.base_color.set_a(alpha);

--- a/examples/3d/transparency_3d.rs
+++ b/examples/3d/transparency_3d.rs
@@ -13,9 +13,6 @@ fn main() {
         .run();
 }
 
-#[derive(Component)]
-pub struct FadeTransparency;
-
 fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,

--- a/examples/3d/transparency_3d.rs
+++ b/examples/3d/transparency_3d.rs
@@ -39,7 +39,7 @@ fn setup(
             // `fade_transparency` function.
             // Note that the transparency has no effect on the objects shadow.
             base_color: Color::rgba(0.2, 0.7, 0.1, 0.0),
-            // Maks sets a cutoff for transparency. Alpha values below are fully transparent,
+            // Mask sets a cutoff for transparency. Alpha values below are fully transparent,
             // alpha values above are fully opaque.
             alpha_mode: AlphaMode::Mask(0.5),
             ..default()
@@ -90,7 +90,10 @@ fn setup(
 /// - `Mask(f32)`: Object appears when the alpha value goes above the mask's threshold, disappears
 ///                when the alpha value goes back below the threshold.
 /// - `Blend`: Object fades in and out smoothly.
-pub fn fade_transparency(time: Res<Time>, mut materials: ResMut<Assets<StandardMaterial>>) {
+pub fn fade_transparency(
+    time: Res<Time>,
+    mut materials: ResMut<Assets<StandardMaterial>>
+) {
     let alpha = (time.time_since_startup().as_secs_f32().sin() / 2.0) + 0.5;
     for (_, material) in materials.iter_mut() {
         material.base_color.set_a(alpha);


### PR DESCRIPTION
Fixed a typo, removed unused component, normalized comments added a touch more detail.