### PR TITLE
[Merged by Bors] - Use circle for breakout example

### DIFF
--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -210,7 +210,7 @@ fn setup(
         .spawn()
         .insert(Ball)
         .insert_bundle(MaterialMesh2dBundle {
-            mesh: meshes.add(shape::Circle::new(0.5).into()).into(),
+            mesh: meshes.add(shape::Circle::default().into()).into(),
             material: materials.add(ColorMaterial::from(BALL_COLOR)),
             transform: Transform::from_translation(BALL_STARTING_POSITION)
                 .with_scale(BALL_SIZE),

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -3,6 +3,7 @@
 use bevy::{
     prelude::*,
     sprite::collide_aabb::{collide, Collision},
+    sprite::MaterialMesh2dBundle,
     time::FixedTimestep,
 };
 
@@ -171,7 +172,12 @@ struct Scoreboard {
 }
 
 // Add the game's entities to our world
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    asset_server: Res<AssetServer>,
+) {
     // Camera
     commands.spawn_bundle(Camera2dBundle::default());
 
@@ -203,16 +209,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn()
         .insert(Ball)
-        .insert_bundle(SpriteBundle {
-            transform: Transform {
-                scale: BALL_SIZE,
-                translation: BALL_STARTING_POSITION,
-                ..default()
-            },
-            sprite: Sprite {
-                color: BALL_COLOR,
-                ..default()
-            },
+        .insert_bundle(MaterialMesh2dBundle {
+            mesh: meshes.add(shape::Circle::new(0.5).into()).into(),
+            material: materials.add(ColorMaterial::from(BALL_COLOR)),
+            transform: Transform::from_translation(BALL_STARTING_POSITION)
+                .with_scale(BALL_SIZE),
             ..default()
         })
         .insert(Velocity(INITIAL_BALL_DIRECTION.normalize() * BALL_SPEED));

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -212,8 +212,7 @@ fn setup(
         .insert_bundle(MaterialMesh2dBundle {
             mesh: meshes.add(shape::Circle::default().into()).into(),
             material: materials.add(ColorMaterial::from(BALL_COLOR)),
-            transform: Transform::from_translation(BALL_STARTING_POSITION)
-                .with_scale(BALL_SIZE),
+            transform: Transform::from_translation(BALL_STARTING_POSITION).with_scale(BALL_SIZE),
             ..default()
         })
         .insert(Velocity(INITIAL_BALL_DIRECTION.normalize() * BALL_SPEED));


### PR DESCRIPTION
# Objective

- Replace the square with a circle in the breakout example.
- Fixes #4324, adopted from #4682 by @shaderduck.

## Solution
- Uses the Mesh2D APIs to draw a circle. The collision still uses the AABB algorithm, but it seems to be working fine, and I haven't seen any odd looking cases.