### PR TITLE
[Merged by Bors] - Improve Gamepad DPad Button Detection

### DIFF
--- a/crates/bevy_gilrs/src/converter.rs
+++ b/crates/bevy_gilrs/src/converter.rs
@@ -37,8 +37,9 @@ pub fn convert_axis(axis: gilrs::Axis) -> Option<GamepadAxisType> {
         gilrs::Axis::RightStickX => Some(GamepadAxisType::RightStickX),
         gilrs::Axis::RightStickY => Some(GamepadAxisType::RightStickY),
         gilrs::Axis::RightZ => Some(GamepadAxisType::RightZ),
-        gilrs::Axis::DPadX => Some(GamepadAxisType::DPadX),
-        gilrs::Axis::DPadY => Some(GamepadAxisType::DPadY),
-        gilrs::Axis::Unknown => None,
+        // The `axis_dpad_to_button` gilrs filter should filter out all DPadX and DPadY events. If
+        // it doesn't then we probably need an entry added to the following repo and an update to
+        // GilRs to use the updated database: https://github.com/gabomdq/SDL_GameControllerDB
+        gilrs::Axis::Unknown | gilrs::Axis::DPadX | gilrs::Axis::DPadY => None,
     }
 }

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -135,8 +135,6 @@ pub enum GamepadAxisType {
     RightStickX,
     RightStickY,
     RightZ,
-    DPadX,
-    DPadY,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -412,15 +410,13 @@ const ALL_BUTTON_TYPES: [GamepadButtonType; 19] = [
     GamepadButtonType::DPadRight,
 ];
 
-const ALL_AXIS_TYPES: [GamepadAxisType; 8] = [
+const ALL_AXIS_TYPES: [GamepadAxisType; 6] = [
     GamepadAxisType::LeftStickX,
     GamepadAxisType::LeftStickY,
     GamepadAxisType::LeftZ,
     GamepadAxisType::RightStickX,
     GamepadAxisType::RightStickY,
     GamepadAxisType::RightZ,
-    GamepadAxisType::DPadX,
-    GamepadAxisType::DPadY,
 ];
 
 #[cfg(test)]


### PR DESCRIPTION
# Objective

- Enable the `axis_dpad_to_button` gilrs filter to map hats to dpad buttons on supported remotes.
- Fixes https://github.com/Leafwing-Studios/leafwing-input-manager/issues/149
- Might have fixed the confusion related to https://github.com/bevyengine/bevy/issues/3229

## Solution

- Enables the `axis_dpad_to_button` filter in `gilrs` which will use it's remote mapping information to see if there are hats mapped to dpads for that remote model. I don't really understand the logic it uses exactly, but it is usually enabled by default in gilrs and I believe it probably leads to more intuitive mapping compared to the current situation of dpad buttons being mapped to an axis.
- Removes the `GamepadAxisType::DPadX` and `GamepadAxisType::DPadY` enum variants to avoid user confusion. Those variants should never be emitted anyway, for all supported remotes.

---

## Changelog

### Changed

- Removed `GamepadAxisType::DPadX` and `GamepadAxisType::DPadY` in favor of using `GamepadButtonType::DPad[Up/Down/Left/Right]` instead.

## Migration Guide

If your game reads gamepad events or queries the axis state of `GamePadAxisType::DPadX` or `GamePadAxisType::DPadY`, then you must migrate your code to check whether or not the `GamepadButtonType::DPadUp`, `GamepadButtonType::DPadDown`, etc. buttons were pressed instead.