### PR TITLE
[Merged by Bors] - relax `Sized` bounds around change detection types

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -130,7 +130,6 @@ macro_rules! change_detection_impl {
     };
 }
 
-
 macro_rules! impl_into_inner {
     ($name:ident < $( $generics:tt ),+ >, $target:ty, $($traits:ident)?) => {
         impl<$($generics),* : ?Sized $(+ $traits)?> $name<$($generics),*> {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -69,7 +69,7 @@ pub trait DetectChanges {
 
 macro_rules! change_detection_impl {
     ($name:ident < $( $generics:tt ),+ >, $target:ty, $($traits:ident)?) => {
-        impl<$($generics),* $(: $traits)?> DetectChanges for $name<$($generics),*> {
+        impl<$($generics),* : ?Sized $(+ $traits)?> DetectChanges for $name<$($generics),*> {
             #[inline]
             fn is_added(&self) -> bool {
                 self.ticks
@@ -97,7 +97,7 @@ macro_rules! change_detection_impl {
             }
         }
 
-        impl<$($generics),* $(: $traits)?> Deref for $name<$($generics),*> {
+        impl<$($generics),*: ?Sized $(+ $traits)?> Deref for $name<$($generics),*> {
             type Target = $target;
 
             #[inline]
@@ -106,7 +106,7 @@ macro_rules! change_detection_impl {
             }
         }
 
-        impl<$($generics),* $(: $traits)?> DerefMut for $name<$($generics),*> {
+        impl<$($generics),* : ?Sized $(+ $traits)?> DerefMut for $name<$($generics),*> {
             #[inline]
             fn deref_mut(&mut self) -> &mut Self::Target {
                 self.set_changed();
@@ -130,9 +130,10 @@ macro_rules! change_detection_impl {
     };
 }
 
+
 macro_rules! impl_into_inner {
     ($name:ident < $( $generics:tt ),+ >, $target:ty, $($traits:ident)?) => {
-        impl<$($generics),* $(: $traits)?> $name<$($generics),*> {
+        impl<$($generics),* : ?Sized $(+ $traits)?> $name<$($generics),*> {
             /// Consume `self` and return a mutable reference to the
             /// contained value while marking `self` as "changed".
             #[inline]
@@ -146,12 +147,12 @@ macro_rules! impl_into_inner {
 
 macro_rules! impl_debug {
     ($name:ident < $( $generics:tt ),+ >, $($traits:ident)?) => {
-        impl<$($generics),* $(: $traits)?> std::fmt::Debug for $name<$($generics),*>
+        impl<$($generics),* : ?Sized $(+ $traits)?> std::fmt::Debug for $name<$($generics),*>
             where T: std::fmt::Debug
         {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 f.debug_tuple(stringify!($name))
-                    .field(self.value)
+                    .field(&self.value)
                     .finish()
             }
         }
@@ -176,7 +177,7 @@ pub(crate) struct Ticks<'a> {
 /// Panics when used as a [`SystemParam`](crate::system::SystemParam) if the resource does not exist.
 ///
 /// Use `Option<ResMut<T>>` instead if the resource might not always exist.
-pub struct ResMut<'a, T: Resource> {
+pub struct ResMut<'a, T: ?Sized + Resource> {
     pub(crate) value: &'a mut T,
     pub(crate) ticks: Ticks<'a>,
 }
@@ -208,7 +209,7 @@ impl<'a, T: Resource> From<ResMut<'a, T>> for Mut<'a, T> {
 /// Panics when used as a `SystemParameter` if the resource does not exist.
 ///
 /// Use `Option<NonSendMut<T>>` instead if the resource might not always exist.
-pub struct NonSendMut<'a, T: 'static> {
+pub struct NonSendMut<'a, T: ?Sized + 'static> {
     pub(crate) value: &'a mut T,
     pub(crate) ticks: Ticks<'a>,
 }


### PR DESCRIPTION
# Objective

I wanted to run the code
```rust
let reflect_resource: ReflectResource = ...;
let value: Mut<dyn Reflect> = reflect_resource.reflect(world);
value.deref();
// ^ ERROR: deref method doesn't exist because `dyn Reflect` doesnt satisfy `: Sized`.
```

## Solution

Relax `Sized` bounds in all the methods and trait implementations for `Mut` and friends.