### PR TITLE
Added block_on method for AssetServer

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -586,8 +586,7 @@ impl AssetServer {
                     )))
                 }
                 LoadState::Unloaded => {
-                    warn!("Asset was unloaded - attempting to reload");
-                    handle = self.load_untyped(path.clone());
+                    panic!("Asset at {} was unloaded", path.path().display());
                 }
             }
         }

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -570,14 +570,13 @@ impl AssetServer {
                 "Handle does not have a corresponding Path"
             ))
         })?;
-        'block_on: loop {
+        loop {
             match self.get_load_state(handle.clone()) {
                 LoadState::NotLoaded => {
                     handle = self.load_untyped(path.clone());
-                    continue 'block_on;
                 }
                 LoadState::Loading => {
-                    continue 'block_on;
+                    std::thread::yield_now();
                 }
                 LoadState::Loaded => return Ok(handle),
                 LoadState::Failed => {


### PR DESCRIPTION
# Objective

Often in prototyping or game jam type situations when loading assets, you want to just hard wait til an asset finishes. 

## Solution
This PR adds a helper method (block_on) to AssetServer, to block the system its called in until the asset either loads successfully or returns an error. 
Its not that difficult to implement this per game but it would be nice if bevy could do that.

I'm pretty sure this needs some work before it's ready to merge (if at all?). 