### PR TITLE
[Merged by Bors] - Fix broken `WorldCell` test

### DIFF
--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -420,12 +420,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn world_cell_ref_and_ref() {
         let mut world = World::default();
         world.insert_resource(1u32);
         let cell = world.cell();
-        let _value_a = cell.resource_mut::<u32>();
+        let _value_a = cell.resource::<u32>();
         let _value_b = cell.resource::<u32>();
     }
 }


### PR DESCRIPTION
# Objective

Fixes #5008. Aliasing references is allowed under Rust if and only if they are immutable.

This logic applies to `WorldCell` as well.