### PR TITLE
Add component to control UI camera position

### DIFF
--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -136,18 +136,28 @@ impl Default for ButtonBundle {
         }
     }
 }
+/// Configuration for cameras related to UI.
+///
+/// When a [`Camera`] doesn't have the [`CameraUiConfig`] component,
+/// it will display the UI by default.
+///
+/// [`Camera`]: bevy_render::camera::Camera
 #[derive(Component, Clone)]
-pub struct CameraUi {
-    pub is_enabled: bool,
+pub struct CameraUiConfig {
+    /// Whether to output UI to this camera view.
+    ///
+    /// When a `Camera` doesn't have the [`CameraUiConfig`] component,
+    /// it will display the UI by default.
+    pub show_ui: bool,
 }
 
-impl Default for CameraUi {
+impl Default for CameraUiConfig {
     fn default() -> Self {
-        Self { is_enabled: true }
+        Self { show_ui: true }
     }
 }
 
-impl ExtractComponent for CameraUi {
+impl ExtractComponent for CameraUiConfig {
     type Query = &'static Self;
     type Filter = With<Camera>;
 

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -12,7 +12,6 @@ pub mod entity;
 pub mod update;
 pub mod widget;
 
-use bevy_core_pipeline::{core_2d::Camera2d, prelude::Camera3d};
 pub use flex::*;
 pub use focus::*;
 pub use geometry::*;
@@ -27,13 +26,11 @@ pub mod prelude {
 
 use crate::Size;
 use bevy_app::prelude::*;
-use bevy_ecs::schedule::{ParallelSystemDescriptorCoercion, SystemLabel, SystemSet};
+use bevy_ecs::schedule::{ParallelSystemDescriptorCoercion, SystemLabel};
 use bevy_input::InputSystem;
 use bevy_transform::TransformSystem;
 use bevy_window::ModifiesWindows;
-use update::{ui_z_system, update_clipping_system, update_ui_camera_data};
-
-use crate::prelude::CameraUiConfig;
+use update::{ui_z_system, update_clipping_system};
 
 /// The basic plugin for Bevy UI
 #[derive(Default)]
@@ -51,7 +48,6 @@ pub enum UiSystem {
 impl Plugin for UiPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<FlexSurface>()
-            .register_type::<CameraUiConfig>()
             .register_type::<AlignContent>()
             .register_type::<AlignItems>()
             .register_type::<AlignSelf>()
@@ -104,12 +100,6 @@ impl Plugin for UiPlugin {
                 ui_z_system
                     .after(UiSystem::Flex)
                     .before(TransformSystem::TransformPropagate),
-            )
-            .add_system_set_to_stage(
-                CoreStage::PostUpdate,
-                SystemSet::new()
-                    .with_system(update_ui_camera_data::<Camera2d>)
-                    .with_system(update_ui_camera_data::<Camera3d>),
             )
             .add_system_to_stage(
                 CoreStage::PostUpdate,

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -33,7 +33,7 @@ use bevy_transform::TransformSystem;
 use bevy_window::ModifiesWindows;
 use update::{ui_z_system, update_clipping_system};
 
-use crate::prelude::CameraUi;
+use crate::prelude::CameraUiConfig;
 
 /// The basic plugin for Bevy UI
 #[derive(Default)]
@@ -50,7 +50,7 @@ pub enum UiSystem {
 
 impl Plugin for UiPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugin(ExtractComponentPlugin::<CameraUi>::default())
+        app.add_plugin(ExtractComponentPlugin::<CameraUiConfig>::default())
             .init_resource::<FlexSurface>()
             .register_type::<AlignContent>()
             .register_type::<AlignItems>()

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -5,7 +5,7 @@ use bevy_core_pipeline::{core_2d::Camera2d, core_3d::Camera3d};
 pub use pipeline::*;
 pub use render_pass::*;
 
-use crate::{prelude::CameraUi, CalculatedClip, Node, UiColor, UiImage};
+use crate::{prelude::CameraUiConfig, CalculatedClip, Node, UiColor, UiImage};
 use bevy_app::prelude::*;
 use bevy_asset::{load_internal_asset, AssetEvent, Assets, Handle, HandleUntyped};
 use bevy_ecs::prelude::*;
@@ -227,14 +227,11 @@ pub struct DefaultCameraView(pub Entity);
 pub fn extract_default_ui_camera_view<T: Component>(
     mut commands: Commands,
     render_world: Res<RenderWorld>,
-    query: Query<(Entity, &Camera, Option<&CameraUi>), With<T>>,
+    query: Query<(Entity, &Camera, Option<&CameraUiConfig>), With<T>>,
 ) {
     for (entity, camera, camera_ui) in query.iter() {
         // ignore cameras with disabled ui
-        if let Some(&CameraUi {
-            is_enabled: false, ..
-        }) = camera_ui
-        {
+        if matches!(camera_ui, Some(&CameraUiConfig { show_ui: false, .. })) {
             continue;
         }
         if let (Some(logical_size), Some(physical_size)) = (

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -1,5 +1,5 @@
 use super::{UiBatch, UiImageBindGroups, UiMeta};
-use crate::{prelude::CameraUi, DefaultCameraView};
+use crate::{prelude::CameraUiConfig, DefaultCameraView};
 use bevy_ecs::{
     prelude::*,
     system::{lifetimeless::*, SystemParamItem},
@@ -20,7 +20,7 @@ pub struct UiPassNode {
         (
             &'static RenderPhase<TransparentUi>,
             &'static ViewTarget,
-            Option<&'static CameraUi>,
+            Option<&'static CameraUiConfig>,
         ),
         With<ExtractedView>,
     >,
@@ -66,7 +66,7 @@ impl Node for UiPassNode {
             return Ok(());
         }
         // Don't render UI for cameras where it is explicitly disabled
-        if let Some(&CameraUi { is_enabled: false }) = camera_ui {
+        if matches!(camera_ui, Some(&CameraUiConfig { show_ui: false })) {
             return Ok(());
         }
 

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -1,22 +1,16 @@
 //! This module contains systems that update the UI when something changes
 
-use crate::{
-    prelude::{CameraUiConfig, UiCameraRenderInfo},
-    CalculatedClip, Overflow, Style, UI_CAMERA_FAR,
-};
+use crate::{CalculatedClip, Overflow, Style};
 
 use super::Node;
 use bevy_ecs::{
     entity::Entity,
-    prelude::{ChangeTrackers, Changed, Component, Or},
     query::{With, Without},
     system::{Commands, Query},
 };
 use bevy_hierarchy::{Children, Parent};
 use bevy_math::Vec2;
-use bevy_render::camera::{
-    Camera, CameraProjection, DepthCalculation, OrthographicProjection, WindowOrigin,
-};
+
 use bevy_sprite::Rect;
 use bevy_transform::components::{GlobalTransform, Transform};
 
@@ -134,64 +128,6 @@ fn update_clipping(
     if let Ok(children) = children_query.get(entity) {
         for child in children.iter().cloned() {
             update_clipping(commands, children_query, node_query, child, children_clip);
-        }
-    }
-}
-
-pub fn update_ui_camera_data<T: Component>(
-    mut commands: Commands,
-    mut query: Query<
-        (
-            Entity,
-            &Camera,
-            Option<&CameraUiConfig>,
-            Option<&mut UiCameraRenderInfo>,
-            Option<ChangeTrackers<CameraUiConfig>>,
-        ),
-        (With<T>, Or<(Changed<Camera>, Changed<CameraUiConfig>)>),
-    >,
-) {
-    for (entity, camera, config, render_info, config_changed) in query.iter_mut() {
-        if matches!(config, Some(&CameraUiConfig { show_ui: false, .. })) {
-            commands.entity(entity).remove::<UiCameraRenderInfo>();
-            continue;
-        }
-        let logical_size = if let Some(logical_size) = camera.logical_viewport_size() {
-            logical_size
-        } else {
-            commands.entity(entity).remove::<UiCameraRenderInfo>();
-            continue;
-        };
-        // skip work if there is no changes.
-        if let (Some(projection), Some(config_changed)) = (&render_info, config_changed) {
-            if projection.old_logical_size == logical_size && !config_changed.is_changed() {
-                continue;
-            }
-        }
-
-        let (view_pos, scale) = if let Some(config) = config {
-            (config.position, config.scale)
-        } else {
-            (Vec2::new(0.0, 0.0), 1.0)
-        };
-        let mut new_projection = OrthographicProjection {
-            far: UI_CAMERA_FAR,
-            scale,
-            window_origin: WindowOrigin::BottomLeft,
-            depth_calculation: DepthCalculation::ZDifference,
-            ..Default::default()
-        };
-        new_projection.update(logical_size.x, logical_size.y);
-        if let Some(mut info) = render_info {
-            info.projection = new_projection;
-            info.position = view_pos;
-            info.old_logical_size = logical_size;
-        } else {
-            commands.entity(entity).insert(UiCameraRenderInfo {
-                projection: new_projection,
-                position: view_pos,
-                old_logical_size: logical_size,
-            });
         }
     }
 }

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -13,12 +13,18 @@ fn main() {
         .insert_resource(WinitSettings::desktop_app())
         .add_startup_system(setup)
         .add_system(mouse_scroll)
+        .add_system(change_ui_camera)
         .run();
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Camera
-    commands.spawn_bundle(Camera2dBundle::default());
+    commands
+        .spawn_bundle(Camera2dBundle::default())
+        .insert(CameraUiConfig {
+            show_ui: true,
+            ..default()
+        });
 
     // root node
     commands
@@ -309,6 +315,29 @@ struct ScrollingList {
     position: f32,
 }
 
+fn change_ui_camera(
+    mouse: Res<Input<MouseButton>>,
+    keyboard: Res<Input<KeyCode>>,
+    mut ui_config: Query<&mut CameraUiConfig>,
+) {
+    for mut config in ui_config.iter_mut() {
+        if mouse.just_pressed(MouseButton::Left) {
+            config.show_ui = !config.show_ui;
+        }
+        if keyboard.pressed(KeyCode::A) {
+            config.position.x -= 1.0;
+        }
+        if keyboard.pressed(KeyCode::D) {
+            config.position.x += 1.0;
+        }
+        if keyboard.pressed(KeyCode::W) {
+            config.scale *= 0.99;
+        }
+        if keyboard.pressed(KeyCode::S) {
+            config.scale *= 1.01;
+        }
+    }
+}
 fn mouse_scroll(
     mut mouse_wheel_events: EventReader<MouseWheel>,
     mut query_list: Query<(&mut ScrollingList, &mut Style, &Children, &Node)>,

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -324,16 +324,16 @@ fn change_ui_camera(
         if mouse.just_pressed(MouseButton::Left) {
             config.show_ui = !config.show_ui;
         }
-        if keyboard.pressed(KeyCode::A) {
+        if keyboard.pressed(KeyCode::Left) {
             config.position.x -= 1.0;
         }
-        if keyboard.pressed(KeyCode::D) {
+        if keyboard.pressed(KeyCode::Right) {
             config.position.x += 1.0;
         }
-        if keyboard.pressed(KeyCode::W) {
+        if keyboard.pressed(KeyCode::Up) {
             config.scale *= 0.99;
         }
-        if keyboard.pressed(KeyCode::S) {
+        if keyboard.pressed(KeyCode::Down) {
             config.scale *= 1.01;
         }
     }


### PR DESCRIPTION
# Objective

Enable user manipulation of UI camera.
* Fixes #5242

## Solution

Extend `CameraUiConfig` to include info about the UI camera position in
the "ui world". This allows fancy effects like moving UI, which was
possible before the migration to camera-driven rendering.

Note that the first commit of this PR (aa9593d5e) is part of PR #5234, only the second one is relevant.

---

## Changelog

- Add `position` and `scale` fields to `CameraUiConfig` to enable manipulating the position of the attached UI camera.

## Migration Guide

- Instead of spawning an individual ui camera with `UiCameraBundle` and manipulating its `OrthographicProjection` and `GlobalTransform`, add a `CameraUiConfig` component to your viewport camera, and use its field to change the ui camera position.