### PR TITLE
[Merged by Bors] - Separate PBR and tone mapping into 2 functions

### DIFF
--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -85,7 +85,7 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
         );
         pbr_input.V = calculate_view(in.world_position, pbr_input.is_orthographic);
 
-        output_color = pbr(pbr_input);
+        output_color = tone_mapping(pbr(pbr_input));
     }
 
     return output_color;

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -186,11 +186,14 @@ fn pbr(
         cluster_index,
     );
 
+    return output_color;
+}
+
+fn tone_mapping(in: vec4<f32>) -> vec4<f32> {
     // tone_mapping
-    output_color = vec4<f32>(reinhard_luminance(output_color.rgb), output_color.a);
+    return vec4<f32>(reinhard_luminance(in.rgb), in.a);
+    
     // Gamma correction.
     // Not needed with sRGB buffer
     // output_color.rgb = pow(output_color.rgb, vec3(1.0 / 2.2));
-
-    return output_color;
 }


### PR DESCRIPTION
# Objective

- Allow custom shaders to reuse the HDR results of PBR.

## Solution

- Separate `pbr()` and `tone_mapping()` into 2 functions in `pbr_functions.wgsl`.
