### PR TITLE
[Merged by Bors] - Add UI scaling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1453,8 +1453,14 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
-name = "scaling"
+name = "ui_scaling"
 path = "examples/ui/scaling.rs"
+
+[package.metadata.example.ui_scaling]
+name = "UI Scaling"
+description = "Illustrates how to scale the UI"
+category = "UI (User Interface)"
+wasm = true
 
 # Window
 [[example]]

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -216,19 +216,12 @@ pub fn flex_node_system(
 
     // assume one window for time being...
     let logical_to_physical_factor = windows.scale_factor(WindowId::primary());
+    let scale_factor = logical_to_physical_factor * ui_scale.scale;
 
     if scale_factor_events.iter().next_back().is_some() || ui_scale.is_changed() {
-        update_changed(
-            &mut *flex_surface,
-            logical_to_physical_factor * ui_scale.scale,
-            full_node_query,
-        );
+        update_changed(&mut *flex_surface, scale_factor, full_node_query);
     } else {
-        update_changed(
-            &mut *flex_surface,
-            logical_to_physical_factor * ui_scale.scale,
-            node_query,
-        );
+        update_changed(&mut *flex_surface, scale_factor, node_query);
     }
 
     fn update_changed<F: WorldQuery>(
@@ -248,12 +241,7 @@ pub fn flex_node_system(
     }
 
     for (entity, style, calculated_size) in &changed_size_query {
-        flex_surface.upsert_leaf(
-            entity,
-            style,
-            *calculated_size,
-            logical_to_physical_factor * ui_scale.scale,
-        );
+        flex_surface.upsert_leaf(entity, style, *calculated_size, scale_factor);
     }
 
     // TODO: handle removed nodes

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -53,7 +53,7 @@ pub enum UiSystem {
 /// The current scale of the UI.
 ///
 /// A multiplier to fixed-sized ui values.
-/// **Note:** This will not affect non-fixed ui values like [`Val::Percent`]
+/// **Note:** This will only affect fixed ui values like [`Val::Px`]
 #[derive(Debug, Resource)]
 pub struct UiScale {
     /// The scale to be applied.

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -22,13 +22,14 @@ pub use ui_node::*;
 #[doc(hidden)]
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{
-        entity::*, geometry::*, ui_node::*, widget::Button, Interaction, UiScale,
-    };
+    pub use crate::{entity::*, geometry::*, ui_node::*, widget::Button, Interaction, UiScale};
 }
 
 use bevy_app::prelude::*;
-use bevy_ecs::schedule::{ParallelSystemDescriptorCoercion, SystemLabel};
+use bevy_ecs::{
+    schedule::{ParallelSystemDescriptorCoercion, SystemLabel},
+    system::Resource,
+};
 use bevy_input::InputSystem;
 use bevy_transform::TransformSystem;
 use bevy_window::ModifiesWindows;
@@ -49,7 +50,6 @@ pub enum UiSystem {
     Focus,
 }
 
-#[derive(Debug)]
 /// The current scale of the UI for all windows
 ///
 /// ## Note
@@ -57,6 +57,7 @@ pub enum UiSystem {
 /// be considered like a zoom
 ///
 /// This only affects pixel sizes, so a percent size will stay at that
+#[derive(Debug, Resource)]
 pub struct UiScale {
     /// The scale to be applied
     ///

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -50,20 +50,13 @@ pub enum UiSystem {
     Focus,
 }
 
-/// The current scale of the UI for all windows
+/// The current scale of the UI.
 ///
-/// ## Note
-/// This is purely about the logical scale, and can
-/// be considered like a zoom
-///
-/// This only affects pixel sizes, so a percent size will stay at that
+/// A multiplier to fixed-sized ui values.
+/// **Note:** This will not affect non-fixed ui values like [`Val::Percent`]
 #[derive(Debug, Resource)]
 pub struct UiScale {
-    /// The scale to be applied
-    ///
-    /// # Example
-    ///
-    /// A scale of `2.` will make every pixel size twice as large.
+    /// The scale to be applied.
     pub scale: f64,
 }
 

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -9,7 +9,7 @@ use bevy_math::Vec2;
 use bevy_render::texture::Image;
 use bevy_sprite::TextureAtlas;
 use bevy_text::{DefaultTextPipeline, Font, FontAtlasSet, Text, TextError};
-use bevy_window::{WindowId, Windows};
+use bevy_window::Windows;
 
 #[derive(Debug, Default)]
 pub struct QueuedText {
@@ -53,6 +53,8 @@ pub fn text_system(
         Query<(&Text, &Style, &mut CalculatedSize)>,
     )>,
 ) {
+    // TODO: This should support window-independent scale settings.
+    // See https://github.com/bevyengine/bevy/issues/5621
     let scale_factor = if let Some(window) = windows.get_primary() {
         window.scale_factor() * ui_scale.scale
     } else {

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,4 +1,4 @@
-use crate::{CalculatedSize, Style, UiScale, Val};
+use crate::{CalculatedSize, Size, Style, UiScale, Val};
 use bevy_asset::Assets;
 use bevy_ecs::{
     entity::Entity,

--- a/examples/README.md
+++ b/examples/README.md
@@ -313,7 +313,7 @@ Example | Description
 [Text Debug](../examples/ui/text_debug.rs) | An example for debugging text layout
 [Transparency UI](../examples/ui/transparency_ui.rs) | Demonstrates transparency for UI
 [UI](../examples/ui/ui.rs) | Illustrates various features of Bevy UI
-`scaling` | [`ui/scaling.rs`](./ui/scaling.rs) | Illustrates how to scale the UI
+[UI Scaling](../examples/ui/scaling.rs) | Illustrates how to scale the UI
 
 ## Window
 

--- a/examples/ui/scaling.rs
+++ b/examples/ui/scaling.rs
@@ -1,4 +1,4 @@
-//! This example illustrates the [`UIScale`] resource from bevy_ui
+//! This example illustrates the [`UIScale`] resource from `bevy_ui`.
 
 use bevy::{prelude::*, utils::Duration};
 

--- a/examples/ui/scaling.rs
+++ b/examples/ui/scaling.rs
@@ -1,3 +1,5 @@
+//! This example illustrates the UIScale resource from bevy_ui
+
 use bevy::{prelude::*, utils::Duration};
 
 const SCALE_TIME: u64 = 400;
@@ -5,7 +7,6 @@ const SCALE_TIME: u64 = 400;
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, SystemLabel)]
 struct ApplyScaling;
 
-/// This example illustrates the UIScale resource from bevy_ui
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -20,12 +21,8 @@ fn main() {
         .run();
 }
 
-fn setup(
-    mut commands: Commands,
-    asset_server: ResMut<AssetServer>,
-    mut materials: ResMut<Assets<ColorMaterial>>,
-) {
-    commands.spawn_bundle(UiCameraBundle::default());
+fn setup(mut commands: Commands, asset_server: ResMut<AssetServer>) {
+    commands.spawn_bundle(Camera2dBundle::default());
 
     let text_style = TextStyle {
         font: asset_server.load("fonts/FiraMono-Medium.ttf"),
@@ -38,53 +35,51 @@ fn setup(
             style: Style {
                 size: Size::new(Val::Percent(50.0), Val::Percent(50.0)),
                 position_type: PositionType::Absolute,
-                position: Rect {
+                position: UiRect {
                     left: Val::Percent(25.),
                     top: Val::Percent(25.),
-                    ..Default::default()
+                    ..default()
                 },
                 justify_content: JustifyContent::SpaceAround,
                 align_items: AlignItems::Center,
-                ..Default::default()
+                ..default()
             },
-            material: materials.add(Color::ANTIQUE_WHITE.into()),
-            ..Default::default()
+            color: Color::ANTIQUE_WHITE.into(),
+            ..default()
         })
         .with_children(|parent| {
             parent
                 .spawn_bundle(NodeBundle {
                     style: Style {
                         size: Size::new(Val::Px(40.), Val::Px(40.)),
-                        ..Default::default()
+                        ..default()
                     },
-                    material: materials.add(Color::RED.into()),
-                    ..Default::default()
+                    color: Color::RED.into(),
+                    ..default()
                 })
                 .with_children(|parent| {
-                    parent.spawn_bundle(TextBundle {
-                        text: Text::with_section("Size!", text_style, TextAlignment::default()),
-                        ..Default::default()
-                    });
+                    parent.spawn_bundle(TextBundle::from_section("Size!", text_style));
                 });
             parent.spawn_bundle(NodeBundle {
                 style: Style {
                     size: Size::new(Val::Percent(15.), Val::Percent(15.)),
-                    ..Default::default()
+                    ..default()
                 },
-                material: materials.add(Color::BLUE.into()),
-                ..Default::default()
+                color: Color::BLUE.into(),
+                ..default()
             });
             parent.spawn_bundle(ImageBundle {
                 style: Style {
                     size: Size::new(Val::Px(30.0), Val::Px(30.0)),
-                    ..Default::default()
+                    ..default()
                 },
-                material: materials.add(asset_server.load("branding/icon.png").into()),
-                ..Default::default()
+                image: asset_server.load("branding/icon.png").into(),
+                ..default()
             });
         });
 }
 
+/// System that changes the scale of the ui when pressing up or down on the keyboard.
 fn change_scaling(input: Res<Input<KeyCode>>, mut ui_scale: ResMut<TargetScale>) {
     if input.just_pressed(KeyCode::Up) {
         let scale = (ui_scale.target_scale * 2.0).min(8.);
@@ -98,6 +93,7 @@ fn change_scaling(input: Res<Input<KeyCode>>, mut ui_scale: ResMut<TargetScale>)
     }
 }
 
+#[derive(Resource)]
 struct TargetScale {
     start_scale: f64,
     target_scale: f64,

--- a/examples/ui/scaling.rs
+++ b/examples/ui/scaling.rs
@@ -1,4 +1,4 @@
-//! This example illustrates the UIScale resource from bevy_ui
+//! This example illustrates the [`UIScale`] resource from bevy_ui
 
 use bevy::{prelude::*, utils::Duration};
 


### PR DESCRIPTION
# Objective

- Allow users to change the scaling of the UI
- Adopted from #2808

## Solution

- This is an accessibility feature for fixed-size UI elements, allowing the developer to expose a range of UI scales for the player to set a scale that works for their needs.

> - The user can modify the UiScale struct to change the scaling at runtime. This multiplies the Px values by the scale given, while not touching any others.
> - The example showcases how this even allows for fluid transitions

> Here's how the example looks like:

https://user-images.githubusercontent.com/1631166/132979069-044161a9-8e85-45ab-9e93-fcf8e3852c2b.mp4

---

## Changelog

- Added a `UiScale` which can be used to scale all of UI
