### PR TITLE
[Merged by Bors] - Disable Vsync for stress tests.

### DIFF
--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -13,13 +13,13 @@
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     math::{DVec2, DVec3},
-    prelude::*,
+    prelude::*, window::PresentMode,
 };
 
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
-            present_mode: bevy::window::PresentMode::Immediate,
+            present_mode: PresentMode::Immediate,
             ..default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -13,7 +13,8 @@
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     math::{DVec2, DVec3},
-    prelude::*, window::PresentMode,
+    prelude::*,
+    window::PresentMode,
 };
 
 fn main() {

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -18,6 +18,10 @@ use bevy::{
 
 fn main() {
     App::new()
+        .insert_resource(WindowDescriptor {
+            present_mode: bevy::window::PresentMode::Immediate,
+            ..default()
+        })
         .add_plugins(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -3,7 +3,8 @@
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
-    prelude::*, window::PresentMode,
+    prelude::*,
+    window::PresentMode,
 };
 
 struct Foxes {

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -16,6 +16,7 @@ fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
             title: "🦊🦊🦊 Many Foxes! 🦊🦊🦊".to_string(),
+            present_mode: bevy::window::PresentMode::Immediate,
             ..default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -3,7 +3,7 @@
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
-    prelude::*,
+    prelude::*, window::PresentMode,
 };
 
 struct Foxes {
@@ -16,7 +16,7 @@ fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
             title: "🦊🦊🦊 Many Foxes! 🦊🦊🦊".to_string(),
-            present_mode: bevy::window::PresentMode::Immediate,
+            present_mode: PresentMode::Immediate,
             ..default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -6,7 +6,8 @@ use bevy::{
     math::{DVec2, DVec3},
     pbr::{ExtractedPointLight, GlobalLightMeta},
     prelude::*,
-    render::{camera::ScalingMode, RenderApp, RenderStage}, window::PresentMode,
+    render::{camera::ScalingMode, RenderApp, RenderStage},
+    window::PresentMode,
 };
 use rand::{thread_rng, Rng};
 

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -6,7 +6,7 @@ use bevy::{
     math::{DVec2, DVec3},
     pbr::{ExtractedPointLight, GlobalLightMeta},
     prelude::*,
-    render::{camera::ScalingMode, RenderApp, RenderStage},
+    render::{camera::ScalingMode, RenderApp, RenderStage}, window::PresentMode,
 };
 use rand::{thread_rng, Rng};
 
@@ -16,7 +16,7 @@ fn main() {
             width: 1024.0,
             height: 768.0,
             title: "many_lights".to_string(),
-            present_mode: bevy::window::PresentMode::Immediate,
+            present_mode: PresentMode::Immediate,
             ..default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -8,7 +8,7 @@ use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     math::Quat,
     prelude::*,
-    render::camera::Camera,
+    render::camera::Camera, window::PresentMode,
 };
 
 use rand::Rng;
@@ -18,7 +18,7 @@ const CAMERA_SPEED: f32 = 1000.0;
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
-            present_mode: bevy::window::PresentMode::Immediate,
+            present_mode: PresentMode::Immediate,
             ..default()
         })
         // Since this is also used as a benchmark, we want it to display performance data.

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -17,6 +17,10 @@ const CAMERA_SPEED: f32 = 1000.0;
 
 fn main() {
     App::new()
+        .insert_resource(WindowDescriptor {
+            present_mode: bevy::window::PresentMode::Immediate,
+            ..default()
+        })
         // Since this is also used as a benchmark, we want it to display performance data.
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_plugin(FrameTimeDiagnosticsPlugin::default())

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -8,7 +8,8 @@ use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     math::Quat,
     prelude::*,
-    render::camera::Camera, window::PresentMode,
+    render::camera::Camera,
+    window::PresentMode,
 };
 
 use rand::Rng;


### PR DESCRIPTION
# Objective

Currently stress tests are vsynced. This is undesirable for a stress test, as you want to run them with uncapped framerates.

## Solution

Ensure all stress tests are using PresentMode::Immediate if they render anything.
