### PR TITLE
Add API for simple system ordering

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -33,9 +33,10 @@ pub mod prelude {
         event::{EventReader, EventWriter},
         query::{Added, AnyOf, ChangeTrackers, Changed, Or, QueryState, With, Without},
         schedule::{
-            AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,
-            RunCriteria, RunCriteriaDescriptorCoercion, RunCriteriaLabel, Schedule, Stage,
-            StageLabel, State, SystemLabel, SystemSet, SystemStage,
+            AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, IntoLinkedSystemSet,
+            IntoSequentialSystemSet, ParallelSystemDescriptorCoercion, RunCriteria,
+            RunCriteriaDescriptorCoercion, RunCriteriaLabel, Schedule, Stage, StageLabel, State,
+            SystemLabel, SystemSet, SystemStage,
         },
         system::{
             Commands, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend,


### PR DESCRIPTION
# Objective

- Add API for easy system ordering.
- Fixes #4220

## Solution

- Create new traits `IntoLinkedSystemSet` and `IntoSequentialSystemSet`.
- Using these trait methods will produce a `SystemSet` that can be added to `App` through `App::add_system_set`.

### `IntoLinkedSystemSet`
- `IntoLinkedSystemSet` is a trait that provides a method `link()`.
- `IntoLinkedSystemSet` is implemented on tuples of systems containing 2 to 15 elements.

Syntax: 

```
(system_a, system_b, system_c, system_d).link()
```

This is equal to:

```rust
SystemSet::new()
    .with_system(system_a)
    .with_system(system_b.after(system_a))
    .with_system(system_c.after(system_b))
    .with_system(system_d.after(system_c));
```

### `IntoSequentialSystemSet`
- `IntoSequentialSystemSet` is trait that provides a method `then(next_system)`
- `IntoSequentialSystemSet` is implemented on a system, and accepts a system.

Syntax: 

```
system_a.then(system_b)
```

This is equal to:

```rust
SystemSet::new()
    .with_system(system_a)
    .with_system(system_b.after(system_a));
```

Or

```rust
(system_a, system_b).link()
```

## Known Limitations

- `IntoSequentialSystemSet` is not implemented for `SystemSet`. This means you can't do `system_a.then(system_b).then(system_c)`.
- `IntoLinkedSystemSet` is not implemented for tuples with more than 15 elements.

---

## Changelog

### Added

- Allow sequential ordering of two systems by using `IntoSequentialSystemSet::then` and doing `system_a.then(system_b)`.
- Allow sequential ordering of multiple systems (up to 15) by using `IntoLinkedSystemSet::link` on tuples of systems.

---

> P.S.: writing and debugging proc macros is not a very fun experience lol