### PR TITLE
[Merged by Bors] - Add ambiguity detection tests

### DIFF
--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -135,6 +135,13 @@ impl SystemStage {
         }
     }
 
+    /// Returns all execution order ambiguities between systems
+    ///
+    /// Returns 4 vectors of ambiguities for each stage, in the following order:
+    /// - parallel
+    /// - exclusive at start,
+    /// - exclusive before commands
+    /// - exclusive at end
     fn ambiguities(&self, world: &World) -> Vec<SystemOrderAmbiguity> {
         let parallel = find_ambiguities(&self.parallel).into_iter().map(
             |(system_a_index, system_b_index, component_ids)| {

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -5,74 +5,195 @@ use crate::component::ComponentId;
 use crate::schedule::{SystemContainer, SystemStage};
 use crate::world::World;
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SystemOrderAmbiguity {
+    // Note: In order for comparisons to work correctly,
+    // `system_names` and `conflicts` must be sorted at all times.
+    system_names: [String; 2],
+    conflicts: Vec<String>,
+    pub segment: SystemStageSegment,
+}
+
+/// Which part of a [`SystemStage`] was a [`SystemOrderAmbiguity`] detected in?
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum SystemStageSegment {
+    Parallel,
+    ExclusiveAtStart,
+    ExclusiveBeforeCommands,
+    ExclusiveAtEnd,
+}
+
+impl SystemStageSegment {
+    pub fn desc(&self) -> &'static str {
+        match self {
+            SystemStageSegment::Parallel => "Parallel systems",
+            SystemStageSegment::ExclusiveAtStart => "Exclusive systems at start of stage",
+            SystemStageSegment::ExclusiveBeforeCommands => {
+                "Exclusive systems before commands of stage"
+            }
+            SystemStageSegment::ExclusiveAtEnd => "Exclusive systems at end of stage",
+        }
+    }
+}
+
+impl SystemOrderAmbiguity {
+    fn from_raw(
+        system_a_index: usize,
+        system_b_index: usize,
+        component_ids: Vec<ComponentId>,
+        segment: SystemStageSegment,
+        stage: &SystemStage,
+        world: &World,
+    ) -> Self {
+        use crate::schedule::graph_utils::GraphNode;
+        use SystemStageSegment::*;
+
+        // TODO: blocked on https://github.com/bevyengine/bevy/pull/4166
+        // We can't grab the system container generically, because .parallel_systems()
+        // and the exclusive equivalent return a different type,
+        // and SystemContainer is not object-safe
+        let (system_a_name, system_b_name) = match segment {
+            Parallel => {
+                let system_container = stage.parallel_systems();
+                (
+                    system_container[system_a_index].name(),
+                    system_container[system_b_index].name(),
+                )
+            }
+            ExclusiveAtStart => {
+                let system_container = stage.exclusive_at_start_systems();
+                (
+                    system_container[system_a_index].name(),
+                    system_container[system_b_index].name(),
+                )
+            }
+            ExclusiveBeforeCommands => {
+                let system_container = stage.exclusive_before_commands_systems();
+                (
+                    system_container[system_a_index].name(),
+                    system_container[system_b_index].name(),
+                )
+            }
+            ExclusiveAtEnd => {
+                let system_container = stage.exclusive_at_end_systems();
+                (
+                    system_container[system_a_index].name(),
+                    system_container[system_b_index].name(),
+                )
+            }
+        };
+
+        let mut system_names = [system_a_name.to_string(), system_b_name.to_string()];
+        system_names.sort();
+
+        let mut conflicts: Vec<_> = component_ids
+            .iter()
+            .map(|id| world.components().get_info(*id).unwrap().name().to_owned())
+            .collect();
+        conflicts.sort();
+
+        Self {
+            system_names,
+            conflicts,
+            segment,
+        }
+    }
+}
+
 impl SystemStage {
     /// Logs execution order ambiguities between systems. System orders must be fresh.
     pub fn report_ambiguities(&self, world: &World) {
         debug_assert!(!self.systems_modified);
         use std::fmt::Write;
-        fn write_display_names_of_pairs(
-            string: &mut String,
-            systems: &[impl SystemContainer],
-            mut ambiguities: Vec<(usize, usize, Vec<ComponentId>)>,
-            world: &World,
-        ) {
-            for (index_a, index_b, conflicts) in ambiguities.drain(..) {
-                writeln!(
-                    string,
-                    " -- {:?} and {:?}",
-                    systems[index_a].name(),
-                    systems[index_b].name()
-                )
-                .unwrap();
-                if !conflicts.is_empty() {
-                    let names = conflicts
-                        .iter()
-                        .map(|id| world.components().get_info(*id).unwrap().name())
-                        .collect::<Vec<_>>();
-                    writeln!(string, "    conflicts: {:?}", names).unwrap();
-                }
-            }
-        }
-        let parallel = find_ambiguities(&self.parallel);
-        let at_start = find_ambiguities(&self.exclusive_at_start);
-        let before_commands = find_ambiguities(&self.exclusive_before_commands);
-        let at_end = find_ambiguities(&self.exclusive_at_end);
-        if !(parallel.is_empty()
-            && at_start.is_empty()
-            && before_commands.is_empty()
-            && at_end.is_empty())
-        {
+        let ambiguities = self.ambiguities(world);
+        if !ambiguities.is_empty() {
             let mut string = "Execution order ambiguities detected, you might want to \
 						add an explicit dependency relation between some of these systems:\n"
                 .to_owned();
-            if !parallel.is_empty() {
-                writeln!(string, " * Parallel systems:").unwrap();
-                write_display_names_of_pairs(&mut string, &self.parallel, parallel, world);
+
+            let mut last_segment_kind = None;
+
+            for SystemOrderAmbiguity {
+                system_names: [system_a, system_b],
+                conflicts,
+                segment,
+            } in &ambiguities
+            {
+                // If the ambiguity occurred in a different segment than the previous one, write a header for the segment.
+                if last_segment_kind != Some(segment) {
+                    writeln!(string, " * {}:", segment.desc()).unwrap();
+                    last_segment_kind = Some(segment);
+                }
+
+                writeln!(string, " -- {:?} and {:?}", system_a, system_b).unwrap();
+
+                if !conflicts.is_empty() {
+                    writeln!(string, "    conflicts: {conflicts:?}").unwrap();
+                }
             }
-            if !at_start.is_empty() {
-                writeln!(string, " * Exclusive systems at start of stage:").unwrap();
-                write_display_names_of_pairs(
-                    &mut string,
-                    &self.exclusive_at_start,
-                    at_start,
-                    world,
-                );
-            }
-            if !before_commands.is_empty() {
-                writeln!(string, " * Exclusive systems before commands of stage:").unwrap();
-                write_display_names_of_pairs(
-                    &mut string,
-                    &self.exclusive_before_commands,
-                    before_commands,
-                    world,
-                );
-            }
-            if !at_end.is_empty() {
-                writeln!(string, " * Exclusive systems at end of stage:").unwrap();
-                write_display_names_of_pairs(&mut string, &self.exclusive_at_end, at_end, world);
-            }
+
             info!("{}", string);
         }
+    }
+
+    fn ambiguities(&self, world: &World) -> Vec<SystemOrderAmbiguity> {
+        let parallel = find_ambiguities(&self.parallel).into_iter().map(
+            |(system_a_index, system_b_index, component_ids)| {
+                SystemOrderAmbiguity::from_raw(
+                    system_a_index,
+                    system_b_index,
+                    component_ids.to_vec(),
+                    SystemStageSegment::Parallel,
+                    self,
+                    world,
+                )
+            },
+        );
+
+        let at_start = find_ambiguities(&self.exclusive_at_start).into_iter().map(
+            |(system_a_index, system_b_index, component_ids)| {
+                SystemOrderAmbiguity::from_raw(
+                    system_a_index,
+                    system_b_index,
+                    component_ids,
+                    SystemStageSegment::ExclusiveAtStart,
+                    self,
+                    world,
+                )
+            },
+        );
+
+        let before_commands = find_ambiguities(&self.exclusive_before_commands)
+            .into_iter()
+            .map(|(system_a_index, system_b_index, component_ids)| {
+                SystemOrderAmbiguity::from_raw(
+                    system_a_index,
+                    system_b_index,
+                    component_ids,
+                    SystemStageSegment::ExclusiveBeforeCommands,
+                    self,
+                    world,
+                )
+            });
+
+        let at_end = find_ambiguities(&self.exclusive_at_end).into_iter().map(
+            |(system_a_index, system_b_index, component_ids)| {
+                SystemOrderAmbiguity::from_raw(
+                    system_a_index,
+                    system_b_index,
+                    component_ids,
+                    SystemStageSegment::ExclusiveAtEnd,
+                    self,
+                    world,
+                )
+            },
+        );
+
+        at_start
+            .chain(parallel)
+            .chain(before_commands)
+            .chain(at_end)
+            .collect()
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -6,7 +6,7 @@ use crate::schedule::{SystemContainer, SystemStage};
 use crate::world::World;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SystemOrderAmbiguity {
+struct SystemOrderAmbiguity {
     pub segment: SystemStageSegment,
     // Note: In order for comparisons to work correctly,
     // `system_names` and `conflicts` must be sorted at all times.
@@ -16,7 +16,7 @@ pub struct SystemOrderAmbiguity {
 
 /// Which part of a [`SystemStage`] was a [`SystemOrderAmbiguity`] detected in?
 #[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
-pub enum SystemStageSegment {
+enum SystemStageSegment {
     Parallel,
     ExclusiveAtStart,
     ExclusiveBeforeCommands,
@@ -144,7 +144,7 @@ impl SystemStage {
     /// - exclusive at end
     ///
     /// This stage must have been initialized with `world`.
-    pub fn ambiguities(&self, world: &World) -> Vec<SystemOrderAmbiguity> {
+    fn ambiguities(&self, world: &World) -> Vec<SystemOrderAmbiguity> {
         let parallel = find_ambiguities(&self.parallel).into_iter().map(
             |(system_a_index, system_b_index, component_ids)| {
                 SystemOrderAmbiguity::from_raw(

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -212,7 +212,7 @@ impl SystemStage {
     ///
     /// The result may be incorrect if this stage has not been initialized with `world`.
     #[allow(dead_code)]
-    fn n_ambiguities(&self, world: &World) -> usize {
+    fn ambiguity_count(&self, world: &World) -> usize {
         self.ambiguities(world).len()
     }
 }
@@ -333,7 +333,7 @@ mod tests {
 
         test_stage.run(&mut world);
 
-        assert_eq!(test_stage.n_ambiguities(&world), 0);
+        assert_eq!(test_stage.ambiguity_count(&world), 0);
     }
 
     #[test]
@@ -360,7 +360,7 @@ mod tests {
 
         test_stage.run(&mut world);
 
-        assert_eq!(test_stage.n_ambiguities(&world), 0);
+        assert_eq!(test_stage.ambiguity_count(&world), 0);
     }
 
     #[test]
@@ -380,7 +380,7 @@ mod tests {
 
         test_stage.run(&mut world);
 
-        assert_eq!(test_stage.n_ambiguities(&world), 3);
+        assert_eq!(test_stage.ambiguity_count(&world), 3);
     }
 
     #[test]
@@ -393,7 +393,7 @@ mod tests {
 
         test_stage.run(&mut world);
 
-        assert_eq!(test_stage.n_ambiguities(&world), 1);
+        assert_eq!(test_stage.ambiguity_count(&world), 1);
     }
 
     #[test]
@@ -408,7 +408,7 @@ mod tests {
 
         test_stage.run(&mut world);
 
-        assert_eq!(test_stage.n_ambiguities(&world), 1);
+        assert_eq!(test_stage.ambiguity_count(&world), 1);
     }
 
     #[test]
@@ -423,7 +423,7 @@ mod tests {
 
         test_stage.run(&mut world);
 
-        assert_eq!(test_stage.n_ambiguities(&world), 1);
+        assert_eq!(test_stage.ambiguity_count(&world), 1);
     }
 
     #[test]
@@ -439,7 +439,7 @@ mod tests {
 
         test_stage.run(&mut world);
 
-        assert_eq!(test_stage.n_ambiguities(&world), 0);
+        assert_eq!(test_stage.ambiguity_count(&world), 0);
     }
 
     #[test]
@@ -456,7 +456,7 @@ mod tests {
 
         test_stage.run(&mut world);
 
-        assert_eq!(test_stage.n_ambiguities(&world), 3);
+        assert_eq!(test_stage.ambiguity_count(&world), 3);
     }
 
     #[test]
@@ -478,7 +478,7 @@ mod tests {
 
         test_stage.run(&mut world);
 
-        assert_eq!(test_stage.n_ambiguities(&world), 3);
+        assert_eq!(test_stage.ambiguity_count(&world), 3);
     }
 
     // Tests for silencing and resolving ambiguities
@@ -496,6 +496,6 @@ mod tests {
 
         test_stage.run(&mut world);
 
-        assert_eq!(test_stage.n_ambiguities(&world), 0);
+        assert_eq!(test_stage.ambiguity_count(&world), 0);
     }
 }

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -101,7 +101,9 @@ impl SystemOrderAmbiguity {
 }
 
 impl SystemStage {
-    /// Logs execution order ambiguities between systems. System orders must be fresh.
+    /// Logs execution order ambiguities between systems.
+    ///
+    /// The output may be incorrect if this stage has not been initialized with `world`.
     pub fn report_ambiguities(&self, world: &World) {
         debug_assert!(!self.systems_modified);
         use std::fmt::Write;
@@ -143,7 +145,7 @@ impl SystemStage {
     /// - exclusive before commands
     /// - exclusive at end
     ///
-    /// This stage must have been initialized with `world`.
+    /// The result may be incorrect if this stage has not been initialized with `world`.
     fn ambiguities(&self, world: &World) -> Vec<SystemOrderAmbiguity> {
         let parallel = find_ambiguities(&self.parallel).into_iter().map(
             |(system_a_index, system_b_index, component_ids)| {
@@ -207,7 +209,8 @@ impl SystemStage {
     }
 
     /// Returns the number of system order ambiguities between systems in this stage.
-    /// This stage must have been initialized with `world`.
+    ///
+    /// The result may be incorrect if this stage has not been initialized with `world`.
     #[allow(dead_code)]
     fn n_ambiguities(&self, world: &World) -> usize {
         self.ambiguities(world).len()

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -7,7 +7,7 @@ use crate::world::World;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct SystemOrderAmbiguity {
-    pub segment: SystemStageSegment,
+    segment: SystemStageSegment,
     // Note: In order for comparisons to work correctly,
     // `system_names` and `conflicts` must be sorted at all times.
     system_names: [String; 2],

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -5,17 +5,17 @@ use crate::component::ComponentId;
 use crate::schedule::{SystemContainer, SystemStage};
 use crate::world::World;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SystemOrderAmbiguity {
+    pub segment: SystemStageSegment,
     // Note: In order for comparisons to work correctly,
     // `system_names` and `conflicts` must be sorted at all times.
     system_names: [String; 2],
     conflicts: Vec<String>,
-    pub segment: SystemStageSegment,
 }
 
 /// Which part of a [`SystemStage`] was a [`SystemOrderAmbiguity`] detected in?
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
 pub enum SystemStageSegment {
     Parallel,
     ExclusiveAtStart,
@@ -112,7 +112,6 @@ impl SystemStage {
                 .to_owned();
 
             let mut last_segment_kind = None;
-
             for SystemOrderAmbiguity {
                 system_names: [system_a, system_b],
                 conflicts,
@@ -189,11 +188,13 @@ impl SystemStage {
             },
         );
 
-        at_start
+        let mut ambiguities: Vec<_> = at_start
             .chain(parallel)
             .chain(before_commands)
             .chain(at_end)
-            .collect()
+            .collect();
+        ambiguities.sort();
+        ambiguities
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -277,8 +277,6 @@ fn find_ambiguities(systems: &[impl SystemContainer]) -> Vec<(usize, usize, Vec<
     ambiguities
 }
 
-// Systems and TestResource are used in tests
-#[allow(dead_code)]
 #[cfg(test)]
 mod tests {
     // Required to make the derive macro behave

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -211,7 +211,7 @@ impl SystemStage {
     /// Returns the number of system order ambiguities between systems in this stage.
     ///
     /// The result may be incorrect if this stage has not been initialized with `world`.
-    #[allow(dead_code)]
+    #[cfg(test)]
     fn ambiguity_count(&self, world: &World) -> usize {
         self.ambiguities(world).len()
     }

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -325,7 +325,6 @@ mod tests {
 
         let mut test_stage = SystemStage::parallel();
         test_stage
-            .add_system(empty_system)
             // nonsendmut system deliberately conflicts with resmut system
             .add_system(resmut_system)
             .add_system(write_component_system)
@@ -372,7 +371,6 @@ mod tests {
 
         let mut test_stage = SystemStage::parallel();
         test_stage
-            .add_system(empty_system)
             .add_system(resmut_system)
             .add_system(write_component_system)
             .add_system(event_writer_system)

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -208,7 +208,8 @@ impl SystemStage {
 
     /// Returns the number of system order ambiguities between systems in this stage.
     /// This stage must have been initialized with `world`.
-    pub fn n_ambiguities(&self, world: &World) -> usize {
+    #[allow(dead_code)]
+    fn n_ambiguities(&self, world: &World) -> usize {
         self.ambiguities(world).len()
     }
 }


### PR DESCRIPTION
# Objective

- Add unit tests for ambiguity detection reporting.
- Incremental implementation of #4299.

## Solution

- Refactor ambiguity detection internals to make it testable. As a bonus, this should make it easier to extend in the future.

## Notes

* This code was copy-pasted from #4299 and modified. Credit goes to @alice-i-cecile and @afonsolage, though I'm not sure who wrote what at this point.
