### PR TITLE
bevy_reflect: Recursive registration

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
@@ -470,7 +470,12 @@ impl<'a> ReflectMeta<'a> {
         &self,
         where_clause_options: &WhereClauseOptions,
     ) -> proc_macro2::TokenStream {
-        crate::registration::impl_get_type_registration(self, where_clause_options, None)
+        crate::registration::impl_get_type_registration(
+            self,
+            where_clause_options,
+            None,
+            None::<std::iter::Empty<&Type>>,
+        )
     }
 
     /// The collection of docstrings for this type, if any.
@@ -502,6 +507,7 @@ impl<'a> ReflectStruct<'a> {
             self.meta(),
             where_clause_options,
             self.serialization_data(),
+            Some(self.active_types().iter()),
         )
     }
 
@@ -512,22 +518,21 @@ impl<'a> ReflectStruct<'a> {
             .collect()
     }
 
-    /// Get an iterator of fields which are exposed to the reflection API
+    /// Get an iterator of fields which are exposed to the reflection API.
     pub fn active_fields(&self) -> impl Iterator<Item = &StructField<'a>> {
-        self.fields
+        self.fields()
             .iter()
             .filter(|field| field.attrs.ignore.is_active())
     }
 
     /// Get an iterator of fields which are ignored by the reflection API
     pub fn ignored_fields(&self) -> impl Iterator<Item = &StructField<'a>> {
-        self.fields
+        self.fields()
             .iter()
             .filter(|field| field.attrs.ignore.is_ignored())
     }
 
     /// The complete set of fields in this struct.
-    #[allow(dead_code)]
     pub fn fields(&self) -> &[StructField<'a>] {
         &self.fields
     }
@@ -572,6 +577,21 @@ impl<'a> ReflectEnum<'a> {
 
     pub fn where_clause_options(&self) -> WhereClauseOptions {
         WhereClauseOptions::new_with_fields(self.meta(), self.active_types().into_boxed_slice())
+    }
+
+    /// Returns the `GetTypeRegistration` impl as a `TokenStream`.
+    ///
+    /// Returns a specific implementation for enums and this method should be preferred over the generic [`get_type_registration`](crate::ReflectMeta) method
+    pub fn get_type_registration(
+        &self,
+        where_clause_options: &WhereClauseOptions,
+    ) -> proc_macro2::TokenStream {
+        crate::registration::impl_get_type_registration(
+            self.meta(),
+            where_clause_options,
+            None,
+            Some(self.active_fields().map(|field| &field.data.ty)),
+        )
     }
 }
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
@@ -474,7 +474,7 @@ impl<'a> ReflectMeta<'a> {
             self,
             where_clause_options,
             None,
-            None::<std::iter::Empty<&Type>>,
+            Option::<std::iter::Empty<&Type>>::None,
         )
     }
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -84,9 +84,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
 
     let type_path_impl = impl_type_path(reflect_enum.meta());
 
-    let get_type_registration_impl = reflect_enum
-        .meta()
-        .get_type_registration(&where_clause_options);
+    let get_type_registration_impl = reflect_enum.get_type_registration(&where_clause_options);
 
     let (impl_generics, ty_generics, where_clause) =
         reflect_enum.meta().type_path().generics().split_for_impl();

--- a/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
@@ -20,6 +20,7 @@ pub(crate) fn impl_get_type_registration<'a>(
 
     let type_deps_fn = type_dependencies.map(|deps| {
         quote! {
+            #[inline(never)]
             fn register_type_dependencies(registry: &mut #bevy_reflect_path::TypeRegistry) {
                 #(<#deps as #bevy_reflect_path::__macro_exports::RegisterForReflection>::__register(registry);)*
             }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
@@ -21,7 +21,7 @@ pub(crate) fn impl_get_type_registration<'a>(
     let type_deps_fn = type_dependencies.map(|deps| {
         quote! {
             fn register_type_dependencies(registry: &mut #bevy_reflect_path::TypeRegistry) {
-                #(registry.register::<#deps>();)*
+                #(<#deps as #bevy_reflect_path::__macro_exports::RegisterForReflection>::__register(registry);)*
             }
         }
     });

--- a/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
@@ -21,7 +21,7 @@ pub(crate) fn impl_get_type_registration<'a>(
     let type_deps_fn = type_dependencies.map(|deps| {
         quote! {
             fn register_type_dependencies(registry: &mut #bevy_reflect_path::TypeRegistry) {
-                #(registry.try_register::<#deps>();)*
+                #(registry.register::<#deps>();)*
             }
         }
     });

--- a/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
@@ -4,17 +4,28 @@ use crate::derive_data::ReflectMeta;
 use crate::serialization::SerializationDataDef;
 use crate::utility::WhereClauseOptions;
 use quote::quote;
+use syn::Type;
 
 /// Creates the `GetTypeRegistration` impl for the given type data.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn impl_get_type_registration(
+pub(crate) fn impl_get_type_registration<'a>(
     meta: &ReflectMeta,
     where_clause_options: &WhereClauseOptions,
     serialization_data: Option<&SerializationDataDef>,
+    type_dependencies: Option<impl Iterator<Item = &'a Type>>,
 ) -> proc_macro2::TokenStream {
     let type_path = meta.type_path();
     let bevy_reflect_path = meta.bevy_reflect_path();
     let registration_data = meta.attrs().idents();
+
+    let type_deps_fn = type_dependencies.map(|deps| {
+        quote! {
+            fn register_type_dependencies(registry: &mut #bevy_reflect_path::TypeRegistry) {
+                #(registry.try_register::<#deps>();)*
+            }
+        }
+    });
+
     let (impl_generics, ty_generics, where_clause) = type_path.generics().split_for_impl();
     let where_reflect_clause = where_clause_options.extend_where_clause(where_clause);
 
@@ -44,6 +55,8 @@ pub(crate) fn impl_get_type_registration(
                 #(registration.insert::<#registration_data>(#bevy_reflect_path::FromType::<Self>::from_type());)*
                 registration
             }
+
+            #type_deps_fn
         }
     }
 }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -217,10 +217,14 @@ impl<'a, 'b> WhereClauseOptions<'a, 'b> {
 
             // `TypePath` is always required for active fields since they are used to
             // construct `NamedField` and `UnnamedField` instances for the `Typed` impl.
+            // Likewise, `GetTypeRegistration` is always required for active fields since
+            // they are used to register the type's dependencies.
             Some(
                 self.active_fields
                     .iter()
-                    .map(move |ty| quote!(#ty : #reflect_bound + #bevy_reflect_path::TypePath)),
+                    .map(move |ty| quote!(
+                        #ty : #reflect_bound + #bevy_reflect_path::TypePath + #bevy_reflect_path::GetTypeRegistration
+                    )),
             )
         }
     }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -219,13 +219,13 @@ impl<'a, 'b> WhereClauseOptions<'a, 'b> {
             // construct `NamedField` and `UnnamedField` instances for the `Typed` impl.
             // Likewise, `GetTypeRegistration` is always required for active fields since
             // they are used to register the type's dependencies.
-            Some(
-                self.active_fields
-                    .iter()
-                    .map(move |ty| quote!(
-                        #ty : #reflect_bound + #bevy_reflect_path::TypePath + #bevy_reflect_path::GetTypeRegistration
-                    )),
-            )
+            Some(self.active_fields.iter().map(move |ty| {
+                quote!(
+                    #ty : #reflect_bound
+                        + #bevy_reflect_path::TypePath
+                        + #bevy_reflect_path::__macro_exports::RegisterForReflection
+                )
+            }))
         }
     }
 

--- a/crates/bevy_reflect/src/enums/mod.rs
+++ b/crates/bevy_reflect/src/enums/mod.rs
@@ -324,7 +324,7 @@ mod tests {
     #[test]
     fn enum_should_allow_generics() {
         #[derive(Reflect, Debug, PartialEq)]
-        enum TestEnum<T: FromReflect + GetTypeRegistration> {
+        enum TestEnum<T: FromReflect> {
             A,
             B(T),
             C { value: T },

--- a/crates/bevy_reflect/src/enums/mod.rs
+++ b/crates/bevy_reflect/src/enums/mod.rs
@@ -324,7 +324,7 @@ mod tests {
     #[test]
     fn enum_should_allow_generics() {
         #[derive(Reflect, Debug, PartialEq)]
-        enum TestEnum<T: FromReflect> {
+        enum TestEnum<T: FromReflect + GetTypeRegistration> {
             A,
             B(T),
             C { value: T },

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -364,7 +364,7 @@ macro_rules! impl_reflect_for_veclike {
             }
 
             fn register_type_dependencies(registry: &mut TypeRegistry) {
-                registry.try_register::<T>();
+                registry.register::<T>();
             }
         }
 
@@ -594,8 +594,8 @@ macro_rules! impl_reflect_for_hashmap {
             }
 
             fn register_type_dependencies(registry: &mut TypeRegistry) {
-                registry.try_register::<K>();
-                registry.try_register::<V>();
+                registry.register::<K>();
+                registry.register::<V>();
             }
         }
 
@@ -990,7 +990,7 @@ impl<T: Reflect + TypePath + GetTypeRegistration, const N: usize> GetTypeRegistr
     }
 
     fn register_type_dependencies(registry: &mut TypeRegistry) {
-        registry.try_register::<T>();
+        registry.register::<T>();
     }
 }
 
@@ -1000,7 +1000,7 @@ impl<T: FromReflect + TypePath + GetTypeRegistration> GetTypeRegistration for Op
     }
 
     fn register_type_dependencies(registry: &mut TypeRegistry) {
-        registry.try_register::<T>();
+        registry.register::<T>();
     }
 }
 
@@ -1532,7 +1532,7 @@ impl<T: FromReflect + Clone + TypePath + GetTypeRegistration> GetTypeRegistratio
     }
 
     fn register_type_dependencies(registry: &mut TypeRegistry) {
-        registry.try_register::<T>();
+        registry.register::<T>();
     }
 }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1410,7 +1410,7 @@ mod tests {
 
         // Struct (generic)
         #[derive(Reflect)]
-        struct MyGenericStruct<T: GetTypeRegistration> {
+        struct MyGenericStruct<T> {
             foo: T,
             bar: usize,
         }
@@ -1999,8 +1999,8 @@ bevy_reflect::tests::Test {
     #[test]
     fn should_allow_multiple_custom_where() {
         #[derive(Reflect)]
-        #[reflect(where T: Default + GetTypeRegistration)]
-        #[reflect(where U: std::ops::Add < T > + GetTypeRegistration)]
+        #[reflect(where T: Default)]
+        #[reflect(where U: std::ops::Add < T >)]
         struct Foo<T, U>(T, U);
 
         #[derive(Reflect)]
@@ -2021,7 +2021,7 @@ bevy_reflect::tests::Test {
 
         // We don't need `T` to be `Reflect` since we only care about `T::Assoc`
         #[derive(Reflect)]
-        #[reflect(where T::Assoc: core::fmt::Display + GetTypeRegistration)]
+        #[reflect(where T::Assoc: core::fmt::Display)]
         struct Foo<T: Trait>(T::Assoc);
 
         #[derive(TypePath)]
@@ -2045,7 +2045,7 @@ bevy_reflect::tests::Test {
     #[test]
     fn recursive_typed_storage_does_not_hang() {
         #[derive(Reflect)]
-        struct Recurse<T: GetTypeRegistration>(T);
+        struct Recurse<T>(T);
 
         let _ = <Recurse<Recurse<()>> as Typed>::type_info();
         let _ = <Recurse<Recurse<()>> as TypePath>::type_path();
@@ -2080,7 +2080,7 @@ bevy_reflect::tests::Test {
     #[test]
     fn recursive_registration_does_not_hang() {
         #[derive(Reflect)]
-        struct Recurse<T: GetTypeRegistration>(T);
+        struct Recurse<T>(T);
 
         let mut registry = TypeRegistry::empty();
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2149,6 +2149,29 @@ bevy_reflect::tests::Test {
         let mut registry = TypeRegistry::empty();
 
         registry.register::<Recurse<Recurse<()>>>();
+
+        #[derive(Reflect)]
+        #[reflect(no_field_bounds)]
+        struct SelfRecurse {
+            recurse: Vec<SelfRecurse>,
+        }
+
+        registry.register::<SelfRecurse>();
+
+        #[derive(Reflect)]
+        #[reflect(no_field_bounds)]
+        enum RecurseA {
+            Recurse(RecurseB),
+        }
+
+        #[derive(Reflect)]
+        struct RecurseB {
+            vector: Vec<RecurseA>,
+        }
+
+        registry.register::<RecurseA>();
+        assert!(registry.contains(TypeId::of::<RecurseA>()));
+        assert!(registry.contains(TypeId::of::<RecurseB>()));
     }
 
     #[test]

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2064,7 +2064,7 @@ bevy_reflect::tests::Test {
     fn should_allow_multiple_custom_where() {
         #[derive(Reflect)]
         #[reflect(where T: Default)]
-        #[reflect(where U: std::ops::Add < T >)]
+        #[reflect(where U: std::ops::Add<T>)]
         struct Foo<T, U>(T, U);
 
         #[derive(Reflect)]

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -538,7 +538,7 @@ pub use erased_serde;
 
 extern crate alloc;
 
-/// Exorts used by the reflection macros.
+/// Exports used by the reflection macros.
 ///
 /// These are not meant to be used directly and are subject to breaking changes.
 #[doc(hidden)]

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -3,8 +3,8 @@ use bevy_utils::all_tuples;
 
 use crate::{
     self as bevy_reflect, utility::GenericTypePathCell, FromReflect, GetTypeRegistration, Reflect,
-    ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypeRegistration, Typed,
-    UnnamedField,
+    ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypeRegistration, TypeRegistry,
+    Typed, UnnamedField,
 };
 use crate::{ReflectKind, TypePathTable};
 use std::any::{Any, TypeId};
@@ -461,7 +461,7 @@ pub fn tuple_debug(dyn_tuple: &dyn Tuple, f: &mut Formatter<'_>) -> std::fmt::Re
 
 macro_rules! impl_reflect_tuple {
     {$($index:tt : $name:tt),*} => {
-        impl<$($name: Reflect + TypePath),*> Tuple for ($($name,)*) {
+        impl<$($name: Reflect + TypePath + GetTypeRegistration),*> Tuple for ($($name,)*) {
             #[inline]
             fn field(&self, index: usize) -> Option<&dyn Reflect> {
                 match index {
@@ -512,7 +512,7 @@ macro_rules! impl_reflect_tuple {
             }
         }
 
-        impl<$($name: Reflect + TypePath),*> Reflect for ($($name,)*) {
+        impl<$($name: Reflect + TypePath + GetTypeRegistration),*> Reflect for ($($name,)*) {
             fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
                 Some(<Self as Typed>::type_info())
             }
@@ -575,7 +575,7 @@ macro_rules! impl_reflect_tuple {
             }
         }
 
-        impl <$($name: Reflect + TypePath),*> Typed for ($($name,)*) {
+        impl <$($name: Reflect + TypePath + GetTypeRegistration),*> Typed for ($($name,)*) {
             fn type_info() -> &'static TypeInfo {
                 static CELL: $crate::utility::GenericTypeInfoCell = $crate::utility::GenericTypeInfoCell::new();
                 CELL.get_or_insert::<Self, _>(|| {
@@ -588,14 +588,17 @@ macro_rules! impl_reflect_tuple {
             }
         }
 
-
-        impl<$($name: Reflect + TypePath),*> GetTypeRegistration for ($($name,)*) {
+        impl<$($name: Reflect + TypePath + GetTypeRegistration),*> GetTypeRegistration for ($($name,)*) {
             fn get_type_registration() -> TypeRegistration {
                 TypeRegistration::of::<($($name,)*)>()
             }
+
+            fn register_type_dependencies(_registry: &mut TypeRegistry) {
+                $(_registry.try_register::<$name>();)*
+            }
         }
 
-        impl<$($name: FromReflect + TypePath),*> FromReflect for ($($name,)*)
+        impl<$($name: FromReflect + TypePath + GetTypeRegistration),*> FromReflect for ($($name,)*)
         {
             fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
                 if let ReflectRef::Tuple(_ref_tuple) = reflect.reflect_ref() {

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -594,7 +594,7 @@ macro_rules! impl_reflect_tuple {
             }
 
             fn register_type_dependencies(_registry: &mut TypeRegistry) {
-                $(_registry.try_register::<$name>();)*
+                $(_registry.register::<$name>();)*
             }
         }
 

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -137,14 +137,17 @@ impl TypeRegistry {
     /// To forcibly register the type, overwriting any existing registration, use the
     /// [`overwrite_registration`](Self::overwrite_registration) method instead.
     ///
-    /// Returns `true` if the registration was successfully added,
-    /// or `false` if it already exists.
-    pub fn add_registration(&mut self, registration: TypeRegistration) -> bool {
+    /// Returns `None` if the registration was successfully added,
+    /// or `Some(existing)` if it already exists.
+    pub fn add_registration(
+        &mut self,
+        registration: TypeRegistration,
+    ) -> Option<&TypeRegistration> {
         if self.contains(registration.type_id()) {
-            false
+            self.get(registration.type_id())
         } else {
             self.overwrite_registration(registration);
-            true
+            None
         }
     }
 

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -56,7 +56,7 @@ impl Debug for TypeRegistryArc {
 /// See the [crate-level documentation] for more information on type registration.
 ///
 /// [crate-level documentation]: crate
-pub trait GetTypeRegistration {
+pub trait GetTypeRegistration: 'static {
     /// Returns the default [`TypeRegistration`] for this type.
     fn get_type_registration() -> TypeRegistration;
     /// Registers other types needed by this type.
@@ -122,10 +122,11 @@ impl TypeRegistry {
     where
         T: GetTypeRegistration,
     {
-        if !self.add_registration(T::get_type_registration()) {
+        if self.contains(TypeId::of::<T>()) {
             return;
         }
 
+        self.force_add_registration(T::get_type_registration());
         T::register_type_dependencies(self);
     }
 

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -126,7 +126,7 @@ impl TypeRegistry {
             return;
         }
 
-        self.force_add_registration(T::get_type_registration());
+        self.overwrite_registration(T::get_type_registration());
         T::register_type_dependencies(self);
     }
 
@@ -135,7 +135,7 @@ impl TypeRegistry {
     /// If the registration for the type already exists, it will not be registered again.
     ///
     /// To forcibly register the type, overwriting any existing registration, use the
-    /// [`force_add_registration`](Self::force_add_registration) method instead.
+    /// [`overwrite_registration`](Self::overwrite_registration) method instead.
     ///
     /// Returns `true` if the registration was successfully added,
     /// or `false` if it already exists.
@@ -143,7 +143,7 @@ impl TypeRegistry {
         if self.contains(registration.type_id()) {
             false
         } else {
-            self.force_add_registration(registration);
+            self.overwrite_registration(registration);
             true
         }
     }
@@ -154,7 +154,7 @@ impl TypeRegistry {
     ///
     /// To avoid overwriting existing registrations, it's recommended to use the
     /// [`register`](Self::register) or [`add_registration`](Self::add_registration) methods instead.
-    pub fn force_add_registration(&mut self, registration: TypeRegistration) {
+    pub fn overwrite_registration(&mut self, registration: TypeRegistration) {
         let short_name = registration.type_info().type_path_table().short_path();
         if self.short_path_to_id.contains_key(short_name)
             || self.ambiguous_names.contains(short_name)

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.rs
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.rs
@@ -1,4 +1,4 @@
-use bevy_reflect::{GetField, Reflect, Struct};
+use bevy_reflect::{GetField, Reflect, Struct, TypePath};
 
 #[derive(Reflect)]
 #[reflect(from_reflect = false)]

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.rs
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.rs
@@ -1,4 +1,4 @@
-use bevy_reflect::{Reflect, TypePath};
+use bevy_reflect::{GetField, Reflect, Struct};
 
 #[derive(Reflect)]
 #[reflect(from_reflect = false)]
@@ -11,7 +11,7 @@ struct Foo<T> {
 struct NoReflect(f32);
 
 fn main() {
-    let mut foo: Box<dyn Reflect> = Box::new(Foo::<NoReflect> { a: NoReflect(42.0) });
+    let mut foo: Box<dyn Struct> = Box::new(Foo::<NoReflect> { a: NoReflect(42.0) });
     // foo doesn't implement Reflect because NoReflect doesn't implement Reflect
     foo.get_field::<NoReflect>("a").unwrap();
 }

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.stderr
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.stderr
@@ -1,19 +1,10 @@
-error: cannot find derive macro `TypePath` in this scope
-  --> tests/reflect_derive/generics.fail.rs:10:10
-   |
-10 | #[derive(TypePath)]
-   |          ^^^^^^^^
-   |
-help: consider importing this derive macro
-   |
-1  + use bevy_reflect::TypePath;
-   |
-
 error[E0277]: the trait bound `NoReflect: Reflect` is not satisfied
    --> tests/reflect_derive/generics.fail.rs:16:21
     |
 16  |     foo.get_field::<NoReflect>("a").unwrap();
-    |                     ^^^^^^^^^ the trait `Reflect` is not implemented for `NoReflect`
+    |         ---------   ^^^^^^^^^ the trait `Reflect` is not implemented for `NoReflect`
+    |         |
+    |         required by a bound introduced by this call
     |
     = help: the following other types implement trait `Reflect`:
               bool
@@ -47,33 +38,7 @@ error[E0277]: the trait bound `NoReflect: GetTypeRegistration` is not satisfied
              i64
              i128
            and $N others
-note: required for `Foo<NoReflect>` to implement `bevy_reflect::Struct`
-  --> tests/reflect_derive/generics.fail.rs:3:10
-   |
-3  | #[derive(Reflect)]
-   |          ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
-4  | #[reflect(from_reflect = false)]
-5  | struct Foo<T> {
-   |        ^^^^^^
-   = note: required for the cast from `Box<Foo<NoReflect>>` to `Box<(dyn bevy_reflect::Struct + 'static)>`
-   = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `NoReflect: TypePath` is not satisfied
-  --> tests/reflect_derive/generics.fail.rs:14:36
-   |
-14 |     let mut foo: Box<dyn Struct> = Box::new(Foo::<NoReflect> { a: NoReflect(42.0) });
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TypePath` is not implemented for `NoReflect`
-   |
-   = help: the following other types implement trait `TypePath`:
-             bool
-             char
-             isize
-             i8
-             i16
-             i32
-             i64
-             i128
-           and $N others
+   = note: required for `NoReflect` to implement `RegisterForReflection`
 note: required for `Foo<NoReflect>` to implement `bevy_reflect::Struct`
   --> tests/reflect_derive/generics.fail.rs:3:10
    |

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.stderr
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.stderr
@@ -1,16 +1,43 @@
-error[E0599]: no method named `get_field` found for struct `Box<(dyn Reflect + 'static)>` in the current scope
-  --> tests/reflect_derive/generics.fail.rs:16:9
+error: cannot find derive macro `TypePath` in this scope
+  --> tests/reflect_derive/generics.fail.rs:10:10
    |
-16 |     foo.get_field::<NoReflect>("a").unwrap();
-   |         ^^^^^^^^^ method not found in `Box<dyn Reflect>`
+10 | #[derive(TypePath)]
+   |          ^^^^^^^^
+   |
+help: consider importing this derive macro
+   |
+1  + use bevy_reflect::TypePath;
+   |
 
 error[E0277]: the trait bound `NoReflect: Reflect` is not satisfied
-  --> tests/reflect_derive/generics.fail.rs:14:37
+   --> tests/reflect_derive/generics.fail.rs:16:21
+    |
+16  |     foo.get_field::<NoReflect>("a").unwrap();
+    |                     ^^^^^^^^^ the trait `Reflect` is not implemented for `NoReflect`
+    |
+    = help: the following other types implement trait `Reflect`:
+              bool
+              char
+              isize
+              i8
+              i16
+              i32
+              i64
+              i128
+            and $N others
+note: required by a bound in `bevy_reflect::GetField::get_field`
+   --> /home/runner/work/bevy/bevy/crates/bevy_reflect/src/struct_trait.rs:242:21
+    |
+242 |     fn get_field<T: Reflect>(&self, name: &str) -> Option<&T>;
+    |                     ^^^^^^^ required by this bound in `GetField::get_field`
+
+error[E0277]: the trait bound `NoReflect: GetTypeRegistration` is not satisfied
+  --> tests/reflect_derive/generics.fail.rs:14:36
    |
-14 |     let mut foo: Box<dyn Reflect> = Box::new(Foo::<NoReflect> { a: NoReflect(42.0) });
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Reflect` is not implemented for `NoReflect`
+14 |     let mut foo: Box<dyn Struct> = Box::new(Foo::<NoReflect> { a: NoReflect(42.0) });
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `GetTypeRegistration` is not implemented for `NoReflect`
    |
-   = help: the following other types implement trait `Reflect`:
+   = help: the following other types implement trait `GetTypeRegistration`:
              bool
              char
              isize
@@ -20,7 +47,7 @@ error[E0277]: the trait bound `NoReflect: Reflect` is not satisfied
              i64
              i128
            and $N others
-note: required for `Foo<NoReflect>` to implement `Reflect`
+note: required for `Foo<NoReflect>` to implement `bevy_reflect::Struct`
   --> tests/reflect_derive/generics.fail.rs:3:10
    |
 3  | #[derive(Reflect)]
@@ -28,5 +55,32 @@ note: required for `Foo<NoReflect>` to implement `Reflect`
 4  | #[reflect(from_reflect = false)]
 5  | struct Foo<T> {
    |        ^^^^^^
-   = note: required for the cast from `Box<Foo<NoReflect>>` to `Box<(dyn Reflect + 'static)>`
+   = note: required for the cast from `Box<Foo<NoReflect>>` to `Box<(dyn bevy_reflect::Struct + 'static)>`
+   = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NoReflect: TypePath` is not satisfied
+  --> tests/reflect_derive/generics.fail.rs:14:36
+   |
+14 |     let mut foo: Box<dyn Struct> = Box::new(Foo::<NoReflect> { a: NoReflect(42.0) });
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TypePath` is not implemented for `NoReflect`
+   |
+   = help: the following other types implement trait `TypePath`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required for `Foo<NoReflect>` to implement `bevy_reflect::Struct`
+  --> tests/reflect_derive/generics.fail.rs:3:10
+   |
+3  | #[derive(Reflect)]
+   |          ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+4  | #[reflect(from_reflect = false)]
+5  | struct Foo<T> {
+   |        ^^^^^^
+   = note: required for the cast from `Box<Foo<NoReflect>>` to `Box<(dyn bevy_reflect::Struct + 'static)>`
    = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -7,10 +7,12 @@ use bevy_ecs::{
     system::{StaticSystemParam, SystemParam, SystemParamItem, SystemState},
     world::{FromWorld, Mut},
 };
+use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::{
     utility::{reflect_hasher, NonGenericTypeInfoCell},
-    FromReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath,
-    Typed, ValueInfo,
+    FromReflect, FromType, GetTypeRegistration, Reflect, ReflectDeserialize, ReflectFromPtr,
+    ReflectFromReflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, ReflectSerialize,
+    TypeInfo, TypePath, TypeRegistration, Typed, ValueInfo,
 };
 use bevy_utils::{thiserror::Error, HashMap, HashSet};
 use serde::{Deserialize, Serialize};
@@ -152,6 +154,18 @@ impl Reflect for RenderAssetUsages {
         } else {
             Some(false)
         }
+    }
+}
+
+impl GetTypeRegistration for RenderAssetUsages {
+    fn get_type_registration() -> TypeRegistration {
+        let mut registration = TypeRegistration::of::<Self>();
+        registration.insert::<ReflectSerialize>(FromType::<Self>::from_type());
+        registration.insert::<ReflectDeserialize>(FromType::<Self>::from_type());
+        registration.insert::<ReflectDefault>(FromType::<Self>::from_type());
+        registration.insert::<ReflectFromReflect>(FromType::<Self>::from_type());
+        registration.insert::<ReflectFromPtr>(FromType::<Self>::from_type());
+        registration
     }
 }
 

--- a/examples/reflection/generic_reflection.rs
+++ b/examples/reflection/generic_reflection.rs
@@ -1,7 +1,6 @@
 //! Demonstrates how reflection is used with generic Rust types.
 
 use bevy::prelude::*;
-use bevy::reflect::GetTypeRegistration;
 use std::any::TypeId;
 
 fn main() {
@@ -13,8 +12,10 @@ fn main() {
         .run();
 }
 
+/// The `#[derive(Reflect)]` macro will automatically add any required bounds to `T`,
+/// such as `Reflect` and `GetTypeRegistration`.
 #[derive(Reflect)]
-struct MyType<T: Reflect + GetTypeRegistration> {
+struct MyType<T> {
     value: T,
 }
 

--- a/examples/reflection/generic_reflection.rs
+++ b/examples/reflection/generic_reflection.rs
@@ -1,6 +1,7 @@
 //! Demonstrates how reflection is used with generic Rust types.
 
 use bevy::prelude::*;
+use bevy::reflect::GetTypeRegistration;
 use std::any::TypeId;
 
 fn main() {
@@ -13,7 +14,7 @@ fn main() {
 }
 
 #[derive(Reflect)]
-struct MyType<T: Reflect> {
+struct MyType<T: Reflect + GetTypeRegistration> {
     value: T,
 }
 


### PR DESCRIPTION
# Objective

Resolves #4154

Currently, registration must all be done manually:

```rust
#[derive(Reflect)]
struct Foo(Bar);

#[derive(Reflect)]
struct Bar(Baz);

#[derive(Reflect)]
struct Baz(usize);

fn main() {
  // ...
  app
    .register_type::<Foo>()
    .register_type::<Bar>()
    .register_type::<Baz>()
    // .register_type::<usize>() <- This one is handled by Bevy, thankfully
  // ...
}
```

This can grow really quickly and become very annoying to add, remove, and update as types change. It would be great if we could help reduce the number of types that a user must manually implement themselves.

## Solution

As suggested in #4154, this PR adds automatic recursive registration. Essentially, when a type is registered, it may now also choose to register additional types along with it using the new `GetTypeRegistration::register_type_dependencies` trait method.

The `Reflect` derive macro now automatically does this for all fields in structs, tuple structs, struct variants, and tuple variants. This is also done for tuples, arrays, `Vec<T>`, `HashMap<K, V>`, and `Option<T>`.

This allows us to simplify the code above like:

```rust
#[derive(Reflect)]
struct Foo(Bar);

#[derive(Reflect)]
struct Bar(Baz);

#[derive(Reflect)]
struct Baz(usize);

fn main() {
  // ...
  app.register_type::<Foo>()
  // ...
}
```

This automatic registration only occurs if the type has not yet been registered. If it has been registered, we simply skip it and move to the next one. This reduces the cost of registration and prevents overwriting customized registrations.

## Considerations

While this does improve ergonomics on one front, it's important to look at some of the arguments against adopting a PR like this.

#### Generic Bounds

~~Since we need to be able to register the fields individually, we need those fields to implement `GetTypeRegistration`. This forces users to then add this trait as a bound on their generic arguments. This annoyance could be relieved with something like #5772.~~

This is no longer a major issue as the `Reflect` derive now adds the `GetTypeRegistration` bound by default. This should technically be okay, since we already add the `Reflect` bound.

However, this can also be considered a breaking change for manual implementations that left out a `GetTypeRegistration` impl ~~or for items that contain dynamic types (e.g. `DynamicStruct`) since those also do not implement `GetTypeRegistration`~~.

#### Registration Assumptions

By automatically registering fields, users might inadvertently be relying on certain types to be automatically registered. If `Foo` auto-registers `Bar`, but `Foo` is later removed from the code, then anywhere that previously used or relied on `Bar`'s registration would now fail.

---

## Changelog

- Added recursive type registration to structs, tuple structs, struct variants, tuple variants, tuples, arrays, `Vec<T>`, `HashMap<K, V>`, and `Option<T>`
- Added a new trait in the hidden `bevy_reflect::__macro_exports` module called `RegisterForReflection`
- Added `GetTypeRegistration` impl for `bevy_render::render_asset::RenderAssetUsages`

## Migration Guide

All types that derive `Reflect` will now automatically add `GetTypeRegistration` as a bound on all (unignored) fields. This means that all reflected fields will need to also implement `GetTypeRegistration`.

If all fields **derive** `Reflect` or are implemented in `bevy_reflect`, this should not cause any issues. However, manual implementations of `Reflect` that excluded a `GetTypeRegistration` impl for their type will need to add one.

```rust
#[derive(Reflect)]
struct Foo<T: FromReflect> {
  data: MyCustomType<T>
}

// OLD
impl<T: FromReflect> Reflect for MyCustomType<T> {/* ... */}

// NEW
impl<T: FromReflect + GetTypeRegistration> Reflect for MyCustomType<T> {/* ... */}
impl<T: FromReflect + GetTypeRegistration> GetTypeRegistration for MyCustomType<T> {/* ... */}
```