### PR TITLE
[Merged by Bors] - fix order of exit/close window systems

### DIFF
--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -22,7 +22,10 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
-use bevy_ecs::{event::Events, schedule::SystemLabel};
+use bevy_ecs::{
+    event::Events,
+    schedule::{ParallelSystemDescriptorCoercion, SystemLabel},
+};
 
 /// The configuration information for the [`WindowPlugin`].
 ///
@@ -106,7 +109,10 @@ impl Plugin for WindowPlugin {
         }
 
         if settings.exit_on_all_closed {
-            app.add_system(exit_on_all_closed);
+            app.add_system_to_stage(
+                CoreStage::PostUpdate,
+                exit_on_all_closed.after(ModifiesWindows),
+            );
         }
         if settings.close_when_requested {
             app.add_system(close_when_requested);


### PR DESCRIPTION
# Objective

Fixes #5384 and maybe other issues around window closing/app not exiting

## Solution

There are three systems involved in exiting when closing a window:
- `close_when_requested` asking Winit to close the window in stage `Update`
- `exit_on_all_closed` exiting when no window remains opened in stage `Update`
- `change_window` removing windows that are closed in stage `PostUpdate`

This ordering meant that when closing a window, we had to run one more frame to actually exit. As there was no window, panics could occur in systems assuming there was a window. In case of Bevy app using a low power options, that means waiting for the timeout before actually exiting the app (60 seconds by default)

This PR changes the ordering so that `exit_on_all_closed` happens after `change_window` in the same frame, so there isn't an extra frame without window