### PR TITLE
[Merged by Bors] - Update `clap` to 3.2 in tools using `value_parser`

### DIFF
--- a/tools/build-wasm-example/Cargo.toml
+++ b/tools/build-wasm-example/Cargo.toml
@@ -9,4 +9,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 xshell = "0.2"
-clap = { version = "3.1.12", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }

--- a/tools/spancmp/Cargo.toml
+++ b/tools/spancmp/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-clap = { version = "3.1.12", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 regex = "1.5"
 termcolor = "1.1"
 bevy_reflect = { path = "../../crates/bevy_reflect", version = "0.8.0-dev" }


### PR DESCRIPTION
**Why?**
The `value_parser` `clap` attribute was added in
[version 3.2.0][0]. With the current version of `3.1.12` users can get
errors like:

```
error: unexpected attribute: value_parser
  --> tools/spancmp/src/main.rs:18:25
   |
18 |     #[clap(short, long, value_parser, default_value_t = 0.0)]
   |                         ^^^^^^^^^^^^
```

See https://github.com/bevyengine/bevy/pull/4944#issuecomment-1157704785 for more details.

[0]: https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#320---2022-06-13