### PR TITLE
[Merged by Bors] - Fix small typo in example name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1435,7 +1435,7 @@ name = "scale_factor_override"
 path = "examples/window/scale_factor_override.rs"
 
 [package.metadata.example.scale_factor_override]
-name = "Scale Factor Iverride"
+name = "Scale Factor Override"
 description = "Illustrates how to customize the default window settings"
 category = "Window"
 wasm = true

--- a/examples/README.md
+++ b/examples/README.md
@@ -317,7 +317,7 @@ Example | Description
 [Clear Color](../examples/window/clear_color.rs) | Creates a solid color window
 [Low Power](../examples/window/low_power.rs) | Demonstrates settings to reduce power use for bevy applications
 [Multiple Windows](../examples/window/multiple_windows.rs) | Demonstrates creating multiple windows, and rendering to them
-[Scale Factor Iverride](../examples/window/scale_factor_override.rs) | Illustrates how to customize the default window settings
+[Scale Factor Override](../examples/window/scale_factor_override.rs) | Illustrates how to customize the default window settings
 [Transparent Window](../examples/window/transparent_window.rs) | Illustrates making the window transparent and hiding the window decoration
 [Window Settings](../examples/window/window_settings.rs) | Demonstrates customizing default window settings
 


### PR DESCRIPTION
**This Commit**
Renames "Scale Factor Iverride" to
"Scale Factor Override".

**Why?**
I imagine the current name is a typo.