### PR TITLE
UI render layers

### DIFF
--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -4,14 +4,10 @@ use crate::{
     widget::{Button, ImageMode},
     CalculatedSize, FocusPolicy, Interaction, Node, Style, UiColor, UiImage,
 };
-use bevy_ecs::{
-    bundle::Bundle,
-    prelude::{Component, With},
-    query::QueryItem,
-};
+use bevy_ecs::{bundle::Bundle, prelude::Component};
 use bevy_render::{
-    camera::Camera, extract_component::ExtractComponent, prelude::ComputedVisibility,
-    view::Visibility,
+    prelude::ComputedVisibility,
+    view::{RenderLayers, Visibility},
 };
 use bevy_text::{Text, TextAlignment, TextSection, TextStyle};
 use bevy_transform::prelude::{GlobalTransform, Transform};
@@ -37,6 +33,8 @@ pub struct NodeBundle {
     pub visibility: Visibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub computed_visibility: ComputedVisibility,
+    /// The UI camera layers this node is visible in.
+    pub render_layers: RenderLayers,
 }
 
 /// A UI node that is an image
@@ -64,6 +62,8 @@ pub struct ImageBundle {
     pub visibility: Visibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub computed_visibility: ComputedVisibility,
+    /// The ui camera layers this image is visible in.
+    pub render_layers: RenderLayers,
 }
 
 /// A UI node that is text
@@ -87,6 +87,8 @@ pub struct TextBundle {
     pub visibility: Visibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub computed_visibility: ComputedVisibility,
+    /// The ui camera layers this text is visible in.
+    pub render_layers: RenderLayers,
 }
 
 impl TextBundle {
@@ -135,12 +137,13 @@ impl Default for TextBundle {
             global_transform: Default::default(),
             visibility: Default::default(),
             computed_visibility: Default::default(),
+            render_layers: Default::default(),
         }
     }
 }
 
 /// A UI node that is a button
-#[derive(Bundle, Clone, Debug)]
+#[derive(Bundle, Clone, Debug, Default)]
 pub struct ButtonBundle {
     /// Describes the size of the node
     pub node: Node,
@@ -164,25 +167,10 @@ pub struct ButtonBundle {
     pub visibility: Visibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub computed_visibility: ComputedVisibility,
+    /// The ui camera layers this button is visible in.
+    pub render_layers: RenderLayers,
 }
 
-impl Default for ButtonBundle {
-    fn default() -> Self {
-        ButtonBundle {
-            button: Button,
-            interaction: Default::default(),
-            focus_policy: Default::default(),
-            node: Default::default(),
-            style: Default::default(),
-            color: Default::default(),
-            image: Default::default(),
-            transform: Default::default(),
-            global_transform: Default::default(),
-            visibility: Default::default(),
-            computed_visibility: Default::default(),
-        }
-    }
-}
 /// Configuration for cameras related to UI.
 ///
 /// When a [`Camera`] doesn't have the [`UiCameraConfig`] component,
@@ -196,19 +184,15 @@ pub struct UiCameraConfig {
     /// When a `Camera` doesn't have the [`UiCameraConfig`] component,
     /// it will display the UI by default.
     pub show_ui: bool,
+    /// The ui camera layers this camera can see.
+    pub ui_render_layers: RenderLayers,
 }
 
 impl Default for UiCameraConfig {
     fn default() -> Self {
-        Self { show_ui: true }
-    }
-}
-
-impl ExtractComponent for UiCameraConfig {
-    type Query = &'static Self;
-    type Filter = With<Camera>;
-
-    fn extract_component(item: QueryItem<Self::Query>) -> Self {
-        item.clone()
+        Self {
+            show_ui: true,
+            ui_render_layers: Default::default(),
+        }
     }
 }

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -177,7 +177,7 @@ pub struct ButtonBundle {
 /// it will display the UI by default.
 ///
 /// [`Camera`]: bevy_render::camera::Camera
-#[derive(Component, Clone)]
+#[derive(Component, Debug, Clone)]
 pub struct UiCameraConfig {
     /// Whether to output UI to this camera view.
     ///

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -27,9 +27,10 @@ pub mod prelude {
 use bevy_app::prelude::*;
 use bevy_ecs::schedule::{ParallelSystemDescriptorCoercion, SystemLabel};
 use bevy_input::InputSystem;
+use bevy_render::view::VisibilitySystems;
 use bevy_transform::TransformSystem;
 use bevy_window::ModifiesWindows;
-use update::{ui_z_system, update_clipping_system};
+use update::{ui_z_system, update_clipping_system, update_layer_visibility};
 
 /// The basic plugin for Bevy UI
 #[derive(Default)]
@@ -42,6 +43,11 @@ pub enum UiSystem {
     Flex,
     /// After this label, input interactions with UI entities have been updated for this frame
     Focus,
+    /// Update the [`ComputedVisibility`] component of [`Node`] entities to reflect
+    /// their visibility in accordance to UI cameras.
+    ///
+    /// [`ComputedVisibility`]: bevy_render::view::ComputedVisibility
+    LayerVisibility,
 }
 
 impl Plugin for UiPlugin {
@@ -93,6 +99,12 @@ impl Plugin for UiPlugin {
                     .label(UiSystem::Flex)
                     .before(TransformSystem::TransformPropagate)
                     .after(ModifiesWindows),
+            )
+            .add_system_to_stage(
+                CoreStage::PostUpdate,
+                update_layer_visibility
+                    .label(UiSystem::LayerVisibility)
+                    .after(VisibilitySystems::CheckVisibility),
             )
             .add_system_to_stage(
                 CoreStage::PostUpdate,

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -12,7 +12,6 @@ pub mod entity;
 pub mod update;
 pub mod widget;
 
-use bevy_render::extract_component::ExtractComponentPlugin;
 pub use flex::*;
 pub use focus::*;
 pub use geometry::*;
@@ -32,8 +31,6 @@ use bevy_transform::TransformSystem;
 use bevy_window::ModifiesWindows;
 use update::{ui_z_system, update_clipping_system};
 
-use crate::prelude::UiCameraConfig;
-
 /// The basic plugin for Bevy UI
 #[derive(Default)]
 pub struct UiPlugin;
@@ -49,8 +46,7 @@ pub enum UiSystem {
 
 impl Plugin for UiPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugin(ExtractComponentPlugin::<UiCameraConfig>::default())
-            .init_resource::<FlexSurface>()
+        app.init_resource::<FlexSurface>()
             .register_type::<AlignContent>()
             .register_type::<AlignItems>()
             .register_type::<AlignSelf>()

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -44,9 +44,10 @@ pub enum UiSystem {
     /// After this label, input interactions with UI entities have been updated for this frame
     Focus,
     /// Update the [`ComputedVisibility`] component of [`Node`] entities to reflect
-    /// their visibility in accordance to UI cameras.
+    /// their visibility based on available [`UiCameraConfig.ui_render_layers`].
     ///
     /// [`ComputedVisibility`]: bevy_render::view::ComputedVisibility
+    /// [`UiCameraConfig.ui_render_layers`]: crate::entity::UiCameraConfig::ui_render_layers
     LayerVisibility,
 }
 

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -158,6 +158,7 @@ fn get_ui_graph(render_app: &mut App) -> RenderGraph {
     ui_graph
 }
 
+#[derive(Debug)]
 pub struct ExtractedUiNode {
     pub transform: Mat4,
     pub color: Color,
@@ -224,9 +225,19 @@ const UI_CAMERA_FAR: f32 = 1000.0;
 // TODO: Evaluate if we still need this.
 const UI_CAMERA_TRANSFORM_OFFSET: f32 = -0.1;
 
+/// The UI camera used by this Camera's viewport.
+///
+/// This component is inserted into the render world in the
+/// [`extract_default_ui_camera_view`] system.
+///
+/// The component is attached to the "actual" viewport's camera.
+/// The UI camera's `ExtractedView` is attached to the entity in the
+/// `entity` field.
 #[derive(Component, Debug)]
 pub struct UiCamera {
+    /// The entity for the UI camera.
     pub entity: Entity,
+    /// UI nodes layer this camera shows.
     layers: RenderLayers,
 }
 

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -225,17 +225,18 @@ const UI_CAMERA_FAR: f32 = 1000.0;
 // TODO: Evaluate if we still need this.
 const UI_CAMERA_TRANSFORM_OFFSET: f32 = -0.1;
 
-/// The UI camera used by this Camera's viewport.
+/// Extra information relevant to UI attached to cameras.
 ///
-/// This component is inserted into the render world in the
-/// [`extract_default_ui_camera_view`] system.
+/// This component only exist in the render world.
+/// You would only want to interact with it if you are creating your own
+/// UI rendering and want to re-use bevy's systems.
 ///
 /// The component is attached to the "actual" viewport's camera.
-/// The UI camera's `ExtractedView` is attached to the entity in the
+/// The UI camera's [`ExtractedView`] is attached to the entity in the
 /// `entity` field.
 #[derive(Component, Debug)]
-pub struct UiCamera {
-    /// The entity for the UI camera.
+pub struct UiCameraView {
+    /// The entity with the UI camera's `ExtractedView` component.
     pub entity: Entity,
     /// UI nodes layer this camera shows.
     layers: RenderLayers,
@@ -278,7 +279,7 @@ pub fn extract_default_ui_camera_view<T: Component>(
                 })
                 .id();
             commands.get_or_spawn(camera_entity).insert_bundle((
-                UiCamera {
+                UiCameraView {
                     entity: ui_camera,
                     layers: ui_config.ui_render_layers,
                 },
@@ -546,7 +547,7 @@ pub fn queue_uinodes(
     mut image_bind_groups: ResMut<UiImageBindGroups>,
     gpu_images: Res<RenderAssets<Image>>,
     ui_batches: Query<(Entity, &UiBatch)>,
-    mut views: Query<(&mut RenderPhase<TransparentUi>, &UiCamera)>,
+    mut views: Query<(&mut RenderPhase<TransparentUi>, &UiCameraView)>,
     events: Res<SpriteAssetEvents>,
 ) {
     // If an image has changed, the GpuImage has (probably) changed

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -1,4 +1,4 @@
-use crate::UiCamera;
+use crate::UiCameraView;
 
 use super::{UiBatch, UiImageBindGroups, UiMeta};
 use bevy_ecs::{
@@ -19,7 +19,7 @@ use bevy_utils::FloatOrd;
 pub struct UiPassNode {
     view_query:
         QueryState<(&'static RenderPhase<TransparentUi>, &'static ViewTarget), With<ExtractedView>>,
-    ui_camera_query: QueryState<&'static UiCamera>,
+    ui_camera_query: QueryState<&'static UiCameraView>,
 }
 
 impl UiPassNode {

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -2,7 +2,7 @@
 
 use bevy::{
     prelude::*,
-    render::camera::RenderTarget,
+    render::{camera::RenderTarget, view::RenderLayers},
     window::{CreateWindow, PresentMode, WindowId},
 };
 
@@ -30,10 +30,17 @@ fn setup(
         ..default()
     });
     // main camera
-    commands.spawn_bundle(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 0.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands
+        .spawn_bundle(Camera3dBundle {
+            transform: Transform::from_xyz(0.0, 0.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        })
+        .insert(UiCameraConfig {
+            // We set the UI cameras of each window to use a different layer,
+            // so that we can display different text per window.
+            ui_render_layers: RenderLayers::layer(1),
+            ..default()
+        });
 
     let window_id = WindowId::new();
 
@@ -50,12 +57,34 @@ fn setup(
     });
 
     // second window camera
-    commands.spawn_bundle(Camera3dBundle {
-        transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
-        camera: Camera {
-            target: RenderTarget::Window(window_id),
+    commands
+        .spawn_bundle(Camera3dBundle {
+            transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+            camera: Camera {
+                target: RenderTarget::Window(window_id),
+                ..default()
+            },
             ..default()
-        },
-        ..default()
+        })
+        .insert(UiCameraConfig {
+            ui_render_layers: RenderLayers::layer(2),
+            ..default()
+        });
+    let text_style = TextStyle {
+        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+        font_size: 100.0,
+        color: Color::WHITE,
+    };
+    commands.spawn_bundle(TextBundle {
+        render_layers: RenderLayers::layer(1),
+        ..TextBundle::from_section("Face", text_style.clone())
+    });
+    commands.spawn_bundle(TextBundle {
+        render_layers: RenderLayers::layer(2),
+        ..TextBundle::from_section("Profile", text_style.clone())
+    });
+    commands.spawn_bundle(TextBundle {
+        render_layers: RenderLayers::all(),
+        ..TextBundle::from_section("view", text_style)
     });
 }


### PR DESCRIPTION

# Objective

This enables having different UI per camera. With #5225, this enables
having different interactive UIs per window. Although, to properly
complete this, the focus system will need to account for RenderLayer of
UI nodes.

## Solution

- Add the `render_layers: RenderLayers` field to UI bundles
- Add the `ui_render_layers` field to `UiCameraConfig`
- Keep track of UI `RenderLayers` in the UI render code

---

## Changelog

- Add `RenderLayers` support to UI nodes, you now can display different UIs on different cameras.