### PR TITLE
Feat/5764 map paths in bevy reflect

### DIFF
--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -143,22 +143,7 @@ impl GetPath for dyn Reflect {
                             }
                         },
                         Some(Token::SingleQuote) => {
-                            let ident =
-                                if let Some(Token::Ident(ident)) = next_token(path, &mut index) {
-                                    ident
-                                } else {
-                                    return Err(ReflectPathError::ExpectedIdent {
-                                        index: current_index,
-                                    });
-                                };
-
-                            if let Some(Token::SingleQuote) = next_token(path, &mut index) {
-                            } else {
-                                return Err(ReflectPathError::ExpectedToken {
-                                    index: current_index,
-                                    token: "'",
-                                });
-                            }
+                            let ident = match_quoted_ident(path, &mut index, current_index)?;
 
                             match current.reflect_ref() {
                                 ReflectRef::Map(reflect_list) => {
@@ -182,7 +167,7 @@ impl GetPath for dyn Reflect {
                                 index: current_index,
                             });
                         }
-                    };
+                    }
 
                     if let Some(Token::CloseBracket) = next_token(path, &mut index) {
                     } else {
@@ -251,22 +236,7 @@ impl GetPath for dyn Reflect {
                             }
                         },
                         Some(Token::SingleQuote) => {
-                            let ident =
-                                if let Some(Token::Ident(ident)) = next_token(path, &mut index) {
-                                    ident
-                                } else {
-                                    return Err(ReflectPathError::ExpectedIdent {
-                                        index: current_index,
-                                    });
-                                };
-
-                            if let Some(Token::SingleQuote) = next_token(path, &mut index) {
-                            } else {
-                                return Err(ReflectPathError::ExpectedToken {
-                                    index: current_index,
-                                    token: "'",
-                                });
-                            }
+                            let ident = match_quoted_ident(path, &mut index, current_index)?;
 
                             match current.reflect_mut() {
                                 ReflectMut::Map(reflect_list) => {
@@ -427,6 +397,29 @@ fn next_token<'a>(path: &'a str, index: &mut usize) -> Option<Token<'a>> {
     let ident = Token::Ident(&path[*index..]);
     *index = path.len();
     Some(ident)
+}
+
+fn match_quoted_ident<'a>(
+    path: &'a str,
+    mut index: &mut usize,
+    current_index: usize,
+) -> Result<&'a str, ReflectPathError<'a>> {
+    let ident = if let Some(Token::Ident(ident)) = next_token(path, &mut index) {
+        ident
+    } else {
+        return Err(ReflectPathError::ExpectedIdent {
+            index: current_index,
+        });
+    };
+
+    if !matches!(next_token(path, &mut index), Some(Token::SingleQuote)) {
+        return Err(ReflectPathError::ExpectedToken {
+            index: current_index,
+            token: "'",
+        });
+    }
+
+    Ok(ident)
 }
 
 #[cfg(test)]

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -146,8 +146,8 @@ impl GetPath for dyn Reflect {
                             let ident = match_quoted_ident(path, &mut index)?;
 
                             match current.reflect_ref() {
-                                ReflectRef::Map(reflect_list) => {
-                                    let list_item = reflect_list.get(&String::from(ident)).ok_or(
+                                ReflectRef::Map(reflect_map) => {
+                                    let list_item = reflect_map.get(&String::from(ident)).ok_or(
                                         ReflectPathError::InvalidMapKey {
                                             index: current_index,
                                             map_key: ident,
@@ -238,8 +238,8 @@ impl GetPath for dyn Reflect {
                             let ident = match_quoted_ident(path, &mut index)?;
 
                             match current.reflect_mut() {
-                                ReflectMut::Map(reflect_list) => {
-                                    let list_item = reflect_list
+                                ReflectMut::Map(reflect_map) => {
+                                    let list_item = reflect_map
                                         .get_mut(&String::from(ident))
                                         .ok_or(ReflectPathError::InvalidMapKey {
                                             index: current_index,

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -399,10 +399,10 @@ fn next_token<'a>(path: &'a str, index: &mut usize) -> Option<Token<'a>> {
 
 fn match_quoted_ident<'a>(
     path: &'a str,
-    mut index: &mut usize,
+    index: &mut usize,
 ) -> Result<&'a str, ReflectPathError<'a>> {
     let start_of_ident_index = *index;
-    let ident = if let Some(Token::Ident(ident)) = next_token(path, &mut index) {
+    let ident = if let Some(Token::Ident(ident)) = next_token(path, index) {
         ident
     } else {
         return Err(ReflectPathError::ExpectedIdent {
@@ -411,7 +411,7 @@ fn match_quoted_ident<'a>(
     };
 
     let end_of_ident_index = *index;
-    if !matches!(next_token(path, &mut index), Some(Token::SingleQuote)) {
+    if !matches!(next_token(path, index), Some(Token::SingleQuote)) {
         return Err(ReflectPathError::ExpectedToken {
             index: end_of_ident_index,
             token: "'",


### PR DESCRIPTION
# Objective

I aimed to solve #5764 here, implementing a way to access map entries using bevy_reflects `get_path` and `get_path_mut`. 

## Solution

The implementation is incomplete, only allowing to access entries in maps with `String`s as key. I wasnt able to come up with a proper solution yet on how to get from having a `&str ident` to a `K map_key` for a `Map<K, V>`. 

The current implementation uses the `m['key']` syntax for specifiing the map key, but it should be easy to adapt it to a different syntax, if required.

I added a new `SingleQuote`  `Token` variant, which is returned by `next_token`  when it encounters a  `'`. 
Then extended the `get_path` and `get_path_mut` methods to support a `SingleQuote` token after a `OpenBracket` token instead of an `Ident`.  If thats encountered, we expect the next token to be an `Ident` (the key) and then a closing `SingleQuote`, and we expect the `current` reflect node to be a `Map`.

Resolving the `map_key` from the read `ident` seems to only challenging part here and thus its the only part I was not able to solve (or I might have missed other stuff?). I opted for going for "String keys only for the first draft", but of course I do not expect this to be merged like this. 

Everything after that is basically a mirror of the behaviour for lists. 

Additionally I split/copied the test for get_path into a second one for get_path_mut which basically tests the exact same stuff but using the `_mut` variant to make sure both behave the same, since their code is roughly identical and seems prone to minor differences which may cause subtle bugs/inconsistencies.

## Changelog

> TBD 

## TODO

I plan on doing some experiments on how the `&str ident => K map_key` resolution could work, but if anyone got a good idea on how this can be done, I'd very happy to read that!

