### PR TITLE
[WIP] World query filter proposal prototype implementation.

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -431,7 +431,14 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(WorldQuery, attributes(world_query))]
 pub fn derive_world_query(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
-    derive_world_query_impl(ast)
+    derive_world_query_impl(ast, false)
+}
+
+/// Implement `WorldQueryFilter` to use a struct as a parameter in a query
+#[proc_macro_derive(WorldQueryFilter, attributes(world_query))]
+pub fn derive_world_query_filter(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    derive_world_query_impl(ast, true)
 }
 
 #[proc_macro_derive(SystemLabel)]

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -56,7 +56,7 @@ mod tests {
         bundle::Bundle,
         component::{Component, ComponentId},
         entity::Entity,
-        query::{Added, ChangeTrackers, Changed, FilteredAccess, With, Without, WorldQuery},
+        query::{Added, ChangeTrackers, Changed, FilteredAccess, With, Without, WorldQueryFilter},
         world::{Mut, World},
     };
     use bevy_tasks::{ComputeTaskPool, TaskPool};
@@ -900,7 +900,7 @@ mod tests {
             }
         }
 
-        fn get_filtered<F: WorldQuery>(world: &mut World) -> Vec<Entity> {
+        fn get_filtered<F: WorldQueryFilter>(world: &mut World) -> Vec<Entity> {
             world
                 .query_filtered::<Entity, F>()
                 .iter(world)

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -4,7 +4,7 @@ use crate::{
     entity::Entity,
     query::{
         debug_checked_unreachable, Access, Fetch, FetchState, FilteredAccess, QueryFetch,
-        ROQueryFetch, WorldQuery, WorldQueryGats,
+        ROQueryFetch, WorldQuery, WorldQueryFilter, WorldQueryGats,
     },
     storage::{ComponentSparseSet, Table, Tables},
     world::World,
@@ -54,6 +54,8 @@ impl<T: Component> WorldQuery for With<T> {
         item
     }
 }
+
+impl<T: Component> WorldQueryFilter for With<T> {}
 
 /// The [`Fetch`] of [`With`].
 #[doc(hidden)]
@@ -194,6 +196,8 @@ impl<T: Component> WorldQuery for Without<T> {
         item
     }
 }
+
+impl<T: Component> WorldQueryFilter for Without<T> {}
 
 /// The [`Fetch`] of [`Without`].
 #[doc(hidden)]
@@ -349,6 +353,11 @@ macro_rules! impl_query_filter_tuple {
             fn shrink<'wlong: 'wshort, 'wshort>(item: super::QueryItem<'wlong, Self>) -> super::QueryItem<'wshort, Self> {
                 item
             }
+        }
+
+        #[allow(unused_variables)]
+        #[allow(non_snake_case)]
+        impl<$($filter: WorldQuery),*> WorldQueryFilter for Or<($($filter,)*)> {
         }
 
         #[allow(unused_variables)]
@@ -521,6 +530,9 @@ macro_rules! impl_tick_filter {
             fn shrink<'wlong: 'wshort, 'wshort>(item: super::QueryItem<'wlong, Self>) -> super::QueryItem<'wshort, Self> {
                 item
             }
+        }
+
+        impl<T: Component> WorldQueryFilter for $name<T> {
         }
 
         // SAFETY: this reads the T component. archetype component access and component access are updated to reflect that

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -19,7 +19,7 @@ unsafe fn debug_checked_unreachable() -> ! {
 
 #[cfg(test)]
 mod tests {
-    use super::WorldQuery;
+    use super::{WorldQuery, WorldQueryFilter};
     use crate::prelude::{AnyOf, Entity, Or, With, Without};
     use crate::system::{IntoSystem, Query, System};
     use crate::{self as bevy_ecs, component::Component, world::World};
@@ -458,13 +458,39 @@ mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(custom_param_data, normal_data);
         }
+    }
+
+    #[test]
+    fn derived_worldqueryfilters() {
+        let mut world = World::new();
+
+        world.spawn().insert_bundle((A(10), B(18), C(3), Sparse(4)));
+
+        world.spawn().insert_bundle((A(101), B(148), C(13)));
+        world.spawn().insert_bundle((A(51), B(46), Sparse(72)));
+        world.spawn().insert_bundle((A(398), C(6), Sparse(9)));
+        world.spawn().insert_bundle((B(11), C(28), Sparse(92)));
+
+        world.spawn().insert_bundle((C(18348), Sparse(101)));
+        world.spawn().insert_bundle((B(839), Sparse(5)));
+        world.spawn().insert_bundle((B(6721), C(122)));
+        world.spawn().insert_bundle((A(220), Sparse(63)));
+        world.spawn().insert_bundle((A(1092), C(382)));
+        world.spawn().insert_bundle((A(2058), B(3019)));
+
+        world.spawn().insert_bundle((B(38), C(8), Sparse(100)));
+        world.spawn().insert_bundle((A(111), C(52), Sparse(1)));
+        world.spawn().insert_bundle((A(599), B(39), Sparse(13)));
+        world.spawn().insert_bundle((A(55), B(66), C(77)));
+
+        world.spawn();
 
         {
-            #[derive(WorldQuery)]
+            #[derive(WorldQueryFilter)]
             struct AOrBFilter {
                 a: Or<(With<A>, With<B>)>,
             }
-            #[derive(WorldQuery)]
+            #[derive(WorldQueryFilter)]
             struct NoSparseThatsSlow {
                 no: Without<Sparse>,
             }
@@ -481,7 +507,7 @@ mod tests {
         }
 
         {
-            #[derive(WorldQuery)]
+            #[derive(WorldQueryFilter)]
             struct CSparseFilter {
                 tuple_structs_pls: With<C>,
                 ugh: With<Sparse>,
@@ -499,7 +525,7 @@ mod tests {
         }
 
         {
-            #[derive(WorldQuery)]
+            #[derive(WorldQueryFilter)]
             struct WithoutComps {
                 _1: Without<A>,
                 _2: Without<B>,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -5,7 +5,7 @@ use crate::{
     prelude::FromWorld,
     query::{
         Access, Fetch, FetchState, FilteredAccess, NopFetch, QueryCombinationIter, QueryIter,
-        WorldQuery,
+        WorldQuery, WorldQueryFilter,
     },
     storage::TableId,
     world::{World, WorldId},
@@ -19,7 +19,7 @@ use std::{borrow::Borrow, fmt};
 use super::{QueryFetch, QueryItem, QueryManyIter, ROQueryFetch, ROQueryItem};
 
 /// Provides scoped access to a [`World`] state according to a given [`WorldQuery`] and query filter.
-pub struct QueryState<Q: WorldQuery, F: WorldQuery = ()> {
+pub struct QueryState<Q: WorldQuery, F: WorldQueryFilter = ()> {
     world_id: WorldId,
     pub(crate) archetype_generation: ArchetypeGeneration,
     pub(crate) matched_tables: FixedBitSet,
@@ -34,13 +34,13 @@ pub struct QueryState<Q: WorldQuery, F: WorldQuery = ()> {
     pub(crate) filter_state: F::State,
 }
 
-impl<Q: WorldQuery, F: WorldQuery> FromWorld for QueryState<Q, F> {
+impl<Q: WorldQuery, F: WorldQueryFilter> FromWorld for QueryState<Q, F> {
     fn from_world(world: &mut World) -> Self {
         world.query_filtered()
     }
 }
 
-impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
+impl<Q: WorldQuery, F: WorldQueryFilter> QueryState<Q, F> {
     /// Creates a new [`QueryState`] from a given [`World`] and inherits the result of `world.id()`.
     pub fn new(world: &mut World) -> Self {
         let fetch_state = <Q::State as FetchState>::init(world);

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -4,7 +4,7 @@ use crate::{
     query::{
         NopFetch, QueryCombinationIter, QueryEntityError, QueryFetch, QueryItem, QueryIter,
         QueryManyIter, QuerySingleError, QueryState, ROQueryFetch, ROQueryItem, ReadOnlyFetch,
-        WorldQuery,
+        WorldQuery, WorldQueryFilter,
     },
     world::{Mut, World},
 };
@@ -239,14 +239,14 @@ use std::{any::TypeId, borrow::Borrow, fmt::Debug};
 /// methods instead. Keep in mind though that they will return a [`QuerySingleError`] if the
 /// number of query results differ from being exactly one. If that's the case, use `iter.next()`
 /// (or `iter_mut.next()`) to only get the first query result.
-pub struct Query<'world, 'state, Q: WorldQuery, F: WorldQuery = ()> {
+pub struct Query<'world, 'state, Q: WorldQuery, F: WorldQueryFilter = ()> {
     pub(crate) world: &'world World,
     pub(crate) state: &'state QueryState<Q, F>,
     pub(crate) last_change_tick: u32,
     pub(crate) change_tick: u32,
 }
 
-impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
+impl<'w, 's, Q: WorldQuery, F: WorldQueryFilter> Query<'w, 's, Q, F> {
     /// Creates a new query.
     ///
     /// # Safety
@@ -1252,7 +1252,7 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     }
 }
 
-impl<'w, 's, Q: WorldQuery, F: WorldQuery> IntoIterator for &'w Query<'_, 's, Q, F> {
+impl<'w, 's, Q: WorldQuery, F: WorldQueryFilter> IntoIterator for &'w Query<'_, 's, Q, F> {
     type Item = ROQueryItem<'w, Q>;
     type IntoIter = QueryIter<'w, 's, Q, ROQueryFetch<'w, Q>, F>;
 
@@ -1261,7 +1261,7 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> IntoIterator for &'w Query<'_, 's, Q,
     }
 }
 
-impl<'w, Q: WorldQuery, F: WorldQuery> IntoIterator for &'w mut Query<'_, '_, Q, F> {
+impl<'w, Q: WorldQuery, F: WorldQueryFilter> IntoIterator for &'w mut Query<'_, '_, Q, F> {
     type Item = QueryItem<'w, Q>;
     type IntoIter = QueryIter<'w, 'w, Q, QueryFetch<'w, Q>, F>;
 
@@ -1306,7 +1306,7 @@ impl std::fmt::Display for QueryComponentError {
     }
 }
 
-impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F>
+impl<'w, 's, Q: WorldQuery, F: WorldQueryFilter> Query<'w, 's, Q, F>
 where
     QueryFetch<'w, Q>: ReadOnlyFetch,
 {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         Component, ComponentDescriptor, ComponentId, ComponentTicks, Components, StorageType,
     },
     entity::{AllocAtWithoutReplacement, Entities, Entity},
-    query::{QueryState, WorldQuery},
+    query::{QueryState, WorldQuery, WorldQueryFilter},
     storage::{Column, SparseSet, Storages},
     system::Resource,
 };
@@ -578,7 +578,7 @@ impl World {
     /// assert_eq!(matching_entities, vec![e2]);
     /// ```
     #[inline]
-    pub fn query_filtered<Q: WorldQuery, F: WorldQuery>(&mut self) -> QueryState<Q, F> {
+    pub fn query_filtered<Q: WorldQuery, F: WorldQueryFilter>(&mut self) -> QueryState<Q, F> {
         QueryState::new(self)
     }
 

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_filter_derive.rs
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_filter_derive.rs
@@ -1,0 +1,12 @@
+use bevy_ecs::prelude::*;
+use bevy_ecs::query::WorldQueryFilter;
+
+#[derive(Component)]
+struct Foo;
+
+#[derive(WorldQueryFilter)]
+struct ComponentQuery {
+    a: &'static Foo,
+}
+
+fn main() {}

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_filter_derive.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_filter_derive.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the trait bound `&'static Foo: WorldQueryFilter` is not satisfied
+ --> tests/ui/world_query_filter_derive.rs:9:8
+  |
+9 |     a: &'static Foo,
+  |        ^^^^^^^^^^^^ the trait `WorldQueryFilter` is not implemented for `&'static Foo`
+  |
+note: required by a bound in `assert_world_query_filter`
+ --> tests/ui/world_query_filter_derive.rs:7:10
+  |
+7 | #[derive(WorldQueryFilter)]
+  |          ^^^^^^^^^^^^^^^^ required by this bound in `assert_world_query_filter`
+  = note: this error originates in the derive macro `WorldQueryFilter` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -9,7 +9,7 @@ use bevy_asset::{Asset, Handle};
 use bevy_ecs::{
     component::Component,
     prelude::*,
-    query::{QueryItem, WorldQuery},
+    query::{QueryItem, WorldQuery, WorldQueryFilter},
     system::{lifetimeless::Read, StaticSystemParam},
 };
 use std::{marker::PhantomData, ops::Deref};
@@ -36,7 +36,7 @@ pub trait ExtractComponent: Component {
     /// ECS [`WorldQuery`] to fetch the components to extract.
     type Query: WorldQuery;
     /// Filters the entities with additional constraints.
-    type Filter: WorldQuery;
+    type Filter: WorldQueryFilter;
     /// Defines how the component is transferred into the "render world".
     fn extract_component(item: QueryItem<Self::Query>) -> Self;
 }

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -4,7 +4,7 @@ use crate::{CalculatedSize, Node, Style};
 use bevy_ecs::{
     entity::Entity,
     event::EventReader,
-    query::{Changed, With, Without, WorldQuery},
+    query::{Changed, With, Without, WorldQueryFilter},
     system::{Query, Res, ResMut},
 };
 use bevy_hierarchy::{Children, Parent};
@@ -231,7 +231,7 @@ pub fn flex_node_system(
         update_changed(&mut *flex_surface, logical_to_physical_factor, node_query);
     }
 
-    fn update_changed<F: WorldQuery>(
+    fn update_changed<F: WorldQueryFilter>(
         flex_surface: &mut FlexSurface,
         scaling_factor: f64,
         query: Query<(Entity, &Style, Option<&CalculatedSize>), F>,

--- a/examples/ecs/custom_query_param.rs
+++ b/examples/ecs/custom_query_param.rs
@@ -13,7 +13,7 @@
 //! For more details on the `WorldQuery` derive macro, see the trait documentation.
 
 use bevy::{
-    ecs::{component::Component, query::WorldQuery},
+    ecs::{component::Component, query::WorldQuery, query::WorldQueryFilter},
     prelude::*,
 };
 use std::fmt::Debug;
@@ -106,7 +106,7 @@ struct GenericQuery<T: Component, P: Component> {
     generic: (&'static T, &'static P),
 }
 
-#[derive(WorldQuery)]
+#[derive(WorldQueryFilter)]
 struct QueryFilter<T: Component, P: Component> {
     _c: With<ComponentC>,
     _d: With<ComponentD>,


### PR DESCRIPTION
This PR is a prototype implementaton of https://github.com/bevyengine/rfcs/pull/58 RFC that proposes disallowing using component types as query filters. This PR also introduces `derive(WorldQueryFilter)` proc macro to make custom query filters, analogous to custom queries.