### PR TITLE
 Warn when `WindowDescriptor` is inserted after adding `WindowPlugin`.

### DIFF
--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -26,7 +26,7 @@ use bevy_app::prelude::*;
 use bevy_ecs::{
     event::Events,
     schedule::{ParallelSystemDescriptorCoercion, SystemLabel},
-    system::{Local, Res, Resource},
+    system::{Res, Resource},
 };
 
 /// The configuration information for the [`WindowPlugin`].
@@ -121,10 +121,11 @@ impl Plugin for WindowPlugin {
 
         #[cfg(debug_assertions)]
         {
-            app.add_system(|wd: Option<Res<WindowDescriptor>>, mut once: Local<bool>| {
-                if !*once && wd.is_some() {
-                    warn!("The WindowDescriptor resource must be inserted before the WindowPlugin is added. Make sure to insert WindowDescriptor before adding the DefaultPlugins.");
-                    *once = true;
+            app.add_system(|wd: Option<Res<WindowDescriptor>>| {
+                if let Some(wd) = wd {
+                    if wd.is_added() {
+                        warn!("The WindowDescriptor resource must be inserted before the WindowPlugin is added. Make sure to insert WindowDescriptor before adding the DefaultPlugins.");
+                    }
                 }
             });
         }

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -125,7 +125,7 @@ impl Plugin for WindowPlugin {
                 if wd.is_added() {
                     warn!(
                         "The WindowDescriptor resource must be inserted before the WindowPlugin is added. \
-                        Make sure to insert WindowDescriptor before adding the DefaultPlugins.",
+                        Make sure to insert WindowDescriptor before adding the DefaultPlugins or the WindowPlugin.",
                     );
                 }
             }

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -123,7 +123,10 @@ impl Plugin for WindowPlugin {
         app.add_system(|wd: Option<Res<WindowDescriptor>>| {
             if let Some(wd) = wd {
                 if wd.is_added() {
-                    warn!("The WindowDescriptor resource must be inserted before the WindowPlugin is added. Make sure to insert WindowDescriptor before adding the DefaultPlugins.");
+                    warn!(
+                        "The WindowDescriptor resource must be inserted before the WindowPlugin is added. \
+                        Make sure to insert WindowDescriptor before adding the DefaultPlugins.",
+                    );
                 }
             }
         });

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -120,15 +120,13 @@ impl Plugin for WindowPlugin {
         }
 
         #[cfg(debug_assertions)]
-        {
-            app.add_system(|wd: Option<Res<WindowDescriptor>>| {
-                if let Some(wd) = wd {
-                    if wd.is_added() {
-                        warn!("The WindowDescriptor resource must be inserted before the WindowPlugin is added. Make sure to insert WindowDescriptor before adding the DefaultPlugins.");
-                    }
+        app.add_system(|wd: Option<Res<WindowDescriptor>>| {
+            if let Some(wd) = wd {
+                if wd.is_added() {
+                    warn!("The WindowDescriptor resource must be inserted before the WindowPlugin is added. Make sure to insert WindowDescriptor before adding the DefaultPlugins.");
                 }
-            });
-        }
+            }
+        });
     }
 }
 


### PR DESCRIPTION
# Objective

Warn the user when `WindowDescriptor` is inserted after adding the `WindowPlugin`.
As a bonus, panic when trying to access `WindowDescriptor` in a system.
Fixes #5884.

# Migration Guide
The `WindowDescriptor` resource is now removed after the `WindowPlugin` is added.
Use the `Windows` resource to edit or read info from the primary window.
```rust
fn system(windows: Res<Windows>) {
    let window = windows.primary();
}
```