### PR TITLE
[Merged by Bors] - don't cull ui nodes that have a rotation

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -435,11 +435,14 @@ pub fn prepare_uinodes(
 
         let transformed_rect_size = extracted_uinode.transform.transform_vector3(rect_size);
 
-        // Cull nodes that are completely clipped
-        if positions_diff[0].x - positions_diff[1].x >= transformed_rect_size.x
-            || positions_diff[1].y - positions_diff[2].y >= transformed_rect_size.y
-        {
-            continue;
+        // Don't try to cull nodes that have a rotation
+        if extracted_uinode.transform.x_axis[1] == 0.0 {
+            // Cull nodes that are completely clipped
+            if positions_diff[0].x - positions_diff[1].x >= transformed_rect_size.x
+                || positions_diff[1].y - positions_diff[2].y >= transformed_rect_size.y
+            {
+                continue;
+            }
         }
 
         // Clip UVs (Note: y is reversed in UV space)

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -436,6 +436,11 @@ pub fn prepare_uinodes(
         let transformed_rect_size = extracted_uinode.transform.transform_vector3(rect_size);
 
         // Don't try to cull nodes that have a rotation
+        // In a rotation around the Z-axis, this value is 0.0 for an angle of 0.0 or π
+        // In those two cases, the culling check can proceed normally as corners will be on
+        // horizontal / vertical lines
+        // For all other angles, bypass the culling check
+        // This does not properly handles all rotations on all axis
         if extracted_uinode.transform.x_axis[1] == 0.0 {
             // Cull nodes that are completely clipped
             if positions_diff[0].x - positions_diff[1].x >= transformed_rect_size.x


### PR DESCRIPTION
# Objective

- Fixes #5293 
- UI nodes with a rotation that made the top left corner lower than the top right corner (z rotations greater than π/4) were culled

## Solution

- Do not cull nodes with a rotation, but don't do proper culling in this case



As a reminder, changing rotation and scale of UI nodes is not recommended as it won't impact layout. This is a quick fix but doesn't handle properly rotations and scale in clipping/culling. This would need a lot more work as mentioned here: https://github.com/bevyengine/bevy/blob/c2b332f98a0bcab7390e4b184099202cfb4fbbe1/crates/bevy_ui/src/render/mod.rs#L404-L405