### PR TITLE
Create a DynamicScene from a world and an entity root

### DIFF
--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -20,6 +20,22 @@ pub struct DespawnChildrenRecursive {
     pub entity: Entity,
 }
 
+/// List all descendants of a given entity
+pub fn list_all_descendants(world: &World, root: Entity) -> Vec<Entity> {
+    let mut entities_of_interest = Vec::new();
+    let mut entities_to_process = vec![root];
+    while let Some(entity) = entities_to_process.pop() {
+        if entity != root {
+            // root is not a descendant of itself
+            entities_of_interest.push(entity);
+        }
+        if let Some(children) = world.entity(entity).get::<Children>() {
+            entities_to_process.extend(children.iter());
+        }
+    }
+    entities_of_interest
+}
+
 /// Function for despawning an entity and all its children
 pub fn despawn_with_children_recursive(world: &mut World, entity: Entity) {
     // first, make the entity's own parent forget about it

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
     reflect::{ReflectComponent, ReflectMapEntities},
     world::World,
 };
-use bevy_hierarchy::Children;
+use bevy_hierarchy::list_all_descendants;
 use bevy_reflect::{Reflect, TypeRegistryArc, TypeUuid};
 use serde::Serialize;
 
@@ -80,7 +80,7 @@ impl DynamicScene {
 
     /// Create a new dynamic scene from a given [`World`] at a given [`Entity`].
     ///
-    /// All descendents entities from the given one will be extracted.
+    /// All descendants entities from the given one will be extracted.
     pub fn from_world_at_root(
         world: &World,
         root: Entity,
@@ -90,14 +90,8 @@ impl DynamicScene {
         let type_registry = type_registry.read();
 
         // Extract all entities that are a descendent of root
-        let mut entities_of_interest = Vec::new();
-        let mut entities_to_process = vec![root];
-        while let Some(entity) = entities_to_process.pop() {
-            entities_of_interest.push(entity);
-            if let Some(children) = world.entity(entity).get::<Children>() {
-                entities_to_process.extend(children.iter());
-            }
-        }
+        let mut entities_of_interest = list_all_descendants(world, root);
+        entities_of_interest.push(root);
 
         for archetype in world.archetypes().iter() {
             let entities_offset = scene.entities.len();

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -93,39 +93,26 @@ impl DynamicScene {
         let mut entities_of_interest = list_all_descendants(world, root);
         entities_of_interest.push(root);
 
-        for archetype in world.archetypes().iter() {
-            let entities_offset = scene.entities.len();
+        for entity in entities_of_interest {
+            scene.entities.push(DynamicEntity {
+                entity: entity.id(),
+                components: Vec::new(),
+            });
 
-            // List all entities in an archetype that are part of the descendants
-            let archetype_entities_of_interest = archetype
-                .entities()
-                .iter()
-                .filter(|entity| entities_of_interest.contains(entity))
-                .collect::<Vec<_>>();
-
-            // Create a new dynamic entity for each entity of the given archetype
-            // and insert it into the dynamic scene.
-            for entity in &archetype_entities_of_interest {
-                scene.entities.push(DynamicEntity {
-                    entity: entity.id(),
-                    components: Vec::new(),
-                });
-            }
-
-            // Add each reflection-powered component to the entity it belongs to.
-            for component_id in archetype.components() {
+            for component_id in world.entity(entity).archetype().components() {
                 let reflect_component = world
                     .components()
                     .get_info(component_id)
                     .and_then(|info| type_registry.get(info.type_id().unwrap()))
                     .and_then(|registration| registration.data::<ReflectComponent>());
                 if let Some(reflect_component) = reflect_component {
-                    for (i, entity) in archetype_entities_of_interest.iter().enumerate() {
-                        if let Some(component) = reflect_component.reflect(world, **entity) {
-                            scene.entities[entities_offset + i]
-                                .components
-                                .push(component.clone_value());
-                        }
+                    if let Some(component) = reflect_component.reflect(world, entity) {
+                        scene
+                            .entities
+                            .last_mut()
+                            .unwrap()
+                            .components
+                            .push(component.clone_value());
                     }
                 }
             }

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -78,7 +78,9 @@ impl DynamicScene {
         scene
     }
 
-    /// Create a new dynamic scene from a given world at a given root.
+    /// Create a new dynamic scene from a given [`World`] at a given [`Entity`].
+    ///
+    /// All descendents entities from the given one will be extracted.
     pub fn from_world_at_root(
         world: &World,
         root: Entity,

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -33,12 +33,12 @@ pub struct DynamicEntity {
 
 impl DynamicScene {
     /// Create a new dynamic scene from a given scene.
-    pub fn from_scene(scene: &Scene, type_registry: &TypeRegistryArc) -> Self {
+    pub fn from_scene(scene: &Scene, type_registry: &AppTypeRegistry) -> Self {
         Self::from_world(&scene.world, type_registry)
     }
 
     /// Create a new dynamic scene from a given world.
-    pub fn from_world(world: &World, type_registry: &TypeRegistryArc) -> Self {
+    pub fn from_world(world: &World, type_registry: &AppTypeRegistry) -> Self {
         let mut scene = DynamicScene::default();
         let type_registry = type_registry.read();
 
@@ -80,13 +80,13 @@ impl DynamicScene {
     ///
     /// This method will return a [`SceneSpawnError`] if a type either is not registered
     /// or doesn't reflect the [`Component`](bevy_ecs::component::Component) trait.
-    pub fn write_to_world(
+    pub fn write_to_world_with(
         &self,
         world: &mut World,
         entity_map: &mut EntityMap,
+        type_registry: &AppTypeRegistry,
     ) -> Result<(), SceneSpawnError> {
-        let registry = world.resource::<AppTypeRegistry>().clone();
-        let type_registry = registry.read();
+        let type_registry = type_registry.read();
 
         for scene_entity in &self.entities {
             // Fetch the entity with the given entity id from the `entity_map`

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
 };
 use bevy_reflect::TypeUuid;
 
-use crate::{InstanceInfo, SceneSpawnError};
+use crate::{DynamicScene, InstanceInfo, SceneSpawnError};
 
 /// To spawn a scene, you can use either:
 /// * [`SceneSpawner::spawn`](crate::SceneSpawner::spawn)
@@ -23,6 +23,18 @@ pub struct Scene {
 impl Scene {
     pub fn new(world: World) -> Self {
         Self { world }
+    }
+
+    /// Create a new scene from a given dynamic scene.
+    pub fn from_dynamic_scene(
+        dynamic_scene: &DynamicScene,
+        type_registry: &AppTypeRegistry,
+    ) -> Result<Scene, SceneSpawnError> {
+        let mut world = World::new();
+        let mut entity_map = EntityMap::default();
+        dynamic_scene.write_to_world_with(&mut world, &mut entity_map, type_registry)?;
+
+        Ok(Self { world })
     }
 
     /// Clone the scene.

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -1,4 +1,5 @@
 use bevy_app::AppTypeRegistry;
+use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     entity::EntityMap,
     reflect::{ReflectComponent, ReflectMapEntities},
@@ -14,7 +15,7 @@ use crate::{DynamicScene, InstanceInfo, SceneSpawnError};
 /// * adding the [`Handle<Scene>`](bevy_asset::Handle) to an entity (the scene will only be
 /// visible if the entity already has [`Transform`](bevy_transform::components::Transform) and
 /// [`GlobalTransform`](bevy_transform::components::GlobalTransform) components)
-#[derive(Debug, TypeUuid)]
+#[derive(Debug, TypeUuid, Deref, DerefMut)]
 #[uuid = "c156503c-edd9-4ec7-8d33-dab392df03cd"]
 pub struct Scene {
     pub world: World,

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -144,7 +144,11 @@ impl SceneSpawner {
                     .ok_or_else(|| SceneSpawnError::NonExistentScene {
                         handle: scene_handle.clone_weak(),
                     })?;
-            scene.write_to_world(world, entity_map)
+            scene.write_to_world_with(
+                world,
+                entity_map,
+                &world.resource::<AppTypeRegistry>().clone(),
+            )
         })
     }
 


### PR DESCRIPTION
# Objective

- Create a dynamic scene from a world and an entity root.
- Sneaked in a few improvements on `Scene` and `DynamicScene` to have a more coherent API between the two

## Solution

- From the root, select all entities that are in the world and descendent of root, and extract all registered components to a dynamic scene

extract all registered components:

```rust
DynamicScene::from_world_at_root(
    world,
    Entity::from_bits(0), // Should be a proper way to have an entity here
    world.resource::<AppTypeRegistry>(),
);
```

extract only a subset of components (here `Transform`):

```rust
let mut atr = AppTypeRegistry::default();
atr.write().register::<Transform>();
DynamicScene::from_world_at_root(
    world,
    Entity::from_bits(0), // Should be a proper way to have an entity here
    &atr,
);

```