### PR TITLE
[Merged by Bors] - Rework manual event iterator so we can actually name the type

### DIFF
--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -427,7 +427,7 @@ impl<'a, E: Event> ManualEventIteratorWithId<'a, E> {
         Self {
             reader,
             chain,
-            oldest_id: event.oldest_id(),
+            oldest_id: events.oldest_id(),
         }
     }
 

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -399,7 +399,7 @@ impl<'a, E: Event> DoubleEndedIterator for ManualEventIterator<'a, E> {
 pub struct ManualEventIteratorWithId<'a, E: Event> {
     reader: &'a mut ManualEventReader<E>,
     chain: Chain<Iter<'a, EventInstance<E>>, Iter<'a, EventInstance<E>>>,
-    oldest_id: usize,
+    unread: usize,
 }
 
 impl<'a, E: Event> ManualEventIteratorWithId<'a, E> {
@@ -427,7 +427,7 @@ impl<'a, E: Event> ManualEventIteratorWithId<'a, E> {
         Self {
             reader,
             chain,
-            oldest_id: events.oldest_id(),
+            unread: unread_count,
         }
     }
 
@@ -447,6 +447,7 @@ impl<'a, E: Event> Iterator for ManualEventIteratorWithId<'a, E> {
         {
             Some(item) => {
                 self.reader.last_event_count += 1;
+                self.unread -= 1;
                 Some(item)
             }
             None => None,
@@ -466,7 +467,7 @@ impl<'a, E: Event> DoubleEndedIterator for ManualEventIteratorWithId<'a, E> {
             .map(|instance| (&instance.event, instance.event_id))
         {
             Some(item) => {
-                self.oldest_id -= 1;
+                self.unread -= 1;
                 Some(item)
             }
             None => None,
@@ -476,7 +477,7 @@ impl<'a, E: Event> DoubleEndedIterator for ManualEventIteratorWithId<'a, E> {
 
 impl<'a, E: Event> ExactSizeIterator for ManualEventIteratorWithId<'a, E> {
     fn len(&self) -> usize {
-        self.oldest_id.saturating_sub(self.reader.last_event_count)
+        self.unread
     }
 }
 

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -572,10 +572,9 @@ impl<E: Event> Events<E> {
         let sequence = self.sequence(id);
         let index = id.saturating_sub(sequence.start_event_count);
 
-        match sequence.get(index) {
-            Some(instance) => Some((&instance.event, instance.event_id)),
-            None => None,
-        }
+        sequence
+            .get(index)
+            .map(|instance| (&instance.event, instance.event_id))
     }
 
     /// Oldest id still in the events buffer.

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -4,7 +4,7 @@ use crate as bevy_ecs;
 use crate::system::{Local, Res, ResMut, Resource, SystemParam};
 use bevy_utils::tracing::trace;
 use std::ops::{Deref, DerefMut};
-use std::{fmt, hash::Hash, marker::PhantomData, slice::Iter, iter::Chain};
+use std::{fmt, hash::Hash, iter::Chain, marker::PhantomData, slice::Iter};
 /// A type that can be stored in an [`Events<E>`] resource
 /// You can conveniently access events using the [`EventReader`] and [`EventWriter`] system parameter.
 ///
@@ -441,7 +441,11 @@ impl<'a, E: Event> ManualEventIteratorWithId<'a, E> {
 impl<'a, E: Event> Iterator for ManualEventIteratorWithId<'a, E> {
     type Item = (&'a E, EventId<E>);
     fn next(&mut self) -> Option<Self::Item> {
-        match self.chain.next().map(|instance| (&instance.event, instance.event_id)) {
+        match self
+            .chain
+            .next()
+            .map(|instance| (&instance.event, instance.event_id))
+        {
             Some(item) => {
                 self.reader.last_event_count += 1;
                 Some(item)
@@ -457,7 +461,9 @@ impl<'a, E: Event> Iterator for ManualEventIteratorWithId<'a, E> {
 
 impl<'a, E: Event> DoubleEndedIterator for ManualEventIteratorWithId<'a, E> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.chain.next_back().map(|instance| (&instance.event, instance.event_id))
+        self.chain
+            .next_back()
+            .map(|instance| (&instance.event, instance.event_id))
     }
 }
 

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -377,6 +377,10 @@ impl<'a, E: Event> Iterator for ManualEventIterator<'a, E> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(event, _)| event)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl<'a, E: Event> ExactSizeIterator for ManualEventIterator<'a, E> {
@@ -434,6 +438,10 @@ impl<'a, E: Event> Iterator for ManualEventIteratorWithId<'a, E> {
             }
             None => None,
         }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
     }
 }
 

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -460,9 +460,11 @@ impl<'a, E: Event> Iterator for ManualEventIteratorWithId<'a, E> {
 
 impl<'a, E: Event> DoubleEndedIterator for ManualEventIteratorWithId<'a, E> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        match self.chain
+        match self
+            .chain
             .next_back()
-            .map(|instance| (&instance.event, instance.event_id)) {
+            .map(|instance| (&instance.event, instance.event_id))
+        {
             Some(item) => {
                 self.oldest_id -= 1;
                 Some(item)

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -402,6 +402,10 @@ pub struct ManualEventIteratorWithId<'a, E: Event> {
     unread: usize,
 }
 
+fn event_trace<E: Event>(id: EventId<E>) {
+    trace!("EventReader::iter() -> {}", id);
+}
+
 impl<'a, E: Event> ManualEventIteratorWithId<'a, E> {
     pub fn new(reader: &'a mut ManualEventReader<E>, events: &'a Events<E>) -> Self {
         // Check if we are behind the oldest event.
@@ -446,6 +450,7 @@ impl<'a, E: Event> Iterator for ManualEventIteratorWithId<'a, E> {
             .map(|instance| (&instance.event, instance.event_id))
         {
             Some(item) => {
+                event_trace(item.1);
                 self.reader.last_event_count += 1;
                 self.unread -= 1;
                 Some(item)
@@ -467,6 +472,7 @@ impl<'a, E: Event> DoubleEndedIterator for ManualEventIteratorWithId<'a, E> {
             .map(|instance| (&instance.event, instance.event_id))
         {
             Some(item) => {
+                event_trace(item.1);
                 self.unread -= 1;
                 Some(item)
             }

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -408,13 +408,6 @@ fn event_trace<E: Event>(id: EventId<E>) {
 
 impl<'a, E: Event> ManualEventIteratorWithId<'a, E> {
     pub fn new(reader: &'a mut ManualEventReader<E>, events: &'a Events<E>) -> Self {
-        // Check if we are behind the oldest event.
-        //
-        // This means we missed events.
-        if reader.last_event_count < events.oldest_id() {
-            reader.last_event_count = events.oldest_id();
-        }
-
         let a_index = (reader.last_event_count).saturating_sub(events.events_a.start_event_count);
         let b_index = (reader.last_event_count).saturating_sub(events.events_b.start_event_count);
         let a = events.events_a.get(a_index..).unwrap_or_default();
@@ -423,8 +416,7 @@ impl<'a, E: Event> ManualEventIteratorWithId<'a, E> {
         let unread_count = a.len() + b.len();
         // Ensure `len` is implemented correctly
         debug_assert_eq!(unread_count, reader.len(events));
-
-        //self.last_event_count = events.event_count - unread_count;
+        reader.last_event_count = events.event_count - unread_count;
         // Iterate the oldest first, then the newer events
         let chain = a.iter().chain(b.iter());
 


### PR DESCRIPTION
# Objective
- Be able to name the type that `ManualEventReader::iter/iter_with_id` returns and `EventReader::iter/iter_with_id` by proxy.
  Currently for the purpose of https://github.com/bevyengine/bevy/pull/5719

## Solution
- Create a custom `Iterator` type.
