### PR TITLE
[Merged by Bors] - #5817: derive_bundle macro is not hygienic

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -149,8 +149,8 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
             fn component_ids(
                 components: &mut #ecs_path::component::Components,
                 storages: &mut #ecs_path::storage::Storages,
-            ) -> Vec<#ecs_path::component::ComponentId> {
-                let mut component_ids = Vec::with_capacity(#field_len);
+            ) -> ::std::vec::Vec<#ecs_path::component::ComponentId> {
+                let mut component_ids = ::std::vec::Vec::with_capacity(#field_len);
                 #(#field_component_ids)*
                 component_ids
             }


### PR DESCRIPTION
# Objective
- Fixes #5817.
- Removes std::vec::Vec ambiguities in derive_bundle macro

## Solution
Prepend :: to standard library full Vec qualified type name (::std::vec::Vec)
