### PR TITLE
[Merged by Bors] - Change window position types from tuple to vec

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,4 +1,4 @@
-use bevy_math::{DVec2, IVec2, Vec2};
+use bevy_math::{DVec2, IVec2, UVec2, Vec2};
 use bevy_utils::{tracing::warn, Uuid};
 use raw_window_handle::RawWindowHandle;
 
@@ -202,7 +202,7 @@ pub enum WindowCommand {
     /// Set the window's [`WindowMode`].
     SetWindowMode {
         mode: WindowMode,
-        resolution: (u32, u32),
+        resolution: UVec2,
     },
     /// Set the window's title.
     SetTitle {
@@ -214,7 +214,7 @@ pub enum WindowCommand {
     },
     /// Set the window's resolution.
     SetResolution {
-        logical_resolution: (f32, f32),
+        logical_resolution: Vec2,
         scale_factor: f64,
     },
     /// Set the window's [`PresentMode`].
@@ -447,7 +447,7 @@ impl Window {
         self.requested_width = width;
         self.requested_height = height;
         self.command_queue.push(WindowCommand::SetResolution {
-            logical_resolution: (self.requested_width, self.requested_height),
+            logical_resolution: Vec2::new(self.requested_width, self.requested_height),
             scale_factor: self.scale_factor(),
         });
     }
@@ -464,7 +464,7 @@ impl Window {
             scale_factor: self.scale_factor(),
         });
         self.command_queue.push(WindowCommand::SetResolution {
-            logical_resolution: (self.requested_width, self.requested_height),
+            logical_resolution: Vec2::new(self.requested_width, self.requested_height),
             scale_factor: self.scale_factor(),
         });
     }
@@ -668,7 +668,7 @@ impl Window {
         self.mode = mode;
         self.command_queue.push(WindowCommand::SetWindowMode {
             mode,
-            resolution: (self.physical_width, self.physical_height),
+            resolution: UVec2::new(self.physical_width, self.physical_height),
         });
     }
     /// Close the operating system window corresponding to this [`Window`].

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -18,7 +18,7 @@ use bevy_input::{
     mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
     touch::TouchInput,
 };
-use bevy_math::{ivec2, DVec2, Vec2};
+use bevy_math::{ivec2, DVec2, UVec2, Vec2};
 use bevy_utils::{
     tracing::{error, info, trace, warn},
     Instant,
@@ -74,7 +74,11 @@ fn change_window(
             match command {
                 bevy_window::WindowCommand::SetWindowMode {
                     mode,
-                    resolution: (width, height),
+                    resolution:
+                        UVec2 {
+                            x: width,
+                            y: height,
+                        },
                 } => {
                     let window = winit_windows.get_window(id).unwrap();
                     match mode {
@@ -105,7 +109,11 @@ fn change_window(
                     window_dpi_changed_events.send(WindowScaleFactorChanged { id, scale_factor });
                 }
                 bevy_window::WindowCommand::SetResolution {
-                    logical_resolution: (width, height),
+                    logical_resolution:
+                        Vec2 {
+                            x: width,
+                            y: height,
+                        },
                     scale_factor,
                 } => {
                     let window = winit_windows.get_window(id).unwrap();


### PR DESCRIPTION
Resolves #5004. As suggested in the original issue, change tuple types to their corresponding vector type.

## migration guide

Changed the following fields
- `WindowCommand::SetWindowMode.resolution` from `(u32, u32)` to `UVec2`
- `WindowCommand::SetResolution.logical_resolution` from `(f32, f32)` to `Vec2`