### PR TITLE
[Merged by Bors] - changed diagnostics from seconds to milliseconds

### DIFF
--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -27,7 +27,7 @@ impl FrameTimeDiagnosticsPlugin {
         DiagnosticId::from_u128(73441630925388532774622109383099159699);
 
     pub fn setup_system(mut diagnostics: ResMut<Diagnostics>) {
-        diagnostics.add(Diagnostic::new(Self::FRAME_TIME, "frame_time", 20).with_suffix("s"));
+        diagnostics.add(Diagnostic::new(Self::FRAME_TIME, "frame_time", 20).with_suffix("ms"));
         diagnostics.add(Diagnostic::new(Self::FPS, "fps", 20));
         diagnostics.add(Diagnostic::new(Self::FRAME_COUNT, "frame_count", 1));
     }
@@ -46,7 +46,7 @@ impl FrameTimeDiagnosticsPlugin {
             return;
         }
 
-        diagnostics.add_measurement(Self::FRAME_TIME, || time.delta_seconds_f64());
+        diagnostics.add_measurement(Self::FRAME_TIME, || time.delta_seconds_f64() * 1000.);
 
         diagnostics.add_measurement(Self::FPS, || 1.0 / time.delta_seconds_f64());
     }

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -27,7 +27,7 @@ impl FrameTimeDiagnosticsPlugin {
         DiagnosticId::from_u128(73441630925388532774622109383099159699);
 
     pub fn setup_system(mut diagnostics: ResMut<Diagnostics>) {
-        diagnostics.add(Diagnostic::new(Self::FRAME_TIME, "frame_time", 20).with_suffix("ms"));
+        diagnostics.add(Diagnostic::new(Self::FRAME_TIME, "frame_time", 20).with_suffix(" ms"));
         diagnostics.add(Diagnostic::new(Self::FPS, "fps", 20));
         diagnostics.add(Diagnostic::new(Self::FRAME_COUNT, "frame_count", 1));
     }

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -27,7 +27,7 @@ impl FrameTimeDiagnosticsPlugin {
         DiagnosticId::from_u128(73441630925388532774622109383099159699);
 
     pub fn setup_system(mut diagnostics: ResMut<Diagnostics>) {
-        diagnostics.add(Diagnostic::new(Self::FRAME_TIME, "frame_time", 20).with_suffix(" ms"));
+        diagnostics.add(Diagnostic::new(Self::FRAME_TIME, "frame_time", 20).with_suffix("ms"));
         diagnostics.add(Diagnostic::new(Self::FPS, "fps", 20));
         diagnostics.add(Diagnostic::new(Self::FRAME_COUNT, "frame_count", 1));
     }

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -176,12 +176,11 @@ fn change_text_system(
 
         text.sections[0].value = format!(
             "This text changes in the bottom right - {:.1} fps, {:.3} ms/frame",
-            fps,
-            frame_time * 1000.0,
+            fps, frame_time,
         );
 
         text.sections[2].value = format!("{:.1}", fps);
 
-        text.sections[4].value = format!("{:.3}", frame_time * 1000.0);
+        text.sections[4].value = format!("{:.3}", frame_time);
     }
 }


### PR DESCRIPTION
Co-authored-by: Alice Cecile <alice.i.cecile@gmail.com>

# Objective

Change frametimediagnostic from seconds to milliseconds because this will always be less than one seconds and is the common diagnostic display unit for game engines.

## Solution

- multiplied the existing value by 1000

---

## Changelog

Frametimes are now reported in milliseconds