### PR TITLE
Remove generic from UiRect

### DIFF
--- a/crates/bevy_ui/src/flex/convert.rs
+++ b/crates/bevy_ui/src/flex/convert.rs
@@ -5,7 +5,7 @@ use crate::{
 
 pub fn from_rect(
     scale_factor: f64,
-    rect: UiRect<Val>,
+    rect: UiRect,
 ) -> taffy::geometry::Rect<taffy::style::Dimension> {
     taffy::geometry::Rect {
         start: from_val(scale_factor, rect.left),

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -1,3 +1,4 @@
+use crate::Val;
 use bevy_math::Vec2;
 use bevy_reflect::Reflect;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
@@ -119,20 +120,20 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 ///     bottom: Val::Px(40.0),
 /// };
 /// ```
-#[derive(Copy, Clone, PartialEq, Debug, Reflect)]
+#[derive(Copy, Clone, PartialEq, Debug, Reflect, Default)]
 #[reflect(PartialEq)]
-pub struct UiRect<T: Reflect + PartialEq> {
+pub struct UiRect {
     /// The value corresponding to the left side of the UI rect.
-    pub left: T,
+    pub left: Val,
     /// The value corresponding to the right side of the UI rect.
-    pub right: T,
+    pub right: Val,
     /// The value corresponding to the top side of the UI rect.
-    pub top: T,
+    pub top: Val,
     /// The value corresponding to the bottom side of the UI rect.
-    pub bottom: T,
+    pub bottom: Val,
 }
 
-impl<T: Reflect + PartialEq> UiRect<T> {
+impl UiRect {
     /// Creates a new [`UiRect`] from the values specified.
     ///
     /// # Example
@@ -152,7 +153,7 @@ impl<T: Reflect + PartialEq> UiRect<T> {
     /// assert_eq!(ui_rect.top, Val::Px(30.0));
     /// assert_eq!(ui_rect.bottom, Val::Px(40.0));
     /// ```
-    pub fn new(left: T, right: T, top: T, bottom: T) -> Self {
+    pub fn new(left: Val, right: Val, top: Val, bottom: Val) -> Self {
         UiRect {
             left,
             right,
@@ -175,26 +176,12 @@ impl<T: Reflect + PartialEq> UiRect<T> {
     /// assert_eq!(ui_rect.top, Val::Px(10.0));
     /// assert_eq!(ui_rect.bottom, Val::Px(10.0));
     /// ```
-    pub fn all(value: T) -> Self
-    where
-        T: Clone,
-    {
+    pub const fn all(value: Val) -> Self {
         UiRect {
-            left: value.clone(),
-            right: value.clone(),
-            top: value.clone(),
+            left: value,
+            right: value,
+            top: value,
             bottom: value,
-        }
-    }
-}
-
-impl<T: Default + Reflect + PartialEq> Default for UiRect<T> {
-    fn default() -> Self {
-        Self {
-            left: Default::default(),
-            right: Default::default(),
-            top: Default::default(),
-            bottom: Default::default(),
         }
     }
 }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -69,7 +69,7 @@ impl Plugin for UiPlugin {
             .register_type::<PositionType>()
             .register_type::<Size<f32>>()
             .register_type::<Size<Val>>()
-            .register_type::<UiRect<Val>>()
+            .register_type::<UiRect>()
             .register_type::<Style>()
             .register_type::<UiColor>()
             .register_type::<UiImage>()

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -87,13 +87,13 @@ pub struct Style {
     /// How items align according to the main axis
     pub justify_content: JustifyContent,
     /// The position of the node as described by its Rect
-    pub position: UiRect<Val>,
+    pub position: UiRect,
     /// The margin of the node
-    pub margin: UiRect<Val>,
+    pub margin: UiRect,
     /// The padding of the node
-    pub padding: UiRect<Val>,
+    pub padding: UiRect,
     /// The border of the node
-    pub border: UiRect<Val>,
+    pub border: UiRect,
     /// Defines how much a flexbox item should grow if there's space available
     pub flex_grow: f32,
     /// How to shrink if there's not enough space available


### PR DESCRIPTION
(This was first noticed by @KDecay; please include them as a coauthor).

# Objective

- This generic was always set to `Val` in engine and user code.
- We already have a way to modify the units: the `Val::enum`.
- Reduce incidental complexity and boilerplate in `bevy_ui`'s code.

## Changelog

- Removed the generic type `T` from `UiRect`. This is now always set to the `Val` enum.

## Migration Guide

- `UiRect` no longer supports generic types. Use a `Val` instead.