### PR TITLE
Sprite Sheet Example: Skip "idle" frame.

### DIFF
--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -39,7 +39,14 @@ fn setup(
     mut texture_atlases: ResMut<Assets<TextureAtlas>>,
 ) {
     let texture_handle = asset_server.load("textures/rpg/chars/gabe/gabe-idle-run.png");
-    let texture_atlas = TextureAtlas::from_grid(texture_handle, Vec2::new(24.0, 24.0), 7, 1);
+    let texture_atlas = TextureAtlas::from_grid_with_padding(
+        texture_handle,
+        Vec2::new(24.0, 24.0),
+        6,
+        1,
+        Vec2::ZERO,
+        Vec2::new(24.0, 0.0), // skip first tile
+    );
     let texture_atlas_handle = texture_atlases.add(texture_atlas);
     commands.spawn_bundle(Camera2dBundle::default());
     commands


### PR DESCRIPTION
# Objective

- Make running animation fluid skipping 'idle' frame.

## Solution

- Replace `TextureAtlas::from_grid()` with `TextureAtlas::from_grid_with_padding()` and provide an offset of 1 tile.

The example is correct, is just the feeling that the animation loop is not seamless.