### PR TITLE
[Merged by Bors] - Move the configuration of the WindowPlugin to a resource

### DIFF
--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -24,8 +24,12 @@ pub mod prelude {
 use bevy_app::prelude::*;
 use bevy_ecs::{event::Events, schedule::SystemLabel};
 
-/// A [`Plugin`] that defines an interface for windowing support in Bevy.
-pub struct WindowPlugin {
+/// The configuration information for the [`WindowPlugin`].
+///
+/// It can be added as a [`Resource`](bevy_ecs::system::Resource) before the [`WindowPlugin`]
+/// runs, to configure how it behaves.
+#[derive(Clone)]
+pub struct WindowSettings {
     /// Whether to create a window when added.
     ///
     /// Note that if there are no windows, by default the App will exit,
@@ -49,15 +53,19 @@ pub struct WindowPlugin {
     pub close_when_requested: bool,
 }
 
-impl Default for WindowPlugin {
+impl Default for WindowSettings {
     fn default() -> Self {
-        WindowPlugin {
+        WindowSettings {
             add_primary_window: true,
             exit_on_all_closed: true,
             close_when_requested: true,
         }
     }
 }
+
+/// A [`Plugin`] that defines an interface for windowing support in Bevy.
+#[derive(Default)]
+pub struct WindowPlugin;
 
 impl Plugin for WindowPlugin {
     fn build(&self, app: &mut App) {
@@ -78,11 +86,17 @@ impl Plugin for WindowPlugin {
             .add_event::<WindowMoved>()
             .init_resource::<Windows>();
 
-        if self.add_primary_window {
+        let settings = app
+            .world
+            .get_resource::<WindowSettings>()
+            .cloned()
+            .unwrap_or_default();
+
+        if settings.add_primary_window {
             let window_descriptor = app
                 .world
                 .get_resource::<WindowDescriptor>()
-                .map(|descriptor| (*descriptor).clone())
+                .cloned()
                 .unwrap_or_default();
             let mut create_window_event = app.world.resource_mut::<Events<CreateWindow>>();
             create_window_event.send(CreateWindow {
@@ -91,10 +105,10 @@ impl Plugin for WindowPlugin {
             });
         }
 
-        if self.exit_on_all_closed {
+        if settings.exit_on_all_closed {
             app.add_system(exit_on_all_closed);
         }
-        if self.close_when_requested {
+        if settings.close_when_requested {
             app.add_system(close_when_requested);
         }
     }


### PR DESCRIPTION
# Objective

It is currently hard to configure the `WindowPlugin`, as it is added as part of the `DefaultPlugins`. Ideally this should not be difficult.

## Solution

Remove the configuration from the plugin itself and put it as a `Resource`, similar to how it is done for almost all other plugins.

## Migration Guide

If you are currently configuring the behavior of the `WindowPlugin`, by constructing it manually, then you will need to instead create add the `WindowSettings` as a resource.