### PR TITLE
[Merged by Bors] - update camera projection if viewport changed

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -439,22 +439,20 @@ pub fn camera_system<T: CameraProjection + Component>(
         .collect();
 
     for (mut camera, mut camera_projection) in &mut cameras {
+        let viewport_size = camera
+            .viewport
+            .as_ref()
+            .map(|viewport| viewport.physical_size);
+
         if camera
             .target
             .is_changed(&changed_window_ids, &changed_image_handles)
             || camera.is_added()
             || camera_projection.is_changed()
-            || camera.computed.old_viewport_size
-                != camera
-                    .viewport
-                    .as_ref()
-                    .map(|viewport| viewport.physical_size)
+            || camera.computed.old_viewport_size != viewport_size
         {
             camera.computed.target_info = camera.target.get_render_target_info(&windows, &images);
-            camera.computed.old_viewport_size = camera
-                .viewport
-                .as_ref()
-                .map(|viewport| viewport.physical_size);
+            camera.computed.old_viewport_size = viewport_size;
             if let Some(size) = camera.logical_viewport_size() {
                 camera_projection.update(size.x, size.y);
                 camera.computed.projection_matrix = camera_projection.get_projection_matrix();

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -68,7 +68,7 @@ pub struct ComputedCameraValues {
     projection_matrix: Mat4,
     target_info: Option<RenderTargetInfo>,
     // position and size of the `Viewport`
-    old_viewport: Option<(UVec2, UVec2)>,
+    old_viewport_size: Option<UVec2>,
 }
 
 /// The defining component for camera entities, storing information about how and what to render
@@ -444,17 +444,17 @@ pub fn camera_system<T: CameraProjection + Component>(
             .is_changed(&changed_window_ids, &changed_image_handles)
             || camera.is_added()
             || camera_projection.is_changed()
-            || camera.computed.old_viewport
+            || camera.computed.old_viewport_size
                 != camera
                     .viewport
                     .as_ref()
-                    .map(|viewport| (viewport.physical_position, viewport.physical_size))
+                    .map(|viewport| viewport.physical_size)
         {
             camera.computed.target_info = camera.target.get_render_target_info(&windows, &images);
-            camera.computed.old_viewport = camera
+            camera.computed.old_viewport_size = camera
                 .viewport
                 .as_ref()
-                .map(|viewport| (viewport.physical_position, viewport.physical_size));
+                .map(|viewport| viewport.physical_size);
             if let Some(size) = camera.logical_viewport_size() {
                 camera_projection.update(size.x, size.y);
                 camera.computed.projection_matrix = camera_projection.get_projection_matrix();


### PR DESCRIPTION
fixes https://github.com/bevyengine/bevy/issues/5944

Uses the second solution:
> 2. keep track of the old viewport in the computed_state, and if camera.viewport != camera.computed_state.old_viewport, then update the projection. This is more reliable, but needs to store two UVec2s more in the camera (probably not a big deal).