### PR TITLE
[Merged by Bors] - don't render completely transparent UI nodes

### DIFF
--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -294,6 +294,7 @@ impl Color {
     }
 
     /// Get alpha.
+    #[inline(always)]
     pub fn a(&self) -> f32 {
         match self {
             Color::Rgba { alpha, .. }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -197,6 +197,10 @@ pub fn extract_uinodes(
         if !images.contains(&image) {
             continue;
         }
+        // Skip completely transparent nodes
+        if color.0.a() == 0.0 {
+            continue;
+        }
         extracted_uinodes.uinodes.push(ExtractedUiNode {
             transform: transform.compute_matrix(),
             color: color.0,


### PR DESCRIPTION
# Objective

- I often have UI nodes that are completely transparent and just for organisation
- Don't render them
- I doesn't bring a lot of improvements, but it doesn't add a lot of complexity either