### PR TITLE
Improve some error messages for bevy_ecs generated by nightly rustc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ debug_asset_server = ["bevy_internal/debug_asset_server"]
 
 # Enable animation support, and glTF animation loading
 animation = ["bevy_internal/animation"]
+nightly-error-messages = ["bevy_internal/nightly-error-messages"]
 
 [dependencies]
 bevy_dylib = { path = "crates/bevy_dylib", version = "0.9.0-dev", default-features = false, optional = true }

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["game-engines", "data-structures"]
 [features]
 trace = []
 default = ["bevy_reflect"]
+nightly-error-messages = []
 
 [dependencies]
 bevy_ptr = { path = "../bevy_ptr", version = "0.9.0-dev" }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::undocumented_unsafe_blocks)]
 #![doc = include_str!("../README.md")]
+#![cfg_attr(feature = "nightly-error-messages", feature(rustc_attrs))]
 
 #[cfg(target_pointer_width = "16")]
 compile_error!("bevy_ecs cannot safely compile for a 16-bit platform.");

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -325,6 +325,14 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 /// [`WorldQuery::update_archetype_component_access`] exactly reflects the results of
 /// [`WorldQuery::matches_component_set`], [`WorldQuery::archetype_fetch`], and
 /// [`WorldQuery::table_fetch`].
+#[cfg_attr(
+    feature = "nightly-error-messages",
+    rustc_on_unimplemented(on(
+        not(any(_Self = "& _", _Self = "&mut _", _Self = "()", _Self = "(_, _)")),
+        message = "Using a `WorldQuery` object as parameter to `Query` requires the usage of a reference",
+        label = "consider using `& {Self}` here"
+    ),)
+)]
 pub unsafe trait WorldQuery: for<'w> WorldQueryGats<'w> {
     /// The read-only variant of this [`WorldQuery`], which satisfies the [`ReadOnlyWorldQuery`] trait.
     type ReadOnly: ReadOnlyWorldQuery<State = Self::State>;

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -252,6 +252,10 @@ impl_param_set!();
 /// # schedule.add_system_to_stage("update", write_resource_system.after("first"));
 /// # schedule.run_once(&mut world);
 /// ```
+#[cfg_attr(
+    feature = "nightly-error-messages",
+    rustc_on_unimplemented(note = "consider adding `#[derive(bevy::Resource)]` to `{Self}`")
+)]
 pub trait Resource: Send + Sync + 'static {}
 
 /// Shared borrow of a [`Resource`].

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -22,6 +22,7 @@ trace_chrome = [ "bevy_log/tracing-chrome" ]
 trace_tracy = ["bevy_render?/tracing-tracy", "bevy_log/tracing-tracy" ]
 wgpu_trace = ["bevy_render/wgpu_trace"]
 debug_asset_server = ["bevy_asset/debug_asset_server"]
+nightly-error-messages = ["bevy_ecs/nightly-error-messages"]
 
 # Image format support for texture loading (PNG and HDR are enabled by default)
 hdr = ["bevy_render/hdr"]


### PR DESCRIPTION
This commit introduces a new feature flags that let's user opt into the
nightly only `#[rustc_on_unimplemented]` attribute. This attribute can
be used to improve error messages generated by missing trait
implementations. This commit adds annotations to two locations in bevy
to improve error messages submitted as part of
https://github.com/weiznich/rust-foundation-community-grant/issues/3

Addresses https://github.com/bevyengine/bevy/issues/1519

