### PR TITLE
[Merged by Bors] - Add associated constant `IDENTITY` to `Transform` and friends.

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -466,7 +466,7 @@ async fn load_gltf<'a, 'b>(
 
         world
             .spawn()
-            .insert_bundle(SpatialBundle::visible_identity())
+            .insert_bundle(SpatialBundle::VISIBLE_IDENTITY)
             .with_children(|parent| {
                 for node in scene.nodes() {
                     let result = load_node(
@@ -1169,7 +1169,7 @@ mod test {
             GltfNode {
                 children: vec![],
                 mesh: None,
-                transform: bevy_transform::prelude::Transform::identity(),
+                transform: bevy_transform::prelude::Transform::IDENTITY,
             }
         }
     }

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1450,7 +1450,7 @@ pub fn update_point_light_frusta(
         Mat4::perspective_infinite_reverse_rh(std::f32::consts::FRAC_PI_2, 1.0, POINT_LIGHT_NEAR_Z);
     let view_rotations = CUBE_MAP_FACES
         .iter()
-        .map(|CubeMapFace { target, up }| Transform::identity().looking_at(*target, *up))
+        .map(|CubeMapFace { target, up }| Transform::IDENTITY.looking_at(*target, *up))
         .collect::<Vec<_>>();
 
     for (entity, transform, point_light, mut cubemap_frusta) in &mut views {

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -781,7 +781,7 @@ pub fn prepare_lights(
         Mat4::perspective_infinite_reverse_rh(std::f32::consts::FRAC_PI_2, 1.0, POINT_LIGHT_NEAR_Z);
     let cube_face_rotations = CUBE_MAP_FACES
         .iter()
-        .map(|CubeMapFace { target, up }| Transform::identity().looking_at(*target, *up))
+        .map(|CubeMapFace { target, up }| Transform::IDENTITY.looking_at(*target, *up))
         .collect::<Vec<_>>();
 
     global_light_meta.entity_to_index.clear();

--- a/crates/bevy_render/src/spatial_bundle.rs
+++ b/crates/bevy_render/src/spatial_bundle.rs
@@ -33,22 +33,25 @@ impl SpatialBundle {
     pub const fn from_transform(transform: Transform) -> Self {
         SpatialBundle {
             transform,
-            // Note: `..Default::default()` cannot be used here, because it isn't const
-            ..Self::visible_identity()
+            ..Self::VISIBLE_IDENTITY
         }
     }
 
-    /// Creates a new identity [`SpatialBundle`], with no translation, rotation, and a scale of 1
-    /// on all axes.
-    #[inline]
-    pub const fn visible_identity() -> Self {
-        SpatialBundle {
-            transform: Transform::identity(),
-            global_transform: GlobalTransform::identity(),
-            visibility: Visibility::visible(),
-            computed: ComputedVisibility::not_visible(),
-        }
-    }
+    /// A visible [`SpatialBundle`], with no translation, rotation, and a scale of 1 on all axes.
+    pub const VISIBLE_IDENTITY: Self = SpatialBundle {
+        visibility: Visibility::VISIBLE,
+        computed: ComputedVisibility::NOT_VISIBLE,
+        transform: Transform::IDENTITY,
+        global_transform: GlobalTransform::IDENTITY,
+    };
+
+    /// An invisible [`SpatialBundle`], with no translation, rotation, and a scale of 1 on all axes.
+    pub const INVISIBLE_IDENTITY: Self = SpatialBundle {
+        visibility: Visibility::INVISIBLE,
+        computed: ComputedVisibility::NOT_VISIBLE,
+        transform: Transform::IDENTITY,
+        global_transform: GlobalTransform::IDENTITY,
+    };
 }
 
 impl From<Transform> for SpatialBundle {

--- a/crates/bevy_render/src/spatial_bundle.rs
+++ b/crates/bevy_render/src/spatial_bundle.rs
@@ -40,7 +40,7 @@ impl SpatialBundle {
     /// A visible [`SpatialBundle`], with no translation, rotation, and a scale of 1 on all axes.
     pub const VISIBLE_IDENTITY: Self = SpatialBundle {
         visibility: Visibility::VISIBLE,
-        computed: ComputedVisibility::NOT_VISIBLE,
+        computed: ComputedVisibility::DEFAULT,
         transform: Transform::IDENTITY,
         global_transform: GlobalTransform::IDENTITY,
     };
@@ -48,9 +48,7 @@ impl SpatialBundle {
     /// An invisible [`SpatialBundle`], with no translation, rotation, and a scale of 1 on all axes.
     pub const INVISIBLE_IDENTITY: Self = SpatialBundle {
         visibility: Visibility::INVISIBLE,
-        computed: ComputedVisibility::NOT_VISIBLE,
-        transform: Transform::IDENTITY,
-        global_transform: GlobalTransform::IDENTITY,
+        ..Self::VISIBLE_IDENTITY
     };
 }
 

--- a/crates/bevy_render/src/spatial_bundle.rs
+++ b/crates/bevy_render/src/spatial_bundle.rs
@@ -40,7 +40,7 @@ impl SpatialBundle {
     /// A visible [`SpatialBundle`], with no translation, rotation, and a scale of 1 on all axes.
     pub const VISIBLE_IDENTITY: Self = SpatialBundle {
         visibility: Visibility::VISIBLE,
-        computed: ComputedVisibility::DEFAULT,
+        computed: ComputedVisibility::INVISIBLE,
         transform: Transform::IDENTITY,
         global_transform: GlobalTransform::IDENTITY,
     };

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -59,13 +59,13 @@ pub struct ComputedVisibility {
 
 impl Default for ComputedVisibility {
     fn default() -> Self {
-        Self::NOT_VISIBLE
+        Self::DEFAULT
     }
 }
 
 impl ComputedVisibility {
-    /// Creates a new [`ComputedVisibility`], set as not visible
-    pub const NOT_VISIBLE: Self = ComputedVisibility {
+    /// A [`ComputedVisibility`], set as invisible.
+    pub const DEFAULT: Self = ComputedVisibility {
         is_visible_in_hierarchy: false,
         is_visible_in_view: false,
     };

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -37,15 +37,16 @@ pub struct Visibility {
 
 impl Default for Visibility {
     fn default() -> Self {
-        Self::visible()
+        Visibility::VISIBLE
     }
 }
 
 impl Visibility {
-    /// Creates a new [`Visibility`], set as visible
-    pub const fn visible() -> Self {
-        Self { is_visible: true }
-    }
+    /// A [`Visibility`], set as visible.
+    pub const VISIBLE: Self = Visibility { is_visible: true };
+
+    /// A [`Visibility`], set as invisible.
+    pub const INVISIBLE: Self = Visibility { is_visible: false };
 }
 
 /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
@@ -58,18 +59,16 @@ pub struct ComputedVisibility {
 
 impl Default for ComputedVisibility {
     fn default() -> Self {
-        Self::not_visible()
+        Self::NOT_VISIBLE
     }
 }
 
 impl ComputedVisibility {
     /// Creates a new [`ComputedVisibility`], set as not visible
-    pub const fn not_visible() -> Self {
-        Self {
-            is_visible_in_hierarchy: false,
-            is_visible_in_view: false,
-        }
-    }
+    pub const NOT_VISIBLE: Self = ComputedVisibility {
+        is_visible_in_hierarchy: false,
+        is_visible_in_view: false,
+    };
 
     /// Whether this entity is visible to something this frame. This is true if and only if [`Self::is_visible_in_hierarchy`] and [`Self::is_visible_in_view`]
     /// are true. This is the canonical method to call to determine if an entity should be drawn.

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -59,13 +59,13 @@ pub struct ComputedVisibility {
 
 impl Default for ComputedVisibility {
     fn default() -> Self {
-        Self::DEFAULT
+        Self::INVISIBLE
     }
 }
 
 impl ComputedVisibility {
     /// A [`ComputedVisibility`], set as invisible.
-    pub const DEFAULT: Self = ComputedVisibility {
+    pub const INVISIBLE: Self = ComputedVisibility {
         is_visible_in_hierarchy: false,
         is_visible_in_view: false,
     };

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -46,6 +46,9 @@ macro_rules! impl_local_axis {
 }
 
 impl GlobalTransform {
+    /// An identity [`GlobalTransform`] that maps all points in space to themselves.
+    pub const IDENTITY: Self = Self(Affine3A::IDENTITY);
+
     #[doc(hidden)]
     #[inline]
     pub fn from_xyz(x: f32, y: f32, z: f32) -> Self {
@@ -107,8 +110,9 @@ impl GlobalTransform {
 
     /// Creates a new identity [`GlobalTransform`], that maps all points in space to themselves.
     #[inline]
+    #[deprecated = "Use `GlobalTransform::IDENTITY` instead."]
     pub const fn identity() -> Self {
-        Self(Affine3A::IDENTITY)
+        GlobalTransform::IDENTITY
     }
 
     impl_local_axis!(right, left, X);
@@ -154,7 +158,7 @@ impl GlobalTransform {
 
 impl Default for GlobalTransform {
     fn default() -> Self {
-        Self::identity()
+        Self::IDENTITY
     }
 }
 

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -108,13 +108,6 @@ impl GlobalTransform {
         self.0.to_scale_rotation_translation()
     }
 
-    /// Creates a new identity [`GlobalTransform`], that maps all points in space to themselves.
-    #[inline]
-    #[deprecated = "Use `GlobalTransform::IDENTITY` instead."]
-    pub const fn identity() -> Self {
-        GlobalTransform::IDENTITY
-    }
-
     impl_local_axis!(right, left, X);
     impl_local_axis!(up, down, Y);
     impl_local_axis!(back, forward, Z);

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -38,6 +38,13 @@ pub struct Transform {
 }
 
 impl Transform {
+    /// An identity [`Transform`] with no translation, rotation, and a scale of 1 on all axes.
+    pub const IDENTITY: Self = Transform {
+        translation: Vec3::ZERO,
+        rotation: Quat::IDENTITY,
+        scale: Vec3::ONE,
+    };
+
     /// Creates a new [`Transform`] at the position `(x, y, z)`. In 2d, the `z` component
     /// is used for z-ordering elements: higher `z`-value will be in front of lower
     /// `z`-value.
@@ -49,12 +56,9 @@ impl Transform {
     /// Creates a new identity [`Transform`], with no translation, rotation, and a scale of 1 on
     /// all axes.
     #[inline]
+    #[deprecated = "Use `Transform::IDENTITY` instead."]
     pub const fn identity() -> Self {
-        Transform {
-            translation: Vec3::ZERO,
-            rotation: Quat::IDENTITY,
-            scale: Vec3::ONE,
-        }
+        Transform::IDENTITY
     }
 
     /// Extracts the translation, rotation, and scale from `matrix`. It must be a 3d affine
@@ -76,7 +80,7 @@ impl Transform {
     pub const fn from_translation(translation: Vec3) -> Self {
         Transform {
             translation,
-            ..Self::identity()
+            ..Self::IDENTITY
         }
     }
 
@@ -86,7 +90,7 @@ impl Transform {
     pub const fn from_rotation(rotation: Quat) -> Self {
         Transform {
             rotation,
-            ..Self::identity()
+            ..Self::IDENTITY
         }
     }
 
@@ -96,7 +100,7 @@ impl Transform {
     pub const fn from_scale(scale: Vec3) -> Self {
         Transform {
             scale,
-            ..Self::identity()
+            ..Self::IDENTITY
         }
     }
 
@@ -335,7 +339,7 @@ impl Transform {
 
 impl Default for Transform {
     fn default() -> Self {
-        Self::identity()
+        Self::IDENTITY
     }
 }
 

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -53,14 +53,6 @@ impl Transform {
         Self::from_translation(Vec3::new(x, y, z))
     }
 
-    /// Creates a new identity [`Transform`], with no translation, rotation, and a scale of 1 on
-    /// all axes.
-    #[inline]
-    #[deprecated = "Use `Transform::IDENTITY` instead."]
-    pub const fn identity() -> Self {
-        Transform::IDENTITY
-    }
-
     /// Extracts the translation, rotation, and scale from `matrix`. It must be a 3d affine
     /// transformation matrix.
     #[inline]

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -47,7 +47,7 @@ pub struct TransformBundle {
 
 impl TransformBundle {
     /// An identity [`TransformBundle`] with no translation, rotation, and a scale of 1 on all axes.
-    pub const IDENTITY: Self = Self {
+    pub const IDENTITY: Self = TransformBundle {
         local: Transform::IDENTITY,
         global: GlobalTransform::IDENTITY,
     };
@@ -62,14 +62,6 @@ impl TransformBundle {
             local: transform,
             ..Self::IDENTITY
         }
-    }
-
-    /// Creates a new identity [`TransformBundle`], with no translation, rotation, and a scale of 1
-    /// on all axes.
-    #[inline]
-    #[deprecated = "Use `TransformBundle::IDENTITY` instead."]
-    pub const fn identity() -> Self {
-        TransformBundle::IDENTITY
     }
 }
 

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -46,6 +46,12 @@ pub struct TransformBundle {
 }
 
 impl TransformBundle {
+    /// An identity [`TransformBundle`] with no translation, rotation, and a scale of 1 on all axes.
+    pub const IDENTITY: Self = Self {
+        local: Transform::IDENTITY,
+        global: GlobalTransform::IDENTITY,
+    };
+
     /// Creates a new [`TransformBundle`] from a [`Transform`].
     ///
     /// This initializes [`GlobalTransform`] as identity, to be updated later by the
@@ -54,19 +60,16 @@ impl TransformBundle {
     pub const fn from_transform(transform: Transform) -> Self {
         TransformBundle {
             local: transform,
-            // Note: `..Default::default()` cannot be used here, because it isn't const
-            ..Self::identity()
+            ..Self::IDENTITY
         }
     }
 
     /// Creates a new identity [`TransformBundle`], with no translation, rotation, and a scale of 1
     /// on all axes.
     #[inline]
+    #[deprecated = "Use `TransformBundle::IDENTITY` instead."]
     pub const fn identity() -> Self {
-        TransformBundle {
-            local: Transform::identity(),
-            global: GlobalTransform::identity(),
-        }
+        TransformBundle::IDENTITY
     }
 }
 

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -297,14 +297,12 @@ mod test {
             .world
             .spawn()
             .insert(Transform::from_translation(translation))
-            .insert(GlobalTransform::default())
+            .insert(GlobalTransform::IDENTITY)
             .with_children(|builder| {
                 child = builder
-                    .spawn_bundle((Transform::identity(), GlobalTransform::default()))
+                    .spawn_bundle(TransformBundle::IDENTITY)
                     .with_children(|builder| {
-                        grandchild = builder
-                            .spawn_bundle((Transform::identity(), GlobalTransform::default()))
-                            .id();
+                        grandchild = builder.spawn_bundle(TransformBundle::IDENTITY).id();
                     })
                     .id();
             })
@@ -338,11 +336,11 @@ mod test {
             let mut grandchild = Entity::from_raw(0);
             let child = world
                 .spawn()
-                .insert_bundle((Transform::identity(), GlobalTransform::default()))
+                .insert_bundle(TransformBundle::IDENTITY)
                 .with_children(|builder| {
                     grandchild = builder
                         .spawn()
-                        .insert_bundle((Transform::identity(), GlobalTransform::default()))
+                        .insert_bundle(TransformBundle::IDENTITY)
                         .id();
                 })
                 .id();
@@ -357,7 +355,7 @@ mod test {
 
         app.world
             .spawn()
-            .insert_bundle((Transform::default(), GlobalTransform::default()))
+            .insert_bundle(TransformBundle::IDENTITY)
             .push_children(&[child]);
         std::mem::swap(
             &mut *app.world.get_mut::<Parent>(child).unwrap(),

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -150,7 +150,7 @@ mod tests {
     struct Label(&'static str);
 
     fn node_with_transform(name: &'static str) -> (Label, Node, Transform) {
-        (Label(name), Node::default(), Transform::identity())
+        (Label(name), Node::default(), Transform::IDENTITY)
     }
 
     fn node_without_transform(name: &'static str) -> (Label, Node) {

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -125,7 +125,7 @@ fn setup(
         .insert_bundle((planet, player))
         .with_children(|p| {
             // This entity is just used for animation, but doesn't display anything
-            p.spawn_bundle(SpatialBundle::default())
+            p.spawn_bundle(SpatialBundle::VISIBLE_IDENTITY)
                 // Add the Name component
                 .insert(orbit_controller)
                 .with_children(|p| {

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -123,14 +123,14 @@ fn setup(
         let joint_0 = commands
             .spawn_bundle((
                 Transform::from_xyz(i as f32 * 1.5, 0.0, 0.0),
-                GlobalTransform::identity(),
+                GlobalTransform::IDENTITY,
             ))
             .id();
         let joint_1 = commands
             .spawn_bundle((
                 AnimatedJoint,
-                Transform::identity(),
-                GlobalTransform::identity(),
+                Transform::IDENTITY,
+                GlobalTransform::IDENTITY,
             ))
             .id();
 

--- a/examples/ecs/component_change_detection.rs
+++ b/examples/ecs/component_change_detection.rs
@@ -18,7 +18,7 @@ struct MyComponent(f64);
 
 fn setup(mut commands: Commands) {
     commands.spawn().insert(MyComponent(0.));
-    commands.spawn().insert(Transform::identity());
+    commands.spawn().insert(Transform::IDENTITY);
 }
 
 fn change_component(time: Res<Time>, mut query: Query<(Entity, &mut MyComponent)>) {

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -84,7 +84,7 @@ fn save_scene_system(world: &mut World) {
     scene_world.spawn().insert_bundle((
         component_b,
         ComponentA { x: 1.0, y: 2.0 },
-        Transform::identity(),
+        Transform::IDENTITY,
     ));
     scene_world
         .spawn()


### PR DESCRIPTION
# Objective
Since `identity` is a const fn that takes no arguments it seems logical to make it an associated constant.
This is also more in line with types from glam (eg. `Quat::IDENTITY`).

## Migration Guide

The method `identity()` on `Transform`, `GlobalTransform` and `TransformBundle` has been deprecated.
Use the associated constant `IDENTITY` instead.