### PR TITLE
Implement `Debug` for `Gamepads`

### DIFF
--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -15,7 +15,7 @@ impl Gamepad {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 /// Container of unique connected [`Gamepad`]s
 ///
 /// [`Gamepad`]s are registered and deregistered in [`gamepad_connection_system`]


### PR DESCRIPTION
Generally a good idea.

I ran into this because I wanted to store `Gamepads` in a wrapper struct in https://github.com/Leafwing-Studios/leafwing-input-manager/pull/168. 

This PR allows the `Debug` derive used there to continue working. I could workaround this with a custom impl, but a PR upstream seemed like the right fix.