### PR TITLE
[Merged by Bors] - SystemParam for the name of the system you are currently in

### DIFF
--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -59,6 +59,7 @@
 //! - [`NonSendMut`] and `Option<NonSendMut>`
 //! - [`&World`](crate::world::World)
 //! - [`RemovedComponents`]
+//! - [`SystemName`]
 //! - [`SystemChangeTick`]
 //! - [`Archetypes`](crate::archetype::Archetypes) (Provides Archetype metadata)
 //! - [`Bundles`](crate::bundle::Bundles) (Provides Bundles metadata)

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1309,7 +1309,6 @@ impl<'w, 's> SystemParamFetch<'w, 's> for SystemChangeTickState {
 ///
 /// This is not a reliable identifier, it is more so useful for debugging
 /// purposes of finding where a system parameter is being used incorrectly.
-#[derive(Debug)]
 pub struct SystemName<'s> {
     name: &'s str,
 }
@@ -1336,6 +1335,20 @@ impl<'s> AsRef<str> for SystemName<'s> {
 impl<'s> Into<&'s str> for SystemName<'s> {
     fn into(self) -> &'s str {
         self.name
+    }
+}
+
+impl<'s> std::fmt::Debug for SystemName<'s> {
+    #[inline(always)]
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_tuple("SystemName").field(&self.name()).finish()
+    }
+}
+
+impl<'s> std::fmt::Display for SystemName<'s> {
+    #[inline(always)]
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.name(), f)
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1332,9 +1332,9 @@ impl<'s> AsRef<str> for SystemName<'s> {
     }
 }
 
-impl<'s> Into<&'s str> for SystemName<'s> {
-    fn into(self) -> &'s str {
-        self.name
+impl<'s> From<SystemName<'s>> for &'s str {
+    fn from(name: SystemName<'s>) -> &'s str {
+        name.name
     }
 }
 
@@ -1357,7 +1357,7 @@ impl<'s> SystemParam for SystemName<'s> {
 }
 
 // SAFETY: Only reads internal system state
-unsafe impl<'a> ReadOnlySystemParamFetch for SystemNameState {}
+unsafe impl ReadOnlySystemParamFetch for SystemNameState {}
 
 /// The [`SystemParamState`] of [`SystemName`].
 #[doc(hidden)]

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1305,7 +1305,7 @@ impl<'w, 's> SystemParamFetch<'w, 's> for SystemChangeTickState {
     }
 }
 
-/// Name of the system that corresponds to this [`SystemState`].
+/// Name of the system that corresponds to this [`crate::system::SystemState`].
 ///
 /// This is not a reliable identifier, it is more so useful for debugging
 /// purposes of finding where a system parameter is being used incorrectly.


### PR DESCRIPTION
# Objective
- Similar to `SystemChangeTick`, probably somewhat useful for debugging messages.

---

## Changelog

- Added `SystemName` which copies the `SystemMeta::name` field so it can be accessed within a system.