### PR TITLE
[Merged by Bors] - Remove `insert_resource_with_id`

### DIFF
--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -99,14 +99,6 @@ impl Column {
     /// # Safety
     /// index must be in-bounds
     #[inline]
-    pub(crate) unsafe fn get_ticks_unchecked_mut(&mut self, row: usize) -> &mut ComponentTicks {
-        debug_assert!(row < self.len());
-        self.ticks.get_unchecked_mut(row).get_mut()
-    }
-
-    /// # Safety
-    /// index must be in-bounds
-    #[inline]
     pub(crate) unsafe fn swap_remove_unchecked(&mut self, row: usize) {
         self.data.swap_remove_and_drop_unchecked(row);
         self.ticks.swap_remove(row);

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -689,7 +689,7 @@ impl World {
     pub fn insert_resource<R: Resource>(&mut self, value: R) {
         let component_id = self.components.init_resource::<R>();
         OwningPtr::make(value, |ptr| {
-            // SAFETY: component_id just initialized and corresponds to resource of type T
+            // SAFETY: component_id was just initialized and corresponds to resource of type R
             unsafe {
                 self.insert_resource_by_id(component_id, ptr);
             }
@@ -721,7 +721,7 @@ impl World {
         self.validate_non_send_access::<R>();
         let component_id = self.components.init_non_send::<R>();
         OwningPtr::make(value, |ptr| {
-            // SAFETY: component_id just initialized and corresponds to resource of type R
+            // SAFETY: component_id was just initialized and corresponds to resource of type R
             unsafe {
                 self.insert_resource_by_id(component_id, ptr);
             }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1245,6 +1245,7 @@ impl World {
     /// # Safety
     /// The value referenced by `value` must be valid for the given [`ComponentId`] of this world
     /// `component_id` must exist in this [`World`]
+    #[inline]
     pub unsafe fn insert_resource_by_id(
         &mut self,
         component_id: ComponentId,

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -688,9 +688,11 @@ impl World {
     #[inline]
     pub fn insert_resource<R: Resource>(&mut self, value: R) {
         let component_id = self.components.init_resource::<R>();
-        // SAFETY: component_id just initialized and corresponds to resource of type T
-        OwningPtr::make(value, |ptr| unsafe {
-            self.insert_resource_by_id(component_id, ptr)
+        OwningPtr::make(value, |ptr| {
+            // SAFETY: component_id just initialized and corresponds to resource of type T
+            unsafe {
+                self.insert_resource_by_id(component_id, ptr);
+            }
         });
     }
 
@@ -718,9 +720,11 @@ impl World {
     pub fn insert_non_send_resource<R: 'static>(&mut self, value: R) {
         self.validate_non_send_access::<R>();
         let component_id = self.components.init_non_send::<R>();
-        // SAFETY: component_id just initialized and corresponds to resource of type R
-        OwningPtr::make(value, |ptr| unsafe {
-            self.insert_resource_by_id(component_id, ptr)
+        OwningPtr::make(value, |ptr| {
+            // SAFETY: component_id just initialized and corresponds to resource of type R
+            unsafe {
+                self.insert_resource_by_id(component_id, ptr);
+            }
         });
     }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1577,7 +1577,7 @@ mod tests {
     use super::World;
     use crate::{
         change_detection::DetectChanges,
-        component::{ComponentDescriptor, ComponentId, ComponentInfo, StorageType},
+        component::{ComponentDescriptor, ComponentInfo, StorageType},
         ptr::OwningPtr,
     };
     use bevy_ecs_macros::Component;
@@ -1793,20 +1793,6 @@ mod tests {
         assert!(world.remove_resource_by_id(component_id).is_some());
 
         assert_eq!(DROP_COUNT.load(std::sync::atomic::Ordering::SeqCst), 1);
-    }
-
-    #[test]
-    #[should_panic = "insert_resource_by_id called with component id which doesn't exist in this world"]
-    fn insert_resource_by_id_invalid_component_id() {
-        let invalid_component_id = ComponentId::new(usize::MAX);
-
-        let mut world = World::new();
-        OwningPtr::make((), |ptr| {
-            // SAFETY: ptr must be valid for the component_id `invalid_component_id` which is invalid, but checked by `insert_resource_by_id`
-            unsafe {
-                world.insert_resource_by_id(invalid_component_id, ptr);
-            }
-        });
     }
 
     #[derive(Component)]


### PR DESCRIPTION
# Objective

remove `insert_resource_with_id` because `insert_resource_by_id` exists and does almost exactly the same thing

blocked on #5587 because otherwise we will leak a resource when it's inserted 

## Solution

remove the function and also add a safety invariant of to `insert_resource_by_id` that the id be valid for the world.

I didn't see any discussion in #4447 about this safety invariant being left off in favor of a panic so I'm curious if there was one or if it just seemed nicer to have less safety invariants for callers to uphold :sweat_smile: 

---

## Changelog

- safety invariant added to `insert_resource_by_id` requiring the id to be valid for world

## Migration Guide

- audit any calls to `insert_resource_by_id` making sure that the id is valid for the world