### PR TITLE
[Merged by Bors] - Fixed docs for `derive(WorldQuery)`.

### DIFF
--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -188,7 +188,11 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
                 #(#(#field_attrs)* #field_visibilities #field_idents: <#field_types as #path::query::WorldQueryGats<'__w>>::Item,)*
                 #(#(#ignored_field_attrs)* #ignored_field_visibilities #ignored_field_idents: #ignored_field_types,)*
             }
+<<<<<<< HEAD
 
+=======
+            
+>>>>>>> be4e9bc8 (Added suggestions by @alice-i-cecile.)
             #[doc(hidden)]
             #[doc = "Automatically generated internal [`WorldQuery`] fetch type for [`"]
             #[doc = stringify!(#struct_name)]

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -180,6 +180,9 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
 
         quote! {
             #derive_macro_call
+            #[doc = "Automatically generated [`WorldQuery`] item type for [`"]
+            #[doc = stringify!(#struct_name)]
+            #[doc = "`], returned when iterating over query results."]
             #[automatically_derived]
             #visibility struct #item_struct_name #user_impl_generics_with_world #user_where_clauses_with_world {
                 #(#(#field_attrs)* #field_visibilities #field_idents: <#field_types as #path::query::WorldQueryGats<'__w>>::Item,)*
@@ -187,6 +190,10 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
             }
 
             #[doc(hidden)]
+            #[doc = "Automatically generated internal [`WorldQuery`] fetch type for [`"]
+            #[doc = stringify!(#struct_name)]
+            #[doc = "`], used to define the world data accessed by this query."]
+            #[automatically_derived]
             #visibility struct #fetch_struct_name #user_impl_generics_with_world #user_where_clauses_with_world {
                 #(#field_idents: <#field_types as #path::query::WorldQueryGats<'__w>>::Fetch,)*
                 #(#ignored_field_idents: #ignored_field_types,)*
@@ -369,6 +376,10 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
         #readonly_impl
 
         #[doc(hidden)]
+        #[doc = "Automatically generated internal [`WorldQuery`] state type for [`"]
+        #[doc = stringify!(#struct_name)]
+        #[doc = "`], used for caching."]
+        #[automatically_derived]
         #visibility struct #state_struct_name #user_impl_generics #user_where_clauses {
             #(#field_idents: <#field_types as #path::query::WorldQuery>::State,)*
             #(#ignored_field_idents: #ignored_field_types,)*

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -338,6 +338,10 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
     let readonly_impl = if fetch_struct_attributes.is_mutable {
         let world_query_impl = impl_fetch(true);
         quote! {
+            #[doc(hidden)]
+            #[doc = "Automatically generated internal [`WorldQuery`] type for [`"]
+            #[doc = stringify!(#struct_name)]
+            #[doc = "`], used for read-only access."]
             #[automatically_derived]
             #visibility struct #read_only_struct_name #user_impl_generics #user_where_clauses {
                 #( #field_idents: #read_only_field_types, )*

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -188,7 +188,7 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
                 #(#(#field_attrs)* #field_visibilities #field_idents: <#field_types as #path::query::WorldQueryGats<'__w>>::Item,)*
                 #(#(#ignored_field_attrs)* #ignored_field_visibilities #ignored_field_idents: #ignored_field_types,)*
             }
-            
+
             #[doc(hidden)]
             #[doc = "Automatically generated internal [`WorldQuery`] fetch type for [`"]
             #[doc = stringify!(#struct_name)]


### PR DESCRIPTION
For `derive(WorldQuery)`, there are three structs generated, `Item`, `Fetch` and `State`. 
These inherit the visibility of the derived structure, thus `#![warn(missing_docs)]` would
warn about missing documentation for these structures.

- [ ] I'd like some advice on what to write here, as I personally don't really understand `Fetch` nor `State`. 
