### PR TITLE
[Merged by Bors] - enable optional dependencies to stay optional

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -12,14 +12,14 @@ categories = ["game-engines", "graphics", "gui", "rendering"]
 [features]
 trace = [
     "bevy_app/trace",
-    "bevy_core_pipeline/trace",
+    "bevy_core_pipeline?/trace",
     "bevy_ecs/trace",
     "bevy_log/trace",
-    "bevy_render/trace",
+    "bevy_render?/trace",
     "bevy_hierarchy/trace"
 ]
 trace_chrome = [ "bevy_log/tracing-chrome" ]
-trace_tracy = ["bevy_render/tracing-tracy", "bevy_log/tracing-tracy" ]
+trace_tracy = ["bevy_render?/tracing-tracy", "bevy_log/tracing-tracy" ]
 wgpu_trace = ["bevy_render/wgpu_trace"]
 debug_asset_server = ["bevy_asset/debug_asset_server"]
 
@@ -55,13 +55,13 @@ x11 = ["bevy_winit/x11"]
 subpixel_glyph_atlas = ["bevy_text/subpixel_glyph_atlas"]
 
 # Optimise for WebGL2
-webgl = ["bevy_core_pipeline/webgl", "bevy_pbr/webgl", "bevy_render/webgl"]
+webgl = ["bevy_core_pipeline?/webgl", "bevy_pbr?/webgl", "bevy_render?/webgl"]
 
 # enable systems that allow for automated testing on CI
 bevy_ci_testing = ["bevy_app/bevy_ci_testing", "bevy_render/ci_limits"]
 
 # Enable animation support, and glTF animation loading
-animation = ["bevy_animation", "bevy_gltf/bevy_animation"]
+animation = ["bevy_animation", "bevy_gltf?/bevy_animation"]
 
 [dependencies]
 # bevy


### PR DESCRIPTION
# Objective

- Optional dependencies were enabled by some features as a side effect. for example, enabling the `webgl` feature enables the `bevy_pbr` optional dependency

## Solution

- Use the syntax introduced in rust 1.60 to specify weak dependency features: https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html#new-syntax-for-cargo-features

> Weak dependency features tackle the second issue where the `"optional-dependency/feature-name"` syntax would always enable `optional-dependency`. However, often you want to enable the feature on the optional dependency only if some other feature has enabled the optional dependency. Starting in 1.60, you can add a ? as in `"package-name?/feature-name"` which will only enable the given feature if something else has enabled the optional dependency.
