### PR TITLE
[Merged by Bors] - Remove unused DepthCalculation enum

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -2,9 +2,7 @@ use crate::clear_color::ClearColorConfig;
 use bevy_ecs::{prelude::*, query::QueryItem};
 use bevy_reflect::Reflect;
 use bevy_render::{
-    camera::{
-        Camera, CameraProjection, CameraRenderGraph, DepthCalculation, OrthographicProjection,
-    },
+    camera::{Camera, CameraProjection, CameraRenderGraph, OrthographicProjection},
     extract_component::ExtractComponent,
     primitives::Frustum,
     view::VisibleEntities,
@@ -56,7 +54,6 @@ impl Camera2dBundle {
         // the camera's translation by far and use a right handed coordinate system
         let projection = OrthographicProjection {
             far,
-            depth_calculation: DepthCalculation::ZDifference,
             ..Default::default()
         };
         let transform = Transform::from_xyz(0.0, 0.0, far - 0.1);

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -19,7 +19,6 @@ use bevy_ecs::{
 };
 use bevy_math::{Mat4, UVec2, Vec2, Vec3};
 use bevy_reflect::prelude::*;
-use bevy_reflect::FromReflect;
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::HashSet;
 use bevy_window::{WindowCreated, WindowId, WindowResized, Windows};
@@ -82,8 +81,6 @@ pub struct Camera {
     /// If this is set to true, this camera will be rendered to its specified [`RenderTarget`]. If false, this
     /// camera will not be rendered.
     pub is_active: bool,
-    /// The method used to calculate this camera's depth. This will be used for projections and visibility.
-    pub depth_calculation: DepthCalculation,
     /// Computed values for this camera, such as the projection matrix and the render target size.
     #[reflect(ignore)]
     pub computed: ComputedCameraValues,
@@ -100,7 +97,6 @@ impl Default for Camera {
             viewport: None,
             computed: Default::default(),
             target: Default::default(),
-            depth_calculation: Default::default(),
         }
     }
 }
@@ -310,16 +306,6 @@ impl RenderTarget {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, Reflect, FromReflect, Serialize, Deserialize)]
-#[reflect(Serialize, Deserialize)]
-pub enum DepthCalculation {
-    /// Pythagorean distance; works everywhere, more expensive to compute.
-    #[default]
-    Distance,
-    /// Optimization for 2D; assuming the camera points towards `-Z`.
-    ZDifference,
-}
-
 pub fn camera_system<T: CameraProjection + Component>(
     mut window_resized_events: EventReader<WindowResized>,
     mut window_created_events: EventReader<WindowCreated>,
@@ -378,7 +364,6 @@ pub fn camera_system<T: CameraProjection + Component>(
             if let Some(size) = camera.logical_viewport_size() {
                 camera_projection.update(size.x, size.y);
                 camera.computed.projection_matrix = camera_projection.get_projection_matrix();
-                camera.depth_calculation = camera_projection.depth_calculation();
             }
         }
     }

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -26,7 +26,6 @@ impl Plugin for CameraPlugin {
             .register_type::<VisibleEntities>()
             .register_type::<WindowOrigin>()
             .register_type::<ScalingMode>()
-            .register_type::<DepthCalculation>()
             .register_type::<Aabb>()
             .register_type::<CameraRenderGraph>()
             .add_plugin(CameraProjectionPlugin::<Projection>::default())

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 
-use super::DepthCalculation;
 use bevy_app::{App, CoreStage, Plugin, StartupStage};
 use bevy_ecs::{prelude::*, reflect::ReflectComponent};
 use bevy_math::Mat4;
@@ -42,7 +41,6 @@ impl<T: CameraProjection + Component + GetTypeRegistration> Plugin for CameraPro
 pub trait CameraProjection {
     fn get_projection_matrix(&self) -> Mat4;
     fn update(&mut self, width: f32, height: f32);
-    fn depth_calculation(&self) -> DepthCalculation;
     fn far(&self) -> f32;
 }
 
@@ -81,13 +79,6 @@ impl CameraProjection for Projection {
         }
     }
 
-    fn depth_calculation(&self) -> DepthCalculation {
-        match self {
-            Projection::Perspective(projection) => projection.depth_calculation(),
-            Projection::Orthographic(projection) => projection.depth_calculation(),
-        }
-    }
-
     fn far(&self) -> f32 {
         match self {
             Projection::Perspective(projection) => projection.far(),
@@ -118,10 +109,6 @@ impl CameraProjection for PerspectiveProjection {
 
     fn update(&mut self, width: f32, height: f32) {
         self.aspect_ratio = width / height;
-    }
-
-    fn depth_calculation(&self) -> DepthCalculation {
-        DepthCalculation::Distance
     }
 
     fn far(&self) -> f32 {
@@ -179,7 +166,6 @@ pub struct OrthographicProjection {
     pub window_origin: WindowOrigin,
     pub scaling_mode: ScalingMode,
     pub scale: f32,
-    pub depth_calculation: DepthCalculation,
 }
 
 impl CameraProjection for OrthographicProjection {
@@ -245,10 +231,6 @@ impl CameraProjection for OrthographicProjection {
         }
     }
 
-    fn depth_calculation(&self) -> DepthCalculation {
-        self.depth_calculation
-    }
-
     fn far(&self) -> f32 {
         self.far
     }
@@ -266,7 +248,6 @@ impl Default for OrthographicProjection {
             window_origin: WindowOrigin::Center,
             scaling_mode: ScalingMode::WindowSize,
             scale: 1.0,
-            depth_calculation: DepthCalculation::Distance,
         }
     }
 }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -12,7 +12,7 @@ use bevy_ecs::prelude::*;
 use bevy_math::{Mat4, Vec2, Vec3, Vec4Swizzles};
 use bevy_reflect::TypeUuid;
 use bevy_render::{
-    camera::{Camera, CameraProjection, DepthCalculation, OrthographicProjection, WindowOrigin},
+    camera::{Camera, CameraProjection, OrthographicProjection, WindowOrigin},
     color::Color,
     render_asset::RenderAssets,
     render_graph::{RenderGraph, RunGraphOnViewNode, SlotInfo, SlotType},
@@ -245,7 +245,6 @@ pub fn extract_default_ui_camera_view<T: Component>(
             let mut projection = OrthographicProjection {
                 far: UI_CAMERA_FAR,
                 window_origin: WindowOrigin::BottomLeft,
-                depth_calculation: DepthCalculation::ZDifference,
                 ..Default::default()
             };
             projection.update(logical_size.x, logical_size.y);


### PR DESCRIPTION
# Objective

Remove unused `enum DepthCalculation` and its usages. This was used to compute visible entities in the [old renderer](https://github.com/bevyengine/bevy/blob/db665b96c07084f081b0c9ab367e67297fe35132/crates/bevy_render/src/camera/visible_entities.rs), but is now unused.

## Solution

`sed 's/DepthCalculation//g'`

---

## Changelog
### Changed
Removed `bevy_render::camera::DepthCalculation`.

## Migration Guide
Remove references to `bevy_render::camera::DepthCalculation`, such as `use bevy_render::camera::DepthCalculation`. Remove `depth_calculation` fields from Projections.
