### PR TITLE
[Merged by Bors] - Remove spirv-reflect from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ cargo run --example breakout
 
 Bevy can be built just fine using default configuration on stable Rust. However for really fast iterative compiles, you should enable the "fast compiles" setup by [following the instructions here](http://bevyengine.org/learn/book/getting-started/setup/).
 
+## Libraries Used
+
+Bevy is only possible because of the hard work put into these foundational technologies:
+
+* [wgpu](https://wgpu.rs/): modern / low-level / cross-platform graphics library inspired by Vulkan
+* [glam-rs](https://github.com/bitshifter/glam-rs): a simple and fast 3D math library for games and graphics
+* [winit](https://github.com/rust-windowing/winit): cross-platform window creation and management in Rust
+
 ## [Bevy Cargo Features][cargo_features]
 
 This [list][cargo_features] outlines the different cargo features supported by Bevy. These allow you to customize the Bevy feature set for your use-case.

--- a/README.md
+++ b/README.md
@@ -71,15 +71,6 @@ cargo run --example breakout
 
 Bevy can be built just fine using default configuration on stable Rust. However for really fast iterative compiles, you should enable the "fast compiles" setup by [following the instructions here](http://bevyengine.org/learn/book/getting-started/setup/).
 
-## Libraries Used
-
-Bevy is only possible because of the hard work put into these foundational technologies:
-
-* [wgpu](https://wgpu.rs/): modern / low-level / cross-platform graphics library inspired by Vulkan
-* [glam-rs](https://github.com/bitshifter/glam-rs): a simple and fast 3D math library for games and graphics
-* [winit](https://github.com/rust-windowing/winit): cross-platform window creation and management in Rust
-* [spirv-reflect](https://github.com/gwihlidal/spirv-reflect-rs): Reflection API in rust for SPIR-V shader byte code
-
 ## [Bevy Cargo Features][cargo_features]
 
 This [list][cargo_features] outlines the different cargo features supported by Bevy. These allow you to customize the Bevy feature set for your use-case.


### PR DESCRIPTION
# Objective

- The libraries used section of the README is outdated and is missing a lot of libraries
- The README isn't really the place for that anyway

## Solution

- Remove the section