### PR TITLE
[Merged by Bors] - fix `Quat` type name in scene example scene file

### DIFF
--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -10,7 +10,7 @@
             "value": (0.0, 0.0, 0.0),
           },
           "rotation": {
-            "type": "glam::f32::scalar::quat::Quat",
+            "type": "glam::f32::sse2::quat::Quat",
             "value": (0.0, 0.0, 0.0, 1.0),
           },
           "scale": {


### PR DESCRIPTION
# Objective

fix #5790 

## Solution

Change type name in the scene file by its new name `glam::f32::sse2::quat::Quat`.