### PR TITLE
[Merged by Bors] - Remove Sync bound from Command

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -41,7 +41,7 @@ use super::Resource;
 ///     commands.add(AddToCounter(42));
 /// }
 /// ```
-pub trait Command: Send + Sync + 'static {
+pub trait Command: Send + 'static {
     fn write(self, world: &mut World);
 }
 


### PR DESCRIPTION
Unless I'm mistaken it is unnecessary, Commands are never accessed from two threads simultaneously. It unnecessarily restricts Command structs