### PR TITLE
[Merged by Bors] - Add `pop` method for `List` trait.

### DIFF
--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -54,6 +54,10 @@ where
         });
         SmallVec::push(self, value);
     }
+
+    fn pop(&mut self) -> Option<Box<dyn Reflect>> {
+        self.pop().map(|value| Box::new(value) as Box<dyn Reflect>)
+    }
 }
 
 impl<T: smallvec::Array + Send + Sync + 'static> Reflect for SmallVec<T>

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -127,6 +127,10 @@ impl<T: FromReflect> List for Vec<T> {
         });
         Vec::push(self, value);
     }
+
+    fn pop(&mut self) -> Option<Box<dyn Reflect>> {
+        self.pop().map(|value| Box::new(value) as Box<dyn Reflect>)
+    }
 }
 
 impl<T: FromReflect> Reflect for Vec<T> {

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -15,7 +15,7 @@ pub trait List: Reflect + Array {
     /// Appends an element to the list.
     fn push(&mut self, value: Box<dyn Reflect>);
 
-    /// Removes the last element from the list and returns it, or [`None`] if it is empty.
+    /// Removes the last element from the list (highest index in the array) and returns it, or [`None`] if it is empty.
     fn pop(&mut self) -> Option<Box<dyn Reflect>>;
 
     /// Clones the list, producing a [`DynamicList`].

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -15,7 +15,7 @@ pub trait List: Reflect + Array {
     /// Appends an element to the list.
     fn push(&mut self, value: Box<dyn Reflect>);
 
-    /// Removes the last element from a list and returns it, or [`None`] if it is empty.
+    /// Removes the last element from the list and returns it, or [`None`] if it is empty.
     fn pop(&mut self) -> Option<Box<dyn Reflect>>;
 
     /// Clones the list, producing a [`DynamicList`].

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -15,6 +15,9 @@ pub trait List: Reflect + Array {
     /// Appends an element to the list.
     fn push(&mut self, value: Box<dyn Reflect>);
 
+    /// Removes the last element from a list and returns it, or [`None`] if it is empty.
+    fn pop(&mut self) -> Option<Box<dyn Reflect>>;
+
     /// Clones the list, producing a [`DynamicList`].
     fn clone_dynamic(&self) -> DynamicList {
         DynamicList {
@@ -149,6 +152,10 @@ impl Array for DynamicList {
 impl List for DynamicList {
     fn push(&mut self, value: Box<dyn Reflect>) {
         DynamicList::push_box(self, value);
+    }
+
+    fn pop(&mut self) -> Option<Box<dyn Reflect>> {
+        self.values.pop()
     }
 
     fn clone_dynamic(&self) -> DynamicList {


### PR DESCRIPTION
# Objective

- The reflection `List` trait does not have a `pop` function.
- Popping elements off a list is a common use case and is almost always supported by `List`-like types.

## Solution

- Add the `pop()` method to the `List` trait and add the appropriate implementations of this function.

## Migration Guide

- Any custom type that implements the `List` trait will now need to implement the `pop` method.
