### PR TITLE
[Merged by Bors] - Update rodio requirement from 0.15 to 0.16

### DIFF
--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -18,11 +18,11 @@ bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
 
 # other
 anyhow = "1.0.4"
-rodio = { version = "0.15", default-features = false }
+rodio = { version = "0.16", default-features = false }
 parking_lot = "0.12.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-rodio = { version = "0.15", default-features = false, features = ["wasm-bindgen"] }
+rodio = { version = "0.16", default-features = false, features = ["wasm-bindgen"] }
 
 
 [features]

--- a/deny.toml
+++ b/deny.toml
@@ -40,12 +40,19 @@ skip = [
     { name = "core-foundation-sys", version = "0.7" },  # from winit v0.26.0
     { name = "core-graphics", version = "0.19" },       # from winit v0.26.0
     { name = "ndk", version = "0.5" },                  # from winit v0.26.1
+    { name = "ndk", version = "0.6" },                  # from rodio v0.16.0
     { name = "ndk-glue", version = "0.5" },             # from winit v0.26.1
     { name = "ndk-sys", version = "0.2" },              # from winit v0.26.1
-    { name = "parking_lot", version = "0.11" },         # from rodio v0.15.0
-    { name = "parking_lot_core", version = "0.8" },     # from rodio v0.15.0
-    { name = "stdweb", version = "0.1" },               # from rodio v0.15.0
+    { name = "ndk-sys", version = "0.3" },              # from rodio v0.16.0
+    { name = "parking_lot", version = "0.11" },         # from winit v0.26.1
+    { name = "parking_lot_core", version = "0.8" },     # from winit v0.26.1
+    { name = "raw-window-handle", version = "0.4" },    # from wgpu v0.13.0
     { name = "nix", version = "0.23.1" },               # from alsa v0.6.0
+    { name = "windows_aarch64_msvc", version = "0.36" }, # from notify v5.0.0
+    { name = "windows_i686_gnu", version = "0.36" },    # from notify v5.0.0
+    { name = "windows_i686_msvc", version = "0.36" },   # from notify v5.0.0
+    { name = "windows_x86_64_gnu", version = "0.36" },  # from notify v5.0.0
+    { name = "windows_x86_64_msvc", version = "0.36" }, # from notify v5.0.0
 ]
 
 [sources]


### PR DESCRIPTION
# Objective

- #6019 but with the duplicate package list updated
- Fixes #5774
