### PR TITLE
add shortcut methods for ui/Interaction enum

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -32,6 +32,21 @@ pub enum Interaction {
     None,
 }
 
+impl Interaction {
+    #[inline]
+    pub fn is_clicked(&self) -> bool {
+        matches!(self, Interaction::Clicked)
+    }
+    #[inline]
+    pub fn is_hovered(&self) -> bool {
+        matches!(self, Interaction::Hovered)
+    }
+    #[inline]
+    pub fn is_none(&self) -> bool {
+        matches!(self, Interaction::None)
+    }
+}
+
 /// Describes whether the node should block interactions with lower nodes
 #[derive(
     Component, Copy, Clone, Default, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize,


### PR DESCRIPTION
# Objective

Make it easiest to read `Interaction`, especially when only one variant is required:

```rust
fn on_btn_clicked(q: Query<&Interaction, With<MyButton>>) {
    for interaction in q.iter() {
        if interaction.is_clicked() {
            /* ... */
        }
    }
}
```

## Solution

Add `is_*` methods for each variant, that returns a boolean.
