### PR TITLE
[Merged by Bors] - Add support for removing attributes from meshes.

### DIFF
--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -119,10 +119,10 @@ impl Mesh {
     /// Removes the data for a vertex attribute
     pub fn remove_attribute(
         &mut self,
-        attribute: MeshVertexAttribute,
+        attribute: impl Into<MeshVertexAttributeId>,
     ) -> Option<VertexAttributeValues> {
         self.attributes
-            .remove(&attribute.id)
+            .remove(&attribute.into())
             .map(|data| data.values)
     }
 

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -116,6 +116,16 @@ impl Mesh {
         );
     }
 
+    /// Removes the data for a vertex attribute
+    pub fn remove_attribute(
+        &mut self,
+        attribute: MeshVertexAttribute,
+    ) -> Option<VertexAttributeValues> {
+        self.attributes
+            .remove(&attribute.id)
+            .map(|data| data.values)
+    }
+
     #[inline]
     pub fn contains_attribute(&self, id: impl Into<MeshVertexAttributeId>) -> bool {
         self.attributes.contains_key(&id.into())


### PR DESCRIPTION
# Objective

Support removing attributes from meshes. For an example use case, meshes created using the bevy::predule::shape types or loaded from external files may have attributes that are not needed for the materials they will be rendered with.

This was extracted from PR #5222.

## Solution

Implement Mesh::remove_attribute().