### PR TITLE
bevy_reflect: Trait casting

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
     Reflect,
     FromReflect,
 )]
-#[reflect_value(Serialize, Deserialize, PartialEq, Hash)]
+#[reflect_value(Deserialize, PartialEq, Hash)]
 pub enum HandleId {
     Id(Uuid, u64),
     AssetPathId(AssetPathId),

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -60,19 +60,19 @@ impl<'a> AssetPath<'a> {
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize, Reflect,
 )]
-#[reflect_value(PartialEq, Hash, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Hash, Deserialize)]
 pub struct AssetPathId(SourcePathId, LabelId);
 
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize, Reflect,
 )]
-#[reflect_value(PartialEq, Hash, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Hash, Deserialize)]
 pub struct SourcePathId(u64);
 
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize, Reflect,
 )]
-#[reflect_value(PartialEq, Hash, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Hash, Deserialize)]
 pub struct LabelId(u64);
 
 impl<'a> From<&'a Path> for SourcePathId {

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -16,8 +16,7 @@ pub mod prelude {
 
 use bevy_app::prelude::*;
 use bevy_ecs::entity::Entity;
-use bevy_utils::HashSet;
-use std::ops::Range;
+use bevy_reflect::TypeRegistryArc;
 
 /// Adds core functionality to Apps.
 #[derive(Default)]
@@ -34,29 +33,49 @@ impl Plugin for CorePlugin {
 
         app.register_type::<Entity>().register_type::<Name>();
 
-        register_rust_types(app);
-        register_math_types(app);
+        let registry = app.world.resource::<TypeRegistryArc>();
+        let mut registry = registry.write();
+        rust_types::register_types(&mut registry);
+        math_types::register_types(&mut registry);
     }
 }
 
-fn register_rust_types(app: &mut App) {
-    app.register_type::<Range<f32>>()
-        .register_type::<String>()
-        .register_type::<HashSet<String>>()
-        .register_type::<Option<String>>();
+mod rust_types {
+    use bevy_reflect::erased_serde::Serialize;
+    use bevy_reflect::register_all;
+    use bevy_utils::HashSet;
+    use std::ops::Range;
+
+    register_all! {
+        traits: [Serialize],
+        types: [
+            String,
+            Option<String>,
+            Range<f32>,
+            HashSet<String>
+        ]
+    }
 }
 
-fn register_math_types(app: &mut App) {
-    app.register_type::<bevy_math::IVec2>()
-        .register_type::<bevy_math::IVec3>()
-        .register_type::<bevy_math::IVec4>()
-        .register_type::<bevy_math::UVec2>()
-        .register_type::<bevy_math::UVec3>()
-        .register_type::<bevy_math::UVec4>()
-        .register_type::<bevy_math::Vec2>()
-        .register_type::<bevy_math::Vec3>()
-        .register_type::<bevy_math::Vec4>()
-        .register_type::<bevy_math::Mat3>()
-        .register_type::<bevy_math::Mat4>()
-        .register_type::<bevy_math::Quat>();
+mod math_types {
+    use bevy_reflect::erased_serde::Serialize;
+    use bevy_reflect::register_all;
+
+    register_all! {
+        traits: [Serialize],
+        types: [
+            bevy_math::IVec2,
+            bevy_math::IVec3,
+            bevy_math::IVec4,
+            bevy_math::UVec2,
+            bevy_math::UVec3,
+            bevy_math::UVec4,
+            bevy_math::Vec2,
+            bevy_math::Vec3,
+            bevy_math::Vec4,
+            bevy_math::Mat3,
+            bevy_math::Mat4,
+            bevy_math::Quat,
+        ]
+    }
 }

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -122,7 +122,7 @@ impl<C: Component + Reflect + FromWorld> FromType<C> for ReflectComponent {
     }
 }
 
-impl_reflect_value!(Entity(Hash, PartialEq, Serialize, Deserialize));
+impl_reflect_value!(Entity(Hash, PartialEq, Deserialize));
 impl_from_reflect_value!(Entity);
 
 #[derive(Clone)]

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -172,3 +172,31 @@ pub fn impl_from_reflect_value(input: TokenStream) -> TokenStream {
     let ty = &reflect_value_def.type_name;
     from_reflect::impl_value(ty, &reflect_value_def.generics, &bevy_reflect_path)
 }
+
+/// A macro that allows for mass type and trait registration.
+///
+/// This will generate a public function with the signature: `fn register_types(&mut TypeRegistry)`.
+/// You can then use this generated function to register the given types and traits.
+///
+/// # Example
+///
+/// ```
+/// use bevy_reflect_derive::register_all;
+///
+/// trait MyTrait {}
+/// struct MyType;
+/// struct MyOtherType;
+///
+/// impl MyTrait for MyType {}
+///
+/// // Not all types need to implement all traits
+/// register_all! {
+///     traits: [MyTrait],
+///     types: [MyType, MyOtherType],
+/// }
+///
+/// ```
+#[proc_macro]
+pub fn register_all(item: TokenStream) -> TokenStream {
+    registration::register_all_internal(item)
+}

--- a/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
@@ -1,7 +1,12 @@
 //! Contains code related specifically to Bevy's type registration.
 
+use bevy_macro_utils::BevyManifest;
+use proc_macro::TokenStream;
 use proc_macro2::Ident;
 use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::{Iter, Punctuated};
+use syn::{bracketed, parse_macro_input, Token, Type};
 use syn::{Generics, Path};
 
 /// Creates the `GetTypeRegistration` impl for the given type data.
@@ -22,4 +27,111 @@ pub(crate) fn impl_get_type_registration(
             }
         }
     }
+}
+
+pub fn register_all_internal(item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as RegisterAllData);
+
+    let registration_params = input.types().map(|ty| {
+        let trait_type = input.traits();
+        quote! {
+            #ty, #(#trait_type),*
+        }
+    });
+
+    let bevy_reflect_path = BevyManifest::default().get_path("bevy_reflect");
+
+    TokenStream::from(quote! {
+        pub fn register_types(registry: &mut #bevy_reflect_path::TypeRegistry) {
+            #(#bevy_reflect_path::register_type!(registry, #registration_params));*
+        }
+    })
+}
+
+/// Maps to the following invocation:
+///
+/// ```
+/// use bevy_reflect_derive::register_all;
+///
+/// trait MyTrait {}
+/// struct MyType {}
+///
+/// register_all! {
+///     traits: [MyTrait],
+///     types: [MyType],
+/// }
+/// ```
+///
+/// > Note: The order of the `traits` and `types` fields does not matter. Additionally,
+/// > the commas (separating and trailing) may be omitted entirely.
+struct RegisterAllData {
+    trait_list: Punctuated<Type, Token![,]>,
+    type_list: Punctuated<Type, Token![,]>,
+}
+
+impl RegisterAllData {
+    /// Returns an iterator over the types to register.
+    fn types(&self) -> Iter<Type> {
+        self.type_list.iter()
+    }
+
+    /// Returns an iterator over the traits to register.
+    fn traits(&self) -> Iter<Type> {
+        self.trait_list.iter()
+    }
+
+    /// Parse a list of types.
+    ///
+    /// This is the portion _after_ the the respective keyword and consumes: `: [ Foo, Bar, Baz ]`
+    fn parse_list(input: &mut ParseStream) -> syn::Result<Punctuated<Type, Token![,]>> {
+        input.parse::<Token![:]>()?;
+        let list;
+        bracketed!(list in input);
+        list.parse_terminated(Type::parse)
+    }
+}
+
+impl Parse for RegisterAllData {
+    fn parse(mut input: ParseStream) -> syn::Result<Self> {
+        let trait_list;
+        let type_list;
+
+        let lookahead = input.lookahead1();
+        if lookahead.peek(kw::traits) {
+            // Parse `traits` then `types`
+            input.parse::<kw::traits>()?;
+            trait_list = Self::parse_list(&mut input)?;
+            // Optional separating comma
+            input.parse::<Option<Token![,]>>()?;
+            input.parse::<kw::types>()?;
+            type_list = Self::parse_list(&mut input)?;
+            // Optional trailing comma
+            input.parse::<Option<Token![,]>>()?;
+        } else if lookahead.peek(kw::types) {
+            // Parse `types` then `traits`
+            input.parse::<kw::types>()?;
+            type_list = Self::parse_list(&mut input)?;
+            // Optional separating comma
+            input.parse::<Option<Token![,]>>()?;
+            input.parse::<kw::traits>()?;
+            trait_list = Self::parse_list(&mut input)?;
+            // Optional trailing comma
+            input.parse::<Option<Token![,]>>()?;
+        } else {
+            return Err(syn::Error::new(
+                input.span(),
+                "expected either 'traits' or 'types' field",
+            ));
+        }
+
+        Ok(Self {
+            trait_list,
+            type_list,
+        })
+    }
+}
+
+mod kw {
+    syn::custom_keyword!(traits);
+    syn::custom_keyword!(types);
 }

--- a/crates/bevy_reflect/src/impls/glam.rs
+++ b/crates/bevy_reflect/src/impls/glam.rs
@@ -6,14 +6,14 @@ use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_struct, impl_ref
 use glam::*;
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct IVec2 {
         x: i32,
         y: i32,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct IVec3 {
         x: i32,
         y: i32,
@@ -21,7 +21,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct IVec4 {
         x: i32,
         y: i32,
@@ -31,14 +31,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct UVec2 {
         x: u32,
         y: u32,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct UVec3 {
         x: u32,
         y: u32,
@@ -46,7 +46,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct UVec4 {
         x: u32,
         y: u32,
@@ -56,14 +56,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct Vec2 {
         x: f32,
         y: f32,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct Vec3 {
         x: f32,
         y: f32,
@@ -71,7 +71,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct Vec3A {
         x: f32,
         y: f32,
@@ -79,7 +79,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct Vec4 {
         x: f32,
         y: f32,
@@ -89,14 +89,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct DVec2 {
         x: f64,
         y: f64,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct DVec3 {
         x: f64,
         y: f64,
@@ -104,7 +104,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct DVec4 {
         x: f64,
         y: f64,
@@ -114,7 +114,7 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct Mat3 {
         x_axis: Vec3,
         y_axis: Vec3,
@@ -122,7 +122,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct Mat4 {
         x_axis: Vec4,
         y_axis: Vec4,
@@ -132,7 +132,7 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct DMat3 {
         x_axis: DVec3,
         y_axis: DVec3,
@@ -140,7 +140,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Deserialize, Default)]
     struct DMat4 {
         x_axis: DVec4,
         y_axis: DVec4,
@@ -153,8 +153,8 @@ impl_reflect_struct!(
 // mechanisms for read-only fields. I doubt those mechanisms would be added,
 // so for now quaternions will remain as values. They are represented identically
 // to Vec4 and DVec4, so you may use those instead and convert between.
-impl_reflect_value!(Quat(Debug, PartialEq, Serialize, Deserialize, Default));
-impl_reflect_value!(DQuat(Debug, PartialEq, Serialize, Deserialize, Default));
+impl_reflect_value!(Quat(Debug, PartialEq, Deserialize, Default));
+impl_reflect_value!(DQuat(Debug, PartialEq, Deserialize, Default));
 
 impl_from_reflect_value!(Quat);
 impl_from_reflect_value!(DQuat);

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -5,6 +5,7 @@ use crate::{
     ReflectMut, ReflectRef, TypeInfo, TypeRegistration, Typed, ValueInfo,
 };
 
+use crate::serde::Serializable;
 use crate::utility::{GenericTypeInfoCell, NonGenericTypeInfoCell};
 use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_value};
 use bevy_utils::{Duration, HashMap, HashSet};
@@ -15,7 +16,6 @@ use std::{
     hash::{Hash, Hasher},
     ops::Range,
 };
-use crate::serde::Serializable;
 
 impl_reflect_value!(bool(Debug, Hash, PartialEq, Deserialize));
 impl_reflect_value!(char(Debug, Hash, PartialEq, Deserialize));
@@ -329,9 +329,9 @@ impl<K: Reflect + Eq + Hash, V: Reflect> Typed for HashMap<K, V> {
 }
 
 impl<K, V> GetTypeRegistration for HashMap<K, V>
-    where
-        K: Reflect + Clone + Eq + Hash + for<'de> Deserialize<'de>,
-        V: Reflect + Clone + for<'de> Deserialize<'de>,
+where
+    K: Reflect + Clone + Eq + Hash + for<'de> Deserialize<'de>,
+    V: Reflect + Clone + for<'de> Deserialize<'de>,
 {
     fn get_type_registration() -> TypeRegistration {
         let mut registration = TypeRegistration::of::<Self>();

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,42 +1,43 @@
-use crate as bevy_reflect;
+use crate::{self as bevy_reflect};
 use crate::{
-    map_partial_eq, serde::Serializable, Array, ArrayInfo, ArrayIter, DynamicMap, FromReflect,
-    FromType, GetTypeRegistration, List, ListInfo, Map, MapInfo, MapIter, Reflect,
-    ReflectDeserialize, ReflectMut, ReflectRef, TypeInfo, TypeRegistration, Typed, ValueInfo,
+    map_partial_eq, Array, ArrayInfo, ArrayIter, DynamicMap, FromReflect, FromType,
+    GetTypeRegistration, List, ListInfo, Map, MapInfo, MapIter, Reflect, ReflectDeserialize,
+    ReflectMut, ReflectRef, TypeInfo, TypeRegistration, Typed, ValueInfo,
 };
 
 use crate::utility::{GenericTypeInfoCell, NonGenericTypeInfoCell};
 use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_value};
 use bevy_utils::{Duration, HashMap, HashSet};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::{
     any::Any,
     borrow::Cow,
     hash::{Hash, Hasher},
     ops::Range,
 };
+use crate::serde::Serializable;
 
-impl_reflect_value!(bool(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(char(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(u8(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(u16(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(u32(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(u64(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(u128(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(usize(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(i8(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(i16(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(i32(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(i64(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(i128(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(isize(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(f32(Debug, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(f64(Debug, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(String(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(Option<T: Serialize + Clone + for<'de> Deserialize<'de> + Reflect + 'static>(Serialize, Deserialize));
-impl_reflect_value!(HashSet<T: Serialize + Hash + Eq + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>(Serialize, Deserialize));
-impl_reflect_value!(Range<T: Serialize + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>(Serialize, Deserialize));
-impl_reflect_value!(Duration(Debug, Hash, PartialEq, Serialize, Deserialize));
+impl_reflect_value!(bool(Debug, Hash, PartialEq, Deserialize));
+impl_reflect_value!(char(Debug, Hash, PartialEq, Deserialize));
+impl_reflect_value!(u8(Debug, Hash, PartialEq, Deserialize));
+impl_reflect_value!(u16(Debug, Hash, PartialEq, Deserialize));
+impl_reflect_value!(u32(Debug, Hash, PartialEq, Deserialize));
+impl_reflect_value!(u64(Debug, Hash, PartialEq, Deserialize));
+impl_reflect_value!(u128(Debug, Hash, PartialEq, Deserialize));
+impl_reflect_value!(usize(Debug, Hash, PartialEq, Deserialize));
+impl_reflect_value!(i8(Debug, Hash, PartialEq, Deserialize));
+impl_reflect_value!(i16(Debug, Hash, PartialEq, Deserialize));
+impl_reflect_value!(i32(Debug, Hash, PartialEq, Deserialize));
+impl_reflect_value!(i64(Debug, Hash, PartialEq, Deserialize));
+impl_reflect_value!(i128(Debug, Hash, PartialEq, Deserialize));
+impl_reflect_value!(isize(Debug, Hash, PartialEq, Deserialize));
+impl_reflect_value!(f32(Debug, PartialEq, Deserialize));
+impl_reflect_value!(f64(Debug, PartialEq, Deserialize));
+impl_reflect_value!(String(Debug, Hash, PartialEq, Deserialize));
+impl_reflect_value!(Option<T: Clone + for<'de> Deserialize<'de> + Reflect + 'static>(Deserialize));
+impl_reflect_value!(HashSet<T: Hash + Eq + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>(Deserialize));
+impl_reflect_value!(Range<T: Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>(Deserialize));
+impl_reflect_value!(Duration(Debug, Hash, PartialEq, Deserialize));
 
 impl_from_reflect_value!(bool);
 impl_from_reflect_value!(char);
@@ -55,15 +56,11 @@ impl_from_reflect_value!(isize);
 impl_from_reflect_value!(f32);
 impl_from_reflect_value!(f64);
 impl_from_reflect_value!(String);
+impl_from_reflect_value!(Option<T: for<'de> Deserialize<'de> + Clone + Reflect + 'static>);
 impl_from_reflect_value!(
-    Option<T: Serialize + Clone + for<'de> Deserialize<'de> + Reflect + 'static>
+    HashSet<T: for<'de> Deserialize<'de> + Hash + Eq + Clone + Send + Sync + 'static>
 );
-impl_from_reflect_value!(
-    HashSet<T: Serialize + Hash + Eq + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>
-);
-impl_from_reflect_value!(
-    Range<T: Serialize + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>
-);
+impl_from_reflect_value!(Range<T: for<'de> Deserialize<'de> + Clone + Send + Sync + 'static>);
 impl_from_reflect_value!(Duration);
 
 impl<T: FromReflect> Array for Vec<T> {
@@ -302,9 +299,9 @@ impl<K: Reflect + Eq + Hash, V: Reflect> Typed for HashMap<K, V> {
 }
 
 impl<K, V> GetTypeRegistration for HashMap<K, V>
-where
-    K: Reflect + Clone + Eq + Hash + for<'de> Deserialize<'de>,
-    V: Reflect + Clone + for<'de> Deserialize<'de>,
+    where
+        K: Reflect + Clone + Eq + Hash + for<'de> Deserialize<'de>,
+        V: Reflect + Clone + for<'de> Deserialize<'de>,
 {
     fn get_type_registration() -> TypeRegistration {
         let mut registration = TypeRegistration::of::<Self>();
@@ -541,10 +538,6 @@ unsafe impl Reflect for Cow<'static, str> {
             Some(false)
         }
     }
-
-    fn serializable(&self) -> Option<Serializable> {
-        Some(Serializable::Borrowed(self))
-    }
 }
 
 impl Typed for Cow<'static, str> {
@@ -570,13 +563,20 @@ impl FromReflect for Cow<'static, str> {
 
 #[cfg(test)]
 mod tests {
-    use crate::Reflect;
+    use crate::{serde::is_serializable, Reflect, TypeRegistry};
     use bevy_utils::HashMap;
     use std::f32::consts::{PI, TAU};
 
     #[test]
     fn can_serialize_duration() {
-        assert!(std::time::Duration::ZERO.serializable().is_some());
+        let mut registry = TypeRegistry::default();
+        macro_rules! register {
+            ($type_registry:ident, $this_type:ty) => {
+                crate::register_type!($type_registry, $this_type, erased_serde::Serialize)
+            };
+        }
+        register!(registry, std::time::Duration);
+        assert!(is_serializable(&registry, &std::time::Duration::ZERO));
     }
 
     #[test]

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -63,6 +63,36 @@ impl_from_reflect_value!(
 impl_from_reflect_value!(Range<T: for<'de> Deserialize<'de> + Clone + Send + Sync + 'static>);
 impl_from_reflect_value!(Duration);
 
+pub mod registrations {
+    use crate as bevy_reflect;
+    use crate::erased_serde::Serialize;
+    use crate::register_all;
+
+    register_all! {
+        traits: [Serialize],
+        types: [
+            bool,
+            char,
+            u8,
+            u16,
+            u32,
+            u64,
+            u128,
+            usize,
+            i8,
+            i16,
+            i32,
+            i64,
+            i128,
+            isize,
+            f32,
+            f64,
+            String,
+            Option<String>,
+        ]
+    }
+}
+
 impl<T: FromReflect> Array for Vec<T> {
     #[inline]
     fn get(&self, index: usize) -> Option<&dyn Reflect> {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -884,8 +884,8 @@ bevy_reflect::tests::should_reflect_debug::Test {
             let v = vec3(12.0, 3.0, -6.9);
 
             let mut registry = TypeRegistry::default();
-            registry.add_registration(Vec3::get_type_registration());
-            registry.add_registration(f32::get_type_registration());
+            register_type!(registry, Vec3, erased_serde::Serialize);
+            register_type!(registry, f32, erased_serde::Serialize);
 
             let ser = ReflectSerializer::new(&v, &registry);
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -465,14 +465,19 @@ mod tests {
             h: [2; 2],
         };
 
+        macro_rules! register {
+            ($type_registry:ident, $this_type:ty) => {
+                register_type!($type_registry, $this_type, erased_serde::Serialize)
+            };
+        }
         let mut registry = TypeRegistry::default();
-        registry.register::<u32>();
-        registry.register::<isize>();
-        registry.register::<usize>();
-        registry.register::<Bar>();
-        registry.register::<String>();
-        registry.register::<i8>();
-        registry.register::<i32>();
+        register!(registry, u32);
+        register!(registry, isize);
+        register!(registry, usize);
+        register!(registry, Bar);
+        register!(registry, String);
+        register!(registry, i8);
+        register!(registry, i32);
 
         let serializer = ReflectSerializer::new(&foo, &registry);
         let serialized = to_string_pretty(&serializer, PrettyConfig::default()).unwrap();
@@ -879,6 +884,7 @@ bevy_reflect::tests::should_reflect_debug::Test {
 
             let mut registry = TypeRegistry::default();
             registry.add_registration(Vec3::get_type_registration());
+            registry.add_registration(f32::get_type_registration());
 
             let ser = ReflectSerializer::new(&v, &registry);
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../README.md")]
+#![doc = include_str ! ("../README.md")]
 
 mod array;
 mod fields;
@@ -12,6 +12,7 @@ mod tuple_struct;
 mod type_info;
 mod type_registry;
 mod type_uuid;
+
 mod impls {
     #[cfg(feature = "glam")]
     mod glam;
@@ -960,6 +961,37 @@ bevy_reflect::tests::should_reflect_debug::Test {
             v.apply(&d);
 
             assert_eq!(v, vec3(4.0, 2.0, 1.0));
+        }
+        #[test]
+        fn register_all_types() {
+            #[derive(Reflect)]
+            struct Foo;
+            #[derive(Reflect)]
+            struct Bar;
+            #[derive(Reflect)]
+            struct Baz;
+
+            trait SomeTrait {}
+            trait NoneTrait {}
+
+            impl SomeTrait for Foo {}
+            impl SomeTrait for Bar {}
+
+            register_all! {
+                traits: [SomeTrait],
+                types: [Foo, Bar, Baz]
+            }
+
+            let mut registry = TypeRegistry::default();
+            register_types(&mut registry);
+
+            let ty = registry.get(TypeId::of::<Foo>()).unwrap();
+            assert!(ty.trait_cast::<dyn SomeTrait>(&Foo).is_some());
+            assert!(ty.trait_cast::<dyn NoneTrait>(&Foo).is_none());
+
+            let ty = registry.get(TypeId::of::<Baz>()).unwrap();
+            assert!(ty.trait_cast::<dyn SomeTrait>(&Baz).is_none());
+            assert!(ty.trait_cast::<dyn NoneTrait>(&Baz).is_none());
         }
     }
 }

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -876,6 +876,7 @@ bevy_reflect::tests::should_reflect_debug::Test {
 
     #[cfg(feature = "glam")]
     mod glam {
+        use std::any::TypeId;
         use super::*;
         use ::serde::Serialize;
 

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -1,12 +1,12 @@
 use std::any::{Any, TypeId};
 use std::fmt::{Debug, Formatter};
 
+use crate::serde::Serializable;
 use crate::utility::NonGenericTypeInfoCell;
 use crate::{
     Array, ArrayIter, DynamicArray, DynamicInfo, FromReflect, Reflect, ReflectMut, ReflectRef,
     TypeInfo, Typed,
 };
-use crate::serde::Serializable;
 
 /// An ordered, mutable list of [Reflect] items. This corresponds to types like [`std::vec::Vec`].
 ///

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -3,9 +3,10 @@ use std::fmt::{Debug, Formatter};
 
 use crate::utility::NonGenericTypeInfoCell;
 use crate::{
-    serde::Serializable, Array, ArrayIter, DynamicArray, DynamicInfo, FromReflect, Reflect,
-    ReflectMut, ReflectRef, TypeInfo, Typed,
+    Array, ArrayIter, DynamicArray, DynamicInfo, FromReflect, Reflect, ReflectMut, ReflectRef,
+    TypeInfo, Typed,
 };
+use crate::serde::Serializable;
 
 /// An ordered, mutable list of [Reflect] items. This corresponds to types like [`std::vec::Vec`].
 ///

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -217,7 +217,7 @@ impl<'a, 'de> Visitor<'de> for ReflectVisitor<'a> {
                     let deserialize_reflect =
                         registration.data::<ReflectDeserialize>().ok_or_else(|| {
                             de::Error::custom(format_args!(
-                                "The TypeRegistration for {} doesn't have DeserializeReflect",
+                                "The TypeRegistration for {} doesn't have ReflectDeserialize",
                                 type_name
                             ))
                         })?;

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -54,21 +54,7 @@ impl TypeRegistry {
     /// Create a type registry with default registrations for primitive types.
     pub fn new() -> Self {
         let mut registry = Self::empty();
-        registry.register::<bool>();
-        registry.register::<u8>();
-        registry.register::<u16>();
-        registry.register::<u32>();
-        registry.register::<u64>();
-        registry.register::<u128>();
-        registry.register::<usize>();
-        registry.register::<i8>();
-        registry.register::<i16>();
-        registry.register::<i32>();
-        registry.register::<i64>();
-        registry.register::<i128>();
-        registry.register::<isize>();
-        registry.register::<f32>();
-        registry.register::<f64>();
+        crate::impls::registrations::register_types(&mut registry);
         registry
     }
 

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -226,7 +226,7 @@ impl ErasedNonNull {
                 &val as *const *const T as *const u8,
                 storage.as_mut_ptr() as *mut u8,
                 size,
-            )
+            );
         };
         Self {
             storage,

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -690,6 +690,6 @@ mod tests {
     fn erased_non_null_should_panic_for_wrong_type() {
         let input = "Hello, World!";
         let erased = ErasedNonNull::new(input);
-        let output = unsafe { erased.into_ref::<i32>() };
+        let _ = unsafe { erased.into_ref::<i32>() };
     }
 }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -304,7 +304,7 @@ impl RenderTarget {
 }
 
 #[derive(Debug, Clone, Copy, Reflect, Serialize, Deserialize)]
-#[reflect_value(Serialize, Deserialize)]
+#[reflect_value(Deserialize)]
 pub enum DepthCalculation {
     /// Pythagorean distance; works everywhere, more expensive to compute.
     Distance,

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -139,14 +139,14 @@ impl Default for PerspectiveProjection {
 
 // TODO: make this a component instead of a property
 #[derive(Debug, Clone, Reflect, Serialize, Deserialize)]
-#[reflect_value(Serialize, Deserialize)]
+#[reflect_value(Deserialize)]
 pub enum WindowOrigin {
     Center,
     BottomLeft,
 }
 
 #[derive(Debug, Clone, Reflect, Serialize, Deserialize)]
-#[reflect_value(Serialize, Deserialize)]
+#[reflect_value(Deserialize)]
 pub enum ScalingMode {
     /// Manually specify left/right/top/bottom values.
     /// Ignore window resizing; the image will stretch.

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -10,7 +10,7 @@ use std::ops::{Add, AddAssign, Mul, MulAssign};
 use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(PartialEq, Deserialize)]
 pub enum Color {
     /// sRGBA color
     Rgba {

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -87,7 +87,7 @@ impl Default for TextAlignment {
 
 /// Describes horizontal alignment preference for positioning & bounds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
-#[reflect_value(Serialize, Deserialize)]
+#[reflect_value(Deserialize)]
 pub enum HorizontalAlign {
     /// Leftmost character is immediately to the right of the render position.<br/>
     /// Bounds start from the render position and advance rightwards.
@@ -113,7 +113,7 @@ impl From<HorizontalAlign> for glyph_brush_layout::HorizontalAlign {
 /// Describes vertical alignment preference for positioning & bounds. Currently a placeholder
 /// for future functionality.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
-#[reflect_value(Serialize, Deserialize)]
+#[reflect_value(Deserialize)]
 pub enum VerticalAlign {
     /// Characters/bounds start underneath the render position and progress downwards.
     Top,

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -18,7 +18,7 @@ use smallvec::SmallVec;
 ///
 /// This is commonly queried with a `Changed<Interaction>` filter.
 #[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize)]
-#[reflect_value(Component, Serialize, Deserialize, PartialEq)]
+#[reflect_value(Component, Deserialize, PartialEq)]
 pub enum Interaction {
     /// The node has been clicked
     Clicked,
@@ -36,7 +36,7 @@ impl Default for Interaction {
 
 /// Describes whether the node should block interactions with lower nodes
 #[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize)]
-#[reflect_value(Component, Serialize, Deserialize, PartialEq)]
+#[reflect_value(Component, Deserialize, PartialEq)]
 pub enum FocusPolicy {
     /// Blocks interaction
     Block,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -21,7 +21,7 @@ pub struct Node {
 
 /// An enum that describes possible types of value in flexbox layout options
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum Val {
     /// No value defined
     Undefined,
@@ -145,7 +145,7 @@ impl Default for Style {
 
 /// How items are aligned according to the cross axis
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum AlignItems {
     /// Items are aligned at the start
     FlexStart,
@@ -167,7 +167,7 @@ impl Default for AlignItems {
 
 /// Works like [`AlignItems`] but applies only to a single item
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum AlignSelf {
     /// Use the value of [`AlignItems`]
     Auto,
@@ -193,7 +193,7 @@ impl Default for AlignSelf {
 ///
 /// It only applies if [`FlexWrap::Wrap`] is present and if there are multiple lines of items.
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum AlignContent {
     /// Each line moves towards the start of the cross axis
     FlexStart,
@@ -221,7 +221,7 @@ impl Default for AlignContent {
 ///
 /// For example English is written LTR (left-to-right) while Arabic is written RTL (right-to-left).
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum Direction {
     /// Inherit from parent node
     Inherit,
@@ -239,7 +239,7 @@ impl Default for Direction {
 
 /// Whether to use Flexbox layout
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum Display {
     /// Use flexbox
     Flex,
@@ -255,7 +255,7 @@ impl Default for Display {
 
 /// Defines how flexbox items are ordered within a flexbox
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum FlexDirection {
     /// Same way as text direction along the main axis
     Row,
@@ -275,7 +275,7 @@ impl Default for FlexDirection {
 
 /// Defines how items are aligned according to the main axis
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum JustifyContent {
     /// Pushed towards the start
     FlexStart,
@@ -299,7 +299,7 @@ impl Default for JustifyContent {
 
 /// Whether to show or hide overflowing items
 #[derive(Copy, Clone, PartialEq, Debug, Reflect, Serialize, Deserialize)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum Overflow {
     /// Show overflowing items
     Visible,
@@ -315,7 +315,7 @@ impl Default for Overflow {
 
 /// The strategy used to position this node
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum PositionType {
     /// Relative to all other nodes with the [`PositionType::Relative`] value
     Relative,
@@ -333,7 +333,7 @@ impl Default for PositionType {
 
 /// Defines if flexbox items appear on a single line or on multiple lines
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum FlexWrap {
     /// Single line, will overflow if needed
     NoWrap,

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 /// Describes how to resize the Image node
 #[derive(Component, Debug, Clone, Reflect, Serialize, Deserialize)]
-#[reflect_value(Component, Serialize, Deserialize)]
+#[reflect_value(Component, Deserialize)]
 pub enum ImageMode {
     /// Keep the aspect ratio of the image
     KeepAspect,

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -37,7 +37,7 @@ pub struct C(usize);
 /// `Reflect::serialize()`. You can force these implementations to use the actual trait
 /// implementations (instead of their defaults) like this:
 #[derive(Reflect, Hash, Serialize, PartialEq)]
-#[reflect(Hash, Serialize, PartialEq)]
+#[reflect(Hash, PartialEq)]
 pub struct D {
     x: usize,
 }
@@ -48,7 +48,7 @@ pub struct D {
 /// traits on `reflect_value` types to ensure that these values behave as expected when nested
 /// underneath Reflect-ed structs.
 #[derive(Reflect, Copy, Clone, PartialEq, Serialize, Deserialize)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(PartialEq, Deserialize)]
 pub enum E {
     X,
     Y,


### PR DESCRIPTION
## Objective

> **Note:** The majority of this PR was implemented by @kabergstrom. They kindly asked that I head up the PR due to possible unavailability to make any requested changes. But all credit should go to them!

### Trait Casting

Currently the best way of converting a reflected type to a trait object is to go through a multi-step process wherein a user must:

1. Mark the trait with `#[reflect_trait]`
2. Import the generated `ReflectSomeTrait`
3. Mark the implementor structs with `#[reflect(SomeTrait)]`
4. Get the stored `ReflectSomeTrait` from the registry
5. Use the `ReflectSomeTrait` to cast your reflected value to `&dyn SomeTrait`

<details>
<summary><string>Example Code</strong></summary>

```rust
#[reflect_trait]
trait SomeTrait {
  fn foo(&self);
}

#[derive(Reflect)]
#[reflect(SomeTrait)]
struct MyStruct {}

fn try_cast(value: &dyn Reflect, registry: &TypeRegistry) -> &dyn SomeTrait {
  let reflect_some_trait = registry
    .get_type_data::<ReflectSomeTrait>(value.type_id())
    .unwrap();
  
  reflect_some_trait.get(&*value).unwrap()
}
```

</details>

This is both complicated and annoying to code out, with lots of places to go wrong. Ideally there would be a way for casting to Just Work™.

## Solution

### Trait Casting

Added the following methods to `TypeRegistration`:

* `has_trait_cast<T: ?Sized + 'static>(&self) -> bool`
  Returns whether or not a given value can be cast to a given trait object.
  
  ```rust
  let is_implemented: bool = type_registration.has_trait_cast::<dyn SomeTrait>();
  ```

* `trait_cast<'a, T: ?Sized + 'static>(&self, val: &'a dyn Reflect) -> Option<&'a T>`
  Attempts to cast a given value to a given trait object.
  
  ```rust
  let obj: &dyn SomeTrait = type_registration.trait_cast::<dyn SomeTrait>(&some_struct).unwrap();
  ```

Together, these methods can turn the previous code:

```rust
let reflect_some_trait = registry
    .get_type_data::<ReflectSomeTrait>(value.type_id())
    .unwrap();
  
  reflect_some_trait.get(&*value).unwrap()
```

into the following:

```rust
let reflect_some_trait = registry
    .trait_cast::<dyn SomeTrait>(&value)
    .unwrap();
```

This is a small improvement, but it's not where the magic of this PR happens. That takes place during type registration.

### Type Registration

The biggest difficulty with handling traits using Bevy's reflection system is that each trait has to be registered per implementor— at the implementor's definition. This can be difficult to maintain as implementors need to import the generated `ReflectMyTrait` structs.

To get around this issue, this PR adds the `register_all` macro, which allows multiple traits and types to be registered at once, and let the compiler figure out which types can register which trait.

```rust
#[derive(Reflect)]
struct Foo;
#[derive(Reflect)]
struct Bar;

trait SomeTrait {}
impl SomeTrait for Foo {}

register_all! {
  traits: [SomeTrait],
  types: [Foo, Bar]
}

// Registers:
// Foo with SomeTrait trait cast
// Bar with nothing
register_types(&mut type_registry);
```

The `register_all` registers a trait cast for each trait that a given type implements. It then generates a public function called `register_types` which can be used to mass register all types.

#### Benefits

Aside from just being more compact, the macro automatically allows usage of the new `trait_cast` methods, making it much easier to cast types to their respective traits. It also makes using managing reflected traits a lot simpler (users don't need to worry about importing/exporting the proper `ReflectMyTrait` structs).

Additionally, it makes it much easier to reflect third-party traits. Instead of manually creating the struct (or using a macro to do it for you), you can simply add it to the list of traits in the `register_all!` macro (same goes for third-party structs as well).

#### Considerations

One downside of this is that it ends up generating a fair amount of code (~40 lines per type per trait) as each type needs to check if it implements a given trait. This means that the total number of generated "blocks" is equal to the number of types times the number of traits.

However, it might be worth it for widely used traits or when used more granularly.

<details>
<summary><strong>Sample Output</strong></summary>

```rust
pub fn register_types(registry: &mut bevy_reflect::TypeRegistry) {
  {
    let type_registration = match registry.get_mut(::std::any::TypeId::of::<Foo>()) {
      Some(registration) => registration,
      None => {
        registry.register::<Foo>();
        registry.get_mut(::std::any::TypeId::of::<Foo>()).unwrap()
      }
    };
    if let Some(cast_fn) = {
      {
        trait NotTrait {
          const CAST_FN: Option<for<'a> fn(&'a Foo) -> &'a dyn SomeTrait> = None;
        }
        impl<T> NotTrait for T {}
        struct IsImplemented<T>(core::marker::PhantomData<T>);
        impl<T: SomeTrait + 'static> IsImplemented<T> {
          #[allow(dead_code)]
          const CAST_FN: Option<for<'a> fn(&'a T) -> &'a dyn SomeTrait> =
            Some(|a| a);
        }
        if IsImplemented::<Foo>::CAST_FN.is_some() {
          let f: fn(&dyn crate::Reflect) -> crate::ErasedNonNull =
            |val: &dyn crate::Reflect| {
              let cast_fn = IsImplemented::<Foo>::CAST_FN.unwrap();
              let static_val: &Foo = val.downcast_ref::<Foo>().unwrap();
              let trait_val: &dyn SomeTrait = (cast_fn)(static_val);
              crate::ErasedNonNull::new(
                trait_val,
                core::any::TypeId::of::<dyn SomeTrait>(),
              )
            };
          Some(f)
        } else {
          None
        }
      }
    } {
      {
        type_registration.register_trait_cast::<dyn SomeTrait>(cast_fn);
      }
    }
  };
  {
    let type_registration = match registry.get_mut(::std::any::TypeId::of::<Bar>()) {
      Some(registration) => registration,
      None => {
        registry.register::<Bar>();
        registry.get_mut(::std::any::TypeId::of::<Bar>()).unwrap()
      }
    };
    if let Some(cast_fn) = {
      {
        trait NotTrait {
          const CAST_FN: Option<for<'a> fn(&'a Bar) -> &'a dyn SomeTrait> = None;
        }
        impl<T> NotTrait for T {}
        struct IsImplemented<T>(core::marker::PhantomData<T>);
        impl<T: SomeTrait + 'static> IsImplemented<T> {
          #[allow(dead_code)]
          const CAST_FN: Option<for<'a> fn(&'a T) -> &'a dyn SomeTrait> =
            Some(|a| a);
        }
        if IsImplemented::<Bar>::CAST_FN.is_some() {
          let f: fn(&dyn crate::Reflect) -> crate::ErasedNonNull =
            |val: &dyn crate::Reflect| {
              let cast_fn = IsImplemented::<Bar>::CAST_FN.unwrap();
              let static_val: &Bar = val.downcast_ref::<Bar>().unwrap();
              let trait_val: &dyn SomeTrait = (cast_fn)(static_val);
              crate::ErasedNonNull::new(
                trait_val,
                core::any::TypeId::of::<dyn SomeTrait>(),
              )
            };
          Some(f)
        } else {
          None
        }
      }
    } {
      {
        type_registration.register_trait_cast::<dyn SomeTrait>(cast_fn);
      }
    }
  }
}
```

</details>

### Example

As an example of how this works, `bevy_reflect::impls` now exports a `registrations` module:

```rust
mod registrations {
    use crate as bevy_reflect;
    use crate::erased_serde::Serialize;
    use crate::register_all;

    register_all! {
        traits: [Serialize],
        types: [
            bool,
            char,
            u8,
            u16,
            u32,
            u64,
            u128,
            usize,
            i8,
            i16,
            i32,
            i64,
            i128,
            isize,
            f32,
            f64,
            String,
            Option<String>,
        ]
    }
}
```

Because we register all these types with a `Serialize` trait cast, we can use it in our `ReflectSerializer` as easily as:

```rust
// `unwrap()` used for conciseness here
let registration = self.registry
  .get(self.value.type_id())
  .unwrap();
let serializable = registration
  .trait_cast::<dyn erased_serde::Serialize>(self.value)
  .unwrap();
```

## Todo

- [ ] Replace existing registrations with `register_all` (?)