### PR TITLE
[Merged by Bors] - Make the contributor birbs bounce to the window height!

### DIFF
--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -58,7 +58,7 @@ struct Velocity {
     rotation: f32,
 }
 
-const GRAVITY: f32 = -9.821 * 100.0;
+const GRAVITY: f32 = 9.821 * 100.0;
 const SPRITE_SIZE: f32 = 75.0;
 
 const SATURATION_DESELECTED: f32 = 0.3;
@@ -243,7 +243,7 @@ fn velocity_system(time: Res<Time>, mut velocity_query: Query<&mut Velocity>) {
     let delta = time.delta_seconds();
 
     for mut velocity in &mut velocity_query {
-        velocity.translation += Vec3::new(0.0, GRAVITY * delta, 0.0);
+        velocity.translation.y -= GRAVITY * delta;
     }
 }
 
@@ -256,15 +256,23 @@ fn collision_system(
     windows: Res<Windows>,
     mut query: Query<(&mut Velocity, &mut Transform), With<Contributor>>,
 ) {
-    let mut rng = rand::thread_rng();
-
-    let window = windows.primary();
+    let window = if let Some(window) = windows.get_primary() {
+        window
+    } else {
+        println!("The window was closed. Bye!");
+        return;
+    };
 
     let ceiling = window.height() / 2.;
     let ground = -(window.height() / 2.);
 
     let wall_left = -(window.width() / 2.);
     let wall_right = window.width() / 2.;
+
+    // The maximum height the birbs should try to reach is one birb below the top of the window.
+    let max_bounce_height = window.height() - SPRITE_SIZE * 2.0;
+
+    let mut rng = rand::thread_rng();
 
     for (mut velocity, mut transform) in &mut query {
         let left = transform.translation.x - SPRITE_SIZE / 2.0;
@@ -275,11 +283,16 @@ fn collision_system(
         // clamp the translation to not go out of the bounds
         if bottom < ground {
             transform.translation.y = ground + SPRITE_SIZE / 2.0;
-            // apply an impulse upwards
-            velocity.translation.y = rng.gen_range(700.0..1000.0);
+
+            // How high this birb will bounce.
+            let bounce_height = rng.gen_range((max_bounce_height * 0.4)..max_bounce_height);
+
+            // Apply the velocity that would bounce the birb up to bounce_height.
+            velocity.translation.y = (bounce_height * GRAVITY * 2.).sqrt();
         }
         if top > ceiling {
             transform.translation.y = ceiling - SPRITE_SIZE / 2.0;
+            velocity.translation.y *= -1.0;
         }
         // on side walls flip the horizontal velocity
         if left < wall_left {

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -259,7 +259,6 @@ fn collision_system(
     let window = if let Some(window) = windows.get_primary() {
         window
     } else {
-        println!("The window was closed. Bye!");
         return;
     };
 


### PR DESCRIPTION
Birbs no longer bounce too low, not coming close to their true bouncy potential.
Birbs also no longer bonk head when window is smaller. (Will still bonk head when window is made smaller too fast! pls no)

*cough cough*
Make the height of the birb-bounces dependent on the window size so they always bounce elegantly towards the top of the window.
Also no longer panics when closing the window q:

~~Might put a video here if I figure out how to.~~
<sup> rendering video is hard. birbrate go brr