### PR TITLE
[Merged by Bors] - Remove `Sync` requirement in `Decodable::Decoder`

### DIFF
--- a/crates/bevy_audio/src/audio_source.rs
+++ b/crates/bevy_audio/src/audio_source.rs
@@ -58,7 +58,7 @@ impl AssetLoader for AudioLoader {
 /// A type implementing this trait can be decoded as a rodio source
 pub trait Decodable: Send + Sync + 'static {
     /// The decoder that can decode the implementing type
-    type Decoder: rodio::Source + Send + Sync + Iterator<Item = Self::DecoderItem>;
+    type Decoder: rodio::Source + Send + Iterator<Item = Self::DecoderItem>;
     /// A single value given by the decoder
     type DecoderItem: rodio::Sample + Send + Sync;
 


### PR DESCRIPTION
# Objective

- Allow non-`Sync` Decoders
- Unblocks #5422.
- Unblocks harudagondi/bevy_fundsp#1

## Solution

- Remove `Sync` requirement in `Decodable::Decoder`
- This aligns with kira's [`Sound`] and majority of [oddio]'s types (like [`Mixer`]).

[`Sound`]: https://docs.rs/kira/latest/kira/sound/trait.Sound.html
[oddio]: https://docs.rs/oddio/latest/oddio/index.html
[`Mixer`]: https://docs.rs/oddio/latest/oddio/struct.Mixer.html

---

## Changelog

### Changed

- `Decodable::Decoder` now no longer requires `Sync` types.
