### PR TITLE
Enable loading textures of unlimited size

### DIFF
--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -381,7 +381,10 @@ impl Image {
                 let image_crate_format = format.as_image_crate_format().ok_or_else(|| {
                     TextureError::UnsupportedTextureFormat(format!("{:?}", format))
                 })?;
-                let dyn_img = image::load_from_memory_with_format(buffer, image_crate_format)?;
+                let mut reader = image::io::Reader::new(std::io::Cursor::new(buffer));
+                reader.set_format(image_crate_format);
+                reader.no_limits();
+                let dyn_img = reader.decode()?;
                 Ok(image_to_texture(dyn_img, is_srgb))
             }
         }


### PR DESCRIPTION
# Objective

Fixes #5304 

## Solution

Instead of using a simple utility function for loading, which uses a default allocation limit of 512MB, we use a Reader object which can be configured ad hoc.

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- Allows loading of textures larger than 512MB
