### PR TITLE
[Merged by Bors] - Added multi windows check for bevy_ui `Interaction`.

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -1,4 +1,4 @@
-use crate::{entity::CameraUi, CalculatedClip, Node};
+use crate::{entity::UiCameraConfig, CalculatedClip, Node};
 use bevy_ecs::{
     entity::Entity,
     prelude::Component,
@@ -53,7 +53,7 @@ pub struct State {
 /// The system that sets Interaction for all UI elements based on the mouse cursor activity
 pub fn ui_focus_system(
     mut state: Local<State>,
-    camera: Query<(&Camera, Option<&CameraUi>)>,
+    camera: Query<(&Camera, Option<&UiCameraConfig>)>,
     windows: Res<Windows>,
     mouse_button_input: Res<Input<MouseButton>>,
     touches_input: Res<Touches>,
@@ -90,15 +90,8 @@ pub fn ui_focus_system(
     let mouse_clicked =
         mouse_button_input.just_pressed(MouseButton::Left) || touches_input.any_just_pressed();
 
-    let is_ui_disabled = |camera_ui| {
-        matches!(
-            camera_ui,
-            Some(&CameraUi {
-                is_enabled: false,
-                ..
-            })
-        )
-    };
+    let is_ui_disabled =
+        |camera_ui| matches!(camera_ui, Some(&UiCameraConfig { show_ui: false, .. }));
 
     let cursor_position = camera
         .iter()

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -104,12 +104,13 @@ pub fn ui_focus_system(
             match camera.target {
                 RenderTarget::Window(window_id) => {
                     // Get the cursor position from the currently focused window with camera
-                    if let Some(window) = windows.get(window_id) {
+                    windows.get(window_id).and_then(|window| {
                         if window.is_focused() {
-                            return window.cursor_position();
+                            window.cursor_position()
+                        } else {
+                            None
                         }
-                    }
-                    None
+                    })
                 }
                 _ => None,
             }

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -89,8 +89,9 @@ pub fn ui_focus_system(
         mouse_button_input.just_pressed(MouseButton::Left) || touches_input.any_just_pressed();
 
     let cursor_position = windows
-        .get_primary()
-        .and_then(|window| window.cursor_position())
+        .iter()
+        .filter_map(|window| window.cursor_position())
+        .next()
         .or_else(|| touches_input.first_pressed_position());
 
     let mut moused_over_z_sorted_nodes = node_query


### PR DESCRIPTION
# Objective

- Currently bevy_ui only checks for primary window cursor position to determine `Interaction` behavior.
- Added checks for focused window where cursor position is available.
- Fixes #5224.

## Solution

- Added checks for focused windows in `Interaction` focus system.

## Follow Up

- All windows with camera will be rendering the UI elements right now.
- We will need some way to tell which camera to render which UI.

---