### PR TITLE
[Merged by Bors] - Ensure 2D phase items are sorted before batching

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -46,7 +46,10 @@ impl Plugin for Core2dPlugin {
             .init_resource::<DrawFunctions<Transparent2d>>()
             .add_system_to_stage(RenderStage::Extract, extract_core_2d_camera_phases)
             .add_system_to_stage(RenderStage::PhaseSort, sort_phase_system::<Transparent2d>)
-            .add_system_to_stage(RenderStage::PhaseSort, batch_phase_system::<Transparent2d>);
+            .add_system_to_stage(
+                RenderStage::PhaseSort,
+                batch_phase_system::<Transparent2d>.after(sort_phase_system::<Transparent2d>),
+            );
 
         let pass_node_2d = MainPass2dNode::new(&mut render_app.world);
         let mut graph = render_app.world.resource_mut::<RenderGraph>();


### PR DESCRIPTION
# Objective

Without this we can inappropriately merge batches together without properly accounting for non-batch items between them, and the merged batch will then be sorted incorrectly later.

This change seems to reliably fix the issue I was seeing in #5919.

## Solution

Ensure the `batch_phase_system` runs after the `sort_phase_system`, so that batching can only look at actually adjacent phase items.

