### PR TITLE
[Merged by Bors] - Don't panic when StandardMaterial normal_map hasn't loaded yet

### DIFF
--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -190,19 +190,17 @@ impl AsBindGroupShaderType<StandardMaterialUniform> for StandardMaterial {
         }
         let has_normal_map = self.normal_map_texture.is_some();
         if has_normal_map {
-            match images
-                .get(self.normal_map_texture.as_ref().unwrap())
-                .expect("expect normal map asset to have finished loading already")
-                .texture_format
-            {
-                // All 2-component unorm formats
-                TextureFormat::Rg8Unorm
-                | TextureFormat::Rg16Unorm
-                | TextureFormat::Bc5RgUnorm
-                | TextureFormat::EacRg11Unorm => {
-                    flags |= StandardMaterialFlags::TWO_COMPONENT_NORMAL_MAP;
+            if let Some(texture) = images.get(self.normal_map_texture.as_ref().unwrap()) {
+                match texture.texture_format {
+                    // All 2-component unorm formats
+                    TextureFormat::Rg8Unorm
+                    | TextureFormat::Rg16Unorm
+                    | TextureFormat::Bc5RgUnorm
+                    | TextureFormat::EacRg11Unorm => {
+                        flags |= StandardMaterialFlags::TWO_COMPONENT_NORMAL_MAP;
+                    }
+                    _ => {}
                 }
-                _ => {}
             }
             if self.flip_normal_map_y {
                 flags |= StandardMaterialFlags::FLIP_NORMAL_MAP_Y;

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -192,7 +192,7 @@ impl AsBindGroupShaderType<StandardMaterialUniform> for StandardMaterial {
         if has_normal_map {
             match images
                 .get(self.normal_map_texture.as_ref().unwrap())
-                .unwrap()
+                .expect("expect normal map asset to have finished loading already")
                 .texture_format
             {
                 // All 2-component unorm formats


### PR DESCRIPTION
# Objective

[This unwrap()](https://github.com/bevyengine/bevy/blob/de484c1e4147d01bf34c88a10797b75128a0d98a/crates/bevy_pbr/src/pbr_material.rs#L195) in pbr_material.rs will be hit if a StandardMaterial normal_map image has not finished loading, resulting in an error message that is hard to debug.

## Solution

~~This PR improves the error message including a potential indication of why the unwrap() could have panic'd by using expect() instead of unwrap().~~

This PR removes the panic by only proceeding if the image is found.

---

## Changelog

Don't panic when StandardMaterial normal_map images have not finished loading.
