### PR TITLE
[Merged by Bors] - Fix clap for CI

### DIFF
--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -6,17 +6,18 @@ use xshell::{cmd, Shell};
 #[derive(Parser, Debug)]
 struct Args {
     /// Examples to build
+    #[clap(value_parser)]
     examples: Vec<String>,
 
-    #[clap(short, long)]
+    #[clap(short, long, value_parser)]
     /// Run tests
     test: bool,
 
-    #[clap(short, long)]
+    #[clap(short, long, value_parser)]
     /// Run on the given browsers. By default, chromium, firefox, webkit
     browsers: Vec<String>,
 
-    #[clap(short, long)]
+    #[clap(short, long, value_parser)]
     /// Stop after this number of frames
     frames: Option<usize>,
 }

--- a/tools/spancmp/src/main.rs
+++ b/tools/spancmp/src/main.rs
@@ -15,20 +15,22 @@ mod pretty;
 
 #[derive(Parser, Debug)]
 struct Args {
-    #[clap(short, long, default_value_t = 0.0)]
+    #[clap(short, long, value_parser, default_value_t = 0.0)]
     /// Filter spans that have an average shorther than the threshold
     threshold: f32,
 
-    #[clap(short, long)]
+    #[clap(short, long, value_parser)]
     /// Filter spans by name matching the pattern
     pattern: Option<Regex>,
 
-    #[clap(short, long)]
+    #[clap(short, long, value_parser)]
     /// Simplify system names
     short: bool,
 
+    #[clap(value_parser)]
     trace: String,
     /// Optional, second trace to compare
+    #[clap(value_parser)]
     second_trace: Option<String>,
 }
 


### PR DESCRIPTION
# Objective

- Fix CI
- relevant clap issue https://github.com/clap-rs/clap/issues/3822

## Solution

- slap `value_parser` on all the clap derives. This tells clap to use the default parser for the type.