### PR TITLE
Implemented num traits for Val

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -20,6 +20,16 @@ pub struct Node {
 }
 
 /// An enum that describes possible types of value in flexbox layout options
+///
+/// There are numeric traits implemented for this enum so you can multiply, divide, add, and subtract
+/// with an `f32` value or another `Val`.
+/// If you use any of the math operations with an `f32` it will only be applied for the `Px` and `Percent` variants.
+/// `Undefined` and `Auto` will stay unchanged.
+/// When both operators are `Val`s the result is computed by following these rules:
+/// * If any operator is `Undefined` the result is `Undefined`
+/// * If any operator is `Auto` the result is `Auto`
+/// * If both operators are of the same unit the operation is applied to the value
+/// * If both operators are of different units the result is `Undefined`
 #[derive(Copy, Clone, PartialEq, Debug, Default, Serialize, Deserialize, Reflect)]
 #[reflect(PartialEq, Serialize, Deserialize)]
 pub enum Val {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -122,6 +122,86 @@ impl DivAssign<f32> for Val {
     }
 }
 
+impl Add<Val> for Val {
+    type Output = Val;
+
+    fn add(self, rhs: Val) -> Self::Output {
+        match (self, rhs) {
+            (Val::Undefined, _) | (_, Val::Undefined) => Val::Undefined,
+            (Val::Auto, _) | (_, Val::Auto) => Val::Auto,
+            (Val::Px(lhs), Val::Px(rhs)) => Val::Px(lhs + rhs),
+            (Val::Percent(lhs), Val::Percent(rhs)) => Val::Percent(lhs + rhs),
+            _ => Val::Undefined,
+        }
+    }
+}
+
+impl AddAssign<Val> for Val {
+    fn add_assign(&mut self, rhs: Val) {
+        *self = *self + rhs;
+    }
+}
+
+impl Sub<Val> for Val {
+    type Output = Val;
+
+    fn sub(self, rhs: Val) -> Self::Output {
+        match (self, rhs) {
+            (Val::Undefined, _) | (_, Val::Undefined) => Val::Undefined,
+            (Val::Auto, _) | (_, Val::Auto) => Val::Auto,
+            (Val::Px(lhs), Val::Px(rhs)) => Val::Px(lhs - rhs),
+            (Val::Percent(lhs), Val::Percent(rhs)) => Val::Percent(lhs - rhs),
+            _ => Val::Undefined,
+        }
+    }
+}
+
+impl SubAssign<Val> for Val {
+    fn sub_assign(&mut self, rhs: Val) {
+        *self = *self - rhs;
+    }
+}
+
+impl Mul<Val> for Val {
+    type Output = Val;
+
+    fn mul(self, rhs: Val) -> Self::Output {
+        match (self, rhs) {
+            (Val::Undefined, _) | (_, Val::Undefined) => Val::Undefined,
+            (Val::Auto, _) | (_, Val::Auto) => Val::Auto,
+            (Val::Px(lhs), Val::Px(rhs)) => Val::Px(lhs * rhs),
+            (Val::Percent(lhs), Val::Percent(rhs)) => Val::Percent(lhs * rhs),
+            _ => Val::Undefined,
+        }
+    }
+}
+
+impl MulAssign<Val> for Val {
+    fn mul_assign(&mut self, rhs: Val) {
+        *self = *self * rhs;
+    }
+}
+
+impl Div<Val> for Val {
+    type Output = Val;
+
+    fn div(self, rhs: Val) -> Self::Output {
+        match (self, rhs) {
+            (Val::Undefined, _) | (_, Val::Undefined) => Val::Undefined,
+            (Val::Auto, _) | (_, Val::Auto) => Val::Auto,
+            (Val::Px(lhs), Val::Px(rhs)) => Val::Px(lhs / rhs),
+            (Val::Percent(lhs), Val::Percent(rhs)) => Val::Percent(lhs / rhs),
+            _ => Val::Undefined,
+        }
+    }
+}
+
+impl DivAssign<Val> for Val {
+    fn div_assign(&mut self, rhs: Val) {
+        *self = *self / rhs;
+    }
+}
+
 /// Describes the style of a UI node
 ///
 /// It uses the [Flexbox](https://cssreference.io/flexbox/) system.


### PR DESCRIPTION
# Objective

- Fixes #5525

## Solution

I tried to "extrapolate" the `match` patterns from the `f32` implementations. The principle I ended following is:
- Anything touches undefined becomes undefined
- Else anything that touches auto becomes auto
- Only the same unit can do the math operation
- If they're different units it becomes undefined

I feel there's a high probability that this is not exactly what you had in mind. 😄 
Let me know!

