### PR TITLE
[Merged by Bors] - Remove unnecessary `use` from examples

### DIFF
--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -1,7 +1,7 @@
 //! Renders an animated sprite by loading all animation frames from a single image (a sprite sheet)
 //! into a texture atlas, and changing the displayed image periodically.
 
-use bevy::{prelude::*, render::texture::ImageSettings};
+use bevy::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -1,7 +1,7 @@
 //! In this example we generate a new texture atlas (sprite sheet) from a folder containing
 //! individual sprites.
 
-use bevy::{asset::LoadState, prelude::*, render::texture::ImageSettings};
+use bevy::{asset::LoadState, prelude::*};
 
 fn main() {
     App::new()

--- a/examples/3d/shapes.rs
+++ b/examples/3d/shapes.rs
@@ -3,10 +3,7 @@
 
 use bevy::{
     prelude::*,
-    render::{
-        render_resource::{Extent3d, TextureDimension, TextureFormat},
-        texture::ImageSettings,
-    },
+    render::render_resource::{Extent3d, TextureDimension, TextureFormat},
 };
 
 fn main() {


### PR DESCRIPTION
# Objective

`bevy::render::texture::ImageSettings` was added to prelude in #5566, so these `use` statements are unnecessary and the examples can be made a bit more concise.

## Solution

Remove `use bevy::render::texture::ImageSettings`
