### PR TITLE
[Merged by Bors] - Mark `Task` as `#[must_use]`

### DIFF
--- a/crates/bevy_tasks/src/task.rs
+++ b/crates/bevy_tasks/src/task.rs
@@ -14,6 +14,7 @@ use std::{
 /// Tasks that panic get immediately canceled. Awaiting a canceled task also causes a panic.
 /// Wraps `async_executor::Task`
 #[derive(Debug)]
+#[must_use = "Tasks are canceled when dropped, use `.detach()` to run them in the background"]
 pub struct Task<T>(async_executor::Task<T>);
 
 impl<T> Task<T> {

--- a/crates/bevy_tasks/src/task.rs
+++ b/crates/bevy_tasks/src/task.rs
@@ -14,7 +14,7 @@ use std::{
 /// Tasks that panic get immediately canceled. Awaiting a canceled task also causes a panic.
 /// Wraps `async_executor::Task`
 #[derive(Debug)]
-#[must_use = "Tasks are canceled when dropped, use `.detach()` to run them in the background"]
+#[must_use = "Tasks are canceled when dropped, use `.detach()` to run them in the background."]
 pub struct Task<T>(async_executor::Task<T>);
 
 impl<T> Task<T> {


### PR DESCRIPTION
The `async_executor::Task` that it wraps is also `#[must_use]` with the same message.