### PR TITLE
Support optional far-plane culling

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -4,6 +4,7 @@ use bevy_reflect::Reflect;
 use bevy_render::{
     camera::{
         Camera, CameraProjection, CameraRenderGraph, DepthCalculation, OrthographicProjection,
+        DEFAULT_PROJECTION_FAR,
     },
     extract_component::ExtractComponent,
     primitives::Frustum,
@@ -40,7 +41,7 @@ pub struct Camera2dBundle {
 
 impl Default for Camera2dBundle {
     fn default() -> Self {
-        Self::new_with_far(1000.0)
+        Self::new_with_far(DEFAULT_PROJECTION_FAR)
     }
 }
 
@@ -66,7 +67,8 @@ impl Camera2dBundle {
             &view_projection,
             &transform.translation,
             &transform.back(),
-            projection.far(),
+            // NOTE: Orthographic projections always return `Some` for `far()`
+            projection.far().unwrap(),
         );
         Self {
             camera_render_graph: CameraRenderGraph::new(crate::core_2d::graph::NAME),

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -735,11 +735,9 @@ fn load_node(
                 let mut perspective_projection: PerspectiveProjection = PerspectiveProjection {
                     fov: perspective.yfov(),
                     near: perspective.znear(),
+                    far: perspective.zfar(),
                     ..Default::default()
                 };
-                if let Some(zfar) = perspective.zfar() {
-                    perspective_projection.far = zfar;
-                }
                 if let Some(aspect_ratio) = perspective.aspect_ratio() {
                     perspective_projection.aspect_ratio = aspect_ratio;
                 }

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1434,7 +1434,9 @@ pub fn update_directional_light_frusta(
             &view_projection,
             &transform.translation,
             &transform.back(),
-            directional_light.shadow_projection.far(),
+            // NOTE: Unwrap is safe as this projection is always orthographic and so always has a
+            // far plane
+            directional_light.shadow_projection.far().unwrap(),
         );
     }
 }

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -42,7 +42,7 @@ pub trait CameraProjection {
     fn get_projection_matrix(&self) -> Mat4;
     fn update(&mut self, width: f32, height: f32);
     fn depth_calculation(&self) -> DepthCalculation;
-    fn far(&self) -> f32;
+    fn far(&self) -> Option<f32>;
 }
 
 /// A configurable [`CameraProjection`] that can select its projection type at runtime.
@@ -87,7 +87,7 @@ impl CameraProjection for Projection {
         }
     }
 
-    fn far(&self) -> f32 {
+    fn far(&self) -> Option<f32> {
         match self {
             Projection::Perspective(projection) => projection.far(),
             Projection::Orthographic(projection) => projection.far(),
@@ -101,13 +101,15 @@ impl Default for Projection {
     }
 }
 
+pub const DEFAULT_PROJECTION_FAR: f32 = 1000.0;
+
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct PerspectiveProjection {
     pub fov: f32,
     pub aspect_ratio: f32,
     pub near: f32,
-    pub far: f32,
+    pub far: Option<f32>,
 }
 
 impl CameraProjection for PerspectiveProjection {
@@ -123,7 +125,7 @@ impl CameraProjection for PerspectiveProjection {
         DepthCalculation::Distance
     }
 
-    fn far(&self) -> f32 {
+    fn far(&self) -> Option<f32> {
         self.far
     }
 }
@@ -133,7 +135,7 @@ impl Default for PerspectiveProjection {
         PerspectiveProjection {
             fov: std::f32::consts::PI / 4.0,
             near: 0.1,
-            far: 1000.0,
+            far: Some(DEFAULT_PROJECTION_FAR),
             aspect_ratio: 1.0,
         }
     }
@@ -248,8 +250,8 @@ impl CameraProjection for OrthographicProjection {
         self.depth_calculation
     }
 
-    fn far(&self) -> f32 {
-        self.far
+    fn far(&self) -> Option<f32> {
+        Some(self.far)
     }
 }
 
@@ -261,7 +263,7 @@ impl Default for OrthographicProjection {
             bottom: -1.0,
             top: 1.0,
             near: 0.0,
-            far: 1000.0,
+            far: DEFAULT_PROJECTION_FAR,
             window_origin: WindowOrigin::Center,
             scaling_mode: ScalingMode::WindowSize,
             scale: 1.0,

--- a/examples/tools/scene_viewer.rs
+++ b/examples/tools/scene_viewer.rs
@@ -238,7 +238,7 @@ fn setup_scene_after_load(
 
         info!("Spawning a controllable 3D perspective camera");
         let mut projection = PerspectiveProjection::default();
-        projection.far = projection.far.max(size * 10.0);
+        projection.far = projection.far.map(|far| far.max(size * 10.0));
         commands
             .spawn_bundle(Camera3dBundle {
                 projection: projection.into(),


### PR DESCRIPTION
# Objective

- Support optional far-plane culling for perspective projections
- Fixes #4596 

## Solution

- Make the `PerspectiveProjection` `far` member into an `Option<f32>`
  - If it is set to `None`, do not frustum cull meshes against the far plane
  - If it is set to `Some(f32)`, frustum cull against that value
  - Default to `Some(1000.0)`

---

## Changelog

- Changed: `PerspectiveProjection` `far` became an `Option<f32>` to support optional far-plane frustum culling, with a default of `Some(1000.0)` and so far-plane culling is enabled.

## Migration Guide

In 0.7, this would not do far-plane frustum culling of meshes, only of lights:
```rust
PerspectiveProjection {
    far: 1000.0,
    ..default()
}
```

In 0.8, this will do far-plane frustum culling of meshes and lights (also this is the new default behavior):
```rust
PerspectiveProjection {
    far: Some(1000.0),
    ..default()
}
```

To disable far-plane frustum culling for meshes (still enabled for lights using a value of 1000.0):
```rust
PerspectiveProjection {
    far: None,
    ..default()
}
```

## Open questions

- Should there be separate optional far planes for lighting and meshes?