### PR TITLE
get `unchecked_mut` variants to `by_id` methods

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -197,7 +197,7 @@ impl<'w> EntityRef<'w> {
     /// compile time.**
     ///
     /// Unlike [`EntityRef::get`], this returns a raw pointer to the component,
-    /// which is only valid while the `'w` borrow of the lifetime is active.
+    /// instead of a reference.
     ///
     /// # Safety
     ///

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -201,7 +201,7 @@ impl<'w> EntityRef<'w> {
     ///
     /// # Safety
     ///
-    /// - The returned reference must never alias a mutable borrow of this component.
+    /// - The returned reference must never alias another reference to this component
     /// - The returned reference must not be used after this component is moved which
     ///   may happen from **any** `insert_component`, `remove_component` or `despawn`
     ///   operation on this world (non-exhaustive list).
@@ -211,7 +211,8 @@ impl<'w> EntityRef<'w> {
         component_id: ComponentId,
     ) -> Option<MutUntyped<'w>> {
         self.world.components().get_info(component_id)?;
-        // SAFETY: entity_location is valid, component_id is valid as checked by the line above, world access is promised by the caller
+        // SAFETY: entity_location is valid, component_id is valid as checked by the line above,
+        // the caller promises that they can uniquely access this component
         get_mut_by_id(self.world, self.entity, self.location, component_id)
     }
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1533,7 +1533,8 @@ impl World {
         };
 
         Some(MutUntyped {
-            // SAFETY: This function has exclusive access to the world so nothing aliases `ptr`.
+            // SAFETY: the caller of this function has to ensure that they can mutably access this
+            // component for the duration of the `'_` lifetime
             value: ptr.assert_unique(),
             ticks,
         })


### PR DESCRIPTION
# Objective

The `World` stores its components and resources in `UnsafeCell`s, which means that (with the necessary care) you can get a `&mut T` from a `&World` soundly. Having two `&mut World`s however is unsound.

To support use cases like bevy's systems where multiple callers share a `&World` but mutably access different parts of it, there are `_unchecked` versions of many functions:
- `EntityRef::get_unchecked_mut`
- `World::get_resource_unchecked_mut`
- `Query:.get_unchecked`
- ... (https://docs.rs/bevy_ecs/latest/bevy_ecs/?search=unchecked_mut)

I have a use case where I have two `&Worlds` where one may access resources and the other one may access components, and I would like to use untyped `by_id` methods there.

## Solution

- add `World::get_resource_unchecked_mut_by_id`
- add `EntityRef::get_unchecked_mut_by_id`

both with safety comments like the *by_id* variant.

## Changelog

- add `World::get_resource_unchecked_mut_by_id` and `EntityRef::get_unchecked_mut_by_id` for manually synchronized mutable world access with untyped pointers