### PR TITLE
Wrap return value of `Commands::get_or_spawn` into an `Option`

### DIFF
--- a/benches/benches/bevy_ecs/world/commands.rs
+++ b/benches/benches/bevy_ecs/world/commands.rs
@@ -238,7 +238,7 @@ pub fn get_or_spawn(criterion: &mut Criterion) {
             for i in 0..10_000 {
                 commands
                     .get_or_spawn(Entity::from_raw(i))
-                    .expect("Entity ID is already reserved.")
+                    .unwrap()
                     .insert_bundle((Matrix::default(), Vec3::default()));
             }
             command_queue.apply(&mut world);

--- a/benches/benches/bevy_ecs/world/commands.rs
+++ b/benches/benches/bevy_ecs/world/commands.rs
@@ -238,7 +238,7 @@ pub fn get_or_spawn(criterion: &mut Criterion) {
             for i in 0..10_000 {
                 commands
                     .get_or_spawn(Entity::from_raw(i))
-                    .expect("Entity not found.")
+                    .expect("Entity ID is already reserved.")
                     .insert_bundle((Matrix::default(), Vec3::default()));
             }
             command_queue.apply(&mut world);

--- a/benches/benches/bevy_ecs/world/commands.rs
+++ b/benches/benches/bevy_ecs/world/commands.rs
@@ -238,7 +238,8 @@ pub fn get_or_spawn(criterion: &mut Criterion) {
             for i in 0..10_000 {
                 commands
                     .get_or_spawn(Entity::from_raw(i))
-                    .insert((Matrix::default(), Vec3::default()));
+                    .expect("Entity not found.")
+                    .insert_bundle((Matrix::default(), Vec3::default()));
             }
             command_queue.apply(&mut world);
         });

--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -132,7 +132,12 @@ pub fn extract_core_2d_camera_phases(
         if camera.is_active {
             commands
                 .get_or_spawn(entity)
-                .expect("Entity ID is already reserved.")
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Entity {:?} already exists with a different generation.",
+                        entity
+                    )
+                })
                 .insert(RenderPhase::<Transparent2d>::default());
         }
     }

--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -132,6 +132,7 @@ pub fn extract_core_2d_camera_phases(
         if camera.is_active {
             commands
                 .get_or_spawn(entity)
+                .expect("Entity not found.")
                 .insert(RenderPhase::<Transparent2d>::default());
         }
     }

--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -132,7 +132,7 @@ pub fn extract_core_2d_camera_phases(
         if camera.is_active {
             commands
                 .get_or_spawn(entity)
-                .expect("Entity not found.")
+                .expect("Entity ID is already reserved.")
                 .insert(RenderPhase::<Transparent2d>::default());
         }
     }

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -215,7 +215,7 @@ pub fn extract_core_3d_camera_phases(
         if camera.is_active {
             commands
                 .get_or_spawn(entity)
-                .expect("Entity not found.")
+                .expect("Entity ID is already reserved.")
                 .insert_bundle((
                     RenderPhase::<Opaque3d>::default(),
                     RenderPhase::<AlphaMask3d>::default(),

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -221,7 +221,7 @@ pub fn extract_core_3d_camera_phases(
                         entity
                     )
                 })
-                .insert_bundle((
+                .insert((
                     RenderPhase::<Opaque3d>::default(),
                     RenderPhase::<AlphaMask3d>::default(),
                     RenderPhase::<Transparent3d>::default(),

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -215,7 +215,12 @@ pub fn extract_core_3d_camera_phases(
         if camera.is_active {
             commands
                 .get_or_spawn(entity)
-                .expect("Entity ID is already reserved.")
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Entity {:?} already exists with a different generation.",
+                        entity
+                    )
+                })
                 .insert_bundle((
                     RenderPhase::<Opaque3d>::default(),
                     RenderPhase::<AlphaMask3d>::default(),

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -213,11 +213,14 @@ pub fn extract_core_3d_camera_phases(
 ) {
     for (entity, camera) in &cameras_3d {
         if camera.is_active {
-            commands.get_or_spawn(entity).insert((
-                RenderPhase::<Opaque3d>::default(),
-                RenderPhase::<AlphaMask3d>::default(),
-                RenderPhase::<Transparent3d>::default(),
-            ));
+            commands
+                .get_or_spawn(entity)
+                .expect("Entity not found.")
+                .insert_bundle((
+                    RenderPhase::<Opaque3d>::default(),
+                    RenderPhase::<AlphaMask3d>::default(),
+                    RenderPhase::<Transparent3d>::default(),
+                ));
         }
     }
 }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -176,12 +176,12 @@ impl<'w, 's> Commands<'w, 's> {
     /// [`Commands::spawn`]. This method should generally only be used for sharing entities across
     /// apps, and only when they have a scheme worked out to share an ID space (which doesn't happen
     /// by default).
-    pub fn get_or_spawn<'a>(&'a mut self, entity: Entity) -> EntityCommands<'w, 's, 'a> {
+    pub fn get_or_spawn<'a>(&'a mut self, entity: Entity) -> Option<EntityCommands<'w, 's, 'a>> {
         self.add(GetOrSpawn { entity });
-        EntityCommands {
+        self.entities.contains(entity).then_some(EntityCommands {
             entity,
             commands: self,
-        }
+        })
     }
 
     /// Pushes a [`Command`] to the queue for creating a new entity with the given [`Bundle`]'s components,

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -168,7 +168,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// Pushes a [`Command`] to the queue for creating the given [`Entity`] if it does not exist,
     /// and returns its corresponding [`EntityCommands`].
     ///
-    /// Returns `None` if the entity does not exist.
+    /// Returns `None` if there is already an entity with the same ID but with a different generation.
     ///
     /// See [`World::get_or_spawn`] for more details.
     ///

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -168,6 +168,8 @@ impl<'w, 's> Commands<'w, 's> {
     /// Pushes a [`Command`] to the queue for creating a new [`Entity`] if the given one does not exists,
     /// and returns its corresponding [`EntityCommands`].
     ///
+    /// Returns `None` if the entity does not exist.
+    ///
     /// See [`World::get_or_spawn`] for more details.
     ///
     /// # Note

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -180,10 +180,17 @@ impl<'w, 's> Commands<'w, 's> {
     /// by default).
     pub fn get_or_spawn<'a>(&'a mut self, entity: Entity) -> Option<EntityCommands<'w, 's, 'a>> {
         self.add(GetOrSpawn { entity });
-        self.entities.contains(entity).then_some(EntityCommands {
-            entity,
-            commands: self,
-        })
+        match self.entities.resolve_from_id(entity.id()) {
+            Some(resolved_entity) => (resolved_entity.generation() == entity.generation())
+                .then_some(EntityCommands {
+                    entity,
+                    commands: self,
+                }),
+            None => Some(EntityCommands {
+                entity,
+                commands: self,
+            }),
+        }
     }
 
     /// Pushes a [`Command`] to the queue for creating a new entity with the given [`Bundle`]'s components,

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -165,7 +165,7 @@ impl<'w, 's> Commands<'w, 's> {
         }
     }
 
-    /// Pushes a [`Command`] to the queue for creating a new [`Entity`] if the given one does not exists,
+    /// Pushes a [`Command`] to the queue for creating the given [`Entity`] if it does not exist,
     /// and returns its corresponding [`EntityCommands`].
     ///
     /// Returns `None` if the entity does not exist.

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -393,17 +393,20 @@ pub fn extract_clusters(
     mut commands: Commands,
     views: Extract<Query<(Entity, &Clusters), With<Camera>>>,
 ) {
-    for (entity, clusters) in &views {
-        commands.get_or_spawn(entity).insert((
-            ExtractedClustersPointLights {
-                data: clusters.lights.clone(),
-            },
-            ExtractedClusterConfig {
-                near: clusters.near,
-                far: clusters.far,
-                dimensions: clusters.dimensions,
-            },
-        ));
+    for (entity, clusters) in views.iter() {
+        commands
+            .get_or_spawn(entity)
+            .expect("Entity not found.")
+            .insert_bundle((
+                ExtractedClustersPointLights {
+                    data: clusters.lights.clone(),
+                },
+                ExtractedClusterConfig {
+                    near: clusters.near,
+                    far: clusters.far,
+                    dimensions: clusters.dimensions,
+                },
+            ));
     }
 }
 
@@ -564,21 +567,24 @@ pub fn extract_lights(
             largest_dimension / directional_light_shadow_map.size as f32;
         // TODO: As above
         let render_visible_entities = visible_entities.clone();
-        commands.get_or_spawn(entity).insert((
-            ExtractedDirectionalLight {
-                color: directional_light.color,
-                illuminance: directional_light.illuminance,
-                direction: transform.forward(),
-                projection: directional_light.shadow_projection.get_projection_matrix(),
-                shadows_enabled: directional_light.shadows_enabled,
-                shadow_depth_bias: directional_light.shadow_depth_bias,
-                // The factor of SQRT_2 is for the worst-case diagonal offset
-                shadow_normal_bias: directional_light.shadow_normal_bias
-                    * directional_light_texel_size
-                    * std::f32::consts::SQRT_2,
-            },
-            render_visible_entities,
-        ));
+        commands
+            .get_or_spawn(entity)
+            .expect("Entity not found.")
+            .insert_bundle((
+                ExtractedDirectionalLight {
+                    color: directional_light.color,
+                    illuminance: directional_light.illuminance,
+                    direction: transform.forward(),
+                    projection: directional_light.shadow_projection.get_projection_matrix(),
+                    shadows_enabled: directional_light.shadows_enabled,
+                    shadow_depth_bias: directional_light.shadow_depth_bias,
+                    // The factor of SQRT_2 is for the worst-case diagonal offset
+                    shadow_normal_bias: directional_light.shadow_normal_bias
+                        * directional_light_texel_size
+                        * std::f32::consts::SQRT_2,
+                },
+                render_visible_entities,
+            ));
     }
 }
 
@@ -1563,7 +1569,10 @@ pub fn prepare_clusters(
 
         view_clusters_bindings.write_buffers(render_device, &render_queue);
 
-        commands.get_or_spawn(entity).insert(view_clusters_bindings);
+        commands
+            .get_or_spawn(entity)
+            .expect("Entity not found.")
+            .insert(view_clusters_bindings);
     }
 }
 

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -396,7 +396,12 @@ pub fn extract_clusters(
     for (entity, clusters) in views.iter() {
         commands
             .get_or_spawn(entity)
-            .expect("Entity ID is already reserved.")
+            .unwrap_or_else(|| {
+                panic!(
+                    "Entity {:?} already exists with a different generation.",
+                    entity
+                )
+            })
             .insert_bundle((
                 ExtractedClustersPointLights {
                     data: clusters.lights.clone(),
@@ -569,7 +574,12 @@ pub fn extract_lights(
         let render_visible_entities = visible_entities.clone();
         commands
             .get_or_spawn(entity)
-            .expect("Entity ID is already reserved.")
+            .unwrap_or_else(|| {
+                panic!(
+                    "Entity {:?} already exists with a different generation.",
+                    entity
+                )
+            })
             .insert_bundle((
                 ExtractedDirectionalLight {
                     color: directional_light.color,
@@ -1571,7 +1581,12 @@ pub fn prepare_clusters(
 
         commands
             .get_or_spawn(entity)
-            .expect("Entity ID is already reserved.")
+            .unwrap_or_else(|| {
+                panic!(
+                    "Entity {:?} already exists with a different generation.",
+                    entity
+                )
+            })
             .insert(view_clusters_bindings);
     }
 }

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -402,7 +402,7 @@ pub fn extract_clusters(
                     entity
                 )
             })
-            .insert_bundle((
+            .insert((
                 ExtractedClustersPointLights {
                     data: clusters.lights.clone(),
                 },
@@ -580,7 +580,7 @@ pub fn extract_lights(
                     entity
                 )
             })
-            .insert_bundle((
+            .insert((
                 ExtractedDirectionalLight {
                     color: directional_light.color,
                     illuminance: directional_light.illuminance,

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -396,7 +396,7 @@ pub fn extract_clusters(
     for (entity, clusters) in views.iter() {
         commands
             .get_or_spawn(entity)
-            .expect("Entity not found.")
+            .expect("Entity ID is already reserved.")
             .insert_bundle((
                 ExtractedClustersPointLights {
                     data: clusters.lights.clone(),
@@ -569,7 +569,7 @@ pub fn extract_lights(
         let render_visible_entities = visible_entities.clone();
         commands
             .get_or_spawn(entity)
-            .expect("Entity not found.")
+            .expect("Entity ID is already reserved.")
             .insert_bundle((
                 ExtractedDirectionalLight {
                     color: directional_light.color,
@@ -1571,7 +1571,7 @@ pub fn prepare_clusters(
 
         commands
             .get_or_spawn(entity)
-            .expect("Entity not found.")
+            .expect("Entity ID is already reserved.")
             .insert(view_clusters_bindings);
     }
 }

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -55,7 +55,7 @@ fn extract_wireframes(mut commands: Commands, query: Extract<Query<Entity, With<
     for entity in query.iter() {
         commands
             .get_or_spawn(entity)
-            .expect("Entity not found.")
+            .expect("Entity ID is already reserved.")
             .insert(Wireframe);
     }
 }

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -55,7 +55,12 @@ fn extract_wireframes(mut commands: Commands, query: Extract<Query<Entity, With<
     for entity in query.iter() {
         commands
             .get_or_spawn(entity)
-            .expect("Entity ID is already reserved.")
+            .unwrap_or_else(|| {
+                panic!(
+                    "Entity {:?} already exists with a different generation.",
+                    entity
+                )
+            })
             .insert(Wireframe);
     }
 }

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -52,8 +52,11 @@ impl Plugin for WireframePlugin {
 }
 
 fn extract_wireframes(mut commands: Commands, query: Extract<Query<Entity, With<Wireframe>>>) {
-    for entity in &query {
-        commands.get_or_spawn(entity).insert(Wireframe);
+    for entity in query.iter() {
+        commands
+            .get_or_spawn(entity)
+            .expect("Entity not found.")
+            .insert(Wireframe);
     }
 }
 

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -428,7 +428,7 @@ pub fn extract_cameras(
             }
             commands
                 .get_or_spawn(entity)
-                .expect("Entity not found.")
+                .expect("Entity ID is already reserved.")
                 .insert_bundle((
                     ExtractedCamera {
                         target: camera.target.clone(),

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -428,7 +428,12 @@ pub fn extract_cameras(
             }
             commands
                 .get_or_spawn(entity)
-                .expect("Entity ID is already reserved.")
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Entity {:?} already exists with a different generation.",
+                        entity
+                    )
+                })
                 .insert_bundle((
                     ExtractedCamera {
                         target: camera.target.clone(),

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -434,7 +434,7 @@ pub fn extract_cameras(
                         entity
                     )
                 })
-                .insert_bundle((
+                .insert((
                     ExtractedCamera {
                         target: camera.target.clone(),
                         viewport: camera.viewport.clone(),

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -426,27 +426,30 @@ pub fn extract_cameras(
             if target_size.x == 0 || target_size.y == 0 {
                 continue;
             }
-            commands.get_or_spawn(entity).insert((
-                ExtractedCamera {
-                    target: camera.target.clone(),
-                    viewport: camera.viewport.clone(),
-                    physical_viewport_size: Some(viewport_size),
-                    physical_target_size: Some(target_size),
-                    render_graph: camera_render_graph.0.clone(),
-                    priority: camera.priority,
-                },
-                ExtractedView {
-                    projection: camera.projection_matrix(),
-                    transform: *transform,
-                    viewport: UVec4::new(
-                        viewport_origin.x,
-                        viewport_origin.y,
-                        viewport_size.x,
-                        viewport_size.y,
-                    ),
-                },
-                visible_entities.clone(),
-            ));
+            commands
+                .get_or_spawn(entity)
+                .expect("Entity not found.")
+                .insert_bundle((
+                    ExtractedCamera {
+                        target: camera.target.clone(),
+                        viewport: camera.viewport.clone(),
+                        physical_viewport_size: Some(viewport_size),
+                        physical_target_size: Some(target_size),
+                        render_graph: camera_render_graph.0.clone(),
+                        priority: camera.priority,
+                    },
+                    ExtractedView {
+                        projection: camera.projection_matrix(),
+                        transform: *transform,
+                        viewport: UVec4::new(
+                            viewport_origin.x,
+                            viewport_origin.y,
+                            viewport_size.x,
+                            viewport_size.y,
+                        ),
+                    },
+                    visible_entities.clone(),
+                ));
         }
     }
 }

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -35,7 +35,7 @@ use std::ops::{Deref, DerefMut};
 /// # struct Cloud;
 /// fn extract_clouds(mut commands: Commands, clouds: Extract<Query<Entity, With<Cloud>>>) {
 ///     for cloud in &clouds {
-///         commands.get_or_spawn(cloud).insert(Cloud);
+///         commands.get_or_spawn(cloud).expect("Entity not found.").insert(Cloud);
 ///     }
 /// }
 /// ```

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -35,7 +35,7 @@ use std::ops::{Deref, DerefMut};
 /// # struct Cloud;
 /// fn extract_clouds(mut commands: Commands, clouds: Extract<Query<Entity, With<Cloud>>>) {
 ///     for cloud in &clouds {
-///         commands.get_or_spawn(cloud).expect("Entity not found.").insert(Cloud);
+///         commands.get_or_spawn(cloud).expect("Entity ID is already reserved.").insert(Cloud);
 ///     }
 /// }
 /// ```

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -35,7 +35,7 @@ use std::ops::{Deref, DerefMut};
 /// # struct Cloud;
 /// fn extract_clouds(mut commands: Commands, clouds: Extract<Query<Entity, With<Cloud>>>) {
 ///     for cloud in &clouds {
-///         commands.get_or_spawn(cloud).expect("Entity ID is already reserved.").insert(Cloud);
+///         commands.get_or_spawn(cloud).unwrap().insert(Cloud);
 ///     }
 /// }
 /// ```

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -265,10 +265,13 @@ pub fn extract_default_ui_camera_view<T: Component>(
                     ),
                 })
                 .id();
-            commands.get_or_spawn(entity).insert((
-                DefaultCameraView(default_camera_view),
-                RenderPhase::<TransparentUi>::default(),
-            ));
+            commands
+                .get_or_spawn(entity)
+                .expect("Entity not found.")
+                .insert_bundle((
+                    DefaultCameraView(default_camera_view),
+                    RenderPhase::<TransparentUi>::default(),
+                ));
         }
     }
 }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -267,7 +267,12 @@ pub fn extract_default_ui_camera_view<T: Component>(
                 .id();
             commands
                 .get_or_spawn(entity)
-                .expect("Entity ID is already reserved.")
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Entity {:?} already exists with a different generation.",
+                        entity
+                    )
+                })
                 .insert_bundle((
                     DefaultCameraView(default_camera_view),
                     RenderPhase::<TransparentUi>::default(),

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -267,7 +267,7 @@ pub fn extract_default_ui_camera_view<T: Component>(
                 .id();
             commands
                 .get_or_spawn(entity)
-                .expect("Entity not found.")
+                .expect("Entity ID is already reserved.")
                 .insert_bundle((
                     DefaultCameraView(default_camera_view),
                     RenderPhase::<TransparentUi>::default(),

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -273,7 +273,7 @@ pub fn extract_default_ui_camera_view<T: Component>(
                         entity
                     )
                 })
-                .insert_bundle((
+                .insert((
                     DefaultCameraView(default_camera_view),
                     RenderPhase::<TransparentUi>::default(),
                 ));

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -424,7 +424,12 @@ fn spawn_tree(
 
         commands
             .get_or_spawn(ents[parent_idx])
-            .expect("Entity ID is already reserved.")
+            .unwrap_or_else(|| {
+                panic!(
+                    "Entity {:?} already exists with a different generation.",
+                    ents[parent_idx]
+                )
+            })
             .add_child(child_entity);
 
         ents.push(child_entity);

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -424,7 +424,7 @@ fn spawn_tree(
 
         commands
             .get_or_spawn(ents[parent_idx])
-            .expect("Entity not found.")
+            .expect("Entity ID is already reserved.")
             .add_child(child_entity);
 
         ents.push(child_entity);

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -424,6 +424,7 @@ fn spawn_tree(
 
         commands
             .get_or_spawn(ents[parent_idx])
+            .expect("Entity not found.")
             .add_child(child_entity);
 
         ents.push(child_entity);


### PR DESCRIPTION
# Objective

- Fixes #5960

## Solution

- Wrap return value of `Commands::get_or_spawn` into an `Option`, to mimic the behavior of `World::get_or_spawn`.

## Future work

- An issue may be opened to let `World::get_or_spawn` and `Commands::get_or_spawn` return a `Result` instead of an `Option`, so that in case of an already existing entity with a different generation gets correctly reported in panic messages. ([Rationale])

---

## Changelog

- Changed: `Commands::get_or_spawn` returns `Option<EntityCommands>` instead of `EntityCommands`

## Migration Guide

The returned `EntityCommands` by `Commands::get_or_spawn` is now wrapped into an `Option`. So you have to unwrap it to access `EntityCommands`.

```diff
- commands.get_or_spawn(my_entity).some_function();
+ commands.get_or_spawn(my_entity).expect("Entity index is already reserved.").some_function();
```

[Rationale]: https://github.com/bevyengine/bevy/pull/5961#discussion_r976877822