### PR TITLE
[Merged by Bors] - Remove dead `SystemLabelMarker` struct

### DIFF
--- a/crates/bevy_ecs/src/schedule/system_descriptor.rs
+++ b/crates/bevy_ecs/src/schedule/system_descriptor.rs
@@ -46,8 +46,6 @@ pub trait IntoSystemDescriptor<Params> {
     fn into_descriptor(self) -> SystemDescriptor;
 }
 
-pub struct SystemLabelMarker;
-
 impl IntoSystemDescriptor<()> for ParallelSystemDescriptor {
     fn into_descriptor(self) -> SystemDescriptor {
         SystemDescriptor::Parallel(self)


### PR DESCRIPTION
This struct had no internal use, docs, or intuitable external use.

It has been removed.