### PR TITLE
Added a dedicated HandleMap

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,6 +11,7 @@ glam = "0.24"
 rand = "0.8"
 rand_chacha = "0.3"
 criterion = { version = "0.3", features = ["html_reports"] }
+bevy_asset = { path = "../crates/bevy_asset" }
 bevy_app = { path = "../crates/bevy_app" }
 bevy_ecs = { path = "../crates/bevy_ecs" }
 bevy_reflect = { path = "../crates/bevy_reflect" }
@@ -25,6 +26,11 @@ lto = true
 [[bench]]
 name = "change_detection"
 path = "benches/bevy_ecs/change_detection.rs"
+harness = false
+
+[[bench]]
+name = "handle_map"
+path = "benches/bevy_asset/handle_map.rs"
 harness = false
 
 [[bench]]

--- a/benches/benches/bevy_asset/handle_map.rs
+++ b/benches/benches/bevy_asset/handle_map.rs
@@ -1,5 +1,5 @@
 use bevy_asset::{AssetPath, Handle, HandleId, HandleMap};
-use bevy_reflect::TypeUuid;
+use bevy_reflect::{TypePath, TypeUuid};
 use bevy_utils::HashMap;
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
@@ -8,7 +8,7 @@ use rand::prelude::*;
 const NUM_UNIQUE_IDS: u64 = 10000;
 const NUM_GET: usize = 1000000;
 
-#[derive(TypeUuid)]
+#[derive(TypeUuid, TypePath)]
 #[uuid = "c976f5a3-a461-459e-bfb6-424e9e72f708"]
 struct TestAsset {}
 

--- a/benches/benches/bevy_asset/handle_map.rs
+++ b/benches/benches/bevy_asset/handle_map.rs
@@ -1,0 +1,79 @@
+use bevy_asset::{AssetPath, Handle, HandleId, HandleMap};
+use bevy_reflect::TypeUuid;
+use bevy_utils::HashMap;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rand::prelude::*;
+
+const NUM_UNIQUE_IDS: u64 = 10000;
+const NUM_GET: usize = 1000000;
+
+#[derive(TypeUuid)]
+#[uuid = "c976f5a3-a461-459e-bfb6-424e9e72f708"]
+struct TestAsset {}
+
+fn bench_overhead(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Handle Map");
+
+    let mut rng = thread_rng();
+
+    for ratio in [0.0, 0.2, 0.4, 0.6, 0.8, 1.0] {
+        let handles: Vec<_> = (0..NUM_UNIQUE_IDS)
+            .map(|i| {
+                let id = if i < (NUM_UNIQUE_IDS as f32 * ratio) as u64 {
+                    HandleId::Id(TestAsset::TYPE_UUID, i)
+                } else {
+                    HandleId::AssetPathId(
+                        AssetPath::new(format!("Asset Path Id Number: {}", i).into(), None)
+                            .get_id(),
+                    )
+                };
+
+                Handle::<TestAsset>::weak(id)
+            })
+            .collect();
+        let access_order: Vec<_> = (0..NUM_GET)
+            .map(|_| rng.gen_range(0..NUM_UNIQUE_IDS) as usize)
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("HashMap", ratio),
+            &handles,
+            |b, handles| {
+                b.iter(|| {
+                    let mut map: HashMap<Handle<TestAsset>, u64> = HashMap::with_capacity(10000);
+
+                    for (i, handle) in handles.iter().enumerate() {
+                        map.insert(handle.clone_weak(), i as u64);
+                    }
+
+                    for handle_idx in &access_order {
+                        black_box(map.get(&handles[*handle_idx]));
+                    }
+                })
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("HandleMap", ratio),
+            &handles,
+            |b, handles| {
+                b.iter(|| {
+                    let mut map: HandleMap<TestAsset, u64> = HandleMap::with_capacity(5000, 5000);
+
+                    for (i, handle) in handles.iter().enumerate() {
+                        map.insert(handle, i as u64);
+                    }
+
+                    for handle_idx in &access_order {
+                        black_box(map.get(&handles[*handle_idx]));
+                    }
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_overhead);
+criterion_main!(benches);

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -472,7 +472,7 @@ impl Default for RefChangeChannel {
 }
 
 /// A map between an instance of an asset and some value.
-/// Performs slightly faster than HashMap<Handle<K>, Vs>.s
+/// Performs slightly faster than [`HashMap<Handle<K>, V>`].
 pub struct HandleMap<K: Asset, V> {
     id_map: HashMap<u64, (V, HandleType)>,
     asset_path_id_map: HashMap<AssetPathId, (V, HandleType)>,
@@ -481,7 +481,7 @@ pub struct HandleMap<K: Asset, V> {
 }
 
 impl<K: Asset, V> HandleMap<K, V> {
-    /// Create a [`HandleMap`] with specific capacity of id and asset_id [`HashMap`] slots.
+    /// Create a [`HandleMap`] with specific capacity of `id` and `asset_path_id` [`HashMap`] slots.
     pub fn with_capacity(id_map: usize, asset_path_id_map: usize) -> Self {
         HandleMap {
             id_map: HashMap::with_capacity(id_map),


### PR DESCRIPTION
This version is nowhere ready to merge. I am mostly looking for people's opinion. Idk if I missed something obvious in the benchmark. 

# Objective

Add a `HandleMap<K, V>` to replace `HashMap<Handle<K>, V>`. Its goal is to increase performance by reducing the amount of data that needs to be hashed to access a value in a hash map.

A limitation of the current implementation of `HandleMap<K, V>` is that it can't store a strong handle whereas `HashMap<Handle<K>, V>` can. I don't know how often this capability is required.

## Bench

Time taken to call .get 1,000,000 times:

| `HandleId::Id` / Total IDs    | 0.0       | 0.2       | 0.4       | 0.6       | 0.8       | 1.0       |
|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
| `HashMap<Handle<K>, V>`   | 21.049 ms | 23.680 ms | 26.296 ms | 28.023 ms | 27.600 ms | 28.015 ms |
| `HandleMap<K, V>` | 16.563 ms | 18.593 ms | 20.135 ms | 19.353 ms | 16.935 ms | 14.077 ms |
