### PR TITLE
User UI camera control

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1427,6 +1427,16 @@ description = "Illustrates various features of Bevy UI"
 category = "UI (User Interface)"
 wasm = true
 
+[[example]]
+name = "ui_camera_movement"
+path = "examples/ui/ui_camera_movement.rs"
+
+[package.metadata.example.ui_camera_movement]
+name = "UI Camera control"
+description = "Illustrates how to move and zoom the UI camera"
+category = "UI (User Interface)"
+wasm = true
+
 # Window
 [[example]]
 name = "clear_color"

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -4,14 +4,10 @@ use crate::{
     widget::{Button, ImageMode},
     CalculatedSize, FocusPolicy, Interaction, Node, Style, UiColor, UiImage,
 };
-use bevy_ecs::{
-    bundle::Bundle,
-    prelude::{Component, With},
-    query::QueryItem,
-};
+use bevy_ecs::{bundle::Bundle, prelude::Component};
 use bevy_render::{
-    camera::Camera, extract_component::ExtractComponent, prelude::ComputedVisibility,
-    view::Visibility,
+    prelude::ComputedVisibility,
+    view::{RenderLayers, Visibility},
 };
 use bevy_text::{Text, TextAlignment, TextSection, TextStyle};
 use bevy_transform::prelude::{GlobalTransform, Transform};
@@ -37,6 +33,8 @@ pub struct NodeBundle {
     pub visibility: Visibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub computed_visibility: ComputedVisibility,
+    /// The UI camera layers this node is visible in.
+    pub render_layers: RenderLayers,
 }
 
 /// A UI node that is an image
@@ -64,6 +62,8 @@ pub struct ImageBundle {
     pub visibility: Visibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub computed_visibility: ComputedVisibility,
+    /// The ui camera layers this image is visible in.
+    pub render_layers: RenderLayers,
 }
 
 /// A UI node that is text
@@ -87,6 +87,8 @@ pub struct TextBundle {
     pub visibility: Visibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub computed_visibility: ComputedVisibility,
+    /// The ui camera layers this text is visible in.
+    pub render_layers: RenderLayers,
 }
 
 impl TextBundle {
@@ -135,12 +137,13 @@ impl Default for TextBundle {
             global_transform: Default::default(),
             visibility: Default::default(),
             computed_visibility: Default::default(),
+            render_layers: Default::default(),
         }
     }
 }
 
 /// A UI node that is a button
-#[derive(Bundle, Clone, Debug)]
+#[derive(Bundle, Clone, Debug, Default)]
 pub struct ButtonBundle {
     /// Describes the size of the node
     pub node: Node,
@@ -164,25 +167,10 @@ pub struct ButtonBundle {
     pub visibility: Visibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub computed_visibility: ComputedVisibility,
+    /// The ui camera layers this button is visible in.
+    pub render_layers: RenderLayers,
 }
 
-impl Default for ButtonBundle {
-    fn default() -> Self {
-        ButtonBundle {
-            button: Button,
-            interaction: Default::default(),
-            focus_policy: Default::default(),
-            node: Default::default(),
-            style: Default::default(),
-            color: Default::default(),
-            image: Default::default(),
-            transform: Default::default(),
-            global_transform: Default::default(),
-            visibility: Default::default(),
-            computed_visibility: Default::default(),
-        }
-    }
-}
 /// Configuration for cameras related to UI.
 ///
 /// When a [`Camera`] doesn't have the [`UiCameraConfig`] component,
@@ -196,19 +184,15 @@ pub struct UiCameraConfig {
     /// When a `Camera` doesn't have the [`UiCameraConfig`] component,
     /// it will display the UI by default.
     pub show_ui: bool,
+    /// The ui camera layers this camera can see.
+    pub ui_render_layers: RenderLayers,
 }
 
 impl Default for UiCameraConfig {
     fn default() -> Self {
-        Self { show_ui: true }
-    }
-}
-
-impl ExtractComponent for UiCameraConfig {
-    type Query = &'static Self;
-    type Filter = With<Camera>;
-
-    fn extract_component(item: QueryItem<Self::Query>) -> Self {
-        item.clone()
+        Self {
+            show_ui: true,
+            ui_render_layers: Default::default(),
+        }
     }
 }

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -177,7 +177,7 @@ pub struct ButtonBundle {
 /// it will display the UI by default.
 ///
 /// [`Camera`]: bevy_render::camera::Camera
-#[derive(Component, Clone)]
+#[derive(Component, Debug, Clone)]
 pub struct UiCameraConfig {
     /// Whether to output UI to this camera view.
     ///

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -5,6 +5,7 @@ use crate::{
     CalculatedSize, FocusPolicy, Interaction, Node, Style, UiColor, UiImage,
 };
 use bevy_ecs::{bundle::Bundle, prelude::Component};
+use bevy_math::Vec2;
 use bevy_render::{
     prelude::ComputedVisibility,
     view::{RenderLayers, Visibility},
@@ -186,6 +187,8 @@ pub struct UiCameraConfig {
     pub show_ui: bool,
     /// The ui camera layers this camera can see.
     pub ui_render_layers: RenderLayers,
+    /// The position of the UI camera in UI space.
+    pub position: Vec2,
 }
 
 impl Default for UiCameraConfig {
@@ -193,6 +196,7 @@ impl Default for UiCameraConfig {
         Self {
             show_ui: true,
             ui_render_layers: Default::default(),
+            position: Vec2::ZERO,
         }
     }
 }

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -7,6 +7,7 @@ use crate::{
 use bevy_ecs::{bundle::Bundle, prelude::Component};
 use bevy_math::Vec2;
 use bevy_render::{
+    camera::{OrthographicProjection, WindowOrigin},
     prelude::ComputedVisibility,
     view::{RenderLayers, Visibility},
 };
@@ -177,7 +178,11 @@ pub struct ButtonBundle {
 /// When a [`Camera`] doesn't have the [`UiCameraConfig`] component,
 /// it will display the UI by default.
 ///
+/// Note that the projection is available as the [`UiCameraProjection`] component,
+/// and is updated in the [`update_ui_camera_projection`] system.
+///
 /// [`Camera`]: bevy_render::camera::Camera
+/// [`update_ui_camera_projection`]: crate::update::update_ui_camera_projection
 #[derive(Component, Debug, Clone)]
 pub struct UiCameraConfig {
     /// Whether to output UI to this camera view.
@@ -189,6 +194,30 @@ pub struct UiCameraConfig {
     pub ui_render_layers: RenderLayers,
     /// The position of the UI camera in UI space.
     pub position: Vec2,
+    /// The scale of this camera's UI.
+    pub scale: f32,
+    /// The window origin of the UI camera's perspective.
+    pub window_origin: WindowOrigin,
+}
+
+/// The projection data for the UI camera.
+///
+/// This is read-only, use [`UiCameraProjection::projection`]
+/// to get the projection of the UI camera attached to this camera.
+///
+/// This component is on a [`Camera`] entity with a set UI camera.
+///
+/// Note that the projection is updated in the [`update_ui_camera_projection`] system.
+///
+/// [`Camera`]: bevy_render::camera::Camera
+/// [`update_ui_camera_projection`]: crate::update::update_ui_camera_projection
+#[derive(Component, Debug)]
+pub struct UiCameraProjection(pub(crate) OrthographicProjection);
+impl UiCameraProjection {
+    /// The projection of the UI camera attached to this camera.
+    pub fn projection(&self) -> &OrthographicProjection {
+        &self.0
+    }
 }
 
 impl Default for UiCameraConfig {
@@ -197,6 +226,8 @@ impl Default for UiCameraConfig {
             show_ui: true,
             ui_render_layers: Default::default(),
             position: Vec2::ZERO,
+            scale: 1.0,
+            window_origin: WindowOrigin::BottomLeft,
         }
     }
 }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -27,9 +27,10 @@ pub mod prelude {
 use bevy_app::prelude::*;
 use bevy_ecs::schedule::{ParallelSystemDescriptorCoercion, SystemLabel};
 use bevy_input::InputSystem;
+use bevy_render::view::VisibilitySystems;
 use bevy_transform::TransformSystem;
 use bevy_window::ModifiesWindows;
-use update::{ui_z_system, update_clipping_system};
+use update::{ui_z_system, update_clipping_system, update_layer_visibility};
 
 /// The basic plugin for Bevy UI
 #[derive(Default)]
@@ -42,6 +43,11 @@ pub enum UiSystem {
     Flex,
     /// After this label, input interactions with UI entities have been updated for this frame
     Focus,
+    /// Update the [`ComputedVisibility`] component of [`Node`] entities to reflect
+    /// their visibility in accordance to UI cameras.
+    ///
+    /// [`ComputedVisibility`]: bevy_render::view::ComputedVisibility
+    LayerVisibility,
 }
 
 impl Plugin for UiPlugin {
@@ -93,6 +99,12 @@ impl Plugin for UiPlugin {
                     .label(UiSystem::Flex)
                     .before(TransformSystem::TransformPropagate)
                     .after(ModifiesWindows),
+            )
+            .add_system_to_stage(
+                CoreStage::PostUpdate,
+                update_layer_visibility
+                    .label(UiSystem::LayerVisibility)
+                    .after(VisibilitySystems::CheckVisibility),
             )
             .add_system_to_stage(
                 CoreStage::PostUpdate,

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -30,7 +30,9 @@ use bevy_input::InputSystem;
 use bevy_render::view::VisibilitySystems;
 use bevy_transform::TransformSystem;
 use bevy_window::ModifiesWindows;
-use update::{ui_z_system, update_clipping_system, update_layer_visibility};
+use update::{
+    ui_z_system, update_clipping_system, update_layer_visibility, update_ui_camera_projection,
+};
 
 /// The basic plugin for Bevy UI
 #[derive(Default)]
@@ -48,6 +50,9 @@ pub enum UiSystem {
     ///
     /// [`ComputedVisibility`]: bevy_render::view::ComputedVisibility
     LayerVisibility,
+    /// Update UI camera projection to fit changes to the viewport logical size
+    /// or configurated UI scale.
+    UiCameraProjection,
 }
 
 impl Plugin for UiPlugin {
@@ -92,6 +97,10 @@ impl Plugin for UiPlugin {
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 widget::image_node_system.before(UiSystem::Flex),
+            )
+            .add_system_to_stage(
+                CoreStage::PostUpdate,
+                update_ui_camera_projection.label(UiSystem::UiCameraProjection),
             )
             .add_system_to_stage(
                 CoreStage::PostUpdate,

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -12,7 +12,6 @@ pub mod entity;
 pub mod update;
 pub mod widget;
 
-use bevy_render::extract_component::ExtractComponentPlugin;
 pub use flex::*;
 pub use focus::*;
 pub use geometry::*;
@@ -32,8 +31,6 @@ use bevy_transform::TransformSystem;
 use bevy_window::ModifiesWindows;
 use update::{ui_z_system, update_clipping_system};
 
-use crate::prelude::UiCameraConfig;
-
 /// The basic plugin for Bevy UI
 #[derive(Default)]
 pub struct UiPlugin;
@@ -49,8 +46,7 @@ pub enum UiSystem {
 
 impl Plugin for UiPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugin(ExtractComponentPlugin::<UiCameraConfig>::default())
-            .init_resource::<FlexSurface>()
+        app.init_resource::<FlexSurface>()
             .register_type::<AlignContent>()
             .register_type::<AlignItems>()
             .register_type::<AlignSelf>()

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -158,6 +158,7 @@ fn get_ui_graph(render_app: &mut App) -> RenderGraph {
     ui_graph
 }
 
+#[derive(Debug)]
 pub struct ExtractedUiNode {
     pub transform: Mat4,
     pub color: Color,
@@ -224,9 +225,19 @@ const UI_CAMERA_FAR: f32 = 1000.0;
 // TODO: Evaluate if we still need this.
 const UI_CAMERA_TRANSFORM_OFFSET: f32 = -0.1;
 
+/// The UI camera used by this Camera's viewport.
+///
+/// This component is inserted into the render world in the
+/// [`extract_default_ui_camera_view`] system.
+///
+/// The component is attached to the "actual" viewport's camera.
+/// The UI camera's `ExtractedView` is attached to the entity in the
+/// `entity` field.
 #[derive(Component, Debug)]
 pub struct UiCamera {
+    /// The entity for the UI camera.
     pub entity: Entity,
+    /// UI nodes layer this camera shows.
     layers: RenderLayers,
 }
 

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -269,8 +269,8 @@ pub fn extract_default_ui_camera_view<T: Component>(
                 .insert(ExtractedView {
                     projection: projection.get_projection_matrix(),
                     transform: GlobalTransform::from_xyz(
-                        0.0,
-                        0.0,
+                        ui_config.position.x,
+                        ui_config.position.y,
                         UI_CAMERA_FAR + UI_CAMERA_TRANSFORM_OFFSET,
                     ),
                     width: physical_size.x,

--- a/examples/README.md
+++ b/examples/README.md
@@ -311,6 +311,7 @@ Example | Description
 [Text Debug](../examples/ui/text_debug.rs) | An example for debugging text layout
 [Transparency UI](../examples/ui/transparency_ui.rs) | Demonstrates transparency for UI
 [UI](../examples/ui/ui.rs) | Illustrates various features of Bevy UI
+[UI Camera control](../examples/ui/ui_camera_movement.rs) | Illustrates how to move and zoom the UI camera
 
 ## Window
 

--- a/examples/ui/ui_camera_movement.rs
+++ b/examples/ui/ui_camera_movement.rs
@@ -1,0 +1,102 @@
+use bevy::{prelude::*, render::camera::WindowOrigin};
+
+/// This example shows how to manipulate the UI camera projection and position.
+/// Controls:
+/// * Arrow keys: move UI camera around,
+/// * Left/Right mouse buttons: zoom in/out
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(setup)
+        .add_system(cam_system)
+        .add_system(button_system)
+        .run();
+}
+
+#[derive(Component)]
+struct IdleColor(UiColor);
+
+// UI Camera data are modifyed through the `UiCameraConfig` component.
+// Note that you must insert one to your screen camera.
+fn cam_system(
+    mut cam_configs: Query<&mut UiCameraConfig>,
+    keyboard: Res<Input<KeyCode>>,
+    mouse: Res<Input<MouseButton>>,
+) {
+    for mut cam_config in &mut cam_configs {
+        let mut offset = match () {
+            () if keyboard.pressed(KeyCode::Left) => -Vec2::X,
+            () if keyboard.pressed(KeyCode::Right) => Vec2::X,
+            () => Vec2::ZERO,
+        };
+        offset += match () {
+            () if keyboard.pressed(KeyCode::Down) => -Vec2::Y,
+            () if keyboard.pressed(KeyCode::Up) => Vec2::Y,
+            () => Vec2::ZERO,
+        };
+        // We only modify the transform when there is a change, so as
+        // to not trigger change detection.
+        if offset != Vec2::ZERO {
+            let scale = cam_config.scale;
+            cam_config.position += offset * scale * 30.0;
+        }
+        let scale_offset = match () {
+            () if mouse.pressed(MouseButton::Left) => 0.9,
+            () if mouse.pressed(MouseButton::Right) => 1.1,
+            () => 0.0,
+        };
+        if scale_offset != 0.0 {
+            cam_config.scale *= scale_offset;
+        }
+    }
+}
+
+fn button_system(
+    mut interaction_query: Query<(&Interaction, &mut UiColor, &IdleColor), Changed<Interaction>>,
+) {
+    for (interaction, mut material, IdleColor(idle_color)) in &mut interaction_query {
+        if let Interaction::Hovered = interaction {
+            *material = Color::WHITE.into();
+        } else {
+            *material = *idle_color;
+        }
+    }
+}
+
+fn setup(mut commands: Commands) {
+    let button_row_count = 35;
+    let as_rainbow = |i: u32| Color::hsl((i as f32 / button_row_count as f32) * 360.0, 0.9, 0.5);
+    commands
+        .spawn_bundle(Camera2dBundle::default())
+        // Insert a UiCameraConfig to customize the UI camera.
+        .insert(UiCameraConfig {
+            window_origin: WindowOrigin::Center,
+            ..default()
+        });
+    for i in 0..button_row_count {
+        for j in 0..button_row_count {
+            let full = (i + j).max(1);
+            let color = as_rainbow((i * j) % full).into();
+            spawn_button(&mut commands, color, button_row_count, i, j);
+        }
+    }
+}
+fn spawn_button(commands: &mut Commands, color: UiColor, max: u32, i: u32, j: u32) {
+    let size = 340.0 / max as f32;
+    commands
+        .spawn_bundle(ButtonBundle {
+            color,
+            style: Style {
+                size: Size::new(Val::Percent(size), Val::Percent(size)),
+                position_type: PositionType::Absolute,
+                position: UiRect {
+                    bottom: Val::Percent((400.0 / max as f32) * i as f32),
+                    left: Val::Percent((400.0 / max as f32) * j as f32),
+                    ..default()
+                },
+                ..default()
+            },
+            ..default()
+        })
+        .insert(IdleColor(color));
+}

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -2,7 +2,7 @@
 
 use bevy::{
     prelude::*,
-    render::camera::RenderTarget,
+    render::{camera::RenderTarget, view::RenderLayers},
     window::{CreateWindow, PresentMode, WindowId},
 };
 
@@ -30,10 +30,17 @@ fn setup(
         ..default()
     });
     // main camera
-    commands.spawn_bundle(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 0.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands
+        .spawn_bundle(Camera3dBundle {
+            transform: Transform::from_xyz(0.0, 0.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        })
+        .insert(UiCameraConfig {
+            // We set the UI cameras of each window to use a different layer,
+            // so that we can display different text per window.
+            ui_render_layers: RenderLayers::layer(1),
+            ..default()
+        });
 
     let window_id = WindowId::new();
 
@@ -50,12 +57,34 @@ fn setup(
     });
 
     // second window camera
-    commands.spawn_bundle(Camera3dBundle {
-        transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
-        camera: Camera {
-            target: RenderTarget::Window(window_id),
+    commands
+        .spawn_bundle(Camera3dBundle {
+            transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+            camera: Camera {
+                target: RenderTarget::Window(window_id),
+                ..default()
+            },
             ..default()
-        },
-        ..default()
+        })
+        .insert(UiCameraConfig {
+            ui_render_layers: RenderLayers::layer(2),
+            ..default()
+        });
+    let text_style = TextStyle {
+        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+        font_size: 100.0,
+        color: Color::WHITE,
+    };
+    commands.spawn_bundle(TextBundle {
+        render_layers: RenderLayers::layer(1),
+        ..TextBundle::from_section("Face", text_style.clone())
+    });
+    commands.spawn_bundle(TextBundle {
+        render_layers: RenderLayers::layer(2),
+        ..TextBundle::from_section("Profile", text_style.clone())
+    });
+    commands.spawn_bundle(TextBundle {
+        render_layers: RenderLayers::all(),
+        ..TextBundle::from_section("view", text_style)
     });
 }


### PR DESCRIPTION
# Objective

Enable user manipulation of UI camera.
* Fixes #5242
* Supersedes #5243
* Depends on (the **two first** commits of this PR) #5414 

## Solution

### Add user control of UI cameras

Add fields to UiCameraConfig to control the UI camera scale and
position.

Fixes #5242. It is again possible to manipulate the ui camera.

An alternative design was considered, where instead of having a
component that controls all of the UI camera settings, the component
would only hold an Entity referencing another camera.

That design was abandoned in favor of the current one because the
viewport is tightly bound to the "actual" camera the UI camera is
attached to. So it would be awkward to maintain independently two
different cameras.

---

## Changelog

- Add `position`, `scale` and `window_origin` fields to `UiCameraConfig` to enable
  manipulating the position of the attached UI camera.
- Add UI Camera control example
- Fix UI focus not working properly with moving cameras

## Migration Guide

- Instead of spawning an individual ui camera with `UiCameraBundle`
  and manipulating its `OrthographicProjection` and `GlobalTransform`,
  add a `UiCameraConfig` component to your viewport camera, and
  use its field to change the ui camera position
- Use the `UiCameraProjection` component to access the UI camera's projection.