### PR TITLE
make it easier to change app to single threaded stages

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -112,7 +112,7 @@ impl App {
 
     /// Creates a new [`App`] with some default structure,
     /// but allow picking the threading model using [`AppThreading`]
-    fn new_with_threading_option(threading: AppThreading) -> App {
+    pub fn new_with_threading_option(threading: AppThreading) -> App {
         let mut app = App::empty();
         #[cfg(feature = "bevy_reflect")]
         app.init_resource::<AppTypeRegistry>();

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -627,7 +627,7 @@ impl App {
     /// let app = App::empty().add_default_stages(AppThreading::Multi);
     /// ```
     pub fn add_default_stages(&mut self, threading: AppThreading) -> &mut Self {
-        self.add_stage(CoreStage::First, SystemStage::single_threaded())
+        self.add_stage(CoreStage::First, Self::get_stage(threading))
             .add_stage(
                 StartupSchedule,
                 Schedule::default()

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -659,7 +659,6 @@ impl App {
             .add_stage(CoreStage::Last, threading.get_stage())
     }
 
-
     /// Setup the application to manage events of type `T`.
     ///
     /// This is done by adding a [`Resource`] of type [`Events::<T>`],

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -85,6 +85,7 @@ pub enum AppThreading {
 }
 
 impl AppThreading {
+    /// Gets a new instance of [`SystemStage`] for the corresponding value of [`AppThreading`]
     pub fn get_stage(&self) -> SystemStage {
         match self {
             AppThreading::Multi => SystemStage::parallel(),

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -96,7 +96,7 @@ impl DefaultStagesThreading {
 
 impl Default for App {
     fn default() -> Self {
-        App::single_threaded()
+        App::multi_threaded()
     }
 }
 

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -76,20 +76,20 @@ struct SubApp {
     runner: Box<dyn Fn(&mut World, &mut App)>,
 }
 
-/// Sets the default stages to be single or multi threaded.
-pub enum AppThreading {
+/// Option for [`App::add_default_stages`] that sets the stages to be single or multi threaded.
+pub enum DefaultStagesThreading {
     /// run app single threaded
     Single,
     /// run app multi threaded
     Multi,
 }
 
-impl AppThreading {
-    /// Gets a new instance of [`SystemStage`] for the corresponding value of [`AppThreading`]
+impl DefaultStagesThreading {
+    /// Gets a new instance of [`SystemStage`] for the corresponding value of [`DefaultStagesThreading`]
     pub fn get_stage(&self) -> SystemStage {
         match self {
-            AppThreading::Multi => SystemStage::parallel(),
-            AppThreading::Single => SystemStage::single_threaded(),
+            DefaultStagesThreading::Multi => SystemStage::parallel(),
+            DefaultStagesThreading::Single => SystemStage::single_threaded(),
         }
     }
 }
@@ -121,15 +121,15 @@ impl App {
 
     /// Creates a new [`App`] with some default structure with all default stages set to use single threaded system executor.
     pub fn single_threaded() -> App {
-        App::new_with_threading_option(AppThreading::Single)
+        App::new_with_threading_option(DefaultStagesThreading::Single)
     }
 
     /// Creates a new [`App`] with some default structure with all default stages set to use multithreaded system executor.
     pub fn multi_threaded() -> App {
-        App::new_with_threading_option(AppThreading::Multi)
+        App::new_with_threading_option(DefaultStagesThreading::Multi)
     }
 
-    fn new_with_threading_option(threading: AppThreading) -> App {
+    fn new_with_threading_option(threading: DefaultStagesThreading) -> App {
         let mut app = App::empty();
         #[cfg(feature = "bevy_reflect")]
         app.init_resource::<AppTypeRegistry>();
@@ -613,7 +613,7 @@ impl App {
     /// done by default by calling `App::default`, which is in turn called by
     /// [`App::new`].
     ///
-    /// Use [`AppThreading`] to specify the threading model to be used by the default stages.
+    /// Use [`DefaultStagesThreading`] to specify the threading model to be used by the default stages.
     ///
     /// # The stages
     ///
@@ -640,11 +640,11 @@ impl App {
     ///
     /// ```
     /// # use bevy_app::prelude::*;
-    /// # use bevy_app::AppThreading;
+    /// # use bevy_app::DefaultStagesThreading;
     /// #
-    /// let app = App::empty().add_default_stages(AppThreading::Multi);
+    /// let app = App::empty().add_default_stages(DefaultStagesThreading::Multi);
     /// ```
-    pub fn add_default_stages(&mut self, threading: AppThreading) -> &mut Self {
+    pub fn add_default_stages(&mut self, threading: DefaultStagesThreading) -> &mut Self {
         self.add_stage(CoreStage::First, threading.get_stage())
             .add_stage(
                 StartupSchedule,

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -622,6 +622,7 @@ impl App {
     ///
     /// ```
     /// # use bevy_app::prelude::*;
+    /// # use bevy_app::AppThreading;
     /// #
     /// let app = App::empty().add_default_stages(AppThreading::Multi);
     /// ```


### PR DESCRIPTION
# Objective

- Users should have an easier way of switching their threading model.
- I also want this for fixing https://github.com/bevyengine/bevy/issues/5285 to make it easy to switch the panicking test to single threaded.

## Solution

- change add_default_stages to take an option to pick threading model of the default stages
- added constructors on App, `App::single_threaded` and `App::multithreaded` that allow users to construct an app with default stages as single threaded or multi threaded.

## Migration Guide

`add_default_stages` now takes an option.

Before
```rust
App::empty().add_default_stages();
```
After
```rust
App::empty().add_default_stages(AppThreading::Multi);
```

## Notes

- ~~Not sure if `App::new_with_threading_options` should just replace `App::new()`. It would mean we'd need to change all the examples to use `App::default()` instead of `new`~~ *added separate constructors with the option set instead*