### PR TITLE
[Merged by Bors] -  Support monitor selection for all window modes.

### DIFF
--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -17,7 +17,8 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
         CursorEntered, CursorIcon, CursorLeft, CursorMoved, FileDragAndDrop, MonitorSelection,
-        ReceivedCharacter, Window, WindowDescriptor, WindowMoved, WindowPosition, Windows,
+        ReceivedCharacter, Window, WindowDescriptor, WindowMode, WindowMoved, WindowPosition,
+        Windows,
     };
 }
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -277,7 +277,7 @@ pub enum WindowCommand {
         monitor_selection: MonitorSelection,
         position: IVec2,
     },
-    /// Modifies the position of the window to be in the center of the current monitor
+    /// Sets the position of the window to be in the center of the selected monitor.
     Center(MonitorSelection),
     /// Set the window's [`WindowResizeConstraints`]
     SetResizeConstraints {
@@ -749,11 +749,15 @@ impl Window {
 pub enum WindowPosition {
     /// The position will be set by the window manager.
     Automatic,
-    /// Window will be centered on the selected monitor.
-    Centered,
-    /// The window's top-left corner will be placed at the specified position (in pixels).
+    /// Center the window on the monitor.
     ///
-    /// (0,0) represents top-left corner of the selected monitor.
+    /// The monitor to center the window on can be selected with the `monitor` field in `WindowDescriptor`.
+    Centered,
+    /// The window's top-left corner will be placed at the specified position in pixels.
+    ///
+    /// (0,0) represents top-left corner of the monitor.
+    ///
+    /// The monitor to position the window on can be selected with the `monitor` field in `WindowDescriptor`.
     At(Vec2),
 }
 
@@ -790,9 +794,11 @@ pub struct WindowDescriptor {
     pub height: f32,
     /// The position on the screen that the window will be placed at.
     ///
+    /// The monitor to place the window on can be selected with the `monitor` field.
+    ///
     /// Ignored if `mode` is set to something other than [`WindowMode::Windowed`]
     ///
-    /// `WindowPosition::Automatic` will be overridden with `WindowPosition::At(Vec2::ZERO)` if a specific `monitor` is selected.
+    /// `WindowPosition::Automatic` will be overridden with `WindowPosition::At(Vec2::ZERO)` if a specific monitor is selected.
     pub position: WindowPosition,
     /// The monitor to place the window on.
     pub monitor: MonitorSelection,
@@ -825,6 +831,8 @@ pub struct WindowDescriptor {
     /// Sets whether the window locks the cursor inside its borders when the window has focus.
     pub cursor_locked: bool,
     /// Sets the [`WindowMode`](crate::WindowMode).
+    ///
+    /// The monitor to go fullscreen on can be selected with the `monitor` field.
     pub mode: WindowMode,
     /// Sets whether the background of the window should be transparent.
     ///

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -747,15 +747,13 @@ impl Window {
 /// Defines where window should be placed at on creation.
 #[derive(Debug, Clone, Copy)]
 pub enum WindowPosition {
-    /// Position will be set by the window manager
+    /// The position will be set by the window manager.
     Automatic,
-    /// Window will be centered on the selected monitor
+    /// Window will be centered on the selected monitor.
+    Centered,
+    /// The window's top-left corner will be placed at the specified position (in pixels).
     ///
-    /// Note that this does not account for window decorations.
-    Centered(MonitorSelection),
-    /// The window's top-left corner will be placed at the specified position (in pixels)
-    ///
-    /// (0,0) represents top-left corner of screen space.
+    /// (0,0) represents top-left corner of the selected monitor.
     At(Vec2),
 }
 
@@ -763,11 +761,13 @@ pub enum WindowPosition {
 #[derive(Debug, Clone, Copy)]
 pub enum MonitorSelection {
     /// Uses current monitor of the window.
+    ///
+    /// Will fall back to the system default if the window has not yet been created.
     Current,
     /// Uses primary monitor of the system.
     Primary,
     /// Uses monitor with the specified index.
-    Number(usize),
+    Index(usize),
 }
 
 /// Describes the information needed for creating a window.
@@ -789,7 +789,13 @@ pub struct WindowDescriptor {
     /// May vary from the physical height due to different pixel density on different monitors.
     pub height: f32,
     /// The position on the screen that the window will be placed at.
+    ///
+    /// Ignored if `mode` is set to something other than [`WindowMode::Windowed`]
+    ///
+    /// `WindowPosition::Automatic` will be overridden with `WindowPosition::At(Vec2::ZERO)` if a specific `monitor` is set.
     pub position: WindowPosition,
+    /// The monitor to place the window on.
+    pub monitor: MonitorSelection,
     /// Sets minimum and maximum resize limits.
     pub resize_constraints: WindowResizeConstraints,
     /// Overrides the window's ratio of physical pixels to logical pixels.
@@ -854,6 +860,7 @@ impl Default for WindowDescriptor {
             width: 1280.,
             height: 720.,
             position: WindowPosition::Automatic,
+            monitor: MonitorSelection::Current,
             resize_constraints: WindowResizeConstraints::default(),
             scale_factor_override: None,
             present_mode: PresentMode::Fifo,

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -272,8 +272,9 @@ pub enum WindowCommand {
     SetMinimized {
         minimized: bool,
     },
-    /// Set the window's position on the screen.
+    /// Set the window's position on the selected monitor.
     SetPosition {
+        monitor_selection: MonitorSelection,
         position: IVec2,
     },
     /// Modifies the position of the window to be in the center of the current monitor
@@ -416,12 +417,9 @@ impl Window {
             .push(WindowCommand::SetMinimized { minimized });
     }
 
-    /// Modifies the position of the window in physical pixels.
+    /// Sets the `position` of the window on the selected `monitor` in physical pixels.
     ///
-    /// Note that the top-left hand corner of the desktop is not necessarily the same as the screen.
-    /// If the user uses a desktop with multiple monitors, the top-left hand corner of the
-    /// desktop is the top-left hand corner of the monitor at the top-left of the desktop. This
-    /// automatically un-maximizes the window if it's maximized.
+    /// This automatically un-maximizes the window if it's maximized.
     ///
     /// # Platform-specific
     ///
@@ -430,9 +428,11 @@ impl Window {
     /// - Web: Sets the top-left coordinates relative to the viewport.
     /// - Android / Wayland: Unsupported.
     #[inline]
-    pub fn set_position(&mut self, position: IVec2) {
-        self.command_queue
-            .push(WindowCommand::SetPosition { position });
+    pub fn set_position(&mut self, monitor: MonitorSelection, position: IVec2) {
+        self.command_queue.push(WindowCommand::SetPosition {
+            monitor_selection: monitor,
+            position,
+        });
     }
 
     /// Modifies the position of the window to be in the center of the current monitor

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -792,7 +792,7 @@ pub struct WindowDescriptor {
     ///
     /// Ignored if `mode` is set to something other than [`WindowMode::Windowed`]
     ///
-    /// `WindowPosition::Automatic` will be overridden with `WindowPosition::At(Vec2::ZERO)` if a specific `monitor` is set.
+    /// `WindowPosition::Automatic` will be overridden with `WindowPosition::At(Vec2::ZERO)` if a specific `monitor` is selected.
     pub position: WindowPosition,
     /// The monitor to place the window on.
     pub monitor: MonitorSelection,

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -18,7 +18,7 @@ use bevy_input::{
     mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
     touch::TouchInput,
 };
-use bevy_math::{ivec2, DVec2, UVec2, Vec2};
+use bevy_math::{ivec2, DVec2, IVec2, UVec2, Vec2};
 use bevy_utils::{
     tracing::{error, info, trace, warn},
     Instant,
@@ -31,7 +31,7 @@ use bevy_window::{
 };
 
 use winit::{
-    dpi::{LogicalSize, PhysicalPosition},
+    dpi::{LogicalPosition, LogicalSize, PhysicalPosition},
     event::{self, DeviceEvent, Event, StartCause, WindowEvent},
     event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
 };
@@ -149,7 +149,7 @@ fn change_window(
                     let window = winit_windows.get_window(id).unwrap();
                     let inner_size = window.inner_size().to_logical::<f32>(window.scale_factor());
                     window
-                        .set_cursor_position(winit::dpi::LogicalPosition::new(
+                        .set_cursor_position(LogicalPosition::new(
                             position.x,
                             inner_size.height - position.y,
                         ))
@@ -163,12 +163,11 @@ fn change_window(
                     let window = winit_windows.get_window(id).unwrap();
                     window.set_minimized(minimized);
                 }
-                bevy_window::WindowCommand::SetPosition { position } => {
+                bevy_window::WindowCommand::SetPosition {
+                    position: IVec2 { x, y },
+                } => {
                     let window = winit_windows.get_window(id).unwrap();
-                    window.set_outer_position(PhysicalPosition {
-                        x: position[0],
-                        y: position[1],
-                    });
+                    window.set_outer_position(PhysicalPosition { x, y });
                 }
                 bevy_window::WindowCommand::Center(monitor_selection) => {
                     let window = winit_windows.get_window(id).unwrap();
@@ -177,19 +176,20 @@ fn change_window(
                     let maybe_monitor = match monitor_selection {
                         Current => window.current_monitor(),
                         Primary => window.primary_monitor(),
-                        Number(n) => window.available_monitors().nth(n),
+                        Index(i) => window.available_monitors().nth(i),
                     };
 
                     if let Some(monitor) = maybe_monitor {
-                        let screen_size = monitor.size();
+                        let monitor_size = monitor.size();
+                        let monitor_position = monitor.position().cast::<f64>();
 
                         let window_size = window.outer_size();
 
                         window.set_outer_position(PhysicalPosition {
-                            x: screen_size.width.saturating_sub(window_size.width) as f64 / 2.
-                                + monitor.position().x as f64,
-                            y: screen_size.height.saturating_sub(window_size.height) as f64 / 2.
-                                + monitor.position().y as f64,
+                            x: monitor_size.width.saturating_sub(window_size.width) as f64 / 2.
+                                + monitor_position.x,
+                            y: monitor_size.height.saturating_sub(window_size.height) as f64 / 2.
+                                + monitor_position.y,
                         });
                     } else {
                         warn!("Couldn't get monitor selected with: {monitor_selection:?}");
@@ -578,12 +578,12 @@ pub fn winit_runner_with(mut app: App) {
                 }
             }
             event::Event::DeviceEvent {
-                event: DeviceEvent::MouseMotion { delta },
+                event: DeviceEvent::MouseMotion { delta: (x, y) },
                 ..
             } => {
                 let mut mouse_motion_events = app.world.resource_mut::<Events<MouseMotion>>();
                 mouse_motion_events.send(MouseMotion {
-                    delta: Vec2::new(delta.0 as f32, delta.1 as f32),
+                    delta: DVec2 { x, y }.as_vec2(),
                 });
             }
             event::Event::Suspended => {


### PR DESCRIPTION
# Objective
Support monitor selection for all window modes.
Fixes #5875.

## Changelog

* Moved `MonitorSelection` out of `WindowPosition::Centered`, into `WindowDescriptor`.
* `WindowPosition::At` is now relative to the monitor instead of being in 'desktop space'.
* Renamed `MonitorSelection::Number` to `MonitorSelection::Index` for clarity.
* Added `WindowMode` to the prelude.
* `Window::set_position` is now relative to a monitor and takes a `MonitorSelection` as argument.

## Migration Guide

`MonitorSelection` was moved out of `WindowPosition::Centered`, into `WindowDescriptor`.
`MonitorSelection::Number` was renamed to `MonitorSelection::Index`.
```rust
// Before
.insert_resource(WindowDescriptor {
    position: WindowPosition::Centered(MonitorSelection::Number(1)),
    ..default()
})
// After
.insert_resource(WindowDescriptor {
    monitor: MonitorSelection::Index(1),
    position: WindowPosition::Centered,
    ..default()
})
```
`Window::set_position` now takes a `MonitorSelection` as argument.
```rust
window.set_position(MonitorSelection::Current, position);
```