### PR TITLE
Parameterize nightly toolchain in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        toolchain: [stable, ${{env.NIGHTLY_TOOLCHAIN}}]
+        toolchain: [stable, ${env.NIGHTLY_TOOLCHAIN}]
         os: [windows-latest, ubuntu-latest, macos-latest]
         exclude:
           - os: macos-latest
@@ -135,7 +135,7 @@ jobs:
   build-wasm:
     strategy:
       matrix:
-        toolchain: [stable, ${{env.NIGHTLY_TOOLCHAIN}}]
+        toolchain: [stable, ${env.NIGHTLY_TOOLCHAIN}]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - ${{env.NIGHTLY_TOOLCHAIN}}
+          - ${env.NIGHTLY_TOOLCHAIN}
         os: [windows-latest, ubuntu-latest, macos-latest]
         exclude:
           - os: macos-latest
@@ -139,7 +139,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - ${{env.NIGHTLY_TOOLCHAIN}}
+          - ${env.NIGHTLY_TOOLCHAIN}
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,16 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # KEEP THESE TWO VALUES IN SYNC
+  # If anyone can find a way to unify these, that would be much better
   NIGHTLY_TOOLCHAIN: nightly-2022-07-13
+  NIGHTLY_AND_STABLE_ARRAY: [stable, nightly-2022-07-13]
 
 jobs:
   build:
     strategy:
       matrix:
-        toolchain: [stable, ${env.NIGHTLY_TOOLCHAIN}]
+        toolchain: ${{env.NIGHTLY_AND_STABLE_ARRAY}}
         os: [windows-latest, ubuntu-latest, macos-latest]
         exclude:
           - os: macos-latest
@@ -135,7 +138,7 @@ jobs:
   build-wasm:
     strategy:
       matrix:
-        toolchain: [stable, ${env.NIGHTLY_TOOLCHAIN}]
+        toolchain: ${{env.NIGHTLY_AND_STABLE_ARRAY}}
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,15 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # KEEP THESE TWO VALUES IN SYNC
-  # If anyone can find a way to unify these, that would be much better
   NIGHTLY_TOOLCHAIN: nightly-2022-07-13
-  NIGHTLY_AND_STABLE_ARRAY: [stable, nightly-2022-07-13]
 
 jobs:
   build:
     strategy:
       matrix:
-        toolchain: ${{env.NIGHTLY_AND_STABLE_ARRAY}}
+        toolchain:
+          - stable
+          - ${{env.NIGHTLY_TOOLCHAIN}}
         os: [windows-latest, ubuntu-latest, macos-latest]
         exclude:
           - os: macos-latest
@@ -138,7 +137,9 @@ jobs:
   build-wasm:
     strategy:
       matrix:
-        toolchain: ${{env.NIGHTLY_AND_STABLE_ARRAY}}
+        toolchain:
+          - stable
+          - ${{env.NIGHTLY_TOOLCHAIN}}
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - '${env.NIGHTLY_TOOLCHAIN}'
+          - ${{ env.NIGHTLY_TOOLCHAIN }}
         os: [windows-latest, ubuntu-latest, macos-latest]
         exclude:
           - os: macos-latest
-            toolchain: ${{env.NIGHTLY_TOOLCHAIN}}
+            toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           - os: windows-latest
-            toolchain: ${{env.NIGHTLY_TOOLCHAIN}}
+            toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -90,7 +90,7 @@ jobs:
           key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.toml') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{env.NIGHTLY_TOOLCHAIN}}
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           components: miri
           override: true
       - name: Install alsa and udev
@@ -139,7 +139,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - '${env.NIGHTLY_TOOLCHAIN}'
+          - ${{ env.NIGHTLY_TOOLCHAIN }}
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     needs: build
@@ -296,7 +296,7 @@ jobs:
           key: ${{ runner.os }}-cargo-check-unused-dependencies-${{ hashFiles('**/Cargo.toml') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{env.NIGHTLY_TOOLCHAIN}}
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           override: true
       - name: Installs cargo-udeps
         run: cargo install --force cargo-udeps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,19 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  NIGHTLY_TOOLCHAIN: nightly-2022-07-13
 
 jobs:
   build:
     strategy:
       matrix:
-        toolchain: [stable, nightly]
+        toolchain: [stable, ${{env.NIGHTLY_TOOLCHAIN}}]
         os: [windows-latest, ubuntu-latest, macos-latest]
         exclude:
           - os: macos-latest
-            toolchain: nightly
+            toolchain: ${{env.NIGHTLY_TOOLCHAIN}}
           - os: windows-latest
-            toolchain: nightly
+            toolchain: ${{env.NIGHTLY_TOOLCHAIN}}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -87,7 +88,7 @@ jobs:
           key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.toml') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{env.NIGHTLY_TOOLCHAIN}}
           components: miri
           override: true
       - name: Install alsa and udev
@@ -134,7 +135,7 @@ jobs:
   build-wasm:
     strategy:
       matrix:
-        toolchain: [stable, nightly]
+        toolchain: [stable, ${{env.NIGHTLY_TOOLCHAIN}}]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     needs: build
@@ -291,7 +292,7 @@ jobs:
           key: ${{ runner.os }}-cargo-check-unused-dependencies-${{ hashFiles('**/Cargo.toml') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{env.NIGHTLY_TOOLCHAIN}}
           override: true
       - name: Installs cargo-udeps
         run: cargo install --force cargo-udeps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - ${env.NIGHTLY_TOOLCHAIN}
+          - '${env.NIGHTLY_TOOLCHAIN}'
         os: [windows-latest, ubuntu-latest, macos-latest]
         exclude:
           - os: macos-latest
@@ -139,7 +139,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - ${env.NIGHTLY_TOOLCHAIN}
+          - '${env.NIGHTLY_TOOLCHAIN}'
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     needs: build

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -11,25 +11,25 @@ fn main() {
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut touch: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // plane
-    commands.spawn_bundle(PbrBundle {
+    touch.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
         material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
         ..default()
     });
     // cube
-    commands.spawn_bundle(PbrBundle {
+    touch.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });
     // light
-    commands.spawn_bundle(PointLightBundle {
+    touch.spawn_bundle(PointLightBundle {
         point_light: PointLight {
             intensity: 1500.0,
             shadows_enabled: true,
@@ -39,7 +39,7 @@ fn setup(
         ..default()
     });
     // camera
-    commands.spawn_bundle(Camera3dBundle {
+    touch.spawn_bundle(Camera3dBundle {
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
     });


### PR DESCRIPTION
# Objective

Rust's nightly builds semi-regularly break us (or our dependencies). This creates churn and angst when we're just trying to get our jobs done.

We do still want nightly builds for a variety of reasons:
* `cargo-udeps` requires nightly and likely always will.
* Helps us catch rust nightly bugs quickly. We're "good citizens" if we regularly report regressions. 
* Lets us prepare for "actual expected breakage" ahead of stable releases so we avoid breaking `main` users.

## Solution

This pr parameterizes the nightly toolchain, making it an easy one-liner to pin our builds to a specific nightly, when required. 