### PR TITLE
[Merged by Bors] - Ignore RUSTSEC-2021-0139

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,7 @@ yanked = "deny"
 notice = "deny"
 ignore = [
     "RUSTSEC-2020-0056", # from gilrs v0.8.1 - unmaintained - https://github.com/koute/stdweb/issues/403
+    "RUSTSEC-2021-0139" # from ansi_term v0.12.1 - unmaintained - https://github.com/ogham/rust-ansi-term/issues/72
 ]
 
 [licenses]


### PR DESCRIPTION
# Objective

- `ansi_term` has become unmaintained: https://github.com/ogham/rust-ansi-term/issues/72
- This is now blocking our CI so we need to find a way around that.


## Solution

Temporary add `RUSTSEC-2021-0139` to ignore until tracing switches to a new crate: https://github.com/tokio-rs/tracing/pull/2040

## Dependency tree
```
ansi_term v0.12.1
     └── tracing-subscriber v0.3.15
         ├── bevy_log v0.9.0-dev
         │   ├── bevy_asset v0.9.0-dev
         │   │   ├── bevy_animation v0.9.0-dev
         │   │   │   ├── bevy_gltf v0.9.0-dev
         │   │   │   │   └── bevy_internal v0.9.0-dev
         │   │   │   │       ├── bevy v0.9.0-dev
         │   │   │   │       └── bevy v0.9.0-dev (*)
         │   │   │   └── bevy_internal v0.9.0-dev (*)
         │   │   ├── bevy_audio v0.9.0-dev
         │   │   │   └── bevy_internal v0.9.0-dev (*)
         │   │   ├── bevy_core_pipeline v0.9.0-dev
         │   │   │   ├── bevy_gltf v0.9.0-dev (*)
         │   │   │   ├── bevy_internal v0.9.0-dev (*)
         │   │   │   ├── bevy_pbr v0.9.0-dev
         │   │   │   │   ├── bevy_gltf v0.9.0-dev (*)
         │   │   │   │   └── bevy_internal v0.9.0-dev (*)
         │   │   │   ├── bevy_sprite v0.9.0-dev
         │   │   │   │   ├── bevy_internal v0.9.0-dev (*)
         │   │   │   │   ├── bevy_text v0.9.0-dev
         │   │   │   │   │   ├── bevy_internal v0.9.0-dev (*)
         │   │   │   │   │   └── bevy_ui v0.9.0-dev
         │   │   │   │   │       └── bevy_internal v0.9.0-dev (*)
         │   │   │   │   └── bevy_ui v0.9.0-dev (*)
         │   │   │   └── bevy_ui v0.9.0-dev (*)
         │   │   ├── bevy_gltf v0.9.0-dev (*)
         │   │   ├── bevy_internal v0.9.0-dev (*)
         │   │   ├── bevy_pbr v0.9.0-dev (*)
         │   │   ├── bevy_render v0.9.0-dev
         │   │   │   ├── bevy_core_pipeline v0.9.0-dev (*)
         │   │   │   ├── bevy_gltf v0.9.0-dev (*)
         │   │   │   ├── bevy_internal v0.9.0-dev (*)
         │   │   │   ├── bevy_pbr v0.9.0-dev (*)
         │   │   │   ├── bevy_scene v0.9.0-dev
         │   │   │   │   ├── bevy_gltf v0.9.0-dev (*)
         │   │   │   │   └── bevy_internal v0.9.0-dev (*)
         │   │   │   ├── bevy_sprite v0.9.0-dev (*)
         │   │   │   ├── bevy_text v0.9.0-dev (*)
         │   │   │   └── bevy_ui v0.9.0-dev (*)
         │   │   ├── bevy_scene v0.9.0-dev (*)
         │   │   ├── bevy_sprite v0.9.0-dev (*)
         │   │   ├── bevy_text v0.9.0-dev (*)
         │   │   └── bevy_ui v0.9.0-dev (*)
         │   ├── bevy_diagnostic v0.9.0-dev
         │   │   ├── bevy_asset v0.9.0-dev (*)
         │   │   └── bevy_internal v0.9.0-dev (*)
         │   ├── bevy_gltf v0.9.0-dev (*)
         │   ├── bevy_internal v0.9.0-dev (*)
         │   ├── bevy_render v0.9.0-dev (*)
         │   ├── bevy_sprite v0.9.0-dev (*)
         │   └── bevy_ui v0.9.0-dev (*)
         └── tracing-wasm v0.2.1
             └── bevy_log v0.9.0-dev (*)
```
