### PR TITLE
Simplify sprite flipping

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -182,8 +182,6 @@ pub struct ExtractedSprite {
     /// Handle to the `Image` of this sprite
     /// PERF: storing a `HandleId` instead of `Handle<Image>` enables some optimizations (`ExtractedSprite` becomes `Copy` and doesn't need to be dropped)
     pub image_handle_id: HandleId,
-    pub flip_x: bool,
-    pub flip_y: bool,
     pub anchor: Vec2,
 }
 
@@ -246,8 +244,6 @@ pub fn extract_sprites(
             rect: None,
             // Pass the custom size
             custom_size: sprite.custom_size,
-            flip_x: sprite.flip_x,
-            flip_y: sprite.flip_y,
             image_handle_id: handle.id,
             anchor: sprite.anchor.as_vec(),
         });
@@ -265,8 +261,6 @@ pub fn extract_sprites(
                 rect,
                 // Pass the custom size
                 custom_size: atlas_sprite.custom_size,
-                flip_x: atlas_sprite.flip_x,
-                flip_y: atlas_sprite.flip_y,
                 image_handle_id: texture_atlas.texture.id,
                 anchor: atlas_sprite.anchor.as_vec(),
             });
@@ -465,12 +459,6 @@ pub fn queue_sprites(
                 // Calculate vertex data for this item
 
                 let mut uvs = QUAD_UVS;
-                if extracted_sprite.flip_x {
-                    uvs = [uvs[1], uvs[0], uvs[3], uvs[2]];
-                }
-                if extracted_sprite.flip_y {
-                    uvs = [uvs[3], uvs[2], uvs[1], uvs[0]];
-                }
 
                 // By default, the size of the quad is the size of the texture
                 let mut quad_size = current_image_size;

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -8,10 +8,6 @@ use bevy_render::color::Color;
 pub struct Sprite {
     /// The sprite's color tint
     pub color: Color,
-    /// Flip the sprite along the X axis
-    pub flip_x: bool,
-    /// Flip the sprite along the Y axis
-    pub flip_y: bool,
     /// An optional custom size for the sprite that will be used when rendering, instead of the size
     /// of the sprite's image
     pub custom_size: Option<Vec2>,

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -25,8 +25,6 @@ pub struct TextureAtlas {
 pub struct TextureAtlasSprite {
     pub color: Color,
     pub index: usize,
-    pub flip_x: bool,
-    pub flip_y: bool,
     /// An optional custom size for the sprite that will be used when rendering, instead of the size
     /// of the sprite's image in the atlas
     pub custom_size: Option<Vec2>,
@@ -38,8 +36,6 @@ impl Default for TextureAtlasSprite {
         Self {
             index: 0,
             color: Color::WHITE,
-            flip_x: false,
-            flip_y: false,
             custom_size: None,
             anchor: Anchor::default(),
         }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -116,8 +116,6 @@ pub fn extract_text2d_sprite(
                     rect,
                     custom_size: None,
                     image_handle_id: handle.id,
-                    flip_x: false,
-                    flip_y: false,
                     anchor: Anchor::Center.as_vec(),
                 });
             }

--- a/examples/2d/sprite_flipping.rs
+++ b/examples/2d/sprite_flipping.rs
@@ -13,13 +13,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands.spawn_bundle(SpriteBundle {
         texture: asset_server.load("branding/icon.png"),
-        sprite: Sprite {
-            // Flip the logo to the left
-            flip_x: true,
-            // And don't flip it upside-down ( the default )
-            flip_y: false,
-            ..default()
-        },
+        sprite: Sprite::default(),
+        // Use a negative x scaling to flip the logo to the left
+        transform: Transform::from_scale(Vec3::new(-1.0, 1.0, 1.0)),
         ..default()
     });
 }

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -99,7 +99,8 @@ fn setup_contributor_selection(mut commands: Commands, asset_server: Res<AssetSe
         // some sprites should be flipped
         let flipped = rng.gen_bool(0.5);
 
-        let transform = Transform::from_xyz(pos.0, pos.1, 0.0);
+        let mut transform = Transform::from_xyz(pos.0, pos.1, 0.0);
+        transform.scale.x *= if flipped { -1.0 } else { 1.0 };
 
         let entity = commands
             .spawn()
@@ -114,7 +115,6 @@ fn setup_contributor_selection(mut commands: Commands, asset_server: Res<AssetSe
                 sprite: Sprite {
                     custom_size: Some(Vec2::new(1.0, 1.0) * SPRITE_SIZE),
                     color: Color::hsla(hue, SATURATION_DESELECTED, LIGHTNESS_DESELECTED, ALPHA),
-                    flip_x: flipped,
                     ..default()
                 },
                 texture: texture_handle.clone(),


### PR DESCRIPTION
# Objective

Using `flip_x` and `flip_y` for sprite flipping leads to unexpected behavior for sprite hierarchies.

Using a negative scale instead as the standard method of sprite flipping simplifies the `Sprite` interface, and has the added benefit of behaving correctly for hierarchies.

Addresses #4930

## Solution

- Remove the `flip_x` and `flip_y` fields from `Sprite` and `TextureAtlasSprite`.
- Update the sprite flipping example to use a negative `Transform` scale.

---

## Migration Guide

The `flip_x` and `flip_y` fields on `Sprite` and `TextureAtlasSprite` have been removed. Use a negative x/y `Transform` scale instead.