### PR TITLE
[Merged by Bors] - Remove the dependency cycles

### DIFF
--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -31,6 +31,3 @@ ron = { version = "0.7.0", optional = true }
 wasm-bindgen = { version = "0.2" }
 web-sys = { version = "0.3", features = [ "Window" ] }
 
-[dev-dependencies]
-# bevy
-bevy_log = { path = "../bevy_log", version = "0.8.0-dev" }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -761,6 +761,16 @@ impl App {
     /// ```
     /// # use bevy_app::prelude::*;
     /// #
+    /// # // Dummies created to avoid using `bevy_log`,
+    /// # // which pulls in too many dependencies and breaks rust-analyzer
+    /// # pub mod bevy_log {
+    /// #     use bevy_app::prelude::*;
+    /// #     #[derive(Default)]
+    /// #     pub struct LogPlugin;
+    /// #     impl Plugin for LogPlugin{
+    /// #        fn build(&self, app: &mut App) {}
+    /// #     }
+    /// # }
     /// App::new().add_plugin(bevy_log::LogPlugin::default());
     /// ```
     pub fn add_plugin<T>(&mut self, plugin: T) -> &mut Self
@@ -810,9 +820,10 @@ impl App {
     /// #
     /// # // Dummies created to avoid using `bevy_internal` and `bevy_log`,
     /// # // which pulls in too many dependencies and breaks rust-analyzer
-    /// # mod bevy_log {
-    /// #     struct LogPlugin;
+    /// # pub mod bevy_log {
     /// #     use bevy_app::prelude::*;
+    /// #     #[derive(Default)]
+    /// #     pub struct LogPlugin;
     /// #     impl Plugin for LogPlugin{
     /// #        fn build(&self, app: &mut App) {}
     /// #     }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -784,13 +784,7 @@ impl App {
     ///
     /// ## Examples
     /// ```
-    /// # use bevy_app::{prelude::*, PluginGroupBuilder};
-    /// #
-    /// # // Dummy created to avoid using bevy_internal, which pulls in to many dependencies.
-    /// # struct MinimalPlugins;
-    /// # impl PluginGroup for MinimalPlugins {
-    /// #     fn build(&mut self, group: &mut PluginGroupBuilder){;}
-    /// # }
+    /// # use bevy_app::{prelude::*, PluginGroupBuilder, NoopPluginGroup as MinimalPlugins};
     /// #
     /// App::new()
     ///     .add_plugins(MinimalPlugins);
@@ -814,7 +808,15 @@ impl App {
     /// ```
     /// # use bevy_app::{prelude::*, PluginGroupBuilder};
     /// #
-    /// # // Dummies created to avoid using bevy_internal which pulls in too many dependencies.
+    /// # // Dummies created to avoid using `bevy_internal` and `bevy_log`,
+    /// # // which pulls in too many dependencies and breaks rust-analyzer
+    /// # mod bevy_log {
+    /// #     struct LogPlugin;
+    /// #     use bevy_app::prelude::*;
+    /// #     impl Plugin for LogPlugin{
+    /// #        fn build(&self, app: &mut App) {}
+    /// #     }
+    /// # }
     /// # struct DefaultPlugins;
     /// # impl PluginGroup for DefaultPlugins {
     /// #     fn build(&mut self, group: &mut PluginGroupBuilder){

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -139,6 +139,21 @@ impl PluginGroupBuilder {
     }
 }
 
+/// A plugin group which doesn't do anything. Useful for examples:
+/// ```rust
+/// # use bevy_app::prelude::*;
+/// use bevy_app::NoopPluginGroup as MinimalPlugins;
+///
+/// fn main(){
+///     App::new().add_plugins(MinimalPlugins).run();
+/// }
+/// ```
+pub struct NoopPluginGroup;
+
+impl PluginGroup for NoopPluginGroup {
+    fn build(&mut self, _: &mut PluginGroupBuilder) {}
+}
+
 #[cfg(test)]
 mod tests {
     use super::PluginGroupBuilder;

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -148,6 +148,7 @@ impl PluginGroupBuilder {
 ///     App::new().add_plugins(MinimalPlugins).run();
 /// }
 /// ```
+#[doc(hidden)]
 pub struct NoopPluginGroup;
 
 impl PluginGroup for NoopPluginGroup {

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -24,9 +24,6 @@ parking_lot = "0.11.0"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 rodio = { version = "0.15", default-features = false, features = ["wasm-bindgen"] }
 
-[dev-dependencies]
-# bevy
-bevy_internal = { path = "../bevy_internal", version = "0.8.0-dev" }
 
 [features]
 mp3 = ["rodio/mp3"]

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -1,17 +1,15 @@
 //! Audio support for the game engine Bevy
 //!
-//! ```
+//! ```no_run
 //! # use bevy_ecs::{system::Res, event::EventWriter};
 //! # use bevy_audio::{Audio, AudioPlugin};
 //! # use bevy_asset::{AssetPlugin, AssetServer};
-//! # use bevy_app::{App, AppExit};
-//! # use bevy_internal::MinimalPlugins;
+//! # use bevy_app::{App, AppExit, NoopPluginGroup as MinimalPlugins};;
 //! fn main() {
 //!    App::new()
 //!         .add_plugins(MinimalPlugins)
 //!         .add_plugin(AssetPlugin)
 //!         .add_plugin(AudioPlugin)
-//! #       .add_system(stop)
 //!         .add_startup_system(play_background_audio)
 //!         .run();
 //! }
@@ -19,10 +17,6 @@
 //! fn play_background_audio(asset_server: Res<AssetServer>, audio: Res<Audio>) {
 //!     audio.play(asset_server.load("background_audio.ogg"));
 //! }
-//!
-//! # fn stop(mut events: EventWriter<AppExit>) {
-//! #     events.send(AppExit)
-//! # }
 //! ```
 
 #![forbid(unsafe_code)]

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -4,7 +4,7 @@
 //! # use bevy_ecs::{system::Res, event::EventWriter};
 //! # use bevy_audio::{Audio, AudioPlugin};
 //! # use bevy_asset::{AssetPlugin, AssetServer};
-//! # use bevy_app::{App, AppExit, NoopPluginGroup as MinimalPlugins};;
+//! # use bevy_app::{App, AppExit, NoopPluginGroup as MinimalPlugins};
 //! fn main() {
 //!    App::new()
 //!         .add_plugins(MinimalPlugins)

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -27,6 +27,3 @@ android_log-sys = "0.2.0"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.6"
 tracing-wasm = "0.2.1"
-
-[dev-dependencies]
-bevy_internal = { path = "../bevy_internal", version = "0.8.0-dev" }

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -47,8 +47,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 ///
 /// You can configure this plugin using the resource [`LogSettings`].
 /// ```no_run
-/// # use bevy_internal::DefaultPlugins;
-/// # use bevy_app::App;
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins};
 /// # use bevy_log::LogSettings;
 /// # use bevy_utils::tracing::Level;
 /// fn main() {
@@ -72,8 +71,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// If you want to setup your own tracing collector, you should disable this
 /// plugin from `DefaultPlugins` with [`App::add_plugins_with`]:
 /// ```no_run
-/// # use bevy_internal::DefaultPlugins;
-/// # use bevy_app::App;
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins};
 /// # use bevy_log::LogPlugin;
 /// fn main() {
 ///     App::new()


### PR DESCRIPTION
# Objective

- I think our codebase is hit badly by rust-lang/rust-analyzer#11410
- None of our uses of cyclic dependencies are remotely necessary
- Note that these are false positives in rust-analyzer, however it's probably easier for us to work around this
- Note also that I haven't confirmed that this is causing rust-analyzer to not work very well, but it's not a bad guess.

## Solution

- Remove our cyclic dependencies
- Import the trick from #2851 for no-op plugin groups.