### PR TITLE
[Merged by Bors] - add default direction to DirectionalLight docs

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -92,8 +92,8 @@ impl Default for PointLightShadowMap {
 /// approximation for light sources VERY far away, like the sun or
 /// the moon.
 ///
-/// By default, the light shines along the negative-Z axis and the local
-/// rotation adjusts its direction.
+/// The light shines along the forward direction of the entity's transform. With a default transform
+/// this would be along the negative-Z axis.
 ///
 /// Valid values for `illuminance` are:
 ///

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -93,7 +93,7 @@ impl Default for PointLightShadowMap {
 /// the moon.
 ///
 /// By default, the light shines along the negative-Z axis and the local
-/// transform adjusts its direction.
+/// rotation adjusts its direction.
 ///
 /// Valid values for `illuminance` are:
 ///

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -92,6 +92,9 @@ impl Default for PointLightShadowMap {
 /// approximation for light sources VERY far away, like the sun or
 /// the moon.
 ///
+/// The light's default direction is negative-Z (0, 0, -1) and is
+/// adjusted by the GlobalTransform.
+///
 /// Valid values for `illuminance` are:
 ///
 /// | Illuminance (lux) | Surfaces illuminated by                        |

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -92,8 +92,8 @@ impl Default for PointLightShadowMap {
 /// approximation for light sources VERY far away, like the sun or
 /// the moon.
 ///
-/// The light's default direction is negative-Z (0, 0, -1) and is
-/// adjusted by the GlobalTransform.
+/// By default, the light shines in the negative-Z and the local
+/// transform adjusts its direction.
 ///
 /// Valid values for `illuminance` are:
 ///

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -92,7 +92,7 @@ impl Default for PointLightShadowMap {
 /// approximation for light sources VERY far away, like the sun or
 /// the moon.
 ///
-/// By default, the light shines in the negative-Z and the local
+/// By default, the light shines along the negative-Z axis and the local
 /// transform adjusts its direction.
 ///
 /// Valid values for `illuminance` are:


### PR DESCRIPTION
# Objective

- Adds a default direction to the documentation of DirectionalLight 

## Solution

Suggestion from Q&A answer: 
https://github.com/bevyengine/bevy/discussions/5186#discussioncomment-3073767