### PR TITLE
[Merged by Bors] - insert_attribute panic with full message

### DIFF
--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -110,15 +110,13 @@ impl Mesh {
         attribute: MeshVertexAttribute,
         values: impl Into<VertexAttributeValues>,
     ) {
-        let values: VertexAttributeValues = values.into();
-
+        let values = values.into();
         let values_format = VertexFormat::from(&values);
         if values_format != attribute.format {
-            error!(
-                "Invalid attribute format for {}. Given format is {:?} but expected {:?}",
+            panic!(
+                "Failed to insert attribute. Invalid attribute format for {}. Given format is {:?} but expected {:?}",
                 attribute.name, values_format, attribute.format
             );
-            panic!("Failed to insert attribute");
         }
 
         self.attributes


### PR DESCRIPTION
# Objective

When an invalid attribute is inserted and the LogPlugin is not enabled the full error is not printed which means makes it hard to diagnose.

## Solution

- Always print the full message in the panic.

## Notes

I originally had a separate error log because I wanted to make it clearer for users, but this is probably causing more issues than necessary.
