### PR TITLE
[Merged by Bors] - Make internal struct `ShaderData` non-`pub`

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -72,7 +72,7 @@ impl CachedPipelineState {
 }
 
 #[derive(Default)]
-pub struct ShaderData {
+struct ShaderData {
     pipelines: HashSet<CachedPipelineId>,
     processed_shaders: HashMap<Vec<String>, Arc<ShaderModule>>,
     resolved_imports: HashMap<ShaderImport, Handle<Shader>>,


### PR DESCRIPTION
# Objective

`ShaderData` is marked as public, but is an internal type only used by one other
internal type, so it should be made private.

## Solution

`ShaderData` is only used in `ShaderCache`, and the latter is private,
so there is no need to make the former public. This change removes the
`pub` keyword from `ShaderData`, hidding it as the implementation detail
it is.

Split from #5600