### PR TITLE
[Merged by Bors] - Derive default for enums where possible

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -109,16 +109,12 @@ where
     marker: PhantomData<fn() -> T>,
 }
 
+// FIXME: Default is only needed because `Handle`'s field `handle_type` is currently ignored for reflection
+#[derive(Default)]
 enum HandleType {
+    #[default]
     Weak,
     Strong(Sender<RefChange>),
-}
-
-// FIXME: This only is needed because `Handle`'s field `handle_type` is currently ignored for reflection
-impl Default for HandleType {
-    fn default() -> Self {
-        Self::Weak
-    }
 }
 
 impl Debug for HandleType {

--- a/crates/bevy_core_pipeline/src/clear_color.rs
+++ b/crates/bevy_core_pipeline/src/clear_color.rs
@@ -4,18 +4,13 @@ use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render::{color::Color, extract_resource::ExtractResource};
 use serde::{Deserialize, Serialize};
 
-#[derive(Reflect, Serialize, Deserialize, Clone, Debug)]
+#[derive(Reflect, Serialize, Deserialize, Clone, Debug, Default)]
 #[reflect_value(Serialize, Deserialize)]
 pub enum ClearColorConfig {
+    #[default]
     Default,
     Custom(Color),
     None,
-}
-
-impl Default for ClearColorConfig {
-    fn default() -> Self {
-        ClearColorConfig::Default
-    }
 }
 
 /// When used as a resource, sets the color that is used to clear the screen between frames.

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -145,19 +145,14 @@ mod sealed {
 /// #[component(storage = "SparseSet")]
 /// struct A;
 /// ```
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
 pub enum StorageType {
     /// Provides fast and cache-friendly iteration, but slower addition and removal of components.
     /// This is the default storage type.
+    #[default]
     Table,
     /// Provides fast addition and removal of components, but slower iteration.
     SparseSet,
-}
-
-impl Default for StorageType {
-    fn default() -> Self {
-        StorageType::Table
-    }
 }
 
 #[derive(Debug)]

--- a/crates/bevy_pbr/src/alpha.rs
+++ b/crates/bevy_pbr/src/alpha.rs
@@ -4,9 +4,10 @@ use bevy_reflect::Reflect;
 
 // FIXME: This should probably be part of bevy_render2!
 /// Alpha mode
-#[derive(Component, Debug, Reflect, Copy, Clone, PartialEq)]
+#[derive(Component, Debug, Default, Reflect, Copy, Clone, PartialEq)]
 #[reflect(Component, Default)]
 pub enum AlphaMode {
+    #[default]
     Opaque,
     /// An alpha cutoff must be supplied where alpha values >= the cutoff
     /// will be fully opaque and < will be fully transparent
@@ -15,9 +16,3 @@ pub enum AlphaMode {
 }
 
 impl Eq for AlphaMode {}
-
-impl Default for AlphaMode {
-    fn default() -> Self {
-        AlphaMode::Opaque
-    }
-}

--- a/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
@@ -24,9 +24,10 @@ const HASH_ATTR: &str = "Hash";
 pub(crate) const REFLECT_DEFAULT: &str = "ReflectDefault";
 
 /// A marker for trait implementations registered via the `Reflect` derive macro.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub(crate) enum TraitImpl {
     /// The trait is not registered as implemented.
+    #[default]
     NotImplemented,
     /// The trait is registered as implemented.
     Implemented,
@@ -35,13 +36,6 @@ pub(crate) enum TraitImpl {
     /// The trait is registered with a custom function rather than an actual implementation.
     Custom(Ident),
 }
-
-impl Default for TraitImpl {
-    fn default() -> Self {
-        Self::NotImplemented
-    }
-}
-
 /// A collection of traits that have been registered for a reflected type.
 ///
 /// This keeps track of a few traits that are utilized internally for reflection

--- a/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
@@ -22,8 +22,10 @@ pub(crate) struct ReflectFieldAttr {
 }
 
 /// Controls how the default value is determined for a field.
+#[derive(Default)]
 pub(crate) enum DefaultBehavior {
     /// Field is required.
+    #[default]
     Required,
     /// Field can be defaulted using `Default::default()`.
     Default,
@@ -32,12 +34,6 @@ pub(crate) enum DefaultBehavior {
     /// This assumes the function is in scope, is callable with zero arguments,
     /// and returns the expected type.
     Func(syn::ExprPath),
-}
-
-impl Default for DefaultBehavior {
-    fn default() -> Self {
-        Self::Required
-    }
 }
 
 /// Parse all field attributes marked "reflect" (such as `#[reflect(ignore)]`).

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -307,19 +307,14 @@ impl RenderTarget {
     }
 }
 
-#[derive(Debug, Clone, Copy, Reflect, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, Reflect, Serialize, Deserialize)]
 #[reflect_value(Serialize, Deserialize)]
 pub enum DepthCalculation {
     /// Pythagorean distance; works everywhere, more expensive to compute.
+    #[default]
     Distance,
     /// Optimization for 2D; assuming the camera points towards -Z.
     ZDifference,
-}
-
-impl Default for DepthCalculation {
-    fn default() -> Self {
-        DepthCalculation::Distance
-    }
 }
 
 pub fn camera_system<T: CameraProjection + Component>(

--- a/crates/bevy_render/src/mesh/shape/capsule.rs
+++ b/crates/bevy_render/src/mesh/shape/capsule.rs
@@ -31,22 +31,17 @@ impl Default for Capsule {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 /// Manner in which UV coordinates are distributed vertically.
 pub enum CapsuleUvProfile {
     /// UV space is distributed by how much of the capsule consists of the hemispheres.
+    #[default]
     Aspect,
     /// Hemispheres get UV space according to the ratio of latitudes to rings.
     Uniform,
     /// Upper third of the texture goes to the northern hemisphere, middle third to the cylinder
     /// and lower third to the southern one.
     Fixed,
-}
-
-impl Default for CapsuleUvProfile {
-    fn default() -> Self {
-        CapsuleUvProfile::Aspect
-    }
 }
 
 impl From<Capsule> for Mesh {

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -39,17 +39,12 @@ pub trait RenderAsset: Asset {
     ) -> Result<Self::PreparedAsset, PrepareAssetError<Self::ExtractedAsset>>;
 }
 
-#[derive(Clone, Hash, Debug, PartialEq, Eq, SystemLabel)]
+#[derive(Clone, Hash, Debug, Default, PartialEq, Eq, SystemLabel)]
 pub enum PrepareAssetLabel {
     PreAssetPrepare,
+    #[default]
     AssetPrepare,
     PostAssetPrepare,
-}
-
-impl Default for PrepareAssetLabel {
-    fn default() -> Self {
-        Self::AssetPrepare
-    }
 }
 
 /// This plugin extracts the changed assets from the "app world" into the "render world"

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -115,17 +115,13 @@ pub struct Image {
 /// Used in [`Image`], this determines what image sampler to use when rendering. The default setting,
 /// [`ImageSampler::Default`], will read the sampler from the [`ImageSettings`] resource at runtime.
 /// Setting this to [`ImageSampler::Descriptor`] will override the global default descriptor for this [`Image`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub enum ImageSampler {
     /// Default image sampler, derived from the [`ImageSettings`] resource.
+    #[default]
     Default,
     /// Custom sampler for this image which will override global default.
     Descriptor(wgpu::SamplerDescriptor<'static>),
-}
-impl Default for ImageSampler {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 impl ImageSampler {

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -21,9 +21,10 @@ pub struct Sprite {
 
 /// How a sprite is positioned relative to its [`Transform`](bevy_transform::components::Transform).
 /// It defaults to `Anchor::Center`.
-#[derive(Debug, Clone, Reflect)]
+#[derive(Debug, Clone, Default, Reflect)]
 #[doc(alias = "pivot")]
 pub enum Anchor {
+    #[default]
     Center,
     BottomLeft,
     BottomCenter,
@@ -36,12 +37,6 @@ pub enum Anchor {
     /// Custom anchor point. Top left is `(-0.5, 0.5)`, center is `(0.0, 0.0)`. The value will
     /// be scaled with the sprite size.
     Custom(Vec2),
-}
-
-impl Default for Anchor {
-    fn default() -> Self {
-        Anchor::Center
-    }
 }
 
 impl Anchor {

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -17,7 +17,9 @@ use smallvec::SmallVec;
 /// Describes what type of input interaction has occurred for a UI node.
 ///
 /// This is commonly queried with a `Changed<Interaction>` filter.
-#[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize)]
+#[derive(
+    Component, Copy, Clone, Default, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize,
+)]
 #[reflect_value(Component, Serialize, Deserialize, PartialEq)]
 pub enum Interaction {
     /// The node has been clicked
@@ -25,31 +27,22 @@ pub enum Interaction {
     /// The node has been hovered over
     Hovered,
     /// Nothing has happened
+    #[default]
     None,
 }
 
-impl Default for Interaction {
-    fn default() -> Self {
-        Interaction::None
-    }
-}
-
 /// Describes whether the node should block interactions with lower nodes
-#[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize)]
+#[derive(
+    Component, Copy, Clone, Default, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize,
+)]
 #[reflect_value(Component, Serialize, Deserialize, PartialEq)]
 pub enum FocusPolicy {
     /// Blocks interaction
+    #[default]
     Block,
     /// Lets interaction pass through
     Pass,
 }
-
-impl Default for FocusPolicy {
-    fn default() -> Self {
-        FocusPolicy::Block
-    }
-}
-
 /// Contains entities whose Interaction should be set to None
 #[derive(Default)]
 pub struct State {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -20,10 +20,11 @@ pub struct Node {
 }
 
 /// An enum that describes possible types of value in flexbox layout options
-#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Serialize, Deserialize, Reflect)]
 #[reflect_value(PartialEq, Serialize, Deserialize)]
 pub enum Val {
     /// No value defined
+    #[default]
     Undefined,
     /// Automatically determine this value
     Auto,
@@ -31,12 +32,6 @@ pub enum Val {
     Px(f32),
     /// Set this value in percent
     Percent(f32),
-}
-
-impl Default for Val {
-    fn default() -> Self {
-        Val::Undefined
-    }
 }
 
 impl Add<f32> for Val {
@@ -144,7 +139,7 @@ impl Default for Style {
 }
 
 /// How items are aligned according to the cross axis
-#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Serialize, Deserialize, Reflect)]
 #[reflect_value(PartialEq, Serialize, Deserialize)]
 pub enum AlignItems {
     /// Items are aligned at the start
@@ -156,20 +151,16 @@ pub enum AlignItems {
     /// Items are aligned at the baseline
     Baseline,
     /// Items are stretched across the whole cross axis
+    #[default]
     Stretch,
 }
 
-impl Default for AlignItems {
-    fn default() -> AlignItems {
-        AlignItems::Stretch
-    }
-}
-
 /// Works like [`AlignItems`] but applies only to a single item
-#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Serialize, Deserialize, Reflect)]
 #[reflect_value(PartialEq, Serialize, Deserialize)]
 pub enum AlignSelf {
     /// Use the value of [`AlignItems`]
+    #[default]
     Auto,
     /// If the parent has [`AlignItems::Center`] only this item will be at the start
     FlexStart,
@@ -183,16 +174,10 @@ pub enum AlignSelf {
     Stretch,
 }
 
-impl Default for AlignSelf {
-    fn default() -> AlignSelf {
-        AlignSelf::Auto
-    }
-}
-
 /// Defines how each line is aligned within the flexbox.
 ///
 /// It only applies if [`FlexWrap::Wrap`] is present and if there are multiple lines of items.
-#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Serialize, Deserialize, Reflect)]
 #[reflect_value(PartialEq, Serialize, Deserialize)]
 pub enum AlignContent {
     /// Each line moves towards the start of the cross axis
@@ -202,6 +187,7 @@ pub enum AlignContent {
     /// Each line moves towards the center of the cross axis
     Center,
     /// Each line will stretch to fill the remaining space
+    #[default]
     Stretch,
     /// Each line fills the space it needs, putting the remaining space, if any
     /// inbetween the lines
@@ -211,19 +197,14 @@ pub enum AlignContent {
     SpaceAround,
 }
 
-impl Default for AlignContent {
-    fn default() -> AlignContent {
-        AlignContent::Stretch
-    }
-}
-
 /// Defines the text direction
 ///
 /// For example English is written LTR (left-to-right) while Arabic is written RTL (right-to-left).
-#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Serialize, Deserialize, Reflect)]
 #[reflect_value(PartialEq, Serialize, Deserialize)]
 pub enum Direction {
     /// Inherit from parent node
+    #[default]
     Inherit,
     /// Text is written left to right
     LeftToRight,
@@ -231,33 +212,23 @@ pub enum Direction {
     RightToLeft,
 }
 
-impl Default for Direction {
-    fn default() -> Direction {
-        Direction::Inherit
-    }
-}
-
 /// Whether to use Flexbox layout
-#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Serialize, Deserialize, Reflect)]
 #[reflect_value(PartialEq, Serialize, Deserialize)]
 pub enum Display {
     /// Use flexbox
+    #[default]
     Flex,
     /// Use no layout, don't render this node and its children
     None,
 }
 
-impl Default for Display {
-    fn default() -> Display {
-        Display::Flex
-    }
-}
-
 /// Defines how flexbox items are ordered within a flexbox
-#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Serialize, Deserialize, Reflect)]
 #[reflect_value(PartialEq, Serialize, Deserialize)]
 pub enum FlexDirection {
     /// Same way as text direction along the main axis
+    #[default]
     Row,
     /// Flex from bottom to top
     Column,
@@ -267,17 +238,12 @@ pub enum FlexDirection {
     ColumnReverse,
 }
 
-impl Default for FlexDirection {
-    fn default() -> FlexDirection {
-        FlexDirection::Row
-    }
-}
-
 /// Defines how items are aligned according to the main axis
-#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Serialize, Deserialize, Reflect)]
 #[reflect_value(PartialEq, Serialize, Deserialize)]
 pub enum JustifyContent {
     /// Pushed towards the start
+    #[default]
     FlexStart,
     /// Pushed towards the end
     FlexEnd,
@@ -291,33 +257,23 @@ pub enum JustifyContent {
     SpaceEvenly,
 }
 
-impl Default for JustifyContent {
-    fn default() -> JustifyContent {
-        JustifyContent::FlexStart
-    }
-}
-
 /// Whether to show or hide overflowing items
-#[derive(Copy, Clone, PartialEq, Debug, Reflect, Serialize, Deserialize)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Reflect, Serialize, Deserialize)]
 #[reflect_value(PartialEq, Serialize, Deserialize)]
 pub enum Overflow {
     /// Show overflowing items
+    #[default]
     Visible,
     /// Hide overflowing items
     Hidden,
 }
 
-impl Default for Overflow {
-    fn default() -> Overflow {
-        Overflow::Visible
-    }
-}
-
 /// The strategy used to position this node
-#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Serialize, Deserialize, Reflect)]
 #[reflect_value(PartialEq, Serialize, Deserialize)]
 pub enum PositionType {
     /// Relative to all other nodes with the [`PositionType::Relative`] value
+    #[default]
     Relative,
     /// Independent of all other nodes
     ///
@@ -325,28 +281,17 @@ pub enum PositionType {
     Absolute,
 }
 
-impl Default for PositionType {
-    fn default() -> PositionType {
-        PositionType::Relative
-    }
-}
-
 /// Defines if flexbox items appear on a single line or on multiple lines
-#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Serialize, Deserialize, Reflect)]
 #[reflect_value(PartialEq, Serialize, Deserialize)]
 pub enum FlexWrap {
     /// Single line, will overflow if needed
+    #[default]
     NoWrap,
     /// Multiple lines, if needed
     Wrap,
     /// Same as [`FlexWrap::Wrap`] but new lines will appear before the previous one
     WrapReverse,
-}
-
-impl Default for FlexWrap {
-    fn default() -> FlexWrap {
-        FlexWrap::NoWrap
-    }
 }
 
 /// The calculated size of the node

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -12,17 +12,12 @@ use bevy_render::texture::Image;
 use serde::{Deserialize, Serialize};
 
 /// Describes how to resize the Image node
-#[derive(Component, Debug, Clone, Reflect, Serialize, Deserialize)]
+#[derive(Component, Debug, Default, Clone, Reflect, Serialize, Deserialize)]
 #[reflect_value(Component, Serialize, Deserialize)]
 pub enum ImageMode {
     /// Keep the aspect ratio of the image
+    #[default]
     KeepAspect,
-}
-
-impl Default for ImageMode {
-    fn default() -> Self {
-        ImageMode::KeepAspect
-    }
 }
 
 /// Updates calculated size of the node based on the image provided


### PR DESCRIPTION
# Objective

Fixes #5153

## Solution

Search for all enums and manually check if they have default impls that can use this new derive.

By my reckoning:

| enum | num |
|-|-|
| total | 159 |
| has default impl | 29 |
| default is unit variant | 23 |  
