### PR TITLE
[Merged by Bors] - Add missing `ReadOnly = Self` bound

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -168,7 +168,7 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 /// ```
 ///
 /// **Note:** if you omit the `mutable` attribute for a query that doesn't implement
-/// `ReadOnlyFetch`, compilation will fail. We insert static checks as in the example above for
+/// [`ReadOnlyWorldQuery`], compilation will fail. We insert static checks as in the example above for
 /// every query component and a nested query.
 /// (The checks neither affect the runtime, nor pollute your local namespace.)
 ///
@@ -333,7 +333,7 @@ pub unsafe trait WorldQuery: for<'w> WorldQueryGats<'w, _State = Self::State> {
 /// # Safety
 ///
 /// This must only be implemented for read-only [`WorldQuery`]'s.
-pub unsafe trait ReadOnlyWorldQuery: WorldQuery {}
+pub unsafe trait ReadOnlyWorldQuery: WorldQuery<ReadOnly = Self> {}
 
 /// The [`Fetch`] of a [`WorldQuery`], which declares which data it needs access to
 pub type QueryFetch<'w, Q> = <Q as WorldQueryGats<'w>>::Fetch;

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -306,7 +306,7 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        // Safety: it is safe to alias for ReadOnlyFetch
+        // Safety: it is safe to alias for ReadOnlyWorldQuery
         unsafe { QueryCombinationIter::fetch_next_aliased_unchecked(self) }
     }
 

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -54,6 +54,17 @@ use std::{any::TypeId, borrow::Borrow, fmt::Debug};
 /// # bevy_ecs::system::assert_is_system(system);
 /// ```
 ///
+/// You can use the [`ReadOnlyWorldQuery`] trait to abstract over read only query generics:
+/// ```
+/// # use bevy_ecs::system::Query;
+/// # use bevy_ecs::query::{QueryItem, ReadOnlyWorldQuery};
+/// fn system<Q: ReadOnlyWorldQuery>(
+///     query: Query<Q>,
+/// ) {
+///     let _: Option<QueryItem<Q>> = query.iter().next();
+/// }
+/// ```
+///
 /// ## Mutable component access
 ///
 /// The following example is similar to the previous one, with the exception of `ComponentA`


### PR DESCRIPTION
# Objective
`ReadOnlyWorldQuery` should have required `Self::ReadOnly = Self` so that calling `.iter()` on a readonly query is equivelent to calling `iter_mut()`.

## Solution

add `ReadOnly = Self` to the definition of `ReadOnlyWorldQuery`

---

## Changelog

ReadOnlyWorldQuery's `ReadOnly` assoc type is now always equal to `Self`

## Migration Guide

Make `Self::ReadOnly = Self` hold