### PR TITLE
added some simple functions to AnimationPlayer

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -180,8 +180,6 @@ impl AnimationPlayer {
     }
 
     /// Handle to the animation clip.
-    ///
-    /// Can be the default Handle, which usually represents no animation.
     pub fn animation_clip(&self) -> &Option<Handle<AnimationClip>> {
         &self.animation_clip
     }

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -96,6 +96,7 @@ impl AnimationClip {
 pub struct AnimationPlayer {
     paused: bool,
     repeat: bool,
+    finished: bool,
     speed: f32,
     elapsed: f32,
     animation_clip: Handle<AnimationClip>,
@@ -106,6 +107,7 @@ impl Default for AnimationPlayer {
         Self {
             paused: false,
             repeat: false,
+            finished: false,
             speed: 1.0,
             elapsed: 0.0,
             animation_clip: Default::default(),
@@ -150,6 +152,11 @@ impl AnimationPlayer {
         self.paused
     }
 
+    /// Is the animation finished
+    pub fn is_finished(&self) -> bool {
+        self.finished
+    }
+
     /// Speed of the animation playback
     pub fn speed(&self) -> f32 {
         self.speed
@@ -170,6 +177,13 @@ impl AnimationPlayer {
     pub fn set_elapsed(&mut self, elapsed: f32) -> &mut Self {
         self.elapsed = elapsed;
         self
+    }
+
+    /// Handle to the animation clip.
+    ///
+    /// Can be the default Handle, which usually represents no animation.
+    pub fn animation_clip(&self) -> &Handle<AnimationClip> {
+        &self.animation_clip
     }
 }
 
@@ -199,6 +213,8 @@ pub fn animation_player(
             }
             if elapsed < 0.0 {
                 elapsed += animation_clip.duration;
+            } else if elapsed > animation_clip.duration {
+                player.finished = true;
             }
             'entity: for (path, curves) in &animation_clip.curves {
                 // PERF: finding the target entity can be optimised

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -180,8 +180,8 @@ impl AnimationPlayer {
     }
 
     /// Handle to the animation clip.
-    pub fn animation_clip(&self) -> &Option<Handle<AnimationClip>> {
-        &self.animation_clip
+    pub fn animation_clip(&self) -> Option<&Handle<AnimationClip>> {
+        self.animation_clip.as_ref()
     }
 }
 
@@ -196,11 +196,7 @@ pub fn animation_player(
     children: Query<&Children>,
 ) {
     for (entity, mut player) in &mut animation_players {
-        if let Some(animation_clip) = player
-            .animation_clip
-            .as_ref()
-            .and_then(|x| animations.get(x))
-        {
+        if let Some(animation_clip) = player.animation_clip().and_then(|x| animations.get(x)) {
             // Continue if paused unless the `AnimationPlayer` was changed
             // This allow the animation to still be updated if the player.elapsed field was manually updated in pause
             if player.paused && !player.is_changed() {

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -99,7 +99,7 @@ pub struct AnimationPlayer {
     finished: bool,
     speed: f32,
     elapsed: f32,
-    animation_clip: Handle<AnimationClip>,
+    animation_clip: Option<Handle<AnimationClip>>,
 }
 
 impl Default for AnimationPlayer {
@@ -119,7 +119,7 @@ impl AnimationPlayer {
     /// Start playing an animation, resetting state of the player
     pub fn play(&mut self, handle: Handle<AnimationClip>) -> &mut Self {
         *self = Self {
-            animation_clip: handle,
+            animation_clip: Some(handle),
             ..Default::default()
         };
         self
@@ -182,7 +182,7 @@ impl AnimationPlayer {
     /// Handle to the animation clip.
     ///
     /// Can be the default Handle, which usually represents no animation.
-    pub fn animation_clip(&self) -> &Handle<AnimationClip> {
+    pub fn animation_clip(&self) -> &Option<Handle<AnimationClip>> {
         &self.animation_clip
     }
 }
@@ -198,7 +198,11 @@ pub fn animation_player(
     children: Query<&Children>,
 ) {
     for (entity, mut player) in &mut animation_players {
-        if let Some(animation_clip) = animations.get(&player.animation_clip) {
+        if let Some(animation_clip) = player
+            .animation_clip
+            .as_ref()
+            .and_then(|x| animations.get(x))
+        {
             // Continue if paused unless the `AnimationPlayer` was changed
             // This allow the animation to still be updated if the player.elapsed field was manually updated in pause
             if player.paused && !player.is_changed() {


### PR DESCRIPTION
# Objective

Fixes #5848.

## Solution

- Adding function to get `animation_clip` from `AnimationPlayer` while documenting that it could be the default handle.
- Adding a function which tells if the animation player has finished playing the `animation_clip`.

---

The language used to explain what the default handle implies could be more clear. My problem is that the default handle could actually refer to an actual animation if an `AnimationClip` is set for the default handle, which leads me to ask, "Should `animation_clip` should be an `Option`?"
