### PR TITLE
[Merged by Bors] - Enable single-commit option for doc deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,3 +55,4 @@ jobs:
           branch: gh-pages
           folder: target/doc
           single-commit: true
+          force: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,3 +54,4 @@ jobs:
         with:
           branch: gh-pages
           folder: target/doc
+          single-commit: true


### PR DESCRIPTION
Closes #5092.

The `force` option wasn't needed as it is [already enabled by default](https://github.com/JamesIves/github-pages-deploy-action#optional-choices) (however I can add it if it would be better to have it explicitly specified).