### PR TITLE
bevy_render: Improve Aabb maintenance from O(n^2) to O(n) for n meshes

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -181,7 +181,6 @@ impl Plugin for PbrPlugin {
                 check_light_mesh_visibility
                     .label(SimulationLightSystems::CheckLightVisibility)
                     .after(TransformSystem::TransformPropagate)
-                    .after(VisibilitySystems::CalculateBounds)
                     .after(SimulationLightSystems::UpdateLightFrusta)
                     // NOTE: This MUST be scheduled AFTER the core renderer visibility check
                     // because that resets entity ComputedVisibility for the first view


### PR DESCRIPTION
# Objective

- Despawning many entities with `Handle<Mesh>` would cause O(n^2) worst case behaviour in `update_bounds` after #4944 . Improve performance here.

## Background and desired behaviours

The use cases to be supported are:
  - Entities being spawn with a `Handle<Mesh>`, maybe an `Aabb` component, and maybe a `NoAabbUpdate` component
  - The `Handle<Mesh>` component being modified
  - The `Mesh` asset being modified

In addition to this, I decided to consider the cases of many unique meshes (i.e. one Mesh asset per entity for many entities) and instanced meshes (i.e. one Mesh asset for many entities).

The resulting behaviours in the solution are:
- If unique meshes are spawned, Aabbs are computed and Aabb components are inserted
- If unique meshes with aabbs are spawned, aabbs are not recomputed, nor are they modified/inserted
- If unique meshes with aabbs are spawned and no aabb update is configured, aabbs are not recomputed, nor are they modified/inserted
- If an instanced mesh is spawned with aabbs and no aabb update, aabbs are not recomputed, nor are they modified/inserted
- If an instanced mesh is spawned with aabbs, aabbs are not recomputed, nor are they modified/inserted
- If an instanced mesh is spawned, one aabb is computed, Aabb components are inserted
- If an instanced mesh is modified, one aabb is computed and the entity Aabb components are updated in-place
- If an instanced mesh has its mesh handle re-assigned, the entity Aabb components are updated in-place

## Solution

- Remove `EntityMeshMap`
- Remove the `calculate_bounds` system
- Add `MeshAabbMap` containing `HashMap<Handle<Mesh>, Aabb>` to track the `Aabb` calculated for each `Mesh` asset for fast lookup
- Modify `update_bounds` and add comments explaining how it works and why each portion of code or non-obvious logic is there.

---

## Changelog

- Removed: The `calculate_bounds` system and its label were removed. Now all Aabb updates happen in the `update_bounds` system.
- Fixed: Performance regression when despawning many mesh entities that was introduced in #4944

## Migration Guide

If your system previously depended on the `CalculateBounds` label, it should now depend on the `UpdateBounds` label.