### PR TITLE
Enable trace by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ default = [
   "vorbis",
   "x11",
   "filesystem_watcher",
+  "trace",
 ]
 
 # Force dynamic linking, which improves iterative compile times

--- a/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
@@ -12,7 +12,7 @@ use bevy_render::{
     view::{ExtractedView, ViewTarget},
 };
 #[cfg(feature = "trace")]
-use bevy_utils::tracing::info_span;
+use bevy_utils::tracing::debug_span;
 
 pub struct MainPass2dNode {
     query: QueryState<
@@ -61,7 +61,7 @@ impl Node for MainPass2dNode {
             };
         {
             #[cfg(feature = "trace")]
-            let _main_pass_2d = info_span!("main_pass_2d").entered();
+            let _main_pass_2d = debug_span!("main_pass_2d").entered();
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("main_pass_2d"),
                 color_attachments: &[Some(target.get_color_attachment(Operations {
@@ -99,7 +99,7 @@ impl Node for MainPass2dNode {
         #[cfg(feature = "webgl")]
         if camera.viewport.is_some() {
             #[cfg(feature = "trace")]
-            let _reset_viewport_pass_2d = info_span!("reset_viewport_pass_2d").entered();
+            let _reset_viewport_pass_2d = debug_span!("reset_viewport_pass_2d").entered();
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("reset_viewport_pass_2d"),
                 color_attachments: &[Some(target.get_color_attachment(Operations {

--- a/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
@@ -12,7 +12,7 @@ use bevy_render::{
     view::{ExtractedView, ViewDepthTexture, ViewTarget},
 };
 #[cfg(feature = "trace")]
-use bevy_utils::tracing::info_span;
+use bevy_utils::tracing::debug_span;
 
 pub struct MainPass3dNode {
     query: QueryState<
@@ -68,7 +68,7 @@ impl Node for MainPass3dNode {
             // Run the opaque pass, sorted front-to-back
             // NOTE: Scoped to drop the mutable borrow of render_context
             #[cfg(feature = "trace")]
-            let _main_opaque_pass_3d_span = info_span!("main_opaque_pass_3d").entered();
+            let _main_opaque_pass_3d_span = debug_span!("main_opaque_pass_3d").entered();
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("main_opaque_pass_3d"),
                 // NOTE: The opaque pass loads the color
@@ -115,7 +115,7 @@ impl Node for MainPass3dNode {
             // Run the alpha mask pass, sorted front-to-back
             // NOTE: Scoped to drop the mutable borrow of render_context
             #[cfg(feature = "trace")]
-            let _main_alpha_mask_pass_3d_span = info_span!("main_alpha_mask_pass_3d").entered();
+            let _main_alpha_mask_pass_3d_span = debug_span!("main_alpha_mask_pass_3d").entered();
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("main_alpha_mask_pass_3d"),
                 // NOTE: The alpha_mask pass loads the color buffer as well as overwriting it where appropriate.
@@ -154,7 +154,7 @@ impl Node for MainPass3dNode {
             // Run the transparent pass, sorted back-to-front
             // NOTE: Scoped to drop the mutable borrow of render_context
             #[cfg(feature = "trace")]
-            let _main_transparent_pass_3d_span = info_span!("main_transparent_pass_3d").entered();
+            let _main_transparent_pass_3d_span = debug_span!("main_transparent_pass_3d").entered();
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("main_transparent_pass_3d"),
                 // NOTE: The transparent pass loads the color buffer as well as overwriting it where appropriate.
@@ -199,7 +199,7 @@ impl Node for MainPass3dNode {
         #[cfg(feature = "webgl")]
         if camera.viewport.is_some() {
             #[cfg(feature = "trace")]
-            let _reset_viewport_pass_3d = info_span!("reset_viewport_pass_3d").entered();
+            let _reset_viewport_pass_3d = debug_span!("reset_viewport_pass_3d").entered();
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("reset_viewport_pass_3d"),
                 color_attachments: &[Some(target.get_color_attachment(Operations {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1014,7 +1014,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
                             }
                         };
                         #[cfg(feature = "trace")]
-                        let span = bevy_utils::tracing::info_span!(
+                        let span = bevy_utils::tracing::debug_span!(
                             "par_for_each",
                             query = std::any::type_name::<Q>(),
                             filter = std::any::type_name::<F>(),
@@ -1061,7 +1061,7 @@ impl<Q: WorldQuery, F: WorldQuery> QueryState<Q, F> {
                         };
 
                         #[cfg(feature = "trace")]
-                        let span = bevy_utils::tracing::info_span!(
+                        let span = bevy_utils::tracing::debug_span!(
                             "par_for_each",
                             query = std::any::type_name::<Q>(),
                             filter = std::any::type_name::<F>(),

--- a/crates/bevy_ecs/src/schedule/executor_parallel.rs
+++ b/crates/bevy_ecs/src/schedule/executor_parallel.rs
@@ -113,7 +113,7 @@ impl ParallelSystemExecutor for ParallelExecutor {
 
         {
             #[cfg(feature = "trace")]
-            let _span = bevy_utils::tracing::info_span!("update_archetypes").entered();
+            let _span = bevy_utils::tracing::debug_span!("update_archetypes").entered();
             for (index, container) in systems.iter_mut().enumerate() {
                 let meta = &mut self.system_metadata[index];
                 let system = container.system_mut();
@@ -149,7 +149,7 @@ impl ParallelSystemExecutor for ParallelExecutor {
                 }
             };
             #[cfg(feature = "trace")]
-            let span = bevy_utils::tracing::info_span!("parallel executor");
+            let span = bevy_utils::tracing::debug_span!("parallel executor");
             #[cfg(feature = "trace")]
             let parallel_executor = parallel_executor.instrument(span);
             scope.spawn(parallel_executor);
@@ -167,7 +167,7 @@ impl ParallelExecutor {
         world: &'scope World,
     ) {
         #[cfg(feature = "trace")]
-        let _span = bevy_utils::tracing::info_span!("prepare_systems").entered();
+        let _span = bevy_utils::tracing::debug_span!("prepare_systems").entered();
         self.should_run.clear();
         for (index, (system_data, system)) in
             self.system_metadata.iter_mut().zip(systems).enumerate()
@@ -182,7 +182,7 @@ impl ParallelExecutor {
                 let system_span = bevy_utils::tracing::info_span!("system", name = &*system.name());
                 #[cfg(feature = "trace")]
                 let overhead_span =
-                    bevy_utils::tracing::info_span!("system overhead", name = &*system.name());
+                    bevy_utils::tracing::debug_span!("system overhead", name = &*system.name());
                 let task = async move {
                     start_receiver
                         .recv()

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -830,7 +830,7 @@ impl Stage for SystemStage {
 
                 #[cfg(feature = "trace")]
                 let _span =
-                    bevy_utils::tracing::info_span!("run criteria", name = &*criteria.name())
+                    bevy_utils::tracing::debug_span!("run criteria", name = &*criteria.name())
                         .entered();
 
                 match &mut criteria.inner {

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -57,7 +57,7 @@ fn despawn_children(world: &mut World, entity: Entity) {
 impl Command for DespawnRecursive {
     fn write(self, world: &mut World) {
         #[cfg(feature = "trace")]
-        let _span = bevy_utils::tracing::info_span!(
+        let _span = bevy_utils::tracing::debug_span!(
             "command",
             name = "DespawnRecursive",
             entity = bevy_utils::tracing::field::debug(self.entity)
@@ -70,7 +70,7 @@ impl Command for DespawnRecursive {
 impl Command for DespawnChildrenRecursive {
     fn write(self, world: &mut World) {
         #[cfg(feature = "trace")]
-        let _span = bevy_utils::tracing::info_span!(
+        let _span = bevy_utils::tracing::debug_span!(
             "command",
             name = "DespawnChildrenRecursive",
             entity = bevy_utils::tracing::field::debug(self.entity)
@@ -108,7 +108,7 @@ impl<'w> DespawnRecursiveExt for EntityMut<'w> {
         let entity = self.id();
 
         #[cfg(feature = "trace")]
-        let _span = bevy_utils::tracing::info_span!(
+        let _span = bevy_utils::tracing::debug_span!(
             "despawn_recursive",
             entity = bevy_utils::tracing::field::debug(entity)
         )
@@ -125,7 +125,7 @@ impl<'w> DespawnRecursiveExt for EntityMut<'w> {
         let entity = self.id();
 
         #[cfg(feature = "trace")]
-        let _span = bevy_utils::tracing::info_span!(
+        let _span = bevy_utils::tracing::debug_span!(
             "despawn_descendants",
             entity = bevy_utils::tracing::field::debug(entity)
         )

--- a/crates/bevy_render/src/camera/camera_driver_node.rs
+++ b/crates/bevy_render/src/camera/camera_driver_node.rs
@@ -85,7 +85,7 @@ impl Node for CameraDriverNode {
             };
 
             #[cfg(feature = "trace")]
-            let _span = bevy_utils::tracing::info_span!("no_camera_clear_pass").entered();
+            let _span = bevy_utils::tracing::debug_span!("no_camera_clear_pass").entered();
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("no_camera_clear_pass"),
                 color_attachments: &[Some(RenderPassColorAttachment {

--- a/crates/bevy_render/src/renderer/graph_runner.rs
+++ b/crates/bevy_render/src/renderer/graph_runner.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::world::World;
 #[cfg(feature = "trace")]
-use bevy_utils::tracing::info_span;
+use bevy_utils::tracing::debug_span;
 use bevy_utils::HashMap;
 use smallvec::{smallvec, SmallVec};
 #[cfg(feature = "trace")]
@@ -68,7 +68,7 @@ impl RenderGraphRunner {
         Self::run_graph(graph, None, &mut render_context, world, &[])?;
         {
             #[cfg(feature = "trace")]
-            let _span = info_span!("submit_graph_commands").entered();
+            let _span = debug_span!("submit_graph_commands").entered();
             queue.submit(vec![render_context.command_encoder.finish()]);
         }
         Ok(())
@@ -84,9 +84,9 @@ impl RenderGraphRunner {
         let mut node_outputs: HashMap<NodeId, SmallVec<[SlotValue; 4]>> = HashMap::default();
         #[cfg(feature = "trace")]
         let span = if let Some(name) = &graph_name {
-            info_span!("run_graph", name = name.deref())
+            debug_span!("run_graph", name = name.deref())
         } else {
-            info_span!("run_graph", name = "main_graph")
+            debug_span!("run_graph", name = "main_graph")
         };
         #[cfg(feature = "trace")]
         let _guard = span.enter();
@@ -183,7 +183,7 @@ impl RenderGraphRunner {
                 let mut context = RenderGraphContext::new(graph, node_state, &inputs, &mut outputs);
                 {
                     #[cfg(feature = "trace")]
-                    let _span = info_span!("node", name = node_state.type_name).entered();
+                    let _span = debug_span!("node", name = node_state.type_name).entered();
 
                     node_state.node.run(&mut context, render_context, world)?;
                 }

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -17,6 +17,7 @@
 |vorbis|Ogg Vorbis audio format support.|
 |x11|Make GUI applications use X11 protocol. You could enable wayland feature to override this.|
 |filesystem_watcher|Enable watching the file system for asset hot reload|
+|trace|Enables system tracing.|
 
 ## Optional Features
 
@@ -24,7 +25,6 @@
 |-|-|
 |bevy_dynamic_plugin|Plugin for dynamic loading (using [libloading](https://crates.io/crates/libloading)).|
 |dynamic|Forces bevy to be dynamically linked, which improves iterative compile times.|
-|trace|Enables system tracing.|
 |trace_chrome|Enables [tracing-chrome](https://github.com/thoren-d/tracing-chrome) as bevy_log output. This allows you to visualize system execution.|
 |trace_tracy|Enables [Tracy](https://github.com/wolfpld/tracy) as bevy_log output. This allows `Tracy` to connect to and capture profiling data as well as visualize system execution in real-time, present statistics about system execution times, and more.|
 |wgpu_trace|For tracing wgpu.|


### PR DESCRIPTION
# Objective

- Because spans are 🔥 

## Solution

- Move some spans to debug to reduce the default volume of spans created
- Span reduction is enough to change the tracy trace from 1 minute of breakout from 64MB to 22MB
- The spans still at info level are: frame, stages, system, system commands. those should be the most useful to help debug issues as a user
- if someone wants all the spans, they just need to set the log level to debug
