### PR TITLE
[Merged by Bors] - Enable wgpu profiling spans when using bevy's trace feature

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -55,7 +55,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 ///     App::new()
 ///         .insert_resource(LogSettings {
 ///             level: Level::DEBUG,
-///             filter: "wgpu=info,bevy_render=info,bevy_ecs=trace".to_string(),
+///             filter: "wgpu=error,bevy_render=info,bevy_ecs=trace".to_string(),
 ///         })
 ///         .add_plugins(DefaultPlugins)
 ///         .run();
@@ -63,7 +63,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// ```
 ///
 /// Log level can also be changed using the `RUST_LOG` environment variable.
-/// For example, using `RUST_LOG=wgpu=info,bevy_render=info,bevy_ecs=trace cargo run ..`
+/// For example, using `RUST_LOG=wgpu=error,bevy_render=info,bevy_ecs=trace cargo run ..`
 ///
 /// It has the same syntax as the field [`LogSettings::filter`], see [`EnvFilter`].
 /// If you define the `RUST_LOG` environment variable, the [`LogSettings`] resource
@@ -103,7 +103,7 @@ pub struct LogSettings {
 impl Default for LogSettings {
     fn default() -> Self {
         Self {
-            filter: "wgpu=info".to_string(),
+            filter: "wgpu=error".to_string(),
             level: Level::INFO,
         }
     }

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -55,7 +55,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 ///     App::new()
 ///         .insert_resource(LogSettings {
 ///             level: Level::DEBUG,
-///             filter: "wgpu=error,bevy_render=info,bevy_ecs=trace".to_string(),
+///             filter: "wgpu=info,bevy_render=info,bevy_ecs=trace".to_string(),
 ///         })
 ///         .add_plugins(DefaultPlugins)
 ///         .run();
@@ -63,7 +63,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// ```
 ///
 /// Log level can also be changed using the `RUST_LOG` environment variable.
-/// For example, using `RUST_LOG=wgpu=error,bevy_render=info,bevy_ecs=trace cargo run ..`
+/// For example, using `RUST_LOG=wgpu=info,bevy_render=info,bevy_ecs=trace cargo run ..`
 ///
 /// It has the same syntax as the field [`LogSettings::filter`], see [`EnvFilter`].
 /// If you define the `RUST_LOG` environment variable, the [`LogSettings`] resource
@@ -103,7 +103,7 @@ pub struct LogSettings {
 impl Default for LogSettings {
     fn default() -> Self {
         Self {
-            filter: "wgpu=error".to_string(),
+            filter: "wgpu=info".to_string(),
             level: Level::INFO,
         }
     }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -71,5 +71,5 @@ ruzstd = { version = "0.2.4", optional = true }
 # For transcoding of UASTC/ETC1S universal formats, and for .basis file support
 basis-universal = { version = "0.2.0", optional = true }
 encase = { version = "0.3", features = ["glam"] }
-# for wgpu profiling using tracing
+# For wgpu profiling using tracing. Use `RUST_LOG=info` to also capture the wgpu spans.
 profiling = { version = "1", features = ["profile-with-tracing"], optional = true }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -20,7 +20,7 @@ dds = ["ddsfile"]
 zlib = ["flate2"]
 zstd = ["ruzstd"]
 
-trace = []
+trace = ["profiling"]
 tracing-tracy = []
 wgpu_trace = ["wgpu/trace"]
 ci_limits = []
@@ -71,3 +71,5 @@ ruzstd = { version = "0.2.4", optional = true }
 # For transcoding of UASTC/ETC1S universal formats, and for .basis file support
 basis-universal = { version = "0.2.0", optional = true }
 encase = { version = "0.2", features = ["glam"] }
+# for wgpu profiling using tracing
+profiling = { version = "1", features = ["profile-with-tracing"], optional = true }


### PR DESCRIPTION
# Objective

- Enable `wgpu` profiling spans

## Solution

- `wgpu` uses the `profiling` crate to add profiling span instrumentation to their code
- `profiling` offers multiple 'backends' for profiling, including `tracing`
- When the `bevy` `trace` feature is used, add the `profiling` crate with its `profile-with-tracing` feature to enable appropriate profiling spans in `wgpu` using `tracing` which fits nicely into our infrastructure
- Bump our default `tracing` subscriber filter to `wgpu=info` from `wgpu=error` so that the profiling spans are not filtered out as they are created at the `info` level.

---

## Changelog

- Added: `tracing` profiling support for `wgpu` when using bevy's `trace` feature
- Changed: The default `tracing` filter statement for `wgpu` has been changed from the `error` level to the `info` level to not filter out the wgpu profiling spans