### PR TITLE
[Merged by Bors] - Update shader_material_glsl example to include texture sampling

### DIFF
--- a/assets/shaders/custom_material.frag
+++ b/assets/shaders/custom_material.frag
@@ -7,8 +7,6 @@ layout(set = 1, binding = 0) uniform CustomMaterial {
     vec4 Color;
 };
 
-// Naga GLSL does not support the sampler2D type, but only a texture2D + sampler combination
-// See https://github.com/gfx-rs/naga/issues/1012
 layout(set = 1, binding = 1) uniform texture2D CustomMaterial_texture;
 layout(set = 1, binding = 2) uniform sampler CustomMaterial_sampler;
 

--- a/assets/shaders/custom_material.frag
+++ b/assets/shaders/custom_material.frag
@@ -1,4 +1,5 @@
 #version 450
+layout(location = 0) in vec2 v_Uv;
 
 layout(location = 0) out vec4 o_Target;
 
@@ -6,6 +7,12 @@ layout(set = 1, binding = 0) uniform CustomMaterial {
     vec4 Color;
 };
 
+// Naga GLSL does not support the sampler2D type, but only a texture2D + sampler combination
+// See https://github.com/gfx-rs/naga/issues/1012
+layout(set = 1, binding = 1) uniform texture2D CustomMaterial_texture;
+layout(set = 1, binding = 2) uniform sampler CustomMaterial_sampler;
+
+
 void main() {
-    o_Target = Color;
+    o_Target = Color * texture(sampler2D(CustomMaterial_texture,CustomMaterial_sampler), v_Uv);
 }

--- a/assets/shaders/custom_material.vert
+++ b/assets/shaders/custom_material.vert
@@ -4,6 +4,8 @@ layout(location = 0) in vec3 Vertex_Position;
 layout(location = 1) in vec3 Vertex_Normal;
 layout(location = 2) in vec2 Vertex_Uv;
 
+layout(location = 0) out vec2 v_Uv;
+
 layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 ViewProj;
     mat4 View;
@@ -21,5 +23,6 @@ layout(set = 2, binding = 0) uniform Mesh {
 };
 
 void main() {
+    v_Uv = Vertex_Uv;
     gl_Position = ViewProj * Model * vec4(Vertex_Position, 1.0);
 }

--- a/examples/shader/shader_material_glsl.rs
+++ b/examples/shader/shader_material_glsl.rs
@@ -25,13 +25,16 @@ fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<CustomMaterial>>,
+    asset_server: Res<AssetServer>,
 ) {
     // cube
     commands.spawn().insert_bundle(MaterialMeshBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         material: materials.add(CustomMaterial {
-            color: Color::GREEN,
+            color: Color::BLUE,
+            color_texture: Some(asset_server.load("branding/icon.png")),
+            alpha_mode: AlphaMode::Blend,
         }),
         ..default()
     });
@@ -43,13 +46,21 @@ fn setup(
     });
 }
 
+// This is the struct that will be passed to your shader
 #[derive(AsBindGroup, Clone, TypeUuid)]
 #[uuid = "4ee9c363-1124-4113-890e-199d81b00281"]
 pub struct CustomMaterial {
     #[uniform(0)]
     color: Color,
+    #[texture(1)]
+    #[sampler(2)]
+    color_texture: Option<Handle<Image>>,
+    alpha_mode: AlphaMode,
 }
 
+/// The Material trait is very configurable, but comes with sensible defaults for all methods.
+/// You only need to implement functions for features that need non-default behavior. See the Material api docs for details!
+/// When using the GLSL shading language for your shader, the specialize method must be overriden.
 impl Material for CustomMaterial {
     fn vertex_shader() -> ShaderRef {
         "shaders/custom_material.vert".into()
@@ -57,6 +68,10 @@ impl Material for CustomMaterial {
 
     fn fragment_shader() -> ShaderRef {
         "shaders/custom_material.frag".into()
+    }
+
+    fn alpha_mode(&self) -> AlphaMode {
+        self.alpha_mode
     }
 
     // Bevy assumes by default that vertex shaders use the "vertex" entry point


### PR DESCRIPTION
# Objective

Add texture sampling to the GLSL shader example, as naga does not support the commonly used sampler2d type.
Fixes #5059

## Solution

- Align the shader_material_glsl example behaviour with the shader_material example,  as the later includes texture sampling.
- Update the GLSL shader to do texture sampling the way naga supports it, and document the way naga does not support it.

## Changelog

- The shader_material_glsl example has been updated to demonstrate texture sampling using the GLSL shading language.
