### PR TITLE
Draft: Don't crash on symlinks that point outside asset_io.root_path.

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["bevy"]
 
 [features]
 default = []
-filesystem_watcher = ["notify"]
+filesystem_watcher = ["notify", "pathdiff"]
 debug_asset_server = ["filesystem_watcher"]
 
 [dependencies]
@@ -31,6 +31,7 @@ thiserror = "1.0"
 downcast-rs = "1.2.0"
 fastrand = "1.7.0"
 notify = { version = "=5.0.0-pre.15", optional = true }
+pathdiff = {version = "0.2.1", optional = true }
 parking_lot = "0.12.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -188,7 +188,7 @@ pub fn filesystem_watcher_system(asset_server: Res<AssetServer>) {
             {
                 for path in &paths {
                     if !changed.contains(path) {
-                        let relative_path = path.strip_prefix(&asset_io.root_path).unwrap();
+                        let relative_path = pathdiff::diff_paths(path, &asset_io.root_path).unwrap();
                         let _ = asset_server.load_untracked(relative_path.into(), true);
                     }
                 }


### PR DESCRIPTION
# Objective

- Some exploration with possible solutions to https://github.com/bevyengine/bevy/issues/5689

## Solution

- Using the `pathdiff` crate (which apparently is foraged from the Rust stdlib relpath calculating implementation, but never stabilized and was replaced with simpler `strip_prefix`!), we can prevent Bevy from panicking and crashing, but this isn't an ideal solution, as it still doesn't understand that the assets loaded from outside the asset directory path are the same as the ones inside, so the filesystem watching functionality doesn't update the right asset. For assets that are originally meant to be picked up dynamically via filesystem watching events, it somehow works, but this is almost never the case.