### PR TITLE
Use a finite `State` machine instead of a stack

### DIFF
--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -181,7 +181,6 @@ where
 pub enum StateError {
     AlreadyInState,
     StateAlreadyQueued,
-    StackEmpty,
 }
 
 impl std::error::Error for StateError {}
@@ -196,9 +195,6 @@ impl fmt::Display for StateError {
                 f,
                 "Attempted to queue a state change, but there was already a state queued."
             ),
-            StateError::StackEmpty => {
-                write!(f, "Attempted to queue a pop, but there is nothing to pop.")
-            }
         }
     }
 }

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -126,15 +126,14 @@ where
     /// If `state` is the same as the current one, this does nothing.
     /// Use [`restart`](#method.restart) to trigger `on_exit` and `on_enter` for the current state.
     pub fn set(&mut self, state: T) -> Result<(), StateError> {
-        if self.current_state == state {
-            return Ok(());
-        }
-
         if self.next_state.is_some() || self.transition.is_some() {
             return Err(StateError::StateAlreadyQueued);
         }
 
-        self.next_state = Some(state);
+        // Only schedule a transition if the passed `state` is distinct from the current one.
+        if self.current_state != state {
+            self.next_state = Some(state);
+        }
         Ok(())
     }
 

--- a/crates/bevy_ecs/src/schedule/system_set.rs
+++ b/crates/bevy_ecs/src/schedule/system_set.rs
@@ -27,20 +27,6 @@ impl SystemSet {
         Self::new().with_run_criteria(State::<T>::on_update(s))
     }
 
-    pub fn on_inactive_update<T>(s: T) -> SystemSet
-    where
-        T: StateData,
-    {
-        Self::new().with_run_criteria(State::<T>::on_inactive_update(s))
-    }
-
-    pub fn on_in_stack_update<T>(s: T) -> SystemSet
-    where
-        T: StateData,
-    {
-        Self::new().with_run_criteria(State::<T>::on_in_stack_update(s))
-    }
-
     pub fn on_enter<T>(s: T) -> SystemSet
     where
         T: StateData,
@@ -53,20 +39,6 @@ impl SystemSet {
         T: StateData,
     {
         Self::new().with_run_criteria(State::<T>::on_exit(s))
-    }
-
-    pub fn on_pause<T>(s: T) -> SystemSet
-    where
-        T: StateData,
-    {
-        Self::new().with_run_criteria(State::<T>::on_pause(s))
-    }
-
-    pub fn on_resume<T>(s: T) -> SystemSet
-    where
-        T: StateData,
-    {
-        Self::new().with_run_criteria(State::<T>::on_resume(s))
     }
 
     #[must_use]

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -301,8 +301,7 @@ fn spawn_bonus(
         commands.entity(entity).despawn_recursive();
         game.bonus.entity = None;
         if game.score <= -5 {
-            // We don't particularly care if this operation fails
-            let _ = state.overwrite_set(GameState::GameOver);
+            state.overwrite_set(GameState::GameOver);
             return;
         }
     }


### PR DESCRIPTION
# Objective

- Stack-based state machines only make sense in specific circumstances -- finite state machines are more generally applicable.
- Increase parity with #4391
- Far less confusing.

## Solution

- Subtractive design -- most of the current API stays the same, we just yeet everything related to the old stack.
  - Should make it easier to migrate towards the full `State` overhaul in Stageless.

---

## Changelog

- Replaced the old stack-based state machine with a finite state machine.
- `State` transition methods no longer return an error when trying to transition from to a duplicate state.

## Migration Guide

All `State` methods relating to the previous stack-based implementation have been removed. The only operations are `set` and `overwrite_set`. The only associated run criteria are `on_update`, `on_enter`, and `on_exit`.
