### PR TITLE
[Merged by Bors] - Fix window centering when scale_factor is not 1.0

### DIFF
--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -66,7 +66,7 @@ impl WinitWindows {
                         if let Some(monitor) = maybe_monitor {
                             let screen_size = monitor.size();
 
-                            let scale_factor = scale_factor_override.unwrap_or(1.0);
+                            let scale_factor = monitor.scale_factor();
 
                             // Logical to physical window size
                             let (width, height): (u32, u32) = LogicalSize::new(*width, *height)


### PR DESCRIPTION
# Objective

Fixes #5581

## Solution

`Window::scale_factor` already has logic for selecting the overridden or actual scale factor, so use it.

I tested this with the displays I have access to, but more testing would be nice. This seems like a pretty straightforward bug/fix though.

## Changelog

### Fixed

Fixed window centering on high-dpi displays.