### PR TITLE
[Merged by Bors] - add `Axis::devices` to get all the input devices

### DIFF
--- a/crates/bevy_input/src/axis.rs
+++ b/crates/bevy_input/src/axis.rs
@@ -111,7 +111,7 @@ mod tests {
             assert_eq!(expected, actual);
         }
     }
-    
+
     #[test]
     fn test_axis_devices() {
         let mut axis = Axis::<GamepadButton>::default();

--- a/crates/bevy_input/src/axis.rs
+++ b/crates/bevy_input/src/axis.rs
@@ -51,6 +51,10 @@ where
     pub fn remove(&mut self, input_device: T) -> Option<f32> {
         self.axis_data.remove(&input_device)
     }
+    /// Returns an iterator of all the input devices that have position data
+    pub fn devices(&self) -> impl ExactSizeIterator<Item = &T> {
+        self.axis_data.keys()
+    }
 }
 
 #[cfg(test)]
@@ -106,5 +110,35 @@ mod tests {
 
             assert_eq!(expected, actual);
         }
+    }
+    
+    #[test]
+    fn test_axis_devices() {
+        let mut axis = Axis::<GamepadButton>::default();
+        assert_eq!(axis.devices().count(), 0);
+
+        axis.set(
+            GamepadButton::new(Gamepad::new(1), GamepadButtonType::RightTrigger),
+            0.1,
+        );
+        assert_eq!(axis.devices().count(), 1);
+
+        axis.set(
+            GamepadButton::new(Gamepad::new(1), GamepadButtonType::LeftTrigger),
+            0.5,
+        );
+        assert_eq!(axis.devices().count(), 2);
+
+        axis.set(
+            GamepadButton::new(Gamepad::new(1), GamepadButtonType::RightTrigger),
+            -0.1,
+        );
+        assert_eq!(axis.devices().count(), 2);
+
+        axis.remove(GamepadButton::new(
+            Gamepad::new(1),
+            GamepadButtonType::RightTrigger,
+        ));
+        assert_eq!(axis.devices().count(), 1);
     }
 }


### PR DESCRIPTION
(github made me type out a message for the commit which looked like it was for the pr, sorry)

# Objective

- Add a way to get all of the input devices of an `Axis`, primarily useful for looping through them

## Solution

- Adds `Axis<T>::devices()` which returns a `FixedSizeIterator<Item = &T>`
- Adds a (probably unneeded) `test_axis_devices` test because tests are cool.

---

## Changelog

- Added `Axis<T>::devices()` method

## Migration Guide

Not a breaking change.