### PR TITLE
Add UiImage offset property

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1403,6 +1403,16 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "image_button"
+path = "examples/ui/image_button.rs"
+
+[package.metadata.example.image_button]
+name = "Image Button"
+description = "Illustrates creating and updating a button using images"
+category = "UI (User Interface)"
+wasm = true
+
+[[example]]
 name = "font_atlas_debug"
 path = "examples/ui/font_atlas_debug.rs"
 

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -192,7 +192,7 @@ pub fn extract_uinodes(
         if !visibility.is_visible() {
             continue;
         }
-        let image = image.0.clone_weak();
+        let image = image.handle.clone_weak();
         // Skip loading images
         if !images.contains(&image) {
             continue;

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -392,7 +392,7 @@ impl From<Color> for UiColor {
 pub struct UiImage {
     /// The asset handle used to display image.
     pub handle: Handle<Image>,
-    /// Defines a portion of the image to be rendered where [`Rect::min`] is the begining and [`Rect::max`] is the inclusive end.
+    /// Defines a portion of the image to be rendered where [`bevy_sprite::Rect::min`] is the begining and [`bevy_sprite::Rect::max`] is the inclusive end.
     /// Defaults to zero sized rect, which loads the full imagem.
     pub offset: bevy_sprite::Rect,
 }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -390,15 +390,18 @@ impl From<Color> for UiColor {
 #[derive(Component, Clone, Debug, Reflect)]
 #[reflect(Component, Default)]
 pub struct UiImage {
+    /// The asset handle used to display image.
     pub handle: Handle<Image>,
-    pub offset: UiRect,
+    /// Defines a portion of the image to be rendered where [`Rect::min`] is the begining and [`Rect::max`] is the inclusive end.
+    /// Defaults to zero sized rect, which loads the full imagem.
+    pub offset: bevy_sprite::Rect,
 }
 
 impl Default for UiImage {
     fn default() -> Self {
         Self {
             handle: DEFAULT_IMAGE_HANDLE.typed(),
-            ..default()
+            offset: default(),
         }
     }
 }
@@ -407,7 +410,7 @@ impl From<Handle<Image>> for UiImage {
     fn from(handle: Handle<Image>) -> Self {
         Self {
             handle,
-            ..default()
+            offset: default(),
         }
     }
 }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1,6 +1,5 @@
 use crate::{Size, UiRect};
 use bevy_asset::Handle;
-use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{prelude::Component, reflect::ReflectComponent};
 use bevy_math::Vec2;
 use bevy_reflect::prelude::*;
@@ -8,6 +7,7 @@ use bevy_render::{
     color::Color,
     texture::{Image, DEFAULT_IMAGE_HANDLE},
 };
+use bevy_utils::default;
 use serde::{Deserialize, Serialize};
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
@@ -387,19 +387,28 @@ impl From<Color> for UiColor {
 }
 
 /// The image of the node
-#[derive(Component, Clone, Debug, Reflect, Deref, DerefMut)]
+#[derive(Component, Clone, Debug, Reflect)]
 #[reflect(Component, Default)]
-pub struct UiImage(pub Handle<Image>);
+pub struct UiImage {
+    pub handle: Handle<Image>,
+    pub offset: UiRect,
+}
 
 impl Default for UiImage {
     fn default() -> Self {
-        Self(DEFAULT_IMAGE_HANDLE.typed())
+        Self {
+            handle: DEFAULT_IMAGE_HANDLE.typed(),
+            ..default()
+        }
     }
 }
 
 impl From<Handle<Image>> for UiImage {
     fn from(handle: Handle<Image>) -> Self {
-        Self(handle)
+        Self {
+            handle,
+            ..default()
+        }
     }
 }
 

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -25,7 +25,7 @@ pub fn image_node_system(
     mut query: Query<(&mut CalculatedSize, &UiImage), With<ImageMode>>,
 ) {
     for (mut calculated_size, image) in &mut query {
-        if let Some(texture) = textures.get(image) {
+        if let Some(texture) = textures.get(&image.handle) {
             let size = Size {
                 width: Val::Px(texture.texture_descriptor.size.width as f32),
                 height: Val::Px(texture.texture_descriptor.size.height as f32),

--- a/examples/README.md
+++ b/examples/README.md
@@ -56,6 +56,23 @@ git checkout v0.4.0
   - [Transforms](#transforms)
   - [UI (User Interface)](#ui-user-interface)
   - [Window](#window)
+- [Tests](#tests)
+- [Platform-Specific Examples](#platform-specific-examples)
+  - [Android](#android)
+    - [Setup](#setup)
+    - [Build & Run](#build--run)
+    - [Debugging](#debugging)
+    - [Old phones](#old-phones)
+  - [iOS](#ios)
+    - [Setup](#setup-1)
+    - [Build & Run](#build--run-1)
+  - [WASM](#wasm)
+    - [Setup](#setup-2)
+    - [Build & Run](#build--run-2)
+    - [Optimizing](#optimizing)
+      - [1. Tweak your `Cargo.toml`](#1-tweak-your-cargotoml)
+      - [2. Use `wasm-opt` from the binaryen package](#2-use-wasm-opt-from-the-binaryen-package)
+    - [Loading Assets](#loading-assets)
 
 - [Tests](#tests)
 - [Platform-Specific Examples](#platform-specific-examples)
@@ -308,6 +325,7 @@ Example | Description
 Example | Description
 --- | ---
 [Button](../examples/ui/button.rs) | Illustrates creating and updating a button
+[Imagem Button](../examples/ui/image_button.rs) | Illustrates creating and updating a button using images
 [Font Atlas Debug](../examples/ui/font_atlas_debug.rs) | Illustrates how FontAtlases are populated (used to optimize text rendering internally)
 [Text](../examples/ui/text.rs) | Illustrates creating and updating text
 [Text Debug](../examples/ui/text_debug.rs) | An example for debugging text layout

--- a/examples/README.md
+++ b/examples/README.md
@@ -56,23 +56,6 @@ git checkout v0.4.0
   - [Transforms](#transforms)
   - [UI (User Interface)](#ui-user-interface)
   - [Window](#window)
-- [Tests](#tests)
-- [Platform-Specific Examples](#platform-specific-examples)
-  - [Android](#android)
-    - [Setup](#setup)
-    - [Build & Run](#build--run)
-    - [Debugging](#debugging)
-    - [Old phones](#old-phones)
-  - [iOS](#ios)
-    - [Setup](#setup-1)
-    - [Build & Run](#build--run-1)
-  - [WASM](#wasm)
-    - [Setup](#setup-2)
-    - [Build & Run](#build--run-2)
-    - [Optimizing](#optimizing)
-      - [1. Tweak your `Cargo.toml`](#1-tweak-your-cargotoml)
-      - [2. Use `wasm-opt` from the binaryen package](#2-use-wasm-opt-from-the-binaryen-package)
-    - [Loading Assets](#loading-assets)
 
 - [Tests](#tests)
 - [Platform-Specific Examples](#platform-specific-examples)
@@ -325,8 +308,8 @@ Example | Description
 Example | Description
 --- | ---
 [Button](../examples/ui/button.rs) | Illustrates creating and updating a button
-[Imagem Button](../examples/ui/image_button.rs) | Illustrates creating and updating a button using images
 [Font Atlas Debug](../examples/ui/font_atlas_debug.rs) | Illustrates how FontAtlases are populated (used to optimize text rendering internally)
+[Image Button](../examples/ui/image_button.rs) | Illustrates creating and updating a button using images
 [Text](../examples/ui/text.rs) | Illustrates creating and updating text
 [Text Debug](../examples/ui/text_debug.rs) | An example for debugging text layout
 [Transparency UI](../examples/ui/transparency_ui.rs) | Demonstrates transparency for UI

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -90,7 +90,7 @@ mod splash {
                     size: Size::new(Val::Px(200.0), Val::Auto),
                     ..default()
                 },
-                image: UiImage(icon),
+                image: icon.into(),
                 ..default()
             })
             .insert(OnSplashScreen);
@@ -456,7 +456,7 @@ mod menu {
                         let icon = asset_server.load("textures/Game Icons/right.png");
                         parent.spawn_bundle(ImageBundle {
                             style: button_icon_style.clone(),
-                            image: UiImage(icon),
+                            image: icon.into(),
                             ..default()
                         });
                         parent.spawn_bundle(TextBundle::from_section(
@@ -475,7 +475,7 @@ mod menu {
                         let icon = asset_server.load("textures/Game Icons/wrench.png");
                         parent.spawn_bundle(ImageBundle {
                             style: button_icon_style.clone(),
-                            image: UiImage(icon),
+                            image: icon.into(),
                             ..default()
                         });
                         parent.spawn_bundle(TextBundle::from_section(
@@ -494,7 +494,7 @@ mod menu {
                         let icon = asset_server.load("textures/Game Icons/exitRight.png");
                         parent.spawn_bundle(ImageBundle {
                             style: button_icon_style,
-                            image: UiImage(icon),
+                            image: icon.into(),
                             ..default()
                         });
                         parent.spawn_bundle(TextBundle::from_section("Quit", button_text_style));

--- a/examples/ui/image_button.rs
+++ b/examples/ui/image_button.rs
@@ -1,0 +1,68 @@
+//! This example illustrates how to create an imagem button that changes image offset based on its
+//! interaction state.
+
+use bevy::{prelude::*, sprite::Rect, winit::WinitSettings};
+
+fn main() {
+    App::new()
+        // Change image filter to a pixel-art friendly
+        .insert_resource(ImageSettings::default_nearest())
+        // Match the background color with base image color
+        .insert_resource(ClearColor(Color::rgb(0.475, 0.239, 0.306)))
+        .add_plugins(DefaultPlugins)
+        // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
+        .insert_resource(WinitSettings::desktop_app())
+        .add_startup_system(setup)
+        .add_system(button_system)
+        .run();
+}
+
+// Image rect in pixels, inside the base image.
+// Values are using to built a rect with begin (X, Y) and end (X, Y) format
+const HOVERED_BUTTON_OFFSET: [f32; 4] = [23.0, 38.0, 36.0, 52.0];
+const NORMAL_BUTTON_OFFSET: [f32; 4] = [7.0, 38.0, 20.0, 52.0];
+const CLICKED_BUTTON_OFFSET: [f32; 4] = [39.0, 38.0, 52.0, 52.0];
+
+fn button_system(
+    mut interaction_query: Query<
+        (&Interaction, &mut UiImage),
+        (Changed<Interaction>, With<Button>),
+    >,
+) {
+    for (interaction, mut ui_image) in &mut interaction_query {
+        let offset = match *interaction {
+            Interaction::Hovered => NORMAL_BUTTON_OFFSET,
+            Interaction::None => HOVERED_BUTTON_OFFSET,
+            Interaction::Clicked => CLICKED_BUTTON_OFFSET,
+        };
+
+        ui_image.offset = Rect {
+            min: Vec2::new(offset[0], offset[1]),
+            max: Vec2::new(offset[2], offset[3]),
+        };
+    }
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    // ui camera
+    commands.spawn_bundle(Camera2dBundle::default());
+
+    // image button
+    commands.spawn_bundle(ButtonBundle {
+        style: Style {
+            size: Size::new(Val::Px(150.0), Val::Px(150.0)),
+            // center button
+            margin: UiRect::all(Val::Auto),
+            // horizontally center child text
+            justify_content: JustifyContent::Center,
+            // vertically center child text
+            align_items: AlignItems::Center,
+            ..default()
+        },
+        // Default image has no offset, but that's OK since it'll be update it on button_system
+        image: asset_server
+            .load("textures/rpg/ui/generic-rpg-ui-inventario.png")
+            .into(),
+        ..default()
+    });
+}


### PR DESCRIPTION
# Objective

Currently `UiImage` component is just a unit struct for `Handle<Image>` . At it's core, it draws the image and that's it. If someone needs to have a more complex use case, like implementing a [nine patch](https://docs.unity3d.com/Manual/9SliceSprites.html), one have to use `TextureAtlas` which is good, but is a overkill for ui works.

This PR is related to https://github.com/bevyengine/bevy/pull/5070, but it aims to make `TextureAtlas` to work with `UiImage` which is a different use case IMO, since one should use `TextureAtlas` and `UiImage` together on same entity.


## Solution

Add an `offset` property to `UiImage` and enable to render a portion of the image, much like a `TexturaAtlas` but simplified, so users may create it's own image atlas and reuse on many `UiImage` components.

## Changelog

- Added `offset` property on `UiImage` and changed to from unit struct to normal struct;
- Removed `Deref` and `DerefMut` from `UiImage` since it's no longer a unit struct;
- Changed `extract_uinodes` to use `UiImage::offset` when it's non-zero;
- Added `image_button` example:
![image_button](https://user-images.githubusercontent.com/1176452/183666458-ccceb87f-6861-41b2-908c-c65bcd51055d.gif)

## Migration Guide

`UiImage` is now a normal struct so it can't be directly dereferenced anymore and should use normal struct initialization.
