### PR TITLE
[Merged by Bors] - bevy_reflect: remove `glam` from a test which is active without the glam feature

### DIFF
--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -490,7 +490,6 @@ mod tests {
         #[derive(Reflect, Clone, Debug, PartialEq)]
         struct Bar {
             y: u8,
-            z: ::glam::Mat4,
         }
 
         #[derive(Reflect, Clone, Debug, PartialEq)]
@@ -499,21 +498,15 @@ mod tests {
             s: String,
             b: Bar,
             u: usize,
-            t: (Vec3, String),
+            t: ([f32; 3], String),
         }
 
         let foo = Foo {
             x: 123,
             s: "String".to_string(),
-            b: Bar {
-                y: 255,
-                z: ::glam::Mat4::from_cols_array(&[
-                    0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0,
-                    15.0,
-                ]),
-            },
+            b: Bar { y: 255 },
             u: 1111111111111,
-            t: (Vec3::new(3.0, 2.0, 1.0), "Tuple String".to_string()),
+            t: ([3.0, 2.0, 1.0], "Tuple String".to_string()),
         };
 
         let foo2: Box<dyn Reflect> = Box::new(foo.clone());


### PR DESCRIPTION
# Objective

`glam` is an optional feature in `bevy_reflect` and there is a separate `mod test { #[cfg(feature = "glam")] mod glam { .. }}`.
The `reflect_downcast` test is not in that module and doesn't depend on glam, which breaks `cargo test -p bevy_reflect` without the `glam` feature.

## Solution

- Remove the glam types from the test, they're not relevant to it
