### PR TITLE
[Merged by Bors] - Add option to center a window

### DIFF
--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -17,7 +17,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
         CursorEntered, CursorIcon, CursorLeft, CursorMoved, FileDragAndDrop, ReceivedCharacter,
-        Window, WindowDescriptor, WindowMoved, Windows,
+        Window, WindowDescriptor, WindowMoved, WindowPosition, Windows,
     };
 }
 

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -16,8 +16,8 @@ pub use windows::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        CursorEntered, CursorIcon, CursorLeft, CursorMoved, FileDragAndDrop, ReceivedCharacter,
-        Window, WindowDescriptor, WindowMoved, WindowPosition, Windows,
+        CursorEntered, CursorIcon, CursorLeft, CursorMoved, FileDragAndDrop, MonitorSelection,
+        ReceivedCharacter, Window, WindowDescriptor, WindowMoved, WindowPosition, Windows,
     };
 }
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -260,7 +260,7 @@ pub enum WindowCommand {
         position: IVec2,
     },
     /// Modifies the position of the window to be in the center of the current monitor
-    Center,
+    Center(MonitorSelection),
     /// Set the window's [`WindowResizeConstraints`]
     SetResizeConstraints {
         resize_constraints: WindowResizeConstraints,
@@ -424,8 +424,9 @@ impl Window {
     /// - iOS: Can only be called on the main thread.
     /// - Web / Android / Wayland: Unsupported.
     #[inline]
-    pub fn center_window(&mut self) {
-        self.command_queue.push(WindowCommand::Center);
+    pub fn center_window(&mut self, monitor_selection: MonitorSelection) {
+        self.command_queue
+            .push(WindowCommand::Center(monitor_selection));
     }
 
     /// Modifies the minimum and maximum window bounds for resizing in logical pixels.
@@ -727,18 +728,29 @@ impl Window {
 }
 
 /// Defines where window should be placed at on creation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum WindowPosition {
     /// Position will be set by the window manager
     Automatic,
-    /// Window will be centered on the primary monitor
+    /// Window will be centered on the selected monitor
     ///
     /// Note that this does not account for window decorations.
-    Centered,
+    Centered(MonitorSelection),
     /// The window's top-left corner will be placed at the specified position (in pixels)
     ///
     /// (0,0) represents top-left corner of screen space.
     At(Vec2),
+}
+
+/// Defines which monitor to use.
+#[derive(Debug, Clone, Copy)]
+pub enum MonitorSelection {
+    /// Uses current monitor of the window.
+    Current,
+    /// Uses primary monitor of the system.
+    Primary,
+    /// Uses monitor with the specified index.
+    Number(usize),
 }
 
 /// Describes the information needed for creating a window.

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -729,13 +729,15 @@ impl Window {
 /// Defines where window should be placed at on creation.
 #[derive(Debug, Clone)]
 pub enum WindowPosition {
-    /// Position will be set by window manager
+    /// Position will be set by the window manager
     Automatic,
     /// Window will be centered on the primary monitor
     ///
     /// Note that this does not account for window decorations.
     Centered,
-    /// Window will be placed at specified position
+    /// The window's top-left corner will be placed at the specified position (in pixels)
+    ///
+    /// (0,0) represents top-left corner of screen space.
     At(Vec2),
 }
 
@@ -822,7 +824,7 @@ impl Default for WindowDescriptor {
             title: "app".to_string(),
             width: 1280.,
             height: 720.,
-            position: WindowPosition::Default,
+            position: WindowPosition::Automatic,
             resize_constraints: WindowResizeConstraints::default(),
             scale_factor_override: None,
             present_mode: PresentMode::Fifo,

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -730,8 +730,10 @@ impl Window {
 #[derive(Debug, Clone)]
 pub enum WindowPosition {
     /// Position will be set by window manager
-    Default,
-    /// Window will be centered at primary monitor
+    Automatic,
+    /// Window will be centered on the primary monitor
+    ///
+    /// Note that this does not account for window decorations.
     Centered,
     /// Window will be placed at specified position
     At(Vec2),

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -158,6 +158,21 @@ fn change_window(
                         y: position[1],
                     });
                 }
+                bevy_window::WindowCommand::Center => {
+                    let window = winit_windows.get_window(id).unwrap();
+
+                    // What to do if current_monitor is None?
+                    // Abort?
+                    // Or use primary_monitor? And then what if that also is None?
+                    let screen_size = window.current_monitor().unwrap().size();
+
+                    let window_size = window.outer_size();
+
+                    window.set_outer_position(PhysicalPosition {
+                        x: (screen_size.width - window_size.width) as f64 / 2.,
+                        y: (screen_size.height - window_size.height) as f64 / 2.,
+                    });
+                }
                 bevy_window::WindowCommand::SetResizeConstraints { resize_constraints } => {
                     let window = winit_windows.get_window(id).unwrap();
                     let constraints = resize_constraints.check_constraints();

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -158,20 +158,30 @@ fn change_window(
                         y: position[1],
                     });
                 }
-                bevy_window::WindowCommand::Center => {
+                bevy_window::WindowCommand::Center(monitor_selection) => {
                     let window = winit_windows.get_window(id).unwrap();
 
-                    // What to do if current_monitor is None?
-                    // Abort?
-                    // Or use primary_monitor? And then what if that also is None?
-                    let screen_size = window.current_monitor().unwrap().size();
+                    use bevy_window::MonitorSelection::*;
+                    let maybe_monitor = match monitor_selection {
+                        Current => window.current_monitor(),
+                        Primary => window.primary_monitor(),
+                        Number(n) => window.available_monitors().nth(n),
+                    };
 
-                    let window_size = window.outer_size();
+                    if let Some(monitor) = maybe_monitor {
+                        let screen_size = monitor.size();
 
-                    window.set_outer_position(PhysicalPosition {
-                        x: (screen_size.width - window_size.width) as f64 / 2.,
-                        y: (screen_size.height - window_size.height) as f64 / 2.,
-                    });
+                        let window_size = window.outer_size();
+
+                        window.set_outer_position(PhysicalPosition {
+                            x: screen_size.width.saturating_sub(window_size.width) as f64 / 2.
+                                + monitor.position().x as f64,
+                            y: screen_size.height.saturating_sub(window_size.height) as f64 / 2.
+                                + monitor.position().y as f64,
+                        });
+                    } else {
+                        warn!("Couldn't get monitor selected with: {monitor_selection:?}");
+                    }
                 }
                 bevy_window::WindowCommand::SetResizeConstraints { resize_constraints } => {
                     let window = winit_windows.get_window(id).unwrap();

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -51,7 +51,7 @@ impl WinitWindows {
 
                 use bevy_window::WindowPosition::*;
                 match position {
-                    Default => { /* Window manager will handle position */ }
+                    Automatic => { /* Window manager will handle position */ }
                     Centered => {
                         if let Some(monitor) = event_loop.primary_monitor() {
                             let screen_size = monitor.size();


### PR DESCRIPTION
# Objective
- Fixes #4993 

## Solution

- ~~Add `centered` property to `WindowDescriptor`~~
- Add `WindowPosition` enum
- `WindowDescriptor.position` is now `WindowPosition` instead of `Option<Vec2>`
- Add `center_window` function to `Window`

## Migration Guide
- If using `WindowDescriptor`, replace `position: None` with `position: WindowPosition::Default` and `position: Some(vec2)`  with `WindowPosition::At(vec2)`.

I'm not sure if this is the best approach, so feel free to give any feedback.
Also I'm not sure how `Option`s should be handled in `bevy_winit/src/lib.rs:161`.

Also, on window creation we can't (or at least I couldn't) get `outer_size`, so this doesn't include decorations in calculations.
