### PR TITLE
[Merged by Bors] - register missing reflect types

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -16,7 +16,7 @@ pub mod prelude {
 
 use bevy_app::prelude::*;
 use bevy_ecs::entity::Entity;
-use bevy_utils::HashSet;
+use bevy_utils::{Duration, HashSet, Instant};
 use std::borrow::Cow;
 use std::ops::Range;
 
@@ -45,7 +45,9 @@ fn register_rust_types(app: &mut App) {
         .register_type::<String>()
         .register_type::<HashSet<String>>()
         .register_type::<Option<String>>()
-        .register_type::<Cow<'static, str>>();
+        .register_type::<Cow<'static, str>>()
+        .register_type::<Duration>()
+        .register_type::<Instant>();
 }
 
 fn register_math_types(app: &mut App) {

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -43,6 +43,7 @@ pub struct Core3dPlugin;
 impl Plugin for Core3dPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Camera3d>()
+            .register_type::<Camera3dDepthLoadOp>()
             .add_plugin(ExtractComponentPlugin::<Camera3d>::default());
 
         let render_app = match app.get_sub_app_mut(RenderApp) {

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -11,10 +11,13 @@ pub mod prelude {
     };
 }
 
-use crate::{clear_color::ClearColor, core_2d::Core2dPlugin, core_3d::Core3dPlugin};
+use crate::{
+    clear_color::{ClearColor, ClearColorConfig},
+    core_2d::Core2dPlugin,
+    core_3d::Core3dPlugin,
+};
 use bevy_app::{App, Plugin};
 use bevy_render::extract_resource::ExtractResourcePlugin;
-use clear_color::ClearColorConfig;
 
 #[derive(Default)]
 pub struct CorePipelinePlugin;

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -14,6 +14,7 @@ pub mod prelude {
 use crate::{clear_color::ClearColor, core_2d::Core2dPlugin, core_3d::Core3dPlugin};
 use bevy_app::{App, Plugin};
 use bevy_render::extract_resource::ExtractResourcePlugin;
+use clear_color::ClearColorConfig;
 
 #[derive(Default)]
 pub struct CorePipelinePlugin;
@@ -21,6 +22,7 @@ pub struct CorePipelinePlugin;
 impl Plugin for CorePipelinePlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<ClearColor>()
+            .register_type::<ClearColorConfig>()
             .init_resource::<ClearColor>()
             .add_plugin(ExtractResourcePlugin::<ClearColor>::default())
             .add_plugin(Core2dPlugin)

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -18,6 +18,7 @@ bevy_app = { path = "../bevy_app", version = "0.9.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.9.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev" }
 
 # other
 serde = { version = "1", features = ["derive"], optional = true }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -23,7 +23,6 @@ use bevy_reflect::FromReflect;
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::HashSet;
 use bevy_window::{WindowCreated, WindowId, WindowResized, Windows};
-use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, ops::Range};
 use wgpu::Extent3d;
 
@@ -32,9 +31,8 @@ use wgpu::Extent3d;
 /// The viewport defines the area on the render target to which the camera renders its image.
 /// You can overlay multiple cameras in a single window using viewports to create effects like
 /// split screen, minimaps, and character viewers.
-// TODO: remove reflect_value when possible
-#[derive(Reflect, FromReflect, Debug, Clone, Serialize, Deserialize)]
-#[reflect_value(Default, Serialize, Deserialize)]
+#[derive(Reflect, FromReflect, Debug, Clone)]
+#[reflect(Default)]
 pub struct Viewport {
     /// The physical position to render this viewport to within the [`RenderTarget`] of this [`Camera`].
     /// (0,0) corresponds to the top-left corner

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -21,6 +21,7 @@ pub struct CameraPlugin;
 impl Plugin for CameraPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Camera>()
+            .register_type::<Viewport>()
             .register_type::<Visibility>()
             .register_type::<ComputedVisibility>()
             .register_type::<VisibleEntities>()

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -57,6 +57,7 @@ impl Plugin for SpritePlugin {
         shaders.set_untracked(SPRITE_SHADER_HANDLE, sprite_shader);
         app.add_asset::<TextureAtlas>()
             .register_type::<Sprite>()
+            .register_type::<Anchor>()
             .register_type::<Mesh2dHandle>()
             .add_plugin(Mesh2dRenderPlugin)
             .add_plugin(ColorMaterialPlugin);

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -43,6 +43,8 @@ impl Plugin for TextPlugin {
         app.add_asset::<Font>()
             .add_asset::<FontAtlasSet>()
             .register_type::<Text>()
+            .register_type::<TextSection>()
+            .register_type::<TextAlignment>()
             .register_type::<VerticalAlign>()
             .register_type::<HorizontalAlign>()
             .init_asset_loader::<FontLoader>()

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -36,6 +36,8 @@ impl Plugin for TimePlugin {
         app.init_resource::<Time>()
             .init_resource::<FixedTimesteps>()
             .register_type::<Timer>()
+            .register_type::<Time>()
+            .register_type::<Stopwatch>()
             // time system is added as an "exclusive system" to ensure it runs before other systems
             // in CoreStage::First
             .add_system_to_stage(


### PR DESCRIPTION
# Objective

- While generating https://github.com/jakobhellermann/bevy_reflect_ts_type_export/blob/main/generated/types.ts, I noticed that some types that implement `Reflect` did not register themselves
- `Viewport` isn't reflect but can be (there's a TODO)


## Solution

- register all reflected types
- derive `Reflect` for `Viewport`


## Changelog
- more types are not registered in the type registry
- remove `Serialize`, `Deserialize` impls from `Viewport`


I also decided to remove the `Serialize, Deserialize` from the `Viewport`, since they were (AFAIK) only used for reflection, which now is done without serde. So this is technically a breaking change for people who relied on that impl directly.
Personally I don't think that every bevy type should implement `Serialize, Deserialize`, as that would lead to a ton of code generation that mostly isn't necessary because we can do the same with `Reflect`, but if this is deemed controversial I can remove it from this PR.

## Migration Guide
- `KeyCode` now implements `Reflect` not as `reflect_value`, but with proper struct reflection. The `Serialize` and `Deserialize` impls were removed, now that they are no longer required for scene serialization.