### PR TITLE
Run fixed time-step in an exclusive system

### DIFF
--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -25,6 +25,7 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.8.0-dev" }
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }
 ron = { version = "0.7.0", optional = true }
+thiserror = "1.0"
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -6,6 +6,7 @@ mod app;
 mod plugin;
 mod plugin_group;
 mod schedule_runner;
+mod sub_schedule;
 
 #[cfg(feature = "bevy_ci_testing")]
 mod ci_testing;
@@ -15,12 +16,14 @@ pub use bevy_derive::DynamicPlugin;
 pub use plugin::*;
 pub use plugin_group::*;
 pub use schedule_runner::*;
+pub use sub_schedule::*;
 
 #[allow(missing_docs)]
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        app::App, CoreStage, DynamicPlugin, Plugin, PluginGroup, StartupSchedule, StartupStage,
+        app::App, CoreStage, DynamicPlugin, IntoSubSchedule, Plugin, PluginGroup, StartupSchedule,
+        StartupStage,
     };
 }
 

--- a/crates/bevy_app/src/sub_schedule.rs
+++ b/crates/bevy_app/src/sub_schedule.rs
@@ -1,0 +1,216 @@
+use std::fmt::Debug;
+
+use bevy_ecs::{
+    change_detection::Mut,
+    schedule::{ScheduleLabel, ScheduleLabelId, Stage, StageLabel, StageLabelId},
+    system::IntoExclusiveSystem,
+    world::World,
+};
+use bevy_utils::HashMap;
+
+use crate::App;
+
+/// Methods for converting a schedule into a [sub-Schedule](SubSchedule) descriptor.
+pub trait IntoSubSchedule: Sized {
+    /// The wrapped schedule type.
+    type Sched: Stage;
+    /// The type that controls the behaviour of the exclusive system
+    /// which runs [`SubSchedule`]s of this type.
+    type Runner: FnMut(&mut Self::Sched, &mut World) + Send + Sync + 'static;
+
+    /// Applies the specified label to the current schedule.
+    /// This means it will be accessible in the [`SubSchedules`] resource after
+    /// being added to the [`App`].
+    fn label(self, label: impl ScheduleLabel) -> SubSchedule<Self::Sched, Self::Runner> {
+        let mut sub = Self::into_sched(self);
+        sub.label = Some(label.as_label());
+        sub
+    }
+    /// Defines a function that runs the current schedule. It will be inserted into
+    /// an exclusive system within the stage `stage`.
+    ///
+    /// Overwrites any previously set runner or stage.
+    fn with_runner<F>(self, stage: impl StageLabel, f: F) -> SubSchedule<Self::Sched, F>
+    where
+        F: FnMut(&mut Self::Sched, &mut World) + Send + Sync + 'static,
+    {
+        let SubSchedule {
+            schedule, label, ..
+        } = Self::into_sched(self);
+        SubSchedule {
+            schedule,
+            label,
+            runner: Some((stage.as_label(), f)),
+        }
+    }
+
+    /// Performs the conversion. You usually do not need to call this directly.
+    fn into_sched(_: Self) -> SubSchedule<Self::Sched, Self::Runner>;
+}
+
+impl<S: Stage> IntoSubSchedule for S {
+    type Sched = Self;
+    type Runner = fn(&mut Self, &mut World);
+    fn into_sched(schedule: Self) -> SubSchedule<Self, Self::Runner> {
+        SubSchedule {
+            schedule,
+            label: None,
+            runner: None,
+        }
+    }
+}
+
+impl<S: Stage, R> IntoSubSchedule for SubSchedule<S, R>
+where
+    R: FnMut(&mut S, &mut World) + Send + Sync + 'static,
+{
+    type Sched = S;
+    type Runner = R;
+    #[inline]
+    fn into_sched(sched: Self) -> SubSchedule<S, R> {
+        sched
+    }
+}
+
+/// A schedule that may run independently of the main app schedule.
+pub struct SubSchedule<S: Stage, F>
+where
+    F: FnMut(&mut S, &mut World) + Send + Sync + 'static,
+{
+    schedule: S,
+    label: Option<ScheduleLabelId>,
+    runner: Option<(StageLabelId, F)>,
+}
+
+/// A [resource](bevy_ecs::system::Res) that stores all labeled [`SubSchedule`]s.
+#[derive(Default)]
+pub struct SubSchedules {
+    // INVARIANT: A `SubSlot` cannot be removed once added, and is associated with
+    // a single schedule. Even if a slot gets temporarily emptied, it is guaranteed
+    // that the slot will always get refilled by the same exact schedule.
+    map: HashMap<ScheduleLabelId, SubSlot>,
+}
+
+struct SubSlot(Option<Box<dyn Stage>>);
+impl SubSchedules {
+    /// Inserts a new sub-schedule.
+    ///
+    /// # Panics
+    /// If there is already a sub-schedule labeled `label`.
+    #[track_caller]
+    pub fn insert(&mut self, label: impl ScheduleLabel, sched: Box<dyn Stage>) {
+        let label = label.as_label();
+        let old = self.map.insert(label, SubSlot(Some(sched)));
+        if old.is_some() {
+            panic!("there is already a sub-schedule with label '{label:?}'");
+        }
+    }
+
+    /// Temporarily extracts a [`SubSchedule`] from the world, and provides a scope
+    /// that has mutable access to both the schedule and the [`World`].
+    /// At the end of this scope, the sub-schedule is automatically reinserted.
+    ///
+    /// # Panics
+    /// If there is no schedule associated with `label`, or if that schedule
+    /// is currently already extracted.
+    #[track_caller]
+    pub fn extract_scope<F, T>(world: &mut World, label: impl ScheduleLabel, f: F) -> T
+    where
+        F: FnOnce(&mut World, &mut dyn Stage) -> T,
+    {
+        #[inline(never)]
+        fn panic_none(label: impl Debug) -> ! {
+            panic!("there is no sub-schedule with label '{label:?}'")
+        }
+        #[inline(never)]
+        fn panic_extracted(label: impl Debug) -> ! {
+            panic!("cannot extract sub-schedule '{label:?}', as it is currently extracted already")
+        }
+
+        let label = label.as_label();
+
+        // Extract.
+        let mut schedules = world.resource_mut::<Self>();
+        let mut sched = match schedules.map.get_mut(&label) {
+            Some(x) => match x.0.take() {
+                Some(x) => x,
+                None => panic_extracted(label),
+            },
+            None => panic_none(label),
+        };
+
+        // Execute.
+        let val = f(world, sched.as_mut());
+
+        // Re-insert.
+        let mut schedules = world.resource_mut::<Self>();
+        schedules.map.get_mut(&label).unwrap().0 = Some(sched);
+
+        val
+    }
+
+    /// Gets a mutable reference to the sub-schedule identified by `label`.
+    ///
+    /// # Panics
+    /// If the schedule is currently [extracted](#method.extract_scope).
+    pub fn get_mut<S: Stage>(&mut self, label: impl ScheduleLabel) -> Option<&mut S> {
+        #[cold]
+        fn panic(label: impl Debug) -> ! {
+            panic!("cannot get sub-schedule '{label:?}', as it is currently extracted")
+        }
+
+        let label = label.as_label();
+        let sched = match self.map.get_mut(&label)?.0.as_deref_mut() {
+            Some(x) => x,
+            None => panic(label),
+        };
+        sched.downcast_mut()
+    }
+}
+
+#[track_caller]
+pub(crate) fn add_to_app<S: Stage>(app: &mut App, schedule: impl IntoSubSchedule<Sched = S>) {
+    let SubSchedule {
+        mut schedule,
+        label,
+        runner,
+    } = IntoSubSchedule::into_sched(schedule);
+
+    // If it has a label, insert it to the public resource.
+    if let Some(label) = label {
+        let mut res: Mut<SubSchedules> = app.world.get_resource_or_insert_with(Default::default);
+        res.insert(label, Box::new(schedule));
+
+        if let Some((stage, mut runner)) = runner {
+            // Driver which extracts the schedule from the world and runs it.
+            let driver = move |w: &mut World| {
+                SubSchedules::extract_scope(w, label, |w, sched| {
+                    let sched = if let Some(s) = sched.downcast_mut::<S>() {
+                        s
+                    } else {
+                        #[cfg(debug_assertions)]
+                        unreachable!("the sub-schedule '{label:?}' somehow changed type after being inserted!");
+                        // SAFETY: Due to the invariant on `SubSchedules`, we can be sure that
+                        // `sched` is the same instance that we inserted.
+                        // Thus, we can rely on its type matching `S`.
+                        #[cfg(not(debug_assertions))]
+                        unsafe {
+                            std::hint::unreachable_unchecked()
+                        }
+                    };
+                    runner(sched, w);
+                });
+            };
+            app.add_system_to_stage(stage, driver.exclusive_system());
+        }
+    } else if let Some((stage, mut runner)) = runner {
+        // If there's no label, then the schedule isn't visible publicly.
+        // We can just store it locally
+        let driver = move |w: &mut World| {
+            runner(&mut schedule, w);
+        };
+        app.add_system_to_stage(stage, driver.exclusive_system());
+    } else {
+        panic!("inserted sub-schedule can never be accessed, as it has neither a label nor a runner function")
+    }
+}

--- a/crates/bevy_app/src/sub_schedule.rs
+++ b/crates/bevy_app/src/sub_schedule.rs
@@ -237,13 +237,3 @@ pub(crate) fn add_to_app(app: &mut App, schedule: impl IntoSubSchedule) {
         panic!("inserted sub-schedule can never be accessed, as it has neither a label nor a runner function")
     }
 }
-
-/// Trait that lets us get the type name of a trait object for debugging purposes.
-trait AnyTypeName: 'static {
-    fn name(&self) -> &'static str;
-}
-impl<T: ?Sized + 'static> AnyTypeName for T {
-    fn name(&self) -> &'static str {
-        std::any::type_name::<Self>()
-    }
-}

--- a/crates/bevy_app/src/sub_schedule.rs
+++ b/crates/bevy_app/src/sub_schedule.rs
@@ -115,7 +115,7 @@ impl Debug for ExtractError {
 #[non_exhaustive]
 pub enum InsertError {
     /// A schedule with this label already exists.
-    #[error("there is no sub-schedule with label '{0:?}'")]
+    #[error("a sub-schedule with label '{0:?}' already exists")]
     Duplicate(ScheduleLabelId),
 }
 impl Debug for InsertError {

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -492,6 +492,21 @@ pub fn derive_run_criteria_label(input: TokenStream) -> TokenStream {
     derive_label(input, &trait_path, "run_criteria_label")
 }
 
+/// Generates an impl of the `ScheduleLabel` trait.
+///
+/// This works only for unit structs, or enums with only unit variants.
+/// You may force a struct or variant to behave as if it were fieldless with `#[schedule_label(ignore_fields)]`.
+#[proc_macro_derive(ScheduleLabel, attributes(schedule_label))]
+pub fn derive_schedule_label(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let mut trait_path = bevy_ecs_path();
+    trait_path.segments.push(format_ident!("schedule").into());
+    trait_path
+        .segments
+        .push(format_ident!("ScheduleLabel").into());
+    derive_label(input, &trait_path, "schedule_label")
+}
+
 pub(crate) fn bevy_ecs_path() -> syn::Path {
     BevyManifest::default().get_path("bevy_ecs")
 }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -35,8 +35,8 @@ pub mod prelude {
         query::{Added, AnyOf, ChangeTrackers, Changed, Or, QueryState, With, Without},
         schedule::{
             AmbiguitySetLabel, ExclusiveSystemDescriptorCoercion, ParallelSystemDescriptorCoercion,
-            RunCriteria, RunCriteriaDescriptorCoercion, RunCriteriaLabel, Schedule, Stage,
-            StageLabel, State, SystemLabel, SystemSet, SystemStage,
+            RunCriteria, RunCriteriaDescriptorCoercion, RunCriteriaLabel, Schedule, ScheduleLabel,
+            Stage, StageLabel, State, SystemLabel, SystemSet, SystemStage,
         },
         system::{
             Commands, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend,

--- a/crates/bevy_ecs/src/schedule/label.rs
+++ b/crates/bevy_ecs/src/schedule/label.rs
@@ -1,4 +1,6 @@
-pub use bevy_ecs_macros::{AmbiguitySetLabel, RunCriteriaLabel, StageLabel, SystemLabel};
+pub use bevy_ecs_macros::{
+    AmbiguitySetLabel, RunCriteriaLabel, ScheduleLabel, StageLabel, SystemLabel,
+};
 use bevy_utils::define_label;
 
 define_label!(
@@ -24,4 +26,12 @@ define_label!(
     RunCriteriaLabel,
     /// Strongly-typed identifier for a [`RunCriteriaLabel`].
     RunCriteriaLabelId,
+);
+
+// note: this type won't be necessary come stageless, but we need it for now.
+define_label!(
+    /// A strongly-typed class of labels used to identify a [`Schedule`](crate::schedule::Schedule).
+    ScheduleLabel,
+    /// Strongly-typed identifier for a [`ScheduleLabel`].
+    ScheduleLabelId,
 );

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -61,7 +61,7 @@ impl TimestepAppExt for App {
                 panic(label)
             }
 
-            let runner = move |s: &mut S, w: &mut World| {
+            let runner = move |s: &mut dyn Stage, w: &mut World| {
                 let mut state = *w.resource::<FixedTimesteps>().get(label).unwrap();
 
                 // Core looping functionality.
@@ -85,7 +85,7 @@ impl TimestepAppExt for App {
                 step,
                 accumulator: 0.0,
             };
-            let runner = move |sched: &mut S, w: &mut World| {
+            let runner = move |sched: &mut dyn Stage, w: &mut World| {
                 // Core looping functionality.
                 let time = w.resource::<Time>();
                 state.accumulator += time.delta_seconds_f64();

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -16,7 +16,7 @@ use crossbeam_channel::{Receiver, Sender};
 pub mod prelude {
     //! The Bevy Time Prelude.
     #[doc(hidden)]
-    pub use crate::{Time, Timer};
+    pub use crate::{Time, Timer, TimestepAppExt};
 }
 
 use bevy_app::prelude::*;
@@ -34,7 +34,6 @@ pub struct TimeSystem;
 impl Plugin for TimePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<Time>()
-            .init_resource::<FixedTimesteps>()
             .register_type::<Timer>()
             // time system is added as an "exclusive system" to ensure it runs before other systems
             // in CoreStage::First

--- a/examples/2d/rotation.rs
+++ b/examples/2d/rotation.rs
@@ -9,9 +9,9 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system_set(
-            SystemSet::new()
-                .with_run_criteria(FixedTimestep::step(TIME_STEP as f64))
+        .add_fixed_schedule(
+            FixedTimestep::step(TIME_STEP as f64),
+            SystemStage::parallel()
                 .with_system(player_movement_system)
                 .with_system(snap_to_player_system)
                 .with_system(rotate_to_player_system),

--- a/examples/ecs/fixed_timestep.rs
+++ b/examples/ecs/fixed_timestep.rs
@@ -5,28 +5,19 @@ use bevy::{
     time::{FixedTimestep, FixedTimesteps},
 };
 
-const LABEL: &str = "my_fixed_timestep";
-
-#[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
-struct FixedUpdateStage;
+/// Label for our fixed time-step.
+#[derive(ScheduleLabel)]
+struct FixedUpdate;
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         // this system will run once every update (it should match your screen's refresh rate)
         .add_system(frame_update)
-        // add a new stage that runs twice a second
-        .add_stage_after(
-            CoreStage::Update,
-            FixedUpdateStage,
-            SystemStage::parallel()
-                .with_run_criteria(
-                    FixedTimestep::step(0.5)
-                        // labels are optional. they provide a way to access the current
-                        // FixedTimestep state from within a system
-                        .with_label(LABEL),
-                )
-                .with_system(fixed_update),
+        // add a new schedule that runs twice a second
+        .add_fixed_schedule(
+            FixedTimestep::step(0.5).with_label(FixedUpdate),
+            SystemStage::single_threaded().with_system(fixed_update),
         )
         .run();
 }
@@ -42,11 +33,8 @@ fn fixed_update(mut last_time: Local<f64>, time: Res<Time>, fixed_timesteps: Res
         time.seconds_since_startup() - *last_time,
     );
 
-    let fixed_timestep = fixed_timesteps.get(LABEL).unwrap();
-    info!(
-        "  overstep_percentage: {}",
-        fixed_timestep.overstep_percentage()
-    );
+    let dbg = fixed_timesteps.get(FixedUpdate).unwrap();
+    info!("  overstep_percentage: {}", dbg.overstep_percentage());
 
     *last_time = time.seconds_since_startup();
 }

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -16,11 +16,9 @@ fn main() {
             ..default()
         })
         .add_startup_system(generate_bodies)
-        .add_stage_after(
-            CoreStage::Update,
-            FixedUpdateStage,
+        .add_fixed_schedule(
+            FixedTimestep::step(DELTA_TIME),
             SystemStage::parallel()
-                .with_run_criteria(FixedTimestep::step(DELTA_TIME))
                 .with_system(interact_bodies)
                 .with_system(integrate),
         )

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -27,10 +27,9 @@ fn main() {
         .add_system_set(SystemSet::on_enter(GameState::GameOver).with_system(display_score))
         .add_system_set(SystemSet::on_update(GameState::GameOver).with_system(gameover_keyboard))
         .add_system_set(SystemSet::on_exit(GameState::GameOver).with_system(teardown))
-        .add_system_set(
-            SystemSet::new()
-                .with_run_criteria(FixedTimestep::step(5.0))
-                .with_system(spawn_bonus),
+        .add_fixed_schedule(
+            FixedTimestep::step(5.0),
+            SystemStage::single_threaded().with_system(spawn_bonus),
         )
         .add_system(bevy::window::close_on_esc)
         .run();

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -57,9 +57,9 @@ fn main() {
         .insert_resource(ClearColor(BACKGROUND_COLOR))
         .add_startup_system(setup)
         .add_event::<CollisionEvent>()
-        .add_system_set(
-            SystemSet::new()
-                .with_run_criteria(FixedTimestep::step(TIME_STEP as f64))
+        .add_fixed_schedule(
+            FixedTimestep::step(TIME_STEP as f64),
+            SystemStage::parallel()
                 .with_system(check_for_collisions)
                 .with_system(move_paddle.before(check_for_collisions))
                 .with_system(apply_velocity.before(check_for_collisions))

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -48,10 +48,10 @@ fn main() {
         .add_system(movement_system)
         .add_system(collision_system)
         .add_system(counter_system)
-        .add_system_set(
-            SystemSet::new()
-                .with_run_criteria(FixedTimestep::step(0.2))
-                .with_system(scheduled_spawner),
+        // System that runs every 0.2 seconds
+        .add_fixed_schedule(
+            FixedTimestep::step(0.2),
+            SystemStage::single_threaded().with_system(scheduled_spawner),
         )
         .run();
 }


### PR DESCRIPTION
# Objective

- Allow combining fixed time-steps with run criteria.
- Lets us yeet looping run criteria in the future.

## Solution

- `SubSchedule` -- a schedule that does not necessarily run along with the main schedule.
  - Gets stored in a public resource, and then extracted and run in an exclusive system.
  - Useful not just for fixed time-steps -- they could be used to invoke a collection of systems as a sort of callback, at any time. Example: `OnEnter` or `OnExit` for states.
  - Analogous to the system sets on #4391 -- only `SubSchedule` is worse since it's split into stages.
    - Eventually this API should be fully replaced in stageless. The primary motivation of this API is to ease migration.

---

## Changelog

todo

## Migration Guide

Before:
```rust
App::new()
    .add_system_set(
        SystemSet::new()
            .with_run_criteria(FixedTimestep::step(1.0 / 60.0))
            .with_system(my_system),
    );
```
After:
```rust
App::new()
    .add_fixed_schedule(
        FixedTimestep::step(1.0 / 60.0),
        SystemStage::single_threaded().with_system(my_system),
    );
```
More complex schedules:
```rust
#[derive(ScheduleLabel)]
struct FixedUpdate;

#[derive(StageLabel)]
struct FixedStage {
    A,
    B,
}

App::new()
    .add_fixed_schedule_to_stage(
        CoreStage::PreUpdate,
        FixedTimestep::steps_per_second(60.0).with_label(FixedUpdate),
        Schedule::default()
            .with_stage(FixedStage::A, SystemStage::parallel())
            .with_stage(FixedStage::B, SystemStage::parallel()),
    )
    .sub_schedule(FixedUpdate, |s: &mut Schedule| {
        s.add_system_to_stage(FixedStage::A, foo);
        s.add_system_to_stage(FixedStage::B, bar);
    });
```

## Notes

This PR adds `thiserror` as a direct dependency for `bevy_app`, but it was already in the dependency tree.