### PR TITLE
[Merged by Bors] - Add AUTO and UNDEFINED const constructors for `Size`

### DIFF
--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -214,12 +214,18 @@ impl Size {
     pub fn new(width: Val, height: Val) -> Self {
         Size { width, height }
     }
-    
+
     /// Creates a Size where both values are [`Val::Auto`].
-    pub const AUTO: Size = Size { width: Val::Auto, height: Val::Auto };
+    pub const AUTO: Size = Size {
+        width: Val::Auto,
+        height: Val::Auto,
+    };
 
     /// Creates a Size where both values are [`Val::Undefined`].
-    pub const UNDEFINED: Size = Size { width: Val::Undefined, height: Val::Undefined };
+    pub const UNDEFINED: Size = Size {
+        width: Val::Undefined,
+        height: Val::Undefined,
+    };
 }
 
 impl Add<Vec2> for Size {

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -214,6 +214,12 @@ impl Size {
     pub fn new(width: Val, height: Val) -> Self {
         Size { width, height }
     }
+    
+    /// Creates a Size where both values are [`Val::Auto`].
+    pub const AUTO: Size = Size { width: Val::Auto, height: Val::Auto };
+
+    /// Creates a Size where both values are [`Val::Undefined`].
+    pub const UNDEFINED: Size = Size { width: Val::Undefined, height: Val::Undefined };
 }
 
 impl Add<Vec2> for Size {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -197,9 +197,9 @@ impl Default for Style {
             flex_grow: 0.0,
             flex_shrink: 1.0,
             flex_basis: Val::Auto,
-            size: Size::new(Val::Auto, Val::Auto),
-            min_size: Size::new(Val::Auto, Val::Auto),
-            max_size: Size::new(Val::Auto, Val::Auto),
+            size: Size::AUTO,
+            min_size: Size::AUTO,
+            max_size: Size::AUTO,
             aspect_ratio: Default::default(),
             overflow: Default::default(),
         }

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -126,7 +126,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     style: Style {
                                         flex_direction: FlexDirection::ColumnReverse,
                                         flex_grow: 1.0,
-                                        max_size: Size::new(Val::Undefined, Val::Undefined),
+                                        max_size: Size::UNDEFINED,
                                         ..default()
                                     },
                                     color: Color::NONE.into(),


### PR DESCRIPTION
# Objective

Very small convenience constructors added to `Size`. 

Does not change current examples too much but I'm working on a rather complex UI use-case where this cuts down on some extra typing :)
