### PR TITLE
fix startup on android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1474,12 +1474,15 @@ path = "examples/android/android.rs"
 hidden = true
 
 [package.metadata.android]
-apk_label = "Bevy Example"
+package = "org.bevyengine.example"
+apk_name = "bevyexample"
 assets = "assets"
 resources = "assets/android-res"
 build_targets = ["aarch64-linux-android", "armv7-linux-androideabi"]
-min_sdk_version = 16
-target_sdk_version = 29
+
+[package.metadata.android.sdk]
+target_sdk_version = 31
 
 [package.metadata.android.application]
 icon = "@mipmap/ic_launcher"
+label = "Bevy Example"

--- a/crates/bevy_derive/src/bevy_main.rs
+++ b/crates/bevy_derive/src/bevy_main.rs
@@ -10,19 +10,10 @@ pub fn bevy_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     );
 
     TokenStream::from(quote! {
-        #[no_mangle]
         #[cfg(target_os = "android")]
-        unsafe extern "C" fn ANativeActivity_onCreate(
-            activity: *mut std::os::raw::c_void,
-            saved_state: *mut std::os::raw::c_void,
-            saved_state_size: usize,
-        ) {
-            bevy::ndk_glue::init(
-                activity as _,
-                saved_state as _,
-                saved_state_size as _,
-                main,
-            );
+        #[cfg_attr(target_os = "android", bevy::ndk_glue::main(backtrace = "on", ndk_glue = "bevy::ndk_glue"))]
+        fn android_main() {
+            main()
         }
 
         #[no_mangle]

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -48,9 +48,13 @@ impl Plugin for WinitPlugin {
         #[cfg(target_arch = "wasm32")]
         app.add_plugin(web_resize::CanvasParentResizePlugin);
         let event_loop = EventLoop::new();
+        #[cfg(not(target_os = "android"))]
         let mut create_window_reader = WinitCreateWindowReader::default();
+        #[cfg(target_os = "android")]
+        let create_window_reader = WinitCreateWindowReader::default();
         // Note that we create a window here "early" because WASM/WebGL requires the window to exist prior to initializing
         // the renderer.
+        #[cfg(not(target_os = "android"))]
         handle_create_window_events(&mut app.world, &event_loop, &mut create_window_reader.0);
         app.insert_resource(create_window_reader)
             .insert_non_send_resource(event_loop);

--- a/examples/README.md
+++ b/examples/README.md
@@ -356,22 +356,23 @@ When using Bevy as a library, the following fields must be added to `Cargo.toml`
 ```toml
 [package.metadata.android]
 build_targets = ["aarch64-linux-android", "armv7-linux-androideabi"]
-target_sdk_version = 29
-min_sdk_version = 16
+
+[package.metadata.android.sdk]
+target_sdk_version = 31
 ```
 
 Please reference `cargo-apk` [README](https://crates.io/crates/cargo-apk) for other Android Manifest fields.
 
 ### Old phones
 
-Bevy by default targets Android API level 29 in its examples which is the <!-- markdown-link-check-disable -->
+Bevy by default targets Android API level 31 in its examples which is the <!-- markdown-link-check-disable -->
 [Play Store's minimum API to upload or update apps](https://developer.android.com/distribute/best-practices/develop/target-sdk). <!-- markdown-link-check-enable -->
 Users of older phones may want to use an older API when testing.
 
 To use a different API, the following fields must be updated in Cargo.toml:
 
 ```toml
-[package.metadata.android]
+[package.metadata.android.sdk]
 target_sdk_version = >>API<<
 min_sdk_version = >>API or less<<
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -363,6 +363,22 @@ target_sdk_version = 31
 
 Please reference `cargo-apk` [README](https://crates.io/crates/cargo-apk) for other Android Manifest fields.
 
+### Debugging
+
+You can view the logs with the following command:
+
+```
+adb logcat | grep 'RustStdoutStderr\|bevy\|wgpu'
+```
+
+In case of an error getting a GPU or setting it up, you can try settings logs of `wgpu_hal` to `DEBUG` to get more informations.
+
+Sometimes, running the app complains about an unknown activity. This may be fixed by uninstalling the application:
+
+```
+adb uninstall org.bevyengine.example
+```
+
 ### Old phones
 
 Bevy by default targets Android API level 31 in its examples which is the <!-- markdown-link-check-disable -->

--- a/examples/README.md.tpl
+++ b/examples/README.md.tpl
@@ -108,22 +108,23 @@ When using Bevy as a library, the following fields must be added to `Cargo.toml`
 ```toml
 [package.metadata.android]
 build_targets = ["aarch64-linux-android", "armv7-linux-androideabi"]
-target_sdk_version = 29
-min_sdk_version = 16
+
+[package.metadata.android.sdk]
+target_sdk_version = 31
 ```
 
 Please reference `cargo-apk` [README](https://crates.io/crates/cargo-apk) for other Android Manifest fields.
 
 ### Old phones
 
-Bevy by default targets Android API level 29 in its examples which is the <!-- markdown-link-check-disable -->
+Bevy by default targets Android API level 31 in its examples which is the <!-- markdown-link-check-disable -->
 [Play Store's minimum API to upload or update apps](https://developer.android.com/distribute/best-practices/develop/target-sdk). <!-- markdown-link-check-enable -->
 Users of older phones may want to use an older API when testing.
 
 To use a different API, the following fields must be updated in Cargo.toml:
 
 ```toml
-[package.metadata.android]
+[package.metadata.android.sdk]
 target_sdk_version = >>API<<
 min_sdk_version = >>API or less<<
 ```

--- a/examples/README.md.tpl
+++ b/examples/README.md.tpl
@@ -115,6 +115,22 @@ target_sdk_version = 31
 
 Please reference `cargo-apk` [README](https://crates.io/crates/cargo-apk) for other Android Manifest fields.
 
+### Debugging
+
+You can view the logs with the following command:
+
+```
+adb logcat | grep 'RustStdoutStderr\|bevy\|wgpu'
+```
+
+In case of an error getting a GPU or setting it up, you can try settings logs of `wgpu_hal` to `DEBUG` to get more informations.
+
+Sometimes, running the app complains about an unknown activity. This may be fixed by uninstalling the application:
+
+```
+adb uninstall org.bevyengine.example
+```
+
 ### Old phones
 
 Bevy by default targets Android API level 31 in its examples which is the <!-- markdown-link-check-disable -->

--- a/examples/android/android.rs
+++ b/examples/android/android.rs
@@ -1,9 +1,22 @@
-use bevy::prelude::*;
+use bevy::{
+    prelude::*,
+    render::{
+        render_resource::WgpuLimits,
+        settings::{WgpuSettings, WgpuSettingsPriority},
+    },
+};
 
 // the `bevy_main` proc_macro generates the required android boilerplate
 #[bevy_main]
 fn main() {
     App::new()
+        // This settings use the most compatible settings for wgpu. THey help with compatibilty
+        // with as many devices as possible
+        .insert_resource(WgpuSettings {
+            priority: WgpuSettingsPriority::Compatibility,
+            limits: WgpuLimits::downlevel_defaults(),
+            ..default()
+        })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .run();


### PR DESCRIPTION
# Objective

- Make Bevy work on android

## Solution

- Update android metadata and add a few more
- Set the target sdk to 31 as it will soon (in august) be the minimum sdk level for play store
- Remove the custom code to create an activity and use ndk-glue macro instead
- Delay window creation event on android
- Set the example with compatibility settings for wgpu. Those are needed for Bevy to work on my 2019 android tablet
- Add a few details on how to debug in case of failures

Bevy still doesn't work on android with this, audio features need to be disabled because of an ndk-glue version mismatch: rodio depends on 0.6.2, winit on 0.5.2

