### PR TITLE
allow user-defined mesh-view bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,6 +310,16 @@ category = "3D Rendering"
 wasm = true
 
 [[example]]
+name = "custom_view_binding"
+path = "examples/3d/custom_view_binding.rs"
+
+[package.metadata.example.custom_view_binding]
+name = "Custom View Binding"
+description = "Illustrates a custom view binding"
+category = "3D Rendering"
+wasm = true
+
+[[example]]
 name = "load_gltf"
 path = "examples/3d/load_gltf.rs"
 

--- a/assets/shaders/custom_view_binding_material.wgsl
+++ b/assets/shaders/custom_view_binding_material.wgsl
@@ -1,0 +1,15 @@
+#import bevy_pbr::mesh_view_bindings
+
+struct CustomMaterial {
+    color: vec4<f32>,
+};
+
+@group(1) @binding(0)
+var<uniform> material: CustomMaterial;
+
+@fragment
+fn fragment(
+    #import bevy_pbr::mesh_vertex_output
+) -> @location(0) vec4<f32> {
+    return material.color * (0.5 + 0.5 * sin(custom_view_binding.time));
+}

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -78,7 +78,12 @@ impl Plugin for MeshRenderPlugin {
             Shader::from_wgsl
         );
         load_internal_asset!(app, MESH_TYPES_HANDLE, "mesh_types.wgsl", Shader::from_wgsl);
-        load_internal_asset!(app, MESH_VIEW_USER_BINDINGS_HANDLE, "mesh_view_user_bindings.wgsl", Shader::from_wgsl);
+        load_internal_asset!(
+            app,
+            MESH_VIEW_USER_BINDINGS_HANDLE,
+            "mesh_view_user_bindings.wgsl",
+            Shader::from_wgsl
+        );
         load_internal_asset!(
             app,
             MESH_BINDINGS_HANDLE,
@@ -273,7 +278,7 @@ pub struct UserViewBindGroupLayoutEntry {
     pub ty: BindingType,
 }
 
-pub trait GetBinding : Send + Sync {
+pub trait GetBinding: Send + Sync {
     fn get_binding(&self) -> BindingResource;
 }
 
@@ -300,7 +305,8 @@ impl FromWorld for MeshPipeline {
             Res<RenderQueue>,
             ResMut<UserViewBindingsLayouts>,
         )> = SystemState::new(world);
-        let (render_device, default_sampler, render_queue, user_entries) = system_state.get_mut(world);
+        let (render_device, default_sampler, render_queue, user_entries) =
+            system_state.get_mut(world);
         let clustered_forward_buffer_binding_type = render_device
             .get_supported_read_only_binding_type(CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT);
 
@@ -414,14 +420,18 @@ impl FromWorld for MeshPipeline {
             },
         ];
 
-        entries.extend(user_entries.entries.iter().enumerate().map(|(i, (_key, value))| {
-            BindGroupLayoutEntry {
-                binding: 9 + i as u32,
-                visibility: value.visibility,
-                ty: value.ty,
-                count: None,
-            }
-        }));
+        entries.extend(
+            user_entries
+                .entries
+                .iter()
+                .enumerate()
+                .map(|(i, (_key, value))| BindGroupLayoutEntry {
+                    binding: 9 + i as u32,
+                    visibility: value.visibility,
+                    ty: value.ty,
+                    count: None,
+                }),
+        );
 
         let view_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
             entries: &entries,
@@ -838,9 +848,7 @@ pub fn queue_mesh_view_bind_groups(
                 },
                 BindGroupEntry {
                     binding: 5,
-                    resource: BindingResource::Sampler(
-                        &shadow_pipeline.directional_light_sampler,
-                    ),
+                    resource: BindingResource::Sampler(&shadow_pipeline.directional_light_sampler),
                 },
                 BindGroupEntry {
                     binding: 6,
@@ -856,12 +864,17 @@ pub fn queue_mesh_view_bind_groups(
                 },
             ];
 
-            let user_buffers: Vec<_> = user_bindings.entries.iter().map(|(key, _)| {
-                user_binding_entries.entries.get(key).unwrap().get_binding()
-            }).collect();
+            let user_buffers: Vec<_> = user_bindings
+                .entries
+                .iter()
+                .map(|(key, _)| user_binding_entries.entries.get(key).unwrap().get_binding())
+                .collect();
 
             entries.extend(user_buffers.into_iter().enumerate().map(|(i, resource)| {
-                BindGroupEntry { binding: 9 + i as u32, resource }
+                BindGroupEntry {
+                    binding: 9 + i as u32,
+                    resource,
+                }
             }));
 
             let view_bind_group = render_device.create_bind_group(&BindGroupDescriptor {

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -420,13 +420,15 @@ impl FromWorld for MeshPipeline {
             },
         ];
 
+        let user_binding_offset = entries.len();
+
         entries.extend(
             user_entries
                 .entries
                 .iter()
                 .enumerate()
                 .map(|(i, (_key, value))| BindGroupLayoutEntry {
-                    binding: 9 + i as u32,
+                    binding: (user_binding_offset + i) as u32,
                     visibility: value.visibility,
                     ty: value.ty,
                     count: None,
@@ -864,6 +866,9 @@ pub fn queue_mesh_view_bind_groups(
                 },
             ];
 
+            let user_binding_offset = entries.len();
+
+            // collect binding resources in the layout vec order
             let user_buffers: Vec<_> = user_bindings
                 .entries
                 .iter()
@@ -872,7 +877,7 @@ pub fn queue_mesh_view_bind_groups(
 
             entries.extend(user_buffers.into_iter().enumerate().map(|(i, resource)| {
                 BindGroupEntry {
-                    binding: 9 + i as u32,
+                    binding: (user_binding_offset + i) as u32,
                     resource,
                 }
             }));

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -308,6 +308,12 @@ pub trait GetBinding: Send + Sync {
     fn get_binding(&self) -> BindingResource;
 }
 
+impl GetBinding for Buffer {
+    fn get_binding(&self) -> BindingResource {
+        self.as_entire_binding()
+    }
+}
+
 #[derive(Default)]
 pub struct UserViewBindingsEntries {
     pub entries: HashMap<&'static str, Box<dyn GetBinding>>,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -869,18 +869,19 @@ pub fn queue_mesh_view_bind_groups(
             let user_binding_offset = entries.len();
 
             // collect binding resources in the layout vec order
-            let user_buffers: Vec<_> = user_bindings
+            let user_buffers = user_bindings
                 .entries
                 .iter()
-                .map(|(key, _)| user_binding_entries.entries.get(key).unwrap().get_binding())
-                .collect();
+                .map(|(key, _)| user_binding_entries.entries.get(key).unwrap().get_binding());
 
-            entries.extend(user_buffers.into_iter().enumerate().map(|(i, resource)| {
-                BindGroupEntry {
-                    binding: (user_binding_offset + i) as u32,
-                    resource,
-                }
-            }));
+            entries.extend(
+                user_buffers
+                    .enumerate()
+                    .map(|(i, resource)| BindGroupEntry {
+                        binding: (user_binding_offset + i) as u32,
+                        resource,
+                    }),
+            );
 
             let view_bind_group = render_device.create_bind_group(&BindGroupDescriptor {
                 entries: &entries,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -107,7 +107,7 @@ impl Plugin for MeshRenderPlugin {
             String::from("#define_import_path bevy_pbr::mesh_view_user_bindings\n\n");
         for def in &user_view_layouts.binding_shaders {
             let mut preprocessed_binding_shader = def.shader.clone();
-            for i in 0..def.num_bindings {
+            for i in (0..def.num_bindings).rev() {
                 preprocessed_binding_shader = preprocessed_binding_shader.replace(
                     format!("@binding({})", i).as_str(),
                     format!("@binding({})", offset + i).as_str(),

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -316,14 +316,14 @@ impl GetBinding for Buffer {
 
 impl GetBinding for Handle<Image> {
     fn get_binding<'a>(&'a self, gpu_images: &'a RenderAssets<Image>) -> BindingResource<'a> {
-        let gpu_image = gpu_images.get(&self).unwrap(); // use default instead of unwrap
+        let gpu_image = gpu_images.get(self).unwrap(); // use default instead of unwrap
         BindingResource::TextureView(&gpu_image.texture_view)
     }
 }
 
 impl GetBinding for Sampler {
     fn get_binding(&self, _: &RenderAssets<Image>) -> BindingResource {
-        BindingResource::Sampler(&self)
+        BindingResource::Sampler(self)
     }
 }
 

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -105,7 +105,7 @@ impl Plugin for MeshRenderPlugin {
         let mut offset = MESH_VIEW_DEFAULT_BINDINGS_COUNT;
         let mut mesh_view_user_bindings =
             String::from("#define_import_path bevy_pbr::mesh_view_user_bindings\n\n");
-        for def in user_view_layouts.binding_shaders.iter() {
+        for def in &user_view_layouts.binding_shaders {
             let mut preprocessed_binding_shader = def.shader.clone();
             for i in 0..def.num_bindings {
                 preprocessed_binding_shader = preprocessed_binding_shader.replace(

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -40,3 +40,5 @@ var<storage> cluster_light_index_lists: ClusterLightIndexLists;
 @group(0) @binding(8)
 var<storage> cluster_offsets_and_counts: ClusterOffsetsAndCounts;
 #endif
+
+#import bevy_pbr::mesh_view_user_bindings

--- a/crates/bevy_pbr/src/render/mesh_view_user_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_user_bindings.wgsl
@@ -1,0 +1,3 @@
+#define_import_path bevy_pbr::mesh_view_user_bindings
+
+// add user bindings and replace this handle

--- a/examples/3d/custom_view_binding.rs
+++ b/examples/3d/custom_view_binding.rs
@@ -1,0 +1,135 @@
+use bevy::{prelude::*, render::{render_resource::{ShaderType, AsBindGroup, Buffer, ShaderStages, BindingType, BufferBindingType, encase::UniformBuffer, BufferInitDescriptor, BufferUsages, ShaderRef}, RenderApp, RenderStage, Extract, renderer::RenderDevice}, pbr::{GetBinding, UserViewBindingsLayouts, UserViewBindGroupLayoutEntry, MESH_VIEW_USER_BINDINGS_HANDLE, queue_mesh_view_bind_groups, UserViewBindingsEntries}, asset::load_internal_asset, reflect::TypeUuid};
+
+fn main() {
+    let mut app = App::new();
+    // add view bindings before adding default plugins
+    CustomViewBindingPlugin::add_view_bindings(&mut app);
+    app.add_plugins(DefaultPlugins)
+        // plugin to populate the custom view binding
+        .add_plugin(CustomViewBindingPlugin)
+        // example material using the binding
+        .add_plugin(MaterialPlugin::<CustomMaterial>::default())
+        .add_startup_system(setup)
+        .run();
+}
+
+// material to use the custom binding
+impl Material for CustomMaterial {
+    fn fragment_shader() -> ShaderRef {
+        "shaders/custom_view_binding_material.wgsl".into()
+    }
+}
+
+// This is the struct that will be passed to your shader
+#[derive(AsBindGroup, TypeUuid, Debug, Clone)]
+#[uuid = "f690fdae-d598-45ab-8225-97e2a3f056e0"]
+pub struct CustomMaterial {
+    #[uniform(0)]
+    color: Color,
+}
+
+// simple scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut custom_materials: ResMut<Assets<CustomMaterial>>,
+    mut standard_materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // cube using the example material
+    commands.spawn_bundle(MaterialMeshBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: custom_materials.add(CustomMaterial {
+            color: Color::PINK,
+        }),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        ..default()
+    });
+
+    // cube using standard pbr material
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: standard_materials.add(StandardMaterial {
+            base_color: Color::PINK,
+            ..Default::default()
+        }),
+        transform: Transform::from_xyz(0.0, 0.5, -5.0),
+        ..default()
+    });
+
+    // camera
+    commands.spawn_bundle(Camera3dBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+}
+
+#[derive(ShaderType, AsBindGroup)]
+struct CustomViewUniform {
+    time: f32,
+}
+
+struct CustomViewUniformBuffer {
+    buffer: Buffer,
+}
+
+impl GetBinding for CustomViewUniformBuffer {
+    fn get_binding(&self) -> bevy::render::render_resource::BindingResource {
+        self.buffer.as_entire_binding()
+    }
+}
+
+pub struct CustomViewBindingPlugin;
+
+impl CustomViewBindingPlugin {
+    pub fn add_view_bindings(app: &mut App) {
+        let mut user_bindings = app.world.get_resource_or_insert_with::<UserViewBindingsLayouts>(|| Default::default());
+        user_bindings.entries.push(("example custom view binding", UserViewBindGroupLayoutEntry {
+            visibility: ShaderStages::FRAGMENT,
+            ty: BindingType::Buffer { ty: BufferBindingType::Uniform, has_dynamic_offset: false, min_binding_size: Some(CustomViewUniform::min_size()) },
+        }));
+    }
+}
+
+impl Plugin for CustomViewBindingPlugin {
+    fn build(&self, app: &mut App) {
+        // override mesh view bindings
+        load_internal_asset!(app, MESH_VIEW_USER_BINDINGS_HANDLE, "custom_view_bindings.wgsl", Shader::from_wgsl);
+
+        // extract resource
+        app.sub_app_mut(RenderApp).add_system_to_stage(RenderStage::Extract, extract_time);
+
+        // add custom view binding
+        app.sub_app_mut(RenderApp).add_system_to_stage(RenderStage::Queue, queue_custom_view_binding.before(queue_mesh_view_bind_groups));
+    }
+}
+
+
+fn extract_time(mut commands: Commands, time: Extract<Res<Time>>) {
+    commands.insert_resource(time.clone());
+}
+
+fn queue_custom_view_binding(
+    mut entries: ResMut<UserViewBindingsEntries>,
+    render_device: Res<RenderDevice>,
+    time: Res<Time>,
+) {
+    let view_uniform = CustomViewUniform {
+        time: time.seconds_since_startup() as f32,
+    };
+
+    let byte_buffer = vec![0u8; CustomViewUniform::min_size().get() as usize];
+    let mut buffer = UniformBuffer::new(byte_buffer);
+    buffer.write(&view_uniform).unwrap();
+
+    let view_uniform_buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
+        label: Some("custom view uniform"),
+        usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+        contents: buffer.as_ref(),
+    });
+
+    let uniform_buffer = CustomViewUniformBuffer {
+        buffer: view_uniform_buffer
+    };
+
+    entries.entries.insert("example custom view binding", Box::new(uniform_buffer));
+}

--- a/examples/3d/custom_view_binding.rs
+++ b/examples/3d/custom_view_binding.rs
@@ -97,7 +97,7 @@ impl CustomViewBindingPlugin {
     pub fn add_view_bindings(app: &mut App) {
         let mut user_bindings: Mut<UserViewBindingsLayouts> = app
             .world
-            .get_resource_or_insert_with(|| UserViewBindingsLayouts::default());
+            .get_resource_or_insert_with(UserViewBindingsLayouts::default);
         user_bindings.entries.push((
             "example custom view binding",
             UserViewBindGroupLayoutEntry {

--- a/examples/3d/custom_view_binding.rs
+++ b/examples/3d/custom_view_binding.rs
@@ -36,7 +36,6 @@ impl Material for CustomMaterial {
     }
 }
 
-// This is the struct that will be passed to your shader
 #[derive(AsBindGroup, TypeUuid, Debug, Clone)]
 #[uuid = "f690fdae-d598-45ab-8225-97e2a3f056e0"]
 pub struct CustomMaterial {
@@ -116,6 +115,9 @@ impl CustomViewBindingPlugin {
 impl Plugin for CustomViewBindingPlugin {
     fn build(&self, app: &mut App) {
         // override mesh view bindings
+        // note: if an app uses multiple plugins with custom view bindings, you will need to create
+        // a single view_binding .wgsl file containing all the bindings from the plugins, and override
+        // the MESH_VIEW_USER_BINDINGS_HANDLE again after adding the plugins
         load_internal_asset!(
             app,
             MESH_VIEW_USER_BINDINGS_HANDLE,
@@ -123,14 +125,16 @@ impl Plugin for CustomViewBindingPlugin {
             Shader::from_wgsl
         );
 
-        // extract resource
+        // extract example resource
         app.sub_app_mut(RenderApp)
             .add_system_to_stage(RenderStage::Extract, extract_time);
 
-        // add custom view binding
+        // create the custom view binding buffer
         app.sub_app_mut(RenderApp).add_system_to_stage(
             RenderStage::Queue,
-            queue_custom_view_binding.before(queue_mesh_view_bind_groups),
+            queue_custom_view_binding
+                // must be before queue_mesh_view_bind_groups which requests the user bindings
+                .before(queue_mesh_view_bind_groups),
         );
     }
 }

--- a/examples/3d/custom_view_binding.rs
+++ b/examples/3d/custom_view_binding.rs
@@ -1,8 +1,7 @@
 use bevy::{
-    asset::load_internal_asset,
     pbr::{
         queue_mesh_view_bind_groups, GetBinding, UserViewBindGroupLayoutEntry,
-        UserViewBindingsEntries, UserViewBindingsLayouts, MESH_VIEW_USER_BINDINGS_HANDLE,
+        UserViewBindingsEntries, UserViewBindingsShader, UserViewBindingsSpec,
     },
     prelude::*,
     reflect::TypeUuid,
@@ -95,10 +94,10 @@ pub struct CustomViewBindingPlugin;
 
 impl CustomViewBindingPlugin {
     pub fn add_view_bindings(app: &mut App) {
-        let mut user_bindings: Mut<UserViewBindingsLayouts> = app
+        let mut user_bindings: Mut<UserViewBindingsSpec> = app
             .world
-            .get_resource_or_insert_with(UserViewBindingsLayouts::default);
-        user_bindings.entries.push((
+            .get_resource_or_insert_with(UserViewBindingsSpec::default);
+        user_bindings.layout_entries.push((
             "example custom view binding",
             UserViewBindGroupLayoutEntry {
                 visibility: ShaderStages::FRAGMENT,
@@ -109,22 +108,15 @@ impl CustomViewBindingPlugin {
                 },
             },
         ));
+        user_bindings.binding_shaders.push(UserViewBindingsShader {
+            shader: String::from(include_str!("custom_view_bindings.wgsl")),
+            num_bindings: 1,
+        });
     }
 }
 
 impl Plugin for CustomViewBindingPlugin {
     fn build(&self, app: &mut App) {
-        // override mesh view bindings
-        // note: if an app uses multiple plugins with custom view bindings, you will need to create
-        // a single view_binding .wgsl file containing all the bindings from the plugins, and override
-        // the MESH_VIEW_USER_BINDINGS_HANDLE again after adding the plugins
-        load_internal_asset!(
-            app,
-            MESH_VIEW_USER_BINDINGS_HANDLE,
-            "custom_view_bindings.wgsl",
-            Shader::from_wgsl
-        );
-
         // extract example resource
         app.sub_app_mut(RenderApp)
             .add_system_to_stage(RenderStage::Extract, extract_time);

--- a/examples/3d/custom_view_binding.rs
+++ b/examples/3d/custom_view_binding.rs
@@ -1,13 +1,13 @@
 use bevy::{
     pbr::{
-        queue_mesh_view_bind_groups, GetBinding, UserViewBindGroupLayoutEntry,
-        UserViewBindingsEntries, UserViewBindingsShader, UserViewBindingsSpec,
+        queue_mesh_view_bind_groups, UserViewBindGroupLayoutEntry, UserViewBindingsEntries,
+        UserViewBindingsShader, UserViewBindingsSpec,
     },
     prelude::*,
     reflect::TypeUuid,
     render::{
         render_resource::{
-            encase::UniformBuffer, AsBindGroup, BindingType, Buffer, BufferBindingType,
+            encase::UniformBuffer, AsBindGroup, BindingType, BufferBindingType,
             BufferInitDescriptor, BufferUsages, ShaderRef, ShaderStages, ShaderType,
         },
         renderer::RenderDevice,
@@ -80,16 +80,6 @@ struct CustomViewUniform {
     time: f32,
 }
 
-struct CustomViewUniformBuffer {
-    buffer: Buffer,
-}
-
-impl GetBinding for CustomViewUniformBuffer {
-    fn get_binding(&self) -> bevy::render::render_resource::BindingResource {
-        self.buffer.as_entire_binding()
-    }
-}
-
 pub struct CustomViewBindingPlugin;
 
 impl CustomViewBindingPlugin {
@@ -154,11 +144,7 @@ fn queue_custom_view_binding(
         contents: buffer.as_ref(),
     });
 
-    let uniform_buffer = CustomViewUniformBuffer {
-        buffer: view_uniform_buffer,
-    };
-
     entries
         .entries
-        .insert("example custom view binding", Box::new(uniform_buffer));
+        .insert("example custom view binding", Box::new(view_uniform_buffer));
 }

--- a/examples/3d/custom_view_binding.rs
+++ b/examples/3d/custom_view_binding.rs
@@ -95,9 +95,9 @@ pub struct CustomViewBindingPlugin;
 
 impl CustomViewBindingPlugin {
     pub fn add_view_bindings(app: &mut App) {
-        let mut user_bindings = app
+        let mut user_bindings: Mut<UserViewBindingsLayouts> = app
             .world
-            .get_resource_or_insert_with::<UserViewBindingsLayouts>(|| Default::default());
+            .get_resource_or_insert_with(|| UserViewBindingsLayouts::default());
         user_bindings.entries.push((
             "example custom view binding",
             UserViewBindGroupLayoutEntry {

--- a/examples/3d/custom_view_bindings.wgsl
+++ b/examples/3d/custom_view_bindings.wgsl
@@ -1,0 +1,8 @@
+#define_import_path bevy_pbr::mesh_view_user_bindings
+
+struct CustomViewUniform {
+    time: f32,
+};
+
+@group(0) @binding(9)
+var<uniform> custom_view_binding: CustomViewUniform;

--- a/examples/3d/custom_view_bindings.wgsl
+++ b/examples/3d/custom_view_bindings.wgsl
@@ -1,8 +1,6 @@
-#define_import_path bevy_pbr::mesh_view_user_bindings
-
 struct CustomViewUniform {
     time: f32,
 };
 
-@group(0) @binding(9)
+@group(0) @binding(0)
 var<uniform> custom_view_binding: CustomViewUniform;

--- a/examples/README.md
+++ b/examples/README.md
@@ -106,6 +106,7 @@ Example | Description
 --- | ---
 [3D Scene](../examples/3d/3d_scene.rs) | Simple 3D scene with basic shapes and lighting
 [3D Shapes](../examples/3d/shapes.rs) | A scene showcasing the built-in 3D shapes
+[Custom View Binding](../examples/3d/custom_view_binding.rs) | Illustrates a custom view binding
 [Lighting](../examples/3d/lighting.rs) | Illustrates various lighting options in a simple scene
 [Lines](../examples/3d/lines.rs) | Create a custom material to draw 3d lines
 [Load glTF](../examples/3d/load_gltf.rs) | Loads and renders a glTF file as a scene


### PR DESCRIPTION
# Objective

allow user-defined mesh-view bindings to be added for use in custom materials or user-overridden pbr functions.

## Solution

- add resources `UserViewBindingsLayouts` and `UserViewBindingsEntries`, add the layouts to MeshPipeline's view_layout at build time and then add entries to the bind group each frame
- add a `bevy_pbr::mesh_view_user_bindings` wgsl import which can be overridden to pull the user bindings into the shaders
- add an example `custom_view_bindings` to show how to use it

the layouts are keyed by a string, so that a plugin doesn't need to know what other plugins are adding view bindings.
unfortunately if multiple plugins with view bindings are being used, the app author will need to make their own composite `bevy_pbr::mesh_view_user_bindings` containing the bindings from all the plugins (and they will need to have no overlap in names).

this is pretty ugly so i welcome any suggestions to improve it, and i won't be upset if it's not accepted - i think the functionality is needed but this may be too hacky. 

i can't think of a clean way to specify the bindings per-plugin without extending the preprocessor, and i don't want to do that without feedback on the approach first.
