### PR TITLE
[Merged by Bors] - Add warning when using load_folder on web

### DIFF
--- a/crates/bevy_asset/src/io/wasm_asset_io.rs
+++ b/crates/bevy_asset/src/io/wasm_asset_io.rs
@@ -52,6 +52,7 @@ impl AssetIo for WasmAssetIo {
         &self,
         _path: &Path,
     ) -> Result<Box<dyn Iterator<Item = PathBuf>>, AssetIoError> {
+        bevy_log::warn!("Loading folders is not supported in WASM");
         Ok(Box::new(std::iter::empty::<PathBuf>()))
     }
 


### PR DESCRIPTION
# Objective

Help users who are using `load_folder` in wasm builds to find a slightly shorter path to figuring out why their stuff is broken.

## Solution

Adds a warning to `read_directory` in the `WasmAssetIo`.

This is extremely similar to the warning already emitted a few lines below for `watch_for_changes`.