### PR TITLE
Make RenderPlugin emit only a soft error when there's no gpu, instead of panicking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -921,6 +921,16 @@ description = "Illustrates ticking `Timer` resources inside systems and handling
 category = "ECS (Entity Component System)"
 wasm = false
 
+[[example]]
+name = "automated_tests"
+path = "tests/automated_tests.rs"
+
+[package.metadata.example.automated_tests]
+name = "Automated Tests"
+description = "Illustrates how to test systems. Note that this example is in `tests/automated_tests.rs`."
+category = "ECS (Entity Component System)"
+wasm = false
+
 # Games
 [[example]]
 name = "alien_cake_addict"

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -815,7 +815,7 @@ impl App {
     /// [`Plugin`]s can be grouped into a set by using a [`PluginGroup`].
     ///
     /// There are built-in [`PluginGroup`]s that provide core engine functionality.
-    /// The [`PluginGroup`]s available by default are `DefaultPlugins` and `MinimalPlugins`.
+    /// The [`PluginGroup`]s available by default are `DefaultPlugins`, `MinimalPlugins`, and `TestPlugins`.
     ///
     /// To customize the plugins in the group (reorder, disable a plugin, add a new plugin
     /// before / after another plugin), see [`add_plugins_with`](Self::add_plugins_with).

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -81,6 +81,43 @@ impl PluginGroup for DefaultPlugins {
     }
 }
 
+impl DefaultPlugins {
+    /// Usage: `DefaultPlugins::for_testing()`.
+    /// Like `DefaultPlugins`, but omits some plugins that are likely to be problematic during tests and on CI builds.
+    ///
+    /// * [`RenderPlugin`](bevy_render::RenderPlugin) - with feature `bevy_render`
+    /// * [`SpritePlugin`](bevy_sprite::SpritePlugin) - with feature `bevy_sprite`
+    /// * [`PbrPlugin`](bevy_pbr::PbrPlugin) - with feature `bevy_pbr`
+    /// * [`UiPlugin`](bevy_ui::UiPlugin) - with feature `bevy_ui`
+    /// * [`TextPlugin`](bevy_text::TextPlugin) - with feature `bevy_text`
+    /// * [`AudioPlugin`](bevy_audio::AudioPlugin) - with feature `bevy_audio`
+    /// * [`GltfPlugin`](bevy_gltf::GltfPlugin) - with feature `bevy_gltf`
+    /// * [`WinitPlugin`](bevy_winit::WinitPlugin) - with feature `bevy_winit`
+    ///
+    /// And adds:
+    ///
+    /// * [`ScheduleRunnerPlugin`](bevy_app::ScheduleRunnerPlugin)
+    ///
+    /// Leaving:
+    ///
+    /// * [`CorePlugin`](bevy_core::CorePlugin)
+    /// * [`TimePlugin`](bevy_time::TimePlugin)
+    /// * [`TransformPlugin`](bevy_transform::TransformPlugin)
+    /// * [`HierarchyPlugin`](bevy_hierarchy::HierarchyPlugin)
+    /// * [`DiagnosticsPlugin`](bevy_diagnostic::DiagnosticsPlugin)
+    /// * [`InputPlugin`](bevy_input::InputPlugin)
+    /// * [`WindowPlugin`](bevy_window::WindowPlugin)
+    /// * [`AssetPlugin`](bevy_asset::AssetPlugin)
+    /// * [`ScenePlugin`](bevy_scene::ScenePlugin)
+    /// * [`GilrsPlugin`](bevy_gilrs::GilrsPlugin) - with feature `bevy_gilrs`
+    /// * [`ScheduleRunnerPlugin`](bevy_app::ScheduleRunnerPlugin)
+    ///
+    /// You should probably not use this plugin except in automated tests.
+    pub fn for_testing() -> impl PluginGroup {
+        TestPlugins
+    }
+}
+
 /// Minimal plugin group that will add the following plugins:
 /// * [`CorePlugin`](bevy_core::CorePlugin)
 /// * [`TimePlugin`](bevy_time::TimePlugin)
@@ -97,36 +134,30 @@ impl PluginGroup for MinimalPlugins {
     }
 }
 
-/// Plugin group intended for use in tests, that will add the following plugins:
-/// * [`CorePlugin`](bevy_core::CorePlugin)
-/// * [`TimePlugin`](bevy_time::TimePlugin)
-/// * [`ScheduleRunnerPlugin`](bevy_app::ScheduleRunnerPlugin)
-/// * [`AssetPlugin`](bevy_asset::AssetPlugin)
-/// * [`ScenePlugin`](bevy_scene::ScenePlugin)
-/// * [`WindowPlugin`](bevy_window::WindowPlugin)
-/// * [`RenderPlugin`](bevy_render::RenderPlugin)
-/// * [`GilrsPlugin`](bevy_gilrs::GilrsPlugin)
-/// * [`TransformPlugin`](bevy_transform::TransformPlugin)
-/// * [`HierarchyPlugin`](bevy_hierarchy::HierarchyPlugin)
-/// * [`DiagnosticsPlugin`](bevy_diagnostic::DiagnosticsPlugin)
-/// * [`InputPlugin`](bevy_input::InputPlugin)
-///
-/// See also [`DefaultPlugins`] for a more complete set of plugins
-pub struct TestPlugins;
+/// Only accessible through `DefaultPlugins::for_testing()`.
+struct TestPlugins;
 
 impl PluginGroup for TestPlugins {
     fn build(&mut self, group: &mut PluginGroupBuilder) {
         group.add(bevy_core::CorePlugin::default());
         group.add(bevy_time::TimePlugin::default());
         group.add(bevy_app::ScheduleRunnerPlugin::default());
-        group.add(bevy_asset::AssetPlugin);
-        group.add(bevy_scene::ScenePlugin);
         group.add(bevy_window::WindowPlugin);
-        group.add(bevy_render::RenderPlugin);
-        group.add(bevy_gilrs::GilrsPlugin);
         group.add(bevy_transform::TransformPlugin);
         group.add(bevy_hierarchy::HierarchyPlugin);
         group.add(bevy_diagnostic::DiagnosticsPlugin);
         group.add(bevy_input::InputPlugin);
+
+        #[cfg(feature = "bevy_asset")]
+        group.add(bevy_asset::AssetPlugin::default());
+
+        #[cfg(feature = "debug_asset_server")]
+        group.add(bevy_asset::debug_asset_server::DebugAssetServerPlugin::default());
+
+        #[cfg(feature = "bevy_scene")]
+        group.add(bevy_scene::ScenePlugin::default());
+
+        #[cfg(feature = "bevy_gilrs")]
+        group.add(bevy_gilrs::GilrsPlugin::default());
     }
 }

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -96,3 +96,37 @@ impl PluginGroup for MinimalPlugins {
         group.add(bevy_app::ScheduleRunnerPlugin::default());
     }
 }
+
+/// Plugin group intended for use in tests, that will add the following plugins:
+/// * [`CorePlugin`](bevy_core::CorePlugin)
+/// * [`TimePlugin`](bevy_time::TimePlugin)
+/// * [`ScheduleRunnerPlugin`](bevy_app::ScheduleRunnerPlugin)
+/// * [`AssetPlugin`](bevy_asset::AssetPlugin)
+/// * [`ScenePlugin`](bevy_scene::ScenePlugin)
+/// * [`WindowPlugin`](bevy_window::WindowPlugin)
+/// * [`RenderPlugin`](bevy_render::RenderPlugin)
+/// * [`GilrsPlugin`](bevy_gilrs::GilrsPlugin)
+/// * [`TransformPlugin`](bevy_transform::TransformPlugin)
+/// * [`HierarchyPlugin`](bevy_hierarchy::HierarchyPlugin)
+/// * [`DiagnosticsPlugin`](bevy_diagnostic::DiagnosticsPlugin)
+/// * [`InputPlugin`](bevy_input::InputPlugin)
+///
+/// See also [`DefaultPlugins`] for a more complete set of plugins
+pub struct TestPlugins;
+
+impl PluginGroup for TestPlugins {
+    fn build(&mut self, group: &mut PluginGroupBuilder) {
+        group.add(bevy_core::CorePlugin::default());
+        group.add(bevy_time::TimePlugin::default());
+        group.add(bevy_app::ScheduleRunnerPlugin::default());
+        group.add(bevy_asset::AssetPlugin);
+        group.add(bevy_scene::ScenePlugin);
+        group.add(bevy_window::WindowPlugin);
+        group.add(bevy_render::RenderPlugin);
+        group.add(bevy_gilrs::GilrsPlugin);
+        group.add(bevy_transform::TransformPlugin);
+        group.add(bevy_hierarchy::HierarchyPlugin);
+        group.add(bevy_diagnostic::DiagnosticsPlugin);
+        group.add(bevy_input::InputPlugin);
+    }
+}

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -85,7 +85,6 @@ impl DefaultPlugins {
     /// Usage: `DefaultPlugins::for_testing()`.
     /// Like `DefaultPlugins`, but omits some plugins that are likely to be problematic during tests and on CI builds.
     ///
-    /// * [`RenderPlugin`](bevy_render::RenderPlugin) - with feature `bevy_render`
     /// * [`SpritePlugin`](bevy_sprite::SpritePlugin) - with feature `bevy_sprite`
     /// * [`PbrPlugin`](bevy_pbr::PbrPlugin) - with feature `bevy_pbr`
     /// * [`UiPlugin`](bevy_ui::UiPlugin) - with feature `bevy_ui`
@@ -109,6 +108,7 @@ impl DefaultPlugins {
     /// * [`WindowPlugin`](bevy_window::WindowPlugin)
     /// * [`AssetPlugin`](bevy_asset::AssetPlugin)
     /// * [`ScenePlugin`](bevy_scene::ScenePlugin)
+    /// * [`RenderPlugin`](bevy_render::RenderPlugin) - with feature `bevy_render`
     /// * [`GilrsPlugin`](bevy_gilrs::GilrsPlugin) - with feature `bevy_gilrs`
     /// * [`ScheduleRunnerPlugin`](bevy_app::ScheduleRunnerPlugin)
     ///
@@ -159,5 +159,8 @@ impl PluginGroup for TestPlugins {
 
         #[cfg(feature = "bevy_gilrs")]
         group.add(bevy_gilrs::GilrsPlugin::default());
+
+        #[cfg(feature = "bevy_render")]
+        group.add(bevy_render::RenderPlugin::default());
     }
 }

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -3,6 +3,7 @@ pub use crate::{
     app::prelude::*, core::prelude::*, ecs::prelude::*, hierarchy::prelude::*, input::prelude::*,
     log::prelude::*, math::prelude::*, reflect::prelude::*, time::prelude::*,
     transform::prelude::*, utils::prelude::*, window::prelude::*, DefaultPlugins, MinimalPlugins,
+    TestPlugins,
 };
 
 pub use bevy_derive::{bevy_main, Deref, DerefMut};

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -3,7 +3,6 @@ pub use crate::{
     app::prelude::*, core::prelude::*, ecs::prelude::*, hierarchy::prelude::*, input::prelude::*,
     log::prelude::*, math::prelude::*, reflect::prelude::*, time::prelude::*,
     transform::prelude::*, utils::prelude::*, window::prelude::*, DefaultPlugins, MinimalPlugins,
-    TestPlugins,
 };
 
 pub use bevy_derive::{bevy_main, Deref, DerefMut};

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -152,167 +152,170 @@ impl Plugin for RenderPlugin {
                 compatible_surface: surface.as_ref(),
                 ..Default::default()
             };
-            let (device, queue, adapter_info) = futures_lite::future::block_on(
+            // `renderer::initialize_renderer` will `error!` before returning `None`, so we don't need to do it here.
+            if let Some((device, queue, adapter_info)) = futures_lite::future::block_on(
                 renderer::initialize_renderer(&instance, &options, &request_adapter_options),
-            );
-            debug!("Configured wgpu adapter Limits: {:#?}", device.limits());
-            debug!("Configured wgpu adapter Features: {:#?}", device.features());
-            app.insert_resource(device.clone())
-                .insert_resource(queue.clone())
-                .insert_resource(adapter_info.clone())
-                .init_resource::<ScratchMainWorld>()
-                .register_type::<Frustum>()
-                .register_type::<CubemapFrusta>();
+            ) {
+                debug!("Configured wgpu adapter Limits: {:#?}", device.limits());
+                debug!("Configured wgpu adapter Features: {:#?}", device.features());
+                app.insert_resource(device.clone())
+                    .insert_resource(queue.clone())
+                    .insert_resource(adapter_info.clone())
+                    .init_resource::<ScratchMainWorld>()
+                    .register_type::<Frustum>()
+                    .register_type::<CubemapFrusta>();
 
-            let pipeline_cache = PipelineCache::new(device.clone());
-            let asset_server = app.world.resource::<AssetServer>().clone();
+                let pipeline_cache = PipelineCache::new(device.clone());
+                let asset_server = app.world.resource::<AssetServer>().clone();
 
-            let mut render_app = App::empty();
-            let mut extract_stage =
-                SystemStage::parallel().with_system(PipelineCache::extract_shaders);
-            // Get the ComponentId for MainWorld. This does technically 'waste' a `WorldId`, but that's probably fine
-            render_app.init_resource::<MainWorld>();
-            render_app.world.remove_resource::<MainWorld>();
-            let main_world_in_render = render_app
-                .world
-                .components()
-                .get_resource_id(TypeId::of::<MainWorld>());
-            // `Extract` systems must read from the main world. We want to emit an error when that doesn't occur
-            // Safe to unwrap: Ensured it existed just above
-            extract_stage.set_must_read_resource(main_world_in_render.unwrap());
-            // don't apply buffers when the stage finishes running
-            // extract stage runs on the render world, but buffers are applied
-            // after access to the main world is removed
-            // See also https://github.com/bevyengine/bevy/issues/5082
-            extract_stage.set_apply_buffers(false);
-            render_app
-                .add_stage(RenderStage::Extract, extract_stage)
-                .add_stage(RenderStage::Prepare, SystemStage::parallel())
-                .add_stage(RenderStage::Queue, SystemStage::parallel())
-                .add_stage(RenderStage::PhaseSort, SystemStage::parallel())
-                .add_stage(
-                    RenderStage::Render,
-                    SystemStage::parallel()
-                        .with_system(PipelineCache::process_pipeline_queue_system)
-                        .with_system(render_system.exclusive_system().at_end()),
-                )
-                .add_stage(RenderStage::Cleanup, SystemStage::parallel())
-                .init_resource::<RenderGraph>()
-                .insert_resource(RenderInstance(instance))
-                .insert_resource(device)
-                .insert_resource(queue)
-                .insert_resource(adapter_info)
-                .insert_resource(pipeline_cache)
-                .insert_resource(asset_server);
+                let mut render_app = App::empty();
+                let mut extract_stage =
+                    SystemStage::parallel().with_system(PipelineCache::extract_shaders);
+                // Get the ComponentId for MainWorld. This does technically 'waste' a `WorldId`, but that's probably fine
+                render_app.init_resource::<MainWorld>();
+                render_app.world.remove_resource::<MainWorld>();
+                let main_world_in_render = render_app
+                    .world
+                    .components()
+                    .get_resource_id(TypeId::of::<MainWorld>());
+                // `Extract` systems must read from the main world. We want to emit an error when that doesn't occur
+                // Safe to unwrap: Ensured it existed just above
+                extract_stage.set_must_read_resource(main_world_in_render.unwrap());
+                // don't apply buffers when the stage finishes running
+                // extract stage runs on the render world, but buffers are applied
+                // after access to the main world is removed
+                // See also https://github.com/bevyengine/bevy/issues/5082
+                extract_stage.set_apply_buffers(false);
+                render_app
+                    .add_stage(RenderStage::Extract, extract_stage)
+                    .add_stage(RenderStage::Prepare, SystemStage::parallel())
+                    .add_stage(RenderStage::Queue, SystemStage::parallel())
+                    .add_stage(RenderStage::PhaseSort, SystemStage::parallel())
+                    .add_stage(
+                        RenderStage::Render,
+                        SystemStage::parallel()
+                            .with_system(PipelineCache::process_pipeline_queue_system)
+                            .with_system(render_system.exclusive_system().at_end()),
+                    )
+                    .add_stage(RenderStage::Cleanup, SystemStage::parallel())
+                    .init_resource::<RenderGraph>()
+                    .insert_resource(RenderInstance(instance))
+                    .insert_resource(device)
+                    .insert_resource(queue)
+                    .insert_resource(adapter_info)
+                    .insert_resource(pipeline_cache)
+                    .insert_resource(asset_server);
 
-            let (sender, receiver) = bevy_time::create_time_channels();
-            app.insert_resource(receiver);
-            render_app.insert_resource(sender);
+                let (sender, receiver) = bevy_time::create_time_channels();
+                app.insert_resource(receiver);
+                render_app.insert_resource(sender);
 
-            app.add_sub_app(RenderApp, render_app, move |app_world, render_app| {
-                #[cfg(feature = "trace")]
-                let _render_span = bevy_utils::tracing::info_span!("renderer subapp").entered();
-                {
+                app.add_sub_app(RenderApp, render_app, move |app_world, render_app| {
                     #[cfg(feature = "trace")]
-                    let _stage_span =
-                        bevy_utils::tracing::info_span!("stage", name = "reserve_and_flush")
-                            .entered();
+                    let _render_span = bevy_utils::tracing::info_span!("renderer subapp").entered();
+                    {
+                        #[cfg(feature = "trace")]
+                        let _stage_span =
+                            bevy_utils::tracing::info_span!("stage", name = "reserve_and_flush")
+                                .entered();
 
-                    // reserve all existing app entities for use in render_app
-                    // they can only be spawned using `get_or_spawn()`
-                    let meta_len = app_world.entities().meta_len();
-                    render_app
-                        .world
-                        .entities()
-                        .reserve_entities(meta_len as u32);
+                        // reserve all existing app entities for use in render_app
+                        // they can only be spawned using `get_or_spawn()`
+                        let meta_len = app_world.entities().meta_len();
+                        render_app
+                            .world
+                            .entities()
+                            .reserve_entities(meta_len as u32);
 
-                    // flushing as "invalid" ensures that app world entities aren't added as "empty archetype" entities by default
-                    // these entities cannot be accessed without spawning directly onto them
-                    // this _only_ works as expected because clear_entities() is called at the end of every frame.
-                    unsafe { render_app.world.entities_mut() }.flush_as_invalid();
-                }
+                        // flushing as "invalid" ensures that app world entities aren't added as "empty archetype" entities by default
+                        // these entities cannot be accessed without spawning directly onto them
+                        // this _only_ works as expected because clear_entities() is called at the end of every frame.
+                        unsafe { render_app.world.entities_mut() }.flush_as_invalid();
+                    }
 
-                {
-                    #[cfg(feature = "trace")]
-                    let _stage_span =
-                        bevy_utils::tracing::info_span!("stage", name = "extract").entered();
+                    {
+                        #[cfg(feature = "trace")]
+                        let _stage_span =
+                            bevy_utils::tracing::info_span!("stage", name = "extract").entered();
 
-                    // extract
-                    extract(app_world, render_app);
-                }
+                        // extract
+                        extract(app_world, render_app);
+                    }
 
-                {
-                    #[cfg(feature = "trace")]
-                    let _stage_span =
-                        bevy_utils::tracing::info_span!("stage", name = "prepare").entered();
+                    {
+                        #[cfg(feature = "trace")]
+                        let _stage_span =
+                            bevy_utils::tracing::info_span!("stage", name = "prepare").entered();
 
-                    // prepare
-                    let prepare = render_app
-                        .schedule
-                        .get_stage_mut::<SystemStage>(RenderStage::Prepare)
-                        .unwrap();
-                    prepare.run(&mut render_app.world);
-                }
+                        // prepare
+                        let prepare = render_app
+                            .schedule
+                            .get_stage_mut::<SystemStage>(RenderStage::Prepare)
+                            .unwrap();
+                        prepare.run(&mut render_app.world);
+                    }
 
-                {
-                    #[cfg(feature = "trace")]
-                    let _stage_span =
-                        bevy_utils::tracing::info_span!("stage", name = "queue").entered();
+                    {
+                        #[cfg(feature = "trace")]
+                        let _stage_span =
+                            bevy_utils::tracing::info_span!("stage", name = "queue").entered();
 
-                    // queue
-                    let queue = render_app
-                        .schedule
-                        .get_stage_mut::<SystemStage>(RenderStage::Queue)
-                        .unwrap();
-                    queue.run(&mut render_app.world);
-                }
+                        // queue
+                        let queue = render_app
+                            .schedule
+                            .get_stage_mut::<SystemStage>(RenderStage::Queue)
+                            .unwrap();
+                        queue.run(&mut render_app.world);
+                    }
 
-                {
-                    #[cfg(feature = "trace")]
-                    let _stage_span =
-                        bevy_utils::tracing::info_span!("stage", name = "sort").entered();
+                    {
+                        #[cfg(feature = "trace")]
+                        let _stage_span =
+                            bevy_utils::tracing::info_span!("stage", name = "sort").entered();
 
-                    // phase sort
-                    let phase_sort = render_app
-                        .schedule
-                        .get_stage_mut::<SystemStage>(RenderStage::PhaseSort)
-                        .unwrap();
-                    phase_sort.run(&mut render_app.world);
-                }
+                        // phase sort
+                        let phase_sort = render_app
+                            .schedule
+                            .get_stage_mut::<SystemStage>(RenderStage::PhaseSort)
+                            .unwrap();
+                        phase_sort.run(&mut render_app.world);
+                    }
 
-                {
-                    #[cfg(feature = "trace")]
-                    let _stage_span =
-                        bevy_utils::tracing::info_span!("stage", name = "render").entered();
+                    {
+                        #[cfg(feature = "trace")]
+                        let _stage_span =
+                            bevy_utils::tracing::info_span!("stage", name = "render").entered();
 
-                    // render
-                    let render = render_app
-                        .schedule
-                        .get_stage_mut::<SystemStage>(RenderStage::Render)
-                        .unwrap();
-                    render.run(&mut render_app.world);
-                }
+                        // render
+                        let render = render_app
+                            .schedule
+                            .get_stage_mut::<SystemStage>(RenderStage::Render)
+                            .unwrap();
+                        render.run(&mut render_app.world);
+                    }
 
-                {
-                    #[cfg(feature = "trace")]
-                    let _stage_span =
-                        bevy_utils::tracing::info_span!("stage", name = "cleanup").entered();
+                    {
+                        #[cfg(feature = "trace")]
+                        let _stage_span =
+                            bevy_utils::tracing::info_span!("stage", name = "cleanup").entered();
 
-                    // cleanup
-                    let cleanup = render_app
-                        .schedule
-                        .get_stage_mut::<SystemStage>(RenderStage::Cleanup)
-                        .unwrap();
-                    cleanup.run(&mut render_app.world);
-                }
-                {
-                    #[cfg(feature = "trace")]
-                    let _stage_span =
-                        bevy_utils::tracing::info_span!("stage", name = "clear_entities").entered();
+                        // cleanup
+                        let cleanup = render_app
+                            .schedule
+                            .get_stage_mut::<SystemStage>(RenderStage::Cleanup)
+                            .unwrap();
+                        cleanup.run(&mut render_app.world);
+                    }
+                    {
+                        #[cfg(feature = "trace")]
+                        let _stage_span =
+                            bevy_utils::tracing::info_span!("stage", name = "clear_entities")
+                                .entered();
 
-                    render_app.world.clear_entities();
-                }
-            });
+                        render_app.world.clear_entities();
+                    }
+                });
+            }
         }
 
         app.add_plugin(WindowRenderPlugin)

--- a/examples/README.md
+++ b/examples/README.md
@@ -187,6 +187,7 @@ Example | Description
 
 Example | Description
 --- | ---
+[Automated Tests](../tests/automated_tests.rs) | Illustrates how to test systems. Note that this example is in `tests/automated_tests.rs`.
 [Component Change Detection](../examples/ecs/component_change_detection.rs) | Change detection on components
 [Custom Query Parameters](../examples/ecs/custom_query_param.rs) | Groups commonly used compound queries and query filters into a single type
 [ECS Guide](../examples/ecs/ecs_guide.rs) | Full guide to Bevy's ECS

--- a/tests/automated_tests.rs
+++ b/tests/automated_tests.rs
@@ -1,0 +1,49 @@
+//! This example illustrates test systems.
+fn main() {
+    println!("This example is special! Run it with `cargo test --example automated_tests`.");
+    println!(
+        "Or use `cargo test --example automated_tests -- --nocapture` to see the debug output."
+    );
+}
+
+#[cfg(test)]
+mod test {
+    use bevy::prelude::*;
+
+    #[test]
+    fn simple_test() {
+        // Setup the app with the TestPlugins – these will run fine in tests and in CI.
+        // Note that many 3rd-party plugins will require DefaultPlugins, not just TestPlugins.
+        let mut app = App::new();
+        app.add_plugins(DefaultPlugins::for_testing())
+            .add_system(increment);
+
+        // Spawn a new entity with a Counter component, and record its ID.
+        let counter_id = app.world.spawn().insert(Counter::default()).id();
+
+        // Simulate for a 10 frames
+        let num_frames = 10;
+        for _ in 0..num_frames {
+            app.update();
+        }
+
+        // Check that the counter was incremented 10 times.
+        let count = app.world.get::<Counter>(counter_id).unwrap().counter;
+        assert_eq!(count, num_frames);
+
+        println!("Success!");
+    }
+    // Define a system and a component that we can use in our test.
+    #[derive(Debug, Default, Component, Clone, Copy)]
+    struct Counter {
+        counter: u64,
+    }
+
+    /// Increment the counter every frame
+    fn increment(mut query: Query<&mut Counter>) {
+        for mut counter in query.iter_mut() {
+            counter.counter += 1;
+            println!("Counter: {}", counter.counter);
+        }
+    }
+}


### PR DESCRIPTION
- Depends on #5932

# Objective

- Fixes #5931

## Solution

- In initialize_renderer, I just replaced the `.expect` with a `error!`, and made the function return an `Option` 
- In [bevy_render/src/lib.rs](https://github.com/bevyengine/bevy/compare/main...anchpop:%40anchpop/soft-error-when-no-gpu?expand=1#diff-856082d916c7309cbe6c8b2a231f703c8ab0769db951591018a5f217e6c42823) I wrapped some code in an `if let`. (The diff is huge, but it's just indentation changes.)
- Now that `RenderPlugin` will work in gpu-less environments like CI, I added it to `TestPlugins`.

---

## Changelog

### Fixed
- `RenderPlugin` no longer panics when run on a device without a GPU.
