### PR TITLE
Add test plugin group

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -921,6 +921,16 @@ description = "Illustrates ticking `Timer` resources inside systems and handling
 category = "ECS (Entity Component System)"
 wasm = false
 
+[[example]]
+name = "automated_tests"
+path = "tests/automated_tests.rs"
+
+[package.metadata.example.automated_tests]
+name = "Automated Tests"
+description = "Illustrates how to test systems. Note that this example is in `tests/automated_tests.rs`."
+category = "ECS (Entity Component System)"
+wasm = false
+
 # Games
 [[example]]
 name = "alien_cake_addict"

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -815,7 +815,7 @@ impl App {
     /// [`Plugin`]s can be grouped into a set by using a [`PluginGroup`].
     ///
     /// There are built-in [`PluginGroup`]s that provide core engine functionality.
-    /// The [`PluginGroup`]s available by default are `DefaultPlugins` and `MinimalPlugins`.
+    /// The [`PluginGroup`]s available by default are `DefaultPlugins`, `MinimalPlugins`, and `TestPlugins`.
     ///
     /// To customize the plugins in the group (reorder, disable a plugin, add a new plugin
     /// before / after another plugin), see [`add_plugins_with`](Self::add_plugins_with).

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -81,6 +81,43 @@ impl PluginGroup for DefaultPlugins {
     }
 }
 
+impl DefaultPlugins {
+    /// Usage: `DefaultPlugins::for_testing()`.
+    /// Like `DefaultPlugins`, but omits some plugins that are likely to be problematic during tests and on CI builds.
+    ///
+    /// * [`RenderPlugin`](bevy_render::RenderPlugin) - with feature `bevy_render`
+    /// * [`SpritePlugin`](bevy_sprite::SpritePlugin) - with feature `bevy_sprite`
+    /// * [`PbrPlugin`](bevy_pbr::PbrPlugin) - with feature `bevy_pbr`
+    /// * [`UiPlugin`](bevy_ui::UiPlugin) - with feature `bevy_ui`
+    /// * [`TextPlugin`](bevy_text::TextPlugin) - with feature `bevy_text`
+    /// * [`AudioPlugin`](bevy_audio::AudioPlugin) - with feature `bevy_audio`
+    /// * [`GltfPlugin`](bevy_gltf::GltfPlugin) - with feature `bevy_gltf`
+    /// * [`WinitPlugin`](bevy_winit::WinitPlugin) - with feature `bevy_winit`
+    ///
+    /// And adds:
+    ///
+    /// * [`ScheduleRunnerPlugin`](bevy_app::ScheduleRunnerPlugin)
+    ///
+    /// Leaving:
+    ///
+    /// * [`CorePlugin`](bevy_core::CorePlugin)
+    /// * [`TimePlugin`](bevy_time::TimePlugin)
+    /// * [`TransformPlugin`](bevy_transform::TransformPlugin)
+    /// * [`HierarchyPlugin`](bevy_hierarchy::HierarchyPlugin)
+    /// * [`DiagnosticsPlugin`](bevy_diagnostic::DiagnosticsPlugin)
+    /// * [`InputPlugin`](bevy_input::InputPlugin)
+    /// * [`WindowPlugin`](bevy_window::WindowPlugin)
+    /// * [`AssetPlugin`](bevy_asset::AssetPlugin)
+    /// * [`ScenePlugin`](bevy_scene::ScenePlugin)
+    /// * [`GilrsPlugin`](bevy_gilrs::GilrsPlugin) - with feature `bevy_gilrs`
+    /// * [`ScheduleRunnerPlugin`](bevy_app::ScheduleRunnerPlugin)
+    ///
+    /// You should probably not use this plugin except in automated tests.
+    pub fn for_testing() -> impl PluginGroup {
+        TestPlugins
+    }
+}
+
 /// Minimal plugin group that will add the following plugins:
 /// * [`CorePlugin`](bevy_core::CorePlugin)
 /// * [`TimePlugin`](bevy_time::TimePlugin)
@@ -97,36 +134,30 @@ impl PluginGroup for MinimalPlugins {
     }
 }
 
-/// Plugin group intended for use in tests, that will add the following plugins:
-/// * [`CorePlugin`](bevy_core::CorePlugin)
-/// * [`TimePlugin`](bevy_time::TimePlugin)
-/// * [`ScheduleRunnerPlugin`](bevy_app::ScheduleRunnerPlugin)
-/// * [`AssetPlugin`](bevy_asset::AssetPlugin)
-/// * [`ScenePlugin`](bevy_scene::ScenePlugin)
-/// * [`WindowPlugin`](bevy_window::WindowPlugin)
-/// * [`RenderPlugin`](bevy_render::RenderPlugin)
-/// * [`GilrsPlugin`](bevy_gilrs::GilrsPlugin)
-/// * [`TransformPlugin`](bevy_transform::TransformPlugin)
-/// * [`HierarchyPlugin`](bevy_hierarchy::HierarchyPlugin)
-/// * [`DiagnosticsPlugin`](bevy_diagnostic::DiagnosticsPlugin)
-/// * [`InputPlugin`](bevy_input::InputPlugin)
-///
-/// See also [`DefaultPlugins`] for a more complete set of plugins
-pub struct TestPlugins;
+/// Only accessible through `DefaultPlugins::for_testing()`.
+struct TestPlugins;
 
 impl PluginGroup for TestPlugins {
     fn build(&mut self, group: &mut PluginGroupBuilder) {
         group.add(bevy_core::CorePlugin::default());
         group.add(bevy_time::TimePlugin::default());
         group.add(bevy_app::ScheduleRunnerPlugin::default());
-        group.add(bevy_asset::AssetPlugin);
-        group.add(bevy_scene::ScenePlugin);
         group.add(bevy_window::WindowPlugin);
-        group.add(bevy_render::RenderPlugin);
-        group.add(bevy_gilrs::GilrsPlugin);
         group.add(bevy_transform::TransformPlugin);
         group.add(bevy_hierarchy::HierarchyPlugin);
         group.add(bevy_diagnostic::DiagnosticsPlugin);
         group.add(bevy_input::InputPlugin);
+
+        #[cfg(feature = "bevy_asset")]
+        group.add(bevy_asset::AssetPlugin::default());
+
+        #[cfg(feature = "debug_asset_server")]
+        group.add(bevy_asset::debug_asset_server::DebugAssetServerPlugin::default());
+
+        #[cfg(feature = "bevy_scene")]
+        group.add(bevy_scene::ScenePlugin::default());
+
+        #[cfg(feature = "bevy_gilrs")]
+        group.add(bevy_gilrs::GilrsPlugin::default());
     }
 }

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -96,3 +96,37 @@ impl PluginGroup for MinimalPlugins {
         group.add(bevy_app::ScheduleRunnerPlugin::default());
     }
 }
+
+/// Plugin group intended for use in tests, that will add the following plugins:
+/// * [`CorePlugin`](bevy_core::CorePlugin)
+/// * [`TimePlugin`](bevy_time::TimePlugin)
+/// * [`ScheduleRunnerPlugin`](bevy_app::ScheduleRunnerPlugin)
+/// * [`AssetPlugin`](bevy_asset::AssetPlugin)
+/// * [`ScenePlugin`](bevy_scene::ScenePlugin)
+/// * [`WindowPlugin`](bevy_window::WindowPlugin)
+/// * [`RenderPlugin`](bevy_render::RenderPlugin)
+/// * [`GilrsPlugin`](bevy_gilrs::GilrsPlugin)
+/// * [`TransformPlugin`](bevy_transform::TransformPlugin)
+/// * [`HierarchyPlugin`](bevy_hierarchy::HierarchyPlugin)
+/// * [`DiagnosticsPlugin`](bevy_diagnostic::DiagnosticsPlugin)
+/// * [`InputPlugin`](bevy_input::InputPlugin)
+///
+/// See also [`DefaultPlugins`] for a more complete set of plugins
+pub struct TestPlugins;
+
+impl PluginGroup for TestPlugins {
+    fn build(&mut self, group: &mut PluginGroupBuilder) {
+        group.add(bevy_core::CorePlugin::default());
+        group.add(bevy_time::TimePlugin::default());
+        group.add(bevy_app::ScheduleRunnerPlugin::default());
+        group.add(bevy_asset::AssetPlugin);
+        group.add(bevy_scene::ScenePlugin);
+        group.add(bevy_window::WindowPlugin);
+        group.add(bevy_render::RenderPlugin);
+        group.add(bevy_gilrs::GilrsPlugin);
+        group.add(bevy_transform::TransformPlugin);
+        group.add(bevy_hierarchy::HierarchyPlugin);
+        group.add(bevy_diagnostic::DiagnosticsPlugin);
+        group.add(bevy_input::InputPlugin);
+    }
+}

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -3,6 +3,7 @@ pub use crate::{
     app::prelude::*, core::prelude::*, ecs::prelude::*, hierarchy::prelude::*, input::prelude::*,
     log::prelude::*, math::prelude::*, reflect::prelude::*, time::prelude::*,
     transform::prelude::*, utils::prelude::*, window::prelude::*, DefaultPlugins, MinimalPlugins,
+    TestPlugins,
 };
 
 pub use bevy_derive::{bevy_main, Deref, DerefMut};

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -3,7 +3,6 @@ pub use crate::{
     app::prelude::*, core::prelude::*, ecs::prelude::*, hierarchy::prelude::*, input::prelude::*,
     log::prelude::*, math::prelude::*, reflect::prelude::*, time::prelude::*,
     transform::prelude::*, utils::prelude::*, window::prelude::*, DefaultPlugins, MinimalPlugins,
-    TestPlugins,
 };
 
 pub use bevy_derive::{bevy_main, Deref, DerefMut};

--- a/examples/README.md
+++ b/examples/README.md
@@ -187,6 +187,7 @@ Example | Description
 
 Example | Description
 --- | ---
+[Automated Tests](../tests/automated_tests.rs) | Illustrates how to test systems. Note that this example is in `tests/automated_tests.rs`.
 [Component Change Detection](../examples/ecs/component_change_detection.rs) | Change detection on components
 [Custom Query Parameters](../examples/ecs/custom_query_param.rs) | Groups commonly used compound queries and query filters into a single type
 [ECS Guide](../examples/ecs/ecs_guide.rs) | Full guide to Bevy's ECS

--- a/tests/automated_tests.rs
+++ b/tests/automated_tests.rs
@@ -1,0 +1,49 @@
+//! This example illustrates test systems.
+fn main() {
+    println!("This example is special! Run it with `cargo test --example automated_tests`.");
+    println!(
+        "Or use `cargo test --example automated_tests -- --nocapture` to see the debug output."
+    );
+}
+
+#[cfg(test)]
+mod test {
+    use bevy::prelude::*;
+
+    #[test]
+    fn simple_test() {
+        // Setup the app with the TestPlugins – these will run fine in tests and in CI.
+        // Note that many 3rd-party plugins will require DefaultPlugins, not just TestPlugins.
+        let mut app = App::new();
+        app.add_plugins(DefaultPlugins::for_testing())
+            .add_system(increment);
+
+        // Spawn a new entity with a Counter component, and record its ID.
+        let counter_id = app.world.spawn().insert(Counter::default()).id();
+
+        // Simulate for a 10 frames
+        let num_frames = 10;
+        for _ in 0..num_frames {
+            app.update();
+        }
+
+        // Check that the counter was incremented 10 times.
+        let count = app.world.get::<Counter>(counter_id).unwrap().counter;
+        assert_eq!(count, num_frames);
+
+        println!("Success!");
+    }
+    // Define a system and a component that we can use in our test.
+    #[derive(Debug, Default, Component, Clone, Copy)]
+    struct Counter {
+        counter: u64,
+    }
+
+    /// Increment the counter every frame
+    fn increment(mut query: Query<&mut Counter>) {
+        for mut counter in query.iter_mut() {
+            counter.counter += 1;
+            println!("Counter: {}", counter.counter);
+        }
+    }
+}


### PR DESCRIPTION
# Objective

Work towards closing #5931

## Solution

- Add a `TestPlugins` group that adds `MinimalPlugins`, `AssetPlugin`, `ScenePlugin`, `WindowPlugin`, `GilrsPlugin`, `TransformPlugin`, `HierarchyPlugin`, `DiagnosticsPlugin`, and `InputPlugin`.
- Added an example for how to use it. The example gets run in CI, which should make sure that no future change ever breaks any of the plugins in Github Actions

## Limitations

- `bevy_rapier` will not work as it depends on `RenderPlugin`, but this is fixed in #5933.
- While this is usable, `LogPlugin` cannot be added until #4934 is resolved

---

## Changelog

### Added

`TestPlugins` group that adds plugins suitable for use in automated tests.