### PR TITLE
Make window invisible until RedrawEventsCleared (#5236)

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -554,11 +554,13 @@ impl Window {
             .push(WindowCommand::SetResizable { resizable });
     }
     /// Get whether or not the window is visible.
+    /// NOTE: This function has been added for internal use, overriding it will have no effect.
     #[inline]
     pub fn visible(&self) -> bool {
         self.visible
     }
     /// Set whether or not the window is visible.
+    /// NOTE: This function has been added for internal use, overriding it will have no effect.
     #[inline]
     pub fn set_visible(&mut self, visible: bool) {
         self.visible = visible;
@@ -814,6 +816,7 @@ pub struct WindowDescriptor {
     /// - iOS / Android / Web: Unsupported.
     pub resizable: bool,
     /// Sets whether the window should be visible or not.
+    /// NOTE: This field has been added for internal use, overriding will have no effect.
     pub visible: bool,
     /// Sets whether the window should have borders and bars.
     pub decorations: bool,

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -181,6 +181,7 @@ pub struct Window {
     title: String,
     present_mode: PresentMode,
     resizable: bool,
+    visible: bool,
     decorations: bool,
     cursor_icon: CursorIcon,
     cursor_visible: bool,
@@ -224,6 +225,10 @@ pub enum WindowCommand {
     /// Set whether or not the window is resizable.
     SetResizable {
         resizable: bool,
+    },
+    /// Set whether or not the window is visible.
+    SetVisible {
+        visible: bool,
     },
     /// Set whether or not the window has decorations.
     ///
@@ -307,6 +312,7 @@ impl Window {
             title: window_descriptor.title.clone(),
             present_mode: window_descriptor.present_mode,
             resizable: window_descriptor.resizable,
+            visible: window_descriptor.visible,
             decorations: window_descriptor.decorations,
             cursor_visible: window_descriptor.cursor_visible,
             cursor_locked: window_descriptor.cursor_locked,
@@ -546,6 +552,18 @@ impl Window {
         self.resizable = resizable;
         self.command_queue
             .push(WindowCommand::SetResizable { resizable });
+    }
+    /// Get whether or not the window is visible.
+    #[inline]
+    pub fn visible(&self) -> bool {
+        self.visible
+    }
+    /// Set whether or not the window is visible.
+    #[inline]
+    pub fn set_visible(&mut self, visible: bool) {
+        self.visible = visible;
+        self.command_queue
+            .push(WindowCommand::SetVisible { visible });
     }
     /// Get whether or not decorations are enabled.
     ///
@@ -795,6 +813,8 @@ pub struct WindowDescriptor {
     /// ## Platform-specific
     /// - iOS / Android / Web: Unsupported.
     pub resizable: bool,
+    /// Sets whether the window should be visible or not.
+    pub visible: bool,
     /// Sets whether the window should have borders and bars.
     pub decorations: bool,
     /// Sets whether the cursor is visible when the window has focus.
@@ -841,6 +861,7 @@ impl Default for WindowDescriptor {
             scale_factor_override: None,
             present_mode: PresentMode::Fifo,
             resizable: true,
+            visible: false,
             decorations: true,
             cursor_locked: false,
             cursor_visible: true,

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -618,12 +618,10 @@ pub fn winit_runner_with(mut app: App) {
                 {
                     let mut windows = app.world.resource_mut::<Windows>();
                     let focused = windows.iter().any(|w| w.is_focused());
-                    if !windows.iter().any(|w| w.visible()) {
-                        windows
-                            .iter_mut()
-                            .filter(|w| !w.visible())
-                            .for_each(|w| w.set_visible(true));
-                    }
+                    windows
+                        .iter_mut()
+                        .filter(|w| !w.visible())
+                        .for_each(|w| w.set_visible(true));
                     let winit_config = app.world.resource::<WinitSettings>();
                     let now = Instant::now();
                     use UpdateMode::*;

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -618,11 +618,11 @@ pub fn winit_runner_with(mut app: App) {
                 {
                     let mut windows = app.world.resource_mut::<Windows>();
                     let focused = windows.iter().any(|w| w.is_focused());
-                    if windows.iter().any(|w| w.visible()) == false {
+                    if !windows.iter().any(|w| w.visible()) {
                         windows
                             .iter_mut()
                             .filter(|w| !w.visible())
-                            .for_each(|w| w.set_visible(true))
+                            .for_each(|w| w.set_visible(true));
                     }
                     let winit_config = app.world.resource::<WinitSettings>();
                     let now = Instant::now();

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -119,6 +119,10 @@ fn change_window(
                     let window = winit_windows.get_window(id).unwrap();
                     window.set_resizable(resizable);
                 }
+                bevy_window::WindowCommand::SetVisible { visible } => {
+                    let window = winit_windows.get_window(id).unwrap();
+                    window.set_visible(visible);
+                }
                 bevy_window::WindowCommand::SetDecorations { decorations } => {
                     let window = winit_windows.get_window(id).unwrap();
                     window.set_decorations(decorations);
@@ -612,9 +616,15 @@ pub fn winit_runner_with(mut app: App) {
             }
             Event::RedrawEventsCleared => {
                 {
-                    let winit_config = app.world.resource::<WinitSettings>();
-                    let windows = app.world.resource::<Windows>();
+                    let mut windows = app.world.resource_mut::<Windows>();
                     let focused = windows.iter().any(|w| w.is_focused());
+                    if windows.iter().any(|w| w.visible()) == false {
+                        windows
+                            .iter_mut()
+                            .filter(|w| !w.visible())
+                            .for_each(|w| w.set_visible(true))
+                    }
+                    let winit_config = app.world.resource::<WinitSettings>();
                     let now = Instant::now();
                     use UpdateMode::*;
                     *control_flow = match winit_config.update_mode(focused) {

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -107,6 +107,7 @@ impl WinitWindows {
                 }
             }
             .with_resizable(window_descriptor.resizable)
+            .with_visible(window_descriptor.visible)
             .with_decorations(window_descriptor.decorations)
             .with_transparent(window_descriptor.transparent),
         };


### PR DESCRIPTION
# Objective

Fixes #5236.

## Solution

Makes bevy spawn invisible winduw and exposes `set_visible()` and `visible()` to make it visible once renderer is working to prevent white/black surface from winit being displayed menawhile.

## Changelog

- Add `bevy_window::Window::set_visible()` and `bevy_window::Window::visible()` methods for manipulating window visibility options.