### PR TITLE
[Merged by Bors] - bevy_reflect: Improve serialization format even more

### DIFF
--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -1,25 +1,29 @@
 [
-
   (
     entity: 0,
     components: [
       {
-        "type": "bevy_transform::components::transform::Transform",
-        "value": {
-          "translation": (0.0, 0.0, 0.0),
+        "bevy_transform::components::transform::Transform": {
+          "translation": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
           "rotation": (0.0, 0.0, 0.0, 1.0),
-          "scale": (1.0, 1.0, 1.0),
+          "scale": {
+            "x": 1.0,
+            "y": 1.0,
+            "z": 1.0
+          },
         },
       },
       {
-        "type": "scene::ComponentB",
-        "value": {
+        "scene::ComponentB": {
           "value": "hello",
         },
       },
       {
-        "type": "scene::ComponentA",
-        "value": {
+        "scene::ComponentA": {
           "x": 1.0,
           "y": 2.0,
         },
@@ -30,8 +34,7 @@
     entity: 1,
     components: [
       {
-        "type": "scene::ComponentA",
-        "value": {
+        "scene::ComponentA": {
           "x": 3.0,
           "y": 4.0,
         },

--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -3,30 +3,30 @@
     entity: 0,
     components: [
       {
-        "bevy_transform::components::transform::Transform": {
-          "translation": {
-            "x": 0.0,
-            "y": 0.0,
-            "z": 0.0
-          },
-          "rotation": (0.0, 0.0, 0.0, 1.0),
-          "scale": {
-            "x": 1.0,
-            "y": 1.0,
-            "z": 1.0
-          },
-        },
+        "bevy_transform::components::transform::Transform": (
+          translation: (
+            x: 0.0,
+            y: 0.0,
+            z: 0.0
+          ),
+          rotation: (0.0, 0.0, 0.0, 1.0),
+          scale: (
+            x: 1.0,
+            y: 1.0,
+            z: 1.0
+          ),
+        ),
       },
       {
-        "scene::ComponentB": {
-          "value": "hello",
-        },
+        "scene::ComponentB": (
+          value: "hello",
+        ),
       },
       {
-        "scene::ComponentA": {
-          "x": 1.0,
-          "y": 2.0,
-        },
+        "scene::ComponentA": (
+          x: 1.0,
+          y: 2.0,
+        ),
       },
     ],
   ),
@@ -34,10 +34,10 @@
     entity: 1,
     components: [
       {
-        "scene::ComponentA": {
-          "x": 3.0,
-          "y": 4.0,
-        },
+        "scene::ComponentA": (
+          x: 3.0,
+          y: 4.0,
+        ),
       },
     ],
   ),

--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -1,44 +1,27 @@
 [
+
   (
     entity: 0,
     components: [
       {
         "type": "bevy_transform::components::transform::Transform",
-        "struct": {
-          "translation": {
-            "type": "glam::f32::vec3::Vec3",
-            "value": (0.0, 0.0, 0.0),
-          },
-          "rotation": {
-            "type": "glam::f32::sse2::quat::Quat",
-            "value": (0.0, 0.0, 0.0, 1.0),
-          },
-          "scale": {
-            "type": "glam::f32::vec3::Vec3",
-            "value": (1.0, 1.0, 1.0),
-          },
+        "value": {
+          "translation": (0.0, 0.0, 0.0),
+          "rotation": (0.0, 0.0, 0.0, 1.0),
+          "scale": (1.0, 1.0, 1.0),
         },
       },
       {
         "type": "scene::ComponentB",
-        "struct": {
-          "value": {
-            "type": "alloc::string::String",
-            "value": "hello",
-          },
+        "value": {
+          "value": "hello",
         },
       },
       {
         "type": "scene::ComponentA",
-        "struct": {
-          "x": {
-            "type": "f32",
-            "value": 1.0,
-          },
-          "y": {
-            "type": "f32",
-            "value": 2.0,
-          },
+        "value": {
+          "x": 1.0,
+          "y": 2.0,
         },
       },
     ],
@@ -48,15 +31,9 @@
     components: [
       {
         "type": "scene::ComponentA",
-        "struct": {
-          "x": {
-            "type": "f32",
-            "value": 3.0,
-          },
-          "y": {
-            "type": "f32",
-            "value": 4.0,
-          },
+        "value": {
+          "x": 3.0,
+          "y": 4.0,
         },
       },
     ],

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -53,12 +53,13 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
             }
         });
 
+    let string_name = enum_name.to_string();
     let typed_impl = impl_typed(
         enum_name,
         reflect_enum.meta().generics(),
         quote! {
             let variants = [#(#variant_info),*];
-            let info = #bevy_reflect_path::EnumInfo::new::<Self>(&variants);
+            let info = #bevy_reflect_path::EnumInfo::new::<Self>(#string_name, &variants);
             #bevy_reflect_path::TypeInfo::Enum(info)
         },
         bevy_reflect_path,

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -343,7 +343,7 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
                     });
 
                     let field_ty = &field.data.ty;
-                    quote! { #bevy_reflect_path::NamedField::new::<#field_ty, _>(#field_name) }
+                    quote! { #bevy_reflect_path::NamedField::new::<#field_ty>(#field_name) }
                 });
                 let arguments = quote!(#name, &[ #(#argument),* ]);
                 add_fields_branch("Struct", "StructVariantInfo", arguments, field_len);

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
@@ -57,7 +57,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
         reflect_struct.meta().generics(),
         quote! {
            let fields = [
-                #(#bevy_reflect_path::NamedField::new::<#field_types, _>(#field_names),)*
+                #(#bevy_reflect_path::NamedField::new::<#field_types>(#field_names),)*
             ];
             let info = #bevy_reflect_path::StructInfo::new::<Self>(#string_name, &fields);
             #bevy_reflect_path::TypeInfo::Struct(info)

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
@@ -51,6 +51,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
             }
         });
 
+    let string_name = struct_name.to_string();
     let typed_impl = impl_typed(
         struct_name,
         reflect_struct.meta().generics(),
@@ -58,7 +59,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
            let fields = [
                 #(#bevy_reflect_path::NamedField::new::<#field_types, _>(#field_names),)*
             ];
-            let info = #bevy_reflect_path::StructInfo::new::<Self>(&fields);
+            let info = #bevy_reflect_path::StructInfo::new::<Self>(#string_name, &fields);
             #bevy_reflect_path::TypeInfo::Struct(info)
         },
         bevy_reflect_path,

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
@@ -35,6 +35,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
             }
         });
 
+    let string_name = struct_name.to_string();
     let typed_impl = impl_typed(
         struct_name,
         reflect_struct.meta().generics(),
@@ -42,7 +43,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
             let fields = [
                 #(#bevy_reflect_path::UnnamedField::new::<#field_types>(#field_idents),)*
             ];
-            let info = #bevy_reflect_path::TupleStructInfo::new::<Self>(&fields);
+            let info = #bevy_reflect_path::TupleStructInfo::new::<Self>(#string_name, &fields);
             #bevy_reflect_path::TypeInfo::TupleStruct(info)
         },
         bevy_reflect_path,

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -124,10 +124,7 @@ where
     let mut bitset = BitSet::default();
 
     member_iter.fold(0, |next_idx, member| match member {
-        ReflectIgnoreBehavior::IgnoreAlways => {
-            bitset.insert(next_idx);
-            next_idx
-        }
+        ReflectIgnoreBehavior::IgnoreAlways => next_idx,
         ReflectIgnoreBehavior::IgnoreSerialization => {
             bitset.insert(next_idx);
             next_idx + 1

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -113,6 +113,8 @@ pub trait Enum: Reflect {
     fn field_len(&self) -> usize;
     /// The name of the current variant.
     fn variant_name(&self) -> &str;
+    /// The index of the current variant.
+    fn variant_index(&self) -> usize;
     /// The type of the current variant.
     fn variant_type(&self) -> VariantType;
     // Clones the enum into a [`DynamicEnum`].

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -150,10 +150,7 @@ impl EnumInfo {
         let variant_indices = variants
             .iter()
             .enumerate()
-            .map(|(index, variant)| {
-                let name = variant.name().clone();
-                (name, index)
-            })
+            .map(|(index, variant)| (variant.name(), index))
             .collect::<HashMap<_, _>>();
 
         let variant_names = variants

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -1,7 +1,6 @@
 use crate::{DynamicEnum, Reflect, VariantInfo, VariantType};
 use bevy_utils::HashMap;
 use std::any::{Any, TypeId};
-use std::borrow::Cow;
 use std::slice::Iter;
 
 /// A trait representing a [reflected] enum.
@@ -131,10 +130,12 @@ pub trait Enum: Reflect {
 /// A container for compile-time enum info, used by [`TypeInfo`](crate::TypeInfo).
 #[derive(Clone, Debug)]
 pub struct EnumInfo {
+    name: &'static str,
     type_name: &'static str,
     type_id: TypeId,
     variants: Box<[VariantInfo]>,
-    variant_indices: HashMap<Cow<'static, str>, usize>,
+    variant_names: Box<[&'static str]>,
+    variant_indices: HashMap<&'static str, usize>,
 }
 
 impl EnumInfo {
@@ -142,9 +143,10 @@ impl EnumInfo {
     ///
     /// # Arguments
     ///
+    /// * `name`: The name of this enum (_without_ generics or lifetimes)
     /// * `variants`: The variants of this enum in the order they are defined
     ///
-    pub fn new<TEnum: Enum>(variants: &[VariantInfo]) -> Self {
+    pub fn new<TEnum: Enum>(name: &'static str, variants: &[VariantInfo]) -> Self {
         let variant_indices = variants
             .iter()
             .enumerate()
@@ -154,10 +156,17 @@ impl EnumInfo {
             })
             .collect::<HashMap<_, _>>();
 
+        let variant_names = variants
+            .iter()
+            .map(|variant| variant.name())
+            .collect::<Vec<_>>();
+
         Self {
+            name,
             type_name: std::any::type_name::<TEnum>(),
             type_id: TypeId::of::<TEnum>(),
             variants: variants.to_vec().into_boxed_slice(),
+            variant_names: variant_names.into_boxed_slice(),
             variant_indices,
         }
     }
@@ -167,6 +176,11 @@ impl EnumInfo {
         self.variant_indices
             .get(name)
             .map(|index| &self.variants[*index])
+    }
+
+    /// A slice containing the names of all variants in order.
+    pub fn variant_names(&self) -> &[&'static str] {
+        &self.variant_names
     }
 
     /// Get a variant at the given index.
@@ -199,6 +213,15 @@ impl EnumInfo {
     /// The number of variants in this enum.
     pub fn variant_len(&self) -> usize {
         self.variants.len()
+    }
+
+    /// The name of the enum.
+    ///
+    /// This does _not_ include any generics or lifetimes.
+    ///
+    /// For example, `foo::bar::Baz<'a, T>` would simply be `Baz`.
+    pub fn name(&self) -> &'static str {
+        self.name
     }
 
     /// The [type name] of the enum.

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -136,7 +136,6 @@ pub struct EnumInfo {
     type_name: &'static str,
     type_id: TypeId,
     variants: Box<[VariantInfo]>,
-    variant_names: Box<[&'static str]>,
     variant_indices: HashMap<&'static str, usize>,
 }
 
@@ -155,17 +154,11 @@ impl EnumInfo {
             .map(|(index, variant)| (variant.name(), index))
             .collect::<HashMap<_, _>>();
 
-        let variant_names = variants
-            .iter()
-            .map(|variant| variant.name())
-            .collect::<Vec<_>>();
-
         Self {
             name,
             type_name: std::any::type_name::<TEnum>(),
             type_id: TypeId::of::<TEnum>(),
             variants: variants.to_vec().into_boxed_slice(),
-            variant_names: variant_names.into_boxed_slice(),
             variant_indices,
         }
     }
@@ -175,11 +168,6 @@ impl EnumInfo {
         self.variant_indices
             .get(name)
             .map(|index| &self.variants[*index])
-    }
-
-    /// A slice containing the names of all variants in order.
-    pub fn variant_names(&self) -> &[&'static str] {
-        &self.variant_names
     }
 
     /// Get a variant at the given index.

--- a/crates/bevy_reflect/src/enums/variants.rs
+++ b/crates/bevy_reflect/src/enums/variants.rs
@@ -137,10 +137,7 @@ impl StructVariantInfo {
         fields
             .iter()
             .enumerate()
-            .map(|(index, field)| {
-                let name = field.name().clone();
-                (name, index)
-            })
+            .map(|(index, field)| (field.name(), index))
             .collect()
     }
 }

--- a/crates/bevy_reflect/src/enums/variants.rs
+++ b/crates/bevy_reflect/src/enums/variants.rs
@@ -79,7 +79,6 @@ impl VariantInfo {
 pub struct StructVariantInfo {
     name: &'static str,
     fields: Box<[NamedField]>,
-    field_names: Box<[&'static str]>,
     field_indices: HashMap<&'static str, usize>,
 }
 
@@ -87,11 +86,9 @@ impl StructVariantInfo {
     /// Create a new [`StructVariantInfo`].
     pub fn new(name: &'static str, fields: &[NamedField]) -> Self {
         let field_indices = Self::collect_field_indices(fields);
-        let field_names = fields.iter().map(|field| field.name()).collect::<Vec<_>>();
         Self {
             name,
             fields: fields.to_vec().into_boxed_slice(),
-            field_names: field_names.into_boxed_slice(),
             field_indices,
         }
     }
@@ -106,11 +103,6 @@ impl StructVariantInfo {
         self.field_indices
             .get(name)
             .map(|index| &self.fields[*index])
-    }
-
-    /// A slice containing the names of all fields in order.
-    pub fn field_names(&self) -> &[&'static str] {
-        &self.field_names
     }
 
     /// Get the field at the given index.

--- a/crates/bevy_reflect/src/enums/variants.rs
+++ b/crates/bevy_reflect/src/enums/variants.rs
@@ -1,6 +1,5 @@
 use crate::{NamedField, UnnamedField};
 use bevy_utils::HashMap;
-use std::borrow::Cow;
 use std::slice::Iter;
 
 /// Describes the form of an enum variant.
@@ -66,7 +65,7 @@ pub enum VariantInfo {
 }
 
 impl VariantInfo {
-    pub fn name(&self) -> &Cow<'static, str> {
+    pub fn name(&self) -> &'static str {
         match self {
             Self::Struct(info) => info.name(),
             Self::Tuple(info) => info.name(),
@@ -78,39 +77,28 @@ impl VariantInfo {
 /// Type info for struct variants.
 #[derive(Clone, Debug)]
 pub struct StructVariantInfo {
-    name: Cow<'static, str>,
+    name: &'static str,
     fields: Box<[NamedField]>,
-    field_indices: HashMap<Cow<'static, str>, usize>,
+    field_names: Box<[&'static str]>,
+    field_indices: HashMap<&'static str, usize>,
 }
 
 impl StructVariantInfo {
     /// Create a new [`StructVariantInfo`].
-    pub fn new(name: &str, fields: &[NamedField]) -> Self {
+    pub fn new(name: &'static str, fields: &[NamedField]) -> Self {
         let field_indices = Self::collect_field_indices(fields);
-
+        let field_names = fields.iter().map(|field| field.name()).collect::<Vec<_>>();
         Self {
-            name: Cow::Owned(name.into()),
+            name,
             fields: fields.to_vec().into_boxed_slice(),
-            field_indices,
-        }
-    }
-
-    /// Create a new [`StructVariantInfo`] using a static string.
-    ///
-    /// This helps save an allocation when the string has a static lifetime, such
-    /// as when using defined sa a literal.
-    pub fn new_static(name: &'static str, fields: &[NamedField]) -> Self {
-        let field_indices = Self::collect_field_indices(fields);
-        Self {
-            name: Cow::Borrowed(name),
-            fields: fields.to_vec().into_boxed_slice(),
+            field_names: field_names.into_boxed_slice(),
             field_indices,
         }
     }
 
     /// The name of this variant.
-    pub fn name(&self) -> &Cow<'static, str> {
-        &self.name
+    pub fn name(&self) -> &'static str {
+        self.name
     }
 
     /// Get the field with the given name.
@@ -118,6 +106,11 @@ impl StructVariantInfo {
         self.field_indices
             .get(name)
             .map(|index| &self.fields[*index])
+    }
+
+    /// A slice containing the names of all fields in order.
+    pub fn field_names(&self) -> &[&'static str] {
+        &self.field_names
     }
 
     /// Get the field at the given index.
@@ -140,7 +133,7 @@ impl StructVariantInfo {
         self.fields.len()
     }
 
-    fn collect_field_indices(fields: &[NamedField]) -> HashMap<Cow<'static, str>, usize> {
+    fn collect_field_indices(fields: &[NamedField]) -> HashMap<&'static str, usize> {
         fields
             .iter()
             .enumerate()
@@ -155,33 +148,22 @@ impl StructVariantInfo {
 /// Type info for tuple variants.
 #[derive(Clone, Debug)]
 pub struct TupleVariantInfo {
-    name: Cow<'static, str>,
+    name: &'static str,
     fields: Box<[UnnamedField]>,
 }
 
 impl TupleVariantInfo {
     /// Create a new [`TupleVariantInfo`].
-    pub fn new(name: &str, fields: &[UnnamedField]) -> Self {
+    pub fn new(name: &'static str, fields: &[UnnamedField]) -> Self {
         Self {
-            name: Cow::Owned(name.into()),
-            fields: fields.to_vec().into_boxed_slice(),
-        }
-    }
-
-    /// Create a new [`TupleVariantInfo`] using a static string.
-    ///
-    /// This helps save an allocation when the string has a static lifetime, such
-    /// as when using defined sa a literal.
-    pub fn new_static(name: &'static str, fields: &[UnnamedField]) -> Self {
-        Self {
-            name: Cow::Borrowed(name),
+            name,
             fields: fields.to_vec().into_boxed_slice(),
         }
     }
 
     /// The name of this variant.
-    pub fn name(&self) -> &Cow<'static, str> {
-        &self.name
+    pub fn name(&self) -> &'static str {
+        self.name
     }
 
     /// Get the field at the given index.
@@ -203,29 +185,17 @@ impl TupleVariantInfo {
 /// Type info for unit variants.
 #[derive(Clone, Debug)]
 pub struct UnitVariantInfo {
-    name: Cow<'static, str>,
+    name: &'static str,
 }
 
 impl UnitVariantInfo {
     /// Create a new [`UnitVariantInfo`].
-    pub fn new(name: &str) -> Self {
-        Self {
-            name: Cow::Owned(name.into()),
-        }
-    }
-
-    /// Create a new [`UnitVariantInfo`] using a static string.
-    ///
-    /// This helps save an allocation when the string has a static lifetime, such
-    /// as when using defined sa a literal.
-    pub fn new_static(name: &'static str) -> Self {
-        Self {
-            name: Cow::Borrowed(name),
-        }
+    pub fn new(name: &'static str) -> Self {
+        Self { name }
     }
 
     /// The name of this variant.
-    pub fn name(&self) -> &Cow<'static, str> {
-        &self.name
+    pub fn name(&self) -> &'static str {
+        self.name
     }
 }

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -11,9 +11,9 @@ pub struct NamedField {
 
 impl NamedField {
     /// Create a new [`NamedField`].
-    pub fn new<T: Reflect, TName: Into<&'static str>>(name: TName) -> Self {
+    pub fn new<T: Reflect>(name: &'static str) -> Self {
         Self {
-            name: name.into(),
+            name,
             type_name: std::any::type_name::<T>(),
             type_id: TypeId::of::<T>(),
         }

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -21,7 +21,7 @@ impl NamedField {
 
     /// The name of the field.
     pub fn name(&self) -> &'static str {
-        &self.name
+        self.name
     }
 
     /// The [type name] of the field.

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -1,18 +1,17 @@
 use crate::Reflect;
 use std::any::{Any, TypeId};
-use std::borrow::Cow;
 
 /// The named field of a reflected struct.
 #[derive(Clone, Debug)]
 pub struct NamedField {
-    name: Cow<'static, str>,
+    name: &'static str,
     type_name: &'static str,
     type_id: TypeId,
 }
 
 impl NamedField {
     /// Create a new [`NamedField`].
-    pub fn new<T: Reflect, TName: Into<Cow<'static, str>>>(name: TName) -> Self {
+    pub fn new<T: Reflect, TName: Into<&'static str>>(name: TName) -> Self {
         Self {
             name: name.into(),
             type_name: std::any::type_name::<T>(),
@@ -21,7 +20,7 @@ impl NamedField {
     }
 
     /// The name of the field.
-    pub fn name(&self) -> &Cow<'static, str> {
+    pub fn name(&self) -> &'static str {
         &self.name
     }
 

--- a/crates/bevy_reflect/src/impls/glam.rs
+++ b/crates/bevy_reflect/src/impls/glam.rs
@@ -6,14 +6,14 @@ use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_struct, impl_ref
 use glam::*;
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct IVec2 {
         x: i32,
         y: i32,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct IVec3 {
         x: i32,
         y: i32,
@@ -21,7 +21,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct IVec4 {
         x: i32,
         y: i32,
@@ -31,14 +31,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct UVec2 {
         x: u32,
         y: u32,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct UVec3 {
         x: u32,
         y: u32,
@@ -46,7 +46,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct UVec4 {
         x: u32,
         y: u32,
@@ -56,14 +56,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct Vec2 {
         x: f32,
         y: f32,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct Vec3 {
         x: f32,
         y: f32,
@@ -71,7 +71,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct Vec3A {
         x: f32,
         y: f32,
@@ -79,7 +79,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct Vec4 {
         x: f32,
         y: f32,
@@ -114,14 +114,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct DVec2 {
         x: f64,
         y: f64,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct DVec3 {
         x: f64,
         y: f64,
@@ -129,7 +129,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct DVec4 {
         x: f64,
         y: f64,

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -844,12 +844,13 @@ impl<T: FromReflect> Typed for Option<T> {
     fn type_info() -> &'static TypeInfo {
         static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
         CELL.get_or_insert::<Self, _>(|| {
-            let none_variant = VariantInfo::Unit(UnitVariantInfo::new_static("None"));
-            let some_variant = VariantInfo::Tuple(TupleVariantInfo::new_static(
-                "Some",
-                &[UnnamedField::new::<T>(0)],
-            ));
-            TypeInfo::Enum(EnumInfo::new::<Self>(&[none_variant, some_variant]))
+            let none_variant = VariantInfo::Unit(UnitVariantInfo::new("None"));
+            let some_variant =
+                VariantInfo::Tuple(TupleVariantInfo::new("Some", &[UnnamedField::new::<T>(0)]));
+            TypeInfo::Enum(EnumInfo::new::<Self>(
+                "Option",
+                &[none_variant, some_variant],
+            ))
         })
     }
 }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -682,6 +682,13 @@ impl<T: FromReflect> Enum for Option<T> {
         }
     }
 
+    fn variant_index(&self) -> usize {
+        match self {
+            None => 0,
+            Some(..) => 1,
+        }
+    }
+
     #[inline]
     fn variant_type(&self) -> VariantType {
         match self {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -108,7 +108,7 @@ mod tests {
     use super::prelude::*;
     use super::*;
     use crate as bevy_reflect;
-    use crate::serde::{ReflectDeserializer, ReflectSerializer};
+    use crate::serde::{UntypedReflectDeserializer, ReflectSerializer};
 
     #[test]
     fn reflect_struct() {
@@ -493,7 +493,7 @@ mod tests {
         let serialized = to_string_pretty(&serializer, PrettyConfig::default()).unwrap();
 
         let mut deserializer = Deserializer::from_str(&serialized).unwrap();
-        let reflect_deserializer = ReflectDeserializer::new(&registry);
+        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
         let value = reflect_deserializer.deserialize(&mut deserializer).unwrap();
         let dynamic_struct = value.take::<DynamicStruct>().unwrap();
 
@@ -995,7 +995,7 @@ bevy_reflect::tests::should_reflect_debug::Test {
             registry.add_registration(Vec3::get_type_registration());
             registry.add_registration(f32::get_type_registration());
 
-            let de = ReflectDeserializer::new(&registry);
+            let de = UntypedReflectDeserializer::new(&registry);
 
             let mut deserializer =
                 ron::de::Deserializer::from_str(data).expect("Failed to acquire deserializer");

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -108,7 +108,7 @@ mod tests {
     use super::prelude::*;
     use super::*;
     use crate as bevy_reflect;
-    use crate::serde::{UntypedReflectDeserializer, ReflectSerializer};
+    use crate::serde::{ReflectSerializer, UntypedReflectDeserializer};
 
     #[test]
     fn reflect_struct() {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -961,17 +961,33 @@ bevy_reflect::tests::should_reflect_debug::Test {
 
             let ser = ReflectSerializer::new(&v, &registry);
 
-            let result = ron::to_string(&ser).expect("Failed to serialize to string");
+            let output = to_string_pretty(&ser, Default::default()).unwrap();
+            let expected = r#"
+{
+    "type": "glam::f32::vec3::Vec3",
+    "value": {
+        "x": 12.0,
+        "y": 3.0,
+        "z": -6.9,
+    },
+}
+"#;
 
-            assert_eq!(
-                result,
-                r#"{"type":"glam::f32::vec3::Vec3","value":(12.0,3.0,-6.9)}"#
-            );
+            assert_eq!(expected, format!("\n{}\n", output));
         }
 
         #[test]
         fn vec3_deserialization() {
-            let data = r#"{"type":"glam::f32::vec3::Vec3","value":(12.0,3.0,-6.9)}"#;
+            let data = r#"
+{
+    "type": "glam::f32::vec3::Vec3",
+    "value": {
+        "x": 12,
+        "y": 3,
+        "z": -6.9,
+    },
+}
+"#;
 
             let mut registry = TypeRegistry::default();
             registry.add_registration(Vec3::get_type_registration());

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -962,7 +962,8 @@ bevy_reflect::tests::should_reflect_debug::Test {
 
             let ser = ReflectSerializer::new(&v, &registry);
 
-            let output = to_string_pretty(&ser, Default::default()).unwrap();
+            let config = PrettyConfig::default().new_line(String::from("\n"));
+            let output = to_string_pretty(&ser, config).unwrap();
             let expected = r#"
 {
     "type": "glam::f32::vec3::Vec3",

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -968,8 +968,7 @@ bevy_reflect::tests::should_reflect_debug::Test {
             let output = to_string_pretty(&ser, config).unwrap();
             let expected = r#"
 {
-    "type": "glam::f32::vec3::Vec3",
-    "value": {
+    "glam::f32::vec3::Vec3": {
         "x": 12.0,
         "y": 3.0,
         "z": -6.9,
@@ -983,8 +982,7 @@ bevy_reflect::tests::should_reflect_debug::Test {
         fn vec3_deserialization() {
             let data = r#"
 {
-    "type": "glam::f32::vec3::Vec3",
-    "value": {
+    "glam::f32::vec3::Vec3": {
         "x": 12.0,
         "y": 3.0,
         "z": -6.9,

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -962,7 +962,9 @@ bevy_reflect::tests::should_reflect_debug::Test {
 
             let ser = ReflectSerializer::new(&v, &registry);
 
-            let config = PrettyConfig::default().new_line(String::from("\n"));
+            let config = PrettyConfig::default()
+                .new_line(String::from("\n"))
+                .indentor(String::from("    "));
             let output = to_string_pretty(&ser, config).unwrap();
             let expected = r#"
 {
@@ -972,10 +974,9 @@ bevy_reflect::tests::should_reflect_debug::Test {
         "y": 3.0,
         "z": -6.9,
     },
-}
-"#;
+}"#;
 
-            assert_eq!(expected, format!("\n{}\n", output));
+            assert_eq!(expected, format!("\n{}", output));
         }
 
         #[test]
@@ -984,12 +985,11 @@ bevy_reflect::tests::should_reflect_debug::Test {
 {
     "type": "glam::f32::vec3::Vec3",
     "value": {
-        "x": 12,
-        "y": 3,
+        "x": 12.0,
+        "y": 3.0,
         "z": -6.9,
     },
-}
-"#;
+}"#;
 
             let mut registry = TypeRegistry::default();
             registry.add_registration(Vec3::get_type_registration());

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -476,12 +476,17 @@ mod tests {
 
         let mut registry = TypeRegistry::default();
         registry.register::<u32>();
-        registry.register::<isize>();
-        registry.register::<usize>();
-        registry.register::<Bar>();
-        registry.register::<String>();
         registry.register::<i8>();
         registry.register::<i32>();
+        registry.register::<usize>();
+        registry.register::<isize>();
+        registry.register::<Foo>();
+        registry.register::<Bar>();
+        registry.register::<String>();
+        registry.register::<Vec<isize>>();
+        registry.register::<HashMap<usize, i8>>();
+        registry.register::<(i32, Vec<isize>, Bar)>();
+        registry.register::<[u32; 2]>();
 
         let serializer = ReflectSerializer::new(&foo, &registry);
         let serialized = to_string_pretty(&serializer, PrettyConfig::default()).unwrap();
@@ -960,13 +965,13 @@ bevy_reflect::tests::should_reflect_debug::Test {
 
             assert_eq!(
                 result,
-                r#"{"type":"glam::f32::vec3::Vec3","struct":{"x":{"type":"f32","value":12.0},"y":{"type":"f32","value":3.0},"z":{"type":"f32","value":-6.9}}}"#
+                r#"{"type":"glam::f32::vec3::Vec3","value":(12.0,3.0,-6.9)}"#
             );
         }
 
         #[test]
         fn vec3_deserialization() {
-            let data = r#"{"type":"glam::vec3::Vec3","struct":{"x":{"type":"f32","value":12},"y":{"type":"f32","value":3},"z":{"type":"f32","value":-6.9}}}"#;
+            let data = r#"{"type":"glam::f32::vec3::Vec3","value":(12.0,3.0,-6.9)}"#;
 
             let mut registry = TypeRegistry::default();
             registry.add_registration(Vec3::get_type_registration());

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -968,11 +968,11 @@ bevy_reflect::tests::should_reflect_debug::Test {
             let output = to_string_pretty(&ser, config).unwrap();
             let expected = r#"
 {
-    "glam::f32::vec3::Vec3": {
-        "x": 12.0,
-        "y": 3.0,
-        "z": -6.9,
-    },
+    "glam::f32::vec3::Vec3": (
+        x: 12.0,
+        y: 3.0,
+        z: -6.9,
+    ),
 }"#;
 
             assert_eq!(expected, format!("\n{}", output));
@@ -982,11 +982,11 @@ bevy_reflect::tests::should_reflect_debug::Test {
         fn vec3_deserialization() {
             let data = r#"
 {
-    "glam::f32::vec3::Vec3": {
-        "x": 12.0,
-        "y": 3.0,
-        "z": -6.9,
-    },
+    "glam::f32::vec3::Vec3": (
+        x: 12.0,
+        y: 3.0,
+        z: -6.9,
+    ),
 }"#;
 
             let mut registry = TypeRegistry::default();

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -97,7 +97,7 @@ pub mod __macro_exports {
 mod tests {
     #[cfg(feature = "glam")]
     use ::glam::{vec3, Vec3};
-    use ::serde::de::DeserializeSeed;
+    use ::serde::{de::DeserializeSeed, Deserialize, Serialize};
     use bevy_utils::HashMap;
     use ron::{
         ser::{to_string_pretty, PrettyConfig},
@@ -455,7 +455,8 @@ mod tests {
             h: [u32; 2],
         }
 
-        #[derive(Reflect)]
+        #[derive(Reflect, Serialize, Deserialize)]
+        #[reflect(Serialize, Deserialize)]
         struct Bar {
             x: u32,
         }

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -108,7 +108,7 @@ impl<'a, 'de> DeserializeSeed<'de> for ReflectDeserializer<'a> {
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_any(ReflectDeserializerVisitor {
+        deserializer.deserialize_map(ReflectDeserializerVisitor {
             registry: self.registry,
         })
     }

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -765,7 +765,7 @@ mod tests {
         foo: i64,
     }
 
-    /// Implements a custom deserialize using #[reflect(Deserialize)].
+    /// Implements a custom deserialize using `#[reflect(Deserialize)]`.
     ///
     /// For testing purposes, this is just the auto-generated one from deriving.
     #[derive(Reflect, FromReflect, Debug, PartialEq, Deserialize)]

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -744,6 +744,10 @@ mod tests {
         map_value: HashMap<u8, usize>,
         struct_value: SomeStruct,
         tuple_struct_value: SomeTupleStruct,
+        unit_enum: SomeEnum,
+        newtype_enum: SomeEnum,
+        tuple_enum: SomeEnum,
+        struct_enum: SomeEnum,
         custom_deserialize: CustomDeserialize,
     }
 
@@ -766,12 +770,21 @@ mod tests {
         inner_struct: SomeStruct,
     }
 
+    #[derive(Reflect, FromReflect, Debug, PartialEq)]
+    enum SomeEnum {
+        Unit,
+        NewType(usize),
+        Tuple(f32, f32),
+        Struct { foo: String },
+    }
+
     fn get_registry() -> TypeRegistry {
         let mut registry = TypeRegistry::default();
         registry.register::<MyStruct>();
         registry.register::<SomeStruct>();
         registry.register::<SomeTupleStruct>();
         registry.register::<CustomDeserialize>();
+        registry.register::<SomeEnum>();
         registry.register::<i8>();
         registry.register::<String>();
         registry.register::<i64>();
@@ -786,6 +799,138 @@ mod tests {
         registry.register::<Option<String>>();
         registry.register_type_data::<Option<String>, ReflectDeserialize>();
         registry
+    }
+
+    #[test]
+    fn should_deserialize() {
+        let mut map = HashMap::new();
+        map.insert(64, 32);
+
+        let expected = MyStruct {
+            primitive_value: 123,
+            option_value: Some(String::from("Hello world!")),
+            tuple_value: (PI, 1337),
+            list_value: vec![-2, -1, 0, 1, 2],
+            array_value: [-2, -1, 0, 1, 2],
+            map_value: map,
+            struct_value: SomeStruct { foo: 999999999 },
+            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
+            unit_enum: SomeEnum::Unit,
+            newtype_enum: SomeEnum::NewType(123),
+            tuple_enum: SomeEnum::Tuple(1.23, 3.21),
+            struct_enum: SomeEnum::Struct {
+                foo: String::from("Struct variant value"),
+            },
+            custom_deserialize: CustomDeserialize {
+                value: 100,
+                inner_struct: SomeStruct { foo: 101 },
+            },
+        };
+
+        let input = r#"{
+            "bevy_reflect::serde::de::tests::MyStruct": {
+                "primitive_value": 123,
+                "option_value": Some("Hello world!"),
+                "tuple_value": (
+                    3.1415927,
+                    1337,
+                ),
+                "list_value": [
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                ],
+                "array_value": (
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                ),
+                "map_value": {
+                    64: 32,
+                },
+                "struct_value": {
+                    "foo": 999999999,
+                },
+                "tuple_struct_value": ("Tuple Struct"),
+                "unit_enum": {
+                    "Unit": (),
+                },
+                "newtype_enum": {
+                    "NewType": (123),
+                },
+                "tuple_enum": {
+                    "Tuple": (1.23, 3.21),
+                },
+                "struct_enum": {
+                    "Struct": {
+                        "foo": "Struct variant value",
+                    },
+                },
+                "custom_deserialize": (
+                    value: 100,
+                    renamed: (
+                        foo: 101,
+                    ),
+                )
+            },
+        }"#;
+
+        let registry = get_registry();
+        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
+        let mut ron_deserializer = ron::de::Deserializer::from_str(input).unwrap();
+        let dynamic_output = reflect_deserializer
+            .deserialize(&mut ron_deserializer)
+            .unwrap();
+
+        let output = <MyStruct as FromReflect>::from_reflect(dynamic_output.as_ref()).unwrap();
+        assert_eq!(expected, output);
+    }
+
+    #[test]
+    fn should_deserialize_value() {
+        let input = r#"{
+            "f32": 1.23,
+        }"#;
+
+        let registry = get_registry();
+        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
+        let mut ron_deserializer = ron::de::Deserializer::from_str(input).unwrap();
+        let dynamic_output = reflect_deserializer
+            .deserialize(&mut ron_deserializer)
+            .unwrap();
+        let output = dynamic_output
+            .take::<f32>()
+            .expect("underlying type should be f32");
+        assert_eq!(1.23, output);
+    }
+
+    #[test]
+    fn should_deserialized_typed() {
+        #[derive(Reflect, FromReflect, Debug, PartialEq)]
+        struct Foo {
+            bar: i32,
+        }
+
+        let expected = Foo { bar: 123 };
+
+        let input = r#"{
+            "bar": 123
+        }"#;
+
+        let mut registry = get_registry();
+        registry.register::<Foo>();
+        let reflect_deserializer = TypedReflectDeserializer::new(Foo::type_info(), &registry);
+        let mut ron_deserializer = ron::de::Deserializer::from_str(input).unwrap();
+        let dynamic_output = reflect_deserializer
+            .deserialize(&mut ron_deserializer)
+            .unwrap();
+
+        let output = <Foo as FromReflect>::from_reflect(dynamic_output.as_ref()).unwrap();
+        assert_eq!(expected, output);
     }
 
     #[test]
@@ -856,117 +1001,5 @@ mod tests {
             value: String::from("I <3 Enums"),
         });
         assert!(expected.reflect_partial_eq(output.as_ref()).unwrap());
-    }
-
-    #[test]
-    fn should_deserialize() {
-        let mut map = HashMap::new();
-        map.insert(64, 32);
-
-        let expected = MyStruct {
-            primitive_value: 123,
-            option_value: Some(String::from("Hello world!")),
-            tuple_value: (PI, 1337),
-            list_value: vec![-2, -1, 0, 1, 2],
-            array_value: [-2, -1, 0, 1, 2],
-            map_value: map,
-            struct_value: SomeStruct { foo: 999999999 },
-            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
-            custom_deserialize: CustomDeserialize {
-                value: 100,
-                inner_struct: SomeStruct { foo: 101 },
-            },
-        };
-
-        let input = r#"{
-            "bevy_reflect::serde::de::tests::MyStruct": {
-                "primitive_value": 123,
-                "option_value": Some("Hello world!"),
-                "tuple_value": (
-                    3.1415927,
-                    1337,
-                ),
-                "list_value": [
-                    -2,
-                    -1,
-                    0,
-                    1,
-                    2,
-                ],
-                "array_value": (
-                    -2,
-                    -1,
-                    0,
-                    1,
-                    2,
-                ),
-                "map_value": {
-                    64: 32,
-                },
-                "struct_value": {
-                    "foo": 999999999,
-                },
-                "tuple_struct_value": ("Tuple Struct"),
-                "custom_deserialize": (
-                    value: 100,
-                    renamed: (
-                        foo: 101,
-                    ),
-                )
-            },
-        }"#;
-
-        let registry = get_registry();
-        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
-        let mut ron_deserializer = ron::de::Deserializer::from_str(input).unwrap();
-        let dynamic_output = reflect_deserializer
-            .deserialize(&mut ron_deserializer)
-            .unwrap();
-
-        let output = <MyStruct as FromReflect>::from_reflect(dynamic_output.as_ref()).unwrap();
-        assert_eq!(expected, output);
-    }
-
-    #[test]
-    fn should_deserialize_value() {
-        let input = r#"{
-            "f32": 1.23,
-        }"#;
-
-        let registry = get_registry();
-        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
-        let mut ron_deserializer = ron::de::Deserializer::from_str(input).unwrap();
-        let dynamic_output = reflect_deserializer
-            .deserialize(&mut ron_deserializer)
-            .unwrap();
-        let output = dynamic_output
-            .take::<f32>()
-            .expect("underlying type should be f32");
-        assert_eq!(1.23, output);
-    }
-
-    #[test]
-    fn should_deserialized_typed() {
-        #[derive(Reflect, FromReflect, Debug, PartialEq)]
-        struct Foo {
-            bar: i32,
-        }
-
-        let expected = Foo { bar: 123 };
-
-        let input = r#"{
-            "bar": 123
-        }"#;
-
-        let mut registry = get_registry();
-        registry.register::<Foo>();
-        let reflect_deserializer = TypedReflectDeserializer::new(Foo::type_info(), &registry);
-        let mut ron_deserializer = ron::de::Deserializer::from_str(input).unwrap();
-        let dynamic_output = reflect_deserializer
-            .deserialize(&mut ron_deserializer)
-            .unwrap();
-
-        let output = <Foo as FromReflect>::from_reflect(dynamic_output.as_ref()).unwrap();
-        assert_eq!(expected, output);
     }
 }

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -711,11 +711,7 @@ where
 
     let get_field_info = |index: usize| -> Result<&TypeInfo, V::Error> {
         let field = info.get_field(index).ok_or_else(|| {
-            Error::custom(format_args!(
-                "no field at index {} on tuple {}",
-                index,
-                info.get_name(),
-            ))
+            Error::invalid_length(index, &info.get_field_len().to_string().as_str())
         })?;
         get_type_info(field.type_id(), field.type_name(), registry)
     };

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -1,9 +1,14 @@
+use crate::serde::SerializationData;
 use crate::{
-    serde::type_fields, DynamicArray, DynamicEnum, DynamicList, DynamicMap, DynamicStruct,
-    DynamicTuple, DynamicTupleStruct, Map, Reflect, ReflectDeserialize, TypeRegistry,
+    serde::type_fields, ArrayInfo, DynamicArray, DynamicEnum, DynamicList, DynamicMap,
+    DynamicStruct, DynamicTuple, DynamicTupleStruct, EnumInfo, ListInfo, Map, MapInfo, NamedField,
+    Reflect, ReflectDeserialize, StructInfo, StructVariantInfo, Tuple, TupleInfo, TupleStruct,
+    TupleStructInfo, TupleVariantInfo, TypeInfo, TypeRegistry, UnnamedField, VariantInfo,
 };
 use erased_serde::Deserializer;
 use serde::de::{self, DeserializeSeed, Error, MapAccess, SeqAccess, Visitor};
+use std::any::TypeId;
+use std::fmt::Formatter;
 
 pub trait DeserializeValue {
     fn deserialize(
@@ -12,6 +17,80 @@ pub trait DeserializeValue {
     ) -> Result<Box<dyn Reflect>, erased_serde::Error>;
 }
 
+trait StructLikeInfo {
+    fn get_name(&self) -> &str;
+    fn get_field(&self, name: &str) -> Option<&NamedField>;
+}
+
+trait TupleLikeInfo {
+    fn get_name(&self) -> &str;
+    fn get_field(&self, index: usize) -> Option<&UnnamedField>;
+    fn get_field_len(&self) -> usize;
+}
+
+impl StructLikeInfo for StructInfo {
+    fn get_name(&self) -> &str {
+        self.type_name()
+    }
+
+    fn get_field(&self, name: &str) -> Option<&NamedField> {
+        self.field(name)
+    }
+}
+
+impl StructLikeInfo for StructVariantInfo {
+    fn get_name(&self) -> &str {
+        self.name()
+    }
+
+    fn get_field(&self, name: &str) -> Option<&NamedField> {
+        self.field(name)
+    }
+}
+
+impl TupleLikeInfo for TupleInfo {
+    fn get_name(&self) -> &str {
+        self.type_name()
+    }
+
+    fn get_field(&self, index: usize) -> Option<&UnnamedField> {
+        self.field_at(index)
+    }
+
+    fn get_field_len(&self) -> usize {
+        self.field_len()
+    }
+}
+
+impl TupleLikeInfo for TupleVariantInfo {
+    fn get_name(&self) -> &str {
+        self.name()
+    }
+
+    fn get_field(&self, index: usize) -> Option<&UnnamedField> {
+        self.field_at(index)
+    }
+
+    fn get_field_len(&self) -> usize {
+        self.field_len()
+    }
+}
+
+/// A general purpose deserializer for reflected types.
+///
+/// For non-value types, this will return the dynamic equivalent. For example, a
+/// deserialized struct will return a [`DynamicStruct`] and a `Vec` will return a
+/// [`DynamicList`].
+///
+/// The serialized data must take the form of a map containing the following entries:
+/// 1. `type`: The _full_ [type name]
+/// 2. `value`: The serialized value of the reflected type
+///
+/// > Note: The ordering is important here. `type` _must_ come before `value`.
+///
+/// [`DynamicStruct`]: crate::DynamicStruct
+/// [`DynamicList`]: crate::DynamicList
+/// [type name]: std::any::type_name
 pub struct ReflectDeserializer<'a> {
     registry: &'a TypeRegistry,
 }
@@ -29,254 +108,266 @@ impl<'a, 'de> DeserializeSeed<'de> for ReflectDeserializer<'a> {
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_any(ReflectVisitor {
+        deserializer.deserialize_any(ReflectDeserializerVisitor {
             registry: self.registry,
         })
     }
 }
 
-struct ReflectVisitor<'a> {
+struct ReflectDeserializerVisitor<'a> {
     registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> Visitor<'de> for ReflectVisitor<'a> {
+impl<'a, 'de> Visitor<'de> for ReflectDeserializerVisitor<'a> {
     type Value = Box<dyn Reflect>;
 
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        formatter.write_str("map containing `type` and `value` entries for the reflected value")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let type_name = match map.next_key::<&str>()? {
+            Some(type_fields::TYPE) => map.next_value::<&str>()?,
+            Some(type_fields::VALUE) => {
+                // `type` must come before `value`.
+                return Err(de::Error::missing_field(type_fields::TYPE));
+            }
+            Some(field) => {
+                return Err(de::Error::unknown_field(field, &[type_fields::TYPE]));
+            }
+            None => {
+                return Err(de::Error::invalid_length(
+                    0,
+                    &"two entries: `type` and `value`",
+                ));
+            }
+        };
+
+        match map.next_key::<&str>()? {
+            Some(type_fields::VALUE) => {
+                let registration = self.registry.get_with_name(&type_name).ok_or_else(|| {
+                    de::Error::custom(format_args!("No registration found for {}", type_name))
+                })?;
+                let type_info = registration.type_info();
+                let value = map.next_value_seed(TypedReflectDeserializer {
+                    type_info,
+                    registry: self.registry,
+                })?;
+                Ok(value)
+            }
+            Some(type_fields::TYPE) => Err(de::Error::duplicate_field(type_fields::TYPE)),
+            Some(field) => Err(de::Error::unknown_field(field, &[type_fields::VALUE])),
+            None => {
+                return Err(de::Error::invalid_length(
+                    0,
+                    &"two entries: `type` and `value`",
+                ));
+            }
+        }
+    }
+}
+
+/// A deserializer for reflected types whose [`TypeInfo`] is known.
+///
+/// For non-value types, this will return the dynamic equivalent. For example, a
+/// deserialized struct will return a [`DynamicStruct`] and a `Vec` will return a
+/// [`DynamicList`].
+///
+/// [`TypeInfo`]: crate::TypeInfo
+/// [`DynamicStruct`]: crate::DynamicStruct
+/// [`DynamicList`]: crate::DynamicList
+pub struct TypedReflectDeserializer<'a> {
+    type_info: &'a TypeInfo,
+    registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> DeserializeSeed<'de> for TypedReflectDeserializer<'a> {
+    type Value = Box<dyn Reflect>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Handle both Value case and types that have a custom `ReflectDeserialize`
+        let type_id = self.type_info.type_id();
+        let type_name = self.type_info.type_name();
+        let registration = self.registry.get(type_id).ok_or_else(|| {
+            de::Error::custom(format_args!("no registration found for {}", type_name))
+        })?;
+
+        if let Some(deserialize_reflect) = registration.data::<ReflectDeserialize>() {
+            let value = deserialize_reflect.deserialize(deserializer)?;
+            return Ok(value);
+        }
+
+        match self.type_info {
+            TypeInfo::Struct(struct_info) => {
+                let mut dynamic_struct = deserializer.deserialize_map(StructVisitor {
+                    struct_info,
+                    registry: self.registry,
+                })?;
+                dynamic_struct.set_name(struct_info.type_name().to_string());
+                Ok(Box::new(dynamic_struct))
+            }
+            TypeInfo::TupleStruct(tuple_struct_info) => {
+                let mut dynamic_tuple_struct = deserializer.deserialize_tuple(
+                    tuple_struct_info.field_len(),
+                    TupleStructVisitor {
+                        tuple_struct_info,
+                        registry: self.registry,
+                    },
+                )?;
+                dynamic_tuple_struct.set_name(tuple_struct_info.type_name().to_string());
+                Ok(Box::new(dynamic_tuple_struct))
+            }
+            TypeInfo::List(list_info) => {
+                let mut dynamic_list = deserializer.deserialize_seq(ListVisitor {
+                    list_info,
+                    registry: self.registry,
+                })?;
+                dynamic_list.set_name(list_info.type_name().to_string());
+                Ok(Box::new(dynamic_list))
+            }
+            TypeInfo::Array(array_info) => {
+                let mut dynamic_array = deserializer.deserialize_tuple(
+                    array_info.capacity(),
+                    ArrayVisitor {
+                        array_info,
+                        registry: self.registry,
+                    },
+                )?;
+                dynamic_array.set_name(array_info.type_name().to_string());
+                Ok(Box::new(dynamic_array))
+            }
+            TypeInfo::Map(map_info) => {
+                let mut dynamic_map = deserializer.deserialize_map(MapVisitor {
+                    map_info,
+                    registry: self.registry,
+                })?;
+                dynamic_map.set_name(map_info.type_name().to_string());
+                Ok(Box::new(dynamic_map))
+            }
+            TypeInfo::Tuple(tuple_info) => {
+                let mut dynamic_tuple = deserializer.deserialize_tuple(
+                    tuple_info.field_len(),
+                    TupleVisitor {
+                        tuple_info,
+                        registry: self.registry,
+                    },
+                )?;
+                dynamic_tuple.set_name(tuple_info.type_name().to_string());
+                Ok(Box::new(dynamic_tuple))
+            }
+            TypeInfo::Enum(enum_info) => {
+                let mut dynamic_enum = deserializer.deserialize_map(EnumVisitor {
+                    enum_info,
+                    registry: self.registry,
+                })?;
+                dynamic_enum.set_name(enum_info.type_name().to_string());
+                Ok(Box::new(dynamic_enum))
+            }
+            TypeInfo::Value(_) => {
+                // This case should already be handled
+                Err(de::Error::custom(format_args!(
+                    "the TypeRegistration for {} doesn't have ReflectDeserialize",
+                    type_name
+                )))
+            }
+            TypeInfo::Dynamic(_) => {
+                // We could potentially allow this but we'd have no idea what the actual types of the
+                // fields are and would rely on the deserializer to determine them (e.g. `i32` vs `i64`)
+                Err(de::Error::custom(format_args!(
+                    "cannot deserialize arbitrary dynamic type {}",
+                    type_name
+                )))
+            }
+        }
+    }
+}
+
+struct StructVisitor<'a> {
+    struct_info: &'a StructInfo,
+    registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> Visitor<'de> for StructVisitor<'a> {
+    type Value = DynamicStruct;
+
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("reflect value")
-    }
-
-    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v))
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(Box::new(v.to_string()))
+        formatter.write_str("reflected struct value")
     }
 
     fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
     where
         V: MapAccess<'de>,
     {
-        let mut type_name: Option<String> = None;
-        while let Some(key) = map.next_key::<String>()? {
-            match key.as_str() {
-                type_fields::TYPE => {
-                    type_name = Some(map.next_value()?);
-                }
-                type_fields::MAP => {
-                    let _type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let map = map.next_value_seed(MapDeserializer {
-                        registry: self.registry,
-                    })?;
-                    return Ok(Box::new(map));
-                }
-                type_fields::STRUCT => {
-                    let type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let mut dynamic_struct = map.next_value_seed(StructDeserializer {
-                        registry: self.registry,
-                    })?;
-                    dynamic_struct.set_name(type_name);
-                    return Ok(Box::new(dynamic_struct));
-                }
-                type_fields::TUPLE_STRUCT => {
-                    let type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let mut tuple_struct = map.next_value_seed(TupleStructDeserializer {
-                        registry: self.registry,
-                    })?;
-                    tuple_struct.set_name(type_name);
-                    return Ok(Box::new(tuple_struct));
-                }
-                type_fields::TUPLE => {
-                    let _type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let tuple = map.next_value_seed(TupleDeserializer {
-                        registry: self.registry,
-                    })?;
-                    return Ok(Box::new(tuple));
-                }
-                type_fields::LIST => {
-                    let _type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let list = map.next_value_seed(ListDeserializer {
-                        registry: self.registry,
-                    })?;
-                    return Ok(Box::new(list));
-                }
-                type_fields::ARRAY => {
-                    let _type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let array = map.next_value_seed(ArrayDeserializer {
-                        registry: self.registry,
-                    })?;
-                    return Ok(Box::new(array));
-                }
-                type_fields::ENUM => {
-                    let type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let mut dynamic_enum = map.next_value_seed(EnumDeserializer {
-                        registry: self.registry,
-                    })?;
-                    dynamic_enum.set_name(type_name);
-                    return Ok(Box::new(dynamic_enum));
-                }
-                type_fields::VALUE => {
-                    let type_name = type_name
-                        .take()
-                        .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let registration =
-                        self.registry.get_with_name(&type_name).ok_or_else(|| {
-                            de::Error::custom(format_args!(
-                                "No registration found for {}",
-                                type_name
-                            ))
-                        })?;
-                    let deserialize_reflect =
-                        registration.data::<ReflectDeserialize>().ok_or_else(|| {
-                            de::Error::custom(format_args!(
-                                "The TypeRegistration for {} doesn't have DeserializeReflect",
-                                type_name
-                            ))
-                        })?;
-                    let value = map.next_value_seed(DeserializeReflectDeserializer {
-                        reflect_deserialize: deserialize_reflect,
-                    })?;
-                    return Ok(value);
-                }
-                _ => return Err(de::Error::unknown_field(key.as_str(), &[])),
-            }
-        }
-
-        Err(de::Error::custom("Maps in this location must have the \'type\' field and one of the following fields: \'map\', \'seq\', \'value\'"))
+        visit_struct(&mut map, self.struct_info, self.registry)
     }
 }
 
-struct DeserializeReflectDeserializer<'a> {
-    reflect_deserialize: &'a ReflectDeserialize,
-}
-
-impl<'a, 'de> DeserializeSeed<'de> for DeserializeReflectDeserializer<'a> {
-    type Value = Box<dyn Reflect>;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        self.reflect_deserialize.deserialize(deserializer)
-    }
-}
-
-struct ListDeserializer<'a> {
+struct TupleStructVisitor<'a> {
+    tuple_struct_info: &'a TupleStructInfo,
     registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> DeserializeSeed<'de> for ListDeserializer<'a> {
-    type Value = DynamicList;
+impl<'a, 'de> Visitor<'de> for TupleStructVisitor<'a> {
+    type Value = DynamicTupleStruct;
 
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("reflected tuple struct value")
+    }
+
+    fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
     where
-        D: serde::Deserializer<'de>,
+        V: SeqAccess<'de>,
     {
-        deserializer.deserialize_seq(ListVisitor {
+        let mut index = 0usize;
+        let mut tuple_struct = DynamicTupleStruct::default();
+
+        let get_field_info = |index: usize| -> Result<&'a TypeInfo, V::Error> {
+            let field = self.tuple_struct_info.field_at(index).ok_or_else(|| {
+                de::Error::custom(format_args!(
+                    "no field at index {} on tuple {}",
+                    index,
+                    self.tuple_struct_info.type_name(),
+                ))
+            })?;
+            get_type_info(field.type_id(), field.type_name(), self.registry)
+        };
+
+        while let Some(value) = seq.next_element_seed(TypedReflectDeserializer {
+            type_info: get_field_info(index)?,
             registry: self.registry,
-        })
+        })? {
+            tuple_struct.insert_boxed(value);
+            index += 1;
+            if index >= self.tuple_struct_info.field_len() {
+                break;
+            }
+        }
+
+        let ignored_len = self
+            .registry
+            .get(self.tuple_struct_info.type_id())
+            .and_then(|registration| registration.data::<SerializationData>())
+            .map(|data| data.len())
+            .unwrap_or(0);
+        if tuple_struct.field_len() != self.tuple_struct_info.field_len() - ignored_len {
+            return Err(Error::invalid_length(
+                tuple_struct.field_len(),
+                &self.tuple_struct_info.field_len().to_string().as_str(),
+            ));
+        }
+
+        Ok(tuple_struct)
     }
 }
 
 struct ListVisitor<'a> {
+    list_info: &'a ListInfo,
     registry: &'a TypeRegistry,
 }
 
@@ -284,7 +375,7 @@ impl<'a, 'de> Visitor<'de> for ListVisitor<'a> {
     type Value = DynamicList;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("list value")
+        formatter.write_str("reflected list value")
     }
 
     fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
@@ -292,7 +383,13 @@ impl<'a, 'de> Visitor<'de> for ListVisitor<'a> {
         V: SeqAccess<'de>,
     {
         let mut list = DynamicList::default();
-        while let Some(value) = seq.next_element_seed(ReflectDeserializer {
+        let type_info = get_type_info(
+            self.list_info.item_type_id(),
+            self.list_info.item_type_name(),
+            self.registry,
+        )?;
+        while let Some(value) = seq.next_element_seed(TypedReflectDeserializer {
+            type_info,
             registry: self.registry,
         })? {
             list.push_box(value);
@@ -301,24 +398,8 @@ impl<'a, 'de> Visitor<'de> for ListVisitor<'a> {
     }
 }
 
-struct ArrayDeserializer<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> DeserializeSeed<'de> for ArrayDeserializer<'a> {
-    type Value = DynamicArray;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_seq(ArrayVisitor {
-            registry: self.registry,
-        })
-    }
-}
-
 struct ArrayVisitor<'a> {
+    array_info: &'a ArrayInfo,
     registry: &'a TypeRegistry,
 }
 
@@ -326,7 +407,7 @@ impl<'a, 'de> Visitor<'de> for ArrayVisitor<'a> {
     type Value = DynamicArray;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("array value")
+        formatter.write_str("reflected array value")
     }
 
     fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
@@ -334,34 +415,31 @@ impl<'a, 'de> Visitor<'de> for ArrayVisitor<'a> {
         V: SeqAccess<'de>,
     {
         let mut vec = Vec::with_capacity(seq.size_hint().unwrap_or_default());
-        while let Some(value) = seq.next_element_seed(ReflectDeserializer {
+        let type_info = get_type_info(
+            self.array_info.item_type_id(),
+            self.array_info.item_type_name(),
+            self.registry,
+        )?;
+        while let Some(value) = seq.next_element_seed(TypedReflectDeserializer {
+            type_info,
             registry: self.registry,
         })? {
             vec.push(value);
         }
 
-        Ok(DynamicArray::new(Box::from(vec)))
-    }
-}
+        if vec.len() != self.array_info.capacity() {
+            return Err(Error::invalid_length(
+                vec.len(),
+                &self.array_info.capacity().to_string().as_str(),
+            ));
+        }
 
-struct MapDeserializer<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> DeserializeSeed<'de> for MapDeserializer<'a> {
-    type Value = DynamicMap;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_map(MapVisitor {
-            registry: self.registry,
-        })
+        Ok(DynamicArray::new(vec.into_boxed_slice()))
     }
 }
 
 struct MapVisitor<'a> {
+    map_info: &'a MapInfo,
     registry: &'a TypeRegistry,
 }
 
@@ -369,7 +447,7 @@ impl<'a, 'de> Visitor<'de> for MapVisitor<'a> {
     type Value = DynamicMap;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("map value")
+        formatter.write_str("reflected map value")
     }
 
     fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
@@ -377,10 +455,22 @@ impl<'a, 'de> Visitor<'de> for MapVisitor<'a> {
         V: MapAccess<'de>,
     {
         let mut dynamic_map = DynamicMap::default();
-        while let Some(key) = map.next_key_seed(ReflectDeserializer {
+        let key_type_info = get_type_info(
+            self.map_info.key_type_id(),
+            self.map_info.key_type_name(),
+            self.registry,
+        )?;
+        let value_type_info = get_type_info(
+            self.map_info.value_type_id(),
+            self.map_info.value_type_name(),
+            self.registry,
+        )?;
+        while let Some(key) = map.next_key_seed(TypedReflectDeserializer {
+            type_info: key_type_info,
             registry: self.registry,
         })? {
-            let value = map.next_value_seed(ReflectDeserializer {
+            let value = map.next_value_seed(TypedReflectDeserializer {
+                type_info: value_type_info,
                 registry: self.registry,
             })?;
             dynamic_map.insert_boxed(key, value);
@@ -390,110 +480,8 @@ impl<'a, 'de> Visitor<'de> for MapVisitor<'a> {
     }
 }
 
-struct StructDeserializer<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> DeserializeSeed<'de> for StructDeserializer<'a> {
-    type Value = DynamicStruct;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_map(StructVisitor {
-            registry: self.registry,
-        })
-    }
-}
-
-struct StructVisitor<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> Visitor<'de> for StructVisitor<'a> {
-    type Value = DynamicStruct;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("struct value")
-    }
-
-    fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
-    where
-        V: MapAccess<'de>,
-    {
-        let mut dynamic_struct = DynamicStruct::default();
-        while let Some(key) = map.next_key::<String>()? {
-            let value = map.next_value_seed(ReflectDeserializer {
-                registry: self.registry,
-            })?;
-            dynamic_struct.insert_boxed(&key, value);
-        }
-
-        Ok(dynamic_struct)
-    }
-}
-
-struct TupleStructDeserializer<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> DeserializeSeed<'de> for TupleStructDeserializer<'a> {
-    type Value = DynamicTupleStruct;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_seq(TupleStructVisitor {
-            registry: self.registry,
-        })
-    }
-}
-
-struct TupleStructVisitor<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> Visitor<'de> for TupleStructVisitor<'a> {
-    type Value = DynamicTupleStruct;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("tuple struct value")
-    }
-
-    fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
-    where
-        V: SeqAccess<'de>,
-    {
-        let mut tuple_struct = DynamicTupleStruct::default();
-        while let Some(value) = seq.next_element_seed(ReflectDeserializer {
-            registry: self.registry,
-        })? {
-            tuple_struct.insert_boxed(value);
-        }
-        Ok(tuple_struct)
-    }
-}
-
-struct TupleDeserializer<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> DeserializeSeed<'de> for TupleDeserializer<'a> {
-    type Value = DynamicTuple;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_seq(TupleVisitor {
-            registry: self.registry,
-        })
-    }
-}
-
 struct TupleVisitor<'a> {
+    tuple_info: &'a TupleInfo,
     registry: &'a TypeRegistry,
 }
 
@@ -501,41 +489,19 @@ impl<'a, 'de> Visitor<'de> for TupleVisitor<'a> {
     type Value = DynamicTuple;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("tuple value")
+        formatter.write_str("reflected tuple value")
     }
 
     fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
     where
         V: SeqAccess<'de>,
     {
-        let mut tuple = DynamicTuple::default();
-        while let Some(value) = seq.next_element_seed(ReflectDeserializer {
-            registry: self.registry,
-        })? {
-            tuple.insert_boxed(value);
-        }
-        Ok(tuple)
-    }
-}
-
-struct EnumDeserializer<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> DeserializeSeed<'de> for EnumDeserializer<'a> {
-    type Value = DynamicEnum;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_map(EnumVisitor {
-            registry: self.registry,
-        })
+        visit_tuple(&mut seq, self.tuple_info, self.registry)
     }
 }
 
 struct EnumVisitor<'a> {
+    enum_info: &'a EnumInfo,
     registry: &'a TypeRegistry,
 }
 
@@ -543,67 +509,276 @@ impl<'a, 'de> Visitor<'de> for EnumVisitor<'a> {
     type Value = DynamicEnum;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("enum value")
+        formatter.write_str("reflected enum value")
     }
 
     fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
     where
         V: MapAccess<'de>,
     {
-        let key = map.next_key::<String>()?;
-        match key.as_deref() {
-            Some(type_fields::VARIANT) => {}
-            Some(key) => return Err(V::Error::unknown_field(key, &[type_fields::VARIANT])),
-            _ => {
-                return Err(V::Error::missing_field(type_fields::VARIANT));
-            }
-        }
+        let variant_name = map
+            .next_key::<&str>()?
+            .ok_or_else(|| Error::missing_field("the variant name of the enum"))?;
 
-        let variant_name = map.next_value::<String>()?;
+        let variant_info = self
+            .enum_info
+            .variant(variant_name)
+            .ok_or_else(|| Error::custom(format_args!("unknown variant {}", variant_name)))?;
 
         let mut dynamic_enum = DynamicEnum::default();
 
-        let key = map.next_key::<String>()?;
-        match key.as_deref() {
-            Some(type_fields::STRUCT) => {
-                let dynamic_struct = map.next_value_seed(StructDeserializer {
+        match variant_info {
+            VariantInfo::Struct(struct_info) => {
+                let dynamic_struct = map.next_value_seed(StructVariantDeserializer {
+                    struct_info,
                     registry: self.registry,
                 })?;
                 dynamic_enum.set_variant(variant_name, dynamic_struct);
             }
-            Some(type_fields::TUPLE) => {
-                let dynamic_tuple = map.next_value_seed(TupleDeserializer {
+            VariantInfo::Tuple(tuple_info) => {
+                let dynamic_tuple = map.next_value_seed(TupleVariantDeserializer {
+                    tuple_info,
                     registry: self.registry,
                 })?;
                 dynamic_enum.set_variant(variant_name, dynamic_tuple);
             }
-            Some(invalid_key) => {
-                return Err(V::Error::unknown_field(
-                    invalid_key,
-                    &[type_fields::STRUCT, type_fields::TUPLE],
-                ));
+            VariantInfo::Unit(..) => {
+                map.next_value::<()>()?;
+                dynamic_enum.set_variant(variant_name, ());
             }
-            None => dynamic_enum.set_variant(variant_name, ()),
         }
 
         Ok(dynamic_enum)
     }
 }
 
+struct StructVariantDeserializer<'a> {
+    struct_info: &'a StructVariantInfo,
+    registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> DeserializeSeed<'de> for StructVariantDeserializer<'a> {
+    type Value = DynamicStruct;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(StructVariantVisitor {
+            struct_info: self.struct_info,
+            registry: self.registry,
+        })
+    }
+}
+
+struct StructVariantVisitor<'a> {
+    struct_info: &'a StructVariantInfo,
+    registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> Visitor<'de> for StructVariantVisitor<'a> {
+    type Value = DynamicStruct;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("reflected struct variant value")
+    }
+
+    fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+    where
+        V: MapAccess<'de>,
+    {
+        visit_struct(&mut map, self.struct_info, self.registry)
+    }
+}
+
+struct TupleVariantDeserializer<'a> {
+    tuple_info: &'a TupleVariantInfo,
+    registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> DeserializeSeed<'de> for TupleVariantDeserializer<'a> {
+    type Value = DynamicTuple;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_tuple(
+            self.tuple_info.field_len(),
+            TupleVariantVisitor {
+                tuple_info: self.tuple_info,
+                registry: self.registry,
+            },
+        )
+    }
+}
+
+struct TupleVariantVisitor<'a> {
+    tuple_info: &'a TupleVariantInfo,
+    registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> Visitor<'de> for TupleVariantVisitor<'a> {
+    type Value = DynamicTuple;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("reflected tuple variant value")
+    }
+
+    fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
+    where
+        V: SeqAccess<'de>,
+    {
+        visit_tuple(&mut seq, self.tuple_info, self.registry)
+    }
+}
+
+fn visit_struct<'de, T, V>(
+    map: &mut V,
+    info: &T,
+    registry: &TypeRegistry,
+) -> Result<DynamicStruct, V::Error>
+where
+    T: StructLikeInfo,
+    V: MapAccess<'de>,
+{
+    let mut dynamic_struct = DynamicStruct::default();
+    while let Some(key) = map.next_key::<String>()? {
+        let field = info.get_field(&key).ok_or_else(|| {
+            Error::custom(format_args!(
+                "no field named {} on struct {}",
+                key,
+                info.get_name(),
+            ))
+        })?;
+        let type_info = get_type_info(field.type_id(), field.type_name(), registry)?;
+        let value = map.next_value_seed(TypedReflectDeserializer {
+            type_info,
+            registry,
+        })?;
+        dynamic_struct.insert_boxed(&key, value);
+    }
+
+    Ok(dynamic_struct)
+}
+
+fn visit_tuple<'de, T, V>(
+    seq: &mut V,
+    info: &T,
+    registry: &TypeRegistry,
+) -> Result<DynamicTuple, V::Error>
+where
+    T: TupleLikeInfo,
+    V: SeqAccess<'de>,
+{
+    let mut tuple = DynamicTuple::default();
+    let mut index = 0usize;
+
+    let get_field_info = |index: usize| -> Result<&TypeInfo, V::Error> {
+        let field = info.get_field(index).ok_or_else(|| {
+            Error::custom(format_args!(
+                "no field at index {} on tuple {}",
+                index,
+                info.get_name(),
+            ))
+        })?;
+        get_type_info(field.type_id(), field.type_name(), registry)
+    };
+
+    while let Some(value) = seq.next_element_seed(TypedReflectDeserializer {
+        type_info: get_field_info(index)?,
+        registry,
+    })? {
+        tuple.insert_boxed(value);
+        index += 1;
+        if index >= info.get_field_len() {
+            break;
+        }
+    }
+
+    let len = info.get_field_len();
+
+    if tuple.field_len() != len {
+        return Err(Error::invalid_length(
+            tuple.field_len(),
+            &len.to_string().as_str(),
+        ));
+    }
+
+    Ok(tuple)
+}
+
+fn get_type_info<'a, E: de::Error>(
+    type_id: TypeId,
+    type_name: &'a str,
+    registry: &'a TypeRegistry,
+) -> Result<&'a TypeInfo, E> {
+    let registration = registry.get(type_id).ok_or_else(|| {
+        de::Error::custom(format_args!("no registration found for type {}", type_name))
+    })?;
+    Ok(registration.type_info())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::ReflectDeserializer;
     use crate as bevy_reflect;
-    use crate::prelude::*;
-    use crate::{DynamicEnum, TypeRegistry};
-    use ::serde::de::DeserializeSeed;
+    use crate::serde::ReflectDeserializer;
+    use crate::{DynamicEnum, FromReflect, Reflect, ReflectDeserialize, TypeRegistry};
+    use bevy_utils::HashMap;
+    use serde::de::DeserializeSeed;
+    use serde::Deserialize;
+
+    #[derive(Reflect, FromReflect, Debug, PartialEq)]
+    struct MyStruct {
+        primitive_value: i8,
+        option_value: Option<String>,
+        tuple_value: (f32, usize),
+        list_value: Vec<i32>,
+        array_value: [i32; 5],
+        map_value: HashMap<u8, usize>,
+        struct_value: SomeStruct,
+        tuple_struct_value: SomeTupleStruct,
+        custom_deserialize: CustomDeserialize,
+    }
+
+    #[derive(Reflect, FromReflect, Debug, PartialEq, Deserialize)]
+    struct SomeStruct {
+        foo: i64,
+    }
+
+    #[derive(Reflect, FromReflect, Debug, PartialEq)]
+    struct SomeTupleStruct(String);
+
+    /// Implements a custom deserialize using #[reflect(Deserialize)].
+    ///
+    /// For testing purposes, this is just the auto-generated one from deriving.
+    #[derive(Reflect, FromReflect, Debug, PartialEq, Deserialize)]
+    #[reflect(Deserialize)]
+    struct CustomDeserialize {
+        value: usize,
+        #[serde(rename = "renamed")]
+        inner_struct: SomeStruct,
+    }
 
     fn get_registry() -> TypeRegistry {
         let mut registry = TypeRegistry::default();
-        registry.register::<usize>();
-        registry.register::<f32>();
+        registry.register::<MyStruct>();
+        registry.register::<SomeStruct>();
+        registry.register::<SomeTupleStruct>();
+        registry.register::<CustomDeserialize>();
+        registry.register::<i8>();
         registry.register::<String>();
-        registry.register::<(f32, f32)>();
+        registry.register::<i64>();
+        registry.register::<f32>();
+        registry.register::<usize>();
+        registry.register::<i32>();
+        registry.register::<u8>();
+        registry.register::<(f32, usize)>();
+        registry.register::<[i32; 5]>();
+        registry.register::<Vec<i32>>();
+        registry.register::<HashMap<u8, usize>>();
+        registry.register::<Option<String>>();
+        registry.register_type_data::<Option<String>, ReflectDeserialize>();
         registry
     }
 
@@ -622,11 +797,11 @@ mod tests {
 
         // === Unit Variant === //
         let input = r#"{
-    "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
-    "enum": {
-        "variant": "Unit",
-    },
-}"#;
+            "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
+            "value": {
+                "Unit": (),
+            },
+        }"#;
         let reflect_deserializer = ReflectDeserializer::new(&registry);
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
@@ -636,17 +811,11 @@ mod tests {
 
         // === NewType Variant === //
         let input = r#"{
-    "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
-    "enum": {
-        "variant": "NewType",
-        "tuple": [
-            {
-                "type": "usize",
-                "value": 123,
+            "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
+            "value": {
+                "NewType": (123),
             },
-        ],
-    },
-}"#;
+        }"#;
         let reflect_deserializer = ReflectDeserializer::new(&registry);
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
@@ -656,21 +825,11 @@ mod tests {
 
         // === Tuple Variant === //
         let input = r#"{
-    "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
-    "enum": {
-        "variant": "Tuple",
-        "tuple": [
-            {
-                "type": "f32",
-                "value": 1.23,
+            "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
+            "value": {
+                "Tuple": (1.23, 3.21),
             },
-            {
-                "type": "f32",
-                "value": 3.21,
-            },
-        ],
-    },
-}"#;
+        }"#;
         let reflect_deserializer = ReflectDeserializer::new(&registry);
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
@@ -680,17 +839,13 @@ mod tests {
 
         // === Struct Variant === //
         let input = r#"{
-    "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
-    "enum": {
-        "variant": "Struct",
-        "struct": {
+            "type": "bevy_reflect::serde::de::tests::enum_should_deserialize::MyEnum",
             "value": {
-                "type": "alloc::string::String",
-                "value": "I <3 Enums",
+                "Struct": {
+                    "value": "I <3 Enums",
+                },
             },
-        },
-    },
-}"#;
+        }"#;
         let reflect_deserializer = ReflectDeserializer::new(&registry);
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
@@ -699,5 +854,76 @@ mod tests {
             value: String::from("I <3 Enums"),
         });
         assert!(expected.reflect_partial_eq(output.as_ref()).unwrap());
+    }
+
+    #[test]
+    fn should_deserialize() {
+        let mut map = HashMap::new();
+        map.insert(64, 32);
+
+        // TODO: Add test for standard tuples (requires https://github.com/bevyengine/bevy/pull/4226)
+        let expected = MyStruct {
+            primitive_value: 123,
+            option_value: Some(String::from("Hello world!")),
+            tuple_value: (3.14, 1337),
+            list_value: vec![-2, -1, 0, 1, 2],
+            array_value: [-2, -1, 0, 1, 2],
+            map_value: map,
+            struct_value: SomeStruct { foo: 999999999 },
+            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
+            custom_deserialize: CustomDeserialize {
+                value: 100,
+                inner_struct: SomeStruct { foo: 101 },
+            },
+        };
+
+        let input = r#"{
+            "type": "bevy_reflect::serde::de::tests::MyStruct",
+            "value": {
+                "primitive_value": 123,
+                "option_value": Some("Hello world!"),
+                "tuple_value": (
+                    3.14,
+                    1337,
+                ),
+                "list_value": [
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                ],
+                "array_value": (
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                ),
+                "map_value": {
+                    64: 32,
+                },
+                "struct_value": {
+                    "foo": 999999999,
+                },
+                "tuple_struct_value": ("Tuple Struct"),
+                "custom_deserialize": (
+                    value: 100,
+                    renamed: (
+                        foo: 101,
+                    ),
+                )
+            },
+        }"#;
+
+        let registry = get_registry();
+        let reflect_deserializer = ReflectDeserializer::new(&registry);
+        let mut ron_deserializer = ron::de::Deserializer::from_str(input).unwrap();
+        let dynamic_output = reflect_deserializer
+            .deserialize(&mut ron_deserializer)
+            .unwrap();
+
+        let output = <MyStruct as FromReflect>::from_reflect(dynamic_output.as_ref()).unwrap();
+        assert_eq!(expected, output);
     }
 }

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -860,7 +860,6 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(64, 32);
 
-        // TODO: Add test for standard tuples (requires https://github.com/bevyengine/bevy/pull/4226)
         let expected = MyStruct {
             primitive_value: 123,
             option_value: Some(String::from("Hello world!")),

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -148,7 +148,7 @@ impl<'a, 'de> Visitor<'de> for ReflectDeserializerVisitor<'a> {
 
         match map.next_key::<&str>()? {
             Some(type_fields::VALUE) => {
-                let registration = self.registry.get_with_name(&type_name).ok_or_else(|| {
+                let registration = self.registry.get_with_name(type_name).ok_or_else(|| {
                     de::Error::custom(format_args!("No registration found for {}", type_name))
                 })?;
                 let type_info = registration.type_info();
@@ -160,12 +160,10 @@ impl<'a, 'de> Visitor<'de> for ReflectDeserializerVisitor<'a> {
             }
             Some(type_fields::TYPE) => Err(de::Error::duplicate_field(type_fields::TYPE)),
             Some(field) => Err(de::Error::unknown_field(field, &[type_fields::VALUE])),
-            None => {
-                return Err(de::Error::invalid_length(
-                    0,
-                    &"two entries: `type` and `value`",
-                ));
-            }
+            None => Err(de::Error::invalid_length(
+                0,
+                &"two entries: `type` and `value`",
+            )),
         }
     }
 }
@@ -727,6 +725,7 @@ mod tests {
     use bevy_utils::HashMap;
     use serde::de::DeserializeSeed;
     use serde::Deserialize;
+    use std::f32::consts::PI;
 
     #[derive(Reflect, FromReflect, Debug, PartialEq)]
     struct MyStruct {
@@ -865,7 +864,7 @@ mod tests {
         let expected = MyStruct {
             primitive_value: 123,
             option_value: Some(String::from("Hello world!")),
-            tuple_value: (3.14, 1337),
+            tuple_value: (PI, 1337),
             list_value: vec![-2, -1, 0, 1, 2],
             array_value: [-2, -1, 0, 1, 2],
             map_value: map,
@@ -883,7 +882,7 @@ mod tests {
                 "primitive_value": 123,
                 "option_value": Some("Hello world!"),
                 "tuple_value": (
-                    3.14,
+                    3.1415927,
                     1337,
                 ),
                 "list_value": [

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -117,7 +117,7 @@ impl<'a, 'de> DeserializeSeed<'de> for UntypedReflectDeserializer<'a> {
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_map(UntypedReflectDeserializerVisitor {
+        deserializer.deserialize_any(UntypedReflectDeserializerVisitor {
             registry: self.registry,
         })
     }

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -78,47 +78,56 @@ impl TupleLikeInfo for TupleVariantInfo {
 
 /// A general purpose deserializer for reflected types.
 ///
-/// For non-value types, this will return the dynamic equivalent. For example, a
+/// This will return a [`Box<dyn Reflect>`] containing the deserialized data.
+/// For non-value types, this `Box` will contain the dynamic equivalent. For example, a
 /// deserialized struct will return a [`DynamicStruct`] and a `Vec` will return a
-/// [`DynamicList`].
+/// [`DynamicList`]. For value types, this `Box` will contain the actual value.
+/// For example, an `f32` will contain the actual `f32` type.
 ///
-/// The serialized data must take the form of a map containing the following entries:
+/// This means that converting to any concrete instance will require the use of
+/// [`FromReflect`], or downcasting for value types.
+///
+/// Because the type isn't known ahead of time, the serialized data must take the form of
+/// a map containing the following entries (in order):
 /// 1. `type`: The _full_ [type name]
 /// 2. `value`: The serialized value of the reflected type
 ///
-/// > Note: The ordering is important here. `type` _must_ come before `value`.
+/// If the type is already known and the [`TypeInfo`] for it can be retrieved,
+/// [`TypedReflectDeserializer`] may be used instead to avoid requiring these entries.
 ///
+/// [`Box<dyn Reflect>`]: crate::Reflect
 /// [`DynamicStruct`]: crate::DynamicStruct
 /// [`DynamicList`]: crate::DynamicList
+/// [`FromReflect`]: crate::FromReflect
 /// [type name]: std::any::type_name
-pub struct ReflectDeserializer<'a> {
+pub struct UntypedReflectDeserializer<'a> {
     registry: &'a TypeRegistry,
 }
 
-impl<'a> ReflectDeserializer<'a> {
+impl<'a> UntypedReflectDeserializer<'a> {
     pub fn new(registry: &'a TypeRegistry) -> Self {
-        ReflectDeserializer { registry }
+        Self { registry }
     }
 }
 
-impl<'a, 'de> DeserializeSeed<'de> for ReflectDeserializer<'a> {
+impl<'a, 'de> DeserializeSeed<'de> for UntypedReflectDeserializer<'a> {
     type Value = Box<dyn Reflect>;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_map(ReflectDeserializerVisitor {
+        deserializer.deserialize_map(UntypedReflectDeserializerVisitor {
             registry: self.registry,
         })
     }
 }
 
-struct ReflectDeserializerVisitor<'a> {
+struct UntypedReflectDeserializerVisitor<'a> {
     registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> Visitor<'de> for ReflectDeserializerVisitor<'a> {
+impl<'a, 'de> Visitor<'de> for UntypedReflectDeserializerVisitor<'a> {
     type Value = Box<dyn Reflect>;
 
     fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
@@ -170,13 +179,22 @@ impl<'a, 'de> Visitor<'de> for ReflectDeserializerVisitor<'a> {
 
 /// A deserializer for reflected types whose [`TypeInfo`] is known.
 ///
-/// For non-value types, this will return the dynamic equivalent. For example, a
+/// This will return a [`Box<dyn Reflect>`] containing the deserialized data.
+/// For non-value types, this `Box` will contain the dynamic equivalent. For example, a
 /// deserialized struct will return a [`DynamicStruct`] and a `Vec` will return a
-/// [`DynamicList`].
+/// [`DynamicList`]. For value types, this `Box` will contain the actual value.
+/// For example, an `f32` will contain the actual `f32` type.
+///
+/// This means that converting to any concrete instance will require the use of
+/// [`FromReflect`], or downcasting for value types.
+///
+/// If the type is not known ahead of time, use [`UntypedReflectDeserializer`] instead.
 ///
 /// [`TypeInfo`]: crate::TypeInfo
+/// [`Box<dyn Reflect>`]: crate::Reflect
 /// [`DynamicStruct`]: crate::DynamicStruct
 /// [`DynamicList`]: crate::DynamicList
+/// [`FromReflect`]: crate::FromReflect
 pub struct TypedReflectDeserializer<'a> {
     type_info: &'a TypeInfo,
     registry: &'a TypeRegistry,
@@ -720,7 +738,7 @@ fn get_type_info<'a, E: de::Error>(
 #[cfg(test)]
 mod tests {
     use crate as bevy_reflect;
-    use crate::serde::ReflectDeserializer;
+    use crate::serde::UntypedReflectDeserializer;
     use crate::{DynamicEnum, FromReflect, Reflect, ReflectDeserialize, TypeRegistry};
     use bevy_utils::HashMap;
     use serde::de::DeserializeSeed;
@@ -801,7 +819,7 @@ mod tests {
                 "Unit": (),
             },
         }"#;
-        let reflect_deserializer = ReflectDeserializer::new(&registry);
+        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 
@@ -815,7 +833,7 @@ mod tests {
                 "NewType": (123),
             },
         }"#;
-        let reflect_deserializer = ReflectDeserializer::new(&registry);
+        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 
@@ -829,7 +847,7 @@ mod tests {
                 "Tuple": (1.23, 3.21),
             },
         }"#;
-        let reflect_deserializer = ReflectDeserializer::new(&registry);
+        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 
@@ -845,7 +863,7 @@ mod tests {
                 },
             },
         }"#;
-        let reflect_deserializer = ReflectDeserializer::new(&registry);
+        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 
@@ -915,7 +933,7 @@ mod tests {
         }"#;
 
         let registry = get_registry();
-        let reflect_deserializer = ReflectDeserializer::new(&registry);
+        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
         let mut ron_deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let dynamic_output = reflect_deserializer
             .deserialize(&mut ron_deserializer)

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -391,35 +391,23 @@ impl<'a, 'de> Visitor<'de> for TupleStructVisitor<'a> {
     }
 }
 
-struct ListVisitor<'a> {
-    list_info: &'a ListInfo,
+struct TupleVisitor<'a> {
+    tuple_info: &'a TupleInfo,
     registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> Visitor<'de> for ListVisitor<'a> {
-    type Value = DynamicList;
+impl<'a, 'de> Visitor<'de> for TupleVisitor<'a> {
+    type Value = DynamicTuple;
 
     fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-        formatter.write_str("reflected list value")
+        formatter.write_str("reflected tuple value")
     }
 
     fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
-    where
-        V: SeqAccess<'de>,
+        where
+            V: SeqAccess<'de>,
     {
-        let mut list = DynamicList::default();
-        let type_info = get_type_info(
-            self.list_info.item_type_id(),
-            self.list_info.item_type_name(),
-            self.registry,
-        )?;
-        while let Some(value) = seq.next_element_seed(TypedReflectDeserializer {
-            type_info,
-            registry: self.registry,
-        })? {
-            list.push_box(value);
-        }
-        Ok(list)
+        visit_tuple(&mut seq, self.tuple_info, self.registry)
     }
 }
 
@@ -463,6 +451,38 @@ impl<'a, 'de> Visitor<'de> for ArrayVisitor<'a> {
     }
 }
 
+struct ListVisitor<'a> {
+    list_info: &'a ListInfo,
+    registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> Visitor<'de> for ListVisitor<'a> {
+    type Value = DynamicList;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        formatter.write_str("reflected list value")
+    }
+
+    fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
+    where
+        V: SeqAccess<'de>,
+    {
+        let mut list = DynamicList::default();
+        let type_info = get_type_info(
+            self.list_info.item_type_id(),
+            self.list_info.item_type_name(),
+            self.registry,
+        )?;
+        while let Some(value) = seq.next_element_seed(TypedReflectDeserializer {
+            type_info,
+            registry: self.registry,
+        })? {
+            list.push_box(value);
+        }
+        Ok(list)
+    }
+}
+
 struct MapVisitor<'a> {
     map_info: &'a MapInfo,
     registry: &'a TypeRegistry,
@@ -502,26 +522,6 @@ impl<'a, 'de> Visitor<'de> for MapVisitor<'a> {
         }
 
         Ok(dynamic_map)
-    }
-}
-
-struct TupleVisitor<'a> {
-    tuple_info: &'a TupleInfo,
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> Visitor<'de> for TupleVisitor<'a> {
-    type Value = DynamicTuple;
-
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-        formatter.write_str("reflected tuple value")
-    }
-
-    fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
-    where
-        V: SeqAccess<'de>,
-    {
-        visit_tuple(&mut seq, self.tuple_info, self.registry)
     }
 }
 
@@ -968,7 +968,9 @@ mod tests {
         let dynamic_output = reflect_deserializer
             .deserialize(&mut ron_deserializer)
             .unwrap();
-        let output = dynamic_output.take::<f32>().expect("underlying type should be f32");
+        let output = dynamic_output
+            .take::<f32>()
+            .expect("underlying type should be f32");
         assert_eq!(1.23, output);
     }
 

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -296,6 +296,7 @@ impl<'a, 'de> DeserializeSeed<'de> for TypedReflectDeserializer<'a> {
                     TupleStructVisitor {
                         tuple_struct_info,
                         registry: self.registry,
+                        registration: self.registration,
                     },
                 )?;
                 dynamic_tuple_struct.set_name(tuple_struct_info.type_name().to_string());
@@ -402,6 +403,7 @@ impl<'a, 'de> Visitor<'de> for StructVisitor<'a> {
 struct TupleStructVisitor<'a> {
     tuple_struct_info: &'static TupleStructInfo,
     registry: &'a TypeRegistry,
+    registration: &'a TypeRegistration,
 }
 
 impl<'a, 'de> Visitor<'de> for TupleStructVisitor<'a> {
@@ -441,9 +443,8 @@ impl<'a, 'de> Visitor<'de> for TupleStructVisitor<'a> {
         }
 
         let ignored_len = self
-            .registry
-            .get(self.tuple_struct_info.type_id())
-            .and_then(|registration| registration.data::<SerializationData>())
+            .registration
+            .data::<SerializationData>()
             .map(|data| data.len())
             .unwrap_or(0);
         if tuple_struct.field_len() != self.tuple_struct_info.field_len() - ignored_len {

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -956,6 +956,23 @@ mod tests {
     }
 
     #[test]
+    fn should_deserialize_value() {
+        let input = r#"{
+            "type": "f32",
+            "value": 1.23,
+        }"#;
+
+        let registry = get_registry();
+        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
+        let mut ron_deserializer = ron::de::Deserializer::from_str(input).unwrap();
+        let dynamic_output = reflect_deserializer
+            .deserialize(&mut ron_deserializer)
+            .unwrap();
+        let output = dynamic_output.take::<f32>().expect("underlying type should be f32");
+        assert_eq!(1.23, output);
+    }
+
+    #[test]
     fn should_deserialized_typed() {
         #[derive(Reflect, FromReflect, Debug, PartialEq)]
         struct Foo {

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -294,7 +294,7 @@ struct StructVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for StructVisitor<'a> {
     type Value = DynamicStruct;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
         formatter.write_str("reflected struct value")
     }
 
@@ -314,7 +314,7 @@ struct TupleStructVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for TupleStructVisitor<'a> {
     type Value = DynamicTupleStruct;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
         formatter.write_str("reflected tuple struct value")
     }
 
@@ -372,7 +372,7 @@ struct ListVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for ListVisitor<'a> {
     type Value = DynamicList;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
         formatter.write_str("reflected list value")
     }
 
@@ -404,7 +404,7 @@ struct ArrayVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for ArrayVisitor<'a> {
     type Value = DynamicArray;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
         formatter.write_str("reflected array value")
     }
 
@@ -444,7 +444,7 @@ struct MapVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for MapVisitor<'a> {
     type Value = DynamicMap;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
         formatter.write_str("reflected map value")
     }
 
@@ -486,7 +486,7 @@ struct TupleVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for TupleVisitor<'a> {
     type Value = DynamicTuple;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
         formatter.write_str("reflected tuple value")
     }
 

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -738,6 +738,7 @@ mod tests {
     struct MyStruct {
         primitive_value: i8,
         option_value: Option<String>,
+        option_value_complex: Option<SomeStruct>,
         tuple_value: (f32, usize),
         list_value: Vec<i32>,
         array_value: [i32; 5],
@@ -751,13 +752,18 @@ mod tests {
         custom_deserialize: CustomDeserialize,
     }
 
-    #[derive(Reflect, FromReflect, Debug, PartialEq, Deserialize)]
+    #[derive(Reflect, FromReflect, Debug, PartialEq)]
     struct SomeStruct {
         foo: i64,
     }
 
     #[derive(Reflect, FromReflect, Debug, PartialEq)]
     struct SomeTupleStruct(String);
+
+    #[derive(Reflect, FromReflect, Debug, PartialEq, Deserialize)]
+    struct SomeDeserializableStruct {
+        foo: i64,
+    }
 
     /// Implements a custom deserialize using #[reflect(Deserialize)].
     ///
@@ -767,7 +773,7 @@ mod tests {
     struct CustomDeserialize {
         value: usize,
         #[serde(rename = "renamed")]
-        inner_struct: SomeStruct,
+        inner_struct: SomeDeserializableStruct,
     }
 
     #[derive(Reflect, FromReflect, Debug, PartialEq)]
@@ -784,6 +790,7 @@ mod tests {
         registry.register::<SomeStruct>();
         registry.register::<SomeTupleStruct>();
         registry.register::<CustomDeserialize>();
+        registry.register::<SomeDeserializableStruct>();
         registry.register::<SomeEnum>();
         registry.register::<i8>();
         registry.register::<String>();
@@ -796,6 +803,7 @@ mod tests {
         registry.register::<[i32; 5]>();
         registry.register::<Vec<i32>>();
         registry.register::<HashMap<u8, usize>>();
+        registry.register::<Option<SomeStruct>>();
         registry.register::<Option<String>>();
         registry.register_type_data::<Option<String>, ReflectDeserialize>();
         registry
@@ -809,6 +817,7 @@ mod tests {
         let expected = MyStruct {
             primitive_value: 123,
             option_value: Some(String::from("Hello world!")),
+            option_value_complex: Some(SomeStruct { foo: 123 }),
             tuple_value: (PI, 1337),
             list_value: vec![-2, -1, 0, 1, 2],
             array_value: [-2, -1, 0, 1, 2],
@@ -823,7 +832,7 @@ mod tests {
             },
             custom_deserialize: CustomDeserialize {
                 value: 100,
-                inner_struct: SomeStruct { foo: 101 },
+                inner_struct: SomeDeserializableStruct { foo: 101 },
             },
         };
 
@@ -831,6 +840,11 @@ mod tests {
             "bevy_reflect::serde::de::tests::MyStruct": {
                 "primitive_value": 123,
                 "option_value": Some("Hello world!"),
+                "option_value_complex": {
+                    "Some": ({
+                        "foo": 123,
+                    }),
+                },
                 "tuple_value": (
                     3.1415927,
                     1337,

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -139,10 +139,10 @@ impl<'a, 'de> Visitor<'de> for UntypedReflectDeserializerVisitor<'a> {
         A: MapAccess<'de>,
     {
         let type_name = map
-            .next_key::<&str>()?
+            .next_key::<String>()?
             .ok_or_else(|| Error::invalid_length(0, &"at least one entry"))?;
 
-        let registration = self.registry.get_with_name(type_name).ok_or_else(|| {
+        let registration = self.registry.get_with_name(&type_name).ok_or_else(|| {
             Error::custom(format_args!("No registration found for {}", type_name))
         })?;
         let type_info = registration.type_info();
@@ -519,12 +519,12 @@ impl<'a, 'de> Visitor<'de> for EnumVisitor<'a> {
         V: MapAccess<'de>,
     {
         let variant_name = map
-            .next_key::<&str>()?
+            .next_key::<String>()?
             .ok_or_else(|| Error::missing_field("the variant name of the enum"))?;
 
         let variant_info = self
             .enum_info
-            .variant(variant_name)
+            .variant(&variant_name)
             .ok_or_else(|| Error::custom(format_args!("unknown variant {}", variant_name)))?;
 
         let mut dynamic_enum = DynamicEnum::default();

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -99,22 +99,12 @@ impl TupleLikeInfo for TupleVariantInfo {
 /// let expected = vec!["foo", "bar", "baz"];
 /// assert_eq!("`foo`, `bar`, `baz`", format!("{}", ExpectedValues(expected)));
 /// ```
-struct ExpectedValues<TIntoIter, TIter, TItem>(TIntoIter)
-where
-    TIntoIter: IntoIterator<IntoIter = TIter> + Clone,
-    TIter: Iterator<Item = TItem> + ExactSizeIterator,
-    TItem: Display;
+struct ExpectedValues<T: Display>(Vec<T>);
 
-impl<TIntoIter, TIter, TItem> Debug for ExpectedValues<TIntoIter, TIter, TItem>
-where
-    TIntoIter: IntoIterator<IntoIter = TIter> + Clone,
-    TIter: Iterator<Item = TItem> + ExactSizeIterator,
-    TItem: Display,
-{
+impl<T: Display> Debug for ExpectedValues<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let iter = self.0.clone().into_iter();
-        let len = iter.len();
-        for (index, item) in iter.enumerate() {
+        let len = self.0.len();
+        for (index, item) in self.0.iter().enumerate() {
             write!(f, "`{}`", item)?;
             if index < len - 1 {
                 write!(f, ", ")?;
@@ -624,7 +614,7 @@ impl<'a, 'de> Visitor<'de> for EnumVisitor<'a> {
             Error::custom(format_args!(
                 "unknown variant `{}`, expected one of {:?}",
                 variant_name,
-                ExpectedValues(names)
+                ExpectedValues(names.collect())
             ))
         })?;
         let value: DynamicVariant = match variant_info {
@@ -773,7 +763,7 @@ where
             Error::custom(format_args!(
                 "unknown field `{}`, expected one of {:?}",
                 key,
-                ExpectedValues(fields)
+                ExpectedValues(fields.collect())
             ))
         })?;
         let registration = get_registration(field.type_id(), field.type_name(), registry)?;

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -370,7 +370,7 @@ impl<'a, 'de> Visitor<'de> for StructVisitor<'a> {
 }
 
 struct TupleStructVisitor<'a> {
-    tuple_struct_info: &'a TupleStructInfo,
+    tuple_struct_info: &'static TupleStructInfo,
     registry: &'a TypeRegistry,
 }
 
@@ -428,7 +428,7 @@ impl<'a, 'de> Visitor<'de> for TupleStructVisitor<'a> {
 }
 
 struct TupleVisitor<'a> {
-    tuple_info: &'a TupleInfo,
+    tuple_info: &'static TupleInfo,
     registry: &'a TypeRegistry,
 }
 
@@ -448,7 +448,7 @@ impl<'a, 'de> Visitor<'de> for TupleVisitor<'a> {
 }
 
 struct ArrayVisitor<'a> {
-    array_info: &'a ArrayInfo,
+    array_info: &'static ArrayInfo,
     registry: &'a TypeRegistry,
 }
 
@@ -488,7 +488,7 @@ impl<'a, 'de> Visitor<'de> for ArrayVisitor<'a> {
 }
 
 struct ListVisitor<'a> {
-    list_info: &'a ListInfo,
+    list_info: &'static ListInfo,
     registry: &'a TypeRegistry,
 }
 
@@ -520,7 +520,7 @@ impl<'a, 'de> Visitor<'de> for ListVisitor<'a> {
 }
 
 struct MapVisitor<'a> {
-    map_info: &'a MapInfo,
+    map_info: &'static MapInfo,
     registry: &'a TypeRegistry,
 }
 
@@ -653,7 +653,7 @@ impl<'a, 'de> Visitor<'de> for StructVariantVisitor<'a> {
 }
 
 struct TupleVariantVisitor<'a> {
-    tuple_info: &'a TupleVariantInfo,
+    tuple_info: &'static TupleVariantInfo,
     registry: &'a TypeRegistry,
 }
 

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -8,14 +8,6 @@ pub use type_data::*;
 
 pub(crate) mod type_fields {
     pub const TYPE: &str = "type";
-    pub const MAP: &str = "map";
-    pub const STRUCT: &str = "struct";
-    pub const TUPLE_STRUCT: &str = "tuple_struct";
-    pub const ENUM: &str = "enum";
-    pub const VARIANT: &str = "variant";
-    pub const TUPLE: &str = "tuple";
-    pub const LIST: &str = "list";
-    pub const ARRAY: &str = "array";
     pub const VALUE: &str = "value";
 }
 

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -6,16 +6,11 @@ pub use de::*;
 pub use ser::*;
 pub use type_data::*;
 
-pub(crate) mod type_fields {
-    pub const TYPE: &str = "type";
-    pub const VALUE: &str = "value";
-}
-
 #[cfg(test)]
 mod tests {
     use crate::{self as bevy_reflect, DynamicTupleStruct};
     use crate::{
-        serde::{ReflectDeserializer, ReflectSerializer},
+        serde::{ReflectSerializer, UntypedReflectDeserializer},
         type_registry::TypeRegistry,
         DynamicStruct, Reflect,
     };
@@ -53,7 +48,7 @@ mod tests {
         expected.insert("d", 6);
 
         let mut deserializer = ron::de::Deserializer::from_str(&serialized).unwrap();
-        let reflect_deserializer = ReflectDeserializer::new(&registry);
+        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
         let value = reflect_deserializer.deserialize(&mut deserializer).unwrap();
         let deserialized = value.take::<DynamicStruct>().unwrap();
 
@@ -88,7 +83,7 @@ mod tests {
         expected.insert(6);
 
         let mut deserializer = ron::de::Deserializer::from_str(&serialized).unwrap();
-        let reflect_deserializer = ReflectDeserializer::new(&registry);
+        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
         let value = reflect_deserializer.deserialize(&mut deserializer).unwrap();
         let deserialized = value.take::<DynamicTupleStruct>().unwrap();
 

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -463,7 +463,9 @@ mod tests {
         let registry = get_registry();
         let serializer = ReflectSerializer::new(&input, &registry);
 
-        let config = PrettyConfig::default().new_line(String::from("\n"));
+        let config = PrettyConfig::default()
+            .new_line(String::from("\n"))
+            .indentor(String::from("    "));
 
         let output = ron::ser::to_string_pretty(&serializer, config).unwrap();
         let expected = r#"{

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -303,22 +303,15 @@ impl<'a> Serialize for EnumSerializer<'a> {
         };
 
         let enum_name = enum_info.name();
+        let variant_index = self.enum_value.variant_index() as u32;
         let variant_info = enum_info
-            .variant(self.enum_value.variant_name())
+            .variant_at(variant_index as usize)
             .ok_or_else(|| {
                 Error::custom(format_args!(
-                    "variant `{}` does not exist",
-                    self.enum_value.variant_name()
+                    "variant at index `{}` does not exist",
+                    variant_index
                 ))
             })?;
-        let variant_index = enum_info
-            .index_of(self.enum_value.variant_name())
-            .ok_or_else(|| {
-                Error::custom(format_args!(
-                    "variant `{}` does not exist",
-                    self.enum_value.variant_name()
-                ))
-            })? as u32;
         let variant_name = variant_info.name();
         let variant_type = self.enum_value.variant_type();
         let field_len = self.enum_value.field_len();

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -55,12 +55,10 @@ fn get_type_info<E: Error>(
     match type_info {
         TypeInfo::Dynamic(..) => match registry.get_with_name(type_name) {
             Some(registration) => Ok(registration.type_info()),
-            None => {
-                return Err(Error::custom(format_args!(
-                    "no registration found for dynamic type with name {}",
-                    type_name
-                )))
-            }
+            None => Err(Error::custom(format_args!(
+                "no registration found for dynamic type with name {}",
+                type_name
+            ))),
         },
         info => Ok(info),
     }
@@ -223,7 +221,7 @@ impl<'a> Serialize for StructSerializer<'a> {
                 continue;
             }
             let key = struct_info.field_at(index).unwrap().name();
-            state.serialize_field(&key, &TypedReflectSerializer::new(value, self.registry))?;
+            state.serialize_field(key, &TypedReflectSerializer::new(value, self.registry))?;
         }
         state.end()
     }

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -463,7 +463,9 @@ mod tests {
         let registry = get_registry();
         let serializer = ReflectSerializer::new(&input, &registry);
 
-        let output = ron::ser::to_string_pretty(&serializer, Default::default()).unwrap();
+        let config = PrettyConfig::default().new_line(String::from("\n"));
+
+        let output = ron::ser::to_string_pretty(&serializer, config).unwrap();
         let expected = r#"{
     "type": "bevy_reflect::serde::ser::tests::MyStruct",
     "value": {

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -394,6 +394,7 @@ mod tests {
     use bevy_utils::HashMap;
     use ron::ser::PrettyConfig;
     use serde::Serialize;
+    use std::f32::consts::PI;
 
     #[derive(Reflect, Debug, PartialEq)]
     struct MyStruct {
@@ -447,7 +448,7 @@ mod tests {
         let input = MyStruct {
             primitive_value: 123,
             option_value: Some(String::from("Hello world!")),
-            tuple_value: (3.14, 1337),
+            tuple_value: (PI, 1337),
             list_value: vec![-2, -1, 0, 1, 2],
             array_value: [-2, -1, 0, 1, 2],
             map_value: map,
@@ -468,7 +469,7 @@ mod tests {
     "value": {
         "primitive_value": 123,
         "option_value": Some("Hello world!"),
-        "tuple_value": (3.14, 1337),
+        "tuple_value": (3.1415927, 1337),
         "list_value": [
             -2,
             -1,

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -1,6 +1,6 @@
 use crate::{
-    serde::type_fields, Array, Enum, List, Map, Reflect, ReflectRef, ReflectSerialize, Struct,
-    Tuple, TupleStruct, TypeRegistry, VariantType,
+    Array, Enum, List, Map, Reflect, ReflectRef, ReflectSerialize, Struct, Tuple, TupleStruct,
+    TypeRegistry, VariantType,
 };
 use serde::ser::SerializeTuple;
 use serde::{
@@ -63,10 +63,9 @@ impl<'a> Serialize for ReflectSerializer<'a> {
     where
         S: serde::Serializer,
     {
-        let mut state = serializer.serialize_map(Some(2))?;
-        state.serialize_entry(type_fields::TYPE, self.value.type_name())?;
+        let mut state = serializer.serialize_map(Some(1))?;
         state.serialize_entry(
-            type_fields::VALUE,
+            self.value.type_name(),
             &TypedReflectSerializer::new(self.value, self.registry),
         )?;
         state.end()
@@ -469,8 +468,7 @@ mod tests {
 
         let output = ron::ser::to_string_pretty(&serializer, config).unwrap();
         let expected = r#"{
-    "type": "bevy_reflect::serde::ser::tests::MyStruct",
-    "value": {
+    "bevy_reflect::serde::ser::tests::MyStruct": {
         "primitive_value": 123,
         "option_value": Some("Hello world!"),
         "tuple_value": (3.1415927, 1337),
@@ -520,8 +518,7 @@ mod tests {
         let serializer = ReflectSerializer::new(&value, &registry);
         let output = ron::ser::to_string_pretty(&serializer, config.clone()).unwrap();
         let expected = r#"{
-    "type": "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum",
-    "value": {
+    "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum": {
         "Unit": (),
     },
 }"#;
@@ -532,8 +529,7 @@ mod tests {
         let serializer = ReflectSerializer::new(&value, &registry);
         let output = ron::ser::to_string_pretty(&serializer, config.clone()).unwrap();
         let expected = r#"{
-    "type": "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum",
-    "value": {
+    "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum": {
         "NewType": (123),
     },
 }"#;
@@ -544,8 +540,7 @@ mod tests {
         let serializer = ReflectSerializer::new(&value, &registry);
         let output = ron::ser::to_string_pretty(&serializer, config.clone()).unwrap();
         let expected = r#"{
-    "type": "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum",
-    "value": {
+    "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum": {
         "Tuple": (1.23, 3.21),
     },
 }"#;
@@ -558,8 +553,7 @@ mod tests {
         let serializer = ReflectSerializer::new(&value, &registry);
         let output = ron::ser::to_string_pretty(&serializer, config).unwrap();
         let expected = r#"{
-    "type": "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum",
-    "value": {
+    "bevy_reflect::serde::ser::tests::enum_should_serialize::MyEnum": {
         "Struct": {
             "value": "I <3 Enums",
         },

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -389,7 +389,7 @@ impl<'a> Serialize for ArraySerializer<'a> {
 mod tests {
     use crate as bevy_reflect;
     use crate::serde::ReflectSerializer;
-    use crate::{Reflect, ReflectSerialize, TypeRegistry};
+    use crate::{FromReflect, Reflect, ReflectSerialize, TypeRegistry};
     use bevy_utils::HashMap;
     use ron::ser::PrettyConfig;
     use serde::Serialize;
@@ -399,6 +399,7 @@ mod tests {
     struct MyStruct {
         primitive_value: i8,
         option_value: Option<String>,
+        option_value_complex: Option<SomeStruct>,
         tuple_value: (f32, usize),
         list_value: Vec<i32>,
         array_value: [i32; 5],
@@ -412,7 +413,7 @@ mod tests {
         custom_serialize: CustomSerialize,
     }
 
-    #[derive(Reflect, Debug, PartialEq, Serialize)]
+    #[derive(Reflect, FromReflect, Debug, PartialEq)]
     struct SomeStruct {
         foo: i64,
     }
@@ -428,6 +429,11 @@ mod tests {
         Struct { foo: String },
     }
 
+    #[derive(Reflect, Debug, PartialEq, Serialize)]
+    struct SomeSerializableStruct {
+        foo: i64,
+    }
+
     /// Implements a custom serialize using `#[reflect(Serialize)]`.
     ///
     /// For testing purposes, this just uses the generated one from deriving Serialize.
@@ -436,7 +442,7 @@ mod tests {
     struct CustomSerialize {
         value: usize,
         #[serde(rename = "renamed")]
-        inner_struct: SomeStruct,
+        inner_struct: SomeSerializableStruct,
     }
 
     fn get_registry() -> TypeRegistry {
@@ -445,6 +451,8 @@ mod tests {
         registry.register::<SomeStruct>();
         registry.register::<SomeTupleStruct>();
         registry.register::<CustomSerialize>();
+        registry.register::<SomeSerializableStruct>();
+        registry.register_type_data::<SomeSerializableStruct, ReflectSerialize>();
         registry.register::<String>();
         registry.register::<Option<String>>();
         registry.register_type_data::<Option<String>, ReflectSerialize>();
@@ -459,6 +467,7 @@ mod tests {
         let input = MyStruct {
             primitive_value: 123,
             option_value: Some(String::from("Hello world!")),
+            option_value_complex: Some(SomeStruct { foo: 123 }),
             tuple_value: (PI, 1337),
             list_value: vec![-2, -1, 0, 1, 2],
             array_value: [-2, -1, 0, 1, 2],
@@ -473,7 +482,7 @@ mod tests {
             },
             custom_serialize: CustomSerialize {
                 value: 100,
-                inner_struct: SomeStruct { foo: 101 },
+                inner_struct: SomeSerializableStruct { foo: 101 },
             },
         };
 
@@ -489,6 +498,11 @@ mod tests {
     "bevy_reflect::serde::ser::tests::MyStruct": {
         "primitive_value": 123,
         "option_value": Some("Hello world!"),
+        "option_value_complex": {
+            "Some": ({
+                "foo": 123,
+            }),
+        },
         "tuple_value": (3.1415927, 1337),
         "list_value": [
             -2,

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -416,9 +416,9 @@ mod tests {
     #[derive(Reflect, Debug, PartialEq)]
     struct SomeTupleStruct(String);
 
-    /// Implements a custom serialize using #[reflect(Serialize)].
+    /// Implements a custom serialize using `#[reflect(Serialize)]`.
     ///
-    /// For testing purposes, this is just the auto-generated one from deriving.
+    /// For testing purposes, this just uses the generated one from deriving Serialize.
     #[derive(Reflect, Debug, PartialEq, Serialize)]
     #[reflect(Serialize)]
     struct CustomSerialize {

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -405,6 +405,10 @@ mod tests {
         map_value: HashMap<u8, usize>,
         struct_value: SomeStruct,
         tuple_struct_value: SomeTupleStruct,
+        unit_enum: SomeEnum,
+        newtype_enum: SomeEnum,
+        tuple_enum: SomeEnum,
+        struct_enum: SomeEnum,
         custom_serialize: CustomSerialize,
     }
 
@@ -415,6 +419,14 @@ mod tests {
 
     #[derive(Reflect, Debug, PartialEq)]
     struct SomeTupleStruct(String);
+
+    #[derive(Reflect, Debug, PartialEq)]
+    enum SomeEnum {
+        Unit,
+        NewType(usize),
+        Tuple(f32, f32),
+        Struct { foo: String },
+    }
 
     /// Implements a custom serialize using `#[reflect(Serialize)]`.
     ///
@@ -453,6 +465,12 @@ mod tests {
             map_value: map,
             struct_value: SomeStruct { foo: 999999999 },
             tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
+            unit_enum: SomeEnum::Unit,
+            newtype_enum: SomeEnum::NewType(123),
+            tuple_enum: SomeEnum::Tuple(1.23, 3.21),
+            struct_enum: SomeEnum::Struct {
+                foo: String::from("Struct variant value"),
+            },
             custom_serialize: CustomSerialize {
                 value: 100,
                 inner_struct: SomeStruct { foo: 101 },
@@ -487,6 +505,20 @@ mod tests {
             "foo": 999999999,
         },
         "tuple_struct_value": ("Tuple Struct"),
+        "unit_enum": {
+            "Unit": (),
+        },
+        "newtype_enum": {
+            "NewType": (123),
+        },
+        "tuple_enum": {
+            "Tuple": (1.23, 3.21),
+        },
+        "struct_enum": {
+            "Struct": {
+                "foo": "Struct variant value",
+            },
+        },
         "custom_serialize": (
             value: 100,
             renamed: (

--- a/crates/bevy_reflect/src/serde/type_data.rs
+++ b/crates/bevy_reflect/src/serde/type_data.rs
@@ -31,4 +31,14 @@ impl SerializationData {
     pub fn is_ignored_field(&self, index: usize) -> bool {
         self.ignored_field_indices.contains(&index)
     }
+
+    /// Returns the number of ignored fields.
+    pub fn len(&self) -> usize {
+        self.ignored_field_indices.len()
+    }
+
+    /// Returns true if there are no ignored fields.
+    pub fn is_empty(&self) -> bool {
+        self.ignored_field_indices.is_empty()
+    }
 }

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -94,10 +94,7 @@ impl StructInfo {
                 (name, index)
             })
             .collect::<HashMap<_, _>>();
-        let field_names = fields
-            .iter()
-            .map(|field| field.name())
-            .collect::<Vec<_>>();
+        let field_names = fields.iter().map(|field| field.name()).collect::<Vec<_>>();
 
         Self {
             name,

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -73,7 +73,6 @@ pub struct StructInfo {
     type_name: &'static str,
     type_id: TypeId,
     fields: Box<[NamedField]>,
-    field_names: Box<[&'static str]>,
     field_indices: HashMap<&'static str, usize>,
 }
 
@@ -91,13 +90,11 @@ impl StructInfo {
             .enumerate()
             .map(|(index, field)| (field.name(), index))
             .collect::<HashMap<_, _>>();
-        let field_names = fields.iter().map(|field| field.name()).collect::<Vec<_>>();
 
         Self {
             name,
             type_name: std::any::type_name::<T>(),
             type_id: TypeId::of::<T>(),
-            field_names: field_names.into_boxed_slice(),
             fields: fields.to_vec().into_boxed_slice(),
             field_indices,
         }
@@ -108,11 +105,6 @@ impl StructInfo {
         self.field_indices
             .get(name)
             .map(|index| &self.fields[*index])
-    }
-
-    /// A slice containing the names of all fields in order.
-    pub fn field_names(&self) -> &[&'static str] {
-        &self.field_names
     }
 
     /// Get the field at the given index.

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -89,10 +89,7 @@ impl StructInfo {
         let field_indices = fields
             .iter()
             .enumerate()
-            .map(|(index, field)| {
-                let name = field.name().clone();
-                (name, index)
-            })
+            .map(|(index, field)| (field.name(), index))
             .collect::<HashMap<_, _>>();
         let field_names = fields.iter().map(|field| field.name()).collect::<Vec<_>>();
 

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -49,6 +49,7 @@ pub trait TupleStruct: Reflect {
 /// A container for compile-time tuple struct info.
 #[derive(Clone, Debug)]
 pub struct TupleStructInfo {
+    name: &'static str,
     type_name: &'static str,
     type_id: TypeId,
     fields: Box<[UnnamedField]>,
@@ -59,10 +60,12 @@ impl TupleStructInfo {
     ///
     /// # Arguments
     ///
+    /// * `name`: The name of this struct (_without_ generics or lifetimes)
     /// * `fields`: The fields of this struct in the order they are defined
     ///
-    pub fn new<T: Reflect>(fields: &[UnnamedField]) -> Self {
+    pub fn new<T: Reflect>(name: &'static str, fields: &[UnnamedField]) -> Self {
         Self {
+            name,
             type_name: std::any::type_name::<T>(),
             type_id: TypeId::of::<T>(),
             fields: fields.to_vec().into_boxed_slice(),
@@ -82,6 +85,15 @@ impl TupleStructInfo {
     /// The total number of fields in this struct.
     pub fn field_len(&self) -> usize {
         self.fields.len()
+    }
+
+    /// The name of the struct.
+    ///
+    /// This does _not_ include any generics or lifetimes.
+    ///
+    /// For example, `foo::bar::Baz<'a, T>` would simply be `Baz`.
+    pub fn name(&self) -> &'static str {
+        self.name
     }
 
     /// The [type name] of the tuple struct.

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -40,7 +40,7 @@ use std::any::{Any, TypeId};
 ///         NamedField::new::<usize, _>("foo"),
 ///         NamedField::new::<(f32, f32), _>("bar"),
 ///       ];
-///       let info = StructInfo::new::<Self>(&fields);
+///       let info = StructInfo::new::<Self>("MyStruct", &fields);
 ///       TypeInfo::Struct(info)
 ///     })
 ///   }

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -37,8 +37,8 @@ use std::any::{Any, TypeId};
 ///     static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
 ///     CELL.get_or_set(|| {
 ///       let fields = [
-///         NamedField::new::<usize, _>("foo"),
-///         NamedField::new::<(f32, f32), _>("bar"),
+///         NamedField::new::<usize >("foo"),
+///         NamedField::new::<(f32, f32) >("bar"),
 ///       ];
 ///       let info = StructInfo::new::<Self>("MyStruct", &fields);
 ///       TypeInfo::Struct(info)

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -27,7 +27,7 @@ use std::any::{Any, TypeId};
 ///   fn type_info() -> &'static TypeInfo {
 ///     static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
 ///     CELL.get_or_set(|| {
-///       let fields = [NamedField::new::<i32, _>("bar")];
+///       let fields = [NamedField::new::<i32>("bar")];
 ///       let info = StructInfo::new::<Self>("Foo", &fields);
 ///       TypeInfo::Struct(info)
 ///     })

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -28,7 +28,7 @@ use std::any::{Any, TypeId};
 ///     static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
 ///     CELL.get_or_set(|| {
 ///       let fields = [NamedField::new::<i32, _>("bar")];
-///       let info = StructInfo::new::<Self>(&fields);
+///       let info = StructInfo::new::<Self>("Foo", &fields);
 ///       TypeInfo::Struct(info)
 ///     })
 ///   }
@@ -89,7 +89,7 @@ impl NonGenericTypeInfoCell {
 ///     static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
 ///     CELL.get_or_insert::<Self, _>(|| {
 ///       let fields = [UnnamedField::new::<T>(0)];
-///       let info = TupleStructInfo::new::<Self>(&fields);
+///       let info = TupleStructInfo::new::<Self>("Foo", &fields);
 ///       TypeInfo::TupleStruct(info)
 ///     })
 ///   }

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -1,7 +1,7 @@
 use crate::{DynamicEntity, DynamicScene};
 use anyhow::Result;
 use bevy_reflect::{
-    serde::{UntypedReflectDeserializer, ReflectSerializer},
+    serde::{ReflectSerializer, UntypedReflectDeserializer},
     Reflect, TypeRegistry, TypeRegistryArc,
 };
 use serde::{
@@ -242,7 +242,9 @@ impl<'a, 'de> Visitor<'de> for ComponentSeqVisitor<'a> {
         A: SeqAccess<'de>,
     {
         let mut dynamic_properties = Vec::new();
-        while let Some(entity) = seq.next_element_seed(UntypedReflectDeserializer::new(self.registry))? {
+        while let Some(entity) =
+            seq.next_element_seed(UntypedReflectDeserializer::new(self.registry))?
+        {
             dynamic_properties.push(entity);
         }
 

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -1,7 +1,7 @@
 use crate::{DynamicEntity, DynamicScene};
 use anyhow::Result;
 use bevy_reflect::{
-    serde::{ReflectDeserializer, ReflectSerializer},
+    serde::{UntypedReflectDeserializer, ReflectSerializer},
     Reflect, TypeRegistry, TypeRegistryArc,
 };
 use serde::{
@@ -242,7 +242,7 @@ impl<'a, 'de> Visitor<'de> for ComponentSeqVisitor<'a> {
         A: SeqAccess<'de>,
     {
         let mut dynamic_properties = Vec::new();
-        while let Some(entity) = seq.next_element_seed(ReflectDeserializer::new(self.registry))? {
+        while let Some(entity) = seq.next_element_seed(UntypedReflectDeserializer::new(self.registry))? {
             dynamic_properties.push(entity);
         }
 

--- a/examples/reflection/reflection.rs
+++ b/examples/reflection/reflection.rs
@@ -7,7 +7,7 @@
 use bevy::{
     prelude::*,
     reflect::{
-        serde::{ReflectDeserializer, ReflectSerializer},
+        serde::{ReflectSerializer, UntypedReflectDeserializer},
         DynamicStruct,
     },
 };
@@ -81,7 +81,7 @@ fn setup(type_registry: Res<AppTypeRegistry>) {
     info!("{}\n", ron_string);
 
     // Dynamic properties can be deserialized
-    let reflect_deserializer = ReflectDeserializer::new(&type_registry);
+    let reflect_deserializer = UntypedReflectDeserializer::new(&type_registry);
     let mut deserializer = ron::de::Deserializer::from_str(&ron_string).unwrap();
     let reflect_value = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 


### PR DESCRIPTION
> Note: This is rebased off #4561 and can be viewed as a competitor to that PR. See `Comparison with #4561` section for details.

# Objective

The current serialization format used by `bevy_reflect` is both verbose and error-prone. Taking the following structs[^1] for example:

```rust
// -- src/inventory.rs

#[derive(Reflect)]
struct Inventory {
  id: String,
  max_storage: usize,
  items: Vec<Item>
}

#[derive(Reflect)]
struct Item {
  name: String
}
```

Given an inventory of a single item, this would serialize to something like:

```rust
// -- assets/inventory.ron

{
  "type": "my_game::inventory::Inventory",
  "struct": {
    "id": {
      "type": "alloc::string::String",
      "value": "inv001",
    },
    "max_storage": {
      "type": "usize",
      "value": 10
    },
    "items": {
      "type": "alloc::vec::Vec<alloc::string::String>",
      "list": [
        {
          "type": "my_game::inventory::Item",
          "struct": {
            "name": {
              "type": "alloc::string::String",
              "value": "Pickaxe"
            },
          },
        },
      ],
    },
  },
}
```

Aside from being really long and difficult to read, it also has a few "gotchas" that users need to be aware of if they want to edit the file manually. A major one is the requirement that you use the proper keys for a given type. For structs, you need `"struct"`. For lists, `"list"`. For tuple structs, `"tuple_struct"`. And so on.

It also ***requires*** that the `"type"` entry come before the actual data. Despite being a map— which in programming is almost always orderless by default— the entries need to be in a particular order. Failure to follow the ordering convention results in a failure to deserialize the data.

This makes it very prone to errors and annoyances.


## Solution

Using #4042, we can remove a lot of the boilerplate and metadata needed by this older system. Since we now have static access to type information, we can simplify our serialized data to look like:

```rust
// -- assets/inventory.ron

{
  "my_game::inventory::Inventory": (
    id: "inv001",
    max_storage: 10,
    items: [
      (
        name: "Pickaxe"
      ),
    ],
  ),
}
```

This is much more digestible and a lot less error-prone (no more key requirements and no more extra type names).

Additionally, it is a lot more familiar to users as it follows conventional serde mechanics. For example, the struct is represented with `(...)` when serialized to RON.

#### Custom Serialization

Additionally, this PR adds the opt-in ability to specify a custom serde implementation to be used rather than the one created via reflection. For example[^1]:

```rust
// -- src/inventory.rs

#[derive(Reflect, Serialize)]
#[reflect(Serialize)]
struct Item {
  #[serde(alias = "id")]
  name: String
}
```

```rust
// -- assets/inventory.ron

{
  "my_game::inventory::Inventory": (
    id: "inv001",
    max_storage: 10,
    items: [
      (
        id: "Pickaxe"
      ),
    ],
  ),
},
```

By allowing users to define their own serialization methods, we do two things:

1. We give more control over how data is serialized/deserialized to the end user
2. We avoid having to re-define serde's attributes and forcing users to apply both (e.g. we don't need a `#[reflect(alias)]` attribute).

### Improved Formats

One of the improvements this PR provides is the ability to represent data in ways that are more conventional and/or familiar to users. Many users are familiar with RON so here are some of the ways we can now represent data in RON:

###### Structs

```js
{
  "my_crate::Foo": (
    bar: 123
  )
}
// OR
{
  "my_crate::Foo": Foo(
    bar: 123
  )
}
```

<details>
<summary>Old Format</summary>

```js
{
  "type": "my_crate::Foo",
  "struct": {
    "bar": {
      "type": "usize",
      "value": 123
    }
  }
}
```

</details>

###### Tuples

```js
{
  "(f32, f32)": (1.0, 2.0)
}
```

<details>
<summary>Old Format</summary>

```js
{
  "type": "(f32, f32)",
  "tuple": [
    {
      "type": "f32",
      "value": 1.0
    },
    {
      "type": "f32",
      "value": 2.0
    }
  ]
}
```

</details>

###### Tuple Structs

```js
{
  "my_crate::Bar": ("Hello World!")
}
// OR
{
  "my_crate::Bar": Bar("Hello World!")
}
```

<details>
<summary>Old Format</summary>

```js
{
  "type": "my_crate::Bar",
  "tuple_struct": [
    {
      "type": "alloc::string::String",
      "value": "Hello World!"
    }
  ]
}
```

</details>

###### Arrays

It may be a bit surprising to some, but arrays now also use the tuple format. This is because they essentially _are_ tuples (a sequence of values with a fixed size), but only allow for homogenous types. Additionally, this is how RON handles them and is probably a result of the 32-capacity limit imposed on them (both by [serde](https://docs.rs/serde/latest/serde/trait.Serialize.html#impl-Serialize-for-%5BT%3B%2032%5D) and by [bevy_reflect](https://docs.rs/bevy/latest/bevy/reflect/trait.GetTypeRegistration.html#impl-GetTypeRegistration-for-%5BT%3B%2032%5D)).

```js
{
  "[i32; 3]": (1, 2, 3)
}
```

<details>
<summary>Old Format</summary>

```js
{
  "type": "[i32; 3]",
  "array": [
    {
      "type": "i32",
      "value": 1
    },
    {
      "type": "i32",
      "value": 2
    },
    {
      "type": "i32",
      "value": 3
    }
  ]
}
```

</details>

###### Enums

To make things simple, I'll just put a struct variant here, but the style applies to all variant types:

```js
{
  "my_crate::ItemType": Consumable(
    name: "Healing potion"
  )
}
```

<details>
<summary>Old Format</summary>

```js
{
  "type": "my_crate::ItemType",
  "enum": {
    "variant": "Consumable",
    "struct": {
      "name": {
        "type": "alloc::string::String",
        "value": "Healing potion"
      }
    }
  }
}
```

</details>

### Comparison with #4561

This PR is a rebased version of #4561. The reason for the split between the two is because this PR creates a _very_ different scene format. You may notice that the PR descriptions for either PR are pretty similar. This was done to better convey the changes depending on which (if any) gets merged first. If #4561 makes it in first, I will update this PR description accordingly.

---

## Changelog

* Re-worked serialization/deserialization for reflected types
* Added `TypedReflectDeserializer` for deserializing data with known `TypeInfo`
* Renamed `ReflectDeserializer` to `UntypedReflectDeserializer` 
* ~~Replaced usages of `deserialize_any` with `deserialize_map` for non-self-describing formats~~ Reverted this change since there are still some issues that need to be sorted out (in a separate PR). By reverting this, crates like `bincode` can throw an error when attempting to deserialize non-self-describing formats (`bincode` results in `DeserializeAnyNotSupported`)
* Structs, tuples, tuple structs, arrays, and enums are now all de/serialized using conventional serde methods

## Migration Guide

* This PR reduces the verbosity of the scene format. Scenes will need to be updated accordingly:

```js
// Old format
{
  "type": "my_game::item::Item",
  "struct": {
    "id": {
      "type": "alloc::string::String",
      "value": "bevycraft:stone",
    },
    "tags": {
      "type": "alloc::vec::Vec<alloc::string::String>",
      "list": [
        {
          "type": "alloc::string::String",
          "value": "material"
        },
      ],
    },
}

// New format
{
  "my_game::item::Item": (
    id: "bevycraft:stone",
    tags: ["material"]
  )
}
```

[^1]: Some derives omitted for brevity.