### PR TITLE
Gltf update: use instance iteration instead of hierarchy iteration

### DIFF
--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -332,14 +332,19 @@ impl SceneSpawner {
         self.spawned_instances.contains_key(&instance_id)
     }
 
-    /// Get an iterator over the entities in an instance, once it's spawned
+    /// Get an iterator over the entities in an instance, once it's spawned.
+    ///
+    /// Before the scene is spawned, the iterator will be empty. Use [`instance_is_ready`]
+    /// to check if the instance is ready.
     pub fn iter_instance_entities(
         &'_ self,
         instance_id: InstanceId,
-    ) -> Option<impl Iterator<Item = Entity> + '_> {
+    ) -> impl Iterator<Item = Entity> + '_ {
         self.spawned_instances
             .get(&instance_id)
             .map(|instance| instance.entity_map.values())
+            .into_iter()
+            .flatten()
     }
 }
 

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -334,7 +334,7 @@ impl SceneSpawner {
 
     /// Get an iterator over the entities in an instance, once it's spawned.
     ///
-    /// Before the scene is spawned, the iterator will be empty. Use [`instance_is_ready`]
+    /// Before the scene is spawned, the iterator will be empty. Use [`Self::instance_is_ready`]
     /// to check if the instance is ready.
     pub fn iter_instance_entities(
         &'_ self,


### PR DESCRIPTION
# Objective

- Improve example on how to use the `SceneBundle` to iterate on entities in the scene instance spawned

## Solution

- Use the scene instance and `iter_instance_entities`
- Also improves a little the method and doc
