### PR TITLE
[Merged by Bors] - Make the fields of the Material2dKey public

### DIFF
--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -216,8 +216,8 @@ pub struct Material2dPipeline<M: SpecializedMaterial2d> {
 
 #[derive(Eq, PartialEq, Clone, Hash)]
 pub struct Material2dKey<T> {
-    mesh_key: Mesh2dPipelineKey,
-    material_key: T,
+    pub mesh_key: Mesh2dPipelineKey,
+    pub material_key: T,
 }
 
 impl<M: SpecializedMaterial2d> SpecializedMeshPipeline for Material2dPipeline<M> {


### PR DESCRIPTION
# Objective

Make it easier to create pipelines derived from the `Material2dPipeline`. Currently this is made difficult because the fields of `Material2dKey` are private.

## Solution

Make the fields public.