### PR TITLE
[Merged by Bors] - Export anyhow::error for custom asset loaders

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -32,6 +32,7 @@ pub mod prelude {
     pub use crate::{AddAsset, AssetEvent, AssetServer, Assets, Handle, HandleUntyped};
 }
 
+pub use anyhow::Error;
 pub use asset_server::*;
 pub use assets::*;
 pub use bevy_utils::BoxedFuture;

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -2,6 +2,7 @@ use crate::{
     path::AssetPath, AssetIo, AssetIoError, AssetMeta, AssetServer, Assets, Handle, HandleId,
     RefChangeChannel,
 };
+use anyhow::Error;
 use anyhow::Result;
 use bevy_ecs::system::{Res, ResMut};
 use bevy_reflect::{TypeUuid, TypeUuidDynamic};
@@ -20,7 +21,7 @@ pub trait AssetLoader: Send + Sync + 'static {
         &'a self,
         bytes: &'a [u8],
         load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<(), anyhow::Error>>;
+    ) -> BoxedFuture<'a, Result<(), Error>>;
 
     /// Returns a list of extensions supported by this asset loader, without the preceding dot.
     fn extensions(&self) -> &[&str];

--- a/examples/asset/custom_asset.rs
+++ b/examples/asset/custom_asset.rs
@@ -22,7 +22,7 @@ impl AssetLoader for CustomAssetLoader {
         &'a self,
         bytes: &'a [u8],
         load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<(), anyhow::Error>> {
+    ) -> BoxedFuture<'a, Result<(), bevy::asset::Error>> {
         Box::pin(async move {
             let custom_asset = ron::de::from_bytes::<CustomAsset>(bytes)?;
             load_context.set_default_asset(LoadedAsset::new(custom_asset));


### PR DESCRIPTION
If users try to implement a custom asset loader, they must manually import anyhow::error as it's used by the asset loader trait but not exported.

https://github.com/bevyengine/bevy/blob/2b93ab58128178fef64de8134a130f036f07dc5d/examples/asset/custom_asset.rs#L25

Fixes #3138