### PR TITLE
bevy_reflect: Type aliases

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -12,6 +12,7 @@ use bevy_ecs::{
     world::World,
 };
 use bevy_utils::{tracing::debug, HashMap};
+use std::borrow::Cow;
 use std::fmt::Debug;
 
 #[cfg(feature = "trace")]
@@ -919,6 +920,155 @@ impl App {
         {
             let registry = self.world.resource_mut::<AppTypeRegistry>();
             registry.write().register_type_data::<T, D>();
+        }
+        self
+    }
+
+    /// Register an alias for the given type, `T`, in the [`TypeRegistry`] resource.
+    ///
+    /// This will implicitly overwrite existing usages of the given alias and print a warning to the console if it does so.
+    ///
+    /// To register the alias only if it isn't already in use, try using [`try_register_type_alias`].
+    /// Otherwise, to explicitly overwrite existing aliases without the warning, try using [`overwrite_type_alias`].
+    ///
+    /// If an alias was overwritten, then the [`TypeId`] of the previous type is returned.
+    ///
+    /// [`TypeRegistry`]: bevy_reflect::TypeRegistry
+    /// [`try_register_type_alias`]: Self::try_register_type_alias
+    /// [`overwrite_type_alias`]: Self::overwrite_type_alias
+    /// [`TypeId`]: std::any::TypeId
+    #[cfg(feature = "bevy_reflect")]
+    pub fn register_type_alias<T: bevy_reflect::Reflect>(
+        &mut self,
+        alias: impl Into<Cow<'static, str>>,
+    ) -> &mut Self {
+        {
+            let registry = self.world.resource_mut::<AppTypeRegistry>();
+            registry.write().register_alias::<T>(alias);
+        }
+        self
+    }
+
+    /// Register a _deprecated_ alias for the given type, `T`, in the [`TypeRegistry`] resource.
+    ///
+    /// To register an alias that isn't marked as deprecated, use [`register_type_alias`].
+    ///
+    /// This will implicitly overwrite existing usages of the given alias and print a warning to the console if it does so.
+    ///
+    /// To register the alias only if it isn't already in use, try using [`try_register_type_alias`].
+    /// Otherwise, to explicitly overwrite existing aliases without the warning, try using [`overwrite_type_alias`].
+    ///
+    /// If an alias was overwritten, then the [`TypeId`] of the previous type is returned.
+    ///
+    /// [`TypeRegistry`]: bevy_reflect::TypeRegistry
+    /// [`register_type_alias`]: Self::register_type_alias
+    /// [`try_register_type_alias`]: Self::try_register_type_alias
+    /// [`overwrite_type_alias`]: Self::overwrite_type_alias
+    /// [`TypeId`]: std::any::TypeId
+    #[cfg(feature = "bevy_reflect")]
+    pub fn register_deprecated_type_alias<T: bevy_reflect::Reflect>(
+        &mut self,
+        alias: impl Into<Cow<'static, str>>,
+    ) -> &mut Self {
+        {
+            let registry = self.world.resource_mut::<AppTypeRegistry>();
+            registry.write().register_deprecated_alias::<T>(alias);
+        }
+        self
+    }
+
+    /// Attempts to register an alias for the given type, `T`, in the [`TypeRegistry`] resource if it isn't already in use.
+    ///
+    /// To register the alias whether or not it exists, try using either [`register_type_alias`] or [`overwrite_type_alias`].
+    ///
+    /// If the given alias is already in use, then the [`TypeId`] of that type is returned.
+    ///
+    /// [`TypeRegistry`]: bevy_reflect::TypeRegistry
+    /// [`register_type_alias`]: Self::register_type_alias
+    /// [`overwrite_type_alias`]: Self::overwrite_type_alias
+    /// [`TypeId`]: std::any::TypeId
+    #[cfg(feature = "bevy_reflect")]
+    pub fn try_register_type_alias<T: bevy_reflect::Reflect>(
+        &mut self,
+        alias: impl Into<Cow<'static, str>>,
+    ) -> &mut Self {
+        {
+            let registry = self.world.resource_mut::<AppTypeRegistry>();
+            registry.write().try_register_alias::<T>(alias);
+        }
+        self
+    }
+
+    /// Attempts to register a _deprecated_ alias for the given type, `T`, in the [`TypeRegistry`] resource if it isn't already in use.
+    ///
+    /// To try and register an alias that isn't marked as deprecated, use [`try_register_type_alias`].
+    ///
+    /// To register the alias whether or not it exists, try using either [`register_deprecated_type_alias`] or [`overwrite_deprecated_type_alias`].
+    ///
+    /// If the given alias is already in use, then the [`TypeId`] of that type is returned.
+    ///
+    /// [`TypeRegistry`]: bevy_reflect::TypeRegistry
+    /// [`try_register_type_alias`]: Self::try_register_type_alias
+    /// [`register_deprecated_type_alias`]: Self::register_deprecated_type_alias
+    /// [`overwrite_deprecated_type_alias`]: Self::overwrite_deprecated_type_alias
+    /// [`TypeId`]: std::any::TypeId
+    #[cfg(feature = "bevy_reflect")]
+    pub fn try_register_deprecated_type_alias<T: bevy_reflect::Reflect>(
+        &mut self,
+        alias: impl Into<Cow<'static, str>>,
+    ) -> &mut Self {
+        {
+            let registry = self.world.resource_mut::<AppTypeRegistry>();
+            registry.write().try_register_deprecated_alias::<T>(alias);
+        }
+        self
+    }
+
+    /// Register an alias for the given type, `T`, in the [`TypeRegistry`] resource, explicitly overwriting existing aliases.
+    ///
+    /// Unlike, [`register_type_alias`], this does not print a warning when overwriting existing aliases.
+    ///
+    /// To register the alias only if it isn't already in use, try using [`try_register_type_alias`].
+    ///
+    /// If an alias was overwritten, then the [`TypeId`] of the previous type is returned.
+    /// [`TypeRegistry`]: bevy_reflect::TypeRegistry
+    /// [`register_type_alias`]: Self::register_type_alias
+    /// [`try_register_type_alias`]: Self::try_register_type_alias
+    /// [`TypeId`]: std::any::TypeId
+    #[cfg(feature = "bevy_reflect")]
+    pub fn overwrite_type_alias<T: bevy_reflect::Reflect>(
+        &mut self,
+        alias: impl Into<Cow<'static, str>>,
+    ) -> &mut Self {
+        {
+            let registry = self.world.resource_mut::<AppTypeRegistry>();
+            registry.write().overwrite_alias::<T>(alias);
+        }
+        self
+    }
+
+    /// Register a _deprecated_ alias for the given type, `T`, in the [`TypeRegistry`] resource, explicitly overwriting existing aliases.
+    ///
+    /// To register an alias that isn't marked as deprecated, use [`overwrite_type_alias`].
+    ///
+    /// Unlike, [`register_type_alias`], this does not print a warning when overwriting existing aliases.
+    ///
+    /// To register the alias only if it isn't already in use, try using [`try_register_type_alias`].
+    ///
+    /// If an alias was overwritten, then the [`TypeId`] of the previous type is returned.
+    /// [`TypeRegistry`]: bevy_reflect::TypeRegistry
+    /// [`overwrite_type_alias`]: Self::overwrite_type_alias
+    /// [`register_type_alias`]: Self::register_type_alias
+    /// [`try_register_type_alias`]: Self::try_register_type_alias
+    /// [`TypeId`]: std::any::TypeId
+    #[cfg(feature = "bevy_reflect")]
+    pub fn overwrite_deprecated_type_alias<T: bevy_reflect::Reflect>(
+        &mut self,
+        alias: impl Into<Cow<'static, str>>,
+    ) -> &mut Self {
+        {
+            let registry = self.world.resource_mut::<AppTypeRegistry>();
+            registry.write().overwrite_deprecated_alias::<T>(alias);
         }
         self
     }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
@@ -221,11 +221,9 @@ impl ReflectTraits {
         }
 
         for ident in other.idents {
-            if self.idents.contains(&ident) {
-                continue;
+            if !self.idents.contains(&ident) {
+                self.idents.push(ident);
             }
-
-            self.idents.push(ident);
         }
 
         for alias in other.aliases {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
@@ -231,12 +231,10 @@ impl ReflectTraits {
             if self
                 .aliases
                 .iter()
-                .any(|other_alias| value == other_alias.value())
+                .all(|other_alias| value != other_alias.value())
             {
-                continue;
+                self.aliases.push(alias);
             }
-
-            self.aliases.push(alias);
         }
 
         for alias in other.deprecated_aliases {
@@ -244,12 +242,10 @@ impl ReflectTraits {
             if self
                 .deprecated_aliases
                 .iter()
-                .any(|other_alias| value == other_alias.value())
+                .all(|other_alias| value != other_alias.value())
             {
-                continue;
+                self.deprecated_aliases.push(alias);
             }
-
-            self.deprecated_aliases.push(alias);
         }
     }
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
@@ -170,7 +170,7 @@ impl ReflectTraits {
                     // Closure that handles defining an alias on a generic type
                     let try_handle_generic_alias = || -> syn::Result<()> {
                         if is_generic {
-                            Err(syn::Error::new(ident.span(), "cannot specify non-generic aliases on generic types. Consider using `TypeRegistry::register_alias` instead"))
+                            Err(syn::Error::new(ident.span(), "alias attributes cannot be used on generic types. Consider using `TypeRegistry::register_alias` instead"))
                         } else {
                             Ok(())
                         }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
@@ -110,6 +110,8 @@ impl<'a> ReflectDerive<'a> {
         // Should indicate whether `#[reflect_value]` was used
         let mut force_reflect_value = false;
 
+        let is_generic = utility::is_generic(&input.generics, false);
+
         for attribute in input.attrs.iter().filter_map(|attr| attr.parse_meta().ok()) {
             let meta_list = if let Meta::List(meta_list) = attribute {
                 meta_list
@@ -121,16 +123,22 @@ impl<'a> ReflectDerive<'a> {
                 if ident == REFLECT_ATTRIBUTE_NAME {
                     if force_reflect_value {
                         force_reflect_value = false;
-                        traits = ReflectTraits::from_nested_metas(&meta_list.nested)?;
+                        traits = ReflectTraits::from_nested_metas(&meta_list.nested, is_generic)?;
                     } else {
-                        traits.combine(ReflectTraits::from_nested_metas(&meta_list.nested)?);
+                        traits.combine(ReflectTraits::from_nested_metas(
+                            &meta_list.nested,
+                            is_generic,
+                        )?);
                     }
                 } else if ident == REFLECT_VALUE_ATTRIBUTE_NAME {
                     if !force_reflect_value {
                         force_reflect_value = true;
-                        traits = ReflectTraits::from_nested_metas(&meta_list.nested)?;
+                        traits = ReflectTraits::from_nested_metas(&meta_list.nested, is_generic)?;
                     } else {
-                        traits.combine(ReflectTraits::from_nested_metas(&meta_list.nested)?);
+                        traits.combine(ReflectTraits::from_nested_metas(
+                            &meta_list.nested,
+                            is_generic,
+                        )?);
                     }
                 }
             }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
@@ -1,17 +1,19 @@
 //! Contains code related specifically to Bevy's type registration.
 
-use proc_macro2::Ident;
+use crate::ReflectMeta;
 use quote::quote;
-use syn::{Generics, Path};
 
 /// Creates the `GetTypeRegistration` impl for the given type data.
-pub(crate) fn impl_get_type_registration(
-    type_name: &Ident,
-    bevy_reflect_path: &Path,
-    registration_data: &[Ident],
-    generics: &Generics,
-) -> proc_macro2::TokenStream {
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+pub(crate) fn impl_get_type_registration(meta: &ReflectMeta) -> proc_macro2::TokenStream {
+    let type_name = meta.type_name();
+    let bevy_reflect_path = meta.bevy_reflect_path();
+
+    let registration_data = meta.traits().idents();
+
+    let aliases = meta.traits().aliases();
+    let deprecated_aliases = meta.traits().deprecated_aliases();
+
+    let (impl_generics, ty_generics, where_clause) = meta.generics().split_for_impl();
     quote! {
         #[allow(unused_mut)]
         impl #impl_generics #bevy_reflect_path::GetTypeRegistration for #type_name #ty_generics #where_clause {
@@ -20,6 +22,14 @@ pub(crate) fn impl_get_type_registration(
                 registration.insert::<#bevy_reflect_path::ReflectFromPtr>(#bevy_reflect_path::FromType::<#type_name #ty_generics>::from_type());
                 #(registration.insert::<#registration_data>(#bevy_reflect_path::FromType::<#type_name #ty_generics>::from_type());)*
                 registration
+            }
+
+            fn aliases() -> &'static [&'static str] {
+                &[#(#aliases),*]
+            }
+
+            fn deprecated_aliases() -> &'static [&'static str] {
+                &[#(#deprecated_aliases),*]
             }
         }
     }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -2,7 +2,7 @@
 
 use bevy_macro_utils::BevyManifest;
 use proc_macro2::{Ident, Span};
-use syn::{Member, Path};
+use syn::{Generics, Member, Path};
 
 /// Returns the correct path for `bevy_reflect`.
 pub(crate) fn get_bevy_reflect_path() -> Path {
@@ -94,5 +94,16 @@ impl<T> ResultSifter<T> {
         } else {
             Ok(self.items)
         }
+    }
+}
+
+/// Returns true if the given [`Generics`] contains generic information.
+///
+/// If `include_lifetimes` is false, this does not count lifetime arguments.
+pub(crate) fn is_generic(generics: &Generics, include_lifetimes: bool) -> bool {
+    if include_lifetimes {
+        generics.params.len() - generics.lifetimes().count() > 0
+    } else {
+        !generics.params.is_empty()
     }
 }

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -145,7 +145,11 @@ impl<'a, 'de> Visitor<'de> for ReflectVisitor<'a> {
         while let Some(key) = map.next_key::<String>()? {
             match key.as_str() {
                 type_fields::TYPE => {
-                    type_name = Some(map.next_value()?);
+                    let key = map.next_value::<String>()?;
+
+                    self.registry.warn_on_alias_deprecation(&key);
+
+                    type_name = Some(key);
                 }
                 type_fields::MAP => {
                     let _type_name = type_name

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -217,8 +217,11 @@ impl<'a, 'de> Visitor<'de> for ReflectVisitor<'a> {
                     let type_name = type_name
                         .take()
                         .ok_or_else(|| de::Error::missing_field(type_fields::TYPE))?;
-                    let registration =
-                        self.registry.get_with_name(&type_name).ok_or_else(|| {
+                    let registration = self
+                        .registry
+                        .get_with_name(&type_name)
+                        .or_else(|| self.registry.get_with_alias(&type_name))
+                        .ok_or_else(|| {
                             de::Error::custom(format_args!(
                                 "No registration found for {}",
                                 type_name

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -39,7 +39,7 @@ pub trait GetTypeRegistration {
 
     /// Returns the static set of aliases that can be used to refer to this type.
     ///
-    /// Note that these are the _default_ aliases— used specifically for type registration.
+    /// Note that these are the _default_ aliases used specifically for type registration.
     /// For a given [registry], the actual set of aliases for a registered type may differ from the
     /// ones listed here.
     ///
@@ -54,7 +54,7 @@ pub trait GetTypeRegistration {
     ///
     /// For the list of _current_ aliases, try using [`aliases`] instead.
     ///
-    /// Note that, like [`aliases`], this is the _default_ set— used specifically for type registration.
+    /// Note that, like [`aliases`], this is the _default_ set used specifically for type registration.
     /// For a given [registry], the actual set of deprecated aliases for a registered type may differ from the
     /// ones listed here.
     ///
@@ -425,8 +425,8 @@ impl TypeRegistry {
     /// Prints a warning stating that the given alias has been deprecated for the given registration.
     fn warn_alias_deprecation(alias: &str, registration: &TypeRegistration) {
         warn!(
-            "the alias `{}` has been deprecated for the type `{}` ({:?}). Consider using the full type name or \
-            one of the current aliases: {:?}",
+            "the alias `{}` has been deprecated for the type `{}` ({:?}) and may be removed in the future. \
+            Consider using the full type name or one of the current aliases: {:?}",
             alias,
             registration.type_name(),
             registration.type_id(),

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -316,7 +316,8 @@ impl TypeRegistry {
     /// and print a warning to the console if it does so.
     ///
     /// To register the alias only if it isn't already in use, try using [`try_register_alias`](Self::try_register_alias).
-    /// Otherwise, to explicitly overwrite existing aliases without the warning, try using [`overwrite_alias`](Self::overwrite_alias).
+    /// Otherwise, to explicitly overwrite existing aliases without the warning,
+    /// try using [`overwrite_alias`](Self::overwrite_alias).
     ///
     /// If an alias was overwritten, then the [`TypeId`] of the previous type is returned.
     pub fn register_alias<T: Reflect + 'static>(
@@ -331,11 +332,12 @@ impl TypeRegistry {
     ///
     /// To register an alias that isn't marked as deprecated, use [`register_alias`](Self::register_alias).
     ///
-    /// This will implicitly overwrite existing usages of the given alias
-    /// and print a warning to the console if it does so.
+    /// This will implicitly overwrite existing usages of the given alias and print a warning to the console if it does so.
     ///
-    /// To register the alias only if it isn't already in use, try using [`try_register_deprecated_alias`](Self::try_register_deprecated_alias).
-    /// Otherwise, to explicitly overwrite existing aliases without the warning, try using [`overwrite_deprecated_alias`](Self::overwrite_deprecated_alias).
+    /// To register the alias only if it isn't already in use,
+    /// try using [`try_register_deprecated_alias`](Self::try_register_deprecated_alias).
+    /// Otherwise, to explicitly overwrite existing aliases without the warning,
+    /// try using [`overwrite_deprecated_alias`](Self::overwrite_deprecated_alias).
     ///
     /// If an alias was overwritten, then the [`TypeId`] of the previous type is returned.
     pub fn register_deprecated_alias<T: Reflect + 'static>(
@@ -349,8 +351,8 @@ impl TypeRegistry {
 
     /// Attempts to register an alias for the given type, `T`, if it isn't already in use.
     ///
-    /// To register the alias whether or not it exists, try using either [`register_alias`](Self::register_alias) or
-    /// [`overwrite_alias`](Self::overwrite_alias).
+    /// To register the alias whether or not it exists,
+    /// try using either [`register_alias`](Self::register_alias) or [`overwrite_alias`](Self::overwrite_alias).
     ///
     /// If the given alias is already in use, then the [`TypeId`] of that type is returned.
     pub fn try_register_alias<T: Reflect + 'static>(
@@ -365,8 +367,9 @@ impl TypeRegistry {
     ///
     /// To try and register an alias that isn't marked as deprecated, use [`try_register_alias`](Self::try_register_alias).
     ///
-    /// To register the alias whether or not it exists, try using either [`register_deprecated_alias`](Self::register_deprecated_alias) or
-    /// [`overwrite_deprecated_alias`](Self::overwrite_deprecated_alias).
+    /// To register the alias whether or not it exists,
+    /// try using either [`register_deprecated_alias`](Self::register_deprecated_alias)
+    /// or [`overwrite_deprecated_alias`](Self::overwrite_deprecated_alias).
     ///
     /// If the given alias is already in use, then the [`TypeId`] of that type is returned.
     pub fn try_register_deprecated_alias<T: Reflect + 'static>(
@@ -397,9 +400,11 @@ impl TypeRegistry {
     ///
     /// To register an alias that isn't marked as deprecated, use [`overwrite_alias`](Self::overwrite_alias).
     ///
-    /// Unlike, [`register_deprecated_alias`](Self::register_deprecated_alias), this does not print a warning when overwriting existing aliases.
+    /// Unlike, [`register_deprecated_alias`](Self::register_deprecated_alias),
+    /// this does not print a warning when overwriting existing aliases.
     ///
-    /// To register the alias only if it isn't already in use, try using [`try_register_deprecated_alias`](Self::try_register_deprecated_alias).
+    /// To register the alias only if it isn't already in use,
+    /// try using [`try_register_deprecated_alias`](Self::try_register_deprecated_alias).
     ///
     /// If an alias was overwritten, then the [`TypeId`] of the previous type is returned.
     pub fn overwrite_deprecated_alias<T: Reflect + 'static>(

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -221,7 +221,7 @@ impl TypeRegistry {
         let registration = self.get(alias_data.type_id)?;
 
         if alias_data.is_deprecated {
-            Self::warn_alias_deprecation(alias, registration);
+            Self::warn_alias_deprecation_internal(alias, registration);
         }
 
         Some(registration)
@@ -236,7 +236,7 @@ impl TypeRegistry {
         let registration = self.get_mut(alias_data.type_id)?;
 
         if alias_data.is_deprecated {
-            Self::warn_alias_deprecation(alias, registration);
+            Self::warn_alias_deprecation_internal(alias, registration);
         }
 
         Some(registration)
@@ -453,8 +453,19 @@ impl TypeRegistry {
         }
     }
 
+    /// If the given alias exists in the registry, prints a warning if it's deprecated.
+    pub(crate) fn warn_on_alias_deprecation(&self, alias: &str) {
+        if let Some(data) = self.alias_to_id.get(alias) {
+            if data.is_deprecated {
+                if let Some(registration) = self.get(data.type_id) {
+                    Self::warn_alias_deprecation_internal(alias, registration);
+                }
+            }
+        }
+    }
+
     /// Prints a warning stating that the given alias has been deprecated for the given registration.
-    fn warn_alias_deprecation(alias: &str, registration: &TypeRegistration) {
+    fn warn_alias_deprecation_internal(alias: &str, registration: &TypeRegistration) {
         warn!(
             "the alias `{}` has been deprecated for the type `{}` ({:?}) and may be removed in the future. \
             Consider using the full type name or one of the current aliases: {:?}",


### PR DESCRIPTION
# Objective

Reflection relies on type names to access type registrations. Unfortunately, these type names can be (1) rather long, (2) unstable between a crate's features/versions, and (3) very programmer-focused. 

This can be problematic for serialized formats such as Bevy's scenes. Something as innocuous as performing an internal refactor can result in downstream users needing to update all of their scenes. For example, moving `my_crate::foo::Foo` to `my_crate::Foo` requires updating the type name everywhere it's used. 

Additionally, it's not always programmers that are dealing with this data. Designers may find it difficult to understand that `my_crate::inventory::utility::BaseContainer<my_crate::inventory::Item, 10>` really just represents `PlayerHotbar`. In fact, the programmers may have even shortened this themselves using `type PlayerHotbar = ...` (not fair!).

Ideally there would be a way to refer to types that were shorter, more stable, and non-programmer friendly.

## Solution

Add the ability to register aliases for a type.

Aliases are designated using an attribute on the derive macro for `Reflect`:

```rust
#[derive(Reflect)]
#[reflect(alias = "MyCoolAlias")]
#[reflect(alias = "MyOtherCoolAlias")]
struct Foo;
```

> As seen above, we can define multiple aliases by just adding another attribute!

With this, we can now change our scenes from this:

```js
{
  "type": "my_crate::foo::Foo",
  // ...
}
```

to:

```js
{
  "type": "MyCoolAlias",
  // ...
}
```

Alternatively, we could have assigned the aliases via the registry:

```rust
registry.register_alias::<Foo>("MyCoolAlias");
registry.register_alias::<Foo>("MyOtherCoolAlias");
```

### Generics

Unfortunately, we cannot so easily handle generic types. The reason for this is that a type with generics will monomorphize to many types— so which type gets the alias? Because aliases map to a single type, we cannot specify them via the macro.

This means that registering generic types requires using the registry:

```rust
registry.register_alias::<BaseContainer<Item, 10>>("PlayerHotbar");
```

### Deprecation Warnings

As users and crates in the ecosystem start to use aliases, they may at some point decide they want to move from one alias to a new one. We can aid user migration by allowing some aliases to be marked as "deprecated". This means that a user can continue to use a deprecated alias as normal; however, it will print a warning to the console letting them know that the alias may be removed entirely in the future.

To specify a deprecated alias:

```rust
#[derive(Reflect)]
#[reflect(alias = "MyNewAlias")]
#[reflect(deprecated_alias = "MyOldAlias")]
struct Foo;
```

__Note:__ This works in theory, but due to how the deserializer is setup, we only actually warn when deserializing Value types. This should be more useful when something like #4561 or #5723 lands.

### Comparison to #5805

Both this PR and #5805 are very similar. However, they have slightly different goals and actually pair well together.

#5805 is concerned with defining a replacement for `std::any::type_name`. It is supposed to provide a stable and (generally) unique identifier for a given type. There can only be one for a given type.

This PR is concerned with defining multiple names that can _optionally_ be used to refer to a type. These names can be overwritten by users and other crates. It gives users more control over how their type can be represented.

In other words, #5805 defines the "one true" type name, while this PR defines "many optional" type names. Or, to use a serde analogy, #5805 is [`#[serde(rename)]`](https://serde.rs/field-attrs.html#rename), while this PR is [`#[serde(alias)]`](https://serde.rs/field-attrs.html#alias).

---

## Task List

Feel free to leave comments regarding the items on this list:

- [x] Allow defining deprecated aliases (separate methods or boolean argument?)
- [x] Add warning to deserialization (should we error on unregistered type?)
- [x] Add methods to `app` (which ones? are they worth having?)

## Changelog

TODO

## Migration Guide

TODO
