### PR TITLE
[Merged by Bors] - Update WorldQueryGats doc with type aliases

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -436,7 +436,9 @@ pub unsafe trait WorldQuery: for<'w> WorldQueryGats<'w> {
     ) -> bool;
 }
 
-/// A helper trait for [`WorldQuery`] that works around Rust's lack of Generic Associated Types
+/// A helper trait for [`WorldQuery`] that works around Rust's lack of Generic Associated Types.
+///
+/// **Note**: Consider using the type aliases [`QueryItem`] and [`QueryFetch`] when using `Item` or `Fetch`.
 pub trait WorldQueryGats<'world> {
     type Item;
     type Fetch;


### PR DESCRIPTION
Make API users aware that the type aliases `QueryItem` and `QueryFetch` can be used instead of the more bloated alternative with `WorldQueryGats`.

Fixes #5842