### PR TITLE
[Merged by Bors] - Fix for bevy CI on main - clippy safety comments on trait.

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -675,7 +675,7 @@ impl<'w, 's> SystemParamFetch<'w, 's> for WorldState {
 /// ```
 pub struct Local<'a, T: FromWorld + Send + Sync + 'static>(&'a mut T);
 
-// SAFE: Local only accesses internal state
+// SAFETY: Local only accesses internal state
 unsafe impl<T: Send + Sync + 'static> ReadOnlySystemParamFetch for LocalState<T> {}
 
 impl<'a, T: FromWorld + Send + Sync + 'static> Debug for Local<'a, T>
@@ -711,7 +711,7 @@ impl<'a, T: Send + Sync + 'static + FromWorld> SystemParam for Local<'a, T> {
     type Fetch = LocalState<T>;
 }
 
-// SAFE: only local state is accessed
+// SAFETY: only local state is accessed
 unsafe impl<T: FromWorld + Send + Sync + 'static> SystemParamState for LocalState<T> {
     fn init(world: &mut World, _system_meta: &mut SystemMeta) -> Self {
         Self(T::from_world(world))


### PR DESCRIPTION
# Objective

Make CI pass on bevy main.

Update to rust-1.63, updated clippy to 1.63 which introduced the following enhancements:
- [undocumented_unsafe_blocks](https://rust-lang.github.io/rust-clippy/master/index.html#undocumented_unsafe_blocks): Now also lints on unsafe trait implementations

This caught two incorrectly written ( but existing) safety comments for unsafe  traits.

## Solution

Fix the comment to use `SAFETY:` 
