### PR TITLE
[Merged by Bors] - Support for additional gamepad buttons and axis

### DIFF
--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -278,7 +278,7 @@ pub enum GamepadButtonType {
     DPadRight,
 
     /// Miscellaneous buttons, considered non-standard (i.e. Extra buttons on a flight stick that do not have a gamepad equivalent).
-    Button(u8),
+    Other(u8),
 }
 
 /// A button of a [`Gamepad`].

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -276,6 +276,9 @@ pub enum GamepadButtonType {
     DPadLeft,
     /// The right button of the D-Pad.
     DPadRight,
+
+    /// Miscellaneous buttons, considered non-standard (i.e. Extra buttons on a flight stick that do not have a gamepad equivalent).
+    Button(u8),
 }
 
 /// A button of a [`Gamepad`].
@@ -341,6 +344,9 @@ pub enum GamepadAxisType {
     RightStickY,
     /// The value of the right `Z` button.
     RightZ,
+
+    /// Non-standard support for other axis types (i.e. HOTAS sliders, potentiometers, etc).
+    Other(u8),
 }
 
 /// An axis of a [`Gamepad`].


### PR DESCRIPTION
# Objective

Extend the scope of Gamepad to accommodate devices that have more inputs than a typical controller.

## Solution

Add additional enum variants to both _GamepadButtonType_ and _GamepadAxisType_ that supports up to 255 more non-standard buttons/axis respectively. 

## Personal motivation

I have been writing an alternative to the GILRS crate, and with this simple change to the source code, It will be a trivial thing to direct new devices through the bevy systems, even when they do not always behave exactly like your typical controller.