### PR TITLE
[Merged by Bors] - Remove redundant `Size` import

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -25,7 +25,6 @@ pub mod prelude {
     pub use crate::{entity::*, geometry::*, ui_node::*, widget::Button, Interaction};
 }
 
-use crate::Size;
 use bevy_app::prelude::*;
 use bevy_ecs::schedule::{ParallelSystemDescriptorCoercion, SystemLabel};
 use bevy_input::InputSystem;


### PR DESCRIPTION
# Objective

- Fixes  #5338 
- Allow the usage of `use bevy::ui::Size` (see migration guide in #4285)

## Solution

- Remove the `use crate::Size` import so that the `pub use geometry::*` import also publicly uses the `Size` struct.