### PR TITLE
fix pest dependency

### DIFF
--- a/tools/build-example-pages/Cargo.toml
+++ b/tools/build-example-pages/Cargo.toml
@@ -11,3 +11,5 @@ toml = "0.5"
 tera = "1.15"
 serde = { version = "1.0", features = [ "derive" ] }
 bitflags = "1.3"
+# https://github.com/Keats/tera/issues/739
+pest = "=2.1"


### PR DESCRIPTION
# Objective

- Ci is failing 😱 
- Pest (a dependency of Tera) published a new version 2.2.0 with quite a few breaking changes

## Solution

- Fix Pest to not be updated
