### PR TITLE
[Merged by Bors] - use bevy_default() for texture format in post_processing

### DIFF
--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -13,6 +13,7 @@ use bevy::{
             AsBindGroup, Extent3d, ShaderRef, TextureDescriptor, TextureDimension, TextureFormat,
             TextureUsages,
         },
+        texture::BevyDefault,
         view::RenderLayers,
     },
     sprite::{Material2d, Material2dPlugin, MaterialMesh2dBundle},
@@ -56,7 +57,7 @@ fn setup(
             label: None,
             size,
             dimension: TextureDimension::D2,
-            format: TextureFormat::Bgra8UnormSrgb,
+            format: TextureFormat::bevy_default(),
             mip_level_count: 1,
             sample_count: 1,
             usage: TextureUsages::TEXTURE_BINDING


### PR DESCRIPTION
# Objective

Fixes https://github.com/bevyengine/bevy/issues/5599

## Solution

Use bevy_default() for texture format in example to get proper texture format for wasm.

