### PR TITLE
Granular event privacy

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1058,5 +1058,5 @@ fn run_once(mut app: App) {
 /// You can also use this event to detect that an exit was requested. In order to receive it, systems
 /// subscribing to this event should run after it was emitted and before the schedule of the same
 /// frame is over.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Event)]
 pub struct AppExit;

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use bevy_app::App;
 use bevy_ecs::{
-    event::{EventWriter, Events},
+    event::{Event, EventWriter, Events},
     system::ResMut,
     world::FromWorld,
 };
@@ -16,6 +16,7 @@ use std::fmt::Debug;
 ///
 /// Events sent via the [`Assets`] struct will always be sent with a _Weak_ handle, because the
 /// asset may not exist by the time the event is handled.
+#[derive(Event)]
 pub enum AssetEvent<T: Asset> {
     #[allow(missing_docs)]
     Created { handle: Handle<T> },

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -287,6 +287,7 @@ Events offer a communication channel between one or more systems. Events can be 
 ```rust
 use bevy_ecs::prelude::*;
 
+#[derive(Event)]
 struct MyEvent {
     message: String,
 }

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -35,6 +35,7 @@ fn main() {
 }
 
 // This is our event that we will send and receive in systems
+#[derive(Event)]
 struct MyEvent {
     pub message: String,
     pub random_value: f32,

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -173,6 +173,25 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
     })
 }
 
+#[proc_macro_derive(Event, attributes(event))]
+pub fn derive_event(input: TokenStream) -> TokenStream {
+    let path = bevy_ecs_path();
+
+    let input = parse_macro_input!(input as DeriveInput);
+    let ident = input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let where_clause = where_clause.cloned().unwrap_or_else(|| syn::WhereClause {
+        where_token: Default::default(),
+        predicates: Default::default(),
+    });
+
+    quote! {
+        impl #impl_generics #path::event::Read for #ident #ty_generics #where_clause { }
+        impl #impl_generics #path::event::Write for #ident #ty_generics #where_clause { }
+    }
+    .into()
+}
+
 fn get_idents(fmt_string: fn(usize) -> String, count: usize) -> Vec<Ident> {
     (0..count)
         .map(|i| Ident::new(&fmt_string(i), Span::call_site()))

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -17,6 +17,8 @@ use std::{
 pub trait Event: Send + Sync + 'static {}
 impl<T> Event for T where T: Send + Sync + 'static {}
 
+pub use bevy_ecs_macros::Event;
+
 /// An `EventId` uniquely identifies an event.
 ///
 /// An `EventId` can among other things be used to trace the flow of an event from the point it was
@@ -82,8 +84,9 @@ struct EventInstance<E: Event> {
 ///
 /// # Example
 /// ```
-/// use bevy_ecs::event::Events;
+/// use bevy_ecs::prelude::*;
 ///
+/// #[derive(Event)]
 /// struct MyEvent {
 ///     value: usize
 /// }
@@ -239,6 +242,7 @@ where
     /// ```
     /// # use bevy_ecs::prelude::*;
     /// #
+    /// #[derive(Event)]
     /// struct CollisionEvent;
     ///
     /// fn play_collision_sound(events: EventReader<CollisionEvent>) {
@@ -281,7 +285,9 @@ pub trait Write<Vis = ()> {}
 /// ```
 /// # use bevy_ecs::prelude::*;
 ///
+/// #[derive(Event)]
 /// pub struct MyEvent; // Custom event type.
+///
 /// fn my_system(mut writer: EventWriter<MyEvent>) {
 ///     writer.send(MyEvent);
 /// }
@@ -344,7 +350,7 @@ pub trait Write<Vis = ()> {}
 ///
 /// ```
 /// # use bevy_ecs::{prelude::*, event::Events};
-///
+/// # #[derive(Event)]
 /// # pub struct MyEvent;
 /// fn send_untyped(mut commands: Commands) {
 ///     // Send an event of a specific type without having to declare that
@@ -702,7 +708,7 @@ mod tests {
 
     use super::*;
 
-    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug, Event)]
     struct TestEvent {
         i: usize,
     }
@@ -798,14 +804,14 @@ mod tests {
         );
     }
 
-    fn get_events<E: Event + Clone>(
+    fn get_events<E: Event + Clone + Read>(
         events: &Events<E>,
         reader: &mut ManualEventReader<E>,
     ) -> Vec<E> {
         reader.iter(events).cloned().collect::<Vec<E>>()
     }
 
-    #[derive(PartialEq, Eq, Debug)]
+    #[derive(Event, PartialEq, Eq, Debug)]
     struct E(usize);
 
     fn events_clear_and_read_impl(clear_func: impl FnOnce(&mut Events<E>)) {
@@ -953,7 +959,7 @@ mod tests {
         assert!(is_empty, "EventReader should be empty");
     }
 
-    #[derive(Clone, PartialEq, Debug, Default)]
+    #[derive(Clone, PartialEq, Debug, Default, Event)]
     struct EmptyTestEvent;
 
     #[test]
@@ -970,7 +976,7 @@ mod tests {
 
     #[test]
     fn ensure_reader_readonly() {
-        fn read_for<E: Event>() {
+        fn read_for<E: Event + Read>() {
             let mut world = World::new();
             world.init_resource::<Events<E>>();
             let mut state = SystemState::<EventReader<E>>::new(&mut world);

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -31,7 +31,7 @@ pub mod prelude {
         change_detection::DetectChanges,
         component::Component,
         entity::Entity,
-        event::{EventReader, EventWriter, Events},
+        event::{Event, EventReader, EventWriter, Events},
         query::{Added, AnyOf, ChangeTrackers, Changed, Or, QueryState, With, Without},
         schedule::{
             AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -81,6 +81,7 @@ impl SystemMeta {
 /// use bevy_ecs::{system::SystemState};
 /// use bevy_ecs::event::Events;
 ///
+/// #[derive(Event)]
 /// struct MyEvent;
 /// struct MyResource(u32);
 ///
@@ -109,6 +110,7 @@ impl SystemMeta {
 /// use bevy_ecs::{system::SystemState};
 /// use bevy_ecs::event::Events;
 ///
+/// #[derive(Event)]
 /// struct MyEvent;
 /// struct CachedSystemState<'w, 's>{
 ///    event_state: SystemState<EventReader<'w, 's, MyEvent>>

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -16,6 +16,7 @@ use crate::{
         StorageType,
     },
     entity::{AllocAtWithoutReplacement, Entities, Entity},
+    event,
     query::{QueryState, WorldQuery},
     storage::{Column, SparseSet, Storages},
     system::Resource,
@@ -1158,19 +1159,28 @@ impl World {
 
     /// Sends an [`Event`](crate::event::Event).
     #[inline]
-    pub fn send_event<E: crate::event::Event>(&mut self, event: E) {
+    pub fn send_event<E, Vis>(&mut self, event: E)
+    where
+        E: event::Event + event::Write<Vis>,
+    {
         self.send_event_batch(std::iter::once(event));
     }
 
     /// Sends the default value of the [`Event`](crate::event::Event) of type `E`.
     #[inline]
-    pub fn send_event_default<E: crate::event::Event + Default>(&mut self) {
+    pub fn send_event_default<E>(&mut self)
+    where
+        E: event::Event + event::Write + Default,
+    {
         self.send_event_batch(std::iter::once(E::default()));
     }
 
     /// Sends a batch of [`Event`](crate::event::Event)s from an iterator.
     #[inline]
-    pub fn send_event_batch<E: crate::event::Event>(&mut self, events: impl Iterator<Item = E>) {
+    pub fn send_event_batch<E, Vis>(&mut self, events: impl Iterator<Item = E>)
+    where
+        E: event::Event + event::Write<Vis>,
+    {
         match self.get_resource_mut::<crate::event::Events<E>>() {
             Some(mut events_resource) => events_resource.extend(events),
             None => bevy_utils::tracing::error!(

--- a/crates/bevy_hierarchy/src/events.rs
+++ b/crates/bevy_hierarchy/src/events.rs
@@ -1,10 +1,10 @@
-use bevy_ecs::prelude::Entity;
+use bevy_ecs::{event::Event, prelude::Entity};
 
 /// A [`Event`] that is fired whenever there is a change in the world's
 /// hierarchy.
 ///
 /// [`Event`]: bevy_ecs::event::Event
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub enum HierarchyEvent {
     /// Fired whenever an [`Entity`] is added as a child to a new parent.
     ChildAdded {

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -1,5 +1,5 @@
 use crate::{Axis, Input};
-use bevy_ecs::event::{EventReader, EventWriter};
+use bevy_ecs::event::{Event, EventReader, EventWriter};
 use bevy_ecs::system::{Res, ResMut};
 use bevy_utils::{tracing::info, HashMap, HashSet};
 
@@ -54,7 +54,7 @@ pub enum GamepadEventType {
     AxisChanged(GamepadAxisType, f32),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Event)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct GamepadEvent {
     pub gamepad: Gamepad,
@@ -70,7 +70,7 @@ impl GamepadEvent {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Event)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct GamepadEventRaw {
     pub gamepad: Gamepad,

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -1,5 +1,8 @@
 use crate::{ButtonState, Input};
-use bevy_ecs::{event::EventReader, system::ResMut};
+use bevy_ecs::{
+    event::{Event, EventReader},
+    system::ResMut,
+};
 
 /// A keyboard input event.
 ///
@@ -10,7 +13,7 @@ use bevy_ecs::{event::EventReader, system::ResMut};
 ///
 /// The event is consumed inside of the [`keyboard_input_system`](crate::keyboard::keyboard_input_system)
 /// to update the [`Input<KeyCode>`](crate::Input<KeyCode>) resource.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct KeyboardInput {
     /// The scan code of the key.
     pub scan_code: u32,

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -1,5 +1,8 @@
 use crate::{ButtonState, Input};
-use bevy_ecs::{event::EventReader, system::ResMut};
+use bevy_ecs::{
+    event::{Event, EventReader},
+    system::ResMut,
+};
 use bevy_math::Vec2;
 
 /// A mouse button input event.
@@ -10,7 +13,7 @@ use bevy_math::Vec2;
 ///
 /// The event is read inside of the [`mouse_button_input_system`](crate::mouse::mouse_button_input_system)
 /// to update the [`Input<MouseButton>`](crate::Input<MouseButton>) resource.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct MouseButtonInput {
     /// The mouse button assigned to the event.
     pub button: MouseButton,
@@ -50,7 +53,7 @@ pub enum MouseButton {
 /// However, the event data does not make it possible to distinguish which device it is referring to.
 ///
 /// [`DeviceEvent::MouseMotion`]: https://docs.rs/winit/latest/winit/event/enum.DeviceEvent.html#variant.MouseMotion
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct MouseMotion {
     /// The change in the position of the pointing device since the last event was sent.
     pub delta: Vec2,
@@ -79,7 +82,7 @@ pub enum MouseScrollUnit {
 /// A mouse wheel event.
 ///
 /// This event is the translated version of the `WindowEvent::MouseWheel` from the `winit` crate.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct MouseWheel {
     /// The mouse scroll unit.
     pub unit: MouseScrollUnit,

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -1,4 +1,4 @@
-use bevy_ecs::event::EventReader;
+use bevy_ecs::event::{Event, EventReader};
 use bevy_ecs::system::ResMut;
 use bevy_math::Vec2;
 use bevy_utils::HashMap;
@@ -26,7 +26,7 @@ use bevy_utils::HashMap;
 ///
 /// This event is the translated version of the `WindowEvent::Touch` from the `winit` crate.
 /// It is available to the end user and can be used for game logic.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Event)]
 pub struct TouchInput {
     /// The phase of the touch input.
     pub phase: TouchPhase,

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -1,10 +1,11 @@
 use std::path::PathBuf;
 
 use super::{WindowDescriptor, WindowId};
+use bevy_ecs::event::Event;
 use bevy_math::{IVec2, Vec2};
 
 /// A window event that is sent whenever a window's logical size has changed.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct WindowResized {
     pub id: WindowId,
     /// The new logical width of the window.
@@ -14,7 +15,7 @@ pub struct WindowResized {
 }
 
 /// An event that indicates that a new window should be created.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct CreateWindow {
     pub id: WindowId,
     pub descriptor: WindowDescriptor,
@@ -22,14 +23,14 @@ pub struct CreateWindow {
 
 /// An event that indicates the window should redraw, even if its control flow is set to `Wait` and
 /// there have been no window events.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct RequestRedraw;
 
 /// An event that is sent whenever a new window is created.
 ///
 /// To create a new window, send a [`CreateWindow`] event - this
 /// event will be sent in the handler for that event.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct WindowCreated {
     pub id: WindowId,
 }
@@ -45,7 +46,7 @@ pub struct WindowCreated {
 /// [`WindowPlugin`]: crate::WindowPlugin
 /// [`Window`]: crate::Window
 /// [closing]: crate::Window::close
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct WindowCloseRequested {
     pub id: WindowId,
 }
@@ -54,7 +55,7 @@ pub struct WindowCloseRequested {
 /// handler for [`Window::close`].
 ///
 /// [`Window::close`]: crate::Window::close
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct WindowClosed {
     pub id: WindowId,
 }
@@ -67,7 +68,7 @@ pub struct WindowClosed {
 ///
 /// [`WindowEvent::CursorMoved`]: https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.CursorMoved
 /// [`MouseMotion`]: bevy_input::mouse::MouseMotion
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct CursorMoved {
     /// The identifier of the window the cursor has moved on.
     pub id: WindowId,
@@ -76,45 +77,45 @@ pub struct CursorMoved {
     pub position: Vec2,
 }
 /// An event that is sent whenever the user's cursor enters a window.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct CursorEntered {
     pub id: WindowId,
 }
 /// An event that is sent whenever the user's cursor leaves a window.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct CursorLeft {
     pub id: WindowId,
 }
 
 /// An event that is sent whenever a window receives a character from the OS or underlying system.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct ReceivedCharacter {
     pub id: WindowId,
     pub char: char,
 }
 
 /// An event that indicates a window has received or lost focus.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct WindowFocused {
     pub id: WindowId,
     pub focused: bool,
 }
 
 /// An event that indicates a window's scale factor has changed.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct WindowScaleFactorChanged {
     pub id: WindowId,
     pub scale_factor: f64,
 }
 /// An event that indicates a window's OS-reported scale factor has changed.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct WindowBackendScaleFactorChanged {
     pub id: WindowId,
     pub scale_factor: f64,
 }
 
 /// Events related to files being dragged and dropped on a window.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub enum FileDragAndDrop {
     DroppedFile { id: WindowId, path_buf: PathBuf },
 
@@ -124,7 +125,7 @@ pub enum FileDragAndDrop {
 }
 
 /// An event that is sent when a window is repositioned in physical pixels.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Event)]
 pub struct WindowMoved {
     pub id: WindowId,
     pub position: IVec2,

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -19,6 +19,7 @@ fn main() {
 
 #[derive(Deref)]
 struct StreamReceiver(Receiver<u32>);
+#[derive(Event)]
 struct StreamEvent(u32);
 
 #[derive(Deref)]

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -15,11 +15,12 @@ fn main() {
         .run();
 }
 
+#[derive(Event)]
 struct MyEvent {
     pub message: String,
 }
 
-#[derive(Default)]
+#[derive(Default, Event)]
 struct PlaySound;
 
 struct EventTriggerState {

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -82,7 +82,7 @@ struct Velocity(Vec2);
 #[derive(Component)]
 struct Collider;
 
-#[derive(Default)]
+#[derive(Default, Event)]
 struct CollisionEvent;
 
 #[derive(Component)]

--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -6,6 +6,7 @@ struct Enemy {
     score_value: u32,
 }
 
+#[derive(Event)]
 struct EnemyDied(u32);
 
 struct Score(u32);


### PR DESCRIPTION
# Objective

- Allow users to separately restrict access to either `EventReader<T>` or `EventWriter<T>`, for a given `T`.
- Support construction of robust API's by making it easy to restrict access.
  - Read-only events - good for sending messages to downstream plugins without letting them interfere with one another.
  - Write-only events - good for sending messages to upstream plugins without letting the downstream plugins observe each other.
- Enforce invariants - by allowing users to enforce invariants, it could allow type-specific optimizations in the future.
  - Example - if you know that there is only one `EventReader` of a given type, you can massively simplify the implementation of the event queue.
  - Example - if you know that there is only one `EventWriter` of a given type, you don't need to bother with synchronizing writes.
  - This would require some way of changing the "event handler" from `Events<T>` to a custom implementation.

## Solution

* Add marker traits `Read<>` and `Write<>`, which restrict access to `EventReader` and `EventWriter` based on the visibility of a marker type parameter.
* Default to unrestricted visibility - no breaking changes.

```rust
mod inner {
    struct Private;

    #[derive(Default)]
    pub struct MyEvent;

    // Can only send events if you can name the type `Private`.
    // Here, that means only within the module `inner`.
    impl bevy_ecs::event::Write<Private> for MyEvent {}

    // No restrictions on where you can send events.
    impl bevy_ecs::event::Read for MyEvent {}

    // the type `Private` is like a key that unlocks the `EventReader`.
    fn inner_system(mut writer: EventWriter<MyEvent, Private>) {
        writer.send_default();
    }
}

// This doesn't compile, can't name `Private` outside of its module.
fn outer_system(mut writer: EventWriter<inner::MyEvent, inner::Private>) {}

// ...and this doesn't compile either.
fn outer_system2(mut writer: EventWriter<inner::MyEvent>) {}

// This *does* compile - reads are unrestricted so we don't even need to worry about `Private`.
fn read_system(mut reader: EventReader<inner::MyEvent>) {}

// For the common case where you want unrestricted writes and reads, you can just
#[derive(Event)]
pub struct YourEvent

// We are allowed to read or write anywhere we want.
fn your_system(mut writer: EventWriter<YourEvent>) {}
fn your_system2(mut reader: EventReader<YourEvent>) {}
```

## Notes

`#[derive(Event)]` macro is necessary to make this change ergonomic, but it seems like we're already going that direction since other PRs require configuring events at the type level. For example, some of the discussion in #4832.

---

## Changelog

<!--
> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- What changed as a result of this PR?
- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!
  - -->
