### PR TITLE
Improve formatting for execution order ambiguity reports

### DIFF
--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -28,14 +28,19 @@ impl SystemStage {
                 } = ambiguity;
 
                 writeln!(string).unwrap();
-                writeln!(string, "({i}) Ambiguity - {}", segment.desc()).unwrap();
+                writeln!(
+                    string,
+                    "({i}) Ambiguous system ordering - {}",
+                    segment.desc()
+                )
+                .unwrap();
 
                 for name in system_names {
                     writeln!(string, " * {name}").unwrap();
                 }
 
                 writeln!(string).unwrap();
-                writeln!(string, " Conflicts:").unwrap();
+                writeln!(string, " Data access conflicts:").unwrap();
                 for conflict in conflicts {
                     writeln!(string, " * {conflict}").unwrap();
                 }

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -60,7 +60,7 @@ impl SystemStage {
     ///
     /// The result may be incorrect if this stage has not been initialized with `world`.
     fn ambiguities(&self, world: &World) -> Vec<SystemOrderAmbiguity> {
-        fn foo<'a>(
+        fn find_ambiguities_in<'a>(
             segment: SystemStageSegment,
             container: &'a [impl SystemContainer],
             world: &'a World,
@@ -88,18 +88,18 @@ impl SystemStage {
             )
         }
 
-        foo(SystemStageSegment::Parallel, &self.parallel, world)
-            .chain(foo(
+        find_ambiguities_in(SystemStageSegment::Parallel, &self.parallel, world)
+            .chain(find_ambiguities_in(
                 SystemStageSegment::ExclusiveAtStart,
                 &self.exclusive_at_start,
                 world,
             ))
-            .chain(foo(
+            .chain(find_ambiguities_in(
                 SystemStageSegment::ExclusiveBeforeCommands,
                 &self.exclusive_before_commands,
                 world,
             ))
-            .chain(foo(
+            .chain(find_ambiguities_in(
                 SystemStageSegment::ExclusiveAtEnd,
                 &self.exclusive_at_end,
                 world,

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -19,24 +19,25 @@ impl SystemStage {
 						add an explicit dependency relation between some of these systems:\n"
                 .to_owned();
 
-            let mut last_segment_kind = None;
-            for SystemOrderAmbiguity {
-                segment,
-                conflicts,
-                system_names,
-                ..
-            } in &ambiguities
-            {
-                // If the ambiguity occurred in a different segment than the previous one, write a header for the segment.
-                if last_segment_kind != Some(segment) {
-                    writeln!(string, " * {}:", segment.desc()).unwrap();
-                    last_segment_kind = Some(segment);
+            for (i, ambiguity) in ambiguities.iter().enumerate() {
+                let SystemOrderAmbiguity {
+                    segment,
+                    conflicts,
+                    system_names,
+                    ..
+                } = ambiguity;
+
+                writeln!(string).unwrap();
+                writeln!(string, "({i}) Ambiguity - {}", segment.desc()).unwrap();
+
+                for name in system_names {
+                    writeln!(string, " * {name}").unwrap();
                 }
 
-                writeln!(string, " -- {system_names:?}").unwrap();
-
-                if !conflicts.is_empty() {
-                    writeln!(string, "    conflicts: {conflicts:?}").unwrap();
+                writeln!(string).unwrap();
+                writeln!(string, " Conflicts:").unwrap();
+                for conflict in conflicts {
+                    writeln!(string, " * {conflict}").unwrap();
                 }
             }
 

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -195,13 +195,15 @@ impl AmbiguityInfo {
                 adj[b_index].set(a_index, true);
             }
 
-            // Find decompose into "subgraphs" -- sets of systems that are all ambiguous with one another.
+            // Find sets of systems that are all ambiguous with one another.
             let mut subgraphs = Vec::new();
             for [a_index, b_index] in pairs_as_indices {
                 let intersection: FixedBitSet = adj[a_index].intersection(&adj[b_index]).collect();
-                if intersection.count_ones(..) == 0 {
+                // If this pair has been included in another set, skip it.
+                if intersection.count_ones(..) <= 1 {
                     continue;
                 }
+                debug_assert!(intersection.count_ones(..) > 1);
 
                 for i in intersection.ones() {
                     adj[i].difference_with(&intersection);

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -6,6 +6,35 @@ use crate::component::ComponentId;
 use crate::schedule::{SystemContainer, SystemStage};
 use crate::world::World;
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct SystemOrderAmbiguity {
+    segment: SystemStageSegment,
+    conflicts: Vec<String>,
+    system_names: Vec<String>,
+}
+
+/// Which part of a [`SystemStage`] was a [`SystemOrderAmbiguity`] detected in?
+#[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
+enum SystemStageSegment {
+    Parallel,
+    ExclusiveAtStart,
+    ExclusiveBeforeCommands,
+    ExclusiveAtEnd,
+}
+
+impl SystemStageSegment {
+    pub fn desc(&self) -> &'static str {
+        match self {
+            SystemStageSegment::Parallel => "Parallel systems",
+            SystemStageSegment::ExclusiveAtStart => "Exclusive systems at start of stage",
+            SystemStageSegment::ExclusiveBeforeCommands => {
+                "Exclusive systems before commands of stage"
+            }
+            SystemStageSegment::ExclusiveAtEnd => "Exclusive systems at end of stage",
+        }
+    }
+}
+
 impl SystemStage {
     /// Logs execution order ambiguities between systems.
     ///
@@ -120,35 +149,6 @@ impl SystemStage {
             .iter()
             .map(|a| binomial_coefficient(a.system_names.len(), 2))
             .sum()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct SystemOrderAmbiguity {
-    segment: SystemStageSegment,
-    conflicts: Vec<String>,
-    system_names: Vec<String>,
-}
-
-/// Which part of a [`SystemStage`] was a [`SystemOrderAmbiguity`] detected in?
-#[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
-enum SystemStageSegment {
-    Parallel,
-    ExclusiveAtStart,
-    ExclusiveBeforeCommands,
-    ExclusiveAtEnd,
-}
-
-impl SystemStageSegment {
-    pub fn desc(&self) -> &'static str {
-        match self {
-            SystemStageSegment::Parallel => "Parallel systems",
-            SystemStageSegment::ExclusiveAtStart => "Exclusive systems at start of stage",
-            SystemStageSegment::ExclusiveBeforeCommands => {
-                "Exclusive systems before commands of stage"
-            }
-            SystemStageSegment::ExclusiveAtEnd => "Exclusive systems at end of stage",
-        }
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -203,7 +203,6 @@ impl AmbiguityInfo {
                 if intersection.count_ones(..) <= 1 {
                     continue;
                 }
-                debug_assert!(intersection.count_ones(..) > 1);
 
                 for i in intersection.ones() {
                     adj[i].difference_with(&intersection);

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -69,10 +69,11 @@ impl SystemStage {
                         .iter()
                         .map(|id| world.components().get_info(*id).unwrap().name().to_owned())
                         .collect();
-                    let system_names = systems
+                    let mut system_names: Vec<_> = systems
                         .iter()
                         .map(|&SystemIndex(i)| container[i].name().to_string())
                         .collect();
+                    system_names.sort();
                     SystemOrderAmbiguity {
                         segment,
                         conflicts,

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -111,11 +111,15 @@ impl SystemStage {
     ///
     /// The result may be incorrect if this stage has not been initialized with `world`.
     #[cfg(test)]
-    fn ambiguity_count(&self, _world: &World) -> usize {
-        find_ambiguities(&self.parallel).len()
-            + find_ambiguities(&self.exclusive_at_start).len()
-            + find_ambiguities(&self.exclusive_before_commands).len()
-            + find_ambiguities(&self.exclusive_at_end).len()
+    fn ambiguity_count(&self, world: &World) -> usize {
+        fn binomial_coefficient(n: usize, k: usize) -> usize {
+            (0..k).fold(1, |x, i| x * (n - i) / (i + 1))
+        }
+
+        self.ambiguities(world)
+            .iter()
+            .map(|a| binomial_coefficient(a.system_names.len(), 2))
+            .sum()
     }
 }
 

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -2,7 +2,11 @@
 
 use std::f32::consts::PI;
 
-use bevy::{ecs::schedule::SystemSet, prelude::*, time::FixedTimestep};
+use bevy::{
+    ecs::schedule::{ReportExecutionOrderAmbiguities, SystemSet},
+    prelude::*,
+    time::FixedTimestep,
+};
 use rand::Rng;
 
 #[derive(Clone, Eq, PartialEq, Debug, Hash)]
@@ -15,6 +19,7 @@ fn main() {
     App::new()
         .init_resource::<Game>()
         .add_plugins(DefaultPlugins)
+        .insert_resource(ReportExecutionOrderAmbiguities)
         .add_state(GameState::Playing)
         .add_startup_system(setup_cameras)
         .add_system_set(SystemSet::on_enter(GameState::Playing).with_system(setup))

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -2,11 +2,7 @@
 
 use std::f32::consts::PI;
 
-use bevy::{
-    ecs::schedule::{ReportExecutionOrderAmbiguities, SystemSet},
-    prelude::*,
-    time::FixedTimestep,
-};
+use bevy::{ecs::schedule::SystemSet, prelude::*, time::FixedTimestep};
 use rand::Rng;
 
 #[derive(Clone, Eq, PartialEq, Debug, Hash)]
@@ -19,7 +15,6 @@ fn main() {
     App::new()
         .init_resource::<Game>()
         .add_plugins(DefaultPlugins)
-        .insert_resource(ReportExecutionOrderAmbiguities)
         .add_state(GameState::Playing)
         .add_startup_system(setup_cameras)
         .add_system_set(SystemSet::on_enter(GameState::Playing).with_system(setup))


### PR DESCRIPTION
Related to #4299

# Objective

This is how ambiguities are reported currently.

```
 * Parallel systems:
 -- "bevy_render::camera::camera::camera_system<bevy_render::camera::projection::Projection>" and "bevy_ui::widget::text::text_system"
    conflicts: ["bevy_asset::assets::Assets<bevy_render::texture::image::Image>"]
 -- "bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::OrthographicProjection>" and "bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::PerspectiveProjection>"
    conflicts: ["bevy_render::primitives::Frustum"]
 -- "bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::OrthographicProjection>" and "bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::Projection>"
    conflicts: ["bevy_render::primitives::Frustum"]
 -- "bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::PerspectiveProjection>" and "bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::Projection>"
    conflicts: ["bevy_render::primitives::Frustum"]
 -- "bevy_text::text2d::update_text2d_layout" and "bevy_ui::widget::image::image_node_system"
    conflicts: ["bevy_asset::assets::Assets<bevy_render::texture::image::Image>"]
 -- "bevy_text::text2d::update_text2d_layout" and "bevy_ui::widget::text::text_system"
    conflicts: ["bevy_asset::assets::Assets<bevy_render::texture::image::Image>", "bevy_asset::assets::Assets<bevy_sprite::texture_atlas::TextureAtlas>", "bevy_asset::assets::Assets<bevy_text::font_atlas_set::FontAtlasSet>", "bevy_text::pipeline::TextLayoutInfo", "bevy_text::pipeline::TextPipeline"]
 -- "bevy_ui::widget::image::image_node_system" and "bevy_ui::widget::text::text_system"
    conflicts: ["bevy_asset::assets::Assets<bevy_render::texture::image::Image>", "bevy_ui::ui_node::CalculatedSize"]
```

## Solution

* Group systems that are all ambiguous with one another.
* Break up noise with whitespace.
* Use vertical lists, so names have a consistent horizontal position. This makes scanning for a specific name far easier.
* Assign a number to each ambiguity, to make them easier to discuss in a team.

## Example output

```
(9) Ambiguous system ordering - Parallel systems
 * bevy_text::text2d::update_text2d_layout
 * bevy_ui::widget::text::text_system

 Data access conflicts:
 * bevy_asset::assets::Assets<bevy_render::texture::image::Image>
 * bevy_asset::assets::Assets<bevy_sprite::texture_atlas::TextureAtlas>
 * bevy_asset::assets::Assets<bevy_text::font_atlas_set::FontAtlasSet>
 * bevy_text::pipeline::TextPipeline
 * bevy_text::pipeline::TextLayoutInfo

(10) Ambiguous system ordering - Parallel systems
 * bevy_ui::widget::image::image_node_system
 * bevy_ui::widget::text::text_system

 Data access conflicts:
 * bevy_asset::assets::Assets<bevy_render::texture::image::Image>
 * bevy_ui::ui_node::CalculatedSize

(11) Ambiguous system ordering - Parallel systems
 * bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::OrthographicProjection>
 * bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::PerspectiveProjection>
 * bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::Projection>

 Data access conflicts:
 * bevy_render::primitives::Frustum

(12) Ambiguous system ordering - Parallel systems
 * bevy_pbr::light::assign_lights_to_clusters
 * bevy_pbr::light::update_directional_light_frusta

 Data access conflicts:
 * bevy_render::primitives::Frustum
```