### PR TITLE
Exposed a  `CursorPosition` resource

### DIFF
--- a/crates/bevy_window/src/cursor.rs
+++ b/crates/bevy_window/src/cursor.rs
@@ -1,32 +1,19 @@
 use crate::WindowId;
 use bevy_math::Vec2;
-use bevy_utils::HashMap;
 
 #[derive(Debug, Clone, Default)]
-/// Resource storing the cursor position on the app windows
-pub struct CursorPositions {
-    pub(crate) positions: HashMap<WindowId, Vec2>,
-}
+/// Resource storing the cursor position on the app window
+pub struct CursorPosition(pub(crate) Option<(WindowId, Vec2)>);
 
-impl CursorPositions {
+impl CursorPosition {
     /// Retrieves the cursor position from the given [`WindowId`]
-    pub fn get(&self, id: WindowId) -> Option<Vec2> {
-        self.positions.get(&id).copied()
+    pub fn position(&self) -> Option<Vec2> {
+        self.0.map(|(_, p)| p)
     }
 
     /// Retrieves the cursor position from the *primary* window
-    pub fn primary_position(&self) -> Option<Vec2> {
-        self.get(WindowId::primary())
-    }
-
-    /// Returns an iterator on cursor positions
-    pub fn positions_iter(&self) -> impl Iterator<Item = &Vec2> {
-        self.positions.values()
-    }
-
-    /// Returns an iterator on window ids and cursor positions
-    pub fn iter(&self) -> impl Iterator<Item = (&WindowId, &Vec2)> {
-        self.positions.iter()
+    pub fn window_id(&self) -> Option<WindowId> {
+        self.0.map(|(id, _)| id)
     }
 }
 

--- a/crates/bevy_window/src/cursor.rs
+++ b/crates/bevy_window/src/cursor.rs
@@ -1,9 +1,38 @@
 use crate::WindowId;
 use bevy_math::Vec2;
+use std::ops::Deref;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Deref)]
 /// Resource storing the cursor position on the app window
-pub struct CursorPosition(pub(crate) Option<(WindowId, Vec2)>);
+///
+/// ## Usage
+///
+/// You can use this resource to retrieve the cursor position:
+///
+/// ```rust
+/// # use bevy_window::*;
+/// # use bevy_ecs::prelude::*;
+/// #
+/// fn my_system(cursor: Res<CursorPosition>) {
+///     if let Some(pos) = cursor.position() {
+///         // Do something
+///     }   
+/// }
+/// ```
+///
+/// If you want both the position and window id you may do:
+///
+/// ```rust
+/// # use bevy_window::*;
+/// # use bevy_ecs::prelude::*;
+/// #
+/// fn my_system(cursor: Res<CursorPosition>) {
+///     if let Some((window_id, pos)) = cursor.0 {
+///         // Do something
+///     }   
+/// }
+/// ```
+pub struct CursorPosition(pub Option<(WindowId, Vec2)>);
 
 impl CursorPosition {
     /// Retrieves the cursor position from the given [`WindowId`]

--- a/crates/bevy_window/src/cursor.rs
+++ b/crates/bevy_window/src/cursor.rs
@@ -1,3 +1,35 @@
+use crate::WindowId;
+use bevy_math::Vec2;
+use bevy_utils::HashMap;
+
+#[derive(Debug, Clone, Default)]
+/// Resource storing the cursor position on the app windows
+pub struct CursorPositions {
+    pub(crate) positions: HashMap<WindowId, Vec2>,
+}
+
+impl CursorPositions {
+    /// Retrieves the cursor position from the given [`WindowId`]
+    pub fn get(&self, id: WindowId) -> Option<Vec2> {
+        self.positions.get(&id).copied()
+    }
+
+    /// Retrieves the cursor position from the *primary* window
+    pub fn primary_position(&self) -> Option<Vec2> {
+        self.get(WindowId::primary())
+    }
+
+    /// Returns an iterator on cursor positions
+    pub fn positions_iter(&self) -> impl Iterator<Item = &Vec2> {
+        self.positions.values()
+    }
+
+    /// Returns an iterator on window ids and cursor positions
+    pub fn iter(&self) -> impl Iterator<Item = (&WindowId, &Vec2)> {
+        self.positions.iter()
+    }
+}
+
 /// The icon to display for a window's cursor.
 ///
 /// Examples of all of these cursors can be found [here](https://www.w3schools.com/cssref/playit.asp?filename=playcss_cursor).

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -95,8 +95,8 @@ impl Plugin for WindowPlugin {
         }
 
         if self.update_cursor_position {
-            app.init_resource::<CursorPositions>();
-            app.add_system(update_cursor_positions);
+            app.init_resource::<CursorPosition>();
+            app.add_system(update_cursor_position);
         }
 
         if self.exit_on_all_closed {

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -47,7 +47,7 @@ pub struct WindowPlugin {
     /// If this system (or a replacement) is not running, the close button will have no effect.
     /// This may surprise your users. It is recommended to leave this setting as `true`.
     pub close_when_requested: bool,
-    /// Whether the plugin will update a [`CursorPositions`] resource every frame.
+    /// Whether the plugin will update a [`CursorPosition`] resource every frame.
     pub update_cursor_position: bool,
 }
 

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -47,6 +47,8 @@ pub struct WindowPlugin {
     /// If this system (or a replacement) is not running, the close button will have no effect.
     /// This may surprise your users. It is recommended to leave this setting as `true`.
     pub close_when_requested: bool,
+    /// Whether the plugin will update a [`CursorPositions`] resource every frame.
+    pub update_cursor_position: bool,
 }
 
 impl Default for WindowPlugin {
@@ -55,6 +57,7 @@ impl Default for WindowPlugin {
             add_primary_window: true,
             exit_on_all_closed: true,
             close_when_requested: true,
+            update_cursor_position: true,
         }
     }
 }
@@ -89,6 +92,11 @@ impl Plugin for WindowPlugin {
                 id: WindowId::primary(),
                 descriptor: window_descriptor,
             });
+        }
+
+        if self.update_cursor_position {
+            app.init_resource::<CursorPositions>();
+            app.add_system(update_cursor_positions);
         }
 
         if self.exit_on_all_closed {

--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -1,8 +1,16 @@
-use crate::{Window, WindowCloseRequested, WindowFocused, WindowId, Windows};
+use crate::{CursorPositions, Window, WindowCloseRequested, WindowFocused, WindowId, Windows};
 
 use bevy_app::AppExit;
 use bevy_ecs::prelude::*;
 use bevy_input::{keyboard::KeyCode, Input};
+
+/// Updates the [`CursorPositions`] resource
+pub fn update_cursor_positions(mut positions: ResMut<CursorPositions>, windows: Res<Windows>) {
+    positions.positions = windows
+        .iter()
+        .flat_map(|w| w.cursor_position().map(|p| (w.id(), p)))
+        .collect();
+}
 
 /// Exit the application when there are no open windows.
 ///

--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -1,15 +1,14 @@
-use crate::{CursorPositions, Window, WindowCloseRequested, WindowFocused, WindowId, Windows};
+use crate::{CursorPosition, Window, WindowCloseRequested, WindowFocused, WindowId, Windows};
 
 use bevy_app::AppExit;
 use bevy_ecs::prelude::*;
 use bevy_input::{keyboard::KeyCode, Input};
 
 /// Updates the [`CursorPositions`] resource
-pub fn update_cursor_positions(mut positions: ResMut<CursorPositions>, windows: Res<Windows>) {
-    positions.positions = windows
+pub fn update_cursor_position(mut positions: ResMut<CursorPosition>, windows: Res<Windows>) {
+    positions.0 = windows
         .iter()
-        .flat_map(|w| w.cursor_position().map(|p| (w.id(), p)))
-        .collect();
+        .find_map(|w| w.cursor_position().map(|p| (w.id(), p)));
 }
 
 /// Exit the application when there are no open windows.


### PR DESCRIPTION
# Objective

Addresses #5034 

## Solution

I added a `CursorPosition` resource, updated every frame if `WindowPlugin::update_cursor_position` is enabled.

Usage:

Instead of:

```rust
fn my_system(windows: Res<Windows>) {
     let position = windows.get_primary().unwrap().cursor_position;
     if let Some(pos) = position {
        // Do stuff
     }
}
```

We have:

```rust
fn my_system(cursor: Res<CursorPosition>) {
     if let Some(pos) = cursor.position() {
        // Do stuff
     }
}
```

## Notes

I think the update system should probably be in a `PreUpdate` stage?
