### PR TITLE
[Merged by Bors] - Add `inverse_projection` and `inverse_view_proj` fields to shader view uniform

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -2,9 +2,11 @@
 
 struct View {
     view_proj: mat4x4<f32>;
+    inverse_view_proj: mat4x4<f32>;
     view: mat4x4<f32>;
     inverse_view: mat4x4<f32>;
     projection: mat4x4<f32>;
+    inverse_projection: mat4x4<f32>;
     world_position: vec3<f32>;
     width: f32;
     height: f32;

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -84,9 +84,11 @@ pub struct ExtractedView {
 #[derive(Clone, ShaderType)]
 pub struct ViewUniform {
     view_proj: Mat4,
+    inverse_view_proj: Mat4,
     view: Mat4,
     inverse_view: Mat4,
     projection: Mat4,
+    inverse_projection: Mat4,
     world_position: Vec3,
     width: f32,
     height: f32,
@@ -138,14 +140,17 @@ fn prepare_view_uniforms(
     view_uniforms.uniforms.clear();
     for (entity, camera) in views.iter() {
         let projection = camera.projection;
+        let inverse_projection = projection.inverse();
         let view = camera.transform.compute_matrix();
         let inverse_view = view.inverse();
         let view_uniforms = ViewUniformOffset {
             offset: view_uniforms.uniforms.push(ViewUniform {
                 view_proj: projection * inverse_view,
+                inverse_view_proj: inverse_projection * view,
                 view,
                 inverse_view,
                 projection,
+                inverse_projection,
                 world_position: camera.transform.translation,
                 width: camera.width as f32,
                 height: camera.height as f32,

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -146,7 +146,7 @@ fn prepare_view_uniforms(
         let view_uniforms = ViewUniformOffset {
             offset: view_uniforms.uniforms.push(ViewUniform {
                 view_proj: projection * inverse_view,
-                inverse_view_proj: inverse_projection * view,
+                inverse_view_proj: view * inverse_projection,
                 view,
                 inverse_view,
                 projection,


### PR DESCRIPTION
# Objective

Transform screen-space coordinates into world space in shaders. (My use case is for generating rays for ray tracing with the same perspective as the 3d camera).

## Solution

Add `inverse_projection` and `inverse_view_proj` fields to shader view uniform

---

## Changelog

### Added
`inverse_projection` and `inverse_view_proj` fields to shader view uniform

## Note

It'd probably be good to double-check that I did the matrix multiplication in the right order for `inverse_proj_view`. Thanks!