### PR TITLE
[Merged by Bors] - fix: grammar and typo fixes in rendergraph docs

### DIFF
--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -12,7 +12,7 @@ use std::{borrow::Cow, fmt::Debug};
 use super::EdgeExistence;
 
 /// The render graph configures the modular, parallel and re-usable render logic.
-/// It is a retained and stateless (nodes itself my have their internal state) structure,
+/// It is a retained and stateless (nodes themselves may have their own internal state) structure,
 /// which can not be modified while it is executed by the graph runner.
 ///
 /// The `RenderGraphRunner` is responsible for executing the entire graph each frame.


### PR DESCRIPTION
# Objective

- fix a typo on RendGraph Docs

## Solution

- fixed typo

---
