### PR TITLE
Set a minimum rust-version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bevy"
 version = "0.8.0"
 edition = "2021"
+rust-version = "1.62"
 categories = ["game-engines", "graphics", "gui", "rendering"]
 description = "A refreshingly simple data-driven game engine and app framework"
 exclude = ["assets/", "tools/", ".github/", "crates/", "examples/wasm/assets/"]


### PR DESCRIPTION
# Objective

Trying to compile Bevy on Rust 1.61 or below causes compile errors because `deriving 'Default' on enums is experimental`, which is confusing to users who don't realize that they need to update their toolchain to fix it.

## Solution

Set `rust-version = 1.62` so that Cargo gives a clearer error.