### PR TITLE
Bump winit version and ndk-glue versions

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -40,7 +40,7 @@ wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-glue = { version = "0.5" }
+ndk-glue = { version = "0.7" }
 
 [dev-dependencies]
 futures-lite = "1.4.0"

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -100,4 +100,4 @@ bevy_gilrs = { path = "../bevy_gilrs", optional = true, version = "0.9.0-dev" }
 [target.'cfg(target_os = "android")'.dependencies]
 # This version *must* be the same as the version used by winit,
 # or Android will break: https://github.com/rust-windowing/winit#android
-ndk-glue = {version = "0.5", features = ["logger"]}
+ndk-glue = {version = "0.7", features = ["logger"]}

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -22,12 +22,12 @@ bevy_window = { path = "../bevy_window", version = "0.9.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
 
 # other
-winit = { version = "0.26.0", default-features = false }
+winit = { version = "0.27.3", default-features = false }
 approx = { version = "0.5.0", default-features = false }
 raw-window-handle = "0.4.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-winit = { version = "0.26.0", default-features = false }
+winit = { version = "0.27.3", default-features = false }
 wasm-bindgen = { version = "0.2" }
 web-sys = "0.3"
 crossbeam-channel = "0.5"

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -34,6 +34,7 @@ use winit::{
     dpi::{LogicalPosition, LogicalSize, PhysicalPosition},
     event::{self, DeviceEvent, Event, StartCause, WindowEvent},
     event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
+    window::CursorGrabMode,
 };
 
 #[derive(Default)]
@@ -140,7 +141,11 @@ fn change_window(
                 bevy_window::WindowCommand::SetCursorLockMode { locked } => {
                     let window = winit_windows.get_window(id).unwrap();
                     window
-                        .set_cursor_grab(locked)
+                        .set_cursor_grab(if locked {
+                            CursorGrabMode::Locked
+                        } else {
+                            CursorGrabMode::Locked
+                        })
                         .unwrap_or_else(|e| error!("Unable to un/grab cursor: {}", e));
                 }
                 bevy_window::WindowCommand::SetCursorVisibility { visible } => {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -144,7 +144,7 @@ fn change_window(
                         .set_cursor_grab(if locked {
                             CursorGrabMode::Locked
                         } else {
-                            CursorGrabMode::Locked
+                            CursorGrabMode::None
                         })
                         .unwrap_or_else(|e| error!("Unable to un/grab cursor: {}", e));
                 }

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -4,7 +4,7 @@ use bevy_window::{MonitorSelection, Window, WindowDescriptor, WindowId, WindowMo
 use raw_window_handle::HasRawWindowHandle;
 use winit::{
     dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize},
-    window::Fullscreen,
+    window::{CursorGrabMode, Fullscreen},
 };
 
 #[derive(Debug, Default)]
@@ -159,7 +159,7 @@ impl WinitWindows {
         }
 
         if window_descriptor.cursor_locked {
-            match winit_window.set_cursor_grab(true) {
+            match winit_window.set_cursor_grab(CursorGrabMode::Locked) {
                 Ok(_) | Err(winit::error::ExternalError::NotSupported(_)) => {}
                 Err(err) => Err(err).unwrap(),
             }
@@ -241,7 +241,9 @@ pub fn get_fitting_videomode(
         match abs_diff(a.size().width, width).cmp(&abs_diff(b.size().width, width)) {
             Equal => {
                 match abs_diff(a.size().height, height).cmp(&abs_diff(b.size().height, height)) {
-                    Equal => b.refresh_rate().cmp(&a.refresh_rate()),
+                    Equal => b
+                        .refresh_rate_millihertz()
+                        .cmp(&a.refresh_rate_millihertz()),
                     default => default,
                 }
             }
@@ -258,7 +260,9 @@ pub fn get_best_videomode(monitor: &winit::monitor::MonitorHandle) -> winit::mon
         use std::cmp::Ordering::*;
         match b.size().width.cmp(&a.size().width) {
             Equal => match b.size().height.cmp(&a.size().height) {
-                Equal => b.refresh_rate().cmp(&a.refresh_rate()),
+                Equal => b
+                    .refresh_rate_millihertz()
+                    .cmp(&a.refresh_rate_millihertz()),
                 default => default,
             },
             default => default,


### PR DESCRIPTION
# Objective

- Android build currently fails as it has several ndk-glue versions.
- Winit has released new versions.

## Solution

- Bump winit to latest version `0.27.3`.
- Bumo ndk-glue versions to `0.7`.
