### PR TITLE
[Merged by Bors] - remove an unused import in release

### DIFF
--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -1,7 +1,9 @@
 use std::marker::PhantomData;
 
 use bevy_app::{App, Plugin};
-use bevy_ecs::system::{Commands, Local, Res, ResMut, Resource};
+#[cfg(debug_assertions)]
+use bevy_ecs::system::Local;
+use bevy_ecs::system::{Commands, Res, ResMut, Resource};
 pub use bevy_render_macros::ExtractResource;
 
 use crate::{Extract, RenderApp, RenderStage};


### PR DESCRIPTION
# Objective

- There is a warning when building in release:
```
warning: unused import: `Local`
 --> crates/bevy_render/src/extract_resource.rs:4:34
  |
4 | use bevy_ecs::system::{Commands, Local, Res, ResMut, Resource};
  |                                  ^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```
- It's used https://github.com/bevyengine/bevy/blob/814f8d1635587ad26d9e1e6e08e7d63b4355f4d7/crates/bevy_render/src/extract_resource.rs#L45
- Fix it

## Solution

- Gate the import
