### PR TITLE
[Merged by Bors] - remove QF generics from all `Query/State` methods and types

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -318,7 +318,8 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 /// ```
 /// # Safety
 ///
-/// component access of `ROQueryFetch<Self>` should be a subset of `QueryFetch<Self>`
+/// component access of `ROQueryFetch<Self>` must be a subset of `QueryFetch<Self>`
+/// and `ROQueryFetch<Self>` must match exactly the same archetypes/tables as `QueryFetch<Self>`
 pub unsafe trait WorldQuery: for<'w> WorldQueryGats<'w, _State = Self::State> {
     type ReadOnly: ReadOnlyWorldQuery<State = Self::State>;
     type State: FetchState;
@@ -1608,6 +1609,25 @@ macro_rules! impl_anytuple_fetch {
 all_tuples!(impl_tuple_fetch, 0, 15, F, S);
 all_tuples!(impl_anytuple_fetch, 0, 15, F, S);
 
+/// [`WorldQuery`] used to nullify queries by turning `Query<Q>` into `Query<NopWorldQuery<Q>>`
+///
+/// This will rarely be useful to consumers of `bevy_ecs`.
+pub struct NopWorldQuery<Q: WorldQuery>(PhantomData<Q>);
+
+/// SAFETY: `Self::ReadOnly` is `Self`
+unsafe impl<Q: WorldQuery> WorldQuery for NopWorldQuery<Q> {
+    type ReadOnly = Self;
+    type State = Q::State;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(_: ()) {}
+}
+impl<'a, Q: WorldQuery> WorldQueryGats<'a> for NopWorldQuery<Q> {
+    type Fetch = NopFetch<QueryFetch<'a, Q>>;
+    type _State = <Q as WorldQueryGats<'a>>::_State;
+}
+/// SAFETY: `NopFetch` never accesses any data
+unsafe impl<Q: WorldQuery> ReadOnlyWorldQuery for NopWorldQuery<Q> {}
+
 /// [`Fetch`] that does not actually fetch anything
 ///
 /// Mostly useful when something is generic over the Fetch and you don't want to fetch as you will discard the result
@@ -1616,18 +1636,18 @@ pub struct NopFetch<State> {
 }
 
 // SAFETY: NopFetch doesnt access anything
-unsafe impl<'w, State: FetchState> Fetch<'w> for NopFetch<State> {
+unsafe impl<'w, F: Fetch<'w>> Fetch<'w> for NopFetch<F> {
     type Item = ();
-    type State = State;
+    type State = F::State;
 
-    const IS_DENSE: bool = true;
+    const IS_DENSE: bool = F::IS_DENSE;
 
     const IS_ARCHETYPAL: bool = true;
 
     #[inline(always)]
     unsafe fn init(
         _world: &'w World,
-        _state: &State,
+        _state: &F::State,
         _last_change_tick: u32,
         _change_tick: u32,
     ) -> Self {

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -13,17 +13,14 @@ use super::{QueryFetch, QueryItem, ReadOnlyWorldQuery};
 ///
 /// This struct is created by the [`Query::iter`](crate::system::Query::iter) and
 /// [`Query::iter_mut`](crate::system::Query::iter_mut) methods.
-pub struct QueryIter<'w, 's, Q: WorldQuery, QF: Fetch<'w, State = Q::State>, F: WorldQuery> {
+pub struct QueryIter<'w, 's, Q: WorldQuery, F: WorldQuery> {
     tables: &'w Tables,
     archetypes: &'w Archetypes,
     query_state: &'s QueryState<Q, F>,
-    cursor: QueryIterationCursor<'w, 's, Q, QF, F>,
+    cursor: QueryIterationCursor<'w, 's, Q, F>,
 }
 
-impl<'w, 's, Q: WorldQuery, QF, F: WorldQuery> QueryIter<'w, 's, Q, QF, F>
-where
-    QF: Fetch<'w, State = Q::State>,
-{
+impl<'w, 's, Q: WorldQuery, F: WorldQuery> QueryIter<'w, 's, Q, F> {
     /// # Safety
     /// This does not check for mutable query correctness. To be safe, make sure mutable queries
     /// have unique access to the components they query.
@@ -44,11 +41,8 @@ where
     }
 }
 
-impl<'w, 's, Q: WorldQuery, QF, F: WorldQuery> Iterator for QueryIter<'w, 's, Q, QF, F>
-where
-    QF: Fetch<'w, State = Q::State>,
-{
-    type Item = QF::Item;
+impl<'w, 's, Q: WorldQuery, F: WorldQuery> Iterator for QueryIter<'w, 's, Q, F> {
+    type Item = QueryItem<'w, Q>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -69,42 +63,32 @@ where
             .map(|id| self.archetypes[*id].len())
             .sum();
 
-        let archetype_query = F::Fetch::IS_ARCHETYPAL && QF::IS_ARCHETYPAL;
+        let archetype_query = Q::Fetch::IS_ARCHETYPAL && F::Fetch::IS_ARCHETYPAL;
         let min_size = if archetype_query { max_size } else { 0 };
         (min_size, Some(max_size))
     }
 }
 
 // This is correct as [`QueryIter`] always returns `None` once exhausted.
-impl<'w, 's, Q: WorldQuery, QF, F: WorldQuery> FusedIterator for QueryIter<'w, 's, Q, QF, F> where
-    QF: Fetch<'w, State = Q::State>
-{
-}
+impl<'w, 's, Q: WorldQuery, F: WorldQuery> FusedIterator for QueryIter<'w, 's, Q, F> {}
 
 /// An [`Iterator`] over query results of a [`Query`](crate::system::Query).
 ///
 /// This struct is created by the [`Query::iter_many`](crate::system::Query::iter_many) method.
-pub struct QueryManyIter<
-    'w,
-    's,
-    Q: WorldQuery,
-    QF: Fetch<'w, State = Q::State>,
-    F: WorldQuery,
-    I: Iterator,
-> where
+pub struct QueryManyIter<'w, 's, Q: WorldQuery, F: WorldQuery, I: Iterator>
+where
     I::Item: Borrow<Entity>,
 {
     entity_iter: I,
     entities: &'w Entities,
     tables: &'w Tables,
     archetypes: &'w Archetypes,
-    fetch: QF,
+    fetch: QueryFetch<'w, Q>,
     filter: QueryFetch<'w, F>,
     query_state: &'s QueryState<Q, F>,
 }
 
-impl<'w, 's, Q: WorldQuery, QF: Fetch<'w, State = Q::State>, F: WorldQuery, I: Iterator>
-    QueryManyIter<'w, 's, Q, QF, F, I>
+impl<'w, 's, Q: WorldQuery, F: WorldQuery, I: Iterator> QueryManyIter<'w, 's, Q, F, I>
 where
     I::Item: Borrow<Entity>,
 {
@@ -119,14 +103,14 @@ where
         entity_list: EntityList,
         last_change_tick: u32,
         change_tick: u32,
-    ) -> QueryManyIter<'w, 's, Q, QF, F, I> {
-        let fetch = QF::init(
+    ) -> QueryManyIter<'w, 's, Q, F, I> {
+        let fetch = Q::Fetch::init(
             world,
             &query_state.fetch_state,
             last_change_tick,
             change_tick,
         );
-        let filter = QueryFetch::<F>::init(
+        let filter = F::Fetch::init(
             world,
             &query_state.filter_state,
             last_change_tick,
@@ -144,12 +128,11 @@ where
     }
 }
 
-impl<'w, 's, Q: WorldQuery, QF: Fetch<'w, State = Q::State>, F: WorldQuery, I: Iterator> Iterator
-    for QueryManyIter<'w, 's, Q, QF, F, I>
+impl<'w, 's, Q: WorldQuery, F: WorldQuery, I: Iterator> Iterator for QueryManyIter<'w, 's, Q, F, I>
 where
     I::Item: Borrow<Entity>,
 {
-    type Item = QF::Item;
+    type Item = QueryItem<'w, Q>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -201,7 +184,7 @@ pub struct QueryCombinationIter<'w, 's, Q: WorldQuery, F: WorldQuery, const K: u
     tables: &'w Tables,
     archetypes: &'w Archetypes,
     query_state: &'s QueryState<Q, F>,
-    cursors: [QueryIterationCursor<'w, 's, Q, QueryFetch<'w, Q>, F>; K],
+    cursors: [QueryIterationCursor<'w, 's, Q, F>; K],
 }
 
 impl<'w, 's, Q: WorldQuery, F: WorldQuery, const K: usize> QueryCombinationIter<'w, 's, Q, F, K> {
@@ -219,11 +202,10 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery, const K: usize> QueryCombinationIter<
         // Initialize array with cursors.
         // There is no FromIterator on arrays, so instead initialize it manually with MaybeUninit
 
-        let mut array: MaybeUninit<[QueryIterationCursor<'w, 's, Q, QueryFetch<'w, Q>, F>; K]> =
-            MaybeUninit::uninit();
+        let mut array: MaybeUninit<[QueryIterationCursor<'w, 's, Q, F>; K]> = MaybeUninit::uninit();
         let ptr = array
             .as_mut_ptr()
-            .cast::<QueryIterationCursor<'w, 's, Q, QueryFetch<'w, Q>, F>>();
+            .cast::<QueryIterationCursor<'w, 's, Q, F>>();
         if K != 0 {
             ptr.write(QueryIterationCursor::init(
                 world,
@@ -367,10 +349,9 @@ where
     }
 }
 
-impl<'w, 's, Q: WorldQuery, QF, F> ExactSizeIterator for QueryIter<'w, 's, Q, QF, F>
+impl<'w, 's, Q: WorldQuery, F: WorldQuery> ExactSizeIterator for QueryIter<'w, 's, Q, F>
 where
-    QF: Fetch<'w, State = Q::State>,
-    F: WorldQuery + ArchetypeFilter,
+    F: ArchetypeFilter,
 {
     fn len(&self) -> usize {
         self.query_state
@@ -405,21 +386,21 @@ where
 {
 }
 
-struct QueryIterationCursor<'w, 's, Q: WorldQuery, QF: Fetch<'w, State = Q::State>, F: WorldQuery> {
+struct QueryIterationCursor<'w, 's, Q: WorldQuery, F: WorldQuery> {
     table_id_iter: std::slice::Iter<'s, TableId>,
     archetype_id_iter: std::slice::Iter<'s, ArchetypeId>,
-    fetch: QF,
+    fetch: QueryFetch<'w, Q>,
     filter: QueryFetch<'w, F>,
     // length of the table table or length of the archetype, depending on whether both `Q`'s and `F`'s fetches are dense
     current_len: usize,
     // either table row or archetype index, depending on whether both `Q`'s and `F`'s fetches are dense
     current_index: usize,
-    phantom: PhantomData<(&'w (), Q)>,
+    phantom: PhantomData<Q>,
 }
 
-impl<'w, 's, Q: WorldQuery, QF, F: WorldQuery> Clone for QueryIterationCursor<'w, 's, Q, QF, F>
+impl<'w, 's, Q: WorldQuery, F: WorldQuery> Clone for QueryIterationCursor<'w, 's, Q, F>
 where
-    QF: Fetch<'w, State = Q::State> + Clone,
+    QueryFetch<'w, Q>: Clone,
     QueryFetch<'w, F>: Clone,
 {
     fn clone(&self) -> Self {
@@ -435,11 +416,8 @@ where
     }
 }
 
-impl<'w, 's, Q: WorldQuery, QF, F: WorldQuery> QueryIterationCursor<'w, 's, Q, QF, F>
-where
-    QF: Fetch<'w, State = Q::State>,
-{
-    const IS_DENSE: bool = QF::IS_DENSE && <QueryFetch<'static, F>>::IS_DENSE;
+impl<'w, 's, Q: WorldQuery, F: WorldQuery> QueryIterationCursor<'w, 's, Q, F> {
+    const IS_DENSE: bool = Q::Fetch::IS_DENSE && F::Fetch::IS_DENSE;
 
     unsafe fn init_empty(
         world: &'w World,
@@ -460,13 +438,13 @@ where
         last_change_tick: u32,
         change_tick: u32,
     ) -> Self {
-        let fetch = QF::init(
+        let fetch = Q::Fetch::init(
             world,
             &query_state.fetch_state,
             last_change_tick,
             change_tick,
         );
-        let filter = QueryFetch::<F>::init(
+        let filter = F::Fetch::init(
             world,
             &query_state.filter_state,
             last_change_tick,
@@ -485,7 +463,7 @@ where
 
     /// retrieve item returned from most recent `next` call again.
     #[inline]
-    unsafe fn peek_last(&mut self) -> Option<QF::Item> {
+    unsafe fn peek_last(&mut self) -> Option<QueryItem<'w, Q>> {
         if self.current_index > 0 {
             if Self::IS_DENSE {
                 Some(self.fetch.table_fetch(self.current_index - 1))
@@ -509,7 +487,7 @@ where
         tables: &'w Tables,
         archetypes: &'w Archetypes,
         query_state: &'s QueryState<Q, F>,
-    ) -> Option<QF::Item> {
+    ) -> Option<QueryItem<'w, Q>> {
         if Self::IS_DENSE {
             loop {
                 // we are on the beginning of the query, or finished processing a table, so skip to the next

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -19,6 +19,9 @@ use super::{NopWorldQuery, QueryFetch, QueryItem, QueryManyIter, ROQueryItem};
 
 /// Provides scoped access to a [`World`] state according to a given [`WorldQuery`] and query filter.
 #[repr(C)]
+// SAFETY NOTE:
+// Do not add any new fields that use the `Q` or `F` generic parameters as this may
+// make `QueryState::as_transmuted_state` unsound if not done with care.
 pub struct QueryState<Q: WorldQuery, F: WorldQuery = ()> {
     world_id: WorldId,
     pub(crate) archetype_generation: ArchetypeGeneration,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -4,8 +4,7 @@ use crate::{
     entity::Entity,
     prelude::FromWorld,
     query::{
-        Access, Fetch, FetchState, FilteredAccess, NopFetch, QueryCombinationIter, QueryIter,
-        WorldQuery,
+        Access, Fetch, FetchState, FilteredAccess, QueryCombinationIter, QueryIter, WorldQuery,
     },
     storage::TableId,
     world::{World, WorldId},
@@ -16,9 +15,10 @@ use bevy_utils::tracing::Instrument;
 use fixedbitset::FixedBitSet;
 use std::{borrow::Borrow, fmt};
 
-use super::{QueryFetch, QueryItem, QueryManyIter, ROQueryFetch, ROQueryItem};
+use super::{NopWorldQuery, QueryFetch, QueryItem, QueryManyIter, ROQueryItem};
 
 /// Provides scoped access to a [`World`] state according to a given [`WorldQuery`] and query filter.
+#[repr(C)]
 pub struct QueryState<Q: WorldQuery, F: WorldQuery = ()> {
     world_id: WorldId,
     pub(crate) archetype_generation: ArchetypeGeneration,
@@ -37,6 +37,44 @@ pub struct QueryState<Q: WorldQuery, F: WorldQuery = ()> {
 impl<Q: WorldQuery, F: WorldQuery> FromWorld for QueryState<Q, F> {
     fn from_world(world: &mut World) -> Self {
         world.query_filtered()
+    }
+}
+
+impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
+    /// Converts this `QueryState` reference to a `QueryState` that does not access anything mutably.
+    pub fn as_readonly(&self) -> &QueryState<Q::ReadOnly, F::ReadOnly> {
+        // SAFETY: invariant on `WorldQuery` trait upholds that `Q::ReadOnly` and `F::ReadOnly`
+        // have a subset of the access, and match the exact same archetypes/tables as `Q`/`F` respectively.
+        unsafe { self.as_transmuted_state::<Q::ReadOnly, F::ReadOnly>() }
+    }
+
+    /// Converts this `QueryState` reference to a `QueryState` that does not return any data
+    /// which can be faster.
+    ///
+    /// This doesn't use `NopWorldQuery` as it loses filter functionality, for example
+    /// `NopWorldQuery<Changed<T>>` is functionally equivelent to `With<T>`.
+    pub fn as_nop(&self) -> &QueryState<NopWorldQuery<Q>, F> {
+        // SAFETY: `NopWorldQuery` doesn't have any accesses and defers to
+        // `Q` for table/archetype matching
+        unsafe { self.as_transmuted_state::<NopWorldQuery<Q>, F>() }
+    }
+
+    /// Converts this `QueryState` reference to any other `QueryState` with
+    /// the same `WorldQuery::State` associated types.
+    ///
+    /// Consider using `as_readonly` or `as_nop` instead which are safe functions.
+    ///
+    /// # SAFETY
+    ///
+    /// `NewQ` must have a subset of the access that `Q` does and match the exact same archetypes/tables
+    /// `NewF` must have a subset of the access that `F` does and match the exact same archetypes/tables
+    pub(crate) unsafe fn as_transmuted_state<
+        NewQ: WorldQuery<State = Q::State>,
+        NewF: WorldQuery<State = F::State>,
+    >(
+        &self,
+    ) -> &QueryState<NewQ, NewF> {
+        &*(self as *const QueryState<Q, F> as *const QueryState<NewQ, NewF>)
     }
 }
 
@@ -83,7 +121,8 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     pub fn is_empty(&self, world: &World, last_change_tick: u32, change_tick: u32) -> bool {
         // SAFETY: NopFetch does not access any members while &self ensures no one has exclusive access
         unsafe {
-            self.iter_unchecked_manual::<NopFetch<Q::State>>(world, last_change_tick, change_tick)
+            self.as_nop()
+                .iter_unchecked_manual(world, last_change_tick, change_tick)
                 .next()
                 .is_none()
         }
@@ -162,7 +201,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         self.update_archetypes(world);
         // SAFETY: query is read only
         unsafe {
-            self.get_unchecked_manual::<ROQueryFetch<'w, Q>>(
+            self.as_readonly().get_unchecked_manual(
                 world,
                 entity,
                 world.last_change_tick(),
@@ -232,7 +271,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         self.update_archetypes(world);
         // SAFETY: query has unique world access
         unsafe {
-            self.get_unchecked_manual::<QueryFetch<'w, Q>>(
+            self.get_unchecked_manual(
                 world,
                 entity,
                 world.last_change_tick(),
@@ -308,7 +347,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         self.validate_world(world);
         // SAFETY: query is read only and world is validated
         unsafe {
-            self.get_unchecked_manual::<ROQueryFetch<'w, Q>>(
+            self.as_readonly().get_unchecked_manual(
                 world,
                 entity,
                 world.last_change_tick(),
@@ -330,7 +369,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         entity: Entity,
     ) -> Result<QueryItem<'w, Q>, QueryEntityError> {
         self.update_archetypes(world);
-        self.get_unchecked_manual::<QueryFetch<'w, Q>>(
+        self.get_unchecked_manual(
             world,
             entity,
             world.last_change_tick(),
@@ -348,13 +387,13 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     ///
     /// This must be called on the same `World` that the `Query` was generated from:
     /// use `QueryState::validate_world` to verify this.
-    pub(crate) unsafe fn get_unchecked_manual<'w, QF: Fetch<'w, State = Q::State>>(
+    pub(crate) unsafe fn get_unchecked_manual<'w>(
         &self,
         world: &'w World,
         entity: Entity,
         last_change_tick: u32,
         change_tick: u32,
-    ) -> Result<QF::Item, QueryEntityError> {
+    ) -> Result<QueryItem<'w, Q>, QueryEntityError> {
         let location = world
             .entities
             .get(entity)
@@ -366,7 +405,8 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
             return Err(QueryEntityError::QueryDoesNotMatch(entity));
         }
         let archetype = &world.archetypes[location.archetype_id];
-        let mut fetch = QF::init(world, &self.fetch_state, last_change_tick, change_tick);
+        let mut fetch =
+            <QueryFetch<Q> as Fetch>::init(world, &self.fetch_state, last_change_tick, change_tick);
         let mut filter = <QueryFetch<F> as Fetch>::init(
             world,
             &self.filter_state,
@@ -400,12 +440,8 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         // SAFETY: fetch is read-only
         // and world must be validated
         let array_of_results = entities.map(|entity| {
-            self.get_unchecked_manual::<ROQueryFetch<'w, Q>>(
-                world,
-                entity,
-                last_change_tick,
-                change_tick,
-            )
+            self.as_readonly()
+                .get_unchecked_manual(world, entity, last_change_tick, change_tick)
         });
 
         // TODO: Replace with TryMap once https://github.com/rust-lang/rust/issues/79711 is stabilized
@@ -447,14 +483,8 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
             }
         }
 
-        let array_of_results = entities.map(|entity| {
-            self.get_unchecked_manual::<QueryFetch<'w, Q>>(
-                world,
-                entity,
-                last_change_tick,
-                change_tick,
-            )
-        });
+        let array_of_results = entities
+            .map(|entity| self.get_unchecked_manual(world, entity, last_change_tick, change_tick));
 
         // If any of the get calls failed, bubble up the error
         for result in &array_of_results {
@@ -475,20 +505,21 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     pub fn iter<'w, 's>(
         &'s mut self,
         world: &'w World,
-    ) -> QueryIter<'w, 's, Q, ROQueryFetch<'w, Q>, F> {
+    ) -> QueryIter<'w, 's, Q::ReadOnly, F::ReadOnly> {
         // SAFETY: query is read only
         unsafe {
             self.update_archetypes(world);
-            self.iter_unchecked_manual(world, world.last_change_tick(), world.read_change_tick())
+            self.as_readonly().iter_unchecked_manual(
+                world,
+                world.last_change_tick(),
+                world.read_change_tick(),
+            )
         }
     }
 
     /// Returns an [`Iterator`] over the query results for the given [`World`].
     #[inline]
-    pub fn iter_mut<'w, 's>(
-        &'s mut self,
-        world: &'w mut World,
-    ) -> QueryIter<'w, 's, Q, QueryFetch<'w, Q>, F> {
+    pub fn iter_mut<'w, 's>(&'s mut self, world: &'w mut World) -> QueryIter<'w, 's, Q, F> {
         // SAFETY: query has unique world access
         unsafe {
             self.update_archetypes(world);
@@ -504,11 +535,15 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     pub fn iter_manual<'w, 's>(
         &'s self,
         world: &'w World,
-    ) -> QueryIter<'w, 's, Q, ROQueryFetch<'w, Q>, F> {
+    ) -> QueryIter<'w, 's, Q::ReadOnly, F::ReadOnly> {
         self.validate_world(world);
         // SAFETY: query is read only and world is validated
         unsafe {
-            self.iter_unchecked_manual(world, world.last_change_tick(), world.read_change_tick())
+            self.as_readonly().iter_unchecked_manual(
+                world,
+                world.last_change_tick(),
+                world.read_change_tick(),
+            )
         }
     }
 
@@ -526,11 +561,11 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     pub fn iter_combinations<'w, 's, const K: usize>(
         &'s mut self,
         world: &'w World,
-    ) -> QueryCombinationIter<'w, 's, Q, F, K> {
+    ) -> QueryCombinationIter<'w, 's, Q::ReadOnly, F::ReadOnly, K> {
         // SAFETY: query is read only
         unsafe {
             self.update_archetypes(world);
-            self.iter_combinations_unchecked_manual(
+            self.as_readonly().iter_combinations_unchecked_manual(
                 world,
                 world.last_change_tick(),
                 world.read_change_tick(),
@@ -571,14 +606,14 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         &'s mut self,
         world: &'w World,
         entities: EntityList,
-    ) -> QueryManyIter<'w, 's, Q, ROQueryFetch<'w, Q>, F, EntityList::IntoIter>
+    ) -> QueryManyIter<'w, 's, Q::ReadOnly, F::ReadOnly, EntityList::IntoIter>
     where
         EntityList::Item: Borrow<Entity>,
     {
         // SAFETY: query is read only
         unsafe {
             self.update_archetypes(world);
-            self.iter_many_unchecked_manual(
+            self.as_readonly().iter_many_unchecked_manual(
                 entities,
                 world,
                 world.last_change_tick(),
@@ -597,7 +632,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     pub unsafe fn iter_unchecked<'w, 's>(
         &'s mut self,
         world: &'w World,
-    ) -> QueryIter<'w, 's, Q, QueryFetch<'w, Q>, F> {
+    ) -> QueryIter<'w, 's, Q, F> {
         self.update_archetypes(world);
         self.iter_unchecked_manual(world, world.last_change_tick(), world.read_change_tick())
     }
@@ -633,12 +668,12 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     /// This does not validate that `world.id()` matches `self.world_id`. Calling this on a `world`
     /// with a mismatched [`WorldId`] is unsound.
     #[inline]
-    pub(crate) unsafe fn iter_unchecked_manual<'w, 's, QF: Fetch<'w, State = Q::State>>(
+    pub(crate) unsafe fn iter_unchecked_manual<'w, 's>(
         &'s self,
         world: &'w World,
         last_change_tick: u32,
         change_tick: u32,
-    ) -> QueryIter<'w, 's, Q, QF, F> {
+    ) -> QueryIter<'w, 's, Q, F> {
         QueryIter::new(world, self, last_change_tick, change_tick)
     }
 
@@ -649,22 +684,17 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     ///
     /// This does not check for mutable query correctness. To be safe, make sure mutable queries
     /// have unique access to the components they query.
-    /// this does not check for entity uniqueness
+    /// This does not check for entity uniqueness
     /// This does not validate that `world.id()` matches `self.world_id`. Calling this on a `world`
     /// with a mismatched [`WorldId`] is unsound.
     #[inline]
-    pub(crate) unsafe fn iter_many_unchecked_manual<
-        'w,
-        's,
-        QF: Fetch<'w, State = Q::State>,
-        EntityList: IntoIterator,
-    >(
+    pub(crate) unsafe fn iter_many_unchecked_manual<'w, 's, EntityList: IntoIterator>(
         &'s self,
         entities: EntityList,
         world: &'w World,
         last_change_tick: u32,
         change_tick: u32,
-    ) -> QueryManyIter<'w, 's, Q, QF, F, EntityList::IntoIter>
+    ) -> QueryManyIter<'w, 's, Q, F, EntityList::IntoIter>
     where
         EntityList::Item: Borrow<Entity>,
     {
@@ -700,7 +730,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         // SAFETY: query is read only
         unsafe {
             self.update_archetypes(world);
-            self.for_each_unchecked_manual::<ROQueryFetch<Q>, FN>(
+            self.as_readonly().for_each_unchecked_manual(
                 world,
                 func,
                 world.last_change_tick(),
@@ -720,7 +750,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         // SAFETY: query has unique world access
         unsafe {
             self.update_archetypes(world);
-            self.for_each_unchecked_manual::<QueryFetch<Q>, FN>(
+            self.for_each_unchecked_manual(
                 world,
                 func,
                 world.last_change_tick(),
@@ -745,7 +775,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         func: FN,
     ) {
         self.update_archetypes(world);
-        self.for_each_unchecked_manual::<QueryFetch<Q>, FN>(
+        self.for_each_unchecked_manual(
             world,
             func,
             world.last_change_tick(),
@@ -771,7 +801,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         // SAFETY: query is read only
         unsafe {
             self.update_archetypes(world);
-            self.par_for_each_unchecked_manual::<ROQueryFetch<Q>, FN>(
+            self.as_readonly().par_for_each_unchecked_manual(
                 world,
                 batch_size,
                 func,
@@ -796,7 +826,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         // SAFETY: query has unique world access
         unsafe {
             self.update_archetypes(world);
-            self.par_for_each_unchecked_manual::<QueryFetch<Q>, FN>(
+            self.par_for_each_unchecked_manual(
                 world,
                 batch_size,
                 func,
@@ -826,7 +856,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         func: FN,
     ) {
         self.update_archetypes(world);
-        self.par_for_each_unchecked_manual::<QueryFetch<Q>, FN>(
+        self.par_for_each_unchecked_manual(
             world,
             batch_size,
             func,
@@ -868,11 +898,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     /// have unique access to the components they query.
     /// This does not validate that `world.id()` matches `self.world_id`. Calling this on a `world`
     /// with a mismatched [`WorldId`] is unsound.
-    pub(crate) unsafe fn for_each_unchecked_manual<
-        'w,
-        QF: Fetch<'w, State = Q::State>,
-        FN: FnMut(QF::Item),
-    >(
+    pub(crate) unsafe fn for_each_unchecked_manual<'w, FN: FnMut(QueryItem<'w, Q>)>(
         &self,
         world: &'w World,
         mut func: FN,
@@ -881,7 +907,8 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     ) {
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
         // QueryIter, QueryIterationCursor, QueryState::for_each_unchecked_manual, QueryState::many_for_each_unchecked_manual, QueryState::par_for_each_unchecked_manual
-        let mut fetch = QF::init(world, &self.fetch_state, last_change_tick, change_tick);
+        let mut fetch =
+            <QueryFetch<Q> as Fetch>::init(world, &self.fetch_state, last_change_tick, change_tick);
         let mut filter = <QueryFetch<F> as Fetch>::init(
             world,
             &self.filter_state,
@@ -938,8 +965,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     /// with a mismatched [`WorldId`] is unsound.
     pub(crate) unsafe fn par_for_each_unchecked_manual<
         'w,
-        QF: Fetch<'w, State = Q::State>,
-        FN: Fn(QF::Item) + Send + Sync + Clone,
+        FN: Fn(QueryItem<'w, Q>) + Send + Sync + Clone,
     >(
         &self,
         world: &'w World,
@@ -951,7 +977,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
         // QueryIter, QueryIterationCursor, QueryState::for_each_unchecked_manual, QueryState::many_for_each_unchecked_manual, QueryState::par_for_each_unchecked_manual
         ComputeTaskPool::get().scope(|scope| {
-            if QF::IS_DENSE && <QueryFetch<'static, F>>::IS_DENSE {
+            if <QueryFetch<'static, Q>>::IS_DENSE && <QueryFetch<'static, F>>::IS_DENSE {
                 let tables = &world.storages().tables;
                 for table_id in &self.matched_table_ids {
                     let table = &tables[*table_id];
@@ -960,8 +986,12 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
                         let func = func.clone();
                         let len = batch_size.min(table.len() - offset);
                         let task = async move {
-                            let mut fetch =
-                                QF::init(world, &self.fetch_state, last_change_tick, change_tick);
+                            let mut fetch = <QueryFetch<Q> as Fetch>::init(
+                                world,
+                                &self.fetch_state,
+                                last_change_tick,
+                                change_tick,
+                            );
                             let mut filter = <QueryFetch<F> as Fetch>::init(
                                 world,
                                 &self.filter_state,
@@ -1002,8 +1032,12 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
                         let func = func.clone();
                         let len = batch_size.min(archetype.len() - offset);
                         let task = async move {
-                            let mut fetch =
-                                QF::init(world, &self.fetch_state, last_change_tick, change_tick);
+                            let mut fetch = <QueryFetch<Q> as Fetch>::init(
+                                world,
+                                &self.fetch_state,
+                                last_change_tick,
+                                change_tick,
+                            );
                             let mut filter = <QueryFetch<F> as Fetch>::init(
                                 world,
                                 &self.filter_state,
@@ -1130,7 +1164,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
 
         // SAFETY: query is read only
         unsafe {
-            self.get_single_unchecked_manual::<ROQueryFetch<'w, Q>>(
+            self.as_readonly().get_single_unchecked_manual(
                 world,
                 world.last_change_tick(),
                 world.read_change_tick(),
@@ -1166,7 +1200,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
 
         // SAFETY: query has unique world access
         unsafe {
-            self.get_single_unchecked_manual::<QueryFetch<'w, Q>>(
+            self.get_single_unchecked_manual(
                 world,
                 world.last_change_tick(),
                 world.read_change_tick(),
@@ -1189,12 +1223,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
         world: &'w World,
     ) -> Result<QueryItem<'w, Q>, QuerySingleError> {
         self.update_archetypes(world);
-
-        self.get_single_unchecked_manual::<QueryFetch<'w, Q>>(
-            world,
-            world.last_change_tick(),
-            world.read_change_tick(),
-        )
+        self.get_single_unchecked_manual(world, world.last_change_tick(), world.read_change_tick())
     }
 
     /// Returns a query result when there is exactly one entity matching the query,
@@ -1208,13 +1237,13 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
     /// This does not check for mutable query correctness. To be safe, make sure mutable queries
     /// have unique access to the components they query.
     #[inline]
-    pub unsafe fn get_single_unchecked_manual<'w, QF: Fetch<'w, State = Q::State>>(
+    pub unsafe fn get_single_unchecked_manual<'w>(
         &self,
         world: &'w World,
         last_change_tick: u32,
         change_tick: u32,
-    ) -> Result<QF::Item, QuerySingleError> {
-        let mut query = self.iter_unchecked_manual::<QF>(world, last_change_tick, change_tick);
+    ) -> Result<QueryItem<'w, Q>, QuerySingleError> {
+        let mut query = self.iter_unchecked_manual(world, last_change_tick, change_tick);
         let first = query.next();
         let extra = query.next().is_some();
 

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_exact_sized_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_exact_sized_iterator_safety.stderr
@@ -16,7 +16,7 @@ error[E0277]: the trait bound `bevy_ecs::query::Changed<Foo>: ArchetypeFilter` i
              (F0, F1, F2, F3, F4, F5, F6)
              (F0, F1, F2, F3, F4, F5, F6, F7)
            and 26 others
-   = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryIter<'_, '_, &Foo, ReadFetch<'_, Foo>, bevy_ecs::query::Changed<Foo>>`
+   = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Changed<Foo>>`
 note: required by a bound in `is_exact_size_iterator`
   --> tests/ui/query_exact_sized_iterator_safety.rs:16:30
    |
@@ -41,7 +41,7 @@ error[E0277]: the trait bound `bevy_ecs::query::Added<Foo>: ArchetypeFilter` is 
              (F0, F1, F2, F3, F4, F5, F6)
              (F0, F1, F2, F3, F4, F5, F6, F7)
            and 26 others
-   = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryIter<'_, '_, &Foo, ReadFetch<'_, Foo>, bevy_ecs::query::Added<Foo>>`
+   = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Added<Foo>>`
 note: required by a bound in `is_exact_size_iterator`
   --> tests/ui/query_exact_sized_iterator_safety.rs:16:30
    |

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
@@ -21,7 +21,7 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not sati
              (F0, F1, F2, F3, F4)
              (F0, F1, F2, F3, F4, F5)
              (F0, F1, F2, F3, F4, F5, F6)
-           and 48 others
+           and 49 others
    = note: `ReadOnlyWorldQuery` is implemented for `&'static Foo`, but not for `&'static mut Foo`
    = note: required because of the requirements on the impl of `ReadOnlySystemParamFetch` for `QueryState<&'static mut Foo>`
    = note: 2 redundant requirements hidden

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_derive.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_derive.stderr
@@ -13,7 +13,7 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not sati
             (F0, F1, F2, F3, F4)
             (F0, F1, F2, F3, F4, F5)
             (F0, F1, F2, F3, F4, F5, F6)
-          and 51 others
+          and 52 others
 note: required by a bound in `_::assert_readonly`
  --> tests/ui/world_query_derive.rs:7:10
   |
@@ -36,7 +36,7 @@ error[E0277]: the trait bound `MutableMarked: ReadOnlyWorldQuery` is not satisfi
              (F0, F1, F2, F3, F4)
              (F0, F1, F2, F3, F4, F5)
              (F0, F1, F2, F3, F4, F5, F6)
-           and 51 others
+           and 52 others
 note: required by a bound in `_::assert_readonly`
   --> tests/ui/world_query_derive.rs:18:10
    |


### PR DESCRIPTION
# Objective

remove `QF` generics from a bunch of types and methods on query related items. this has a few benefits:
- simplifies type signatures `fn iter(&self) -> QueryIter<'_, 's, Q::ReadOnly, F::ReadOnly>` is (imo) conceptually simpler than `fn iter(&self) -> QueryIter<'_, 's, Q, ROQueryFetch<'_, Q>, F>`
- `Fetch` is mostly an implementation detail but previously we had to expose it on every `iter` `get` etc method
- Allows us to potentially in the future simplify the `WorldQuery` trait hierarchy by removing the `Fetch` trait

## Solution

remove the `QF` generic and add a way to (unsafely) turn `&QueryState<Q1, F1>` into `&QueryState<Q2, F2>`

---

## Changelog/Migration Guide

The `QF` generic was removed from various `Query` iterator types and some methods, you should update your code to use the type of the corresponding worldquery of the fetch type that was being used, or call `as_readonly`/`as_nop` to convert a querystate to the appropriate type. For example:
`.get_single_unchecked_manual::<ROQueryFetch<Q>>(..)` -> `.as_readonly().get_single_unchecked_manual(..)`
`my_field: QueryIter<'w, 's, Q, ROQueryFetch<'w, Q>, F>` -> `my_field: QueryIter<'w, 's, Q::ReadOnly, F::ReadOnly>`