### PR TITLE
[Merged by Bors] - fix nightly for miri to 2022-06-08 to avoid timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,8 @@ jobs:
           key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.toml') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          # TODO: check again with nightly once https://github.com/rust-lang/miri/issues/2223 is fixed
+          toolchain: nightly-2022-06-08
           components: miri
           override: true
       - name: Install alsa and udev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,15 +76,16 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.toml') }}
+      # TODO: re-enable cache once nightly is unpined
+      # - uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       ~/.cargo/bin/
+      #       ~/.cargo/registry/index/
+      #       ~/.cargo/registry/cache/
+      #       ~/.cargo/git/db/
+      #       target/
+      #     key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.toml') }}
       - uses: actions-rs/toolchain@v1
         with:
           # TODO: check again with nightly once https://github.com/rust-lang/miri/issues/2223 is fixed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
-      # TODO: re-enable cache once nightly is unpined
+      # TODO: re-enable cache once nightly is unpinned
       # - uses: actions/cache@v3
       #   with:
       #     path: |


### PR DESCRIPTION
# Objective

- Fix timeout in miri

## Solution

- Use a nightly version from before the issue happened: 2022-06-08
- To be checked after https://github.com/rust-lang/miri/issues/2223 is fixed
