### PR TITLE
Add subgroup

### DIFF
--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -83,6 +83,7 @@ impl PluginGroupBuilder {
     ///
     /// ```
     /// # use bevy::prelude::*;
+    /// # use bevy::app::PluginGroupBuilder;
     /// #
     /// struct GamePlugins;
     ///

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -78,6 +78,22 @@ impl PluginGroupBuilder {
     }
 
     /// Merges a [`PluginGroup`] into the current group.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy::prelude::*;
+    /// #
+    /// struct GamePlugins;
+    ///
+    /// impl PluginGroup for GamePlugins {
+    ///     fn build(&mut self, group: &mut PlugingGroupBuilder) {
+    ///         group.add_subgroup(DefaultPlugins);
+    ///
+    ///         // Add more plugins here...
+    ///     }
+    /// }
+    /// ```
     pub fn add_subgroup<T: PluginGroup>(&mut self, mut subgroup: T) -> &mut Self {
         subgroup.build(self);
         self

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -82,13 +82,19 @@ impl PluginGroupBuilder {
     /// # Example
     ///
     /// ```
-    /// # use bevy::prelude::*;
-    /// # use bevy::app::PluginGroupBuilder;
+    /// # use bevy_app::{PluginGroup, PluginGroupBuilder};
+    /// #
+    /// # // Hacky alternative because bevy_internal is not available.
+    /// # struct DefaultPlugins;
+    /// #
+    /// # impl PluginGroup for DefaultPlugins {
+    /// #     fn build(&mut self, _: &mut PluginGroupBuilder) {}
+    /// # }
     /// #
     /// struct GamePlugins;
     ///
     /// impl PluginGroup for GamePlugins {
-    ///     fn build(&mut self, group: &mut PlugingGroupBuilder) {
+    ///     fn build(&mut self, group: &mut PluginGroupBuilder) {
     ///         group.add_subgroup(DefaultPlugins);
     ///
     ///         // Add more plugins here...

--- a/examples/app/plugin_group.rs
+++ b/examples/app/plugin_group.rs
@@ -5,8 +5,6 @@ use bevy::{app::PluginGroupBuilder, prelude::*};
 
 fn main() {
     App::new()
-        // Two PluginGroups that are included with bevy are DefaultPlugins and MinimalPlugins
-        .add_plugins(DefaultPlugins)
         // Adding a plugin group adds all plugins in the group by default
         .add_plugins(HelloWorldPlugins)
         // You can also modify a PluginGroup (such as disabling plugins) like this:
@@ -23,7 +21,12 @@ pub struct HelloWorldPlugins;
 
 impl PluginGroup for HelloWorldPlugins {
     fn build(&mut self, group: &mut PluginGroupBuilder) {
-        group.add(PrintHelloPlugin).add(PrintWorldPlugin);
+        group
+            // HelloWorldPlugins requires DefaultPlugins as well
+            .add_subgroup(DefaultPlugins)
+            // Add the plugins
+            .add(PrintHelloPlugin)
+            .add(PrintWorldPlugin);
     }
 }
 


### PR DESCRIPTION
# Objective

Sometimes a `PluginGroup` requires another `PluginGroup`, like `DefaultPlugins`. The previous solution to this was:

```rust
use bevy::prelude::*;
use bevy::app::PluginGroupBuilder;

struct GamePlugins;

impl PluginGroup for GamePlugins {
    fn build(&mut self, group: &mut PluginGroupBuilder) {
        DefaultPlugins.build(group);

        // Add more plugins here...
    }
}
```

This feels backwards, even though it is correct.

## Solution

Add a quality-of-life function that merges another group into the current one.

```rust
use bevy::prelude::*;
use bevy::app::PluginGroupBuilder;

struct GamePlugins;

impl PluginGroup for GamePlugins {
    fn build(&mut self, group: &mut PluginGroupBuilder) {
        group.add_subgroup(DefaultPlugins);

        // Add more plugins here...
    }
}
```

---

## Changelog

Added `PlugingGroupBuilder::add_subgroup()`.

## Reasoning

My game is structured in a set of plugins. All you need to do is call `App::new().add_plugins(GamePlugins).run()`. This ensures that all the required plugins are registered. If `main.rs` has to also register `DefaultPlugins`, but doesn't, then my game would break. To fix this, I attach the default plugins as seen in the first example. I was dissatisfied with how that broke the flow of the code, so I wrote this function to fix it.