### PR TITLE
[Merged by Bors] - can clone a scene

### DIFF
--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -78,7 +78,7 @@ impl DynamicScene {
 
     /// Write the dynamic entities and their corresponding components to the given world.
     ///
-    /// This method will return a [`SceneSpawnError`] if either a type is not registered
+    /// This method will return a [`SceneSpawnError`] if a type either is not registered
     /// or doesn't reflect the [`Component`](bevy_ecs::component::Component) trait.
     pub fn write_to_world(
         &self,

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -78,8 +78,8 @@ impl DynamicScene {
 
     /// Write the dynamic entities and their corresponding components to the given world.
     ///
-    /// This method will return a `SceneSpawnError` if either a type is not registered
-    /// or doesn't reflect the `Component` trait.
+    /// This method will return a [`SceneSpawnError`] if either a type is not registered
+    /// or doesn't reflect the [`Component`](bevy_ecs::component::Component) trait.
     pub fn write_to_world(
         &self,
         world: &mut World,

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -29,7 +29,7 @@ impl Scene {
     ///
     /// This method will return a `SceneSpawnError` if either a type is not registered in the
     /// provided `AppTypeRegistry` or doesn't reflect the `Component` trait.
-    pub fn clone(&self, type_registry: &AppTypeRegistry) -> Result<Scene, SceneSpawnError> {
+    pub fn clone_with(&self, type_registry: &AppTypeRegistry) -> Result<Scene, SceneSpawnError> {
         let mut new_world = World::new();
         new_world.insert_resource(type_registry.clone());
         self.write_to_world(&mut new_world)?;

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -31,22 +31,23 @@ impl Scene {
     /// provided [`AppTypeRegistry`] or doesn't reflect the [`Component`](bevy_ecs::component::Component) trait.
     pub fn clone_with(&self, type_registry: &AppTypeRegistry) -> Result<Scene, SceneSpawnError> {
         let mut new_world = World::new();
-        new_world.insert_resource(type_registry.clone());
-        self.write_to_world(&mut new_world)?;
-        new_world.remove_resource::<AppTypeRegistry>();
+        self.write_to_world_with(&mut new_world, type_registry)?;
         Ok(Self { world: new_world })
     }
 
     /// Write the entities and their corresponding components to the given world.
     ///
-    /// This method will return a [`SceneSpawnError`] if a type either is not registered
-    /// or doesn't reflect the [`Component`](bevy_ecs::component::Component) trait.
-    pub fn write_to_world(&self, world: &mut World) -> Result<InstanceInfo, SceneSpawnError> {
+    /// This method will return a [`SceneSpawnError`] if a type either is not registered in the
+    /// provided [`AppTypeRegistry`] or doesn't reflect the [`Component`](bevy_ecs::component::Component) trait.
+    pub fn write_to_world_with(
+        &self,
+        world: &mut World,
+        type_registry: &AppTypeRegistry,
+    ) -> Result<InstanceInfo, SceneSpawnError> {
         let mut instance_info = InstanceInfo {
             entity_map: EntityMap::default(),
         };
 
-        let type_registry = world.resource::<AppTypeRegistry>().clone();
         let type_registry = type_registry.read();
         for archetype in self.world.archetypes().iter() {
             for scene_entity in archetype.entities() {

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -1,5 +1,12 @@
-use bevy_ecs::world::World;
+use bevy_app::AppTypeRegistry;
+use bevy_ecs::{
+    entity::EntityMap,
+    reflect::{ReflectComponent, ReflectMapEntities},
+    world::World,
+};
 use bevy_reflect::TypeUuid;
+
+use crate::{InstanceInfo, SceneSpawnError};
 
 /// To spawn a scene, you can use either:
 /// * [`SceneSpawner::spawn`](crate::SceneSpawner::spawn)
@@ -16,5 +23,70 @@ pub struct Scene {
 impl Scene {
     pub fn new(world: World) -> Self {
         Self { world }
+    }
+}
+
+impl Scene {
+    /// Clone the scene.
+    ///
+    /// This method will return a `SceneSpawnError` if either a type is not registered in the
+    /// provided `AppTypeRegistry` or doesn't reflect the `Component` trait.
+    pub fn clone(&self, type_registry: &AppTypeRegistry) -> Result<Scene, SceneSpawnError> {
+        let mut new_world = World::new();
+        new_world.insert_resource(type_registry.clone());
+        self.write_to_world(&mut new_world)?;
+        new_world.remove_resource::<AppTypeRegistry>();
+        Ok(Self { world: new_world })
+    }
+
+    /// Write the entities and their corresponding components to the given world.
+    ///
+    /// This method will return a `SceneSpawnError` if either a type is not registered
+    /// or doesn't reflect the `Component` trait.
+    pub fn write_to_world(&self, world: &mut World) -> Result<InstanceInfo, SceneSpawnError> {
+        let mut instance_info = InstanceInfo {
+            entity_map: EntityMap::default(),
+        };
+
+        let type_registry = world.resource::<AppTypeRegistry>().clone();
+        let type_registry = type_registry.read();
+        for archetype in self.world.archetypes().iter() {
+            for scene_entity in archetype.entities() {
+                let entity = *instance_info
+                    .entity_map
+                    .entry(*scene_entity)
+                    .or_insert_with(|| world.spawn().id());
+                for component_id in archetype.components() {
+                    let component_info = self
+                        .world
+                        .components()
+                        .get_info(component_id)
+                        .expect("component_ids in archetypes should have ComponentInfo");
+
+                    let reflect_component = type_registry
+                        .get(component_info.type_id().unwrap())
+                        .ok_or_else(|| SceneSpawnError::UnregisteredType {
+                            type_name: component_info.name().to_string(),
+                        })
+                        .and_then(|registration| {
+                            registration.data::<ReflectComponent>().ok_or_else(|| {
+                                SceneSpawnError::UnregisteredComponent {
+                                    type_name: component_info.name().to_string(),
+                                }
+                            })
+                        })?;
+                    reflect_component.copy(&self.world, world, *scene_entity, entity);
+                }
+            }
+        }
+        for registration in type_registry.iter() {
+            if let Some(map_entities_reflect) = registration.data::<ReflectMapEntities>() {
+                map_entities_reflect
+                    .map_entities(world, &instance_info.entity_map)
+                    .unwrap();
+            }
+        }
+
+        Ok(instance_info)
     }
 }

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -27,8 +27,8 @@ impl Scene {
 
     /// Clone the scene.
     ///
-    /// This method will return a `SceneSpawnError` if either a type is not registered in the
-    /// provided `AppTypeRegistry` or doesn't reflect the `Component` trait.
+    /// This method will return a [`SceneSpawnError`] if either a type is not registered in the
+    /// provided [`AppTypeRegistry`] or doesn't reflect the [`Component`](bevy_ecs::component::Component) trait.
     pub fn clone_with(&self, type_registry: &AppTypeRegistry) -> Result<Scene, SceneSpawnError> {
         let mut new_world = World::new();
         new_world.insert_resource(type_registry.clone());
@@ -39,8 +39,8 @@ impl Scene {
 
     /// Write the entities and their corresponding components to the given world.
     ///
-    /// This method will return a `SceneSpawnError` if either a type is not registered
-    /// or doesn't reflect the `Component` trait.
+    /// This method will return a [`SceneSpawnError`] if either a type is not registered
+    /// or doesn't reflect the [`Component`](bevy_ecs::component::Component) trait.
     pub fn write_to_world(&self, world: &mut World) -> Result<InstanceInfo, SceneSpawnError> {
         let mut instance_info = InstanceInfo {
             entity_map: EntityMap::default(),

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -24,9 +24,7 @@ impl Scene {
     pub fn new(world: World) -> Self {
         Self { world }
     }
-}
 
-impl Scene {
     /// Clone the scene.
     ///
     /// This method will return a `SceneSpawnError` if either a type is not registered in the

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -27,7 +27,7 @@ impl Scene {
 
     /// Clone the scene.
     ///
-    /// This method will return a [`SceneSpawnError`] if either a type is not registered in the
+    /// This method will return a [`SceneSpawnError`] if a type either is not registered in the
     /// provided [`AppTypeRegistry`] or doesn't reflect the [`Component`](bevy_ecs::component::Component) trait.
     pub fn clone_with(&self, type_registry: &AppTypeRegistry) -> Result<Scene, SceneSpawnError> {
         let mut new_world = World::new();
@@ -39,7 +39,7 @@ impl Scene {
 
     /// Write the entities and their corresponding components to the given world.
     ///
-    /// This method will return a [`SceneSpawnError`] if either a type is not registered
+    /// This method will return a [`SceneSpawnError`] if a type either is not registered
     /// or doesn't reflect the [`Component`](bevy_ecs::component::Component) trait.
     pub fn write_to_world(&self, world: &mut World) -> Result<InstanceInfo, SceneSpawnError> {
         let mut instance_info = InstanceInfo {

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 /// Informations about a scene instance.
 #[derive(Debug)]
 pub struct InstanceInfo {
-    /// Mapping of entities between the scene world and the instance world.
+    /// Mapping of entities from the scene world to the instance world.
     pub entity_map: EntityMap,
 }
 

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -1,10 +1,8 @@
 use crate::{DynamicScene, Scene};
-use bevy_app::AppTypeRegistry;
 use bevy_asset::{AssetEvent, Assets, Handle};
 use bevy_ecs::{
     entity::{Entity, EntityMap},
     event::{Events, ManualEventReader},
-    reflect::{ReflectComponent, ReflectMapEntities},
     system::{Command, Resource},
     world::{Mut, World},
 };
@@ -13,9 +11,11 @@ use bevy_utils::{tracing::error, HashMap};
 use thiserror::Error;
 use uuid::Uuid;
 
+/// Informations about a scene instance.
 #[derive(Debug)]
-struct InstanceInfo {
-    entity_map: EntityMap,
+pub struct InstanceInfo {
+    /// Mapping of entities between the scene world and the instance world.
+    pub entity_map: EntityMap,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -161,11 +161,6 @@ impl SceneSpawner {
         scene_handle: Handle<Scene>,
         instance_id: InstanceId,
     ) -> Result<InstanceId, SceneSpawnError> {
-        let mut instance_info = InstanceInfo {
-            entity_map: EntityMap::default(),
-        };
-        let type_registry = world.resource::<AppTypeRegistry>().clone();
-        let type_registry = type_registry.read();
         world.resource_scope(|world, scenes: Mut<Assets<Scene>>| {
             let scene =
                 scenes
@@ -174,42 +169,8 @@ impl SceneSpawner {
                         handle: scene_handle.clone(),
                     })?;
 
-            for archetype in scene.world.archetypes().iter() {
-                for scene_entity in archetype.entities() {
-                    let entity = *instance_info
-                        .entity_map
-                        .entry(*scene_entity)
-                        .or_insert_with(|| world.spawn().id());
-                    for component_id in archetype.components() {
-                        let component_info = scene
-                            .world
-                            .components()
-                            .get_info(component_id)
-                            .expect("component_ids in archetypes should have ComponentInfo");
+            let instance_info = scene.write_to_world(world)?;
 
-                        let reflect_component = type_registry
-                            .get(component_info.type_id().unwrap())
-                            .ok_or_else(|| SceneSpawnError::UnregisteredType {
-                                type_name: component_info.name().to_string(),
-                            })
-                            .and_then(|registration| {
-                                registration.data::<ReflectComponent>().ok_or_else(|| {
-                                    SceneSpawnError::UnregisteredComponent {
-                                        type_name: component_info.name().to_string(),
-                                    }
-                                })
-                            })?;
-                        reflect_component.copy(&scene.world, world, *scene_entity, entity);
-                    }
-                }
-            }
-            for registration in type_registry.iter() {
-                if let Some(map_entities_reflect) = registration.data::<ReflectMapEntities>() {
-                    map_entities_reflect
-                        .map_entities(world, &instance_info.entity_map)
-                        .unwrap();
-                }
-            }
             self.spawned_instances.insert(instance_id, instance_info);
             let spawned = self
                 .spawned_scenes

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -1,4 +1,5 @@
 use crate::{DynamicScene, Scene};
+use bevy_app::AppTypeRegistry;
 use bevy_asset::{AssetEvent, Assets, Handle};
 use bevy_ecs::{
     entity::{Entity, EntityMap},
@@ -169,7 +170,8 @@ impl SceneSpawner {
                         handle: scene_handle.clone(),
                     })?;
 
-            let instance_info = scene.write_to_world(world)?;
+            let instance_info =
+                scene.write_to_world_with(world, &world.resource::<AppTypeRegistry>().clone())?;
 
             self.spawned_instances.insert(instance_id, instance_info);
             let spawned = self


### PR DESCRIPTION
# Objective

- Easier to work with model assets
- Models are often one mesh, many textures. This can be hard to use in Bevy as it's not possible to clone the scene to have one scene for each material. It's still possible to instantiate the texture-less scene, then modify the texture material once spawned but that means happening during play and is quite more painful

## Solution

- Expose the code to clone a scene. This code already existed but was only possible to use to spawn the scene
