### PR TITLE
[Merged by Bors] - Fix View by adding missing fields present in ViewUniform

### DIFF
--- a/crates/bevy_sprite/src/mesh2d/mesh2d_view_types.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_view_types.wgsl
@@ -2,9 +2,11 @@
 
 struct View {
     view_proj: mat4x4<f32>,
+    inverse_view_proj: mat4x4<f32>,
     view: mat4x4<f32>,
     inverse_view: mat4x4<f32>,
     projection: mat4x4<f32>,
+    inverse_projection: mat4x4<f32>,
     world_position: vec3<f32>,
     width: f32,
     height: f32,


### PR DESCRIPTION
# Objective

View mesh2d_view_types.wgsl was missing a couple of fields present in bevy::render::ViewUniform, causing rendering issues for shaders using later fields.

## Solution
Solved by adding the fields in question
