### PR TITLE
[Merged by Bors] - Replace `RemovedComponents<T>` backing with `Events<Entity>`

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -3,7 +3,7 @@
 use crate::{
     change_detection::MAX_CHANGE_AGE,
     storage::{SparseSetIndex, Storages},
-    system::{Resource, Local},
+    system::{Local, Resource},
     world::{FromWorld, World},
 };
 pub use bevy_ecs_macros::Component;

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -3,7 +3,7 @@
 use crate::{
     change_detection::MAX_CHANGE_AGE,
     storage::{SparseSetIndex, Storages},
-    system::Resource,
+    system::{Resource, Local},
     world::{FromWorld, World},
 };
 pub use bevy_ecs_macros::Component;
@@ -705,10 +705,11 @@ impl ComponentTicks {
 ///
 /// # Example
 /// ```rust
-/// # use bevy_ecs::{system::Local, component::{Component, ComponentIdFor}};
+/// # use bevy_ecs::{system::Local, component::{Component, ComponentId, ComponentIdFor}};
 /// #[derive(Component)]
 /// struct Player;
-/// fn my_system(my_component_id: Local<ComponentIdFor<Player>>) {
+/// fn my_system(component_id: Local<ComponentIdFor<Player>>) {
+///     let component_id: ComponentId = component_id.into();
 ///     // ...
 /// }
 /// ```
@@ -736,5 +737,11 @@ impl<T: Component> std::ops::Deref for ComponentIdFor<T> {
 impl<T: Component> From<ComponentIdFor<T>> for ComponentId {
     fn from(to_component_id: ComponentIdFor<T>) -> ComponentId {
         *to_component_id
+    }
+}
+
+impl<'s, T: Component> From<Local<'s, ComponentIdFor<T>>> for ComponentId {
+    fn from(to_component_id: Local<ComponentIdFor<T>>) -> ComponentId {
+        **to_component_id
     }
 }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -4,6 +4,7 @@ use crate::{
     change_detection::MAX_CHANGE_AGE,
     storage::{SparseSetIndex, Storages},
     system::Resource,
+    world::{FromWorld, World},
 };
 pub use bevy_ecs_macros::Component;
 use bevy_ptr::{OwningPtr, UnsafeCellDeref};
@@ -12,6 +13,7 @@ use std::{
     alloc::Layout,
     any::{Any, TypeId},
     borrow::Cow,
+    marker::PhantomData,
     mem::needs_drop,
 };
 
@@ -696,5 +698,43 @@ impl ComponentTicks {
     #[inline]
     pub fn set_changed(&mut self, change_tick: u32) {
         self.changed.set_changed(change_tick);
+    }
+}
+
+/// Initialize and fetch a [`ComponentId`] for a specific type.
+///
+/// # Example
+/// ```rust
+/// # use bevy_ecs::{system::Local, component::{Component, ComponentIdFor}};
+/// #[derive(Component)]
+/// struct Player;
+/// fn my_system(my_component_id: Local<ComponentIdFor<Player>>) {
+///     // ...
+/// }
+/// ```
+pub struct ComponentIdFor<T: Component> {
+    component_id: ComponentId,
+    phantom: PhantomData<T>,
+}
+
+impl<T: Component> FromWorld for ComponentIdFor<T> {
+    fn from_world(world: &mut World) -> Self {
+        Self {
+            component_id: world.init_component::<T>(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: Component> std::ops::Deref for ComponentIdFor<T> {
+    type Target = ComponentId;
+    fn deref(&self) -> &Self::Target {
+        &self.component_id
+    }
+}
+
+impl<T: Component> From<ComponentIdFor<T>> for ComponentId {
+    fn from(to_component_id: ComponentIdFor<T>) -> ComponentId {
+        *to_component_id
     }
 }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -13,6 +13,7 @@ pub mod event;
 pub mod query;
 #[cfg(feature = "bevy_reflect")]
 pub mod reflect;
+pub mod removal_detection;
 pub mod schedule;
 pub mod schedule_v3;
 pub mod storage;
@@ -34,6 +35,7 @@ pub mod prelude {
         entity::Entity,
         event::{EventReader, EventWriter, Events},
         query::{Added, AnyOf, ChangeTrackers, Changed, Or, QueryState, With, Without},
+        removal_detection::RemovedComponents,
         schedule::{
             IntoSystemDescriptor, RunCriteria, RunCriteriaDescriptorCoercion, RunCriteriaLabel,
             Schedule, Stage, StageLabel, State, SystemLabel, SystemSet, SystemStage,
@@ -42,7 +44,7 @@ pub mod prelude {
             adapter as system_adapter,
             adapter::{dbg, error, ignore, info, unwrap, warn},
             Commands, In, IntoPipeSystem, IntoSystem, Local, NonSend, NonSendMut, ParallelCommands,
-            ParamSet, Query, RemovedComponents, Res, ResMut, Resource, System, SystemParamFunction,
+            ParamSet, Query, Res, ResMut, Resource, System, SystemParamFunction,
         },
         world::{FromWorld, World},
     };

--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -1,0 +1,143 @@
+//! Alerting events when a component is removed from an entity.
+
+use crate::{
+    self as bevy_ecs,
+    component::{Component, ComponentId, ComponentIdFor},
+    entity::Entity,
+    event::{Events, ManualEventIterator, ManualEventReader},
+    prelude::Local,
+    storage::SparseSet,
+};
+use bevy_ecs_macros::SystemParam;
+
+use std::{
+    fmt::Debug,
+    iter,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+    option,
+};
+
+/// Wrapper around a [`ManualEventReader<Entity>`] so that we
+/// can differentiate events between components.
+#[derive(Debug)]
+pub struct RemovedComponentReader<T>
+where
+    T: Component,
+{
+    reader: ManualEventReader<Entity>,
+    marker: PhantomData<T>,
+}
+
+impl<T: Component> Default for RemovedComponentReader<T> {
+    fn default() -> Self {
+        Self {
+            reader: Default::default(),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T: Component> Deref for RemovedComponentReader<T> {
+    type Target = ManualEventReader<Entity>;
+    fn deref(&self) -> &Self::Target {
+        &self.reader
+    }
+}
+
+impl<T: Component> DerefMut for RemovedComponentReader<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.reader
+    }
+}
+
+/// Wrapper around a map of components to [`Events<Entity>`].
+/// So that we can find the events without naming the type directly.
+#[derive(Default, Debug)]
+pub struct RemovedComponentEvents {
+    event_sets: SparseSet<ComponentId, Events<Entity>>,
+}
+
+impl RemovedComponentEvents {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn update(&mut self) {
+        for (_component_id, events) in self.event_sets.iter_mut() {
+            events.update();
+        }
+    }
+
+    pub fn get(&self, component_id: impl Into<ComponentId>) -> Option<&Events<Entity>> {
+        self.event_sets.get(component_id.into())
+    }
+
+    pub fn send(&mut self, component_id: impl Into<ComponentId>, entity: Entity) {
+        self.event_sets
+            .get_or_insert_with(component_id.into(), Default::default)
+            .send(entity);
+    }
+}
+
+/// A [`SystemParam`] that grants access to the entities that had their `T` [`Component`] removed.
+///
+/// Note that this does not allow you to see which data existed before removal.
+/// If you need this, you will need to track the component data value on your own,
+/// using a regularly scheduled system that requests `Query<(Entity, &T), Changed<T>>`
+/// and stores the data somewhere safe to later cross-reference.
+///
+/// If you are using `bevy_ecs` as a standalone crate,
+/// note that the `RemovedComponents` list will not be automatically cleared for you,
+/// and will need to be manually flushed using [`World::clear_trackers`](crate::world::World::clear_trackers)
+///
+/// For users of `bevy` and `bevy_app`, this is automatically done in `bevy_app::App::update`.
+/// For the main world, [`World::clear_trackers`](crate::world::World::clear_trackers) is run after the main schedule is run and after
+/// `SubApp`'s have run.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// # use bevy_ecs::component::Component;
+/// # use bevy_ecs::system::IntoSystem;
+/// # use bevy_ecs::removal_detection::RemovedComponents;
+/// #
+/// # #[derive(Component)]
+/// # struct MyComponent;
+/// fn react_on_removal(mut removed: RemovedComponents<MyComponent>) {
+///     removed.iter().for_each(|removed_entity| println!("{:?}", removed_entity));
+/// }
+/// # bevy_ecs::system::assert_is_system(react_on_removal);
+/// ```
+#[derive(SystemParam)]
+pub struct RemovedComponents<'w, 's, T: Component> {
+    component_id: Local<'s, ComponentIdFor<T>>,
+    reader: Local<'s, RemovedComponentReader<T>>,
+    event_sets: &'w RemovedComponentEvents,
+}
+
+type RemovedIter<'a> =
+    iter::Flatten<option::IntoIter<iter::Cloned<ManualEventIterator<'a, Entity>>>>;
+
+impl<'w, 's, T: Component> RemovedComponents<'w, 's, T> {
+    pub fn iter(&mut self) -> RemovedIter<'_> {
+        self.event_sets
+            .get(**self.component_id)
+            .map(|events| self.reader.iter(events).cloned())
+            .into_iter()
+            .flatten()
+    }
+}
+
+impl<'a, 'w, 's: 'a, T> IntoIterator for &'a mut RemovedComponents<'w, 's, T>
+where
+    T: Component,
+{
+    type Item = Entity;
+    type IntoIter = RemovedIter<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -8,7 +8,6 @@ use crate::{
     query::{
         Access, FilteredAccess, FilteredAccessSet, QueryState, ReadOnlyWorldQuery, WorldQuery,
     },
-    removal_detection::RemovedComponentEvents,
     system::{CommandQueue, Commands, Query, SystemMeta},
     world::{FromWorld, World},
 };
@@ -1102,27 +1101,6 @@ unsafe impl<'a> SystemParam for &'a Bundles {
         _change_tick: u32,
     ) -> Self::Item<'w, 's> {
         world.bundles()
-    }
-}
-
-// SAFETY: Only reads World removed component events
-unsafe impl<'a> ReadOnlySystemParam for &'a RemovedComponentEvents {}
-
-// SAFETY: no component value access
-unsafe impl<'a> SystemParam for &'a RemovedComponentEvents {
-    type State = ();
-    type Item<'w, 's> = &'w RemovedComponentEvents;
-
-    fn init_state(_world: &mut World, _system_meta: &mut SystemMeta) -> Self::State {}
-
-    #[inline]
-    unsafe fn get_param<'w, 's>(
-        _state: &'s mut Self::State,
-        _system_meta: &SystemMeta,
-        world: &'w World,
-        _change_tick: u32,
-    ) -> Self::Item<'w, 's> {
-        world.removed_components()
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1398,6 +1398,7 @@ mod tests {
         query::{ReadOnlyWorldQuery, WorldQuery},
         system::Query,
     };
+    use std::marker::PhantomData;
 
     // Compile test for https://github.com/bevyengine/bevy/pull/2838.
     #[derive(SystemParam)]

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -3,11 +3,12 @@ use crate::{
     archetype::{Archetype, Archetypes},
     bundle::Bundles,
     change_detection::{Ticks, TicksMut},
-    component::{Component, ComponentId, ComponentTicks, Components},
-    entity::{Entities, Entity},
+    component::{ComponentId, ComponentTicks, Components},
+    entity::Entities,
     query::{
         Access, FilteredAccess, FilteredAccessSet, QueryState, ReadOnlyWorldQuery, WorldQuery,
     },
+    removal_detection::RemovedComponentEvents,
     system::{CommandQueue, Commands, Query, SystemMeta},
     world::{FromWorld, World},
 };
@@ -19,7 +20,6 @@ use bevy_utils::synccell::SyncCell;
 use std::{
     borrow::Cow,
     fmt::Debug,
-    marker::PhantomData,
     ops::{Deref, DerefMut},
 };
 
@@ -787,89 +787,6 @@ unsafe impl<'a, T: FromWorld + Send + 'static> SystemParam for Local<'a, T> {
     }
 }
 
-/// A [`SystemParam`] that grants access to the entities that had their `T` [`Component`] removed.
-///
-/// Note that this does not allow you to see which data existed before removal.
-/// If you need this, you will need to track the component data value on your own,
-/// using a regularly scheduled system that requests `Query<(Entity, &T), Changed<T>>`
-/// and stores the data somewhere safe to later cross-reference.
-///
-/// If you are using `bevy_ecs` as a standalone crate,
-/// note that the `RemovedComponents` list will not be automatically cleared for you,
-/// and will need to be manually flushed using [`World::clear_trackers`]
-///
-/// For users of `bevy` and `bevy_app`, this is automatically done in `bevy_app::App::update`.
-/// For the main world, [`World::clear_trackers`] is run after the main schedule is run and after
-/// `SubApp`'s have run.
-///
-/// # Examples
-///
-/// Basic usage:
-///
-/// ```
-/// # use bevy_ecs::component::Component;
-/// # use bevy_ecs::system::IntoSystem;
-/// # use bevy_ecs::system::RemovedComponents;
-/// #
-/// # #[derive(Component)]
-/// # struct MyComponent;
-///
-/// fn react_on_removal(removed: RemovedComponents<MyComponent>) {
-///     removed.iter().for_each(|removed_entity| println!("{:?}", removed_entity));
-/// }
-///
-/// # bevy_ecs::system::assert_is_system(react_on_removal);
-/// ```
-pub struct RemovedComponents<'a, T: Component> {
-    world: &'a World,
-    component_id: ComponentId,
-    marker: PhantomData<T>,
-}
-
-impl<'a, T: Component> RemovedComponents<'a, T> {
-    /// Returns an iterator over the entities that had their `T` [`Component`] removed.
-    pub fn iter(&self) -> std::iter::Cloned<std::slice::Iter<'_, Entity>> {
-        self.world.removed_with_id(self.component_id)
-    }
-}
-
-impl<'a, T: Component> IntoIterator for &'a RemovedComponents<'a, T> {
-    type Item = Entity;
-    type IntoIter = std::iter::Cloned<std::slice::Iter<'a, Entity>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-// SAFETY: Only reads World components
-unsafe impl<'a, T: Component> ReadOnlySystemParam for RemovedComponents<'a, T> {}
-
-// SAFETY: no component access. removed component entity collections can be read in parallel and are
-// never mutably borrowed during system execution
-unsafe impl<'a, T: Component> SystemParam for RemovedComponents<'a, T> {
-    type State = ComponentId;
-    type Item<'w, 's> = RemovedComponents<'w, T>;
-
-    fn init_state(world: &mut World, _system_meta: &mut SystemMeta) -> Self::State {
-        world.init_component::<T>()
-    }
-
-    #[inline]
-    unsafe fn get_param<'w, 's>(
-        &mut component_id: &'s mut Self::State,
-        _system_meta: &SystemMeta,
-        world: &'w World,
-        _change_tick: u32,
-    ) -> Self::Item<'w, 's> {
-        RemovedComponents {
-            world,
-            component_id,
-            marker: PhantomData,
-        }
-    }
-}
-
 /// Shared borrow of a non-[`Send`] resource.
 ///
 /// Only `Send` resources may be accessed with the [`Res`] [`SystemParam`]. In case that the
@@ -1185,6 +1102,27 @@ unsafe impl<'a> SystemParam for &'a Bundles {
         _change_tick: u32,
     ) -> Self::Item<'w, 's> {
         world.bundles()
+    }
+}
+
+// SAFETY: Only reads World removed component events
+unsafe impl<'a> ReadOnlySystemParam for &'a RemovedComponentEvents {}
+
+// SAFETY: no component value access
+unsafe impl<'a> SystemParam for &'a RemovedComponentEvents {
+    type State = ();
+    type Item<'w, 's> = &'w RemovedComponentEvents;
+
+    fn init_state(_world: &mut World, _system_meta: &mut SystemMeta) -> Self::State {}
+
+    #[inline]
+    unsafe fn get_param<'w, 's>(
+        _state: &'s mut Self::State,
+        _system_meta: &SystemMeta,
+        world: &'w World,
+        _change_tick: u32,
+    ) -> Self::Item<'w, 's> {
+        world.removed_components()
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1483,7 +1483,7 @@ mod tests {
     struct MyParam<'w, T: Resource, Marker: 'static> {
         _foo: Res<'w, T>,
         #[system_param(ignore)]
-        marker: PhantomData<Marker>,
+        marker: std::marker::PhantomData<Marker>,
     }
 
     // Compile tests for https://github.com/bevyengine/bevy/pull/6957.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -19,7 +19,8 @@ use crate::{
     entity::{AllocAtWithoutReplacement, Entities, Entity, EntityLocation},
     event::{Event, Events},
     query::{DebugCheckedUnwrap, QueryState, ReadOnlyWorldQuery, WorldQuery},
-    storage::{Column, ComponentSparseSet, ResourceData, SparseSet, Storages, TableRow},
+    removal_detection::RemovedComponentEvents,
+    storage::{Column, ComponentSparseSet, ResourceData, Storages, TableRow},
     system::Resource,
 };
 use bevy_ptr::{OwningPtr, Ptr};
@@ -62,7 +63,7 @@ pub struct World {
     pub(crate) archetypes: Archetypes,
     pub(crate) storages: Storages,
     pub(crate) bundles: Bundles,
-    pub(crate) removed_components: SparseSet<ComponentId, Vec<Entity>>,
+    pub(crate) removed_components: RemovedComponentEvents,
     /// Access cache used by [WorldCell]. Is only accessed in the `Drop` impl of `WorldCell`.
     pub(crate) archetype_component_access: UnsafeCell<ArchetypeComponentAccess>,
     pub(crate) change_tick: AtomicU32,
@@ -163,6 +164,12 @@ impl World {
     #[inline]
     pub fn bundles(&self) -> &Bundles {
         &self.bundles
+    }
+
+    /// Retrieves this world's [`RemovedComponentEvents`] collection
+    #[inline]
+    pub fn removed_components(&self) -> &RemovedComponentEvents {
+        &self.removed_components
     }
 
     /// Retrieves a [`WorldCell`], which safely enables multiple mutable World accesses at the same
@@ -666,12 +673,9 @@ impl World {
     /// assert!(!transform.is_changed());
     /// ```
     ///
-    /// [`RemovedComponents`]: crate::system::RemovedComponents
+    /// [`RemovedComponents`]: crate::removal_detection::RemovedComponents
     pub fn clear_trackers(&mut self) {
-        for entities in self.removed_components.values_mut() {
-            entities.clear();
-        }
-
+        self.removed_components.update();
         self.last_change_tick = self.increment_change_tick();
     }
 
@@ -768,12 +772,12 @@ impl World {
 
     /// Returns an iterator of entities that had components of type `T` removed
     /// since the last call to [`World::clear_trackers`].
-    pub fn removed<T: Component>(&self) -> std::iter::Cloned<std::slice::Iter<'_, Entity>> {
-        if let Some(component_id) = self.components.get_id(TypeId::of::<T>()) {
-            self.removed_with_id(component_id)
-        } else {
-            [].iter().cloned()
-        }
+    pub fn removed<T: Component>(&self) -> impl DoubleEndedIterator<Item = Entity> + '_ {
+        self.components
+            .get_id(TypeId::of::<T>())
+            .map(|component_id| self.removed_with_id(component_id))
+            .into_iter()
+            .flatten()
     }
 
     /// Returns an iterator of entities that had components with the given `component_id` removed
@@ -781,12 +785,12 @@ impl World {
     pub fn removed_with_id(
         &self,
         component_id: ComponentId,
-    ) -> std::iter::Cloned<std::slice::Iter<'_, Entity>> {
-        if let Some(removed) = self.removed_components.get(component_id) {
-            removed.iter().cloned()
-        } else {
-            [].iter().cloned()
-        }
+    ) -> impl DoubleEndedIterator<Item = Entity> + '_ {
+        self.removed_components
+            .get(component_id)
+            .map(|removed| removed.iter_current_update_events().cloned())
+            .into_iter()
+            .flatten()
     }
 
     /// Initializes a new resource and returns the [`ComponentId`] created for it.

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -6,7 +6,8 @@ use bevy_ecs::{
     entity::Entity,
     event::EventReader,
     query::{Changed, ReadOnlyWorldQuery, With, Without},
-    system::{Query, RemovedComponents, Res, ResMut, Resource},
+    removal_detection::RemovedComponents,
+    system::{Query, Res, ResMut, Resource},
 };
 use bevy_hierarchy::{Children, Parent};
 use bevy_log::warn;
@@ -233,9 +234,9 @@ pub fn flex_node_system(
         (With<Node>, Changed<CalculatedSize>),
     >,
     children_query: Query<(Entity, &Children), (With<Node>, Changed<Children>)>,
-    removed_children: RemovedComponents<Children>,
+    mut removed_children: RemovedComponents<Children>,
     mut node_transform_query: Query<(Entity, &mut Node, &mut Transform, Option<&Parent>)>,
-    removed_nodes: RemovedComponents<Node>,
+    mut removed_nodes: RemovedComponents<Node>,
 ) {
     // assume one window for time being...
     // TODO: Support window-independent scaling: https://github.com/bevyengine/bevy/issues/5621
@@ -280,13 +281,13 @@ pub fn flex_node_system(
     }
 
     // clean up removed nodes
-    flex_surface.remove_entities(&removed_nodes);
+    flex_surface.remove_entities(removed_nodes.iter());
 
     // update window children (for now assuming all Nodes live in the primary window)
     flex_surface.set_window_children(primary_window_entity, root_node_query.iter());
 
     // update and remove children
-    for entity in &removed_children {
+    for entity in removed_children.iter() {
         flex_surface.try_remove_children(entity);
     }
     for (entity, children) in &children_query {

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -2,7 +2,8 @@ use bevy_ecs::{
     entity::Entity,
     event::EventWriter,
     prelude::{Changed, Component, Resource},
-    system::{Commands, NonSendMut, Query, RemovedComponents},
+    removal_detection::RemovedComponents,
+    system::{Commands, NonSendMut, Query},
     world::Mut,
 };
 use bevy_utils::{
@@ -86,7 +87,7 @@ pub(crate) fn create_window<'a>(
 pub struct WindowTitleCache(HashMap<Entity, String>);
 
 pub(crate) fn despawn_window(
-    closed: RemovedComponents<Window>,
+    mut closed: RemovedComponents<Window>,
     mut close_events: EventWriter<WindowClosed>,
     mut winit_windows: NonSendMut<WinitWindows>,
 ) {

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -51,10 +51,10 @@ fn remove_component(
     }
 }
 
-fn react_on_removal(removed: RemovedComponents<MyComponent>, mut query: Query<&mut Sprite>) {
+fn react_on_removal(mut removed: RemovedComponents<MyComponent>, mut query: Query<&mut Sprite>) {
     // `RemovedComponents<T>::iter()` returns an iterator with the `Entity`s that had their
     // `Component` `T` (in this case `MyComponent`) removed at some point earlier during the frame.
-    for entity in removed.iter() {
+    for entity in &mut removed {
         if let Ok(mut sprite) = query.get_mut(entity) {
             sprite.color.set_r(0.0);
         }


### PR DESCRIPTION
# Objective
Removal events are unwieldy and require some knowledge of when to put systems that need to catch events for them, it is very easy to end up missing one and end up with memory leak-ish issues where you don't clean up after yourself.

## Solution
Consolidate removals with the benefits of `Events<...>` (such as double buffering and per system ticks for reading the events) and reduce the special casing of it, ideally I was hoping to move the removals to a `Resource` in the world, but that seems a bit more rough to implement/maintain because of double mutable borrowing issues.

This doesn't go the full length of change detection esque removal detection a la https://github.com/bevyengine/rfcs/pull/44.
Just tries to make the current workflow a bit more user friendly so detecting removals isn't such a scheduling nightmare.

---

## Changelog
- RemovedComponents<T> is now backed by an `Events<Entity>` for the benefits of double buffering.

## Migration Guide
- Add a `mut` for `removed: RemovedComponents<T>` since we are now modifying an event reader internally.
- Iterating over removed components now requires `&mut removed_components` or `removed_components.iter()` instead of `&removed_components`.
