### PR TITLE
Add interaction for render target with custom size

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -119,23 +119,23 @@ pub fn ui_focus_system(
         .find_map(|(camera, _)| {
             match &camera.target {
                 RenderTarget::Window(window_id) => windows.get(*window_id).and_then(|window| {
-                    if window.is_focused() {
-                        window.cursor_position()
-                    } else {
-                        None
-                    }
+                    window
+                        .is_focused()
+                        .then(|| window.cursor_position())
+                        .flatten()
                 }),
                 RenderTarget::Image(handle) => images
                     .get(handle)
                     .and_then(|image| windows.get_primary().map(|window| (window, image)))
                     .and_then(|(window, image)| {
-                        if window.is_focused() {
-                            window
-                                .cursor_position()
-                                .map(|cursor_position| (window, cursor_position, image.size()))
-                        } else {
-                            None
-                        }
+                        window
+                            .is_focused()
+                            .then(|| {
+                                window
+                                    .cursor_position()
+                                    .map(|cursor_position| (window, cursor_position, image.size()))
+                            })
+                            .flatten()
                     })
                     .map(|(window, cursor_position, image)| {
                         // cursor_position goes from 0 to window width and height

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -139,7 +139,7 @@ pub fn ui_focus_system(
                     })
                     .map(|(window, cursor_position, image)| {
                         // cursor_position goes from 0 to window width and height
-                        // This needs to be map from 0 to image width and height instead
+                        // This needs to be mapped from 0 to image width and height instead
                         let x = cursor_position.x / window.width() * image.x;
                         let y = cursor_position.y / window.height() * image.y;
                         Vec2::new(x, y)


### PR DESCRIPTION
# Objective

Add support for UI interactivity when rendering to an image texture with a different size to the window.

Previously, the cursor's interaction with UI on image render targets with a different size to the window caused a visual mismatch.

![phoneui](https://user-images.githubusercontent.com/16362377/187035880-6d1d5b1d-4f37-47ee-a58c-6250d98efaae.gif)

In the gif above, the smaller UI is the main camera, and the full screen ui is behind post processing rendered to a downscaled image texture. The smaller UI is usually hidden with `UiCameraConfig { show_ui: false })`, but I've enabled it to show the issue.

## Solution

Map the cursor x and y position based on the scale of the image texture compared to the window for `ui_focus_system`.

---

## Changelog

### Added

- Support for UI interaction on image render targets.