### PR TITLE
Unify sprites and sprite sheets

### DIFF
--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -1,47 +1,15 @@
-use crate::{
-    texture_atlas::{TextureAtlas, TextureAtlasSprite},
-    Sprite,
-};
-use bevy_asset::Handle;
+use crate::{Sprite, SpriteImage};
 use bevy_ecs::bundle::Bundle;
-use bevy_render::{
-    texture::{Image, DEFAULT_IMAGE_HANDLE},
-    view::Visibility,
-};
+use bevy_render::view::Visibility;
 use bevy_transform::components::{GlobalTransform, Transform};
 
-#[derive(Bundle, Clone)]
+#[derive(Bundle, Clone, Default)]
 pub struct SpriteBundle {
     pub sprite: Sprite,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
-    pub texture: Handle<Image>,
-    /// User indication of whether an entity is visible
-    pub visibility: Visibility,
-}
-
-impl Default for SpriteBundle {
-    fn default() -> Self {
-        Self {
-            sprite: Default::default(),
-            transform: Default::default(),
-            global_transform: Default::default(),
-            texture: DEFAULT_IMAGE_HANDLE.typed(),
-            visibility: Default::default(),
-        }
-    }
-}
-/// A Bundle of components for drawing a single sprite from a sprite sheet (also referred
-/// to as a `TextureAtlas`)
-#[derive(Bundle, Clone, Default)]
-pub struct SpriteSheetBundle {
-    /// The specific sprite from the texture atlas to be drawn
-    pub sprite: TextureAtlasSprite,
-    /// A handle to the texture atlas that holds the sprite images
-    pub texture_atlas: Handle<TextureAtlas>,
-    /// Data pertaining to how the sprite is drawn on the screen
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
+    /// The sprite texture
+    pub texture: SpriteImage,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
 }

--- a/crates/bevy_sprite/src/image.rs
+++ b/crates/bevy_sprite/src/image.rs
@@ -1,0 +1,31 @@
+use crate::TextureAtlas;
+use bevy_asset::Handle;
+use bevy_ecs::component::Component;
+use bevy_reflect::Reflect;
+use bevy_render::texture::{Image, DEFAULT_IMAGE_HANDLE};
+
+/// The sprite texture
+#[derive(Component, Clone, Debug, Reflect)]
+pub enum SpriteImage {
+    /// Single texture
+    Image(Handle<Image>),
+    /// Texture atlas.
+    TextureAtlas {
+        /// Texture atlas handle
+        handle: Handle<TextureAtlas>,
+        /// Texture atlas index
+        index: usize,
+    },
+}
+
+impl Default for SpriteImage {
+    fn default() -> Self {
+        Self::Image(DEFAULT_IMAGE_HANDLE.typed())
+    }
+}
+
+impl From<Handle<Image>> for SpriteImage {
+    fn from(handle: Handle<Image>) -> Self {
+        Self::Image(handle)
+    }
+}

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -1,5 +1,6 @@
 mod bundle;
 mod dynamic_texture_atlas_builder;
+mod image;
 mod mesh2d;
 mod rect;
 mod render;
@@ -12,15 +13,14 @@ pub mod collide_aabb;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        bundle::{SpriteBundle, SpriteSheetBundle},
-        sprite::Sprite,
-        texture_atlas::{TextureAtlas, TextureAtlasSprite},
+        bundle::SpriteBundle, image::SpriteImage, sprite::Sprite, texture_atlas::TextureAtlas,
         ColorMaterial, ColorMesh2dBundle, TextureAtlasBuilder,
     };
 }
 
 pub use bundle::*;
 pub use dynamic_texture_atlas_builder::*;
+pub use image::*;
 pub use mesh2d::*;
 pub use rect::*;
 pub use render::*;

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -1,9 +1,8 @@
-use crate::{Anchor, Rect};
+use crate::Rect;
 use bevy_asset::Handle;
-use bevy_ecs::component::Component;
 use bevy_math::Vec2;
-use bevy_reflect::{Reflect, TypeUuid};
-use bevy_render::{color::Color, texture::Image};
+use bevy_reflect::TypeUuid;
+use bevy_render::texture::Image;
 use bevy_utils::HashMap;
 
 /// An atlas containing multiple textures (like a spritesheet or a tilemap).
@@ -19,40 +18,6 @@ pub struct TextureAtlas {
     /// The specific areas of the atlas where each texture can be found
     pub textures: Vec<Rect>,
     pub texture_handles: Option<HashMap<Handle<Image>, usize>>,
-}
-
-#[derive(Component, Debug, Clone, Reflect)]
-pub struct TextureAtlasSprite {
-    pub color: Color,
-    pub index: usize,
-    pub flip_x: bool,
-    pub flip_y: bool,
-    /// An optional custom size for the sprite that will be used when rendering, instead of the size
-    /// of the sprite's image in the atlas
-    pub custom_size: Option<Vec2>,
-    pub anchor: Anchor,
-}
-
-impl Default for TextureAtlasSprite {
-    fn default() -> Self {
-        Self {
-            index: 0,
-            color: Color::WHITE,
-            flip_x: false,
-            flip_y: false,
-            custom_size: None,
-            anchor: Anchor::default(),
-        }
-    }
-}
-
-impl TextureAtlasSprite {
-    pub fn new(index: usize) -> TextureAtlasSprite {
-        Self {
-            index,
-            ..Default::default()
-        }
-    }
 }
 
 impl TextureAtlas {

--- a/examples/2d/move_sprite.rs
+++ b/examples/2d/move_sprite.rs
@@ -20,7 +20,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands
         .spawn_bundle(SpriteBundle {
-            texture: asset_server.load("branding/icon.png"),
+            texture: asset_server.load("branding/icon.png").into(),
             transform: Transform::from_xyz(100., 0., 0.),
             ..default()
         })

--- a/examples/2d/rotation.rs
+++ b/examples/2d/rotation.rs
@@ -67,7 +67,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // player controlled ship
     commands
         .spawn_bundle(SpriteBundle {
-            texture: ship_handle,
+            texture: ship_handle.into(),
             ..default()
         })
         .insert(Player {
@@ -78,14 +78,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // enemy that snaps to face the player spawns on the bottom and left
     commands
         .spawn_bundle(SpriteBundle {
-            texture: enemy_a_handle.clone(),
+            texture: enemy_a_handle.clone().into(),
             transform: Transform::from_xyz(0.0 - horizontal_margin, 0.0, 0.0),
             ..default()
         })
         .insert(SnapToPlayer);
     commands
         .spawn_bundle(SpriteBundle {
-            texture: enemy_a_handle,
+            texture: enemy_a_handle.into(),
             transform: Transform::from_xyz(0.0, 0.0 - vertical_margin, 0.0),
             ..default()
         })
@@ -94,7 +94,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // enemy that rotates to face the player enemy spawns on the top and right
     commands
         .spawn_bundle(SpriteBundle {
-            texture: enemy_b_handle.clone(),
+            texture: enemy_b_handle.clone().into(),
             transform: Transform::from_xyz(0.0 + horizontal_margin, 0.0, 0.0),
             ..default()
         })
@@ -103,7 +103,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         });
     commands
         .spawn_bundle(SpriteBundle {
-            texture: enemy_b_handle,
+            texture: enemy_b_handle.into(),
             transform: Transform::from_xyz(0.0, 0.0 + vertical_margin, 0.0),
             ..default()
         })

--- a/examples/2d/sprite.rs
+++ b/examples/2d/sprite.rs
@@ -12,7 +12,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands.spawn_bundle(SpriteBundle {
-        texture: asset_server.load("branding/icon.png"),
+        texture: asset_server.load("branding/icon.png").into(),
         ..default()
     });
 }

--- a/examples/2d/sprite_flipping.rs
+++ b/examples/2d/sprite_flipping.rs
@@ -12,7 +12,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands.spawn_bundle(SpriteBundle {
-        texture: asset_server.load("branding/icon.png"),
+        texture: asset_server.load("branding/icon.png").into(),
         sprite: Sprite {
             // Flip the logo to the left
             flip_x: true,

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -65,19 +65,21 @@ fn setup(
     // set up a scene to display our texture atlas
     commands.spawn_bundle(Camera2dBundle::default());
     // draw a sprite from the atlas
-    commands.spawn_bundle(SpriteSheetBundle {
+    commands.spawn_bundle(SpriteBundle {
         transform: Transform {
             translation: Vec3::new(150.0, 0.0, 0.0),
             scale: Vec3::splat(4.0),
             ..default()
         },
-        sprite: TextureAtlasSprite::new(vendor_index),
-        texture_atlas: atlas_handle,
+        texture: SpriteImage::TextureAtlas {
+            handle: atlas_handle,
+            index: vendor_index,
+        },
         ..default()
     });
     // draw the atlas itself
     commands.spawn_bundle(SpriteBundle {
-        texture: texture_atlas_texture,
+        texture: texture_atlas_texture.into(),
         transform: Transform::from_xyz(-300.0, 0.0, 0.0),
         ..default()
     });

--- a/examples/2d/transparency_2d.rs
+++ b/examples/2d/transparency_2d.rs
@@ -16,7 +16,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let sprite_handle = asset_server.load("branding/icon.png");
 
     commands.spawn_bundle(SpriteBundle {
-        texture: sprite_handle.clone(),
+        texture: sprite_handle.clone().into(),
         ..default()
     });
     commands.spawn_bundle(SpriteBundle {
@@ -25,7 +25,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             color: Color::rgba(0.0, 0.0, 1.0, 0.7),
             ..default()
         },
-        texture: sprite_handle.clone(),
+        texture: sprite_handle.clone().into(),
         transform: Transform::from_xyz(100.0, 0.0, 0.0),
         ..default()
     });
@@ -34,7 +34,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             color: Color::rgba(0.0, 1.0, 0.0, 0.3),
             ..default()
         },
-        texture: sprite_handle,
+        texture: sprite_handle.into(),
         transform: Transform::from_xyz(200.0, 0.0, 0.0),
         ..default()
     });

--- a/examples/asset/custom_asset_io.rs
+++ b/examples/asset/custom_asset_io.rs
@@ -87,7 +87,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands.spawn_bundle(SpriteBundle {
-        texture: asset_server.load("branding/icon.png"),
+        texture: asset_server.load("branding/icon.png").into(),
         ..default()
     });
 }

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -18,7 +18,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let parent = commands
         .spawn_bundle(SpriteBundle {
             transform: Transform::from_scale(Vec3::splat(0.75)),
-            texture: texture.clone(),
+            texture: texture.clone().into(),
             ..default()
         })
         // With that entity as a parent, run a lambda that spawns its children
@@ -30,7 +30,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     scale: Vec3::splat(0.75),
                     ..default()
                 },
-                texture: texture.clone(),
+                texture: texture.clone().into(),
                 sprite: Sprite {
                     color: Color::BLUE,
                     ..default()
@@ -52,7 +52,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 scale: Vec3::splat(0.75),
                 ..default()
             },
-            texture: texture.clone(),
+            texture: texture.clone().into(),
             sprite: Sprite {
                 color: Color::RED,
                 ..default()
@@ -71,7 +71,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 scale: Vec3::splat(0.75),
                 ..default()
             },
-            texture,
+            texture: texture.into(),
             sprite: Sprite {
                 color: Color::GREEN,
                 ..default()

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -12,7 +12,7 @@ fn spawn_system(mut commands: Commands, asset_server: Res<AssetServer>) {
     for _ in 0..128 {
         commands
             .spawn_bundle(SpriteBundle {
-                texture: texture.clone(),
+                texture: texture.clone().into(),
                 transform: Transform::from_scale(Vec3::splat(0.1)),
                 ..default()
             })

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -30,7 +30,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands
         .spawn_bundle(SpriteBundle {
-            texture: asset_server.load("branding/icon.png"),
+            texture: asset_server.load("branding/icon.png").into(),
             ..default()
         })
         .insert(MyComponent); // Add the `Component`.

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -101,7 +101,7 @@ fn cleanup_menu(mut commands: Commands, menu_data: Res<MenuData>) {
 
 fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(SpriteBundle {
-        texture: asset_server.load("branding/icon.png"),
+        texture: asset_server.load("branding/icon.png").into(),
         ..default()
     });
 }

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -117,7 +117,7 @@ fn setup_contributor_selection(mut commands: Commands, asset_server: Res<AssetSe
                     flip_x: flipped,
                     ..default()
                 },
-                texture: texture_handle.clone(),
+                texture: texture_handle.clone().into(),
                 transform,
                 ..default()
             })

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -54,7 +54,7 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
             custom_size: Some(Vec2::new(SIZE.0 as f32, SIZE.1 as f32)),
             ..default()
         },
-        texture: image.clone(),
+        texture: image.clone().into(),
         ..default()
     });
     commands.spawn_bundle(Camera2dBundle::default());

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -199,7 +199,7 @@ fn spawn_birds(
         let bird_z = (counter.count + count) as f32 * 0.00001;
         commands
             .spawn_bundle(SpriteBundle {
-                texture: texture.clone(),
+                texture: texture.clone().into(),
                 transform: Transform {
                     translation: Vec3::new(bird_x, bird_y, bird_z),
                     scale: Vec3::splat(BIRD_SCALE),

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -54,7 +54,7 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
             let scale = Vec3::splat(rng.gen::<f32>() * 2.0);
 
             sprites.push(SpriteBundle {
-                texture: sprite_handle.clone(),
+                texture: sprite_handle.clone().into(),
                 transform: Transform {
                     translation,
                     rotation,

--- a/examples/window/transparent_window.rs
+++ b/examples/window/transparent_window.rs
@@ -5,7 +5,6 @@
 //! for more details.
 
 use bevy::{prelude::*, window::WindowDescriptor};
-
 fn main() {
     App::new()
         // ClearColor must have 0 alpha, otherwise some color will bleed through
@@ -25,7 +24,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands.spawn_bundle(SpriteBundle {
-        texture: asset_server.load("branding/icon.png"),
+        texture: asset_server.load("branding/icon.png").into(),
         ..default()
     });
 }


### PR DESCRIPTION
Related PR: #5070 (bevy_ui support for texture sheets)

# Objective

Improve ergonomics for sprite sheets and remove:
- `SpriteSheetBundle`
- `TextureAtlasSprite` which is almost identic to `Sprite`

Dev side, this will improve maintenance and avoid duplicate queries and systems for sprite sheets

## Solution

I replaced the `SpriteBundle::texture` field , a `Handle<Image>`, by a custom `SpriteImage` enum which can store either:
- a `Handle<Image>`
- a `Handle<TextureAtlas>` and texture sheet `index`

Tasks:
- [x] `SpriteImage`
- [x]  Update extraction system
- [x]  Docs
- [x] Update examples
- [x] test examples

---

## Changelog

- (**BREAKING**) `SpriteBundle` now takes a `SpriteImage` instead of a `Handle<Image>`
- (**BREAKING**) Removed `SpriteSheetBundle`
- (**BREAKING**) Removed `TextureAtlasSprite` component

## Migration Guide

### Sprites

```diff
let handle = asset_server.load("my_icon.png");
commands.spawn_bundle(SpriteBundle {
-   texture: handle,
+   texture: handle.into(),
   ..default()
});
```
or

```diff
let handle = asset_server.load("my_icon.png");
commands.spawn_bundle(SpriteBundle {
-   texture: handle,
+   texture: SpriteImage::Image(handle),
   ..default()
});
```

### Sprite sheets

Before:
```rust
let image = asset_server.load("sheet.png");
let atlas_handle = texture_atlases.add(TextureAtlas::from_grid(image, Vec2::splate(100.0), 2, 2);
commands.spawn_bundle(SpriteSheetBundle {
   texture_atlas: atlas_handle,
   sprite: TextureAtlasSprite::new(0),
   ..default()
});
```

after:
```rust
let image = asset_server.load("sheet.png");
let atlas_handle = texture_atlases.add(TextureAtlas::from_grid(image, Vec2::splate(100.0), 2, 2);
commands.spawn_bundle(SpriteBundle {
   texture: SpriteImage::TextureAtlas {
      handle: atlas_handle,
      index: 0,
   },
   ..default()
});
```