### PR TITLE
Remove Sync bound on Component and Resource (adopted)

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -36,7 +36,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     ast.generics
         .make_where_clause()
         .predicates
-        .push(parse_quote! { Self: Send + Sync + 'static });
+        .push(parse_quote! { Self: Send + 'static });
 
     let struct_name = &ast.ident;
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -76,7 +76,7 @@ use std::{any::TypeId, collections::HashMap};
 /// bundle, in the _exact_ order that [`Bundle::get_components`] is called.
 /// - [`Bundle::from_components`] must call `func` exactly once for each [`ComponentId`] returned by
 ///   [`Bundle::component_ids`].
-pub unsafe trait Bundle: Send + Sync + 'static {
+pub unsafe trait Bundle: Send + 'static {
     /// Gets this [`Bundle`]'s component ids, in the order of this bundle's [`Component`]s
     fn component_ids(components: &mut Components, storages: &mut Storages) -> Vec<ComponentId>;
 

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -749,7 +749,7 @@ pub struct WriteFetch<'w, T> {
 }
 
 /// SAFETY: access of `&T` is a subset of `&mut T`
-unsafe impl<'__w, T: Component+ Sync> WorldQuery for &'__w mut T {
+unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
     type ReadOnly = &'__w T;
     type State = ComponentId;
 

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -25,7 +25,7 @@ use std::fmt::Debug;
 use super::IntoSystemDescriptor;
 
 /// A type that can run as a step of a [`Schedule`](super::Schedule).
-pub trait Stage: Downcast + Send + Sync {
+pub trait Stage: Downcast + Send {
     /// Runs the stage; this happens once per update.
     /// Implementors must initialize all of their state and systems before running the first time.
     fn run(&mut self, world: &mut World);

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -41,7 +41,7 @@ use super::Resource;
 ///     commands.add(AddToCounter(42));
 /// }
 /// ```
-pub trait Command: Send + Sync + 'static {
+pub trait Command: Send + 'static {
     fn write(self, world: &mut World);
 }
 
@@ -337,7 +337,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// worked out to share an ID space (which doesn't happen by default).
     pub fn insert_or_spawn_batch<I, B>(&mut self, bundles_iter: I)
     where
-        I: IntoIterator + Send + Sync + 'static,
+        I: IntoIterator + Send + 'static,
         I::IntoIter: Iterator<Item = (Entity, B)>,
         B: Bundle,
     {
@@ -728,7 +728,7 @@ where
 
 pub struct InsertOrSpawnBatch<I, B>
 where
-    I: IntoIterator + Send + Sync + 'static,
+    I: IntoIterator + Send + 'static,
     B: Bundle,
     I::IntoIter: Iterator<Item = (Entity, B)>,
 {
@@ -737,7 +737,7 @@ where
 
 impl<I, B> Command for InsertOrSpawnBatch<I, B>
 where
-    I: IntoIterator + Send + Sync + 'static,
+    I: IntoIterator + Send + 'static,
     B: Bundle,
     I::IntoIter: Iterator<Item = (Entity, B)>,
 {

--- a/crates/bevy_ecs/src/system/exclusive_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use std::borrow::Cow;
 
-pub trait ExclusiveSystem: Send + Sync + 'static {
+pub trait ExclusiveSystem: Send + 'static {
     fn name(&self) -> Cow<'static, str>;
 
     fn run(&mut self, world: &mut World);

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1070,7 +1070,10 @@ impl<'w, 's, Q: WorldQuery, F: WorldQuery> Query<'w, 's, Q, F> {
     ///
     /// - [`get_component_mut`](Self::get_component_mut) to get a mutable reference of a component.
     #[inline]
-    pub fn get_component<T: Component>(&self, entity: Entity) -> Result<&T, QueryComponentError> {
+    pub fn get_component<T: Component + Sync>(
+        &self,
+        entity: Entity,
+    ) -> Result<&T, QueryComponentError> {
         let world = self.world;
         let entity_ref = world
             .get_entity(entity)

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -17,7 +17,7 @@ use std::borrow::Cow;
 /// Systems are executed in parallel, in opportunistic order; data access is managed automatically.
 /// It's possible to specify explicit execution order between specific systems,
 /// see [`SystemDescriptor`](crate::schedule::SystemDescriptor).
-pub trait System: Send + Sync + 'static {
+pub trait System: Send + 'static {
     /// The system's input. See [`In`](crate::system::In) for
     /// [`FunctionSystem`](crate::system::FunctionSystem)s.
     type In;

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -63,8 +63,30 @@ impl<'w> EntityRef<'w> {
         contains_component_with_type(self.world, type_id, self.location)
     }
 
+    /// Gets the [`Component`] of a given type for the referenced entity, if available.
+    /// Returns `None` if not present.
+    ///
+    /// This component type must be [`Sync`]. Attempting to use a non-`Sync` type will
+    /// fail to compile. To safely access a non-`Sync` component, use [`EntityMut::get_mut`]
+    /// instead.
+    ///
+    /// ```compile_fail,E0277
+    /// # use bevy_ecs::{component::Component, world::World};
+    /// # use std::cell::Cell;
+    ///
+    /// #[derive(Component)]
+    /// struct NotSync(Cell<usize>);
+    ///
+    /// # fn main() {
+    /// # let world = World::new();
+    /// # let entity = todo!();
+    /// let entity_ref = world.entity(entity);
+    /// // Will fail to compile!
+    /// entity_ref.get::<NotSync>();
+    /// # }
+    /// ```
     #[inline]
-    pub fn get<T: Component>(&self) -> Option<&'w T> {
+    pub fn get<T: Component + Sync>(&self) -> Option<&'w T> {
         // SAFETY: entity location is valid and returned component is of type T
         unsafe {
             get_component_with_type(self.world, TypeId::of::<T>(), self.entity, self.location)
@@ -188,8 +210,30 @@ impl<'w> EntityMut<'w> {
         contains_component_with_type(self.world, type_id, self.location)
     }
 
+    /// Gets the [`Component`] of a given type for the referenced entity, if available.
+    /// Returns `None` if not present.
+    ///
+    /// This component type must be [`Sync`]. Attempting to use a non-`Sync` type will
+    /// fail to compile. To safely access a non-`Sync` component, use [`get_mut`](Self::get_mut)
+    /// instead.
+    ///
+    /// ```compile_fail,E0277
+    /// # use bevy_ecs::{component::Component, world::World};
+    /// # use std::cell::Cell;
+    ///
+    /// #[derive(Component)]
+    /// struct NotSync(Cell<usize>);
+    ///
+    /// # fn main() {
+    /// # let world = World::new();
+    /// # let entity = todo!();
+    /// let entity_mut = world.entity_mut(entity);
+    /// // Will fail to compile!
+    /// entity_mut.get::<NotSync>();
+    /// # }
+    /// ```
     #[inline]
-    pub fn get<T: Component>(&self) -> Option<&'_ T> {
+    pub fn get<T: Component + Sync>(&self) -> Option<&'_ T> {
         // SAFETY: lifetimes enforce correct usage of returned borrow
         unsafe {
             get_component_with_type(self.world, TypeId::of::<T>(), self.entity, self.location)

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -22,7 +22,7 @@ impl<T: CameraProjection> Default for CameraProjectionPlugin<T> {
 #[derive(SystemLabel, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct CameraUpdateSystem;
 
-impl<T: CameraProjection + Component + GetTypeRegistration> Plugin for CameraProjectionPlugin<T> {
+impl<T: CameraProjection + Component + GetTypeRegistration + Sync> Plugin for CameraProjectionPlugin<T> {
     fn build(&self, app: &mut App) {
         app.register_type::<T>()
             .add_startup_system_to_stage(

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -58,7 +58,7 @@ impl<C> Default for UniformComponentPlugin<C> {
     }
 }
 
-impl<C: Component + ShaderType + WriteInto + Clone> Plugin for UniformComponentPlugin<C> {
+impl<C: Component + ShaderType + WriteInto + Clone + Sync> Plugin for UniformComponentPlugin<C> {
     fn build(&self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
@@ -70,11 +70,11 @@ impl<C: Component + ShaderType + WriteInto + Clone> Plugin for UniformComponentP
 
 /// Stores all uniforms of the component type.
 #[derive(Resource)]
-pub struct ComponentUniforms<C: Component + ShaderType> {
+pub struct ComponentUniforms<C: Component + ShaderType + Sync> {
     uniforms: DynamicUniformBuffer<C>,
 }
 
-impl<C: Component + ShaderType> Deref for ComponentUniforms<C> {
+impl<C: Component + ShaderType + Sync> Deref for ComponentUniforms<C> {
     type Target = DynamicUniformBuffer<C>;
 
     #[inline]
@@ -83,14 +83,14 @@ impl<C: Component + ShaderType> Deref for ComponentUniforms<C> {
     }
 }
 
-impl<C: Component + ShaderType> ComponentUniforms<C> {
+impl<C: Component + ShaderType + Sync> ComponentUniforms<C> {
     #[inline]
     pub fn uniforms(&self) -> &DynamicUniformBuffer<C> {
         &self.uniforms
     }
 }
 
-impl<C: Component + ShaderType> Default for ComponentUniforms<C> {
+impl<C: Component + ShaderType + Sync> Default for ComponentUniforms<C> {
     fn default() -> Self {
         Self {
             uniforms: Default::default(),
@@ -100,7 +100,7 @@ impl<C: Component + ShaderType> Default for ComponentUniforms<C> {
 
 /// This system prepares all components of the corresponding component type.
 /// They are transformed into uniforms and stored in the [`ComponentUniforms`] resource.
-fn prepare_uniform_components<C: Component>(
+fn prepare_uniform_components<C: Component + Sync>(
     mut commands: Commands,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -13,7 +13,7 @@ use crate::{Extract, RenderApp, RenderStage};
 /// Therefore the resource is transferred from the "main world" into the "render world"
 /// in the [`RenderStage::Extract`](crate::RenderStage::Extract) step.
 pub trait ExtractResource: Resource {
-    type Source: Resource;
+    type Source: Resource + Sync;
 
     /// Defines how the resource is transferred into the "render world".
     fn extract_resource(source: &Self::Source) -> Self;
@@ -31,7 +31,7 @@ impl<R: ExtractResource> Default for ExtractResourcePlugin<R> {
     }
 }
 
-impl<R: ExtractResource> Plugin for ExtractResourcePlugin<R> {
+impl<R: ExtractResource + Sync> Plugin for ExtractResourcePlugin<R> {
     fn build(&self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.add_system_to_stage(RenderStage::Extract, extract_resource::<R>);

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -307,6 +307,7 @@ impl<P: PhaseItem, C: RenderCommand<P>> RenderCommandState<P, C> {
 impl<P: PhaseItem, C: RenderCommand<P> + Send + Sync + 'static> Draw<P> for RenderCommandState<P, C>
 where
     <C::Param as SystemParam>::Fetch: ReadOnlySystemParamFetch,
+    SystemState<C::Param>: Sync,
 {
     /// Prepares the ECS parameters for the wrapped [`RenderCommand`] and then renders it.
     fn draw<'w>(
@@ -329,7 +330,8 @@ pub trait AddRenderCommand {
         &mut self,
     ) -> &mut Self
     where
-        <C::Param as SystemParam>::Fetch: ReadOnlySystemParamFetch;
+        <C::Param as SystemParam>::Fetch: ReadOnlySystemParamFetch,
+        <<C as RenderCommand<P>>::Param as SystemParam>::Fetch: Sync;
 }
 
 impl AddRenderCommand for App {
@@ -338,6 +340,7 @@ impl AddRenderCommand for App {
     ) -> &mut Self
     where
         <C::Param as SystemParam>::Fetch: ReadOnlySystemParamFetch,
+        <<C as RenderCommand<P>>::Param as SystemParam>::Fetch: Sync,
     {
         let draw_function = RenderCommandState::<P, C>::new(&mut self.world);
         let draw_functions = self

--- a/examples/ecs/custom_query_param.rs
+++ b/examples/ecs/custom_query_param.rs
@@ -41,7 +41,7 @@ struct ComponentZ;
 
 #[derive(WorldQuery)]
 #[world_query(derive(Debug))]
-struct ReadOnlyCustomQuery<T: Component + Debug, P: Component + Debug> {
+struct ReadOnlyCustomQuery<T: Component + Debug + Sync, P: Component + Debug + Sync> {
     entity: Entity,
     a: &'static ComponentA,
     b: Option<&'static ComponentB>,
@@ -75,7 +75,7 @@ fn print_components_read_only(
 // using the `derive` attribute.
 #[derive(WorldQuery)]
 #[world_query(mutable, derive(Debug))]
-struct CustomQuery<T: Component + Debug, P: Component + Debug> {
+struct CustomQuery<T: Component + Debug + Sync, P: Component + Debug + Sync> {
     entity: Entity,
     a: &'static mut ComponentA,
     b: Option<&'static mut ComponentB>,
@@ -102,7 +102,7 @@ struct NestedQuery {
 
 #[derive(WorldQuery)]
 #[world_query(derive(Debug))]
-struct GenericQuery<T: Component, P: Component> {
+struct GenericQuery<T: Component + Sync, P: Component + Sync> {
     generic: (&'static T, &'static P),
 }
 

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -362,7 +362,7 @@ mod menu {
 
     // This system updates the settings when a new value for a setting is selected, and marks
     // the button as the one currently selected
-    fn setting_button<T: Resource + Component + PartialEq + Copy>(
+    fn setting_button<T: Resource + Component + PartialEq + Copy + Sync>(
         interaction_query: Query<(&Interaction, &T, Entity), (Changed<Interaction>, With<Button>)>,
         mut selected_query: Query<(Entity, &mut UiColor), With<SelectedOption>>,
         mut commands: Commands,


### PR DESCRIPTION
Adoption of https://github.com/bevyengine/bevy/pull/4680

# Objective

Fixes https://github.com/bevyengine/bevy/issues/2487. Remove the `Sync` bound on `Component` and `Resource` to allow Send-only components.

## Solution

- Remove `Sync` bound from `Component` and `Resource`.
- Address the compilation errors.
- Changed the `PhantomData<T>` in `FetchState` and `SystemParamState` to use `PhantomData<fn() -> T>` to ensure they're `Sync`.
- Add a `compile_fail_test`.
- Add `Sync` bound on the `WorldQuery` impl for `&T`.
- Add `Sync` bound on `Res<T>` and `Option<Res<T>>`
- Add `Sync` bound on `Query::get_component`, `World::get`, `EntityRef::get`, and `EntityMut::get`.

---

## Changelog

Removed: `Sync` bound on `Component` and `Resource`.

## Migration Guide

`Component` and `Resource` no longer requires `Sync`. Any generic code using `Component` as a bound, `&T` as Query parameter, or `Res<T>` might require an additional `Sync` bound.
