### PR TITLE
[Merged by Bors] - Remove `AssetServer::watch_for_changes()`

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -79,7 +79,13 @@ pub struct AssetServerInternal {
 ///
 /// The asset server is the primary way of loading assets in bevy. It keeps track of the load state
 /// of the assets it manages and can even reload them from the filesystem with
-/// [`AssetServer::watch_for_changes`]!
+/// ```
+/// // AssetServerSettings must be inserted before adding the AssetPlugin or DefaultPlugins.
+///	app.insert_resource(AssetServerSettings {
+///     watch_for_changes: true,
+/// 	..default()
+///	})
+/// ```
 ///
 /// The asset server is a _resource_, so in order to access it in a system you need a `Res`
 /// accessor, like this:

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -81,10 +81,10 @@ pub struct AssetServerInternal {
 /// of the assets it manages and can even reload them from the filesystem with
 /// ```
 /// // AssetServerSettings must be inserted before adding the AssetPlugin or DefaultPlugins.
-///	app.insert_resource(AssetServerSettings {
+/// app.insert_resource(AssetServerSettings {
 ///     watch_for_changes: true,
 ///     ..default()
-///	})
+/// })
 /// ```
 ///
 /// The asset server is a _resource_, so in order to access it in a system you need a `Res`

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -80,11 +80,14 @@ pub struct AssetServerInternal {
 /// The asset server is the primary way of loading assets in bevy. It keeps track of the load state
 /// of the assets it manages and can even reload them from the filesystem with
 /// ```
+/// # use bevy_asset::*;
+/// # use bevy_app::*;
+/// # let mut app = App::new();
 /// // AssetServerSettings must be inserted before adding the AssetPlugin or DefaultPlugins.
 /// app.insert_resource(AssetServerSettings {
 ///     watch_for_changes: true,
-///     ..default()
-/// })
+///     ..Default::default()
+/// });
 /// ```
 ///
 /// The asset server is a _resource_, so in order to access it in a system you need a `Res`

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -83,7 +83,7 @@ pub struct AssetServerInternal {
 /// // AssetServerSettings must be inserted before adding the AssetPlugin or DefaultPlugins.
 ///	app.insert_resource(AssetServerSettings {
 ///     watch_for_changes: true,
-/// 	..default()
+///     ..default()
 ///	})
 /// ```
 ///

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -169,13 +169,6 @@ impl AssetServer {
         loaders.push(Arc::new(loader));
     }
 
-    /// Enable watching of the filesystem for changes, if support is available, starting from after
-    /// the point of calling this function.
-    pub fn watch_for_changes(&self) -> Result<(), AssetServerError> {
-        self.asset_io().watch_for_changes()?;
-        Ok(())
-    }
-
     /// Gets a strong handle for an asset with the provided id.
     pub fn get_handle<T: Asset, I: Into<HandleId>>(&self, id: I) -> Handle<T> {
         let sender = self.server.asset_ref_counter.channel.sender.clone();

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -29,7 +29,9 @@ mod path;
 /// The `bevy_asset` prelude.
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{AddAsset, AssetEvent, AssetServer, Assets, Handle, HandleUntyped};
+    pub use crate::{
+        AddAsset, AssetEvent, AssetServer, AssetServerSettings, Assets, Handle, HandleUntyped,
+    };
 }
 
 pub use anyhow::Error;

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -6,6 +6,13 @@ use bevy::{prelude::*, tasks::IoTaskPool, utils::Duration};
 
 fn main() {
     App::new()
+        // This tells the AssetServer to watch for changes to assets.
+        // It enables our scenes to automatically reload in game when we modify their files.
+        // AssetServerSettings must be inserted before the DefaultPlugins are added.
+        .insert_resource(AssetServerSettings {
+            watch_for_changes: true,
+            ..default()
+        })
         .add_plugins(DefaultPlugins)
         .register_type::<ComponentA>()
         .register_type::<ComponentB>()
@@ -65,10 +72,6 @@ fn load_scene_system(mut commands: Commands, asset_server: Res<AssetServer>) {
         scene: asset_server.load(SCENE_FILE_PATH),
         ..default()
     });
-
-    // This tells the AssetServer to watch for changes to assets.
-    // It enables our scenes to automatically reload in game when we modify their files
-    asset_server.watch_for_changes().unwrap();
 }
 
 // This system logs all ComponentA components in our world. Try making a change to a ComponentA in

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -8,7 +8,7 @@ use bevy::{
     prelude::*,
     reflect::TypeUuid,
     render::{
-        camera::{Camera, RenderTarget},
+        camera::RenderTarget,
         render_resource::{
             AsBindGroup, Extent3d, ShaderRef, TextureDescriptor, TextureDimension, TextureFormat,
             TextureUsages,
@@ -20,13 +20,16 @@ use bevy::{
 };
 
 fn main() {
-    let mut app = App::new();
-    app.add_plugins(DefaultPlugins)
+    App::new()
+        .insert_resource(AssetServerSettings {
+            watch_for_changes: true,
+            ..default()
+        })
+        .add_plugins(DefaultPlugins)
         .add_plugin(Material2dPlugin::<PostProcessingMaterial>::default())
         .add_startup_system(setup)
-        .add_system(main_camera_cube_rotator_system);
-
-    app.run();
+        .add_system(main_camera_cube_rotator_system)
+        .run();
 }
 
 /// Marks the first camera cube (rendered to a texture.)
@@ -40,11 +43,8 @@ fn setup(
     mut post_processing_materials: ResMut<Assets<PostProcessingMaterial>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut images: ResMut<Assets<Image>>,
-    asset_server: Res<AssetServer>,
 ) {
-    asset_server.watch_for_changes().unwrap();
-
-    let window = windows.get_primary_mut().unwrap();
+    let window = windows.primary_mut();
     let size = Extent3d {
         width: window.physical_width(),
         height: window.physical_height(),

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -21,10 +21,6 @@ use bevy::{
 
 fn main() {
     App::new()
-        .insert_resource(AssetServerSettings {
-            watch_for_changes: true,
-            ..default()
-        })
         .add_plugins(DefaultPlugins)
         .add_plugin(Material2dPlugin::<PostProcessingMaterial>::default())
         .add_startup_system(setup)

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -23,6 +23,10 @@ use bytemuck::{Pod, Zeroable};
 
 fn main() {
     App::new()
+        .insert_resource(AssetServerSettings {
+            watch_for_changes: true,
+            ..default()
+        })
         .add_plugins(DefaultPlugins)
         .add_plugin(CustomMaterialPlugin)
         .add_startup_system(setup)
@@ -168,7 +172,6 @@ pub struct CustomPipeline {
 impl FromWorld for CustomPipeline {
     fn from_world(world: &mut World) -> Self {
         let asset_server = world.resource::<AssetServer>();
-        asset_server.watch_for_changes().unwrap();
         let shader = asset_server.load("shaders/instancing.wgsl");
 
         let mesh_pipeline = world.resource::<MeshPipeline>();

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -23,10 +23,6 @@ use bytemuck::{Pod, Zeroable};
 
 fn main() {
     App::new()
-        .insert_resource(AssetServerSettings {
-            watch_for_changes: true,
-            ..default()
-        })
         .add_plugins(DefaultPlugins)
         .add_plugin(CustomMaterialPlugin)
         .add_startup_system(setup)

--- a/examples/tools/scene_viewer.rs
+++ b/examples/tools/scene_viewer.rs
@@ -5,7 +5,7 @@
 //! With no arguments it will load the `FieldHelmet` glTF model from the repository assets subdirectory.
 
 use bevy::{
-    asset::{AssetServerSettings, LoadState},
+    asset::LoadState,
     gltf::Gltf,
     input::mouse::MouseMotion,
     math::Vec3A,


### PR DESCRIPTION
# Objective
`AssetServer::watch_for_changes()` is racy and redundant with `AssetServerSettings`.
Closes #5964.

## Changelog

* Remove `AssetServer::watch_for_changes()`
* Add `AssetServerSettings` to the prelude.
* Minor cleanup.

## Migration Guide
`AssetServer::watch_for_changes()` was removed.
Instead, use the `AssetServerSettings` resource.
```rust
app // AssetServerSettings must be inserted before adding the AssetPlugin or DefaultPlugins.
	.insert_resource(AssetServerSettings {
		watch_for_changes: true,
		..default()
	})
```
