### PR TITLE
Implement Reflect for PhantomData

### DIFF
--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -13,7 +13,8 @@ use std::{
     any::Any,
     borrow::Cow,
     hash::{Hash, Hasher},
-    ops::Range, marker::PhantomData,
+    marker::PhantomData,
+    ops::Range,
 };
 
 impl_reflect_value!(bool(Debug, Hash, PartialEq, Serialize, Deserialize));

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -600,7 +600,9 @@ mod tests {
         type_registry.register::<std::marker::PhantomData<()>>();
 
         let reflect_serialize = type_registry
-            .get_type_data::<ReflectSerialize>(std::any::TypeId::of::<std::marker::PhantomData<()>>())
+            .get_type_data::<ReflectSerialize>(
+                std::any::TypeId::of::<std::marker::PhantomData<()>>(),
+            )
             .unwrap();
         let _serializable = reflect_serialize.get_serializable(&std::marker::PhantomData::<()>);
     }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -624,7 +624,7 @@ mod tests {
         let value = reflect_deserializer.deserialize(&mut deserializer).unwrap();
         let dynamic_struct = value.take::<DynamicStruct>().unwrap();
 
-        assert_eq!(serialized, "{\"type\":\"bevy_reflect::impls::std::tests::can_serialize_phantomdata::Foo<u8>\",\"struct\":{\"a\":{\"type\":\"u32\",\"value\":1},\"_phantomdata\":{\"type\":\"core::marker::PhantomData<u8>\",\"value\":()}}}");
+        assert_eq!(serialized, r#"{"type":"bevy_reflect::impls::std::tests::can_serialize_phantomdata::Foo<u8>","struct":{"a":{"type":"u32","value":1},"_phantomdata":{"type":"core::marker::PhantomData<u8>","value":()}}}"#);
         assert!(foo.reflect_partial_eq(&dynamic_struct).unwrap());
     }
 

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -624,7 +624,10 @@ mod tests {
         let value = reflect_deserializer.deserialize(&mut deserializer).unwrap();
         let dynamic_struct = value.take::<DynamicStruct>().unwrap();
 
-        assert_eq!(serialized, r#"{"type":"bevy_reflect::impls::std::tests::can_serialize_phantomdata::Foo<u8>","struct":{"a":{"type":"u32","value":1},"_phantomdata":{"type":"core::marker::PhantomData<u8>","value":()}}}"#);
+        assert_eq!(
+            serialized,
+            r#"{"type":"bevy_reflect::impls::std::tests::can_serialize_phantomdata::Foo<u8>","struct":{"a":{"type":"u32","value":1},"_phantomdata":{"type":"core::marker::PhantomData<u8>","value":()}}}"#
+        );
         assert!(foo.reflect_partial_eq(&dynamic_struct).unwrap());
     }
 

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -13,7 +13,7 @@ use std::{
     any::Any,
     borrow::Cow,
     hash::{Hash, Hasher},
-    ops::Range,
+    ops::Range, marker::PhantomData,
 };
 
 impl_reflect_value!(bool(Debug, Hash, PartialEq, Serialize, Deserialize));
@@ -37,6 +37,7 @@ impl_reflect_value!(Option<T: Serialize + Clone + for<'de> Deserialize<'de> + Re
 impl_reflect_value!(HashSet<T: Serialize + Hash + Eq + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>(Serialize, Deserialize));
 impl_reflect_value!(Range<T: Serialize + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>(Serialize, Deserialize));
 impl_reflect_value!(Duration(Debug, Hash, PartialEq, Serialize, Deserialize));
+impl_reflect_value!(PhantomData<T: Reflect>);
 
 impl_from_reflect_value!(bool);
 impl_from_reflect_value!(char);
@@ -65,6 +66,7 @@ impl_from_reflect_value!(
     Range<T: Serialize + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>
 );
 impl_from_reflect_value!(Duration);
+impl_from_reflect_value!(PhantomData<T: Reflect>);
 
 impl<T: FromReflect> Array for Vec<T> {
     #[inline]

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -38,7 +38,7 @@ impl_reflect_value!(Option<T: Serialize + Clone + for<'de> Deserialize<'de> + Re
 impl_reflect_value!(HashSet<T: Serialize + Hash + Eq + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>(Serialize, Deserialize));
 impl_reflect_value!(Range<T: Serialize + Clone + for<'de> Deserialize<'de> + Send + Sync + 'static>(Serialize, Deserialize));
 impl_reflect_value!(Duration(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(PhantomData<T: Reflect>);
+impl_reflect_value!(PhantomData<T: Reflect>(Serialize, Deserialize));
 
 impl_from_reflect_value!(bool);
 impl_from_reflect_value!(char);
@@ -592,6 +592,17 @@ mod tests {
             .get_type_data::<ReflectSerialize>(std::any::TypeId::of::<std::time::Duration>())
             .unwrap();
         let _serializable = reflect_serialize.get_serializable(&std::time::Duration::ZERO);
+    }
+
+    #[test]
+    fn can_serialize_phantomdata() {
+        let mut type_registry = TypeRegistry::default();
+        type_registry.register::<std::marker::PhantomData<()>>();
+
+        let reflect_serialize = type_registry
+            .get_type_data::<ReflectSerialize>(std::any::TypeId::of::<std::marker::PhantomData<()>>())
+            .unwrap();
+        let _serializable = reflect_serialize.get_serializable(&std::marker::PhantomData::<()>);
     }
 
     #[test]


### PR DESCRIPTION
# Objective

Implement `Reflect` for `PhantomData`. Fixes #5144.

## Solution

Use the `impl_reflect_value` and `impl_from_reflect_value` macros to derive the implementation.

I hope I did this correctly.