### PR TITLE
Move adding DynamicUniformIndex to Extract

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -149,6 +149,7 @@ pub fn extract_meshes(
             entity,
             (
                 handle.clone_weak(),
+                DynamicUniformIndex::<MeshUniform>::default(),
                 MeshUniform {
                     flags: if not_receiver.is_some() {
                         MeshFlags::empty().bits
@@ -174,6 +175,7 @@ pub fn extract_meshes(
             entity,
             (
                 mesh.clone_weak(),
+                DynamicUniformIndex::<MeshUniform>::default(),
                 MeshUniform {
                     flags: if not_receiver.is_some() {
                         MeshFlags::empty().bits

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -128,6 +128,7 @@ pub fn extract_mesh2d(
             entity,
             (
                 Mesh2dHandle(handle.0.clone_weak()),
+                DynamicUniformIndex::<Mesh2dUniform>::default(),
                 Mesh2dUniform {
                     flags: MeshFlags::empty().bits,
                     transform,


### PR DESCRIPTION
# Objective
`prepare_uniform_components`'s commands must be run with exclusive access to the render world and can take quite a bit of time for components on lots of entities, particularly with archetypes with many big components. This is doing redundant work that is already being done in `Extract`.

## Solution
 - Implement `Default` on `DynamicUniformIndex`.
 - Move adding `DynamicUniformIndex` into Extract instead of `Prepare`.
 - Change `prepare_uniform_components` to query for `&mut DynamicUniformIndex` instead of using commands.

## Performance
This was tested against the `many_cubes` stress test. Here are the respective timing changes:

|stage/system|main|this PR|
|:--|:--|:--|
|Full Frame|20.52ms|18.79ms|
|Extract (Stage)|3.7ms|3.83ms|
|Prepare (Stage)|2.64ms|1.13ms|
|extract_meshes (system)|1.45ms|1.69us|
|extract_meshes (commands)|881.75us|1.48ms|
|prepare_uniform_components<MeshUniform> (system)|1.12ms|929.56us|
|prepare_uniform_components<MeshUniform> (commands)|1.26ms|253ns|

---

## Changelog
TODO

## Migration Guide
TODO