### PR TITLE
implement component access for `WorldCell`

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -58,11 +58,12 @@ pub struct World {
     pub(crate) storages: Storages,
     pub(crate) bundles: Bundles,
     pub(crate) removed_components: SparseSet<ComponentId, Vec<Entity>>,
-    /// Access cache used by [WorldCell].
-    pub(crate) archetype_component_access: ArchetypeComponentAccess,
     main_thread_validator: MainThreadValidator,
     pub(crate) change_tick: AtomicU32,
     pub(crate) last_change_tick: u32,
+    /// Access cache used by [WorldCell].
+    pub(crate) archetype_component_access: ArchetypeComponentAccess,
+    pub(crate) entity_component_access: EntityComponentAccess,
 }
 
 impl Default for World {
@@ -75,12 +76,13 @@ impl Default for World {
             storages: Default::default(),
             bundles: Default::default(),
             removed_components: Default::default(),
-            archetype_component_access: Default::default(),
             main_thread_validator: Default::default(),
             // Default value is `1`, and `last_change_tick`s default to `0`, such that changes
             // are detected on first system runs and for direct world queries.
             change_tick: AtomicU32::new(1),
             last_change_tick: 0,
+            archetype_component_access: Default::default(),
+            entity_component_access: Default::default(),
         }
     }
 }

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -1,5 +1,10 @@
+use bevy_utils::HashMap;
+
 use crate::{
     archetype::ArchetypeComponentId,
+    component::ComponentId,
+    entity::Entity,
+    prelude::Component,
     storage::SparseSet,
     system::Resource,
     world::{Mut, World},
@@ -15,19 +20,13 @@ use std::{
 /// World in a way that violates Rust's mutability rules will panic thanks to runtime checks.
 pub struct WorldCell<'w> {
     pub(crate) world: &'w mut World,
-    pub(crate) access: Rc<RefCell<ArchetypeComponentAccess>>,
+    pub(crate) resource_access: Rc<RefCell<ArchetypeComponentAccess>>,
+    pub(crate) component_access: Rc<RefCell<EntityComponentAccess>>,
 }
 
+#[derive(Default)]
 pub(crate) struct ArchetypeComponentAccess {
     access: SparseSet<ArchetypeComponentId, usize>,
-}
-
-impl Default for ArchetypeComponentAccess {
-    fn default() -> Self {
-        Self {
-            access: SparseSet::new(),
-        }
-    }
 }
 
 const UNIQUE_ACCESS: usize = 0;
@@ -70,35 +69,97 @@ impl ArchetypeComponentAccess {
     }
 }
 
+#[derive(Default)]
+pub(crate) struct EntityComponentAccess {
+    access: HashMap<(Entity, ComponentId), usize>,
+}
+
+impl EntityComponentAccess {
+    fn read(&mut self, id: (Entity, ComponentId)) -> bool {
+        let id_access = self.access.entry(id).or_insert(BASE_ACCESS);
+        if *id_access == UNIQUE_ACCESS {
+            false
+        } else {
+            *id_access += 1;
+            true
+        }
+    }
+
+    fn drop_read(&mut self, id: (Entity, ComponentId)) {
+        let id_access = self.access.entry(id).or_insert(BASE_ACCESS);
+        *id_access -= 1;
+    }
+
+    fn write(&mut self, id: (Entity, ComponentId)) -> bool {
+        let id_access = self.access.entry(id).or_insert(BASE_ACCESS);
+        if *id_access == BASE_ACCESS {
+            *id_access = UNIQUE_ACCESS;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn drop_write(&mut self, id: (Entity, ComponentId)) {
+        let id_access = self.access.entry(id).or_insert(BASE_ACCESS);
+        *id_access = BASE_ACCESS;
+    }
+}
+
 impl<'w> Drop for WorldCell<'w> {
     fn drop(&mut self) {
-        let mut access = self.access.borrow_mut();
+        let mut access = self.resource_access.borrow_mut();
         // give world ArchetypeComponentAccess back to reuse allocations
         std::mem::swap(&mut self.world.archetype_component_access, &mut *access);
     }
 }
 
+enum WorldCellId {
+    Resource(ArchetypeComponentId),
+    Component((Entity, ComponentId)),
+}
+impl From<ArchetypeComponentId> for WorldCellId {
+    fn from(id: ArchetypeComponentId) -> Self {
+        WorldCellId::Resource(id)
+    }
+}
+
 pub struct WorldBorrow<'w, T> {
     value: &'w T,
-    archetype_component_id: ArchetypeComponentId,
-    access: Rc<RefCell<ArchetypeComponentAccess>>,
+    id: WorldCellId,
+    resource_access: Rc<RefCell<ArchetypeComponentAccess>>,
+    component_access: Rc<RefCell<EntityComponentAccess>>,
 }
 
 impl<'w, T> WorldBorrow<'w, T> {
     fn new(
         value: &'w T,
-        archetype_component_id: ArchetypeComponentId,
-        access: Rc<RefCell<ArchetypeComponentAccess>>,
+        id: WorldCellId,
+        resource_access: Rc<RefCell<ArchetypeComponentAccess>>,
+        component_access: Rc<RefCell<EntityComponentAccess>>,
     ) -> Self {
-        assert!(
-            access.borrow_mut().read(archetype_component_id),
-            "Attempted to immutably access {}, but it is already mutably borrowed",
-            std::any::type_name::<T>(),
-        );
+        match id {
+            WorldCellId::Resource(archetype_component_id) => {
+                assert!(
+                    resource_access.borrow_mut().read(archetype_component_id),
+                    "Attempted to immutably access {}, but it is already mutably borrowed",
+                    std::any::type_name::<T>(),
+                );
+            }
+            WorldCellId::Component((entity, component_id)) => {
+                assert!(
+                    component_access.borrow_mut().read((entity, component_id)),
+                    "Attempted to immutably access component {} on entity {:?}, but it is already mutably borrowed",
+                    std::any::type_name::<T>(),
+                    entity,
+                );
+            }
+        }
         Self {
             value,
-            archetype_component_id,
-            access,
+            id,
+            resource_access,
+            component_access,
         }
     }
 }
@@ -114,32 +175,49 @@ impl<'w, T> Deref for WorldBorrow<'w, T> {
 
 impl<'w, T> Drop for WorldBorrow<'w, T> {
     fn drop(&mut self) {
-        let mut access = self.access.borrow_mut();
-        access.drop_read(self.archetype_component_id);
+        match self.id {
+            WorldCellId::Resource(id) => self.resource_access.borrow_mut().drop_read(id),
+            WorldCellId::Component(id) => self.component_access.borrow_mut().drop_read(id),
+        }
     }
 }
 
 pub struct WorldBorrowMut<'w, T> {
     value: Mut<'w, T>,
-    archetype_component_id: ArchetypeComponentId,
-    access: Rc<RefCell<ArchetypeComponentAccess>>,
+    id: WorldCellId,
+    resource_access: Rc<RefCell<ArchetypeComponentAccess>>,
+    component_access: Rc<RefCell<EntityComponentAccess>>,
 }
 
 impl<'w, T> WorldBorrowMut<'w, T> {
     fn new(
         value: Mut<'w, T>,
-        archetype_component_id: ArchetypeComponentId,
-        access: Rc<RefCell<ArchetypeComponentAccess>>,
+        id: WorldCellId,
+        resource_access: Rc<RefCell<ArchetypeComponentAccess>>,
+        component_access: Rc<RefCell<EntityComponentAccess>>,
     ) -> Self {
-        assert!(
-            access.borrow_mut().write(archetype_component_id),
-            "Attempted to mutably access {}, but it is already mutably borrowed",
-            std::any::type_name::<T>(),
-        );
+        match id {
+            WorldCellId::Resource(archetype_component_id) => {
+                assert!(
+                    resource_access.borrow_mut().write(archetype_component_id),
+                    "Attempted to mutably access {}, but it is already mutably borrowed",
+                    std::any::type_name::<T>(),
+                );
+            }
+            WorldCellId::Component((entity, component)) => {
+                assert!(
+                    component_access.borrow_mut().write((entity, component)),
+                    "Attempted to mutably access component {} at entity {:?}, but it is already mutably borrowed",
+                    std::any::type_name::<T>(),
+                    entity
+                );
+            }
+        }
         Self {
             value,
-            archetype_component_id,
-            access,
+            id,
+            resource_access,
+            component_access,
         }
     }
 }
@@ -161,22 +239,33 @@ impl<'w, T> DerefMut for WorldBorrowMut<'w, T> {
 
 impl<'w, T> Drop for WorldBorrowMut<'w, T> {
     fn drop(&mut self) {
-        let mut access = self.access.borrow_mut();
-        access.drop_write(self.archetype_component_id);
+        match self.id {
+            WorldCellId::Resource(id) => {
+                self.resource_access.borrow_mut().drop_write(id);
+            }
+            WorldCellId::Component(id) => {
+                self.component_access.borrow_mut().drop_write(id);
+            }
+        }
     }
 }
 
 impl<'w> WorldCell<'w> {
     pub(crate) fn new(world: &'w mut World) -> Self {
         // this is cheap because ArchetypeComponentAccess::new() is const / allocation free
-        let access = std::mem::replace(
+        let resource_access = std::mem::replace(
             &mut world.archetype_component_access,
             ArchetypeComponentAccess::new(),
+        );
+        let component_access = std::mem::replace(
+            &mut world.entity_component_access,
+            EntityComponentAccess::default(),
         );
         // world's ArchetypeComponentAccess is recycled to cut down on allocations
         Self {
             world,
-            access: Rc::new(RefCell::new(access)),
+            resource_access: Rc::new(RefCell::new(resource_access)),
+            component_access: Rc::new(RefCell::new(component_access)),
         }
     }
 
@@ -188,8 +277,9 @@ impl<'w> WorldCell<'w> {
         Some(WorldBorrow::new(
             // SAFETY: ComponentId matches TypeId
             unsafe { self.world.get_resource_with_id(component_id)? },
-            archetype_component_id,
-            self.access.clone(),
+            archetype_component_id.into(),
+            self.resource_access.clone(),
+            self.component_access.clone(),
         ))
     }
 
@@ -223,8 +313,9 @@ impl<'w> WorldCell<'w> {
                 self.world
                     .get_resource_unchecked_mut_with_id(component_id)?
             },
-            archetype_component_id,
-            self.access.clone(),
+            archetype_component_id.into(),
+            self.resource_access.clone(),
+            self.component_access.clone(),
         ))
     }
 
@@ -255,8 +346,9 @@ impl<'w> WorldCell<'w> {
         Some(WorldBorrow::new(
             // SAFETY: ComponentId matches TypeId
             unsafe { self.world.get_non_send_with_id(component_id)? },
-            archetype_component_id,
-            self.access.clone(),
+            archetype_component_id.into(),
+            self.resource_access.clone(),
+            self.component_access.clone(),
         ))
     }
 
@@ -290,8 +382,9 @@ impl<'w> WorldCell<'w> {
                 self.world
                     .get_non_send_unchecked_mut_with_id(component_id)?
             },
-            archetype_component_id,
-            self.access.clone(),
+            archetype_component_id.into(),
+            self.resource_access.clone(),
+            self.component_access.clone(),
         ))
     }
 
@@ -313,19 +406,49 @@ impl<'w> WorldCell<'w> {
             ),
         }
     }
+
+    /// Gets a reference to the component of the given type
+    pub fn get_component<T: Component>(&self, entity: Entity) -> Option<WorldBorrow<'_, T>> {
+        let component_id = self.world.components.get_id(TypeId::of::<T>())?;
+        Some(WorldBorrow::new(
+            // SAFETY: ComponentId matches TypeId
+            self.world.get(entity)?,
+            WorldCellId::Component((entity, component_id)),
+            self.resource_access.clone(),
+            self.component_access.clone(),
+        ))
+    }
+    /// Gets a mutable reference to the component of the given type
+    pub fn get_component_mut<T: Component>(&self, entity: Entity) -> Option<WorldBorrowMut<'_, T>> {
+        let component_id = self.world.components.get_id(TypeId::of::<T>())?;
+        let last_change_tick = self.world.last_change_tick();
+        let change_tick = self.world.read_change_tick();
+        Some(WorldBorrowMut::new(
+            // SAFETY: ComponentId matches TypeId
+            unsafe {
+                self.world
+                    .get_entity(entity)?
+                    .get_unchecked_mut(last_change_tick, change_tick)?
+            },
+            WorldCellId::Component((entity, component_id)),
+            self.resource_access.clone(),
+            self.component_access.clone(),
+        ))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::BASE_ACCESS;
     use crate as bevy_ecs;
+    use crate::prelude::Component;
     use crate::{archetype::ArchetypeId, system::Resource, world::World};
     use std::any::TypeId;
 
-    #[derive(Resource)]
+    #[derive(Component, Resource)]
     struct A(u32);
 
-    #[derive(Resource)]
+    #[derive(Component, Resource)]
     struct B(u64);
 
     #[test]
@@ -430,5 +553,34 @@ mod tests {
         let cell = world.cell();
         let _value_a = cell.resource::<A>();
         let _value_b = cell.resource::<A>();
+    }
+
+    #[test]
+    #[should_panic]
+    fn world_cell_component_mut_and_ref() {
+        let mut world = World::default();
+        let entity = world.spawn().insert(A(1)).id();
+        let cell = world.cell();
+        let _value_a = cell.get_component_mut::<A>(entity).unwrap();
+        let _value_b = cell.get_component::<A>(entity).unwrap();
+    }
+
+    #[test]
+    fn world_cell_component_ref_and_ref() {
+        let mut world = World::default();
+        let entity = world.spawn().insert(A(1)).id();
+        let cell = world.cell();
+        let _value_a = cell.get_component::<A>(entity).unwrap();
+        let _value_b = cell.get_component::<A>(entity).unwrap();
+    }
+
+    #[test]
+    fn world_cell_component_mut_and_ref_different_entities() {
+        let mut world = World::default();
+        let entity_1 = world.spawn().insert(A(1)).id();
+        let entity_2 = world.spawn().insert(A(1)).id();
+        let cell = world.cell();
+        let _value_1 = cell.get_component_mut::<A>(entity_1).unwrap();
+        let _value_2 = cell.get_component::<A>(entity_2).unwrap();
     }
 }


### PR DESCRIPTION
# Objective

- `WorldCell` can hand out multiple mutable references to resources checked at runtime, but it would be nice if it also worked for components

## Solution

- duplicate `ArchetypeComponentAccess` into `EntityComponentAccess`
- adapt `WorldBorrow[Mut]` to be able to handle accesses of both kinds (resource and component)


**NOTE**: this implementation may not be the most efficient, I'm just using a `HashMap` for the access. We could perhaps implement a more optimized approach inspired by https://github.com/Ralith/hecs/pull/247, but that is something for another PR.


## Changelog

- add `WorldCell::get_component` and `WorldCell::get_component_mut`