### PR TITLE
[Merged by Bors] - Fix CI issues arising from use of Rust 1.64

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -294,7 +294,7 @@ impl ComponentDescriptor {
             is_send_and_sync: true,
             type_id: Some(TypeId::of::<T>()),
             layout: Layout::new::<T>(),
-            drop: needs_drop::<T>().then(|| Self::drop_ptr::<T> as _),
+            drop: needs_drop::<T>().then_some(Self::drop_ptr::<T> as _),
         }
     }
 
@@ -331,7 +331,7 @@ impl ComponentDescriptor {
             is_send_and_sync: true,
             type_id: Some(TypeId::of::<T>()),
             layout: Layout::new::<T>(),
-            drop: needs_drop::<T>().then(|| Self::drop_ptr::<T> as _),
+            drop: needs_drop::<T>().then_some(Self::drop_ptr::<T> as _),
         }
     }
 
@@ -342,7 +342,7 @@ impl ComponentDescriptor {
             is_send_and_sync: false,
             type_id: Some(TypeId::of::<T>()),
             layout: Layout::new::<T>(),
-            drop: needs_drop::<T>().then(|| Self::drop_ptr::<T> as _),
+            drop: needs_drop::<T>().then_some(Self::drop_ptr::<T> as _),
         }
     }
 

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -547,7 +547,7 @@ impl Entities {
             // If this entity was manually created, then free_cursor might be positive
             // Returning None handles that case correctly
             let num_pending = usize::try_from(-free_cursor).ok()?;
-            (idu < self.meta.len() + num_pending).then(|| Entity { generation: 0, id })
+            (idu < self.meta.len() + num_pending).then_some(Entity { generation: 0, id })
         }
     }
 

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_combin_exact_sized_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_combin_exact_sized_iterator_safety.stderr
@@ -17,7 +17,7 @@ error[E0277]: the trait bound `bevy_ecs::query::Changed<Foo>: ArchetypeFilter` i
              (F0, F1, F2, F3, F4, F5, F6, F7)
            and 26 others
    = note: required because of the requirements on the impl of `ArchetypeFilter` for `bevy_ecs::query::Or<(bevy_ecs::query::Changed<Foo>, bevy_ecs::query::With<Bar>)>`
-   = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryCombinationIter<'_, '_, &Foo, bevy_ecs::query::Or<(bevy_ecs::query::Changed<Foo>, bevy_ecs::query::With<Bar>)>, 2_usize>`
+   = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryCombinationIter<'_, '_, &Foo, bevy_ecs::query::Or<(bevy_ecs::query::Changed<Foo>, bevy_ecs::query::With<Bar>)>, 2>`
 note: required by a bound in `is_exact_size_iterator`
   --> tests/ui/query_combin_exact_sized_iterator_safety.rs:18:30
    |
@@ -43,7 +43,7 @@ error[E0277]: the trait bound `bevy_ecs::query::Added<Foo>: ArchetypeFilter` is 
              (F0, F1, F2, F3, F4, F5, F6, F7)
            and 26 others
    = note: required because of the requirements on the impl of `ArchetypeFilter` for `(bevy_ecs::query::Added<Foo>, bevy_ecs::query::Without<Bar>)`
-   = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryCombinationIter<'_, '_, &Foo, (bevy_ecs::query::Added<Foo>, bevy_ecs::query::Without<Bar>), 2_usize>`
+   = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryCombinationIter<'_, '_, &Foo, (bevy_ecs::query::Added<Foo>, bevy_ecs::query::Without<Bar>), 2>`
 note: required by a bound in `is_exact_size_iterator`
   --> tests/ui/query_combin_exact_sized_iterator_safety.rs:18:30
    |

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
@@ -17,7 +17,7 @@ error[E0277]: the trait bound `&mut A: ReadOnlyWorldQuery` is not satisfied
              (F0, F1, F2, F3, F4, F5, F6)
            and 49 others
    = note: `ReadOnlyWorldQuery` is implemented for `&A`, but not for `&mut A`
-   = note: required because of the requirements on the impl of `Iterator` for `QueryCombinationIter<'_, '_, &mut A, (), {_: usize}>`
+   = note: required because of the requirements on the impl of `Iterator` for `QueryCombinationIter<'_, '_, &mut A, (), _>`
 note: required by a bound in `is_iterator`
   --> tests/ui/query_iter_combinations_mut_iterator_safety.rs:13:19
    |

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_many_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_many_mut_iterator_safety.stderr
@@ -17,7 +17,7 @@ error[E0277]: the trait bound `&mut A: ReadOnlyWorldQuery` is not satisfied
              (F0, F1, F2, F3, F4, F5, F6)
            and 49 others
    = note: `ReadOnlyWorldQuery` is implemented for `&A`, but not for `&mut A`
-   = note: required because of the requirements on the impl of `Iterator` for `QueryManyIter<'_, '_, &mut A, (), std::array::IntoIter<bevy_ecs::entity::Entity, 1_usize>>`
+   = note: required because of the requirements on the impl of `Iterator` for `QueryManyIter<'_, '_, &mut A, (), std::array::IntoIter<bevy_ecs::entity::Entity, 1>>`
 note: required by a bound in `is_iterator`
   --> tests/ui/query_iter_many_mut_iterator_safety.rs:13:19
    |

--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -44,7 +44,7 @@ pub fn close_on_esc(
 ) {
     // TODO: Track this in e.g. a resource to ensure consistent behaviour across similar systems
     for event in focused_events.iter() {
-        *focused = event.focused.then(|| event.id);
+        *focused = event.focused.then_some(event.id);
     }
 
     if let Some(focused) = &*focused {

--- a/tools/build-example-pages/src/main.rs
+++ b/tools/build-example-pages/src/main.rs
@@ -112,7 +112,7 @@ fn parse_examples(panic_on_missing: bool) -> Vec<Example> {
                 .get(&technical_name)
                 .and_then(|metadata| metadata.get("hidden"))
                 .and_then(|hidden| hidden.as_bool())
-                .and_then(|hidden| hidden.then(|| ()))
+                .and_then(|hidden| hidden.then_some(()))
                 .is_some()
             {
                 return None;


### PR DESCRIPTION
## Objective

Fixes https://github.com/bevyengine/bevy/issues/6063

## Solution

- Use `then_some(x)` instead of `then( || x)`.
- Updated error logs from `bevy_ecs_compile_fail_tests`.

## Migration Guide

From Rust 1.63 to 1.64, a new Clippy error was added; now one should use `then_some(x)` instead of `then( || x)`.
