### PR TITLE
[Merged by Bors] - Add attribute to ignore fields of derived labels

### DIFF
--- a/crates/bevy_derive/src/lib.rs
+++ b/crates/bevy_derive/src/lib.rs
@@ -80,6 +80,10 @@ pub fn derive_enum_variant_meta(input: TokenStream) -> TokenStream {
     enum_variant_meta::derive_enum_variant_meta(input)
 }
 
+/// Generates an impl of the `AppLabel` trait.
+///
+/// This works only for unit structs, or enums with only unit variants.
+/// You may force a struct or variant to behave as if it were fieldless with `#[app_label(ignore_fields)]`.
 #[proc_macro_derive(AppLabel, attributes(app_label))]
 pub fn derive_app_label(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);

--- a/crates/bevy_derive/src/lib.rs
+++ b/crates/bevy_derive/src/lib.rs
@@ -80,7 +80,7 @@ pub fn derive_enum_variant_meta(input: TokenStream) -> TokenStream {
     enum_variant_meta::derive_enum_variant_meta(input)
 }
 
-#[proc_macro_derive(AppLabel)]
+#[proc_macro_derive(AppLabel, attributes(app_label))]
 pub fn derive_app_label(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
     let mut trait_path = BevyManifest::default().get_path("bevy_app");

--- a/crates/bevy_derive/src/lib.rs
+++ b/crates/bevy_derive/src/lib.rs
@@ -89,5 +89,5 @@ pub fn derive_app_label(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
     let mut trait_path = BevyManifest::default().get_path("bevy_app");
     trait_path.segments.push(format_ident!("AppLabel").into());
-    derive_label(input, &trait_path)
+    derive_label(input, &trait_path, "app_label")
 }

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -41,3 +41,7 @@ path = "examples/resources.rs"
 [[example]]
 name = "change_detection"
 path = "examples/change_detection.rs"
+
+[[example]]
+name = "derive_label"
+path = "examples/derive_label.rs"

--- a/crates/bevy_ecs/examples/derive_label.rs
+++ b/crates/bevy_ecs/examples/derive_label.rs
@@ -1,0 +1,47 @@
+use std::marker::PhantomData;
+
+use bevy_ecs::prelude::*;
+
+fn main() {
+    // Unit labels are always equal.
+    assert_eq!(UnitLabel.as_label(), UnitLabel.as_label());
+
+    // Enum labels depend on the variant.
+    assert_eq!(EnumLabel::One.as_label(), EnumLabel::One.as_label());
+    assert_ne!(EnumLabel::One.as_label(), EnumLabel::Two.as_label());
+
+    // Shockingly, labels annotated with `ignore_fields` ignore their fields.
+    assert_eq!(WeirdLabel(1).as_label(), WeirdLabel(2).as_label());
+
+    // Labels of different types are distinct, even if they look similar.
+    assert_ne!(
+        GenericLabel::<f64>::One.as_label(),
+        GenericLabel::<char>::One.as_label(),
+    );
+}
+
+#[derive(SystemLabel)]
+pub struct UnitLabel;
+
+#[derive(SystemLabel)]
+pub enum EnumLabel {
+    One,
+    Two,
+}
+
+#[derive(SystemLabel)]
+#[system_label(ignore_fields)]
+pub struct WeirdLabel(i32);
+
+#[derive(SystemLabel)]
+pub enum GenericLabel<T> {
+    One,
+    #[system_label(ignore_fields)]
+    Two(PhantomData<T>),
+}
+
+// FIXME: this should be a compile_fail test
+/*#[derive(SystemLabel)]
+pub union Foo {
+    x: i32,
+}*/

--- a/crates/bevy_ecs/examples/derive_label.rs
+++ b/crates/bevy_ecs/examples/derive_label.rs
@@ -45,3 +45,18 @@ pub enum GenericLabel<T> {
 pub union Foo {
     x: i32,
 }*/
+
+// FIXME: this should be a compile_fail test
+/*#[derive(SystemLabel)]
+#[system_label(ignore_fields)]
+pub enum BadLabel {
+    One,
+    Two,
+}*/
+
+// FIXME: this should be a compile_fail test
+/*#[derive(SystemLabel)]
+pub struct BadLabel2 {
+    #[system_label(ignore_fields)]
+    x: (),
+}*/

--- a/crates/bevy_ecs/examples/derive_label.rs
+++ b/crates/bevy_ecs/examples/derive_label.rs
@@ -10,10 +10,10 @@ fn main() {
     assert_eq!(EnumLabel::One.as_label(), EnumLabel::One.as_label());
     assert_ne!(EnumLabel::One.as_label(), EnumLabel::Two.as_label());
 
-    // Shockingly, labels annotated with `ignore_fields` ignore their fields.
+    // Labels annotated with `ignore_fields` ignore their fields.
     assert_eq!(WeirdLabel(1).as_label(), WeirdLabel(2).as_label());
 
-    // Labels of different types are distinct, even if they look similar.
+    // Labels don't depend only on the variant name but on the full type
     assert_ne!(
         GenericLabel::<f64>::One.as_label(),
         GenericLabel::<char>::One.as_label(),

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -434,7 +434,7 @@ pub fn derive_world_query(input: TokenStream) -> TokenStream {
     derive_world_query_impl(ast)
 }
 
-#[proc_macro_derive(SystemLabel)]
+#[proc_macro_derive(SystemLabel, attributes(system_label))]
 pub fn derive_system_label(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let mut trait_path = bevy_ecs_path();
@@ -445,7 +445,7 @@ pub fn derive_system_label(input: TokenStream) -> TokenStream {
     derive_label(input, &trait_path)
 }
 
-#[proc_macro_derive(StageLabel)]
+#[proc_macro_derive(StageLabel, attributes(stage_label))]
 pub fn derive_stage_label(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let mut trait_path = bevy_ecs_path();
@@ -454,7 +454,7 @@ pub fn derive_stage_label(input: TokenStream) -> TokenStream {
     derive_label(input, &trait_path)
 }
 
-#[proc_macro_derive(AmbiguitySetLabel)]
+#[proc_macro_derive(AmbiguitySetLabel, attributes(ambiguity_set_label))]
 pub fn derive_ambiguity_set_label(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let mut trait_path = bevy_ecs_path();

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -446,7 +446,7 @@ pub fn derive_system_label(input: TokenStream) -> TokenStream {
     trait_path
         .segments
         .push(format_ident!("SystemLabel").into());
-    derive_label(input, &trait_path)
+    derive_label(input, &trait_path, "system_label")
 }
 
 /// Generates an impl of the `StageLabel` trait.
@@ -459,7 +459,7 @@ pub fn derive_stage_label(input: TokenStream) -> TokenStream {
     let mut trait_path = bevy_ecs_path();
     trait_path.segments.push(format_ident!("schedule").into());
     trait_path.segments.push(format_ident!("StageLabel").into());
-    derive_label(input, &trait_path)
+    derive_label(input, &trait_path, "stage_label")
 }
 
 /// Generates an impl of the `AmbiguitySetLabel` trait.
@@ -474,14 +474,14 @@ pub fn derive_ambiguity_set_label(input: TokenStream) -> TokenStream {
     trait_path
         .segments
         .push(format_ident!("AmbiguitySetLabel").into());
-    derive_label(input, &trait_path)
+    derive_label(input, &trait_path, "ambiguity_set_label")
 }
 
 /// Generates an impl of the `RunCriteriaLabel` trait.
 ///
 /// This works only for unit structs, or enums with only unit variants.
 /// You may force a struct or variant to behave as if it were fieldless with `#[run_criteria_label(ignore_fields)]`.
-#[proc_macro_derive(RunCriteriaLabel)]
+#[proc_macro_derive(RunCriteriaLabel, attributes(run_criteria_label))]
 pub fn derive_run_criteria_label(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let mut trait_path = bevy_ecs_path();
@@ -489,7 +489,7 @@ pub fn derive_run_criteria_label(input: TokenStream) -> TokenStream {
     trait_path
         .segments
         .push(format_ident!("RunCriteriaLabel").into());
-    derive_label(input, &trait_path)
+    derive_label(input, &trait_path, "run_criteria_label")
 }
 
 pub(crate) fn bevy_ecs_path() -> syn::Path {

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -434,6 +434,10 @@ pub fn derive_world_query(input: TokenStream) -> TokenStream {
     derive_world_query_impl(ast)
 }
 
+/// Generates an impl of the `SystemLabel` trait.
+///
+/// This works only for unit structs, or enums with only unit variants.
+/// You may force a struct or variant to behave as if it were fieldless with `#[system_label(ignore_fields)]`.
 #[proc_macro_derive(SystemLabel, attributes(system_label))]
 pub fn derive_system_label(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -445,6 +449,10 @@ pub fn derive_system_label(input: TokenStream) -> TokenStream {
     derive_label(input, &trait_path)
 }
 
+/// Generates an impl of the `StageLabel` trait.
+///
+/// This works only for unit structs, or enums with only unit variants.
+/// You may force a struct or variant to behave as if it were fieldless with `#[stage_label(ignore_fields)]`.
 #[proc_macro_derive(StageLabel, attributes(stage_label))]
 pub fn derive_stage_label(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -454,6 +462,10 @@ pub fn derive_stage_label(input: TokenStream) -> TokenStream {
     derive_label(input, &trait_path)
 }
 
+/// Generates an impl of the `AmbiguitySetLabel` trait.
+///
+/// This works only for unit structs, or enums with only unit variants.
+/// You may force a struct or variant to behave as if it were fieldless with `#[ambiguity_set_label(ignore_fields)]`.
 #[proc_macro_derive(AmbiguitySetLabel, attributes(ambiguity_set_label))]
 pub fn derive_ambiguity_set_label(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -465,6 +477,10 @@ pub fn derive_ambiguity_set_label(input: TokenStream) -> TokenStream {
     derive_label(input, &trait_path)
 }
 
+/// Generates an impl of the `RunCriteriaLabel` trait.
+///
+/// This works only for unit structs, or enums with only unit variants.
+/// You may force a struct or variant to behave as if it were fieldless with `#[run_criteria_label(ignore_fields)]`.
 #[proc_macro_derive(RunCriteriaLabel)]
 pub fn derive_run_criteria_label(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -12,3 +12,4 @@ keywords = ["bevy"]
 toml = "0.5.8"
 syn = "1.0"
 quote = "1.0"
+convert_case = { version = "0.5.0", default-features = false }

--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -12,4 +12,3 @@ keywords = ["bevy"]
 toml = "0.5.8"
 syn = "1.0"
 quote = "1.0"
-convert_case = { version = "0.5.0", default-features = false }


### PR DESCRIPTION
# Objective

Fixes #5362 

## Solution

Add the attribute `#[label(ignore_fields)]` for `*Label` types.

```rust
#[derive(SystemLabel)]
pub enum MyLabel {
    One,

    // Previously this was not allowed since labels cannot contain data.
    #[system_label(ignore_fields)]
    Two(PhantomData<usize>),
}
```

## Notes

This label makes it possible for equality to behave differently depending on whether or not you are treating the type as a label. For example:

```rust
#[derive(SystemLabel, PartialEq, Eq)]
#[system_label(ignore_fields)]
pub struct Foo(usize);
```

If you compare it as a label, it will ignore the wrapped fields as the user requested. But if you compare it as a `Foo`, the derive will incorrectly compare the inner fields. I see a few solutions

1. Do nothing. This is technically intended behavior, but I think we should do our best to prevent footguns.
2. Generate impls of `PartialEq` and `Eq` along with the `#[derive(Label)]` macros. This is a breaking change as it requires all users to remove these derives from their types.
3. Only allow `PhantomData` to be used with `ignore_fields` -- seems needlessly prescriptive.

---

## Changelog

* Added the `ignore_fields` attribute to the derive macros for `*Label` types.
* Added an example showing off different forms of the derive macro.

<!--
## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- If this PR is a breaking change (relative to the last release of Bevy), describe how a user might need to migrate their code to support these changes
- Simply adding new functionality is not a breaking change.
- Fixing behavior that was definitely a bug, rather than a questionable design choice is not a breaking change.
-->