### PR TITLE
[Merged by Bors] - Fix Nix section of linux_dependencies.md

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -84,7 +84,7 @@ with pkgs; mkShell {
   ];
   buildInputs = [
     udev alsaLib vulkan-loader
-    x11 xorg.libXcursor xorg.libXrandr xorg.libXi # To use x11 feature
+    xlibsWrapper xorg.libXcursor xorg.libXrandr xorg.libXi # To use x11 feature
     libxkbcommon wayland # To use wayland feature
   ];
   shellHook = ''export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${pkgs.lib.makeLibraryPath [


### PR DESCRIPTION


# Objective

`nix-shell` reported: ```error: 'x11' has been renamed to/replaced by 'xlibsWrapper'```.

## Solution

Replacing `x11` with `xlibsWrapper` in the Nix section of linux_dependencies.md fixes the problem on my system, and bevy projects build fine.

