### PR TITLE
Make sprites respect RenderLayers

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -3,7 +3,7 @@ use crate::{
     prelude::Image,
     render_asset::RenderAssets,
     render_resource::TextureView,
-    view::{ExtractedView, ExtractedWindows, VisibleEntities},
+    view::{ExtractedView, ExtractedWindows, RenderLayers, VisibleEntities},
 };
 use bevy_asset::{AssetEvent, Assets, Handle};
 use bevy_derive::{Deref, DerefMut};
@@ -404,9 +404,12 @@ pub fn extract_cameras(
         &CameraRenderGraph,
         &GlobalTransform,
         &VisibleEntities,
+        Option<&RenderLayers>,
     )>,
 ) {
-    for (entity, camera, camera_render_graph, transform, visible_entities) in query.iter() {
+    for (entity, camera, camera_render_graph, transform, visible_entities, maybe_view_mask) in
+        query.iter()
+    {
         if !camera.is_active {
             continue;
         }
@@ -433,6 +436,7 @@ pub fn extract_cameras(
                     height: viewport_size.y,
                 },
                 visible_entities.clone(),
+                maybe_view_mask.cloned().unwrap_or_default(),
             ));
         }
     }

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -6,7 +6,7 @@ use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
 use bevy_render::{
     texture::{Image, DEFAULT_IMAGE_HANDLE},
-    view::Visibility,
+    view::{ComputedVisibility, Visibility},
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 
@@ -18,6 +18,8 @@ pub struct SpriteBundle {
     pub texture: Handle<Image>,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
+    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    pub computed_visibility: ComputedVisibility,
 }
 
 impl Default for SpriteBundle {
@@ -28,6 +30,7 @@ impl Default for SpriteBundle {
             global_transform: Default::default(),
             texture: DEFAULT_IMAGE_HANDLE.typed(),
             visibility: Default::default(),
+            computed_visibility: Default::default(),
         }
     }
 }
@@ -44,4 +47,6 @@ pub struct SpriteSheetBundle {
     pub global_transform: GlobalTransform,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
+    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    pub computed_visibility: ComputedVisibility,
 }

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -6,7 +6,7 @@ use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
 use bevy_render::{
     texture::{Image, DEFAULT_IMAGE_HANDLE},
-    view::{ComputedVisibility, Visibility},
+    view::Visibility,
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 
@@ -18,8 +18,6 @@ pub struct SpriteBundle {
     pub texture: Handle<Image>,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
-    pub computed_visibility: ComputedVisibility,
 }
 
 impl Default for SpriteBundle {
@@ -30,7 +28,6 @@ impl Default for SpriteBundle {
             global_transform: Default::default(),
             texture: DEFAULT_IMAGE_HANDLE.typed(),
             visibility: Default::default(),
-            computed_visibility: Default::default(),
         }
     }
 }
@@ -47,6 +44,4 @@ pub struct SpriteSheetBundle {
     pub global_transform: GlobalTransform,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
-    pub computed_visibility: ComputedVisibility,
 }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -10,7 +10,11 @@ use bevy_ecs::{
 };
 use bevy_math::{Vec2, Vec3};
 use bevy_reflect::Reflect;
-use bevy_render::{texture::Image, view::Visibility, RenderWorld};
+use bevy_render::{
+    texture::Image,
+    view::{ComputedVisibility, RenderLayers, Visibility},
+    RenderWorld,
+};
 use bevy_sprite::{Anchor, ExtractedSprite, ExtractedSprites, TextureAtlas};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 use bevy_utils::HashSet;
@@ -58,6 +62,7 @@ pub struct Text2dBundle {
     pub text_2d_size: Text2dSize,
     pub text_2d_bounds: Text2dBounds,
     pub visibility: Visibility,
+    pub coputed_visibility: Visibility,
 }
 
 pub fn extract_text2d_sprite(
@@ -65,14 +70,23 @@ pub fn extract_text2d_sprite(
     texture_atlases: Res<Assets<TextureAtlas>>,
     text_pipeline: Res<DefaultTextPipeline>,
     windows: Res<Windows>,
-    text2d_query: Query<(Entity, &Visibility, &Text, &GlobalTransform, &Text2dSize)>,
+    text2d_query: Query<(
+        Entity,
+        &ComputedVisibility,
+        &Text,
+        &GlobalTransform,
+        &Text2dSize,
+        Option<&RenderLayers>,
+    )>,
 ) {
     let mut extracted_sprites = render_world.resource_mut::<ExtractedSprites>();
 
     let scale_factor = windows.scale_factor(WindowId::primary()) as f32;
 
-    for (entity, visibility, text, transform, calculated_size) in text2d_query.iter() {
-        if !visibility.is_visible {
+    for (entity, computed_visibility, text, transform, calculated_size, maybe_view_mask) in
+        text2d_query.iter()
+    {
+        if !computed_visibility.is_visible {
             continue;
         }
         let (width, height) = (calculated_size.size.x, calculated_size.size.y);
@@ -119,6 +133,7 @@ pub fn extract_text2d_sprite(
                     flip_x: false,
                     flip_y: false,
                     anchor: Anchor::Center.as_vec(),
+                    view_mask: maybe_view_mask.copied().unwrap_or_default(),
                 });
             }
         }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -62,7 +62,7 @@ pub struct Text2dBundle {
     pub text_2d_size: Text2dSize,
     pub text_2d_bounds: Text2dBounds,
     pub visibility: Visibility,
-    pub coputed_visibility: Visibility,
+    pub computed_visibility: Visibility,
 }
 
 pub fn extract_text2d_sprite(

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -12,7 +12,7 @@ use bevy_math::{Vec2, Vec3};
 use bevy_reflect::Reflect;
 use bevy_render::{
     texture::Image,
-    view::{ComputedVisibility, RenderLayers, Visibility},
+    view::{RenderLayers, Visibility},
     RenderWorld,
 };
 use bevy_sprite::{Anchor, ExtractedSprite, ExtractedSprites, TextureAtlas};
@@ -62,7 +62,6 @@ pub struct Text2dBundle {
     pub text_2d_size: Text2dSize,
     pub text_2d_bounds: Text2dBounds,
     pub visibility: Visibility,
-    pub computed_visibility: Visibility,
 }
 
 pub fn extract_text2d_sprite(
@@ -72,7 +71,7 @@ pub fn extract_text2d_sprite(
     windows: Res<Windows>,
     text2d_query: Query<(
         Entity,
-        &ComputedVisibility,
+        &Visibility,
         &Text,
         &GlobalTransform,
         &Text2dSize,
@@ -83,10 +82,10 @@ pub fn extract_text2d_sprite(
 
     let scale_factor = windows.scale_factor(WindowId::primary()) as f32;
 
-    for (entity, computed_visibility, text, transform, calculated_size, maybe_view_mask) in
+    for (entity, visibility, text, transform, calculated_size, maybe_view_mask) in
         text2d_query.iter()
     {
-        if !computed_visibility.is_visible {
+        if !visibility.is_visible {
             continue;
         }
         let (width, height) = (calculated_size.size.x, calculated_size.size.y);


### PR DESCRIPTION
# Objective

Make sprites respect RenderLayers. Alternative to #4007.

## Solution

- Add ComputedVisibility to SpriteBundle, SpriteSheetBundle, Text2dBundle and sprites extract stage. Potentially useful for dropping sprites by AABB checks.
- At sprites queue stage use RenderLayers directly.
- As a side fix: sorting of extracted sprites is done once for all the views as it is not changed in between.

Compared to #4007:

- Pros: no performance penalty on many_sprites.
- Cons: some duplicate logic between visibility computation and sprites.
 



