### PR TITLE
[Merged by Bors] - Implement IntoIterator for ECS wrapper types.

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -251,7 +251,6 @@ where
     &'a T: IntoIterator,
 {
     type Item = <&'a T as IntoIterator>::Item;
-
     type IntoIter = <&'a T as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -264,7 +263,6 @@ where
     &'a mut T: IntoIterator,
 {
     type Item = <&'a mut T as IntoIterator>::Item;
-
     type IntoIter = <&'a mut T as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -330,7 +328,6 @@ where
     &'a T: IntoIterator,
 {
     type Item = <&'a T as IntoIterator>::Item;
-
     type IntoIter = <&'a T as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -343,7 +340,6 @@ where
     &'a mut T: IntoIterator,
 {
     type Item = <&'a mut T as IntoIterator>::Item;
-
     type IntoIter = <&'a mut T as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -246,6 +246,32 @@ pub struct ResMut<'a, T: ?Sized + Resource> {
     pub(crate) ticks: Ticks<'a>,
 }
 
+impl<'w, 'a, T: Resource> IntoIterator for &'a ResMut<'w, T>
+where
+    &'a T: IntoIterator,
+{
+    type Item = <&'a T as IntoIterator>::Item;
+
+    type IntoIter = <&'a T as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.value.into_iter()
+    }
+}
+
+impl<'w, 'a, T: Resource> IntoIterator for &'a mut ResMut<'w, T>
+where
+    &'a mut T: IntoIterator,
+{
+    type Item = <&'a mut T as IntoIterator>::Item;
+
+    type IntoIter = <&'a mut T as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.value.into_iter()
+    }
+}
+
 change_detection_impl!(ResMut<'a, T>, T, Resource);
 impl_methods!(ResMut<'a, T>, T, Resource);
 impl_debug!(ResMut<'a, T>, Resource);
@@ -297,6 +323,32 @@ impl<'a, T: 'static> From<NonSendMut<'a, T>> for Mut<'a, T> {
 pub struct Mut<'a, T: ?Sized> {
     pub(crate) value: &'a mut T,
     pub(crate) ticks: Ticks<'a>,
+}
+
+impl<'w, 'a, T: Resource> IntoIterator for &'a Mut<'w, T>
+where
+    &'a T: IntoIterator,
+{
+    type Item = <&'a T as IntoIterator>::Item;
+
+    type IntoIter = <&'a T as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.value.into_iter()
+    }
+}
+
+impl<'w, 'a, T: Resource> IntoIterator for &'a mut Mut<'w, T>
+where
+    &'a mut T: IntoIterator,
+{
+    type Item = <&'a mut T as IntoIterator>::Item;
+
+    type IntoIter = <&'a mut T as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.value.into_iter()
+    }
 }
 
 change_detection_impl!(Mut<'a, T>, T,);

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -266,6 +266,7 @@ where
     type IntoIter = <&'a mut T as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
+        self.set_changed();
         self.value.into_iter()
     }
 }
@@ -343,6 +344,7 @@ where
     type IntoIter = <&'a mut T as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
+        self.set_changed();
         self.value.into_iter()
     }
 }

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -325,7 +325,7 @@ pub struct Mut<'a, T: ?Sized> {
     pub(crate) ticks: Ticks<'a>,
 }
 
-impl<'w, 'a, T: Resource> IntoIterator for &'a Mut<'w, T>
+impl<'w, 'a, T> IntoIterator for &'a Mut<'w, T>
 where
     &'a T: IntoIterator,
 {
@@ -338,7 +338,7 @@ where
     }
 }
 
-impl<'w, 'a, T: Resource> IntoIterator for &'a mut Mut<'w, T>
+impl<'w, 'a, T> IntoIterator for &'a mut Mut<'w, T>
 where
     &'a mut T: IntoIterator,
 {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -344,6 +344,19 @@ impl<'w, T: Resource> From<ResMut<'w, T>> for Res<'w, T> {
     }
 }
 
+impl<'w, 'a, T: Resource> IntoIterator for &'a Res<'w, T>
+where
+    &'a T: IntoIterator,
+{
+    type Item = <&'a T as IntoIterator>::Item;
+
+    type IntoIter = <&'a T as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.value.into_iter()
+    }
+}
+
 /// The [`SystemParamState`] of [`Res<T>`].
 #[doc(hidden)]
 pub struct ResState<T> {
@@ -718,6 +731,32 @@ impl<'a, T: FromWorld + Send + Sync + 'static> DerefMut for Local<'a, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
+    }
+}
+
+impl<'w, 'a, T: Resource> IntoIterator for &'a Local<'w, T>
+where
+    &'a T: IntoIterator,
+{
+    type Item = <&'a T as IntoIterator>::Item;
+
+    type IntoIter = <&'a T as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'w, 'a, T: Resource> IntoIterator for &'a mut Local<'w, T>
+where
+    &'a mut T: IntoIterator,
+{
+    type Item = <&'a mut T as IntoIterator>::Item;
+
+    type IntoIter = <&'a mut T as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -734,7 +734,7 @@ impl<'a, T: FromWorld + Send + Sync + 'static> DerefMut for Local<'a, T> {
     }
 }
 
-impl<'w, 'a, T: Resource> IntoIterator for &'a Local<'w, T>
+impl<'w, 'a, T: FromWorld + Send + 'static> IntoIterator for &'a Local<'w, T>
 where
     &'a T: IntoIterator,
 {
@@ -747,7 +747,7 @@ where
     }
 }
 
-impl<'w, 'a, T: Resource> IntoIterator for &'a mut Local<'w, T>
+impl<'w, 'a, T: FromWorld + Send + 'static> IntoIterator for &'a mut Local<'w, T>
 where
     &'a mut T: IntoIterator,
 {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -349,7 +349,6 @@ where
     &'a T: IntoIterator,
 {
     type Item = <&'a T as IntoIterator>::Item;
-
     type IntoIter = <&'a T as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -739,7 +738,6 @@ where
     &'a T: IntoIterator,
 {
     type Item = <&'a T as IntoIterator>::Item;
-
     type IntoIter = <&'a T as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -752,7 +750,6 @@ where
     &'a mut T: IntoIterator,
 {
     type Item = <&'a mut T as IntoIterator>::Item;
-
     type IntoIter = <&'a mut T as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -971,7 +971,7 @@ pub(crate) fn assign_lights_to_clusters(
 
         if config.dynamic_resizing() {
             let mut cluster_index_estimate = 0.0;
-            for light in lights.iter() {
+            for light in &lights {
                 let light_sphere = light.sphere();
 
                 // Check if the light is within the view frustum
@@ -1126,7 +1126,7 @@ pub(crate) fn assign_lights_to_clusters(
         }
 
         let mut update_from_light_intersections = |visible_lights: &mut Vec<Entity>| {
-            for light in lights.iter() {
+            for light in &lights {
                 let light_sphere = light.sphere();
 
                 // Check if the light is within the view frustum


### PR DESCRIPTION
# Objective

Improve ergonomics by passing on the `IntoIterator` impl of the underlying type to wrapper types.

## Solution

Implement `IntoIterator` for ECS wrapper types (Mut, Local, Res, etc.).