### PR TITLE
Add way to insert components to loaded scenes

### DIFF
--- a/crates/bevy_scene/src/bundle.rs
+++ b/crates/bevy_scene/src/bundle.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 
-use crate::{DynamicScene, InstanceId, Scene, SceneSpawner};
+use crate::{DynamicScene, InstanceId, Scene, SceneHook, SceneSpawner};
 
 /// [`InstanceId`] of a spawned scene. It can be used with the [`SceneSpawner`] to
 /// interact with the spawned scene.
@@ -26,6 +26,7 @@ pub struct SceneBundle {
     pub scene: Handle<Scene>,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
+    pub hook: SceneHook,
 }
 
 /// A component bundle for a [`DynamicScene`] root.
@@ -38,6 +39,7 @@ pub struct DynamicSceneBundle {
     pub scene: Handle<DynamicScene>,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
+    pub hook: SceneHook,
 }
 
 /// System that will spawn scenes from [`SceneBundle`].

--- a/crates/bevy_scene/src/hook.rs
+++ b/crates/bevy_scene/src/hook.rs
@@ -1,0 +1,174 @@
+//! Systems to insert components on loaded scenes.
+//!
+//! Please see the [`SceneHook`] documentation for detailed examples.
+
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    prelude::{Without, World},
+    system::{Commands, EntityCommands, Query, Res},
+    world::EntityRef,
+};
+
+use crate::{SceneInstance, SceneSpawner};
+
+/// Marker Component for scenes that were hooked.
+#[derive(Component)]
+#[non_exhaustive]
+pub struct SceneHooked;
+
+/// Add this as a component to any entity to trigger `hook`'s
+/// [`Hook::hook_entity`] method when the scene is loaded.
+///
+/// You can use it to add your own non-serializable components to entites
+/// present in a scene file.
+///
+/// A typical usage is adding animation, physics collision data or marker
+/// components to a scene spawned from a file format that do not support it.
+///
+/// # Example
+///
+///  ```rust
+/// # use bevy_ecs::{system::Res, component::Component, system::Commands};
+/// # use bevy_asset::AssetServer;
+/// # use bevy_utils::default;
+/// use bevy_scene::{Hook, SceneHook, SceneBundle};
+/// # #[derive(Component)]
+/// # struct Name; impl Name { fn as_str(&self) -> &str { todo!() } }
+/// enum PileType { Drawing }
+///
+/// #[derive(Component)]
+/// struct Pile(PileType);
+///
+/// #[derive(Component)]
+/// struct Card;
+///
+/// fn load_scene(mut cmds: Commands, asset_server: Res<AssetServer>) {
+///     cmds.spawn_bundle(SceneBundle {
+///         scene: asset_server.load("scene.glb#Scene0"),
+///         hook: SceneHook::new_fn(|entity, cmds| {
+///             match entity.get::<Name>().map(|t|t.as_str()) {
+///                 Some("Pile") => cmds.insert(Pile(PileType::Drawing)),
+///                 Some("Card") => cmds.insert(Card),
+///                 _ => cmds,
+///             };
+///         }),
+///         ..default()
+///     });
+/// }
+/// ```
+#[derive(Component)]
+pub struct SceneHook {
+    hook: Box<dyn Hook>,
+}
+impl Default for SceneHook {
+    fn default() -> Self {
+        Self { hook: Box::new(()) }
+    }
+}
+impl<T: Hook> From<T> for SceneHook {
+    fn from(hook: T) -> Self {
+        Self::new(hook)
+    }
+}
+impl SceneHook {
+    /// Add a hook to a scene, to run for each entities when the scene is
+    /// loaded, closures implement `Hook`.
+    ///
+    ///  You can also implement [`Hook`] on your own types and provide one. Note
+    ///  that strictly speaking, you might as well pass a closure. Please check
+    ///  the [`Hook`] trait documentation for details.
+    pub fn new<T: Hook>(hook: T) -> Self {
+        let hook = Box::new(hook);
+        Self { hook }
+    }
+
+    /// Same as [`Self::new`] but with type bounds to make it easier to
+    /// use a closure.
+    pub fn new_fn<F: Fn(&EntityRef, &mut EntityCommands) + Send + Sync + 'static>(hook: F) -> Self {
+        Self::new(hook)
+    }
+
+    /// Add a closure with component parameter as hook.
+    ///
+    /// This is useful if you only care about a specific component to identify
+    /// individual entities of your scene, rather than every possible components.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use bevy_ecs::{
+    ///     world::EntityRef, component::Component,
+    ///     system::{Commands, Res, EntityCommands}
+    /// # };
+    /// # use bevy_asset::{AssetServer, Handle};
+    /// # use bevy_utils::default;
+    /// # use bevy_scene::Scene;
+    /// use bevy_scene::{Hook, SceneHook, SceneBundle};
+    /// # #[derive(Component)] struct Name;
+    /// # type DeckData = Scene;
+    /// #[derive(Clone)]
+    /// struct DeckAssets { player: Handle<DeckData>, oppo: Handle<DeckData> }
+    ///
+    /// fn hook(decks: &DeckAssets, name: &Name, cmds: &mut EntityCommands) {}
+    /// fn load_scene(mut cmds: Commands, decks: Res<DeckAssets>, assets: Res<AssetServer>) {
+    ///     let decks = decks.clone();
+    ///     cmds.spawn_bundle(SceneBundle {
+    ///         scene: assets.load("scene.glb#Scene0"),
+    ///         hook: SceneHook::new_comp(move |name, cmds| hook(&decks, name, cmds)),
+    ///         ..default()
+    ///     });
+    /// }
+    /// ```
+    pub fn new_comp<C, F>(hook: F) -> Self
+    where
+        F: Fn(&C, &mut EntityCommands) + Send + Sync + 'static,
+        C: Component,
+    {
+        let hook = move |e: &EntityRef, cmds: &mut EntityCommands| match e.get::<C>() {
+            Some(comp) => hook(comp, cmds),
+            None => {}
+        };
+        Self::new(hook)
+    }
+}
+
+/// Handle adding components to entites named in a loaded scene.
+///
+/// The [`hook_entity`][Hook::hook_entity] method is called once per Entity
+/// added in a scene in the [`run_hooks`] system.
+pub trait Hook: Send + Sync + 'static {
+    /// Add [`Component`]s or do anything with entity in the spawned scene
+    /// refered by `entity_ref`.
+    ///
+    /// This runs once for all entities in the spawned scene, once loaded.
+    fn hook_entity(&self, entity_ref: &EntityRef, commands: &mut EntityCommands);
+}
+
+/// Run once [`SceneHook`]s added to [`SceneBundle`](crate::SceneBundle) or
+/// [`DynamicSceneBundle`](crate::DynamicSceneBundle) when the scenes are loaded.
+pub fn run_hooks(
+    unloaded_instances: Query<(Entity, &SceneInstance, &SceneHook), Without<SceneHooked>>,
+    scene_manager: Res<SceneSpawner>,
+    world: &World,
+    mut cmds: Commands,
+) {
+    for (entity, instance, hooked) in unloaded_instances.iter() {
+        if let Some(entities) = scene_manager.iter_instance_entities(**instance) {
+            for entity_ref in entities.filter_map(|e| world.get_entity(e)) {
+                let mut cmd = cmds.entity(entity_ref.id());
+                hooked.hook.hook_entity(&entity_ref, &mut cmd);
+            }
+            cmds.entity(entity).insert(SceneHooked);
+        }
+    }
+}
+impl<F: Fn(&EntityRef, &mut EntityCommands) + Send + Sync + 'static> Hook for F {
+    fn hook_entity(&self, entity_ref: &EntityRef, commands: &mut EntityCommands) {
+        (self)(entity_ref, commands);
+    }
+}
+// This is useful for the `Default` implementation of `SceneBundle`
+impl Hook for () {
+    fn hook_entity(&self, _: &EntityRef, _: &mut EntityCommands) {}
+}

--- a/crates/bevy_scene/src/hook.rs
+++ b/crates/bevy_scene/src/hook.rs
@@ -17,8 +17,8 @@ use crate::{SceneInstance, SceneSpawner};
 #[non_exhaustive]
 pub struct SceneHooked;
 
-/// Add this as a component to any entity to trigger `hook`'s
-/// [`Hook::hook_entity`] method when the scene is loaded.
+/// Add this as a component to any entity to run `hook`
+/// when the scene is loaded.
 ///
 /// You can use it to add your own non-serializable components to entites
 /// present in a scene file.
@@ -32,7 +32,7 @@ pub struct SceneHooked;
 /// # use bevy_ecs::{system::Res, component::Component, system::Commands};
 /// # use bevy_asset::AssetServer;
 /// # use bevy_utils::default;
-/// use bevy_scene::{Hook, SceneHook, SceneBundle};
+/// use bevy_scene::{SceneHook, SceneBundle};
 /// # #[derive(Component)]
 /// # struct Name; impl Name { fn as_str(&self) -> &str { todo!() } }
 /// enum PileType { Drawing }
@@ -46,7 +46,7 @@ pub struct SceneHooked;
 /// fn load_scene(mut cmds: Commands, asset_server: Res<AssetServer>) {
 ///     cmds.spawn_bundle(SceneBundle {
 ///         scene: asset_server.load("scene.glb#Scene0"),
-///         hook: SceneHook::new_fn(|entity, cmds| {
+///         hook: SceneHook::new(|entity, cmds| {
 ///             match entity.get::<Name>().map(|t|t.as_str()) {
 ///                 Some("Pile") => cmds.insert(Pile(PileType::Drawing)),
 ///                 Some("Card") => cmds.insert(Card),
@@ -59,36 +59,14 @@ pub struct SceneHooked;
 /// ```
 #[derive(Component, Default)]
 pub struct SceneHook {
-    hook: Option<Box<dyn Hook>>,
-}
-impl<T: Hook> From<T> for SceneHook {
-    fn from(hook: T) -> Self {
-        Self::new(hook)
-    }
+    hook: Option<Box<dyn Fn(&EntityRef, &mut EntityCommands) + Send + Sync + 'static>>,
 }
 impl SceneHook {
     /// Add a hook to a scene, to run for each entities when the scene is
-    /// loaded, closures implement `Hook`.
+    /// loaded.
     ///
-    ///  You can also implement [`Hook`] on your own types and provide one. Note
-    ///  that strictly speaking, you might as well pass a closure. Please check
-    ///  the [`Hook`] trait documentation for details.
-    pub fn new<T: Hook>(hook: T) -> Self {
-        Self {
-            hook: Some(Box::new(hook)),
-        }
-    }
-
-    /// Same as [`Self::new`] but with type bounds to make it easier to
-    /// use a closure.
-    pub fn new_fn<F: Fn(&EntityRef, &mut EntityCommands) + Send + Sync + 'static>(hook: F) -> Self {
-        Self::new(hook)
-    }
-
-    /// Add a closure with component parameter as hook.
-    ///
-    /// This is useful if you only care about a specific component to identify
-    /// individual entities of your scene, rather than every possible components.
+    /// The hook adds [`Component`]s or do anything with entity in the spawned
+    /// scene refered by `EntityRef`.
     ///
     /// # Example
     ///
@@ -100,45 +78,27 @@ impl SceneHook {
     /// # use bevy_asset::{AssetServer, Handle};
     /// # use bevy_utils::default;
     /// # use bevy_scene::Scene;
-    /// use bevy_scene::{Hook, SceneHook, SceneBundle};
+    /// use bevy_scene::{SceneHook, SceneBundle};
     /// # #[derive(Component)] struct Name;
     /// # type DeckData = Scene;
     /// #[derive(Clone)]
     /// struct DeckAssets { player: Handle<DeckData>, oppo: Handle<DeckData> }
     ///
-    /// fn hook(decks: &DeckAssets, name: &Name, cmds: &mut EntityCommands) {}
+    /// fn hook(decks: &DeckAssets, entity: &EntityRef, cmds: &mut EntityCommands) {}
     /// fn load_scene(mut cmds: Commands, decks: Res<DeckAssets>, assets: Res<AssetServer>) {
     ///     let decks = decks.clone();
     ///     cmds.spawn_bundle(SceneBundle {
     ///         scene: assets.load("scene.glb#Scene0"),
-    ///         hook: SceneHook::new_comp(move |name, cmds| hook(&decks, name, cmds)),
+    ///         hook: SceneHook::new(move |entity, cmds| hook(&decks, entity, cmds)),
     ///         ..default()
     ///     });
     /// }
     /// ```
-    pub fn new_comp<C, F>(hook: F) -> Self
-    where
-        F: Fn(&C, &mut EntityCommands) + Send + Sync + 'static,
-        C: Component,
-    {
-        let hook = move |e: &EntityRef, cmds: &mut EntityCommands| match e.get::<C>() {
-            Some(comp) => hook(comp, cmds),
-            None => {}
-        };
-        Self::new(hook)
+    pub fn new<F: Fn(&EntityRef, &mut EntityCommands) + Send + Sync + 'static>(hook: F) -> Self {
+        Self {
+            hook: Some(Box::new(hook)),
+        }
     }
-}
-
-/// Handle adding components to entites named in a loaded scene.
-///
-/// The [`hook_entity`][Hook::hook_entity] method is called once per Entity
-/// added in a scene in the [`run_hooks`] system.
-pub trait Hook: Send + Sync + 'static {
-    /// Add [`Component`]s or do anything with entity in the spawned scene
-    /// refered by `entity_ref`.
-    ///
-    /// This runs once for all entities in the spawned scene, once loaded.
-    fn hook_entity(&self, entity_ref: &EntityRef, commands: &mut EntityCommands);
 }
 
 /// Run once [`SceneHook`]s added to [`SceneBundle`](crate::SceneBundle) or
@@ -154,15 +114,10 @@ pub fn run_hooks(
             if let Some(hook) = hooked.hook.as_deref() {
                 for entity_ref in entities.filter_map(|e| world.get_entity(e)) {
                     let mut cmd = cmds.entity(entity_ref.id());
-                    hook.hook_entity(&entity_ref, &mut cmd);
+                    hook(&entity_ref, &mut cmd);
                 }
             }
             cmds.entity(entity).insert(SceneHooked);
         }
-    }
-}
-impl<F: Fn(&EntityRef, &mut EntityCommands) + Send + Sync + 'static> Hook for F {
-    fn hook_entity(&self, entity_ref: &EntityRef, commands: &mut EntityCommands) {
-        (self)(entity_ref, commands);
     }
 }

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1,5 +1,6 @@
 mod bundle;
 mod dynamic_scene;
+mod hook;
 mod scene;
 mod scene_loader;
 mod scene_spawner;
@@ -7,6 +8,7 @@ pub mod serde;
 
 pub use bundle::*;
 pub use dynamic_scene::*;
+pub use hook::*;
 pub use scene::*;
 pub use scene_loader::*;
 pub use scene_spawner::*;
@@ -33,6 +35,7 @@ impl Plugin for ScenePlugin {
                 CoreStage::PreUpdate,
                 scene_spawner_system.exclusive_system().at_end(),
             )
+            .add_system_to_stage(CoreStage::PreUpdate, run_hooks)
             // Systems `*_bundle_spawner` must run before `scene_spawner_system`
             .add_system_to_stage(CoreStage::PreUpdate, scene_spawner);
     }


### PR DESCRIPTION
This adds the `hook` field to `SceneBundle`. The `hook` is a
`SceneHook`, which accepts a closure, that is ran once per entity in the
scene. The closure can use the `EntityRef` argument to check components
the entity has, and use the `EntityCommands` to add components and
children to the entity.

This code is adapted from https://github.com/nicopap/bevy-scene-hook

# Objective

Simplify and streamline adding components to entities within scenes that were just loaded.

Often, when loading objects from a `glb` file or any scene format, we want to add custom ad-hoc components the scene format doesn't handle.

For example, when loading a 3d model, we might be interested in adding components to handle physics interactions or basic animation. We could also want to add marker components so that it's easier to work with the entities that were added to the world through the scene.

A good example of this pattern can be seen in the warlock's gambit source: https://github.com/team-plover/warlocks-gambit/blob/3f8132fbbd6cce124a1cd102755dad228035b2dc/src/scene.rs

Closes #4933 

## Solution

The solution involves running a function once per entity added to the scene. This has 3 requirements:
- We want a way to capture the environment and use it in the function. So that it's possible to use things already in the world in the function (for example, to add `Handle`s from asset resources as components). Here, this is by passing the `self` parameter to the `Hook::hook_entity` method. This also allows using closures with captured environment.
- We want to be able to check which entity we are dealing with, so we need access to the components already attached to it. We have a `EntityRef` argument for that purpose.
- We obviously want to be able to add components and children to the entity in question, so we provide a `EntityCommands` argument as well.

Ideally, we'd rather not want to have to add an individual system per scene. And this is why we use a dynamic object `Box<dyn Hook>` stored in a component.

This is added as a component in `SceneBundle` (more precisely, as a field of the `SceneHook` component), since we want to associate scenes with the hook that run for them.

@Sheepyhead & @Shatur will most likely be interested in this PR.

## Drawbacks & Side effects

- A `SceneHook` will be added to all `SceneBundle`
- as a result, `run_hook` will run once per added scene, though if the `SceneHook` is not specified, the default value will cause `run_hook` to iterate over all entities added to the scene with a no-op, only once. 
- as a result, all added scene will have a `SceneHooked` marker component added once they are fully loaded, which can have other benefits.

---

## Changelog

- Added `hook` field to `SceneBundle`, to make it easy to add components to entities loaded from any scene format.
