### PR TITLE
[Merged by Bors] - allow unicode license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -22,7 +22,9 @@ allow = [
     "0BSD",
     "BSD-2-Clause",
     "CC0-1.0",
-    "Unicode-DFS-2016",
+]
+exceptions = [
+    { name = "unicode-ident", allow = ["Unicode-DFS-2016"] },
 ]
 default = "deny"
 

--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,7 @@ allow = [
     "0BSD",
     "BSD-2-Clause",
     "CC0-1.0",
+    "Unicode-DFS-2016",
 ]
 default = "deny"
 


### PR DESCRIPTION
# Objective

- Crate `unicode-ident` added the [unicode license](https://github.com/dtolnay/unicode-ident/blob/master/LICENSE-UNICODE). See https://github.com/dtolnay/unicode-ident#license. The only requirement seems to be to include the license in the distribution
- This makes license check fail

## Solution

- The license should be ok for Bevy, add it to the allowed licenses

