### PR TITLE
[Merged by Bors] - ImageSampler linear/nearest constructors

### DIFF
--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -126,16 +126,19 @@ pub enum ImageSampler {
 
 impl ImageSampler {
     /// Returns an image sampler with `Linear` min and mag filters
+    #[inline]
     pub fn linear() -> ImageSampler {
         ImageSampler::Descriptor(Self::linear_descriptor())
     }
 
     /// Returns an image sampler with `nearest` min and mag filters
+    #[inline]
     pub fn nearest() -> ImageSampler {
         ImageSampler::Descriptor(Self::nearest_descriptor())
     }
 
     /// Returns a sampler descriptor with `Linear` min and mag filters
+    #[inline]
     pub fn linear_descriptor() -> wgpu::SamplerDescriptor<'static> {
         wgpu::SamplerDescriptor {
             mag_filter: wgpu::FilterMode::Linear,
@@ -145,6 +148,7 @@ impl ImageSampler {
     }
 
     /// Returns a sampler descriptor with `Nearest` min and mag filters
+    #[inline]
     pub fn nearest_descriptor() -> wgpu::SamplerDescriptor<'static> {
         wgpu::SamplerDescriptor {
             mag_filter: wgpu::FilterMode::Nearest,

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -125,6 +125,16 @@ pub enum ImageSampler {
 }
 
 impl ImageSampler {
+    /// Returns an image sampler with `Linear` min and mag filters
+    pub fn linear() -> ImageSampler {
+        ImageSampler::Descriptor(Self::linear_descriptor())
+    }
+
+    /// Returns an image sampler with `nearest` min and mag filters
+    pub fn nearest() -> ImageSampler {
+        ImageSampler::Descriptor(Self::nearest_descriptor())
+    }
+
     /// Returns a sampler descriptor with `Linear` min and mag filters
     pub fn linear_descriptor() -> wgpu::SamplerDescriptor<'static> {
         wgpu::SamplerDescriptor {


### PR DESCRIPTION
# Objective

I found this small ux hiccup when writing the 0.8 blog post:

```rust
image.sampler = ImageSampler::Descriptor(ImageSampler::nearest_descriptor());
```

Not good!

## Solution

```rust
image.sampler = ImageSampler::nearest();
```

(there are Good Reasons to keep around the nearest_descriptor() constructor and I think it belongs on this type)