### PR TITLE
[Merged by Bors] - set ndk env variable

### DIFF
--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -59,7 +59,7 @@ jobs:
         run: cargo install --force cargo-apk
       
       - name: Build APK
-        run: cargo apk build --example android_example
+        run: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME cargo apk build --example android_example
 
   run-examples-on-windows-dx12:
     runs-on: windows-latest


### PR DESCRIPTION
# Objective

- Fixes #5463
- set ANDROID_NDK_ROOT
- GitHub recently updated their ubuntu container, removing some of the android environment variable: https://github.com/actions/virtual-environments/commit/ca5d04c7da260089447a4b445d6951e204373989
- `cargo-apk` is not reading the new environment variable: https://github.com/rust-windowing/android-ndk-rs/blob/9a8be258a951e213f4d07abe3c4c190d568c9694/ndk-build/src/ndk.rs#L33-L38
- this also means CI will now use the latest android NDK, I don't know if that's an issue