### PR TITLE
[Merged by Bors] - Remove an outdated workaround for `impl Trait`

### DIFF
--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -211,9 +211,10 @@ impl Schedule {
             )
         }
 
+        let stage_label = stage_label.as_label();
         let stage = self
-            .get_stage_mut::<SystemStage>(&stage_label)
-            .unwrap_or_else(move || stage_not_found(&stage_label.as_label()));
+            .get_stage_mut::<SystemStage>(stage_label)
+            .unwrap_or_else(move || stage_not_found(&stage_label));
         stage.add_system(system);
         self
     }
@@ -281,11 +282,9 @@ impl Schedule {
         label: impl StageLabel,
         func: F,
     ) -> &mut Self {
-        let stage = self.get_stage_mut::<T>(&label).unwrap_or_else(move || {
-            panic!(
-                "stage '{:?}' does not exist or is the wrong type",
-                label.as_label()
-            )
+        let label = label.as_label();
+        let stage = self.get_stage_mut::<T>(label).unwrap_or_else(move || {
+            panic!("stage '{label:?}' does not exist or is the wrong type",)
         });
         func(stage);
         self
@@ -304,9 +303,9 @@ impl Schedule {
     /// # let mut schedule = Schedule::default();
     /// # schedule.add_stage("my_stage", SystemStage::parallel());
     /// #
-    /// let stage = schedule.get_stage::<SystemStage>(&"my_stage").unwrap();
+    /// let stage = schedule.get_stage::<SystemStage>("my_stage").unwrap();
     /// ```
-    pub fn get_stage<T: Stage>(&self, label: &dyn StageLabel) -> Option<&T> {
+    pub fn get_stage<T: Stage>(&self, label: impl StageLabel) -> Option<&T> {
         self.stages
             .get(&label.as_label())
             .and_then(|stage| stage.downcast_ref::<T>())
@@ -325,9 +324,9 @@ impl Schedule {
     /// # let mut schedule = Schedule::default();
     /// # schedule.add_stage("my_stage", SystemStage::parallel());
     /// #
-    /// let stage = schedule.get_stage_mut::<SystemStage>(&"my_stage").unwrap();
+    /// let stage = schedule.get_stage_mut::<SystemStage>("my_stage").unwrap();
     /// ```
-    pub fn get_stage_mut<T: Stage>(&mut self, label: &dyn StageLabel) -> Option<&mut T> {
+    pub fn get_stage_mut<T: Stage>(&mut self, label: impl StageLabel) -> Option<&mut T> {
         self.stages
             .get_mut(&label.as_label())
             .and_then(|stage| stage.downcast_mut::<T>())

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -211,10 +211,10 @@ impl Schedule {
             )
         }
 
-        let stage_label = stage_label.as_label();
+        let label = stage_label.as_label();
         let stage = self
-            .get_stage_mut::<SystemStage>(stage_label)
-            .unwrap_or_else(move || stage_not_found(&stage_label));
+            .get_stage_mut::<SystemStage>(label)
+            .unwrap_or_else(move || stage_not_found(&label));
         stage.add_system(system);
         self
     }
@@ -279,10 +279,10 @@ impl Schedule {
     /// Panics if `label` refers to a non-existing stage, or if it's not of type `T`.
     pub fn stage<T: Stage, F: FnOnce(&mut T) -> &mut T>(
         &mut self,
-        label: impl StageLabel,
+        stage_label: impl StageLabel,
         func: F,
     ) -> &mut Self {
-        let label = label.as_label();
+        let label = stage_label.as_label();
         let stage = self.get_stage_mut::<T>(label).unwrap_or_else(move || {
             panic!("stage '{label:?}' does not exist or is the wrong type",)
         });
@@ -305,9 +305,10 @@ impl Schedule {
     /// #
     /// let stage = schedule.get_stage::<SystemStage>("my_stage").unwrap();
     /// ```
-    pub fn get_stage<T: Stage>(&self, label: impl StageLabel) -> Option<&T> {
+    pub fn get_stage<T: Stage>(&self, stage_label: impl StageLabel) -> Option<&T> {
+        let label = stage_label.as_label();
         self.stages
-            .get(&label.as_label())
+            .get(&label)
             .and_then(|stage| stage.downcast_ref::<T>())
     }
 
@@ -326,9 +327,10 @@ impl Schedule {
     /// #
     /// let stage = schedule.get_stage_mut::<SystemStage>("my_stage").unwrap();
     /// ```
-    pub fn get_stage_mut<T: Stage>(&mut self, label: impl StageLabel) -> Option<&mut T> {
+    pub fn get_stage_mut<T: Stage>(&mut self, stage_label: impl StageLabel) -> Option<&mut T> {
+        let label = stage_label.as_label();
         self.stages
-            .get_mut(&label.as_label())
+            .get_mut(&label)
             .and_then(|stage| stage.downcast_mut::<T>())
     }
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -249,7 +249,7 @@ impl Plugin for RenderPlugin {
                     // prepare
                     let prepare = render_app
                         .schedule
-                        .get_stage_mut::<SystemStage>(&RenderStage::Prepare)
+                        .get_stage_mut::<SystemStage>(RenderStage::Prepare)
                         .unwrap();
                     prepare.run(&mut render_app.world);
                 }
@@ -262,7 +262,7 @@ impl Plugin for RenderPlugin {
                     // queue
                     let queue = render_app
                         .schedule
-                        .get_stage_mut::<SystemStage>(&RenderStage::Queue)
+                        .get_stage_mut::<SystemStage>(RenderStage::Queue)
                         .unwrap();
                     queue.run(&mut render_app.world);
                 }
@@ -275,7 +275,7 @@ impl Plugin for RenderPlugin {
                     // phase sort
                     let phase_sort = render_app
                         .schedule
-                        .get_stage_mut::<SystemStage>(&RenderStage::PhaseSort)
+                        .get_stage_mut::<SystemStage>(RenderStage::PhaseSort)
                         .unwrap();
                     phase_sort.run(&mut render_app.world);
                 }
@@ -288,7 +288,7 @@ impl Plugin for RenderPlugin {
                     // render
                     let render = render_app
                         .schedule
-                        .get_stage_mut::<SystemStage>(&RenderStage::Render)
+                        .get_stage_mut::<SystemStage>(RenderStage::Render)
                         .unwrap();
                     render.run(&mut render_app.world);
                 }
@@ -301,7 +301,7 @@ impl Plugin for RenderPlugin {
                     // cleanup
                     let cleanup = render_app
                         .schedule
-                        .get_stage_mut::<SystemStage>(&RenderStage::Cleanup)
+                        .get_stage_mut::<SystemStage>(RenderStage::Cleanup)
                         .unwrap();
                     cleanup.run(&mut render_app.world);
                 }
@@ -335,7 +335,7 @@ struct ScratchMainWorld(World);
 fn extract(app_world: &mut World, render_app: &mut App) {
     let extract = render_app
         .schedule
-        .get_stage_mut::<SystemStage>(&RenderStage::Extract)
+        .get_stage_mut::<SystemStage>(RenderStage::Extract)
         .unwrap();
 
     // temporarily add the app world to the render world as a resource


### PR DESCRIPTION
# Objective

Rust 1.63 resolved [an issue](https://github.com/rust-lang/rust/issues/83701) that prevents you from combining explicit generic arguments with `impl Trait` arguments.

Now, we no longer need to use dynamic dispatch to work around this.

## Migration Guide

The methods `Schedule::get_stage` and `get_stage_mut` now accept `impl StageLabel` instead of `&dyn StageLabel`.

### Before
```rust
let stage = schedule.get_stage_mut::<SystemStage>(&MyLabel)?;
```

### After
```rust
let stage = schedule.get_stage_mut::<SystemStage>(MyLabel)?;
```
