### PR TITLE
Add NameLookup Type to make looking up entities by name easier

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -13,7 +13,8 @@ use bevy_ecs::{
     prelude::Component,
     reflect::ReflectComponent,
     schedule::ParallelSystemDescriptorCoercion,
-    system::{Query, Res},
+    system::{Query, Res, SystemParam},
+    query::QueryEntityError,
 };
 use bevy_hierarchy::Children;
 use bevy_math::{Quat, Vec3};
@@ -29,6 +30,89 @@ pub mod prelude {
         AnimationClip, AnimationPlayer, AnimationPlugin, EntityPath, Keyframes, VariableCurve,
     };
 }
+
+/// System param to enable entity lookup of an entity via EntityPath
+#[derive(SystemParam)]
+pub struct NameLookup<'w, 's> {
+    named: Query<'w, 's, (Entity, &'static Name)>,
+    children: Query<'w, 's, &'static Children>,
+}
+
+/// Errors when looking up an entity by name
+pub enum LookupError {
+    /// An entity could not be found, this either means the entity has been
+    /// despawned, or the entity doesn't have the required components
+    Query(QueryEntityError),
+    /// The root node does not have the corrent name
+    // TODO: add expected / found name
+    RootNotFound,
+    /// A child was not found
+    // TODO: add expected name
+    ChildNotFound,
+    /// The name does not uniquely identify an entity
+    // TODO: add name
+    NameNotUnique,
+}
+
+impl From<QueryEntityError> for LookupError {
+    fn from(q: QueryEntityError) -> Self {
+        Self::Query(q)
+    }
+}
+
+impl<'w, 's> NameLookup<'w, 's> {
+    /// Find an entity by entity path, may return an error if the root name isn't unique
+    pub fn lookup_any(&self, path: &EntityPath) -> Result<Entity, LookupError> {
+        let mut path = path.parts.iter();
+        let root_name = path.next().unwrap();
+        let mut root = None;
+        for (entity, name) in self.named.iter() {
+            if root_name == name {
+                if root.is_some() {
+                    return Err(LookupError::NameNotUnique);
+                }
+                root = Some(entity);
+            }
+        }
+        let mut current_node = root.ok_or(LookupError::RootNotFound)?;
+        for part in path {
+            current_node = self.find_child(current_node, part)?;
+        }
+        Ok(current_node)
+    }
+
+    /// Find an entity by the root & entity path
+    pub fn lookup(&self, root: Entity, path: &EntityPath) -> Result<Entity, LookupError> {
+        let mut path = path.parts.iter();
+        let (_, root_name) = self.named.get(root)?;
+        if root_name != path.next().unwrap() {
+            return Err(LookupError::RootNotFound);
+        }
+        let mut current_node = root;
+        for part in path {
+            current_node = self.find_child(current_node, part)?;
+        }
+        Ok(current_node)
+    }
+
+    /// Internal function to get the child of `current_node` that has the name `part`
+    fn find_child(&self, current_node: Entity, part: &Name) -> Result<Entity, LookupError> {
+        let children = self.children.get(current_node)?;
+        let mut ret = Err(LookupError::ChildNotFound);
+        for child in children {
+            if let Ok((_, name)) = self.named.get(*child) {
+                if name == part {
+                    if ret.is_ok() {
+                        return Err(LookupError::NameNotUnique);
+                    }
+                    ret = Ok(*child);
+                }
+            }
+        }
+        ret
+    }
+}
+
 
 /// List of keyframes for one of the attribute of a [`Transform`].
 #[derive(Clone, Debug)]

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -6,7 +6,8 @@ use std::ops::Deref;
 
 use bevy_app::{App, CoreStage, Plugin};
 use bevy_asset::{AddAsset, Assets, Handle};
-use bevy_core::{EntityPath, Name, NameLookup};
+use bevy_core::{Name, NameLookup};
+pub use bevy_core::EntityPath;
 use bevy_ecs::{
     change_detection::DetectChanges,
     entity::Entity,
@@ -26,7 +27,7 @@ use bevy_utils::{tracing::warn, HashMap};
 #[allow(missing_docs)]
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{AnimationClip, AnimationPlayer, AnimationPlugin, Keyframes, VariableCurve};
+    pub use crate::{AnimationClip, AnimationPlayer, AnimationPlugin, Keyframes, VariableCurve, EntityPath};
 }
 
 /// List of keyframes for one of the attribute of a [`Transform`].

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -17,6 +17,7 @@ bevy_math = { path = "../bevy_math", version = "0.9.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"] }
 bevy_tasks = { path = "../bevy_tasks", version = "0.9.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.9.0-dev" }
 
 # other
 bytemuck = "1.5"

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -1,4 +1,11 @@
-use bevy_ecs::{component::Component, reflect::ReflectComponent};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    query::QueryEntityError,
+    reflect::ReflectComponent,
+    system::{Query, SystemParam},
+};
+use bevy_hierarchy::Children;
 use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::Reflect;
 use bevy_utils::AHasher;
@@ -148,5 +155,94 @@ impl Deref for Name {
 
     fn deref(&self) -> &Self::Target {
         self.name.as_ref()
+    }
+}
+
+/// Path to an entity, with [`Name`]s. Each entity in a path must have a name.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Default)]
+pub struct EntityPath {
+    /// Parts of the path
+    pub parts: Vec<Name>,
+}
+
+/// System param to enable entity lookup of an entity via EntityPath
+#[derive(SystemParam)]
+pub struct NameLookup<'w, 's> {
+    named: Query<'w, 's, (Entity, &'static Name)>,
+    children: Query<'w, 's, &'static Children>,
+}
+
+/// Errors when looking up an entity by name
+pub enum LookupError {
+    /// An entity could not be found, this either means the entity has been
+    /// despawned, or the entity doesn't have the required components
+    Query(QueryEntityError),
+    /// The root node does not have the corrent name
+    // TODO: add expected / found name
+    RootNotFound,
+    /// A child was not found
+    // TODO: add expected name
+    ChildNotFound,
+    /// The name does not uniquely identify an entity
+    // TODO: add name
+    NameNotUnique,
+}
+
+impl From<QueryEntityError> for LookupError {
+    fn from(q: QueryEntityError) -> Self {
+        Self::Query(q)
+    }
+}
+
+impl<'w, 's> NameLookup<'w, 's> {
+    /// Find an entity by entity path, may return an error if the root name isn't unique
+    pub fn lookup_any(&self, path: &EntityPath) -> Result<Entity, LookupError> {
+        let mut path = path.parts.iter();
+        let root_name = path.next().unwrap();
+        let mut root = None;
+        for (entity, name) in self.named.iter() {
+            if root_name == name {
+                if root.is_some() {
+                    return Err(LookupError::NameNotUnique);
+                }
+                root = Some(entity);
+            }
+        }
+        let mut current_node = root.ok_or(LookupError::RootNotFound)?;
+        for part in path {
+            current_node = self.find_child(current_node, part)?;
+        }
+        Ok(current_node)
+    }
+
+    /// Find an entity by the root & entity path
+    pub fn lookup(&self, root: Entity, path: &EntityPath) -> Result<Entity, LookupError> {
+        let mut path = path.parts.iter();
+        let (_, root_name) = self.named.get(root)?;
+        if root_name != path.next().unwrap() {
+            return Err(LookupError::RootNotFound);
+        }
+        let mut current_node = root;
+        for part in path {
+            current_node = self.find_child(current_node, part)?;
+        }
+        Ok(current_node)
+    }
+
+    /// Internal function to get the child of `current_node` that has the name `part`
+    fn find_child(&self, current_node: Entity, part: &Name) -> Result<Entity, LookupError> {
+        let children = self.children.get(current_node)?;
+        let mut ret = Err(LookupError::ChildNotFound);
+        for child in children {
+            if let Ok((_, name)) = self.named.get(*child) {
+                if name == part {
+                    if ret.is_ok() {
+                        return Err(LookupError::NameNotUnique);
+                    }
+                    ret = Ok(*child);
+                }
+            }
+        }
+        ret
     }
 }

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -204,7 +204,7 @@ async fn load_gltf<'a, 'b>(
                 if let Some((root_index, path)) = paths.get(&node.index()) {
                     animation_roots.insert(root_index);
                     animation_clip.add_curve_to_path(
-                        bevy_animation::EntityPath {
+                        bevy_core::EntityPath {
                             parts: path.clone(),
                         },
                         bevy_animation::VariableCurve {


### PR DESCRIPTION
## Objective

Looking up an entity by name is somewhat difficult, and only done within `bevy_animation`. The actual code is difficult to read, and outside crates also have a need to lookup entities by name. To facilitate an easier interface, I've created a `NameLookup` type (which implements SystemParam), and provided a few methods for looking up entities.

## Motivation

I'm currently working on a Inverse Kinematics solver for Bevy, which requires the ability to lookup bones in an armature by name (in the same way an animation does).

## Solution

I've provided an implementation of a `NameLookup` type, which implements `SystemParam`.

The interface is roughly:

```rust
impl NameLookup {
    pub fn lookup_any(&self, path: &EntityPath) -> Result<Entity>;
    pub fn lookup(&self, root: Entity, path: &EntityPath) -> Result<Entity>;
}
```

This also avoids the need to use loop labels (sort of a goto), be refactoring into multiple methods. 

There is a note in the current code that lookup by EntityPath can be optimized for better performance. By refactoring it into an independent method, we isolate the lookup itself, and allow benchmarking & testing of the lookup code independent of the rest of the animation logic. Because this is also a public type, external crates can also benefit from performance improvements. Finally, this is also a unified place to implement caching (if possible), to avoid repeated lookups.