### PR TITLE
[Merged by Bors] - Fix a small doc typo: grater -> greater

### DIFF
--- a/crates/bevy_core/src/task_pool_options.rs
+++ b/crates/bevy_core/src/task_pool_options.rs
@@ -39,7 +39,7 @@ pub struct DefaultTaskPoolOptions {
     /// If the number of physical cores is less than min_total_threads, force using
     /// min_total_threads
     pub min_total_threads: usize,
-    /// If the number of physical cores is grater than max_total_threads, force using
+    /// If the number of physical cores is greater than max_total_threads, force using
     /// max_total_threads
     pub max_total_threads: usize,
 


### PR DESCRIPTION
# Objective

Fix a small typo in the docs: [DefaultTaskPoolOptions::max_total_threads](https://docs.rs/bevy/latest/bevy/core/struct.DefaultTaskPoolOptions.html#structfield.max_total_threads)

## Solution

Change the spelling. :+1: 