### PR TITLE
[Merged by Bors] - Add TextureAtlas stress test based on many_sprites and sprite_sheet examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1220,6 +1220,12 @@ wasm = true
 name = "many_animated_sprites"
 path = "examples/stress_tests/many_animated_sprites.rs"
 
+[package.metadata.example.many_animated_sprites]
+name = "Many Animated Sprites"
+description = "Displays many animated sprites in a grid arragement with slight offsets to their animation timers. Used for performance testing."
+category = "Stress Tests"
+wasm = true
+
 [[example]]
 name = "many_cubes"
 path = "examples/stress_tests/many_cubes.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -559,6 +559,10 @@ name = "bevymark"
 path = "examples/stress_tests/bevymark.rs"
 
 [[example]]
+name = "many_animated_sprites"
+path = "examples/stress_tests/many_animated_sprites.rs"
+
+[[example]]
 name = "many_cubes"
 path = "examples/stress_tests/many_cubes.rs"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -273,7 +273,6 @@ Due to the focus on performance it's recommended to run the stress tests in rele
 cargo run --release --example <example name>
 ```
 
-
 Example | Description
 --- | ---
 [Bevymark](../examples/stress_tests/bevymark.rs) | A heavy sprite rendering workload to benchmark your system with Bevy

--- a/examples/README.md
+++ b/examples/README.md
@@ -275,6 +275,7 @@ cargo run --release --example <example name>
 Example | File | Description
 --- | --- | ---
 `bevymark` | [`stress_tests/bevymark.rs`](./stress_tests/bevymark.rs) | A heavy sprite rendering workload to benchmark your system with Bevy
+`many_animated_sprites` | [`stress_tests/many_animated_sprites.rs`](./stress_tests/many_animated_sprites.rs) | Displays many animated sprites in a grid arragement with slight offsets to their animation timers. Used for performance testing.
 `many_cubes` | [`stress_tests/many_cubes.rs`](./stress_tests/many_cubes.rs) | Simple benchmark to test per-entity draw overhead. Run with the `sphere` argument to test frustum culling.
 `many_foxes` | [`stress_tests/many_foxes.rs`](./stress_tests/many_foxes.rs) | Loads an animated fox model and spawns lots of them. Good for testing skinned mesh performance. Takes an unsigned integer argument for the number of foxes to spawn. Defaults to 1000.
 `many_lights` | [`stress_tests/many_lights.rs`](./stress_tests/many_lights.rs) | Simple benchmark to test rendering many point lights. Run with `WGPU_SETTINGS_PRIO=webgl2` to restrict to uniform buffers and max 256 lights.

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -2,10 +2,9 @@
 //!
 //! It sets up many animated sprites in different sizes and rotations, and at different scales in the world,
 //! and moves the camera over them to see how well frustum culling works.
-//! 
+//!
 //! To measure performance realistically, be sure to run this in release mode.
 //! `cargo run --example many_animated_sprites --release`
-
 
 use std::time::Duration;
 
@@ -33,7 +32,11 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, assets: Res<AssetServer>, mut texture_atlases: ResMut<Assets<TextureAtlas>>) {
+fn setup(
+    mut commands: Commands,
+    assets: Res<AssetServer>,
+    mut texture_atlases: ResMut<Assets<TextureAtlas>>,
+) {
     let mut rng = rand::thread_rng();
 
     let tile_size = Vec2::splat(64.0);
@@ -62,19 +65,21 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>, mut texture_atlases: 
             let mut timer = Timer::from_seconds(0.1, true);
             timer.set_elapsed(Duration::from_secs_f32(rng.gen::<f32>()));
 
-            commands.spawn_bundle(SpriteSheetBundle {
-                texture_atlas: texture_atlas_handle.clone(),
-                transform: Transform {
-                    translation,
-                    rotation,
-                    scale,
-                },
-                sprite: TextureAtlasSprite {
-                    custom_size: Some(tile_size),
+            commands
+                .spawn_bundle(SpriteSheetBundle {
+                    texture_atlas: texture_atlas_handle.clone(),
+                    transform: Transform {
+                        translation,
+                        rotation,
+                        scale,
+                    },
+                    sprite: TextureAtlasSprite {
+                        custom_size: Some(tile_size),
+                        ..default()
+                    },
                     ..default()
-                },
-                ..default()
-            }).insert(AnimationTimer(timer));
+                })
+                .insert(AnimationTimer(timer));
         }
     }
 }

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -1,0 +1,127 @@
+//! Renders a lot of animated sprites to allow performance testing.
+//!
+//! It sets up many animated sprites in different sizes and rotations, and at different scales in the world,
+//! and moves the camera over them to see how well frustum culling works.
+//! 
+//! To measure performance realistically, be sure to run this in release mode.
+//! `cargo run --example many_animated_sprites --release`
+
+
+use std::time::Duration;
+
+use bevy::{
+    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    math::Quat,
+    prelude::*,
+    render::camera::Camera,
+};
+
+use rand::Rng;
+
+const CAMERA_SPEED: f32 = 1000.0;
+
+fn main() {
+    App::new()
+        // Since this is also used as a benchmark, we want it to display performance data.
+        .add_plugin(LogDiagnosticsPlugin::default())
+        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(setup)
+        .add_system(animate_sprite)
+        .add_system(print_sprite_count)
+        .add_system(move_camera.after(print_sprite_count))
+        .run();
+}
+
+fn setup(mut commands: Commands, assets: Res<AssetServer>, mut texture_atlases: ResMut<Assets<TextureAtlas>>) {
+    let mut rng = rand::thread_rng();
+
+    let tile_size = Vec2::splat(64.0);
+    let map_size = Vec2::splat(320.0);
+
+    let half_x = (map_size.x / 2.0) as i32;
+    let half_y = (map_size.y / 2.0) as i32;
+
+    let texture_handle = assets.load("textures/rpg/chars/gabe/gabe-idle-run.png");
+    let texture_atlas = TextureAtlas::from_grid(texture_handle, Vec2::new(24.0, 24.0), 7, 1);
+    let texture_atlas_handle = texture_atlases.add(texture_atlas);
+
+    // Spawns the camera
+    commands
+        .spawn()
+        .insert_bundle(Camera2dBundle::default())
+        .insert(Transform::from_xyz(0.0, 0.0, 1000.0));
+
+    // Builds and spawns the sprites
+    for y in -half_y..half_y {
+        for x in -half_x..half_x {
+            let position = Vec2::new(x as f32, y as f32);
+            let translation = (position * tile_size).extend(rng.gen::<f32>());
+            let rotation = Quat::from_rotation_z(rng.gen::<f32>());
+            let scale = Vec3::splat(rng.gen::<f32>() * 2.0);
+            let mut timer = Timer::from_seconds(0.1, true);
+            timer.set_elapsed(Duration::from_secs_f32(rng.gen::<f32>()));
+
+            commands.spawn_bundle(SpriteSheetBundle {
+                texture_atlas: texture_atlas_handle.clone(),
+                transform: Transform {
+                    translation,
+                    rotation,
+                    scale,
+                },
+                sprite: TextureAtlasSprite {
+                    custom_size: Some(tile_size),
+                    ..default()
+                },
+                ..default()
+            }).insert(AnimationTimer(timer));
+        }
+    }
+}
+
+// System for rotating and translating the camera
+fn move_camera(time: Res<Time>, mut camera_query: Query<&mut Transform, With<Camera>>) {
+    let mut camera_transform = camera_query.single_mut();
+    camera_transform.rotate(Quat::from_rotation_z(time.delta_seconds() * 0.5));
+    *camera_transform = *camera_transform
+        * Transform::from_translation(Vec3::X * CAMERA_SPEED * time.delta_seconds());
+}
+
+#[derive(Component, Deref, DerefMut)]
+struct AnimationTimer(Timer);
+
+fn animate_sprite(
+    time: Res<Time>,
+    texture_atlases: Res<Assets<TextureAtlas>>,
+    mut query: Query<(
+        &mut AnimationTimer,
+        &mut TextureAtlasSprite,
+        &Handle<TextureAtlas>,
+    )>,
+) {
+    for (mut timer, mut sprite, texture_atlas_handle) in query.iter_mut() {
+        timer.tick(time.delta());
+        if timer.just_finished() {
+            let texture_atlas = texture_atlases.get(texture_atlas_handle).unwrap();
+            sprite.index = (sprite.index + 1) % texture_atlas.textures.len();
+        }
+    }
+}
+
+#[derive(Deref, DerefMut)]
+struct PrintingTimer(Timer);
+
+impl Default for PrintingTimer {
+    fn default() -> Self {
+        Self(Timer::from_seconds(1.0, true))
+    }
+}
+
+// System for printing the number of sprites on every tick of the timer
+fn print_sprite_count(time: Res<Time>, mut timer: Local<PrintingTimer>, sprites: Query<&Sprite>) {
+    timer.tick(time.delta());
+
+    if timer.just_finished() {
+        info!("Sprites: {}", sprites.iter().count(),);
+    }
+}

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -123,7 +123,7 @@ impl Default for PrintingTimer {
 }
 
 // System for printing the number of sprites on every tick of the timer
-fn print_sprite_count(time: Res<Time>, mut timer: Local<PrintingTimer>, sprites: Query<&Sprite>) {
+fn print_sprite_count(time: Res<Time>, mut timer: Local<PrintingTimer>, sprites: Query<&TextureAtlasSprite>) {
     timer.tick(time.delta());
 
     if timer.just_finished() {

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -123,7 +123,11 @@ impl Default for PrintingTimer {
 }
 
 // System for printing the number of sprites on every tick of the timer
-fn print_sprite_count(time: Res<Time>, mut timer: Local<PrintingTimer>, sprites: Query<&TextureAtlasSprite>) {
+fn print_sprite_count(
+    time: Res<Time>,
+    mut timer: Local<PrintingTimer>,
+    sprites: Query<&TextureAtlasSprite>,
+) {
     timer.tick(time.delta());
 
     if timer.just_finished() {


### PR DESCRIPTION
# Objective

Intended to close #5073

## Solution

Adds a stress test that use TextureAtlas based on the existing many_sprites test using the animated sprite implementation from the sprite_sheet example.

In order to satisfy the goals described in #5073 the animations are all slightly offset.

Of note is that the original stress test was designed to test fullstrum culling. I kept this test similar as to facilitate easy comparisons between the use of TextureAtlas and without.