### PR TITLE
Add an fps overlay to all Bevy app

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ default = [
   "vorbis",
   "x11",
   "filesystem_watcher",
+  "overlay",
 ]
 
 # Force dynamic linking, which improves iterative compile times
@@ -102,6 +103,9 @@ debug_asset_server = ["bevy_internal/debug_asset_server"]
 
 # Enable animation support, and glTF animation loading
 animation = ["bevy_internal/animation"]
+
+# Enable overlay for FPS monitoring
+overlay = ["bevy_internal/overlay"]
 
 [dependencies]
 bevy_dylib = { path = "crates/bevy_dylib", version = "0.8.0-dev", default-features = false, optional = true }

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -34,3 +34,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 
 serde = { version = "1", features = ["derive"] }
 radsort = "0.1"
+
+[dev-dependencies]
+bevy_internal = { path = "../bevy_internal", version = "0.8.0-dev" }

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -15,15 +15,20 @@ keywords = ["bevy"]
 [features]
 trace = []
 webgl = []
+overlay = ["bevy_diagnostic", "bevy_input", "bevy_math", "bevy_time"]
 
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.8.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.8.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.8.0-dev" }
+bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.8.0-dev", optional = true }
 bevy_ecs = { path = "../bevy_ecs", version = "0.8.0-dev" }
+bevy_input = { path = "../bevy_input", version = "0.8.0-dev", optional = true }
+bevy_math = { path = "../bevy_math", version = "0.8.0-dev", optional = true }
 bevy_reflect = { path = "../bevy_reflect", version = "0.8.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.8.0-dev" }
+bevy_time = { path = "../bevy_time", version = "0.8.0-dev", optional = true }
 bevy_transform = { path = "../bevy_transform", version = "0.8.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
 

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -1,8 +1,13 @@
 pub mod clear_color;
 pub mod core_2d;
 pub mod core_3d;
+#[cfg(feature = "overlay")]
+pub mod overlay;
 
 pub mod prelude {
+    #[doc(hidden)]
+    #[cfg(feature = "overlay")]
+    pub use crate::overlay::{CameraOverlay, CameraOverlayBundle, OverlayPlugin};
     #[doc(hidden)]
     pub use crate::{
         clear_color::ClearColor,

--- a/crates/bevy_core_pipeline/src/overlay/camera_overlay.rs
+++ b/crates/bevy_core_pipeline/src/overlay/camera_overlay.rs
@@ -1,0 +1,63 @@
+use bevy_ecs::{
+    entity::Entity,
+    prelude::{Bundle, Component, With},
+    query::QueryItem,
+    system::{Commands, Query},
+};
+use bevy_render::{
+    camera::{Camera, CameraRenderGraph, OrthographicProjection},
+    extract_component::ExtractComponent,
+    view::VisibleEntities,
+};
+use bevy_transform::prelude::GlobalTransform;
+
+use super::overlay_node::graph;
+
+pub(crate) fn extract_overlay_camera_phases(
+    mut commands: Commands,
+    cameras_overlay: Query<(Entity, &Camera), With<CameraOverlay>>,
+) {
+    for (entity, camera) in cameras_overlay.iter() {
+        if camera.is_active {
+            commands.get_or_spawn(entity);
+        }
+    }
+}
+
+#[derive(Component, Default, Clone)]
+pub struct CameraOverlay {}
+
+impl ExtractComponent for CameraOverlay {
+    type Query = &'static Self;
+    type Filter = With<Camera>;
+
+    fn extract_component(item: QueryItem<Self::Query>) -> Self {
+        item.clone()
+    }
+}
+
+#[derive(Bundle)]
+pub struct CameraOverlayBundle {
+    pub camera: Camera,
+    pub camera_render_graph: CameraRenderGraph,
+    pub projection: OrthographicProjection,
+    pub visible_entities: VisibleEntities,
+    pub global_transform: GlobalTransform,
+    pub camera_overlay: CameraOverlay,
+}
+
+impl Default for CameraOverlayBundle {
+    fn default() -> Self {
+        Self {
+            camera: Camera {
+                priority: isize::MAX,
+                ..Default::default()
+            },
+            camera_render_graph: CameraRenderGraph::new(graph::NAME),
+            visible_entities: Default::default(),
+            projection: Default::default(),
+            global_transform: Default::default(),
+            camera_overlay: Default::default(),
+        }
+    }
+}

--- a/crates/bevy_core_pipeline/src/overlay/camera_overlay.rs
+++ b/crates/bevy_core_pipeline/src/overlay/camera_overlay.rs
@@ -24,8 +24,11 @@ pub(crate) fn extract_overlay_camera_phases(
     }
 }
 
+/// Marker component for the camera used to display the FPS overlay.
+///
+/// See [`CameraOverlayBundle`] for the full list of components needed to display the overlay.
 #[derive(Component, Default, Clone)]
-pub struct CameraOverlay {}
+pub struct CameraOverlay;
 
 impl ExtractComponent for CameraOverlay {
     type Query = &'static Self;
@@ -36,6 +39,9 @@ impl ExtractComponent for CameraOverlay {
     }
 }
 
+/// Bundle of components needed to display the FPS overlay.
+///
+/// See [`OverlayPlugin`](super::OverlayPlugin) on how to enable the overlay.
 #[derive(Bundle)]
 pub struct CameraOverlayBundle {
     pub camera: Camera,

--- a/crates/bevy_core_pipeline/src/overlay/mod.rs
+++ b/crates/bevy_core_pipeline/src/overlay/mod.rs
@@ -1,0 +1,150 @@
+use bevy_app::{App, Plugin};
+use bevy_asset::{load_internal_asset, HandleUntyped};
+use bevy_diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin};
+use bevy_ecs::{
+    entity::Entity,
+    prelude::With,
+    system::{Commands, Local, Query, Res},
+};
+use bevy_input::{keyboard::KeyCode, Input};
+use bevy_reflect::TypeUuid;
+use bevy_render::{
+    extract_component::ExtractComponentPlugin,
+    prelude::Shader,
+    render_graph::{RenderGraph, SlotInfo, SlotType},
+    renderer::RenderQueue,
+    RenderApp, RenderStage,
+};
+
+mod camera_overlay;
+mod overlay_node;
+mod pipeline;
+use bevy_time::Time;
+use bevy_utils::{Duration, Instant};
+pub use camera_overlay::{CameraOverlay, CameraOverlayBundle};
+
+use crate::overlay::{overlay_node::graph, pipeline::OverlayPipeline};
+
+use self::overlay_node::DiagnosticOverlayBuffer;
+
+pub const OVERLAY_SHADER_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 1236245567947772696);
+
+pub(crate) struct OverlayDiagnostics {
+    avg_fps: f32,
+}
+
+fn extract_overlay_diagnostics(
+    mut commands: Commands,
+    diags: Res<Diagnostics>,
+    time: Res<Time>,
+    mut last_update: Local<Option<Instant>>,
+) {
+    if last_update.is_none() {
+        *last_update = time
+            .last_update()
+            .and_then(|lu| lu.checked_sub(Duration::from_secs(1)));
+    }
+
+    if let Some(last_overlay_update) = *last_update {
+        if let Some(current) = time.last_update() {
+            if (current - last_overlay_update).as_secs_f32() > 0.15 {
+                *last_update = time.last_update();
+                commands.insert_resource(OverlayDiagnostics {
+                    avg_fps: diags
+                        .get(FrameTimeDiagnosticsPlugin::FPS)
+                        .and_then(|diag| diag.average())
+                        .unwrap_or_default() as f32,
+                });
+            }
+        }
+    }
+}
+
+fn prepare_overlay_diagnostics(
+    buffer: Res<DiagnosticOverlayBuffer>,
+    render_queue: Res<RenderQueue>,
+    diagnostics: Res<OverlayDiagnostics>,
+) {
+    if diagnostics.is_changed() {
+        buffer.write_buffer(diagnostics.as_ref(), render_queue.as_ref());
+    }
+}
+
+#[derive(Default)]
+pub struct OverlayPlugin {
+    pub trigger: Option<KeyCode>,
+}
+
+impl Plugin for OverlayPlugin {
+    fn build(&self, app: &mut App) {
+        if app
+            .world
+            .resource::<Diagnostics>()
+            .get(FrameTimeDiagnosticsPlugin::FPS)
+            .is_none()
+        {
+            app.add_plugin(FrameTimeDiagnosticsPlugin::default());
+        }
+
+        load_internal_asset!(
+            app,
+            OVERLAY_SHADER_HANDLE,
+            "overlay.wgsl",
+            Shader::from_wgsl
+        );
+
+        let trigger = self.trigger;
+        app.add_plugin(ExtractComponentPlugin::<CameraOverlay>::default())
+            .add_system(
+                move |mut commands: Commands,
+                      keyboard_input: Res<Input<KeyCode>>,
+                      query: Query<Entity, With<CameraOverlay>>| {
+                    if (trigger.is_none()
+                        && keyboard_input.pressed(KeyCode::LControl)
+                        && keyboard_input.pressed(KeyCode::LShift)
+                        && keyboard_input.just_pressed(KeyCode::Tab))
+                        || (trigger.is_some() && keyboard_input.just_pressed(trigger.unwrap()))
+                    {
+                        if let Ok(entity) = query.get_single() {
+                            commands.entity(entity).despawn();
+                        } else {
+                            commands.spawn_bundle(CameraOverlayBundle::default());
+                        }
+                    }
+                },
+            );
+
+        let render_app = match app.get_sub_app_mut(RenderApp) {
+            Ok(render_app) => render_app,
+            Err(_) => return,
+        };
+
+        render_app
+            .init_resource::<OverlayPipeline>()
+            .init_resource::<DiagnosticOverlayBuffer>()
+            .add_system_to_stage(
+                RenderStage::Extract,
+                camera_overlay::extract_overlay_camera_phases,
+            )
+            .add_system_to_stage(RenderStage::Extract, extract_overlay_diagnostics)
+            .add_system_to_stage(RenderStage::Prepare, prepare_overlay_diagnostics);
+
+        let pass_node_overlay = overlay_node::OverlayNode::new(&mut render_app.world);
+        let mut graph = render_app.world.resource_mut::<RenderGraph>();
+
+        let mut overlay_graph = RenderGraph::default();
+        overlay_graph.add_node(graph::NODE, pass_node_overlay);
+        let input_node_id =
+            overlay_graph.set_input(vec![SlotInfo::new(graph::NODE_INPUT, SlotType::Entity)]);
+        overlay_graph
+            .add_slot_edge(
+                input_node_id,
+                graph::NODE_INPUT,
+                graph::NODE,
+                graph::IN_VIEW,
+            )
+            .unwrap();
+        graph.add_sub_graph(graph::NAME, overlay_graph);
+    }
+}

--- a/crates/bevy_core_pipeline/src/overlay/mod.rs
+++ b/crates/bevy_core_pipeline/src/overlay/mod.rs
@@ -71,7 +71,7 @@ fn prepare_overlay_diagnostics(
     }
 }
 
-/// Overlay to display the FPS. This plugin is part of the [`DefaultPlugins`](bevy_internal::DefaultPlugins)
+/// Overlay to display the FPS. This plugin is part of the default plugins,
 /// and enabled by default.
 ///
 /// To disable it, you can either:

--- a/crates/bevy_core_pipeline/src/overlay/mod.rs
+++ b/crates/bevy_core_pipeline/src/overlay/mod.rs
@@ -71,8 +71,31 @@ fn prepare_overlay_diagnostics(
     }
 }
 
+/// Overlay to display the FPS. This plugin is part of the [`DefaultPlugins`](bevy_internal::DefaultPlugins)
+/// and enabled by default.
+///
+/// To disable it, you can either:
+///
+/// ## Remove it when adding the plugin group:
+///
+/// ```no_run
+/// # use bevy_internal::DefaultPlugins;
+/// # use bevy_app::App;
+/// # use bevy_core_pipeline::overlay::OverlayPlugin;
+/// fn main() {
+///     App::new()
+///         .add_plugins_with(DefaultPlugins, |group| group.disable::<OverlayPlugin>())
+///         .run();
+/// }
+/// ```
+///
+/// ## Disable the feature
+///
+/// Disable default features from Bevy, and do not enable the feature `overlay`
 #[derive(Default)]
 pub struct OverlayPlugin {
+    /// [`KeyCode`] to use to trigger the overlay. If set to `None`, the default shortcut is used:
+    /// Left-Control - Left-Shift - Tab
     pub trigger: Option<KeyCode>,
 }
 

--- a/crates/bevy_core_pipeline/src/overlay/overlay.wgsl
+++ b/crates/bevy_core_pipeline/src/overlay/overlay.wgsl
@@ -1,0 +1,108 @@
+// numbers from https://www.shadertoy.com/view/lt3GRj
+
+struct VertexOutput {
+    [[builtin(position)]] clip_position: vec4<f32>;
+};
+
+struct Diagnostics {
+    fps: f32;
+};
+[[group(0), binding(0)]]
+var<uniform> diagnostics: Diagnostics;
+
+[[stage(vertex)]]
+fn vs_main(
+    [[builtin(vertex_index)]] in_vertex_index: u32,
+) -> VertexOutput {
+    var out: VertexOutput;
+    switch (in_vertex_index) {
+        case 0: { out.clip_position = vec4<f32>(-1.0, 3.0, 0.0, 1.0); }
+        case 1: { out.clip_position = vec4<f32>(-1.0, -1.0, 0.0, 1.0); }
+        case 2: { out.clip_position = vec4<f32>(3.0, -1.0, 0.0, 1.0); }
+        default: {}
+    }
+    return out;
+}
+
+fn digit_bin(x: i32) -> f32 {
+    switch (x) {
+        case 0: { return 480599.0; }
+        case 1: { return 139810.0; }
+        case 2: { return 476951.0; }
+        case 3: { return 476999.0; }
+        case 4: { return 350020.0; }
+        case 5: { return 464711.0; }
+        case 6: { return 464727.0; }
+        case 7: { return 476228.0; }
+        case 8: { return 481111.0; }
+        case 9: { return 481095.0; }
+        default: { return 0.0; }
+    }
+}
+
+fn print_value(
+    frag_coord: vec2<f32>,
+    starting_at: vec2<f32>,
+    font_size: vec2<f32>,
+    value: f32,
+    digits: f32,
+    decimals: f32
+) -> f32 {
+    let char_coord: vec2<f32> = (frag_coord * vec2<f32>(1.0, -1.0) - starting_at * vec2<f32>(1.0, -1.0) + font_size) / font_size;
+    if (char_coord.y < 0.0 || char_coord.y >= 1.0) {
+        return 0.0;
+    }
+    var bits: f32 = 0.0;
+    let digit_index_1: f32 = digits - floor(char_coord.x) + 1.0;
+    if (-digit_index_1 <= decimals) {
+        let pow_1: f32 = pow(10.0, digit_index_1);
+        let abs_value: f32 = abs(value);
+        let pivot: f32 = max(abs_value, 1.5) * 10.0;
+        if (pivot < pow_1) {
+            if (value < 0.0 && pivot >= pow_1 * 0.1) {
+                bits = 1792.0;
+            }
+        } else if (digit_index_1 == 0.0) {
+            if (decimals > 0.0) {
+                bits = 2.0;
+            }
+        } else {
+            var value_2: f32;
+            if (digit_index_1 < 0.0) {
+                value_2 = fract(abs_value);
+            } else {
+                value_2 = abs_value * 10.0;
+            }
+            bits = digit_bin(i32((value_2 / pow_1) % 10.0));
+        }
+    }
+    return floor((bits / pow(2.0, floor(fract(char_coord.x) * 4.0) + floor(char_coord.y * 5.0) * 4.0)) % 2.0);
+}
+
+[[stage(fragment)]]
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+    let clear: vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    let background: vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.4);
+    let fps_color: vec4<f32> = vec4<f32>(0.0, 1.0, 0.0, 1.0);
+
+    let font_size: vec2<f32> = vec2<f32>(4.0, 5.0) * 10.0;
+    let margin: vec2<f32> = vec2<f32>(20.0, 25.0);
+
+    let is_fps_digit: f32 = print_value(
+        in.clip_position.xy,
+        margin,
+        font_size,
+        diagnostics.fps,
+        3.0,
+        1.0
+    );
+
+    var color: vec4<f32> = clear;
+    if (in.clip_position.x < font_size.x * 5.0 + margin.x * 2.0
+        && in.clip_position.y < font_size.y + margin.y * 2.0) {
+        color = background;
+    }
+    color = mix(color, fps_color, is_fps_digit);
+
+    return color;
+}

--- a/crates/bevy_core_pipeline/src/overlay/overlay_node.rs
+++ b/crates/bevy_core_pipeline/src/overlay/overlay_node.rs
@@ -1,0 +1,147 @@
+use bevy_ecs::prelude::{FromWorld, QueryState, With, World};
+use bevy_math::Vec4;
+use bevy_render::{
+    render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
+    render_phase::TrackedRenderPass,
+    render_resource::{
+        encase, BindGroup, BindGroupDescriptor, BindGroupEntry, Buffer, BufferInitDescriptor,
+        BufferUsages, CachedRenderPipelineId, LoadOp, Operations, PipelineCache,
+        RenderPassDescriptor, ShaderSize,
+    },
+    renderer::{RenderContext, RenderDevice, RenderQueue},
+    view::ViewTarget,
+};
+
+use super::{pipeline::OverlayPipeline, CameraOverlay, OverlayDiagnostics};
+
+pub(crate) struct DiagnosticOverlayBuffer {
+    buffer: Buffer,
+    bind_group: BindGroup,
+}
+
+pub(crate) mod graph {
+    pub const NAME: &str = "OVERLAY";
+    pub const NODE: &str = "OVERLAY_PASS";
+    pub const NODE_INPUT: &str = "OVERLAY_PASS_VIEW";
+    pub const IN_VIEW: &str = "OVERLAY_IN_VIEW";
+}
+
+impl FromWorld for DiagnosticOverlayBuffer {
+    fn from_world(world: &mut World) -> Self {
+        let render_device = world.get_resource::<RenderDevice>().unwrap();
+        let overlay_pipeline = world.get_resource::<OverlayPipeline>().unwrap();
+
+        let byte_buffer = [0u8; Vec4::SIZE.get() as usize];
+        let mut buffer = encase::UniformBuffer::new(byte_buffer);
+        buffer.write(&[Vec4::ZERO]).unwrap();
+        let diagnostics_buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
+            label: Some("diagnostics Buffer"),
+            contents: buffer.as_ref(),
+            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+        });
+        let diagnostics_bind_group = render_device.create_bind_group(&BindGroupDescriptor {
+            layout: &overlay_pipeline.layout[0],
+            entries: &[BindGroupEntry {
+                binding: 0,
+                resource: diagnostics_buffer.as_entire_binding(),
+            }],
+            label: Some("diagnostics_bind_group"),
+        });
+
+        DiagnosticOverlayBuffer {
+            buffer: diagnostics_buffer,
+            bind_group: diagnostics_bind_group,
+        }
+    }
+}
+
+impl DiagnosticOverlayBuffer {
+    pub(crate) fn write_buffer(
+        &self,
+        diagnostics: &OverlayDiagnostics,
+        render_queue: &RenderQueue,
+    ) {
+        let byte_buffer = [0u8; Vec4::SIZE.get() as usize];
+        let mut buffer = encase::UniformBuffer::new(byte_buffer);
+        buffer
+            .write(&[Vec4::new(diagnostics.avg_fps, 0.0, 0.0, 0.0)])
+            .unwrap();
+        render_queue.write_buffer(&self.buffer, 0, buffer.as_ref());
+    }
+}
+
+pub(crate) struct OverlayNode {
+    query: QueryState<&'static ViewTarget, With<CameraOverlay>>,
+    render_pipeline: CachedRenderPipelineId,
+}
+impl OverlayNode {
+    pub(crate) fn new(world: &mut World) -> Self {
+        let overlay_pipeline = (*world.get_resource::<OverlayPipeline>().unwrap()).clone();
+        let render_pipeline = world
+            .resource_mut::<PipelineCache>()
+            .queue_render_pipeline(overlay_pipeline.get_pipeline());
+
+        Self {
+            query: world.query_filtered(),
+            render_pipeline,
+        }
+    }
+}
+
+impl Node for OverlayNode {
+    fn input(&self) -> Vec<SlotInfo> {
+        vec![SlotInfo::new(graph::IN_VIEW, SlotType::Entity)]
+    }
+
+    fn update(&mut self, world: &mut World) {
+        self.query.update_archetypes(world);
+    }
+
+    fn run(
+        &self,
+        graph: &mut RenderGraphContext,
+        render_context: &mut RenderContext,
+        world: &World,
+    ) -> Result<(), NodeRunError> {
+        let view_entity = graph.get_input_entity(graph::IN_VIEW)?;
+
+        let target = if let Ok(result) = self.query.get_manual(world, view_entity) {
+            result
+        } else {
+            return Ok(());
+        };
+
+        let target = ViewTarget {
+            view: target.view.clone(),
+            sampled_target: None,
+        };
+        let pass_descriptor = RenderPassDescriptor {
+            label: Some("overlay"),
+            color_attachments: &[target.get_color_attachment(Operations {
+                load: LoadOp::Load,
+                store: true,
+            })],
+            depth_stencil_attachment: None,
+        };
+
+        let render_pass = render_context
+            .command_encoder
+            .begin_render_pass(&pass_descriptor);
+
+        let mut tracked = TrackedRenderPass::new(render_pass);
+
+        let render_pipeline = world
+            .resource::<PipelineCache>()
+            .get_render_pipeline(self.render_pipeline)
+            .unwrap();
+
+        let buffer = world.resource::<DiagnosticOverlayBuffer>();
+
+        tracked.set_render_pipeline(render_pipeline);
+        tracked.set_bind_group(0, &buffer.bind_group, &[]);
+
+        tracked.draw(0..3, 0..1);
+
+        Ok(())
+    }
+}

--- a/crates/bevy_core_pipeline/src/overlay/pipeline.rs
+++ b/crates/bevy_core_pipeline/src/overlay/pipeline.rs
@@ -1,0 +1,74 @@
+use bevy_asset::Handle;
+use bevy_ecs::prelude::{FromWorld, World};
+use bevy_render::{
+    prelude::Shader,
+    render_resource::{
+        BindGroupLayout, BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingType, BlendState,
+        BufferBindingType, ColorTargetState, ColorWrites, FragmentState, MultisampleState,
+        PrimitiveState, RenderPipelineDescriptor, ShaderStages, VertexState,
+    },
+    renderer::RenderDevice,
+    texture::BevyDefault,
+};
+
+use super::OVERLAY_SHADER_HANDLE;
+
+#[derive(Clone)]
+pub(crate) struct OverlayPipeline {
+    shader: Handle<Shader>,
+    pub(crate) layout: Vec<BindGroupLayout>,
+}
+
+impl FromWorld for OverlayPipeline {
+    fn from_world(world: &mut World) -> Self {
+        let render_device = world.get_resource::<RenderDevice>().unwrap();
+
+        let diagnostics_bind_group_layout =
+            render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+                entries: &[BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+                label: Some("diagnostics_bind_group_layout"),
+            });
+
+        Self {
+            shader: OVERLAY_SHADER_HANDLE.typed(),
+            layout: vec![diagnostics_bind_group_layout],
+        }
+    }
+}
+
+impl OverlayPipeline {
+    pub(crate) fn get_pipeline(&self) -> RenderPipelineDescriptor {
+        RenderPipelineDescriptor {
+            label: Some("Overlay Pipeline".into()),
+            layout: Some(self.layout.clone()),
+            vertex: VertexState {
+                shader: self.shader.clone(),
+                shader_defs: vec![],
+                entry_point: "vs_main".into(),
+                buffers: vec![],
+            },
+            fragment: Some(FragmentState {
+                shader: self.shader.clone(),
+                shader_defs: vec![],
+                entry_point: "fs_main".into(),
+                targets: vec![ColorTargetState {
+                    format: BevyDefault::bevy_default(),
+                    blend: Some(BlendState::ALPHA_BLENDING),
+                    write_mask: ColorWrites::ALL,
+                }],
+            }),
+            primitive: PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: MultisampleState::default(),
+        }
+    }
+}

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -63,6 +63,9 @@ bevy_ci_testing = ["bevy_app/bevy_ci_testing", "bevy_render/ci_limits"]
 # Enable animation support, and glTF animation loading
 animation = ["bevy_animation", "bevy_gltf?/bevy_animation"]
 
+# Enable overlay for FPS monitoring
+overlay = ["bevy_core_pipeline?/overlay"]
+
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.8.0-dev" }

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -73,6 +73,9 @@ impl PluginGroup for DefaultPlugins {
 
         #[cfg(feature = "bevy_animation")]
         group.add(bevy_animation::AnimationPlugin::default());
+
+        #[cfg(feature = "overlay")]
+        group.add(bevy_core_pipeline::overlay::OverlayPlugin::default());
     }
 }
 

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -15,6 +15,7 @@
 |vorbis|Ogg Vorbis audio format support.|
 |x11|Make GUI applications use X11 protocol. You could enable wayland feature to override this.|
 |filesystem_watcher|Enable watching the file system for asset hot reload|
+|overlay|Enable adding the overlay plugin for diagnostics|
 
 ## Optional Features
 


### PR DESCRIPTION
# Objective

- Provide an easy way to display the current FPS of a Bevy app

## Solution

- Add an overlay node that is rendered after everything else
- Display the FPS from a shader (reusing number rendering from https://www.shadertoy.com/view/lt3GRj)
- add / remove the overlay camera when user press left control + left shift + tab

<img width="1392" alt="Screenshot 2022-06-23 at 22 57 17" src="https://user-images.githubusercontent.com/8672791/175398501-3126b46d-010e-4dc2-af58-287b1fe4c654.png">

