### PR TITLE
[Merged by Bors] - Fix blurry debug texture in 3d shapes example

### DIFF
--- a/examples/3d/shapes.rs
+++ b/examples/3d/shapes.rs
@@ -3,11 +3,15 @@
 
 use bevy::{
     prelude::*,
-    render::render_resource::{Extent3d, TextureDimension, TextureFormat},
+    render::{
+        render_resource::{Extent3d, TextureDimension, TextureFormat},
+        texture::ImageSettings,
+    },
 };
 
 fn main() {
     App::new()
+        .insert_resource(ImageSettings::default_nearest())
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(rotate)


### PR DESCRIPTION
# Objective

The 3d shapes example uses a "UV debug texture" which probably works best with nearest neighbor filtering, but the default is now linear.

<img width="1392" alt="Screen Shot 2022-07-27 at 7 08 19 PM" src="https://user-images.githubusercontent.com/200550/181405101-f91d6ced-be80-4bf4-b6bb-79e0da9b9c6e.png">

## Solution

Add `ImageSettings::default_nearest()`

<img width="1392" alt="Screen Shot 2022-07-27 at 7 08 37 PM" src="https://user-images.githubusercontent.com/200550/181405149-3809f5f9-9ea7-4b4a-8387-6e5bef6d00e4.png">