### PR TITLE
[Merged by Bors] - Make `Children` constructor `pub(crate)`.

### DIFF
--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -414,7 +414,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
                 .retain(|value| !children.contains(value));
             children_component.0.extend(children.iter().cloned());
         } else {
-            self.insert(Children::with(children));
+            self.insert(Children::from_entities(children));
         }
         self
     }
@@ -435,7 +435,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
                 .retain(|value| !children.contains(value));
             children_component.0.insert_from_slice(index, children);
         } else {
-            self.insert(Children::with(children));
+            self.insert(Children::from_entities(children));
         }
         self
     }
@@ -479,7 +479,7 @@ impl<'w> BuildWorldChildren for WorldChildBuilder<'w> {
         } else {
             self.world
                 .entity_mut(parent)
-                .insert(Children::with(children));
+                .insert(Children::from_entities(children));
         }
         self
     }
@@ -497,7 +497,7 @@ impl<'w> BuildWorldChildren for WorldChildBuilder<'w> {
         } else {
             self.world
                 .entity_mut(parent)
-                .insert(Children::with(children));
+                .insert(Children::from_entities(children));
         }
         self
     }

--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -36,12 +36,12 @@ impl FromWorld for Children {
 }
 
 impl Children {
-    /// Builds and returns a [`Children`] component with the given entities
-    pub fn with(entity: &[Entity]) -> Self {
-        Self(SmallVec::from_slice(entity))
+    /// Constructs a [`Children`] component with the given entities.
+    pub(crate) fn from_entities(entities: &[Entity]) -> Self {
+        Self(SmallVec::from_slice(entities))
     }
 
-    /// Swaps the child at `a_index` with the child at `b_index`
+    /// Swaps the child at `a_index` with the child at `b_index`.
     pub fn swap(&mut self, a_index: usize, b_index: usize) {
         self.0.swap(a_index, b_index);
     }


### PR DESCRIPTION
#4197 intended to remove all `pub` constructors of `Children` and `Parent` and it seems like this one was missed.