### PR TITLE
Allow major crates to opt-out of reflection

### DIFF
--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -9,17 +9,16 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = ["events", "app"]
+default = ["events", "bevy_app", "bevy_log", "bevy_core", "bevy_reflect", "bevy_ecs/bevy_reflect"]
 trace = []
 events = []
-app = ["bevy_app", "bevy_log", "bevy_core"]
 
 [dependencies]
 # bevy
-bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev", features = ["bevy_reflect"] }
+bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"] }
 # bevy optional
+bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"], optional = true }
 bevy_app = { path = "../bevy_app", version = "0.9.0-dev", optional = true }
 bevy_core = { path = "../bevy_core", version = "0.9.0-dev", optional = true }
 bevy_log = { path = "../bevy_log", version = "0.9.0-dev", optional = true }

--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -9,16 +9,20 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
+default = ["events", "app"]
 trace = []
+events = []
+app = ["bevy_app", "bevy_log", "bevy_core"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.9.0-dev" }
-bevy_core = { path = "../bevy_core", version = "0.9.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev", features = ["bevy_reflect"] }
-bevy_log = { path = "../bevy_log", version = "0.9.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"] }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"] }
+# bevy optional
+bevy_app = { path = "../bevy_app", version = "0.9.0-dev", optional = true }
+bevy_core = { path = "../bevy_core", version = "0.9.0-dev", optional = true }
+bevy_log = { path = "../bevy_log", version = "0.9.0-dev", optional = true }
 
 # other
 smallvec = { version = "1.6", features = ["serde", "union", "const_generics"] }

--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -9,19 +9,18 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = ["events", "bevy_app", "bevy_log", "bevy_core", "bevy_reflect", "bevy_ecs/bevy_reflect"]
+default = ["bevy_reflect", "bevy_ecs/bevy_reflect"]
 trace = []
-events = []
 
 [dependencies]
 # bevy
 bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
+bevy_app = { path = "../bevy_app", version = "0.9.0-dev" }
+bevy_core = { path = "../bevy_core", version = "0.9.0-dev" }
+bevy_log = { path = "../bevy_log", version = "0.9.0-dev" }
 # bevy optional
 bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"], optional = true }
-bevy_app = { path = "../bevy_app", version = "0.9.0-dev", optional = true }
-bevy_core = { path = "../bevy_core", version = "0.9.0-dev", optional = true }
-bevy_log = { path = "../bevy_log", version = "0.9.0-dev", optional = true }
 
 # other
 smallvec = { version = "1.6", features = ["serde", "union", "const_generics"] }

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -2,10 +2,10 @@ use crate::{
     prelude::{Children, Parent},
     HierarchyEvent,
 };
-use bevy_ecs::event::Events;
 use bevy_ecs::{
     bundle::Bundle,
     entity::Entity,
+    event::Events,
     system::{Command, Commands, EntityCommands},
     world::{EntityMut, World},
 };
@@ -76,6 +76,7 @@ fn remove_children(parent: Entity, children: &[Entity], world: &mut World) {
         });
     }
     push_events(world, events);
+
     if let Some(mut parent_children) = world.get_mut::<Children>(parent) {
         parent_children
             .0
@@ -100,7 +101,6 @@ impl Command for AddChild {
                 return;
             }
             remove_from_children(world, previous, self.child);
-
             if let Some(mut events) = world.get_resource_mut::<Events<HierarchyEvent>>() {
                 events.send(HierarchyEvent::ChildMoved {
                     child: self.child,

--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -1,18 +1,21 @@
+#[cfg(feature = "bevy_reflect")]
+use bevy_ecs::reflect::{ReflectComponent, ReflectMapEntities};
 use bevy_ecs::{
     component::Component,
     entity::{Entity, EntityMap, MapEntities, MapEntitiesError},
     prelude::FromWorld,
-    reflect::{ReflectComponent, ReflectMapEntities},
     world::World,
 };
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 use core::slice;
 use smallvec::SmallVec;
 use std::ops::Deref;
 
 /// Contains references to the child entities of this entity
-#[derive(Component, Debug, Reflect)]
-#[reflect(Component, MapEntities)]
+#[derive(Component, Debug)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Component, MapEntities))]
 pub struct Children(pub(crate) SmallVec<[Entity; 8]>);
 
 impl MapEntities for Children {

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -1,16 +1,19 @@
+#[cfg(feature = "bevy_reflect")]
+use bevy_ecs::reflect::{ReflectComponent, ReflectMapEntities};
 use bevy_ecs::{
     component::Component,
     entity::{Entity, EntityMap, MapEntities, MapEntitiesError},
-    reflect::{ReflectComponent, ReflectMapEntities},
     world::{FromWorld, World},
 };
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 use std::ops::Deref;
 
 /// Holds a reference to the parent entity of this entity.
 /// This component should only be present on entities that actually have a parent entity.
-#[derive(Component, Debug, Eq, PartialEq, Reflect)]
-#[reflect(Component, MapEntities, PartialEq)]
+#[derive(Component, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Component, MapEntities, PartialEq))]
 pub struct Parent(pub(crate) Entity);
 
 impl Parent {

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -13,14 +13,10 @@ pub use hierarchy::*;
 mod child_builder;
 pub use child_builder::*;
 
-#[cfg(feature = "events")]
 mod events;
-#[cfg(feature = "events")]
 pub use events::*;
 
-#[cfg(feature = "bevy_app")]
 mod valid_parent_check_plugin;
-#[cfg(feature = "bevy_app")]
 pub use valid_parent_check_plugin::*;
 
 #[doc(hidden)]
@@ -32,14 +28,14 @@ pub mod prelude {
     pub use crate::{HierarchyPlugin, ValidParentCheckPlugin};
 }
 
+use bevy_app::prelude::*;
+
 /// The base plugin for handling [`Parent`] and [`Children`] components
 #[derive(Default)]
-#[cfg(feature = "bevy_app")]
 pub struct HierarchyPlugin;
 
-#[cfg(feature = "bevy_app")]
-impl bevy_app::Plugin for HierarchyPlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+impl Plugin for HierarchyPlugin {
+    fn build(&self, app: &mut App) {
         #[cfg(feature = "bevy_reflect")]
         app.register_type::<Children>().register_type::<Parent>();
         app.add_event::<HierarchyEvent>();

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -22,10 +22,9 @@ pub use valid_parent_check_plugin::*;
 #[doc(hidden)]
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{child_builder::*, components::*, hierarchy::*};
-    #[doc(hidden)]
-    #[cfg(feature = "app")]
-    pub use crate::{HierarchyPlugin, ValidParentCheckPlugin};
+    pub use crate::{
+        child_builder::*, components::*, hierarchy::*, HierarchyPlugin, ValidParentCheckPlugin,
+    };
 }
 
 use bevy_app::prelude::*;

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -18,9 +18,9 @@ mod events;
 #[cfg(feature = "events")]
 pub use events::*;
 
-#[cfg(feature = "app")]
+#[cfg(feature = "bevy_app")]
 mod valid_parent_check_plugin;
-#[cfg(feature = "app")]
+#[cfg(feature = "bevy_app")]
 pub use valid_parent_check_plugin::*;
 
 #[doc(hidden)]
@@ -34,14 +34,14 @@ pub mod prelude {
 
 /// The base plugin for handling [`Parent`] and [`Children`] components
 #[derive(Default)]
-#[cfg(feature = "app")]
+#[cfg(feature = "bevy_app")]
 pub struct HierarchyPlugin;
 
-#[cfg(feature = "app")]
+#[cfg(feature = "bevy_app")]
 impl bevy_app::Plugin for HierarchyPlugin {
     fn build(&self, app: &mut bevy_app::App) {
-        app.register_type::<Children>()
-            .register_type::<Parent>()
-            .add_event::<HierarchyEvent>();
+        #[cfg(feature = "bevy_reflect")]
+        app.register_type::<Children>().register_type::<Parent>();
+        app.add_event::<HierarchyEvent>();
     }
 }

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -13,28 +13,33 @@ pub use hierarchy::*;
 mod child_builder;
 pub use child_builder::*;
 
+#[cfg(feature = "events")]
 mod events;
+#[cfg(feature = "events")]
 pub use events::*;
 
+#[cfg(feature = "app")]
 mod valid_parent_check_plugin;
+#[cfg(feature = "app")]
 pub use valid_parent_check_plugin::*;
 
 #[doc(hidden)]
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{
-        child_builder::*, components::*, hierarchy::*, HierarchyPlugin, ValidParentCheckPlugin,
-    };
+    pub use crate::{child_builder::*, components::*, hierarchy::*};
+    #[doc(hidden)]
+    #[cfg(feature = "app")]
+    pub use crate::{HierarchyPlugin, ValidParentCheckPlugin};
 }
-
-use bevy_app::prelude::*;
 
 /// The base plugin for handling [`Parent`] and [`Children`] components
 #[derive(Default)]
+#[cfg(feature = "app")]
 pub struct HierarchyPlugin;
 
-impl Plugin for HierarchyPlugin {
-    fn build(&self, app: &mut App) {
+#[cfg(feature = "app")]
+impl bevy_app::Plugin for HierarchyPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
         app.register_type::<Children>()
             .register_type::<Parent>()
             .add_event::<HierarchyEvent>();

--- a/crates/bevy_time/Cargo.toml
+++ b/crates/bevy_time/Cargo.toml
@@ -8,13 +8,16 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
+[features]
+default = ["bevy_app", "crossbeam-channel"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.9.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev", features = ["bevy_reflect"] }
 bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"] }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
+# bevy optional
+bevy_app = { path = "../bevy_app", version = "0.9.0-dev", optional = true }
 
 # other
-crossbeam-channel = "0.5.0"
+crossbeam-channel = { version = "0.5.0", optional = true }

--- a/crates/bevy_time/Cargo.toml
+++ b/crates/bevy_time/Cargo.toml
@@ -9,14 +9,14 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = ["bevy_app", "bevy_reflect", "crossbeam-channel"]
+default = ["bevy_reflect", "crossbeam-channel"]
 
 [dependencies]
 # bevy
+bevy_app = { path = "../bevy_app", version = "0.9.0-dev"}
 bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev", features = ["bevy_reflect"] }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
 # bevy optional
-bevy_app = { path = "../bevy_app", version = "0.9.0-dev", optional = true }
 bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"], optional = true }
 
 # other

--- a/crates/bevy_time/Cargo.toml
+++ b/crates/bevy_time/Cargo.toml
@@ -9,15 +9,15 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = ["bevy_app", "crossbeam-channel"]
+default = ["bevy_app", "bevy_reflect", "crossbeam-channel"]
 
 [dependencies]
 # bevy
 bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev", features = ["bevy_reflect"] }
-bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"] }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
 # bevy optional
 bevy_app = { path = "../bevy_app", version = "0.9.0-dev", optional = true }
+bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"], optional = true }
 
 # other
 crossbeam-channel = { version = "0.5.0", optional = true }

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -38,11 +38,12 @@ pub struct TimeSystem;
 #[cfg(feature = "bevy_app")]
 impl bevy_app::Plugin for TimePlugin {
     fn build(&self, app: &mut bevy_app::App) {
+        #[cfg(feature = "bevy_reflect")]
+        app.register_type::<Timer>()
+            .register_type::<Time>()
+            .register_type::<Stopwatch>();
         app.init_resource::<Time>()
             .init_resource::<FixedTimesteps>()
-            .register_type::<Timer>()
-            .register_type::<Time>()
-            .register_type::<Stopwatch>()
             // time system is added as an "exclusive system" to ensure it runs before other systems
             // in CoreStage::First
             .add_system_to_stage(

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -23,10 +23,10 @@ pub mod prelude {
     pub use crate::{Time, Timer};
 }
 
+use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 
 /// Adds time functionality to Apps.
-#[cfg(feature = "bevy_app")]
 #[derive(Default)]
 pub struct TimePlugin;
 
@@ -35,9 +35,8 @@ pub struct TimePlugin;
 /// this.
 pub struct TimeSystem;
 
-#[cfg(feature = "bevy_app")]
-impl bevy_app::Plugin for TimePlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+impl Plugin for TimePlugin {
+    fn build(&self, app: &mut App) {
         #[cfg(feature = "bevy_reflect")]
         app.register_type::<Timer>()
             .register_type::<Time>()

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -46,7 +46,7 @@ impl Plugin for TimePlugin {
             // time system is added as an "exclusive system" to ensure it runs before other systems
             // in CoreStage::First
             .add_system_to_stage(
-                bevy_app::CoreStage::First,
+                CoreStage::First,
                 time_system.exclusive_system().at_start().label(TimeSystem),
             );
     }

--- a/crates/bevy_time/src/stopwatch.rs
+++ b/crates/bevy_time/src/stopwatch.rs
@@ -1,5 +1,5 @@
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
-use bevy_reflect::Reflect;
 use bevy_utils::Duration;
 
 /// A Stopwatch is a struct that track elapsed time when started.
@@ -23,8 +23,9 @@ use bevy_utils::Duration;
 /// assert!(stopwatch.paused());
 /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
 /// ```
-#[derive(Clone, Debug, Default, Reflect)]
-#[reflect(Default)]
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Default))]
 pub struct Stopwatch {
     elapsed: Duration,
     paused: bool,

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -1,10 +1,14 @@
-use bevy_ecs::{reflect::ReflectResource, system::Resource};
-use bevy_reflect::{FromReflect, Reflect};
+#[cfg(feature = "bevy_reflect")]
+use bevy_ecs::prelude::ReflectResource;
+use bevy_ecs::system::Resource;
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::prelude::*;
 use bevy_utils::{Duration, Instant};
 
 /// Tracks elapsed time since the last update and since the App has started
-#[derive(Resource, Reflect, FromReflect, Debug, Clone)]
-#[reflect(Resource)]
+#[derive(Resource, Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect, FromReflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Resource))]
 pub struct Time {
     delta: Duration,
     last_update: Option<Instant>,

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -1,4 +1,5 @@
 use crate::Stopwatch;
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
 use bevy_utils::Duration;
 
@@ -9,8 +10,9 @@ use bevy_utils::Duration;
 /// exceeded, and can still be reset at any given point.
 ///
 /// Paused timers will not have elapsed time increased.
-#[derive(Clone, Debug, Default, Reflect)]
-#[reflect(Default)]
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Default))]
 pub struct Timer {
     stopwatch: Stopwatch,
     duration: Duration,


### PR DESCRIPTION
# Objective

I use the `bevy_ecs` without `bevy_app` as I need a more custom solution. Some very useful crates like `bevy_time` for Time running criteria and `bevy_hierarchy` all provide a `bevy_app::Plugin` and have extra dependencies I don't need like `bevy_reflect` when I can disable it directly in `bevy_ecs`

## Solution

I added feature gates for `bevy_app`, the reflection and extra features for a more "opt-in" behaviour for people using mainly the ECS
