### PR TITLE
Allow camera viewports to be specified as a percentage of the parent viewport

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
@@ -86,7 +86,8 @@ impl Node for MainPass2dNode {
             let mut draw_functions = draw_functions.write();
             let mut tracked_pass = TrackedRenderPass::new(render_pass);
             if let Some(viewport) = camera.viewport.as_ref() {
-                tracked_pass.set_camera_viewport(viewport);
+                let physical_size = viewport.physical_size.as_absolute_opt(camera.physical_target_size).expect("Couldn't get camera.physical_target_size (needed for relative viewport size)");
+                tracked_pass.set_camera_viewport(viewport, physical_size);
             }
             for item in &transparent_phase.items {
                 let draw_function = draw_functions.get_mut(item.draw_function).unwrap();

--- a/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
@@ -86,7 +86,7 @@ impl Node for MainPass2dNode {
             let mut draw_functions = draw_functions.write();
             let mut tracked_pass = TrackedRenderPass::new(render_pass);
             if let Some(viewport) = camera.viewport.as_ref() {
-                tracked_pass.set_camera_viewport(viewport, camera);
+                tracked_pass.set_camera_viewport(viewport, camera.physical_target_size);
             }
             for item in &transparent_phase.items {
                 let draw_function = draw_functions.get_mut(item.draw_function).unwrap();

--- a/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
@@ -86,8 +86,7 @@ impl Node for MainPass2dNode {
             let mut draw_functions = draw_functions.write();
             let mut tracked_pass = TrackedRenderPass::new(render_pass);
             if let Some(viewport) = camera.viewport.as_ref() {
-                let physical_size = viewport.physical_size.as_absolute_opt(camera.physical_target_size).expect("Couldn't get camera.physical_target_size (needed for relative viewport size)");
-                tracked_pass.set_camera_viewport(viewport, physical_size);
+                tracked_pass.set_camera_viewport(viewport, camera);
             }
             for item in &transparent_phase.items {
                 let draw_function = draw_functions.get_mut(item.draw_function).unwrap();

--- a/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
@@ -103,8 +103,7 @@ impl Node for MainPass3dNode {
             let mut draw_functions = draw_functions.write();
             let mut tracked_pass = TrackedRenderPass::new(render_pass);
             if let Some(viewport) = camera.viewport.as_ref() {
-                let physical_size = viewport.physical_size.as_absolute_opt(camera.physical_target_size).expect("Couldn't get camera.physical_target_size (needed for relative viewport size)");
-                tracked_pass.set_camera_viewport(viewport, physical_size);
+                tracked_pass.set_camera_viewport(viewport, camera);
             }
             for item in &opaque_phase.items {
                 let draw_function = draw_functions.get_mut(item.draw_function).unwrap();
@@ -143,8 +142,7 @@ impl Node for MainPass3dNode {
             let mut draw_functions = draw_functions.write();
             let mut tracked_pass = TrackedRenderPass::new(render_pass);
             if let Some(viewport) = camera.viewport.as_ref() {
-                let physical_size = viewport.physical_size.as_absolute_opt(camera.physical_target_size).expect("Couldn't get camera.physical_target_size (needed for relative viewport size)");
-                tracked_pass.set_camera_viewport(viewport, physical_size);
+                tracked_pass.set_camera_viewport(viewport, camera);
             }
             for item in &alpha_mask_phase.items {
                 let draw_function = draw_functions.get_mut(item.draw_function).unwrap();
@@ -188,8 +186,7 @@ impl Node for MainPass3dNode {
             let mut draw_functions = draw_functions.write();
             let mut tracked_pass = TrackedRenderPass::new(render_pass);
             if let Some(viewport) = camera.viewport.as_ref() {
-                let physical_size = viewport.physical_size.as_absolute_opt(camera.physical_target_size).expect("Couldn't get camera.physical_target_size (needed for relative viewport size)");
-                tracked_pass.set_camera_viewport(viewport, physical_size);
+                tracked_pass.set_camera_viewport(viewport, camera);
             }
             for item in &transparent_phase.items {
                 let draw_function = draw_functions.get_mut(item.draw_function).unwrap();

--- a/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
@@ -103,7 +103,8 @@ impl Node for MainPass3dNode {
             let mut draw_functions = draw_functions.write();
             let mut tracked_pass = TrackedRenderPass::new(render_pass);
             if let Some(viewport) = camera.viewport.as_ref() {
-                tracked_pass.set_camera_viewport(viewport);
+                let physical_size = viewport.physical_size.as_absolute_opt(camera.physical_target_size).expect("Couldn't get camera.physical_target_size (needed for relative viewport size)");
+                tracked_pass.set_camera_viewport(viewport, physical_size);
             }
             for item in &opaque_phase.items {
                 let draw_function = draw_functions.get_mut(item.draw_function).unwrap();
@@ -142,7 +143,8 @@ impl Node for MainPass3dNode {
             let mut draw_functions = draw_functions.write();
             let mut tracked_pass = TrackedRenderPass::new(render_pass);
             if let Some(viewport) = camera.viewport.as_ref() {
-                tracked_pass.set_camera_viewport(viewport);
+                let physical_size = viewport.physical_size.as_absolute_opt(camera.physical_target_size).expect("Couldn't get camera.physical_target_size (needed for relative viewport size)");
+                tracked_pass.set_camera_viewport(viewport, physical_size);
             }
             for item in &alpha_mask_phase.items {
                 let draw_function = draw_functions.get_mut(item.draw_function).unwrap();
@@ -186,7 +188,8 @@ impl Node for MainPass3dNode {
             let mut draw_functions = draw_functions.write();
             let mut tracked_pass = TrackedRenderPass::new(render_pass);
             if let Some(viewport) = camera.viewport.as_ref() {
-                tracked_pass.set_camera_viewport(viewport);
+                let physical_size = viewport.physical_size.as_absolute_opt(camera.physical_target_size).expect("Couldn't get camera.physical_target_size (needed for relative viewport size)");
+                tracked_pass.set_camera_viewport(viewport, physical_size);
             }
             for item in &transparent_phase.items {
                 let draw_function = draw_functions.get_mut(item.draw_function).unwrap();

--- a/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
@@ -103,7 +103,7 @@ impl Node for MainPass3dNode {
             let mut draw_functions = draw_functions.write();
             let mut tracked_pass = TrackedRenderPass::new(render_pass);
             if let Some(viewport) = camera.viewport.as_ref() {
-                tracked_pass.set_camera_viewport(viewport, camera);
+                tracked_pass.set_camera_viewport(viewport, camera.physical_target_size);
             }
             for item in &opaque_phase.items {
                 let draw_function = draw_functions.get_mut(item.draw_function).unwrap();
@@ -142,7 +142,7 @@ impl Node for MainPass3dNode {
             let mut draw_functions = draw_functions.write();
             let mut tracked_pass = TrackedRenderPass::new(render_pass);
             if let Some(viewport) = camera.viewport.as_ref() {
-                tracked_pass.set_camera_viewport(viewport, camera);
+                tracked_pass.set_camera_viewport(viewport, camera.physical_target_size);
             }
             for item in &alpha_mask_phase.items {
                 let draw_function = draw_functions.get_mut(item.draw_function).unwrap();
@@ -186,7 +186,7 @@ impl Node for MainPass3dNode {
             let mut draw_functions = draw_functions.write();
             let mut tracked_pass = TrackedRenderPass::new(render_pass);
             if let Some(viewport) = camera.viewport.as_ref() {
-                tracked_pass.set_camera_viewport(viewport, camera);
+                tracked_pass.set_camera_viewport(viewport, camera.physical_target_size);
             }
             for item in &transparent_phase.items {
                 let draw_function = draw_functions.get_mut(item.draw_function).unwrap();

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -36,32 +36,38 @@ use wgpu::Extent3d;
 pub struct Viewport {
     /// The physical position to render this viewport to within the [`RenderTarget`] of this [`Camera`].
     /// (0,0) corresponds to the top-left corner
-    pub physical_position: UVec2,
+    pub physical_position: AbsOrPercVec,
     /// The physical size of the viewport rectangle to render to within the [`RenderTarget`] of this [`Camera`].
     /// The origin of the rectangle is in the top-left corner.
-    pub physical_size: AbsoluteOrPercentageVec,
+    pub physical_size: AbsOrPercVec,
     /// The minimum and maximum depth to render (on a scale from 0.0 to 1.0).
     pub depth: Range<f32>,
 }
 
 #[derive(Reflect, Debug, Clone, Serialize, Deserialize)]
-pub enum AbsoluteOrPercentageVec {
+pub enum AbsOrPercVec {
     Absolute(UVec2),
     Percentage(Vec2),
 }
 
-impl AbsoluteOrPercentageVec {
+impl Default for AbsOrPercVec {
+    fn default() -> Self {
+        Self::Absolute(Default::default())
+    }
+}
+
+impl AbsOrPercVec {
     pub fn as_absolute(&self, of: UVec2) -> UVec2 {
         match self {
-            AbsoluteOrPercentageVec::Absolute(v) => *v,
-            AbsoluteOrPercentageVec::Percentage(v) => (of.as_vec2() * *v).as_uvec2(),
+            AbsOrPercVec::Absolute(v) => *v,
+            AbsOrPercVec::Percentage(v) => (of.as_vec2() * *v).as_uvec2(),
         }
     }
 
     pub fn as_absolute_opt(&self, of_opt: Option<UVec2>) -> Option<UVec2> {
         match self {
-            AbsoluteOrPercentageVec::Absolute(v) => Some(*v),
-            AbsoluteOrPercentageVec::Percentage(v) => {
+            AbsOrPercVec::Absolute(v) => Some(*v),
+            AbsOrPercVec::Percentage(v) => {
                 if let Some(of) = of_opt {
                     Some((of.as_vec2() * *v).as_uvec2())
                 } else {
@@ -76,7 +82,7 @@ impl Default for Viewport {
     fn default() -> Self {
         Self {
             physical_position: Default::default(),
-            physical_size: AbsoluteOrPercentageVec::Absolute(UVec2::default()),
+            physical_size: Default::default(),
             depth: 0.0..1.0,
         }
     }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -153,7 +153,7 @@ impl Camera {
     /// I.e. multiplies the percentage size of viewport with `physical_target_size` or uses
     /// viewport's absolute size
     ///
-    /// Returns `None` if viewport size is a `Percentage` and [`physical_target_size`] returns
+    /// Returns `None` if viewport size is a `Percentage` and [`Camera::physical_target_size`] returns
     /// `None`
     #[inline]
     pub fn viewport_absolute_size(&self) -> Option<UVec2> {

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -36,48 +36,81 @@ use wgpu::Extent3d;
 pub struct Viewport {
     /// The physical position to render this viewport to within the [`RenderTarget`] of this [`Camera`].
     /// (0,0) corresponds to the top-left corner
-    pub physical_position: AbsOrPercVec,
+    pub physical_position: ViewportPosition,
     /// The physical size of the viewport rectangle to render to within the [`RenderTarget`] of this [`Camera`].
     /// The origin of the rectangle is in the top-left corner.
-    pub physical_size: AbsOrPercVec,
+    pub physical_size: ViewportSize,
     /// The minimum and maximum depth to render (on a scale from 0.0 to 1.0).
     pub depth: Range<f32>,
 }
 
-/// A vector wrapper that represents either absolute value or value as a percentage.
-///
-/// For example, used in representing viewport position, either as absolute pixel value, or as a
-/// percentage of render target size.
+/// An enum that represents viewport's top-left corner position either as absolute value (in pixels)
+/// or as a percentage of camera's render target's size.
+/// (0,0) corresponds to the top-left corner
 #[derive(Reflect, Debug, Clone, Serialize, Deserialize)]
-pub enum AbsOrPercVec {
+pub enum ViewportPosition {
     Absolute(UVec2),
     Percentage(Vec2),
 }
 
-impl Default for AbsOrPercVec {
+impl Default for ViewportPosition {
     fn default() -> Self {
         Self::Absolute(Default::default())
     }
 }
 
-impl AbsOrPercVec {
+impl ViewportPosition {
     /// Converts this size into a absolute size in pixels.
     #[inline]
     pub fn as_absolute(&self, of: UVec2) -> UVec2 {
         match self {
-            AbsOrPercVec::Absolute(v) => *v,
-            AbsOrPercVec::Percentage(v) => (of.as_vec2() * *v).as_uvec2(),
+            ViewportPosition::Absolute(v) => *v,
+            ViewportPosition::Percentage(v) => (of.as_vec2() * *v).as_uvec2(),
         }
     }
 
-    ///  Converts this size into a absolute size in pixels if possible.
-
+    /// Converts this size into a absolute size in pixels if possible.
+    ///
     /// Returns `None` if self is `Percentage` and argument is `None`
     #[inline]
     pub fn try_as_absolute(&self, of_opt: Option<UVec2>) -> Option<UVec2> {
         match self {
-            AbsOrPercVec::Absolute(v) => Some(*v),
-            AbsOrPercVec::Percentage(_) => of_opt.map(|of| self.as_absolute(of)),
+            ViewportPosition::Absolute(v) => Some(*v),
+            ViewportPosition::Percentage(_) => of_opt.map(|of| self.as_absolute(of)),
+        }
+    }
+}
+/// An enum that represents viewport's size either as absolute value (in pixels) or as a percentage of camera's render target's size.
+#[derive(Reflect, Debug, Clone, Serialize, Deserialize)]
+pub enum ViewportSize {
+    Absolute(UVec2),
+    Percentage(Vec2),
+}
+
+impl Default for ViewportSize {
+    fn default() -> Self {
+        Self::Absolute(Default::default())
+    }
+}
+
+impl ViewportSize {
+    /// Converts this size into a absolute size in pixels.
+    #[inline]
+    pub fn as_absolute(&self, of: UVec2) -> UVec2 {
+        match self {
+            ViewportSize::Absolute(v) => *v,
+            ViewportSize::Percentage(v) => (of.as_vec2() * *v).as_uvec2(),
+        }
+    }
+
+    /// Converts this size into a absolute size in pixels if possible.
+    ///
+    /// Returns `None` if self is `Percentage` and argument is `None`
+    #[inline]
+    pub fn try_as_absolute(&self, of_opt: Option<UVec2>) -> Option<UVec2> {
+        match self {
+            ViewportSize::Absolute(v) => Some(*v),
+            ViewportSize::Percentage(_) => of_opt.map(|of| self.as_absolute(of)),
         }
     }
 }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -61,7 +61,7 @@ impl Default for AbsOrPercVec {
 }
 
 impl AbsOrPercVec {
-    /// Returns percentage of provided vec or absolute value from self.
+    /// Converts this size into a absolute size in pixels.
     #[inline]
     pub fn as_absolute(&self, of: UVec2) -> UVec2 {
         match self {
@@ -70,10 +70,11 @@ impl AbsOrPercVec {
         }
     }
 
-    /// Returns percentage of provided vec or absolute value.
+    ///  Converts this size into a absolute size in pixels if possible.
+
     /// Returns `None` if self is `Percentage` and argument is `None`
     #[inline]
-    pub fn as_absolute_opt(&self, of_opt: Option<UVec2>) -> Option<UVec2> {
+    pub fn try_as_absolute(&self, of_opt: Option<UVec2>) -> Option<UVec2> {
         match self {
             AbsOrPercVec::Absolute(v) => Some(*v),
             AbsOrPercVec::Percentage(_) => of_opt.map(|of| self.as_absolute(of)),
@@ -159,7 +160,7 @@ impl Camera {
     pub fn viewport_absolute_size(&self) -> Option<UVec2> {
         self.viewport
             .as_ref()
-            .and_then(|v| v.physical_size.as_absolute_opt(self.physical_target_size()))
+            .and_then(|v| v.physical_size.try_as_absolute(self.physical_target_size()))
     }
 
     /// The rendered physical bounds (minimum, maximum) of the camera. If the `viewport` field is

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -343,12 +343,12 @@ impl<'a> TrackedRenderPass<'a> {
     pub fn set_camera_viewport(&mut self, viewport: &Viewport, camera: &ExtractedCamera) {
         let physical_size = viewport
             .physical_size
-            .as_absolute_opt(camera.physical_target_size)
+            .try_as_absolute(camera.physical_target_size)
             .expect("Couldn't get camera.physical_target_size (needed for relative viewport size)");
 
         let physical_position = viewport
             .physical_position
-            .as_absolute_opt(camera.physical_target_size)
+            .try_as_absolute(camera.physical_target_size)
             .expect(
                 "Couldn't get camera.physical_target_size (needed for relative viewport position)",
             );

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -1,5 +1,5 @@
 use crate::{
-    camera::{ExtractedCamera, Viewport},
+    camera::Viewport,
     prelude::Color,
     render_resource::{
         BindGroup, BindGroupId, Buffer, BufferId, BufferSlice, RenderPipeline, RenderPipelineId,
@@ -340,15 +340,19 @@ impl<'a> TrackedRenderPass<'a> {
     /// Set the rendering viewport to the given [`Camera`](crate::camera::Viewport) [`Viewport`].
     ///
     /// Subsequent draw calls will be projected into that viewport.
-    pub fn set_camera_viewport(&mut self, viewport: &Viewport, camera: &ExtractedCamera) {
+    pub fn set_camera_viewport(
+        &mut self,
+        viewport: &Viewport,
+        physical_target_size: Option<bevy_math::UVec2>,
+    ) {
         let physical_size = viewport
             .physical_size
-            .try_as_absolute(camera.physical_target_size)
+            .try_as_absolute(physical_target_size)
             .expect("Couldn't get camera.physical_target_size (needed for relative viewport size)");
 
         let physical_position = viewport
             .physical_position
-            .try_as_absolute(camera.physical_target_size)
+            .try_as_absolute(physical_target_size)
             .expect(
                 "Couldn't get camera.physical_target_size (needed for relative viewport position)",
             );

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -6,6 +6,7 @@ use crate::{
         ShaderStages,
     },
 };
+use bevy_math::UVec2;
 use bevy_utils::tracing::trace;
 use std::ops::Range;
 use wgpu::{IndexFormat, RenderPass};
@@ -340,12 +341,12 @@ impl<'a> TrackedRenderPass<'a> {
     /// Set the rendering viewport to the given [`Camera`](crate::camera::Viewport) [`Viewport`].
     ///
     /// Subsequent draw calls will be projected into that viewport.
-    pub fn set_camera_viewport(&mut self, viewport: &Viewport) {
+    pub fn set_camera_viewport(&mut self, viewport: &Viewport, physical_size: UVec2) {
         self.set_viewport(
             viewport.physical_position.x as f32,
             viewport.physical_position.y as f32,
-            viewport.physical_size.x as f32,
-            viewport.physical_size.y as f32,
+            physical_size.x as f32,
+            physical_size.y as f32,
             viewport.depth.start,
             viewport.depth.end,
         );

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -107,7 +107,7 @@ fn set_camera_viewports(
 
             let mut right_camera = right_camera.single_mut();
             right_camera.viewport = Some(Viewport {
-                // ... or specify a percentage of the render target.
+                // ... or specify an adaptive percentage of the render target.
                 physical_position: AbsOrPercVec::Percentage(Vec2::new(0.5, 0.0)),
                 physical_size: AbsOrPercVec::Percentage(Vec2::new(0.5, 1.0)),
                 ..default()

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -3,7 +3,7 @@
 use bevy::{
     core_pipeline::clear_color::ClearColorConfig,
     prelude::*,
-    render::camera::{AbsOrPercVec, Viewport},
+    render::camera::{Viewport, ViewportPosition, ViewportSize},
     window::{WindowId, WindowResized},
 };
 
@@ -97,8 +97,8 @@ fn set_camera_viewports(
             let mut left_camera = left_camera.single_mut();
             left_camera.viewport = Some(Viewport {
                 // You can use absolute pixel values...
-                physical_position: AbsOrPercVec::Absolute(UVec2::ZERO),
-                physical_size: AbsOrPercVec::Absolute(UVec2::new(
+                physical_position: ViewportPosition::Absolute(UVec2::ZERO),
+                physical_size: ViewportSize::Absolute(UVec2::new(
                     window.physical_width() / 2,
                     window.physical_height(),
                 )),
@@ -108,8 +108,8 @@ fn set_camera_viewports(
             let mut right_camera = right_camera.single_mut();
             right_camera.viewport = Some(Viewport {
                 // ... or specify an adaptive percentage of the render target.
-                physical_position: AbsOrPercVec::Percentage(Vec2::new(0.5, 0.0)),
-                physical_size: AbsOrPercVec::Percentage(Vec2::new(0.5, 1.0)),
+                physical_position: ViewportPosition::Percentage(Vec2::new(0.5, 0.0)),
+                physical_size: ViewportSize::Percentage(Vec2::new(0.5, 1.0)),
                 ..default()
             });
         }

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -3,7 +3,7 @@
 use bevy::{
     core_pipeline::clear_color::ClearColorConfig,
     prelude::*,
-    render::camera::{AbsoluteOrPercentageVec, Viewport},
+    render::camera::{AbsOrPercVec, Viewport},
     window::{WindowId, WindowResized},
 };
 
@@ -96,8 +96,9 @@ fn set_camera_viewports(
             let window = windows.primary();
             let mut left_camera = left_camera.single_mut();
             left_camera.viewport = Some(Viewport {
-                physical_position: UVec2::new(0, 0),
-                physical_size: AbsoluteOrPercentageVec::Absolute(UVec2::new(
+                // You can use absolute pixel values...
+                physical_position: AbsOrPercVec::Absolute(UVec2::ZERO),
+                physical_size: AbsOrPercVec::Absolute(UVec2::new(
                     window.physical_width() / 2,
                     window.physical_height(),
                 )),
@@ -106,8 +107,9 @@ fn set_camera_viewports(
 
             let mut right_camera = right_camera.single_mut();
             right_camera.viewport = Some(Viewport {
-                physical_position: UVec2::new(window.physical_width() / 2, 0),
-                physical_size: AbsoluteOrPercentageVec::Percentage(Vec2::new(0.5, 1.0)),
+                // ... or specify a percentage of the render target.
+                physical_position: AbsOrPercVec::Percentage(Vec2::new(0.5, 0.0)),
+                physical_size: AbsOrPercVec::Percentage(Vec2::new(0.5, 1.0)),
                 ..default()
             });
         }

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -3,7 +3,7 @@
 use bevy::{
     core_pipeline::clear_color::ClearColorConfig,
     prelude::*,
-    render::camera::Viewport,
+    render::camera::{AbsoluteOrPercentageVec, Viewport},
     window::{WindowId, WindowResized},
 };
 
@@ -97,14 +97,17 @@ fn set_camera_viewports(
             let mut left_camera = left_camera.single_mut();
             left_camera.viewport = Some(Viewport {
                 physical_position: UVec2::new(0, 0),
-                physical_size: UVec2::new(window.physical_width() / 2, window.physical_height()),
+                physical_size: AbsoluteOrPercentageVec::Absolute(UVec2::new(
+                    window.physical_width() / 2,
+                    window.physical_height(),
+                )),
                 ..default()
             });
 
             let mut right_camera = right_camera.single_mut();
             right_camera.viewport = Some(Viewport {
                 physical_position: UVec2::new(window.physical_width() / 2, 0),
-                physical_size: UVec2::new(window.physical_width() / 2, window.physical_height()),
+                physical_size: AbsoluteOrPercentageVec::Percentage(Vec2::new(0.5, 1.0)),
                 ..default()
             });
         }


### PR DESCRIPTION
# Objective

- Closes #4960 

## Solution

- Use enums for viewport position and size, and convert when needed

---

## Changelog
#### Added:
  - `ViewportSize` and `ViewportPosition` enums
  - `Camera::viewport_absolute_size` function to reduce code repetition
  
#### Changed:
  - `Viewport`'s position and size to use new enums
  - `TrackedRenderPass::set_camera_viewport` function to take `ExtractedCamera` as argument (needed to calculate absolute values)
