### PR TITLE
[Merged by Bors] - scenes: simplify return type of iter_instance_entities

### DIFF
--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -297,7 +297,7 @@ impl SceneSpawner {
 
     /// Get an iterator over the entities in an instance, once it's spawned.
     ///
-    /// Before the scene is spawned, the iterator will be empty. Use [`instance_is_ready`]
+    /// Before the scene is spawned, the iterator will be empty. Use [`Self::instance_is_ready`]
     /// to check if the instance is ready.
     pub fn iter_instance_entities(
         &'_ self,

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -295,14 +295,19 @@ impl SceneSpawner {
         self.spawned_instances.contains_key(&instance_id)
     }
 
-    /// Get an iterator over the entities in an instance, once it's spawned
+    /// Get an iterator over the entities in an instance, once it's spawned.
+    ///
+    /// Before the scene is spawned, the iterator will be empty. Use [`instance_is_ready`]
+    /// to check if the instance is ready.
     pub fn iter_instance_entities(
         &'_ self,
         instance_id: InstanceId,
-    ) -> Option<impl Iterator<Item = Entity> + '_> {
+    ) -> impl Iterator<Item = Entity> + '_ {
         self.spawned_instances
             .get(&instance_id)
             .map(|instance| instance.entity_map.values())
+            .into_iter()
+            .flatten()
     }
 }
 


### PR DESCRIPTION
# Objective

- Taking the API improvement out of #5431 
- `iter_instance_entities` used to return an option of iterator, now it just returns an iterator

---

## Changelog

- If you use `SceneSpawner::iter_instance_entities`, it no longer returns an `Option`. The iterator will be empty if the return value used to be `None`
