### PR TITLE
"soft" remove `EntityRef::get_unchecked_mut`

### DIFF
--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -23,7 +23,7 @@ pub struct ReflectComponent {
     apply_or_insert: fn(&mut World, Entity, &dyn Reflect),
     remove: fn(&mut World, Entity),
     reflect: fn(&World, Entity) -> Option<&dyn Reflect>,
-    reflect_mut: unsafe fn(&World, Entity) -> Option<ReflectMut>,
+    reflect_mut: fn(&mut World, Entity) -> Option<ReflectMut>,
     copy: fn(&World, &mut World, Entity, Entity),
 }
 
@@ -71,21 +71,6 @@ impl ReflectComponent {
 
     /// Gets the value of this [`Component`] type from the entity as a mutable reflected reference.
     pub fn reflect_mut<'a>(&self, world: &'a mut World, entity: Entity) -> Option<ReflectMut<'a>> {
-        // SAFETY: unique world access
-        unsafe { (self.reflect_mut)(world, entity) }
-    }
-
-    /// # Safety
-    /// This method does not prevent you from having two mutable pointers to the same data,
-    /// violating Rust's aliasing rules. To avoid this:
-    /// * Only call this method in an exclusive system to avoid sharing across threads (or use a
-    ///   scheduler that enforces safe memory access).
-    /// * Don't call this method more than once in the same scope for a given [`Component`].
-    pub unsafe fn reflect_unchecked_mut<'a>(
-        &self,
-        world: &'a World,
-        entity: Entity,
-    ) -> Option<ReflectMut<'a>> {
         (self.reflect_mut)(world, entity)
     }
 
@@ -149,17 +134,10 @@ impl<C: Component + Reflect + FromWorld> FromType<C> for ReflectComponent {
                     .map(|c| c as &dyn Reflect)
             },
             reflect_mut: |world, entity| {
-                // SAFETY: reflect_mut is an unsafe function pointer used by `reflect_unchecked_mut` which promises to never
-                // produce aliasing mutable references, and reflect_mut, which has mutable world access
-                unsafe {
-                    world
-                        .get_entity(entity)?
-                        .get_unchecked_mut::<C>(world.last_change_tick(), world.read_change_tick())
-                        .map(|c| ReflectMut {
-                            value: c.value as &mut dyn Reflect,
-                            ticks: c.ticks,
-                        })
-                }
+                world.get_mut::<C>(entity).map(|c| ReflectMut {
+                    value: c.value as &mut dyn Reflect,
+                    ticks: c.ticks,
+                })
             },
         }
     }

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1074,7 +1074,7 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
             .has_write(archetype_component)
         {
             entity_ref
-                .get_unchecked_mut::<T>(self.last_change_tick, self.change_tick)
+                .__get_unchecked_mut::<T>(self.last_change_tick, self.change_tick)
                 .ok_or(QueryComponentError::MissingComponent)
         } else {
             Err(QueryComponentError::MissingWriteAccess)

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -83,6 +83,8 @@ impl<'w> EntityRef<'w> {
         }
     }
 
+    /// Do not use this. It will be removed eventually and only exists for `Query::get_component_unchecked_mut`.
+    ///
     /// Gets a mutable reference to the component of type `T` associated with
     /// this entity without ensuring there are no other borrows active and without
     /// ensuring that the returned reference will stay valid.
@@ -94,7 +96,7 @@ impl<'w> EntityRef<'w> {
     ///   may happen from **any** `insert_component`, `remove_component` or `despawn`
     ///   operation on this world (non-exhaustive list).
     #[inline]
-    pub unsafe fn get_unchecked_mut<T: Component>(
+    pub(crate) unsafe fn __get_unchecked_mut<T: Component>(
         &self,
         last_change_tick: u32,
         change_tick: u32,


### PR DESCRIPTION
# Objective

`EntityRef::get_unchecked_mut` existing is sort of "in conflict" with the idea that the `&World` in `EntityRef` is "truly" shared readonly rather than doing interior mutable shenanigans like query (see #5588). So remove it :thinking: 

I am a bit apprehensive about 'just' removing this method since I'm not convinced we have enough interior mutability/world splitting primitives in bevy rn to cover all of the uses that this method might have. Particularly I think you could use this method to accomplish a wildly unsafe unchecked "entity granular borrowck" vs the way `Query` works which is "archetype component id granular" and we don't have an API to do that in bevy atm.

Unfortunately (and somewhat ironically) `Query::get_component_unchecked_mut` uses this fn so instead of outright removing, it's just been made `pub(crate)`. I am not sure if it is better to instead call the "internal" component getter methods in `entity_ref.rs` instead of this. 

need to think about this all a bit more before this is merged I think

---

## Changelog

- `EntityRef::get_unchecked_mut` has been removed

## Migration Guide

Try rearchitecting your code to not require this ( I know not very helpful ), if you have a good use case please share what it is so that it can help inform designing a good API to replace `EntityRef::get_unchecked_mut` :)