### PR TITLE
Allow Visibility to be inherited

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -659,7 +659,7 @@ pub(crate) fn assign_lights_to_clusters(
     lights.extend(
         lights_query
             .iter()
-            .filter(|(.., visibility)| visibility.is_visible)
+            .filter(|(.., visibility)| visibility.is_visible())
             .map(
                 |(entity, transform, light, _visibility)| PointLightAssignmentData {
                     entity,
@@ -1174,7 +1174,7 @@ pub fn update_directional_light_frusta(
         // The frustum is used for culling meshes to the light for shadow mapping
         // so if shadow mapping is disabled for this light, then the frustum is
         // not needed.
-        if !directional_light.shadows_enabled || !visibility.is_visible {
+        if !directional_light.shadows_enabled || !visibility.is_visible() {
             continue;
         }
 
@@ -1269,7 +1269,7 @@ pub fn check_light_mesh_visibility(
         visible_entities.entities.clear();
 
         // NOTE: If shadow mapping is disabled for the light then it must have no visible entities
-        if !directional_light.shadows_enabled || !visibility.is_visible {
+        if !directional_light.shadows_enabled || !visibility.is_visible() {
             continue;
         }
 
@@ -1284,7 +1284,7 @@ pub fn check_light_mesh_visibility(
             maybe_transform,
         ) in visible_entity_query.iter_mut()
         {
-            if !visibility.is_visible {
+            if !visibility.is_visible() {
                 continue;
             }
 
@@ -1343,7 +1343,7 @@ pub fn check_light_mesh_visibility(
                     maybe_transform,
                 ) in visible_entity_query.iter_mut()
                 {
-                    if !visibility.is_visible {
+                    if !visibility.is_visible() {
                         continue;
                     }
 

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -465,7 +465,7 @@ pub fn extract_lights(
     for (entity, directional_light, visible_entities, transform, visibility) in
         directional_lights.iter_mut()
     {
-        if !visibility.is_visible {
+        if !visibility.is_visible() {
             continue;
         }
 

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -34,6 +34,7 @@ bevy_core = { path = "../bevy_core", version = "0.8.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.8.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.8.0-dev" }
 bevy_encase_derive = { path = "../bevy_encase_derive", version = "0.8.0-dev" }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.8.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.8.0-dev" }
 bevy_mikktspace = { path = "../bevy_mikktspace", version = "0.8.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.8.0-dev", features = ["bevy"] }

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -46,7 +46,7 @@ impl Visibility {
 
     /// Checks the local visibility state of the entity.
     ///
-    /// Unlike [`is_visible`], this value is always up to date.
+    /// Unlike [`is_visible`](Self::is_visible), this value is always up to date.
     pub fn is_self_visible(&self) -> bool {
         self.self_visible
     }

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -235,7 +235,7 @@ pub fn extract_sprites(
     let mut extracted_sprites = render_world.resource_mut::<ExtractedSprites>();
     extracted_sprites.sprites.clear();
     for (visibility, sprite, transform, handle) in sprite_query.iter() {
-        if !visibility.is_visible {
+        if !visibility.is_visible() {
             continue;
         }
         // PERF: we don't check in this function that the `Image` asset is ready, since it should be in most cases and hashing the handle is expensive
@@ -253,7 +253,7 @@ pub fn extract_sprites(
         });
     }
     for (visibility, atlas_sprite, transform, texture_atlas_handle) in atlas_query.iter() {
-        if !visibility.is_visible {
+        if !visibility.is_visible() {
             continue;
         }
         if let Some(texture_atlas) = texture_atlases.get(texture_atlas_handle) {

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -72,7 +72,7 @@ pub fn extract_text2d_sprite(
     let scale_factor = windows.scale_factor(WindowId::primary()) as f32;
 
     for (entity, visibility, text, transform, calculated_size) in text2d_query.iter() {
-        if !visibility.is_visible {
+        if !visibility.is_visible() {
             continue;
         }
         let (width, height) = (calculated_size.size.x, calculated_size.size.y);

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -188,7 +188,7 @@ pub fn extract_uinodes(
     let mut extracted_uinodes = render_world.resource_mut::<ExtractedUiNodes>();
     extracted_uinodes.uinodes.clear();
     for (uinode, transform, color, image, visibility, clip) in uinode_query.iter() {
-        if !visibility.is_visible {
+        if !visibility.is_visible() {
             continue;
         }
         let image = image.0.clone_weak();
@@ -289,7 +289,7 @@ pub fn extract_text_uinodes(
     let scale_factor = windows.scale_factor(WindowId::primary()) as f32;
 
     for (entity, uinode, transform, text, visibility, clip) in uinode_query.iter() {
-        if !visibility.is_visible {
+        if !visibility.is_visible() {
             continue;
         }
         // Skip if size is set to zero (e.g. when a parent is set to `Display::None`)


### PR DESCRIPTION
# Objective

Fixes #4907. Fixes #838.
Supercedes #2087. Supercedes #865.

`Visibility` is currently entirely local. Set a parent entity to be invisible, and the children are still visible. This makes it hard for users to hide entire hierarchies of entities.

## Solution
Expand `Visibility` to hold both a "self" visibility, and a "inherited" visibility. The entity is visible if and only if both are true. A system similar to `transform_propagate_system` is then implemented to propagate visibility down through the hierarchy. Unlike Transforms, the action of setting visible or not is relatively light computationally so zero change detection is used for the system.

The `visibility_propagate_system` can run in parallel with `transform_propagate_system`, and is set as a dependency of `check_visibiility`, which will copy the same state to `ComputedVisibilty` once propagated. This structure is to avoid making a serialized chain of `transform_propagate` -> `check_visibiliity ` -> `visibility_propagate`. Due to the lighter nature of the visibility propagation, `visibility_propagate_system` will almost always finish faster than `transform_propagate_system` for perfectly overlapped hierarchies, so there is zero overhead on platforms that support multithreaded execution (basically everywhere except wasm32 platforms right now).

---

## Changelog
TODO

## Migration Guide
TODO