### PR TITLE
[Merged by Bors] - Add helpers to send `Events` from `World`

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1156,7 +1156,7 @@ impl World {
         result
     }
 
-    /// "Sends" an `event`.
+    /// "Sends" an [event](crate::event).
     #[inline]
     pub fn event_send<E: crate::event::Event>(&mut self, event: E) {
         self.resource_mut::<crate::event::Events<E>>().send(event);

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1156,17 +1156,22 @@ impl World {
         result
     }
 
-    /// "Sends" an [event](crate::event).
+    /// Sends an [Event](crate::event::Event).
     #[inline]
-    pub fn event_send<E: crate::event::Event>(&mut self, event: E) {
-        self.resource_mut::<crate::event::Events<E>>().send(event);
+    pub fn send_event<E: crate::event::Event>(&mut self, event: E) {
+        match self.get_resource_mut::<crate::event::Events<E>>() {
+            Some(mut events) => events.send(event),
+            None => bevy_utils::tracing::error!(
+                    "Unable to send event `{}`\n\tEvent must be added to the app with `add_event()`\n\thttps://docs.rs/bevy/*/bevy/app/struct.App.html#method.add_event ",
+                    std::any::type_name::<E>()
+                ),
+        }
     }
 
-    /// Sends the default value of the [event](crate::event).
+    /// Sends the default value of the [Event](crate::event::Event) of type `E`.
     #[inline]
-    pub fn event_send_default<E: crate::event::Event + Default>(&mut self) {
-        self.resource_mut::<crate::event::Events<E>>()
-            .send_default();
+    pub fn send_default_event<E: crate::event::Event + Default>(&mut self) {
+        self.send_event(E::default());
     }
 
     /// # Safety

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1156,7 +1156,7 @@ impl World {
         result
     }
 
-    /// Sends an [Event](crate::event::Event).
+    /// Sends an [`Event`](crate::event::Event).
     #[inline]
     pub fn send_event<E: crate::event::Event>(&mut self, event: E) {
         match self.get_resource_mut::<crate::event::Events<E>>() {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1156,6 +1156,18 @@ impl World {
         result
     }
 
+    /// "Sends" an `event` by writing it to the current event buffer. [`EventReader`]s can then read
+    /// the event.
+    pub fn event_send<E: crate::event::Event>(&mut self, event: E) {
+        self.resource_mut::<crate::event::Events<E>>().send(event);
+    }
+
+    /// Sends the default value of the event. Useful when the event is an empty struct.
+    pub fn event_send_default<E: crate::event::Event + Default>(&mut self) {
+        self.resource_mut::<crate::event::Events<E>>()
+            .send_default();
+    }
+
     /// # Safety
     /// `component_id` must be assigned to a component of type `R`
     #[inline]

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1162,7 +1162,7 @@ impl World {
         self.resource_mut::<crate::event::Events<E>>().send(event);
     }
 
-    /// Sends the default value of the event.
+    /// Sends the default value of the [event](crate::event).
     #[inline]
     pub fn event_send_default<E: crate::event::Event + Default>(&mut self) {
         self.resource_mut::<crate::event::Events<E>>()

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1168,7 +1168,7 @@ impl World {
         }
     }
 
-    /// Sends the default value of the [Event](crate::event::Event) of type `E`.
+    /// Sends the default value of the [`Event`](crate::event::Event) of type `E`.
     #[inline]
     pub fn send_default_event<E: crate::event::Event + Default>(&mut self) {
         self.send_event(E::default());

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1159,18 +1159,18 @@ impl World {
     /// Sends an [`Event`](crate::event::Event).
     #[inline]
     pub fn send_event<E: crate::event::Event>(&mut self, event: E) {
-        self.send_batch(std::iter::once(event));
+        self.send_event_batch(std::iter::once(event));
     }
 
     /// Sends the default value of the [`Event`](crate::event::Event) of type `E`.
     #[inline]
     pub fn send_default_event<E: crate::event::Event + Default>(&mut self) {
-        self.send_batch(std::iter::once(E::default()));
+        self.send_event_batch(std::iter::once(E::default()));
     }
 
     /// Sends a batch of [`Event`](crate::event::Event)s from an iterator.
     #[inline]
-    pub fn send_batch<E: crate::event::Event>(&mut self, events: impl Iterator<Item = E>) {
+    pub fn send_event_batch<E: crate::event::Event>(&mut self, events: impl Iterator<Item = E>) {
         match self.get_resource_mut::<crate::event::Events<E>>() {
             Some(mut events_resource) => events_resource.extend(events),
             None => bevy_utils::tracing::error!(

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1156,13 +1156,14 @@ impl World {
         result
     }
 
-    /// "Sends" an `event` by writing it to the current event buffer. [`EventReader`]s can then read
-    /// the event.
+    /// "Sends" an `event`.
+    #[inline]
     pub fn event_send<E: crate::event::Event>(&mut self, event: E) {
         self.resource_mut::<crate::event::Events<E>>().send(event);
     }
 
-    /// Sends the default value of the event. Useful when the event is an empty struct.
+    /// Sends the default value of the event.
+    #[inline]
     pub fn event_send_default<E: crate::event::Event + Default>(&mut self) {
         self.resource_mut::<crate::event::Events<E>>()
             .send_default();


### PR DESCRIPTION
# Objective

- With access to `World`, it's not obvious how to send an event.
- This is especially useful if you are writing a `Command` that needs to send an `Event`.
- `Events` are a first-class construct in bevy, even though they are just `Resources` under the hood. Their methods should be discoverable.

## Solution

- Provide a simple helpers to send events through `Res<Events<T>>`.
---

## Changelog

> `send_event`, `send_default_event`, and `send_event_batch` methods added to `World`.
