### PR TITLE
Custom ColorAttachments for core pipeline

### DIFF
--- a/crates/bevy_core_pipeline/src/color_attachments.rs
+++ b/crates/bevy_core_pipeline/src/color_attachments.rs
@@ -1,0 +1,43 @@
+use bevy_ecs::prelude::Component;
+use bevy_render::color::Color;
+use bevy_render::render_resource::{LoadOp, Operations, RenderPassColorAttachment, TextureView};
+
+#[derive(Clone, Debug)]
+pub struct ColorAttachment {
+    pub view: TextureView,
+    pub sampled_target: Option<TextureView>,
+}
+
+impl ColorAttachment {
+    pub fn load(&self, load_op: LoadOp<Color>) -> RenderPassColorAttachment {
+        RenderPassColorAttachment {
+            view: self.sampled_target.as_ref().unwrap_or(&self.view),
+            resolve_target: if self.sampled_target.is_some() {
+                Some(&self.view)
+            } else {
+                None
+            },
+            ops: Operations {
+                load: match load_op {
+                    LoadOp::Clear(v) => LoadOp::Clear(v.into()),
+                    LoadOp::Load => LoadOp::Load,
+                },
+                store: true,
+            },
+        }
+    }
+}
+
+#[derive(Component, Clone, Debug)]
+pub struct ColorAttachments {
+    pub attachments: Vec<ColorAttachment>,
+}
+
+impl ColorAttachments {
+    pub fn load(&self, load_op: LoadOp<Color>) -> Vec<Option<RenderPassColorAttachment>> {
+        self.attachments
+            .iter()
+            .map(|a| Some(a.load(load_op)))
+            .collect()
+    }
+}

--- a/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
@@ -5,8 +5,8 @@ use crate::{
 };
 use bevy_ecs::prelude::*;
 use bevy_render::{
-    color::Color,
     camera::ExtractedCamera,
+    color::Color,
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
     render_phase::{DrawFunctions, RenderPhase, TrackedRenderPass},
     render_resource::{LoadOp, Operations, RenderPassDescriptor},
@@ -23,7 +23,7 @@ pub struct MainPass2dNode {
             &'static RenderPhase<Transparent2d>,
             &'static ViewTarget,
             &'static Camera2d,
-            Option<&'static ColorAttachments>
+            Option<&'static ColorAttachments>,
         ),
         With<ExtractedView>,
     >,
@@ -64,9 +64,7 @@ impl Node for MainPass2dNode {
             };
         {
             let load_op = match camera_2d.clear_color {
-                ClearColorConfig::Default => {
-                    LoadOp::Clear(world.resource::<ClearColor>().0)
-                }
+                ClearColorConfig::Default => LoadOp::Clear(world.resource::<ClearColor>().0),
                 ClearColorConfig::Custom(color) => LoadOp::Clear(color),
                 ClearColorConfig::None => LoadOp::Load,
             };
@@ -79,7 +77,7 @@ impl Node for MainPass2dNode {
                     None => vec![Some(target.get_color_attachment(Operations::<Color> {
                         load: load_op,
                         store: true,
-                    }))]
+                    }))],
                 },
                 depth_stencil_attachment: None,
             };
@@ -114,7 +112,7 @@ impl Node for MainPass2dNode {
                     None => vec![Some(target.get_color_attachment(Operations::<Color> {
                         load: LoadOp::Load,
                         store: true,
-                    }))]
+                    }))],
                 },
                 depth_stencil_attachment: None,
             };

--- a/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
@@ -5,8 +5,8 @@ use crate::{
 };
 use bevy_ecs::prelude::*;
 use bevy_render::{
-    color::Color,
     camera::ExtractedCamera,
+    color::Color,
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
     render_phase::{DrawFunctions, RenderPhase, TrackedRenderPass},
     render_resource::{LoadOp, Operations, RenderPassDepthStencilAttachment, RenderPassDescriptor},
@@ -26,7 +26,7 @@ pub struct MainPass3dNode {
             &'static Camera3d,
             &'static ViewTarget,
             &'static ViewDepthTexture,
-            Option<&'static ColorAttachments>
+            Option<&'static ColorAttachments>,
         ),
         With<ExtractedView>,
     >,
@@ -58,20 +58,26 @@ impl Node for MainPass3dNode {
         world: &World,
     ) -> Result<(), NodeRunError> {
         let view_entity = graph.get_input_entity(Self::IN_VIEW)?;
-        let (camera, opaque_phase, alpha_mask_phase, transparent_phase, camera_3d, target, depth, maybe_attachments) =
-            match self.query.get_manual(world, view_entity) {
-                Ok(query) => query,
-                Err(_) => {
-                    return Ok(());
-                } // No window
-            };
+        let (
+            camera,
+            opaque_phase,
+            alpha_mask_phase,
+            transparent_phase,
+            camera_3d,
+            target,
+            depth,
+            maybe_attachments,
+        ) = match self.query.get_manual(world, view_entity) {
+            Ok(query) => query,
+            Err(_) => {
+                return Ok(());
+            } // No window
+        };
 
         // Always run opaque pass to ensure screen is cleared
         {
             let load_op = match camera_3d.clear_color {
-                ClearColorConfig::Default => {
-                    LoadOp::Clear(world.resource::<ClearColor>().0)
-                }
+                ClearColorConfig::Default => LoadOp::Clear(world.resource::<ClearColor>().0),
                 ClearColorConfig::Custom(color) => LoadOp::Clear(color),
                 ClearColorConfig::None => LoadOp::Load,
             };
@@ -89,7 +95,7 @@ impl Node for MainPass3dNode {
                     None => vec![Some(target.get_color_attachment(Operations::<Color> {
                         load: load_op,
                         store: true,
-                    }))]
+                    }))],
                 },
                 depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
                     view: &depth.view,

--- a/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
@@ -224,7 +224,7 @@ impl Node for MainPass3dNode {
                 label: Some("reset_viewport_pass_3d"),
                 color_attachments: &match maybe_attachments {
                     Some(attachments) => attachments.load(LoadOp::Load),
-                    None => [Some(target.get_color_attachment(Operations {
+                    None => vec![Some(target.get_color_attachment(Operations {
                         load: LoadOp::Load,
                         store: true,
                     }))],

--- a/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
@@ -223,7 +223,7 @@ impl Node for MainPass3dNode {
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("reset_viewport_pass_3d"),
                 color_attachments: &match maybe_attachments {
-                    Some(attachments) => target.load(LoadOp::Load),
+                    Some(attachments) => attachments.load(LoadOp::Load),
                     None => [Some(target.get_color_attachment(Operations {
                         load: LoadOp::Load,
                         store: true,

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod clear_color;
+pub mod color_attachments;
 pub mod core_2d;
 pub mod core_3d;
 

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -3,12 +3,13 @@ pub mod window;
 
 pub use visibility::*;
 use wgpu::{
-    Color, Extent3d, Operations, RenderPassColorAttachment, TextureDescriptor, TextureDimension,
+    Extent3d, Operations, LoadOp, RenderPassColorAttachment, TextureDescriptor, TextureDimension,
     TextureFormat, TextureUsages,
 };
 pub use window::*;
 
 use crate::{
+    Color,
     camera::ExtractedCamera,
     extract_resource::{ExtractResource, ExtractResourcePlugin},
     prelude::Image,
@@ -130,7 +131,10 @@ impl ViewTarget {
             } else {
                 None
             },
-            ops,
+            ops: Operations {store: ops.store, load: match ops.load {
+                LoadOp::Clear(c) => LoadOp::Clear(c.into()),
+                LoadOp::Load => LoadOp::Load,
+            }},
         }
     }
 }

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -3,13 +3,12 @@ pub mod window;
 
 pub use visibility::*;
 use wgpu::{
-    Extent3d, Operations, LoadOp, RenderPassColorAttachment, TextureDescriptor, TextureDimension,
+    Extent3d, LoadOp, Operations, RenderPassColorAttachment, TextureDescriptor, TextureDimension,
     TextureFormat, TextureUsages,
 };
 pub use window::*;
 
 use crate::{
-    Color,
     camera::ExtractedCamera,
     extract_resource::{ExtractResource, ExtractResourcePlugin},
     prelude::Image,
@@ -18,7 +17,7 @@ use crate::{
     render_resource::{DynamicUniformBuffer, ShaderType, Texture, TextureView},
     renderer::{RenderDevice, RenderQueue},
     texture::{BevyDefault, TextureCache},
-    RenderApp, RenderStage,
+    Color, RenderApp, RenderStage,
 };
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
@@ -131,10 +130,13 @@ impl ViewTarget {
             } else {
                 None
             },
-            ops: Operations {store: ops.store, load: match ops.load {
-                LoadOp::Clear(c) => LoadOp::Clear(c.into()),
-                LoadOp::Load => LoadOp::Load,
-            }},
+            ops: Operations {
+                store: ops.store,
+                load: match ops.load {
+                    LoadOp::Clear(c) => LoadOp::Clear(c.into()),
+                    LoadOp::Load => LoadOp::Load,
+                },
+            },
         }
     }
 }


### PR DESCRIPTION
## Objective

Currently there is no way to render to additional color attachments using `bevy_core_pipeline`. This can be very useful for deferred shading or post processing.

## Solution

I added new component `ColorAttachments`, that you can add to the exported camera entities during `RenderStage::Prepare` stage and then in shader you can render to these attachments. `MainPass2dNode` and `MainPass3dNome` will ignore `ViewTarget` if there are custom `ColorAttachments` components on camera. (This can also be changed, so that attachment 0 is always `ViewTarget` and `ColorAttachments` are 1, 2... and so on , I think we should discuss it)

