### PR TITLE
Improve comment in extract_windows system about main thread window handling

### DIFF
--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -135,6 +135,7 @@ pub fn prepare_windows(
         let surface = window_surfaces
             .surfaces
             .entry(window.id)
+            // SAFETY: system runs on the main thread due to the presence of the NonSend _marker
             .or_insert_with(|| unsafe {
                 // NOTE: On some OSes this MUST be called from the main thread.
                 render_instance.create_surface(&window.handle.get_handle())

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -135,9 +135,9 @@ pub fn prepare_windows(
         let surface = window_surfaces
             .surfaces
             .entry(window.id)
-            // SAFETY: system runs on the main thread due to the presence of the NonSend _marker
             .or_insert_with(|| unsafe {
                 // NOTE: On some OSes this MUST be called from the main thread.
+                // this is ensured by `_marker` being `NonSend`
                 render_instance.create_surface(&window.handle.get_handle())
             });
 


### PR DESCRIPTION
This is useful to give some indication that the _marker parameter cannot be safely removed.