### PR TITLE
Revert "merge `matches_archetype` and `matches_table` (#4807)"

### DIFF
--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -279,9 +279,12 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
                 #(self.#field_idents.update_archetype_component_access(_archetype, _access);)*
             }
 
-            fn matches_component_set(&self, _set_contains_id: &impl Fn(#path::component::ComponentId) -> bool) -> bool {
-                true #(&& self.#field_idents.matches_component_set(_set_contains_id))*
+            fn matches_archetype(&self, _archetype: &#path::archetype::Archetype) -> bool {
+                true #(&& self.#field_idents.matches_archetype(_archetype))*
+            }
 
+            fn matches_table(&self, _table: &#path::storage::Table) -> bool {
+                true #(&& self.#field_idents.matches_table(_table))*
             }
         }
     };

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -115,12 +115,8 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
 
     /// Creates a new [`Archetype`].
     pub fn new_archetype(&mut self, archetype: &Archetype) {
-        if self
-            .fetch_state
-            .matches_component_set(&|id| archetype.contains(id))
-            && self
-                .filter_state
-                .matches_component_set(&|id| archetype.contains(id))
+        if self.fetch_state.matches_archetype(archetype)
+            && self.filter_state.matches_archetype(archetype)
         {
             self.fetch_state
                 .update_archetype_component_access(archetype, &mut self.archetype_component_access);


### PR DESCRIPTION
Reverts #4807.

@cart [raised some reasonable concerns](https://github.com/bevyengine/bevy/pull/4807#issuecomment-1154399219) about the implications of what appeared to be a simple code-deduplication PR.

> 1. This forces each caller of matches_component_set to decide what it means for an archetype or table to match a component id (edit: and a Query generally). This should not be externalized, it is a core part of what it means for a query to match an archetype / table.
> 2. It assumes that archetype matching will always hinge on ComponentIds. I think there is a reasonable chance that we will add things like "value based" archetype identity (ex: for things like indexing), which would split out our definitions of "matches table" vs "matches archetype".
> 3. We've removed a "duplicate" method from each impl, but it comes at the cost of additional implementation complexity because it adds the abstraction of "calling an arbitrary input function". It is much harder to tell whats going on (and the purpose of the function).

I'm broadly in agreement, especially with point 1, and so I've made this PR to revert those changes.