### PR TITLE
[Merged by Bors] - Grammar fixes in render graph doc

### DIFF
--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -12,7 +12,7 @@ use std::{borrow::Cow, fmt::Debug};
 use super::EdgeExistence;
 
 /// The render graph configures the modular, parallel and re-usable render logic.
-/// It is a retained and stateless (nodes itself my have their internal state) structure,
+/// It is a retained and stateless (nodes themselves may have internal state) structure,
 /// which can not be modified while it is executed by the graph runner.
 ///
 /// The `RenderGraphRunner` is responsible for executing the entire graph each frame.
@@ -25,7 +25,7 @@ use super::EdgeExistence;
 /// Slots describe the render resources created or used by the nodes.
 ///
 /// Additionally a render graph can contain multiple sub graphs, which are run by the
-/// corresponding nodes. Every render graph can have it’s own optional input node.
+/// corresponding nodes. Every render graph can have its own optional input node.
 ///
 /// ## Example
 /// Here is a simple render graph example with two nodes connected by a node edge.


### PR DESCRIPTION
# Objective

Fixing some grammar in the rustdoc for RenderGraph