### PR TITLE
[Merged by Bors] - log system info on startup

### DIFF
--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -21,17 +21,10 @@ bevy_utils = { path = "../bevy_utils", version = "0.9.0" }
 # iOS or MacOS
 [target.'cfg(any(target_os="ios",target_os="macos"))'.dependencies.sysinfo]
 version = "0.27.1"
+# Some features of sysinfo are not supported by apple. This will disable those features on apple devices
 features = ["apple-app-store"]
 default-features = false
 
-# use the unknown ci feature for RPi
-# [target.'cfg(all(target_os="linux",any(target_arch="aarch64",target_arch="arm")))'.dependencies.sysinfo]
-# version = "0.27.1"
-# # this prevents linking to the C interface, which causes some build issues
-# features = ["unknown-ci"]
-# default-features = false
-
-# general case
 [dependencies.sysinfo]
 version = "0.27.1"
 default-features = false

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -25,11 +25,11 @@ features = ["apple-app-store"]
 default-features = false
 
 # use the unknown ci feature for RPi
-[target.'cfg(all(target_os="linux",any(target_arch="aarch64",target_arch="arm")))'.dependencies.sysinfo]
-version = "0.27.1"
-# this prevents linking to the C interface, which causes some build issues
-features = ["unknown-ci"]
-default-features = false
+# [target.'cfg(all(target_os="linux",any(target_arch="aarch64",target_arch="arm")))'.dependencies.sysinfo]
+# version = "0.27.1"
+# # this prevents linking to the C interface, which causes some build issues
+# features = ["unknown-ci"]
+# default-features = false
 
 # general case
 [dependencies.sysinfo]

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -18,13 +18,13 @@ bevy_log = { path = "../bevy_log", version = "0.9.0" }
 bevy_time = { path = "../bevy_time", version = "0.9.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0" }
 
-# iOS or MacOS
-[target.'cfg(any(target_os="ios",target_os="macos"))'.dependencies.sysinfo]
-version = "0.27.1"
+# MacOS
+[target.'cfg(all(target_os="macos"))'.dependencies]
 # Some features of sysinfo are not supported by apple. This will disable those features on apple devices
-features = ["apple-app-store"]
-default-features = false
+sysinfo = { version = "0.27.1", default-features = false, features = [
+    "apple-app-store",
+] }
 
-[dependencies.sysinfo]
-version = "0.27.1"
-default-features = false
+# Only include when not bevy_dynamic_plugin and on linux/windows/android
+[target.'cfg(any(target_os = "linux", target_os = "windows", target_os = "android"))'.dependencies]
+sysinfo = { version = "0.27.1", default-features = false }

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -17,3 +17,20 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.9.0" }
 bevy_log = { path = "../bevy_log", version = "0.9.0" }
 bevy_time = { path = "../bevy_time", version = "0.9.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0" }
+
+# iOS or MacOS
+[target.'cfg(any(target_os="ios",target_os="macos"))'.dependencies.sysinfo]
+version = "0.27.1"
+features = ["apple-app-store"]
+default-features = false
+
+# use the unknown ci feature for RPi
+[target.'cfg(all(target_os="linux",any(target_arch="aarch64",target_arch="arm")))'.dependencies.sysinfo]
+version = "0.27.1"
+# this prevents linking to the C interface, which causes some build issues
+features = ["unknown-ci"]
+default-features = false
+
+# general case
+[dependencies.sysinfo]
+version = "0.27.1"

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -34,3 +34,4 @@ default-features = false
 # general case
 [dependencies.sysinfo]
 version = "0.27.1"
+default-features = false

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -39,27 +39,31 @@ struct SystemInfo {
 const BYTES_TO_GIB: f64 = 1.0 / 1024.0 / 1024.0 / 1024.0;
 
 fn log_system_info() {
-    use sysinfo::{CpuExt, SystemExt};
+    // NOTE: sysinfo fails to compile when using bevy dynamic or on iOS
+    #[cfg(not(any(feature = "bevy_dynamic_plugin", target_os = "ios")))]
+    {
+        use sysinfo::{CpuExt, SystemExt};
 
-    let mut sys = sysinfo::System::new();
-    sys.refresh_cpu();
-    sys.refresh_memory();
+        let mut sys = sysinfo::System::new();
+        sys.refresh_cpu();
+        sys.refresh_memory();
 
-    let info = SystemInfo {
-        os: sys
-            .long_os_version()
-            .unwrap_or_else(|| String::from("not available")),
-        kernel: sys
-            .kernel_version()
-            .unwrap_or_else(|| String::from("not available")),
-        cpu: sys.global_cpu_info().brand().trim().to_string(),
-        core_count: sys
-            .physical_core_count()
-            .map(|x| x.to_string())
-            .unwrap_or_else(|| String::from("not available")),
-        // Convert from Bytes to GibiBytes since it's probably what people expect most of the time
-        memory: format!("{:.1} GiB", sys.total_memory() as f64 * BYTES_TO_GIB),
-    };
+        let info = SystemInfo {
+            os: sys
+                .long_os_version()
+                .unwrap_or_else(|| String::from("not available")),
+            kernel: sys
+                .kernel_version()
+                .unwrap_or_else(|| String::from("not available")),
+            cpu: sys.global_cpu_info().brand().trim().to_string(),
+            core_count: sys
+                .physical_core_count()
+                .map(|x| x.to_string())
+                .unwrap_or_else(|| String::from("not available")),
+            // Convert from Bytes to GibiBytes since it's probably what people expect most of the time
+            memory: format!("{:.1} GiB", sys.total_memory() as f64 * BYTES_TO_GIB),
+        };
 
-    info!("{:?}", info);
+        info!("{:?}", info);
+    }
 }

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -39,8 +39,16 @@ struct SystemInfo {
 const BYTES_TO_GIB: f64 = 1.0 / 1024.0 / 1024.0 / 1024.0;
 
 fn log_system_info() {
-    // NOTE: sysinfo fails to compile when using bevy dynamic or on iOS
-    #[cfg(not(any(feature = "bevy_dynamic_plugin", target_os = "ios")))]
+    // NOTE: sysinfo fails to compile when using bevy dynamic or on iOS and does nothing on wasm
+    #[cfg(all(
+        any(
+            target_os = "linux",
+            target_os = "windows",
+            target_os = "android",
+            target_os = "macos"
+        ),
+        not(feature = "bevy_dynamic_plugin")
+    ))]
     {
         use sysinfo::{CpuExt, SystemExt};
 

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -2,6 +2,7 @@ mod diagnostic;
 mod entity_count_diagnostics_plugin;
 mod frame_time_diagnostics_plugin;
 mod log_diagnostics_plugin;
+use bevy_log::info;
 pub use diagnostic::*;
 pub use entity_count_diagnostics_plugin::EntityCountDiagnosticsPlugin;
 pub use frame_time_diagnostics_plugin::FrameTimeDiagnosticsPlugin;
@@ -15,10 +16,50 @@ pub struct DiagnosticsPlugin;
 
 impl Plugin for DiagnosticsPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<Diagnostics>();
+        app.init_resource::<Diagnostics>()
+            .add_startup_system(log_system_info);
     }
 }
 
 /// The width which diagnostic names will be printed as
 /// Plugin names should not be longer than this value
 pub const MAX_DIAGNOSTIC_NAME_WIDTH: usize = 32;
+
+#[derive(Debug)]
+// This is required because the Debug trait doesn't detect it's used when it's only used in a print :(
+#[allow(dead_code)]
+struct SystemInfo {
+    os: String,
+    kernel: String,
+    cpu: String,
+    core_count: String,
+    memory: String,
+}
+
+const BYTES_TO_GIB: f64 = 1.0 / 1024.0 / 1024.0 / 1024.0;
+
+fn log_system_info() {
+    use sysinfo::{CpuExt, SystemExt};
+
+    let mut sys = sysinfo::System::new();
+    sys.refresh_cpu();
+    sys.refresh_memory();
+
+    let info = SystemInfo {
+        os: sys
+            .long_os_version()
+            .unwrap_or_else(|| String::from("not available")),
+        kernel: sys
+            .kernel_version()
+            .unwrap_or_else(|| String::from("not available")),
+        cpu: sys.global_cpu_info().brand().trim().to_string(),
+        core_count: sys
+            .physical_core_count()
+            .map(|x| x.to_string())
+            .unwrap_or_else(|| String::from("not available")),
+        // Convert from Bytes to GibiBytes since it's probably what people expect most of the time
+        memory: format!("{:.1} GiB", sys.total_memory() as f64 * BYTES_TO_GIB),
+    };
+
+    info!("{:?}", info);
+}


### PR DESCRIPTION
# Objective

- We already log the adapter info on startup when bevy_render is present. It would be nice to have more info about the system to be able to ask users to submit it in bug reports

## Solution

- Use the `sysinfo` crate to get all the information
  - I made sure it _only_ gets the required informations to avoid unnecessary system request
- Add a system that logs this on startup
  - This system is currently in `bevy_diagnostics` because I didn't really know where to put it.

Here's an example log from my system:
```log
INFO bevy_diagnostic: SystemInformation { os: "Windows 10 Pro", kernel: "19044", cpu: "AMD Ryzen 7 5800X 8-Core Processor", core_count: "8", memory: "34282242 KB" }
```
---

## Changelog

- Added a new default log when starting a bevy app that logs the system information