### PR TITLE
[Merged by Bors] - unpin nightly and disable weak memory emulation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,8 @@ jobs:
           # to track down because allocids are nondeterministic.
           # -Zmiri-tag-raw-pointers is not strictly "necessary" but enables a lot of extra UB checks relating
           # to raw pointer aliasing rules that we should be trying to uphold.
-          # TODO: remove once https://github.com/rust-lang/miri/issues/2223 is fixed
-          # -Zmiri-disable-weak-memory-emulation
-          MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-tag-raw-pointers -Zmiri-disable-weak-memory-emulation
+          # -Zmiri-disable-weak-memory-emulation works around an unknown bug in bevy or Miri
+          MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-permissive-provenance -Zmiri-disable-weak-memory-emulation
 
   check-compiles:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,20 +76,18 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
-      # TODO: re-enable cache once nightly is unpinned
-      # - uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       ~/.cargo/bin/
-      #       ~/.cargo/registry/index/
-      #       ~/.cargo/registry/cache/
-      #       ~/.cargo/git/db/
-      #       target/
-      #     key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.toml') }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.toml') }}
       - uses: actions-rs/toolchain@v1
         with:
-          # TODO: check again with nightly once https://github.com/rust-lang/miri/issues/2223 is fixed
-          toolchain: nightly-2022-06-08
+          toolchain: nightly
           components: miri
           override: true
       - name: Install alsa and udev
@@ -104,7 +102,9 @@ jobs:
           # to track down because allocids are nondeterministic.
           # -Zmiri-tag-raw-pointers is not strictly "necessary" but enables a lot of extra UB checks relating
           # to raw pointer aliasing rules that we should be trying to uphold.
-          MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-tag-raw-pointers
+          # TODO: remove once https://github.com/rust-lang/miri/issues/2223 is fixed
+          # -Zmiri-disable-weak-memory-emulation
+          MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-tag-raw-pointers -Zmiri-disable-weak-memory-emulation
 
   check-compiles:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           # -Zmiri-ignore-leaks is needed because running bevy_ecs tests finds a memory leak but its impossible
           # to track down because allocids are nondeterministic.
           # -Zmiri-permissive-provenance disables warnings against int2ptr casts (since those are used by once_cell)
-          # -Zmiri-disable-weak-memory-emulation works around an unknown bug in Bevy or Miri.
+          # -Zmiri-disable-weak-memory-emulation works around https://github.com/bevyengine/bevy/issues/5164.
           MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-permissive-provenance -Zmiri-disable-weak-memory-emulation
 
   check-compiles:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,7 @@ jobs:
           # -Zmiri-disable-isolation is needed because our executor uses `fastrand` which accesses system time.
           # -Zmiri-ignore-leaks is needed because running bevy_ecs tests finds a memory leak but its impossible
           # to track down because allocids are nondeterministic.
-          # -Zmiri-permissive-provenance enables extra UB checks relating to raw pointer aliasing rules that we
-          # should be trying to uphold.
+          # -Zmiri-permissive-provenance disables warnings against int2ptr casts (since those are used by once_cell)
           # -Zmiri-disable-weak-memory-emulation works around an unknown bug in Bevy or Miri.
           MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-permissive-provenance -Zmiri-disable-weak-memory-emulation
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,12 +97,13 @@ jobs:
         env:
           # -Zrandomize-layout makes sure we dont rely on the layout of anything that might change
           RUSTFLAGS: -Zrandomize-layout
+          # https://github.com/rust-lang/miri#miri--z-flags-and-environment-variables
           # -Zmiri-disable-isolation is needed because our executor uses `fastrand` which accesses system time.
           # -Zmiri-ignore-leaks is needed because running bevy_ecs tests finds a memory leak but its impossible
           # to track down because allocids are nondeterministic.
-          # -Zmiri-tag-raw-pointers is not strictly "necessary" but enables a lot of extra UB checks relating
-          # to raw pointer aliasing rules that we should be trying to uphold.
-          # -Zmiri-disable-weak-memory-emulation works around an unknown bug in bevy or Miri
+          # -Zmiri-permissive-provenance enables extra UB checks relating to raw pointer aliasing rules that we
+          # should be trying to uphold.
+          # -Zmiri-disable-weak-memory-emulation works around an unknown bug in Bevy or Miri.
           MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-permissive-provenance -Zmiri-disable-weak-memory-emulation
 
   check-compiles:


### PR DESCRIPTION
# Objective

- Follow suggestion from https://github.com/bevyengine/bevy/pull/4984#issuecomment-1152949640

## Solution

- Unpin nightly, disable weak memory emulation

---

This failed the miri job in my branch with the following error:
```
error: Undefined Behavior: attempting a read access using <untagged> at alloc198028[0x0], but that tag does not exist in the borrow stack for this location
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.12.0/src/imp_std.rs:177:28
    |
177 |                 let next = (*waiter).next;
    |                            ^^^^^^^^^^^^^^
    |                            |
    |                            attempting a read access using <untagged> at alloc198028[0x0], but that tag does not exist in the borrow stack for this location
    |                            this error occurs as part of an access at alloc198028[0x0..0x8]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
```

@BoxyUwU could you take a look? I guess it's related to the issue mentioned in https://github.com/rust-lang/miri/issues/2223