### PR TITLE
[Merged by Bors] - Adding transform example links to documentation

### DIFF
--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -26,7 +26,7 @@ use bevy_reflect::Reflect;
 /// update the [`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.
 ///
-/// Example: [global_vs_local_translation.rs](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs)
+/// Example: [`global_vs_local_translation.rs`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs)
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
 #[reflect(Component, PartialEq)]
 pub struct GlobalTransform(Affine3A);

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -26,7 +26,11 @@ use bevy_reflect::Reflect;
 /// update the [`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.
 ///
-/// Example: [`global_vs_local_translation.rs`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs)
+/// # Examples
+///
+/// - [`global_vs_local_translation`]
+///
+/// [`global_vs_local_translation`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
 #[reflect(Component, PartialEq)]
 pub struct GlobalTransform(Affine3A);

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -25,6 +25,8 @@ use bevy_reflect::Reflect;
 /// This system runs in stage [`CoreStage::PostUpdate`](crate::CoreStage::PostUpdate). If you
 /// update the [`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.
+/// 
+/// Example: [transform](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs),
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
 #[reflect(Component, PartialEq)]
 pub struct GlobalTransform(Affine3A);

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -26,7 +26,7 @@ use bevy_reflect::Reflect;
 /// update the [`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.
 /// 
-/// Example: [transform](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs),
+/// Example: [global_vs_local_translation.rs](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs)
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
 #[reflect(Component, PartialEq)]
 pub struct GlobalTransform(Affine3A);

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -25,7 +25,7 @@ use bevy_reflect::Reflect;
 /// This system runs in stage [`CoreStage::PostUpdate`](crate::CoreStage::PostUpdate). If you
 /// update the [`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.
-/// 
+///
 /// Example: [global_vs_local_translation.rs](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs)
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
 #[reflect(Component, PartialEq)]

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -27,7 +27,7 @@ use std::ops::Mul;
 /// update the [`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.
 ///
-/// Examples: [`transform`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs), [global_vs_local_translation.rs](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs)
+/// Examples: [`transform`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs), [`global_vs_local_translation.rs`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs)
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
 #[reflect(Component, Default, PartialEq)]
 pub struct Transform {

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -26,6 +26,8 @@ use std::ops::Mul;
 /// This system runs in stage [`CoreStage::PostUpdate`](crate::CoreStage::PostUpdate). If you
 /// update the [`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.
+/// 
+/// Examples: [transform](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs), [global_vs_local_translation.rs](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs)
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
 #[reflect(Component, Default, PartialEq)]
 pub struct Transform {
@@ -34,6 +36,8 @@ pub struct Transform {
     /// Rotation of the entity.
     pub rotation: Quat,
     /// Scale of the entity.
+    /// 
+    /// Example: [scale](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/scale.rs)
     pub scale: Vec3,
 }
 
@@ -48,6 +52,8 @@ impl Transform {
     /// Creates a new [`Transform`] at the position `(x, y, z)`. In 2d, the `z` component
     /// is used for z-ordering elements: higher `z`-value will be in front of lower
     /// `z`-value.
+    /// 
+    /// Example: [translations](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/translation.rs)
     #[inline]
     pub const fn from_xyz(x: f32, y: f32, z: f32) -> Self {
         Self::from_translation(Vec3::new(x, y, z))
@@ -201,6 +207,8 @@ impl Transform {
     /// Rotates this [`Transform`] by the given rotation.
     ///
     /// If this [`Transform`] has a parent, the `rotation` is relative to the rotation of the parent.
+    /// 
+    /// Example: [3d_rotation](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/3d_rotation.rs)
     #[inline]
     pub fn rotate(&mut self, rotation: Quat) {
         self.rotation = rotation * self.rotation;

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -27,7 +27,7 @@ use std::ops::Mul;
 /// update the [`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.
 ///
-/// Examples: [transform](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs), [global_vs_local_translation.rs](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs)
+/// Examples: [`transform`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs), [global_vs_local_translation.rs](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs)
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
 #[reflect(Component, Default, PartialEq)]
 pub struct Transform {

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -32,8 +32,12 @@ use std::ops::Mul;
 #[reflect(Component, Default, PartialEq)]
 pub struct Transform {
     /// Position of the entity. In 2d, the last value of the `Vec3` is used for z-ordering.
+    /// 
+    /// Example: [translations](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/translation.rs)
     pub translation: Vec3,
     /// Rotation of the entity.
+    /// 
+    /// Example: [3d_rotation](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/3d_rotation.rs)
     pub rotation: Quat,
     /// Scale of the entity.
     /// 
@@ -53,7 +57,6 @@ impl Transform {
     /// is used for z-ordering elements: higher `z`-value will be in front of lower
     /// `z`-value.
     /// 
-    /// Example: [translations](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/translation.rs)
     #[inline]
     pub const fn from_xyz(x: f32, y: f32, z: f32) -> Self {
         Self::from_translation(Vec3::new(x, y, z))

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -33,15 +33,15 @@ use std::ops::Mul;
 pub struct Transform {
     /// Position of the entity. In 2d, the last value of the `Vec3` is used for z-ordering.
     ///
-    /// Example: [translations](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/translation.rs)
+    /// Example: [`translations`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/translation.rs)
     pub translation: Vec3,
     /// Rotation of the entity.
     ///
-    /// Example: [3d_rotation](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/3d_rotation.rs)
+    /// Example: [`3d_rotation`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/3d_rotation.rs)
     pub rotation: Quat,
     /// Scale of the entity.
     ///
-    /// Example: [scale](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/scale.rs)
+    /// Example: [`scale`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/scale.rs)
     pub scale: Vec3,
 }
 
@@ -211,7 +211,7 @@ impl Transform {
     ///
     /// If this [`Transform`] has a parent, the `rotation` is relative to the rotation of the parent.
     ///
-    /// Example: [3d_rotation](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/3d_rotation.rs)
+    /// Example: [`3d_rotation`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/3d_rotation.rs)
     #[inline]
     pub fn rotate(&mut self, rotation: Quat) {
         self.rotation = rotation * self.rotation;

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -26,21 +26,21 @@ use std::ops::Mul;
 /// This system runs in stage [`CoreStage::PostUpdate`](crate::CoreStage::PostUpdate). If you
 /// update the [`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.
-/// 
+///
 /// Examples: [transform](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs), [global_vs_local_translation.rs](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs)
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
 #[reflect(Component, Default, PartialEq)]
 pub struct Transform {
     /// Position of the entity. In 2d, the last value of the `Vec3` is used for z-ordering.
-    /// 
+    ///
     /// Example: [translations](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/translation.rs)
     pub translation: Vec3,
     /// Rotation of the entity.
-    /// 
+    ///
     /// Example: [3d_rotation](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/3d_rotation.rs)
     pub rotation: Quat,
     /// Scale of the entity.
-    /// 
+    ///
     /// Example: [scale](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/scale.rs)
     pub scale: Vec3,
 }
@@ -56,7 +56,7 @@ impl Transform {
     /// Creates a new [`Transform`] at the position `(x, y, z)`. In 2d, the `z` component
     /// is used for z-ordering elements: higher `z`-value will be in front of lower
     /// `z`-value.
-    /// 
+    ///
     #[inline]
     pub const fn from_xyz(x: f32, y: f32, z: f32) -> Self {
         Self::from_translation(Vec3::new(x, y, z))
@@ -210,7 +210,7 @@ impl Transform {
     /// Rotates this [`Transform`] by the given rotation.
     ///
     /// If this [`Transform`] has a parent, the `rotation` is relative to the rotation of the parent.
-    /// 
+    ///
     /// Example: [3d_rotation](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/3d_rotation.rs)
     #[inline]
     pub fn rotate(&mut self, rotation: Quat) {

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -27,21 +27,33 @@ use std::ops::Mul;
 /// update the [`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.
 ///
-/// Examples: [`transform`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs), [`global_vs_local_translation.rs`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs)
+/// # Examples
+///
+/// - [`transform`]
+/// - [`global_vs_local_translation`]
+///
+/// [`global_vs_local_translation`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs
+/// [`transform`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
 #[reflect(Component, Default, PartialEq)]
 pub struct Transform {
     /// Position of the entity. In 2d, the last value of the `Vec3` is used for z-ordering.
     ///
-    /// Example: [`translations`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/translation.rs)
+    /// See the [`translations`] example for usage.
+    ///
+    /// [`translations`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/translation.rs
     pub translation: Vec3,
     /// Rotation of the entity.
     ///
-    /// Example: [`3d_rotation`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/3d_rotation.rs)
+    /// See the [`3d_rotation`] example for usage.
+    ///
+    /// [`3d_rotation`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/3d_rotation.rs
     pub rotation: Quat,
     /// Scale of the entity.
     ///
-    /// Example: [`scale`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/scale.rs)
+    /// See the [`scale`] example for usage.
+    ///
+    /// [`scale`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/scale.rs
     pub scale: Vec3,
 }
 
@@ -56,7 +68,6 @@ impl Transform {
     /// Creates a new [`Transform`] at the position `(x, y, z)`. In 2d, the `z` component
     /// is used for z-ordering elements: higher `z`-value will be in front of lower
     /// `z`-value.
-    ///
     #[inline]
     pub const fn from_xyz(x: f32, y: f32, z: f32) -> Self {
         Self::from_translation(Vec3::new(x, y, z))
@@ -211,7 +222,11 @@ impl Transform {
     ///
     /// If this [`Transform`] has a parent, the `rotation` is relative to the rotation of the parent.
     ///
-    /// Example: [`3d_rotation`](https://github.com/bevyengine/bevy/blob/latest/examples/transforms/3d_rotation.rs)
+    /// # Examples
+    ///
+    /// - [`3d_rotation`]
+    ///
+    /// [`3d_rotation`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/3d_rotation.rs
     #[inline]
     pub fn rotate(&mut self, rotation: Quat) {
         self.rotation = rotation * self.rotation;


### PR DESCRIPTION
# Objective

Working on issue #1934 , with linking examples to the documentation. PR for transform examples.

## Solution

Added to the documentation in bevy_transform transform.rs and global_transform.rs utilizing links from examples.

[X] 3d_rotations.rs linked to rotate in Transform
[X] global_vs_local_translation.rs linked to top of Transform and GlobalTransform documentation
[X] scale.rs linked to scale Struct in Transform
[X] transform.rs linked to top of Transform documentation
[X] translation.rs linked to from_translation in Transform