### PR TITLE
[Merged by Bors] - Warn when passing invalid argument to CI

### DIFF
--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -33,21 +33,38 @@ fn main() {
     // - Official CI runs latest stable
     // - Local runs use whatever the default Rust is locally
 
-    let what_to_run = match std::env::args().nth(1).as_deref() {
-        Some("format") => Check::FORMAT,
-        Some("clippy") => Check::CLIPPY,
-        Some("compile-fail") => Check::COMPILE_FAIL,
-        Some("test") => Check::TEST,
-        Some("doc-test") => Check::DOC_TEST,
-        Some("doc-check") => Check::DOC_CHECK,
-        Some("bench-check") => Check::BENCH_CHECK,
-        Some("example-check") => Check::EXAMPLE_CHECK,
-        Some("lints") => Check::FORMAT | Check::CLIPPY,
-        Some("doc") => Check::DOC_TEST | Check::DOC_CHECK,
-        Some("compile") => {
-            Check::COMPILE_FAIL | Check::BENCH_CHECK | Check::EXAMPLE_CHECK | Check::COMPILE_CHECK
+    let arguments = [
+        ("lints", Check::FORMAT | Check::CLIPPY),
+        ("test", Check::TEST),
+        ("doc", Check::DOC_TEST | Check::DOC_CHECK),
+        (
+            "compile",
+            Check::COMPILE_FAIL | Check::BENCH_CHECK | Check::EXAMPLE_CHECK | Check::COMPILE_CHECK,
+        ),
+        ("format", Check::FORMAT),
+        ("clippy", Check::CLIPPY),
+        ("compile-fail", Check::COMPILE_FAIL),
+        ("bench-check", Check::BENCH_CHECK),
+        ("example-check", Check::EXAMPLE_CHECK),
+        ("doc-check", Check::DOC_CHECK),
+        ("doc-test", Check::DOC_TEST),
+    ];
+
+    let what_to_run = if let Some(arg) = std::env::args().nth(1).as_deref() {
+        if let Some((_, check)) = arguments.iter().find(|(str, _)| *str == arg) {
+            *check
+        } else {
+            println!(
+                "Invalid argument: {arg:?}.\nEnter one of: {}.",
+                arguments[1..]
+                    .iter()
+                    .map(|(s, _)| s)
+                    .fold(arguments[0].0.to_owned(), |c, v| c + ", " + v)
+            );
+            return;
         }
-        _ => Check::all(),
+    } else {
+        Check::all()
     };
 
     let sh = Shell::new().unwrap();


### PR DESCRIPTION
Example:
```sh
cargo run -p ci -- lint
Invalid argument: "lint".
Enter one of: lints, test, doc, compile, format, clippy, compile-fail, bench-check, example-check, doc-check, doc-test.
```