### PR TITLE
add test checking that types are registered (as far as possible)

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -33,7 +33,9 @@ impl Plugin for CorePlugin {
             .unwrap_or_default()
             .create_default_pools();
 
-        app.register_type::<Entity>().register_type::<Name>();
+        app.register_type::<Entity>()
+            .register_type::<Vec<Entity>>()
+            .register_type::<Name>();
 
         register_rust_types(app);
         register_math_types(app);
@@ -47,7 +49,8 @@ fn register_rust_types(app: &mut App) {
         .register_type::<Option<String>>()
         .register_type::<Cow<'static, str>>()
         .register_type::<Duration>()
-        .register_type::<Instant>();
+        .register_type::<Instant>()
+        .register_type::<Option<Instant>>();
 }
 
 fn register_math_types(app: &mut App) {
@@ -81,5 +84,8 @@ fn register_math_types(app: &mut App) {
         .register_type::<bevy_math::Mat3A>()
         .register_type::<bevy_math::Mat4>()
         .register_type::<bevy_math::DQuat>()
-        .register_type::<bevy_math::Quat>();
+        .register_type::<bevy_math::Quat>()
+        .register_type::<bevy_math::Rect>()
+        .register_type::<Option<bevy_math::Rect>>()
+        .register_type::<Option<bevy_math::Vec2>>();
 }

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -17,6 +17,7 @@ mod events;
 pub use events::*;
 
 mod valid_parent_check_plugin;
+use smallvec::SmallVec;
 pub use valid_parent_check_plugin::*;
 
 #[doc(hidden)]
@@ -36,6 +37,7 @@ pub struct HierarchyPlugin;
 impl Plugin for HierarchyPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Children>()
+            .register_type::<SmallVec<[bevy_ecs::prelude::Entity; 8]>>()
             .register_type::<Parent>()
             .add_event::<HierarchyEvent>();
     }

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -22,6 +22,7 @@ impl Plugin for CameraPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Camera>()
             .register_type::<Viewport>()
+            .register_type::<Option<Viewport>>()
             .register_type::<Visibility>()
             .register_type::<ComputedVisibility>()
             .register_type::<VisibleEntities>()

--- a/tests/check_types_registered.rs
+++ b/tests/check_types_registered.rs
@@ -6,6 +6,42 @@ use bevy::{
 };
 
 #[test]
+fn check_components_resources_registered() {
+    let mut app = App::new();
+    app.add_plugins_with(DefaultPlugins, |g| g.disable::<bevy::winit::WinitPlugin>());
+
+    let type_registry = app.world.resource::<AppTypeRegistry>();
+    let type_registry = type_registry.read();
+
+    for registration in app
+        .world
+        .components()
+        .iter()
+        .filter_map(|info| info.type_id())
+        .filter_map(|type_id| type_registry.get(type_id))
+    {
+        if app
+            .world
+            .components()
+            .get_resource_id(registration.type_id())
+            .is_some()
+        {
+            assert!(
+                registration.data::<ReflectResource>().is_some(),
+                "resource {} has no `ReflectResource`",
+                registration.short_name()
+            );
+        } else {
+            assert!(
+                registration.data::<ReflectComponent>().is_some(),
+                "component {} has no `ReflectComponent`",
+                registration.short_name()
+            );
+        }
+    }
+}
+
+#[test]
 fn check_types_registered_recursive() {
     let mut app = App::new();
     app.add_plugins_with(DefaultPlugins, |g| g.disable::<bevy::winit::WinitPlugin>());

--- a/tests/check_types_registered.rs
+++ b/tests/check_types_registered.rs
@@ -1,0 +1,69 @@
+use std::any::TypeId;
+
+use bevy::{
+    prelude::*,
+    reflect::{TypeInfo, TypeRegistryInternal, VariantInfo},
+};
+
+#[test]
+fn check_types_registered_recursive() {
+    let mut app = App::new();
+    app.add_plugins_with(DefaultPlugins, |g| g.disable::<bevy::winit::WinitPlugin>());
+
+    let type_registry = app.world.resource::<AppTypeRegistry>();
+    let type_registry = type_registry.read();
+
+    for registration in type_registry.iter() {
+        assert_registered_recursive(
+            &*type_registry,
+            registration.type_id(),
+            registration.type_name(),
+        );
+    }
+}
+
+fn assert_registered_recursive(
+    type_registry: &TypeRegistryInternal,
+    type_id: TypeId,
+    name: &'static str,
+) {
+    let registration = type_registry
+        .get(type_id)
+        .unwrap_or_else(|| panic!("{name} is not registered"));
+    match registration.type_info() {
+        TypeInfo::Struct(info) => info.iter().for_each(|field| {
+            assert_registered_recursive(type_registry, field.type_id(), field.type_name())
+        }),
+        TypeInfo::TupleStruct(info) => info.iter().for_each(|field| {
+            assert_registered_recursive(type_registry, field.type_id(), field.type_name())
+        }),
+        TypeInfo::Tuple(info) => info.iter().for_each(|field| {
+            assert_registered_recursive(type_registry, field.type_id(), field.type_name())
+        }),
+        TypeInfo::List(info) => {
+            assert_registered_recursive(type_registry, info.item_type_id(), info.item_type_name())
+        }
+        TypeInfo::Array(info) => {
+            assert_registered_recursive(type_registry, info.item_type_id(), info.item_type_name())
+        }
+        TypeInfo::Map(info) => {
+            assert_registered_recursive(type_registry, info.key_type_id(), info.key_type_name());
+            assert_registered_recursive(
+                type_registry,
+                info.value_type_id(),
+                info.value_type_name(),
+            );
+        }
+        TypeInfo::Enum(info) => info.iter().for_each(|variant| match variant {
+            VariantInfo::Struct(variant) => variant.iter().for_each(|field| {
+                assert_registered_recursive(type_registry, field.type_id(), field.type_name())
+            }),
+            VariantInfo::Tuple(variant) => variant.iter().for_each(|field| {
+                assert_registered_recursive(type_registry, field.type_id(), field.type_name())
+            }),
+            VariantInfo::Unit(_) => {}
+        }),
+        TypeInfo::Value(_) => {}
+        TypeInfo::Dynamic(_) => todo!(),
+    }
+}

--- a/tests/check_types_registered.rs
+++ b/tests/check_types_registered.rs
@@ -8,7 +8,7 @@ use bevy::{
 #[test]
 fn check_components_resources_registered() {
     let mut app = App::new();
-    app.add_plugins_with(DefaultPlugins, |g| g.disable::<bevy::winit::WinitPlugin>());
+    app.add_plugins_with(DefaultPlugins, |g| g.disable::<bevy::winit::WinitPlugin>().disable::<bevy::log::LogPlugin>());
 
     let type_registry = app.world.resource::<AppTypeRegistry>();
     let type_registry = type_registry.read();
@@ -44,7 +44,7 @@ fn check_components_resources_registered() {
 #[test]
 fn check_types_registered_recursive() {
     let mut app = App::new();
-    app.add_plugins_with(DefaultPlugins, |g| g.disable::<bevy::winit::WinitPlugin>());
+    app.add_plugins_with(DefaultPlugins, |g| g.disable::<bevy::winit::WinitPlugin>().disable::<bevy::log::LogPlugin>());
 
     let type_registry = app.world.resource::<AppTypeRegistry>();
     let type_registry = type_registry.read();


### PR DESCRIPTION
# Objective

1. every type that is used somewhere in a reflected type should be registered
2. every component/resource that is registered should include their respective `ReflectResource`/`ReflectComponent` type data

## Solution

- Luckily both objectives can be checked at runtime, so add a test that does exactly that
- register the missing types

**Note**: this does not lint for types that implement `Reflect` but are not registered. This can't be done at runtime, but maybe as a script running on rustdoc output.