### PR TITLE
bevy_reflect: Reflect remote types

### DIFF
--- a/crates/bevy_reflect/compile_fail/Cargo.toml
+++ b/crates/bevy_reflect/compile_fail/Cargo.toml
@@ -20,3 +20,7 @@ harness = false
 [[test]]
 name = "func"
 harness = false
+
+[[test]]
+name = "remote"
+harness = false

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/incorrect_wrapper_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/incorrect_wrapper_fail.rs
@@ -12,6 +12,7 @@ mod external_crate {
 struct MyFoo(#[reflect(ignore)] pub external_crate::TheirFoo);
 
 #[derive(Reflect)]
+//~^ ERROR: the trait bound `MyFoo: ReflectRemote` is not satisfied
 #[reflect(from_reflect = false)]
 struct MyStruct {
     // Reason: `MyFoo` does not implement `ReflectRemote` (from `#[reflect_remote]` attribute)

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/incorrect_wrapper_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/incorrect_wrapper_fail.rs
@@ -1,0 +1,23 @@
+use bevy_reflect::Reflect;
+
+mod external_crate {
+    pub struct TheirFoo {
+        pub value: u32,
+    }
+}
+
+#[repr(transparent)]
+#[derive(Reflect)]
+#[reflect(from_reflect = false)]
+struct MyFoo(#[reflect(ignore)] pub external_crate::TheirFoo);
+
+#[derive(Reflect)]
+#[reflect(from_reflect = false)]
+struct MyStruct {
+    // Reason: `MyFoo` does not implement `ReflectRemote` (from `#[reflect_remote]` attribute)
+    #[reflect(remote = "MyFoo")]
+    //~^ ERROR: the trait bound `MyFoo: ReflectRemote` is not satisfied
+    foo: external_crate::TheirFoo,
+}
+
+fn main() {}

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/incorrect_wrapper_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/incorrect_wrapper_fail.rs
@@ -16,7 +16,7 @@ struct MyFoo(#[reflect(ignore)] pub external_crate::TheirFoo);
 #[reflect(from_reflect = false)]
 struct MyStruct {
     // Reason: `MyFoo` does not implement `ReflectRemote` (from `#[reflect_remote]` attribute)
-    #[reflect(remote = "MyFoo")]
+    #[reflect(remote = MyFoo)]
     //~^ ERROR: the trait bound `MyFoo: ReflectRemote` is not satisfied
     foo: external_crate::TheirFoo,
 }

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/incorrect_wrapper_pass.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/incorrect_wrapper_pass.rs
@@ -14,7 +14,7 @@ struct MyFoo {
 
 #[derive(Reflect)]
 struct MyStruct {
-    #[reflect(remote = "MyFoo")]
+    #[reflect(remote = MyFoo)]
     foo: external_crate::TheirFoo,
 }
 

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/incorrect_wrapper_pass.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/incorrect_wrapper_pass.rs
@@ -1,0 +1,21 @@
+//@check-pass
+use bevy_reflect::{reflect_remote, Reflect};
+
+mod external_crate {
+    pub struct TheirFoo {
+        pub value: u32,
+    }
+}
+
+#[reflect_remote(external_crate::TheirFoo)]
+struct MyFoo {
+    pub value: u32,
+}
+
+#[derive(Reflect)]
+struct MyStruct {
+    #[reflect(remote = "MyFoo")]
+    foo: external_crate::TheirFoo,
+}
+
+fn main() {}

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/invalid_definition_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/invalid_definition_fail.rs
@@ -8,11 +8,11 @@ mod structs {
     }
 
     #[reflect_remote(external_crate::TheirStruct)]
-    //~^ ERROR: mismatched types
-    //~| ERROR: `?` operator has incompatible types
+    //~^ ERROR: `?` operator has incompatible types
     struct MyStruct {
         // Reason: Should be `u32`
         pub value: bool,
+        //~^ ERROR: mismatched types
     }
 }
 
@@ -24,11 +24,11 @@ mod tuple_structs {
     }
 
     #[reflect_remote(external_crate::TheirStruct)]
-    //~^ ERROR: mismatched types
-    //~| ERROR: `?` operator has incompatible types
+    //~^ ERROR: `?` operator has incompatible types
     struct MyStruct(
         // Reason: Should be `u32`
         pub bool,
+        //~^ ERROR: mismatched types
     );
 }
 
@@ -44,9 +44,7 @@ mod enums {
     }
 
     #[reflect_remote(external_crate::TheirStruct)]
-    //~^ ERROR: mismatched types
-    //~| ERROR: mismatched types
-    //~| ERROR: variant `enums::external_crate::TheirStruct::Unit` does not have a field named `0`
+    //~^ ERROR: variant `enums::external_crate::TheirStruct::Unit` does not have a field named `0`
     //~| ERROR: variant `enums::external_crate::TheirStruct::Unit` has no field named `0`
     //~| ERROR: `?` operator has incompatible types
     //~| ERROR: `?` operator has incompatible types
@@ -55,8 +53,10 @@ mod enums {
         Unit(i32),
         // Reason: Should be `u32`
         Tuple(bool),
+        //~^ ERROR: mismatched types
         // Reason: Should be `usize`
         Struct { value: String },
+        //~^ ERROR: mismatched types
     }
 }
 

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/invalid_definition_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/invalid_definition_fail.rs
@@ -1,0 +1,63 @@
+mod structs {
+    use bevy_reflect::reflect_remote;
+
+    mod external_crate {
+        pub struct TheirStruct {
+            pub value: u32,
+        }
+    }
+
+    #[reflect_remote(external_crate::TheirStruct)]
+    //~^ ERROR: mismatched types
+    //~| ERROR: `?` operator has incompatible types
+    struct MyStruct {
+        // Reason: Should be `u32`
+        pub value: bool,
+    }
+}
+
+mod tuple_structs {
+    use bevy_reflect::reflect_remote;
+
+    mod external_crate {
+        pub struct TheirStruct(pub u32);
+    }
+
+    #[reflect_remote(external_crate::TheirStruct)]
+    //~^ ERROR: mismatched types
+    //~| ERROR: `?` operator has incompatible types
+    struct MyStruct(
+        // Reason: Should be `u32`
+        pub bool,
+    );
+}
+
+mod enums {
+    use bevy_reflect::reflect_remote;
+
+    mod external_crate {
+        pub enum TheirStruct {
+            Unit,
+            Tuple(u32),
+            Struct { value: usize },
+        }
+    }
+
+    #[reflect_remote(external_crate::TheirStruct)]
+    //~^ ERROR: mismatched types
+    //~| ERROR: mismatched types
+    //~| ERROR: variant `enums::external_crate::TheirStruct::Unit` does not have a field named `0`
+    //~| ERROR: variant `enums::external_crate::TheirStruct::Unit` has no field named `0`
+    //~| ERROR: `?` operator has incompatible types
+    //~| ERROR: `?` operator has incompatible types
+    enum MyStruct {
+        // Reason: Should be unit variant
+        Unit(i32),
+        // Reason: Should be `u32`
+        Tuple(bool),
+        // Reason: Should be `usize`
+        Struct { value: String },
+    }
+}
+
+fn main() {}

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/invalid_definition_pass.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/invalid_definition_pass.rs
@@ -1,0 +1,48 @@
+//@check-pass
+
+mod structs {
+    use bevy_reflect::reflect_remote;
+
+    mod external_crate {
+        pub struct TheirStruct {
+            pub value: u32,
+        }
+    }
+
+    #[reflect_remote(external_crate::TheirStruct)]
+    struct MyStruct {
+        pub value: u32,
+    }
+}
+
+mod tuple_structs {
+    use bevy_reflect::reflect_remote;
+
+    mod external_crate {
+        pub struct TheirStruct(pub u32);
+    }
+
+    #[reflect_remote(external_crate::TheirStruct)]
+    struct MyStruct(pub u32);
+}
+
+mod enums {
+    use bevy_reflect::reflect_remote;
+
+    mod external_crate {
+        pub enum TheirStruct {
+            Unit,
+            Tuple(u32),
+            Struct { value: usize },
+        }
+    }
+
+    #[reflect_remote(external_crate::TheirStruct)]
+    enum MyStruct {
+        Unit,
+        Tuple(u32),
+        Struct { value: usize },
+    }
+}
+
+fn main() {}

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/macro_order_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/macro_order_fail.rs
@@ -1,0 +1,19 @@
+use bevy_reflect::{reflect_remote, std_traits::ReflectDefault};
+
+mod external_crate {
+    #[derive(Debug, Default)]
+    pub struct TheirType {
+        pub value: String,
+    }
+}
+
+#[derive(Debug, Default)]
+#[reflect_remote(external_crate::TheirType)]
+#[reflect(Debug, Default)]
+struct MyType {
+    pub value: String,
+    //~^ ERROR: no field `value` on type `&MyType`
+    //~| ERROR: struct `MyType` has no field named `value`
+}
+
+fn main() {}

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/macro_order_pass.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/macro_order_pass.rs
@@ -1,0 +1,18 @@
+//@check-pass
+use bevy_reflect::{reflect_remote, std_traits::ReflectDefault};
+
+mod external_crate {
+    #[derive(Debug, Default)]
+    pub struct TheirType {
+        pub value: String,
+    }
+}
+
+#[reflect_remote(external_crate::TheirType)]
+#[derive(Debug, Default)]
+#[reflect(Debug, Default)]
+struct MyType {
+    pub value: String,
+}
+
+fn main() {}

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
@@ -41,10 +41,10 @@ mod mismatched_remote_type {
     use bevy_reflect::{reflect_remote, Reflect};
 
     #[reflect_remote(super::external_crate::TheirOuter<T>)]
-    //~^ ERROR: mismatched types
     struct MyOuter<T: Reflect> {
         // Reason: Should be `MyInner<T>`
         #[reflect(remote = "MyOuter<T>")]
+        //~^ ERROR: mismatched types
         pub inner: super::external_crate::TheirInner<T>,
     }
 

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
@@ -27,10 +27,10 @@ mod incorrect_inner_type {
     //~| ERROR: `TheirInner<T>` can not be reflected
     //~| ERROR: `TheirInner<T>` can not be used as a dynamic type path
     //~| ERROR: `?` operator has incompatible types
-    //~| ERROR: mismatched types
     struct MyOuter<T: Reflect> {
         // Reason: Should not use `MyInner<T>` directly
         pub inner: MyInner<T>,
+        //~^ ERROR: mismatched types
     }
 
     #[reflect_remote(super::external_crate::TheirInner<T>)]
@@ -57,11 +57,11 @@ mod mismatched_remote_generic {
 
     #[reflect_remote(super::external_crate::TheirOuter<T>)]
     //~^ ERROR: `?` operator has incompatible types
-    //~| ERROR: mismatched types
     struct MyOuter<T: Reflect> {
         // Reason: `TheirOuter::inner` is not defined as `TheirInner<bool>`
         #[reflect(remote = "MyInner<bool>")]
         pub inner: super::external_crate::TheirInner<bool>,
+        //~^ ERROR: mismatched types
     }
 
     #[reflect_remote(super::external_crate::TheirInner<T>)]

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
@@ -27,6 +27,7 @@ mod incorrect_inner_type {
     //~| ERROR: `TheirInner<T>` can not be reflected
     //~| ERROR: `TheirInner<T>` can not be used as a dynamic type path
     //~| ERROR: `?` operator has incompatible types
+    //~| ERROR: mismatched types
     struct MyOuter<T: Reflect> {
         // Reason: Should not use `MyInner<T>` directly
         pub inner: MyInner<T>,
@@ -56,6 +57,7 @@ mod mismatched_remote_generic {
 
     #[reflect_remote(super::external_crate::TheirOuter<T>)]
     //~^ ERROR: `?` operator has incompatible types
+    //~| ERROR: mismatched types
     struct MyOuter<T: Reflect> {
         // Reason: `TheirOuter::inner` is not defined as `TheirInner<bool>`
         #[reflect(remote = "MyInner<bool>")]

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
@@ -6,20 +6,20 @@ mod external_crate {
 }
 
 mod missing_attribute {
-    use bevy_reflect::{reflect_remote, Reflect};
+    use bevy_reflect::{FromReflect, GetTypeRegistration, reflect_remote};
 
     #[reflect_remote(super::external_crate::TheirOuter<T>)]
-    struct MyOuter<T: Reflect> {
+    struct MyOuter<T: FromReflect + GetTypeRegistration> {
         // Reason: Missing `#[reflect(remote = "...")]` attribute
         pub inner: super::external_crate::TheirInner<T>,
     }
 
     #[reflect_remote(super::external_crate::TheirInner<T>)]
-    struct MyInner<T: Reflect>(pub T);
+    struct MyInner<T>(pub T);
 }
 
 mod incorrect_inner_type {
-    use bevy_reflect::{reflect_remote, Reflect};
+    use bevy_reflect::{FromReflect, GetTypeRegistration, reflect_remote};
 
     #[reflect_remote(super::external_crate::TheirOuter<T>)]
     //~^ ERROR: `TheirInner<T>` can not be reflected
@@ -27,23 +27,23 @@ mod incorrect_inner_type {
     //~| ERROR: `TheirInner<T>` can not be reflected
     //~| ERROR: `TheirInner<T>` can not be used as a dynamic type path
     //~| ERROR: `?` operator has incompatible types
-    struct MyOuter<T: Reflect> {
+    struct MyOuter<T: FromReflect + GetTypeRegistration> {
         // Reason: Should not use `MyInner<T>` directly
         pub inner: MyInner<T>,
         //~^ ERROR: mismatched types
     }
 
     #[reflect_remote(super::external_crate::TheirInner<T>)]
-    struct MyInner<T: Reflect>(pub T);
+    struct MyInner<T>(pub T);
 }
 
 mod mismatched_remote_type {
-    use bevy_reflect::{reflect_remote, Reflect};
+    use bevy_reflect::{FromReflect, GetTypeRegistration, reflect_remote};
 
     #[reflect_remote(super::external_crate::TheirOuter<T>)]
     //~^ ERROR: mismatched types
     //~| ERROR: mismatched types
-    struct MyOuter<T: Reflect> {
+    struct MyOuter<T: FromReflect + GetTypeRegistration> {
         // Reason: Should be `MyInner<T>`
         #[reflect(remote = "MyOuter<T>")]
         //~^ ERROR: mismatched types
@@ -51,17 +51,17 @@ mod mismatched_remote_type {
     }
 
     #[reflect_remote(super::external_crate::TheirInner<T>)]
-    struct MyInner<T: Reflect>(pub T);
+    struct MyInner<T>(pub T);
 }
 
 mod mismatched_remote_generic {
-    use bevy_reflect::{reflect_remote, Reflect};
+    use bevy_reflect::{FromReflect, GetTypeRegistration, reflect_remote};
 
     #[reflect_remote(super::external_crate::TheirOuter<T>)]
     //~^ ERROR: `?` operator has incompatible types
     //~| ERROR: mismatched types
     //~| ERROR: mismatched types
-    struct MyOuter<T: Reflect> {
+    struct MyOuter<T: FromReflect + GetTypeRegistration> {
         // Reason: `TheirOuter::inner` is not defined as `TheirInner<bool>`
         #[reflect(remote = "MyInner<bool>")]
         pub inner: super::external_crate::TheirInner<bool>,
@@ -69,7 +69,7 @@ mod mismatched_remote_generic {
     }
 
     #[reflect_remote(super::external_crate::TheirInner<T>)]
-    struct MyInner<T: Reflect>(pub T);
+    struct MyInner<T>(pub T);
 }
 
 fn main() {}

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
@@ -41,6 +41,8 @@ mod mismatched_remote_type {
     use bevy_reflect::{reflect_remote, Reflect};
 
     #[reflect_remote(super::external_crate::TheirOuter<T>)]
+    //~^ ERROR: mismatched types
+    //~| ERROR: mismatched types
     struct MyOuter<T: Reflect> {
         // Reason: Should be `MyInner<T>`
         #[reflect(remote = "MyOuter<T>")]
@@ -57,6 +59,8 @@ mod mismatched_remote_generic {
 
     #[reflect_remote(super::external_crate::TheirOuter<T>)]
     //~^ ERROR: `?` operator has incompatible types
+    //~| ERROR: mismatched types
+    //~| ERROR: mismatched types
     struct MyOuter<T: Reflect> {
         // Reason: `TheirOuter::inner` is not defined as `TheirInner<bool>`
         #[reflect(remote = "MyInner<bool>")]

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
@@ -51,4 +51,19 @@ mod mismatched_remote_type {
     struct MyInner<T: Reflect>(pub T);
 }
 
+mod mismatched_remote_generic {
+    use bevy_reflect::{reflect_remote, Reflect};
+
+    #[reflect_remote(super::external_crate::TheirOuter<T>)]
+    //~^ ERROR: `?` operator has incompatible types
+    struct MyOuter<T: Reflect> {
+        // Reason: `TheirOuter::inner` is not defined as `TheirInner<bool>`
+        #[reflect(remote = "MyInner<bool>")]
+        pub inner: super::external_crate::TheirInner<bool>,
+    }
+
+    #[reflect_remote(super::external_crate::TheirInner<T>)]
+    struct MyInner<T: Reflect>(pub T);
+}
+
 fn main() {}

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
@@ -22,9 +22,9 @@ mod incorrect_inner_type {
     use bevy_reflect::{FromReflect, GetTypeRegistration, reflect_remote};
 
     #[reflect_remote(super::external_crate::TheirOuter<T>)]
-    //~^ ERROR: `TheirInner<T>` can not be reflected
-    //~| ERROR: `TheirInner<T>` can not be reflected
-    //~| ERROR: `TheirInner<T>` can not be reflected
+    //~^ ERROR: `TheirInner<T>` does not implement `PartialReflect` so cannot be introspected
+    //~| ERROR: `TheirInner<T>` does not implement `PartialReflect` so cannot be introspected
+    //~| ERROR: `TheirInner<T>` does not implement `PartialReflect` so cannot be introspected
     //~| ERROR: `TheirInner<T>` can not be used as a dynamic type path
     //~| ERROR: `?` operator has incompatible types
     struct MyOuter<T: FromReflect + GetTypeRegistration> {

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
@@ -36,4 +36,19 @@ mod incorrect_inner_type {
     struct MyInner<T: Reflect>(pub T);
 }
 
+mod mismatched_remote_type {
+    use bevy_reflect::{reflect_remote, Reflect};
+
+    #[reflect_remote(super::external_crate::TheirOuter<T>)]
+    //~^ ERROR: mismatched types
+    struct MyOuter<T: Reflect> {
+        // Reason: Should be `MyInner<T>`
+        #[reflect(remote = "MyOuter<T>")]
+        pub inner: super::external_crate::TheirInner<T>,
+    }
+
+    #[reflect_remote(super::external_crate::TheirInner<T>)]
+    struct MyInner<T: Reflect>(pub T);
+}
+
 fn main() {}

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
@@ -1,0 +1,39 @@
+mod external_crate {
+    pub struct TheirOuter<T> {
+        pub inner: TheirInner<T>,
+    }
+    pub struct TheirInner<T>(pub T);
+}
+
+mod missing_attribute {
+    use bevy_reflect::{reflect_remote, Reflect};
+
+    #[reflect_remote(super::external_crate::TheirOuter<T>)]
+    struct MyOuter<T: Reflect> {
+        // Reason: Missing `#[reflect(remote = "...")]` attribute
+        pub inner: super::external_crate::TheirInner<T>,
+    }
+
+    #[reflect_remote(super::external_crate::TheirInner<T>)]
+    struct MyInner<T: Reflect>(pub T);
+}
+
+mod incorrect_inner_type {
+    use bevy_reflect::{reflect_remote, Reflect};
+
+    #[reflect_remote(super::external_crate::TheirOuter<T>)]
+    //~^ ERROR: `TheirInner<T>` can not be reflected
+    //~| ERROR: `TheirInner<T>` can not be reflected
+    //~| ERROR: `TheirInner<T>` can not be reflected
+    //~| ERROR: `TheirInner<T>` can not be used as a dynamic type path
+    //~| ERROR: `?` operator has incompatible types
+    struct MyOuter<T: Reflect> {
+        // Reason: Should not use `MyInner<T>` directly
+        pub inner: MyInner<T>,
+    }
+
+    #[reflect_remote(super::external_crate::TheirInner<T>)]
+    struct MyInner<T: Reflect>(pub T);
+}
+
+fn main() {}

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
@@ -10,7 +10,7 @@ mod missing_attribute {
 
     #[reflect_remote(super::external_crate::TheirOuter<T>)]
     struct MyOuter<T: FromReflect + GetTypeRegistration> {
-        // Reason: Missing `#[reflect(remote = "...")]` attribute
+        // Reason: Missing `#[reflect(remote = ...)]` attribute
         pub inner: super::external_crate::TheirInner<T>,
     }
 
@@ -45,7 +45,7 @@ mod mismatched_remote_type {
     //~| ERROR: mismatched types
     struct MyOuter<T: FromReflect + GetTypeRegistration> {
         // Reason: Should be `MyInner<T>`
-        #[reflect(remote = "MyOuter<T>")]
+        #[reflect(remote = MyOuter<T>)]
         //~^ ERROR: mismatched types
         pub inner: super::external_crate::TheirInner<T>,
     }
@@ -63,7 +63,7 @@ mod mismatched_remote_generic {
     //~| ERROR: mismatched types
     struct MyOuter<T: FromReflect + GetTypeRegistration> {
         // Reason: `TheirOuter::inner` is not defined as `TheirInner<bool>`
-        #[reflect(remote = "MyInner<bool>")]
+        #[reflect(remote = MyInner<bool>)]
         pub inner: super::external_crate::TheirInner<bool>,
         //~^ ERROR: mismatched types
     }

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_pass.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_pass.rs
@@ -1,5 +1,5 @@
 //@check-pass
-use bevy_reflect::{reflect_remote, Reflect};
+use bevy_reflect::{FromReflect, GetTypeRegistration, reflect_remote, Reflect, Typed};
 
 mod external_crate {
     pub struct TheirOuter<T> {
@@ -9,7 +9,7 @@ mod external_crate {
 }
 
 #[reflect_remote(external_crate::TheirOuter<T>)]
-struct MyOuter<T: Reflect> {
+struct MyOuter<T: FromReflect + Typed + GetTypeRegistration> {
     #[reflect(remote = "MyInner<T>")]
     pub inner: external_crate::TheirInner<T>,
 }

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_pass.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_pass.rs
@@ -1,0 +1,20 @@
+//@check-pass
+use bevy_reflect::{reflect_remote, Reflect};
+
+mod external_crate {
+    pub struct TheirOuter<T> {
+        pub inner: TheirInner<T>,
+    }
+    pub struct TheirInner<T>(pub T);
+}
+
+#[reflect_remote(external_crate::TheirOuter<T>)]
+struct MyOuter<T: Reflect> {
+    #[reflect(remote = "MyInner<T>")]
+    pub inner: external_crate::TheirInner<T>,
+}
+
+#[reflect_remote(external_crate::TheirInner<T>)]
+struct MyInner<T: Reflect>(pub T);
+
+fn main() {}

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_pass.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_pass.rs
@@ -10,7 +10,7 @@ mod external_crate {
 
 #[reflect_remote(external_crate::TheirOuter<T>)]
 struct MyOuter<T: FromReflect + Typed + GetTypeRegistration> {
-    #[reflect(remote = "MyInner<T>")]
+    #[reflect(remote = MyInner<T>)]
     pub inner: external_crate::TheirInner<T>,
 }
 

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_fail.rs
@@ -22,6 +22,8 @@ mod structs {
     }
 
     #[derive(Reflect)]
+    //~^ ERROR: mismatched types
+    //~| ERROR: mismatched types
     struct MyStruct {
         // Reason: Should use `MyFoo`
         #[reflect(remote = "MyBar")]
@@ -46,6 +48,8 @@ mod tuple_structs {
     struct MyBar(pub i32);
 
     #[derive(Reflect)]
+    //~^ ERROR: mismatched types
+    //~| ERROR: mismatched types
     struct MyStruct(
         // Reason: Should use `MyFoo`
         #[reflect(remote = "MyBar")] external_crate::TheirFoo,
@@ -80,6 +84,9 @@ mod enums {
     }
 
     #[derive(Reflect)]
+    //~^ ERROR: mismatched types
+    //~| ERROR: mismatched types
+    //~| ERROR: mismatched types
     enum MyStruct {
         Value(
             // Reason: Should use `MyFoo`

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_fail.rs
@@ -73,10 +73,10 @@ mod enums {
 
     #[reflect_remote(external_crate::TheirBar)]
     //~^ ERROR: `?` operator has incompatible types
-    //~| ERROR: mismatched types
     enum MyBar {
         // Reason: Should use `i32`
         Value(u32),
+        //~^ ERROR: mismatched types
     }
 
     #[derive(Reflect)]

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_fail.rs
@@ -73,6 +73,7 @@ mod enums {
 
     #[reflect_remote(external_crate::TheirBar)]
     //~^ ERROR: `?` operator has incompatible types
+    //~| ERROR: mismatched types
     enum MyBar {
         // Reason: Should use `i32`
         Value(u32),

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_fail.rs
@@ -22,10 +22,10 @@ mod structs {
     }
 
     #[derive(Reflect)]
-    //~^ ERROR: mismatched types
     struct MyStruct {
         // Reason: Should use `MyFoo`
         #[reflect(remote = "MyBar")]
+        //~^ ERROR: mismatched types
         foo: external_crate::TheirFoo,
     }
 }
@@ -46,10 +46,10 @@ mod tuple_structs {
     struct MyBar(pub i32);
 
     #[derive(Reflect)]
-    //~^ ERROR: mismatched types
     struct MyStruct(
         // Reason: Should use `MyFoo`
         #[reflect(remote = "MyBar")] external_crate::TheirFoo,
+        //~^ ERROR: mismatched types
     );
 }
 
@@ -80,11 +80,11 @@ mod enums {
     }
 
     #[derive(Reflect)]
-    //~^ ERROR: mismatched types
     enum MyStruct {
         Value(
             // Reason: Should use `MyFoo`
             #[reflect(remote = "MyBar")] external_crate::TheirFoo,
+            //~^ ERROR: mismatched types
         ),
     }
 }

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_fail.rs
@@ -1,0 +1,91 @@
+//@no-rustfix
+
+mod structs {
+    use bevy_reflect::{reflect_remote, Reflect};
+
+    mod external_crate {
+        pub struct TheirFoo {
+            pub value: u32,
+        }
+        pub struct TheirBar {
+            pub value: i32,
+        }
+    }
+
+    #[reflect_remote(external_crate::TheirFoo)]
+    struct MyFoo {
+        pub value: u32,
+    }
+    #[reflect_remote(external_crate::TheirBar)]
+    struct MyBar {
+        pub value: i32,
+    }
+
+    #[derive(Reflect)]
+    //~^ ERROR: mismatched types
+    struct MyStruct {
+        // Reason: Should use `MyFoo`
+        #[reflect(remote = "MyBar")]
+        foo: external_crate::TheirFoo,
+    }
+}
+
+mod tuple_structs {
+    use bevy_reflect::{reflect_remote, Reflect};
+
+    mod external_crate {
+        pub struct TheirFoo(pub u32);
+
+        pub struct TheirBar(pub i32);
+    }
+
+    #[reflect_remote(external_crate::TheirFoo)]
+    struct MyFoo(pub u32);
+
+    #[reflect_remote(external_crate::TheirBar)]
+    struct MyBar(pub i32);
+
+    #[derive(Reflect)]
+    //~^ ERROR: mismatched types
+    struct MyStruct(
+        // Reason: Should use `MyFoo`
+        #[reflect(remote = "MyBar")] external_crate::TheirFoo,
+    );
+}
+
+mod enums {
+    use bevy_reflect::{reflect_remote, Reflect};
+
+    mod external_crate {
+        pub enum TheirFoo {
+            Value(u32),
+        }
+
+        pub enum TheirBar {
+            Value(i32),
+        }
+    }
+
+    #[reflect_remote(external_crate::TheirFoo)]
+    enum MyFoo {
+        Value(u32),
+    }
+
+    #[reflect_remote(external_crate::TheirBar)]
+    //~^ ERROR: `?` operator has incompatible types
+    enum MyBar {
+        // Reason: Should use `i32`
+        Value(u32),
+    }
+
+    #[derive(Reflect)]
+    //~^ ERROR: mismatched types
+    enum MyStruct {
+        Value(
+            // Reason: Should use `MyFoo`
+            #[reflect(remote = "MyBar")] external_crate::TheirFoo,
+        ),
+    }
+}
+
+fn main() {}

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_fail.rs
@@ -26,7 +26,7 @@ mod structs {
     //~| ERROR: mismatched types
     struct MyStruct {
         // Reason: Should use `MyFoo`
-        #[reflect(remote = "MyBar")]
+        #[reflect(remote = MyBar)]
         //~^ ERROR: mismatched types
         foo: external_crate::TheirFoo,
     }
@@ -52,7 +52,7 @@ mod tuple_structs {
     //~| ERROR: mismatched types
     struct MyStruct(
         // Reason: Should use `MyFoo`
-        #[reflect(remote = "MyBar")] external_crate::TheirFoo,
+        #[reflect(remote = MyBar)] external_crate::TheirFoo,
         //~^ ERROR: mismatched types
     );
 }
@@ -90,7 +90,7 @@ mod enums {
     enum MyStruct {
         Value(
             // Reason: Should use `MyFoo`
-            #[reflect(remote = "MyBar")] external_crate::TheirFoo,
+            #[reflect(remote = MyBar)] external_crate::TheirFoo,
             //~^ ERROR: mismatched types
         ),
     }

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_pass.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_pass.rs
@@ -1,0 +1,79 @@
+//@check-pass
+
+mod structs {
+    use bevy_reflect::{reflect_remote, Reflect};
+
+    mod external_crate {
+        pub struct TheirFoo {
+            pub value: u32,
+        }
+        pub struct TheirBar {
+            pub value: i32,
+        }
+    }
+
+    #[reflect_remote(external_crate::TheirFoo)]
+    struct MyFoo {
+        pub value: u32,
+    }
+    #[reflect_remote(external_crate::TheirBar)]
+    struct MyBar {
+        pub value: i32,
+    }
+
+    #[derive(Reflect)]
+    struct MyStruct {
+        #[reflect(remote = "MyFoo")]
+        foo: external_crate::TheirFoo,
+    }
+}
+
+mod tuple_structs {
+    use bevy_reflect::{reflect_remote, Reflect};
+
+    mod external_crate {
+        pub struct TheirFoo(pub u32);
+
+        pub struct TheirBar(pub i32);
+    }
+
+    #[reflect_remote(external_crate::TheirFoo)]
+    struct MyFoo(pub u32);
+
+    #[reflect_remote(external_crate::TheirBar)]
+    struct MyBar(pub i32);
+
+    #[derive(Reflect)]
+    struct MyStruct(#[reflect(remote = "MyFoo")] external_crate::TheirFoo);
+}
+
+mod enums {
+    use bevy_reflect::{reflect_remote, Reflect};
+
+    mod external_crate {
+        pub enum TheirFoo {
+            Value(u32),
+        }
+
+        pub enum TheirBar {
+            Value(i32),
+        }
+    }
+
+    #[reflect_remote(external_crate::TheirFoo)]
+    enum MyFoo {
+        Value(u32),
+    }
+
+    #[reflect_remote(external_crate::TheirBar)]
+    enum MyBar {
+        Value(i32),
+    }
+
+    #[derive(Reflect)]
+    enum MyStruct {
+        Value(#[reflect(remote = "MyFoo")] external_crate::TheirFoo),
+    }
+}
+
+fn main() {}

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_pass.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_pass.rs
@@ -23,7 +23,7 @@ mod structs {
 
     #[derive(Reflect)]
     struct MyStruct {
-        #[reflect(remote = "MyFoo")]
+        #[reflect(remote = MyFoo)]
         foo: external_crate::TheirFoo,
     }
 }
@@ -44,7 +44,7 @@ mod tuple_structs {
     struct MyBar(pub i32);
 
     #[derive(Reflect)]
-    struct MyStruct(#[reflect(remote = "MyFoo")] external_crate::TheirFoo);
+    struct MyStruct(#[reflect(remote = MyFoo)] external_crate::TheirFoo);
 }
 
 mod enums {
@@ -72,7 +72,7 @@ mod enums {
 
     #[derive(Reflect)]
     enum MyStruct {
-        Value(#[reflect(remote = "MyFoo")] external_crate::TheirFoo),
+        Value(#[reflect(remote = MyFoo)] external_crate::TheirFoo),
     }
 }
 

--- a/crates/bevy_reflect/compile_fail/tests/remote.rs
+++ b/crates/bevy_reflect/compile_fail/tests/remote.rs
@@ -1,0 +1,3 @@
+fn main() -> compile_fail_utils::ui_test::Result<()> {
+    compile_fail_utils::test("reflect_remote", "tests/reflect_remote")
+}

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -553,8 +553,13 @@ impl<'a> StructField<'a> {
     ///
     /// Normally this is just the field's defined type.
     /// However, this can be adjusted to use a different type, like for representing remote types.
+    /// In those cases, the returned value is the remote wrapper type.
     pub fn reflected_type(&self) -> &Type {
         self.attrs.remote.as_ref().unwrap_or(&self.data.ty)
+    }
+
+    pub fn attrs(&self) -> &FieldAttributes {
+        &self.attrs
     }
 }
 
@@ -736,7 +741,7 @@ impl<'a> ReflectEnum<'a> {
             self.meta(),
             where_clause_options,
             None,
-            Some(self.active_fields().map(|field| &field.data.ty)),
+            Some(self.active_fields().map(StructField::reflected_type)),
         )
     }
 

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -530,7 +530,7 @@ impl<'a> StructField<'a> {
             }
         };
 
-        let ty = &self.data.ty;
+        let ty = self.reflected_type();
         let custom_attributes = self.attrs.custom_attributes.to_tokens(bevy_reflect_path);
 
         #[allow(unused_mut)] // Needs mutability for the feature gate
@@ -547,6 +547,14 @@ impl<'a> StructField<'a> {
         }
 
         info
+    }
+
+    /// Returns the reflected type of this field.
+    ///
+    /// Normally this is just the field's defined type.
+    /// However, this can be adjusted to use a different type, like for representing remote types.
+    pub fn reflected_type(&self) -> &Type {
+        self.attrs.remote.as_ref().unwrap_or(&self.data.ty)
     }
 }
 
@@ -590,7 +598,7 @@ impl<'a> ReflectStruct<'a> {
     /// Get a collection of types which are exposed to the reflection API
     pub fn active_types(&self) -> Vec<Type> {
         self.active_fields()
-            .map(|field| field.data.ty.clone())
+            .map(|field| field.reflected_type().clone())
             .collect()
     }
 
@@ -704,7 +712,7 @@ impl<'a> ReflectEnum<'a> {
     /// Get a collection of types which are exposed to the reflection API
     pub fn active_types(&self) -> Vec<Type> {
         self.active_fields()
-            .map(|field| field.data.ty.clone())
+            .map(|field| field.reflected_type().clone())
             .collect()
     }
 

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -374,13 +374,23 @@ impl<'a> ReflectDerive<'a> {
         }
     }
 
-    pub fn meta(&self) -> &ReflectMeta<'a> {
+    /// Get the remote type path, if any.
+    pub fn remote_ty(&self) -> Option<RemoteType> {
         match self {
-            ReflectDerive::Struct(data)
-            | ReflectDerive::TupleStruct(data)
-            | ReflectDerive::UnitStruct(data) => data.meta(),
-            ReflectDerive::Enum(data) => data.meta(),
-            ReflectDerive::Value(meta) => meta,
+            Self::Struct(data) | Self::TupleStruct(data) | Self::UnitStruct(data) => {
+                data.remote_ty()
+            }
+            Self::Enum(data) => data.remote_ty(),
+            Self::Value(_) => None,
+        }
+    }
+
+    /// Get the [`ReflectMeta`] for this derived type.
+    pub fn meta(&self) -> &ReflectMeta {
+        match self {
+            Self::Struct(data) | Self::TupleStruct(data) | Self::UnitStruct(data) => data.meta(),
+            Self::Enum(data) => data.meta(),
+            Self::Value(meta) => meta,
         }
     }
 

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -575,7 +575,7 @@ impl<'a> ReflectStruct<'a> {
     }
 
     /// Whether this reflected struct represents a remote type or not.
-    pub fn is_remote(&self) -> bool {
+    pub fn is_remote_wrapper(&self) -> bool {
         self.remote_ty.is_some()
     }
 
@@ -685,7 +685,7 @@ impl<'a> ReflectEnum<'a> {
     }
 
     /// Whether this reflected enum represents a remote type or not.
-    pub fn is_remote(&self) -> bool {
+    pub fn is_remote_wrapper(&self) -> bool {
         self.remote_ty.is_some()
     }
 

--- a/crates/bevy_reflect/derive/src/enum_utility.rs
+++ b/crates/bevy_reflect/derive/src/enum_utility.rs
@@ -113,7 +113,7 @@ pub(crate) trait VariantBuilder: Sized {
 
         if field.field.attrs().remote.is_some() {
             quote! {
-                // SAFETY: The remote type should always be a `#[repr(transparent)]` for the actual field type
+                // SAFE: The wrapper type should be repr(transparent) over the remote type
                 unsafe {
                     ::core::mem::transmute(#construction)
                 }

--- a/crates/bevy_reflect/derive/src/enum_utility.rs
+++ b/crates/bevy_reflect/derive/src/enum_utility.rs
@@ -112,10 +112,19 @@ pub(crate) trait VariantBuilder: Sized {
         };
 
         if field.field.attrs().remote.is_some() {
-            quote! {
-                // SAFE: The wrapper type should be repr(transparent) over the remote type
-                unsafe {
-                    ::core::mem::transmute(#construction)
+            if field.field.attrs().is_remote_generic().unwrap_or_default() {
+                quote! {
+                    // SAFE: The wrapper type should be repr(transparent) over the remote type
+                    unsafe {
+                        ::core::mem::transmute_copy(&#construction)
+                    }
+                }
+            } else {
+                quote! {
+                    // SAFE: The wrapper type should be repr(transparent) over the remote type
+                    unsafe {
+                        ::core::mem::transmute(#construction)
+                    }
                 }
             }
         } else {

--- a/crates/bevy_reflect/derive/src/field_attributes.rs
+++ b/crates/bevy_reflect/derive/src/field_attributes.rs
@@ -200,7 +200,7 @@ impl FieldAttributes {
     /// Parse `remote` attribute.
     ///
     /// Examples:
-    /// - `#[reflect(remote = "path::to::RemoteType")]`
+    /// - `#[reflect(remote = path::to::RemoteType)]`
     fn parse_remote(&mut self, input: ParseStream) -> syn::Result<()> {
         if let Some(remote) = self.remote.as_ref() {
             return Err(input.error(format!(
@@ -212,8 +212,7 @@ impl FieldAttributes {
         input.parse::<kw::remote>()?;
         input.parse::<Token![=]>()?;
 
-        let lit = input.parse::<LitStr>()?;
-        self.remote = Some(lit.parse()?);
+        self.remote = Some(input.parse()?);
 
         Ok(())
     }

--- a/crates/bevy_reflect/derive/src/field_attributes.rs
+++ b/crates/bevy_reflect/derive/src/field_attributes.rs
@@ -217,4 +217,21 @@ impl FieldAttributes {
 
         Ok(())
     }
+
+    /// Returns `Some(true)` if the field has a generic remote type.
+    ///
+    /// If the remote type is not generic, returns `Some(false)`.
+    ///
+    /// If the field does not have a remote type, returns `None`.
+    pub fn is_remote_generic(&self) -> Option<bool> {
+        if let Type::Path(type_path) = self.remote.as_ref()? {
+            type_path
+                .path
+                .segments
+                .last()
+                .map(|segment| !segment.arguments.is_empty())
+        } else {
+            Some(false)
+        }
+    }
 }

--- a/crates/bevy_reflect/derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/derive/src/from_reflect.rs
@@ -115,7 +115,7 @@ fn impl_struct_internal(
 
     let MemberValuePair(active_members, active_values) =
         get_active_fields(reflect_struct, &ref_struct, &ref_struct_type, is_tuple);
-    
+
     let is_defaultable = reflect_struct.meta().attrs().contains(REFLECT_DEFAULT);
 
     // The constructed "Self" ident

--- a/crates/bevy_reflect/derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/derive/src/from_reflect.rs
@@ -52,6 +52,16 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
         ..
     } = FromReflectVariantBuilder::new(reflect_enum).build(&ref_value);
 
+    let match_branches = if reflect_enum.is_remote() {
+        quote! {
+            #(#variant_names => #fqoption::Some(Self(#variant_constructors)),)*
+        }
+    } else {
+        quote! {
+            #(#variant_names => #fqoption::Some(#variant_constructors),)*
+        }
+    };
+
     let (impl_generics, ty_generics, where_clause) = enum_path.generics().split_for_impl();
 
     // Add FromReflect bound for each active field
@@ -66,7 +76,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
                     #bevy_reflect_path::PartialReflect::reflect_ref(#ref_value)
                 {
                     match #bevy_reflect_path::Enum::variant_name(#ref_value) {
-                        #(#variant_names => #fqoption::Some(#variant_constructors),)*
+                        #match_branches
                         name => panic!("variant with name `{}` does not exist on enum `{}`", name, <Self as #bevy_reflect_path::TypePath>::type_path()),
                     }
                 } else {
@@ -105,30 +115,40 @@ fn impl_struct_internal(
 
     let MemberValuePair(active_members, active_values) =
         get_active_fields(reflect_struct, &ref_struct, &ref_struct_type, is_tuple);
-
+    
     let is_defaultable = reflect_struct.meta().attrs().contains(REFLECT_DEFAULT);
+
+    // The constructed "Self" ident
+    let __this = Ident::new("__this", Span::call_site());
+
+    // The reflected type: either `Self` or a remote type
+    let (reflect_ty, retval) = if let Some(remote_ty) = reflect_struct.remote_ty() {
+        (quote!(#remote_ty), quote!(Self(#__this)))
+    } else {
+        (quote!(Self), quote!(#__this))
+    };
+
     let constructor = if is_defaultable {
-        quote!(
-            let mut __this: Self = #FQDefault::default();
+        quote! {
+            let mut #__this = <#reflect_ty as #FQDefault>::default();
             #(
                 if let #fqoption::Some(__field) = #active_values() {
                     // Iff field exists -> use its value
-                    __this.#active_members = __field;
+                    #__this.#active_members = __field;
                 }
             )*
-            #FQOption::Some(__this)
-        )
+            #FQOption::Some(#retval)
+        }
     } else {
         let MemberValuePair(ignored_members, ignored_values) = get_ignored_fields(reflect_struct);
 
-        quote!(
-            #FQOption::Some(
-                Self {
-                    #(#active_members: #active_values()?,)*
-                    #(#ignored_members: #ignored_values,)*
-                }
-            )
-        )
+        quote! {
+            let #__this = #reflect_ty {
+                #(#active_members: #active_values()?,)*
+                #(#ignored_members: #ignored_values,)*
+            };
+            #FQOption::Some(#retval)
+        }
     };
 
     let (impl_generics, ty_generics, where_clause) = reflect_struct
@@ -201,34 +221,65 @@ fn get_active_fields(
                     field.reflection_index.expect("field should be active"),
                     is_tuple,
                 );
-                let ty = field.data.ty.clone();
+                let ty = field.reflected_type().clone();
+                let remote_ty = &field.data.ty;
 
                 let get_field = quote! {
                     #bevy_reflect_path::#struct_type::field(#dyn_struct_name, #accessor)
                 };
 
+                let into_remote = |value: proc_macro2::TokenStream| {
+                    if field.attrs().remote.is_some() {
+                        quote! {
+                            #FQOption::Some(
+                                // SAFETY: The remote type should always be a `#[repr(transparent)]` for the actual field type
+                                unsafe {
+                                    ::core::mem::transmute::<#ty, #remote_ty>(#value?)
+                                }
+                            )
+                        }
+                    } else {
+                        value
+                    }
+                };
+
                 let value = match &field.attrs.default {
-                    DefaultBehavior::Func(path) => quote! {
-                        (||
-                            if let #FQOption::Some(field) = #get_field {
-                                <#ty as #bevy_reflect_path::FromReflect>::from_reflect(field)
-                            } else {
-                                #FQOption::Some(#path())
-                            }
-                        )
-                    },
-                    DefaultBehavior::Default => quote! {
-                        (||
-                            if let #FQOption::Some(field) = #get_field {
-                                <#ty as #bevy_reflect_path::FromReflect>::from_reflect(field)
-                            } else {
-                                #FQOption::Some(#FQDefault::default())
-                            }
-                        )
-                    },
-                    DefaultBehavior::Required => quote! {
-                        (|| <#ty as #bevy_reflect_path::FromReflect>::from_reflect(#get_field?))
-                    },
+                    DefaultBehavior::Func(path) => {
+                        let value = into_remote(quote! {
+                            <#ty as #bevy_reflect_path::FromReflect>::from_reflect(field)
+                        });
+                        quote! {
+                            (||
+                                if let #FQOption::Some(field) = #get_field {
+                                    #value
+                                } else {
+                                    #FQOption::Some(#path())
+                                }
+                            )
+                        }
+                    }
+                    DefaultBehavior::Default => {
+                        let value = into_remote(quote! {
+                            <#ty as #bevy_reflect_path::FromReflect>::from_reflect(field)
+                        });
+                        quote! {
+                            (||
+                                if let #FQOption::Some(field) = #get_field {
+                                    #value
+                                } else {
+                                    #FQOption::Some(#FQDefault::default())
+                                }
+                            )
+                        }
+                    }
+                    DefaultBehavior::Required => {
+                        let value = into_remote(quote! {
+                            <#ty as #bevy_reflect_path::FromReflect>::from_reflect(#get_field?)
+                        });
+                        quote! {
+                            (|| #value)
+                        }
+                    }
                 };
 
                 (member, value)

--- a/crates/bevy_reflect/derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/derive/src/from_reflect.rs
@@ -52,7 +52,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
         ..
     } = FromReflectVariantBuilder::new(reflect_enum).build(&ref_value);
 
-    let match_branches = if reflect_enum.is_remote_wrapper() {
+    let match_branches = if reflect_enum.meta().is_remote_wrapper() {
         quote! {
             #(#variant_names => #fqoption::Some(Self(#variant_constructors)),)*
         }
@@ -104,6 +104,7 @@ fn impl_struct_internal(
     let fqoption = FQOption.into_token_stream();
 
     let struct_path = reflect_struct.meta().type_path();
+    let remote_ty = reflect_struct.meta().remote_ty();
     let bevy_reflect_path = reflect_struct.meta().bevy_reflect_path();
 
     let ref_struct = Ident::new("__ref_struct", Span::call_site());
@@ -122,7 +123,7 @@ fn impl_struct_internal(
     let __this = Ident::new("__this", Span::call_site());
 
     // The reflected type: either `Self` or a remote type
-    let (reflect_ty, constructor, retval) = if let Some(remote_ty) = reflect_struct.remote_ty() {
+    let (reflect_ty, constructor, retval) = if let Some(remote_ty) = remote_ty {
         let constructor = match remote_ty.as_expr_path() {
             Ok(path) => path,
             Err(err) => return err.into_compile_error(),

--- a/crates/bevy_reflect/derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/derive/src/from_reflect.rs
@@ -52,7 +52,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
         ..
     } = FromReflectVariantBuilder::new(reflect_enum).build(&ref_value);
 
-    let match_branches = if reflect_enum.is_remote() {
+    let match_branches = if reflect_enum.is_remote_wrapper() {
         quote! {
             #(#variant_names => #fqoption::Some(Self(#variant_constructors)),)*
         }

--- a/crates/bevy_reflect/derive/src/impls/assertions.rs
+++ b/crates/bevy_reflect/derive/src/impls/assertions.rs
@@ -1,0 +1,14 @@
+use crate::derive_data::ReflectDerive;
+use crate::remote::generate_remote_assertions;
+use quote::quote;
+
+/// Generates an anonymous block containing compile-time assertions.
+pub(crate) fn impl_assertions(derive_data: &ReflectDerive) -> proc_macro2::TokenStream {
+    let mut output = quote!();
+
+    if let Some(assertions) = generate_remote_assertions(derive_data) {
+        output.extend(assertions);
+    }
+
+    output
+}

--- a/crates/bevy_reflect/derive/src/impls/common.rs
+++ b/crates/bevy_reflect/derive/src/impls/common.rs
@@ -7,6 +7,7 @@ use crate::{derive_data::ReflectMeta, utility::WhereClauseOptions};
 pub fn impl_full_reflect(
     meta: &ReflectMeta,
     where_clause_options: &WhereClauseOptions,
+    is_remote_wrapper: bool,
 ) -> proc_macro2::TokenStream {
     let bevy_reflect_path = meta.bevy_reflect_path();
     let type_path = meta.type_path();
@@ -14,8 +15,25 @@ pub fn impl_full_reflect(
     let (impl_generics, ty_generics, where_clause) = type_path.generics().split_for_impl();
     let where_reflect_clause = where_clause_options.extend_where_clause(where_clause);
 
-    quote! {
-        impl #impl_generics #bevy_reflect_path::Reflect for #type_path #ty_generics #where_reflect_clause {
+    let any_impls = if is_remote_wrapper {
+        quote! {
+            #[inline]
+            fn into_any(self: #FQBox<Self>) -> #FQBox<dyn #FQAny> {
+                #FQBox::new(self.0)
+            }
+
+            #[inline]
+            fn as_any(&self) -> &dyn #FQAny {
+                &self.0
+            }
+
+            #[inline]
+            fn as_any_mut(&mut self) -> &mut dyn #FQAny {
+                &mut self.0
+            }
+        }
+    } else {
+        quote! {
             #[inline]
             fn into_any(self: #FQBox<Self>) -> #FQBox<dyn #FQAny> {
                 self
@@ -30,6 +48,12 @@ pub fn impl_full_reflect(
             fn as_any_mut(&mut self) -> &mut dyn #FQAny {
                 self
             }
+        }
+    };
+
+    quote! {
+        impl #impl_generics #bevy_reflect_path::Reflect for #type_path #ty_generics #where_reflect_clause {
+            #any_impls
 
             #[inline]
             fn into_reflect(self: #FQBox<Self>) -> #FQBox<dyn #bevy_reflect_path::Reflect> {

--- a/crates/bevy_reflect/derive/src/impls/common.rs
+++ b/crates/bevy_reflect/derive/src/impls/common.rs
@@ -7,7 +7,6 @@ use crate::{derive_data::ReflectMeta, utility::WhereClauseOptions};
 pub fn impl_full_reflect(
     meta: &ReflectMeta,
     where_clause_options: &WhereClauseOptions,
-    is_remote_wrapper: bool,
 ) -> proc_macro2::TokenStream {
     let bevy_reflect_path = meta.bevy_reflect_path();
     let type_path = meta.type_path();
@@ -15,7 +14,7 @@ pub fn impl_full_reflect(
     let (impl_generics, ty_generics, where_clause) = type_path.generics().split_for_impl();
     let where_reflect_clause = where_clause_options.extend_where_clause(where_clause);
 
-    let any_impls = if is_remote_wrapper {
+    let any_impls = if meta.is_remote_wrapper() {
         quote! {
             #[inline]
             fn into_any(self: #FQBox<Self>) -> #FQBox<dyn #FQAny> {

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -38,7 +38,9 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
 
     let EnumImpls {
         enum_field,
+        enum_field_mut,
         enum_field_at,
+        enum_field_at_mut,
         enum_index_of,
         enum_name_at,
         enum_field_len,
@@ -108,14 +110,14 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
 
             fn field_mut(&mut self, #ref_name: &str) -> #FQOption<&mut dyn #bevy_reflect_path::PartialReflect> {
                  match #match_this_mut {
-                    #(#enum_field,)*
+                    #(#enum_field_mut,)*
                     _ => #FQOption::None,
                 }
             }
 
             fn field_at_mut(&mut self, #ref_index: usize) -> #FQOption<&mut dyn #bevy_reflect_path::PartialReflect> {
                 match #match_this_mut {
-                    #(#enum_field_at,)*
+                    #(#enum_field_at_mut,)*
                     _ => #FQOption::None,
                 }
             }
@@ -263,7 +265,9 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
 
 struct EnumImpls {
     enum_field: Vec<proc_macro2::TokenStream>,
+    enum_field_mut: Vec<proc_macro2::TokenStream>,
     enum_field_at: Vec<proc_macro2::TokenStream>,
+    enum_field_at_mut: Vec<proc_macro2::TokenStream>,
     enum_index_of: Vec<proc_macro2::TokenStream>,
     enum_name_at: Vec<proc_macro2::TokenStream>,
     enum_field_len: Vec<proc_macro2::TokenStream>,
@@ -276,7 +280,9 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
     let bevy_reflect_path = reflect_enum.meta().bevy_reflect_path();
 
     let mut enum_field = Vec::new();
+    let mut enum_field_mut = Vec::new();
     let mut enum_field_at = Vec::new();
+    let mut enum_field_at_mut = Vec::new();
     let mut enum_index_of = Vec::new();
     let mut enum_name_at = Vec::new();
     let mut enum_field_len = Vec::new();
@@ -324,6 +330,27 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
             field_len
         }
 
+        /// Process the field value to account for remote types.
+        ///
+        /// If the field is a remote type, then the value will be transmuted accordingly.
+        fn process_field_value(
+            ident: &Ident,
+            field: &StructField,
+            is_mutable: bool,
+        ) -> proc_macro2::TokenStream {
+            let ref_token = if is_mutable { quote!(&mut) } else { quote!(&) };
+            field
+                .attrs
+                .remote
+                .as_ref()
+                .map(|ty| {
+                    quote! {
+                        unsafe { ::core::mem::transmute::<#ref_token _, #ref_token #ty>(#ident) }
+                    }
+                })
+                .unwrap_or_else(|| quote!(#ident))
+        }
+
         match &variant.fields {
             EnumVariantFields::Unit => {
                 let field_len = process_fields(&[], |_| {});
@@ -339,8 +366,16 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
                         .expect("reflection index should exist for active field");
 
                     let declare_field = syn::Index::from(field.declaration_index);
+
+                    let __value = Ident::new("__value", Span::call_site());
+                    let value_ref = process_field_value(&__value, field, false);
+                    let value_mut = process_field_value(&__value, field, true);
+
                     enum_field_at.push(quote! {
-                        #unit { #declare_field : value, .. } if #ref_index == #reflection_index => #FQOption::Some(value)
+                        #unit { #declare_field : #__value, .. } if #ref_index == #reflection_index => #FQOption::Some(#value_ref)
+                    });
+                    enum_field_at_mut.push(quote! {
+                        #unit { #declare_field : #__value, .. } if #ref_index == #reflection_index => #FQOption::Some(#value_mut)
                     });
                 });
 
@@ -356,11 +391,21 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
                         .reflection_index
                         .expect("reflection index should exist for active field");
 
+                    let __value = Ident::new("__value", Span::call_site());
+                    let value_ref = process_field_value(&__value, field, false);
+                    let value_mut = process_field_value(&__value, field, true);
+
                     enum_field.push(quote! {
-                        #unit{ #field_ident, .. } if #ref_name == #field_name => #FQOption::Some(#field_ident)
+                        #unit{ #field_ident: #__value, .. } if #ref_name == #field_name => #FQOption::Some(#value_ref)
+                    });
+                    enum_field_mut.push(quote! {
+                        #unit{ #field_ident: #__value, .. } if #ref_name == #field_name => #FQOption::Some(#value_mut)
                     });
                     enum_field_at.push(quote! {
-                        #unit{ #field_ident, .. } if #ref_index == #reflection_index => #FQOption::Some(#field_ident)
+                        #unit{ #field_ident: #__value, .. } if #ref_index == #reflection_index => #FQOption::Some(#value_ref)
+                    });
+                    enum_field_at_mut.push(quote! {
+                        #unit{ #field_ident: #__value, .. } if #ref_index == #reflection_index => #FQOption::Some(#value_mut)
                     });
                     enum_index_of.push(quote! {
                         #unit{ .. } if #ref_name == #field_name => #FQOption::Some(#reflection_index)
@@ -379,7 +424,9 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
 
     EnumImpls {
         enum_field,
+        enum_field_mut,
         enum_field_at,
+        enum_field_at_mut,
         enum_index_of,
         enum_name_at,
         enum_field_len,

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -9,7 +9,7 @@ use syn::Fields;
 pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream {
     let bevy_reflect_path = reflect_enum.meta().bevy_reflect_path();
     let enum_path = reflect_enum.meta().type_path();
-    let is_remote = reflect_enum.is_remote();
+    let is_remote = reflect_enum.is_remote_wrapper();
 
     // For `match self` expressions where self is a reference
     let match_this = if is_remote {

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -9,7 +9,7 @@ use syn::{Fields, Path};
 pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream {
     let bevy_reflect_path = reflect_enum.meta().bevy_reflect_path();
     let enum_path = reflect_enum.meta().type_path();
-    let is_remote = reflect_enum.is_remote_wrapper();
+    let is_remote = reflect_enum.meta().is_remote_wrapper();
 
     // For `match self` expressions where self is a reference
     let match_this = if is_remote {
@@ -62,11 +62,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
     );
 
     let type_path_impl = impl_type_path(reflect_enum.meta());
-    let full_reflect_impl = impl_full_reflect(
-        reflect_enum.meta(),
-        &where_clause_options,
-        reflect_enum.is_remote_wrapper(),
-    );
+    let full_reflect_impl = impl_full_reflect(reflect_enum.meta(), &where_clause_options);
     let common_methods = common_partial_reflect_methods(
         reflect_enum.meta(),
         || Some(quote!(#bevy_reflect_path::enum_partial_eq)),

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -9,6 +9,26 @@ use syn::Fields;
 pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream {
     let bevy_reflect_path = reflect_enum.meta().bevy_reflect_path();
     let enum_path = reflect_enum.meta().type_path();
+    let is_remote = reflect_enum.is_remote();
+
+    // For `match self` expressions where self is a reference
+    let match_this = if is_remote {
+        quote!(&self.0)
+    } else {
+        quote!(self)
+    };
+    // For `match self` expressions where self is a mutable reference
+    let match_this_mut = if is_remote {
+        quote!(&mut self.0)
+    } else {
+        quote!(self)
+    };
+    // For `*self` assignments
+    let deref_this = if is_remote {
+        quote!(self.0)
+    } else {
+        quote!(*self)
+    };
 
     let ref_name = Ident::new("__name_param", Span::call_site());
     let ref_index = Ident::new("__index_param", Span::call_site());
@@ -73,42 +93,42 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
 
         impl #impl_generics #bevy_reflect_path::Enum for #enum_path #ty_generics #where_reflect_clause {
             fn field(&self, #ref_name: &str) -> #FQOption<&dyn #bevy_reflect_path::PartialReflect> {
-                 match self {
+                 match #match_this {
                     #(#enum_field,)*
                     _ => #FQOption::None,
                 }
             }
 
             fn field_at(&self, #ref_index: usize) -> #FQOption<&dyn #bevy_reflect_path::PartialReflect> {
-                match self {
+                match #match_this {
                     #(#enum_field_at,)*
                     _ => #FQOption::None,
                 }
             }
 
             fn field_mut(&mut self, #ref_name: &str) -> #FQOption<&mut dyn #bevy_reflect_path::PartialReflect> {
-                 match self {
+                 match #match_this_mut {
                     #(#enum_field,)*
                     _ => #FQOption::None,
                 }
             }
 
             fn field_at_mut(&mut self, #ref_index: usize) -> #FQOption<&mut dyn #bevy_reflect_path::PartialReflect> {
-                match self {
+                match #match_this_mut {
                     #(#enum_field_at,)*
                     _ => #FQOption::None,
                 }
             }
 
             fn index_of(&self, #ref_name: &str) -> #FQOption<usize> {
-                 match self {
+                 match #match_this {
                     #(#enum_index_of,)*
                     _ => #FQOption::None,
                 }
             }
 
             fn name_at(&self, #ref_index: usize) -> #FQOption<&str> {
-                 match self {
+                 match #match_this {
                     #(#enum_name_at,)*
                     _ => #FQOption::None,
                 }
@@ -120,7 +140,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
 
             #[inline]
             fn field_len(&self) -> usize {
-                 match self {
+                 match #match_this {
                     #(#enum_field_len,)*
                     _ => 0,
                 }
@@ -128,7 +148,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
 
             #[inline]
             fn variant_name(&self) -> &str {
-                 match self {
+                 match #match_this {
                     #(#enum_variant_name,)*
                     _ => unreachable!(),
                 }
@@ -136,7 +156,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
 
             #[inline]
             fn variant_index(&self) -> usize {
-                 match self {
+                 match #match_this {
                     #(#enum_variant_index,)*
                     _ => unreachable!(),
                 }
@@ -144,7 +164,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
 
             #[inline]
             fn variant_type(&self) -> #bevy_reflect_path::VariantType {
-                 match self {
+                 match #match_this {
                     #(#enum_variant_type,)*
                     _ => unreachable!(),
                 }
@@ -197,7 +217,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
                         // New variant -> perform a switch
                         match #bevy_reflect_path::Enum::variant_name(#ref_value) {
                             #(#variant_names => {
-                                *self = #variant_constructors
+                                #deref_this = #variant_constructors
                             })*
                             name => {
                                 return #FQResult::Err(

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -349,6 +349,7 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
                 .as_ref()
                 .map(|ty| {
                     quote! {
+                        // SAFE: The wrapper type should be repr(transparent) over the remote type
                         unsafe { ::core::mem::transmute::<#ref_token _, #ref_token #ty>(#ident) }
                     }
                 })

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -62,7 +62,11 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
     );
 
     let type_path_impl = impl_type_path(reflect_enum.meta());
-    let full_reflect_impl = impl_full_reflect(reflect_enum.meta(), &where_clause_options);
+    let full_reflect_impl = impl_full_reflect(
+        reflect_enum.meta(),
+        &where_clause_options,
+        reflect_enum.is_remote_wrapper(),
+    );
     let common_methods = common_partial_reflect_methods(
         reflect_enum.meta(),
         || Some(quote!(#bevy_reflect_path::enum_partial_eq)),

--- a/crates/bevy_reflect/derive/src/impls/mod.rs
+++ b/crates/bevy_reflect/derive/src/impls/mod.rs
@@ -1,3 +1,4 @@
+mod assertions;
 mod common;
 mod enums;
 #[cfg(feature = "functions")]
@@ -7,6 +8,7 @@ mod tuple_structs;
 mod typed;
 mod values;
 
+pub(crate) use assertions::impl_assertions;
 pub(crate) use common::{common_partial_reflect_methods, impl_full_reflect};
 pub(crate) use enums::impl_enum;
 #[cfg(feature = "functions")]

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -39,11 +39,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
     );
 
     let type_path_impl = impl_type_path(reflect_struct.meta());
-    let full_reflect_impl = impl_full_reflect(
-        reflect_struct.meta(),
-        &where_clause_options,
-        reflect_struct.is_remote_wrapper(),
-    );
+    let full_reflect_impl = impl_full_reflect(reflect_struct.meta(), &where_clause_options);
     let common_methods = common_partial_reflect_methods(
         reflect_struct.meta(),
         || Some(quote!(#bevy_reflect_path::struct_partial_eq)),

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -1,5 +1,5 @@
 use crate::impls::{common_partial_reflect_methods, impl_full_reflect, impl_type_path, impl_typed};
-use crate::utility::ident_or_index;
+use crate::struct_utility::FieldAccessors;
 use crate::ReflectStruct;
 use bevy_macro_utils::fq_std::{FQBox, FQDefault, FQOption, FQResult};
 use quote::{quote, ToTokens};
@@ -10,7 +10,6 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
 
     let bevy_reflect_path = reflect_struct.meta().bevy_reflect_path();
     let struct_path = reflect_struct.meta().type_path();
-    let is_remote = reflect_struct.is_remote();
 
     let field_names = reflect_struct
         .active_fields()
@@ -23,20 +22,14 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
                 .unwrap_or_else(|| field.declaration_index.to_string())
         })
         .collect::<Vec<String>>();
-    let field_accessors = reflect_struct
-        .active_fields()
-        .map(|field| {
-            let member = ident_or_index(field.data.ident.as_ref(), field.declaration_index);
 
-            if is_remote {
-                quote!(0.#member)
-            } else {
-                quote!(#member)
-            }
-        })
-        .collect::<Vec<_>>();
-    let field_count = field_accessors.len();
-    let field_indices = (0..field_count).collect::<Vec<usize>>();
+    let FieldAccessors {
+        fields,
+        fields_ref,
+        fields_mut,
+        field_indices,
+        field_count,
+    } = FieldAccessors::new(reflect_struct);
 
     let where_clause_options = reflect_struct.where_clause_options();
     let typed_impl = impl_typed(
@@ -83,28 +76,28 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
         impl #impl_generics #bevy_reflect_path::Struct for #struct_path #ty_generics #where_reflect_clause {
             fn field(&self, name: &str) -> #FQOption<&dyn #bevy_reflect_path::PartialReflect> {
                 match name {
-                    #(#field_names => #fqoption::Some(&self.#field_accessors),)*
+                    #(#field_names => #fqoption::Some(#fields_ref),)*
                     _ => #FQOption::None,
                 }
             }
 
             fn field_mut(&mut self, name: &str) -> #FQOption<&mut dyn #bevy_reflect_path::PartialReflect> {
                 match name {
-                    #(#field_names => #fqoption::Some(&mut self.#field_accessors),)*
+                    #(#field_names => #fqoption::Some(#fields_mut),)*
                     _ => #FQOption::None,
                 }
             }
 
             fn field_at(&self, index: usize) -> #FQOption<&dyn #bevy_reflect_path::PartialReflect> {
                 match index {
-                    #(#field_indices => #fqoption::Some(&self.#field_accessors),)*
+                    #(#field_indices => #fqoption::Some(#fields_ref),)*
                     _ => #FQOption::None,
                 }
             }
 
             fn field_at_mut(&mut self, index: usize) -> #FQOption<&mut dyn #bevy_reflect_path::PartialReflect> {
                 match index {
-                    #(#field_indices => #fqoption::Some(&mut self.#field_accessors),)*
+                    #(#field_indices => #fqoption::Some(#fields_mut),)*
                     _ => #FQOption::None,
                 }
             }
@@ -127,7 +120,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
             fn clone_dynamic(&self) -> #bevy_reflect_path::DynamicStruct {
                 let mut dynamic: #bevy_reflect_path::DynamicStruct = #FQDefault::default();
                 dynamic.set_represented_type(#bevy_reflect_path::PartialReflect::get_represented_type_info(self));
-                #(dynamic.insert_boxed(#field_names, #bevy_reflect_path::PartialReflect::clone_value(&self.#field_accessors));)*
+                #(dynamic.insert_boxed(#field_names, #bevy_reflect_path::PartialReflect::clone_value(&#fields));)*
                 dynamic
             }
         }

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -24,11 +24,11 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
         .collect::<Vec<String>>();
 
     let FieldAccessors {
-        fields,
         fields_ref,
         fields_mut,
         field_indices,
         field_count,
+        ..
     } = FieldAccessors::new(reflect_struct);
 
     let where_clause_options = reflect_struct.where_clause_options();
@@ -124,7 +124,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
             fn clone_dynamic(&self) -> #bevy_reflect_path::DynamicStruct {
                 let mut dynamic: #bevy_reflect_path::DynamicStruct = #FQDefault::default();
                 dynamic.set_represented_type(#bevy_reflect_path::PartialReflect::get_represented_type_info(self));
-                #(dynamic.insert_boxed(#field_names, #bevy_reflect_path::PartialReflect::clone_value(&#fields));)*
+                #(dynamic.insert_boxed(#field_names, #bevy_reflect_path::PartialReflect::clone_value(#fields_ref));)*
                 dynamic
             }
         }

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -39,7 +39,11 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
     );
 
     let type_path_impl = impl_type_path(reflect_struct.meta());
-    let full_reflect_impl = impl_full_reflect(reflect_struct.meta(), &where_clause_options);
+    let full_reflect_impl = impl_full_reflect(
+        reflect_struct.meta(),
+        &where_clause_options,
+        reflect_struct.is_remote_wrapper(),
+    );
     let common_methods = common_partial_reflect_methods(
         reflect_struct.meta(),
         || Some(quote!(#bevy_reflect_path::struct_partial_eq)),

--- a/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
@@ -1,8 +1,8 @@
 use crate::impls::{common_partial_reflect_methods, impl_full_reflect, impl_type_path, impl_typed};
+use crate::struct_utility::FieldAccessors;
 use crate::ReflectStruct;
 use bevy_macro_utils::fq_std::{FQBox, FQDefault, FQOption, FQResult};
 use quote::{quote, ToTokens};
-use syn::{Index, Member};
 
 /// Implements `TupleStruct`, `GetTypeRegistration`, and `Reflect` for the given derive data.
 pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenStream {
@@ -10,21 +10,14 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
 
     let bevy_reflect_path = reflect_struct.meta().bevy_reflect_path();
     let struct_path = reflect_struct.meta().type_path();
-    let is_remote = reflect_struct.is_remote();
 
-    let field_accessors = reflect_struct
-        .active_fields()
-        .map(|field| Member::Unnamed(Index::from(field.declaration_index)))
-        .map(|member| {
-            if is_remote {
-                quote!(0.#member)
-            } else {
-                quote!(#member)
-            }
-        })
-        .collect::<Vec<_>>();
-    let field_count = field_accessors.len();
-    let field_indices = (0..field_count).collect::<Vec<usize>>();
+    let FieldAccessors {
+        fields,
+        fields_ref,
+        fields_mut,
+        field_indices,
+        field_count,
+    } = FieldAccessors::new(reflect_struct);
 
     let where_clause_options = reflect_struct.where_clause_options();
     let get_type_registration_impl = reflect_struct.get_type_registration(&where_clause_options);
@@ -71,14 +64,14 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
         impl #impl_generics #bevy_reflect_path::TupleStruct for #struct_path #ty_generics #where_reflect_clause {
             fn field(&self, index: usize) -> #FQOption<&dyn #bevy_reflect_path::PartialReflect> {
                 match index {
-                    #(#field_indices => #fqoption::Some(&self.#field_accessors),)*
+                    #(#field_indices => #fqoption::Some(#fields_ref),)*
                     _ => #FQOption::None,
                 }
             }
 
             fn field_mut(&mut self, index: usize) -> #FQOption<&mut dyn #bevy_reflect_path::PartialReflect> {
                 match index {
-                    #(#field_indices => #fqoption::Some(&mut self.#field_accessors),)*
+                    #(#field_indices => #fqoption::Some(#fields_mut),)*
                     _ => #FQOption::None,
                 }
             }
@@ -94,7 +87,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
             fn clone_dynamic(&self) -> #bevy_reflect_path::DynamicTupleStruct {
                 let mut dynamic: #bevy_reflect_path::DynamicTupleStruct = #FQDefault::default();
                 dynamic.set_represented_type(#bevy_reflect_path::PartialReflect::get_represented_type_info(self));
-                #(dynamic.insert_boxed(#bevy_reflect_path::PartialReflect::clone_value(&self.#field_accessors));)*
+                #(dynamic.insert_boxed(#bevy_reflect_path::PartialReflect::clone_value(&#fields));)*
                 dynamic
             }
         }

--- a/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
@@ -29,7 +29,11 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
     );
 
     let type_path_impl = impl_type_path(reflect_struct.meta());
-    let full_reflect_impl = impl_full_reflect(reflect_struct.meta(), &where_clause_options);
+    let full_reflect_impl = impl_full_reflect(
+        reflect_struct.meta(),
+        &where_clause_options,
+        reflect_struct.is_remote_wrapper(),
+    );
     let common_methods = common_partial_reflect_methods(
         reflect_struct.meta(),
         || Some(quote!(#bevy_reflect_path::tuple_struct_partial_eq)),

--- a/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
@@ -29,11 +29,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
     );
 
     let type_path_impl = impl_type_path(reflect_struct.meta());
-    let full_reflect_impl = impl_full_reflect(
-        reflect_struct.meta(),
-        &where_clause_options,
-        reflect_struct.is_remote_wrapper(),
-    );
+    let full_reflect_impl = impl_full_reflect(reflect_struct.meta(), &where_clause_options);
     let common_methods = common_partial_reflect_methods(
         reflect_struct.meta(),
         || Some(quote!(#bevy_reflect_path::tuple_struct_partial_eq)),

--- a/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
@@ -12,11 +12,11 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
     let struct_path = reflect_struct.meta().type_path();
 
     let FieldAccessors {
-        fields,
         fields_ref,
         fields_mut,
         field_indices,
         field_count,
+        ..
     } = FieldAccessors::new(reflect_struct);
 
     let where_clause_options = reflect_struct.where_clause_options();
@@ -91,7 +91,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
             fn clone_dynamic(&self) -> #bevy_reflect_path::DynamicTupleStruct {
                 let mut dynamic: #bevy_reflect_path::DynamicTupleStruct = #FQDefault::default();
                 dynamic.set_represented_type(#bevy_reflect_path::PartialReflect::get_represented_type_info(self));
-                #(dynamic.insert_boxed(#bevy_reflect_path::PartialReflect::clone_value(&#fields));)*
+                #(dynamic.insert_boxed(#bevy_reflect_path::PartialReflect::clone_value(#fields_ref));)*
                 dynamic
             }
         }

--- a/crates/bevy_reflect/derive/src/impls/values.rs
+++ b/crates/bevy_reflect/derive/src/impls/values.rs
@@ -28,7 +28,7 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> proc_macro2::TokenStream {
     );
 
     let type_path_impl = impl_type_path(meta);
-    let full_reflect_impl = impl_full_reflect(meta, &where_clause_options);
+    let full_reflect_impl = impl_full_reflect(meta, &where_clause_options, false);
     let common_methods = common_partial_reflect_methods(meta, || None, || None);
 
     #[cfg(not(feature = "functions"))]

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -516,7 +516,7 @@ pub fn reflect_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 /// Generates a wrapper type that can be used to "derive `Reflect`" for remote types.
 ///
 /// This works by wrapping the remote type in a generated wrapper that has the `#[repr(transparent)]` attribute.
-/// This allows the two types to be safely transmuted back-and-forth.
+/// This allows the two types to be safely [transmuted] back-and-forth.
 ///
 /// # Defining the Wrapper
 ///
@@ -572,6 +572,26 @@ pub fn reflect_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 /// pub struct Wrapper<T: Default + Clone>(RemoteType<T>);
 /// ```
 ///
+/// # Usage as a Field
+///
+/// You can tell `Reflect` to use a remote type's wrapper internally on fields of a struct or enum.
+/// This allows the real type to be used as usual while `Reflect` handles everything internally.
+/// To do this, add the `#[reflect(remote = "...")]` attribute to your field:
+///
+/// ```ignore
+/// #[derive(Reflect)]
+/// struct SomeStruct {
+///   #[reflect(remote = "RemoteTypeWrapper")]
+///   data: RemoteType
+/// }
+/// ```
+///
+/// ## Safety
+///
+/// When using the `#[reflect(remote = "...")]` field attribute, be sure you are defining the correct wrapper type.
+/// Internally, this field will be unsafely [transmuted], and is only sound if using a wrapper generated for the remote type.
+/// This also means keeping your wrapper definitions up-to-date with the remote types.
+///
 /// # `FromReflect`
 ///
 /// Because of the way this code modifies the item it's defined on, it is not possible to implement `FromReflect`
@@ -588,6 +608,7 @@ pub fn reflect_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 /// This is the _only_ trait this works with. You cannot derive any other traits using this method.
 /// For those, use regular derive macros below this one.
 ///
+/// [transmuted]: std::mem::transmute
 #[proc_macro_attribute]
 pub fn reflect_remote(args: TokenStream, input: TokenStream) -> TokenStream {
     remote::reflect_remote(args, input)

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -29,6 +29,7 @@ mod reflect_value;
 mod registration;
 mod remote;
 mod serialization;
+mod struct_utility;
 mod trait_reflection;
 mod type_path;
 mod utility;

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -597,22 +597,6 @@ pub fn reflect_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 /// Internally, this field will be unsafely [transmuted], and is only sound if using a wrapper generated for the remote type.
 /// This also means keeping your wrapper definitions up-to-date with the remote types.
 ///
-/// # `FromReflect`
-///
-/// Because of the way this code modifies the item it's defined on, it is not possible to implement `FromReflect`
-/// using a simple derive macro.
-/// Instead, you will need to opt-in to to it by adding `FromReflect`
-/// (just the identifier, no need to import or qualify the actual type)
-/// as the last item in the attribute's argument list:
-///
-/// ```ignore
-/// #[reflect_remote(foo::Foo, FromReflect)]
-/// struct FooWrapper;
-/// ```
-///
-/// This is the _only_ trait this works with. You cannot derive any other traits using this method.
-/// For those, use regular derive macros below this one.
-///
 /// [transmuted]: std::mem::transmute
 #[proc_macro_attribute]
 pub fn reflect_remote(args: TokenStream, input: TokenStream) -> TokenStream {

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -581,19 +581,19 @@ pub fn reflect_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// You can tell `Reflect` to use a remote type's wrapper internally on fields of a struct or enum.
 /// This allows the real type to be used as usual while `Reflect` handles everything internally.
-/// To do this, add the `#[reflect(remote = "...")]` attribute to your field:
+/// To do this, add the `#[reflect(remote = path::to::MyType)]` attribute to your field:
 ///
 /// ```ignore
 /// #[derive(Reflect)]
 /// struct SomeStruct {
-///   #[reflect(remote = "RemoteTypeWrapper")]
+///   #[reflect(remote = RemoteTypeWrapper)]
 ///   data: RemoteType
 /// }
 /// ```
 ///
 /// ## Safety
 ///
-/// When using the `#[reflect(remote = "...")]` field attribute, be sure you are defining the correct wrapper type.
+/// When using the `#[reflect(remote = path::to::MyType)]` field attribute, be sure you are defining the correct wrapper type.
 /// Internally, this field will be unsafely [transmuted], and is only sound if using a wrapper generated for the remote type.
 /// This also means keeping your wrapper definitions up-to-date with the remote types.
 ///

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -64,6 +64,8 @@ fn match_reflect_impls(ast: DeriveInput, source: ReflectImplSource) -> TokenStre
         Err(err) => return err.into_compile_error().into(),
     };
 
+    let assertions = impls::impl_assertions(&derive_data);
+
     let (reflect_impls, from_reflect_impl) = match derive_data {
         ReflectDerive::Struct(struct_data) | ReflectDerive::UnitStruct(struct_data) => (
             impls::impl_struct(&struct_data),
@@ -102,7 +104,10 @@ fn match_reflect_impls(ast: DeriveInput, source: ReflectImplSource) -> TokenStre
     TokenStream::from(quote! {
         const _: () = {
             #reflect_impls
+
             #from_reflect_impl
+
+            #assertions
         };
     })
 }

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -572,6 +572,22 @@ pub fn reflect_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 /// pub struct Wrapper<T: Default + Clone>(RemoteType<T>);
 /// ```
 ///
+/// # `FromReflect`
+///
+/// Because of the way this code modifies the item it's defined on, it is not possible to implement `FromReflect`
+/// using a simple derive macro.
+/// Instead, you will need to opt-in to to it by adding `FromReflect`
+/// (just the identifier, no need to import or qualify the actual type)
+/// as the last item in the attribute's argument list:
+///
+/// ```ignore
+/// #[reflect_remote(foo::Foo, FromReflect)]
+/// struct FooWrapper;
+/// ```
+///
+/// This is the _only_ trait this works with. You cannot derive any other traits using this method.
+/// For those, use regular derive macros below this one.
+///
 #[proc_macro_attribute]
 pub fn reflect_remote(args: TokenStream, input: TokenStream) -> TokenStream {
     remote::reflect_remote(args, input)

--- a/crates/bevy_reflect/derive/src/remote.rs
+++ b/crates/bevy_reflect/derive/src/remote.rs
@@ -192,7 +192,7 @@ fn impl_reflect_remote(input: &ReflectDerive, remote_ty: &TypePath) -> proc_macr
 ///
 /// # Example
 ///
-/// The following would fail to compile due to an incorrect `#[reflect(remote = "...")]` value.
+/// The following would fail to compile due to an incorrect `#[reflect(remote = ...)]` value.
 ///
 /// ```ignore
 /// mod external_crate {
@@ -207,7 +207,7 @@ fn impl_reflect_remote(input: &ReflectDerive, remote_ty: &TypePath) -> proc_macr
 ///
 /// #[derive(Reflect)]
 /// struct MyStruct {
-///   #[reflect(remote = "MyBar")] // ERROR: expected type `TheirFoo` but found struct `TheirBar`
+///   #[reflect(remote = MyBar)] // ERROR: expected type `TheirFoo` but found struct `TheirBar`
 ///   foo: external_crate::TheirFoo
 /// }
 /// ```

--- a/crates/bevy_reflect/derive/src/remote.rs
+++ b/crates/bevy_reflect/derive/src/remote.rs
@@ -106,6 +106,7 @@ pub(crate) fn reflect_remote(args: TokenStream, input: TokenStream) -> TokenStre
 /// ```
 fn generate_remote_wrapper(input: &DeriveInput, remote_ty: &TypePath) -> proc_macro2::TokenStream {
     let ident = &input.ident;
+    let vis = &input.vis;
     let ty_generics = &input.generics;
     let where_clause = &input.generics.where_clause;
     let attrs = input
@@ -117,7 +118,7 @@ fn generate_remote_wrapper(input: &DeriveInput, remote_ty: &TypePath) -> proc_ma
         #(#attrs)*
         #[repr(transparent)]
         #[doc(hidden)]
-        struct #ident #ty_generics (pub #remote_ty) #where_clause;
+        #vis struct #ident #ty_generics (pub #remote_ty) #where_clause;
     }
 }
 

--- a/crates/bevy_reflect/derive/src/remote.rs
+++ b/crates/bevy_reflect/derive/src/remote.rs
@@ -303,6 +303,7 @@ pub(crate) fn generate_remote_assertions(
 
             quote_spanned! {span=>
                 #[allow(non_snake_case)]
+                #[allow(clippy::multiple_bound_locations)]
                 fn #assertion_ident #impl_generics () #where_reflect_clause {
                     let _: <#remote_ty as #bevy_reflect_path::ReflectRemote>::Remote = (|| -> #FQOption<#ty> {
                         None
@@ -415,6 +416,7 @@ fn generate_remote_definition_assertions(derive_data: &ReflectDerive) -> proc_ma
             #[allow(unused_variables)]
             #[allow(unused_assignments)]
             #[allow(unreachable_patterns)]
+            #[allow(clippy::multiple_bound_locations)]
             fn assert_wrapper_definition_matches_remote_type #impl_generics (mut #self_ident: #self_ty) #where_reflect_clause {
                 #assertions
             }

--- a/crates/bevy_reflect/derive/src/remote.rs
+++ b/crates/bevy_reflect/derive/src/remote.rs
@@ -106,7 +106,6 @@ pub(crate) fn reflect_remote(args: TokenStream, input: TokenStream) -> TokenStre
 /// ```
 fn generate_remote_wrapper(input: &DeriveInput, remote_ty: &TypePath) -> proc_macro2::TokenStream {
     let ident = &input.ident;
-    let vis = &input.vis;
     let ty_generics = &input.generics;
     let where_clause = &input.generics.where_clause;
     let attrs = input
@@ -117,7 +116,8 @@ fn generate_remote_wrapper(input: &DeriveInput, remote_ty: &TypePath) -> proc_ma
     quote! {
         #(#attrs)*
         #[repr(transparent)]
-        #vis struct #ident #ty_generics (pub #remote_ty) #where_clause;
+        #[doc(hidden)]
+        struct #ident #ty_generics (pub #remote_ty) #where_clause;
     }
 }
 

--- a/crates/bevy_reflect/derive/src/remote.rs
+++ b/crates/bevy_reflect/derive/src/remote.rs
@@ -154,6 +154,16 @@ fn impl_reflect_remote(input: &ReflectDerive, remote_ty: &TypePath) -> proc_macr
             {
                 // SAFE: The wrapper type should be repr(transparent) over the remote type
                 unsafe {
+                    // Unfortunately, we have to use `transmute_copy` to avoid a compiler error:
+                    // ```
+                    // error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+                    // |
+                    // |                 std::mem::transmute::<A, B>(a)
+                    // |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                    // |
+                    // = note: source type: `A` (this type does not have a fixed size)
+                    // = note: target type: `B` (this type does not have a fixed size)
+                    // ```
                     ::core::mem::transmute_copy::<Self, Self::Remote>(
                         // `ManuallyDrop` is used to prevent double-dropping `self`
                         &::core::mem::ManuallyDrop::new(self)
@@ -173,6 +183,16 @@ fn impl_reflect_remote(input: &ReflectDerive, remote_ty: &TypePath) -> proc_macr
             {
                 // SAFE: The wrapper type should be repr(transparent) over the remote type
                 unsafe {
+                    // Unfortunately, we have to use `transmute_copy` to avoid a compiler error:
+                    // ```
+                    // error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+                    // |
+                    // |                 std::mem::transmute::<A, B>(a)
+                    // |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                    // |
+                    // = note: source type: `A` (this type does not have a fixed size)
+                    // = note: target type: `B` (this type does not have a fixed size)
+                    // ```
                     ::core::mem::transmute_copy::<Self::Remote, Self>(
                         // `ManuallyDrop` is used to prevent double-dropping `self`
                         &::core::mem::ManuallyDrop::new(remote)

--- a/crates/bevy_reflect/derive/src/remote.rs
+++ b/crates/bevy_reflect/derive/src/remote.rs
@@ -123,7 +123,7 @@ fn generate_remote_wrapper(input: &DeriveInput, remote_ty: &TypePath) -> proc_ma
 
 /// Generates the implementation of the `ReflectRemote` trait for the given derive data and remote type.
 ///
-/// # Note
+/// # Note to Developers
 ///
 /// The `ReflectRemote` trait could likely be made with default method implementations.
 /// However, this makes it really easy for a user to accidentally implement this trait in an unsafe way.

--- a/crates/bevy_reflect/derive/src/remote.rs
+++ b/crates/bevy_reflect/derive/src/remote.rs
@@ -1,0 +1,99 @@
+use crate::derive_data::{ReflectImplSource, ReflectProvenance, ReflectTraitToImpl};
+use crate::{from_reflect, impls, ReflectDerive, REFLECT_ATTRIBUTE_NAME};
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::{parse_macro_input, DeriveInput, TypePath};
+
+/// Generates the remote wrapper type and implements all the necessary traits.
+pub(crate) fn reflect_remote(args: TokenStream, input: TokenStream) -> TokenStream {
+    let remote_ty = match syn::parse::<TypePath>(args) {
+        Ok(path) => path,
+        Err(err) => return err.to_compile_error().into(),
+    };
+
+    let ast = parse_macro_input!(input as DeriveInput);
+    let wrapper_definition = generate_remote_wrapper(&ast, &remote_ty);
+
+    let mut derive_data = match ReflectDerive::from_input(
+        &ast,
+        ReflectProvenance {
+            source: ReflectImplSource::RemoteReflect,
+            trait_: ReflectTraitToImpl::Reflect,
+        },
+    ) {
+        Ok(data) => data,
+        Err(err) => return err.into_compile_error().into(),
+    };
+
+    derive_data.set_remote(Some(&remote_ty));
+
+    let (reflect_impls, from_reflect_impl) = match derive_data {
+        ReflectDerive::Struct(struct_data) | ReflectDerive::UnitStruct(struct_data) => (
+            impls::impl_struct(&struct_data),
+            if struct_data.meta().from_reflect().should_auto_derive() {
+                Some(from_reflect::impl_struct(&struct_data))
+            } else {
+                None
+            },
+        ),
+        ReflectDerive::TupleStruct(struct_data) => (
+            impls::impl_tuple_struct(&struct_data),
+            if struct_data.meta().from_reflect().should_auto_derive() {
+                Some(from_reflect::impl_tuple_struct(&struct_data))
+            } else {
+                None
+            },
+        ),
+        ReflectDerive::Enum(enum_data) => (
+            impls::impl_enum(&enum_data),
+            if enum_data.meta().from_reflect().should_auto_derive() {
+                Some(from_reflect::impl_enum(&enum_data))
+            } else {
+                None
+            },
+        ),
+        _ => {
+            return syn::Error::new(ast.span(), "cannot reflect a remote value type")
+                .into_compile_error()
+                .into()
+        }
+    };
+
+    TokenStream::from(quote! {
+        #wrapper_definition
+
+        #reflect_impls
+
+        #from_reflect_impl
+    })
+}
+
+/// Generates the remote wrapper type.
+///
+/// # Example
+///
+/// If the supplied remote type is `Bar<T>`, then the wrapper type— named `Foo<T>`— would look like:
+///
+/// ```
+/// # struct Bar<T>(T);
+///
+/// #[repr(transparent)]
+/// struct Foo<T>(Bar<T>);
+/// ```
+fn generate_remote_wrapper(input: &DeriveInput, remote_ty: &TypePath) -> proc_macro2::TokenStream {
+    let ident = &input.ident;
+    let vis = &input.vis;
+    let ty_generics = &input.generics;
+    let where_clause = &input.generics.where_clause;
+    let attrs = input
+        .attrs
+        .iter()
+        .filter(|attr| !attr.path().is_ident(REFLECT_ATTRIBUTE_NAME));
+
+    quote! {
+        #(#attrs)*
+        #[repr(transparent)]
+        #vis struct #ident #ty_generics (pub #remote_ty) #where_clause;
+    }
+}

--- a/crates/bevy_reflect/derive/src/struct_utility.rs
+++ b/crates/bevy_reflect/derive/src/struct_utility.rs
@@ -1,0 +1,92 @@
+use crate::derive_data::StructField;
+use crate::{utility, ReflectStruct};
+use quote::quote;
+
+/// A helper struct for creating remote-aware field accessors.
+///
+/// These are "remote-aware" because when a field is a remote field, it uses a [`transmute`] internally
+/// to access the field.
+///
+/// [`transmute`]: core::mem::transmute
+pub(crate) struct FieldAccessors {
+    /// The owned field accessors, such as `self.foo`.
+    pub fields: Vec<proc_macro2::TokenStream>,
+    /// The referenced field accessors, such as `&self.foo`.
+    pub fields_ref: Vec<proc_macro2::TokenStream>,
+    /// The mutably referenced field accessors, such as `&mut self.foo`.
+    pub fields_mut: Vec<proc_macro2::TokenStream>,
+    /// The ordered set of field indices (basically just the range of [0, `field_count`).
+    pub field_indices: Vec<usize>,
+    /// The number of fields in the reflected struct.
+    pub field_count: usize,
+}
+
+impl FieldAccessors {
+    pub fn new(reflect_struct: &ReflectStruct) -> Self {
+        let fields = Self::get_fields(reflect_struct, |field, accessor| {
+            match &field.attrs.remote {
+                Some(wrapper_ty) => {
+                    quote! {
+                        unsafe { ::core::mem::transmute_copy::<_, #wrapper_ty>(&#accessor) }
+                    }
+                }
+                None => accessor,
+            }
+        });
+        let fields_ref = Self::get_fields(reflect_struct, |field, accessor| {
+            match &field.attrs.remote {
+                Some(wrapper_ty) => {
+                    quote! {
+                        unsafe { ::core::mem::transmute::<&_, &#wrapper_ty>(&#accessor) }
+                    }
+                }
+                None => quote!(& #accessor),
+            }
+        });
+        let fields_mut = Self::get_fields(reflect_struct, |field, accessor| {
+            match &field.attrs.remote {
+                Some(wrapper_ty) => {
+                    quote! {
+                        unsafe { ::core::mem::transmute::<&mut _, &mut #wrapper_ty>(&mut #accessor) }
+                    }
+                }
+                None => quote!(&mut #accessor),
+            }
+        });
+
+        let field_count = fields.len();
+        let field_indices = (0..field_count).collect();
+
+        Self {
+            fields,
+            fields_ref,
+            fields_mut,
+            field_indices,
+            field_count,
+        }
+    }
+
+    fn get_fields<F>(
+        reflect_struct: &ReflectStruct,
+        mut wrapper_fn: F,
+    ) -> Vec<proc_macro2::TokenStream>
+    where
+        F: FnMut(&StructField, proc_macro2::TokenStream) -> proc_macro2::TokenStream,
+    {
+        let is_remote = reflect_struct.is_remote();
+        reflect_struct
+            .active_fields()
+            .map(|field| {
+                let member =
+                    utility::ident_or_index(field.data.ident.as_ref(), field.declaration_index);
+                let accessor = if is_remote {
+                    quote!(self.0.#member)
+                } else {
+                    quote!(self.#member)
+                };
+
+                wrapper_fn(field, accessor)
+            })
+            .collect::<Vec<_>>()
+    }
+}

--- a/crates/bevy_reflect/derive/src/struct_utility.rs
+++ b/crates/bevy_reflect/derive/src/struct_utility.rs
@@ -61,7 +61,7 @@ impl FieldAccessors {
     where
         F: FnMut(&StructField, proc_macro2::TokenStream) -> proc_macro2::TokenStream,
     {
-        let is_remote = reflect_struct.is_remote_wrapper();
+        let is_remote = reflect_struct.meta().is_remote_wrapper();
         reflect_struct
             .active_fields()
             .map(|field| {

--- a/crates/bevy_reflect/derive/src/struct_utility.rs
+++ b/crates/bevy_reflect/derive/src/struct_utility.rs
@@ -27,6 +27,7 @@ impl FieldAccessors {
             match &field.attrs.remote {
                 Some(wrapper_ty) => {
                     quote! {
+                        // SAFE: The wrapper type should be repr(transparent) over the remote type
                         unsafe { ::core::mem::transmute_copy::<_, #wrapper_ty>(&#accessor) }
                     }
                 }
@@ -37,6 +38,7 @@ impl FieldAccessors {
             match &field.attrs.remote {
                 Some(wrapper_ty) => {
                     quote! {
+                        // SAFE: The wrapper type should be repr(transparent) over the remote type
                         unsafe { ::core::mem::transmute::<&_, &#wrapper_ty>(&#accessor) }
                     }
                 }
@@ -47,6 +49,7 @@ impl FieldAccessors {
             match &field.attrs.remote {
                 Some(wrapper_ty) => {
                     quote! {
+                        // SAFE: The wrapper type should be repr(transparent) over the remote type
                         unsafe { ::core::mem::transmute::<&mut _, &mut #wrapper_ty>(&mut #accessor) }
                     }
                 }

--- a/crates/bevy_reflect/derive/src/struct_utility.rs
+++ b/crates/bevy_reflect/derive/src/struct_utility.rs
@@ -73,7 +73,7 @@ impl FieldAccessors {
     where
         F: FnMut(&StructField, proc_macro2::TokenStream) -> proc_macro2::TokenStream,
     {
-        let is_remote = reflect_struct.is_remote();
+        let is_remote = reflect_struct.is_remote_wrapper();
         reflect_struct
             .active_fields()
             .map(|field| {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2476,7 +2476,7 @@ bevy_reflect::tests::Test {
         assert_impl_all!(TupleStruct: Reflect);
         assert_impl_all!(Enum: Reflect);
     }
-    
+
     #[test]
     fn should_reflect_remote_type() {
         mod external_crate {
@@ -2671,12 +2671,46 @@ bevy_reflect::tests::Test {
             value: "Hello".to_string(),
         }));
 
-        let output: MyType = input.take().expect("data should be of type `MyType`");
+        let output: external_crate::TheirType = input
+            .take()
+            .expect("should downcast to `external_crate::TheirType`");
         assert_eq!(
             external_crate::TheirType {
                 value: "Hello".to_string(),
             },
-            output.0
+            output
+        );
+    }
+
+    #[test]
+    fn should_try_take_remote_type() {
+        mod external_crate {
+            #[derive(Debug, Default, PartialEq, Eq)]
+            pub struct TheirType {
+                pub value: String,
+            }
+        }
+
+        // === Remote Wrapper === //
+        #[reflect_remote(external_crate::TheirType)]
+        #[derive(Debug, Default)]
+        #[reflect(Debug, Default)]
+        struct MyType {
+            pub value: String,
+        }
+
+        let input: Box<dyn PartialReflect> = Box::new(MyType(external_crate::TheirType {
+            value: "Hello".to_string(),
+        }));
+
+        let output: external_crate::TheirType = input
+            .try_take()
+            .expect("should downcast to `external_crate::TheirType`");
+        assert_eq!(
+            external_crate::TheirType {
+                value: "Hello".to_string(),
+            },
+            output
         );
     }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2512,7 +2512,7 @@ bevy_reflect::tests::Test {
         #[derive(Reflect, Debug)]
         #[reflect(from_reflect = false)]
         struct ContainerStruct {
-            #[reflect(remote = "MyType")]
+            #[reflect(remote = MyType)]
             their_type: external_crate::TheirType,
         }
 
@@ -2537,7 +2537,7 @@ bevy_reflect::tests::Test {
 
         // === Tuple Struct Container === //
         #[derive(Reflect, Debug)]
-        struct ContainerTupleStruct(#[reflect(remote = "MyType")] external_crate::TheirType);
+        struct ContainerTupleStruct(#[reflect(remote = MyType)] external_crate::TheirType);
 
         let mut patch = DynamicTupleStruct::default();
         patch.set_represented_type(Some(ContainerTupleStruct::type_info()));
@@ -2600,7 +2600,7 @@ bevy_reflect::tests::Test {
         enum ContainerEnum {
             Foo,
             Bar {
-                #[reflect(remote = "MyType")]
+                #[reflect(remote = MyType)]
                 their_type: external_crate::TheirType,
             },
         }
@@ -2634,9 +2634,9 @@ bevy_reflect::tests::Test {
 
         #[reflect_remote(external_crate::TheirOuter<T>)]
         struct MyOuter<T: FromReflect + Typed + GetTypeRegistration> {
-            #[reflect(remote = "MyInner<T>")]
+            #[reflect(remote = MyInner<T>)]
             pub a: external_crate::TheirInner<T>,
-            #[reflect(remote = "MyInner<bool>")]
+            #[reflect(remote = MyInner<bool>)]
             pub b: external_crate::TheirInner<bool>,
         }
 
@@ -2683,9 +2683,9 @@ bevy_reflect::tests::Test {
         #[derive(Debug)]
         enum MyOuter<T: FromReflect + Typed + Debug + GetTypeRegistration> {
             Unit,
-            Tuple(#[reflect(remote = "MyInner<T>")] external_crate::TheirInner<T>),
+            Tuple(#[reflect(remote = MyInner<T>)] external_crate::TheirInner<T>),
             Struct {
-                #[reflect(remote = "MyInner<T>")]
+                #[reflect(remote = MyInner<T>)]
                 value: external_crate::TheirInner<T>,
             },
         }
@@ -2795,7 +2795,7 @@ bevy_reflect::tests::Test {
 
         #[reflect_remote(external_crate::TheirOuter<T>)]
         struct MyOuter<T: FromReflect + Typed + GetTypeRegistration> {
-            #[reflect(remote = "MyInner<T>")]
+            #[reflect(remote = MyInner<T>)]
             pub inner: external_crate::TheirInner<T>,
         }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2486,6 +2486,7 @@ bevy_reflect::tests::Test {
             }
         }
 
+        // === Remote Wrapper === //
         #[reflect_remote(external_crate::TheirType)]
         // TODO: Remove
         #[reflect(from_reflect = false)]
@@ -2500,6 +2501,54 @@ bevy_reflect::tests::Test {
         patch.insert("value", "Goodbye".to_string());
 
         let mut data = MyType(external_crate::TheirType {
+            value: "Hello".to_string(),
+        });
+
+        assert_eq!("Hello", data.0.value);
+        data.apply(&patch);
+        assert_eq!("Goodbye", data.0.value);
+
+        // === Struct Container === //
+        #[derive(Reflect, Debug)]
+        // TODO: Remove
+        #[reflect(from_reflect = false)]
+        struct ContainerStruct {
+            #[reflect(remote = "MyType")]
+            their_type: external_crate::TheirType,
+        }
+
+        let mut patch = DynamicStruct::default();
+        patch.set_represented_type(Some(ContainerStruct::type_info()));
+        patch.insert(
+            "their_type",
+            MyType(external_crate::TheirType {
+                value: "Goodbye".to_string(),
+            }),
+        );
+
+        let mut data = ContainerStruct {
+            their_type: external_crate::TheirType {
+                value: "Hello".to_string(),
+            },
+        };
+
+        assert_eq!("Hello", data.their_type.value);
+        data.apply(&patch);
+        assert_eq!("Goodbye", data.their_type.value);
+
+        // === Tuple Struct Container === //
+        #[derive(Reflect, Debug)]
+        // TODO: Remove
+        #[reflect(from_reflect = false)]
+        struct ContainerTupleStruct(#[reflect(remote = "MyType")] external_crate::TheirType);
+
+        let mut patch = DynamicTupleStruct::default();
+        patch.set_represented_type(Some(ContainerTupleStruct::type_info()));
+        patch.insert(MyType(external_crate::TheirType {
+            value: "Goodbye".to_string(),
+        }));
+
+        let mut data = ContainerTupleStruct(external_crate::TheirType {
             value: "Hello".to_string(),
         });
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2555,6 +2555,34 @@ bevy_reflect::tests::Test {
     }
 
     #[test]
+    fn should_reflect_remote_type_from_module() {
+        mod wrapper {
+            use super::*;
+
+            // We have to place this module internally to this one to get around the following error:
+            // ```
+            // error[E0433]: failed to resolve: use of undeclared crate or module `external_crate`
+            // ```
+            pub mod external_crate {
+                pub struct TheirType {
+                    pub value: String,
+                }
+            }
+
+            #[reflect_remote(external_crate::TheirType)]
+            pub struct MyType {
+                pub value: String,
+            }
+        }
+
+        #[derive(Reflect)]
+        struct ContainerStruct {
+            #[reflect(remote = wrapper::MyType)]
+            their_type: wrapper::external_crate::TheirType,
+        }
+    }
+
+    #[test]
     fn should_reflect_remote_enum() {
         mod external_crate {
             #[derive(Debug, PartialEq, Eq)]

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -532,6 +532,7 @@ mod list;
 mod map;
 mod path;
 mod reflect;
+mod remote;
 mod set;
 mod struct_trait;
 mod tuple;
@@ -582,6 +583,7 @@ pub use list::*;
 pub use map::*;
 pub use path::*;
 pub use reflect::*;
+pub use remote::*;
 pub use set::*;
 pub use struct_trait::*;
 pub use tuple::*;
@@ -2626,11 +2628,12 @@ bevy_reflect::tests::Test {
                 pub a: TheirInner<T>,
                 pub b: TheirInner<bool>,
             }
+
             pub struct TheirInner<T>(pub T);
         }
 
         #[reflect_remote(external_crate::TheirOuter<T>)]
-        struct MyOuter<T: FromReflect> {
+        struct MyOuter<T: FromReflect + Typed + GetTypeRegistration> {
             #[reflect(remote = "MyInner<T>")]
             pub a: external_crate::TheirInner<T>,
             #[reflect(remote = "MyInner<bool>")]
@@ -2678,7 +2681,7 @@ bevy_reflect::tests::Test {
 
         #[reflect_remote(external_crate::TheirOuter<T>)]
         #[derive(Debug)]
-        enum MyOuter<T: FromReflect + Debug> {
+        enum MyOuter<T: FromReflect + Typed + Debug + GetTypeRegistration> {
             Unit,
             Tuple(#[reflect(remote = "MyInner<T>")] external_crate::TheirInner<T>),
             Struct {
@@ -2791,7 +2794,7 @@ bevy_reflect::tests::Test {
         }
 
         #[reflect_remote(external_crate::TheirOuter<T>)]
-        struct MyOuter<T: FromReflect> {
+        struct MyOuter<T: FromReflect + Typed + GetTypeRegistration> {
             #[reflect(remote = "MyInner<T>")]
             pub inner: external_crate::TheirInner<T>,
         }

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2476,6 +2476,37 @@ bevy_reflect::tests::Test {
         assert_impl_all!(TupleStruct: Reflect);
         assert_impl_all!(Enum: Reflect);
     }
+    
+    #[test]
+    fn should_reflect_remote_type() {
+        mod external_crate {
+            #[derive(Debug, Default)]
+            pub struct TheirType {
+                pub value: String,
+            }
+        }
+
+        #[reflect_remote(external_crate::TheirType)]
+        // TODO: Remove
+        #[reflect(from_reflect = false)]
+        #[derive(Debug, Default)]
+        #[reflect(Debug, Default)]
+        struct MyType {
+            pub value: String,
+        }
+
+        let mut patch = DynamicStruct::default();
+        patch.set_represented_type(Some(MyType::type_info()));
+        patch.insert("value", "Goodbye".to_string());
+
+        let mut data = MyType(external_crate::TheirType {
+            value: "Hello".to_string(),
+        });
+
+        assert_eq!("Hello", data.0.value);
+        data.apply(&patch);
+        assert_eq!("Goodbye", data.0.value);
+    }
 
     #[cfg(feature = "glam")]
     mod glam {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2622,20 +2622,20 @@ bevy_reflect::tests::Test {
     #[test]
     fn should_reflect_nested_remote_type() {
         mod external_crate {
-            pub struct TheirOuter {
-                pub inner: TheirInner,
+            pub struct TheirOuter<T> {
+                pub inner: TheirInner<T>,
             }
-            pub struct TheirInner(pub usize);
+            pub struct TheirInner<T>(pub T);
         }
 
-        #[reflect_remote(external_crate::TheirOuter)]
-        struct MyOuter {
-            #[reflect(remote = "MyInner")]
-            pub inner: external_crate::TheirInner,
+        #[reflect_remote(external_crate::TheirOuter<T>)]
+        struct MyOuter<T: Reflect> {
+            #[reflect(remote = "MyInner<T>")]
+            pub inner: external_crate::TheirInner<T>,
         }
 
-        #[reflect_remote(external_crate::TheirInner)]
-        struct MyInner(usize);
+        #[reflect_remote(external_crate::TheirInner<T>)]
+        struct MyInner<T: Reflect>(pub T);
 
         let mut patch = DynamicStruct::default();
         patch.set_represented_type(Some(MyOuter::type_info()));

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2650,6 +2650,36 @@ bevy_reflect::tests::Test {
         assert_eq!(321, data.0.inner.0);
     }
 
+    #[test]
+    fn should_take_remote_type() {
+        mod external_crate {
+            #[derive(Debug, Default, PartialEq, Eq)]
+            pub struct TheirType {
+                pub value: String,
+            }
+        }
+
+        // === Remote Wrapper === //
+        #[reflect_remote(external_crate::TheirType)]
+        #[derive(Debug, Default)]
+        #[reflect(Debug, Default)]
+        struct MyType {
+            pub value: String,
+        }
+
+        let input: Box<dyn Reflect> = Box::new(MyType(external_crate::TheirType {
+            value: "Hello".to_string(),
+        }));
+
+        let output: MyType = input.take().expect("data should be of type `MyType`");
+        assert_eq!(
+            external_crate::TheirType {
+                value: "Hello".to_string(),
+            },
+            output.0
+        );
+    }
+
     #[cfg(feature = "glam")]
     mod glam {
         use super::*;

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2630,7 +2630,7 @@ bevy_reflect::tests::Test {
         }
 
         #[reflect_remote(external_crate::TheirOuter<T>)]
-        struct MyOuter<T: Reflect> {
+        struct MyOuter<T: FromReflect> {
             #[reflect(remote = "MyInner<T>")]
             pub a: external_crate::TheirInner<T>,
             #[reflect(remote = "MyInner<bool>")]
@@ -2638,7 +2638,7 @@ bevy_reflect::tests::Test {
         }
 
         #[reflect_remote(external_crate::TheirInner<T>)]
-        struct MyInner<T: Reflect>(pub T);
+        struct MyInner<T: FromReflect>(pub T);
 
         let mut patch = DynamicStruct::default();
         patch.set_represented_type(Some(MyOuter::<i32>::type_info()));

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2882,7 +2882,7 @@ bevy_reflect::tests::Test {
                 value: "Hello".to_string(),
             },
             output,
-        )
+        );
     }
 
     #[test]

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2845,6 +2845,26 @@ bevy_reflect::tests::Test {
         );
     }
 
+    #[test]
+    fn should_reflect_external_crate_type() {
+        // This test relies on the external type not implementing `Reflect`,
+        // so let's just double-check that it does not
+        assert_not_impl_all!(std::collections::Bound<i32>: Reflect);
+
+        #[reflect_remote(std::collections::Bound<T>)]
+        enum MyBound<T> {
+            Included(T),
+            Excluded(T),
+            Unbounded,
+        }
+
+        #[derive(Reflect)]
+        struct MyType {
+            #[reflect(remote = MyBound<String>)]
+            bound: std::collections::Bound<String>,
+        }
+    }
+
     #[cfg(feature = "glam")]
     mod glam {
         use super::*;

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -457,7 +457,7 @@ impl dyn PartialReflect {
     /// If the underlying value does not implement [`Reflect`]
     /// or is not of type `T`, returns `Err(self)`.
     ///
-    /// For remote types, `T` should be the type itself rather than the wraper type.
+    /// For remote types, `T` should be the type itself rather than the wrapper type.
     pub fn try_downcast<T: Any>(
         self: Box<dyn PartialReflect>,
     ) -> Result<Box<T>, Box<dyn PartialReflect>> {
@@ -471,7 +471,7 @@ impl dyn PartialReflect {
     /// If the underlying value does not implement [`Reflect`]
     /// or is not of type `T`, returns `Err(self)`.
     ///
-    /// For remote types, `T` should be the type itself rather than the wraper type.
+    /// For remote types, `T` should be the type itself rather than the wrapper type.
     pub fn try_take<T: Any>(self: Box<dyn PartialReflect>) -> Result<T, Box<dyn PartialReflect>> {
         self.try_downcast().map(|value| *value)
     }
@@ -481,7 +481,7 @@ impl dyn PartialReflect {
     /// If the underlying value does not implement [`Reflect`]
     /// or is not of type `T`, returns [`None`].
     ///
-    /// For remote types, `T` should be the type itself rather than the wraper type.
+    /// For remote types, `T` should be the type itself rather than the wrapper type.
     pub fn try_downcast_ref<T: Any>(&self) -> Option<&T> {
         self.try_as_reflect()?.downcast_ref()
     }
@@ -491,7 +491,7 @@ impl dyn PartialReflect {
     /// If the underlying value does not implement [`Reflect`]
     /// or is not of type `T`, returns [`None`].
     ///
-    /// For remote types, `T` should be the type itself rather than the wraper type.
+    /// For remote types, `T` should be the type itself rather than the wrapper type.
     pub fn try_downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
         self.try_as_reflect_mut()?.downcast_mut()
     }
@@ -521,7 +521,7 @@ impl dyn Reflect {
     ///
     /// If the underlying value is not of type `T`, returns `Err(self)`.
     ///
-    /// For remote types, `T` should be the type itself rather than the wraper type.
+    /// For remote types, `T` should be the type itself rather than the wrapper type.
     pub fn downcast<T: Any>(self: Box<dyn Reflect>) -> Result<Box<T>, Box<dyn Reflect>> {
         if self.is::<T>() {
             Ok(self.into_any().downcast().unwrap())
@@ -534,7 +534,7 @@ impl dyn Reflect {
     ///
     /// If the underlying value is not of type `T`, returns `Err(self)`.
     ///
-    /// For remote types, `T` should be the type itself rather than the wraper type.
+    /// For remote types, `T` should be the type itself rather than the wrapper type.
     pub fn take<T: Any>(self: Box<dyn Reflect>) -> Result<T, Box<dyn Reflect>> {
         self.downcast::<T>().map(|value| *value)
     }
@@ -548,7 +548,7 @@ impl dyn Reflect {
     /// to determine what type they represent. Represented types cannot be downcasted
     /// to, but you can use [`FromReflect`] to create a value of the represented type from them.
     ///
-    /// For remote types, `T` should be the type itself rather than the wraper type.
+    /// For remote types, `T` should be the type itself rather than the wrapper type.
     ///
     /// [`FromReflect`]: crate::FromReflect
     #[inline]
@@ -560,7 +560,7 @@ impl dyn Reflect {
     ///
     /// If the underlying value is not of type `T`, returns `None`.
     ///
-    /// For remote types, `T` should be the type itself rather than the wraper type.
+    /// For remote types, `T` should be the type itself rather than the wrapper type.
     #[inline]
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         self.as_any().downcast_ref::<T>()
@@ -570,7 +570,7 @@ impl dyn Reflect {
     ///
     /// If the underlying value is not of type `T`, returns `None`.
     ///
-    /// For remote types, `T` should be the type itself rather than the wraper type.
+    /// For remote types, `T` should be the type itself rather than the wrapper type.
     #[inline]
     pub fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
         self.as_any_mut().downcast_mut::<T>()

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -410,12 +410,18 @@ where
 )]
 pub trait Reflect: PartialReflect + Any {
     /// Returns the value as a [`Box<dyn Any>`][std::any::Any].
+    ///
+    /// For remote wrapper types, this will return the remote type instead.
     fn into_any(self: Box<Self>) -> Box<dyn Any>;
 
     /// Returns the value as a [`&dyn Any`][std::any::Any].
+    ///
+    /// For remote wrapper types, this will return the remote type instead.
     fn as_any(&self) -> &dyn Any;
 
     /// Returns the value as a [`&mut dyn Any`][std::any::Any].
+    ///
+    /// For remote wrapper types, this will return the remote type instead.
     fn as_any_mut(&mut self) -> &mut dyn Any;
 
     /// Casts this type to a boxed, fully-reflected value.
@@ -450,7 +456,9 @@ impl dyn PartialReflect {
     ///
     /// If the underlying value does not implement [`Reflect`]
     /// or is not of type `T`, returns `Err(self)`.
-    pub fn try_downcast<T: Reflect>(
+    ///
+    /// For remote types, `T` should be the type itself rather than the wraper type.
+    pub fn try_downcast<T: Any>(
         self: Box<dyn PartialReflect>,
     ) -> Result<Box<T>, Box<dyn PartialReflect>> {
         self.try_into_reflect()?
@@ -462,9 +470,9 @@ impl dyn PartialReflect {
     ///
     /// If the underlying value does not implement [`Reflect`]
     /// or is not of type `T`, returns `Err(self)`.
-    pub fn try_take<T: Reflect>(
-        self: Box<dyn PartialReflect>,
-    ) -> Result<T, Box<dyn PartialReflect>> {
+    ///
+    /// For remote types, `T` should be the type itself rather than the wraper type.
+    pub fn try_take<T: Any>(self: Box<dyn PartialReflect>) -> Result<T, Box<dyn PartialReflect>> {
         self.try_downcast().map(|value| *value)
     }
 
@@ -472,7 +480,9 @@ impl dyn PartialReflect {
     ///
     /// If the underlying value does not implement [`Reflect`]
     /// or is not of type `T`, returns [`None`].
-    pub fn try_downcast_ref<T: Reflect>(&self) -> Option<&T> {
+    ///
+    /// For remote types, `T` should be the type itself rather than the wraper type.
+    pub fn try_downcast_ref<T: Any>(&self) -> Option<&T> {
         self.try_as_reflect()?.downcast_ref()
     }
 
@@ -480,7 +490,9 @@ impl dyn PartialReflect {
     ///
     /// If the underlying value does not implement [`Reflect`]
     /// or is not of type `T`, returns [`None`].
-    pub fn try_downcast_mut<T: Reflect>(&mut self) -> Option<&mut T> {
+    ///
+    /// For remote types, `T` should be the type itself rather than the wraper type.
+    pub fn try_downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
         self.try_as_reflect_mut()?.downcast_mut()
     }
 }
@@ -508,7 +520,9 @@ impl dyn Reflect {
     /// Downcasts the value to type `T`, consuming the trait object.
     ///
     /// If the underlying value is not of type `T`, returns `Err(self)`.
-    pub fn downcast<T: Reflect>(self: Box<dyn Reflect>) -> Result<Box<T>, Box<dyn Reflect>> {
+    ///
+    /// For remote types, `T` should be the type itself rather than the wraper type.
+    pub fn downcast<T: Any>(self: Box<dyn Reflect>) -> Result<Box<T>, Box<dyn Reflect>> {
         if self.is::<T>() {
             Ok(self.into_any().downcast().unwrap())
         } else {
@@ -519,7 +533,9 @@ impl dyn Reflect {
     /// Downcasts the value to type `T`, unboxing and consuming the trait object.
     ///
     /// If the underlying value is not of type `T`, returns `Err(self)`.
-    pub fn take<T: Reflect>(self: Box<dyn Reflect>) -> Result<T, Box<dyn Reflect>> {
+    ///
+    /// For remote types, `T` should be the type itself rather than the wraper type.
+    pub fn take<T: Any>(self: Box<dyn Reflect>) -> Result<T, Box<dyn Reflect>> {
         self.downcast::<T>().map(|value| *value)
     }
 
@@ -532,25 +548,31 @@ impl dyn Reflect {
     /// to determine what type they represent. Represented types cannot be downcasted
     /// to, but you can use [`FromReflect`] to create a value of the represented type from them.
     ///
+    /// For remote types, `T` should be the type itself rather than the wraper type.
+    ///
     /// [`FromReflect`]: crate::FromReflect
     #[inline]
-    pub fn is<T: Reflect>(&self) -> bool {
-        self.type_id() == TypeId::of::<T>()
+    pub fn is<T: Any>(&self) -> bool {
+        self.as_any().type_id() == TypeId::of::<T>()
     }
 
     /// Downcasts the value to type `T` by reference.
     ///
     /// If the underlying value is not of type `T`, returns `None`.
+    ///
+    /// For remote types, `T` should be the type itself rather than the wraper type.
     #[inline]
-    pub fn downcast_ref<T: Reflect>(&self) -> Option<&T> {
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         self.as_any().downcast_ref::<T>()
     }
 
     /// Downcasts the value to type `T` by mutable reference.
     ///
     /// If the underlying value is not of type `T`, returns `None`.
+    ///
+    /// For remote types, `T` should be the type itself rather than the wraper type.
     #[inline]
-    pub fn downcast_mut<T: Reflect>(&mut self) -> Option<&mut T> {
+    pub fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
         self.as_any_mut().downcast_mut::<T>()
     }
 }

--- a/crates/bevy_reflect/src/remote.rs
+++ b/crates/bevy_reflect/src/remote.rs
@@ -1,0 +1,51 @@
+use crate::Reflect;
+
+/// Marks a type as a [reflectable] wrapper for a remote type.
+///
+/// This allows types from external libraries (remote types) to be included in reflection.
+///
+/// # Safety
+///
+/// Remote reflection uses [`transmute`] internally, which is [very unsafe].
+/// To ensure proper safety, it is recommended that this trait not be manually implemented.
+/// Instead, use the [`#[reflect_remote]`](crate::reflect_remote) attribute macro.
+///
+/// The macro will ensure that the following safety requirements are met:
+/// - `Self` is a single-field tuple struct (i.e. a newtype).
+/// - `Self` is `#[repr(transparent)]` over the remote type.
+///
+/// Additionally, the macro will generate [`Reflect`] and [`FromReflect`] implementations
+/// that make safe use of `transmute`.
+///
+/// # Example
+///
+/// ```
+/// use bevy_reflect_derive::{reflect_remote, Reflect};
+///
+/// mod some_lib {
+///   pub struct TheirType {
+///     pub value: u32
+///   }
+/// }
+///
+/// #[reflect_remote(some_lib::TheirType)]
+/// struct MyType {
+///   pub value: u32
+/// }
+///
+/// #[derive(Reflect)]
+/// struct MyStruct {
+///   #[reflect(remote = "MyType")]
+///   data: some_lib::TheirType,
+/// }
+/// ```
+///
+/// [reflectable]: Reflect
+/// [`transmute`]: core::mem::transmute
+/// [highly unsafe]: https://doc.rust-lang.org/nomicon/transmutes.html
+/// [`FromReflect`]: crate::FromReflect
+#[allow(unsafe_code)]
+pub unsafe trait ReflectRemote: Reflect {
+    /// The remote type this type represents via reflection.
+    type Remote;
+}

--- a/crates/bevy_reflect/src/remote.rs
+++ b/crates/bevy_reflect/src/remote.rs
@@ -35,7 +35,7 @@ use crate::Reflect;
 ///
 /// #[derive(Reflect)]
 /// struct MyStruct {
-///   #[reflect(remote = "MyType")]
+///   #[reflect(remote = MyType)]
 ///   data: some_lib::TheirType,
 /// }
 /// ```

--- a/crates/bevy_reflect/src/remote.rs
+++ b/crates/bevy_reflect/src/remote.rs
@@ -42,7 +42,7 @@ use crate::Reflect;
 ///
 /// [reflectable]: Reflect
 /// [`transmute`]: core::mem::transmute
-/// [very unsafe]: https://doc.rust-lang.org/nomicon/transmutes.html
+/// [very unsafe]: https://doc.rust-lang.org/1.71.0/nomicon/transmutes.html
 /// [`FromReflect`]: crate::FromReflect
 pub trait ReflectRemote: Reflect {
     /// The remote type this type represents via reflection.


### PR DESCRIPTION
# Objective

The goal with this PR is to allow the use of types that don't implement `Reflect` within the reflection API.

Rust's [orphan rule](https://doc.rust-lang.org/book/ch10-02-traits.html#implementing-a-trait-on-a-type) prevents implementing a trait on an external type when neither type nor trait are owned by the implementor. This means that if a crate, `cool_rust_lib`, defines a type, `Foo`, then a user cannot use it with reflection. What this means is that we have to ignore it most of the time:

```rust
#[derive(Reflect)]
struct SomeStruct {
  #[reflect(ignore)]
  data: cool_rust_lib::Foo
}
```

Obviously, it's impossible to implement `Reflect` on `Foo`. But does it *have* to be? 

Most of reflection doesn't deal with concrete types— it's almost all using `dyn Reflect`. And being very metadata-driven, it should theoretically be possible. I mean, [`serde`](https://serde.rs/remote-derive.html) does it.

## Solution

> Special thanks to @danielhenrymantilla for their help reviewing this PR and offering wisdom wrt safety.

Taking a page out of `serde`'s book, this PR adds the ability to easily use "remote types" with reflection. In this context, a "remote type" is the external type for which we have no ability to implement `Reflect`.

This adds the `#[reflect_remote(...)]` attribute macro, which is used to generate "remote type wrappers". All you have to do is define the wrapper exactly the same as the remote type's definition:

```rust
// Pretend this is our external crate
mod cool_rust_lib {
  #[derive(Default)]
  struct Foo {
    pub value: String
  }
}

#[reflect_remote(cool_rust_lib::Foo)]
struct FooWrapper {
  pub value: String
}
```

> **Note:** All fields in the external type *must* be public. This could be addressed with a separate getter/setter attribute either in this PR or in another one.

The macro takes this user-defined item and transforms it into a newtype wrapper around the external type, marking it as `#[repr(transparent)]`. The fields/variants defined by the user are simply used to build out the reflection impls.

Additionally, it generates an implementation of the new trait, `ReflectRemote`, which helps prevent accidental misuses of this API.

Therefore, the output generated by the macro would look something like:

```rust
#[repr(transparent)]
struct FooWrapper(pub cool_rust_lib::Foo);

impl ReflectRemote for FooWrapper {
  type Remote = cool_rust_lib::Foo;

  // transmutation methods...
}

// reflection impls...
// these will acknowledge and make use of the `value` field
```

Internally, the reflection API will pass around the `FooWrapper` and [transmute](https://doc.rust-lang.org/std/mem/fn.transmute.html) it where necessary. All we have to do is then tell `Reflect` to do that. So rather than ignoring the field, we tell `Reflect` to use our wrapper using the `#[reflect(remote = ...)]` field attribute:

```rust
#[derive(Reflect)]
struct SomeStruct {
  #[reflect(remote = FooWrapper)]
  data: cool_rust_lib::Foo
}
```

#### Other Macros & Type Data

Because this macro consumes the defined item and generates a new one, we can't just put our macros anywhere. All macros that should be passed to the generated struct need to come *below* this macro. For example, to derive `Default` and register its associated type data:

```rust
// ✅ GOOD
#[reflect_remote(cool_rust_lib::Foo)]
#[derive(Default)]
#[reflect(Default)]
struct FooWrapper {
  pub value: String
}

// ❌ BAD
#[derive(Default)]
#[reflect_remote(cool_rust_lib::Foo)]
#[reflect(Default)]
struct FooWrapper {
  pub value: String
}
```

#### Generics

Generics are forwarded to the generated struct as well. They should also be defined in the same order:

```rust
#[reflect_remote(RemoteGeneric<'a, T1, T2>)]
struct GenericWrapper<'a, T1, T2> {
  pub foo: &'a T1,
  pub bar: &'a T2,
}
```

> Naming does *not* need to match the original definition's. Only order matters here.

> Also note that the code above is just a demonstration and doesn't actually compile since we'd need to enforce certain bounds (e.g. `T1: Reflect`, `'a: 'static`, etc.)

#### Nesting

And, yes, you can nest remote types:

```rust
#[reflect_remote(RemoteOuter)]
struct OuterWrapper {
  #[reflect(remote = InnerWrapper)]
  pub inner: RemoteInner
}

#[reflect_remote(RemoteInner)]
struct InnerWrapper(usize);
```

#### Assertions

This macro will also generate some compile-time assertions to ensure that the correct types are used. It's important we catch this early so users don't have to wait for something to panic. And it also helps keep our `unsafe` a little safer.

For example, a wrapper definition that does not match its corresponding remote type will result in an error: 

```rust
mod external_crate {
  pub struct TheirStruct(pub u32);
}

#[reflect_remote(external_crate::TheirStruct)]
struct MyStruct(pub String); // ERROR: expected type `u32` but found `String`
```

<details>
<summary>Generated Assertion</summary>

```rust
const _: () = {
  #[allow(non_snake_case)]
  #[allow(unused_variables)]
  #[allow(unused_assignments)]
  #[allow(unreachable_patterns)]
  #[allow(clippy::multiple_bound_locations)]
  fn assert_wrapper_definition_matches_remote_type(
    mut __remote__: external_crate::TheirStruct,
  ) {
    __remote__.0 = (|| -> ::core::option::Option<String> { None })().unwrap();
  }
};
```

</details>

Additionally, using the incorrect type in a `#[reflect(remote = ...)]` attribute should result in an error:

```rust
mod external_crate {
  pub struct TheirFoo(pub u32);
  pub struct TheirBar(pub i32);
}

#[reflect_remote(external_crate::TheirFoo)]
struct MyFoo(pub u32);

#[reflect_remote(external_crate::TheirBar)]
struct MyBar(pub i32);

#[derive(Reflect)]
struct MyStruct {
  #[reflect(remote = MyBar)] // ERROR: expected type `TheirFoo` but found struct `TheirBar`
  foo: external_crate::TheirFoo
}
```

<details>
<summary>Generated Assertion</summary>

```rust
const _: () = {
    struct RemoteFieldAssertions;
    impl RemoteFieldAssertions {
        #[allow(non_snake_case)]
        #[allow(clippy::multiple_bound_locations)]
        fn assert__foo__is_valid_remote() {
            let _: <MyBar as bevy_reflect::ReflectRemote>::Remote = (|| -> ::core::option::Option<external_crate::TheirFoo> {
              None
            })().unwrap();
        }
    }
};
```

</details>

### Discussion

There are a couple points that I think still need discussion or validation.

- [x] 1. `Any` shenanigans

     ~~If we wanted to downcast our remote type from a `dyn Reflect`, we'd have to first downcast to the wrapper then extract the inner type. This PR has a [commit](b840db9f74cb6d357f951cb11b150d46bac89ee2) that addresses this by making all the `Reflect::*any` methods return the inner type rather than the wrapper type. This allows us to downcast directly to our remote type.~~

     ~~However, I'm not sure if this is something we want to do. For unknowing users, it could be confusing and seemingly inconsistent. Is it worth keeping? Or should this behavior be removed?~~

     I think this should be fine. The remote wrapper is an implementation detail and users should not need to downcast to the wrapper type. Feel free to let me know if there are other opinions on this though!

- [x] 2. Implementing `Deref/DerefMut` and `From`

     ~~We don't currently do this, but should we implement other traits on the generated transparent struct? We could implement `Deref`/`DerefMut` to easily access the inner type. And we could implement `From` for easier conversion between the two types (e.g. `T: Into<Foo>`).~~ As mentioned in the comments, we probably don't need to do this. Again, the remote wrapper is an implementation detail, and should generally not be used directly.
     
- [x] 3. ~~Should we define a getter/setter field attribute in this PR as well or leave it for a future one?~~ I think this should be saved for a future PR

- [ ] 4. Any foreseeable issues with this implementation?

#### Alternatives

One alternative to defining our own `ReflectRemote` would be to use [bytemuck's `TransparentWrapper`](https://docs.rs/bytemuck/1.13.1/bytemuck/trait.TransparentWrapper.html) (as suggested by @danielhenrymantilla).

This is definitely a viable option, as `ReflectRemote` is pretty much the same thing as `TransparentWrapper`. However, the cost would be bringing in a new crate— though, it is already in use in a few other sub-crates like bevy_render.

I think we're okay just defining `ReflectRemote` ourselves, but we can go the bytemuck route if we'd prefer offloading that work to another crate.

---

## Changelog

* Added the `#[reflect_remote(...)]` attribute macro to allow `Reflect` to be used on remote types
* Added `ReflectRemote` trait for ensuring proper remote wrapper usage