### PR TITLE
add `FontRef` and `DefaultFont`

### DIFF
--- a/crates/bevy_text/src/error.rs
+++ b/crates/bevy_text/src/error.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 pub enum TextError {
     #[error("font not found")]
     NoSuchFont,
+    #[error("font not loaded")]
+    FontNotLoaded,
     #[error("failed to add glyph to newly-created atlas {0:?}")]
     FailedToAddGlyph(GlyphId),
 }

--- a/crates/bevy_text/src/font.rs
+++ b/crates/bevy_text/src/font.rs
@@ -48,12 +48,12 @@ impl Font {
 /// A reference to a font asset.
 #[derive(Clone, Debug, Reflect, FromReflect, Default)]
 pub enum FontRef {
-    /// Use the "default" font for the current context. This default font is configurable with the FontConfig resource.
+    /// Use the default font it can be configured with the [`DefaultFont`] resource
     #[default]
     Default,
-    /// A handle to a shader stored in the [`Assets<Shader>`](bevy_asset::Assets) resource
+    /// A handle to a font stored in the [`Assets<Font>`](bevy_asset::Assets) resource
     Handle(Handle<Font>),
-    /// An asset path leading to a shader
+    /// An asset path leading to a font
     Path(AssetPath<'static>),
 }
 

--- a/crates/bevy_text/src/font.rs
+++ b/crates/bevy_text/src/font.rs
@@ -46,7 +46,7 @@ impl Font {
 }
 
 /// A reference to a font asset.
-#[derive(Clone, Debug, Reflect, FromReflect, Default)]
+#[derive(Clone, Debug, Default, FromReflect, Reflect)]
 pub enum FontRef {
     /// Use the default font it can be configured with the `DefaultFont` resource
     #[default]
@@ -54,6 +54,7 @@ pub enum FontRef {
     /// A handle to a font stored in the [`Assets<Font>`](bevy_asset::Assets) resource
     Handle(Handle<Font>),
     /// An asset path leading to a font
+    #[reflect(ignore)]
     Path(AssetPath<'static>),
 }
 

--- a/crates/bevy_text/src/font.rs
+++ b/crates/bevy_text/src/font.rs
@@ -48,7 +48,7 @@ impl Font {
 /// A reference to a font asset.
 #[derive(Clone, Debug, Reflect, FromReflect, Default)]
 pub enum FontRef {
-    /// Use the default font it can be configured with the [`DefaultFont`] resource
+    /// Use the default font it can be configured with the `DefaultFont` resource
     #[default]
     Default,
     /// A handle to a font stored in the [`Assets<Font>`](bevy_asset::Assets) resource

--- a/crates/bevy_text/src/font.rs
+++ b/crates/bevy_text/src/font.rs
@@ -1,5 +1,6 @@
 use ab_glyph::{FontArc, FontVec, InvalidFont, OutlinedGlyph};
-use bevy_reflect::TypeUuid;
+use bevy_asset::{AssetPath, Handle};
+use bevy_reflect::{FromReflect, Reflect, TypeUuid};
 use bevy_render::{
     render_resource::{Extent3d, TextureDimension, TextureFormat},
     texture::Image,
@@ -41,5 +42,35 @@ impl Font {
                 .collect::<Vec<u8>>(),
             TextureFormat::Rgba8UnormSrgb,
         )
+    }
+}
+
+/// A reference to a font asset.
+#[derive(Clone, Debug, Reflect, FromReflect, Default)]
+pub enum FontRef {
+    /// Use the "default" font for the current context. This default font is configurable with the FontConfig resource.
+    #[default]
+    Default,
+    /// A handle to a shader stored in the [`Assets<Shader>`](bevy_asset::Assets) resource
+    Handle(Handle<Font>),
+    /// An asset path leading to a shader
+    Path(AssetPath<'static>),
+}
+
+impl From<Handle<Font>> for FontRef {
+    fn from(handle: Handle<Font>) -> Self {
+        Self::Handle(handle)
+    }
+}
+
+impl From<AssetPath<'static>> for FontRef {
+    fn from(path: AssetPath<'static>) -> Self {
+        Self::Path(path)
+    }
+}
+
+impl From<&'static str> for FontRef {
+    fn from(path: &'static str) -> Self {
+        Self::Path(AssetPath::from(path))
     }
 }

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -49,10 +49,12 @@ impl Plugin for TextPlugin {
             .register_type::<HorizontalAlign>()
             .init_asset_loader::<FontLoader>()
             .insert_resource(DefaultTextPipeline::default())
+            .init_resource::<DefaultFont>()
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 update_text2d_layout.after(ModifiesWindows),
-            );
+            )
+            .add_system(load_font);
 
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.add_system_to_stage(

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -21,8 +21,8 @@ pub use text2d::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        Font, HorizontalAlign, Text, Text2dBundle, TextAlignment, TextError, TextSection,
-        TextStyle, VerticalAlign,
+        DefaultFont, Font, HorizontalAlign, Text, Text2dBundle, TextAlignment, TextError,
+        TextSection, TextStyle, VerticalAlign,
     };
 }
 

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -67,10 +67,15 @@ impl<ID: Hash + Eq> TextPipeline<ID> {
         let sections = sections
             .iter()
             .map(|section| {
-                let font = fonts
-                    .get(&section.style.font)
-                    .ok_or(TextError::NoSuchFont)?;
-                let font_id = self.get_or_insert_font_id(&section.style.font, font);
+                let handle = match section.style.font.clone() {
+                    crate::FontRef::Handle(handle) => handle,
+                    _ => {
+                        return Err(TextError::FontNotLoaded);
+                    }
+                };
+
+                let font = fonts.get(&handle).ok_or(TextError::NoSuchFont)?;
+                let font_id = self.get_or_insert_font_id(&handle, font);
                 let font_size = scale_value(section.style.font_size, scale_factor);
 
                 scaled_fonts.push(ab_glyph::Font::as_scaled(&font.font, font_size));

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -257,15 +257,15 @@ impl Default for TextStyle {
     }
 }
 
-/// Used to configure the default font used by TextStyle when the font is set to FontRef::Default
+/// Used to configure the default font used by [`TextStyle`] when the font is set to [`FontRef::Default`]
 #[derive(Default)]
 pub struct DefaultFont {
     pub path: Option<AssetPath<'static>>,
 }
 
-/// Loads fonts defined by a FontRef
-/// If the font has already been loaded then it simply converts the FontRef::Path to a FontRef::Handle
-/// Otherwise it tries to load the font with the asset_server
+/// Loads fonts defined by a [`FontRef`]
+/// If the font has already been loaded then it simply converts the [`FontRef::Path`] to a [`FontRef::Handle`]
+/// Otherwise it tries to load the font with the [`AssetServer`]
 pub fn load_font(
     mut query: Query<&mut Text, Added<Text>>,
     asset_server: Res<AssetServer>,

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -271,6 +271,7 @@ pub fn load_font(
     default_font: Res<DefaultFont>,
     mut event: EventWriter<RequestRedraw>,
 ) {
+    let mut needs_redraw = false;
     for mut text in &mut query {
         for mut section in &mut text.sections {
             let path = match &section.style.font {
@@ -297,10 +298,13 @@ pub fn load_font(
                 }
                 bevy_asset::LoadState::Failed => panic!("Failed to load font {:?}", path),
             };
-            // This is to avoid an issue in low power mode where the fonts were not loaded in time
-            // and there would be no text until the next redraw.
-            event.send(RequestRedraw);
             section.style.font = FontRef::Handle(handle);
+            needs_redraw = true;
         }
+    }
+    if needs_redraw {
+        // This is to avoid an issue in low power mode where the fonts were not loaded in time
+        // and there would be no text until the next redraw.
+        event.send(RequestRedraw);
     }
 }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     prelude::{Component, EventWriter},
     query::Added,
     reflect::ReflectComponent,
-    system::{Query, Res},
+    system::{Query, Res, Resource},
 };
 use bevy_reflect::{prelude::*, FromReflect};
 use bevy_render::color::Color;
@@ -256,7 +256,7 @@ impl Default for TextStyle {
 }
 
 /// Used to configure the default font used by [`TextStyle`] when the font is set to [`FontRef::Default`]
-#[derive(Default)]
+#[derive(Default, Resource)]
 pub struct DefaultFont {
     pub path: Option<AssetPath<'static>>,
 }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -10,6 +10,7 @@ use bevy_ecs::{
 use bevy_reflect::{prelude::*, FromReflect};
 use bevy_render::color::Color;
 use bevy_utils::tracing::warn;
+use bevy_window::RequestRedraw;
 use serde::{Deserialize, Serialize};
 
 use crate::{Font, FontRef};
@@ -268,6 +269,7 @@ pub fn load_font(
     asset_server: Res<AssetServer>,
     fonts: Res<Assets<Font>>,
     default_font: Res<DefaultFont>,
+    mut event: EventWriter<RequestRedraw>,
 ) {
     for mut text in &mut query {
         for mut section in &mut text.sections {
@@ -295,6 +297,9 @@ pub fn load_font(
                 }
                 bevy_asset::LoadState::Failed => panic!("Failed to load font {:?}", path),
             };
+            // This is to avoid an issue in low power mode where the fonts were not loaded in time
+            // and there would be no text until the next redraw.
+            event.send(RequestRedraw);
             section.style.font = FontRef::Handle(handle);
         }
     }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -28,14 +28,12 @@ impl Text {
     /// # use bevy_render::color::Color;
     /// # use bevy_text::{Font, Text, TextAlignment, TextStyle, HorizontalAlign, VerticalAlign};
     /// #
-    /// # let font_handle: Handle<Font> = Default::default();
-    /// #
     /// // Basic usage.
     /// let hello_world = Text::from_section(
     ///     // Accepts a String or any type that converts into a String, such as &str.
     ///     "hello world!",
     ///     TextStyle {
-    ///         font: font_handle.clone(),
+    ///         font: "path/to/font".into(),
     ///         font_size: 60.0,
     ///         color: Color::WHITE,
     ///     },
@@ -44,7 +42,7 @@ impl Text {
     /// let hello_bevy = Text::from_section(
     ///     "hello bevy!",
     ///     TextStyle {
-    ///         font: font_handle,
+    ///         font: "path/to/font".into(),
     ///         font_size: 60.0,
     ///         color: Color::WHITE,
     ///     },
@@ -65,13 +63,11 @@ impl Text {
     /// # use bevy_render::color::Color;
     /// # use bevy_text::{Font, Text, TextStyle, TextSection};
     /// #
-    /// # let font_handle: Handle<Font> = Default::default();
-    /// #
     /// let hello_world = Text::from_sections([
     ///     TextSection::new(
     ///         "Hello, ",
     ///         TextStyle {
-    ///             font: font_handle.clone(),
+    ///             font: "path/to/font".into(),
     ///             font_size: 60.0,
     ///             color: Color::BLUE,
     ///         },
@@ -79,7 +75,7 @@ impl Text {
     ///     TextSection::new(
     ///         "World!",
     ///         TextStyle {
-    ///             font: font_handle,
+    ///             font: "path/to/font".into(),
     ///             font_size: 60.0,
     ///             color: Color::RED,
     ///         },

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -188,7 +188,7 @@ pub fn update_text2d_layout(
                 &mut *texture_atlases,
                 &mut *textures,
             ) {
-                Err(TextError::NoSuchFont) => {
+                Err(TextError::NoSuchFont | TextError::FontNotLoaded) => {
                     // There was an error processing the text layout, let's add this entity to the
                     // queue for further processing
                     queue.insert(entity);

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -112,7 +112,7 @@ pub fn text_system(
                 &mut *texture_atlases,
                 &mut *textures,
             ) {
-                Err(TextError::NoSuchFont) => {
+                Err(TextError::NoSuchFont | TextError::FontNotLoaded) => {
                     // There was an error processing the text layout, let's add this entity to the
                     // queue for further processing
                     new_queue.push(entity);

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -24,10 +24,9 @@ struct AnimateRotation;
 #[derive(Component)]
 struct AnimateScale;
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let font = asset_server.load("fonts/FiraSans-Bold.ttf");
+fn setup(mut commands: Commands) {
     let text_style = TextStyle {
-        font,
+        font: "fonts/FiraSans-Bold.ttf".into(),
         font_size: 60.0,
         color: Color::WHITE,
     };

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -58,7 +58,7 @@ fn spawn_text(
     loaded_font: Res<LoadedFont>,
 ) {
     let text_style = TextStyle {
-        font: loaded_font.clone(),
+        font: loaded_font.clone().into(),
         font_size: 20.0,
         color: Color::WHITE,
     };

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -39,7 +39,7 @@ fn setup(mut commands: Commands) {
     commands.spawn_bundle(Camera2dBundle::default());
 }
 
-fn setup_menu(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup_menu(mut commands: Commands) {
     let button_entity = commands
         .spawn_bundle(ButtonBundle {
             style: Style {
@@ -59,7 +59,7 @@ fn setup_menu(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent.spawn_bundle(TextBundle::from_section(
                 "Play",
                 TextStyle {
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    font: "fonts/FiraSans-Bold.ttf".into(),
                     font_size: 40.0,
                     color: Color::rgb(0.9, 0.9, 0.9),
                 },

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -156,7 +156,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
         TextBundle::from_section(
             "Score:",
             TextStyle {
-                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                font: "fonts/FiraSans-Bold.ttf".into(),
                 font_size: 40.0,
                 color: Color::rgb(0.5, 0.5, 1.0),
             },
@@ -370,7 +370,7 @@ fn gameover_keyboard(mut state: ResMut<State<GameState>>, keyboard_input: Res<In
 }
 
 // display the number of cake eaten before losing
-fn display_score(mut commands: Commands, asset_server: Res<AssetServer>, game: Res<Game>) {
+fn display_score(mut commands: Commands, game: Res<Game>) {
     commands
         .spawn_bundle(NodeBundle {
             style: Style {
@@ -386,7 +386,7 @@ fn display_score(mut commands: Commands, asset_server: Res<AssetServer>, game: R
             parent.spawn_bundle(TextBundle::from_section(
                 format!("Cake eaten: {}", game.cake_eaten),
                 TextStyle {
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    font: "fonts/FiraSans-Bold.ttf".into(),
                     font_size: 80.0,
                     color: Color::rgb(0.5, 0.5, 1.0),
                 },

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -223,13 +223,13 @@ fn setup(
             TextSection::new(
                 "Score: ",
                 TextStyle {
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    font: "fonts/FiraSans-Bold.ttf".into(),
                     font_size: SCOREBOARD_FONT_SIZE,
                     color: TEXT_COLOR,
                 },
             ),
             TextSection::from_style(TextStyle {
-                font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                font: "fonts/FiraMono-Medium.ttf".into(),
                 font_size: SCOREBOARD_FONT_SIZE,
                 color: SCORE_COLOR,
             }),

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -133,7 +133,7 @@ fn setup_contributor_selection(mut commands: Commands, asset_server: Res<AssetSe
     commands.insert_resource(contributor_selection);
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: Commands) {
     commands.spawn_bundle(Camera2dBundle::default());
 
     commands.spawn().insert(ContributorDisplay).insert_bundle(
@@ -141,13 +141,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             TextSection::new(
                 "Contributor showcase",
                 TextStyle {
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    font: "fonts/FiraSans-Bold.ttf".into(),
                     font_size: 60.0,
                     color: Color::WHITE,
                 },
             ),
             TextSection::from_style(TextStyle {
-                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                font: "fonts/FiraSans-Bold.ttf".into(),
                 font_size: 60.0,
                 color: Color::WHITE,
             }),

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -2,7 +2,7 @@
 //! change some settings or quit. There is no actual game, it will just display the current
 //! settings for 5 seconds before going back to the menu.
 
-use bevy::prelude::*;
+use bevy::{prelude::*, text::DefaultFont};
 
 const TEXT_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);
 
@@ -32,6 +32,9 @@ fn main() {
         // Insert as resource the initial value for the settings resources
         .insert_resource(DisplayQuality::Medium)
         .insert_resource(Volume(7))
+        .insert_resource(DefaultFont {
+            path: Some("fonts/FiraSans-Bold.ttf".into()),
+        })
         .add_startup_system(setup)
         // Declare the game state, and set its startup value
         .add_state(GameState::Splash)
@@ -138,12 +141,9 @@ mod game {
 
     fn game_setup(
         mut commands: Commands,
-        asset_server: Res<AssetServer>,
         display_quality: Res<DisplayQuality>,
         volume: Res<Volume>,
     ) {
-        let font = asset_server.load("fonts/FiraSans-Bold.ttf");
-
         commands
             // First create a `NodeBundle` for centering what we want to display
             .spawn_bundle(NodeBundle {
@@ -169,7 +169,7 @@ mod game {
                     TextBundle::from_section(
                         "Will be back to the menu shortly...",
                         TextStyle {
-                            font: font.clone(),
+                            font: default(),
                             font_size: 80.0,
                             color: TEXT_COLOR,
                         },
@@ -184,7 +184,7 @@ mod game {
                         TextSection::new(
                             format!("quality: {:?}", *display_quality),
                             TextStyle {
-                                font: font.clone(),
+                                font: default(),
                                 font_size: 60.0,
                                 color: Color::BLUE,
                             },
@@ -192,7 +192,7 @@ mod game {
                         TextSection::new(
                             " - ",
                             TextStyle {
-                                font: font.clone(),
+                                font: default(),
                                 font_size: 60.0,
                                 color: TEXT_COLOR,
                             },
@@ -200,7 +200,7 @@ mod game {
                         TextSection::new(
                             format!("volume: {:?}", *volume),
                             TextStyle {
-                                font: font.clone(),
+                                font: default(),
                                 font_size: 60.0,
                                 color: Color::GREEN,
                             },
@@ -384,7 +384,6 @@ mod menu {
     }
 
     fn main_menu_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-        let font = asset_server.load("fonts/FiraSans-Bold.ttf");
         // Common style for all buttons on the screen
         let button_style = Style {
             size: Size::new(Val::Px(250.0), Val::Px(65.0)),
@@ -407,7 +406,7 @@ mod menu {
             ..default()
         };
         let button_text_style = TextStyle {
-            font: font.clone(),
+            font: default(),
             font_size: 40.0,
             color: TEXT_COLOR,
         };
@@ -430,7 +429,7 @@ mod menu {
                     TextBundle::from_section(
                         "Bevy Game Menu UI",
                         TextStyle {
-                            font: font.clone(),
+                            font: default(),
                             font_size: 80.0,
                             color: TEXT_COLOR,
                         },
@@ -502,7 +501,7 @@ mod menu {
             });
     }
 
-    fn settings_menu_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    fn settings_menu_setup(mut commands: Commands) {
         let button_style = Style {
             size: Size::new(Val::Px(200.0), Val::Px(65.0)),
             margin: UiRect::all(Val::Px(20.0)),
@@ -512,7 +511,7 @@ mod menu {
         };
 
         let button_text_style = TextStyle {
-            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+            font: default(),
             font_size: 40.0,
             color: TEXT_COLOR,
         };
@@ -552,11 +551,7 @@ mod menu {
             });
     }
 
-    fn display_settings_menu_setup(
-        mut commands: Commands,
-        asset_server: Res<AssetServer>,
-        display_quality: Res<DisplayQuality>,
-    ) {
+    fn display_settings_menu_setup(mut commands: Commands, display_quality: Res<DisplayQuality>) {
         let button_style = Style {
             size: Size::new(Val::Px(200.0), Val::Px(65.0)),
             margin: UiRect::all(Val::Px(20.0)),
@@ -565,7 +560,7 @@ mod menu {
             ..default()
         };
         let button_text_style = TextStyle {
-            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+            font: default(),
             font_size: 40.0,
             color: TEXT_COLOR,
         };
@@ -639,11 +634,7 @@ mod menu {
             });
     }
 
-    fn sound_settings_menu_setup(
-        mut commands: Commands,
-        asset_server: Res<AssetServer>,
-        volume: Res<Volume>,
-    ) {
+    fn sound_settings_menu_setup(mut commands: Commands, volume: Res<Volume>) {
         let button_style = Style {
             size: Size::new(Val::Px(200.0), Val::Px(65.0)),
             margin: UiRect::all(Val::Px(20.0)),
@@ -652,7 +643,7 @@ mod menu {
             ..default()
         };
         let button_text_style = TextStyle {
-            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+            font: default(),
             font_size: 40.0,
             color: TEXT_COLOR,
         };

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -2,7 +2,7 @@
 //! change some settings or quit. There is no actual game, it will just display the current
 //! settings for 5 seconds before going back to the menu.
 
-use bevy::{prelude::*, text::DefaultFont};
+use bevy::prelude::*;
 
 const TEXT_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);
 

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -48,7 +48,6 @@ fn setup_scene(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    asset_server: Res<AssetServer>,
 ) {
     // plane
     commands.spawn_bundle(PbrBundle {
@@ -112,7 +111,7 @@ fn setup_scene(
                 TextBundle::from_section(
                     "Test Button",
                     TextStyle {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font: "fonts/FiraSans-Bold.ttf".into(),
                         font_size: 30.0,
                         color: Color::BLACK,
                     },

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -103,13 +103,13 @@ fn save_scene_system(world: &mut World) {
 
 // This is only necessary for the info message in the UI. See examples/ui/text.rs for a standalone
 // text example.
-fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn infotext_system(mut commands: Commands) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands.spawn_bundle(
         TextBundle::from_section(
             "Nothing to see in this window! Check the console output!",
             TextStyle {
-                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                font: "fonts/FiraSans-Bold.ttf".into(),
                 font_size: 50.0,
                 color: Color::WHITE,
             },

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -103,26 +103,26 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 TextSection::new(
                     "Bird Count: ",
                     TextStyle {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font: "fonts/FiraSans-Bold.ttf".into(),
                         font_size: 40.0,
                         color: Color::rgb(0.0, 1.0, 0.0),
                     },
                 ),
                 TextSection::from_style(TextStyle {
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    font: "fonts/FiraSans-Bold.ttf".into(),
                     font_size: 40.0,
                     color: Color::rgb(0.0, 1.0, 1.0),
                 }),
                 TextSection::new(
                     "\nAverage FPS: ",
                     TextStyle {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font: "fonts/FiraSans-Bold.ttf".into(),
                         font_size: 40.0,
                         color: Color::rgb(0.0, 1.0, 0.0),
                     },
                 ),
                 TextSection::from_style(TextStyle {
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    font: "fonts/FiraSans-Bold.ttf".into(),
                     font_size: 40.0,
                     color: Color::rgb(0.0, 1.0, 1.0),
                 }),

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -101,7 +101,7 @@ fn spawn_button(
             commands.spawn_bundle(TextBundle::from_section(
                 format!("{i}, {j}"),
                 TextStyle {
-                    font,
+                    font: font.into(),
                     font_size: FONT_SIZE,
                     color: Color::rgb(0.2, 0.2, 0.2),
                 },

--- a/examples/transforms/global_vs_local_translation.rs
+++ b/examples/transforms/global_vs_local_translation.rs
@@ -108,7 +108,7 @@ Notice how the green cube will translate further in respect to the yellow in con
 This is due to the use of its LocalTransform that is relative to the yellow cubes transform instead of the GlobalTransform as in the case of the red cube.
 The red cube is moved through its GlobalTransform and thus is unaffected by the yellows transform.",
         TextStyle {
-            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+            font: "fonts/FiraSans-Bold.ttf".into(),
             font_size: 22.0,
             color: Color::WHITE,
         },

--- a/examples/transforms/global_vs_local_translation.rs
+++ b/examples/transforms/global_vs_local_translation.rs
@@ -40,7 +40,6 @@ fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    asset_server: Res<AssetServer>,
 ) {
     // To show the difference between a local transform (rotation, scale and position in respect to a given entity)
     // and global transform (rotation, scale and position in respect to the base coordinate system of the visible scene)

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -43,7 +43,7 @@ fn button_system(
     }
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: Commands) {
     // ui camera
     commands.spawn_bundle(Camera2dBundle::default());
     commands
@@ -65,7 +65,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent.spawn_bundle(TextBundle::from_section(
                 "Button",
                 TextStyle {
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    font: "fonts/FiraSans-Bold.ttf".into(),
                     font_size: 40.0,
                     color: Color::rgb(0.9, 0.9, 0.9),
                 },

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -85,7 +85,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut state: ResM
     commands.spawn_bundle(TextBundle::from_section(
         "a",
         TextStyle {
-            font: font_handle,
+            font: font_handle.into(),
             font_size: 60.0,
             color: Color::YELLOW,
         },

--- a/examples/ui/scaling.rs
+++ b/examples/ui/scaling.rs
@@ -25,7 +25,7 @@ fn setup(mut commands: Commands, asset_server: ResMut<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
 
     let text_style = TextStyle {
-        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+        font: "fonts/FiraMono-Medium.ttf".into(),
         font_size: 16.,
         color: Color::BLACK,
     };

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -6,7 +6,6 @@
 use bevy::{
     diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin},
     prelude::*,
-    text::DefaultFont,
 };
 
 fn main() {

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -26,7 +26,7 @@ struct FpsText;
 #[derive(Component)]
 struct ColorText;
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: Commands) {
     // UI camera
     commands.spawn_bundle(Camera2dBundle::default());
     // Text with one section
@@ -37,7 +37,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 // Accepts a `String` or any type that converts into a `String`, such as `&str`
                 "hello\nbevy!",
                 TextStyle {
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    font: "fonts/FiraSans-Bold.ttf".into(),
                     font_size: 100.0,
                     color: Color::WHITE,
                 },
@@ -64,13 +64,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 TextSection::new(
                     "FPS: ",
                     TextStyle {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font: "fonts/FiraSans-Bold.ttf".into(),
                         font_size: 60.0,
                         color: Color::WHITE,
                     },
                 ),
                 TextSection::from_style(TextStyle {
-                    font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                    font: "fonts/FiraMono-Medium.ttf".into(),
                     font_size: 60.0,
                     color: Color::GOLD,
                 }),

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -6,12 +6,17 @@
 use bevy::{
     diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin},
     prelude::*,
+    text::DefaultFont,
 };
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .insert_resource(DefaultFont {
+            // Configure a default font that will be applied to all text node without a specified font
+            path: Some("fonts/FiraMono-Medium.ttf".into()),
+        })
         .add_startup_system(setup)
         .add_system(text_update_system)
         .add_system(text_color_system)
@@ -70,7 +75,8 @@ fn setup(mut commands: Commands) {
                     },
                 ),
                 TextSection::from_style(TextStyle {
-                    font: "fonts/FiraMono-Medium.ttf".into(),
+                    // Use the default font instead of manually specifying a font
+                    font: default(),
                     font_size: 60.0,
                     color: Color::GOLD,
                 }),

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -22,14 +22,13 @@ fn main() {
 #[derive(Component)]
 struct TextChanges;
 
-fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let font = asset_server.load("fonts/FiraSans-Bold.ttf");
+fn infotext_system(mut commands: Commands) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands.spawn_bundle(
         TextBundle::from_section(
             "This is\ntext with\nline breaks\nin the top left",
             TextStyle {
-                font: font.clone(),
+                font: "fonts/FiraSans-Bold.ttf".into(),
                 font_size: 50.0,
                 color: Color::WHITE,
             },
@@ -48,7 +47,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(TextBundle::from_section(
             "This text is very long, has a limited width, is centred, is positioned in the top right and is also coloured pink.",
             TextStyle {
-                font: font.clone(),
+                font: "fonts/FiraSans-Bold.ttf".into(),
                 font_size: 50.0,
                 color: Color::rgb(0.8, 0.2, 0.7),
             },
@@ -75,7 +74,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 TextSection::new(
                     "This text changes in the bottom right",
                     TextStyle {
-                        font: font.clone(),
+                        font: "fonts/FiraSans-Bold.ttf".into(),
                         font_size: 30.0,
                         color: Color::WHITE,
                     },
@@ -83,33 +82,33 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 TextSection::new(
                     "\nThis text changes in the bottom right - ",
                     TextStyle {
-                        font: font.clone(),
+                        font: "fonts/FiraSans-Bold.ttf".into(),
                         font_size: 30.0,
                         color: Color::RED,
                     },
                 ),
                 TextSection::from_style(TextStyle {
-                    font: font.clone(),
+                    font: "fonts/FiraSans-Bold.ttf".into(),
                     font_size: 30.0,
                     color: Color::ORANGE_RED,
                 }),
                 TextSection::new(
                     " fps, ",
                     TextStyle {
-                        font: font.clone(),
+                        font: "fonts/FiraSans-Bold.ttf".into(),
                         font_size: 30.0,
                         color: Color::YELLOW,
                     },
                 ),
                 TextSection::from_style(TextStyle {
-                    font: font.clone(),
+                    font: "fonts/FiraSans-Bold.ttf".into(),
                     font_size: 30.0,
                     color: Color::GREEN,
                 }),
                 TextSection::new(
                     " ms/frame",
                     TextStyle {
-                        font: font.clone(),
+                        font: "fonts/FiraSans-Bold.ttf".into(),
                         font_size: 30.0,
                         color: Color::BLUE,
                     },
@@ -131,7 +130,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         TextBundle::from_section(
             "This\ntext has\nline breaks and also a set width in the bottom left",
             TextStyle {
-                font,
+                font: "fonts/FiraSans-Bold.ttf".into(),
                 font_size: 50.0,
                 color: Color::WHITE,
             },

--- a/examples/ui/transparency_ui.rs
+++ b/examples/ui/transparency_ui.rs
@@ -11,10 +11,8 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: Commands) {
     commands.spawn_bundle(Camera2dBundle::default());
-
-    let font_handle = asset_server.load("fonts/FiraSans-Bold.ttf");
 
     commands
         .spawn_bundle(ButtonBundle {
@@ -32,7 +30,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent.spawn_bundle(TextBundle::from_section(
                 "Button 1",
                 TextStyle {
-                    font: font_handle.clone(),
+                    font: "fonts/FiraSans-Bold.ttf".into(),
                     font_size: 40.0,
                     // Alpha channel of the color controls transparency.
                     color: Color::rgba(1.0, 1.0, 1.0, 0.2),
@@ -58,7 +56,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent.spawn_bundle(TextBundle::from_section(
                 "Button 2",
                 TextStyle {
-                    font: font_handle.clone(),
+                    font: "fonts/FiraSans-Bold.ttf".into(),
                     font_size: 40.0,
                     // Alpha channel of the color controls transparency.
                     color: Color::rgba(1.0, 1.0, 1.0, 0.2),

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -61,7 +61,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 TextBundle::from_section(
                                     "Text Example",
                                     TextStyle {
-                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                        font: "fonts/FiraSans-Bold.ttf".into(),
                                         font_size: 30.0,
                                         color: Color::WHITE,
                                     },
@@ -91,7 +91,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         TextBundle::from_section(
                             "Scrolling list",
                             TextStyle {
-                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                font: "fonts/FiraSans-Bold.ttf".into(),
                                 font_size: 25.,
                                 color: Color::WHITE,
                             },
@@ -140,8 +140,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                             TextBundle::from_section(
                                                 format!("Item {i}"),
                                                 TextStyle {
-                                                    font: asset_server
-                                                        .load("fonts/FiraSans-Bold.ttf"),
+                                                    font: "fonts/FiraSans-Bold.ttf".into(),
                                                     font_size: 20.,
                                                     color: Color::WHITE,
                                                 },

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -142,7 +142,6 @@ pub(crate) mod test_setup {
         mut meshes: ResMut<Assets<Mesh>>,
         mut materials: ResMut<Assets<StandardMaterial>>,
         mut event: EventWriter<RequestRedraw>,
-        asset_server: Res<AssetServer>,
     ) {
         commands
             .spawn_bundle(PbrBundle {
@@ -171,26 +170,26 @@ pub(crate) mod test_setup {
                     TextSection::new(
                         "Press spacebar to cycle modes\n",
                         TextStyle {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                            font: "fonts/FiraSans-Bold.ttf".into(),
                             font_size: 50.0,
                             color: Color::WHITE,
                         },
                     ),
                     TextSection::from_style(TextStyle {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font: "fonts/FiraSans-Bold.ttf".into(),
                         font_size: 50.0,
                         color: Color::GREEN,
                     }),
                     TextSection::new(
                         "\nFrame: ",
                         TextStyle {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                            font: "fonts/FiraSans-Bold.ttf".into(),
                             font_size: 50.0,
                             color: Color::YELLOW,
                         },
                     ),
                     TextSection::from_style(TextStyle {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font: "fonts/FiraSans-Bold.ttf".into(),
                         font_size: 50.0,
                         color: Color::YELLOW,
                     }),

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -17,7 +17,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: Commands) {
     // camera
     commands.spawn_bundle(Camera2dBundle::default());
     // root node
@@ -48,7 +48,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         TextBundle::from_section(
                             "Example text",
                             TextStyle {
-                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                font: "fonts/FiraSans-Bold.ttf".into(),
                                 font_size: 30.0,
                                 color: Color::WHITE,
                             },

--- a/examples/window/window_resizing.rs
+++ b/examples/window/window_resizing.rs
@@ -34,7 +34,7 @@ fn setup_camera(mut cmd: Commands) {
 }
 
 // Spawns the UI
-fn setup_ui(mut cmd: Commands, asset_server: Res<AssetServer>) {
+fn setup_ui(mut cmd: Commands) {
     // Node that fills entire background
     cmd.spawn_bundle(NodeBundle {
         style: Style {
@@ -48,7 +48,7 @@ fn setup_ui(mut cmd: Commands, asset_server: Res<AssetServer>) {
         root.spawn_bundle(TextBundle::from_section(
             "Resolution",
             TextStyle {
-                font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                font: "fonts/FiraMono-Medium.ttf".into(),
                 font_size: 50.0,
                 color: Color::BLACK,
             },


### PR DESCRIPTION
# Objective

Creating a `TextStyle` requires an `Handle<Font>` which means you either need to pass the text_style around or pass an asset_server everywhere. This makes declaring reusable ui components harder than necessary. 

It should be possible to not need to pass around anything and create it where we want it and let bevy take care of loading the font.

## Solution

- Introduce a new `FontRef` inspired by the `ShaderRef` from the new `Material`
	- A default font that can be configured globally with the new `DefaultFont` resource
	- A string path to a font can be automatically converted to a `FontRef` and the new `bevy_text::load_font()` system will take care of loading the font asset and converting the path to an `Handle<Font>`.
	- Keep support for manually loading fonts and convert the `Handle` to a `FontRef::Handle`

---

## Changelog

- Added `FontRef`
- Added `DefaultFont`
- `TextStyle` now uses `FontRef` instead of `Handle<Font>`

## Migration Guide

Instead of requiring an asset_server to load a font you can now use a string path to a font asset and bevy will take care of loading it properly. This makes declaring `TextStyle` components much easier. If you want to keep the asset_server you can easily convert a `Handle<Font>` to a `FontRed` using `.into()`.

```rust
// 0.8
commands.spawn_bundle(TextBundle::from_section(
    "hello bevy!",
    TextStyle {
        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
		..default()
    },
));

// 0.9
commands.spawn_bundle(TextBundle::from_section(
    "hello bevy!",
    TextStyle {
        font: "fonts/FiraSans-Bold.ttf".into(),
		..default()
    },
));
```

## Notes

I updated all the examples using fonts, but I only used the new DefaultFont on the game_menu example.
If anyone is scared of the amount of files changed, the vast majority of the changes in most files are just converting existing asset_server.load() to the new `FontRef`.


Closes #5515