### PR TITLE
[Merged by Bors] - add `ReflectAsset` and `ReflectHandle`

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -17,7 +17,7 @@ use bevy_ecs::{
 };
 use bevy_hierarchy::Children;
 use bevy_math::{Quat, Vec3};
-use bevy_reflect::{Reflect, TypeUuid};
+use bevy_reflect::{FromReflect, Reflect, TypeUuid};
 use bevy_time::Time;
 use bevy_transform::{prelude::Transform, TransformSystem};
 use bevy_utils::{tracing::warn, HashMap};
@@ -31,7 +31,7 @@ pub mod prelude {
 }
 
 /// List of keyframes for one of the attribute of a [`Transform`].
-#[derive(Clone, Debug)]
+#[derive(Reflect, FromReflect, Clone, Debug)]
 pub enum Keyframes {
     /// Keyframes for rotation.
     Rotation(Vec<Quat>),
@@ -44,7 +44,7 @@ pub enum Keyframes {
 /// Describes how an attribute of a [`Transform`] should be animated.
 ///
 /// `keyframe_timestamps` and `keyframes` should have the same length.
-#[derive(Clone, Debug)]
+#[derive(Reflect, FromReflect, Clone, Debug)]
 pub struct VariableCurve {
     /// Timestamp for each of the keyframes.
     pub keyframe_timestamps: Vec<f32>,
@@ -53,14 +53,14 @@ pub struct VariableCurve {
 }
 
 /// Path to an entity, with [`Name`]s. Each entity in a path must have a name.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Default)]
+#[derive(Reflect, FromReflect, Clone, Debug, Hash, PartialEq, Eq, Default)]
 pub struct EntityPath {
     /// Parts of the path
     pub parts: Vec<Name>,
 }
 
 /// A list of [`VariableCurve`], and the [`EntityPath`] to which they apply.
-#[derive(Clone, TypeUuid, Debug, Default)]
+#[derive(Reflect, FromReflect, Clone, TypeUuid, Debug, Default)]
 #[uuid = "d81b7179-0448-4eb0-89fe-c067222725bf"]
 pub struct AnimationClip {
     curves: HashMap<EntityPath, Vec<VariableCurve>>,
@@ -301,6 +301,7 @@ pub struct AnimationPlugin {}
 impl Plugin for AnimationPlugin {
     fn build(&self, app: &mut App) {
         app.add_asset::<AnimationClip>()
+            .register_asset_reflect::<AnimationClip>()
             .register_type::<AnimationPlayer>()
             .add_system_to_stage(
                 CoreStage::PostUpdate,

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1,6 +1,5 @@
 use crate::{CoreStage, Plugin, PluginGroup, StartupSchedule, StartupStage};
 pub use bevy_derive::AppLabel;
-use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     event::{Event, Events},
     prelude::FromWorld,
@@ -25,7 +24,7 @@ bevy_utils::define_label!(
 
 /// The [`Resource`] that stores the [`App`]'s [`TypeRegistry`](bevy_reflect::TypeRegistry).
 #[cfg(feature = "bevy_reflect")]
-#[derive(Resource, Clone, Deref, DerefMut, Default)]
+#[derive(Resource, Clone, bevy_derive::Deref, bevy_derive::DerefMut, Default)]
 pub struct AppTypeRegistry(pub bevy_reflect::TypeRegistryArc);
 
 #[allow(clippy::needless_doctest_main)]

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -280,7 +280,10 @@ pub trait AddAsset {
     where
         T: Asset;
 
-    /// Registers [`ReflectAsset`] and [`ReflectHandle`] in the [`TypeRegistry]` so that the asset can be used in reflection contexts.
+    /// Registers the asset type `T` using `[App::register]`,
+    /// and adds [`ReflectAsset`] type data to `T` and [`ReflectHandle`] type data to `Handle<T>` in the type registry.
+    ///
+    /// This enables reflection code to access assets. For detailed information, see the docs on [`ReflectAsset`] and [`ReflectHandle`].
     fn register_asset_reflect<T>(&mut self) -> &mut Self
     where
         T: Asset + Reflect + FromReflect + GetTypeRegistration;

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -8,7 +8,7 @@ use bevy_ecs::{
     system::{ResMut, Resource},
     world::FromWorld,
 };
-use bevy_reflect::{FromReflect, FromType, GetTypeRegistration, Reflect};
+use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect};
 use bevy_utils::HashMap;
 use crossbeam_channel::Sender;
 use std::fmt::Debug;

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -281,7 +281,7 @@ pub trait AddAsset {
         T: Asset;
 
     /// Registers the asset type `T` using `[App::register]`,
-    /// and adds [`ReflectAsset`] type data to `T` and [`ReflectHandle`] type data to `Handle<T>` in the type registry.
+    /// and adds [`ReflectAsset`] type data to `T` and [`ReflectHandle`] type data to [`Handle<T>`] in the type registry.
     ///
     /// This enables reflection code to access assets. For detailed information, see the docs on [`ReflectAsset`] and [`ReflectHandle`].
     fn register_asset_reflect<T>(&mut self) -> &mut Self
@@ -351,14 +351,8 @@ impl AddAsset for App {
 
             type_registry.register::<T>();
             type_registry.register::<Handle<T>>();
-            type_registry
-                .get_mut(std::any::TypeId::of::<T>())
-                .unwrap()
-                .insert(<ReflectAsset as FromType<T>>::from_type());
-            type_registry
-                .get_mut(std::any::TypeId::of::<Handle<T>>())
-                .unwrap()
-                .insert(<ReflectHandle as FromType<Handle<T>>>::from_type());
+            type_registry.register_type_data::<T, ReflectAsset>();
+            type_registry.register_type_data::<Handle<T>, ReflectHandle>();
         }
 
         self

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -410,6 +410,16 @@ impl Drop for HandleUntyped {
     }
 }
 
+impl<A: Asset> From<Handle<A>> for HandleUntyped {
+    fn from(mut handle: Handle<A>) -> Self {
+        let handle_type = std::mem::replace(&mut handle.handle_type, HandleType::Weak);
+        HandleUntyped {
+            id: handle.id,
+            handle_type,
+        }
+    }
+}
+
 impl From<&HandleUntyped> for HandleId {
     fn from(value: &HandleUntyped) -> Self {
         value.id

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -25,6 +25,7 @@ mod info;
 mod io;
 mod loader;
 mod path;
+mod reflect;
 
 /// The `bevy_asset` prelude.
 pub mod prelude {
@@ -43,6 +44,7 @@ pub use info::*;
 pub use io::*;
 pub use loader::*;
 pub use path::*;
+pub use reflect::*;
 
 use bevy_app::{prelude::Plugin, App};
 use bevy_ecs::schedule::{StageLabel, SystemStage};

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -62,6 +62,21 @@ impl ReflectAsset {
     /// Only use this method when you have ensured that you are the *only* one with access to the [`Assets`] resource of the asset type.
     /// Furthermore, this does *not* allow you to have look up two distinct handles,
     /// you can only have at most one alive at the same time.
+    /// This means that this is *not allowed*:
+    /// ```rust,no_run
+    /// # use bevy_asset::{ReflectAsset, HandleUntyped};
+    /// # use bevy_ecs::prelude::World;
+    /// # let reflect_asset: ReflectAsset = unimplemented!();
+    /// # let world: World = unimplemented!();
+    /// # let handle_1: HandleUntyped = unimplemented!();
+    /// # let handle_2: HandleUntyped = unimplemented!();
+    /// let a = unsafe { reflect_asset.get_unchecked_mut(&world, handle_1).unwrap() };
+    /// let b = unsafe { reflect_asset.get_unchecked_mut(&world, handle_2).unwrap() };
+    /// // ^ not allowed, two mutable references through the same asset resource, even though the
+    /// // handles are distinct
+    ///
+    /// println!("a = {a:?}, b = {b:?}");
+    /// ```
     ///
     /// # Safety
     /// This method does not prevent you from having two mutable pointers to the same data,
@@ -254,7 +269,7 @@ mod tests {
     }
 
     #[test]
-    fn test() {
+    fn test_reflect_asset_operations() {
         let mut app = App::new();
         app.add_plugin(AssetPlugin)
             .add_asset::<AssetType>()

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -92,6 +92,11 @@ impl ReflectAsset {
         (self.len)(world)
     }
 
+    /// Equivalent of [`Assets::is_empty`]
+    pub fn is_empty(&self, world: &World) -> bool {
+        self.len(world) == 0
+    }
+
     /// Equivalent of [`Assets::ids`]
     pub fn ids<'w>(&self, world: &'w World) -> impl Iterator<Item = HandleId> + 'w {
         (self.ids)(world)

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -88,6 +88,7 @@ impl ReflectAsset {
     }
 
     /// Equivalent of [`Assets::len`]
+    #[allow(clippy::len_without_is_empty)] // clippy expects the `is_empty` method to have the signature `(&self) -> bool`
     pub fn len(&self, world: &World) -> usize {
         (self.len)(world)
     }

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -198,6 +198,7 @@ pub struct ReflectHandle {
     type_uuid: Uuid,
     asset_type_id: TypeId,
     downcast_handle_untyped: fn(&dyn Any) -> Option<HandleUntyped>,
+    typed: fn(HandleUntyped) -> Box<dyn Reflect>,
 }
 impl ReflectHandle {
     /// The [`bevy_reflect::TypeUuid`] of the asset
@@ -213,6 +214,12 @@ impl ReflectHandle {
     pub fn downcast_handle_untyped(&self, handle: &dyn Any) -> Option<HandleUntyped> {
         (self.downcast_handle_untyped)(handle)
     }
+
+    /// A way to go from a [`HandleUntyped`] to a `Handle<T>` in a `Box<dyn Reflect>`.
+    /// Equivalent of [`HandleUntyped::typed`].
+    pub fn typed(&self, handle: HandleUntyped) -> Box<dyn Reflect> {
+        (self.typed)(handle)
+    }
 }
 
 impl<A: Asset> FromType<Handle<A>> for ReflectHandle {
@@ -225,6 +232,7 @@ impl<A: Asset> FromType<Handle<A>> for ReflectHandle {
                     .downcast_ref::<Handle<A>>()
                     .map(|handle| handle.clone_untyped())
             },
+            typed: |handle: HandleUntyped| Box::new(handle.typed::<A>()),
         }
     }
 }

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -271,7 +271,7 @@ mod tests {
     #[test]
     fn test_reflect_asset_operations() {
         let mut app = App::new();
-        app.add_plugin(AssetPlugin)
+        app.add_plugin(AssetPlugin::default())
             .add_asset::<AssetType>()
             .register_asset_reflect::<AssetType>();
 

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -38,7 +38,7 @@ impl ReflectAsset {
         self.handle_type_id
     }
 
-    /// The [`TypeId`] of the [`Assets`] resource
+    /// The [`TypeId`] of the [`Assets<T>`] resource
     pub fn assets_resource_type_id(&self) -> TypeId {
         self.assets_resource_type_id
     }
@@ -47,6 +47,7 @@ impl ReflectAsset {
     pub fn get<'w>(&self, world: &'w World, handle: HandleUntyped) -> Option<&'w dyn Reflect> {
         (self.get)(world, handle)
     }
+
     /// Equivalent of [`Assets::get_mut`]
     pub fn get_mut<'w>(
         &self,
@@ -58,7 +59,7 @@ impl ReflectAsset {
 
     /// Equivalent of [`Assets::get_mut`], but does not require a mutable reference to the world.
     ///
-    /// Only use this method when you have ensured that you are the *only* one with access to the `Assets` resource of the asset type.
+    /// Only use this method when you have ensured that you are the *only* one with access to the [`Assets`] resource of the asset type.
     /// Furthermore, this does *not* allow you to have look up two distinct handles,
     /// you can only have at most one alive at the same time.
     ///
@@ -142,13 +143,13 @@ impl<A: Asset + FromReflect> FromType<A> for ReflectAsset {
             add: |world, value| {
                 let mut assets = world.resource_mut::<Assets<A>>();
                 let value: A = FromReflect::from_reflect(value)
-                    .expect("could not call `FromReflect::from_reflect` in `ReflectAsset::insert`");
+                    .expect("could not call `FromReflect::from_reflect` in `ReflectAsset::add`");
                 assets.add(value).into()
             },
             set: |world, handle, value| {
                 let mut assets = world.resource_mut::<Assets<A>>();
                 let value: A = FromReflect::from_reflect(value)
-                    .expect("could not call `FromReflect::from_reflect` in `ReflectAsset::insert`");
+                    .expect("could not call `FromReflect::from_reflect` in `ReflectAsset::set`");
                 assets.set(handle, value).into()
             },
             len: |world| {
@@ -168,7 +169,7 @@ impl<A: Asset + FromReflect> FromType<A> for ReflectAsset {
     }
 }
 
-/// Reflect type data struct relating a `Handle<T>` back to the `T` asset type.
+/// Reflect type data struct relating a [`Handle<T>`] back to the `T` asset type.
 ///
 /// Say you want to look up the asset values of a list of handles when you have access to their `&dyn Reflect` form.
 /// Assets can be looked up in the world using [`ReflectAsset`], but how do you determine which [`ReflectAsset`] to use when
@@ -210,12 +211,12 @@ impl ReflectHandle {
         self.asset_type_id
     }
 
-    /// A way to go from a `Handle<T>` in a `dyn Any` to a [`HandleUntyped`]
+    /// A way to go from a [`Handle<T>`] in a `dyn Any` to a [`HandleUntyped`]
     pub fn downcast_handle_untyped(&self, handle: &dyn Any) -> Option<HandleUntyped> {
         (self.downcast_handle_untyped)(handle)
     }
 
-    /// A way to go from a [`HandleUntyped`] to a `Handle<T>` in a `Box<dyn Reflect>`.
+    /// A way to go from a [`HandleUntyped`] to a [`Handle<T>`] in a `Box<dyn Reflect>`.
     /// Equivalent of [`HandleUntyped::typed`].
     pub fn typed(&self, handle: HandleUntyped) -> Box<dyn Reflect> {
         (self.typed)(handle)

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -14,6 +14,7 @@ use crate::{Asset, Assets, Handle, HandleId, HandleUntyped};
 #[derive(Clone)]
 pub struct ReflectAsset {
     type_uuid: Uuid,
+    handle_type_id: TypeId,
     assets_resource_type_id: TypeId,
 
     get: fn(&World, HandleUntyped) -> Option<&dyn Reflect>,
@@ -30,6 +31,11 @@ impl ReflectAsset {
     /// The [`bevy_reflect::TypeUuid`] of the asset
     pub fn type_uuid(&self) -> Uuid {
         self.type_uuid
+    }
+
+    /// The [`TypeId`] of the [`Handle<T>`] for this asset
+    pub fn handle_type_id(&self) -> TypeId {
+        self.handle_type_id
     }
 
     /// The [`TypeId`] of the [`Assets`] resource
@@ -111,6 +117,7 @@ impl<A: Asset + FromReflect> FromType<A> for ReflectAsset {
     fn from_type() -> Self {
         ReflectAsset {
             type_uuid: A::TYPE_UUID,
+            handle_type_id: TypeId::of::<Handle<A>>(),
             assets_resource_type_id: TypeId::of::<Assets<A>>(),
             get: |world, handle| {
                 let assets = world.resource::<Assets<A>>();

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -5,10 +5,10 @@ use bevy_reflect::{FromReflect, FromType, Reflect, Uuid};
 
 use crate::{Asset, Assets, Handle, HandleId, HandleUntyped};
 
-/// A struct used to operate on reflected [`Asset`] of a type.
+/// A struct used to operate on reflected [`Asset`]s.
 ///
 /// A [`ReflectAsset`] for type `T` can be obtained via
-/// [`bevy_reflect::TypeRegistration::data`].
+/// [`bevy_reflect::TypeRegistration::data`] if it was registered using [`crate::AddAsset::register_asset_reflect`].
 #[derive(Clone)]
 pub struct ReflectAsset {
     type_uuid: Uuid,
@@ -25,7 +25,7 @@ pub struct ReflectAsset {
 }
 
 impl ReflectAsset {
-    /// The [`TypeUuid`] of the asset
+    /// The [`bevy_reflect::TypeUuid`] of the asset
     pub fn type_uuid(&self) -> Uuid {
         self.type_uuid
     }
@@ -152,7 +152,7 @@ impl<A: Asset + FromReflect> FromType<A> for ReflectAsset {
     }
 }
 
-/// A struct relating a `Handle<T>` back to the `T` asset type.
+/// Reflect type data struct relating a `Handle<T>` back to the `T` asset type.
 #[derive(Clone)]
 pub struct ReflectHandle {
     type_uuid: Uuid,
@@ -160,7 +160,7 @@ pub struct ReflectHandle {
     downcast_handle_untyped: fn(&dyn Any) -> Option<HandleUntyped>,
 }
 impl ReflectHandle {
-    /// The [`TypeUuid`] of the asset
+    /// The [`bevy_reflect::TypeUuid`] of the asset
     pub fn type_uuid(&self) -> Uuid {
         self.type_uuid
     }

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -1,0 +1,159 @@
+use std::any::{Any, TypeId};
+
+use bevy_ecs::world::World;
+use bevy_reflect::{FromReflect, FromType, Reflect, Uuid};
+
+use crate::{Asset, Assets, Handle, HandleUntyped};
+
+/// A struct used to operate on reflected [`Asset`] of a type.
+///
+/// A [`ReflectAsset`] for type `T` can be obtained via
+/// [`bevy_reflect::TypeRegistration::data`].
+#[derive(Clone)]
+pub struct ReflectAsset {
+    type_uuid: Uuid,
+    assets_resource_type_id: TypeId,
+
+    get: fn(&World, HandleUntyped) -> Option<&dyn Reflect>,
+    get_mut: fn(&mut World, HandleUntyped) -> Option<&mut dyn Reflect>,
+    get_unchecked_mut: unsafe fn(&World, HandleUntyped) -> Option<&mut dyn Reflect>,
+    add: fn(&mut World, &dyn Reflect) -> HandleUntyped,
+    set: fn(&mut World, HandleUntyped, &dyn Reflect) -> HandleUntyped,
+}
+
+impl ReflectAsset {
+    /// The [`TypeUuid`] of the asset
+    pub fn type_uuid(&self) -> Uuid {
+        self.type_uuid
+    }
+
+    /// The [`TypeId`] of the [`Assets`] resource
+    pub fn assets_resource_type_id(&self) -> TypeId {
+        self.assets_resource_type_id
+    }
+
+    /// Equivalent of [`Assets::get`]
+    pub fn get<'w>(&self, world: &'w World, handle: HandleUntyped) -> Option<&'w dyn Reflect> {
+        (self.get)(world, handle)
+    }
+    /// Equivalent of [`Assets::get_mut`]
+    pub fn get_mut<'w>(
+        &self,
+        world: &'w mut World,
+        handle: HandleUntyped,
+    ) -> Option<&'w mut dyn Reflect> {
+        (self.get_mut)(world, handle)
+    }
+
+    /// Equivalent of [`Assets::get_mut`], but does not require a mutable reference to the world.
+    /// This is fine if you have ensure that you are the *only* one having access to the `Assets` resource
+    /// of the asset type. Furthermore, this does *not* allow you to have look up two distinct handles,
+    /// you can only have at most one alive at the same time.
+    ///
+    /// # Safety
+    /// This method does not prevent you from having two mutable pointers to the same data,
+    /// violating Rust's aliasing rules. To avoid this:
+    /// * Only call this method when you have exclusive access to the world
+    /// (or use a scheduler that enforces unique access to the `Assets` resource).
+    /// * Don't call this method more than once in the same scope.
+    pub unsafe fn get_unchecked_mut<'w>(
+        &self,
+        world: &'w World,
+        handle: HandleUntyped,
+    ) -> Option<&'w mut dyn Reflect> {
+        // SAFETY: requirements are deferred to the caller
+        (self.get_unchecked_mut)(world, handle)
+    }
+
+    /// Equivalent of [`Assets::add`]
+    pub fn add<'w>(&self, world: &'w mut World, value: &dyn Reflect) -> HandleUntyped {
+        (self.add)(world, value)
+    }
+    /// Equivalent of [`Assets::set`]
+    pub fn set<'w>(
+        &self,
+        world: &'w mut World,
+        handle: HandleUntyped,
+        value: &dyn Reflect,
+    ) -> HandleUntyped {
+        (self.set)(world, handle, value)
+    }
+}
+
+impl<A: Asset + FromReflect> FromType<A> for ReflectAsset {
+    fn from_type() -> Self {
+        ReflectAsset {
+            type_uuid: A::TYPE_UUID,
+            assets_resource_type_id: TypeId::of::<Assets<A>>(),
+            get: |world, handle| {
+                let assets = world.resource::<Assets<A>>();
+                let asset = assets.get(&handle.typed());
+                asset.map(|asset| asset as &dyn Reflect)
+            },
+            get_mut: |world, handle| {
+                let assets = world.resource_mut::<Assets<A>>().into_inner();
+                let asset = assets.get_mut(&handle.typed());
+                asset.map(|asset| asset as &mut dyn Reflect)
+            },
+            get_unchecked_mut: |world, handle| {
+                let assets = unsafe {
+                    world
+                        .get_resource_unchecked_mut::<Assets<A>>()
+                        .unwrap()
+                        .into_inner()
+                };
+                let asset = assets.get_mut(&handle.typed());
+                asset.map(|asset| asset as &mut dyn Reflect)
+            },
+            add: |world, value| {
+                let mut assets = world.resource_mut::<Assets<A>>();
+                let value: A = FromReflect::from_reflect(value)
+                    .expect("could not call `FromReflect::from_reflect` in `ReflectAsset::insert`");
+                assets.add(value).into()
+            },
+            set: |world, handle, value| {
+                let mut assets = world.resource_mut::<Assets<A>>();
+                let value: A = FromReflect::from_reflect(value)
+                    .expect("could not call `FromReflect::from_reflect` in `ReflectAsset::insert`");
+                assets.set(handle, value).into()
+            },
+        }
+    }
+}
+
+/// A struct relating a `Handle<T>` back to the `T` asset type.
+#[derive(Clone)]
+pub struct ReflectHandle {
+    type_uuid: Uuid,
+    asset_type_id: TypeId,
+    downcast_handle_untyped: fn(&dyn Any) -> Option<HandleUntyped>,
+}
+impl ReflectHandle {
+    /// The [`TypeUuid`] of the asset
+    pub fn type_uuid(&self) -> Uuid {
+        self.type_uuid
+    }
+    /// The [`TypeId`] of the asset
+    pub fn asset_type_id(&self) -> TypeId {
+        self.asset_type_id
+    }
+
+    /// A way to go from a `Handle<T>` in a `dyn Any` to a [`HandleUntyped`]
+    pub fn downcast_handle_untyped(&self, handle: &dyn Any) -> Option<HandleUntyped> {
+        (self.downcast_handle_untyped)(handle)
+    }
+}
+
+impl<A: Asset> FromType<Handle<A>> for ReflectHandle {
+    fn from_type() -> Self {
+        ReflectHandle {
+            type_uuid: A::TYPE_UUID,
+            asset_type_id: TypeId::of::<A>(),
+            downcast_handle_untyped: |handle: &dyn Any| {
+                handle
+                    .downcast_ref::<Handle<A>>()
+                    .map(|handle| handle.clone_untyped())
+            },
+        }
+    }
+}

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
-use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::Reflect;
+use bevy_reflect::{std_traits::ReflectDefault, FromReflect};
 use bevy_utils::AHasher;
 use std::{
     borrow::Cow,
@@ -14,7 +14,7 @@ use std::{
 /// [`Name`] should not be treated as a globally unique identifier for entities,
 /// as multiple entities can have the same name.  [`bevy_ecs::entity::Entity`] should be
 /// used instead as the default unique identifier.
-#[derive(Component, Debug, Clone, Reflect)]
+#[derive(Reflect, FromReflect, Component, Debug, Clone)]
 #[reflect(Component, Default)]
 pub struct Name {
     hash: u64, // TODO: Shouldn't be serialized

--- a/crates/bevy_pbr/src/alpha.rs
+++ b/crates/bevy_pbr/src/alpha.rs
@@ -1,10 +1,10 @@
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_reflect::std_traits::ReflectDefault;
-use bevy_reflect::Reflect;
+use bevy_reflect::{FromReflect, Reflect};
 
 // TODO: add discussion about performance.
 /// Sets how a material's base color alpha channel is used for transparency.
-#[derive(Component, Debug, Default, Reflect, Copy, Clone, PartialEq)]
+#[derive(Component, Debug, Default, Reflect, Copy, Clone, PartialEq, FromReflect)]
 #[reflect(Component, Default)]
 pub enum AlphaMode {
     /// Base color alpha values are overridden to be fully opaque (1.0).

--- a/crates/bevy_pbr/src/alpha.rs
+++ b/crates/bevy_pbr/src/alpha.rs
@@ -5,7 +5,7 @@ use bevy_reflect::{FromReflect, Reflect};
 // TODO: add discussion about performance.
 /// Sets how a material's base color alpha channel is used for transparency.
 #[derive(Component, Debug, Default, Reflect, Copy, Clone, PartialEq, FromReflect)]
-#[reflect(Component, Default)]
+#[reflect(Component, Default, Debug)]
 pub enum AlphaMode {
     /// Base color alpha values are overridden to be fully opaque (1.0).
     #[default]

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -38,7 +38,7 @@ pub mod draw_3d_graph {
 }
 
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, Assets, Handle, HandleUntyped};
+use bevy_asset::{load_internal_asset, AddAsset, Assets, Handle, HandleUntyped};
 use bevy_ecs::prelude::*;
 use bevy_reflect::TypeUuid;
 use bevy_render::{
@@ -129,6 +129,7 @@ impl Plugin for PbrPlugin {
             .register_type::<SpotLight>()
             .add_plugin(MeshRenderPlugin)
             .add_plugin(MaterialPlugin::<StandardMaterial>::default())
+            .register_asset_reflect::<StandardMaterial>()
             .register_type::<AmbientLight>()
             .register_type::<DirectionalLightShadowMap>()
             .register_type::<PointLightShadowMap>()

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -1,7 +1,7 @@
 use crate::{AlphaMode, Material, MaterialPipeline, MaterialPipelineKey, PBR_SHADER_HANDLE};
 use bevy_asset::Handle;
 use bevy_math::Vec4;
-use bevy_reflect::TypeUuid;
+use bevy_reflect::{std_traits::ReflectDefault, FromReflect, Reflect, TypeUuid};
 use bevy_render::{
     color::Color, mesh::MeshVertexBufferLayout, render_asset::RenderAssets, render_resource::*,
     texture::Image,
@@ -12,10 +12,11 @@ use bevy_render::{
 /// <https://google.github.io/filament/Material%20Properties.pdf>.
 ///
 /// May be created directly from a [`Color`] or an [`Image`].
-#[derive(AsBindGroup, Debug, Clone, TypeUuid)]
+#[derive(AsBindGroup, Reflect, FromReflect, Debug, Clone, TypeUuid)]
 #[uuid = "7494888b-c082-457b-aacf-517228cc0c22"]
 #[bind_group_data(StandardMaterialKey)]
 #[uniform(0, StandardMaterialUniform)]
+#[reflect(Default)]
 pub struct StandardMaterial {
     /// The color of the surface of the material before lighting.
     ///
@@ -193,6 +194,8 @@ pub struct StandardMaterial {
     /// Your 3D editing software should manage all of that.
     ///
     /// [`Mesh`]: bevy_render::mesh::Mesh
+    // TODO: include this in reflection somehow (maybe via remote types like serde https://serde.rs/remote-derive.html)
+    #[reflect(ignore)]
     pub cull_mode: Option<Face>,
 
     /// Whether to apply only the base color to this material.

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -16,7 +16,7 @@ use bevy_render::{
 #[uuid = "7494888b-c082-457b-aacf-517228cc0c22"]
 #[bind_group_data(StandardMaterialKey)]
 #[uniform(0, StandardMaterialUniform)]
-#[reflect(Default)]
+#[reflect(Default, Debug)]
 pub struct StandardMaterial {
     /// The color of the surface of the material before lighting.
     ///

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -15,7 +15,7 @@ use bevy_asset::HandleUntyped;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::system::{lifetimeless::SRes, Resource, SystemParamItem};
 use bevy_math::Vec2;
-use bevy_reflect::TypeUuid;
+use bevy_reflect::{FromReflect, Reflect, TypeUuid};
 use std::hash::Hash;
 use thiserror::Error;
 use wgpu::{
@@ -101,8 +101,9 @@ impl ImageFormat {
     }
 }
 
-#[derive(Debug, Clone, TypeUuid)]
+#[derive(Reflect, FromReflect, Debug, Clone, TypeUuid)]
 #[uuid = "6ea26da6-6cf8-4ea2-9986-1d7bf6c17d6f"]
+#[reflect_value]
 pub struct Image {
     pub data: Vec<u8>,
     // TODO: this nesting makes accessing Image metadata verbose. Either flatten out descriptor or add accessors

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -86,7 +86,8 @@ impl Plugin for ImagePlugin {
         app.add_plugin(RenderAssetPlugin::<Image>::with_prepare_asset_label(
             PrepareAssetLabel::PreAssetPrepare,
         ))
-        .add_asset::<Image>();
+        .add_asset::<Image>()
+        .register_asset_reflect::<Image>();
         app.world
             .resource_mut::<Assets<Image>>()
             .set_untracked(DEFAULT_IMAGE_HANDLE, Image::default());

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -54,6 +54,7 @@ impl Plugin for SpritePlugin {
         let sprite_shader = Shader::from_wgsl(include_str!("render/sprite.wgsl"));
         shaders.set_untracked(SPRITE_SHADER_HANDLE, sprite_shader);
         app.add_asset::<TextureAtlas>()
+            .register_asset_reflect::<TextureAtlas>()
             .register_type::<Sprite>()
             .register_type::<Anchor>()
             .register_type::<Mesh2dHandle>()

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -40,7 +40,7 @@ impl Plugin for ColorMaterialPlugin {
 
 /// A [2d material](Material2d) that renders [2d meshes](crate::Mesh2dHandle) with a texture tinted by a uniform color
 #[derive(AsBindGroup, Reflect, FromReflect, Debug, Clone, TypeUuid)]
-#[reflect(Default)]
+#[reflect(Default, Debug)]
 #[uuid = "e228a544-e3ca-4e1e-bb9d-4d8bc1ad8c19"]
 #[uniform(0, ColorMaterialUniform)]
 pub struct ColorMaterial {

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -1,7 +1,7 @@
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Assets, Handle, HandleUntyped};
+use bevy_asset::{load_internal_asset, AddAsset, Assets, Handle, HandleUntyped};
 use bevy_math::Vec4;
-use bevy_reflect::TypeUuid;
+use bevy_reflect::{prelude::*, TypeUuid};
 use bevy_render::{
     color::Color, prelude::Shader, render_asset::RenderAssets, render_resource::*, texture::Image,
 };
@@ -23,7 +23,8 @@ impl Plugin for ColorMaterialPlugin {
             Shader::from_wgsl
         );
 
-        app.add_plugin(Material2dPlugin::<ColorMaterial>::default());
+        app.add_plugin(Material2dPlugin::<ColorMaterial>::default())
+            .register_asset_reflect::<ColorMaterial>();
 
         app.world
             .resource_mut::<Assets<ColorMaterial>>()
@@ -38,7 +39,8 @@ impl Plugin for ColorMaterialPlugin {
 }
 
 /// A [2d material](Material2d) that renders [2d meshes](crate::Mesh2dHandle) with a texture tinted by a uniform color
-#[derive(AsBindGroup, Debug, Clone, TypeUuid)]
+#[derive(AsBindGroup, Reflect, FromReflect, Debug, Clone, TypeUuid)]
+#[reflect(Default)]
 #[uuid = "e228a544-e3ca-4e1e-bb9d-4d8bc1ad8c19"]
 #[uniform(0, ColorMaterialUniform)]
 pub struct ColorMaterial {

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -2,14 +2,14 @@ use crate::Anchor;
 use bevy_asset::Handle;
 use bevy_ecs::component::Component;
 use bevy_math::{Rect, Vec2};
-use bevy_reflect::{Reflect, TypeUuid};
+use bevy_reflect::{FromReflect, Reflect, TypeUuid};
 use bevy_render::{color::Color, texture::Image};
 use bevy_utils::HashMap;
 
 /// An atlas containing multiple textures (like a spritesheet or a tilemap).
 /// [Example usage animating sprite.](https://github.com/bevyengine/bevy/blob/latest/examples/2d/sprite_sheet.rs)
 /// [Example usage loading sprite sheet.](https://github.com/bevyengine/bevy/blob/latest/examples/2d/texture_atlas.rs)
-#[derive(Debug, Clone, TypeUuid)]
+#[derive(Reflect, FromReflect, Debug, Clone, TypeUuid)]
 #[uuid = "7233c597-ccfa-411f-bd59-9af349432ada"]
 pub struct TextureAtlas {
     /// The handle to the texture in which the sprites are stored

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -11,6 +11,7 @@ use bevy_utils::HashMap;
 /// [Example usage loading sprite sheet.](https://github.com/bevyengine/bevy/blob/latest/examples/2d/texture_atlas.rs)
 #[derive(Reflect, FromReflect, Debug, Clone, TypeUuid)]
 #[uuid = "7233c597-ccfa-411f-bd59-9af349432ada"]
+#[reflect(Debug)]
 pub struct TextureAtlas {
     /// The handle to the texture in which the sprites are stored
     pub texture: Handle<Image>,


### PR DESCRIPTION
# Objective
![image](https://user-images.githubusercontent.com/22177966/189350194-639a0211-e984-4f73-ae62-0ede44891eb9.png)

^ enable this

Concretely, I need to
- list all handle ids for an asset type
- fetch the asset as `dyn Reflect`, given a `HandleUntyped`
- when encountering a `Handle<T>`, find out what asset type that handle refers to (`T`'s type id) and turn the handle into a `HandleUntyped`

## Solution

- add `ReflectAsset` type containing function pointers for working with assets
```rust
pub struct ReflectAsset {
    type_uuid: Uuid,
    assets_resource_type_id: TypeId, // TypeId of the `Assets<T>` resource

    get: fn(&World, HandleUntyped) -> Option<&dyn Reflect>,
    get_mut: fn(&mut World, HandleUntyped) -> Option<&mut dyn Reflect>,
    get_unchecked_mut: unsafe fn(&World, HandleUntyped) -> Option<&mut dyn Reflect>,
    add: fn(&mut World, &dyn Reflect) -> HandleUntyped,
    set: fn(&mut World, HandleUntyped, &dyn Reflect) -> HandleUntyped,
    len: fn(&World) -> usize,
    ids: for<'w> fn(&'w World) -> Box<dyn Iterator<Item = HandleId> + 'w>,
    remove: fn(&mut World, HandleUntyped) -> Option<Box<dyn Reflect>>,
}
```
- add `ReflectHandle` type relating the handle back to the asset type and providing a way to create a `HandleUntyped`
```rust
pub struct ReflectHandle {
    type_uuid: Uuid,
    asset_type_id: TypeId,
    downcast_handle_untyped: fn(&dyn Any) -> Option<HandleUntyped>,
}
```
- add the corresponding `FromType` impls
- add a function `app.register_asset_reflect` which is supposed to be called after `.add_asset` and registers `ReflectAsset` and `ReflectHandle` in the type registry
---

## Changelog

- add `ReflectAsset` and `ReflectHandle` types, which allow code to use reflection to manipulate arbitrary assets without knowing their types at compile time