### PR TITLE
[Merged by Bors] - fixes the types for Vec3 and Quat in scene example to remove WARN from the logs

### DIFF
--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -6,15 +6,15 @@
         "type": "bevy_transform::components::transform::Transform",
         "struct": {
           "translation": {
-            "type": "glam::vec3::Vec3",
+            "type": "glam::f32::vec3::Vec3",
             "value": (0.0, 0.0, 0.0),
           },
           "rotation": {
-            "type": "glam::quat::Quat",
+            "type": "glam::f32::scalar::quat::Quat",
             "value": (0.0, 0.0, 0.0, 1.0),
           },
           "scale": {
-            "type": "glam::vec3::Vec3",
+            "type": "glam::f32::vec3::Vec3",
             "value": (1.0, 1.0, 1.0),
           },
         },


### PR DESCRIPTION
# Objective
- Fixes #5745.

## Solution
- Changes the Vec3 and Quat types.