### PR TITLE
[Merged by Bors] - Remove unnecessary unsafe `Send` and `Sync` impl for `WinitWindows` on wasm.

### DIFF
--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -264,9 +264,3 @@ pub fn get_best_videomode(monitor: &winit::monitor::MonitorHandle) -> winit::mon
 
     modes.first().unwrap().clone()
 }
-
-// WARNING: this only works under the assumption that wasm runtime is single threaded
-#[cfg(target_arch = "wasm32")]
-unsafe impl Send for WinitWindows {}
-#[cfg(target_arch = "wasm32")]
-unsafe impl Sync for WinitWindows {}


### PR DESCRIPTION
# Objective

https://github.com/bevyengine/bevy/pull/503 added these.
I don't know what problem it solved, the PR doesn't say and the code didn't make it obvious to me.

## Solution

AFAIK removing unsafe `Send`/`Sync` impls can't introduce unsoundness.
Yeet.

## Migration Guide
Why tho.
