### PR TITLE
[Merged by Bors] - rename send_default_event to send_event_default on world

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1164,7 +1164,7 @@ impl World {
 
     /// Sends the default value of the [`Event`](crate::event::Event) of type `E`.
     #[inline]
-    pub fn send_default_event<E: crate::event::Event + Default>(&mut self) {
+    pub fn send_event_default<E: crate::event::Event + Default>(&mut self) {
         self.send_event_batch(std::iter::once(E::default()));
     }
 


### PR DESCRIPTION
after #5355, three methods were added on world:
* `send_event`
* `send_event_batch`
* `send_default_event`

rename `send_default_event` to `send_event_default` for better discoverability