### PR TITLE
[Merged by Bors] - Disabling default features support in bevy_ecs, bevy_reflect and bevy

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -14,6 +14,9 @@ status = [
     "check-compiles",
     "build-and-install-on-iOS",
     "run-examples-on-windows-dx12",
+    "build-without-default-features (bevy)",
+    "build-without-default-features (bevy_ecs)",
+    "build-without-default-features (bevy_reflect)",
 ]
 
 use_squash_merge = true

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -154,3 +154,23 @@ jobs:
         with:
           name: screenshots
           path: .github/start-wasm-example/screenshot-*.png
+
+  build-without-default-features:
+    strategy:
+      matrix:
+        crate: [bevy_ecs, bevy_reflect, bevy]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+        if: runner.os == 'linux'
+      - name: Build
+        run: cargo build -p ${{ matrix.crate }} --no-default-features
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0 -D warnings"

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -168,7 +168,6 @@ jobs:
           override: true
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-        if: runner.os == 'linux'
       - name: Build
         run: cargo build -p ${{ matrix.crate }} --no-default-features
         env:

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1,7 +1,6 @@
 //! Types that detect when their internal data mutate.
 
 use crate::{component::ComponentTicks, ptr::PtrMut, system::Resource};
-#[cfg(feature = "bevy_reflect")]
 use std::ops::{Deref, DerefMut};
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.


### PR DESCRIPTION
# Objective

- Fix disabling features in bevy_ecs (broken by #5630)
- Add tests in CI for bevy_ecs, bevy_reflect and bevy as those crates could be use standalone
