### PR TITLE
Add warnings for if a plugin is inserted twice

### DIFF
--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -1,6 +1,6 @@
-use crate::{App, Plugin};
-use bevy_utils::{tracing::debug, tracing::warn, HashMap};
-use std::any::TypeId;
+use crate::{AddedPluginsRegistry, App, Plugin};
+use bevy_utils::{tracing::debug, tracing::warn, HashMap, HashSet};
+use std::any::{Any, TypeId};
 
 /// Combines multiple [`Plugin`]s into a single unit.
 pub trait PluginGroup {
@@ -132,6 +132,14 @@ impl PluginGroupBuilder {
             if let Some(entry) = self.plugins.get(ty) {
                 if entry.enabled {
                     debug!("added plugin: {}", entry.plugin.name());
+                    if !app
+                        .world
+                        .get_resource_or_insert_with(|| AddedPluginsRegistry(HashSet::new()))
+                        .0
+                        .insert(entry.type_id())
+                    {
+                        warn!("Plugin {} inserted twice!", entry.plugin.name());
+                    }
                     entry.plugin.build(app);
                 }
             }


### PR DESCRIPTION
# Objective

A plugin being inserted multiple times can cause very subtle bugs that are hard to track down

## Solution

Issue a warning if the same plugin is ever inserted multiple times to make tracking down such bugs easier.