### PR TITLE
[Merged by Bors] - update hashbrown to 0.12

### DIFF
--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -26,7 +26,6 @@ once_cell = "1.11"
 serde = "1"
 smallvec = { version = "1.6", features = ["serde", "union", "const_generics"], optional = true }
 glam = { version = "0.20.0", features = ["serde"], optional = true }
-hashbrown = { version = "0.12", features = ["serde"], optional = true }
 
 [dev-dependencies]
 ron = "0.7.0"

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -26,7 +26,7 @@ once_cell = "1.11"
 serde = "1"
 smallvec = { version = "1.6", features = ["serde", "union", "const_generics"], optional = true }
 glam = { version = "0.20.0", features = ["serde"], optional = true }
-hashbrown = { version = "0.11", features = ["serde"], optional = true }
+hashbrown = { version = "0.12", features = ["serde"], optional = true }
 
 [dev-dependencies]
 ron = "0.7.0"

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -13,7 +13,7 @@ ahash = "0.7.0"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 uuid = { version = "1.1", features = ["v4", "serde"] }
-hashbrown = { version = "0.11", features = ["serde"] }
+hashbrown = { version = "0.12", features = ["serde"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = {version = "0.2.0", features = ["js"]}

--- a/deny.toml
+++ b/deny.toml
@@ -37,18 +37,15 @@ highlight = "all"
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
     { name = "cfg-if", version = "0.1" },               # from winit v0.26.0
-    { name = "core-foundation", version = "0.6" },      # from gilrs v0.8.1
     { name = "core-foundation", version = "0.7" },      # from winit v0.26.0
-    { name = "core-foundation-sys", version = "0.6" },  # from gilrs v0.8.1
     { name = "core-foundation-sys", version = "0.7" },  # from winit v0.26.0
     { name = "core-graphics", version = "0.19" },       # from winit v0.26.0
-    { name = "mach", version = "0.2" },                 # from gilrs v0.8.1
+    { name = "hashbrown", version = "0.11" },           # from wgpu v0.12 - https://github.com/zakarumych/gpu-descriptor/pull/21
     { name = "mio", version = "0.7" },                  # from notify v5.0.0-pre.11
     { name = "ndk", version = "0.5" },                  # from winit v0.26.1
     { name = "ndk-glue", version = "0.5" },             # from winit v0.26.1
     { name = "ndk-sys", version = "0.2" },              # from winit v0.26.1
     { name = "stdweb", version = "0.1" },               # from rodio v0.15.0
-    { name = "wasi",  version = "0.10"},                # from ahash v0.7.6
     { name = "nix", version = "0.23.1" },               # from alsa v0.6.0
 ]
 


### PR DESCRIPTION
# Objective

- Update hashbrown to 0.12

## Solution

- Replace #4004
- As the 0.12 is already in Bevy dependency tree, it shouldn't be an issue to update
- The exception for the 0.11 should be removed once https://github.com/zakarumych/gpu-descriptor/pull/21 is merged and released
- Also removed a few exceptions that weren't needed anymore