### PR TITLE
rename Commands to DeferredCommands

### DIFF
--- a/benches/benches/bevy_ecs/world/commands.rs
+++ b/benches/benches/bevy_ecs/world/commands.rs
@@ -1,7 +1,7 @@
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    system::{Command, CommandQueue, Commands},
+    system::{Command, CommandQueue, DeferredCommands},
     world::World,
 };
 use criterion::{black_box, Criterion};
@@ -41,7 +41,7 @@ pub fn spawn_commands(criterion: &mut Criterion) {
             let mut command_queue = CommandQueue::default();
 
             bencher.iter(|| {
-                let mut commands = Commands::new(&mut command_queue, &world);
+                let mut commands = DeferredCommands::new(&mut command_queue, &world);
                 for i in 0..entity_count {
                     let mut entity = commands.spawn();
 
@@ -91,7 +91,7 @@ pub fn insert_commands(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            let mut commands = Commands::new(&mut command_queue, &world);
+            let mut commands = DeferredCommands::new(&mut command_queue, &world);
             for entity in &entities {
                 commands
                     .entity(*entity)
@@ -110,7 +110,7 @@ pub fn insert_commands(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            let mut commands = Commands::new(&mut command_queue, &world);
+            let mut commands = DeferredCommands::new(&mut command_queue, &world);
             let mut values = Vec::with_capacity(entity_count);
             for entity in &entities {
                 values.push((*entity, (Matrix::default(), Vec3::default())));
@@ -152,7 +152,7 @@ pub fn fake_commands(criterion: &mut Criterion) {
             let mut command_queue = CommandQueue::default();
 
             bencher.iter(|| {
-                let mut commands = Commands::new(&mut command_queue, &world);
+                let mut commands = DeferredCommands::new(&mut command_queue, &world);
                 for i in 0..command_count {
                     if black_box(i % 2 == 0) {
                         commands.add(FakeCommandA);
@@ -199,7 +199,7 @@ pub fn sized_commands_impl<T: Default + Command>(criterion: &mut Criterion) {
             let mut command_queue = CommandQueue::default();
 
             bencher.iter(|| {
-                let mut commands = Commands::new(&mut command_queue, &world);
+                let mut commands = DeferredCommands::new(&mut command_queue, &world);
                 for _ in 0..command_count {
                     commands.add(T::default());
                 }
@@ -234,7 +234,7 @@ pub fn get_or_spawn(criterion: &mut Criterion) {
         let mut command_queue = CommandQueue::default();
 
         bencher.iter(|| {
-            let mut commands = Commands::new(&mut command_queue, &world);
+            let mut commands = DeferredCommands::new(&mut command_queue, &world);
             for i in 0..10_000 {
                 commands
                     .get_or_spawn(Entity::from_raw(i))
@@ -249,7 +249,7 @@ pub fn get_or_spawn(criterion: &mut Criterion) {
         let mut command_queue = CommandQueue::default();
 
         bencher.iter(|| {
-            let mut commands = Commands::new(&mut command_queue, &world);
+            let mut commands = DeferredCommands::new(&mut command_queue, &world);
             let mut values = Vec::with_capacity(10_000);
             for i in 0..10_000 {
                 values.push((Entity::from_raw(i), (Matrix::default(), Vec3::default())));

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -447,7 +447,7 @@ impl App {
     /// # use bevy_app::prelude::*;
     /// # use bevy_ecs::prelude::*;
     /// #
-    /// fn my_startup_system(_commands: Commands) {
+    /// fn my_startup_system(_commands: DeferredCommands) {
     ///     println!("My startup system");
     /// }
     ///

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -86,13 +86,13 @@ pub struct AssetServerInternal {
 ///
 /// ```rust,no_run
 /// use bevy_asset::{AssetServer, Handle};
-/// use bevy_ecs::prelude::{Commands, Res};
+/// use bevy_ecs::prelude::{DeferredCommands, Res};
 ///
 /// # #[derive(Debug, bevy_reflect::TypeUuid)]
 /// # #[uuid = "00000000-0000-0000-0000-000000000000"]
 /// # struct Image;
 ///
-/// fn my_system(mut commands: Commands, asset_server: Res<AssetServer>)
+/// fn my_system(mut commands: DeferredCommands, asset_server: Res<AssetServer>)
 /// {
 ///     // Now you can do whatever you want with the asset server, such as loading an asset:
 ///     let asset_handle: Handle<Image> = asset_server.load("cool_picture.png");

--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -122,7 +122,7 @@ impl BatchedPhaseItem for Transparent2d {
 }
 
 pub fn extract_core_2d_camera_phases(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     cameras_2d: Extract<Query<(Entity, &Camera), With<Camera2d>>>,
 ) {
     for (entity, camera) in cameras_2d.iter() {

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -208,7 +208,7 @@ impl CachedRenderPipelinePhaseItem for Transparent3d {
 }
 
 pub fn extract_core_3d_camera_phases(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     cameras_3d: Extract<Query<(Entity, &Camera), With<Camera3d>>>,
 ) {
     for (entity, camera) in cameras_3d.iter() {
@@ -223,7 +223,7 @@ pub fn extract_core_3d_camera_phases(
 }
 
 pub fn prepare_core_3d_depth_textures(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut texture_cache: ResMut<TextureCache>,
     msaa: Res<Msaa>,
     render_device: Res<RenderDevice>,

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -63,7 +63,7 @@ enum SimulationSystem {
 // This system randomly spawns a new entity in 60% of all frames
 // The entity will start with an age of 0 frames
 // If an entity gets spawned, we increase the counter in the EntityCounter resource
-fn spawn_entities(mut commands: Commands, mut entity_counter: ResMut<EntityCounter>) {
+fn spawn_entities(mut commands: DeferredCommands, mut entity_counter: ResMut<EntityCounter>) {
     if rand::thread_rng().gen_bool(0.6) {
         let entity_id = commands.spawn().insert(Age::default()).id();
         println!("    spawning {:?}", entity_id);
@@ -97,7 +97,7 @@ fn age_all_entities(mut entities: Query<&mut Age>) {
 }
 
 // This system iterates over all entities in every frame and despawns entities older than 2 frames
-fn remove_old_entities(mut commands: Commands, entities: Query<(Entity, &Age)>) {
+fn remove_old_entities(mut commands: DeferredCommands, entities: Query<(Entity, &Age)>) {
     for (entity, age) in &entities {
         if age.frames > 2 {
             println!("    despawning {:?} due to age > 2", entity);

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -21,7 +21,7 @@ use std::{any::TypeId, collections::HashMap};
 /// is a very convenient shorthand when working with one-off collections of components. Note
 /// that both the unit type `()` and `(ComponentA, )` are valid bundles. The unit bundle is
 /// particularly useful for spawning multiple empty entities by using
-/// [`Commands::spawn_batch`](crate::system::Commands::spawn_batch).
+/// [`DeferredCommands::spawn_batch`](crate::system::DeferredCommands::spawn_batch).
 ///
 /// # Examples
 ///

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -13,16 +13,16 @@
 //!
 //! |Operation|Command|Method|
 //! |:---:|:---:|:---:|
-//! |Spawn a new entity|[`Commands::spawn`]|[`World::spawn`]|
-//! |Spawn an entity with components|[`Commands::spawn_bundle`]|---|
+//! |Spawn a new entity|[`DeferredCommands::spawn`]|[`World::spawn`]|
+//! |Spawn an entity with components|[`DeferredCommands::spawn_bundle`]|---|
 //! |Despawn an entity|[`EntityCommands::despawn`]|[`World::despawn`]|
 //! |Insert a component to an entity|[`EntityCommands::insert`]|[`EntityMut::insert`]|
 //! |Insert multiple components to an entity|[`EntityCommands::insert_bundle`]|[`EntityMut::insert_bundle`]|
 //! |Remove a component from an entity|[`EntityCommands::remove`]|[`EntityMut::remove`]|
 //!
 //! [`World`]: crate::world::World
-//! [`Commands::spawn`]: crate::system::Commands::spawn
-//! [`Commands::spawn_bundle`]: crate::system::Commands::spawn_bundle
+//! [`DeferredCommands::spawn`]: crate::system::DeferredCommands::spawn
+//! [`DeferredCommands::spawn_bundle`]: crate::system::DeferredCommands::spawn_bundle
 //! [`EntityCommands::despawn`]: crate::system::EntityCommands::despawn
 //! [`EntityCommands::insert`]: crate::system::EntityCommands::insert
 //! [`EntityCommands::insert_bundle`]: crate::system::EntityCommands::insert_bundle
@@ -70,7 +70,7 @@ type IdCursor = isize;
 /// ```
 /// # use bevy_ecs::prelude::*;
 /// #
-/// fn setup(mut commands: Commands) {
+/// fn setup(mut commands: DeferredCommands) {
 ///     // Calling `spawn` returns `EntityCommands`.
 ///     let entity = commands.spawn().id();
 /// }
@@ -92,7 +92,7 @@ type IdCursor = isize;
 /// # #[derive(Component)]
 /// # struct Expired;
 /// #
-/// fn dispose_expired_food(mut commands: Commands, query: Query<Entity, With<Expired>>) {
+/// fn dispose_expired_food(mut commands: DeferredCommands, query: Query<Entity, With<Expired>>) {
 ///     for food_entity in &query {
 ///         commands.entity(food_entity).despawn();
 ///     }
@@ -124,7 +124,7 @@ impl Entity {
     /// # Note
     ///
     /// Spawning a specific `entity` value is __rarely the right choice__. Most apps should favor
-    /// [`Commands::spawn`](crate::system::Commands::spawn). This method should generally
+    /// [`DeferredCommands::spawn`](crate::system::DeferredCommands::spawn). This method should generally
     /// only be used for sharing entities across apps, and only when they have a scheme
     /// worked out to share an ID space (which doesn't happen by default).
     ///

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -281,7 +281,7 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
 /// # use bevy_ecs::{prelude::*, event::Events};
 ///
 /// # pub struct MyEvent;
-/// fn send_untyped(mut commands: Commands) {
+/// fn send_untyped(mut commands: DeferredCommands) {
 ///     // Send an event of a specific type without having to declare that
 ///     // type as a SystemParam.
 ///     //

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -39,7 +39,7 @@ pub mod prelude {
             SystemLabel, SystemSet, SystemStage,
         },
         system::{
-            adapter as system_adapter, Commands, In, IntoChainSystem, IntoExclusiveSystem,
+            adapter as system_adapter, DeferredCommands, In, IntoChainSystem, IntoExclusiveSystem,
             IntoSystem, Local, NonSend, NonSendMut, ParallelCommands, ParamSet, Query,
             RemovedComponents, Res, ResMut, Resource, System, SystemParamFunction,
         },

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -1521,7 +1521,7 @@ mod tests {
             }
         }
 
-        fn spawn_entity(mut commands: crate::prelude::Commands) {
+        fn spawn_entity(mut commands: crate::prelude::DeferredCommands) {
             commands.spawn().insert(Foo);
         }
 
@@ -1563,7 +1563,7 @@ mod tests {
             }
         }
 
-        fn spawn_entity(mut commands: crate::prelude::Commands) {
+        fn spawn_entity(mut commands: crate::prelude::DeferredCommands) {
             commands.spawn().insert(Foo);
         }
 

--- a/crates/bevy_ecs/src/system/commands/command_queue.rs
+++ b/crates/bevy_ecs/src/system/commands/command_queue.rs
@@ -35,7 +35,7 @@ impl CommandQueue {
         C: Command,
     {
         /// SAFETY: This function is only every called when the `command` bytes is the associated
-        /// [`Commands`] `T` type. Also this only reads the data via `read_unaligned` so unaligned
+        /// [`Command`] `T` type. Also this only reads the data via `read_unaligned` so unaligned
         /// accesses are safe.
         unsafe fn write_command<T: Command>(command: *mut MaybeUninit<u8>, world: &mut World) {
             let command = command.cast::<T>().read_unaligned();

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -16,7 +16,7 @@ use super::Resource;
 
 /// A [`World`] mutation.
 ///
-/// Should be used with [`Commands::add`].
+/// Should be used with [`DeferredCommands::add`].
 ///
 /// # Usage
 ///
@@ -37,7 +37,7 @@ use super::Resource;
 ///     }
 /// }
 ///
-/// fn some_system(mut commands: Commands) {
+/// fn some_system(mut commands: DeferredCommands) {
 ///     commands.add(AddToCounter(42));
 /// }
 /// ```
@@ -57,13 +57,13 @@ pub trait Command: Send + Sync + 'static {
 ///
 /// # Usage
 ///
-/// Add `mut commands: Commands` as a function argument to your system to get a copy of this struct that will be applied at the end of the current stage.
-/// Commands are almost always used as a [`SystemParam`](crate::system::SystemParam).
+/// Add `mut commands: DeferredCommands` as a function argument to your system to get a copy of this struct that will be applied at the end of the current stage.
+/// `DeferredCommands` are almost always used as a [`SystemParam`](crate::system::SystemParam).
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
 /// #
-/// fn my_system(mut commands: Commands) {
+/// fn my_system(mut commands: DeferredCommands) {
 ///    // ...
 /// }
 /// # bevy_ecs::system::assert_is_system(my_system);
@@ -73,14 +73,14 @@ pub trait Command: Send + Sync + 'static {
 ///
 /// Each built-in command is implemented as a separate method, e.g. [`spawn`](#method.spawn).
 /// In addition to the pre-defined command methods, you can add commands with any arbitrary
-/// behavior using [`Commands::add`](#method.add), which accepts any type implementing [`Command`].
+/// behavior using [`DeferredCommands::add`](#method.add), which accepts any type implementing [`Command`].
 ///
 /// Since closures and other functions implement this trait automatically, this allows one-shot,
 /// anonymous custom commands.
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
-/// # fn foo(mut commands: Commands) {
+/// # fn foo(mut commands: DeferredCommands) {
 /// // NOTE: type inference fails here, so annotations are required on the closure.
 /// commands.add(|w: &mut World| {
 ///     // Mutate the world however you want...
@@ -88,13 +88,13 @@ pub trait Command: Send + Sync + 'static {
 /// });
 /// # }
 /// ```
-pub struct Commands<'w, 's> {
+pub struct DeferredCommands<'w, 's> {
     queue: &'s mut CommandQueue,
     entities: &'w Entities,
 }
 
-impl<'w, 's> Commands<'w, 's> {
-    /// Create a new `Commands` from a queue and a world.
+impl<'w, 's> DeferredCommands<'w, 's> {
+    /// Create a new `DeferredCommands` from a queue and a world.
     pub fn new(queue: &'s mut CommandQueue, world: &'w World) -> Self {
         Self {
             queue,
@@ -102,7 +102,7 @@ impl<'w, 's> Commands<'w, 's> {
         }
     }
 
-    /// Create a new `Commands` from a queue and an [`Entities`] reference.
+    /// Create a new `DeferredCommands` from a queue and an [`Entities`] reference.
     pub fn new_from_entities(queue: &'s mut CommandQueue, entities: &'w Entities) -> Self {
         Self { queue, entities }
     }
@@ -126,7 +126,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// #[derive(Component)]
     /// struct Agility(u32);
     ///
-    /// fn example_system(mut commands: Commands) {
+    /// fn example_system(mut commands: DeferredCommands) {
     ///     // Create a new empty entity and retrieve its id.
     ///     let empty_entity = commands.spawn().id();
     ///
@@ -152,7 +152,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///
     /// # Note
     /// Spawning a specific `entity` value is rarely the right choice. Most apps should favor
-    /// [`Commands::spawn`]. This method should generally only be used for sharing entities across
+    /// [`DeferredCommands::spawn`]. This method should generally only be used for sharing entities across
     /// apps, and only when they have a scheme worked out to share an ID space (which doesn't happen
     /// by default).
     pub fn get_or_spawn<'a>(&'a mut self, entity: Entity) -> EntityCommands<'w, 's, 'a> {
@@ -194,7 +194,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///     b: Component2,
     /// }
     ///
-    /// fn example_system(mut commands: Commands) {
+    /// fn example_system(mut commands: DeferredCommands) {
     ///     // Create a new entity with a component bundle.
     ///     commands.spawn_bundle(ExampleBundle {
     ///         a: Component1,
@@ -231,7 +231,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// #[derive(Component)]
     /// struct Agility(u32);
 
-    /// fn example_system(mut commands: Commands) {
+    /// fn example_system(mut commands: DeferredCommands) {
     ///     // Create a new, empty entity
     ///     let entity = commands.spawn().id();
     ///
@@ -265,7 +265,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// #[derive(Component)]
     /// struct Label(&'static str);
 
-    /// fn example_system(mut commands: Commands) {
+    /// fn example_system(mut commands: DeferredCommands) {
     ///     // Create a new, empty entity
     ///     let entity = commands.spawn().id();
     ///
@@ -303,7 +303,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// # #[derive(Component)]
     /// # struct Score(u32);
     /// #
-    /// # fn system(mut commands: Commands) {
+    /// # fn system(mut commands: DeferredCommands) {
     /// commands.spawn_batch(vec![
     ///     (
     ///         Name("Alice".to_string()),
@@ -332,7 +332,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///
     /// # Note
     ///
-    /// Spawning a specific `entity` value is rarely the right choice. Most apps should use [`Commands::spawn_batch`].
+    /// Spawning a specific `entity` value is rarely the right choice. Most apps should use [`DeferredCommands::spawn_batch`].
     /// This method should generally only be used for sharing entities across apps, and only when they have a scheme
     /// worked out to share an ID space (which doesn't happen by default).
     pub fn insert_or_spawn_batch<I, B>(&mut self, bundles_iter: I)
@@ -367,7 +367,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// #     high_score: u32,
     /// # }
     /// #
-    /// # fn initialise_scoreboard(mut commands: Commands) {
+    /// # fn initialise_scoreboard(mut commands: DeferredCommands) {
     /// commands.init_resource::<Scoreboard>();
     /// # }
     /// # bevy_ecs::system::assert_is_system(initialise_scoreboard);
@@ -395,7 +395,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// #     high_score: u32,
     /// # }
     /// #
-    /// # fn system(mut commands: Commands) {
+    /// # fn system(mut commands: DeferredCommands) {
     /// commands.insert_resource(Scoreboard {
     ///     current_score: 0,
     ///     high_score: 0,
@@ -422,7 +422,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// #     high_score: u32,
     /// # }
     /// #
-    /// # fn system(mut commands: Commands) {
+    /// # fn system(mut commands: DeferredCommands) {
     /// commands.remove_resource::<Scoreboard>();
     /// # }
     /// # bevy_ecs::system::assert_is_system(system);
@@ -454,10 +454,10 @@ impl<'w, 's> Commands<'w, 's> {
     ///     }
     /// }
     ///
-    /// fn add_three_to_counter_system(mut commands: Commands) {
+    /// fn add_three_to_counter_system(mut commands: DeferredCommands) {
     ///     commands.add(AddToCounter(3));
     /// }
-    /// fn add_twenty_five_to_counter_system(mut commands: Commands) {
+    /// fn add_twenty_five_to_counter_system(mut commands: DeferredCommands) {
     ///     commands.add(|world: &mut World| {
     ///         let mut counter = world.get_resource_or_insert_with(Counter::default);
     ///         counter.0 += 25;
@@ -475,7 +475,7 @@ impl<'w, 's> Commands<'w, 's> {
 /// A list of commands that will be run to modify an [entity](crate::entity).
 pub struct EntityCommands<'w, 's, 'a> {
     entity: Entity,
-    commands: &'a mut Commands<'w, 's>,
+    commands: &'a mut DeferredCommands<'w, 's>,
 }
 
 impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
@@ -486,7 +486,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// ```
     /// # use bevy_ecs::prelude::*;
     /// #
-    /// fn my_system(mut commands: Commands) {
+    /// fn my_system(mut commands: DeferredCommands) {
     ///     let entity_id = commands.spawn().id();
     /// }
     /// # bevy_ecs::system::assert_is_system(my_system);
@@ -520,7 +520,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// #     defense: Defense,
     /// # }
     /// #
-    /// fn add_combat_stats_system(mut commands: Commands, player: Res<PlayerEntity>) {
+    /// fn add_combat_stats_system(mut commands: DeferredCommands, player: Res<PlayerEntity>) {
     ///     commands.entity(player.entity).insert_bundle(CombatBundle {
     ///         health: Health(100),
     ///         strength: Strength(40),
@@ -541,7 +541,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     ///
     /// # Example
     ///
-    /// `Self::insert` can be chained with [`Commands::spawn`].
+    /// `Self::insert` can be chained with [`DeferredCommands::spawn`].
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
@@ -551,7 +551,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// # #[derive(Component)]
     /// # struct Component2;
     /// #
-    /// fn example_system(mut commands: Commands) {
+    /// fn example_system(mut commands: DeferredCommands) {
     ///     // Create a new entity with `Component1` and `Component2`
     ///     commands.spawn()
     ///         .insert(Component1)
@@ -589,7 +589,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// # #[derive(Bundle)]
     /// # struct CombatBundle { a: Dummy }; // dummy field, unit bundles are not permitted.
     /// #
-    /// fn remove_combat_stats_system(mut commands: Commands, player: Res<PlayerEntity>) {
+    /// fn remove_combat_stats_system(mut commands: DeferredCommands, player: Res<PlayerEntity>) {
     ///     commands.entity(player.entity).remove_bundle::<CombatBundle>();
     /// }
     /// # bevy_ecs::system::assert_is_system(remove_combat_stats_system);
@@ -619,7 +619,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// # #[derive(Component)]
     /// # struct Enemy;
     /// #
-    /// fn convert_enemy_system(mut commands: Commands, enemy: Res<TargetEnemy>) {
+    /// fn convert_enemy_system(mut commands: DeferredCommands, enemy: Res<TargetEnemy>) {
     ///     commands.entity(enemy.entity).remove::<Enemy>();
     /// }
     /// # bevy_ecs::system::assert_is_system(convert_enemy_system);
@@ -648,7 +648,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// # struct CharacterToRemove { entity: Entity }
     /// #
     /// fn remove_character_system(
-    ///     mut commands: Commands,
+    ///     mut commands: DeferredCommands,
     ///     character_to_remove: Res<CharacterToRemove>
     /// )
     /// {
@@ -669,8 +669,8 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
         });
     }
 
-    /// Returns the underlying [`Commands`].
-    pub fn commands(&mut self) -> &mut Commands<'w, 's> {
+    /// Returns the underlying [`DeferredCommands`].
+    pub fn commands(&mut self) -> &mut DeferredCommands<'w, 's> {
         self.commands
     }
 }
@@ -890,7 +890,7 @@ mod tests {
     use crate::{
         self as bevy_ecs,
         component::Component,
-        system::{CommandQueue, Commands, Resource},
+        system::{CommandQueue, DeferredCommands, Resource},
         world::World,
     };
     use std::sync::{
@@ -928,7 +928,7 @@ mod tests {
     fn commands() {
         let mut world = World::default();
         let mut command_queue = CommandQueue::default();
-        let entity = Commands::new(&mut command_queue, &world)
+        let entity = DeferredCommands::new(&mut command_queue, &world)
             .spawn_bundle((W(1u32), W(2u64)))
             .id();
         command_queue.apply(&mut world);
@@ -941,7 +941,7 @@ mod tests {
         assert_eq!(results, vec![(1u32, 2u64)]);
         // test entity despawn
         {
-            let mut commands = Commands::new(&mut command_queue, &world);
+            let mut commands = DeferredCommands::new(&mut command_queue, &world);
             commands.entity(entity).despawn();
             commands.entity(entity).despawn(); // double despawn shouldn't panic
         }
@@ -955,7 +955,7 @@ mod tests {
 
         // test adding simple (FnOnce) commands
         {
-            let mut commands = Commands::new(&mut command_queue, &world);
+            let mut commands = DeferredCommands::new(&mut command_queue, &world);
 
             // set up a simple command using a closure that adds one additional entity
             commands.add(|world: &mut World| {
@@ -984,7 +984,7 @@ mod tests {
         let (sparse_dropck, sparse_is_dropped) = DropCk::new_pair();
         let sparse_dropck = SparseDropCk(sparse_dropck);
 
-        let entity = Commands::new(&mut command_queue, &world)
+        let entity = DeferredCommands::new(&mut command_queue, &world)
             .spawn()
             .insert_bundle((W(1u32), W(2u64), dense_dropck, sparse_dropck))
             .id();
@@ -997,7 +997,7 @@ mod tests {
         assert_eq!(results_before, vec![(1u32, 2u64)]);
 
         // test component removal
-        Commands::new(&mut command_queue, &world)
+        DeferredCommands::new(&mut command_queue, &world)
             .entity(entity)
             .remove::<W<u32>>()
             .remove_bundle::<(W<u32>, W<u64>, SparseDropCk, DropCk)>();
@@ -1027,7 +1027,7 @@ mod tests {
         let mut world = World::default();
         let mut queue = CommandQueue::default();
         {
-            let mut commands = Commands::new(&mut queue, &world);
+            let mut commands = DeferredCommands::new(&mut queue, &world);
             commands.insert_resource(W(123i32));
             commands.insert_resource(W(456.0f64));
         }
@@ -1037,7 +1037,7 @@ mod tests {
         assert!(world.contains_resource::<W<f64>>());
 
         {
-            let mut commands = Commands::new(&mut queue, &world);
+            let mut commands = DeferredCommands::new(&mut queue, &world);
             // test resource removal
             commands.remove_resource::<W<i32>>();
         }

--- a/crates/bevy_ecs/src/system/exclusive_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system.rs
@@ -112,7 +112,7 @@ mod tests {
         entity::Entity,
         query::With,
         schedule::{Stage, SystemStage},
-        system::{Commands, IntoExclusiveSystem, Query, ResMut, Resource},
+        system::{DeferredCommands, IntoExclusiveSystem, Query, ResMut, Resource},
         world::World,
     };
 
@@ -127,7 +127,7 @@ mod tests {
         struct Counter(usize);
 
         fn removal(
-            mut commands: Commands,
+            mut commands: DeferredCommands,
             query: Query<Entity, With<Foo>>,
             mut counter: ResMut<Counter>,
         ) {
@@ -157,7 +157,7 @@ mod tests {
         #[derive(Resource, Default)]
         struct CountEntities(Vec<usize>);
 
-        fn spawn_entity(mut commands: crate::prelude::Commands) {
+        fn spawn_entity(mut commands: crate::prelude::DeferredCommands) {
             commands.spawn().insert(Foo(0.0));
         }
 

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -184,7 +184,7 @@ impl<Param: SystemParam> SystemState<Param> {
     }
 
     /// Applies all state queued up for [`SystemParam`] values. For example, this will apply commands queued up
-    /// by a [`Commands`](`super::Commands`) parameter to the given [`World`].
+    /// by a [`DeferredCommands`](`super::DeferredCommands`) parameter to the given [`World`].
     /// This function should be called manually after the values returned by [`SystemState::get`] and [`SystemState::get_mut`]
     /// are finished being used.
     pub fn apply(&mut self, world: &mut World) {

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -51,7 +51,7 @@
 //! - [`Query`]
 //! - [`Res`] and `Option<Res>`
 //! - [`ResMut`] and `Option<ResMut>`
-//! - [`Commands`]
+//! - [`DeferredCommands`]
 //! - [`Local`]
 //! - [`EventReader`](crate::event::EventReader)
 //! - [`EventWriter`](crate::event::EventWriter)
@@ -142,8 +142,8 @@ mod tests {
         query::{Added, Changed, Or, With, Without},
         schedule::{Schedule, Stage, SystemStage},
         system::{
-            Commands, IntoExclusiveSystem, IntoSystem, Local, NonSend, NonSendMut, ParamSet, Query,
-            RemovedComponents, Res, ResMut, Resource, System, SystemState,
+            DeferredCommands, IntoExclusiveSystem, IntoSystem, Local, NonSend, NonSendMut,
+            ParamSet, Query, RemovedComponents, Res, ResMut, Resource, System, SystemState,
         },
         world::{FromWorld, World},
     };
@@ -1170,7 +1170,7 @@ mod tests {
 
         run_system(
             &mut world,
-            move |mut commands_set: ParamSet<(Commands, Commands)>| {
+            move |mut commands_set: ParamSet<(DeferredCommands, DeferredCommands)>| {
                 commands_set.p0().entity(entity).insert(A);
                 commands_set.p1().entity(entity).insert(B);
             },

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -8,7 +8,7 @@ use crate::{
     query::{
         Access, FilteredAccess, FilteredAccessSet, QueryState, ReadOnlyWorldQuery, WorldQuery,
     },
-    system::{CommandQueue, Commands, Query, SystemMeta},
+    system::{CommandQueue, DeferredCommands, Query, SystemMeta},
     world::{FromWorld, World},
 };
 pub use bevy_ecs_macros::Resource;
@@ -547,7 +547,7 @@ impl<'w, 's, T: Resource> SystemParamFetch<'w, 's> for OptionResMutState<T> {
     }
 }
 
-impl<'w, 's> SystemParam for Commands<'w, 's> {
+impl<'w, 's> SystemParam for DeferredCommands<'w, 's> {
     type Fetch = CommandQueue;
 }
 
@@ -566,7 +566,7 @@ unsafe impl SystemParamState for CommandQueue {
 }
 
 impl<'w, 's> SystemParamFetch<'w, 's> for CommandQueue {
-    type Item = Commands<'w, 's>;
+    type Item = DeferredCommands<'w, 's>;
 
     #[inline]
     unsafe fn get_param(
@@ -575,7 +575,7 @@ impl<'w, 's> SystemParamFetch<'w, 's> for CommandQueue {
         world: &'w World,
         _change_tick: u32,
     ) -> Self::Item {
-        Commands::new(state, world)
+        DeferredCommands::new(state, world)
     }
 }
 
@@ -1459,7 +1459,7 @@ pub mod lifetimeless {
     pub type Write<T> = &'static mut T;
     pub type SRes<T> = super::Res<'static, T>;
     pub type SResMut<T> = super::ResMut<'static, T>;
-    pub type SCommands = crate::system::Commands<'static, 'static>;
+    pub type SCommands = crate::system::DeferredCommands<'static, 'static>;
 }
 
 /// A helper for using system parameters in generic contexts

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
     bundle::Bundle,
     entity::Entity,
     event::Events,
-    system::{Command, Commands, EntityCommands},
+    system::{Command, DeferredCommands, EntityCommands},
     world::{EntityMut, World},
 };
 use smallvec::SmallVec;
@@ -180,7 +180,7 @@ impl Command for RemoveChildren {
 
 /// Struct for building children onto an entity
 pub struct ChildBuilder<'w, 's, 'a> {
-    commands: &'a mut Commands<'w, 's>,
+    commands: &'a mut DeferredCommands<'w, 's>,
     push_children: PushChildren,
 }
 
@@ -235,7 +235,7 @@ pub trait BuildChildren {
     /// # #[derive(Component)]
     /// # struct MoreStuff;
     /// #
-    /// # fn foo(mut commands: Commands) {
+    /// # fn foo(mut commands: DeferredCommands) {
     ///     let mut parent_commands = commands.spawn();
     ///     let child_id = parent_commands.add_children(|parent| {
     ///         parent.spawn().id()
@@ -521,7 +521,7 @@ mod tests {
     use bevy_ecs::{
         component::Component,
         entity::Entity,
-        system::{CommandQueue, Commands},
+        system::{CommandQueue, DeferredCommands},
         world::World,
     };
 
@@ -532,7 +532,7 @@ mod tests {
     fn build_children() {
         let mut world = World::default();
         let mut queue = CommandQueue::default();
-        let mut commands = Commands::new(&mut queue, &world);
+        let mut commands = DeferredCommands::new(&mut queue, &world);
 
         let parent = commands.spawn().insert(C(1)).id();
         let children = commands.entity(parent).add_children(|parent| {
@@ -564,7 +564,7 @@ mod tests {
 
         let mut queue = CommandQueue::default();
         {
-            let mut commands = Commands::new(&mut queue, &world);
+            let mut commands = DeferredCommands::new(&mut queue, &world);
             commands.entity(entities[0]).push_children(&entities[1..3]);
         }
         queue.apply(&mut world);
@@ -587,7 +587,7 @@ mod tests {
         assert_eq!(*world.get::<Parent>(child2).unwrap(), Parent(parent));
 
         {
-            let mut commands = Commands::new(&mut queue, &world);
+            let mut commands = DeferredCommands::new(&mut queue, &world);
             commands.entity(parent).insert_children(1, &entities[3..]);
         }
         queue.apply(&mut world);
@@ -602,7 +602,7 @@ mod tests {
 
         let remove_children = [child1, child4];
         {
-            let mut commands = Commands::new(&mut queue, &world);
+            let mut commands = DeferredCommands::new(&mut queue, &world);
             commands.entity(parent).remove_children(&remove_children);
         }
         queue.apply(&mut world);

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -143,7 +143,7 @@ impl<'w> DespawnRecursiveExt for EntityMut<'w> {
 mod tests {
     use bevy_ecs::{
         component::Component,
-        system::{CommandQueue, Commands},
+        system::{CommandQueue, DeferredCommands},
         world::World,
     };
 
@@ -162,7 +162,7 @@ mod tests {
         let mut queue = CommandQueue::default();
         let grandparent_entity;
         {
-            let mut commands = Commands::new(&mut queue, &world);
+            let mut commands = DeferredCommands::new(&mut queue, &world);
 
             commands
                 .spawn_bundle((N("Another parent".to_owned()), Idx(0)))
@@ -200,7 +200,7 @@ mod tests {
         let parent_entity = world.get::<Children>(grandparent_entity).unwrap()[0];
 
         {
-            let mut commands = Commands::new(&mut queue, &world);
+            let mut commands = DeferredCommands::new(&mut queue, &world);
             commands.entity(parent_entity).despawn_recursive();
             // despawning the same entity twice should not panic
             commands.entity(parent_entity).despawn_recursive();

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -216,7 +216,7 @@ impl Plugin for PbrPlugin {
             )
             .add_system_to_stage(
                 RenderStage::Prepare,
-                // this is added as an exclusive system because it contributes new views. it must run (and have Commands applied)
+                // this is added as an exclusive system because it contributes new views. it must run (and have `Command`s applied)
                 // _before_ the `prepare_views()` system is run. ideally this becomes a normal system when "stageless" features come out
                 render::prepare_lights
                     .exclusive_system()

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -459,7 +459,7 @@ fn clip_to_view(inverse_projection: Mat4, clip: Vec4) -> Vec4 {
 }
 
 pub fn add_clusters(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     cameras: Query<(Entity, Option<&ClusterConfig>), (With<Camera>, Without<Clusters>)>,
 ) {
     for (entity, config) in &cameras {
@@ -793,7 +793,7 @@ impl GlobalVisiblePointLights {
 // NOTE: Run this before update_point_light_frusta!
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn assign_lights_to_clusters(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut global_lights: ResMut<GlobalVisiblePointLights>,
     mut views: Query<(
         Entity,

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -13,7 +13,7 @@ use bevy_ecs::{
     schedule::ParallelSystemDescriptorCoercion,
     system::{
         lifetimeless::{Read, SQuery, SRes},
-        Commands, Local, Query, Res, ResMut, Resource, SystemParamItem,
+        DeferredCommands, Local, Query, Res, ResMut, Resource, SystemParamItem,
     },
     world::FromWorld,
 };
@@ -84,7 +84,7 @@ use std::marker::PhantomData;
 /// }
 ///
 /// // Spawn an entity using `CustomMaterial`.
-/// fn setup(mut commands: Commands, mut materials: ResMut<Assets<CustomMaterial>>, asset_server: Res<AssetServer>) {
+/// fn setup(mut commands: DeferredCommands, mut materials: ResMut<Assets<CustomMaterial>>, asset_server: Res<AssetServer>) {
 ///     commands.spawn_bundle(MaterialMeshBundle {
 ///         material: materials.add(CustomMaterial {
 ///             color: Color::RED,
@@ -464,7 +464,7 @@ impl<T: Material> Default for RenderMaterials<T> {
 /// This system extracts all created or modified assets of the corresponding [`Material`] type
 /// into the "render world".
 fn extract_materials<M: Material>(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut events: Extract<EventReader<AssetEvent<M>>>,
     assets: Extract<Res<Assets<M>>>,
 ) {

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -390,7 +390,7 @@ pub struct ExtractedClustersPointLights {
 }
 
 pub fn extract_clusters(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     views: Extract<Query<(Entity, &Clusters), With<Camera>>>,
 ) {
     for (entity, clusters) in views.iter() {
@@ -409,7 +409,7 @@ pub fn extract_clusters(
 
 #[allow(clippy::too_many_arguments)]
 pub fn extract_lights(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     point_light_shadow_map: Extract<Res<PointLightShadowMap>>,
     directional_light_shadow_map: Extract<Res<DirectionalLightShadowMap>>,
     global_point_lights: Extract<Res<GlobalVisiblePointLights>>,
@@ -758,7 +758,7 @@ pub(crate) fn spot_light_projection_matrix(angle: f32) -> Mat4 {
 
 #[allow(clippy::too_many_arguments)]
 pub fn prepare_lights(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut texture_cache: ResMut<TextureCache>,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
@@ -1492,7 +1492,7 @@ impl ViewClusterBindings {
 }
 
 pub fn prepare_clusters(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
     mesh_pipeline: Res<MeshPipeline>,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -126,7 +126,7 @@ bitflags::bitflags! {
 }
 
 pub fn extract_meshes(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut prev_caster_commands_len: Local<usize>,
     mut prev_not_caster_commands_len: Local<usize>,
     meshes_query: Extract<
@@ -218,7 +218,7 @@ impl SkinnedMeshJoints {
 }
 
 pub fn extract_skinned_meshes(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut previous_len: Local<usize>,
     mut previous_joint_len: Local<usize>,
     query: Extract<Query<(Entity, &ComputedVisibility, &SkinnedMesh)>>,
@@ -665,7 +665,7 @@ pub struct MeshBindGroup {
 }
 
 pub fn queue_mesh_bind_group(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mesh_pipeline: Res<MeshPipeline>,
     render_device: Res<RenderDevice>,
     mesh_uniforms: Res<ComponentUniforms<MeshUniform>>,
@@ -756,7 +756,7 @@ pub struct MeshViewBindGroup {
 
 #[allow(clippy::too_many_arguments)]
 pub fn queue_mesh_view_bind_groups(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     render_device: Res<RenderDevice>,
     mesh_pipeline: Res<MeshPipeline>,
     shadow_pipeline: Res<ShadowPipeline>,

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -51,7 +51,10 @@ impl Plugin for WireframePlugin {
     }
 }
 
-fn extract_wireframes(mut commands: Commands, query: Extract<Query<Entity, With<Wireframe>>>) {
+fn extract_wireframes(
+    mut commands: DeferredCommands,
+    query: Extract<Query<Entity, With<Wireframe>>>,
+) {
     for entity in query.iter() {
         commands.get_or_spawn(entity).insert(Wireframe);
     }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -15,7 +15,7 @@ use bevy_ecs::{
     event::EventReader,
     query::Added,
     reflect::ReflectComponent,
-    system::{Commands, ParamSet, Query, Res},
+    system::{DeferredCommands, ParamSet, Query, Res},
 };
 use bevy_math::{Mat4, UVec2, Vec2, Vec3};
 use bevy_reflect::prelude::*;
@@ -403,7 +403,7 @@ pub struct ExtractedCamera {
 }
 
 pub fn extract_cameras(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     query: Extract<
         Query<(
             Entity,

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -101,7 +101,7 @@ impl<C: Component + ShaderType> Default for ComponentUniforms<C> {
 /// This system prepares all components of the corresponding component type.
 /// They are transformed into uniforms and stored in the [`ComponentUniforms`] resource.
 fn prepare_uniform_components<C: Component>(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
     mut component_uniforms: ResMut<ComponentUniforms<C>>,
@@ -181,7 +181,7 @@ impl<T: Asset> ExtractComponent for Handle<T> {
 
 /// This system extracts all components of the corresponding [`ExtractComponent`] type.
 fn extract_components<C: ExtractComponent>(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut previous_len: Local<usize>,
     mut query: Extract<Query<(Entity, C::Query), C::Filter>>,
 ) {
@@ -195,7 +195,7 @@ fn extract_components<C: ExtractComponent>(
 
 /// This system extracts all visible components of the corresponding [`ExtractComponent`] type.
 fn extract_visible_components<C: ExtractComponent>(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut previous_len: Local<usize>,
     mut query: Extract<Query<(Entity, &ComputedVisibility, C::Query), C::Filter>>,
 ) {

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -33,7 +33,7 @@ use std::ops::{Deref, DerefMut};
 /// use bevy_render::Extract;
 /// # #[derive(Component)]
 /// # struct Cloud;
-/// fn extract_clouds(mut commands: Commands, clouds: Extract<Query<Entity, With<Cloud>>>) {
+/// fn extract_clouds(mut commands: DeferredCommands, clouds: Extract<Query<Entity, With<Cloud>>>) {
 ///     for cloud in clouds.iter() {
 ///         commands.get_or_spawn(cloud).insert(Cloud);
 ///     }

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use bevy_app::{App, Plugin};
 #[cfg(debug_assertions)]
 use bevy_ecs::system::Local;
-use bevy_ecs::system::{Commands, Res, ResMut, Resource};
+use bevy_ecs::system::{DeferredCommands, Res, ResMut, Resource};
 pub use bevy_render_macros::ExtractResource;
 
 use crate::{Extract, RenderApp, RenderStage};
@@ -41,7 +41,7 @@ impl<R: ExtractResource> Plugin for ExtractResourcePlugin<R> {
 
 /// This system extracts the resource of the corresponding [`Resource`] type
 pub fn extract_resource<R: ExtractResource>(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     main_resource: Extract<Res<R::Source>>,
     target_resource: Option<ResMut<R>>,
     #[cfg(debug_assertions)] mut has_warned_on_remove: Local<bool>,
@@ -55,7 +55,7 @@ pub fn extract_resource<R: ExtractResource>(
         if !main_resource.is_added() && !*has_warned_on_remove {
             *has_warned_on_remove = true;
             bevy_log::warn!(
-                "Removing resource {} from render world not expected, adding using `Commands`.
+                "Removing resource {} from render world not expected, adding using `DeferredCommands`.
                 This may decrease performance",
                 std::any::type_name::<R>()
             );

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -350,7 +350,7 @@ fn extract(app_world: &mut World, render_app: &mut App) {
     let scratch_world = std::mem::replace(app_world, inserted_world.0);
     app_world.insert_resource(ScratchMainWorld(scratch_world));
 
-    // Note: We apply buffers (read, Commands) after the `MainWorld` has been removed from the render app's world
+    // Note: We apply buffers (read, DeferredCommands) after the `MainWorld` has been removed from the render app's world
     // so that in future, pipelining will be able to do this too without any code relying on it.
     // see <https://github.com/bevyengine/bevy/issues/5082>
     extract.apply_buffers(running_world);

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -131,7 +131,7 @@ impl<A: RenderAsset> Default for RenderAssets<A> {
 /// This system extracts all crated or modified assets of the corresponding [`RenderAsset`] type
 /// into the "render world".
 fn extract_render_asset<A: RenderAsset>(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut events: Extract<EventReader<AssetEvent<A>>>,
     assets: Extract<Res<Assets<A>>>,
 ) {

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -142,7 +142,7 @@ pub struct ViewDepthTexture {
 }
 
 fn prepare_view_uniforms(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
     mut view_uniforms: ResMut<ViewUniforms>,
@@ -178,7 +178,7 @@ fn prepare_view_uniforms(
 
 #[allow(clippy::too_many_arguments)]
 fn prepare_view_targets(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     windows: Res<ExtractedWindows>,
     images: Res<RenderAssets<Image>>,
     msaa: Res<Msaa>,

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -224,7 +224,7 @@ impl Plugin for VisibilityPlugin {
 }
 
 pub fn calculate_bounds(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     meshes: Res<Assets<Mesh>>,
     without_aabb: Query<(Entity, &Handle<Mesh>), (Without<Aabb>, Without<NoFrustumCulling>)>,
 ) {

--- a/crates/bevy_scene/src/bundle.rs
+++ b/crates/bevy_scene/src/bundle.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     change_detection::ResMut,
     entity::Entity,
     prelude::{Changed, Component, Without},
-    system::{Commands, Query},
+    system::{DeferredCommands, Query},
 };
 use bevy_render::prelude::{ComputedVisibility, Visibility};
 use bevy_transform::components::{GlobalTransform, Transform};
@@ -47,7 +47,7 @@ pub struct DynamicSceneBundle {
 
 /// System that will spawn scenes from [`SceneBundle`].
 pub fn scene_spawner(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut scene_to_spawn: Query<
         (Entity, &Handle<Scene>, Option<&mut SceneInstance>),
         (Changed<Handle<Scene>>, Without<Handle<DynamicScene>>),

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
     schedule::ParallelSystemDescriptorCoercion,
     system::{
         lifetimeless::{Read, SQuery, SRes},
-        Commands, Local, Query, Res, ResMut, Resource, SystemParamItem,
+        DeferredCommands, Local, Query, Res, ResMut, Resource, SystemParamItem,
     },
     world::FromWorld,
 };
@@ -87,7 +87,7 @@ use crate::{
 /// }
 ///
 /// // Spawn an entity using `CustomMaterial`.
-/// fn setup(mut commands: Commands, mut materials: ResMut<Assets<CustomMaterial>>, asset_server: Res<AssetServer>) {
+/// fn setup(mut commands: DeferredCommands, mut materials: ResMut<Assets<CustomMaterial>>, asset_server: Res<AssetServer>) {
 ///     commands.spawn_bundle(MaterialMesh2dBundle {
 ///         material: materials.add(CustomMaterial {
 ///             color: Color::RED,
@@ -403,7 +403,7 @@ impl<T: Material2d> Default for RenderMaterials2d<T> {
 /// This system extracts all created or modified assets of the corresponding [`Material2d`] type
 /// into the "render world".
 fn extract_materials_2d<M: Material2d>(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut events: Extract<EventReader<AssetEvent<M>>>,
     assets: Extract<Res<Assets<M>>>,
 ) {

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -122,7 +122,7 @@ bitflags::bitflags! {
 }
 
 pub fn extract_mesh2d(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut previous_len: Local<usize>,
     query: Extract<Query<(Entity, &ComputedVisibility, &GlobalTransform, &Mesh2dHandle)>>,
 ) {
@@ -386,7 +386,7 @@ pub struct Mesh2dBindGroup {
 }
 
 pub fn queue_mesh2d_bind_group(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mesh2d_pipeline: Res<Mesh2dPipeline>,
     render_device: Res<RenderDevice>,
     mesh2d_uniforms: Res<ComponentUniforms<Mesh2dUniform>>,
@@ -411,7 +411,7 @@ pub struct Mesh2dViewBindGroup {
 }
 
 pub fn queue_mesh2d_view_bind_groups(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     render_device: Res<RenderDevice>,
     mesh2d_pipeline: Res<Mesh2dPipeline>,
     view_uniforms: Res<ViewUniforms>,

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -351,7 +351,7 @@ pub struct ImageBindGroups {
 
 #[allow(clippy::too_many_arguments)]
 pub fn queue_sprites(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut view_entities: Local<FixedBitSet>,
     draw_functions: Res<DrawFunctions<Transparent2d>>,
     render_device: Res<RenderDevice>,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
     event::EventReader,
     query::Changed,
     reflect::ReflectComponent,
-    system::{Commands, Local, Query, Res, ResMut},
+    system::{DeferredCommands, Local, Query, Res, ResMut},
 };
 use bevy_math::{Vec2, Vec3};
 use bevy_reflect::Reflect;
@@ -147,7 +147,7 @@ pub fn extract_text2d_sprite(
 /// This information is computed by the `TextPipeline` on insertion, then stored.
 #[allow(clippy::too_many_arguments)]
 pub fn update_text2d_layout(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     // Text items which should be reprocessed again, generally when the font hasn't loaded yet.
     mut queue: Local<HashSet<Entity>>,
     mut textures: ResMut<Assets<Image>>,

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -163,7 +163,7 @@ mod test {
 
         // Root entity
         let mut queue = CommandQueue::default();
-        let mut commands = Commands::new(&mut queue, &world);
+        let mut commands = DeferredCommands::new(&mut queue, &world);
         let mut children = Vec::new();
         commands
             .spawn_bundle(TransformBundle::from(Transform::from_xyz(1.0, 0.0, 0.0)))
@@ -207,7 +207,7 @@ mod test {
         let mut children = Vec::new();
         let parent = {
             let mut command_queue = CommandQueue::default();
-            let mut commands = Commands::new(&mut command_queue, &world);
+            let mut commands = DeferredCommands::new(&mut command_queue, &world);
             let parent = commands
                 .spawn()
                 .insert(Transform::from_xyz(1.0, 0.0, 0.0))
@@ -244,7 +244,7 @@ mod test {
         // Parent `e1` to `e2`.
         {
             let mut command_queue = CommandQueue::default();
-            let mut commands = Commands::new(&mut command_queue, &world);
+            let mut commands = DeferredCommands::new(&mut command_queue, &world);
             commands.entity(children[1]).add_child(children[0]);
             command_queue.apply(&mut world);
             schedule.run(&mut world);
@@ -316,7 +316,7 @@ mod test {
         // check the `Children` structure is spawned
         assert_eq!(&**app.world.get::<Children>(parent).unwrap(), &[child]);
         assert_eq!(&**app.world.get::<Children>(child).unwrap(), &[grandchild]);
-        // Note that at this point, the `GlobalTransform`s will not have updated yet, due to `Commands` delay
+        // Note that at this point, the `GlobalTransform`s will not have updated yet, due to `DeferredCommands` delay
         app.update();
 
         let mut state = app.world.query::<&GlobalTransform>();

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -230,7 +230,7 @@ const UI_CAMERA_TRANSFORM_OFFSET: f32 = -0.1;
 pub struct DefaultCameraView(pub Entity);
 
 pub fn extract_default_ui_camera_view<T: Component>(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     query: Extract<Query<(Entity, &Camera, Option<&UiCameraConfig>), With<T>>>,
 ) {
     for (entity, camera, camera_ui) in query.iter() {
@@ -374,7 +374,7 @@ pub struct UiBatch {
 }
 
 pub fn prepare_uinodes(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
     mut ui_meta: ResMut<UiMeta>,

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -6,7 +6,7 @@ use super::Node;
 use bevy_ecs::{
     entity::Entity,
     query::{With, Without},
-    system::{Commands, Query},
+    system::{DeferredCommands, Query},
 };
 use bevy_hierarchy::{Children, Parent};
 use bevy_math::Rect;
@@ -65,7 +65,7 @@ fn update_hierarchy(
 
 /// Updates clipping for all nodes
 pub fn update_clipping_system(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     root_node_query: Query<Entity, (With<Node>, Without<Parent>)>,
     mut node_query: Query<(&Node, &GlobalTransform, &Style, Option<&mut CalculatedClip>)>,
     children_query: Query<&Children>,
@@ -82,7 +82,7 @@ pub fn update_clipping_system(
 }
 
 fn update_clipping(
-    commands: &mut Commands,
+    commands: &mut DeferredCommands,
     children_query: &Query<&Children>,
     node_query: &mut Query<(&Node, &GlobalTransform, &Style, Option<&mut CalculatedClip>)>,
     entity: Entity,
@@ -125,7 +125,7 @@ mod tests {
     use bevy_ecs::{
         component::Component,
         schedule::{Schedule, Stage, StageLabel, SystemStage},
-        system::{CommandQueue, Commands},
+        system::{CommandQueue, DeferredCommands},
         world::World,
     };
     use bevy_hierarchy::BuildChildren;
@@ -157,7 +157,7 @@ mod tests {
     fn test_ui_z_system() {
         let mut world = World::default();
         let mut queue = CommandQueue::default();
-        let mut commands = Commands::new(&mut queue, &world);
+        let mut commands = DeferredCommands::new(&mut queue, &world);
         commands.spawn_bundle(node_with_transform("0"));
 
         commands

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -3,7 +3,7 @@ use bevy_asset::Assets;
 use bevy_ecs::{
     entity::Entity,
     query::{Changed, Or, With},
-    system::{Commands, Local, ParamSet, Query, Res, ResMut},
+    system::{DeferredCommands, Local, ParamSet, Query, Res, ResMut},
 };
 use bevy_math::Vec2;
 use bevy_render::texture::Image;
@@ -38,7 +38,7 @@ pub fn text_constraint(min_size: Val, size: Val, max_size: Val, scale_factor: f6
 /// This information is computed by the `TextPipeline` on insertion, then stored.
 #[allow(clippy::too_many_arguments)]
 pub fn text_system(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut queued_text: Local<QueuedText>,
     mut last_scale_factor: Local<f64>,
     mut textures: ResMut<Assets<Image>>,

--- a/errors/B0003.md
+++ b/errors/B0003.md
@@ -22,19 +22,19 @@ struct MyEntity(Entity);
 #[derive(Component)]
 struct Hello;
 
-fn setup(mut commands: Commands) {
+fn setup(mut commands: DeferredCommands) {
     let entity = commands.spawn().id();
     commands.insert_resource(MyEntity(entity));
 }
 
-fn despawning(mut commands: Commands, entity: Option<Res<MyEntity>>) {
+fn despawning(mut commands: DeferredCommands, entity: Option<Res<MyEntity>>) {
     if let Some(my_entity) = entity {
         commands.entity(my_entity.0).despawn();
         commands.remove_resource::<MyEntity>();
     }
 }
 
-fn use_entity(mut commands: Commands, entity: Option<Res<MyEntity>>) {
+fn use_entity(mut commands: DeferredCommands, entity: Option<Res<MyEntity>>) {
     if let Some(my_entity) = entity {
         commands.entity(my_entity.0).insert(Hello);
     }

--- a/examples/2d/mesh2d.rs
+++ b/examples/2d/mesh2d.rs
@@ -10,7 +10,7 @@ fn main() {
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -39,7 +39,7 @@ fn main() {
 }
 
 fn star(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     // We will add a new Mesh for the star being created
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
@@ -287,7 +287,7 @@ impl Plugin for ColoredMesh2dPlugin {
 
 /// Extract the [`ColoredMesh2d`] marker component into the render app
 pub fn extract_colored_mesh2d(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut previous_len: Local<usize>,
     // When extracting, you must use `Extract` to mark the `SystemParam`s
     // which should be taken from the main world.

--- a/examples/2d/mesh2d_vertex_color_texture.rs
+++ b/examples/2d/mesh2d_vertex_color_texture.rs
@@ -14,7 +14,7 @@ fn main() {
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
     asset_server: Res<AssetServer>,

--- a/examples/2d/move_sprite.rs
+++ b/examples/2d/move_sprite.rs
@@ -16,7 +16,7 @@ enum Direction {
     Down,
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands
         .spawn_bundle(SpriteBundle {

--- a/examples/2d/rotation.rs
+++ b/examples/2d/rotation.rs
@@ -49,7 +49,7 @@ struct RotateToPlayer {
 /// * `Z` axis goes from far to near (`+Z` points towards you, out of the screen)
 ///
 /// The origin is at the center of the screen.
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     let ship_handle = asset_server.load("textures/simplespace/ship_C.png");
     let enemy_a_handle = asset_server.load("textures/simplespace/enemy_A.png");
     let enemy_b_handle = asset_server.load("textures/simplespace/enemy_B.png");

--- a/examples/2d/shapes.rs
+++ b/examples/2d/shapes.rs
@@ -10,7 +10,7 @@ fn main() {
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {

--- a/examples/2d/sprite.rs
+++ b/examples/2d/sprite.rs
@@ -9,7 +9,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands.spawn_bundle(SpriteBundle {
         texture: asset_server.load("branding/icon.png"),

--- a/examples/2d/sprite_flipping.rs
+++ b/examples/2d/sprite_flipping.rs
@@ -9,7 +9,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands.spawn_bundle(SpriteBundle {
         texture: asset_server.load("branding/icon.png"),

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -34,7 +34,7 @@ fn animate_sprite(
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     asset_server: Res<AssetServer>,
     mut texture_atlases: ResMut<Assets<TextureAtlas>>,
 ) {

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -24,7 +24,7 @@ struct AnimateRotation;
 #[derive(Component)]
 struct AnimateScale;
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     let font = asset_server.load("fonts/FiraSans-Bold.ttf");
     let text_style = TextStyle {
         font,

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -43,7 +43,7 @@ fn check_textures(
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     rpg_sprite_handles: Res<RpgSpriteHandles>,
     asset_server: Res<AssetServer>,
     mut texture_atlases: ResMut<Assets<TextureAtlas>>,

--- a/examples/2d/transparency_2d.rs
+++ b/examples/2d/transparency_2d.rs
@@ -10,7 +10,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
 
     let sprite_handle = asset_server.load("branding/icon.png");

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -11,7 +11,7 @@ fn main() {
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -19,7 +19,7 @@ struct Movable;
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/3d/lines.rs
+++ b/examples/3d/lines.rs
@@ -22,7 +22,7 @@ fn main() {
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<LineMaterial>>,
 ) {

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -16,7 +16,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera3dBundle {
         transform: Transform::from_xyz(0.7, 0.7, 1.0).looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
         ..default()

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -19,7 +19,7 @@ fn main() {
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -11,7 +11,7 @@ fn main() {
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -24,7 +24,7 @@ fn rotator_system(time: Res<Time>, mut query: Query<&mut Transform, With<Rotator
 
 /// set up a simple scene with a "parent" cube and a "child" cube
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -11,7 +11,7 @@ fn main() {
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -32,7 +32,7 @@ struct FirstPassCube;
 struct MainPassCube;
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut images: ResMut<Assets<Image>>,

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -29,7 +29,7 @@ fn main() {
 
 /// set up a 3D scene to test shadow biases and perspective projections
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/3d/shadow_caster_receiver.rs
+++ b/examples/3d/shadow_caster_receiver.rs
@@ -24,7 +24,7 @@ fn main() {
 
 /// set up a 3D scene to test shadow biases and perspective projections
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
@@ -149,7 +149,7 @@ fn toggle_light(
 }
 
 fn toggle_shadows(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     input: Res<Input<KeyCode>>,
     mut queries: ParamSet<(
         Query<Entity, (With<Handle<Mesh>>, With<NotShadowCaster>)>,

--- a/examples/3d/shapes.rs
+++ b/examples/3d/shapes.rs
@@ -24,7 +24,7 @@ struct Shape;
 const X_EXTENT: f32 = 14.;
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut images: ResMut<Assets<Image>>,
     mut materials: ResMut<Assets<StandardMaterial>>,

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -61,7 +61,7 @@ struct Cubemap {
     image_handle: Handle<Image>,
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     // directional 'sun' light
     commands.spawn_bundle(DirectionalLightBundle {
         directional_light: DirectionalLight {
@@ -139,7 +139,7 @@ fn cycle_cubemap_asset(
 }
 
 fn asset_loaded(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     asset_server: Res<AssetServer>,
     mut images: ResMut<Assets<Image>>,
     mut meshes: ResMut<Assets<Mesh>>,

--- a/examples/3d/spherical_area_lights.rs
+++ b/examples/3d/spherical_area_lights.rs
@@ -11,7 +11,7 @@ fn main() {
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -19,7 +19,7 @@ fn main() {
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     asset_server: Res<AssetServer>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -23,7 +23,7 @@ struct Movable;
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -13,7 +13,7 @@ fn main() {
 
 /// sets up a scene with textured entities
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     asset_server: Res<AssetServer>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,

--- a/examples/3d/transparency_3d.rs
+++ b/examples/3d/transparency_3d.rs
@@ -14,7 +14,7 @@ fn main() {
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/3d/two_passes.rs
+++ b/examples/3d/two_passes.rs
@@ -11,7 +11,7 @@ fn main() {
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -14,7 +14,7 @@ fn main() {
 #[derive(Component)]
 struct MovedScene;
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_xyz(4.0, 5.0, 4.0),
         ..default()

--- a/examples/3d/vertex_colors.rs
+++ b/examples/3d/vertex_colors.rs
@@ -11,7 +11,7 @@ fn main() {
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -20,7 +20,7 @@ fn main() {
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut wireframe_config: ResMut<WireframeConfig>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,

--- a/examples/android/android.rs
+++ b/examples/android/android.rs
@@ -20,7 +20,7 @@ fn main() {
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -21,7 +21,7 @@ fn main() {
 struct Animations(Vec<Handle<AnimationClip>>);
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     asset_server: Res<AssetServer>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -16,7 +16,7 @@ fn main() {
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut animations: ResMut<Assets<AnimationClip>>,

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -33,7 +33,7 @@ struct AnimatedJoint;
 ///   and mark the second joint to be animated.
 /// It is similar to the scene defined in `models/SimpleSkin/SimpleSkin.gltf`
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut skinned_mesh_inverse_bindposes_assets: ResMut<Assets<SkinnedMeshInverseBindposes>>,

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -17,7 +17,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     // Create a camera
     commands.spawn_bundle(Camera3dBundle {
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),

--- a/examples/app/without_winit.rs
+++ b/examples/app/without_winit.rs
@@ -10,6 +10,6 @@ fn main() {
         .run();
 }
 
-fn setup_system(mut commands: Commands) {
+fn setup_system(mut commands: DeferredCommands) {
     commands.spawn_bundle(Camera3dBundle::default());
 }

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -10,7 +10,7 @@ fn main() {
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     asset_server: Res<AssetServer>,
     meshes: Res<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,

--- a/examples/asset/custom_asset_io.rs
+++ b/examples/asset/custom_asset_io.rs
@@ -84,7 +84,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands.spawn_bundle(SpriteBundle {
         texture: asset_server.load("branding/icon.png"),

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -16,7 +16,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     // Load our mesh:
     let scene_handle = asset_server.load("models/monkey/Monkey.gltf#Scene0");
 

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -33,7 +33,7 @@ struct BoxMaterialHandle(Handle<StandardMaterial>);
 /// Resources, and stores their handles as resources so we can access
 /// them later when we're ready to render our Boxes
 fn add_assets(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
@@ -51,7 +51,7 @@ struct ComputeTransform(Task<Transform>);
 /// work that potentially spans multiple frames/ticks. A separate
 /// system, `handle_tasks`, will poll the spawned tasks on subsequent
 /// frames/ticks, and use the results to spawn cubes
-fn spawn_tasks(mut commands: Commands) {
+fn spawn_tasks(mut commands: DeferredCommands) {
     let thread_pool = AsyncComputeTaskPool::get();
     for x in 0..NUM_CUBES {
         for y in 0..NUM_CUBES {
@@ -82,7 +82,7 @@ fn spawn_tasks(mut commands: Commands) {
 /// new [`PbrBundle`] of components to the entity using the result from the task's work, and
 /// removes the task component from the entity.
 fn handle_tasks(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut transform_tasks: Query<(Entity, &mut ComputeTransform)>,
     box_mesh_handle: Res<BoxMeshHandle>,
     box_material_handle: Res<BoxMaterialHandle>,
@@ -104,7 +104,7 @@ fn handle_tasks(
 }
 
 /// This system is only used to setup light and camera for the environment
-fn setup_env(mut commands: Commands) {
+fn setup_env(mut commands: DeferredCommands) {
     // Used to center camera on spawned cubes
     let offset = if NUM_CUBES % 2 == 0 {
         (NUM_CUBES / 2) as f32 - 0.5

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -24,7 +24,7 @@ struct StreamEvent(u32);
 #[derive(Resource, Deref)]
 struct LoadedFont(Handle<Font>);
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
 
     let (tx, rx) = bounded::<u32>(10);
@@ -53,7 +53,7 @@ fn read_stream(receiver: ResMut<StreamReceiver>, mut events: EventWriter<StreamE
 }
 
 fn spawn_text(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut reader: EventReader<StreamEvent>,
     loaded_font: Res<LoadedFont>,
 ) {
@@ -78,7 +78,7 @@ fn spawn_text(
 }
 
 fn move_text(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut texts: Query<(Entity, &mut Transform), With<Text>>,
     time: Res<Time>,
 ) {

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -13,7 +13,7 @@ fn main() {
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     asset_server: Res<AssetServer>,
     audio: Res<Audio>,
     audio_sinks: Res<Assets<AudioSink>>,

--- a/examples/ecs/component_change_detection.rs
+++ b/examples/ecs/component_change_detection.rs
@@ -16,7 +16,7 @@ fn main() {
 #[derive(Component, Debug)]
 struct MyComponent(f64);
 
-fn setup(mut commands: Commands) {
+fn setup(mut commands: DeferredCommands) {
     commands.spawn().insert(MyComponent(0.));
     commands.spawn().insert(Transform::IDENTITY);
 }

--- a/examples/ecs/custom_query_param.rs
+++ b/examples/ecs/custom_query_param.rs
@@ -111,7 +111,7 @@ struct QueryFilter<T: Component, P: Component> {
     _generic_tuple: (With<T>, With<P>),
 }
 
-fn spawn(mut commands: Commands) {
+fn spawn(mut commands: DeferredCommands) {
     commands
         .spawn()
         .insert(ComponentA)

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -143,7 +143,7 @@ fn game_over_system(
 // generally used to create the initial "state" of our game. The only thing that distinguishes a
 // "startup" system from a "normal" system is how it is registered:      Startup:
 // app.add_startup_system(startup_system)      Normal:  app.add_system(normal_system)
-fn startup_system(mut commands: Commands, mut game_state: ResMut<GameState>) {
+fn startup_system(mut commands: DeferredCommands, mut game_state: ResMut<GameState>) {
     // Create our game rules resource
     commands.insert_resource(GameRules {
         max_rounds: 10,
@@ -178,7 +178,7 @@ fn startup_system(mut commands: Commands, mut game_state: ResMut<GameState>) {
 // is not thread safe. Command buffers give us the ability to queue up changes to our World without
 // directly accessing it
 fn new_player_system(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     game_rules: Res<GameRules>,
     mut game_state: ResMut<GameState>,
 ) {
@@ -286,7 +286,7 @@ fn main() {
         // splitting systems between stages, because it gives the scheduling algorithm more
         // opportunities to run systems in parallel.
         // Stages are still necessary, however: end of a stage is a hard sync point
-        // (meaning, no systems are running) where `Commands` issued by systems are processed.
+        // (meaning, no systems are running) where `DeferredCommands` issued by systems are processed.
         // This is required because commands can perform operations that are incompatible with
         // having systems in flight, such as spawning or deleting entities,
         // adding or removing resources, etc.

--- a/examples/ecs/generic_system.rs
+++ b/examples/ecs/generic_system.rs
@@ -49,7 +49,7 @@ fn main() {
         .run();
 }
 
-fn setup_system(mut commands: Commands) {
+fn setup_system(mut commands: DeferredCommands) {
     commands
         .spawn()
         .insert(PrinterTick(Timer::from_seconds(1.0, true)))
@@ -84,7 +84,7 @@ fn transition_to_in_game_system(
 
 // Type arguments on functions come after the function name, but before ordinary arguments.
 // Here, the `Component` trait is a trait bound on T, our generic type
-fn cleanup_system<T: Component>(mut commands: Commands, query: Query<Entity, With<T>>) {
+fn cleanup_system<T: Component>(mut commands: DeferredCommands, query: Query<Entity, With<T>>) {
     for e in &query {
         commands.entity(e).despawn_recursive();
     }

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -12,7 +12,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     let texture = asset_server.load("branding/icon.png");
 
@@ -59,7 +59,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 // A simple system to rotate the root entity, and rotate all its children separately
 fn rotate(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     time: Res<Time>,
     mut parents_query: Query<(Entity, &Children), With<Sprite>>,
     mut transform_query: Query<&mut Transform, With<Sprite>>,

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -51,7 +51,7 @@ struct BodyBundle {
 }
 
 fn generate_bodies(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -6,7 +6,7 @@ use rand::random;
 #[derive(Component, Deref)]
 struct Velocity(Vec2);
 
-fn spawn_system(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn spawn_system(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     let texture = asset_server.load("branding/icon.png");
     for _ in 0..128 {

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -26,7 +26,7 @@ fn main() {
 #[derive(Component)]
 struct MyComponent;
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands
         .spawn_bundle(SpriteBundle {
@@ -38,7 +38,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 fn remove_component(
     time: Res<Time>,
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     query: Query<Entity, With<MyComponent>>,
 ) {
     // After two seconds have passed the `Component` is removed.

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -35,11 +35,11 @@ const NORMAL_BUTTON: Color = Color::rgb(0.15, 0.15, 0.15);
 const HOVERED_BUTTON: Color = Color::rgb(0.25, 0.25, 0.25);
 const PRESSED_BUTTON: Color = Color::rgb(0.35, 0.75, 0.35);
 
-fn setup(mut commands: Commands) {
+fn setup(mut commands: DeferredCommands) {
     commands.spawn_bundle(Camera2dBundle::default());
 }
 
-fn setup_menu(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup_menu(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     let button_entity = commands
         .spawn_bundle(ButtonBundle {
             style: Style {
@@ -92,11 +92,11 @@ fn menu(
     }
 }
 
-fn cleanup_menu(mut commands: Commands, menu_data: Res<MenuData>) {
+fn cleanup_menu(mut commands: DeferredCommands, menu_data: Res<MenuData>) {
     commands.entity(menu_data.button_entity).despawn_recursive();
 }
 
-fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup_game(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(SpriteBundle {
         texture: asset_server.load("branding/icon.png"),
         ..default()

--- a/examples/ecs/system_param.rs
+++ b/examples/ecs/system_param.rs
@@ -33,7 +33,7 @@ impl<'w, 's> PlayerCounter<'w, 's> {
 }
 
 /// Spawn some players to count
-fn spawn(mut commands: Commands) {
+fn spawn(mut commands: DeferredCommands) {
     commands.spawn().insert(Player);
     commands.spawn().insert(Player);
     commands.spawn().insert(Player);

--- a/examples/ecs/timers.rs
+++ b/examples/ecs/timers.rs
@@ -36,7 +36,7 @@ impl Default for Countdown {
     }
 }
 
-fn setup(mut commands: Commands) {
+fn setup(mut commands: DeferredCommands) {
     // Add an entity to the world with a timer
     commands
         .spawn()

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -78,7 +78,7 @@ const RESET_FOCUS: [f32; 3] = [
     BOARD_SIZE_J as f32 / 2.0 - 0.5,
 ];
 
-fn setup_cameras(mut commands: Commands, mut game: ResMut<Game>) {
+fn setup_cameras(mut commands: DeferredCommands, mut game: ResMut<Game>) {
     game.camera_should_focus = Vec3::from(RESET_FOCUS);
     game.camera_is_focus = game.camera_should_focus;
     commands.spawn_bundle(Camera3dBundle {
@@ -92,7 +92,7 @@ fn setup_cameras(mut commands: Commands, mut game: ResMut<Game>) {
     });
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMut<Game>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>, mut game: ResMut<Game>) {
     // reset the game state
     game.cake_eaten = 0;
     game.score = 0;
@@ -174,7 +174,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
 }
 
 // remove all entities that are not a camera
-fn teardown(mut commands: Commands, entities: Query<Entity, Without<Camera>>) {
+fn teardown(mut commands: DeferredCommands, entities: Query<Entity, Without<Camera>>) {
     for entity in &entities {
         commands.entity(entity).despawn_recursive();
     }
@@ -182,7 +182,7 @@ fn teardown(mut commands: Commands, entities: Query<Entity, Without<Camera>>) {
 
 // control the game character
 fn move_player(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     keyboard_input: Res<Input<KeyCode>>,
     mut game: ResMut<Game>,
     mut transforms: Query<&mut Transform>,
@@ -292,7 +292,7 @@ fn focus_camera(
 // despawn the bonus if there is one, then spawn a new one at a random location
 fn spawn_bonus(
     mut state: ResMut<State<GameState>>,
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut game: ResMut<Game>,
 ) {
     if *state.current() != GameState::Playing {
@@ -370,7 +370,7 @@ fn gameover_keyboard(mut state: ResMut<State<GameState>>, keyboard_input: Res<In
 }
 
 // display the number of cake eaten before losing
-fn display_score(mut commands: Commands, asset_server: Res<AssetServer>, game: Res<Game>) {
+fn display_score(mut commands: DeferredCommands, asset_server: Res<AssetServer>, game: Res<Game>) {
     commands
         .spawn_bundle(NodeBundle {
             style: Style {

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -173,7 +173,7 @@ struct Scoreboard {
 
 // Add the game's entities to our world
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
     asset_server: Res<AssetServer>,
@@ -350,7 +350,7 @@ fn update_scoreboard(scoreboard: Res<Scoreboard>, mut query: Query<&mut Text>) {
 }
 
 fn check_for_collisions(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut scoreboard: ResMut<Scoreboard>,
     mut ball_query: Query<(&mut Velocity, &Transform), With<Ball>>,
     collider_query: Query<(Entity, &Transform, Option<&Brick>), With<Collider>>,

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -73,7 +73,7 @@ const SHOWCASE_TIMER_SECS: f32 = 3.0;
 
 const CONTRIBUTORS_LIST: &[&str] = &["Carter Anderson", "And Many More"];
 
-fn setup_contributor_selection(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup_contributor_selection(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     // Load contributors from the git history log or use default values from
     // the constant array. Contributors must be unique, so they are stored in a HashSet
     let contribs = contributors().unwrap_or_else(|_| {
@@ -133,7 +133,7 @@ fn setup_contributor_selection(mut commands: Commands, asset_server: Res<AssetSe
     commands.insert_resource(contributor_selection);
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
 
     commands.spawn().insert(ContributorDisplay).insert_bundle(

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -42,7 +42,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands) {
+fn setup(mut commands: DeferredCommands) {
     commands.spawn_bundle(Camera2dBundle::default());
 }
 
@@ -78,7 +78,7 @@ mod splash {
     #[derive(Resource, Deref, DerefMut)]
     struct SplashTimer(Timer);
 
-    fn splash_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    fn splash_setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
         let icon = asset_server.load("branding/icon.png");
         // Display the logo
         commands
@@ -137,7 +137,7 @@ mod game {
     struct GameTimer(Timer);
 
     fn game_setup(
-        mut commands: Commands,
+        mut commands: DeferredCommands,
         asset_server: Res<AssetServer>,
         display_quality: Res<DisplayQuality>,
         volume: Res<Volume>,
@@ -365,7 +365,7 @@ mod menu {
     fn setting_button<T: Resource + Component + PartialEq + Copy>(
         interaction_query: Query<(&Interaction, &T, Entity), (Changed<Interaction>, With<Button>)>,
         mut selected_query: Query<(Entity, &mut UiColor), With<SelectedOption>>,
-        mut commands: Commands,
+        mut commands: DeferredCommands,
         mut setting: ResMut<T>,
     ) {
         for (interaction, button_setting, entity) in &interaction_query {
@@ -383,7 +383,7 @@ mod menu {
         let _ = menu_state.set(MenuState::Main);
     }
 
-    fn main_menu_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    fn main_menu_setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
         let font = asset_server.load("fonts/FiraSans-Bold.ttf");
         // Common style for all buttons on the screen
         let button_style = Style {
@@ -502,7 +502,7 @@ mod menu {
             });
     }
 
-    fn settings_menu_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    fn settings_menu_setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
         let button_style = Style {
             size: Size::new(Val::Px(200.0), Val::Px(65.0)),
             margin: UiRect::all(Val::Px(20.0)),
@@ -553,7 +553,7 @@ mod menu {
     }
 
     fn display_settings_menu_setup(
-        mut commands: Commands,
+        mut commands: DeferredCommands,
         asset_server: Res<AssetServer>,
         display_quality: Res<DisplayQuality>,
     ) {
@@ -640,7 +640,7 @@ mod menu {
     }
 
     fn sound_settings_menu_setup(
-        mut commands: Commands,
+        mut commands: DeferredCommands,
         asset_server: Res<AssetServer>,
         volume: Res<Volume>,
     ) {
@@ -747,7 +747,10 @@ mod menu {
 }
 
 // Generic system that takes a component as a parameter, and will despawn all entities with that component
-fn despawn_screen<T: Component>(to_despawn: Query<Entity, With<T>>, mut commands: Commands) {
+fn despawn_screen<T: Component>(
+    to_despawn: Query<Entity, With<T>>,
+    mut commands: DeferredCommands,
+) {
     for entity in &to_despawn {
         commands.entity(entity).despawn_recursive();
     }

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -45,7 +45,7 @@ fn touch_camera(
 
 /// set up a simple 3D scene
 fn setup_scene(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     asset_server: Res<AssetServer>,

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -49,7 +49,7 @@ impl FromWorld for ComponentB {
     }
 }
 
-fn load_scene_system(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn load_scene_system(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     // "Spawning" a scene bundle creates a new entity and spawns new instances
     // of the given scene's entities as children of that entity.
     commands.spawn_bundle(DynamicSceneBundle {
@@ -103,7 +103,7 @@ fn save_scene_system(world: &mut World) {
 
 // This is only necessary for the info message in the UI. See examples/ui/text.rs for a standalone
 // text example.
-fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn infotext_system(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands.spawn_bundle(
         TextBundle::from_section(

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -37,7 +37,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
+fn setup(mut commands: DeferredCommands, mut meshes: ResMut<Assets<Mesh>>) {
     // cube
     commands.spawn().insert_bundle((
         meshes.add(Mesh::from(shape::Cube { size: 1.0 })),

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -22,7 +22,7 @@ struct LoadingTexture {
     handle: Handle<Image>,
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     // Start loading the texture.
     commands.insert_resource(LoadingTexture {
         is_loaded: false,
@@ -55,7 +55,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 }
 
 fn create_array_texture(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     asset_server: Res<AssetServer>,
     mut loading_texture: ResMut<LoadingTexture>,
     mut images: ResMut<Assets<Image>>,

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -34,7 +34,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
+fn setup(mut commands: DeferredCommands, mut images: ResMut<Assets<Image>>) {
     let mut image = Image::new_fill(
         Extent3d {
             width: SIZE.0,
@@ -92,7 +92,7 @@ struct GameOfLifeImage(Handle<Image>);
 struct GameOfLifeImageBindGroup(BindGroup);
 
 fn queue_bind_group(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     pipeline: Res<GameOfLifePipeline>,
     gpu_images: Res<RenderAssets<Image>>,
     game_of_life_image: Res<GameOfLifeImage>,

--- a/examples/shader/custom_vertex_attribute.rs
+++ b/examples/shader/custom_vertex_attribute.rs
@@ -28,7 +28,7 @@ const ATTRIBUTE_BLEND_COLOR: MeshVertexAttribute =
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<CustomMaterial>>,
 ) {

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -34,7 +34,7 @@ fn main() {
 struct MainCube;
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut windows: ResMut<Windows>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut post_processing_materials: ResMut<Assets<PostProcessingMaterial>>,

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -22,7 +22,7 @@ fn main() {
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<CustomMaterial>>,
 ) {

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -29,7 +29,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
+fn setup(mut commands: DeferredCommands, mut meshes: ResMut<Assets<Mesh>>) {
     commands.spawn().insert_bundle((
         meshes.add(Mesh::from(shape::Cube { size: 0.5 })),
         Transform::from_xyz(0.0, 0.0, 0.0),
@@ -142,7 +142,7 @@ pub struct InstanceBuffer {
 }
 
 fn prepare_instance_buffers(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     query: Query<(Entity, &InstanceMaterialData)>,
     render_device: Res<RenderDevice>,
 ) {

--- a/examples/shader/shader_material.rs
+++ b/examples/shader/shader_material.rs
@@ -16,7 +16,7 @@ fn main() {
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<CustomMaterial>>,
     asset_server: Res<AssetServer>,

--- a/examples/shader/shader_material_glsl.rs
+++ b/examples/shader/shader_material_glsl.rs
@@ -22,7 +22,7 @@ fn main() {
 
 /// set up a simple 3D scene
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<CustomMaterial>>,
     asset_server: Res<AssetServer>,

--- a/examples/shader/shader_material_screenspace_texture.rs
+++ b/examples/shader/shader_material_screenspace_texture.rs
@@ -19,7 +19,7 @@ fn main() {
 struct MainCamera;
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     asset_server: Res<AssetServer>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut custom_materials: ResMut<Assets<CustomMaterial>>,

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -64,7 +64,7 @@ struct BirdScheduled {
 }
 
 fn scheduled_spawner(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     windows: Res<Windows>,
     mut scheduled: ResMut<BirdScheduled>,
     mut counter: ResMut<BevyCounter>,
@@ -91,7 +91,7 @@ struct BirdTexture(Handle<Image>);
 #[derive(Component)]
 struct StatsText;
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     warn!(include_str!("warning_string.txt"));
 
     let texture = asset_server.load("branding/icon.png");
@@ -153,7 +153,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 }
 
 fn mouse_handler(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     time: Res<Time>,
     mouse_button_input: Res<Input<MouseButton>>,
     windows: Res<Windows>,
@@ -178,7 +178,7 @@ fn mouse_handler(
 }
 
 fn spawn_birds(
-    commands: &mut Commands,
+    commands: &mut DeferredCommands,
     windows: &Windows,
     counter: &mut BevyCounter,
     spawn_count: usize,

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -33,7 +33,7 @@ fn main() {
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     assets: Res<AssetServer>,
     mut texture_atlases: ResMut<Assets<TextureAtlas>>,
 ) {

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -49,7 +49,7 @@ impl FromWorld for UiFont {
     }
 }
 
-fn setup(mut commands: Commands, font: Res<UiFont>) {
+fn setup(mut commands: DeferredCommands, font: Res<UiFont>) {
     let count = ROW_COLUMN_COUNT;
     let count_f = count as f32;
     let as_rainbow = |i: usize| Color::hsl((i as f32 / count_f) * 360.0, 0.9, 0.8);

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -35,7 +35,7 @@ fn main() {
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -71,7 +71,7 @@ struct Ring {
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     asset_server: Res<AssetServer>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -33,7 +33,7 @@ fn main() {
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
@@ -179,7 +179,7 @@ fn print_visible_light_count(
 #[derive(Resource, Deref, DerefMut)]
 pub struct ExtractedTime(Time);
 
-fn extract_time(mut commands: Commands, time: Extract<Res<Time>>) {
+fn extract_time(mut commands: DeferredCommands, time: Extract<Res<Time>>) {
     commands.insert_resource(ExtractedTime(time.clone()));
 }
 

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -41,7 +41,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, assets: Res<AssetServer>, color_tint: Res<ColorTint>) {
+fn setup(mut commands: DeferredCommands, assets: Res<AssetServer>, color_tint: Res<ColorTint>) {
     warn!(include_str!("warning_string.txt"));
 
     let mut rng = rand::thread_rng();

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -256,7 +256,7 @@ fn set_translation(translation: &mut Vec3, a: f32) {
     translation.y = a.sin() * 32.0;
 }
 
-fn setup(mut commands: Commands, cfg: Res<Cfg>) {
+fn setup(mut commands: DeferredCommands, cfg: Res<Cfg>) {
     warn!(include_str!("warning_string.txt"));
 
     let mut cam = Camera2dBundle::default();
@@ -344,7 +344,7 @@ impl InsertResult {
 /// the parent map must be ordered (parent must exist before child)
 fn spawn_tree(
     parent_map: &[usize],
-    commands: &mut Commands,
+    commands: &mut DeferredCommands,
     update_filter: &UpdateFilter,
     root_transform: Transform,
 ) -> InsertResult {

--- a/examples/tools/scene_viewer.rs
+++ b/examples/tools/scene_viewer.rs
@@ -79,7 +79,7 @@ struct SceneHandle {
     has_light: bool,
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     let scene_path = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "assets/models/FlightHelmet/FlightHelmet.gltf".to_string());
@@ -206,7 +206,7 @@ fn keyboard_animation_control(
 }
 
 fn setup_scene_after_load(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut setup: Local<bool>,
     mut scene_handle: ResMut<SceneHandle>,
     meshes: Query<(&GlobalTransform, Option<&Aabb>), With<Handle<Mesh>>>,

--- a/examples/transforms/3d_rotation.rs
+++ b/examples/transforms/3d_rotation.rs
@@ -19,7 +19,7 @@ fn main() {
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/transforms/global_vs_local_translation.rs
+++ b/examples/transforms/global_vs_local_translation.rs
@@ -37,7 +37,7 @@ fn main() {
 
 // Startup system to setup the scene and spawn all relevant entities.
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     asset_server: Res<AssetServer>,
@@ -151,7 +151,7 @@ fn update_directional_input(mut direction: ResMut<Direction>, keyboard_input: Re
 
 // This system enables and disables the movement for each entity if their assigned key is pressed.
 fn toggle_movement(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     movable_entities: Query<(Entity, &Handle<StandardMaterial>, &ToggledBy), With<Move>>,
     static_entities: Query<(Entity, &Handle<StandardMaterial>, &ToggledBy), Without<Move>>,
     mut materials: ResMut<Assets<StandardMaterial>>,

--- a/examples/transforms/scale.rs
+++ b/examples/transforms/scale.rs
@@ -37,7 +37,7 @@ fn main() {
 
 // Startup system to setup the scene and spawn all relevant entities.
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/transforms/transform.rs
+++ b/examples/transforms/transform.rs
@@ -33,7 +33,7 @@ fn main() {
 
 // Startup system to setup the scene and spawn all relevant entities.
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/transforms/translation.rs
+++ b/examples/transforms/translation.rs
@@ -32,7 +32,7 @@ fn main() {
 
 // Startup system to setup the scene and spawn all relevant entities.
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -43,7 +43,7 @@ fn button_system(
     }
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     // ui camera
     commands.spawn_bundle(Camera2dBundle::default());
     commands

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -32,7 +32,7 @@ impl Default for State {
 }
 
 fn atlas_render_system(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut state: ResMut<State>,
     font_atlas_sets: Res<Assets<FontAtlasSet>>,
     texture_atlases: Res<Assets<TextureAtlas>>,
@@ -78,7 +78,7 @@ fn text_update_system(mut state: ResMut<State>, time: Res<Time>, mut query: Quer
     }
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut state: ResMut<State>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>, mut state: ResMut<State>) {
     let font_handle = asset_server.load("fonts/FiraSans-Bold.ttf");
     state.handle = font_handle.clone();
     commands.spawn_bundle(Camera2dBundle::default());

--- a/examples/ui/scaling.rs
+++ b/examples/ui/scaling.rs
@@ -21,7 +21,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: ResMut<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: ResMut<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
 
     let text_style = TextStyle {

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -26,7 +26,7 @@ struct FpsText;
 #[derive(Component)]
 struct ColorText;
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     // UI camera
     commands.spawn_bundle(Camera2dBundle::default());
     // Text with one section

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -22,7 +22,7 @@ fn main() {
 #[derive(Component)]
 struct TextChanges;
 
-fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn infotext_system(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     let font = asset_server.load("fonts/FiraSans-Bold.ttf");
     commands.spawn_bundle(Camera2dBundle::default());
     commands.spawn_bundle(

--- a/examples/ui/transparency_ui.rs
+++ b/examples/ui/transparency_ui.rs
@@ -11,7 +11,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
 
     let font_handle = asset_server.load("fonts/FiraSans-Bold.ttf");

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -16,7 +16,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     // Camera
     commands.spawn_bundle(Camera2dBundle::default());
 

--- a/examples/window/clear_color.rs
+++ b/examples/window/clear_color.rs
@@ -13,7 +13,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands) {
+fn setup(mut commands: DeferredCommands) {
     commands.spawn_bundle(Camera2dBundle::default());
 }
 

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -137,7 +137,7 @@ pub(crate) mod test_setup {
 
     /// Set up a scene with a cube and some text
     pub fn setup(
-        mut commands: Commands,
+        mut commands: DeferredCommands,
         mut meshes: ResMut<Assets<Mesh>>,
         mut materials: ResMut<Assets<StandardMaterial>>,
         mut event: EventWriter<RequestRedraw>,

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -15,7 +15,7 @@ fn main() {
 }
 
 fn setup(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     asset_server: Res<AssetServer>,
     mut create_window_events: EventWriter<CreateWindow>,
 ) {

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -17,7 +17,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     // camera
     commands.spawn_bundle(Camera2dBundle::default());
     // root node

--- a/examples/window/transparent_window.rs
+++ b/examples/window/transparent_window.rs
@@ -22,7 +22,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: DeferredCommands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
     commands.spawn_bundle(SpriteBundle {
         texture: asset_server.load("branding/icon.png"),

--- a/examples/window/window_resizing.rs
+++ b/examples/window/window_resizing.rs
@@ -29,12 +29,12 @@ struct ResolutionSettings {
 }
 
 // Spawns the camera that draws UI
-fn setup_camera(mut cmd: Commands) {
+fn setup_camera(mut cmd: DeferredCommands) {
     cmd.spawn_bundle(Camera2dBundle::default());
 }
 
 // Spawns the UI
-fn setup_ui(mut cmd: Commands, asset_server: Res<AssetServer>) {
+fn setup_ui(mut cmd: DeferredCommands, asset_server: Res<AssetServer>) {
     // Node that fills entire background
     cmd.spawn_bundle(NodeBundle {
         style: Style {

--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -18,7 +18,7 @@ fn update_score(mut dead_enemies: EventReader<EnemyDied>, mut score: ResMut<Scor
 }
 
 fn despawn_dead_enemies(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut dead_enemies: EventWriter<EnemyDied>,
     enemies: Query<(Entity, &Enemy)>,
 ) {
@@ -36,7 +36,7 @@ fn hurt_enemies(mut enemies: Query<&mut Enemy>) {
     }
 }
 
-fn spawn_enemy(mut commands: Commands, keyboard_input: Res<Input<KeyCode>>) {
+fn spawn_enemy(mut commands: DeferredCommands, keyboard_input: Res<Input<KeyCode>>) {
     if keyboard_input.just_pressed(KeyCode::Space) {
         commands.spawn().insert(Enemy {
             hit_points: 5,

--- a/tests/window/minimising.rs
+++ b/tests/window/minimising.rs
@@ -27,7 +27,7 @@ fn minimise_automatically(mut windows: ResMut<Windows>, mut frames: Local<u32>) 
 
 /// A simple 3d scene, taken from the `3d_scene` example
 fn setup_3d(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
@@ -62,7 +62,7 @@ fn setup_3d(
 }
 
 /// A simple 2d scene, taken from the `rect` example
-fn setup_2d(mut commands: Commands) {
+fn setup_2d(mut commands: DeferredCommands) {
     commands.spawn_bundle(Camera2dBundle {
         camera: Camera {
             // render the 2d camera after the 3d camera

--- a/tests/window/resizing.rs
+++ b/tests/window/resizing.rs
@@ -107,7 +107,7 @@ fn sync_dimensions(dim: Res<Dimensions>, mut windows: ResMut<Windows>) {
 
 /// A simple 3d scene, taken from the `3d_scene` example
 fn setup_3d(
-    mut commands: Commands,
+    mut commands: DeferredCommands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
@@ -142,7 +142,7 @@ fn setup_3d(
 }
 
 /// A simple 2d scene, taken from the `rect` example
-fn setup_2d(mut commands: Commands) {
+fn setup_2d(mut commands: DeferredCommands) {
     commands.spawn_bundle(Camera2dBundle {
         camera: Camera {
             // render the 2d camera after the 3d camera


### PR DESCRIPTION
# Objective

- Fix #5913

## Solution

- rename `Commands` to `DeferredCommands`

---

## Migration Guide

- rename `Commands` to `DeferredCommands`
