### PR TITLE
bevy_gltf: Label subassets by name if available

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -32,6 +32,7 @@ downcast-rs = "1.2.0"
 fastrand = "1.7.0"
 notify = { version = "5.0.0", optional = true }
 parking_lot = "0.12.1"
+smallvec = { version = "1", features = ["union"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -575,7 +575,7 @@ impl AssetServer {
                 asset_lifecycle.create_asset(id, asset_value, load_context.version);
                 for label in labels.iter().skip(1) {
                     let alias = AssetPath::new_ref(load_context.path, Some(label)).into();
-                    asset_lifecycle.alias_asset(id, alias);
+                    asset_lifecycle.alias_asset(alias, id);
                 }
             } else {
                 panic!(
@@ -617,8 +617,8 @@ impl AssetServer {
                     }
                     assets.set_untracked(result.id, *result.asset);
                 }
-                Ok(AssetLifecycleEvent::Alias { extant, alias }) => {
-                    assets.add_alias(extant, alias);
+                Ok(AssetLifecycleEvent::Alias { for_label, alias }) => {
+                    assets.set_alias(alias, for_label);
                 }
                 Ok(AssetLifecycleEvent::Free(handle_id)) => {
                     if let HandleId::AssetPathId(id) = handle_id {

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -126,10 +126,12 @@ impl<T: Asset> Assets<T> {
     /// Adds a handle that refers to an extant asset
     ///
     /// # Panics
-    /// Panics if the extant asset is not found or the alias already points to an asset.
-    pub(crate) fn add_alias(&mut self, extant: HandleId, alias: HandleId) {
-        let index = *self.indices.get(&extant).expect("Asset to alias not found");
-        assert!(!self.indices.contains_key(&alias));
+    /// Panics if the extant asset is not found
+    pub(crate) fn set_alias(&mut self, alias: HandleId, for_label: HandleId) {
+        let index = *self
+            .indices
+            .get(&for_label)
+            .expect("Asset to alias not found");
         self.indices.insert(alias, index);
         self.assets[index].as_mut().unwrap().handles.push(alias);
     }

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -102,6 +102,9 @@ impl HandleId {
 /// handle to the unloaded asset, but it will not be able to retrieve the image data, resulting in
 /// collisions no longer being detected for that entity.
 ///
+/// # Aliases
+/// It is allowed for multiple handles point to the same asset (`bevy_gltf` labels subassets both by name and by index)
+///
 #[derive(Component, Reflect, FromReflect)]
 #[reflect(Component, Default)]
 pub struct Handle<T>

--- a/crates/bevy_asset/src/info.rs
+++ b/crates/bevy_asset/src/info.rs
@@ -13,8 +13,8 @@ pub struct SourceMeta {
 /// Metadata for an asset.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AssetMeta {
-    /// Asset label.
-    pub label: Option<String>,
+    /// Asset labels, empty for the default asset.
+    pub label: Vec<String>,
     /// Asset dependencies.
     pub dependencies: Vec<AssetPath<'static>>,
     /// An unique identifier for an asset type.

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -175,12 +175,12 @@ impl<'a> LoadContext<'a> {
     /// Adds an alias for an already added secondary asset.
     ///
     /// # Panics
-    /// Panics if `extant` doesn't refer to an asset or alias is ""
-    pub fn add_asset_alias(&mut self, extant: &str, alias: &str) {
+    /// Panics if `for_label` doesn't refer to an asset or alias is ""
+    pub fn add_asset_alias(&mut self, alias: &str, for_label: &str) {
         assert!(!alias.is_empty());
         let index = *self
             .label_indices
-            .get(&Some(extant.to_string()))
+            .get(&Some(for_label.to_string()))
             .expect("Existing asset not found");
         self.labeled_assets[index].0.push(alias.to_string());
         self.label_indices.insert(Some(alias.to_string()), index);
@@ -243,7 +243,7 @@ pub enum AssetLifecycleEvent<T> {
     /// An alias for an already existing asset was created.
     Alias {
         /// An asset that was already created
-        extant: HandleId,
+        for_label: HandleId,
         /// An alias to be added
         alias: HandleId,
     },
@@ -256,7 +256,7 @@ pub trait AssetLifecycle: Downcast + Send + Sync + 'static {
     /// Notifies the asset server that a new asset was created.
     fn create_asset(&self, id: HandleId, asset: Box<dyn AssetDynamic>, version: usize);
     /// Notifies the asset server that there is an alias for an extant asset.
-    fn alias_asset(&self, extant: HandleId, alias: HandleId);
+    fn alias_asset(&self, alias: HandleId, for_label: HandleId);
     /// Notifies the asset server that an asset was freed.
     fn free_asset(&self, id: HandleId);
 }
@@ -280,9 +280,9 @@ impl<T: AssetDynamic> AssetLifecycle for AssetLifecycleChannel<T> {
         }
     }
 
-    fn alias_asset(&self, extant: HandleId, alias: HandleId) {
+    fn alias_asset(&self, alias: HandleId, for_label: HandleId) {
         self.sender
-            .send(AssetLifecycleEvent::Alias { extant, alias })
+            .send(AssetLifecycleEvent::Alias { for_label, alias })
             .unwrap();
     }
 

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -28,9 +28,9 @@ fn setup(
 ) {
     // Insert a resource with the current scene information
     commands.insert_resource(Animations(vec![
-        asset_server.load("models/animated/Fox.glb#Animation2"),
-        asset_server.load("models/animated/Fox.glb#Animation1"),
-        asset_server.load("models/animated/Fox.glb#Animation0"),
+        asset_server.load("models/animated/Fox.glb#Animation/Run"),
+        asset_server.load("models/animated/Fox.glb#Animation/Walk"),
+        asset_server.load("models/animated/Fox.glb#Animation/Survey"),
     ]));
 
     // Camera


### PR DESCRIPTION
# Objective

Fixes #2948 / #5807

## Solution

Support multiple labels for the same subasset. An `AssetLoader` can call `add_asset_alias` to add a label alias to a subasset added via `set_labeled_asset`. `bevy_gltf` uses this to label subassets as e.g. "Animation/Walk" in addition to the previous "Animation5".

---

## Changelog
- Added: `AssetLoader`s can define aliases for subasset labels
- Added: Label gltf subassets by name if available

## Migration Guide
- `AssetLifecycle` and `AssetLifecycleEvent` now have to also handle alias creation events
- `AssetMeta` and `Assets::iter`/`iter_mut` work with a list of labels instead of only a single one