### PR TITLE
[Merged by Bors] - Added colors to sprite stress test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1232,7 +1232,7 @@ path = "examples/stress_tests/many_animated_sprites.rs"
 
 [package.metadata.example.many_animated_sprites]
 name = "Many Animated Sprites"
-description = "Displays many animated sprites in a grid arragement with slight offsets to their animation timers. Used for performance testing."
+description = "Displays many animated sprites in a grid arrangement with slight offsets to their animation timers. Used for performance testing."
 category = "Stress Tests"
 wasm = true
 
@@ -1272,7 +1272,7 @@ path = "examples/stress_tests/many_sprites.rs"
 
 [package.metadata.example.many_sprites]
 name = "Many Sprites"
-description = "Displays many sprites in a grid arragement! Used for performance testing"
+description = "Displays many sprites in a grid arrangement! Used for performance testing. Use `--colored` to enable color tinted sprites."
 category = "Stress Tests"
 wasm = true
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -281,7 +281,7 @@ Example | Description
 [Many Cubes](../examples/stress_tests/many_cubes.rs) | Simple benchmark to test per-entity draw overhead. Run with the `sphere` argument to test frustum culling
 [Many Foxes](../examples/stress_tests/many_foxes.rs) | Loads an animated fox model and spawns lots of them. Good for testing skinned mesh performance. Takes an unsigned integer argument for the number of foxes to spawn. Defaults to 1000
 [Many Lights](../examples/stress_tests/many_lights.rs) | Simple benchmark to test rendering many point lights. Run with `WGPU_SETTINGS_PRIO=webgl2` to restrict to uniform buffers and max 256 lights
-[Many Sprites](../examples/stress_tests/many_sprites.rs) | Displays many sprites in a grid arrangement! Used for performance testing. Add the `--colored` argument for color tinted sprites
+[Many Sprites](../examples/stress_tests/many_sprites.rs) | Displays many sprites in a grid arrangement! Used for performance testing. Use `--colored` to enable color tinted sprites.
 [Transform Hierarchy](../examples/stress_tests/transform_hierarchy.rs) | Various test cases for hierarchy and transform propagation performance
 
 ## Tools

--- a/examples/README.md
+++ b/examples/README.md
@@ -277,11 +277,11 @@ cargo run --release --example <example name>
 Example | Description
 --- | ---
 [Bevymark](../examples/stress_tests/bevymark.rs) | A heavy sprite rendering workload to benchmark your system with Bevy
-[Many Animated Sprites](../examples/stress_tests/many_animated_sprites.rs) | Displays many animated sprites in a grid arragement with slight offsets to their animation timers. Used for performance testing.
+[Many Animated Sprites](../examples/stress_tests/many_animated_sprites.rs) | Displays many animated sprites in a grid arrangement with slight offsets to their animation timers. Used for performance testing.
 [Many Cubes](../examples/stress_tests/many_cubes.rs) | Simple benchmark to test per-entity draw overhead. Run with the `sphere` argument to test frustum culling
 [Many Foxes](../examples/stress_tests/many_foxes.rs) | Loads an animated fox model and spawns lots of them. Good for testing skinned mesh performance. Takes an unsigned integer argument for the number of foxes to spawn. Defaults to 1000
 [Many Lights](../examples/stress_tests/many_lights.rs) | Simple benchmark to test rendering many point lights. Run with `WGPU_SETTINGS_PRIO=webgl2` to restrict to uniform buffers and max 256 lights
-[Many Sprites](../examples/stress_tests/many_sprites.rs) | Displays many sprites in a grid arragement! Used for performance testing
+[Many Sprites](../examples/stress_tests/many_sprites.rs) | Displays many sprites in a grid arrangement! Used for performance testing. Add the `--colored` argument for color tinted sprites
 [Transform Hierarchy](../examples/stress_tests/transform_hierarchy.rs) | Various test cases for hierarchy and transform propagation performance
 
 ## Tools

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -4,7 +4,8 @@
 //! It sets up many sprites in different sizes and rotations, and at different scales in the world,
 //! and moves the camera over them to see how well frustum culling works.
 //!
-//! Add the `--colored` arg to run with color tinted sprites
+//! Add the `--colored` arg to run with color tinted sprites. This will cause the sprites to be rendered
+//! in multiple batches, reducing performance but useful for testing.
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -3,6 +3,8 @@
 //!
 //! It sets up many sprites in different sizes and rotations, and at different scales in the world,
 //! and moves the camera over them to see how well frustum culling works.
+//!
+//! Add the `--colored` arg to run with color tinted sprites
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
@@ -18,12 +20,17 @@ const CAMERA_SPEED: f32 = 1000.0;
 
 const COLORS: [Color; 3] = [Color::BLUE, Color::WHITE, Color::RED];
 
+struct ColorTint(bool);
+
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
             present_mode: PresentMode::Immediate,
             ..default()
         })
+        .insert_resource(ColorTint(
+            std::env::args().nth(1).unwrap_or_default() == "--colored",
+        ))
         // Since this is also used as a benchmark, we want it to display performance data.
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
@@ -34,7 +41,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, assets: Res<AssetServer>) {
+fn setup(mut commands: Commands, assets: Res<AssetServer>, color_tint: Res<ColorTint>) {
     warn!(include_str!("warning_string.txt"));
 
     let mut rng = rand::thread_rng();
@@ -71,7 +78,11 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
                 },
                 sprite: Sprite {
                     custom_size: Some(tile_size),
-                    color: COLORS[rng.gen_range(0..3)],
+                    color: if color_tint.0 {
+                        COLORS[rng.gen_range(0..3)]
+                    } else {
+                        Color::WHITE
+                    },
                     ..default()
                 },
                 ..default()

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -16,6 +16,8 @@ use rand::Rng;
 
 const CAMERA_SPEED: f32 = 1000.0;
 
+const COLORS: [Color; 3] = [Color::BLUE, Color::WHITE, Color::RED];
+
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
@@ -69,6 +71,7 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
                 },
                 sprite: Sprite {
                     custom_size: Some(tile_size),
+                    color: COLORS[rng.gen_range(0..3)],
                     ..default()
                 },
                 ..default()


### PR DESCRIPTION
# Objective

Allow better performance testing for https://github.com/bevyengine/bevy/pull/5247


## Solution

I added color tints to the `many_sprites` example stress test.