### PR TITLE
[Merged by Bors] - Fix player number in example game in the ecs_guide

### DIFF
--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -211,13 +211,14 @@ fn exclusive_player_system(world: &mut World) {
     };
     // Randomly add a new player
     if should_add_player {
+        println!("An exclusive player {} has joined the game!", total_players + 1);
         world.spawn().insert_bundle((
             Player {
-                name: format!("Player {}", total_players),
+                name: format!("Player {}", total_players + 1),
             },
             Score { value: 0 },
         ));
-
+        
         let mut game_state = world.resource_mut::<GameState>();
         game_state.total_players += 1;
     }

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -211,10 +211,7 @@ fn exclusive_player_system(world: &mut World) {
     };
     // Randomly add a new player
     if should_add_player {
-        println!(
-            "An exclusive player {} has joined the game!",
-            total_players + 1
-        );
+        println!("Player {} has joined the game!", total_players + 1);
         world.spawn().insert_bundle((
             Player {
                 name: format!("Player {}", total_players + 1),

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -211,14 +211,17 @@ fn exclusive_player_system(world: &mut World) {
     };
     // Randomly add a new player
     if should_add_player {
-        println!("An exclusive player {} has joined the game!", total_players + 1);
+        println!(
+            "An exclusive player {} has joined the game!",
+            total_players + 1
+        );
         world.spawn().insert_bundle((
             Player {
                 name: format!("Player {}", total_players + 1),
             },
             Score { value: 0 },
         ));
-        
+
         let mut game_state = world.resource_mut::<GameState>();
         game_state.total_players += 1;
     }


### PR DESCRIPTION
# Objective

- Small bug in the example game given in examples/ecs/ecs_guide

Currently, if there are 2 players in this example game, the function exclusive_player_system can add a player with the name "Player 2". However, the name should be "Player 3". This PR fixes this. I also add a message to inform that a new player has arrived in the mock game.