### PR TITLE
Perfect privacy for mutable component access

### DIFF
--- a/benches/benches/bevy_ecs/world/world_get.rs
+++ b/benches/benches/bevy_ecs/world/world_get.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::{
     bundle::Bundle,
-    component::Component,
+    component::WriteComponent,
     entity::Entity,
     prelude::*,
     system::{Query, SystemState},
@@ -29,7 +29,7 @@ fn deterministic_rand() -> ChaCha8Rng {
     ChaCha8Rng::seed_from_u64(42)
 }
 
-fn setup<T: Component + Default>(entity_count: u32) -> World {
+fn setup<T: WriteComponent + Default>(entity_count: u32) -> World {
     let mut world = World::default();
     world.spawn_batch((0..entity_count).map(|_| (T::default(),)));
     black_box(world)

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -55,7 +55,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 
 pub const COMPONENT: Symbol = Symbol("component");
 pub const STORAGE: Symbol = Symbol("storage");
-pub const VISIBILITY: Symbol = Symbol("vis");
+pub const VISIBILITY: Symbol = Symbol("write_marker");
 
 struct Attrs {
     marker: Option<TokenStream2>,

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -113,6 +113,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
     let mut field_component_ids = Vec::new();
     let mut field_get_components = Vec::new();
     let mut field_from_components = Vec::new();
+    let mut field_assert = Vec::new();
     for ((field_type, is_bundle), field) in
         field_type.iter().zip(is_bundle.iter()).zip(field.iter())
     {
@@ -135,6 +136,9 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
             });
             field_from_components.push(quote! {
                 #field: func(ctx).read::<#field_type>(),
+            });
+            field_assert.push(quote! {
+                #ecs_path::component::assert_has_write_access::<#field_type>();
             });
         }
     }
@@ -160,6 +164,8 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
             where
                 __F: FnMut(&mut __T) -> #ecs_path::ptr::OwningPtr<'_>
             {
+                // Make sure each component has unrestricted write access.
+                #(#field_assert)*
                 Self {
                     #(#field_from_components)*
                 }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -6,13 +6,17 @@ pub use bevy_ecs_macros::Bundle;
 
 use crate::{
     archetype::{AddBundle, Archetype, ArchetypeId, Archetypes, ComponentStatus},
-    component::{Component, ComponentId, ComponentTicks, Components, StorageType},
+    component::{ComponentId, ComponentTicks, Components, StorageType},
     entity::{Entities, Entity, EntityLocation},
     storage::{SparseSetIndex, SparseSets, Storages, Table},
 };
 use bevy_ecs_macros::all_tuples;
 use bevy_ptr::OwningPtr;
 use std::{any::TypeId, collections::HashMap};
+
+// We don't use this in code, but we need it for docs.
+#[allow(unused_imports)]
+use crate::component::Component;
 
 /// An ordered collection of [`Component`]s.
 ///
@@ -103,7 +107,7 @@ macro_rules! tuple_impl {
         // - `Bundle::component_ids` returns the `ComponentId`s for each component type in the
         // bundle, in the exact order that `Bundle::get_components` is called.
         // - `Bundle::from_components` calls `func` exactly once for each `ComponentId` returned by `Bundle::component_ids`.
-        unsafe impl<$($name: Component),*> Bundle for ($($name,)*) {
+        unsafe impl<$($name: $crate::component::WriteComponent),*> Bundle for ($($name,)*) {
             #[allow(unused_variables)]
             fn component_ids(components: &mut Components, storages: &mut Storages) -> Vec<ComponentId> {
                 vec![$(components.init_component::<$name>(storages)),*]

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -229,6 +229,7 @@ where
     T: WriteComponent<Marker>,
 {
     // FIXME: Derive this when we can do #[bundle(ignore)].
+    // https://github.com/bevyengine/bevy/pull/5628
     val: Unlocked<T>,
     _marker: PhantomData<fn() -> Marker>,
 }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -113,6 +113,20 @@ pub trait Component: Send + Sync + 'static {
     type Storage: ComponentStorage;
 }
 
+/// Marker trait that allows a [`Component`] to be mutated.
+///
+/// The type parameter `Marker` is used to control the privacy of the access.
+/// You can only mutate a component if you can name the marker type.
+/// By default the marker is the unit type, so anyone can mutate most components.
+pub trait WriteAccess<Marker = ()> {}
+
+/// Asserts at compile time that the specified component has public write access.
+pub fn assert_has_write_access<T: Component + WriteAccess>() {}
+
+/// [`Component`]s that have [write access](WriteAccess) - shorthand for `Component + WriteAccess`.
+pub trait WriteComponent<Marker = ()>: Component + WriteAccess<Marker> {}
+impl<T: ?Sized, Marker> WriteComponent<Marker> for T where T: Component + WriteAccess<Marker> {}
+
 pub struct TableStorage;
 pub struct SparseStorage;
 

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -173,11 +173,11 @@ where
 /// struct Marker;
 ///
 /// #[derive(Component)]
-/// #[component(vis = "Marker")]
+/// #[component(write_marker = "Marker")]
 /// pub struct Chassis;
 ///
 /// #[derive(Component)]
-/// #[component(vis = "Marker")]
+/// #[component(write_marker = "Marker")]
 /// pub struct Axle {
 ///     // The fields can be public, since no one outside this module can get mutable access
 ///     // once this component has been inserted into the world.
@@ -185,7 +185,7 @@ where
 /// }
 ///
 /// #[derive(Component)]
-/// #[component(vis = "Marker")]
+/// #[component(write_marker = "Marker")]
 /// pub struct Tires {
 ///     pub width: f64,
 /// }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1447,7 +1447,7 @@ all_tuples!(impl_system_param_tuple, 0, 16, P);
 pub mod lifetimeless {
     pub type SQuery<Q, F = ()> = super::Query<'static, 'static, Q, F>;
     pub type Read<T> = &'static T;
-    pub type Write<T> = &'static mut T;
+    pub use crate::query::Write;
     pub type SRes<T> = super::Res<'static, T>;
     pub type SResMut<T> = super::ResMut<'static, T>;
     pub type SCommands = crate::system::Commands<'static, 'static>;

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -198,10 +198,7 @@ impl<'w> EntityMut<'w> {
 
     /// Gets mutable access to a component that has protected mutability.
     #[inline]
-    pub fn get_mut_protected<T, Vis>(&mut self) -> Option<Mut<'_, T>>
-    where
-        T: WriteComponent<Vis>,
-    {
+    pub fn get_mut_protected<T: WriteComponent<Vis>, Vis>(&mut self) -> Option<Mut<T>> {
         // SAFETY: world access is unique, and lifetimes enforce correct usage of returned borrow
         unsafe { self.get_unchecked_mut::<T>() }
     }
@@ -460,10 +457,7 @@ impl<'w> EntityMut<'w> {
     }
 
     /// Removes a component that has protected mutability.
-    pub fn remove_protected<T, Vis>(&mut self) -> Option<T>
-    where
-        T: WriteComponent<Vis>,
-    {
+    pub fn remove_protected<T: WriteComponent<Vis>, Vis>(&mut self) -> Option<T> {
         self.remove_bundle::<crate::component::Unlocked<T>>()
             .map(|v| v.0)
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     change_detection::{MutUntyped, Ticks},
     component::{
         Component, ComponentDescriptor, ComponentId, ComponentInfo, ComponentTicks, Components,
-        StorageType,
+        StorageType, WriteComponent,
     },
     entity::{AllocAtWithoutReplacement, Entities, Entity},
     query::{QueryState, WorldQuery},
@@ -478,7 +478,23 @@ impl World {
     /// position.x = 1.0;
     /// ```
     #[inline]
-    pub fn get_mut<T: Component>(&mut self, entity: Entity) -> Option<Mut<T>> {
+    pub fn get_mut<T: WriteComponent>(&mut self, entity: Entity) -> Option<Mut<T>> {
+        self.get_mut_raw::<T>(entity)
+    }
+
+    /// Gets mutable access to a component that has protected mutability.
+    #[inline]
+    pub fn get_mut_protected<T: WriteComponent<Vis>, Vis>(
+        &mut self,
+        entity: Entity,
+    ) -> Option<Mut<T>> {
+        self.get_mut_raw::<T>(entity)
+    }
+
+    /// Allows mutable access to a component while ignoring visibility rules.
+    /// This is not unsafe, just error-prone.
+    #[inline]
+    pub(crate) fn get_mut_raw<T: Component>(&mut self, entity: Entity) -> Option<Mut<T>> {
         // SAFETY: lifetimes enforce correct usage of returned borrow
         unsafe { get_mut(self, entity, self.get_entity(entity)?.location()) }
     }

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/entity_ref_mut_lifetime_safety.rs
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/entity_ref_mut_lifetime_safety.rs
@@ -51,14 +51,14 @@ fn main() {
 
     {
         let gotten: &A = e_mut.get::<A>().unwrap();
-        e_mut.insert::<B>(B);
+        e_mut.insert(B);
         assert_eq!(gotten, &A(Box::new(16_usize))); // oops UB
         e_mut.remove::<B>();
     }
 
     {
         let mut gotten_mut: Mut<A> = e_mut.get_mut::<A>().unwrap();
-        e_mut.insert::<B>(B);
+        e_mut.insert(B);
         assert_eq!(&mut *gotten_mut, &mut A(Box::new(16_usize))); // oops UB
     }
 }

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/entity_ref_mut_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/entity_ref_mut_lifetime_safety.stderr
@@ -53,8 +53,8 @@ error[E0502]: cannot borrow `e_mut` as mutable because it is also borrowed as im
    |
 53 |         let gotten: &A = e_mut.get::<A>().unwrap();
    |                          ---------------- immutable borrow occurs here
-54 |         e_mut.insert::<B>(B);
-   |         ^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
+54 |         e_mut.insert(B);
+   |         ^^^^^^^^^^^^^^^ mutable borrow occurs here
 55 |         assert_eq!(gotten, &A(Box::new(16_usize))); // oops UB
    |         ------------------------------------------ immutable borrow later used here
 
@@ -63,7 +63,7 @@ error[E0499]: cannot borrow `e_mut` as mutable more than once at a time
    |
 60 |         let mut gotten_mut: Mut<A> = e_mut.get_mut::<A>().unwrap();
    |                                      -------------------- first mutable borrow occurs here
-61 |         e_mut.insert::<B>(B);
-   |         ^^^^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+61 |         e_mut.insert(B);
+   |         ^^^^^^^^^^^^^^^ second mutable borrow occurs here
 62 |         assert_eq!(&mut *gotten_mut, &mut A(Box::new(16_usize))); // oops UB
    |                          ---------- first borrow later used here

--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -13,6 +13,7 @@ use std::ops::Deref;
 /// Contains references to the child entities of this entity
 #[derive(Component, Debug, Reflect)]
 #[reflect(Component, MapEntities)]
+#[component(vis = "crate::Vis")]
 pub struct Children(pub(crate) SmallVec<[Entity; 8]>);
 
 impl MapEntities for Children {

--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -13,7 +13,7 @@ use std::ops::Deref;
 /// Contains references to the child entities of this entity
 #[derive(Component, Debug, Reflect)]
 #[reflect(Component, MapEntities)]
-#[component(vis = "crate::Vis")]
+#[component(write_marker = "crate::Vis")]
 pub struct Children(pub(crate) SmallVec<[Entity; 8]>);
 
 impl MapEntities for Children {

--- a/crates/bevy_hierarchy/src/components/mod.rs
+++ b/crates/bevy_hierarchy/src/components/mod.rs
@@ -3,3 +3,5 @@ mod parent;
 
 pub use children::Children;
 pub use parent::Parent;
+
+pub(crate) struct Vis;

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -11,6 +11,7 @@ use std::ops::Deref;
 /// This component should only be present on entities that actually have a parent entity.
 #[derive(Component, Debug, Eq, PartialEq, Reflect)]
 #[reflect(Component, MapEntities, PartialEq)]
+#[component(vis = "crate::Vis")]
 pub struct Parent(pub(crate) Entity);
 
 impl Parent {

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -11,7 +11,7 @@ use std::ops::Deref;
 /// This component should only be present on entities that actually have a parent entity.
 #[derive(Component, Debug, Eq, PartialEq, Reflect)]
 #[reflect(Component, MapEntities, PartialEq)]
-#[component(vis = "crate::Vis")]
+#[component(write_marker = "crate::Vis")]
 pub struct Parent(pub(crate) Entity);
 
 impl Parent {

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -24,7 +24,7 @@ pub struct DespawnChildrenRecursive {
 pub fn despawn_with_children_recursive(world: &mut World, entity: Entity) {
     // first, make the entity's own parent forget about it
     if let Some(parent) = world.get::<Parent>(entity).map(|parent| parent.0) {
-        if let Some(mut children) = world.get_mut::<Children>(parent) {
+        if let Some(mut children) = world.get_mut_protected::<Children, _>(parent) {
             children.0.retain(|c| *c != entity);
         }
     }
@@ -35,7 +35,7 @@ pub fn despawn_with_children_recursive(world: &mut World, entity: Entity) {
 
 // Should only be called by `despawn_with_children_recursive`!
 fn despawn_with_children_recursive_inner(world: &mut World, entity: Entity) {
-    if let Some(mut children) = world.get_mut::<Children>(entity) {
+    if let Some(mut children) = world.get_mut_protected::<Children, _>(entity) {
         for e in std::mem::take(&mut children.0) {
             despawn_with_children_recursive_inner(world, e);
         }
@@ -47,7 +47,7 @@ fn despawn_with_children_recursive_inner(world: &mut World, entity: Entity) {
 }
 
 fn despawn_children(world: &mut World, entity: Entity) {
-    if let Some(mut children) = world.get_mut::<Children>(entity) {
+    if let Some(mut children) = world.get_mut_protected::<Children, _>(entity) {
         for e in std::mem::take(&mut children.0) {
             despawn_with_children_recursive_inner(world, e);
         }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -10,7 +10,7 @@ use bevy_asset::{AssetEvent, Assets, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     change_detection::DetectChanges,
-    component::Component,
+    component::{Component, WriteComponent},
     entity::Entity,
     event::EventReader,
     query::Added,
@@ -305,7 +305,7 @@ impl RenderTarget {
     }
 }
 
-pub fn camera_system<T: CameraProjection + Component>(
+pub fn camera_system<T: CameraProjection + WriteComponent>(
     mut window_resized_events: EventReader<WindowResized>,
     mut window_created_events: EventReader<WindowCreated>,
     mut image_asset_events: EventReader<AssetEvent<Image>>,

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use bevy_app::{App, CoreStage, Plugin, StartupStage};
-use bevy_ecs::{prelude::*, reflect::ReflectComponent};
+use bevy_ecs::{component::WriteComponent, prelude::*, reflect::ReflectComponent};
 use bevy_math::Mat4;
 use bevy_reflect::{
     std_traits::ReflectDefault, FromReflect, GetTypeRegistration, Reflect, ReflectDeserialize,
@@ -22,7 +22,9 @@ impl<T: CameraProjection> Default for CameraProjectionPlugin<T> {
 #[derive(SystemLabel, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct CameraUpdateSystem;
 
-impl<T: CameraProjection + Component + GetTypeRegistration> Plugin for CameraProjectionPlugin<T> {
+impl<T: CameraProjection + WriteComponent + GetTypeRegistration> Plugin
+    for CameraProjectionPlugin<T>
+{
     fn build(&self, app: &mut App) {
         app.register_type::<T>()
             .add_startup_system_to_stage(


### PR DESCRIPTION
# Objective

Preventing mutation is very difficult in bevy. Even if you encapsulate an entire type, you can still acquire a `&mut T` and `std::mem::swap` it out.
The most obvious example of this is the hierarchy. We would like to keep it consistent at all times, but that is not currently possible since anyone can swap out components at any time.

Related to / evolution of #5356

## Solution

* Use marker types to limit where you can acquire mutable access or insert/remove components.
* Components that do not opt in to this feature are unaffected.
* Perfect privacy: since we're leveraging the type sytem, it should be impossible to bypass in safe code.
* Zero-cost: every thing is done statically; no runtime checks; no carrying values around.

## Example

Defining protected components.

```rust
/// Marker type which is only visible within this crate.
pub(crate) type VisMarker;

// Component that stores the ID of the parent entity.
// The field can be public, since no one else can mutate it once it's in the `World`.
#[derive(Component)]
#[component(write_marker = "VisMarker")]
pub struct Parent(pub Entity);
```

Trying to modify protected components incorrectly.

```rust
fn modify_parent(query: Query<&mut Parent>) {
    // This fails to compile since `&mut T` (in a query) requires unrestricted mutable access:
    // error[E0277]: the trait bound `Parent: WriteAccess` is not satisfied
}
```

Modifying the components properly.

```rust
use bevy_ecs::component::Write;
fn swap_parents(
    // `Write<>` is a WorldQuery that gives mutable access to a component.
    // Naming the visibility marker "unlocks" access to the component.
    mut children: Query<Write<Parent, VisMarker>>,
) {
    // Swap everyone's parents around.
    let mut combinations = query.iter_combinations_mut();
    while let Some([parent_a, parent_b]) = combinations.fetch_next() {
        std::mem::swap(&mut *parent_a, &mut *parent_b);
    }

    // What we just did is very bad, which is why no one outside of this crate is allowed to do it anymore.
}
```

Modifying through direct world access.

```rust
fn exclusive(world: &mut World) {
    let my_entity = ...;
    // Type inference fills in `VisMarker` for us.
    let parent = world.get_mut_protected::<Parent, _>(my_entity).unwrap();
}
```

---

## Changelog

- Added the ability to protect components from being mutated outside of their defining crates.
- Made the types `bevy_hierarchy::{Parent, Children}` externally immutable.

## Migration Guide

When writing systems with generic components, you now must specify the trait bound `bevy_ecs::component::WriteComponent` in order to mutate/insert/remove them.

Before:
```rust
fn deref_all<T: Component + DerefMut>(mut query: Query<&mut T>) {
    for mut val in &mut query {
        let val = val.deref_mut();
        // ... do something with the value
    }
}
```

After:
```rust
fn deref_all<T: WriteComponent + DerefMut>(mut query: Query<&mut T>) {
    for mut val in &mut query {
        // ...
    }
}
```
