### PR TITLE
[Merged by Bors] - Fix DrawFunctionId typo

### DIFF
--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -63,7 +63,7 @@ pub trait PhaseItem: Sized + Send + Sync + 'static {
 }
 
 // TODO: make this generic?
-/// /// A [`Draw`] function identifier.
+/// An identifier for a [`Draw`] function stored in [`DrawFunctions`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct DrawFunctionId(usize);
 


### PR DESCRIPTION
Fix extra slashes visible in documentation of `DrawFunctionId`. Also point to where the type is used.