### PR TITLE
[Merged by Bors] - bevy_asset: add missing doc in wasm

### DIFF
--- a/crates/bevy_asset/src/io/wasm_asset_io.rs
+++ b/crates/bevy_asset/src/io/wasm_asset_io.rs
@@ -25,6 +25,7 @@ pub struct WasmAssetIo {
 }
 
 impl WasmAssetIo {
+    /// Creates a new `WasmAssetIo`. The path provided will be used to build URLs to query for assets.
     pub fn new<P: AsRef<Path>>(path: P) -> Self {
         WasmAssetIo {
             root_path: path.as_ref().to_owned(),


### PR DESCRIPTION
# Objective

- `#![warn(missing_docs)]` was added to bevy_asset in #3536
- A method was not documented when targeting wasm

## Solution

- Add documentation for it
