### PR TITLE
[Merged by Bors] - Conversion of `ResMut` and `NonSendMut` to `Mut`

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -185,6 +185,17 @@ change_detection_impl!(ResMut<'a, T>, T, Resource);
 impl_into_inner!(ResMut<'a, T>, T, Resource);
 impl_debug!(ResMut<'a, T>, Resource);
 
+impl<'a, T: Resource> ResMut<'a, T> {
+    /// Convert this `ResMut` into a `Mut`. This allows keeping the change-detection feature of `Mut`
+    /// while losing the specificity of `ResMut` for resources.
+    pub fn into_mut(self) -> Mut<'a, T> {
+        Mut {
+            value: self.value,
+            ticks: self.ticks,
+        }
+    }
+}
+
 /// Unique borrow of a non-[`Send`] resource.
 ///
 /// Only [`Send`] resources may be accessed with the [`ResMut`] [`SystemParam`](crate::system::SystemParam). In case that the
@@ -205,6 +216,17 @@ pub struct NonSendMut<'a, T: 'static> {
 change_detection_impl!(NonSendMut<'a, T>, T,);
 impl_into_inner!(NonSendMut<'a, T>, T,);
 impl_debug!(NonSendMut<'a, T>,);
+
+impl<'a, T: 'static> NonSendMut<'a, T> {
+    /// Convert this `NonSendMut` into a `Mut`. This allows keeping the change-detection feature of `Mut`
+    /// while losing the specificity of `NonSendMut`.
+    pub fn into_mut(self) -> Mut<'a, T> {
+        Mut {
+            value: self.value,
+            ticks: self.ticks,
+        }
+    }
+}
 
 /// Unique mutable borrow of an entity's component
 pub struct Mut<'a, T> {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -308,7 +308,9 @@ impl std::fmt::Debug for MutUntyped<'_> {
 mod tests {
     use crate::{
         self as bevy_ecs,
-        change_detection::{CHECK_TICK_THRESHOLD, MAX_CHANGE_AGE, ComponentTicks, Ticks, Mut, ResMut, NonSendMut},
+        change_detection::{
+            ComponentTicks, Mut, NonSendMut, ResMut, Ticks, CHECK_TICK_THRESHOLD, MAX_CHANGE_AGE,
+        },
         component::Component,
         query::ChangeTrackers,
         system::{IntoSystem, Query, System},
@@ -418,7 +420,7 @@ mod tests {
             last_change_tick: 3,
             change_tick: 4,
         };
-        let mut res = R{};
+        let mut res = R {};
         let res_mut = ResMut {
             value: &mut res,
             ticks,
@@ -442,7 +444,7 @@ mod tests {
             last_change_tick: 3,
             change_tick: 4,
         };
-        let mut res = R{};
+        let mut res = R {};
         let non_send_mut = NonSendMut {
             value: &mut res,
             ticks,

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -185,13 +185,13 @@ change_detection_impl!(ResMut<'a, T>, T, Resource);
 impl_into_inner!(ResMut<'a, T>, T, Resource);
 impl_debug!(ResMut<'a, T>, Resource);
 
-impl<'a, T: Resource> ResMut<'a, T> {
+impl<'a, T: Resource> From<ResMut<'a, T>> for Mut<'a, T> {
     /// Convert this `ResMut` into a `Mut`. This allows keeping the change-detection feature of `Mut`
     /// while losing the specificity of `ResMut` for resources.
-    pub fn into_mut(self) -> Mut<'a, T> {
+    fn from(other: ResMut<'a, T>) -> Mut<'a, T> {
         Mut {
-            value: self.value,
-            ticks: self.ticks,
+            value: other.value,
+            ticks: other.ticks,
         }
     }
 }
@@ -217,13 +217,13 @@ change_detection_impl!(NonSendMut<'a, T>, T,);
 impl_into_inner!(NonSendMut<'a, T>, T,);
 impl_debug!(NonSendMut<'a, T>,);
 
-impl<'a, T: 'static> NonSendMut<'a, T> {
+impl<'a, T: Resource> From<NonSendMut<'a, T>> for Mut<'a, T> {
     /// Convert this `NonSendMut` into a `Mut`. This allows keeping the change-detection feature of `Mut`
     /// while losing the specificity of `NonSendMut`.
-    pub fn into_mut(self) -> Mut<'a, T> {
+    fn from(other: NonSendMut<'a, T>) -> Mut<'a, T> {
         Mut {
-            value: self.value,
-            ticks: self.ticks,
+            value: other.value,
+            ticks: other.ticks,
         }
     }
 }
@@ -308,7 +308,7 @@ impl std::fmt::Debug for MutUntyped<'_> {
 mod tests {
     use crate::{
         self as bevy_ecs,
-        change_detection::{CHECK_TICK_THRESHOLD, MAX_CHANGE_AGE},
+        change_detection::{CHECK_TICK_THRESHOLD, MAX_CHANGE_AGE, ComponentTicks, Ticks, Mut, ResMut, NonSendMut},
         component::Component,
         query::ChangeTrackers,
         system::{IntoSystem, Query, System},
@@ -317,6 +317,8 @@ mod tests {
 
     #[derive(Component)]
     struct C;
+
+    struct R; // Resource
 
     #[test]
     fn change_expiration() {
@@ -403,5 +405,53 @@ mod tests {
             assert!(ticks_since_insert == MAX_CHANGE_AGE);
             assert!(ticks_since_change == MAX_CHANGE_AGE);
         }
+    }
+
+    #[test]
+    fn mut_from_res_mut() {
+        let mut component_ticks = ComponentTicks {
+            added: 1,
+            changed: 2,
+        };
+        let ticks = Ticks {
+            component_ticks: &mut component_ticks,
+            last_change_tick: 3,
+            change_tick: 4,
+        };
+        let mut res = R{};
+        let res_mut = ResMut {
+            value: &mut res,
+            ticks,
+        };
+
+        let into_mut: Mut<R> = res_mut.into();
+        assert_eq!(1, into_mut.ticks.component_ticks.added);
+        assert_eq!(2, into_mut.ticks.component_ticks.changed);
+        assert_eq!(3, into_mut.ticks.last_change_tick);
+        assert_eq!(4, into_mut.ticks.change_tick);
+    }
+
+    #[test]
+    fn mut_from_non_send_mut() {
+        let mut component_ticks = ComponentTicks {
+            added: 1,
+            changed: 2,
+        };
+        let ticks = Ticks {
+            component_ticks: &mut component_ticks,
+            last_change_tick: 3,
+            change_tick: 4,
+        };
+        let mut res = R{};
+        let non_send_mut = NonSendMut {
+            value: &mut res,
+            ticks,
+        };
+
+        let into_mut: Mut<R> = non_send_mut.into();
+        assert_eq!(1, into_mut.ticks.component_ticks.added);
+        assert_eq!(2, into_mut.ticks.component_ticks.changed);
+        assert_eq!(3, into_mut.ticks.last_change_tick);
+        assert_eq!(4, into_mut.ticks.change_tick);
     }
 }


### PR DESCRIPTION
# Objective

Enable treating components and resources equally, which can
simplify the implementation of some systems where only the change
detection feature is relevant and not the kind of object (resource or
component).

## Solution

Implement `From<ResMut<T>>` and `From<NonSendMut<T>>` for
`Mut`. Since the 3 structs are similar, and only differ by their system
param role, the conversion is trivial.

---

## Changelog

Added - `From<ResMut>` and `From<NonSendMut>` for `Mut<T>`.
