### PR TITLE
[Merged by Bors] - Fix rust 1.62 changes

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -11,7 +11,7 @@ status = [
     "run-examples-on-wasm",
     "check-doc",
     "check-missing-examples-in-docs",
-    "check-unused-dependencies",
+    # "check-unused-dependencies",
     "ci",
     "miri",
     "check-compiles",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,27 +274,27 @@ jobs:
           echo "if this step fails, run the following command and commit the changed file on your PR."
           echo " > cargo run -p build-example-pages -- update"
           git diff --quiet HEAD --
-
-  check-unused-dependencies:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-check-unused-dependencies-${{ hashFiles('**/Cargo.toml') }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-      - name: Installs cargo-udeps
-        run: cargo install --force cargo-udeps
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-      - name: Run cargo udeps
-        run: cargo udeps
+  # TODO: re-enable once cargo-udeps builds with changes from rust 1.62
+  # check-unused-dependencies:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/cache@v3
+  #       with:
+  #         path: |
+  #           ~/.cargo/bin/
+  #           ~/.cargo/registry/index/
+  #           ~/.cargo/registry/cache/
+  #           ~/.cargo/git/db/
+  #           target/
+  #         key: ${{ runner.os }}-cargo-check-unused-dependencies-${{ hashFiles('**/Cargo.toml') }}
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: nightly
+  #         override: true
+  #     - name: Installs cargo-udeps
+  #       run: cargo install --force cargo-udeps
+  #     - name: Install alsa and udev
+  #       run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+  #     - name: Run cargo udeps
+  #       run: cargo udeps

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -142,7 +142,7 @@ where
 }
 
 impl<'w, 's, Q: WorldQuery, QF: Fetch<'w, State = Q::State>, F: WorldQuery, I: Iterator> Iterator
-    for QueryManyIter<'w, 'w, Q, QF, F, I>
+    for QueryManyIter<'w, 's, Q, QF, F, I>
 where
     I::Item: Borrow<Entity>,
 {

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_exact_sized_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_exact_sized_iterator_safety.stderr
@@ -6,6 +6,16 @@ error[E0277]: the trait bound `bevy_ecs::query::Changed<Foo>: ArchetypeFilter` i
    |     |
    |     required by a bound introduced by this call
    |
+   = help: the following other types implement trait `ArchetypeFilter`:
+             ()
+             (F0, F1)
+             (F0, F1, F2)
+             (F0, F1, F2, F3)
+             (F0, F1, F2, F3, F4)
+             (F0, F1, F2, F3, F4, F5)
+             (F0, F1, F2, F3, F4, F5, F6)
+             (F0, F1, F2, F3, F4, F5, F6, F7)
+           and 26 others
    = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryIter<'_, '_, &Foo, ReadFetch<'_, Foo>, bevy_ecs::query::Changed<Foo>>`
 note: required by a bound in `is_exact_size_iterator`
   --> tests/ui/query_exact_sized_iterator_safety.rs:16:30
@@ -21,6 +31,16 @@ error[E0277]: the trait bound `bevy_ecs::query::Added<Foo>: ArchetypeFilter` is 
    |     |
    |     required by a bound introduced by this call
    |
+   = help: the following other types implement trait `ArchetypeFilter`:
+             ()
+             (F0, F1)
+             (F0, F1, F2)
+             (F0, F1, F2, F3)
+             (F0, F1, F2, F3, F4)
+             (F0, F1, F2, F3, F4, F5)
+             (F0, F1, F2, F3, F4, F5, F6)
+             (F0, F1, F2, F3, F4, F5, F6, F7)
+           and 26 others
    = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryIter<'_, '_, &Foo, ReadFetch<'_, Foo>, bevy_ecs::query::Added<Foo>>`
 note: required by a bound in `is_exact_size_iterator`
   --> tests/ui/query_exact_sized_iterator_safety.rs:16:30

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
@@ -12,6 +12,16 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not sati
 18 |     assert_readonly::<Mutable>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ReadOnlyWorldQuery` is not implemented for `&'static mut Foo`
    |
+   = help: the following other types implement trait `ReadOnlyWorldQuery`:
+             &T
+             ()
+             (F0, F1)
+             (F0, F1, F2)
+             (F0, F1, F2, F3)
+             (F0, F1, F2, F3, F4)
+             (F0, F1, F2, F3, F4, F5)
+             (F0, F1, F2, F3, F4, F5, F6)
+           and 48 others
    = note: `ReadOnlyWorldQuery` is implemented for `&'static Foo`, but not for `&'static mut Foo`
    = note: required because of the requirements on the impl of `ReadOnlySystemParamFetch` for `QueryState<&'static mut Foo>`
    = note: 2 redundant requirements hidden

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_derive.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_derive.stderr
@@ -4,6 +4,16 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not sati
 9 |     a: &'static mut Foo,
   |        ^^^^^^^^^^^^^^^^ the trait `ReadOnlyWorldQuery` is not implemented for `&'static mut Foo`
   |
+  = help: the following other types implement trait `ReadOnlyWorldQuery`:
+            &T
+            ()
+            (F0, F1)
+            (F0, F1, F2)
+            (F0, F1, F2, F3)
+            (F0, F1, F2, F3, F4)
+            (F0, F1, F2, F3, F4, F5)
+            (F0, F1, F2, F3, F4, F5, F6)
+          and 51 others
 note: required by a bound in `_::assert_readonly`
  --> tests/ui/world_query_derive.rs:7:10
   |
@@ -17,6 +27,16 @@ error[E0277]: the trait bound `MutableMarked: ReadOnlyWorldQuery` is not satisfi
 20 |     a: MutableMarked,
    |        ^^^^^^^^^^^^^ the trait `ReadOnlyWorldQuery` is not implemented for `MutableMarked`
    |
+   = help: the following other types implement trait `ReadOnlyWorldQuery`:
+             &T
+             ()
+             (F0, F1)
+             (F0, F1, F2)
+             (F0, F1, F2, F3)
+             (F0, F1, F2, F3, F4)
+             (F0, F1, F2, F3, F4, F5)
+             (F0, F1, F2, F3, F4, F5, F6)
+           and 51 others
 note: required by a bound in `_::assert_readonly`
   --> tests/ui/world_query_derive.rs:18:10
    |


### PR DESCRIPTION
# Objective

CI is now failing with some changes that landed in 1.62.

## Solution

* Fix an unused lifetime by using it (we double-used the `w` lifetime).
* Update compile_fail error messages
* temporarily disable check-unused-dependencies