### PR TITLE
[Merged by Bors] - unpin nightly in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  NIGHTLY_TOOLCHAIN: nightly-2022-07-13
+  NIGHTLY_TOOLCHAIN: nightly
 
 jobs:
   build:


### PR DESCRIPTION
# Objective

- Nightly was pinned after a Rust regression
- Rust regression has been fixed

## Solution

- Unpin nightly
