### PR TITLE
Query many methods should take a reference

### DIFF
--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1276,7 +1276,7 @@ mod tests {
             query_state
                 .get_many_unchecked_manual::<10>(
                     &world,
-                    &entities.clone().try_into().unwrap(),
+                    entities.as_slice().try_into().unwrap(),
                     last_change_tick,
                     change_tick,
                 )

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -207,7 +207,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     pub fn get_many<'w, const N: usize>(
         &mut self,
         world: &'w World,
-        entities: [Entity; N],
+        entities: &[Entity; N],
     ) -> Result<[ROQueryItem<'w, Q>; N], QueryEntityError> {
         self.update_archetypes(world);
 
@@ -283,7 +283,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     pub fn get_many_mut<'w, const N: usize>(
         &mut self,
         world: &'w mut World,
-        entities: [Entity; N],
+        entities: &[Entity; N],
     ) -> Result<[QueryItem<'w, Q>; N], QueryEntityError> {
         self.update_archetypes(world);
 
@@ -393,7 +393,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     pub(crate) unsafe fn get_many_read_only_manual<'w, const N: usize>(
         &self,
         world: &'w World,
-        entities: [Entity; N],
+        entities: &[Entity; N],
         last_change_tick: u32,
         change_tick: u32,
     ) -> Result<[ROQueryItem<'w, Q>; N], QueryEntityError> {
@@ -434,7 +434,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     pub(crate) unsafe fn get_many_unchecked_manual<'w, const N: usize>(
         &self,
         world: &'w World,
-        entities: [Entity; N],
+        entities: &[Entity; N],
         last_change_tick: u32,
         change_tick: u32,
     ) -> Result<[QueryItem<'w, Q>; N], QueryEntityError> {
@@ -1276,7 +1276,7 @@ mod tests {
             query_state
                 .get_many_unchecked_manual::<10>(
                     &world,
-                    entities.clone().try_into().unwrap(),
+                    &entities.clone().try_into().unwrap(),
                     last_change_tick,
                     change_tick,
                 )
@@ -1288,7 +1288,7 @@ mod tests {
                 query_state
                     .get_many_unchecked_manual(
                         &world,
-                        [entities[0], entities[0]],
+                        &[entities[0], entities[0]],
                         last_change_tick,
                         change_tick,
                     )
@@ -1302,7 +1302,7 @@ mod tests {
                 query_state
                     .get_many_unchecked_manual(
                         &world,
-                        [entities[0], entities[1], entities[0]],
+                        &[entities[0], entities[1], entities[0]],
                         last_change_tick,
                         change_tick,
                     )
@@ -1316,7 +1316,7 @@ mod tests {
                 query_state
                     .get_many_unchecked_manual(
                         &world,
-                        [entities[9], entities[9]],
+                        &[entities[9], entities[9]],
                         last_change_tick,
                         change_tick,
                     )
@@ -1343,7 +1343,7 @@ mod tests {
         let world_2 = World::new();
 
         let mut query_state = world_1.query::<Entity>();
-        let _panics = query_state.get_many(&world_2, []);
+        let _panics = query_state.get_many(&world_2, &[]);
     }
 
     #[test]
@@ -1353,7 +1353,7 @@ mod tests {
         let mut world_2 = World::new();
 
         let mut query_state = world_1.query::<Entity>();
-        let _panics = query_state.get_many_mut(&mut world_2, []);
+        let _panics = query_state.get_many_mut(&mut world_2, &[]);
     }
 }
 

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -744,7 +744,7 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     #[inline]
     pub fn get_many<const N: usize>(
         &self,
-        entities: [Entity; N],
+        entities: &[Entity; N],
     ) -> Result<[ROQueryItem<'_, Q>; N], QueryEntityError> {
         // SAFE: it is the scheduler's responsibility to ensure that `Query` is never handed out on the wrong `World`.
         unsafe {
@@ -793,7 +793,7 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     /// }
     /// ```
     #[inline]
-    pub fn many<const N: usize>(&self, entities: [Entity; N]) -> [ROQueryItem<'_, Q>; N] {
+    pub fn many<const N: usize>(&self, entities: &[Entity; N]) -> [ROQueryItem<'_, Q>; N] {
         self.get_many(entities).unwrap()
     }
 
@@ -844,7 +844,7 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     #[inline]
     pub fn get_many_mut<const N: usize>(
         &mut self,
-        entities: [Entity; N],
+        entities: &[Entity; N],
     ) -> Result<[QueryItem<'_, Q>; N], QueryEntityError> {
         // SAFE: scheduler ensures safe Query world access
         unsafe {
@@ -899,7 +899,7 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     /// }
     /// ```
     #[inline]
-    pub fn many_mut<const N: usize>(&mut self, entities: [Entity; N]) -> [QueryItem<'_, Q>; N] {
+    pub fn many_mut<const N: usize>(&mut self, entities: &[Entity; N]) -> [QueryItem<'_, Q>; N] {
         self.get_many_mut(entities).unwrap()
     }
 


### PR DESCRIPTION
Currently `Query` methods
`many` `many_mut` `get_many` and `get_many_mut`
take `[Entity; N]` as their argument.

While this is ergonomic for pairs and triplets,
it requires copying when working with bigger collections.

This PR changes it to use `&[Entity; N]` instead.