### PR TITLE
use Component instead of Resource

### DIFF
--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -116,7 +116,7 @@ fn star(
 pub struct ColoredMesh2d;
 
 /// Custom pipeline for 2d meshes with vertex colors
-#[derive(Resource)]
+#[derive(Component)]
 pub struct ColoredMesh2dPipeline {
     /// this pipeline wraps the standard [`Mesh2dPipeline`]
     mesh2d_pipeline: Mesh2dPipeline,


### PR DESCRIPTION
fix "mesh2d_manual" example - replace "Resource" with "Component"

# Objective

Currently, example throws an error:

![image](https://user-images.githubusercontent.com/4569866/183814471-f1471805-75e2-43be-a302-0b66b7ac9023.png)

## Solution

When replaced Resource with Component, it works:

![image](https://user-images.githubusercontent.com/4569866/183814593-3b672e64-11af-45bd-b9c2-b98363b733c7.png)

---