### PR TITLE
[Merged by Bors] - Use latest stable version for CI 'build' job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-build-stable-${{ hashFiles('**/Cargo.toml') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
         if: runner.os == 'linux'


### PR DESCRIPTION
# Objective

Fixes #5668.

The Rust version used in the CI `build` step previously depended on the default Rust version defined by GitHub in the Ubuntu image: <https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#rust-tools>

This currently doesn't allow us to use Rust 1.63 features until this version is updated.

## Solution

We now use the `actions-rs/toolchain@v1` action to always use the latest stable Rust version.
This is already used for other CI jobs that we have.