### PR TITLE
Ensure path scope for file_asset_io.rs

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -481,7 +481,11 @@ impl AssetServer {
         path: P,
     ) -> Result<Vec<HandleUntyped>, AssetServerError> {
         let path = path.as_ref();
-        if !self.asset_io().is_dir(path) {
+        if !self
+            .asset_io()
+            .is_dir(path)
+            .map_err(|e| AssetServerError::AssetIoError(e))?
+        {
             return Err(AssetServerError::AssetFolderNotADirectory(
                 path.to_str().unwrap().to_string(),
             ));
@@ -489,7 +493,11 @@ impl AssetServer {
 
         let mut handles = Vec::new();
         for child_path in self.asset_io().read_directory(path.as_ref())? {
-            if self.asset_io().is_dir(&child_path) {
+            if self
+                .asset_io()
+                .is_dir(&child_path)
+                .map_err(|e| AssetServerError::AssetIoError(e))?
+            {
                 handles.extend(self.load_folder(&child_path)?);
             } else {
                 if self.get_path_asset_loader(&child_path).is_err() {

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -32,6 +32,10 @@ pub enum AssetIoError {
     #[error("path not found: {0}")]
     NotFound(PathBuf),
 
+    /// Path is outside of an intended scope, e.g. assets directory.
+    #[error("path out of scope: {0}")]
+    PathOutOfScope(PathBuf),
+
     /// Encountered an I/O error while loading an asset.
     #[error("encountered an io error while loading asset: {0}")]
     Io(#[from] io::Error),
@@ -72,19 +76,15 @@ pub trait AssetIo: Downcast + Send + Sync + 'static {
     fn watch_for_changes(&self) -> Result<(), AssetIoError>;
 
     /// Returns `true` if the path is a directory.
-    fn is_dir(&self, path: &Path) -> bool {
-        self.get_metadata(path)
-            .as_ref()
-            .map(Metadata::is_dir)
-            .unwrap_or(false)
+    fn is_dir(&self, path: &Path) -> Result<bool, AssetIoError> {
+        let metadata = self.get_metadata(path)?;
+        Ok(metadata.is_dir())
     }
 
     /// Returns `true` if the path is a file.
-    fn is_file(&self, path: &Path) -> bool {
-        self.get_metadata(path)
-            .as_ref()
-            .map(Metadata::is_file)
-            .unwrap_or(false)
+    fn is_file(&self, path: &Path) -> Result<bool, AssetIoError> {
+        let metadata = self.get_metadata(path)?;
+        Ok(metadata.is_file())
     }
 }
 


### PR DESCRIPTION
Ensure path scope for file_asset_io.rs to protect from symlinks pointing outside the asset folder. This protects from bugs and unexpected behaviour and crashes, especially with filesystem watching and asset-auto updates.

# Objective

- Symlinks and paths with `..` pointing outside the `asset` folder are not well supported and cause unexpected behaviour, as described in https://github.com/bevyengine/bevy/issues/5689

## Solution

- One solution would be allowing symlinks. https://github.com/bevyengine/bevy/pull/5690 is an attempt to do this by fixing the crash, but it seems to expose numerous other problems such as:
  - Filesystem watching only detecting some types of changes
  - Bevy not understanding that two assets with a different paths are in fact the same asset
- A good stopgap solution for now seems to be: forbid access outside the `asset` folder root.

---

## Changelog

- Added a method `ensure_scope` to detect access outside of the `assets` directory.
- Added an error case `AssetIoError::PathOutsideScope` to report these accesses.
- Added a call to `ensure_scope` with `<FileAssetIo as AssetIo>` methods that take a path as an argument.
- Changed `read_directory` to detect symlinks and skip them.

## Migration Guide

- If the user used symlinks from `asset` directory to an outside directory, this no longer works. For a workaround, move the assets inside the `asset` directory. If you need the same assets elsewhere, consider pointing to the `assets` directory with a symlink from outside.