### PR TITLE
Improve NodeBundle ergonomics

### DIFF
--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -52,7 +52,7 @@ impl NodeBundle {
     }
 
     /// Returns a node without a background color and that will let interactions go through them
-    /// A transparent node is like a <div> element in HTML
+    /// A container node is like a <div> element in HTML
     pub fn container() -> Self {
         Self {
             color: Color::NONE.into(),

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -53,7 +53,7 @@ impl NodeBundle {
 
     /// Returns a node without a background color and that will let interactions go through them
     /// A transparent node is like a <div> element in HTML
-    pub fn transparent() -> Self {
+    pub fn container() -> Self {
         Self {
             color: Color::NONE.into(),
             focus_policy: FocusPolicy::Pass,

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -67,7 +67,7 @@ impl NodeBundle {
         self
     }
 
-    /// Returns this [`NodeBundle`] with a new [`Style`].
+    /// Returns this [`NodeBundle`] with a new [`UiColor`].
     pub fn with_color(mut self, color: impl Into<UiColor>) -> Self {
         self.color = color.into();
         self

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -43,7 +43,7 @@ pub struct NodeBundle {
 }
 
 impl NodeBundle {
-    pub fn new(style: Style, color: impl Into<UiColor>) -> Self {
+    pub fn styled(style: Style, color: impl Into<UiColor>) -> Self {
         Self {
             style,
             color: color.into(),
@@ -70,6 +70,12 @@ impl NodeBundle {
     /// Returns this [`NodeBundle`] with a new [`UiColor`].
     pub fn with_color(mut self, color: impl Into<UiColor>) -> Self {
         self.color = color.into();
+        self
+    }
+
+    /// Returns this [`NodeBundle`] with a new [`FocusPolicy`].
+    pub fn with_focus_policy(mut self, focus_policy: FocusPolicy) -> Self {
+        self.focus_policy = focus_policy;
         self
     }
 }

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -10,11 +10,14 @@ use bevy_ecs::{
     query::QueryItem,
 };
 use bevy_render::{
-    camera::Camera, extract_component::ExtractComponent, prelude::ComputedVisibility,
+    camera::Camera,
+    extract_component::ExtractComponent,
+    prelude::{Color, ComputedVisibility},
     view::Visibility,
 };
 use bevy_text::{Text, TextAlignment, TextSection, TextStyle};
 use bevy_transform::prelude::{GlobalTransform, Transform};
+use bevy_utils::default;
 
 /// The basic UI node
 #[derive(Bundle, Clone, Debug, Default)]
@@ -37,6 +40,38 @@ pub struct NodeBundle {
     pub visibility: Visibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub computed_visibility: ComputedVisibility,
+}
+
+impl NodeBundle {
+    pub fn new(style: Style, color: impl Into<UiColor>) -> Self {
+        Self {
+            style,
+            color: color.into(),
+            ..default()
+        }
+    }
+
+    /// Returns a node without a background color and that will let interactions go through them
+    /// A transparent node is like a <div> element in HTML
+    pub fn transparent() -> Self {
+        Self {
+            color: Color::NONE.into(),
+            focus_policy: FocusPolicy::Pass,
+            ..default()
+        }
+    }
+
+    /// Returns this [`NodeBundle`] with a new [`Style`].
+    pub const fn with_style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Returns this [`NodeBundle`] with a new [`Style`].
+    pub fn with_color(mut self, color: impl Into<UiColor>) -> Self {
+        self.color = color.into();
+        self
+    }
 }
 
 /// A UI node that is an image

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -370,7 +370,7 @@ fn gameover_keyboard(mut state: ResMut<State<GameState>>, keyboard_input: Res<In
 // display the number of cake eaten before losing
 fn display_score(mut commands: Commands, asset_server: Res<AssetServer>, game: Res<Game>) {
     commands
-        .spawn_bundle(NodeBundle::transparent().with_style(Style {
+        .spawn_bundle(NodeBundle::container().with_style(Style {
             margin: UiRect::all(Val::Auto),
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -370,16 +370,12 @@ fn gameover_keyboard(mut state: ResMut<State<GameState>>, keyboard_input: Res<In
 // display the number of cake eaten before losing
 fn display_score(mut commands: Commands, asset_server: Res<AssetServer>, game: Res<Game>) {
     commands
-        .spawn_bundle(NodeBundle {
-            style: Style {
-                margin: UiRect::all(Val::Auto),
-                justify_content: JustifyContent::Center,
-                align_items: AlignItems::Center,
-                ..default()
-            },
-            color: Color::NONE.into(),
+        .spawn_bundle(NodeBundle::transparent().with_style(Style {
+            margin: UiRect::all(Val::Auto),
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
             ..default()
-        })
+        }))
         .with_children(|parent| {
             parent.spawn_bundle(TextBundle::from_section(
                 format!("Cake eaten: {}", game.cake_eaten),

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -146,8 +146,8 @@ mod game {
 
         commands
             // First create a `NodeBundle` for centering what we want to display
-            .spawn_bundle(NodeBundle {
-                style: Style {
+            .spawn_bundle(NodeBundle::new(
+                Style {
                     // This will center the current node
                     margin: UiRect::all(Val::Auto),
                     // This will display its children in a column, from top to bottom. Unlike
@@ -159,9 +159,8 @@ mod game {
                     align_items: AlignItems::Center,
                     ..default()
                 },
-                color: Color::BLACK.into(),
-                ..default()
-            })
+                Color::BLACK,
+            ))
             .insert(OnGameScreen)
             .with_children(|parent| {
                 // Display two lines of text, the second one with the current settings
@@ -413,16 +412,15 @@ mod menu {
         };
 
         commands
-            .spawn_bundle(NodeBundle {
-                style: Style {
+            .spawn_bundle(NodeBundle::new(
+                Style {
                     margin: UiRect::all(Val::Auto),
                     flex_direction: FlexDirection::ColumnReverse,
                     align_items: AlignItems::Center,
                     ..default()
                 },
-                color: Color::CRIMSON.into(),
-                ..default()
-            })
+                Color::CRIMSON,
+            ))
             .insert(OnMainMenuScreen)
             .with_children(|parent| {
                 // Display the game name
@@ -518,16 +516,15 @@ mod menu {
         };
 
         commands
-            .spawn_bundle(NodeBundle {
-                style: Style {
+            .spawn_bundle(NodeBundle::new(
+                Style {
                     margin: UiRect::all(Val::Auto),
                     flex_direction: FlexDirection::ColumnReverse,
                     align_items: AlignItems::Center,
                     ..default()
                 },
-                color: Color::CRIMSON.into(),
-                ..default()
-            })
+                Color::CRIMSON,
+            ))
             .insert(OnSettingsMenuScreen)
             .with_children(|parent| {
                 for (action, text) in [
@@ -571,29 +568,27 @@ mod menu {
         };
 
         commands
-            .spawn_bundle(NodeBundle {
-                style: Style {
+            .spawn_bundle(NodeBundle::new(
+                Style {
                     margin: UiRect::all(Val::Auto),
                     flex_direction: FlexDirection::ColumnReverse,
                     align_items: AlignItems::Center,
                     ..default()
                 },
-                color: Color::CRIMSON.into(),
-                ..default()
-            })
+                Color::CRIMSON,
+            ))
             .insert(OnDisplaySettingsMenuScreen)
             .with_children(|parent| {
                 // Create a new `NodeBundle`, this time not setting its `flex_direction`. It will
                 // use the default value, `FlexDirection::Row`, from left to right.
                 parent
-                    .spawn_bundle(NodeBundle {
-                        style: Style {
+                    .spawn_bundle(NodeBundle::new(
+                        Style {
                             align_items: AlignItems::Center,
                             ..default()
                         },
-                        color: Color::CRIMSON.into(),
-                        ..default()
-                    })
+                        Color::CRIMSON,
+                    ))
                     .with_children(|parent| {
                         // Display a label for the current setting
                         parent.spawn_bundle(TextBundle::from_section(
@@ -658,27 +653,25 @@ mod menu {
         };
 
         commands
-            .spawn_bundle(NodeBundle {
-                style: Style {
+            .spawn_bundle(NodeBundle::new(
+                Style {
                     margin: UiRect::all(Val::Auto),
                     flex_direction: FlexDirection::ColumnReverse,
                     align_items: AlignItems::Center,
                     ..default()
                 },
-                color: Color::CRIMSON.into(),
-                ..default()
-            })
+                Color::CRIMSON,
+            ))
             .insert(OnSoundSettingsMenuScreen)
             .with_children(|parent| {
                 parent
-                    .spawn_bundle(NodeBundle {
-                        style: Style {
+                    .spawn_bundle(NodeBundle::new(
+                        Style {
                             align_items: AlignItems::Center,
                             ..default()
                         },
-                        color: Color::CRIMSON.into(),
-                        ..default()
-                    })
+                        Color::CRIMSON,
+                    ))
                     .with_children(|parent| {
                         parent.spawn_bundle(TextBundle::from_section(
                             "Volume",

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -146,7 +146,7 @@ mod game {
 
         commands
             // First create a `NodeBundle` for centering what we want to display
-            .spawn_bundle(NodeBundle::new(
+            .spawn_bundle(NodeBundle::styled(
                 Style {
                     // This will center the current node
                     margin: UiRect::all(Val::Auto),
@@ -412,7 +412,7 @@ mod menu {
         };
 
         commands
-            .spawn_bundle(NodeBundle::new(
+            .spawn_bundle(NodeBundle::styled(
                 Style {
                     margin: UiRect::all(Val::Auto),
                     flex_direction: FlexDirection::ColumnReverse,
@@ -516,7 +516,7 @@ mod menu {
         };
 
         commands
-            .spawn_bundle(NodeBundle::new(
+            .spawn_bundle(NodeBundle::styled(
                 Style {
                     margin: UiRect::all(Val::Auto),
                     flex_direction: FlexDirection::ColumnReverse,
@@ -568,7 +568,7 @@ mod menu {
         };
 
         commands
-            .spawn_bundle(NodeBundle::new(
+            .spawn_bundle(NodeBundle::styled(
                 Style {
                     margin: UiRect::all(Val::Auto),
                     flex_direction: FlexDirection::ColumnReverse,
@@ -582,7 +582,7 @@ mod menu {
                 // Create a new `NodeBundle`, this time not setting its `flex_direction`. It will
                 // use the default value, `FlexDirection::Row`, from left to right.
                 parent
-                    .spawn_bundle(NodeBundle::new(
+                    .spawn_bundle(NodeBundle::styled(
                         Style {
                             align_items: AlignItems::Center,
                             ..default()
@@ -653,7 +653,7 @@ mod menu {
         };
 
         commands
-            .spawn_bundle(NodeBundle::new(
+            .spawn_bundle(NodeBundle::styled(
                 Style {
                     margin: UiRect::all(Val::Auto),
                     flex_direction: FlexDirection::ColumnReverse,
@@ -665,7 +665,7 @@ mod menu {
             .insert(OnSoundSettingsMenuScreen)
             .with_children(|parent| {
                 parent
-                    .spawn_bundle(NodeBundle::new(
+                    .spawn_bundle(NodeBundle::styled(
                         Style {
                             align_items: AlignItems::Center,
                             ..default()

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -53,13 +53,10 @@ fn setup(mut commands: Commands, font: Res<UiFont>) {
     let as_rainbow = |i: usize| Color::hsl((i as f32 / count_f) * 360.0, 0.9, 0.8);
     commands.spawn_bundle(Camera2dBundle::default());
     commands
-        .spawn_bundle(NodeBundle {
-            style: Style {
-                size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
-                ..default()
-            },
+        .spawn_bundle(NodeBundle::transparent().with_style(Style {
+            size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
             ..default()
-        })
+        }))
         .with_children(|commands| {
             for i in 0..count {
                 for j in 0..count {

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -53,7 +53,7 @@ fn setup(mut commands: Commands, font: Res<UiFont>) {
     let as_rainbow = |i: usize| Color::hsl((i as f32 / count_f) * 360.0, 0.9, 0.8);
     commands.spawn_bundle(Camera2dBundle::default());
     commands
-        .spawn_bundle(NodeBundle::transparent().with_style(Style {
+        .spawn_bundle(NodeBundle::container().with_style(Style {
             size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
             ..default()
         }))

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -22,7 +22,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // root node
     commands
-        .spawn_bundle(NodeBundle::transparent().with_style(Style {
+        .spawn_bundle(NodeBundle::container().with_style(Style {
             size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
             justify_content: JustifyContent::SpaceBetween,
             ..default()
@@ -114,7 +114,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         .with_children(|parent| {
                             // Moving panel
                             parent
-                                .spawn_bundle(NodeBundle::transparent().with_style(Style {
+                                .spawn_bundle(NodeBundle::container().with_style(Style {
                                     flex_direction: FlexDirection::ColumnReverse,
                                     flex_grow: 1.0,
                                     max_size: Size::new(Val::Undefined, Val::Undefined),
@@ -176,7 +176,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 });
             // render order test: reddest in the back, whitest in the front (flex center)
             parent
-                .spawn_bundle(NodeBundle::transparent().with_style(Style {
+                .spawn_bundle(NodeBundle::container().with_style(Style {
                     size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                     position_type: PositionType::Absolute,
                     align_items: AlignItems::Center,
@@ -250,7 +250,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 });
             // bevy logo (flex center)
             parent
-                .spawn_bundle(NodeBundle::transparent().with_style(Style {
+                .spawn_bundle(NodeBundle::container().with_style(Style {
                     size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                     position_type: PositionType::Absolute,
                     justify_content: JustifyContent::Center,

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -22,39 +22,33 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // root node
     commands
-        .spawn_bundle(NodeBundle {
-            style: Style {
-                size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
-                justify_content: JustifyContent::SpaceBetween,
-                ..default()
-            },
-            color: Color::NONE.into(),
+        .spawn_bundle(NodeBundle::transparent().with_style(Style {
+            size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
+            justify_content: JustifyContent::SpaceBetween,
             ..default()
-        })
+        }))
         .with_children(|parent| {
             // left vertical fill (border)
             parent
-                .spawn_bundle(NodeBundle {
-                    style: Style {
+                .spawn_bundle(NodeBundle::new(
+                    Style {
                         size: Size::new(Val::Px(200.0), Val::Percent(100.0)),
                         border: UiRect::all(Val::Px(2.0)),
                         ..default()
                     },
-                    color: Color::rgb(0.65, 0.65, 0.65).into(),
-                    ..default()
-                })
+                    Color::rgb(0.65, 0.65, 0.65),
+                ))
                 .with_children(|parent| {
                     // left vertical fill (content)
                     parent
-                        .spawn_bundle(NodeBundle {
-                            style: Style {
+                        .spawn_bundle(NodeBundle::new(
+                            Style {
                                 size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                                 align_items: AlignItems::FlexEnd,
                                 ..default()
                             },
-                            color: Color::rgb(0.15, 0.15, 0.15).into(),
-                            ..default()
-                        })
+                            Color::rgb(0.15, 0.15, 0.15),
+                        ))
                         .with_children(|parent| {
                             // text
                             parent.spawn_bundle(
@@ -75,16 +69,15 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 });
             // right vertical fill
             parent
-                .spawn_bundle(NodeBundle {
-                    style: Style {
+                .spawn_bundle(NodeBundle::new(
+                    Style {
                         flex_direction: FlexDirection::ColumnReverse,
                         justify_content: JustifyContent::Center,
                         size: Size::new(Val::Px(200.0), Val::Percent(100.0)),
                         ..default()
                     },
-                    color: Color::rgb(0.15, 0.15, 0.15).into(),
-                    ..default()
-                })
+                    Color::rgb(0.15, 0.15, 0.15),
+                ))
                 .with_children(|parent| {
                     // Title
                     parent.spawn_bundle(
@@ -108,30 +101,25 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     );
                     // List with hidden overflow
                     parent
-                        .spawn_bundle(NodeBundle {
-                            style: Style {
+                        .spawn_bundle(NodeBundle::new(
+                            Style {
                                 flex_direction: FlexDirection::ColumnReverse,
                                 align_self: AlignSelf::Center,
                                 size: Size::new(Val::Percent(100.0), Val::Percent(50.0)),
                                 overflow: Overflow::Hidden,
                                 ..default()
                             },
-                            color: Color::rgb(0.10, 0.10, 0.10).into(),
-                            ..default()
-                        })
+                            Color::rgb(0.10, 0.10, 0.10),
+                        ))
                         .with_children(|parent| {
                             // Moving panel
                             parent
-                                .spawn_bundle(NodeBundle {
-                                    style: Style {
-                                        flex_direction: FlexDirection::ColumnReverse,
-                                        flex_grow: 1.0,
-                                        max_size: Size::new(Val::Undefined, Val::Undefined),
-                                        ..default()
-                                    },
-                                    color: Color::NONE.into(),
+                                .spawn_bundle(NodeBundle::transparent().with_style(Style {
+                                    flex_direction: FlexDirection::ColumnReverse,
+                                    flex_grow: 1.0,
+                                    max_size: Size::new(Val::Undefined, Val::Undefined),
                                     ..default()
-                                })
+                                }))
                                 .insert(ScrollingList::default())
                                 .with_children(|parent| {
                                     // List items
@@ -163,8 +151,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 });
             // absolute positioning
             parent
-                .spawn_bundle(NodeBundle {
-                    style: Style {
+                .spawn_bundle(NodeBundle::new(
+                    Style {
                         size: Size::new(Val::Px(200.0), Val::Px(200.0)),
                         position_type: PositionType::Absolute,
                         position: UiRect {
@@ -175,45 +163,38 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         border: UiRect::all(Val::Px(20.0)),
                         ..default()
                     },
-                    color: Color::rgb(0.4, 0.4, 1.0).into(),
-                    ..default()
-                })
+                    Color::rgb(0.4, 0.4, 1.0),
+                ))
                 .with_children(|parent| {
-                    parent.spawn_bundle(NodeBundle {
-                        style: Style {
+                    parent.spawn_bundle(NodeBundle::new(
+                        Style {
                             size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                             ..default()
                         },
-                        color: Color::rgb(0.8, 0.8, 1.0).into(),
-                        ..default()
-                    });
+                        Color::rgb(0.8, 0.8, 1.0),
+                    ));
                 });
             // render order test: reddest in the back, whitest in the front (flex center)
             parent
-                .spawn_bundle(NodeBundle {
-                    style: Style {
-                        size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
-                        position_type: PositionType::Absolute,
-                        align_items: AlignItems::Center,
-                        justify_content: JustifyContent::Center,
-                        ..default()
-                    },
-                    color: Color::NONE.into(),
+                .spawn_bundle(NodeBundle::transparent().with_style(Style {
+                    size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
+                    position_type: PositionType::Absolute,
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::Center,
                     ..default()
-                })
+                }))
                 .with_children(|parent| {
                     parent
-                        .spawn_bundle(NodeBundle {
-                            style: Style {
+                        .spawn_bundle(NodeBundle::new(
+                            Style {
                                 size: Size::new(Val::Px(100.0), Val::Px(100.0)),
                                 ..default()
                             },
-                            color: Color::rgb(1.0, 0.0, 0.0).into(),
-                            ..default()
-                        })
+                            Color::rgb(1.0, 0.0, 0.0),
+                        ))
                         .with_children(|parent| {
-                            parent.spawn_bundle(NodeBundle {
-                                style: Style {
+                            parent.spawn_bundle(NodeBundle::new(
+                                Style {
                                     size: Size::new(Val::Px(100.0), Val::Px(100.0)),
                                     position_type: PositionType::Absolute,
                                     position: UiRect {
@@ -223,11 +204,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     },
                                     ..default()
                                 },
-                                color: Color::rgb(1.0, 0.3, 0.3).into(),
-                                ..default()
-                            });
-                            parent.spawn_bundle(NodeBundle {
-                                style: Style {
+                                Color::rgb(1.0, 0.3, 0.3),
+                            ));
+                            parent.spawn_bundle(NodeBundle::new(
+                                Style {
                                     size: Size::new(Val::Px(100.0), Val::Px(100.0)),
                                     position_type: PositionType::Absolute,
                                     position: UiRect {
@@ -237,11 +217,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     },
                                     ..default()
                                 },
-                                color: Color::rgb(1.0, 0.5, 0.5).into(),
-                                ..default()
-                            });
-                            parent.spawn_bundle(NodeBundle {
-                                style: Style {
+                                Color::rgb(1.0, 0.5, 0.5),
+                            ));
+                            parent.spawn_bundle(NodeBundle::new(
+                                Style {
                                     size: Size::new(Val::Px(100.0), Val::Px(100.0)),
                                     position_type: PositionType::Absolute,
                                     position: UiRect {
@@ -251,12 +230,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     },
                                     ..default()
                                 },
-                                color: Color::rgb(1.0, 0.7, 0.7).into(),
-                                ..default()
-                            });
+                                Color::rgb(1.0, 0.7, 0.7),
+                            ));
                             // alpha test
-                            parent.spawn_bundle(NodeBundle {
-                                style: Style {
+                            parent.spawn_bundle(NodeBundle::new(
+                                Style {
                                     size: Size::new(Val::Px(100.0), Val::Px(100.0)),
                                     position_type: PositionType::Absolute,
                                     position: UiRect {
@@ -266,24 +244,19 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     },
                                     ..default()
                                 },
-                                color: Color::rgba(1.0, 0.9, 0.9, 0.4).into(),
-                                ..default()
-                            });
+                                Color::rgba(1.0, 0.9, 0.9, 0.4),
+                            ));
                         });
                 });
             // bevy logo (flex center)
             parent
-                .spawn_bundle(NodeBundle {
-                    style: Style {
-                        size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
-                        position_type: PositionType::Absolute,
-                        justify_content: JustifyContent::Center,
-                        align_items: AlignItems::FlexEnd,
-                        ..default()
-                    },
-                    color: Color::NONE.into(),
+                .spawn_bundle(NodeBundle::transparent().with_style(Style {
+                    size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
+                    position_type: PositionType::Absolute,
+                    justify_content: JustifyContent::Center,
+                    align_items: AlignItems::FlexEnd,
                     ..default()
-                })
+                }))
                 .with_children(|parent| {
                     // bevy logo (image)
                     parent.spawn_bundle(ImageBundle {

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -30,7 +30,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .with_children(|parent| {
             // left vertical fill (border)
             parent
-                .spawn_bundle(NodeBundle::new(
+                .spawn_bundle(NodeBundle::styled(
                     Style {
                         size: Size::new(Val::Px(200.0), Val::Percent(100.0)),
                         border: UiRect::all(Val::Px(2.0)),
@@ -41,7 +41,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 .with_children(|parent| {
                     // left vertical fill (content)
                     parent
-                        .spawn_bundle(NodeBundle::new(
+                        .spawn_bundle(NodeBundle::styled(
                             Style {
                                 size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                                 align_items: AlignItems::FlexEnd,
@@ -69,7 +69,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 });
             // right vertical fill
             parent
-                .spawn_bundle(NodeBundle::new(
+                .spawn_bundle(NodeBundle::styled(
                     Style {
                         flex_direction: FlexDirection::ColumnReverse,
                         justify_content: JustifyContent::Center,
@@ -101,7 +101,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     );
                     // List with hidden overflow
                     parent
-                        .spawn_bundle(NodeBundle::new(
+                        .spawn_bundle(NodeBundle::styled(
                             Style {
                                 flex_direction: FlexDirection::ColumnReverse,
                                 align_self: AlignSelf::Center,
@@ -151,7 +151,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 });
             // absolute positioning
             parent
-                .spawn_bundle(NodeBundle::new(
+                .spawn_bundle(NodeBundle::styled(
                     Style {
                         size: Size::new(Val::Px(200.0), Val::Px(200.0)),
                         position_type: PositionType::Absolute,
@@ -166,7 +166,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     Color::rgb(0.4, 0.4, 1.0),
                 ))
                 .with_children(|parent| {
-                    parent.spawn_bundle(NodeBundle::new(
+                    parent.spawn_bundle(NodeBundle::styled(
                         Style {
                             size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                             ..default()
@@ -185,7 +185,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 }))
                 .with_children(|parent| {
                     parent
-                        .spawn_bundle(NodeBundle::new(
+                        .spawn_bundle(NodeBundle::styled(
                             Style {
                                 size: Size::new(Val::Px(100.0), Val::Px(100.0)),
                                 ..default()
@@ -193,7 +193,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             Color::rgb(1.0, 0.0, 0.0),
                         ))
                         .with_children(|parent| {
-                            parent.spawn_bundle(NodeBundle::new(
+                            parent.spawn_bundle(NodeBundle::styled(
                                 Style {
                                     size: Size::new(Val::Px(100.0), Val::Px(100.0)),
                                     position_type: PositionType::Absolute,
@@ -206,7 +206,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 },
                                 Color::rgb(1.0, 0.3, 0.3),
                             ));
-                            parent.spawn_bundle(NodeBundle::new(
+                            parent.spawn_bundle(NodeBundle::styled(
                                 Style {
                                     size: Size::new(Val::Px(100.0), Val::Px(100.0)),
                                     position_type: PositionType::Absolute,
@@ -219,7 +219,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 },
                                 Color::rgb(1.0, 0.5, 0.5),
                             ));
-                            parent.spawn_bundle(NodeBundle::new(
+                            parent.spawn_bundle(NodeBundle::styled(
                                 Style {
                                     size: Size::new(Val::Px(100.0), Val::Px(100.0)),
                                     position_type: PositionType::Absolute,
@@ -233,7 +233,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 Color::rgb(1.0, 0.7, 0.7),
                             ));
                             // alpha test
-                            parent.spawn_bundle(NodeBundle::new(
+                            parent.spawn_bundle(NodeBundle::styled(
                                 Style {
                                     size: Size::new(Val::Px(100.0), Val::Px(100.0)),
                                     position_type: PositionType::Absolute,

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -30,7 +30,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .with_children(|parent| {
             // left vertical fill (border)
             parent
-                .spawn_bundle(NodeBundle::new(
+                .spawn_bundle(NodeBundle::styled(
                     Style {
                         size: Size::new(Val::Px(200.0), Val::Percent(100.0)),
                         border: UiRect::all(Val::Px(2.0)),

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -22,7 +22,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     // root node
     commands
-        .spawn_bundle(NodeBundle::transparent().with_style(Style {
+        .spawn_bundle(NodeBundle::container().with_style(Style {
             size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
             justify_content: JustifyContent::SpaceBetween,
             ..default()

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -22,27 +22,22 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     // root node
     commands
-        .spawn_bundle(NodeBundle {
-            style: Style {
-                size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
-                justify_content: JustifyContent::SpaceBetween,
-                ..default()
-            },
-            color: Color::NONE.into(),
+        .spawn_bundle(NodeBundle::transparent().with_style(Style {
+            size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
+            justify_content: JustifyContent::SpaceBetween,
             ..default()
-        })
+        }))
         .with_children(|parent| {
             // left vertical fill (border)
             parent
-                .spawn_bundle(NodeBundle {
-                    style: Style {
+                .spawn_bundle(NodeBundle::new(
+                    Style {
                         size: Size::new(Val::Px(200.0), Val::Percent(100.0)),
                         border: UiRect::all(Val::Px(2.0)),
                         ..default()
                     },
-                    color: Color::rgb(0.65, 0.65, 0.65).into(),
-                    ..default()
-                })
+                    Color::rgb(0.65, 0.65, 0.65),
+                ))
                 .with_children(|parent| {
                     parent.spawn_bundle(
                         TextBundle::from_section(


### PR DESCRIPTION
# Objective

- `NodeBundle`s  are useful when working with complex UIs but they are very verbose, especially when you just want to use them as a wrapper element since the defaults don't work well for those cases. There's also a lot of repetitions like `style: Style` and `color: Color`.

## Solution

- Add a few impls on `NodeBundle` to improve ergonomics. This was highly inspired by the recent changes to `TextBundle`
	- `NodeBundle::new`: most use of `NodeBundle` is done with a `Style` and a `Color` we should make this simpler to do.
	- `NodeBundle::container`: It's often useful to be able to wrap multiple element under a single node. To do that you always need a node with a transparent color and a focus policy that let's interaction go through it. The default values don't do that in this case so the best way to fix that in a non-breaking way is to have a new constructor.
	- `Self::with_style` and `Self::with_color`: This is mostly useful when you spawn a transparent node and you want to cchange a flex property on the style. the with_color is not as useful but I don't think there's any downsides in including it.

---

## Changelog

- Add a few impls on `NodeBundle`
	- `NodeBundle::new(Style, Color)`, `NodeBundle::container()`, `NodeBundle::with_style()` and `NodeBundle::with_color()`
