### PR TITLE
[Merged by Bors] - Lighter no default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
 [features]
 default = [
   "animation",
+  "bevy_asset",
   "bevy_audio",
   "bevy_gilrs",
   "bevy_scene",
@@ -54,6 +55,7 @@ render = [
 
 # Optional bevy crates
 bevy_animation = ["bevy_internal/bevy_animation"]
+bevy_asset = ["bevy_internal/bevy_asset"]
 bevy_audio = ["bevy_internal/bevy_audio"]
 bevy_core_pipeline = ["bevy_internal/bevy_core_pipeline"]
 bevy_dynamic_plugin = ["bevy_internal/bevy_dynamic_plugin"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ default = [
   "animation",
   "bevy_audio",
   "bevy_gilrs",
+  "bevy_scene",
   "bevy_winit",
   "render",
   "png",
@@ -60,6 +61,7 @@ bevy_gilrs = ["bevy_internal/bevy_gilrs"]
 bevy_gltf = ["bevy_internal/bevy_gltf"]
 bevy_pbr = ["bevy_internal/bevy_pbr"]
 bevy_render = ["bevy_internal/bevy_render"]
+bevy_scene = ["bevy_internal/bevy_scene"]
 bevy_sprite = ["bevy_internal/bevy_sprite"]
 bevy_text = ["bevy_internal/bevy_text"]
 bevy_ui = ["bevy_internal/bevy_ui"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -66,7 +66,6 @@ animation = ["bevy_animation", "bevy_gltf?/bevy_animation"]
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.8.0-dev" }
-bevy_asset = { path = "../bevy_asset", version = "0.8.0-dev" }
 bevy_core = { path = "../bevy_core", version = "0.8.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.8.0-dev" }
 bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.8.0-dev" }
@@ -84,6 +83,7 @@ bevy_window = { path = "../bevy_window", version = "0.8.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.8.0-dev" }
 # bevy (optional)
 bevy_animation = { path = "../bevy_animation", optional = true, version = "0.8.0-dev" }
+bevy_asset = { path = "../bevy_asset", optional = true, version = "0.8.0-dev" }
 bevy_audio = { path = "../bevy_audio", optional = true, version = "0.8.0-dev" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", optional = true, version = "0.8.0-dev" }
 bevy_gltf = { path = "../bevy_gltf", optional = true, version = "0.8.0-dev" }

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -77,7 +77,6 @@ bevy_log = { path = "../bevy_log", version = "0.8.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.8.0-dev" }
 bevy_ptr = { path = "../bevy_ptr", version = "0.8.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.8.0-dev", features = ["bevy"] }
-bevy_scene = { path = "../bevy_scene", version = "0.8.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.8.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.8.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.8.0-dev" }
@@ -91,6 +90,7 @@ bevy_gltf = { path = "../bevy_gltf", optional = true, version = "0.8.0-dev" }
 bevy_pbr = { path = "../bevy_pbr", optional = true, version = "0.8.0-dev" }
 bevy_render = { path = "../bevy_render", optional = true, version = "0.8.0-dev" }
 bevy_dynamic_plugin = { path = "../bevy_dynamic_plugin", optional = true, version = "0.8.0-dev" }
+bevy_scene = { path = "../bevy_scene", optional = true, version = "0.8.0-dev" }
 bevy_sprite = { path = "../bevy_sprite", optional = true, version = "0.8.0-dev" }
 bevy_text = { path = "../bevy_text", optional = true, version = "0.8.0-dev" }
 bevy_ui = { path = "../bevy_ui", optional = true, version = "0.8.0-dev" }

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -34,7 +34,10 @@ impl PluginGroup for DefaultPlugins {
         group.add(bevy_diagnostic::DiagnosticsPlugin::default());
         group.add(bevy_input::InputPlugin::default());
         group.add(bevy_window::WindowPlugin::default());
+
+        #[cfg(feature = "bevy_asset")]
         group.add(bevy_asset::AssetPlugin::default());
+
         #[cfg(feature = "debug_asset_server")]
         group.add(bevy_asset::debug_asset_server::DebugAssetServerPlugin::default());
 

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -37,6 +37,8 @@ impl PluginGroup for DefaultPlugins {
         group.add(bevy_asset::AssetPlugin::default());
         #[cfg(feature = "debug_asset_server")]
         group.add(bevy_asset::debug_asset_server::DebugAssetServerPlugin::default());
+
+        #[cfg(feature = "bevy_scene")]
         group.add(bevy_scene::ScenePlugin::default());
 
         #[cfg(feature = "bevy_winit")]

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -12,6 +12,7 @@ pub mod app {
     pub use bevy_app::*;
 }
 
+#[cfg(feature = "bevy_asset")]
 pub mod asset {
     //! Load and store assets and resources for Apps.
     pub use bevy_asset::*;

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -60,6 +60,7 @@ pub mod reflect {
     };
 }
 
+#[cfg(feature = "bevy_scene")]
 pub mod scene {
     //! Save/load collections of entities and components to/from file.
     pub use bevy_scene::*;

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -1,11 +1,15 @@
 #[doc(hidden)]
 pub use crate::{
-    app::prelude::*, asset::prelude::*, core::prelude::*, ecs::prelude::*, hierarchy::prelude::*,
-    input::prelude::*, log::prelude::*, math::prelude::*, reflect::prelude::*, time::prelude::*,
+    app::prelude::*, core::prelude::*, ecs::prelude::*, hierarchy::prelude::*, input::prelude::*,
+    log::prelude::*, math::prelude::*, reflect::prelude::*, time::prelude::*,
     transform::prelude::*, utils::prelude::*, window::prelude::*, DefaultPlugins, MinimalPlugins,
 };
 
 pub use bevy_derive::{bevy_main, Deref, DerefMut};
+
+#[doc(hidden)]
+#[cfg(feature = "bevy_asset")]
+pub use crate::asset::prelude::*;
 
 #[doc(hidden)]
 #[cfg(feature = "bevy_audio")]

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -1,9 +1,8 @@
 #[doc(hidden)]
 pub use crate::{
     app::prelude::*, asset::prelude::*, core::prelude::*, ecs::prelude::*, hierarchy::prelude::*,
-    input::prelude::*, log::prelude::*, math::prelude::*, reflect::prelude::*, scene::prelude::*,
-    time::prelude::*, transform::prelude::*, utils::prelude::*, window::prelude::*, DefaultPlugins,
-    MinimalPlugins,
+    input::prelude::*, log::prelude::*, math::prelude::*, reflect::prelude::*, time::prelude::*,
+    transform::prelude::*, utils::prelude::*, window::prelude::*, DefaultPlugins, MinimalPlugins,
 };
 
 pub use bevy_derive::{bevy_main, Deref, DerefMut};
@@ -27,6 +26,10 @@ pub use crate::pbr::prelude::*;
 #[doc(hidden)]
 #[cfg(feature = "bevy_render")]
 pub use crate::render::prelude::*;
+
+#[doc(hidden)]
+#[cfg(feature = "bevy_scene")]
+pub use crate::scene::prelude::*;
 
 #[doc(hidden)]
 #[cfg(feature = "bevy_sprite")]

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -5,6 +5,7 @@
 |feature name|description|
 |-|-|
 |animation|Animation support and glTF animation loading.|
+|bevy_asset|Provides asset functionality for Bevy Engine.|
 |bevy_audio|Audio support. Support for all audio formats depends on this.|
 |bevy_gilrs|Adds gamepad support.|
 |bevy_gltf|[glTF](https://www.khronos.org/gltf/) support.|

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -8,6 +8,7 @@
 |bevy_audio|Audio support. Support for all audio formats depends on this.|
 |bevy_gilrs|Adds gamepad support.|
 |bevy_gltf|[glTF](https://www.khronos.org/gltf/) support.|
+|bevy_scene|Provides scene functionality for Bevy Engine.|
 |bevy_winit|GUI support.|
 |render|The render pipeline and all render related plugins.|
 |png|PNG picture format support.|


### PR DESCRIPTION
# Objective

- Even though it's marked as optional, it is no longer possible to not depend on `bevy_render` as it's a dependency of `bevy_scene`

## Solution

- Make `bevy_scene` optional
- For the minimalist among us, also make `bevy_asset` optional
