### PR TITLE
[Merged by Bors] - Stopwatch elapsed secs f64

### DIFF
--- a/crates/bevy_time/src/stopwatch.rs
+++ b/crates/bevy_time/src/stopwatch.rs
@@ -89,15 +89,6 @@ impl Stopwatch {
     /// Returns the elapsed time since the last [`reset`](Stopwatch::reset)
     /// of the stopwatch, in seconds, as f64.
     ///
-    /// # Examples
-    /// ```
-    /// # use bevy_time::*;
-    /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
-    /// stopwatch.tick(Duration::from_secs(1));
-    /// assert_eq!(stopwatch.elapsed_secs_f64(), 1.0);
-    /// ```
-    ///
     /// # See Also
     ///
     /// [`elapsed`](Stopwatch::elapsed) - if a `Duration` is desirable instead.

--- a/crates/bevy_time/src/stopwatch.rs
+++ b/crates/bevy_time/src/stopwatch.rs
@@ -58,7 +58,7 @@ impl Stopwatch {
     ///
     /// # See Also
     ///
-    /// [`elapsed_secs`](Stopwatch::elapsed) - if a `f32` value is desirable instead.
+    /// [`elapsed_secs`](Stopwatch::elapsed_secs) - if a `f32` value is desirable instead.
     /// [`elapsed_secs_f64`](Stopwatch::elapsed_secs_f64) - if a `f64` is desirable instead.
     #[inline]
     pub fn elapsed(&self) -> Duration {

--- a/crates/bevy_time/src/stopwatch.rs
+++ b/crates/bevy_time/src/stopwatch.rs
@@ -59,6 +59,7 @@ impl Stopwatch {
     /// # See Also
     ///
     /// [`elapsed_secs`](Stopwatch::elapsed) - if a `f32` value is desirable instead.
+    /// [`elapsed_secs_f64`](Stopwatch::elapsed_secs_f64) - if a `f64` is desirable instead.
     #[inline]
     pub fn elapsed(&self) -> Duration {
         self.elapsed
@@ -79,9 +80,31 @@ impl Stopwatch {
     /// # See Also
     ///
     /// [`elapsed`](Stopwatch::elapsed) - if a `Duration` is desirable instead.
+    /// [`elapsed_secs_f64`](Stopwatch::elapsed_secs_f64) - if a `f64` is desirable instead.
     #[inline]
     pub fn elapsed_secs(&self) -> f32 {
         self.elapsed().as_secs_f32()
+    }
+
+    /// Returns the elapsed time since the last [`reset`](Stopwatch::reset)
+    /// of the stopwatch, in seconds, as f64.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_time::*;
+    /// use std::time::Duration;
+    /// let mut stopwatch = Stopwatch::new();
+    /// stopwatch.tick(Duration::from_secs(1));
+    /// assert_eq!(stopwatch.elapsed_secs_f64(), 1.0);
+    /// ```
+    ///
+    /// # See Also
+    ///
+    /// [`elapsed`](Stopwatch::elapsed) - if a `Duration` is desirable instead.
+    /// [`elapsed_secs`](Stopwatch::elapsed_secs) - if a `f32` is desirable instead.
+    #[inline]
+    pub fn elapsed_secs_f64(&self) -> f64 {
+        self.elapsed().as_secs_f64()
     }
 
     /// Sets the elapsed time of the stopwatch.


### PR DESCRIPTION
# Objective

While coding in bevy I needed to get the elapsed time of a stopwatch as f64.
I found it quite odd there are functions on Timer to get time as f64 but not on the Stopwatch.

## Solution

- added a function that returns the `Stopwatch` elapsed time as `f64`

---

## Changelog

### Added
- Added a function to get `Stopwatch` elapsed time as `f64`

### Fixed
- The Stopwatch elapsed function had a wrong docs link

