### PR TITLE
[Merged by Bors] - Optional BEVY_ASSET_ROOT to find assets directory

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -284,7 +284,7 @@ impl AssetServer {
     /// to look for loaders of `bar.baz` and `baz` assets.
     ///
     /// By default the `ROOT` is the directory of the Application, but this can be overridden by
-    /// setting the `"CARGO_MANIFEST_DIR"` environment variable
+    /// setting the `"BEVY_ASSET_ROOT"` or `"CARGO_MANIFEST_DIR"` environment variable
     /// (see <https://doc.rust-lang.org/cargo/reference/environment-variables.html>)
     /// to another directory. When the application  is run through Cargo, then
     /// `"CARGO_MANIFEST_DIR"` is automatically set to the root folder of your crate (workspace).

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -65,6 +65,8 @@ impl FileAssetIo {
     pub fn get_base_path() -> PathBuf {
         if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
             PathBuf::from(manifest_dir)
+        } else if let Ok(env_bevy_asset_root) = env::var("BEVY_ASSET_ROOT") {
+            PathBuf::from(env_bevy_asset_root)
         } else {
             env::current_exe()
                 .map(|path| {

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -60,13 +60,15 @@ impl FileAssetIo {
     /// Returns the base path of the assets directory, which is normally the executable's parent
     /// directory.
     ///
-    /// If the `CARGO_MANIFEST_DIR` environment variable is set, then its value will be used
+    /// If a `BEVY_ASSET_ROOT` environment variable is set, then its value will be used.
+    ///
+    /// Else if the `CARGO_MANIFEST_DIR` environment variable is set, then its value will be used
     /// instead. It's set by cargo when running with `cargo run`.
     pub fn get_base_path() -> PathBuf {
-        if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
-            PathBuf::from(manifest_dir)
-        } else if let Ok(env_bevy_asset_root) = env::var("BEVY_ASSET_ROOT") {
+        if let Ok(env_bevy_asset_root) = env::var("BEVY_ASSET_ROOT") {
             PathBuf::from(env_bevy_asset_root)
+        } else if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
+            PathBuf::from(manifest_dir)
         } else {
             env::current_exe()
                 .map(|path| {


### PR DESCRIPTION
# Objective

Fixes #5345

## Changelog

- Support optional env variable `BEVY_ASSET_ROOT` to explicitly specify root assets directory.
