### PR TITLE
[Merged by Bors] - Helpers to check pipeline cache status

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -24,7 +24,7 @@ use wgpu::{
     VertexBufferLayout as RawVertexBufferLayout,
 };
 
-enum PipelineDescriptor {
+pub enum PipelineDescriptor {
     RenderPipelineDescriptor(Box<RenderPipelineDescriptor>),
     ComputePipelineDescriptor(Box<ComputePipelineDescriptor>),
 }
@@ -51,9 +51,9 @@ impl CachedComputePipelineId {
     pub const INVALID: Self = CachedComputePipelineId(usize::MAX);
 }
 
-struct CachedPipeline {
-    descriptor: PipelineDescriptor,
-    state: CachedPipelineState,
+pub struct CachedPipeline {
+    pub descriptor: PipelineDescriptor,
+    pub state: CachedPipelineState,
 }
 
 #[derive(Debug)]
@@ -281,11 +281,8 @@ pub struct PipelineCache {
 }
 
 impl PipelineCache {
-    pub fn count_ready(&self) -> usize {
-        self.pipelines
-            .iter()
-            .filter(|pipeline| matches!(pipeline.state, CachedPipelineState::Ok(_)))
-            .count()
+    pub fn pipelines(&self) -> impl Iterator<Item = &CachedPipeline> {
+        self.pipelines.iter()
     }
 
     pub fn new(device: RenderDevice) -> Self {

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -281,6 +281,13 @@ pub struct PipelineCache {
 }
 
 impl PipelineCache {
+    pub fn count_ready(&self) -> usize {
+        self.pipelines
+            .iter()
+            .filter(|pipeline| matches!(pipeline.state, CachedPipelineState::Ok(_)))
+            .count()
+    }
+
     pub fn new(device: RenderDevice) -> Self {
         Self {
             device,

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -12,7 +12,11 @@ use crate::{
 use bevy_asset::{AssetEvent, Assets, Handle};
 use bevy_ecs::system::{Res, ResMut};
 use bevy_ecs::{event::EventReader, system::Resource};
-use bevy_utils::{default, tracing::error, Entry, HashMap, HashSet};
+use bevy_utils::{
+    default,
+    tracing::{debug, error},
+    Entry, HashMap, HashSet,
+};
 use std::{hash::Hash, iter::FusedIterator, mem, ops::Deref, sync::Arc};
 use thiserror::Error;
 use wgpu::{
@@ -137,6 +141,10 @@ impl ShaderCache {
                     shader_defs.push(String::from("NO_STORAGE_BUFFERS_SUPPORT"));
                 }
 
+                debug!(
+                    "processing shader {:?}, with shader defs {:?}",
+                    handle, shader_defs
+                );
                 let processed = self.processor.process(
                     shader,
                     &shader_defs,


### PR DESCRIPTION
# Objective

- In WASM, creating a pipeline can easily take 2 seconds, freezing the game while doing so
- Preloading pipelines can be done during a "loading" state, but it is not trivial to know which pipeline to preload, or when it's done

## Solution

- Add a log with shaders being loaded and their shader defs
- add a function on `PipelineCache` to return the number of ready pipelines
