### PR TITLE
bevy_render: Centralize shader View uniform type

### DIFF
--- a/crates/bevy_pbr/src/render/depth.wgsl
+++ b/crates/bevy_pbr/src/render/depth.wgsl
@@ -1,8 +1,7 @@
 #import bevy_pbr::mesh_view_types
 #import bevy_pbr::mesh_types
 
-@group(0) @binding(0)
-var<uniform> view: View;
+#import bevy_render::view_bindings
 
 @group(1) @binding(0)
 var<uniform> mesh: Mesh;

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -2,8 +2,8 @@
 
 #import bevy_pbr::mesh_view_types
 
-@group(0) @binding(0)
-var<uniform> view: View;
+#import bevy_render::view_bindings
+
 @group(0) @binding(1)
 var<uniform> lights: Lights;
 #ifdef NO_ARRAY_TEXTURES_SUPPORT

--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -1,17 +1,5 @@
 #define_import_path bevy_pbr::mesh_view_types
 
-struct View {
-    view_proj: mat4x4<f32>,
-    inverse_view_proj: mat4x4<f32>,
-    view: mat4x4<f32>,
-    inverse_view: mat4x4<f32>,
-    projection: mat4x4<f32>,
-    inverse_projection: mat4x4<f32>,
-    world_position: vec3<f32>,
-    width: f32,
-    height: f32,
-};
-
 struct PointLight {
     // For point lights: the lower-right 2x2 values of the projection matrix [2][2] [2][3] [3][2] [3][3]
     // For spot lights: the direction (x,z), spot_scale and spot_offset

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -236,7 +236,7 @@ fn pbr(
 fn tone_mapping(in: vec4<f32>) -> vec4<f32> {
     // tone_mapping
     return vec4<f32>(reinhard_luminance(in.rgb), in.a);
-    
+
     // Gamma correction.
     // Not needed with sRGB buffer
     // output_color.rgb = pow(output_color.rgb, vec3(1.0 / 2.2));

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -1,6 +1,7 @@
 pub mod visibility;
 pub mod window;
 
+use bevy_asset::{load_internal_asset, HandleUntyped};
 pub use visibility::*;
 use wgpu::{
     Color, Extent3d, Operations, RenderPassColorAttachment, TextureDescriptor, TextureDimension,
@@ -11,7 +12,7 @@ pub use window::*;
 use crate::{
     camera::ExtractedCamera,
     extract_resource::{ExtractResource, ExtractResourcePlugin},
-    prelude::Image,
+    prelude::{Image, Shader},
     rangefinder::ViewRangefinder3d,
     render_asset::RenderAssets,
     render_resource::{DynamicUniformBuffer, ShaderType, Texture, TextureView},
@@ -22,14 +23,27 @@ use crate::{
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
 use bevy_math::{Mat4, Vec3};
-use bevy_reflect::Reflect;
+use bevy_reflect::{Reflect, TypeUuid};
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::HashMap;
+
+pub const VIEW_TYPES_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 11632502421781914934);
+pub const VIEW_BINDINGS_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 10087165491189459859);
 
 pub struct ViewPlugin;
 
 impl Plugin for ViewPlugin {
     fn build(&self, app: &mut App) {
+        load_internal_asset!(app, VIEW_TYPES_HANDLE, "view_types.wgsl", Shader::from_wgsl);
+        load_internal_asset!(
+            app,
+            VIEW_BINDINGS_HANDLE,
+            "view_bindings.wgsl",
+            Shader::from_wgsl
+        );
+
         app.register_type::<Msaa>()
             .init_resource::<Msaa>()
             // NOTE: windows.is_changed() handles cases where a window was resized

--- a/crates/bevy_render/src/view/view_bindings.wgsl
+++ b/crates/bevy_render/src/view/view_bindings.wgsl
@@ -1,0 +1,6 @@
+#define_import_path bevy_render::view_bindings
+
+#import bevy_render::view_types
+
+@group(0) @binding(0)
+var<uniform> view: View;

--- a/crates/bevy_render/src/view/view_types.wgsl
+++ b/crates/bevy_render/src/view/view_types.wgsl
@@ -1,5 +1,6 @@
-#define_import_path bevy_sprite::mesh2d_view_types
+#define_import_path bevy_render::view_types
 
+// NOTE: Keep in sync with Rust-side ViewUniform!
 struct View {
     view_proj: mat4x4<f32>,
     inverse_view_proj: mat4x4<f32>,

--- a/crates/bevy_sprite/src/mesh2d/color_material.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/color_material.wgsl
@@ -1,5 +1,4 @@
 #import bevy_sprite::mesh2d_types
-#import bevy_sprite::mesh2d_view_bindings
 
 struct ColorMaterial {
     color: vec4<f32>,
@@ -7,6 +6,8 @@ struct ColorMaterial {
     flags: u32,
 };
 let COLOR_MATERIAL_FLAGS_TEXTURE_BIT: u32 = 1u;
+
+#import bevy_render::view_bindings
 
 @group(1) @binding(0)
 var<uniform> material: ColorMaterial;

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -39,10 +39,6 @@ pub struct Mesh2dRenderPlugin;
 
 pub const MESH2D_VERTEX_OUTPUT: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 7646632476603252194);
-pub const MESH2D_VIEW_TYPES_HANDLE: HandleUntyped =
-    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 12677582416765805110);
-pub const MESH2D_VIEW_BINDINGS_HANDLE: HandleUntyped =
-    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 6901431444735842434);
 pub const MESH2D_TYPES_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 8994673400261890424);
 pub const MESH2D_BINDINGS_HANDLE: HandleUntyped =
@@ -58,18 +54,6 @@ impl Plugin for Mesh2dRenderPlugin {
             app,
             MESH2D_VERTEX_OUTPUT,
             "mesh2d_vertex_output.wgsl",
-            Shader::from_wgsl
-        );
-        load_internal_asset!(
-            app,
-            MESH2D_VIEW_TYPES_HANDLE,
-            "mesh2d_view_types.wgsl",
-            Shader::from_wgsl
-        );
-        load_internal_asset!(
-            app,
-            MESH2D_VIEW_BINDINGS_HANDLE,
-            "mesh2d_view_bindings.wgsl",
             Shader::from_wgsl
         );
         load_internal_asset!(

--- a/crates/bevy_sprite/src/mesh2d/mesh2d.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d.wgsl
@@ -1,4 +1,4 @@
-#import bevy_sprite::mesh2d_view_bindings
+#import bevy_render::view_bindings
 #import bevy_sprite::mesh2d_bindings
 
 // NOTE: Bindings must come before functions that use them!

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_view_bindings.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_view_bindings.wgsl
@@ -1,6 +1,0 @@
-#define_import_path bevy_sprite::mesh2d_view_bindings
-
-#import bevy_sprite::mesh2d_view_types
-
-@group(0) @binding(0)
-var<uniform> view: View;

--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -1,9 +1,5 @@
-struct View {
-    view_proj: mat4x4<f32>,
-    world_position: vec3<f32>,
-};
-@group(0) @binding(0)
-var<uniform> view: View;
+#import bevy_render::view_bindings
+
 
 struct VertexOutput {
     @location(0) uv: vec2<f32>,

--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -1,9 +1,4 @@
-struct View {
-    view_proj: mat4x4<f32>,
-    world_position: vec3<f32>,
-};
-@group(0) @binding(0)
-var<uniform> view: View;
+#import bevy_render::view_bindings
 
 struct VertexOutput {
     @location(0) uv: vec2<f32>,
@@ -22,7 +17,7 @@ fn vertex(
     out.position = view.view_proj * vec4<f32>(vertex_position, 1.0);
     out.color = vertex_color;
     return out;
-} 
+}
 
 @group(1) @binding(0)
 var sprite_texture: texture_2d<f32>;
@@ -31,7 +26,7 @@ var sprite_sampler: sampler;
 
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
-    var color = textureSample(sprite_texture, sprite_sampler, in.uv); 
+    var color = textureSample(sprite_texture, sprite_sampler, in.uv);
     color = in.color * color;
     return color;
 }

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -210,7 +210,8 @@ type DrawColoredMesh2d = (
 const COLORED_MESH2D_SHADER: &str = r"
 // Import the standard 2d mesh uniforms and set their bind groups
 #import bevy_sprite::mesh2d_types
-#import bevy_sprite::mesh2d_view_bindings
+
+#import bevy_render::view_bindings
 
 @group(1) @binding(0)
 var<uniform> mesh: Mesh2d;


### PR DESCRIPTION
# Objective

- Keep the shader-side definition of the `ViewUniform` struct in one place, in `bevy_render`
- The long-term fix from #5512 and #5531 

## Solution

- Move shader `View` struct to a shader import at `bevy_render::view_types`
- Make shader view bindings for binding the view uniform to group 0 binding 0 as this is very common, at `bevy_render::view_bindings` - note that this itself imports `bevy_render::view_types` for convenience as we have done elsewhere
- Remove the shader `View` struct from `mesh_view_types.wgsl` in `bevy_pbr`, `mesh2d_view_types.wgsl` and `sprite.wgsl` in `bevy_sprite` and `ui.wgsl` in `bevy_ui` and instead make use of the above imports.

---

## Changelog

- Removed: `bevy_sprite::mesh2d_view_types` and `bevy_sprite::mesh2d_view_bindings`
- Added: `bevy_render::view_types` and `bevy_render::view_bindings`
- Changed: All of `bevy_pbr`, `bevy_sprite`, and `bevy_ui` now use `bevy_render::view_types` and `bevy_render::view_bindings` to keep the shader `View` struct in-sync

## Migration Guide

If you were using the `bevy_sprite::mesh2d_view_types` and/or `bevy_sprite::mesh2d_view_bindings` shader imports, now use `bevy_render::view_types` and/or `bevy_render::view_bindings` instead.