### PR TITLE
[Merged by Bors] - remove unnecessary unsafe impl of `Send+Sync` for `ParallelSystemContainer`

### DIFF
--- a/crates/bevy_ecs/src/schedule/system_container.rs
+++ b/crates/bevy_ecs/src/schedule/system_container.rs
@@ -117,9 +117,6 @@ pub struct ParallelSystemContainer {
     ambiguity_sets: Vec<BoxedAmbiguitySetLabel>,
 }
 
-unsafe impl Send for ParallelSystemContainer {}
-unsafe impl Sync for ParallelSystemContainer {}
-
 impl ParallelSystemContainer {
     pub(crate) fn from_descriptor(descriptor: ParallelSystemDescriptor) -> Self {
         ParallelSystemContainer {


### PR DESCRIPTION
`ParallelSystemContainer` has no `!Send` or `!Sync` fields, so it doesn't need unsafe impls of these traits.