### PR TITLE
[Merged by Bors] -  add time wrapping to Time

### DIFF
--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -2,10 +2,19 @@ use bevy_ecs::{reflect::ReflectResource, system::Resource};
 use bevy_reflect::{FromReflect, Reflect};
 use bevy_utils::{Duration, Instant};
 
+/// The duration after which the time will go wrap back to 0
 #[derive(Debug, Clone, Copy)]
 pub enum WrapDuration {
+    /// Will wrap after 1 hour or 3600 seconds
     Default,
+    /// Used to provide any duration to use as the period.
+    ///
+    /// It is highly recommended to not go above the maximum value of a day
     Custom(Duration),
+    /// Will wrap after 1 day or 86400 seconds.
+    ///
+    /// `f32`'s have about 6-7 significant numbers and a day is 86400 seconds,
+    /// add a few decimal places for millis and you will start to get precision errors.
     Max,
 }
 

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -13,7 +13,8 @@ pub struct Time {
     seconds_since_startup: f64,
     time_since_startup: Duration,
     startup: Instant,
-    /// The maximum duration before `Self::seconds_since_last_wrapping_period()` wraps back to 0.0
+    /// The maximum duration before `Self::seconds_since_last_wrapping_period()` wraps back to 0.0.
+    /// Defaults to one hour.
     pub max_wrapping_period: Duration,
 }
 

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -149,20 +149,22 @@ impl Time {
 
     /// The time from startup to the last update in seconds
     ///
-    /// If you need an `f32` value, it is highly recommended to use [`Time::seconds_since_startup_f32_wrapped`]
-    /// instead of casting it. Casting to an `f32` can cause floating point precision issues pretty fast.
+    /// If you intend to cast this to an `f32` value, note that this value is monotonically increasing,
+    /// and that its precision as an `f32` will noticeably degrade over time (in a matter of hours).
+    /// If that precision loss is unacceptable, you should use [`Time::seconds_since_startup_f32_wrapped`], 
+    /// which will return the time from startup modulo a wrapping period.
     #[inline]
     pub fn seconds_since_startup(&self) -> f64 {
         self.seconds_since_startup
     }
 
-    /// The time from the last wrap period to the last update in seconds.
+    /// The time from startup to the last update, modulo the given wrapping period, in seconds.
     ///
-    /// When used in shaders, the time is limited to `f32` which can introduce floating point precision issues
-    /// fairly quickly if the app is left open for a while.
-    /// This will wrap the value to 0.0 on the update after the `Self::max_wrapping_period`.
+    /// Time from startup is a monotonically increasing value and so its precision when read as an `f32`
+    /// will noticeably degrade over time, which causes issues for some uses, e.g. shaders.
+    /// This method avoids noticeable degradation by limiting the values to a much smaller range.
     ///
-    /// Defaults to wrapping every hour.
+    /// The default wrapping period is one hour.
     #[inline]
     pub fn seconds_since_startup_f32_wrapped(&self, duration: WrapDuration) -> f32 {
         let duration: Duration = duration.into();

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -3,6 +3,7 @@ use bevy_reflect::{FromReflect, Reflect};
 use bevy_utils::{Duration, Instant};
 
 const SECONDS_PER_HOUR: u64 = 60 * 60;
+
 /// Tracks elapsed time since the last update and since the App has started
 #[derive(Resource, Reflect, FromReflect, Debug, Clone)]
 #[reflect(Resource)]

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -126,6 +126,9 @@ impl Time {
     }
 
     /// The time from startup to the last update in seconds
+    ///
+    /// If you need an f32 value, it is highly recommended to use [`Time::seconds_since_startup_f32_wrapped`]
+    /// instead of casting it. Casting to an f32 can cause floating point precision issues pretty fast.
     #[inline]
     pub fn seconds_since_startup(&self) -> f64 {
         self.seconds_since_startup
@@ -139,7 +142,7 @@ impl Time {
     ///
     /// Defaults to wrapping every hour
     #[inline]
-    pub fn seconds_since_last_wrapping_period(&self) -> f32 {
+    pub fn seconds_since_startup_f32_wrapped(&self) -> f32 {
         (self.seconds_since_startup % self.max_wrapping_period.as_secs_f64()) as f32
     }
 
@@ -186,7 +189,7 @@ mod tests {
         assert_eq!(time.seconds_since_startup(), 0.0);
         assert_eq!(time.time_since_startup(), Duration::from_secs(0));
         assert_eq!(time.delta_seconds(), 0.0);
-        assert_eq!(time.seconds_since_last_wrapping_period(), 0.0);
+        assert_eq!(time.seconds_since_startup_f32_wrapped(), 0.0);
 
         // Update `time` and check results
         let first_update_instant = Instant::now();
@@ -207,7 +210,7 @@ mod tests {
         );
         assert_eq!(time.delta_seconds(), 0.0);
         assert_float_eq(
-            time.seconds_since_last_wrapping_period(),
+            time.seconds_since_startup_f32_wrapped(),
             time.seconds_since_startup() as f32,
         );
 
@@ -232,7 +235,7 @@ mod tests {
         );
         assert_eq!(time.delta_seconds(), time.delta().as_secs_f32());
         assert_float_eq(
-            time.seconds_since_last_wrapping_period(),
+            time.seconds_since_startup_f32_wrapped(),
             time.seconds_since_startup() as f32,
         );
     }
@@ -247,17 +250,17 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(time.seconds_since_last_wrapping_period(), 0.0);
+        assert_eq!(time.seconds_since_startup_f32_wrapped(), 0.0);
 
         time.update_with_instant(start_instant + Duration::from_secs(1));
-        assert_float_eq(time.seconds_since_last_wrapping_period(), 1.0);
+        assert_float_eq(time.seconds_since_startup_f32_wrapped(), 1.0);
 
         time.update_with_instant(start_instant + Duration::from_secs(2));
-        assert_float_eq(time.seconds_since_last_wrapping_period(), 2.0);
+        assert_float_eq(time.seconds_since_startup_f32_wrapped(), 2.0);
 
         // wraps on next update
         time.update_with_instant(start_instant + Duration::from_secs(3));
-        assert_float_eq(time.seconds_since_last_wrapping_period(), 1.0);
+        assert_float_eq(time.seconds_since_startup_f32_wrapped(), 1.0);
     }
 
     fn assert_float_eq(a: f32, b: f32) {

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -151,7 +151,7 @@ impl Time {
     ///
     /// If you intend to cast this to an `f32` value, note that this value is monotonically increasing,
     /// and that its precision as an `f32` will noticeably degrade over time (in a matter of hours).
-    /// If that precision loss is unacceptable, you should use [`Time::seconds_since_startup_f32_wrapped`], 
+    /// If that precision loss is unacceptable, you should use [`Time::seconds_since_startup_f32_wrapped`],
     /// which will return the time from startup modulo a wrapping period.
     #[inline]
     pub fn seconds_since_startup(&self) -> f64 {

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -127,20 +127,20 @@ impl Time {
 
     /// The time from startup to the last update in seconds
     ///
-    /// If you need an f32 value, it is highly recommended to use [`Time::seconds_since_startup_f32_wrapped`]
-    /// instead of casting it. Casting to an f32 can cause floating point precision issues pretty fast.
+    /// If you need an `f32` value, it is highly recommended to use [`Time::seconds_since_startup_f32_wrapped`]
+    /// instead of casting it. Casting to an `f32` can cause floating point precision issues pretty fast.
     #[inline]
     pub fn seconds_since_startup(&self) -> f64 {
         self.seconds_since_startup
     }
 
-    /// The time from the last wrap period to the last update in seconds
+    /// The time from the last wrap period to the last update in seconds.
     ///
-    /// When used in shaders, the time is limited to f32 which can introduce floating point precision issues
-    /// fairly quickly if the app is left open for a while. This will wrap the value to 0.0 on the update after
-    /// the `Self::max_wrapping_period`
+    /// When used in shaders, the time is limited to `f32` which can introduce floating point precision issues
+    /// fairly quickly if the app is left open for a while. 
+    /// This will wrap the value to 0.0 on the update after the `Self::max_wrapping_period`.
     ///
-    /// Defaults to wrapping every hour
+    /// Defaults to wrapping every hour.
     #[inline]
     pub fn seconds_since_startup_f32_wrapped(&self) -> f32 {
         (self.seconds_since_startup % self.max_wrapping_period.as_secs_f64()) as f32
@@ -264,6 +264,6 @@ mod tests {
     }
 
     fn assert_float_eq(a: f32, b: f32) {
-        assert!((a - b) <= f32::EPSILON, "{a} != {b}");
+        assert!((a - b).abs() <= f32::EPSILON, "{a} != {b}");
     }
 }

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -137,7 +137,7 @@ impl Time {
     /// The time from the last wrap period to the last update in seconds.
     ///
     /// When used in shaders, the time is limited to `f32` which can introduce floating point precision issues
-    /// fairly quickly if the app is left open for a while. 
+    /// fairly quickly if the app is left open for a while.
     /// This will wrap the value to 0.0 on the update after the `Self::max_wrapping_period`.
     ///
     /// Defaults to wrapping every hour.


### PR DESCRIPTION
# Objective

- Sometimes, like when using shaders, you can only use a time value in `f32`. Unfortunately this suffers from floating precision issues pretty quickly. The standard approach to this problem is to wrap the time after a given period
- This is necessary for https://github.com/bevyengine/bevy/pull/5409

## Solution

- Add a `seconds_since_last_wrapping_period` method on `Time` that returns a `f32` that is the `seconds_since_startup` modulo the `max_wrapping_period`

---

## Changelog

Added `seconds_since_last_wrapping_period` to `Time`

## Additional info

I'm very opened to hearing better names. I don't really like the current naming, I just went with something descriptive.