### PR TITLE
Use StandardMaterial::depth_bias to bias the vertex shader

### DIFF
--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -214,6 +214,7 @@ pub struct StandardMaterialUniform {
     /// When the alpha mode mask flag is set, any base color alpha above this cutoff means fully opaque,
     /// and any below means fully transparent.
     pub alpha_cutoff: f32,
+    pub depth_bias: f32,
 }
 
 impl AsBindGroupShaderType<StandardMaterialUniform> for StandardMaterial {
@@ -274,6 +275,7 @@ impl AsBindGroupShaderType<StandardMaterialUniform> for StandardMaterial {
             reflectance: self.reflectance,
             flags: flags.bits(),
             alpha_cutoff,
+            depth_bias: self.depth_bias,
         }
     }
 }

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -93,3 +93,48 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
 
     return output_color;
 }
+
+struct Vertex {
+    @location(0) position: vec3<f32>,
+    @location(1) normal: vec3<f32>,
+    @location(2) uv: vec2<f32>,
+#ifdef VERTEX_TANGENTS
+    @location(3) tangent: vec4<f32>,
+#endif
+};
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) world_position: vec4<f32>,
+    @location(1) world_normal: vec3<f32>,
+    @location(2) uv: vec2<f32>,
+#ifdef VERTEX_TANGENTS
+    @location(3) world_tangent: vec4<f32>,
+#endif
+};
+
+@vertex
+fn vertex(vertex: Vertex) -> VertexOutput {
+    let world_position = mesh.model * vec4<f32>(vertex.position, 1.0);
+
+    var out: VertexOutput;
+    out.uv = vertex.uv;
+    out.world_position = world_position;
+    out.clip_position = view.view_proj * world_position + vec4<f32>(0.0, 0.0, material.depth_bias, 0.0);
+    out.world_normal = mat3x3<f32>(
+        mesh.inverse_transpose_model[0].xyz,
+        mesh.inverse_transpose_model[1].xyz,
+        mesh.inverse_transpose_model[2].xyz
+    ) * vertex.normal;
+#ifdef VERTEX_TANGENTS
+    out.world_tangent = vec4<f32>(
+        mat3x3<f32>(
+            mesh.model[0].xyz,
+            mesh.model[1].xyz,
+            mesh.model[2].xyz
+        ) * vertex.tangent.xyz,
+        vertex.tangent.w
+    );
+#endif
+    return out;
+}

--- a/crates/bevy_pbr/src/render/pbr_types.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_types.wgsl
@@ -9,6 +9,7 @@ struct StandardMaterial {
     // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
     flags: u32,
     alpha_cutoff: f32,
+    depth_bias: f32,
 };
 
 let STANDARD_MATERIAL_FLAGS_BASE_COLOR_TEXTURE_BIT: u32         = 1u;
@@ -35,6 +36,7 @@ fn standard_material_new() -> StandardMaterial {
     material.reflectance = 0.5;
     material.flags = STANDARD_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE;
     material.alpha_cutoff = 0.5;
+    material.depth_bias = 0.0;
 
     return material;
 }


### PR DESCRIPTION
# Objective

This adds the capability to bias a mesh so that it is drawn in front of other meshes at a similar depth.

## Solution

#4101 added a `depth_bias` field to bias the sorting of meshes, but this does not affect the depth buffer. So I modified the `StandardMaterial` vertex shader to use this value to bias the Z component in clip space.

## Changelog

Changed: Use `StandardMaterial::depth_bias` to bias clip space depth.
