### PR TITLE
Min and max methods for diagnostics

### DIFF
--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::system::Resource;
 use bevy_log::warn;
-use bevy_utils::{Duration, Instant, StableHashMap, Uuid};
+use bevy_utils::{Duration, FloatOrd, Instant, StableHashMap, Uuid};
 use std::{borrow::Cow, collections::VecDeque};
 
 use crate::MAX_DIAGNOSTIC_NAME_WIDTH;
@@ -113,6 +113,22 @@ impl Diagnostic {
         } else {
             None
         }
+    }
+
+    /// Return the minimum of this diagnostic's values.
+    pub fn min(&self) -> Option<f64> {
+        self.history
+            .iter()
+            .map(|measurement| measurement.value)
+            .min_by(|a, b| FloatOrd(*a as f32).cmp(&FloatOrd(*b as f32)))
+    }
+
+    /// Return the maximum of this diagnostic's values.
+    pub fn max(&self) -> Option<f64> {
+        self.history
+            .iter()
+            .map(|measurement| measurement.value)
+            .max_by(|a, b| FloatOrd(*a as f32).cmp(&FloatOrd(*b as f32)))
     }
 
     /// Return the number of elements for this diagnostic.

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -69,6 +69,36 @@ impl LogDiagnosticsPlugin {
                     );
                     return;
                 }
+
+                if let Some(min) = diagnostic.min() {
+                    info!(
+                        target: "bevy diagnostic",
+                        // Suffix is only used for 's' as in seconds currently,
+                        // so we reserve one column for it; however,
+                        // Do not reserve one column for the suffix in the average
+                        // The ) hugging the value is more aesthetically pleasing
+                        "{name:<name_width$}: {value:>11.6}{suffix:1} (min {min:>.6}{suffix:})",
+                        name = diagnostic.name,
+                        suffix = diagnostic.suffix,
+                        name_width = crate::MAX_DIAGNOSTIC_NAME_WIDTH,
+                    );
+                    return;
+                }
+
+                if let Some(max) = diagnostic.max() {
+                    info!(
+                        target: "bevy diagnostic",
+                        // Suffix is only used for 's' as in seconds currently,
+                        // so we reserve one column for it; however,
+                        // Do not reserve one column for the suffix in the average
+                        // The ) hugging the value is more aesthetically pleasing
+                        "{name:<name_width$}: {value:>11.6}{suffix:1} (max {max:>.6}{suffix:})",
+                        name = diagnostic.name,
+                        suffix = diagnostic.suffix,
+                        name_width = crate::MAX_DIAGNOSTIC_NAME_WIDTH,
+                    );
+                    return;
+                }
             }
             info!(
                 target: "bevy diagnostic",


### PR DESCRIPTION
# Objective

- More methods to analyze the diagnostics' measurements, not super complex but I think FPS min/max are very useful for detecting stutters.

## Solution

- Just adds some convenience methods to the `Diagnostics`, it is more up to the user to display them with `egui`, but I did add them to the text logging.

### Future work
- Maybe cache these or build them similar to the sum so they are less heavy, but I think these are light enough that I moreso doubt it will ever cause issues.

---

## Changelog