### PR TITLE
[Merged by Bors] - Add `Input::reset_all` 

### DIFF
--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -123,6 +123,13 @@ where
         self.just_released.remove(&input);
     }
 
+    /// Clears the `pressed`, `just_pressed`, and `just_released` data for every input.
+    pub fn reset_all(&mut self) {
+        self.pressed.clear();
+        self.just_pressed.clear();
+        self.just_released.clear();
+    }
+
     /// Clears the `just pressed` and `just released` data for every input.
     pub fn clear(&mut self) {
         self.just_pressed.clear();
@@ -282,6 +289,22 @@ mod test {
         assert!(!input.pressed(DummyInput::Input1));
         assert!(!input.just_pressed(DummyInput::Input1));
         assert!(!input.just_released(DummyInput::Input1));
+    }
+
+    #[test]
+    fn test_reset_all() {
+        let mut input = Input::default();
+
+        input.press(DummyInput::Input1);
+        input.press(DummyInput::Input2);
+        input.release(DummyInput::Input2);
+        assert!(input.pressed.contains(&DummyInput::Input1));
+        assert!(input.just_pressed.contains(&DummyInput::Input1));
+        assert!(input.just_released.contains(&DummyInput::Input2));
+        input.reset_all();
+        assert!(input.pressed.is_empty());
+        assert!(input.just_pressed.is_empty());
+        assert!(input.just_released.is_empty());
     }
 
     #[test]

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -124,7 +124,7 @@ where
     }
 
     /// Clears the `pressed`, `just_pressed`, and `just_released` data for every input.
-    /// 
+    ///
     /// See also [`Input::clear`] for simulating elapsed time steps.
     pub fn reset_all(&mut self) {
         self.pressed.clear();
@@ -133,7 +133,7 @@ where
     }
 
     /// Clears the `just pressed` and `just released` data for every input.
-    /// 
+    ///
     /// See also [`Input::reset_all`] for a full reset.
     pub fn clear(&mut self) {
         self.just_pressed.clear();

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -124,6 +124,8 @@ where
     }
 
     /// Clears the `pressed`, `just_pressed`, and `just_released` data for every input.
+    /// 
+    /// See also [`Input::clear`] for simulating elapsed time steps.
     pub fn reset_all(&mut self) {
         self.pressed.clear();
         self.just_pressed.clear();
@@ -131,6 +133,8 @@ where
     }
 
     /// Clears the `just pressed` and `just released` data for every input.
+    /// 
+    /// See also [`Input::reset_all`] for a full reset.
     pub fn clear(&mut self) {
         self.just_pressed.clear();
         self.just_released.clear();


### PR DESCRIPTION
Adds a `reset_all` method to reset `pressed`, `just_pressed`, and `just_released` on the `Input`.

Fixes #3383