### PR TITLE
Add support for multiple render targets.

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
@@ -64,7 +64,7 @@ impl Node for MainPass2dNode {
             let _main_pass_2d = info_span!("main_pass_2d").entered();
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("main_pass_2d"),
-                color_attachments: &[Some(target.get_color_attachment(Operations {
+                color_attachments: &target.get_color_attachments(Operations {
                     load: match camera_2d.clear_color {
                         ClearColorConfig::Default => {
                             LoadOp::Clear(world.resource::<ClearColor>().0.into())
@@ -73,7 +73,7 @@ impl Node for MainPass2dNode {
                         ClearColorConfig::None => LoadOp::Load,
                     },
                     store: true,
-                }))],
+                }),
                 depth_stencil_attachment: None,
             };
 

--- a/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
@@ -73,7 +73,7 @@ impl Node for MainPass3dNode {
                 label: Some("main_opaque_pass_3d"),
                 // NOTE: The opaque pass loads the color
                 // buffer as well as writing to it.
-                color_attachments: &[Some(target.get_color_attachment(Operations {
+                color_attachments: &target.get_color_attachments(Operations {
                     load: match camera_3d.clear_color {
                         ClearColorConfig::Default => {
                             LoadOp::Clear(world.resource::<ClearColor>().0.into())
@@ -82,7 +82,7 @@ impl Node for MainPass3dNode {
                         ClearColorConfig::None => LoadOp::Load,
                     },
                     store: true,
-                }))],
+                }),
                 depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
                     view: &depth.view,
                     // NOTE: The opaque main pass loads the depth buffer and possibly overwrites it
@@ -119,10 +119,10 @@ impl Node for MainPass3dNode {
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("main_alpha_mask_pass_3d"),
                 // NOTE: The alpha_mask pass loads the color buffer as well as overwriting it where appropriate.
-                color_attachments: &[Some(target.get_color_attachment(Operations {
+                color_attachments: &target.get_color_attachments(Operations {
                     load: LoadOp::Load,
                     store: true,
-                }))],
+                }),
                 depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
                     view: &depth.view,
                     // NOTE: The alpha mask pass loads the depth buffer and possibly overwrites it
@@ -158,10 +158,10 @@ impl Node for MainPass3dNode {
             let pass_descriptor = RenderPassDescriptor {
                 label: Some("main_transparent_pass_3d"),
                 // NOTE: The transparent pass loads the color buffer as well as overwriting it where appropriate.
-                color_attachments: &[Some(target.get_color_attachment(Operations {
+                color_attachments: &target.get_color_attachments(Operations {
                     load: LoadOp::Load,
                     store: true,
-                }))],
+                }),
                 depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
                     view: &depth.view,
                     // NOTE: For the transparent pass we load the depth buffer. There should be no

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -82,7 +82,7 @@ impl Node for UiPassNode {
         let pass_descriptor = RenderPassDescriptor {
             label: Some("ui_pass"),
             color_attachments: &[Some(RenderPassColorAttachment {
-                view: &target.view,
+                view: &target.views[0],
                 resolve_target: None,
                 ops: Operations {
                     load: LoadOp::Load,

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -100,7 +100,7 @@ fn setup(
             camera: Camera {
                 // render before the "main pass" camera
                 priority: -1,
-                target: RenderTarget::Image(image_handle.clone()),
+                target: RenderTarget::Image(vec![image_handle.clone()]),
                 ..default()
             },
             transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))


### PR DESCRIPTION
# Objective
This PR adds support for rendering to more than one render target in a single render pass.

## Solution
Change `RenderTarget::Image` from `Handle<Image>` to  `Vec<HandleImage>`.

---

## Changelog

- `RenderTarget::Image` accepts a `Vec` of image handles.

## Migration Guide
- `RenderTarget::Image` now takes a vector instead: `RenderTarget::Image(vec![image_handle])`.
