### PR TITLE
Add Events to `bevy_ecs` prelude

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -30,7 +30,7 @@ pub mod prelude {
         change_detection::DetectChanges,
         component::Component,
         entity::Entity,
-        event::{EventReader, EventWriter},
+        event::{EventReader, Events, EventWriter},
         query::{Added, AnyOf, ChangeTrackers, Changed, Or, QueryState, With, Without},
         schedule::{
             AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,


### PR DESCRIPTION
# Objective

This is a common and useful type. I frequently use this when working with `Events` resource directly in various data storage strategy.

This is also useful when manually configuring the cleanup strategy for events.