### PR TITLE
[Merged by Bors] - Sync up bevy_sprite and bevy_ui shader View struct

### DIFF
--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -1,6 +1,13 @@
 struct View {
     view_proj: mat4x4<f32>,
+    inverse_view_proj: mat4x4<f32>,
+    view: mat4x4<f32>,
+    inverse_view: mat4x4<f32>,
+    projection: mat4x4<f32>,
+    inverse_projection: mat4x4<f32>,
     world_position: vec3<f32>,
+    width: f32,
+    height: f32,
 };
 @group(0) @binding(0)
 var<uniform> view: View;

--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -1,6 +1,13 @@
 struct View {
     view_proj: mat4x4<f32>,
+    inverse_view_proj: mat4x4<f32>,
+    view: mat4x4<f32>,
+    inverse_view: mat4x4<f32>,
+    projection: mat4x4<f32>,
+    inverse_projection: mat4x4<f32>,
     world_position: vec3<f32>,
+    width: f32,
+    height: f32,
 };
 @group(0) @binding(0)
 var<uniform> view: View;
@@ -22,7 +29,7 @@ fn vertex(
     out.position = view.view_proj * vec4<f32>(vertex_position, 1.0);
     out.color = vertex_color;
     return out;
-} 
+}
 
 @group(1) @binding(0)
 var sprite_texture: texture_2d<f32>;
@@ -31,7 +38,7 @@ var sprite_sampler: sampler;
 
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
-    var color = textureSample(sprite_texture, sprite_sampler, in.uv); 
+    var color = textureSample(sprite_texture, sprite_sampler, in.uv);
     color = in.color * color;
     return color;
 }


### PR DESCRIPTION
# Objective

- Similar to #5512 , the `View` struct definition in the shaders in `bevy_sprite` and `bevy_ui` were out of sync with the rust-side `ViewUniform`. Only `view_proj` was being used and is the first member and as those shaders are not customisable it makes little difference in practice, unlike for `Mesh2d`.

## Solution

- Sync shader `View` struct definition in `bevy_sprite` and `bevy_ui` with the correct definition that matches `ViewUniform`