### PR TITLE
[Merged by Bors] - Spotlight shadow bugfix

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -974,7 +974,7 @@ pub fn prepare_lights(
             n_directional_lights: directional_lights.iter().len() as u32,
             // spotlight shadow maps are stored in the directional light array, starting at directional_shadow_maps_count.
             // the spot lights themselves start in the light array at point_light_count. so to go from light
-            // index to shadow map index, we need to subtract point light shadowmap count and add directional shadowmap count.
+            // index to shadow map index, we need to subtract point light count and add directional shadowmap count.
             spot_light_shadowmap_offset: directional_shadow_maps_count as i32
                 - point_light_count as i32,
         };

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -797,10 +797,14 @@ pub fn prepare_lights(
 
     let point_light_count = point_lights
         .iter()
-        .filter(|light| light.1.shadows_enabled && light.1.spot_light_angles.is_none())
+        .filter(|light| light.1.spot_light_angles.is_none())
         .count();
 
-    let point_light_shadow_maps_count = point_light_count.min(max_texture_cubes);
+    let point_light_shadow_maps_count = point_lights
+        .iter()
+        .filter(|light| light.1.shadows_enabled && light.1.spot_light_angles.is_none())
+        .count()
+        .min(max_texture_cubes);
 
     let directional_shadow_maps_count = directional_lights
         .iter()
@@ -1045,7 +1049,7 @@ pub fn prepare_lights(
             let spot_view_transform = spot_view_matrix.into();
 
             let angle = light.spot_light_angles.expect("lights should be sorted so that \
-                [point_light_shadow_maps_count..point_light_shadow_maps_count + spot_light_shadow_maps_count] are spot lights").1;
+                [point_light_count..point_light_count + spot_light_shadow_maps_count] are spot lights").1;
             let spot_projection = spot_light_projection_matrix(angle);
 
             let depth_texture_view =

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -163,7 +163,7 @@ fn setup(
             point_light: PointLight {
                 intensity: 1600.0, // lumens - roughly a 100W non-halogen incandescent bulb
                 color: Color::BLUE,
-                shadows_enabled: false,
+                shadows_enabled: true,
                 ..default()
             },
             ..default()

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -163,7 +163,7 @@ fn setup(
             point_light: PointLight {
                 intensity: 1600.0, // lumens - roughly a 100W non-halogen incandescent bulb
                 color: Color::BLUE,
-                shadows_enabled: true,
+                shadows_enabled: false,
                 ..default()
             },
             ..default()


### PR DESCRIPTION
# Objective

fix an error in shadow map indexing that occurs when point lights without shadows are used in conjunction with spotlights with shadows

## Solution

calculate point_light_count correctly
