### PR TITLE
[Merged by Bors] - Correctly use as_hsla_f32 in Add<Color> and AddAssign<Color>, fixes #5543

### DIFF
--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -745,7 +745,7 @@ impl AddAssign<Color> for Color {
                 lightness,
                 alpha,
             } => {
-                let rhs = rhs.as_linear_rgba_f32();
+                let rhs = rhs.as_hsla_f32();
                 *hue += rhs[0];
                 *saturation += rhs[1];
                 *lightness += rhs[2];
@@ -794,7 +794,7 @@ impl Add<Color> for Color {
                 lightness,
                 alpha,
             } => {
-                let rhs = rhs.as_linear_rgba_f32();
+                let rhs = rhs.as_hsla_f32();
                 Color::Hsla {
                     hue: hue + rhs[0],
                     saturation: saturation + rhs[1],


### PR DESCRIPTION
Probably a copy-paste error, but `Add<Color>` and `AddAssign<Color>` should use `rhs.as_hlsa_f32()` instead of `rhs.as_linear_rgba_f32()` when the LHS is a `Color::Hsla`. Fixes #5543.

