### PR TITLE
[Merged by Bors] - Add note on ordering to AssetServerSettings docs.

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -66,7 +66,7 @@ pub struct AssetPlugin;
 
 /// Settings for the [`AssetServer`].
 ///
-/// This resource must be added before the [`AssetPlugin`] to take effect.
+/// This resource must be added before the [`AssetPlugin`] or [`DefaultPlugins`] to take effect.
 #[derive(Resource)]
 pub struct AssetServerSettings {
     /// The base folder where assets are loaded from, relative to the executable.

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -66,7 +66,7 @@ pub struct AssetPlugin;
 
 /// Settings for the [`AssetServer`].
 ///
-/// This resource must be added before the [`AssetPlugin`] or [`DefaultPlugins`] to take effect.
+/// This resource must be added before the [`AssetPlugin`] or `DefaultPlugins` to take effect.
 #[derive(Resource)]
 pub struct AssetServerSettings {
     /// The base folder where assets are loaded from, relative to the executable.

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -64,7 +64,9 @@ pub enum AssetStage {
 #[derive(Default)]
 pub struct AssetPlugin;
 
-/// [`AssetServer`] settings.
+/// Settings for the [`AssetServer`].
+///
+/// This resource must be added before the [`AssetPlugin`] to take effect.
 #[derive(Resource)]
 pub struct AssetServerSettings {
     /// The base folder where assets are loaded from, relative to the executable.


### PR DESCRIPTION
# Objective

It's not obvious that the `AssetServerSettings` resource must be added before the `AssetPlugin`.

## Solution

Add a doc comment to this effect.