### PR TITLE
[Merged by Bors] - Ignore `Timeout` errors on Linux AMD & Intel

### DIFF
--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -239,14 +239,14 @@ pub fn prepare_windows(
 
         let not_already_configured = window_surfaces.configured_windows.insert(window.id);
 
+        let surface = &surface_data.surface;
         if not_already_configured || window.size_changed || window.present_mode_changed {
-            let no_new_surface_message = "Error configuring surface";
-            let surface = &surface_data.surface;
             render_device.configure_surface(surface, &surface_configuration);
-            let frame = surface.get_current_texture().expect(no_new_surface_message);
+            let frame = surface
+                .get_current_texture()
+                .expect("Error configuring surface");
             window.swap_chain_texture = Some(TextureView::from(frame));
         } else {
-            let surface = &surface_data.surface;
             match surface.get_current_texture() {
                 Ok(frame) => {
                     window.swap_chain_texture = Some(TextureView::from(frame));

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -260,7 +260,7 @@ pub fn prepare_windows(
                 }
                 #[cfg(target_os = "linux")]
                 Err(wgpu::SurfaceError::Timeout) if may_erroneously_timeout() => {
-                    debug!(
+                    bevy_utils::tracing::trace!(
                         "Couldn't get swap chain texture. This is probably a quirk \
                         of your Linux GPU driver, so it can be safely ignored."
                     );

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -240,7 +240,7 @@ pub fn prepare_windows(
         let not_already_configured = window_surfaces.configured_windows.insert(window.id);
 
         if not_already_configured || window.size_changed || window.present_mode_changed {
-            let no_new_surface_message = "Error reconfiguring surface";
+            let no_new_surface_message = "Error configuring surface";
             let surface = &surface_data.surface;
             render_device.configure_surface(surface, &surface_configuration);
             let frame = surface.get_current_texture().expect(no_new_surface_message);


### PR DESCRIPTION
# Objective

- Fix #3606
- Fix #4579
- Fix #3380

## Solution

When running on a Linux machine with some AMD or Intel device, when calling
`surface.get_current_texture()`, ignore `wgpu::SurfaceError::Timeout` errors.


## Alternative

An alternative solution found in the `wgpu` examples is:

```rust
let frame = surface
    .get_current_texture()
    .or_else(|_| {
        render_device.configure_surface(surface, &swap_chain_descriptor);
        surface.get_current_texture()
    })
    .expect("Error reconfiguring surface");
window.swap_chain_texture = Some(TextureView::from(frame));
```

See: <https://github.com/gfx-rs/wgpu/blob/94ce76391b560a66e36df1300bd684321e57511a/wgpu/examples/framework.rs#L362-L370>

Veloren [handles the Timeout error the way this PR proposes to handle it](https://github.com/gfx-rs/wgpu/issues/1218#issuecomment-1092056971).

The reason I went with this PR's solution is that `configure_surface` seems to be quite an expensive operation, and it would run every frame with the wgpu framework solution, despite the fact it works perfectly fine without `configure_surface`.

I know this looks super hacky with the linux-specific line and the AMD check, but my understanding is that the `Timeout` occurrence is specific to a quirk of some AMD drivers on linux, and if otherwise met should be considered a bug.
