### PR TITLE
[Merged by Bors] - Add a module for common system `chain`/`pipe` adapters

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -39,9 +39,9 @@ pub mod prelude {
             StageLabel, State, SystemLabel, SystemSet, SystemStage,
         },
         system::{
-            Commands, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend,
-            NonSendMut, ParallelCommands, ParamSet, Query, RemovedComponents, Res, ResMut,
-            Resource, System, SystemParamFunction,
+            adapter as system_adapter, Commands, In, IntoChainSystem, IntoExclusiveSystem,
+            IntoSystem, Local, NonSend, NonSendMut, ParallelCommands, ParamSet, Query,
+            RemovedComponents, Res, ResMut, Resource, System, SystemParamFunction,
         },
         world::{FromWorld, Mut, World},
     };

--- a/crates/bevy_ecs/src/system/system_chaining.rs
+++ b/crates/bevy_ecs/src/system/system_chaining.rs
@@ -168,31 +168,6 @@ pub mod adapter {
         move |In(x)| f(x)
     }
 
-    /// System adapter that converts [`Result<T, _>`] into [`Option<T>`].
-    pub fn ok<T, E>(In(res): In<Result<T, E>>) -> Option<T> {
-        res.ok()
-    }
-
-    /// System adapter that maps [`None`] -> [`Err`].
-    ///
-    /// Often, it is better to call `Option::ok_or` at the place where the `?` operator is invoked,
-    /// as the extra context allows you to provide a better error message.
-    ///
-    /// Sometimes, it is more conevenient to handle it system-wide, though.
-    pub fn ok_or<T, E: Clone>(err: E) -> impl FnMut(In<Option<T>>) -> Result<T, E> {
-        ok_or_else(move || err.clone())
-    }
-
-    /// System adapter that maps [`None`] -> [`Err`], calling a closure to produce each error.
-    ///
-    /// Often, it is better to call `Option::ok_or_else` at the place where the `?` operator is invoked,
-    /// as the extra context allows you to provide a better error message.
-    ///
-    /// Sometimes, it is more convenient to handle it system-wide, though.
-    pub fn ok_or_else<T, E>(mut f: impl FnMut() -> E) -> impl FnMut(In<Option<T>>) -> Result<T, E> {
-        move |In(x)| x.ok_or_else(&mut f)
-    }
-
     /// System adapter that unwraps the `Ok` variant of a [`Result`].
     /// This is useful for fallible systems that should panic in the case of an error.
     ///
@@ -289,10 +264,6 @@ pub mod adapter {
         fn returning<T>() -> T {
             unimplemented!()
         }
-
-        assert_is_system(returning::<Result<String, std::io::Error>>.chain(ok));
-        assert_is_system(returning::<Option<usize>>.chain(ok_or("Oops")));
-        assert_is_system(returning::<Option<usize>>.chain(ok_or_else(|| "Sorry".to_owned())));
 
         assert_is_system(returning::<Result<u32, std::io::Error>>.chain(unwrap));
         assert_is_system(returning::<Option<()>>.chain(ignore));

--- a/crates/bevy_ecs/src/system/system_chaining.rs
+++ b/crates/bevy_ecs/src/system/system_chaining.rs
@@ -252,7 +252,7 @@ pub mod adapter {
     ///     q: Query<Entity, With<Monster>>
     /// ) -> Option<()> {
     ///     let monster_id = q.iter().next()?;
-    ///     eprintln!("Monster entity is {monster_id:?}");
+    ///     println!("Monster entity is {monster_id:?}");
     ///     Some(())
     /// }
     /// ```

--- a/crates/bevy_ecs/src/system/system_chaining.rs
+++ b/crates/bevy_ecs/src/system/system_chaining.rs
@@ -251,7 +251,6 @@ pub mod adapter {
     /// fn fallible_system(
     ///     q: Query<Entity, With<Monster>>
     /// ) -> Option<()> {
-    ///     # // Note: This *will* fail, since we never create a monster entity.
     ///     let monster_id = q.iter().next()?;
     ///     eprintln!("Monster entity is {monster_id:?}");
     ///     Some(())

--- a/crates/bevy_ecs/src/system/system_chaining.rs
+++ b/crates/bevy_ecs/src/system/system_chaining.rs
@@ -146,7 +146,7 @@ where
 /// A collection of common adapters for [chaining](super::ChainSystem) the result of a system.
 pub mod adapter {
     use crate::system::In;
-    use std::{fmt::Debug, str::FromStr};
+    use std::fmt::Debug;
 
     /// System adapter that converts [`Result<T, _>`] into [`Option<T>`].
     pub fn ok<T, E>(In(res): In<Result<T, E>>) -> Option<T> {
@@ -258,21 +258,6 @@ pub mod adapter {
     /// ```
     pub fn ignore<T>(In(_): In<T>) {}
 
-    /// System adapter that converts the output of a system to type `T`, via the [`Into`] trait.
-    pub fn into<T>(In(val): In<impl Into<T>>) -> T {
-        val.into()
-    }
-
-    /// System adapter that attempts to convert the output of a system to type `T`, via the [`TryInto`] trait.
-    pub fn try_into<T, U: TryInto<T>>(In(val): In<U>) -> Result<T, U::Error> {
-        val.try_into()
-    }
-
-    /// System adapter that attempts to convert a string-like value to type `T`, via the [`FromStr`] trait.
-    pub fn parse<T: FromStr>(In(str): In<impl AsRef<str>>) -> Result<T, T::Err> {
-        str.as_ref().parse::<T>()
-    }
-
     #[cfg(test)]
     #[test]
     fn assert_systems() {
@@ -289,9 +274,5 @@ pub mod adapter {
 
         assert_is_system(returning::<Result<u32, std::io::Error>>.chain(unwrap));
         assert_is_system(returning::<Option<()>>.chain(ignore));
-
-        assert_is_system(returning::<u32>.chain(into::<u64>));
-        assert_is_system(returning::<u64>.chain(try_into::<u32, _>));
-        assert_is_system(returning::<&str>.chain(parse::<u64>).chain(unwrap));
     }
 }

--- a/crates/bevy_ecs/src/system/system_chaining.rs
+++ b/crates/bevy_ecs/src/system/system_chaining.rs
@@ -147,6 +147,31 @@ pub mod adapter {
     use crate::system::In;
     use std::fmt::Debug;
 
+    /// System adapter that converts [`Result<T, _>`] into [`Option<T>`].
+    pub fn ok<T, E>(In(res): In<Result<T, E>>) -> Option<T> {
+        res.ok()
+    }
+
+    /// System adapter that maps [`None`] -> [`Err`].
+    ///
+    /// Often, it is better to call `Option::ok_or` at the place where the `?` operator is invoked,
+    /// as the extra context allows you to provide a better error message.
+    ///
+    /// Sometimes, it is more conevenient to handle it system-wide, though.
+    pub fn ok_or<T, E: Clone>(err: E) -> impl FnMut(In<Option<T>>) -> Result<T, E> {
+        ok_or_else(move || err.clone())
+    }
+
+    /// System adapter that maps [`None`] -> [`Err`], calling a closure to produce each error.
+    ///
+    /// Often, it is better to call `Option::ok_or_else` at the place where the `?` operator is invoked,
+    /// as the extra context allows you to provide a better error message.
+    ///
+    /// Sometimes, it is more convenient to handle it system-wide, though.
+    pub fn ok_or_else<T, E>(mut f: impl FnMut() -> E) -> impl FnMut(In<Option<T>>) -> Result<T, E> {
+        move |In(x)| x.ok_or_else(&mut f)
+    }
+
     /// System adapter that unwraps the `Ok` variant of a [`Result`].
     /// This is useful for fallible systems that should panic in the case of an error.
     ///

--- a/crates/bevy_ecs/src/system/system_chaining.rs
+++ b/crates/bevy_ecs/src/system/system_chaining.rs
@@ -258,4 +258,14 @@ pub mod adapter {
     /// }
     /// ```
     pub fn ignore<T>(In(_): In<T>) {}
+
+    /// System adapter that converts the output of a system to type `T`, via the [`Into`] trait.
+    pub fn into<T>(In(val): In<impl Into<T>>) -> T {
+        val.into()
+    }
+
+    /// System adapter that attempts to convert the output of a system to type `T`, via the [`TryInto`] trait.
+    pub fn try_into<T, U: TryInto<T>>(In(val): In<U>) -> Result<T, U::Error> {
+        val.try_into()
+    }
 }

--- a/crates/bevy_ecs/src/system/system_chaining.rs
+++ b/crates/bevy_ecs/src/system/system_chaining.rs
@@ -143,6 +143,7 @@ where
     }
 }
 
+/// A collection of common adapters for [chaining](super::ChainSystem) the result of a system.
 pub mod adapter {
     use crate::system::In;
     use std::fmt::Debug;

--- a/crates/bevy_ecs/src/system/system_chaining.rs
+++ b/crates/bevy_ecs/src/system/system_chaining.rs
@@ -142,3 +142,94 @@ where
         }
     }
 }
+
+pub mod adapter {
+    use crate::system::In;
+    use std::fmt::Debug;
+
+    /// System adapter that unwraps the `Ok` variant of a [`Result`].
+    /// This is useful for fallible systems that should panic in the case of an error.
+    ///
+    /// There is no equivalent adapter for [`Option`]. Instead, it's best to provide
+    /// an error message and convert to a `Result` using `ok_or{_else}`.
+    ///
+    /// # Examples
+    ///
+    /// Panicking on error
+    ///
+    /// ```
+    /// use bevy_ecs::prelude::*;
+    /// #
+    /// # #[derive(StageLabel)]
+    /// # enum CoreStage { Update };
+    ///
+    /// // Building a new schedule/app...
+    /// # use bevy_ecs::schedule::SystemStage;
+    /// # let mut sched = Schedule::default(); sched
+    /// #     .add_stage(CoreStage::Update, SystemStage::single_threaded())
+    ///     .add_system_to_stage(
+    ///         CoreStage::Update,
+    ///         // Panic if the load system returns an error.
+    ///         load_save_system.chain(system_adapter::unwrap)
+    ///     )
+    ///     // ...
+    /// #   ;
+    /// # let mut world = World::new();
+    /// # sched.run(&mut world);
+    ///
+    /// // A system which may fail irreparably.
+    /// fn load_save_system() -> Result<(), std::io::Error> {
+    ///     let save_file = open_file("my_save.json")?;
+    ///     dbg!(save_file);
+    ///     Ok(())
+    /// }
+    /// # fn open_file(name: &str) -> Result<&'static str, std::io::Error>
+    /// # { Ok("hello world") }
+    /// ```
+    pub fn unwrap<T, E: Debug>(In(res): In<Result<T, E>>) -> T {
+        res.unwrap()
+    }
+
+    /// System adapter that ignores the output of the previous system in a chain.
+    /// This is useful for fallible systems that should simply return early in case of an `Err`/`None`.
+    ///
+    /// # Examples
+    ///
+    /// Returning early
+    ///
+    /// ```
+    /// use bevy_ecs::prelude::*;
+    ///
+    /// // Marker component for an enemy entity.
+    /// #[derive(Component)]
+    /// struct Monster;
+    /// #
+    /// # #[derive(StageLabel)]
+    /// # enum CoreStage { Update };
+    ///
+    /// // Building a new schedule/app...
+    /// # use bevy_ecs::schedule::SystemStage;
+    /// # let mut sched = Schedule::default(); sched
+    /// #     .add_stage(CoreStage::Update, SystemStage::single_threaded())
+    ///     .add_system_to_stage(
+    ///         CoreStage::Update,
+    ///         // If the system fails, just move on and try again next frame.
+    ///         fallible_system.chain(system_adapter::ignore)
+    ///     )
+    ///     // ...
+    /// #   ;
+    /// # let mut world = World::new();
+    /// # sched.run(&mut world);
+    ///
+    /// // A system which may return early. It's more convenient to use the `?` operator for this.
+    /// fn fallible_system(
+    ///     q: Query<Entity, With<Monster>>
+    /// ) -> Option<()> {
+    ///     # // Note: This *will* fail, since we never create a monster entity.
+    ///     let monster_id = q.iter().next()?;
+    ///     eprintln!("Monster entity is {monster_id:?}");
+    ///     Some(())
+    /// }
+    /// ```
+    pub fn ignore<T>(In(_): In<T>) {}
+}

--- a/crates/bevy_ecs/src/system/system_chaining.rs
+++ b/crates/bevy_ecs/src/system/system_chaining.rs
@@ -146,7 +146,7 @@ where
 /// A collection of common adapters for [chaining](super::ChainSystem) the result of a system.
 pub mod adapter {
     use crate::system::In;
-    use std::fmt::Debug;
+    use std::{fmt::Debug, str::FromStr};
 
     /// System adapter that converts [`Result<T, _>`] into [`Option<T>`].
     pub fn ok<T, E>(In(res): In<Result<T, E>>) -> Option<T> {
@@ -267,5 +267,10 @@ pub mod adapter {
     /// System adapter that attempts to convert the output of a system to type `T`, via the [`TryInto`] trait.
     pub fn try_into<T, U: TryInto<T>>(In(val): In<U>) -> Result<T, U::Error> {
         val.try_into()
+    }
+
+    /// System adapter that attempts to convert a string-like value to type `T`, via the [`FromStr`] trait.
+    pub fn parse<T: FromStr>(In(str): In<impl AsRef<str>>) -> Result<T, T::Err> {
+        str.as_ref().parse::<T>()
     }
 }

--- a/crates/bevy_ecs/src/system/system_chaining.rs
+++ b/crates/bevy_ecs/src/system/system_chaining.rs
@@ -273,4 +273,26 @@ pub mod adapter {
     pub fn parse<T: FromStr>(In(str): In<impl AsRef<str>>) -> Result<T, T::Err> {
         str.as_ref().parse::<T>()
     }
+
+    #[cfg(test)]
+    #[test]
+    fn assert_systems() {
+        use crate::{prelude::*, system::assert_is_system};
+
+        /// Mocks a system that returns a value of type `T`.
+        fn returning<T>() -> T {
+            unimplemented!()
+        }
+
+        assert_is_system(returning::<Result<String, std::io::Error>>.chain(ok));
+        assert_is_system(returning::<Option<usize>>.chain(ok_or("Oops")));
+        assert_is_system(returning::<Option<usize>>.chain(ok_or_else(|| "Sorry".to_owned())));
+
+        assert_is_system(returning::<Result<u32, std::io::Error>>.chain(unwrap));
+        assert_is_system(returning::<Option<()>>.chain(ignore));
+
+        assert_is_system(returning::<u32>.chain(into::<u64>));
+        assert_is_system(returning::<u64>.chain(try_into::<u32, _>));
+        assert_is_system(returning::<&str>.chain(parse::<u64>).chain(unwrap));
+    }
 }


### PR DESCRIPTION
# Objective

Right now, users have to implement basic system adapters such as `Option` <-> `Result` conversions by themselves. This is slightly annoying and discourages the use of system chaining.

## Solution

Add the module `system_adapter` to the prelude, which contains a collection of common adapters. This is very ergonomic in practice.

## Examples

Convenient early returning.

```rust
use bevy::prelude::*;

App::new()
    // If the system fails, just try again next frame.
    .add_system(pet_dog.chain(system_adapter::ignore))
    .run();

#[derive(Component)]
struct Dog;

fn pet_dog(dogs: Query<(&Name, Option<&Parent>), With<Dog>>) -> Option<()> {
    let (dog, dad) = dogs.iter().next()?;
    println!("You pet {dog}. He/she/they are a good boy/girl/pupper.");
    let (dad, _) = dogs.get(dad?.get()).ok()?;
    println!("Their dad's name is {dad}");
    Some(())
}
```

Converting the output of a system

```rust
use bevy::prelude::*;

App::new()
    .add_system(
        find_name
            .chain(system_adapter::new(String::from))
            .chain(spawn_with_name),
    )
    .run();

fn find_name() -> &'static str { /* ... */ }
fn spawn_with_name(In(name): In<String>, mut commands: Commands) {
    commands.spawn().insert(Name::new(name));
}
```
---

## Changelog

* Added the module `bevy_ecs::prelude::system_adapter`, which contains a collection of common system chaining adapters.
  * `new` - Converts a regular fn to a system adapter.
  * `unwrap` - Similar to `Result::unwrap`
  * `ignore` - Discards the output of the previous system.