### PR TITLE
[Merged by Bors] - Adds a "Question" link to the new issue selection

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,5 @@
 contact_links:
   - name: Question
-    url: https://github.com/bevyengine/bevy/discussions
-    about: Questions about how to use or contribute to Bevy belong in Github Discussions
+    url: https://github.com/bevyengine/bevy/discussions/categories/q-a
+    about: Questions about how to use or contribute to Bevy belong in Github Discussions.
+      You can use the search to check if someone already answered your question!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
   - name: Question
     url: https://github.com/bevyengine/bevy/discussions
-    about: Please ask and answer questions about Bevy in the "Discussion" section.
+    about: Questions about how to use or contribute to Bevy belong in Github Discussions

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Question
+    url: https://github.com/bevyengine/bevy/discussions
+    about: Please ask and answer questions about Bevy in the "Discussion" section.


### PR DESCRIPTION
This gives users a hint to use the GitHub "Discussions" for questions about bevy, instead of filing an issue.

## Objective
> Users sometimes file unhelpful issues when asking questions about how to use Bevy.

We should provide a link to the Discussion board in the list of "new Issue" options. This hopefully allows users to better find this option and reduces the number of question-issues.

- fixes #5150

## Solution

- add a small config.yml that configures the link

Looks like this (currently live on my local fork https://github.com/themasch/bevy/issues/new/choose):
![grafik](https://user-images.githubusercontent.com/170171/176940564-cd3a4ad1-731b-4417-95c2-3b5285120c88.png)

---

## Open questsions
 - I am unsure about the wording.