### PR TITLE
[Merged by Bors] - Correctly parse labels with '#'

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -154,7 +154,7 @@ impl<'a, 'b> From<&'a AssetPath<'b>> for AssetPathId {
 
 impl<'a> From<&'a str> for AssetPath<'a> {
     fn from(asset_path: &'a str) -> Self {
-        let mut parts = asset_path.split('#');
+        let mut parts = asset_path.splitn(2, '#');
         let path = Path::new(parts.next().expect("Path must be set."));
         let label = parts.next();
         AssetPath {


### PR DESCRIPTION
# Objective

- Fixes #5707 

## Solution

- Used `splitn` instead of `split` to collect the rest of the string into the label after the first '#'.

---

