### PR TITLE
[Merged by Bors] - fix typos in examples

### DIFF
--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -59,7 +59,7 @@ fn star(
     //        6
     //   7        5
     //
-    // These vertices are specificed in 3D space.
+    // These vertices are specified in 3D space.
     let mut v_pos = vec![[0.0, 0.0, 0.0]];
     for i in 0..10 {
         // Angle of each vertex is 1/10 of TAU, plus PI/2 for positioning vertex 0

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -67,7 +67,7 @@ fn setup(
                 ..default()
             },
             camera_3d: Camera3d {
-                // dont clear on the second camera because the first camera already cleared the window
+                // don't clear on the second camera because the first camera already cleared the window
                 clear_color: ClearColorConfig::None,
                 ..default()
             },

--- a/examples/android/android.rs
+++ b/examples/android/android.rs
@@ -8,7 +8,7 @@ use bevy::{
 fn main() {
     App::new()
         // This configures the app to use the most compatible rendering settings.
-        // They help with compatibilty with as many devices as possible.
+        // They help with compatibility with as many devices as possible.
         .insert_resource(WgpuSettings {
             priority: WgpuSettingsPriority::Compatibility,
             ..default()

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -1,5 +1,5 @@
 //! A custom post processing effect, using two cameras, with one reusing the render texture of the first one.
-//! Here a chromatic aberration is applied to a 3d scene containting a rotating cube.
+//! Here a chromatic aberration is applied to a 3d scene containing a rotating cube.
 //! This example is useful to implement your own post-processing effect such as
 //! edge detection, blur, pixelization, vignette... and countless others.
 

--- a/examples/transforms/scale.rs
+++ b/examples/transforms/scale.rs
@@ -13,7 +13,7 @@ struct Scaling {
     min_element_size: f32,
 }
 
-// Implement a simple initialisation.
+// Implement a simple initialization.
 impl Scaling {
     fn new() -> Self {
         Scaling {


### PR DESCRIPTION
## Objective
Fixed some typos I came across while reading examples.
