### PR TITLE
Add `IntoIterator` to &mut EventReader

### DIFF
--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -248,6 +248,14 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
     }
 }
 
+impl<'a, 'w, 's, E: Event> IntoIterator for &'a mut EventReader<'w, 's, E> {
+    type Item = &'a E;
+    type IntoIter = Box<dyn DoubleEndedIterator<Item = &'a E> + 'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        Box::new(self.iter())
+    }
+}
+
 /// Sends events of type `T`.
 ///
 /// # Usage


### PR DESCRIPTION
# Objective
- Convenience method for a common usecase, maybe a bit controversial given the boxing but can't name the iterator directly unless we rework how it works (I could look at doing that if we want though)

## Solution