### PR TITLE
[Merged by Bors] - Clarify index order in TextureAtlas::from_grid

### DIFF
--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -68,7 +68,8 @@ impl TextureAtlas {
     }
 
     /// Generate a `TextureAtlas` by splitting a texture into a grid where each
-    /// `tile_size` by `tile_size` grid-cell is one of the textures in the atlas
+    /// `tile_size` by `tile_size` grid-cell is one of the textures in the
+    /// atlas. Resulting `TextureAtlas` is indexed left to right, top to bottom.
     pub fn from_grid(
         texture: Handle<Image>,
         tile_size: Vec2,
@@ -81,7 +82,8 @@ impl TextureAtlas {
     /// Generate a `TextureAtlas` by splitting a texture into a grid where each
     /// `tile_size` by `tile_size` grid-cell is one of the textures in the
     /// atlas. Grid cells are separated by some `padding`, and the grid starts
-    /// at `offset` pixels from the top left corner.
+    /// at `offset` pixels from the top left corner. Resulting `TextureAtlas` is
+    /// indexed left to right, top to bottom.
     pub fn from_grid_with_padding(
         texture: Handle<Image>,
         tile_size: Vec2,


### PR DESCRIPTION
# Objective

Docs on from_grid/from_grid_with_padding aren't clear on indexing order.

## Solution

Make the docs better!