### PR TITLE
Move Non Send Resources into thread locals

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -312,8 +312,10 @@ impl AddAsset for App {
             let mut app = self
                 .world
                 .non_send_resource_mut::<crate::debug_asset_server::DebugAssetApp>();
-            app.add_asset::<T>()
-                .init_resource::<crate::debug_asset_server::HandleMap<T>>();
+            app.get_mut(|app| {
+                app.add_asset::<T>()
+                    .init_resource::<crate::debug_asset_server::HandleMap<T>>();
+            });
         }
         self
     }
@@ -335,7 +337,9 @@ impl AddAsset for App {
             let mut app = self
                 .world
                 .non_send_resource_mut::<crate::debug_asset_server::DebugAssetApp>();
-            app.init_asset_loader::<T>();
+            app.get_mut(|app| {
+                app.init_asset_loader::<T>();
+            });
         }
         self
     }
@@ -357,13 +361,15 @@ macro_rules! load_internal_asset {
             let mut debug_app = $app
                 .world
                 .non_send_resource_mut::<$crate::debug_asset_server::DebugAssetApp>();
-            $crate::debug_asset_server::register_handle_with_loader(
-                $loader,
-                &mut debug_app,
-                $handle,
-                file!(),
-                $path_str,
-            );
+            debug_app.get_mut(|mut debug_app| {
+                $crate::debug_asset_server::register_handle_with_loader(
+                    $loader,
+                    &mut debug_app,
+                    $handle,
+                    file!(),
+                    $path_str,
+                );
+            });
         }
         let mut assets = $app.world.resource_mut::<$crate::Assets<_>>();
         assets.set_untracked($handle, ($loader)(include_str!($path_str)));

--- a/crates/bevy_asset/src/debug_asset_server.rs
+++ b/crates/bevy_asset/src/debug_asset_server.rs
@@ -77,31 +77,35 @@ impl Plugin for DebugAssetServerPlugin {
 }
 
 fn run_debug_asset_app(mut debug_asset_app: NonSendMut<DebugAssetApp>) {
-    debug_asset_app.0.update();
+    debug_asset_app.get_mut(|debug_asset_app| {
+        debug_asset_app.0.update();
+    });
 }
 
 pub(crate) fn sync_debug_assets<T: Asset + Clone>(
     mut debug_asset_app: NonSendMut<DebugAssetApp>,
     mut assets: ResMut<Assets<T>>,
 ) {
-    let world = &mut debug_asset_app.0.world;
-    let mut state = SystemState::<(
-        Res<Events<AssetEvent<T>>>,
-        Res<HandleMap<T>>,
-        Res<Assets<T>>,
-    )>::new(world);
-    let (changed_shaders, handle_map, debug_assets) = state.get_mut(world);
-    for changed in changed_shaders.iter_current_update_events() {
-        let debug_handle = match changed {
-            AssetEvent::Created { handle } | AssetEvent::Modified { handle } => handle,
-            AssetEvent::Removed { .. } => continue,
-        };
-        if let Some(handle) = handle_map.handles.get(debug_handle) {
-            if let Some(debug_asset) = debug_assets.get(debug_handle) {
-                assets.set_untracked(handle, debug_asset.clone());
+    debug_asset_app.get_mut(|debug_asset_app| {
+        let world = &mut debug_asset_app.0.world;
+        let mut state = SystemState::<(
+            Res<Events<AssetEvent<T>>>,
+            Res<HandleMap<T>>,
+            Res<Assets<T>>,
+        )>::new(world);
+        let (changed_shaders, handle_map, debug_assets) = state.get_mut(world);
+        for changed in changed_shaders.iter_current_update_events() {
+            let debug_handle = match changed {
+                AssetEvent::Created { handle } | AssetEvent::Modified { handle } => handle,
+                AssetEvent::Removed { .. } => continue,
+            };
+            if let Some(handle) = handle_map.handles.get(debug_handle) {
+                if let Some(debug_asset) = debug_assets.get(debug_handle) {
+                    assets.set_untracked(handle, debug_asset.clone());
+                }
             }
         }
-    }
+    });
 }
 
 /// Uses the return type of the given loader to register the given handle with the appropriate type

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -90,7 +90,9 @@ pub fn play_queued_audio_system<Source: Asset + Decodable>(
     mut sinks: ResMut<Assets<AudioSink>>,
 ) {
     if let Some(audio_sources) = audio_sources {
-        audio_output.try_play_queued(&*audio_sources, &mut *audio, &mut *sinks);
+        audio_output.get(|audio_output| {
+            audio_output.try_play_queued(&*audio_sources, &mut *audio, &mut *sinks);
+        });
     };
 }
 

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -22,6 +22,7 @@ bevy_ecs_macros = { path = "macros", version = "0.8.0-dev" }
 
 async-channel = "1.4"
 thread_local = "1.1.4"
+thread-local-object = "0.1.0"
 fixedbitset = "0.4"
 fxhash = "0.2"
 downcast-rs = "1.2"

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1,9 +1,6 @@
 //! Types that detect when their internal data mutate.
 
-use crate::{
-    component::ComponentTicks, ptr::PtrMut, system::Resource,
-    world::ThreadLocalResource,
-};
+use crate::{component::ComponentTicks, ptr::PtrMut, system::Resource, world::ThreadLocalResource};
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 use std::ops::{Deref, DerefMut};

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1,6 +1,9 @@
 //! Types that detect when their internal data mutate.
 
-use crate::{component::ComponentTicks, ptr::PtrMut, system::Resource};
+use crate::{
+    component::ComponentTicks, ptr::PtrMut, system::Resource,
+    world::ThreadLocalResource,
+};
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 use std::ops::{Deref, DerefMut};
@@ -198,12 +201,12 @@ impl_debug!(ResMut<'a, T>, Resource);
 ///
 /// Use `Option<NonSendMut<T>>` instead if the resource might not always exist.
 pub struct NonSendMut<'a, T: 'static> {
-    pub(crate) value: &'a mut T,
+    pub(crate) value: &'a mut ThreadLocalResource<T>,
     pub(crate) ticks: Ticks<'a>,
 }
 
-change_detection_impl!(NonSendMut<'a, T>, T,);
-impl_into_inner!(NonSendMut<'a, T>, T,);
+change_detection_impl!(NonSendMut<'a, T>, ThreadLocalResource<T>,);
+impl_into_inner!(NonSendMut<'a, T>, ThreadLocalResource<T>,);
 impl_debug!(NonSendMut<'a, T>,);
 
 /// Unique mutable borrow of an entity's component

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1189,8 +1189,13 @@ mod tests {
         let mut world = World::default();
         world.insert_non_send_resource(123i32);
         world.insert_non_send_resource(456i64);
-        assert_eq!(*world.non_send_resource::<i32>(), 123);
-        assert_eq!(*world.non_send_resource_mut::<i64>(), 456);
+        world.non_send_resource::<i32>().get(|res| {
+            assert_eq!(*res, 123);
+        });
+
+        world.non_send_resource_mut::<i64>().get(|res| {
+            assert_eq!(*res, 456);
+        });
     }
 
     #[test]

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1204,7 +1204,7 @@ mod tests {
         let mut world = World::default();
         world.insert_non_send_resource(0i32);
         std::thread::spawn(move || {
-            let _ = world.non_send_resource_mut::<i32>();
+            world.non_send_resource_mut::<i32>().get(|_| {});
         })
         .join()
         .unwrap();

--- a/crates/bevy_ecs/src/schedule/executor_parallel.rs
+++ b/crates/bevy_ecs/src/schedule/executor_parallel.rs
@@ -453,7 +453,9 @@ mod tests {
         let mut world = World::new();
         world.insert_non_send_resource(thread::current().id());
         fn non_send(thread_id: NonSend<thread::ThreadId>) {
-            assert_eq!(thread::current().id(), *thread_id);
+            thread_id.get(|thread_id| {
+                assert_eq!(thread::current().id(), *thread_id);
+            });
         }
         fn empty() {}
         let mut stage = SystemStage::parallel()

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -508,7 +508,19 @@ mod tests {
         world.insert_non_send_resource(NotSend1(std::rc::Rc::new(1)));
         world.insert_non_send_resource(NotSend2(std::rc::Rc::new(2)));
 
-        fn sys(_op: NonSend<NotSend1>, mut _op2: NonSendMut<NotSend2>, mut run: ResMut<bool>) {
+        fn sys(
+            non_send: NonSend<NotSend1>,
+            mut non_send_mut: NonSendMut<NotSend2>,
+            mut run: ResMut<bool>,
+        ) {
+            non_send.get(|non_send| {
+                assert_eq!(*non_send.0, 1);
+            });
+
+            non_send_mut.get_mut(|non_send_mut| {
+                assert_eq!(*non_send_mut.0, 2);
+            });
+
             *run = true;
         }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -899,7 +899,6 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendState<T> {
         world: &'w World,
         change_tick: u32,
     ) -> Self::Item {
-        world.validate_non_send_access::<T>();
         let column = world
             .get_populated_resource_column(state.component_id)
             .unwrap_or_else(|| {
@@ -947,7 +946,6 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for OptionNonSendState<T> {
         world: &'w World,
         change_tick: u32,
     ) -> Self::Item {
-        world.validate_non_send_access::<T>();
         world
             .get_populated_resource_column(state.0.component_id)
             .map(|column| NonSend {
@@ -1013,7 +1011,6 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendMutState<T> {
         world: &'w World,
         change_tick: u32,
     ) -> Self::Item {
-        world.validate_non_send_access::<T>();
         let column = world
             .get_populated_resource_column(state.component_id)
             .unwrap_or_else(|| {
@@ -1062,7 +1059,6 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for OptionNonSendMutState<T> {
         world: &'w World,
         change_tick: u32,
     ) -> Self::Item {
-        world.validate_non_send_access::<T>();
         world
             .get_populated_resource_column(state.0.component_id)
             .map(|column| NonSendMut {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -5,11 +5,11 @@ use crate::{
     change_detection::Ticks,
     component::{Component, ComponentId, ComponentTicks, Components},
     entity::{Entities, Entity},
-    world::ThreadLocalResource,
     query::{
         Access, FilteredAccess, FilteredAccessSet, QueryState, ReadOnlyWorldQuery, WorldQuery,
     },
     system::{CommandQueue, Commands, Query, SystemMeta},
+    world::ThreadLocalResource,
     world::{FromWorld, World},
 };
 pub use bevy_ecs_macros::SystemParam;

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1,13 +1,13 @@
 mod entity_ref;
 mod spawn_batch;
-mod world_cell;
 mod thread_local_resource;
+mod world_cell;
 
 pub use crate::change_detection::Mut;
 pub use entity_ref::*;
 pub use spawn_batch::*;
-pub use world_cell::*;
 pub use thread_local_resource::*;
+pub use world_cell::*;
 
 use crate::{
     archetype::{ArchetypeComponentId, ArchetypeComponentInfo, ArchetypeId, Archetypes},

--- a/crates/bevy_ecs/src/world/thread_local_resource.rs
+++ b/crates/bevy_ecs/src/world/thread_local_resource.rs
@@ -1,6 +1,5 @@
 use thread_local_object::ThreadLocal as ThreadLocalObject;
 
-
 // This is a thin wrapper around thread local to make some methods take &mut self.
 // This makes accessing a &mut T require a NonSendMut from a system
 // The underlying implementation panics if there are violations to rusts mutability rules.
@@ -26,21 +25,20 @@ impl<T: 'static> ThreadLocalResource<T> {
     {
         self.0.get(|t|
             // TODO: add typename to error message. possibly add reference to NonSend System param
-            f(t.unwrap_or_else(|| 
+            f(t.unwrap_or_else(||
                 panic!(
                     "Requested non-send resource {} does not exist on this thread.
                     You may be on the wrong thread or need to call .set on the resource.",
                     std::any::type_name::<R>()
                 )
-            ))
-        )
+            )))
     }
 
     pub fn get_mut<F, R>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
     {
-        self.0.get_mut(|t| 
+        self.0.get_mut(|t|
             // TODO: add typename to error message. possibly add reference to NonSend System param
             f(t.unwrap_or_else(||
                 panic!(
@@ -48,18 +46,14 @@ impl<T: 'static> ThreadLocalResource<T> {
                     You may be on the wrong thread or need to call .set on the resource.",
                     std::any::type_name::<R>()
                 )
-            ))
-        )
+            )))
     }
 }
 
 impl<T: 'static + std::fmt::Debug> std::fmt::Debug for ThreadLocalResource<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.get(|field| {
-            f.debug_tuple("ThreadLocalResource")
-            .field(&field)
-            .finish()
-        })
+        self.0
+            .get(|field| f.debug_tuple("ThreadLocalResource").field(&field).finish())
     }
 }
 

--- a/crates/bevy_ecs/src/world/thread_local_resource.rs
+++ b/crates/bevy_ecs/src/world/thread_local_resource.rs
@@ -69,9 +69,12 @@ impl<T: 'static + Default> Default for ThreadLocalResource<T> {
     }
 }
 
-// try to drop the resource on the current thread
-// Note: this does not necessarily drop every resouce in ThreadLocalResource
-// only the one on the thread that drops the TheadLocalResource
+// TODO: This drop impl is needed because AudioOutput was panicking when
+// it was being dropped when the thread local storage was being dropped.
+// This tries to drop the resource on the current thread, which fixes
+// things for when the world is on the main thread, but would probably
+// break if the world is moved to a different thread. We should figure
+// out a more robust way of dropping the resource instead.
 impl<T: 'static> Drop for ThreadLocalResource<T> {
     fn drop(&mut self) {
         self.remove();

--- a/crates/bevy_ecs/src/world/thread_local_resource.rs
+++ b/crates/bevy_ecs/src/world/thread_local_resource.rs
@@ -4,6 +4,7 @@ use thread_local_object::ThreadLocal as ThreadLocalObject;
 // This is a thin wrapper around thread local to make some methods take &mut self.
 // This makes accessing a &mut T require a NonSendMut from a system
 // The underlying implementation panics if there are violations to rusts mutability rules.
+// Used by non-send resources to make sending World safe.
 pub struct ThreadLocalResource<T: 'static>(ThreadLocalObject<T>);
 
 impl<T: 'static> ThreadLocalResource<T> {

--- a/crates/bevy_ecs/src/world/thread_local_resource.rs
+++ b/crates/bevy_ecs/src/world/thread_local_resource.rs
@@ -1,0 +1,78 @@
+use thread_local_object::ThreadLocal as ThreadLocalObject;
+
+
+// This is a thin wrapper around thread local to make some methods take &mut self.
+// This makes accessing a &mut T require a NonSendMut from a system
+// The underlying implementation panics if there are violations to rusts mutability rules.
+pub struct ThreadLocalResource<T: 'static>(ThreadLocalObject<T>);
+
+impl<T: 'static> ThreadLocalResource<T> {
+    pub fn new() -> Self {
+        ThreadLocalResource(ThreadLocalObject::new())
+    }
+
+    pub fn set(&self, value: T) -> Option<T> {
+        self.0.set(value)
+    }
+
+    pub fn remove(&mut self) -> Option<T> {
+        self.0.remove()
+    }
+
+    pub fn get<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&T) -> R,
+    {
+        self.0.get(|t|
+            // TODO: add typename to error message. possibly add reference to NonSend System param
+            f(t.unwrap_or_else(|| 
+                panic!(
+                    "Requested non-send resource {} does not exist on this thread.
+                    You may be on the wrong thread or need to call .set on the resource.",
+                    std::any::type_name::<R>()
+                )
+            ))
+        )
+    }
+
+    pub fn get_mut<F, R>(&mut self, f: F) -> R
+    where
+        F: FnOnce(&mut T) -> R,
+    {
+        self.0.get_mut(|t| 
+            // TODO: add typename to error message. possibly add reference to NonSend System param
+            f(t.unwrap_or_else(||
+                panic!(
+                "Requested non-send resource {} does not exist on this thread.
+                    You may be on the wrong thread or need to call .set on the resource.",
+                    std::any::type_name::<R>()
+                )
+            ))
+        )
+    }
+}
+
+impl<T: 'static + std::fmt::Debug> std::fmt::Debug for ThreadLocalResource<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.get(|field| {
+            f.debug_tuple("ThreadLocalResource")
+            .field(&field)
+            .finish()
+        })
+    }
+}
+
+impl<T: 'static + Default> Default for ThreadLocalResource<T> {
+    fn default() -> Self {
+        ThreadLocalResource::new()
+    }
+}
+
+// try to drop the resource on the current thread
+// Note: this does not necessarily drop every resouce in ThreadLocalResource
+// only the one on the thread that drops the TheadLocalResource
+impl<T: 'static> Drop for ThreadLocalResource<T> {
+    fn drop(&mut self) {
+        self.remove();
+    }
+}

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -2,7 +2,7 @@ use crate::{
     archetype::ArchetypeComponentId,
     storage::SparseSet,
     system::Resource,
-    world::{Mut, World},
+    world::{thread_local_resource::ThreadLocalResource, Mut, World},
 };
 use std::{
     any::TypeId,
@@ -248,8 +248,13 @@ impl<'w> WorldCell<'w> {
     }
 
     /// Gets an immutable reference to the non-send resource of the given type, if it exists.
-    pub fn get_non_send_resource<T: 'static>(&self) -> Option<WorldBorrow<'_, T>> {
-        let component_id = self.world.components.get_resource_id(TypeId::of::<T>())?;
+    pub fn get_non_send_resource<T: 'static>(
+        &self,
+    ) -> Option<WorldBorrow<'_, ThreadLocalResource<T>>> {
+        let component_id = self
+            .world
+            .components
+            .get_resource_id(TypeId::of::<ThreadLocalResource<T>>())?;
         let resource_archetype = self.world.archetypes.resource();
         let archetype_component_id = resource_archetype.get_archetype_component_id(component_id)?;
         Some(WorldBorrow::new(
@@ -267,7 +272,7 @@ impl<'w> WorldCell<'w> {
     /// Panics if the resource does not exist. Use
     /// [`get_non_send_resource`](WorldCell::get_non_send_resource) instead if you want to handle
     /// this case.
-    pub fn non_send_resource<T: 'static>(&self) -> WorldBorrow<'_, T> {
+    pub fn non_send_resource<T: 'static>(&self) -> WorldBorrow<'_, ThreadLocalResource<T>> {
         match self.get_non_send_resource() {
             Some(x) => x,
             None => panic!(
@@ -280,8 +285,13 @@ impl<'w> WorldCell<'w> {
     }
 
     /// Gets a mutable reference to the non-send resource of the given type, if it exists.
-    pub fn get_non_send_resource_mut<T: 'static>(&self) -> Option<WorldBorrowMut<'_, T>> {
-        let component_id = self.world.components.get_resource_id(TypeId::of::<T>())?;
+    pub fn get_non_send_resource_mut<T: 'static>(
+        &self,
+    ) -> Option<WorldBorrowMut<'_, ThreadLocalResource<T>>> {
+        let component_id = self
+            .world
+            .components
+            .get_resource_id(TypeId::of::<ThreadLocalResource<T>>())?;
         let resource_archetype = self.world.archetypes.resource();
         let archetype_component_id = resource_archetype.get_archetype_component_id(component_id)?;
         Some(WorldBorrowMut::new(
@@ -302,7 +312,7 @@ impl<'w> WorldCell<'w> {
     /// Panics if the resource does not exist. Use
     /// [`get_non_send_resource_mut`](WorldCell::get_non_send_resource_mut) instead if you want to
     /// handle this case.
-    pub fn non_send_resource_mut<T: 'static>(&self) -> WorldBorrowMut<'_, T> {
+    pub fn non_send_resource_mut<T: 'static>(&self) -> WorldBorrowMut<'_, ThreadLocalResource<T>> {
         match self.get_non_send_resource_mut() {
             Some(x) => x,
             None => panic!(

--- a/crates/bevy_gilrs/src/gilrs_system.rs
+++ b/crates/bevy_gilrs/src/gilrs_system.rs
@@ -5,47 +5,51 @@ use bevy_input::{gamepad::GamepadEventRaw, prelude::*};
 use gilrs::{EventType, Gilrs};
 
 pub fn gilrs_event_startup_system(gilrs: NonSend<Gilrs>, mut events: EventWriter<GamepadEventRaw>) {
-    for (id, _) in gilrs.gamepads() {
-        events.send(GamepadEventRaw::new(
-            convert_gamepad_id(id),
-            GamepadEventType::Connected,
-        ));
-    }
+    gilrs.get(|gilrs| {
+        for (id, _) in gilrs.gamepads() {
+            events.send(GamepadEventRaw::new(
+                convert_gamepad_id(id),
+                GamepadEventType::Connected,
+            ));
+        }
+    });
 }
 
 pub fn gilrs_event_system(mut gilrs: NonSendMut<Gilrs>, mut events: EventWriter<GamepadEventRaw>) {
-    while let Some(gilrs_event) = gilrs.next_event() {
-        match gilrs_event.event {
-            EventType::Connected => {
-                events.send(GamepadEventRaw::new(
-                    convert_gamepad_id(gilrs_event.id),
-                    GamepadEventType::Connected,
-                ));
-            }
-            EventType::Disconnected => {
-                events.send(GamepadEventRaw::new(
-                    convert_gamepad_id(gilrs_event.id),
-                    GamepadEventType::Disconnected,
-                ));
-            }
-            EventType::ButtonChanged(gilrs_button, value, _) => {
-                if let Some(button_type) = convert_button(gilrs_button) {
+    gilrs.get_mut(|gilrs| {
+        while let Some(gilrs_event) = gilrs.next_event() {
+            match gilrs_event.event {
+                EventType::Connected => {
                     events.send(GamepadEventRaw::new(
                         convert_gamepad_id(gilrs_event.id),
-                        GamepadEventType::ButtonChanged(button_type, value),
+                        GamepadEventType::Connected,
                     ));
                 }
-            }
-            EventType::AxisChanged(gilrs_axis, value, _) => {
-                if let Some(axis_type) = convert_axis(gilrs_axis) {
+                EventType::Disconnected => {
                     events.send(GamepadEventRaw::new(
                         convert_gamepad_id(gilrs_event.id),
-                        GamepadEventType::AxisChanged(axis_type, value),
+                        GamepadEventType::Disconnected,
                     ));
                 }
-            }
-            _ => (),
-        };
-    }
-    gilrs.inc();
+                EventType::ButtonChanged(gilrs_button, value, _) => {
+                    if let Some(button_type) = convert_button(gilrs_button) {
+                        events.send(GamepadEventRaw::new(
+                            convert_gamepad_id(gilrs_event.id),
+                            GamepadEventType::ButtonChanged(button_type, value),
+                        ));
+                    }
+                }
+                EventType::AxisChanged(gilrs_axis, value, _) => {
+                    if let Some(axis_type) = convert_axis(gilrs_axis) {
+                        events.send(GamepadEventRaw::new(
+                            convert_gamepad_id(gilrs_event.id),
+                            GamepadEventType::AxisChanged(axis_type, value),
+                        ));
+                    }
+                }
+                _ => (),
+            };
+        }
+        gilrs.inc();
+    });
 }

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -28,7 +28,7 @@ impl Plugin for WindowRenderPlugin {
             render_app
                 .init_resource::<ExtractedWindows>()
                 .init_resource::<WindowSurfaces>()
-                .init_resource::<NonSendMarker>()
+                .init_non_send_resource::<NonSendMarker>()
                 .add_system_to_stage(RenderStage::Extract, extract_windows)
                 .add_system_to_stage(
                     RenderStage::Prepare,


### PR DESCRIPTION
> Putting this up as a possible fix for non send resource being dropped on the wrong thread. Not sure that this is the direction to take as it significantly complicates the API for non-send resources and has other disadvantages too. See Below. If it is a direction to pursue, this needs additional cleanup, so I've opened it as a draft PR.

## Objective

Fix problem with world being send and dropping non send resources on the wrong thread.

Alternative to https://github.com/bevyengine/bevy/pull/3519,

## Solution

* Use the `thread_local_object` crate to move non send resources into thread local memory. This means that trying to access the non send resource off the thread that spawned it will end up with the resource not being found. 
* `thread_local_object` drops the objects it keeps when the thread is dropped instead of when it's instance is dropped.
* remove thread check validation as it's no longer needed.

### Advantages

* Fixes issue with non-send resources being dropped on wrong thread after sending World.
* This is the idiomatic way in rust to allocate thread local things and drop them on the correct thread. So is less likely to have some weird corner case issue with dropping.
* Easy to extend to have non send resource on threads other than main thread (Not sure this is useful as all the non-send resources in bevy are non-send, because they need os apis that are only accessible on main thread)

### Disadvantages

* non-send resource api is different from normal resources and increases cognitive burden on users.
* increases rightward drift
* There are 2 very similar, but distinct operations. Removing the ThreadLocalResource from the world, `world.remove_non_send_resource` vs removing the resource from the ThreadLocalResource, `ThreadLocalResouce::remove`.
* The stuff referenced by `thread_local_object` are not dropped when the `ThreadLocalResource` is dropped. They are only dropped when the thread is dropped or `ThreadLocalResource;:remove` is called on the corrent thread. I added an explicit drop for the thread that `ThreadLocalResource` is dropped on, but this doesn't help if the world has been sent. So this is a potential memory leak.
* probably gives a stronger guarantee than is necessary. We can probably work around the issues by having a send world and a non send world (turtle).
* adds a level of indirection, which likely hurts performance for accessing the resource

## Migration Guide

// TODO

## ToDo

* [ ] docs! docs! docs!
* [ ] figure out if there's a better way to ensure that audio is dropped correctly
