### PR TITLE
[Merged by Bors] - dds: Ensure the Extent3d for compressed textures represents the physical size

### DIFF
--- a/crates/bevy_render/src/texture/dds.rs
+++ b/crates/bevy_render/src/texture/dds.rs
@@ -27,7 +27,8 @@ pub fn dds_buffer_to_image(
         } else {
             dds.get_depth()
         },
-    };
+    }
+    .physical_size(texture_format);
     image.texture_descriptor.mip_level_count = dds.get_num_mipmap_levels();
     image.texture_descriptor.format = texture_format;
     image.texture_descriptor.dimension = if dds.get_depth() > 1 {


### PR DESCRIPTION
# Objective

- wgpu 0.13 has validation to ensure that the width and height specified for a texture are both multiples of the respective block width and block height. This means validation fails for compressed textures with say a 4x4 block size, but non-modulo-4 image width/height.

## Solution

- Using `Extent3d`'s `physical_size()` method in the `dds` loader. It takes a `TextureFormat` argument and ensures the resolution is correct.

---

## Changelog

- Fixes: Validation failure for compressed textures stored in `dds` where the width/height are not a multiple of the block dimensions.