### PR TITLE
[Merged by Bors] - Update Notify Dependency

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -30,7 +30,7 @@ anyhow = "1.0.4"
 thiserror = "1.0"
 downcast-rs = "1.2.0"
 fastrand = "1.7.0"
-notify = { version = "=5.0.0-pre.11", optional = true }
+notify = { version = "=5.0.0-pre.15", optional = true }
 parking_lot = "0.12.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
# Objective

I want to use the `deno_runtime` crate in my game, but it has a conflict with the version of the `notify` crate that Bevy depends on.

## Solution

Updates the version of the `notify` crate the Bevy depends on.