### PR TITLE
Fix UI scaling issues

### DIFF
--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -46,6 +46,7 @@ pub struct ExtractedWindow {
     pub present_mode: PresentMode,
     pub swap_chain_texture: Option<TextureView>,
     pub size_changed: bool,
+    pub scale_factor: f64,
 }
 
 #[derive(Default)]
@@ -89,6 +90,7 @@ fn extract_windows(
                     present_mode: window.present_mode(),
                     swap_chain_texture: None,
                     size_changed: false,
+                    scale_factor: window.scale_factor(),
                 });
 
         // NOTE: Drop the swap chain frame here


### PR DESCRIPTION
# Objective

Fixes #3493
Adopted from and supersedes #3533 

> The issue was that extracted_uinode.rect is scaled according to the window's scale factor when extracted_uinode.atlas_size is None, but it's not scaled when extracted_uinode.atlas_size is Some.

## Solution

>I changed one condition to avoid relying on extracted_uinode.rect, extracted the window's scale factor into the render app, and applied it as necessary when calculating the clipped UVs.
>To be honest, I can't properly explain why it works this way, and I'm not confident I covered all cases. In #3460, the similar fields extracted_sprite.rect and extracted_sprite.atlas_size are changed to cleanly separate what affects position/size and what affects UVs. I hope to port to UI the sprite improvements of that PR after it's accepted, but meanwhile this smaller PR can fix the issue.

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- What changed as a result of this PR?
- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!

## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- If this PR is a breaking change (relative to the last release of Bevy), describe how a user might need to migrate their code to support these changes
- Simply adding new functionality is not a breaking change.
- Fixing behavior that was definitely a bug, rather than a questionable design choice is not a breaking change.





