### PR TITLE
[Merged by Bors] - Consistently use `PI` to specify angles in examples.

### DIFF
--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -3,7 +3,7 @@
 //! It doesn't use the [`Material2d`] abstraction, but changes the vertex buffer to include vertex color.
 //! Check out the "mesh2d" example for simpler / higher level 2d meshes.
 
-use std::f32::consts::{ PI};
+use std::f32::consts::PI;
 
 use bevy::{
     core_pipeline::core_2d::Transparent2d,

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -3,6 +3,8 @@
 //! It doesn't use the [`Material2d`] abstraction, but changes the vertex buffer to include vertex color.
 //! Check out the "mesh2d" example for simpler / higher level 2d meshes.
 
+use std::f32::consts::TAU;
+
 use bevy::{
     core_pipeline::core_2d::Transparent2d,
     prelude::*,
@@ -62,12 +64,12 @@ fn star(
     // These vertices are specified in 3D space.
     let mut v_pos = vec![[0.0, 0.0, 0.0]];
     for i in 0..10 {
-        // Angle of each vertex is 1/10 of TAU, plus PI/2 for positioning vertex 0
-        let a = std::f32::consts::FRAC_PI_2 - i as f32 * std::f32::consts::TAU / 10.0;
-        // Radius of internal vertices (2, 4, 6, 8, 10) is 100, it's 200 for external
+        // The angle between each vertex is 1/10 of a full rotation.
+        let a = i as f32 * TAU / 10.0;
+        // The radius of inner vertices (even indices) is 100. For outer vertices (odd indices) it's 200.
         let r = (1 - i % 2) as f32 * 100.0 + 100.0;
-        // Add the vertex coordinates
-        v_pos.push([r * a.cos(), r * a.sin(), 0.0]);
+        // Add the vertex position.
+        v_pos.push([r * a.sin(), r * a.cos(), 0.0]);
     }
     // Set the position attribute
     star.insert_attribute(Mesh::ATTRIBUTE_POSITION, v_pos);

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -3,7 +3,7 @@
 //! It doesn't use the [`Material2d`] abstraction, but changes the vertex buffer to include vertex color.
 //! Check out the "mesh2d" example for simpler / higher level 2d meshes.
 
-use std::f32::consts::TAU;
+use std::f32::consts::{ PI};
 
 use bevy::{
     core_pipeline::core_2d::Transparent2d,
@@ -65,7 +65,7 @@ fn star(
     let mut v_pos = vec![[0.0, 0.0, 0.0]];
     for i in 0..10 {
         // The angle between each vertex is 1/10 of a full rotation.
-        let a = i as f32 * TAU / 10.0;
+        let a = i as f32 * PI / 5.0;
         // The radius of inner vertices (even indices) is 100. For outer vertices (odd indices) it's 200.
         let r = (1 - i % 2) as f32 * 100.0 + 100.0;
         // Add the vertex position.

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -1,6 +1,8 @@
 //! Illustrates different lights of various types and colors, some static, some moving over
 //! a simple scene.
 
+use std::f32::consts::TAU;
+
 use bevy::prelude::*;
 
 fn main() {
@@ -34,7 +36,7 @@ fn setup(
 
     // left wall
     let mut transform = Transform::from_xyz(2.5, 2.5, 0.0);
-    transform.rotate_z(std::f32::consts::FRAC_PI_2);
+    transform.rotate_z(TAU / 4.);
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Box::new(5.0, 0.15, 5.0))),
         transform,
@@ -47,7 +49,7 @@ fn setup(
     });
     // back (right) wall
     let mut transform = Transform::from_xyz(0.0, 2.5, -2.5);
-    transform.rotate_x(std::f32::consts::FRAC_PI_2);
+    transform.rotate_x(TAU / 4.);
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Box::new(5.0, 0.15, 5.0))),
         transform,
@@ -138,9 +140,7 @@ fn setup(
         })
         .with_children(|builder| {
             builder.spawn_bundle(PbrBundle {
-                transform: Transform::from_rotation(Quat::from_rotation_x(
-                    std::f32::consts::PI / 2.0,
-                )),
+                transform: Transform::from_rotation(Quat::from_rotation_x(TAU / 4.0)),
                 mesh: meshes.add(Mesh::from(shape::Capsule {
                     depth: 0.125,
                     radius: 0.1,
@@ -202,7 +202,7 @@ fn setup(
         },
         transform: Transform {
             translation: Vec3::new(0.0, 2.0, 0.0),
-            rotation: Quat::from_rotation_x(-std::f32::consts::FRAC_PI_4),
+            rotation: Quat::from_rotation_x(-TAU / 8.),
             ..default()
         },
         ..default()

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -1,7 +1,7 @@
 //! Illustrates different lights of various types and colors, some static, some moving over
 //! a simple scene.
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::prelude::*;
 
@@ -36,7 +36,7 @@ fn setup(
 
     // left wall
     let mut transform = Transform::from_xyz(2.5, 2.5, 0.0);
-    transform.rotate_z(TAU / 4.);
+    transform.rotate_z(PI / 2.);
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Box::new(5.0, 0.15, 5.0))),
         transform,
@@ -49,7 +49,7 @@ fn setup(
     });
     // back (right) wall
     let mut transform = Transform::from_xyz(0.0, 2.5, -2.5);
-    transform.rotate_x(TAU / 4.);
+    transform.rotate_x(PI / 2.);
     commands.spawn_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Box::new(5.0, 0.15, 5.0))),
         transform,
@@ -140,7 +140,7 @@ fn setup(
         })
         .with_children(|builder| {
             builder.spawn_bundle(PbrBundle {
-                transform: Transform::from_rotation(Quat::from_rotation_x(TAU / 4.0)),
+                transform: Transform::from_rotation(Quat::from_rotation_x(PI / 2.0)),
                 mesh: meshes.add(Mesh::from(shape::Capsule {
                     depth: 0.125,
                     radius: 0.1,
@@ -202,7 +202,7 @@ fn setup(
         },
         transform: Transform {
             translation: Vec3::new(0.0, 2.0, 0.0),
-            rotation: Quat::from_rotation_x(-TAU / 8.),
+            rotation: Quat::from_rotation_x(-PI / 4.),
             ..default()
         },
         ..default()

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -1,6 +1,6 @@
 //! Loads and renders a glTF file as a scene.
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::prelude::*;
 
@@ -52,8 +52,8 @@ fn animate_light_direction(
         transform.rotation = Quat::from_euler(
             EulerRot::ZYX,
             0.0,
-            time.seconds_since_startup() as f32 * std::f32::consts::TAU / 10.0,
-            -TAU / 8.,
+            time.seconds_since_startup() as f32 * PI / 5.0,
+            -PI / 4.,
         );
     }
 }

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -1,5 +1,7 @@
 //! Loads and renders a glTF file as a scene.
 
+use std::f32::consts::TAU;
+
 use bevy::prelude::*;
 
 fn main() {
@@ -51,7 +53,7 @@ fn animate_light_direction(
             EulerRot::ZYX,
             0.0,
             time.seconds_since_startup() as f32 * std::f32::consts::TAU / 10.0,
-            -std::f32::consts::FRAC_PI_4,
+            -TAU / 8.,
         );
     }
 }

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -1,6 +1,6 @@
 //! Shows how to render to a texture. Useful for mirrors, UI, or exporting images.
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::{
     core_pipeline::clear_color::ClearColorConfig,
@@ -128,7 +128,7 @@ fn setup(
             mesh: cube_handle,
             material: material_handle,
             transform: Transform::from_xyz(0.0, 0.0, 1.5)
-                .with_rotation(Quat::from_rotation_x(-TAU / 10.0)),
+                .with_rotation(Quat::from_rotation_x(-PI / 5.0)),
             ..default()
         })
         .insert(MainPassCube);

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -1,5 +1,7 @@
 //! Shows how to render to a texture. Useful for mirrors, UI, or exporting images.
 
+use std::f32::consts::TAU;
+
 use bevy::{
     core_pipeline::clear_color::ClearColorConfig,
     prelude::*,
@@ -104,7 +106,7 @@ fn setup(
                 ..default()
             },
             transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
-                .looking_at(Vec3::default(), Vec3::Y),
+                .looking_at(Vec3::ZERO, Vec3::Y),
             ..default()
         })
         .insert(first_pass_layer);
@@ -125,19 +127,15 @@ fn setup(
         .spawn_bundle(PbrBundle {
             mesh: cube_handle,
             material: material_handle,
-            transform: Transform {
-                translation: Vec3::new(0.0, 0.0, 1.5),
-                rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
-                ..default()
-            },
+            transform: Transform::from_xyz(0.0, 0.0, 1.5)
+                .with_rotation(Quat::from_rotation_x(-TAU / 10.0)),
             ..default()
         })
         .insert(MainPassCube);
 
     // The main pass camera.
     commands.spawn_bundle(Camera3dBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
-            .looking_at(Vec3::default(), Vec3::Y),
+        transform: Transform::from_xyz(0.0, 0.0, 15.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
     });
 }

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -1,5 +1,7 @@
 //! Demonstrates how shadow biases affect shadows in a 3d scene.
 
+use std::f32::consts::TAU;
+
 use bevy::{input::mouse::MouseMotion, prelude::*};
 
 fn main() {
@@ -61,8 +63,6 @@ fn setup(
         ..default()
     });
 
-    let theta = std::f32::consts::FRAC_PI_4;
-    let light_transform = Mat4::from_euler(EulerRot::ZYX, 0.0, std::f32::consts::FRAC_PI_2, -theta);
     commands.spawn_bundle(DirectionalLightBundle {
         directional_light: DirectionalLight {
             illuminance: 100000.0,
@@ -80,7 +80,12 @@ fn setup(
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_matrix(light_transform),
+        transform: Transform::from_rotation(Quat::from_euler(
+            EulerRot::ZYX,
+            0.0,
+            TAU / 4.,
+            -TAU / 8.,
+        )),
         ..default()
     });
 
@@ -308,16 +313,10 @@ fn camera_controller(
 
         if mouse_delta != Vec2::ZERO {
             // Apply look update
-            let (pitch, yaw) = (
-                (options.pitch - mouse_delta.y * 0.5 * options.sensitivity * dt).clamp(
-                    -0.99 * std::f32::consts::FRAC_PI_2,
-                    0.99 * std::f32::consts::FRAC_PI_2,
-                ),
-                options.yaw - mouse_delta.x * options.sensitivity * dt,
-            );
-            transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, yaw, pitch);
-            options.pitch = pitch;
-            options.yaw = yaw;
+            options.pitch = (options.pitch - mouse_delta.y * 0.5 * options.sensitivity * dt)
+                .clamp(-TAU / 4., TAU / 4.);
+            options.yaw -= mouse_delta.x * options.sensitivity * dt;
+            transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
         }
     }
 }

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -1,6 +1,6 @@
 //! Demonstrates how shadow biases affect shadows in a 3d scene.
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::{input::mouse::MouseMotion, prelude::*};
 
@@ -83,8 +83,8 @@ fn setup(
         transform: Transform::from_rotation(Quat::from_euler(
             EulerRot::ZYX,
             0.0,
-            TAU / 4.,
-            -TAU / 8.,
+            PI / 2.,
+            -PI / 4.,
         )),
         ..default()
     });
@@ -314,7 +314,7 @@ fn camera_controller(
         if mouse_delta != Vec2::ZERO {
             // Apply look update
             options.pitch = (options.pitch - mouse_delta.y * 0.5 * options.sensitivity * dt)
-                .clamp(-TAU / 4., TAU / 4.);
+                .clamp(-PI / 2., PI / 2.);
             options.yaw -= mouse_delta.x * options.sensitivity * dt;
             transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
         }

--- a/examples/3d/shadow_caster_receiver.rs
+++ b/examples/3d/shadow_caster_receiver.rs
@@ -1,5 +1,7 @@
 //! Demonstrates how to prevent meshes from casting/receiving shadows in a 3d scene.
 
+use std::f32::consts::TAU;
+
 use bevy::{
     pbr::{NotShadowCaster, NotShadowReceiver},
     prelude::*,
@@ -89,8 +91,6 @@ fn setup(
         ..default()
     });
 
-    let theta = std::f32::consts::FRAC_PI_4;
-    let light_transform = Mat4::from_euler(EulerRot::ZYX, 0.0, std::f32::consts::FRAC_PI_2, -theta);
     commands.spawn_bundle(DirectionalLightBundle {
         directional_light: DirectionalLight {
             illuminance: 100000.0,
@@ -106,7 +106,12 @@ fn setup(
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_matrix(light_transform),
+        transform: Transform::from_rotation(Quat::from_euler(
+            EulerRot::ZYX,
+            0.0,
+            TAU / 4.,
+            -TAU / 8.,
+        )),
         ..default()
     });
 

--- a/examples/3d/shadow_caster_receiver.rs
+++ b/examples/3d/shadow_caster_receiver.rs
@@ -1,6 +1,6 @@
 //! Demonstrates how to prevent meshes from casting/receiving shadows in a 3d scene.
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::{
     pbr::{NotShadowCaster, NotShadowReceiver},
@@ -109,8 +109,8 @@ fn setup(
         transform: Transform::from_rotation(Quat::from_euler(
             EulerRot::ZYX,
             0.0,
-            TAU / 4.,
-            -TAU / 8.,
+            PI / 2.,
+            -PI / 4.,
         )),
         ..default()
     });

--- a/examples/3d/shapes.rs
+++ b/examples/3d/shapes.rs
@@ -1,6 +1,8 @@
 //! This example demonstrates the built-in 3d shapes in Bevy.
 //! The scene includes a patterned texture and a rotation for visualizing the normals and UVs.
 
+use std::f32::consts::TAU;
+
 use bevy::{
     prelude::*,
     render::render_resource::{Extent3d, TextureDimension, TextureFormat},
@@ -48,15 +50,12 @@ fn setup(
             .spawn_bundle(PbrBundle {
                 mesh: shape,
                 material: debug_material.clone(),
-                transform: Transform {
-                    translation: Vec3::new(
-                        -X_EXTENT / 2. + i as f32 / (num_shapes - 1) as f32 * X_EXTENT,
-                        2.0,
-                        0.0,
-                    ),
-                    rotation: Quat::from_rotation_x(-std::f32::consts::PI / 4.),
-                    ..default()
-                },
+                transform: Transform::from_xyz(
+                    -X_EXTENT / 2. + i as f32 / (num_shapes - 1) as f32 * X_EXTENT,
+                    2.0,
+                    0.0,
+                )
+                .with_rotation(Quat::from_rotation_x(-TAU / 8.)),
                 ..default()
             })
             .insert(Shape);

--- a/examples/3d/shapes.rs
+++ b/examples/3d/shapes.rs
@@ -1,7 +1,7 @@
 //! This example demonstrates the built-in 3d shapes in Bevy.
 //! The scene includes a patterned texture and a rotation for visualizing the normals and UVs.
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::{
     prelude::*,
@@ -55,7 +55,7 @@ fn setup(
                     2.0,
                     0.0,
                 )
-                .with_rotation(Quat::from_rotation_x(-TAU / 8.)),
+                .with_rotation(Quat::from_rotation_x(-PI / 4.)),
                 ..default()
             })
             .insert(Shape);

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -1,6 +1,6 @@
 //! Load a cubemap texture onto a cube like a skybox and cycle through different compressed texture formats
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::{
     asset::LoadState,
@@ -69,7 +69,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             ..default()
         },
         transform: Transform::from_xyz(0.0, 2.0, 0.0)
-            .with_rotation(Quat::from_rotation_x(-TAU / 8.)),
+            .with_rotation(Quat::from_rotation_x(-PI / 4.)),
         ..default()
     });
 
@@ -410,7 +410,7 @@ pub fn camera_controller(
         if mouse_delta != Vec2::ZERO {
             // Apply look update
             options.pitch = (options.pitch - mouse_delta.y * 0.5 * options.sensitivity * dt)
-                .clamp(-TAU / 4., TAU / 4.);
+                .clamp(-PI / 2., PI / 2.);
             options.yaw -= mouse_delta.x * options.sensitivity * dt;
             transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
         }

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -1,5 +1,7 @@
 //! Load a cubemap texture onto a cube like a skybox and cycle through different compressed texture formats
 
+use std::f32::consts::TAU;
+
 use bevy::{
     asset::LoadState,
     input::mouse::MouseMotion,
@@ -66,11 +68,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             illuminance: 32000.0,
             ..default()
         },
-        transform: Transform {
-            translation: Vec3::new(0.0, 2.0, 0.0),
-            rotation: Quat::from_rotation_x(-std::f32::consts::FRAC_PI_4),
-            ..default()
-        },
+        transform: Transform::from_xyz(0.0, 2.0, 0.0)
+            .with_rotation(Quat::from_rotation_x(-TAU / 8.)),
         ..default()
     });
 
@@ -78,7 +77,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // camera
     commands
         .spawn_bundle(Camera3dBundle {
-            transform: Transform::from_xyz(0.0, 0.0, 8.0).looking_at(Vec3::default(), Vec3::Y),
+            transform: Transform::from_xyz(0.0, 0.0, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..default()
         })
         .insert(CameraController::default());
@@ -410,16 +409,10 @@ pub fn camera_controller(
 
         if mouse_delta != Vec2::ZERO {
             // Apply look update
-            let (pitch, yaw) = (
-                (options.pitch - mouse_delta.y * 0.5 * options.sensitivity * dt).clamp(
-                    -0.99 * std::f32::consts::FRAC_PI_2,
-                    0.99 * std::f32::consts::FRAC_PI_2,
-                ),
-                options.yaw - mouse_delta.x * options.sensitivity * dt,
-            );
-            transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, yaw, pitch);
-            options.pitch = pitch;
-            options.yaw = yaw;
+            options.pitch = (options.pitch - mouse_delta.y * 0.5 * options.sensitivity * dt)
+                .clamp(-TAU / 4., TAU / 4.);
+            options.yaw -= mouse_delta.x * options.sensitivity * dt;
+            transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
         }
     }
 }

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -1,6 +1,6 @@
 //! Renders two cameras to the same window to accomplish "split screen".
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::{
     core_pipeline::clear_color::ClearColorConfig,
@@ -38,7 +38,7 @@ fn setup(
 
     // Light
     commands.spawn_bundle(DirectionalLightBundle {
-        transform: Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, 1.0, -TAU / 8.)),
+        transform: Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, 1.0, -PI / 4.)),
         directional_light: DirectionalLight {
             shadows_enabled: true,
             ..default()

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -1,5 +1,7 @@
 //! Renders two cameras to the same window to accomplish "split screen".
 
+use std::f32::consts::TAU;
+
 use bevy::{
     core_pipeline::clear_color::ClearColorConfig,
     prelude::*,
@@ -36,12 +38,7 @@ fn setup(
 
     // Light
     commands.spawn_bundle(DirectionalLightBundle {
-        transform: Transform::from_rotation(Quat::from_euler(
-            EulerRot::ZYX,
-            0.0,
-            1.0,
-            -std::f32::consts::FRAC_PI_4,
-        )),
+        transform: Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, 1.0, -TAU / 8.)),
         directional_light: DirectionalLight {
             shadows_enabled: true,
             ..default()

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -1,4 +1,4 @@
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
@@ -76,8 +76,8 @@ fn setup(
                         intensity: 200.0, // lumens
                         color: Color::WHITE,
                         shadows_enabled: true,
-                        inner_angle: TAU / 8.0 * 0.85,
-                        outer_angle: TAU / 8.0,
+                        inner_angle: PI / 4.0 * 0.85,
+                        outer_angle: PI / 4.0,
                         ..default()
                     },
                     ..default()
@@ -125,11 +125,11 @@ fn light_sway(time: Res<Time>, mut query: Query<(&mut Transform, &mut SpotLight)
     for (mut transform, mut angles) in query.iter_mut() {
         transform.rotation = Quat::from_euler(
             EulerRot::XYZ,
-            -TAU / 4. + (time.seconds_since_startup() * 0.67 * 3.0).sin() as f32 * 0.5,
+            -PI / 2. + (time.seconds_since_startup() * 0.67 * 3.0).sin() as f32 * 0.5,
             (time.seconds_since_startup() * 3.0).sin() as f32 * 0.5,
             0.0,
         );
-        let angle = ((time.seconds_since_startup() * 1.2).sin() as f32 + 1.0) * (TAU / 8. - 0.1);
+        let angle = ((time.seconds_since_startup() * 1.2).sin() as f32 + 1.0) * (PI / 4. - 0.1);
         angles.inner_angle = angle * 0.8;
         angles.outer_angle = angle;
     }

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -1,3 +1,5 @@
+use std::f32::consts::TAU;
+
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     pbr::NotShadowCaster,
@@ -74,8 +76,8 @@ fn setup(
                         intensity: 200.0, // lumens
                         color: Color::WHITE,
                         shadows_enabled: true,
-                        inner_angle: std::f32::consts::PI / 4.0 * 0.85,
-                        outer_angle: std::f32::consts::PI / 4.0,
+                        inner_angle: TAU / 8.0 * 0.85,
+                        outer_angle: TAU / 8.0,
                         ..default()
                     },
                     ..default()
@@ -123,13 +125,11 @@ fn light_sway(time: Res<Time>, mut query: Query<(&mut Transform, &mut SpotLight)
     for (mut transform, mut angles) in query.iter_mut() {
         transform.rotation = Quat::from_euler(
             EulerRot::XYZ,
-            -std::f32::consts::FRAC_PI_2
-                + (time.seconds_since_startup() * 0.67 * 3.0).sin() as f32 * 0.5,
+            -TAU / 4. + (time.seconds_since_startup() * 0.67 * 3.0).sin() as f32 * 0.5,
             (time.seconds_since_startup() * 3.0).sin() as f32 * 0.5,
             0.0,
         );
-        let angle = ((time.seconds_since_startup() * 1.2).sin() as f32 + 1.0)
-            * (std::f32::consts::FRAC_PI_4 - 0.1);
+        let angle = ((time.seconds_since_startup() * 1.2).sin() as f32 + 1.0) * (TAU / 8. - 0.1);
         angles.inner_angle = angle * 0.8;
         angles.outer_angle = angle;
     }
@@ -140,7 +140,7 @@ fn movement(
     time: Res<Time>,
     mut query: Query<&mut Transform, With<Movable>>,
 ) {
-    for mut transform in query.iter_mut() {
+    for mut transform in &mut query {
         let mut direction = Vec3::ZERO;
         if input.pressed(KeyCode::Up) {
             direction.z -= 1.0;

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -1,6 +1,6 @@
 //! This example shows various ways to configure texture materials in 3D.
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::prelude::*;
 
@@ -59,33 +59,23 @@ fn setup(
     commands.spawn_bundle(PbrBundle {
         mesh: quad_handle.clone(),
         material: material_handle,
-        transform: Transform {
-            translation: Vec3::new(0.0, 0.0, 1.5),
-            rotation: Quat::from_rotation_x(-TAU / 10.0),
-            ..default()
-        },
+        transform: Transform::from_xyz(0.0, 0.0, 1.5)
+            .with_rotation(Quat::from_rotation_x(-PI / 5.0)),
         ..default()
     });
     // textured quad - modulated
     commands.spawn_bundle(PbrBundle {
         mesh: quad_handle.clone(),
         material: red_material_handle,
-        transform: Transform {
-            translation: Vec3::new(0.0, 0.0, 0.0),
-            rotation: Quat::from_rotation_x(-TAU / 10.0),
-            ..default()
-        },
+        transform: Transform::from_rotation(Quat::from_rotation_x(-PI / 5.0)),
         ..default()
     });
     // textured quad - modulated
     commands.spawn_bundle(PbrBundle {
         mesh: quad_handle,
         material: blue_material_handle,
-        transform: Transform {
-            translation: Vec3::new(0.0, 0.0, -1.5),
-            rotation: Quat::from_rotation_x(-TAU / 10.0),
-            ..default()
-        },
+        transform: Transform::from_xyz(0.0, 0.0, -1.5)
+            .with_rotation(Quat::from_rotation_x(-PI / 5.0)),
         ..default()
     });
     // camera

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -1,5 +1,7 @@
 //! This example shows various ways to configure texture materials in 3D.
 
+use std::f32::consts::TAU;
+
 use bevy::prelude::*;
 
 fn main() {
@@ -59,7 +61,7 @@ fn setup(
         material: material_handle,
         transform: Transform {
             translation: Vec3::new(0.0, 0.0, 1.5),
-            rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
+            rotation: Quat::from_rotation_x(-TAU / 10.0),
             ..default()
         },
         ..default()
@@ -70,7 +72,7 @@ fn setup(
         material: red_material_handle,
         transform: Transform {
             translation: Vec3::new(0.0, 0.0, 0.0),
-            rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
+            rotation: Quat::from_rotation_x(-TAU / 10.0),
             ..default()
         },
         ..default()
@@ -81,7 +83,7 @@ fn setup(
         material: blue_material_handle,
         transform: Transform {
             translation: Vec3::new(0.0, 0.0, -1.5),
-            rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
+            rotation: Quat::from_rotation_x(-TAU / 10.0),
             ..default()
         },
         ..default()

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -1,6 +1,6 @@
 //! Plays animations from a skinned glTF.
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::prelude::*;
 
@@ -49,7 +49,7 @@ fn setup(
 
     // Light
     commands.spawn_bundle(DirectionalLightBundle {
-        transform: Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, 1.0, -TAU / 8.)),
+        transform: Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, 1.0, -PI / 4.)),
         directional_light: DirectionalLight {
             shadows_enabled: true,
             ..default()

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -1,5 +1,7 @@
 //! Plays animations from a skinned glTF.
 
+use std::f32::consts::TAU;
+
 use bevy::prelude::*;
 
 fn main() {
@@ -47,12 +49,7 @@ fn setup(
 
     // Light
     commands.spawn_bundle(DirectionalLightBundle {
-        transform: Transform::from_rotation(Quat::from_euler(
-            EulerRot::ZYX,
-            0.0,
-            1.0,
-            -std::f32::consts::FRAC_PI_4,
-        )),
+        transform: Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, 1.0, -TAU / 8.)),
         directional_light: DirectionalLight {
             shadows_enabled: true,
             ..default()

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -1,6 +1,6 @@
 //! Create and play an animation defined by code that operates on the `Transform` component.
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::prelude::*;
 
@@ -63,9 +63,9 @@ fn setup(
             keyframe_timestamps: vec![0.0, 1.0, 2.0, 3.0, 4.0],
             keyframes: Keyframes::Rotation(vec![
                 Quat::IDENTITY,
-                Quat::from_axis_angle(Vec3::Y, TAU / 4.),
-                Quat::from_axis_angle(Vec3::Y, TAU / 4. * 2.),
-                Quat::from_axis_angle(Vec3::Y, TAU / 4. * 3.),
+                Quat::from_axis_angle(Vec3::Y, PI / 2.),
+                Quat::from_axis_angle(Vec3::Y, PI / 2. * 2.),
+                Quat::from_axis_angle(Vec3::Y, PI / 2. * 3.),
                 Quat::IDENTITY,
             ]),
         },
@@ -101,9 +101,9 @@ fn setup(
             keyframe_timestamps: vec![0.0, 1.0, 2.0, 3.0, 4.0],
             keyframes: Keyframes::Rotation(vec![
                 Quat::IDENTITY,
-                Quat::from_axis_angle(Vec3::Y, TAU / 4.),
-                Quat::from_axis_angle(Vec3::Y, TAU / 4. * 2.),
-                Quat::from_axis_angle(Vec3::Y, TAU / 4. * 3.),
+                Quat::from_axis_angle(Vec3::Y, PI / 2.),
+                Quat::from_axis_angle(Vec3::Y, PI / 2. * 2.),
+                Quat::from_axis_angle(Vec3::Y, PI / 2. * 3.),
                 Quat::IDENTITY,
             ]),
         },

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -1,6 +1,6 @@
 //! Create and play an animation defined by code that operates on the `Transform` component.
 
-use std::f32::consts::{FRAC_PI_2, PI};
+use std::f32::consts::TAU;
 
 use bevy::prelude::*;
 
@@ -62,11 +62,11 @@ fn setup(
         VariableCurve {
             keyframe_timestamps: vec![0.0, 1.0, 2.0, 3.0, 4.0],
             keyframes: Keyframes::Rotation(vec![
-                Quat::from_axis_angle(Vec3::Y, 0.0),
-                Quat::from_axis_angle(Vec3::Y, FRAC_PI_2),
-                Quat::from_axis_angle(Vec3::Y, PI),
-                Quat::from_axis_angle(Vec3::Y, 3.0 * FRAC_PI_2),
-                Quat::from_axis_angle(Vec3::Y, 0.0),
+                Quat::IDENTITY,
+                Quat::from_axis_angle(Vec3::Y, TAU / 4.),
+                Quat::from_axis_angle(Vec3::Y, TAU / 4. * 2.),
+                Quat::from_axis_angle(Vec3::Y, TAU / 4. * 3.),
+                Quat::IDENTITY,
             ]),
         },
     );
@@ -100,11 +100,11 @@ fn setup(
         VariableCurve {
             keyframe_timestamps: vec![0.0, 1.0, 2.0, 3.0, 4.0],
             keyframes: Keyframes::Rotation(vec![
-                Quat::from_axis_angle(Vec3::Y, 0.0),
-                Quat::from_axis_angle(Vec3::Y, FRAC_PI_2),
-                Quat::from_axis_angle(Vec3::Y, PI),
-                Quat::from_axis_angle(Vec3::Y, 3.0 * FRAC_PI_2),
-                Quat::from_axis_angle(Vec3::Y, 0.0),
+                Quat::IDENTITY,
+                Quat::from_axis_angle(Vec3::Y, TAU / 4.),
+                Quat::from_axis_angle(Vec3::Y, TAU / 4. * 2.),
+                Quat::from_axis_angle(Vec3::Y, TAU / 4. * 3.),
+                Quat::IDENTITY,
             ]),
         },
     );

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -1,7 +1,7 @@
 //! Skinned mesh example with mesh and joints data defined in code.
 //! Example taken from <https://github.com/KhronosGroup/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_019_SimpleSkin.md>
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::{
     pbr::AmbientLight,
@@ -165,6 +165,6 @@ fn setup(
 fn joint_animation(time: Res<Time>, mut query: Query<&mut Transform, With<AnimatedJoint>>) {
     for mut transform in &mut query {
         transform.rotation =
-            Quat::from_rotation_z(TAU / 4. * time.time_since_startup().as_secs_f32().sin());
+            Quat::from_rotation_z(PI / 2. * time.time_since_startup().as_secs_f32().sin());
     }
 }

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -1,7 +1,7 @@
 //! Skinned mesh example with mesh and joints data defined in code.
 //! Example taken from <https://github.com/KhronosGroup/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_019_SimpleSkin.md>
 
-use std::f32::consts::PI;
+use std::f32::consts::TAU;
 
 use bevy::{
     pbr::AmbientLight,
@@ -164,9 +164,7 @@ fn setup(
 /// Animate the joint marked with [`AnimatedJoint`] component.
 fn joint_animation(time: Res<Time>, mut query: Query<&mut Transform, With<AnimatedJoint>>) {
     for mut transform in &mut query {
-        transform.rotation = Quat::from_axis_angle(
-            Vec3::Z,
-            0.5 * PI * time.time_since_startup().as_secs_f32().sin(),
-        );
+        transform.rotation =
+            Quat::from_rotation_z(TAU / 4. * time.time_since_startup().as_secs_f32().sin());
     }
 }

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -1,7 +1,7 @@
 //! Skinned mesh example with mesh and joints data loaded from a glTF file.
 //! Example taken from <https://github.com/KhronosGroup/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_019_SimpleSkin.md>
 
-use std::f32::consts::PI;
+use std::f32::consts::TAU;
 
 use bevy::{pbr::AmbientLight, prelude::*, render::mesh::skinning::SkinnedMesh};
 
@@ -66,9 +66,7 @@ fn joint_animation(
         // Get `Transform` in the second joint.
         let mut second_joint_transform = transform_query.get_mut(second_joint_entity).unwrap();
 
-        second_joint_transform.rotation = Quat::from_axis_angle(
-            Vec3::Z,
-            0.5 * PI * time.time_since_startup().as_secs_f32().sin(),
-        );
+        second_joint_transform.rotation =
+            Quat::from_rotation_z(TAU / 4. * time.time_since_startup().as_secs_f32().sin());
     }
 }

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -1,7 +1,7 @@
 //! Skinned mesh example with mesh and joints data loaded from a glTF file.
 //! Example taken from <https://github.com/KhronosGroup/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_019_SimpleSkin.md>
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::{pbr::AmbientLight, prelude::*, render::mesh::skinning::SkinnedMesh};
 
@@ -67,6 +67,6 @@ fn joint_animation(
         let mut second_joint_transform = transform_query.get_mut(second_joint_entity).unwrap();
 
         second_joint_transform.rotation =
-            Quat::from_rotation_z(TAU / 4. * time.time_since_startup().as_secs_f32().sin());
+            Quat::from_rotation_z(PI / 2. * time.time_since_startup().as_secs_f32().sin());
     }
 }

--- a/examples/ecs/generic_system.rs
+++ b/examples/ecs/generic_system.rs
@@ -9,7 +9,7 @@
 //! For more advice on working with generic types in Rust, check out <https://doc.rust-lang.org/book/ch10-01-syntax.html>
 //! or <https://doc.rust-lang.org/rust-by-example/generics.html>
 
-use bevy::{ecs::component::Component, prelude::*};
+use bevy::prelude::*;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 enum AppState {
@@ -21,7 +21,7 @@ enum AppState {
 struct TextToPrint(String);
 
 #[derive(Component, Deref, DerefMut)]
-struct PrinterTick(bevy::prelude::Timer);
+struct PrinterTick(Timer);
 
 #[derive(Component)]
 struct MenuClose;
@@ -52,7 +52,7 @@ fn main() {
 fn setup_system(mut commands: Commands) {
     commands
         .spawn()
-        .insert(PrinterTick(bevy::prelude::Timer::from_seconds(1.0, true)))
+        .insert(PrinterTick(Timer::from_seconds(1.0, true)))
         .insert(TextToPrint(
             "I will print until you press space.".to_string(),
         ))
@@ -60,7 +60,7 @@ fn setup_system(mut commands: Commands) {
 
     commands
         .spawn()
-        .insert(PrinterTick(bevy::prelude::Timer::from_seconds(1.0, true)))
+        .insert(PrinterTick(Timer::from_seconds(1.0, true)))
         .insert(TextToPrint("I will always print".to_string()))
         .insert(LevelUnload);
 }

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -1,5 +1,7 @@
 //! Creates a hierarchy of parents and children entities.
 
+use std::f32::consts::TAU;
+
 use bevy::prelude::*;
 
 fn main() {
@@ -25,11 +27,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .with_children(|parent| {
             // parent is a ChildBuilder, which has a similar API to Commands
             parent.spawn_bundle(SpriteBundle {
-                transform: Transform {
-                    translation: Vec3::new(250.0, 0.0, 0.0),
-                    scale: Vec3::splat(0.75),
-                    ..default()
-                },
+                transform: Transform::from_xyz(250.0, 0.0, 0.0).with_scale(Vec3::splat(0.75)),
                 texture: texture.clone(),
                 sprite: Sprite {
                     color: Color::BLUE,
@@ -45,11 +43,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // entity has already been spawned.
     let child = commands
         .spawn_bundle(SpriteBundle {
-            transform: Transform {
-                translation: Vec3::new(0.0, 250.0, 0.0),
-                scale: Vec3::splat(0.75),
-                ..default()
-            },
+            transform: Transform::from_xyz(0.0, 250.0, 0.0).with_scale(Vec3::splat(0.75)),
             texture,
             sprite: Sprite {
                 color: Color::GREEN,
@@ -59,8 +53,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         })
         .id();
 
-    // Pushing takes a slice of children to add:
-    commands.entity(parent).push_children(&[child]);
+    // Add child to the parent.
+    commands.entity(parent).add_child(child);
 }
 
 // A simple system to rotate the root entity, and rotate all its children separately
@@ -70,25 +64,23 @@ fn rotate(
     mut parents_query: Query<(Entity, &Children), With<Sprite>>,
     mut transform_query: Query<&mut Transform, With<Sprite>>,
 ) {
-    let angle = std::f32::consts::PI / 2.0;
     for (parent, children) in &mut parents_query {
         if let Ok(mut transform) = transform_query.get_mut(parent) {
-            transform.rotate_z(-angle * time.delta_seconds());
+            transform.rotate_z(-TAU / 4. * time.delta_seconds());
         }
 
         // To iterate through the entities children, just treat the Children component as a Vec
         // Alternatively, you could query entities that have a Parent component
         for child in children {
             if let Ok(mut transform) = transform_query.get_mut(*child) {
-                transform.rotate_z(angle * 2.0 * time.delta_seconds());
+                transform.rotate_z(TAU / 2. * time.delta_seconds());
             }
         }
 
-        // To demonstrate removing children, we'll start to remove the children after a couple of
-        // seconds
-        if time.seconds_since_startup() >= 2.0 && children.len() == 3 {
-            let child = children.last().copied().unwrap();
-            commands.entity(child).despawn_recursive();
+        // To demonstrate removing children, we'll remove a child after a couple of seconds.
+        if time.seconds_since_startup() >= 2.0 && children.len() == 2 {
+            let child = children.last().unwrap();
+            commands.entity(*child).despawn_recursive();
         }
 
         if time.seconds_since_startup() >= 4.0 {

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -1,6 +1,6 @@
 //! Creates a hierarchy of parents and children entities.
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::prelude::*;
 
@@ -66,14 +66,14 @@ fn rotate(
 ) {
     for (parent, children) in &mut parents_query {
         if let Ok(mut transform) = transform_query.get_mut(parent) {
-            transform.rotate_z(-TAU / 4. * time.delta_seconds());
+            transform.rotate_z(-PI / 2. * time.delta_seconds());
         }
 
         // To iterate through the entities children, just treat the Children component as a Vec
         // Alternatively, you could query entities that have a Parent component
         for child in children {
             if let Ok(mut transform) = transform_query.get_mut(*child) {
-                transform.rotate_z(TAU / 2. * time.delta_seconds());
+                transform.rotate_z(PI * time.delta_seconds());
             }
         }
 

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -1,6 +1,6 @@
 //! Eat the cakes. Eat them all. An example 3D game.
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::{ecs::schedule::SystemSet, prelude::*, time::FixedTimestep};
 use rand::Rng;
@@ -139,7 +139,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
                         game.board[game.player.j][game.player.i].height,
                         game.player.j as f32,
                     ),
-                    rotation: Quat::from_rotation_y(-std::f32::consts::FRAC_PI_2),
+                    rotation: Quat::from_rotation_y(-PI / 2.),
                     ..default()
                 },
                 scene: asset_server.load("models/AlienCake/alien.glb#Scene0"),
@@ -196,21 +196,21 @@ fn move_player(
             if game.player.i < BOARD_SIZE_I - 1 {
                 game.player.i += 1;
             }
-            rotation = -TAU / 4.;
+            rotation = -PI / 2.;
             moved = true;
         }
         if keyboard_input.pressed(KeyCode::Down) {
             if game.player.i > 0 {
                 game.player.i -= 1;
             }
-            rotation = TAU / 4.;
+            rotation = PI / 2.;
             moved = true;
         }
         if keyboard_input.pressed(KeyCode::Right) {
             if game.player.j < BOARD_SIZE_J - 1 {
                 game.player.j += 1;
             }
-            rotation = TAU / 2.;
+            rotation = PI;
             moved = true;
         }
         if keyboard_input.pressed(KeyCode::Left) {

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -1,5 +1,7 @@
 //! Eat the cakes. Eat them all. An example 3D game.
 
+use std::f32::consts::TAU;
+
 use bevy::{ecs::schedule::SystemSet, prelude::*, time::FixedTimestep};
 use rand::Rng;
 
@@ -194,21 +196,21 @@ fn move_player(
             if game.player.i < BOARD_SIZE_I - 1 {
                 game.player.i += 1;
             }
-            rotation = -std::f32::consts::FRAC_PI_2;
+            rotation = -TAU / 4.;
             moved = true;
         }
         if keyboard_input.pressed(KeyCode::Down) {
             if game.player.i > 0 {
                 game.player.i -= 1;
             }
-            rotation = std::f32::consts::FRAC_PI_2;
+            rotation = TAU / 4.;
             moved = true;
         }
         if keyboard_input.pressed(KeyCode::Right) {
             if game.player.j < BOARD_SIZE_J - 1 {
                 game.player.j += 1;
             }
-            rotation = std::f32::consts::PI;
+            rotation = TAU / 2.;
             moved = true;
         }
         if keyboard_input.pressed(KeyCode::Left) {

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -10,7 +10,7 @@
 //! To start the demo using the spherical layout run
 //! `cargo run --example many_cubes --release sphere`
 
-use std::f64::consts::TAU;
+use std::f64::consts::PI;
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
@@ -144,7 +144,7 @@ const EPSILON: f64 = 0.36;
 
 fn fibonacci_spiral_on_sphere(golden_ratio: f64, i: usize, n: usize) -> DVec2 {
     DVec2::new(
-        TAU * (i as f64 / golden_ratio),
+        PI * 2. * (i as f64 / golden_ratio),
         (1.0 - 2.0 * (i as f64 + EPSILON) / (n as f64 - 1.0 + 2.0 * EPSILON)).acos(),
     )
 }

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -10,6 +10,8 @@
 //! To start the demo using the spherical layout run
 //! `cargo run --example many_cubes --release sphere`
 
+use std::f64::consts::TAU;
+
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     math::{DVec2, DVec3},
@@ -142,7 +144,7 @@ const EPSILON: f64 = 0.36;
 
 fn fibonacci_spiral_on_sphere(golden_ratio: f64, i: usize, n: usize) -> DVec2 {
     DVec2::new(
-        2.0 * std::f64::consts::PI * (i as f64 / golden_ratio),
+        TAU * (i as f64 / golden_ratio),
         (1.0 - 2.0 * (i as f64 + EPSILON) / (n as f64 - 1.0 + 2.0 * EPSILON)).acos(),
     )
 }

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -1,7 +1,7 @@
 //! Loads animations from a skinned glTF, spawns many of them, and plays the
 //! animation to stress test skinned meshes.
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
@@ -95,7 +95,7 @@ fn setup(
 
     let ring_directions = [
         (
-            Quat::from_rotation_y(TAU / 2.),
+            Quat::from_rotation_y(PI),
             RotationDirection::CounterClockwise,
         ),
         (Quat::IDENTITY, RotationDirection::Clockwise),
@@ -120,7 +120,7 @@ fn setup(
             ))
             .id();
 
-        let circumference = std::f32::consts::TAU * radius;
+        let circumference = PI * 2. * radius;
         let foxes_in_ring = ((circumference / FOX_SPACING) as usize).min(foxes_remaining);
         let fox_spacing_angle = circumference / (foxes_in_ring as f32 * radius);
 
@@ -167,7 +167,7 @@ fn setup(
 
     // Light
     commands.spawn_bundle(DirectionalLightBundle {
-        transform: Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, 1.0, -TAU / 8.)),
+        transform: Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, 1.0, -PI / 4.)),
         directional_light: DirectionalLight {
             shadows_enabled: true,
             ..default()

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -1,6 +1,8 @@
 //! Loads animations from a skinned glTF, spawns many of them, and plays the
 //! animation to stress test skinned meshes.
 
+use std::f32::consts::TAU;
+
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
@@ -93,7 +95,7 @@ fn setup(
 
     let ring_directions = [
         (
-            Quat::from_rotation_y(std::f32::consts::PI),
+            Quat::from_rotation_y(TAU / 2.),
             RotationDirection::CounterClockwise,
         ),
         (Quat::IDENTITY, RotationDirection::Clockwise),
@@ -165,12 +167,7 @@ fn setup(
 
     // Light
     commands.spawn_bundle(DirectionalLightBundle {
-        transform: Transform::from_rotation(Quat::from_euler(
-            EulerRot::ZYX,
-            0.0,
-            1.0,
-            -std::f32::consts::FRAC_PI_4,
-        )),
+        transform: Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, 1.0, -TAU / 8.)),
         directional_light: DirectionalLight {
             shadows_enabled: true,
             ..default()

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -1,7 +1,7 @@
 //! Simple benchmark to test rendering many point lights.
 //! Run with `WGPU_SETTINGS_PRIO=webgl2` to restrict to uniform buffers and max 256 lights.
 
-use std::f64::consts::TAU;
+use std::f64::consts::PI;
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
@@ -115,7 +115,7 @@ fn setup(
 const EPSILON: f64 = 0.36;
 fn fibonacci_spiral_on_sphere(golden_ratio: f64, i: usize, n: usize) -> DVec2 {
     DVec2::new(
-        TAU * (i as f64 / golden_ratio),
+        PI * 2. * (i as f64 / golden_ratio),
         (1.0 - 2.0 * (i as f64 + EPSILON) / (n as f64 - 1.0 + 2.0 * EPSILON)).acos(),
     )
 }

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -1,6 +1,8 @@
 //! Simple benchmark to test rendering many point lights.
 //! Run with `WGPU_SETTINGS_PRIO=webgl2` to restrict to uniform buffers and max 256 lights.
 
+use std::f64::consts::TAU;
+
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     math::{DVec2, DVec3},
@@ -113,7 +115,7 @@ fn setup(
 const EPSILON: f64 = 0.36;
 fn fibonacci_spiral_on_sphere(golden_ratio: f64, i: usize, n: usize) -> DVec2 {
     DVec2::new(
-        2.0 * std::f64::consts::PI * (i as f64 / golden_ratio),
+        TAU * (i as f64 / golden_ratio),
         (1.0 - 2.0 * (i as f64 + EPSILON) / (n as f64 - 1.0 + 2.0 * EPSILON)).acos(),
     )
 }

--- a/examples/tools/scene_viewer.rs
+++ b/examples/tools/scene_viewer.rs
@@ -526,16 +526,10 @@ fn camera_controller(
 
         if mouse_delta != Vec2::ZERO {
             // Apply look update
-            let (pitch, yaw) = (
-                (options.pitch - mouse_delta.y * 0.5 * options.sensitivity * dt).clamp(
-                    -0.99 * std::f32::consts::FRAC_PI_2,
-                    0.99 * std::f32::consts::FRAC_PI_2,
-                ),
-                options.yaw - mouse_delta.x * options.sensitivity * dt,
-            );
-            transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, yaw, pitch);
-            options.pitch = pitch;
-            options.yaw = yaw;
+            options.pitch = (options.pitch - mouse_delta.y * 0.5 * options.sensitivity * dt)
+                .clamp(-TAU / 4., TAU / 4.);
+            options.yaw -= mouse_delta.x * options.sensitivity * dt;
+            transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
         }
     }
 }

--- a/examples/tools/scene_viewer.rs
+++ b/examples/tools/scene_viewer.rs
@@ -14,7 +14,7 @@ use bevy::{
     scene::InstanceId,
 };
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
 struct CameraControllerCheckSystem;
@@ -330,8 +330,8 @@ fn update_lights(
             transform.rotation = Quat::from_euler(
                 EulerRot::ZYX,
                 0.0,
-                time.seconds_since_startup() as f32 * TAU / 30.0,
-                -TAU / 8.,
+                time.seconds_since_startup() as f32 * PI / 15.0,
+                -PI / 4.,
             );
         }
     }
@@ -527,7 +527,7 @@ fn camera_controller(
         if mouse_delta != Vec2::ZERO {
             // Apply look update
             options.pitch = (options.pitch - mouse_delta.y * 0.5 * options.sensitivity * dt)
-                .clamp(-TAU / 4., TAU / 4.);
+                .clamp(-PI / 2., PI / 2.);
             options.yaw -= mouse_delta.x * options.sensitivity * dt;
             transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
         }

--- a/examples/transforms/scale.rs
+++ b/examples/transforms/scale.rs
@@ -1,6 +1,6 @@
 //! Illustrates how to scale an object in each direction.
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::math::Vec3Swizzles;
 use bevy::prelude::*;
@@ -46,7 +46,7 @@ fn setup(
         .spawn_bundle(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::WHITE.into()),
-            transform: Transform::from_rotation(Quat::from_rotation_y(TAU / 8.0)),
+            transform: Transform::from_rotation(Quat::from_rotation_y(PI / 4.0)),
             ..default()
         })
         .insert(Scaling::new());

--- a/examples/transforms/scale.rs
+++ b/examples/transforms/scale.rs
@@ -1,8 +1,9 @@
 //! Illustrates how to scale an object in each direction.
 
+use std::f32::consts::TAU;
+
 use bevy::math::Vec3Swizzles;
 use bevy::prelude::*;
-use std::f32::consts::PI;
 
 // Define a component to keep information for the scaled object.
 #[derive(Component)]
@@ -45,7 +46,7 @@ fn setup(
         .spawn_bundle(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::WHITE.into()),
-            transform: Transform::from_rotation(Quat::from_rotation_y(PI / 4.0)),
+            transform: Transform::from_rotation(Quat::from_rotation_y(TAU / 8.0)),
             ..default()
         })
         .insert(Scaling::new());

--- a/examples/transforms/transform.rs
+++ b/examples/transforms/transform.rs
@@ -1,6 +1,6 @@
 //! Shows multiple transformations of objects.
 
-use std::f32::consts::TAU;
+use std::f32::consts::PI;
 
 use bevy::prelude::*;
 
@@ -60,7 +60,7 @@ fn setup(
     // Define a start transform for an orbiting cube, that's away from our central object (sphere)
     // and rotate it so it will be able to move around the sphere and not towards it.
     let cube_spawn =
-        Transform::from_translation(Vec3::Z * -10.0).with_rotation(Quat::from_rotation_y(TAU / 4.));
+        Transform::from_translation(Vec3::Z * -10.0).with_rotation(Quat::from_rotation_y(PI / 2.));
     commands
         .spawn_bundle(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),

--- a/examples/transforms/transform.rs
+++ b/examples/transforms/transform.rs
@@ -1,8 +1,8 @@
 //! Shows multiple transformations of objects.
 
-use bevy::prelude::*;
+use std::f32::consts::TAU;
 
-use std::f32::consts::PI;
+use bevy::prelude::*;
 
 // A struct for additional data of for a moving cube.
 #[derive(Component)]
@@ -59,9 +59,8 @@ fn setup(
     // by changing its rotation each frame and moving forward.
     // Define a start transform for an orbiting cube, that's away from our central object (sphere)
     // and rotate it so it will be able to move around the sphere and not towards it.
-    let angle_90 = PI / 2.0;
     let cube_spawn =
-        Transform::from_translation(Vec3::Z * -10.0).with_rotation(Quat::from_rotation_y(angle_90));
+        Transform::from_translation(Vec3::Z * -10.0).with_rotation(Quat::from_rotation_y(TAU / 4.));
     commands
         .spawn_bundle(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),


### PR DESCRIPTION
Examples inconsistently use either `TAU`, `PI`, `FRAC_PI_2` or `FRAC_PI_4`.
Often in odd ways and without `use`ing the constants, making it difficult to parse.

 * Use `PI` to specify angles.
 * General code-quality improvements.
 * Fix borked `hierarchy` example.
