### PR TITLE
[Merged by Bors] - Remove double blank line from component docs

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -16,7 +16,6 @@ use std::{
 
 /// A data type that can be used to store data for an [entity].
 ///
-///
 /// `Component` is a [derivable trait]: this means that a data type can implement it by applying a `#[derive(Component)]` attribute to it.
 /// However, components must always satisfy the `Send + Sync + 'static` trait bounds.
 ///


### PR DESCRIPTION
A small trivial documentation fix. Check the changed file.