### PR TITLE
Move Duration and Instant from bevy_utils to bevy_time, resulting in additional bevy_time_plugin crate

### DIFF
--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -19,6 +19,7 @@ bevy_reflect = ["dep:bevy_reflect", "bevy_ecs/bevy_reflect"]
 bevy_derive = { path = "../bevy_derive", version = "0.9.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev", default-features = false }
 bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", optional = true }
+bevy_time = { path = "../bevy_time", version = "0.9.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
 
 # other

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use bevy_ecs::event::{Events, ManualEventReader};
 use bevy_ecs::prelude::Resource;
-use bevy_utils::{Duration, Instant};
+use bevy_time::{Duration, Instant};
 
 #[cfg(target_arch = "wasm32")]
 use std::{cell::RefCell, rc::Rc};

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -16,7 +16,8 @@ pub mod prelude {
 
 use bevy_app::prelude::*;
 use bevy_ecs::entity::Entity;
-use bevy_utils::{Duration, HashSet, Instant};
+use bevy_time::{Duration, Instant};
+use bevy_utils::HashSet;
 use std::borrow::Cow;
 use std::ops::Range;
 

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -1,6 +1,7 @@
 use bevy_ecs::system::Resource;
 use bevy_log::warn;
-use bevy_utils::{Duration, Instant, StableHashMap, Uuid};
+use bevy_time::{Duration, Instant};
+use bevy_utils::{StableHashMap, Uuid};
 use std::{borrow::Cow, collections::VecDeque};
 
 use crate::MAX_DIAGNOSTIC_NAME_WIDTH;

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -2,8 +2,7 @@ use super::{Diagnostic, DiagnosticId, Diagnostics};
 use bevy_app::prelude::*;
 use bevy_ecs::system::{Res, ResMut, Resource};
 use bevy_log::{debug, info};
-use bevy_time::{Time, Timer};
-use bevy_utils::Duration;
+use bevy_time::{Duration, Time, Timer};
 
 /// An App Plugin that logs diagnostics to the console
 pub struct LogDiagnosticsPlugin {

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -68,7 +68,7 @@ impl Gamepads {
 }
 
 /// The data contained in a [`GamepadEvent`] or [`GamepadEventRaw`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum GamepadEventType {
     /// A [`Gamepad`] has been connected.
@@ -101,7 +101,7 @@ pub enum GamepadEventType {
 /// [`Axis<GamepadAxis>`], and [`Axis<GamepadButton>`] resources won't be updated correctly.
 ///
 /// An example for gamepad input mocking can be seen in the documentation of the [`GamepadEventRaw`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct GamepadEvent {
     /// The gamepad this event corresponds to.
@@ -204,7 +204,7 @@ impl GamepadEvent {
 /// #
 /// # bevy_ecs::system::assert_is_system(change_resource_on_gamepad_button_press);
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct GamepadEventRaw {
     /// The gamepad this event corresponds to.
@@ -703,7 +703,7 @@ pub fn gamepad_event_system(
     for event in raw_events.iter() {
         match event.event_type {
             GamepadEventType::Connected => {
-                events.send(GamepadEvent::new(event.gamepad, event.event_type.clone()));
+                events.send(GamepadEvent::new(event.gamepad, event.event_type));
                 for button_type in &ALL_BUTTON_TYPES {
                     let gamepad_button = GamepadButton::new(event.gamepad, *button_type);
                     button_input.reset(gamepad_button);
@@ -714,7 +714,7 @@ pub fn gamepad_event_system(
                 }
             }
             GamepadEventType::Disconnected => {
-                events.send(GamepadEvent::new(event.gamepad, event.event_type.clone()));
+                events.send(GamepadEvent::new(event.gamepad, event.event_type));
                 for button_type in &ALL_BUTTON_TYPES {
                     let gamepad_button = GamepadButton::new(event.gamepad, *button_type);
                     button_input.reset(gamepad_button);

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -11,7 +11,7 @@ use bevy_reflect::{FromReflect, Reflect};
 ///
 /// The event is consumed inside of the [`keyboard_input_system`](crate::keyboard::keyboard_input_system)
 /// to update the [`Input<KeyCode>`](crate::Input<KeyCode>) resource.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct KeyboardInput {
     /// The scan code of the key.
     pub scan_code: u32,

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -11,7 +11,8 @@ use bevy_reflect::{FromReflect, Reflect};
 ///
 /// The event is consumed inside of the [`keyboard_input_system`](crate::keyboard::keyboard_input_system)
 /// to update the [`Input<KeyCode>`](crate::Input<KeyCode>) resource.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyboardInput {
     /// The scan code of the key.
     pub scan_code: u32,

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -10,7 +10,7 @@ use bevy_math::Vec2;
 ///
 /// The event is read inside of the [`mouse_button_input_system`](crate::mouse::mouse_button_input_system)
 /// to update the [`Input<MouseButton>`](crate::Input<MouseButton>) resource.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct MouseButtonInput {
     /// The mouse button assigned to the event.
     pub button: MouseButton,
@@ -50,7 +50,7 @@ pub enum MouseButton {
 /// However, the event data does not make it possible to distinguish which device it is referring to.
 ///
 /// [`DeviceEvent::MouseMotion`]: https://docs.rs/winit/latest/winit/event/enum.DeviceEvent.html#variant.MouseMotion
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct MouseMotion {
     /// The change in the position of the pointing device since the last event was sent.
     pub delta: Vec2,
@@ -79,7 +79,7 @@ pub enum MouseScrollUnit {
 /// A mouse wheel event.
 ///
 /// This event is the translated version of the `WindowEvent::MouseWheel` from the `winit` crate.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct MouseWheel {
     /// The mouse scroll unit.
     pub unit: MouseScrollUnit,

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -10,7 +10,8 @@ use bevy_math::Vec2;
 ///
 /// The event is read inside of the [`mouse_button_input_system`](crate::mouse::mouse_button_input_system)
 /// to update the [`Input<MouseButton>`](crate::Input<MouseButton>) resource.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct MouseButtonInput {
     /// The mouse button assigned to the event.
     pub button: MouseButton,
@@ -50,7 +51,8 @@ pub enum MouseButton {
 /// However, the event data does not make it possible to distinguish which device it is referring to.
 ///
 /// [`DeviceEvent::MouseMotion`]: https://docs.rs/winit/latest/winit/event/enum.DeviceEvent.html#variant.MouseMotion
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct MouseMotion {
     /// The change in the position of the pointing device since the last event was sent.
     pub delta: Vec2,
@@ -63,6 +65,7 @@ pub struct MouseMotion {
 /// The value of the event can either be interpreted as the amount of lines or the amount of pixels
 /// to scroll.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum MouseScrollUnit {
     /// The line scroll unit.
     ///
@@ -79,7 +82,8 @@ pub enum MouseScrollUnit {
 /// A mouse wheel event.
 ///
 /// This event is the translated version of the `WindowEvent::MouseWheel` from the `winit` crate.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct MouseWheel {
     /// The mouse scroll unit.
     pub unit: MouseScrollUnit,

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -45,7 +45,7 @@ wav = ["bevy_audio/wav"]
 # Enable watching file system for asset hot reload
 filesystem_watcher = ["bevy_asset/filesystem_watcher"]
 
-serialize = ["bevy_input/serialize"]
+serialize = ["bevy_input/serialize", "bevy_window/serialize"]
 
 # Display server protocol support (X11 is enabled by default)
 wayland = ["bevy_winit/wayland"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -77,6 +77,7 @@ bevy_math = { path = "../bevy_math", version = "0.9.0-dev" }
 bevy_ptr = { path = "../bevy_ptr", version = "0.9.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"] }
 bevy_time = { path = "../bevy_time", version = "0.9.0-dev" }
+bevy_time_plugin = { path = "../bevy_time_plugin", version = "0.9.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.9.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.9.0-dev" }

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -3,7 +3,7 @@ use bevy_app::{PluginGroup, PluginGroupBuilder};
 /// This plugin group will add all the default plugins:
 /// * [`LogPlugin`](bevy_log::LogPlugin)
 /// * [`CorePlugin`](bevy_core::CorePlugin)
-/// * [`TimePlugin`](bevy_time::TimePlugin)
+/// * [`TimePlugin`](bevy_time_plugin::TimePlugin)
 /// * [`TransformPlugin`](bevy_transform::TransformPlugin)
 /// * [`HierarchyPlugin`](bevy_hierarchy::HierarchyPlugin)
 /// * [`DiagnosticsPlugin`](bevy_diagnostic::DiagnosticsPlugin)
@@ -28,7 +28,7 @@ impl PluginGroup for DefaultPlugins {
     fn build(&mut self, group: &mut PluginGroupBuilder) {
         group.add(bevy_log::LogPlugin::default());
         group.add(bevy_core::CorePlugin::default());
-        group.add(bevy_time::TimePlugin::default());
+        group.add(bevy_time_plugin::TimePlugin::default());
         group.add(bevy_transform::TransformPlugin::default());
         group.add(bevy_hierarchy::HierarchyPlugin::default());
         group.add(bevy_diagnostic::DiagnosticsPlugin::default());
@@ -83,7 +83,7 @@ impl PluginGroup for DefaultPlugins {
 
 /// Minimal plugin group that will add the following plugins:
 /// * [`CorePlugin`](bevy_core::CorePlugin)
-/// * [`TimePlugin`](bevy_time::TimePlugin)
+/// * [`TimePlugin`](bevy_time_plugin::TimePlugin)
 /// * [`ScheduleRunnerPlugin`](bevy_app::ScheduleRunnerPlugin)
 ///
 /// See also [`DefaultPlugins`] for a more complete set of plugins
@@ -92,7 +92,7 @@ pub struct MinimalPlugins;
 impl PluginGroup for MinimalPlugins {
     fn build(&mut self, group: &mut PluginGroupBuilder) {
         group.add(bevy_core::CorePlugin::default());
-        group.add(bevy_time::TimePlugin::default());
+        group.add(bevy_time_plugin::TimePlugin::default());
         group.add(bevy_app::ScheduleRunnerPlugin::default());
     }
 }

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -28,6 +28,7 @@ once_cell = "1.11"
 serde = "1"
 smallvec = { version = "1.6", features = ["serde", "union", "const_generics"], optional = true }
 glam = { version = "0.21", features = ["serde"], optional = true }
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 
 [dev-dependencies]
 ron = "0.8.0"

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -9,7 +9,8 @@ use crate::{
 
 use crate::utility::{GenericTypeInfoCell, NonGenericTypeInfoCell};
 use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_value};
-use bevy_utils::{Duration, HashMap, HashSet, Instant};
+use bevy_utils::{Duration, Instant};
+use bevy_utils::{HashMap, HashSet};
 use std::{
     any::Any,
     borrow::Cow,
@@ -889,18 +890,19 @@ mod tests {
         Enum, FromReflect, Reflect, ReflectSerialize, TypeInfo, TypeRegistry, Typed, VariantInfo,
         VariantType,
     };
-    use bevy_utils::{HashMap, Instant};
+    use bevy_utils::HashMap;
+    use bevy_utils::{Duration, Instant};
     use std::f32::consts::{PI, TAU};
 
     #[test]
     fn can_serialize_duration() {
         let mut type_registry = TypeRegistry::default();
-        type_registry.register::<std::time::Duration>();
+        type_registry.register::<Duration>();
 
         let reflect_serialize = type_registry
-            .get_type_data::<ReflectSerialize>(std::any::TypeId::of::<std::time::Duration>())
+            .get_type_data::<ReflectSerialize>(std::any::TypeId::of::<Duration>())
             .unwrap();
-        let _serializable = reflect_serialize.get_serializable(&std::time::Duration::ZERO);
+        let _serializable = reflect_serialize.get_serializable(&Duration::ZERO);
     }
 
     #[test]

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -9,8 +9,8 @@ use crate::{
 
 use crate::utility::{GenericTypeInfoCell, NonGenericTypeInfoCell};
 use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_value};
-use bevy_utils::{Duration, Instant};
 use bevy_utils::{HashMap, HashSet};
+use instant::{Duration, Instant};
 use std::{
     any::Any,
     borrow::Cow,
@@ -47,8 +47,6 @@ impl_reflect_value!(RangeFrom<T: Clone + Send + Sync + 'static>());
 impl_reflect_value!(RangeTo<T: Clone + Send + Sync + 'static>());
 impl_reflect_value!(RangeToInclusive<T: Clone + Send + Sync + 'static>());
 impl_reflect_value!(RangeFull());
-impl_reflect_value!(Duration(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(Instant(Debug, Hash, PartialEq));
 impl_reflect_value!(NonZeroI128(Debug, Hash, PartialEq, Serialize, Deserialize));
 impl_reflect_value!(NonZeroU128(Debug, Hash, PartialEq, Serialize, Deserialize));
 impl_reflect_value!(NonZeroIsize(Debug, Hash, PartialEq, Serialize, Deserialize));
@@ -61,6 +59,8 @@ impl_reflect_value!(NonZeroI16(Debug, Hash, PartialEq, Serialize, Deserialize));
 impl_reflect_value!(NonZeroU16(Debug, Hash, PartialEq, Serialize, Deserialize));
 impl_reflect_value!(NonZeroU8(Debug, Hash, PartialEq, Serialize, Deserialize));
 impl_reflect_value!(NonZeroI8(Debug, Hash, PartialEq, Serialize, Deserialize));
+impl_reflect_value!(Duration(Debug, Hash, PartialEq, Serialize, Deserialize));
+impl_reflect_value!(Instant(Debug, Hash, PartialEq));
 
 impl_from_reflect_value!(bool);
 impl_from_reflect_value!(char);
@@ -86,8 +86,6 @@ impl_from_reflect_value!(RangeFrom<T: Clone + Send + Sync + 'static>);
 impl_from_reflect_value!(RangeTo<T: Clone + Send + Sync + 'static>);
 impl_from_reflect_value!(RangeToInclusive<T: Clone + Send + Sync + 'static>);
 impl_from_reflect_value!(RangeFull);
-impl_from_reflect_value!(Duration);
-impl_from_reflect_value!(Instant);
 impl_from_reflect_value!(NonZeroI128);
 impl_from_reflect_value!(NonZeroU128);
 impl_from_reflect_value!(NonZeroIsize);
@@ -100,6 +98,8 @@ impl_from_reflect_value!(NonZeroI16);
 impl_from_reflect_value!(NonZeroU16);
 impl_from_reflect_value!(NonZeroU8);
 impl_from_reflect_value!(NonZeroI8);
+impl_from_reflect_value!(Duration);
+impl_from_reflect_value!(Instant);
 
 impl<T: FromReflect> Array for Vec<T> {
     #[inline]
@@ -886,24 +886,11 @@ impl FromReflect for Cow<'static, str> {
 #[cfg(test)]
 mod tests {
     use crate as bevy_reflect;
-    use crate::{
-        Enum, FromReflect, Reflect, ReflectSerialize, TypeInfo, TypeRegistry, Typed, VariantInfo,
-        VariantType,
-    };
+    use crate::{Enum, FromReflect, Reflect, TypeInfo, Typed, VariantInfo, VariantType};
+    use crate::{ReflectSerialize, TypeRegistry};
     use bevy_utils::HashMap;
-    use bevy_utils::{Duration, Instant};
+    use instant::{Duration, Instant};
     use std::f32::consts::{PI, TAU};
-
-    #[test]
-    fn can_serialize_duration() {
-        let mut type_registry = TypeRegistry::default();
-        type_registry.register::<Duration>();
-
-        let reflect_serialize = type_registry
-            .get_type_data::<ReflectSerialize>(std::any::TypeId::of::<Duration>())
-            .unwrap();
-        let _serializable = reflect_serialize.get_serializable(&Duration::ZERO);
-    }
 
     #[test]
     fn should_partial_eq_char() {
@@ -1084,6 +1071,17 @@ mod tests {
         assert!(a.reflect_partial_eq(b).unwrap_or_default());
         let forty_two: std::num::NonZeroUsize = crate::FromReflect::from_reflect(a).unwrap();
         assert_eq!(forty_two, std::num::NonZeroUsize::new(42).unwrap());
+    }
+
+    #[test]
+    fn can_serialize_duration() {
+        let mut type_registry = TypeRegistry::default();
+        type_registry.register::<Duration>();
+
+        let reflect_serialize = type_registry
+            .get_type_data::<ReflectSerialize>(std::any::TypeId::of::<Duration>())
+            .unwrap();
+        let _serializable = reflect_serialize.get_serializable(&Duration::ZERO);
     }
 
     #[test]

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -41,6 +41,7 @@ bevy_mikktspace = { path = "../bevy_mikktspace", version = "0.9.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"] }
 bevy_render_macros = { path = "macros", version = "0.9.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.9.0-dev" }
+bevy_time_plugin = { path = "../bevy_time_plugin", version = "0.9.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.9.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.9.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -207,7 +207,7 @@ impl Plugin for RenderPlugin {
                 .insert_resource(pipeline_cache)
                 .insert_resource(asset_server);
 
-            let (sender, receiver) = bevy_time::create_time_channels();
+            let (sender, receiver) = bevy_time_plugin::create_time_channels();
             app.insert_resource(receiver);
             render_app.insert_resource(sender);
 

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -12,8 +12,8 @@ use crate::{
     view::{ExtractedWindows, ViewTarget},
 };
 use bevy_ecs::prelude::*;
-use bevy_time::TimeSender;
-use bevy_utils::Instant;
+use bevy_time::Instant;
+use bevy_time_plugin::TimeSender;
 use std::sync::Arc;
 use wgpu::{AdapterInfo, CommandEncoder, Instance, Queue, RequestAdapterOptions};
 

--- a/crates/bevy_time/Cargo.toml
+++ b/crates/bevy_time/Cargo.toml
@@ -11,10 +11,10 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.9.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev", features = ["bevy_reflect"] }
 bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"] }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
 
 # other
 crossbeam-channel = "0.5.0"
+instant = { version = "0.1", features = ["wasm-bindgen"] }

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -237,8 +237,8 @@ impl System for FixedTimestep {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::Instant;
     use bevy_ecs::prelude::*;
-    use bevy_utils::Instant;
     use std::ops::{Add, Mul};
     use std::time::Duration;
 

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -5,80 +5,13 @@ mod time;
 mod timer;
 
 pub use fixed_timestep::*;
+pub use instant::{Duration, Instant};
 pub use stopwatch::*;
 pub use time::*;
 pub use timer::*;
-
-use bevy_ecs::system::{Local, Res, ResMut};
-use bevy_utils::{tracing::warn, Instant};
-use crossbeam_channel::{Receiver, Sender};
 
 pub mod prelude {
     //! The Bevy Time Prelude.
     #[doc(hidden)]
     pub use crate::{Time, Timer};
-}
-
-use bevy_app::prelude::*;
-use bevy_ecs::prelude::*;
-
-/// Adds time functionality to Apps.
-#[derive(Default)]
-pub struct TimePlugin;
-
-#[derive(Debug, PartialEq, Eq, Clone, Hash, SystemLabel)]
-/// Updates the elapsed time. Any system that interacts with [Time] component should run after
-/// this.
-pub struct TimeSystem;
-
-impl Plugin for TimePlugin {
-    fn build(&self, app: &mut App) {
-        app.init_resource::<Time>()
-            .init_resource::<FixedTimesteps>()
-            .register_type::<Timer>()
-            .register_type::<Time>()
-            .register_type::<Stopwatch>()
-            // time system is added as an "exclusive system" to ensure it runs before other systems
-            // in CoreStage::First
-            .add_system_to_stage(
-                CoreStage::First,
-                time_system.exclusive_system().at_start().label(TimeSystem),
-            );
-    }
-}
-
-/// Channel resource used to receive time from render world
-#[derive(Resource)]
-pub struct TimeReceiver(pub Receiver<Instant>);
-
-/// Channel resource used to send time from render world
-#[derive(Resource)]
-pub struct TimeSender(pub Sender<Instant>);
-
-/// Creates channels used for sending time between render world and app world
-pub fn create_time_channels() -> (TimeSender, TimeReceiver) {
-    // bound the channel to 2 since when pipelined the render phase can finish before
-    // the time system runs.
-    let (s, r) = crossbeam_channel::bounded::<Instant>(2);
-    (TimeSender(s), TimeReceiver(r))
-}
-
-/// The system used to update the [`Time`] used by app logic. If there is a render world the time is sent from
-/// there to this system through channels. Otherwise the time is updated in this system.
-fn time_system(
-    mut time: ResMut<Time>,
-    time_recv: Option<Res<TimeReceiver>>,
-    mut has_received_time: Local<bool>,
-) {
-    if let Some(time_recv) = time_recv {
-        // TODO: Figure out how to handle this when using pipelined rendering.
-        if let Ok(new_time) = time_recv.0.try_recv() {
-            time.update_with_instant(new_time);
-            *has_received_time = true;
-        } else if *has_received_time {
-            warn!("time_system did not receive the time from the render world! Calculations depending on the time may be incorrect.");
-        }
-    } else {
-        time.update();
-    }
 }

--- a/crates/bevy_time/src/stopwatch.rs
+++ b/crates/bevy_time/src/stopwatch.rs
@@ -1,6 +1,6 @@
+use crate::Duration;
 use bevy_reflect::prelude::*;
 use bevy_reflect::Reflect;
-use bevy_utils::Duration;
 
 /// A Stopwatch is a struct that track elapsed time when started.
 ///
@@ -8,7 +8,6 @@ use bevy_utils::Duration;
 ///
 /// ```
 /// # use bevy_time::*;
-/// use std::time::Duration;
 /// let mut stopwatch = Stopwatch::new();
 /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
 ///

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -1,6 +1,6 @@
+use crate::{Duration, Instant};
 use bevy_ecs::{reflect::ReflectResource, system::Resource};
 use bevy_reflect::{FromReflect, Reflect};
-use bevy_utils::{Duration, Instant};
 
 /// Tracks elapsed time since the last update and since the App has started
 #[derive(Resource, Reflect, FromReflect, Debug, Clone)]
@@ -32,25 +32,25 @@ impl Default for Time {
 impl Time {
     /// Updates the internal time measurements.
     ///
-    /// Calling this method on the [`Time`] resource as part of your app will most likely result in
-    /// inaccurate timekeeping, as the resource is ordinarily managed by the
-    /// [`TimePlugin`](crate::TimePlugin).
+    // Calling this method on the [`Time`] resource as part of your app will most likely result in
+    // inaccurate timekeeping, as the resource is ordinarily managed by the
+    // [`TimePlugin`](crate::TimePlugin).
     pub fn update(&mut self) {
         self.update_with_instant(Instant::now());
     }
 
     /// Update time with a specified [`Instant`]
     ///
-    /// This method is provided for use in tests. Calling this method on the [`Time`] resource as
-    /// part of your app will most likely result in inaccurate timekeeping, as the resource is
-    /// ordinarily managed by the [`TimePlugin`](crate::TimePlugin).
+    // This method is provided for use in tests. Calling this method on the [`Time`] resource as
+    // part of your app will most likely result in inaccurate timekeeping, as the resource is
+    // ordinarily managed by the [`TimePlugin`](crate::TimePlugin).
     ///
     /// # Examples
     ///
     /// ```
     /// # use bevy_time::prelude::*;
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_utils::Duration;
+    /// # use bevy_time::Duration;
     /// # fn main () {
     /// #     test_health_system();
     /// # }
@@ -150,7 +150,7 @@ impl Time {
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::Time;
-    use bevy_utils::{Duration, Instant};
+    use crate::{Duration, Instant};
 
     #[test]
     fn update_test() {

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -1,6 +1,6 @@
+use crate::Duration;
 use crate::Stopwatch;
 use bevy_reflect::prelude::*;
-use bevy_utils::Duration;
 
 /// Tracks elapsed time. Enters the finished state once `duration` is reached.
 ///

--- a/crates/bevy_time_plugin/Cargo.toml
+++ b/crates/bevy_time_plugin/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "bevy_core"
+name = "bevy_time_plugin"
 version = "0.9.0-dev"
 edition = "2021"
-description = "Provides core functionality for Bevy Engine"
+description = "Provides a time plugin for Bevy Engine"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
@@ -11,13 +11,11 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.9.0-dev", features = ["bevy_reflect"] }
+bevy_app = { path = "../bevy_app", version = "0.9.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev", features = ["bevy_reflect"] }
-bevy_math = { path = "../bevy_math", version = "0.9.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"] }
-bevy_tasks = { path = "../bevy_tasks", version = "0.9.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.9.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
 
 # other
-bytemuck = "1.5"
+crossbeam-channel = "0.5.0"

--- a/crates/bevy_time_plugin/src/lib.rs
+++ b/crates/bevy_time_plugin/src/lib.rs
@@ -1,0 +1,147 @@
+#![allow(unused_imports)]
+use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
+
+use bevy_ecs::system::{IntoExclusiveSystem, Local, Res, ResMut};
+use bevy_time::FixedTimestep;
+use bevy_time::{FixedTimesteps, Instant, Stopwatch, Time, Timer};
+use bevy_utils::tracing::warn;
+use crossbeam_channel::{Receiver, Sender};
+
+/// Adds time functionality to Apps.
+#[derive(Default)]
+pub struct TimePlugin;
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, SystemLabel)]
+/// Updates the elapsed time. Any system that interacts with [Time] component should run after
+/// this.
+pub struct TimeSystem;
+
+impl Plugin for TimePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<Time>()
+            .init_resource::<FixedTimesteps>()
+            .register_type::<Timer>()
+            .register_type::<Time>()
+            .register_type::<Stopwatch>()
+            // time system is added as an "exclusive system" to ensure it runs before other systems
+            // in CoreStage::First
+            .add_system_to_stage(
+                CoreStage::First,
+                time_system.exclusive_system().at_start().label(TimeSystem),
+            );
+    }
+}
+
+/// Channel resource used to receive time from render world
+#[derive(Resource)]
+pub struct TimeReceiver(pub Receiver<Instant>);
+
+/// Channel resource used to send time from render world
+#[derive(Resource)]
+pub struct TimeSender(pub Sender<Instant>);
+
+/// Creates channels used for sending time between render world and app world
+pub fn create_time_channels() -> (TimeSender, TimeReceiver) {
+    // bound the channel to 2 since when pipelined the render phase can finish before
+    // the time system runs.
+    let (s, r) = crossbeam_channel::bounded::<Instant>(2);
+    (TimeSender(s), TimeReceiver(r))
+}
+
+/// The system used to update the [`Time`] used by app logic. If there is a render world the time is sent from
+/// there to this system through channels. Otherwise the time is updated in this system.
+fn time_system(
+    mut time: ResMut<Time>,
+    time_recv: Option<Res<TimeReceiver>>,
+    mut has_received_time: Local<bool>,
+) {
+    if let Some(time_recv) = time_recv {
+        // TODO: Figure out how to handle this when using pipelined rendering.
+        if let Ok(new_time) = time_recv.0.try_recv() {
+            time.update_with_instant(new_time);
+            *has_received_time = true;
+        } else if *has_received_time {
+            warn!("time_system did not receive the time from the render world! Calculations depending on the time may be incorrect.");
+        }
+    } else {
+        time.update();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bevy_time::Instant;
+    use std::ops::{Add, Mul};
+    use std::time::Duration;
+
+    #[derive(Resource)]
+    struct Count(usize);
+    const LABEL: &str = "test_step";
+
+    #[test]
+    fn test() {
+        let mut world = World::default();
+        let mut time = Time::default();
+        let instance = Instant::now();
+        time.update_with_instant(instance);
+        world.insert_resource(time);
+        world.insert_resource(FixedTimesteps::default());
+        world.insert_resource(Count(0));
+        let mut schedule = Schedule::default();
+
+        #[derive(StageLabel)]
+        struct Update;
+        schedule.add_stage(
+            Update,
+            SystemStage::parallel()
+                .with_run_criteria(FixedTimestep::step(0.5).with_label(LABEL))
+                .with_system(fixed_update),
+        );
+
+        // if time does not progress, the step does not run
+        schedule.run(&mut world);
+        schedule.run(&mut world);
+        assert_eq!(0, world.resource::<Count>().0);
+        assert_eq!(0., get_accumulator_deciseconds(&world));
+
+        // let's progress less than one step
+        advance_time(&mut world, instance, 0.4);
+        schedule.run(&mut world);
+        assert_eq!(0, world.resource::<Count>().0);
+        assert_eq!(4., get_accumulator_deciseconds(&world));
+
+        // finish the first step with 0.1s above the step length
+        advance_time(&mut world, instance, 0.6);
+        schedule.run(&mut world);
+        assert_eq!(1, world.resource::<Count>().0);
+        assert_eq!(1., get_accumulator_deciseconds(&world));
+
+        // runs multiple times if the delta is multiple step lengths
+        advance_time(&mut world, instance, 1.7);
+        schedule.run(&mut world);
+        assert_eq!(3, world.resource::<Count>().0);
+        assert_eq!(2., get_accumulator_deciseconds(&world));
+    }
+
+    fn fixed_update(mut count: ResMut<Count>) {
+        count.0 += 1;
+    }
+
+    fn advance_time(world: &mut World, instance: Instant, seconds: f32) {
+        world
+            .resource_mut::<Time>()
+            .update_with_instant(instance.add(Duration::from_secs_f32(seconds)));
+    }
+
+    fn get_accumulator_deciseconds(world: &World) -> f64 {
+        world
+            .resource::<FixedTimesteps>()
+            .get(LABEL)
+            .unwrap()
+            .accumulator()
+            .mul(10.)
+            .round()
+    }
+}

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["bevy"]
 [dependencies]
 ahash = "0.7.0"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-instant = { version = "0.1", features = ["wasm-bindgen"] }
 uuid = { version = "1.1", features = ["v4", "serde"] }
 hashbrown = { version = "0.12", features = ["serde"] }
 

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -15,7 +15,6 @@ pub use ahash::AHasher;
 pub use default::default;
 pub use float_ord::*;
 pub use hashbrown;
-pub use instant::{Duration, Instant};
 pub use tracing;
 pub use uuid::Uuid;
 

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
+[features]
+default = []
+serialize = ["serde"]
+
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.9.0-dev" }
@@ -20,7 +24,7 @@ bevy_input = { path = "../bevy_input", version = "0.9.0-dev" }
 raw-window-handle = "0.4.2"
 
 # other
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = "0.3"

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -20,6 +20,7 @@ bevy_input = { path = "../bevy_input", version = "0.9.0-dev" }
 raw-window-handle = "0.4.2"
 
 # other
+serde = { version = "1.0", features = ["derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = "0.3"

--- a/crates/bevy_window/src/cursor.rs
+++ b/crates/bevy_window/src/cursor.rs
@@ -4,6 +4,7 @@
 /// This `enum` is simply a copy of a similar `enum` found in [`winit`](https://docs.rs/winit/latest/winit/window/enum.CursorIcon.html).
 /// `winit`, in turn, mostly copied cursor types available in the browser.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum CursorIcon {
     /// The platform-dependent default cursor.
     Default,

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -5,6 +5,7 @@ use bevy_math::{IVec2, Vec2};
 
 /// A window event that is sent whenever a window's logical size has changed.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowResized {
     pub id: WindowId,
     /// The new logical width of the window.
@@ -15,6 +16,7 @@ pub struct WindowResized {
 
 /// An event that indicates that a new window should be created.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateWindow {
     pub id: WindowId,
     pub descriptor: WindowDescriptor,
@@ -23,6 +25,7 @@ pub struct CreateWindow {
 /// An event that indicates the window should redraw, even if its control flow is set to `Wait` and
 /// there have been no window events.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct RequestRedraw;
 
 /// An event that is sent whenever a new window is created.
@@ -30,6 +33,7 @@ pub struct RequestRedraw;
 /// To create a new window, send a [`CreateWindow`] event - this
 /// event will be sent in the handler for that event.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowCreated {
     pub id: WindowId,
 }
@@ -46,6 +50,7 @@ pub struct WindowCreated {
 /// [`Window`]: crate::Window
 /// [closing]: crate::Window::close
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowCloseRequested {
     pub id: WindowId,
 }
@@ -55,6 +60,7 @@ pub struct WindowCloseRequested {
 ///
 /// [`Window::close`]: crate::Window::close
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowClosed {
     pub id: WindowId,
 }
@@ -68,6 +74,7 @@ pub struct WindowClosed {
 /// [`WindowEvent::CursorMoved`]: https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.CursorMoved
 /// [`MouseMotion`]: bevy_input::mouse::MouseMotion
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursorMoved {
     /// The identifier of the window the cursor has moved on.
     pub id: WindowId,
@@ -77,17 +84,20 @@ pub struct CursorMoved {
 }
 /// An event that is sent whenever the user's cursor enters a window.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursorEntered {
     pub id: WindowId,
 }
 /// An event that is sent whenever the user's cursor leaves a window.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursorLeft {
     pub id: WindowId,
 }
 
 /// An event that is sent whenever a window receives a character from the OS or underlying system.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReceivedCharacter {
     pub id: WindowId,
     pub char: char,
@@ -102,12 +112,14 @@ pub struct WindowFocused {
 
 /// An event that indicates a window's scale factor has changed.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowScaleFactorChanged {
     pub id: WindowId,
     pub scale_factor: f64,
 }
 /// An event that indicates a window's OS-reported scale factor has changed.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowBackendScaleFactorChanged {
     pub id: WindowId,
     pub scale_factor: f64,
@@ -115,6 +127,7 @@ pub struct WindowBackendScaleFactorChanged {
 
 /// Events related to files being dragged and dropped on a window.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum FileDragAndDrop {
     DroppedFile { id: WindowId, path_buf: PathBuf },
 
@@ -125,6 +138,7 @@ pub enum FileDragAndDrop {
 
 /// An event that is sent when a window is repositioned in physical pixels.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowMoved {
     pub id: WindowId,
     pub position: IVec2,

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -24,7 +24,7 @@ pub struct CreateWindow {
 
 /// An event that indicates the window should redraw, even if its control flow is set to `Wait` and
 /// there have been no window events.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct RequestRedraw;
 
@@ -32,7 +32,7 @@ pub struct RequestRedraw;
 ///
 /// To create a new window, send a [`CreateWindow`] event - this
 /// event will be sent in the handler for that event.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowCreated {
     pub id: WindowId,
@@ -49,7 +49,7 @@ pub struct WindowCreated {
 /// [`WindowPlugin`]: crate::WindowPlugin
 /// [`Window`]: crate::Window
 /// [closing]: crate::Window::close
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowCloseRequested {
     pub id: WindowId,
@@ -59,7 +59,7 @@ pub struct WindowCloseRequested {
 /// handler for [`Window::close`].
 ///
 /// [`Window::close`]: crate::Window::close
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowClosed {
     pub id: WindowId,
@@ -83,20 +83,20 @@ pub struct CursorMoved {
     pub position: Vec2,
 }
 /// An event that is sent whenever the user's cursor enters a window.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursorEntered {
     pub id: WindowId,
 }
 /// An event that is sent whenever the user's cursor leaves a window.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursorLeft {
     pub id: WindowId,
 }
 
 /// An event that is sent whenever a window receives a character from the OS or underlying system.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReceivedCharacter {
     pub id: WindowId,
@@ -104,7 +104,7 @@ pub struct ReceivedCharacter {
 }
 
 /// An event that indicates a window has received or lost focus.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WindowFocused {
     pub id: WindowId,
     pub focused: bool,
@@ -126,7 +126,7 @@ pub struct WindowBackendScaleFactorChanged {
 }
 
 /// Events related to files being dragged and dropped on a window.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum FileDragAndDrop {
     DroppedFile { id: WindowId, path_buf: PathBuf },
@@ -137,7 +137,7 @@ pub enum FileDragAndDrop {
 }
 
 /// An event that is sent when a window is repositioned in physical pixels.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowMoved {
     pub id: WindowId,

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -4,7 +4,7 @@ use super::{WindowDescriptor, WindowId};
 use bevy_math::{IVec2, Vec2};
 
 /// A window event that is sent whenever a window's logical size has changed.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowResized {
     pub id: WindowId,
@@ -15,7 +15,7 @@ pub struct WindowResized {
 }
 
 /// An event that indicates that a new window should be created.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateWindow {
     pub id: WindowId,
@@ -24,7 +24,7 @@ pub struct CreateWindow {
 
 /// An event that indicates the window should redraw, even if its control flow is set to `Wait` and
 /// there have been no window events.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct RequestRedraw;
 
@@ -32,7 +32,7 @@ pub struct RequestRedraw;
 ///
 /// To create a new window, send a [`CreateWindow`] event - this
 /// event will be sent in the handler for that event.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowCreated {
     pub id: WindowId,
@@ -49,7 +49,7 @@ pub struct WindowCreated {
 /// [`WindowPlugin`]: crate::WindowPlugin
 /// [`Window`]: crate::Window
 /// [closing]: crate::Window::close
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowCloseRequested {
     pub id: WindowId,
@@ -59,7 +59,7 @@ pub struct WindowCloseRequested {
 /// handler for [`Window::close`].
 ///
 /// [`Window::close`]: crate::Window::close
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowClosed {
     pub id: WindowId,
@@ -73,7 +73,7 @@ pub struct WindowClosed {
 ///
 /// [`WindowEvent::CursorMoved`]: https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.CursorMoved
 /// [`MouseMotion`]: bevy_input::mouse::MouseMotion
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursorMoved {
     /// The identifier of the window the cursor has moved on.
@@ -83,20 +83,20 @@ pub struct CursorMoved {
     pub position: Vec2,
 }
 /// An event that is sent whenever the user's cursor enters a window.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursorEntered {
     pub id: WindowId,
 }
 /// An event that is sent whenever the user's cursor leaves a window.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursorLeft {
     pub id: WindowId,
 }
 
 /// An event that is sent whenever a window receives a character from the OS or underlying system.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReceivedCharacter {
     pub id: WindowId,
@@ -104,21 +104,21 @@ pub struct ReceivedCharacter {
 }
 
 /// An event that indicates a window has received or lost focus.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WindowFocused {
     pub id: WindowId,
     pub focused: bool,
 }
 
 /// An event that indicates a window's scale factor has changed.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowScaleFactorChanged {
     pub id: WindowId,
     pub scale_factor: f64,
 }
 /// An event that indicates a window's OS-reported scale factor has changed.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowBackendScaleFactorChanged {
     pub id: WindowId,
@@ -126,7 +126,7 @@ pub struct WindowBackendScaleFactorChanged {
 }
 
 /// Events related to files being dragged and dropped on a window.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum FileDragAndDrop {
     DroppedFile { id: WindowId, path_buf: PathBuf },
@@ -137,7 +137,7 @@ pub enum FileDragAndDrop {
 }
 
 /// An event that is sent when a window is repositioned in physical pixels.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowMoved {
     pub id: WindowId,

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -7,6 +7,7 @@ use raw_window_handle::RawWindowHandle;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Reflect, FromReflect)]
 #[reflect_value(PartialEq, Hash)]
 /// A unique ID for a [`Window`].
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowId(Uuid);
 
 /// Presentation mode for a window.
@@ -24,6 +25,7 @@ pub struct WindowId(Uuid);
 /// or updated on a [`Window`](Window::set_present_mode).
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[doc(alias = "vsync")]
 pub enum PresentMode {
     /// Chooses FifoRelaxed -> Fifo based on availability.
@@ -96,6 +98,7 @@ impl Default for WindowId {
 /// maximized it may have a size outside of these limits. The functionality
 /// required to disable maximizing is not yet exposed by winit.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowResizeConstraints {
     pub min_width: f32,
     pub min_height: f32,
@@ -215,6 +218,7 @@ pub struct Window {
 /// Bevy apps don't interact with this `enum` directly. Instead, they should use the methods on [`Window`].
 /// This `enum` is meant for authors of windowing plugins. See the documentation on [`crate::WindowPlugin`] for more information.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum WindowCommand {
     /// Set the window's [`WindowMode`].
     SetWindowMode {
@@ -288,6 +292,7 @@ pub enum WindowCommand {
 
 /// Defines the way a window is displayed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum WindowMode {
     /// Creates a window that uses the given size.
     Windowed,
@@ -746,6 +751,7 @@ impl Window {
 
 /// Defines where window should be placed at on creation.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum WindowPosition {
     /// The position will be set by the window manager.
     Automatic,
@@ -763,6 +769,7 @@ pub enum WindowPosition {
 
 /// Defines which monitor to use.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum MonitorSelection {
     /// Uses current monitor of the window.
     ///
@@ -783,6 +790,7 @@ pub enum MonitorSelection {
 ///
 /// [`examples/window/window_settings.rs`]: https://github.com/bevyengine/bevy/blob/latest/examples/window/window_settings.rs
 #[derive(Resource, Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowDescriptor {
     /// The requested logical width of the window's client area.
     ///

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -97,7 +97,7 @@ impl Default for WindowId {
 /// Please note that if the window is resizable, then when the window is
 /// maximized it may have a size outside of these limits. The functionality
 /// required to disable maximizing is not yet exposed by winit.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowResizeConstraints {
     pub min_width: f32,
@@ -750,7 +750,7 @@ impl Window {
 }
 
 /// Defines where window should be placed at on creation.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum WindowPosition {
     /// The position will be set by the window manager.
@@ -768,7 +768,7 @@ pub enum WindowPosition {
 }
 
 /// Defines which monitor to use.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum MonitorSelection {
     /// Uses current monitor of the window.
@@ -789,7 +789,7 @@ pub enum MonitorSelection {
 /// See [`examples/window/window_settings.rs`] for usage.
 ///
 /// [`examples/window/window_settings.rs`]: https://github.com/bevyengine/bevy/blob/latest/examples/window/window_settings.rs
-#[derive(Resource, Debug, Clone)]
+#[derive(Resource, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowDescriptor {
     /// The requested logical width of the window's client area.

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -768,7 +768,7 @@ pub enum WindowPosition {
 }
 
 /// Defines which monitor to use.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum MonitorSelection {
     /// Uses current monitor of the window.

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -19,6 +19,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.9.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.9.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.9.0-dev" }
+bevy_time = { path = "../bevy_time", version = "0.9.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
 
 # other

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -19,10 +19,8 @@ use bevy_input::{
     touch::TouchInput,
 };
 use bevy_math::{ivec2, DVec2, UVec2, Vec2};
-use bevy_utils::{
-    tracing::{error, info, trace, warn},
-    Instant,
-};
+use bevy_time::Instant;
+use bevy_utils::tracing::{error, info, trace, warn};
 use bevy_window::{
     CreateWindow, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, ModifiesWindows,
     ReceivedCharacter, RequestRedraw, WindowBackendScaleFactorChanged, WindowCloseRequested,

--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::system::Resource;
-use bevy_utils::Duration;
+use bevy_time::Duration;
 
 /// A resource for configuring usage of the `rust_winit` library.
 #[derive(Debug, Resource)]

--- a/examples/app/headless.rs
+++ b/examples/app/headless.rs
@@ -6,7 +6,7 @@
 //! bevy = { version = "*", default-features = false }
 //! # replace "*" with the most recent version of bevy
 
-use bevy::{app::ScheduleRunnerSettings, prelude::*, utils::Duration};
+use bevy::{app::ScheduleRunnerSettings, prelude::*, time::Duration};
 
 fn main() {
     // this app runs once

--- a/examples/app/plugin.rs
+++ b/examples/app/plugin.rs
@@ -4,7 +4,7 @@
 //! that provide a specific piece of functionality (generally the smaller the scope, the better).
 //! This example illustrates how to create a simple plugin that prints out a message.
 
-use bevy::{prelude::*, utils::Duration};
+use bevy::{prelude::*, time::Duration};
 
 fn main() {
     App::new()

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -29,7 +29,7 @@ use bevy::{
     ecs::schedule::ReportExecutionOrderAmbiguities,
     log::LogPlugin,
     prelude::*,
-    utils::Duration,
+    time::Duration,
 };
 use rand::random;
 

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -2,7 +2,7 @@
 use std::fs::File;
 use std::io::Write;
 
-use bevy::{prelude::*, tasks::IoTaskPool, utils::Duration};
+use bevy::{prelude::*, tasks::IoTaskPool, time::Duration};
 
 fn main() {
     App::new()

--- a/examples/ui/scaling.rs
+++ b/examples/ui/scaling.rs
@@ -1,6 +1,6 @@
 //! This example illustrates the [`UIScale`] resource from `bevy_ui`.
 
-use bevy::{prelude::*, utils::Duration};
+use bevy::{prelude::*, time::Duration};
 
 const SCALE_TIME: u64 = 400;
 

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -5,7 +5,7 @@
 
 use bevy::{
     prelude::*,
-    utils::Duration,
+    time::Duration,
     window::{PresentMode, RequestRedraw},
     winit::WinitSettings,
 };


### PR DESCRIPTION
# Objective

- Describe the objective or issue this PR addresses.

Fixes https://github.com/bevyengine/bevy/issues/6027.

## Solution

- Describe the solution used to achieve the objective above.

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- What changed as a result of this PR?
- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!

## Migration Guide

Clients of Instant and/or Duration will need to change from getting them from `bevy_utils` to `bevy_time` or from `bevy::utils` to `bevy::time`.
Clients of TimePlugin will need to change from getting it from `bevy_time` to `bevy_time_plugin`.

