### PR TITLE
Enable some features when generating documentation on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,10 @@ debug_asset_server = ["bevy_internal/debug_asset_server"]
 # Enable animation support, and glTF animation loading
 animation = ["bevy_internal/animation"]
 
+[package.metadata.docs.rs]
+# Enabling all features when the crate is documented on docs.rs
+all-features = true
+
 [dependencies]
 bevy_dylib = { path = "crates/bevy_dylib", version = "0.9.0", default-features = false, optional = true }
 bevy_internal = { path = "crates/bevy_internal", version = "0.9.0", default-features = false }


### PR DESCRIPTION
While looking at some examples, I realized that it needed some features to be enabled because I couldn't find the related docs I built locally. It doesn't solve this issue unfortunately but at least when people will look on docs.rs, they will be able to find these items.