### PR TITLE
[Merged by Bors] - Fix line material shader

### DIFF
--- a/assets/shaders/line_material.wgsl
+++ b/assets/shaders/line_material.wgsl
@@ -1,11 +1,13 @@
 struct LineMaterial {
-    color: vec4<f32>;
+    color: vec4<f32>,
 };
 
-[[group(1), binding(0)]]
+@group(1) @binding(0)
 var<uniform> material: LineMaterial;
 
-[[stage(fragment)]]
-fn fragment() -> [[location(0)]] vec4<f32> {
+@fragment
+fn fragment(
+    #import bevy_pbr::mesh_vertex_output
+) -> @location(0) vec4<f32> {
     return material.color;
 }


### PR DESCRIPTION
# Objective

- The line shader missed the wgpu 0.13 update (#5168) and does not work in it's current state

## Solution

- update the shader