### PR TITLE
[Merged by Bors] - Remove unused dependency from bevy_app

### DIFF
--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -20,7 +20,6 @@ bevy_derive = { path = "../bevy_derive", version = "0.9.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev", default-features = false }
 bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", optional = true }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
-bevy_tasks = { path = "../bevy_tasks", version = "0.9.0-dev" }
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }


### PR DESCRIPTION
# Objective

`bevy_app` has an unused `bevy_tasks` dependency
