### PR TITLE
[Merged by Bors] - Use tone mapping in array_texture example

### DIFF
--- a/assets/shaders/array_texture.wgsl
+++ b/assets/shaders/array_texture.wgsl
@@ -59,5 +59,5 @@ fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
     );
     pbr_input.V = calculate_view(in.world_position, pbr_input.is_orthographic);
 
-    return pbr(pbr_input);
+    return tone_mapping(pbr(pbr_input));
 }


### PR DESCRIPTION
# Objective

The array_texture example does not currently apply tone mapping:
![no_tonemapping](https://user-images.githubusercontent.com/33357138/176327061-4c404b62-d260-458d-b3cb-4671bd8c2735.PNG)

## Solution

Use tone mapping:
![with_tonemapping](https://user-images.githubusercontent.com/33357138/176327092-7aaeac85-0d95-4c7d-9d91-7fe46bed32c3.PNG)
