### PR TITLE
[Merged by Bors] - Add get_entity to Commands

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -245,14 +245,43 @@ impl<'w, 's> Commands<'w, 's> {
     /// ```
     #[track_caller]
     pub fn entity<'a>(&'a mut self, entity: Entity) -> EntityCommands<'w, 's, 'a> {
-        assert!(
-            self.entities.contains(entity),
+        self.get_entity(entity).expect(&format!(
             "Attempting to create an EntityCommands for entity {:?}, which doesn't exist.",
             entity
-        );
-        EntityCommands {
-            entity,
-            commands: self,
+        ))
+    }
+
+    /// Returns an option containing an [`EntityCommands`] builder for the requested [`Entity`] if it exists, otherwise None.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bevy_ecs::prelude::*;
+    ///
+    /// #[derive(Component)]
+    /// struct Label(&'static str);
+
+    /// fn example_system(mut commands: Commands) {
+    ///     // Create a new, empty entity
+    ///     let entity = commands.spawn().id();
+    ///
+    ///     // Get the entity if it still exists, which it will in this case
+    ///     if let Some(mut entity_commands) = commands.get_entity(entity) {
+    ///         // adds a single component to the entity
+    ///         entity_commands.insert(Label("hello world"));
+    ///     }      
+    /// }
+    /// # bevy_ecs::system::assert_is_system(example_system);
+    /// ```
+    #[track_caller]
+    pub fn get_entity<'a>(&'a mut self, entity: Entity) -> Option<EntityCommands<'w, 's, 'a>> {
+        if self.entities.contains(entity) {
+            Some(EntityCommands {
+                entity,
+                commands: self,
+            })
+        } else {
+            None
         }
     }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -243,6 +243,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// }
     /// # bevy_ecs::system::assert_is_system(example_system);
     /// ```
+    #[inline]
     #[track_caller]
     pub fn entity<'a>(&'a mut self, entity: Entity) -> EntityCommands<'w, 's, 'a> {
         self.get_entity(entity).unwrap_or_else(|| {
@@ -275,6 +276,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// }
     /// # bevy_ecs::system::assert_is_system(example_system);
     /// ```
+    #[inline]
     #[track_caller]
     pub fn get_entity<'a>(&'a mut self, entity: Entity) -> Option<EntityCommands<'w, 's, 'a>> {
         self.entities.contains(entity).then_some(EntityCommands {

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -254,7 +254,7 @@ impl<'w, 's> Commands<'w, 's> {
         })
     }
 
-    /// Returns an option containing an [`EntityCommands`] builder for the requested [`Entity`] if it exists, otherwise None.
+    /// Returns an option containing an [`EntityCommands`] builder for the requested [`Entity`] if it exists, otherwise `None`.
     /// This does not ensure that the commands will succeed as the entity may no longer exist by the time they are executed.
     ///
     /// # Example

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -275,7 +275,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// ```
     #[track_caller]
     pub fn get_entity<'a>(&'a mut self, entity: Entity) -> Option<EntityCommands<'w, 's, 'a>> {
-        self.entities.contains(entity).then(EntityCommands {
+        self.entities.contains(entity).then_some(EntityCommands {
             entity,
             commands: self,
         })

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -275,14 +275,10 @@ impl<'w, 's> Commands<'w, 's> {
     /// ```
     #[track_caller]
     pub fn get_entity<'a>(&'a mut self, entity: Entity) -> Option<EntityCommands<'w, 's, 'a>> {
-        if self.entities.contains(entity) {
-            Some(EntityCommands {
-                entity,
-                commands: self,
-            })
-        } else {
-            None
-        }
+        self.entities.contains(entity).then(EntityCommands {
+            entity,
+            commands: self,
+        })
     }
 
     /// Spawns entities to the [`World`] according to the given iterator (or a type that can

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -255,6 +255,7 @@ impl<'w, 's> Commands<'w, 's> {
     }
 
     /// Returns an option containing an [`EntityCommands`] builder for the requested [`Entity`] if it exists, otherwise None.
+    /// This does not ensure that the commands will succeed as the entity may no longer exist by the time they are executed.
     ///
     /// # Example
     ///

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -245,10 +245,12 @@ impl<'w, 's> Commands<'w, 's> {
     /// ```
     #[track_caller]
     pub fn entity<'a>(&'a mut self, entity: Entity) -> EntityCommands<'w, 's, 'a> {
-        self.get_entity(entity).expect(&format!(
-            "Attempting to create an EntityCommands for entity {:?}, which doesn't exist.",
-            entity
-        ))
+        self.get_entity(entity).unwrap_or_else(|| {
+            panic!(
+                "Attempting to create an EntityCommands for entity {:?}, which doesn't exist.",
+                entity
+            )
+        })
     }
 
     /// Returns an option containing an [`EntityCommands`] builder for the requested [`Entity`] if it exists, otherwise None.

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -255,7 +255,7 @@ impl<'w, 's> Commands<'w, 's> {
     }
 
     /// Returns an option containing an [`EntityCommands`] builder for the requested [`Entity`] if it exists, otherwise `None`.
-    /// This does not ensure that the commands will succeed as the entity may no longer exist by the time they are executed.
+    /// This does not ensure that the commands will succeed as the entity may no longer exist by the time the associated commands are executed.
     ///
     /// # Example
     ///


### PR DESCRIPTION
# Objective

- Fixes #5850 

## Solution

- As described in the issue, added a `get_entity` method on `Commands` that returns an `Option<EntityCommands>`

## Changelog
- Added the new method with a simple doc test
- I have re-used `get_entity` in `entity`, similarly to how `get_single` is used in `single` while additionally preserving the error message
- Add `#[inline]` to both functions

Entities that have commands queued to despawn system will still return commands when `get_entity` is called but that is representative of the fact that the entity is still around until those commands are flushed.

A potential `contains_entity` could also be added in this PR if desired, that would effectively be replacing Entities.contains but may be more discoverable if this is a common use case.
