### PR TITLE
[Merged by Bors] - remove `ReflectMut` in favor of `Mut<dyn Reflect>`

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -2,7 +2,6 @@
 
 use crate::{component::ComponentTicks, ptr::PtrMut, system::Resource};
 #[cfg(feature = "bevy_reflect")]
-use bevy_reflect::Reflect;
 use std::ops::{Deref, DerefMut};
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
@@ -230,7 +229,7 @@ impl<'a, T: 'static> From<NonSendMut<'a, T>> for Mut<'a, T> {
 }
 
 /// Unique mutable borrow of an entity's component
-pub struct Mut<'a, T> {
+pub struct Mut<'a, T: ?Sized> {
     pub(crate) value: &'a mut T,
     pub(crate) ticks: Ticks<'a>,
 }
@@ -238,18 +237,6 @@ pub struct Mut<'a, T> {
 change_detection_impl!(Mut<'a, T>, T,);
 impl_into_inner!(Mut<'a, T>, T,);
 impl_debug!(Mut<'a, T>,);
-
-/// Unique mutable borrow of a reflected component or resource
-#[cfg(feature = "bevy_reflect")]
-pub struct ReflectMut<'a> {
-    pub(crate) value: &'a mut dyn Reflect,
-    pub(crate) ticks: Ticks<'a>,
-}
-
-#[cfg(feature = "bevy_reflect")]
-change_detection_impl!(ReflectMut<'a>, dyn Reflect,);
-#[cfg(feature = "bevy_reflect")]
-impl_into_inner!(ReflectMut<'a>, dyn Reflect,);
 
 /// Unique mutable borrow of resources or an entity's component.
 ///


### PR DESCRIPTION
# Objective

- `ReflectMut` served no purpose that wasn't met by `Mut<dyn Reflect>` which is easier to understand since you have to deal with fewer types
- there is another `ReflectMut` type that could be confused with this one

## Solution/Changelog

- relax `T: ?Sized` bound in `Mut<T>`
- replace all instances of `ReflectMut` with `Mut<dyn Reflect>`