### PR TITLE
[Merged by Bors] - Physical viewport calculation fix

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -116,7 +116,11 @@ impl Camera {
     /// the full physical rect of the current [`RenderTarget`].
     #[inline]
     pub fn physical_viewport_rect(&self) -> Option<(UVec2, UVec2)> {
-        let min = self.viewport.as_ref()?.physical_position;
+        let min = self
+            .viewport
+            .as_ref()
+            .map(|v| v.physical_position)
+            .unwrap_or(UVec2::ZERO);
         let max = min + self.physical_viewport_size()?;
         Some((min, max))
     }


### PR DESCRIPTION
# Objective

- Fixes early return when viewport is not set. This now matches the description of the function.

## Solution

- Remove errant try `?`.