### PR TITLE
[Merged by Bors] - Replace fixed timestep in `alien_cake_addict` example with timer

### DIFF
--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -298,8 +298,7 @@ fn spawn_bonus(
     mut game: ResMut<Game>,
 ) {
     // make sure we wait enough time before spawning the next cake
-    timer.0.tick(time.delta());
-    if !timer.0.finished() {
+    if !timer.0.tick(time.delta()).finished() {
         return;
     }
 


### PR DESCRIPTION
# Objective

Examples should use the correct tools for the job.

## Solution

A fixed timestep, by design, can step multiple times consecutively in a single update.

That property used to crash the `alien_cake_addict` example (#2525), which was "fixed" in #3411 (by just not panicking). The proper fix is to use a timer instead, since the system is supposed to spawn a cake every 5 seconds. 

---

A timer guarantees a minimum duration. A fixed timestep guarantees a fixed number of steps per second.
Each one works by essentially sacrificing the other's guarantee.

You can use them together, but no other systems are timestep-based in this example, so the timer is enough.