### PR TITLE
replace `FromWorld` with `FromReflect` in `ReflectComponent`, `ReflectResource`

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -17,7 +17,7 @@ use bevy_ecs::{
 };
 use bevy_hierarchy::Children;
 use bevy_math::{Quat, Vec3};
-use bevy_reflect::{Reflect, TypeUuid};
+use bevy_reflect::{FromReflect, Reflect, TypeUuid};
 use bevy_time::Time;
 use bevy_transform::{prelude::Transform, TransformSystem};
 use bevy_utils::{tracing::warn, HashMap};
@@ -91,7 +91,7 @@ impl AnimationClip {
 }
 
 /// Animation controls
-#[derive(Component, Reflect)]
+#[derive(Component, Reflect, FromReflect)]
 #[reflect(Component)]
 pub struct AnimationPlayer {
     paused: bool,

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_reflect::std_traits::ReflectDefault;
-use bevy_reflect::Reflect;
+use bevy_reflect::{FromReflect, Reflect};
 use bevy_utils::AHasher;
 use std::{
     borrow::Cow,
@@ -19,6 +19,18 @@ use std::{
 pub struct Name {
     hash: u64, // TODO: Shouldn't be serialized
     name: Cow<'static, str>,
+}
+
+impl FromReflect for Name {
+    fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
+        match reflect.reflect_ref() {
+            bevy_reflect::ReflectRef::Struct(strukt) => {
+                let name = Cow::from_reflect(strukt.field("name")?)?;
+                Some(Name::new(name))
+            }
+            _ => None,
+        }
+    }
 }
 
 impl Default for Name {

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -25,7 +25,12 @@ impl FromReflect for Name {
     fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
         match reflect.reflect_ref() {
             bevy_reflect::ReflectRef::Struct(strukt) => {
-                let name = Cow::from_reflect(strukt.field("name")?)?;
+                let name = Cow::from_reflect(
+                    strukt
+                        .field("name")
+                        .expect("missing `name` field to construct a `Name`"),
+                )
+                .expect("`name` field is not a Cow<str>");
                 Some(Name::new(name))
             }
             _ => None,

--- a/crates/bevy_core_pipeline/src/clear_color.rs
+++ b/crates/bevy_core_pipeline/src/clear_color.rs
@@ -1,10 +1,10 @@
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::prelude::*;
-use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
+use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render::{color::Color, extract_resource::ExtractResource};
 use serde::{Deserialize, Serialize};
 
-#[derive(Reflect, Serialize, Deserialize, Clone, Debug, Default)]
+#[derive(Reflect, Serialize, Deserialize, Clone, Debug, Default, FromReflect)]
 #[reflect(Serialize, Deserialize)]
 pub enum ClearColorConfig {
     #[default]
@@ -17,7 +17,7 @@ pub enum ClearColorConfig {
 ///
 /// This color appears as the "background" color for simple apps,
 /// when there are portions of the screen with nothing rendered.
-#[derive(Resource, Clone, Debug, Deref, DerefMut, ExtractResource, Reflect)]
+#[derive(Resource, Clone, Debug, Deref, DerefMut, ExtractResource, Reflect, FromReflect)]
 #[reflect(Resource)]
 pub struct ClearColor(pub Color);
 

--- a/crates/bevy_core_pipeline/src/clear_color.rs
+++ b/crates/bevy_core_pipeline/src/clear_color.rs
@@ -1,6 +1,6 @@
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::prelude::*;
-use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize};
+use bevy_reflect::{prelude::*, FromReflect, Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render::{color::Color, extract_resource::ExtractResource};
 use serde::{Deserialize, Serialize};
 
@@ -18,7 +18,7 @@ pub enum ClearColorConfig {
 /// This color appears as the "background" color for simple apps,
 /// when there are portions of the screen with nothing rendered.
 #[derive(Resource, Clone, Debug, Deref, DerefMut, ExtractResource, Reflect, FromReflect)]
-#[reflect(Resource)]
+#[reflect(Resource, Default)]
 pub struct ClearColor(pub Color);
 
 impl Default for ClearColor {

--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -1,6 +1,6 @@
 use crate::{clear_color::ClearColorConfig, tonemapping::Tonemapping};
 use bevy_ecs::{prelude::*, query::QueryItem};
-use bevy_reflect::Reflect;
+use bevy_reflect::{FromReflect, Reflect};
 use bevy_render::{
     camera::{Camera, CameraProjection, CameraRenderGraph, OrthographicProjection},
     extract_component::ExtractComponent,
@@ -9,7 +9,7 @@ use bevy_render::{
 };
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
-#[derive(Component, Default, Reflect, Clone)]
+#[derive(Component, Default, Reflect, Clone, FromReflect)]
 #[reflect(Component)]
 pub struct Camera2d {
     pub clear_color: ClearColorConfig,

--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -1,6 +1,6 @@
 use crate::{clear_color::ClearColorConfig, tonemapping::Tonemapping};
 use bevy_ecs::{prelude::*, query::QueryItem};
-use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
+use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render::{
     camera::{Camera, CameraRenderGraph, Projection},
     extract_component::ExtractComponent,
@@ -12,7 +12,7 @@ use bevy_transform::prelude::{GlobalTransform, Transform};
 use serde::{Deserialize, Serialize};
 
 /// Configuration for the "main 3d render graph".
-#[derive(Component, Reflect, Clone, Default)]
+#[derive(Component, Reflect, Clone, Default, FromReflect)]
 #[reflect(Component)]
 pub struct Camera3d {
     /// The clear color operation to perform for the main 3d pass.
@@ -22,7 +22,7 @@ pub struct Camera3d {
 }
 
 /// The depth clear operation to perform for the main 3d pass.
-#[derive(Reflect, Serialize, Deserialize, Clone, Debug)]
+#[derive(Reflect, Serialize, Deserialize, Clone, Debug, FromReflect)]
 #[reflect(Serialize, Deserialize)]
 pub enum Camera3dDepthLoadOp {
     /// Clear with a specified value.

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -149,8 +149,8 @@ impl Entity {
     ///
     /// ```no_run
     /// # use bevy_ecs::{prelude::*, component::*};
-    /// # use bevy_reflect::Reflect;
-    /// #[derive(Reflect, Component)]
+    /// # use bevy_reflect::{Reflect, prelude::*};
+    /// #[derive(Reflect, Component, FromReflect)]
     /// #[reflect(Component)]
     /// pub struct MyStruct {
     ///     pub entity: Entity,

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -63,7 +63,7 @@ impl ReflectComponentFns {
     ///
     /// This is useful if you want to start with the default implementation before overriding some
     /// of the functions to create a custom implementation.
-    pub fn new<T: Component + Reflect + FromWorld>() -> Self {
+    pub fn new<T: Component + Reflect + FromReflect>() -> Self {
         <ReflectComponent as FromType<T>>::from_type().0
     }
 }
@@ -273,7 +273,7 @@ impl ReflectResourceFns {
     ///
     /// This is useful if you want to start with the default implementation before overriding some
     /// of the functions to create a custom implementation.
-    pub fn new<T: Resource + Reflect + FromWorld>() -> Self {
+    pub fn new<T: Resource + Reflect + FromReflect>() -> Self {
         <ReflectResource as FromType<T>>::from_type().0
     }
 }

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -9,7 +9,7 @@ use bevy_app::prelude::*;
 use bevy_asset::{AddAsset, Handle};
 use bevy_ecs::{prelude::Component, reflect::ReflectComponent};
 use bevy_pbr::StandardMaterial;
-use bevy_reflect::{Reflect, TypeUuid};
+use bevy_reflect::{FromReflect, Reflect, TypeUuid};
 use bevy_render::mesh::Mesh;
 use bevy_scene::Scene;
 
@@ -72,7 +72,7 @@ pub struct GltfPrimitive {
     pub material: Option<Handle<StandardMaterial>>,
 }
 
-#[derive(Clone, Debug, Reflect, Default, Component)]
+#[derive(Clone, Debug, Reflect, Default, Component, FromReflect)]
 #[reflect(Component)]
 pub struct GltfExtras {
     pub value: String,

--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -5,13 +5,13 @@ use bevy_ecs::{
     reflect::{ReflectComponent, ReflectMapEntities},
     world::World,
 };
-use bevy_reflect::Reflect;
+use bevy_reflect::{FromReflect, Reflect};
 use core::slice;
 use smallvec::SmallVec;
 use std::ops::Deref;
 
 /// Contains references to the child entities of this entity
-#[derive(Component, Debug, Reflect)]
+#[derive(Component, Debug, Reflect, FromReflect)]
 #[reflect(Component, MapEntities)]
 pub struct Children(pub(crate) SmallVec<[Entity; 8]>);
 

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -4,12 +4,12 @@ use bevy_ecs::{
     reflect::{ReflectComponent, ReflectMapEntities},
     world::{FromWorld, World},
 };
-use bevy_reflect::Reflect;
+use bevy_reflect::{FromReflect, Reflect};
 use std::ops::Deref;
 
 /// Holds a reference to the parent entity of this entity.
 /// This component should only be present on entities that actually have a parent entity.
-#[derive(Component, Debug, Eq, PartialEq, Reflect)]
+#[derive(Component, Debug, Eq, PartialEq, Reflect, FromReflect)]
 #[reflect(Component, MapEntities, PartialEq)]
 pub struct Parent(pub(crate) Entity);
 

--- a/crates/bevy_pbr/src/alpha.rs
+++ b/crates/bevy_pbr/src/alpha.rs
@@ -1,10 +1,10 @@
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_reflect::std_traits::ReflectDefault;
-use bevy_reflect::Reflect;
+use bevy_reflect::{FromReflect, Reflect};
 
 // TODO: add discussion about performance.
 /// Sets how a material's base color alpha channel is used for transparency.
-#[derive(Component, Debug, Default, Reflect, Copy, Clone, PartialEq)]
+#[derive(Component, Debug, Default, Reflect, Copy, Clone, PartialEq, FromReflect)]
 #[reflect(Component, Default)]
 pub enum AlphaMode {
     /// Base color alpha values are overridden to be fully opaque (1.0).

--- a/crates/bevy_pbr/src/bundle.rs
+++ b/crates/bevy_pbr/src/bundle.rs
@@ -1,7 +1,7 @@
 use crate::{DirectionalLight, Material, PointLight, SpotLight, StandardMaterial};
 use bevy_asset::Handle;
 use bevy_ecs::{bundle::Bundle, component::Component, reflect::ReflectComponent};
-use bevy_reflect::Reflect;
+use bevy_reflect::{FromReflect, Reflect};
 use bevy_render::{
     mesh::Mesh,
     primitives::{CubemapFrusta, Frustum},
@@ -38,7 +38,7 @@ impl<M: Material> Default for MaterialMeshBundle<M> {
     }
 }
 
-#[derive(Component, Clone, Debug, Default, Reflect)]
+#[derive(Component, Clone, Debug, Default, Reflect, FromReflect)]
 #[reflect(Component)]
 pub struct CubemapVisibleEntities {
     #[reflect(ignore)]

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -38,7 +38,7 @@ use crate::{
 /// | 4000 | 300 |    | 75-100 | 40.5  |
 ///
 /// Source: [Wikipedia](https://en.wikipedia.org/wiki/Lumen_(unit)#Lighting)
-#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[derive(Component, Debug, Clone, Copy, Reflect, FromReflect)]
 #[reflect(Component, Default)]
 pub struct PointLight {
     pub color: Color,
@@ -73,7 +73,7 @@ impl PointLight {
     pub const DEFAULT_SHADOW_NORMAL_BIAS: f32 = 0.6;
 }
 
-#[derive(Resource, Clone, Debug, Reflect)]
+#[derive(Resource, Clone, Debug, Reflect, FromReflect)]
 #[reflect(Resource)]
 pub struct PointLightShadowMap {
     pub size: usize,
@@ -89,7 +89,7 @@ impl Default for PointLightShadowMap {
 /// Behaves like a point light in a perfectly absorbant housing that
 /// shines light only in a given direction. The direction is taken from
 /// the transform, and can be specified with [`Transform::looking_at`](bevy_transform::components::Transform::looking_at).
-#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[derive(Component, Debug, Clone, Copy, Reflect, FromReflect)]
 #[reflect(Component, Default)]
 pub struct SpotLight {
     pub color: Color,
@@ -167,7 +167,7 @@ impl Default for SpotLight {
 /// | 32,000–100,000    | Direct sunlight                                |
 ///
 /// Source: [Wikipedia](https://en.wikipedia.org/wiki/Lux)
-#[derive(Component, Debug, Clone, Reflect)]
+#[derive(Component, Debug, Clone, Reflect, FromReflect)]
 #[reflect(Component, Default)]
 pub struct DirectionalLight {
     pub color: Color,
@@ -208,7 +208,7 @@ impl DirectionalLight {
     pub const DEFAULT_SHADOW_NORMAL_BIAS: f32 = 0.6;
 }
 
-#[derive(Resource, Clone, Debug, Reflect)]
+#[derive(Resource, Clone, Debug, Reflect, FromReflect)]
 #[reflect(Resource)]
 pub struct DirectionalLightShadowMap {
     pub size: usize,
@@ -224,7 +224,7 @@ impl Default for DirectionalLightShadowMap {
 }
 
 /// An ambient light, which lights the entire scene equally.
-#[derive(Resource, Clone, Debug, ExtractResource, Reflect)]
+#[derive(Resource, Clone, Debug, ExtractResource, Reflect, FromReflect)]
 #[reflect(Resource)]
 pub struct AmbientLight {
     pub color: Color,
@@ -242,11 +242,11 @@ impl Default for AmbientLight {
 }
 
 /// Add this component to make a [`Mesh`](bevy_render::mesh::Mesh) not cast shadows.
-#[derive(Component, Reflect, Default)]
+#[derive(Component, Reflect, Default, FromReflect)]
 #[reflect(Component, Default)]
 pub struct NotShadowCaster;
 /// Add this component to make a [`Mesh`](bevy_render::mesh::Mesh) not receive shadows.
-#[derive(Component, Reflect, Default)]
+#[derive(Component, Reflect, Default, FromReflect)]
 #[reflect(Component, Default)]
 pub struct NotShadowReceiver;
 

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -5,7 +5,7 @@ use bevy_asset::{load_internal_asset, Handle, HandleUntyped};
 use bevy_core_pipeline::core_3d::Opaque3d;
 use bevy_ecs::{prelude::*, reflect::ReflectComponent};
 use bevy_reflect::std_traits::ReflectDefault;
-use bevy_reflect::{Reflect, TypeUuid};
+use bevy_reflect::{FromReflect, Reflect, TypeUuid};
 use bevy_render::Extract;
 use bevy_render::{
     extract_resource::{ExtractResource, ExtractResourcePlugin},
@@ -59,11 +59,11 @@ fn extract_wireframes(mut commands: Commands, query: Extract<Query<Entity, With<
 }
 
 /// Controls whether an entity should rendered in wireframe-mode if the [`WireframePlugin`] is enabled
-#[derive(Component, Debug, Clone, Default, Reflect)]
+#[derive(Component, Debug, Clone, Default, Reflect, FromReflect)]
 #[reflect(Component, Default)]
 pub struct Wireframe;
 
-#[derive(Resource, Debug, Clone, Default, ExtractResource, Reflect)]
+#[derive(Resource, Debug, Clone, Default, ExtractResource, Reflect, FromReflect)]
 #[reflect(Resource)]
 pub struct WireframeConfig {
     /// Whether to show wireframes for all meshes. If `false`, only meshes with a [Wireframe] component will be rendered.

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -283,7 +283,7 @@ impl Camera {
 }
 
 /// Configures the [`RenderGraph`](crate::render_graph::RenderGraph) name assigned to be run for a given [`Camera`] entity.
-#[derive(Component, Deref, DerefMut, Reflect, Default)]
+#[derive(Component, Deref, DerefMut, Reflect, Default, FromReflect)]
 #[reflect(Component)]
 pub struct CameraRenderGraph(Cow<'static, str>);
 

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -64,7 +64,7 @@ pub trait CameraProjection {
 }
 
 /// A configurable [`CameraProjection`] that can select its projection type at runtime.
-#[derive(Component, Debug, Clone, Reflect)]
+#[derive(Component, Debug, Clone, Reflect, FromReflect)]
 #[reflect(Component, Default)]
 pub enum Projection {
     Perspective(PerspectiveProjection),

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -7,7 +7,7 @@ use crate::{
 use bevy_app::{App, Plugin};
 use bevy_core::FrameCount;
 use bevy_ecs::prelude::*;
-use bevy_reflect::Reflect;
+use bevy_reflect::{FromReflect, Reflect};
 use bevy_time::Time;
 
 pub struct GlobalsPlugin;
@@ -30,7 +30,7 @@ fn extract_time(mut commands: Commands, time: Extract<Res<Time>>) {
 
 /// Contains global values useful when writing shaders.
 /// Currently only contains values related to time.
-#[derive(Default, Clone, Resource, ExtractResource, Reflect, ShaderType)]
+#[derive(Default, Clone, Resource, ExtractResource, Reflect, ShaderType, FromReflect)]
 #[reflect(Resource)]
 pub struct GlobalsUniform {
     /// The time since startup in seconds.

--- a/crates/bevy_render/src/mesh/mesh/skinning.rs
+++ b/crates/bevy_render/src/mesh/mesh/skinning.rs
@@ -6,10 +6,10 @@ use bevy_ecs::{
     reflect::ReflectMapEntities,
 };
 use bevy_math::Mat4;
-use bevy_reflect::{Reflect, TypeUuid};
+use bevy_reflect::{FromReflect, Reflect, TypeUuid};
 use std::ops::Deref;
 
-#[derive(Component, Debug, Default, Clone, Reflect)]
+#[derive(Component, Debug, Default, Clone, Reflect, FromReflect)]
 #[reflect(Component, MapEntities)]
 pub struct SkinnedMesh {
     pub inverse_bindposes: Handle<SkinnedMeshInverseBindposes>,

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -1,9 +1,9 @@
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_math::{Mat4, Vec3, Vec3A, Vec4, Vec4Swizzles};
-use bevy_reflect::Reflect;
+use bevy_reflect::{FromReflect, Reflect};
 
 /// An Axis-Aligned Bounding Box
-#[derive(Component, Clone, Debug, Default, Reflect)]
+#[derive(Component, Clone, Debug, Default, Reflect, FromReflect)]
 #[reflect(Component)]
 pub struct Aabb {
     pub center: Vec3A,
@@ -126,7 +126,7 @@ impl Plane {
 /// A frustum defined by the 6 containing planes
 /// Planes are ordered left, right, top, bottom, near, far
 /// Normals point into the contained volume
-#[derive(Component, Clone, Copy, Debug, Default, Reflect)]
+#[derive(Component, Clone, Copy, Debug, Default, Reflect, FromReflect)]
 #[reflect(Component)]
 pub struct Frustum {
     #[reflect(ignore)]
@@ -193,7 +193,7 @@ impl Frustum {
     }
 }
 
-#[derive(Component, Debug, Default, Reflect)]
+#[derive(Component, Debug, Default, Reflect, FromReflect)]
 #[reflect(Component)]
 pub struct CubemapFrusta {
     #[reflect(ignore)]

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
 use bevy_math::{Mat4, UVec4, Vec3, Vec4};
-use bevy_reflect::Reflect;
+use bevy_reflect::{FromReflect, Reflect};
 use bevy_transform::components::GlobalTransform;
 
 pub struct ViewPlugin;
@@ -58,7 +58,7 @@ impl Plugin for ViewPlugin {
 ///     .insert_resource(Msaa { samples: 4 })
 ///     .run();
 /// ```
-#[derive(Resource, Clone, ExtractResource, Reflect)]
+#[derive(Resource, Clone, ExtractResource, Reflect, FromReflect)]
 #[reflect(Resource)]
 pub struct Msaa {
     /// The number of samples to run for Multi-Sample Anti-Aliasing. Higher numbers result in

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -6,8 +6,8 @@ use bevy_app::{CoreStage, Plugin};
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::prelude::*;
 use bevy_hierarchy::{Children, Parent};
-use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::Reflect;
+use bevy_reflect::{std_traits::ReflectDefault, FromReflect};
 use bevy_transform::components::GlobalTransform;
 use bevy_transform::TransformSystem;
 use std::cell::Cell;
@@ -26,7 +26,7 @@ use crate::{
 
 /// If an entity is hidden in this way,  all [`Children`] (and all of their children and so on) will also be hidden.
 /// This is done by setting the values of their [`ComputedVisibility`] component.
-#[derive(Component, Clone, Reflect, Debug)]
+#[derive(Component, Clone, Reflect, Debug, FromReflect)]
 #[reflect(Component, Default)]
 pub struct Visibility {
     /// Indicates whether this entity is visible. Hidden values will propagate down the entity hierarchy.
@@ -55,7 +55,7 @@ impl Visibility {
 }
 
 /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
-#[derive(Component, Clone, Reflect, Debug, Eq, PartialEq)]
+#[derive(Component, Clone, Reflect, Debug, Eq, PartialEq, FromReflect)]
 #[reflect(Component, Default)]
 pub struct ComputedVisibility {
     is_visible_in_hierarchy: bool,
@@ -146,7 +146,7 @@ pub struct NoFrustumCulling;
 ///
 /// Currently this component is ignored by the sprite renderer, so sprite rendering
 /// is not optimized per view.
-#[derive(Clone, Component, Default, Debug, Reflect)]
+#[derive(Clone, Component, Default, Debug, Reflect, FromReflect)]
 #[reflect(Component)]
 pub struct VisibleEntities {
     #[reflect(ignore)]

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::prelude::{Component, ReflectComponent};
 use bevy_reflect::std_traits::ReflectDefault;
-use bevy_reflect::Reflect;
+use bevy_reflect::{FromReflect, Reflect};
 
 type LayerMask = u32;
 
@@ -20,7 +20,7 @@ pub type Layer = u8;
 /// An entity with this component without any layers is invisible.
 ///
 /// Entities without this component belong to layer `0`.
-#[derive(Component, Copy, Clone, Reflect, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Component, Copy, Clone, Reflect, PartialEq, Eq, PartialOrd, Ord, FromReflect)]
 #[reflect(Component, Default, PartialEq)]
 pub struct RenderLayers(LayerMask);
 

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -19,8 +19,8 @@ use std::collections::BTreeMap;
 /// # use bevy_ecs::{
 /// #     component::Component, prelude::Entity, query::With, reflect::ReflectComponent, world::World,
 /// # };
-/// # use bevy_reflect::Reflect;
-/// # #[derive(Component, Reflect, Default, Eq, PartialEq, Debug)]
+/// # use bevy_reflect::{Reflect, FromReflect};
+/// # #[derive(Component, Reflect, Default, Eq, PartialEq, Debug, FromReflect)]
 /// # #[reflect(Component)]
 /// # struct ComponentA;
 /// # let mut world = World::default();
@@ -82,8 +82,8 @@ impl<'w> DynamicSceneBuilder<'w> {
     /// # use bevy_ecs::{
     /// #     component::Component, prelude::Entity, query::With, reflect::ReflectComponent, world::World,
     /// # };
-    /// # use bevy_reflect::Reflect;
-    /// #[derive(Component, Default, Reflect)]
+    /// # use bevy_reflect::{Reflect, FromReflect};
+    /// #[derive(Component, Reflect, FromReflect)]
     /// #[reflect(Component)]
     /// struct MyComponent;
     ///
@@ -141,14 +141,14 @@ mod tests {
         component::Component, prelude::Entity, query::With, reflect::ReflectComponent, world::World,
     };
 
-    use bevy_reflect::Reflect;
+    use bevy_reflect::{FromReflect, Reflect};
 
     use super::DynamicSceneBuilder;
 
-    #[derive(Component, Reflect, Default, Eq, PartialEq, Debug)]
+    #[derive(Component, Reflect, Eq, PartialEq, Debug, FromReflect)]
     #[reflect(Component)]
     struct ComponentA;
-    #[derive(Component, Reflect, Default, Eq, PartialEq, Debug)]
+    #[derive(Component, Reflect, Eq, PartialEq, Debug, FromReflect)]
     #[reflect(Component)]
     struct ComponentB;
 

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -381,16 +381,16 @@ mod tests {
     use bevy_app::AppTypeRegistry;
     use bevy_ecs::entity::EntityMap;
     use bevy_ecs::prelude::{Component, ReflectComponent, World};
-    use bevy_reflect::Reflect;
+    use bevy_reflect::{FromReflect, Reflect};
     use serde::de::DeserializeSeed;
 
-    #[derive(Component, Reflect, Default)]
+    #[derive(Component, Reflect, FromReflect)]
     #[reflect(Component)]
     struct Foo(i32);
-    #[derive(Component, Reflect, Default)]
+    #[derive(Component, Reflect, FromReflect)]
     #[reflect(Component)]
     struct Bar(i32);
-    #[derive(Component, Reflect, Default)]
+    #[derive(Component, Reflect, FromReflect)]
     #[reflect(Component)]
     struct Baz(i32);
 

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     system::{lifetimeless::*, SystemParamItem, SystemState},
 };
 use bevy_math::{Mat4, Vec2};
-use bevy_reflect::{Reflect, TypeUuid};
+use bevy_reflect::{FromReflect, Reflect, TypeUuid};
 use bevy_render::{
     extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
     globals::{GlobalsBuffer, GlobalsUniform},
@@ -27,7 +27,7 @@ use bevy_transform::components::GlobalTransform;
 /// Component for rendering with meshes in the 2d pipeline, usually with a [2d material](crate::Material2d) such as [`ColorMaterial`](crate::ColorMaterial).
 ///
 /// It wraps a [`Handle<Mesh>`] to differentiate from the 3d pipelines which use the handles directly as components
-#[derive(Default, Clone, Component, Debug, Reflect)]
+#[derive(Default, Clone, Component, Debug, Reflect, FromReflect)]
 #[reflect(Component)]
 pub struct Mesh2dHandle(pub Handle<Mesh>);
 

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Font;
 
-#[derive(Component, Debug, Default, Clone, Reflect)]
+#[derive(Component, Debug, Default, Clone, Reflect, FromReflect)]
 #[reflect(Component, Default)]
 pub struct Text {
     pub sections: Vec<TextSection>,
@@ -117,7 +117,7 @@ impl TextSection {
     }
 }
 
-#[derive(Debug, Clone, Copy, Reflect)]
+#[derive(Debug, Clone, Copy, Reflect, FromReflect)]
 pub struct TextAlignment {
     pub vertical: VerticalAlign,
     pub horizontal: HorizontalAlign,
@@ -186,7 +186,7 @@ impl Default for TextAlignment {
 }
 
 /// Describes horizontal alignment preference for positioning & bounds.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize, FromReflect)]
 #[reflect(Serialize, Deserialize)]
 pub enum HorizontalAlign {
     /// Leftmost character is immediately to the right of the render position.<br/>
@@ -212,7 +212,7 @@ impl From<HorizontalAlign> for glyph_brush_layout::HorizontalAlign {
 
 /// Describes vertical alignment preference for positioning & bounds. Currently a placeholder
 /// for future functionality.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize, FromReflect)]
 #[reflect(Serialize, Deserialize)]
 pub enum VerticalAlign {
     /// Characters/bounds start underneath the render position and progress downwards.

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
     system::{Commands, Local, Query, Res, ResMut},
 };
 use bevy_math::{Vec2, Vec3};
-use bevy_reflect::Reflect;
+use bevy_reflect::{FromReflect, Reflect};
 use bevy_render::{
     prelude::Color,
     texture::Image,
@@ -27,7 +27,7 @@ use crate::{
 };
 
 /// The calculated size of text drawn in 2D scene.
-#[derive(Component, Default, Copy, Clone, Debug, Reflect)]
+#[derive(Component, Default, Copy, Clone, Debug, Reflect, FromReflect)]
 #[reflect(Component)]
 pub struct Text2dSize {
     pub size: Vec2,
@@ -40,7 +40,7 @@ pub struct Text2dSize {
 /// Note: only characters that are completely out of the bounds will be truncated, so this is not a
 /// reliable limit if it is necessary to contain the text strictly in the bounds. Currently this
 /// component is mainly useful for text wrapping only.
-#[derive(Component, Copy, Clone, Debug, Reflect)]
+#[derive(Component, Copy, Clone, Debug, Reflect, FromReflect)]
 #[reflect(Component)]
 pub struct Text2dBounds {
     pub size: Vec2,

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
 };
 use bevy_input::{mouse::MouseButton, touch::Touches, Input};
 use bevy_math::Vec2;
-use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
+use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render::camera::{Camera, RenderTarget};
 use bevy_render::view::ComputedVisibility;
 use bevy_transform::components::GlobalTransform;
@@ -31,7 +31,17 @@ use smallvec::SmallVec;
 /// Note that you can also control the visibility of a node using the [`Display`](crate::ui_node::Display) property,
 /// which fully collapses it during layout calculations.
 #[derive(
-    Component, Copy, Clone, Default, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize,
+    Component,
+    Copy,
+    Clone,
+    Default,
+    Eq,
+    PartialEq,
+    Debug,
+    Reflect,
+    Serialize,
+    Deserialize,
+    FromReflect,
 )]
 #[reflect(Component, Serialize, Deserialize, PartialEq)]
 pub enum Interaction {
@@ -46,7 +56,17 @@ pub enum Interaction {
 
 /// Describes whether the node should block interactions with lower nodes
 #[derive(
-    Component, Copy, Clone, Default, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize,
+    Component,
+    Copy,
+    Clone,
+    Default,
+    Eq,
+    PartialEq,
+    Debug,
+    Reflect,
+    Serialize,
+    Deserialize,
+    FromReflect,
 )]
 #[reflect(Component, Serialize, Deserialize, PartialEq)]
 pub enum FocusPolicy {

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -1,7 +1,6 @@
 use crate::Val;
-use bevy_reflect::Reflect;
+use bevy_reflect::{FromReflect, Reflect};
 use std::ops::{Div, DivAssign, Mul, MulAssign};
-
 /// A type which is commonly used to define positions, margins, paddings and borders.
 ///
 /// # Examples
@@ -119,7 +118,7 @@ use std::ops::{Div, DivAssign, Mul, MulAssign};
 ///     bottom: Val::Px(40.0),
 /// };
 /// ```
-#[derive(Copy, Clone, PartialEq, Debug, Default, Reflect)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Reflect, FromReflect)]
 #[reflect(PartialEq)]
 pub struct UiRect {
     /// The value corresponding to the left side of the UI rect.
@@ -316,7 +315,7 @@ impl UiRect {
 /// A 2-dimensional area defined by a width and height.
 ///
 /// It is commonly used to define the size of a text or UI element.
-#[derive(Copy, Clone, PartialEq, Debug, Default, Reflect)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Reflect, FromReflect)]
 #[reflect(PartialEq)]
 pub struct Size {
     /// The width of the 2-dimensional area.

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -13,7 +13,7 @@ use std::ops::{Div, DivAssign, Mul, MulAssign};
 use thiserror::Error;
 
 /// Describes the size of a UI node
-#[derive(Component, Debug, Clone, Default, Reflect)]
+#[derive(Component, Debug, Clone, Default, Reflect, FromReflect)]
 #[reflect(Component, Default)]
 pub struct Node {
     /// The size of the node as width and height in pixels
@@ -30,7 +30,7 @@ impl Node {
 }
 
 /// An enum that describes possible types of value in flexbox layout options
-#[derive(Copy, Clone, PartialEq, Debug, Default, Serialize, Deserialize, Reflect)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Serialize, Deserialize, Reflect, FromReflect)]
 #[reflect(PartialEq, Serialize, Deserialize)]
 pub enum Val {
     /// No value defined
@@ -193,7 +193,7 @@ impl Val {
 ///
 /// **Note:** Bevy's UI is upside down compared to how Flexbox normally works, to stay consistent with engine paradigms about layouting from
 /// the upper left corner of the display
-#[derive(Component, Clone, PartialEq, Debug, Reflect)]
+#[derive(Component, Clone, PartialEq, Debug, Reflect, FromReflect)]
 #[reflect(Component, Default, PartialEq)]
 pub struct Style {
     /// Whether to arrange this node and its children with flexbox layout
@@ -272,7 +272,9 @@ impl Default for Style {
 }
 
 /// How items are aligned according to the cross axis
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect, FromReflect,
+)]
 #[reflect(PartialEq, Serialize, Deserialize)]
 pub enum AlignItems {
     /// Items are aligned at the start
@@ -289,7 +291,9 @@ pub enum AlignItems {
 }
 
 /// Works like [`AlignItems`] but applies only to a single item
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect, FromReflect,
+)]
 #[reflect(PartialEq, Serialize, Deserialize)]
 pub enum AlignSelf {
     /// Use the value of [`AlignItems`]
@@ -310,7 +314,9 @@ pub enum AlignSelf {
 /// Defines how each line is aligned within the flexbox.
 ///
 /// It only applies if [`FlexWrap::Wrap`] is present and if there are multiple lines of items.
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect, FromReflect,
+)]
 #[reflect(PartialEq, Serialize, Deserialize)]
 pub enum AlignContent {
     /// Each line moves towards the start of the cross axis
@@ -333,7 +339,9 @@ pub enum AlignContent {
 /// Defines the text direction
 ///
 /// For example English is written LTR (left-to-right) while Arabic is written RTL (right-to-left).
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect, FromReflect,
+)]
 #[reflect(PartialEq, Serialize, Deserialize)]
 pub enum Direction {
     /// Inherit from parent node
@@ -348,7 +356,9 @@ pub enum Direction {
 /// Whether to use a Flexbox layout model.
 ///
 /// Part of the [`Style`] component.
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect, FromReflect,
+)]
 #[reflect(PartialEq, Serialize, Deserialize)]
 pub enum Display {
     /// Use Flexbox layout model to determine the position of this [`Node`].
@@ -362,7 +372,9 @@ pub enum Display {
 }
 
 /// Defines how flexbox items are ordered within a flexbox
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect, FromReflect,
+)]
 #[reflect(PartialEq, Serialize, Deserialize)]
 pub enum FlexDirection {
     /// Same way as text direction along the main axis
@@ -377,7 +389,9 @@ pub enum FlexDirection {
 }
 
 /// Defines how items are aligned according to the main axis
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect, FromReflect,
+)]
 #[reflect(PartialEq, Serialize, Deserialize)]
 pub enum JustifyContent {
     /// Pushed towards the start
@@ -396,7 +410,9 @@ pub enum JustifyContent {
 }
 
 /// Whether to show or hide overflowing items
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default, Reflect, Serialize, Deserialize)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Debug, Default, Reflect, Serialize, Deserialize, FromReflect,
+)]
 #[reflect(PartialEq, Serialize, Deserialize)]
 pub enum Overflow {
     /// Show overflowing items
@@ -407,7 +423,9 @@ pub enum Overflow {
 }
 
 /// The strategy used to position this node
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect, FromReflect,
+)]
 #[reflect(PartialEq, Serialize, Deserialize)]
 pub enum PositionType {
     /// Relative to all other nodes with the [`PositionType::Relative`] value
@@ -420,7 +438,9 @@ pub enum PositionType {
 }
 
 /// Defines if flexbox items appear on a single line or on multiple lines
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Reflect, FromReflect,
+)]
 #[reflect(PartialEq, Serialize, Deserialize)]
 pub enum FlexWrap {
     /// Single line, will overflow if needed
@@ -433,7 +453,7 @@ pub enum FlexWrap {
 }
 
 /// The calculated size of the node
-#[derive(Component, Default, Copy, Clone, Debug, Reflect)]
+#[derive(Component, Default, Copy, Clone, Debug, Reflect, FromReflect)]
 #[reflect(Component)]
 pub struct CalculatedSize {
     /// The size of the node
@@ -444,7 +464,7 @@ pub struct CalculatedSize {
 ///
 /// This serves as the "fill" color.
 /// When combined with [`UiImage`], tints the provided texture.
-#[derive(Component, Default, Copy, Clone, Debug, Reflect)]
+#[derive(Component, Default, Copy, Clone, Debug, Reflect, FromReflect)]
 #[reflect(Component, Default)]
 pub struct BackgroundColor(pub Color);
 
@@ -455,7 +475,7 @@ impl From<Color> for BackgroundColor {
 }
 
 /// The 2D texture displayed for this UI node
-#[derive(Component, Clone, Debug, Reflect, Deref, DerefMut)]
+#[derive(Component, Clone, Debug, Reflect, Deref, DerefMut, FromReflect)]
 #[reflect(Component, Default)]
 pub struct UiImage(pub Handle<Image>);
 
@@ -472,7 +492,7 @@ impl From<Handle<Image>> for UiImage {
 }
 
 /// The calculated clip of the node
-#[derive(Component, Default, Copy, Clone, Debug, Reflect)]
+#[derive(Component, Default, Copy, Clone, Debug, Reflect, FromReflect)]
 #[reflect(Component)]
 pub struct CalculatedClip {
     /// The rect of the clip

--- a/crates/bevy_ui/src/widget/button.rs
+++ b/crates/bevy_ui/src/widget/button.rs
@@ -1,9 +1,9 @@
 use bevy_ecs::prelude::Component;
 use bevy_ecs::reflect::ReflectComponent;
 use bevy_reflect::std_traits::ReflectDefault;
-use bevy_reflect::Reflect;
+use bevy_reflect::{FromReflect, Reflect};
 
 /// Marker struct for buttons
-#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
+#[derive(Component, Debug, Default, Clone, Copy, Reflect, FromReflect)]
 #[reflect(Component, Default)]
 pub struct Button;

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -6,13 +6,13 @@ use bevy_ecs::{
     reflect::ReflectComponent,
     system::{Query, Res},
 };
-use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
+use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render::texture::Image;
 use bevy_text::Text;
 use serde::{Deserialize, Serialize};
 
 /// Describes how to resize the Image node
-#[derive(Component, Debug, Default, Clone, Reflect, Serialize, Deserialize)]
+#[derive(Component, Debug, Default, Clone, Reflect, Serialize, Deserialize, FromReflect)]
 #[reflect(Component, Serialize, Deserialize)]
 pub enum ImageMode {
     /// Keep the aspect ratio of the image

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -27,7 +27,7 @@ fn main() {
 // example. The `FromWorld` trait determines how your component is constructed when it loads.
 // For simple use cases you can just implement the `Default` trait (which automatically implements
 // FromResources). The simplest registered component just needs these two derives:
-#[derive(Component, Reflect, Default)]
+#[derive(Component, Reflect, FromReflect, Default)]
 #[reflect(Component)] // this tells the reflect derive to also reflect component behaviors
 struct ComponentA {
     pub x: f32,
@@ -38,7 +38,7 @@ struct ComponentA {
 // ignored with the #[reflect(skip_serializing)] attribute. This is also generally where the `FromWorld`
 // trait comes into play. `FromWorld` gives you access to your App's current ECS `Resources`
 // when you construct your component.
-#[derive(Component, Reflect)]
+#[derive(Component, Reflect, FromReflect)]
 #[reflect(Component)]
 struct ComponentB {
     pub value: String,


### PR DESCRIPTION
# Objective

There should be no need for components and resources to implement `FromWorld` just for accessing and inserting them into the world.

## Solution

- replace `T: FromWorld` and `let component = T::from_world(world); component.apply(value);` with `T: FromReflect` and `let component = T::from_reflect(value);`

## Changelog

- require `FromReflect` instead of `FromWorld` for `#[reflect(Component)]` and `#[reflect(Resource)]`

## Migration Guide

If you used `#[reflect(Component)]` or `#[reflect(Resource)]` you now need a `#[derive(FromReflect)]` as well, but the `FromWorld` (or `Default`) impl can go away.