### PR TITLE
[Merged by Bors] - Add ability to inspect entity's components

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -588,7 +588,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
         });
     }
 
-    /// Logs the components of the entity at the debug level.
+    /// Logs the components of the entity at the info level.
     pub fn log_components(&mut self) {
         self.commands.add(DebugEntity {
             entity: self.entity,

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -590,7 +590,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
 
     /// Logs the components of the entity at the info level.
     pub fn log_components(&mut self) {
-        self.commands.add(DebugEntity {
+        self.commands.add(LogComponents {
             entity: self.entity,
         });
     }
@@ -801,11 +801,11 @@ impl<R: Resource> Command for RemoveResource<R> {
 }
 
 /// [`Command`] to log the components of a given entity. See [`EntityCommands::log_components`].
-pub struct DebugEntity {
+pub struct LogComponents {
     entity: Entity,
 }
 
-impl Command for DebugEntity {
+impl Command for LogComponents {
     fn write(self, world: &mut World) {
         let debug_infos: Vec<_> = world
             .inspect_entity(self.entity)

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     entity::{Entities, Entity},
     world::{FromWorld, World},
 };
-use bevy_utils::tracing::{error, warn};
+use bevy_utils::tracing::{debug, error, warn};
 pub use command_queue::CommandQueue;
 pub use parallel_scope::*;
 use std::marker::PhantomData;
@@ -215,6 +215,11 @@ impl<'w, 's> Commands<'w, 's> {
             entity,
             commands: self,
         }
+    }
+
+    /// Logs the components of a given entity at the debug level.
+    pub fn debug_entity(&mut self, entity: Entity) {
+        self.queue.push(DebugEntity { entity });
     }
 
     /// Spawns entities to the [`World`] according to the given iterator (or a type that can
@@ -790,6 +795,20 @@ pub struct RemoveResource<R: Resource> {
 impl<R: Resource> Command for RemoveResource<R> {
     fn write(self, world: &mut World) {
         world.remove_resource::<R>();
+    }
+}
+
+pub struct DebugEntity {
+    entity: Entity,
+}
+
+impl Command for DebugEntity {
+    fn write(self, world: &mut World) {
+        debug!(
+            "Entity {:?}: {:?}",
+            self.entity,
+            world.inspect_entity(self.entity)
+        );
     }
 }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -798,6 +798,7 @@ impl<R: Resource> Command for RemoveResource<R> {
     }
 }
 
+/// [`Command`] to log the components of a given entity. See [`Commands::debug_entity`].
 pub struct DebugEntity {
     entity: Entity,
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -284,10 +284,24 @@ impl World {
     /// Returns the components of an [`Entity`](crate::entity::Entity) through [`ComponentInfo`](crate::component::ComponentInfo).
     #[inline]
     pub fn inspect_entity(&mut self, entity: Entity) -> Vec<&ComponentInfo> {
-        let entity_ref = self.entity(entity);
-        self.components()
-            .iter()
-            .filter(|component| entity_ref.contains_id(component.id()))
+        let entity_location = self
+            .entities()
+            .get(entity)
+            .unwrap_or_else(|| panic!("Entity {:?} does not exist", entity));
+
+        let archetype = self
+            .archetypes()
+            .get(entity_location.archetype_id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Archetype {:?} does not exist",
+                    entity_location.archetype_id
+                )
+            });
+
+        archetype
+            .components()
+            .filter_map(|id| self.components().get_info(id))
             .collect()
     }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -283,7 +283,7 @@ impl World {
 
     /// Returns the components of an [`Entity`](crate::entity::Entity) through [`ComponentInfo`](crate::component::ComponentInfo).
     #[inline]
-    pub fn inspect_entity(&mut self, entity: Entity) -> Vec<&ComponentInfo> {
+    pub fn inspect_entity(&self, entity: Entity) -> Vec<&ComponentInfo> {
         let entity_location = self
             .entities()
             .get(entity)

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -12,7 +12,8 @@ use crate::{
     bundle::{Bundle, BundleInserter, BundleSpawner, Bundles},
     change_detection::{MutUntyped, Ticks},
     component::{
-        Component, ComponentDescriptor, ComponentId, ComponentTicks, Components, StorageType,
+        Component, ComponentDescriptor, ComponentId, ComponentInfo, ComponentTicks, Components,
+        StorageType,
     },
     entity::{AllocAtWithoutReplacement, Entities, Entity},
     query::{QueryState, WorldQuery},
@@ -278,6 +279,16 @@ impl World {
         // Lazily evaluate panic!() via unwrap_or_else() to avoid allocation unless failure
         self.get_entity_mut(entity)
             .unwrap_or_else(|| panic!("Entity {:?} does not exist", entity))
+    }
+
+    /// Returns the components of an [`Entity`](crate::entity::Entity) through [`ComponentInfo`](crate::component::ComponentInfo).
+    #[inline]
+    pub fn inspect_entity(&mut self, entity: Entity) -> Vec<&ComponentInfo> {
+        let entity_ref = self.entity(entity);
+        self.components()
+            .iter()
+            .filter(|component| entity_ref.contains_id(component.id()))
+            .collect()
     }
 
     /// Returns an [`EntityMut`] for the given `entity` (if it exists) or spawns one if it doesn't exist.
@@ -1542,11 +1553,13 @@ mod tests {
     use super::World;
     use crate::{
         change_detection::DetectChanges,
-        component::{ComponentDescriptor, ComponentId, StorageType},
+        component::{ComponentDescriptor, ComponentId, ComponentInfo, StorageType},
         ptr::OwningPtr,
     };
     use bevy_ecs_macros::Component;
+    use bevy_utils::HashSet;
     use std::{
+        any::TypeId,
         panic,
         sync::{
             atomic::{AtomicBool, AtomicU32, Ordering},
@@ -1761,5 +1774,65 @@ mod tests {
             // SAFE: ptr must be valid for the component_id `invalid_component_id` which is invalid, but checked by `insert_resource_by_id`
             world.insert_resource_by_id(invalid_component_id, ptr);
         });
+    }
+
+    #[derive(Component)]
+    struct Foo;
+
+    #[derive(Component)]
+    struct Bar;
+
+    #[derive(Component)]
+    struct Baz;
+
+    #[test]
+    fn inspect_entity_components() {
+        let mut world = World::new();
+        let ent0 = world.spawn().insert_bundle((Foo, Bar, Baz)).id();
+        let ent1 = world.spawn().insert_bundle((Foo, Bar)).id();
+        let ent2 = world.spawn().insert_bundle((Bar, Baz)).id();
+        let ent3 = world.spawn().insert_bundle((Foo, Baz)).id();
+        let ent4 = world.spawn().insert_bundle((Foo,)).id();
+        let ent5 = world.spawn().insert_bundle((Bar,)).id();
+        let ent6 = world.spawn().insert_bundle((Baz,)).id();
+
+        fn to_type_ids(component_infos: Vec<&ComponentInfo>) -> HashSet<Option<TypeId>> {
+            component_infos
+                .into_iter()
+                .map(|component_info| component_info.type_id())
+                .collect()
+        }
+
+        let foo_id = TypeId::of::<Foo>();
+        let bar_id = TypeId::of::<Bar>();
+        let baz_id = TypeId::of::<Baz>();
+        assert_eq!(
+            to_type_ids(world.inspect_entity(ent0)),
+            [Some(foo_id), Some(bar_id), Some(baz_id)].into()
+        );
+        assert_eq!(
+            to_type_ids(world.inspect_entity(ent1)),
+            [Some(foo_id), Some(bar_id)].into()
+        );
+        assert_eq!(
+            to_type_ids(world.inspect_entity(ent2)),
+            [Some(bar_id), Some(baz_id)].into()
+        );
+        assert_eq!(
+            to_type_ids(world.inspect_entity(ent3)),
+            [Some(foo_id), Some(baz_id)].into()
+        );
+        assert_eq!(
+            to_type_ids(world.inspect_entity(ent4)),
+            [Some(foo_id)].into()
+        );
+        assert_eq!(
+            to_type_ids(world.inspect_entity(ent5)),
+            [Some(bar_id)].into()
+        );
+        assert_eq!(
+            to_type_ids(world.inspect_entity(ent6)),
+            [Some(baz_id)].into()
+        );
     }
 }


### PR DESCRIPTION
# Objective

- Provide a way to see the components of an entity.
- Fixes #1467

## Solution

- Add `World::inspect_entity`. It accepts an `Entity` and returns a vector of `&ComponentInfo` that the entity has.
- Add `EntityCommands::log_components`. It logs the component names of the entity. (info level)

---

## Changelog

### Added
- Ability to inspect components of an entity through `World::inspect_entity` or `EntityCommands::log_components`
