### PR TITLE
Add WindowId to Touch event and move CursorMoved event into bevy_input

### DIFF
--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -17,6 +17,8 @@ bevy_math = { path = "../bevy_math", version = "0.9.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"] }
 bevy_tasks = { path = "../bevy_tasks", version = "0.9.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
+bevy_window = { path = "../bevy_window", version = "0.9.0-dev" }
+bevy_input = { path = "../bevy_input", version = "0.9.0-dev" }
 
 # other
 bytemuck = "1.5"

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -4,6 +4,12 @@
 mod name;
 mod task_pool_options;
 
+pub use bevy_ecs::{
+    event::EventReader,
+    system::{Local, Res, ResMut},
+};
+pub use bevy_input::{keyboard::KeyCode, Input};
+pub use bevy_window::{WindowFocused, WindowId, Windows};
 pub use bytemuck::{bytes_of, cast_slice, Pod, Zeroable};
 pub use name::*;
 pub use task_pool_options::*;
@@ -82,4 +88,27 @@ fn register_math_types(app: &mut App) {
         .register_type::<bevy_math::Mat4>()
         .register_type::<bevy_math::DQuat>()
         .register_type::<bevy_math::Quat>();
+}
+
+/// Close the focused window whenever the escape key (<kbd>Esc</kbd>) is pressed
+///
+/// This is useful for examples or prototyping.
+pub fn close_on_esc(
+    mut focused: Local<Option<WindowId>>,
+    mut focused_events: EventReader<WindowFocused>,
+    mut windows: ResMut<Windows>,
+    input: Res<Input<KeyCode>>,
+) {
+    // TODO: Track this in e.g. a resource to ensure consistent behaviour across similar systems
+    for event in focused_events.iter() {
+        *focused = event.focused.then_some(event.id);
+    }
+
+    if let Some(focused) = &*focused {
+        if input.just_pressed(KeyCode::Escape) {
+            if let Some(window) = windows.get_mut(*focused) {
+                window.close();
+            }
+        }
+    }
 }

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -19,6 +19,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.9.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev" }
+bevy_window = { path = "../bevy_window", version = "0.9.0-dev" }
 
 # other
 serde = { version = "1", features = ["derive"], optional = true }

--- a/crates/bevy_input/src/cursor.rs
+++ b/crates/bevy_input/src/cursor.rs
@@ -1,5 +1,5 @@
-use bevy_window::WindowId;
 use bevy_math::Vec2;
+use bevy_window::WindowId;
 
 /// An event reporting that the mouse cursor has moved on a window.
 ///

--- a/crates/bevy_input/src/cursor.rs
+++ b/crates/bevy_input/src/cursor.rs
@@ -1,0 +1,21 @@
+use bevy_window::WindowId;
+use bevy_math::Vec2;
+
+/// An event reporting that the mouse cursor has moved on a window.
+///
+/// The event is sent only if the cursor is over one of the application's windows.
+/// It is the translated version of [`WindowEvent::CursorMoved`] from the `winit` crate.
+///
+/// Not to be confused with the [`MouseMotion`] event from `bevy_input`.
+///
+/// [`WindowEvent::CursorMoved`]: https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.CursorMoved
+/// [`MouseMotion`]: bevy_input::mouse::MouseMotion
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct CursorMoved {
+    /// The identifier of the window the cursor has moved on.
+    pub id: WindowId,
+
+    /// The position of the cursor, in window coordinates.
+    pub position: Vec2,
+}

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -1,10 +1,10 @@
 mod axis;
+pub mod cursor;
 pub mod gamepad;
 mod input;
 pub mod keyboard;
 pub mod mouse;
 pub mod touch;
-pub mod cursor;
 
 pub use axis::*;
 use bevy_ecs::schedule::{ParallelSystemDescriptorCoercion, SystemLabel};
@@ -25,11 +25,11 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
+use cursor::CursorMoved;
 use keyboard::{keyboard_input_system, KeyCode, KeyboardInput, ScanCode};
 use mouse::{mouse_button_input_system, MouseButton, MouseButtonInput, MouseMotion, MouseWheel};
 use prelude::Gamepads;
 use touch::{touch_screen_input_system, TouchInput, Touches};
-use cursor::CursorMoved;
 
 use gamepad::{
     gamepad_connection_system, gamepad_event_system, GamepadAxis, GamepadButton, GamepadEvent,

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -4,6 +4,7 @@ mod input;
 pub mod keyboard;
 pub mod mouse;
 pub mod touch;
+pub mod cursor;
 
 pub use axis::*;
 use bevy_ecs::schedule::{ParallelSystemDescriptorCoercion, SystemLabel};
@@ -28,6 +29,7 @@ use keyboard::{keyboard_input_system, KeyCode, KeyboardInput, ScanCode};
 use mouse::{mouse_button_input_system, MouseButton, MouseButtonInput, MouseMotion, MouseWheel};
 use prelude::Gamepads;
 use touch::{touch_screen_input_system, TouchInput, Touches};
+use cursor::CursorMoved;
 
 use gamepad::{
     gamepad_connection_system, gamepad_event_system, GamepadAxis, GamepadButton, GamepadEvent,
@@ -83,7 +85,9 @@ impl Plugin for InputPlugin {
             .add_system_to_stage(
                 CoreStage::PreUpdate,
                 touch_screen_input_system.label(InputSystem),
-            );
+            )
+            // cursor
+            .add_event::<CursorMoved>();
     }
 }
 

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -145,7 +145,7 @@ impl Touch {
         self.id
     }
 
-    /// Returns the `window_id` of the touch
+    /// Returns the `window_id` of the touch.
     #[inline]
     pub fn window_id(&self) -> WindowId {
         self.window_id

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -352,6 +352,7 @@ pub fn touch_screen_input_system(
 
 #[cfg(test)]
 mod test {
+    use bevy_window::WindowId;
 
     #[test]
     fn touch_update() {
@@ -368,7 +369,7 @@ mod test {
             previous_force: None,
             position: Vec2::ZERO,
             force: None,
-            window_id: WindowId::new,
+            window_id: WindowId::primary(),
         };
 
         // Add a touch to `just_pressed`, 'just_released', and 'just cancelled'

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -2,6 +2,7 @@ use bevy_ecs::event::EventReader;
 use bevy_ecs::system::{ResMut, Resource};
 use bevy_math::Vec2;
 use bevy_utils::HashMap;
+use bevy_window::WindowId;
 
 /// A touch input event.
 ///
@@ -39,6 +40,8 @@ pub struct TouchInput {
     pub force: Option<ForceTouch>,
     /// The unique identifier of the finger.
     pub id: u64,
+    /// The id of the window that was touched.
+    pub window_id: WindowId,
 }
 
 /// A force description of a [`Touch`](crate::touch::Touch) input.
@@ -121,6 +124,8 @@ pub struct Touch {
     position: Vec2,
     /// The current force of the touch input.
     force: Option<ForceTouch>,
+    /// The id of the window that was touched.
+    window_id: WindowId,
 }
 
 impl Touch {
@@ -138,6 +143,12 @@ impl Touch {
     #[inline]
     pub fn id(&self) -> u64 {
         self.id
+    }
+
+    /// Returns the `window_id` of the touch
+    #[inline]
+    pub fn window_id(&self) -> WindowId {
+        self.window_id
     }
 
     /// Returns the `start_position` of the touch.
@@ -187,6 +198,7 @@ impl From<&TouchInput> for Touch {
             previous_force: input.force,
             position: input.position,
             force: input.force,
+            window_id: input.window_id,
         }
     }
 }
@@ -356,6 +368,7 @@ mod test {
             previous_force: None,
             position: Vec2::ZERO,
             force: None,
+            window_id: WindowId::new,
         };
 
         // Add a touch to `just_pressed`, 'just_released', and 'just cancelled'
@@ -386,6 +399,7 @@ mod test {
             position: Vec2::splat(4.0),
             force: None,
             id: 4,
+            window_id: WindowId::primary(),
         };
 
         touches.update();
@@ -401,6 +415,7 @@ mod test {
             position: Vec2::splat(5.0),
             force: None,
             id: touch_event.id,
+            window_id: WindowId::primary(),
         };
 
         touches.update();
@@ -422,6 +437,7 @@ mod test {
             position: Vec2::ONE,
             force: None,
             id: touch_event.id,
+            window_id: WindowId::primary(),
         };
 
         touches.update();
@@ -437,6 +453,7 @@ mod test {
             position: Vec2::splat(4.0),
             force: None,
             id: 4,
+            window_id: WindowId::primary(),
         };
 
         touches.update();
@@ -459,6 +476,7 @@ mod test {
             position: Vec2::splat(4.0),
             force: None,
             id: 4,
+            window_id: WindowId::primary(),
         };
 
         // Register the touch and test that it was registered correctly
@@ -481,6 +499,7 @@ mod test {
             position: Vec2::splat(4.0),
             force: None,
             id: 4,
+            window_id: WindowId::primary(),
         };
 
         // Register the touch and test that it was registered correctly
@@ -503,6 +522,7 @@ mod test {
             position: Vec2::splat(4.0),
             force: None,
             id: 4,
+            window_id: WindowId::primary(),
         };
 
         // Register the touch and test that it was registered correctly

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -19,8 +19,6 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.9.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
-# Used for close_on_esc
-bevy_input = { path = "../bevy_input", version = "0.9.0-dev" }
 raw-window-handle = "0.4.2"
 
 # other

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use super::{WindowDescriptor, WindowId};
-use bevy_math::{IVec2, Vec2};
+use bevy_math::IVec2;
 
 /// A window event that is sent whenever a window's logical size has changed.
 #[derive(Debug, Clone, PartialEq)]
@@ -64,24 +64,7 @@ pub struct WindowCloseRequested {
 pub struct WindowClosed {
     pub id: WindowId,
 }
-/// An event reporting that the mouse cursor has moved on a window.
-///
-/// The event is sent only if the cursor is over one of the application's windows.
-/// It is the translated version of [`WindowEvent::CursorMoved`] from the `winit` crate.
-///
-/// Not to be confused with the [`MouseMotion`] event from `bevy_input`.
-///
-/// [`WindowEvent::CursorMoved`]: https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.CursorMoved
-/// [`MouseMotion`]: bevy_input::mouse::MouseMotion
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-pub struct CursorMoved {
-    /// The identifier of the window the cursor has moved on.
-    pub id: WindowId,
 
-    /// The position of the cursor, in window coordinates.
-    pub position: Vec2,
-}
 /// An event that is sent whenever the user's cursor enters a window.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -16,7 +16,7 @@ pub use windows::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        CursorEntered, CursorIcon, CursorLeft, CursorMoved, FileDragAndDrop, MonitorSelection,
+        CursorEntered, CursorIcon, CursorLeft, FileDragAndDrop, MonitorSelection,
         ReceivedCharacter, Window, WindowDescriptor, WindowMode, WindowMoved, WindowPosition,
         Windows,
     };
@@ -80,7 +80,6 @@ impl Plugin for WindowPlugin {
             .add_event::<WindowClosed>()
             .add_event::<WindowCloseRequested>()
             .add_event::<RequestRedraw>()
-            .add_event::<CursorMoved>()
             .add_event::<CursorEntered>()
             .add_event::<CursorLeft>()
             .add_event::<ReceivedCharacter>()

--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -1,8 +1,7 @@
-use crate::{Window, WindowCloseRequested, WindowFocused, WindowId, Windows};
+use crate::{Window, WindowCloseRequested, Windows};
 
 use bevy_app::AppExit;
 use bevy_ecs::prelude::*;
-use bevy_input::{keyboard::KeyCode, Input};
 
 /// Exit the application when there are no open windows.
 ///
@@ -30,28 +29,5 @@ pub fn close_when_requested(
 ) {
     for event in closed.iter() {
         windows.get_mut(event.id).map(Window::close);
-    }
-}
-
-/// Close the focused window whenever the escape key (<kbd>Esc</kbd>) is pressed
-///
-/// This is useful for examples or prototyping.
-pub fn close_on_esc(
-    mut focused: Local<Option<WindowId>>,
-    mut focused_events: EventReader<WindowFocused>,
-    mut windows: ResMut<Windows>,
-    input: Res<Input<KeyCode>>,
-) {
-    // TODO: Track this in e.g. a resource to ensure consistent behaviour across similar systems
-    for event in focused_events.iter() {
-        *focused = event.focused.then_some(event.id);
-    }
-
-    if let Some(focused) = &*focused {
-        if input.just_pressed(KeyCode::Escape) {
-            if let Some(window) = windows.get_mut(*focused) {
-                window.close();
-            }
-        }
     }
 }

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -5,7 +5,7 @@ use bevy_input::{
     ButtonState,
 };
 use bevy_math::Vec2;
-use bevy_window::CursorIcon;
+use bevy_window::{CursorIcon, WindowId};
 
 pub fn convert_keyboard_input(keyboard_input: &winit::event::KeyboardInput) -> KeyboardInput {
     KeyboardInput {
@@ -32,6 +32,7 @@ pub fn convert_mouse_button(mouse_button: winit::event::MouseButton) -> MouseBut
 }
 
 pub fn convert_touch_input(
+    source_window_id: WindowId,
     touch_input: winit::event::Touch,
     location: winit::dpi::LogicalPosition<f32>,
 ) -> TouchInput {
@@ -56,6 +57,7 @@ pub fn convert_touch_input(
             winit::event::Force::Normalized(x) => ForceTouch::Normalized(x),
         }),
         id: touch_input.id,
+        window_id: source_window_id,
     }
 }
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -14,10 +14,10 @@ use bevy_ecs::{
     world::World,
 };
 use bevy_input::{
+    cursor::CursorMoved,
     keyboard::KeyboardInput,
     mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
     touch::TouchInput,
-    cursor::CursorMoved
 };
 use bevy_math::{ivec2, DVec2, UVec2, Vec2};
 use bevy_utils::{
@@ -25,10 +25,9 @@ use bevy_utils::{
     Instant,
 };
 use bevy_window::{
-    CreateWindow, CursorEntered, CursorLeft, FileDragAndDrop, ModifiesWindows,
-    ReceivedCharacter, RequestRedraw, WindowBackendScaleFactorChanged, WindowCloseRequested,
-    WindowClosed, WindowCreated, WindowFocused, WindowMoved, WindowResized,
-    WindowScaleFactorChanged, Windows,
+    CreateWindow, CursorEntered, CursorLeft, FileDragAndDrop, ModifiesWindows, ReceivedCharacter,
+    RequestRedraw, WindowBackendScaleFactorChanged, WindowCloseRequested, WindowClosed,
+    WindowCreated, WindowFocused, WindowMoved, WindowResized, WindowScaleFactorChanged, Windows,
 };
 
 use winit::{

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -17,6 +17,7 @@ use bevy_input::{
     keyboard::KeyboardInput,
     mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
     touch::TouchInput,
+    cursor::CursorMoved
 };
 use bevy_math::{ivec2, DVec2, UVec2, Vec2};
 use bevy_utils::{
@@ -24,7 +25,7 @@ use bevy_utils::{
     Instant,
 };
 use bevy_window::{
-    CreateWindow, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, ModifiesWindows,
+    CreateWindow, CursorEntered, CursorLeft, FileDragAndDrop, ModifiesWindows,
     ReceivedCharacter, RequestRedraw, WindowBackendScaleFactorChanged, WindowCloseRequested,
     WindowClosed, WindowCreated, WindowFocused, WindowMoved, WindowResized,
     WindowScaleFactorChanged, Windows,

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -495,7 +495,8 @@ pub fn winit_runner_with(mut app: App) {
                             let window_height = windows.primary().height();
                             location.y = window_height - location.y;
                         }
-                        touch_input_events.send(converters::convert_touch_input(touch, location));
+                        touch_input_events
+                            .send(converters::convert_touch_input(window_id, touch, location));
                     }
                     WindowEvent::ReceivedCharacter(c) => {
                         let mut char_input_events =

--- a/examples/2d/rotation.rs
+++ b/examples/2d/rotation.rs
@@ -16,7 +16,7 @@ fn main() {
                 .with_system(snap_to_player_system)
                 .with_system(rotate_to_player_system),
         )
-        .add_system(bevy::window::close_on_esc)
+        .add_system(bevy::core::close_on_esc)
         .run();
 }
 

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -34,7 +34,7 @@ fn main() {
                 .with_run_criteria(FixedTimestep::step(5.0))
                 .with_system(spawn_bonus),
         )
-        .add_system(bevy::window::close_on_esc)
+        .add_system(bevy::core::close_on_esc)
         .run();
 }
 

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -67,7 +67,7 @@ fn main() {
                 .with_system(play_collision_sound.after(check_for_collisions)),
         )
         .add_system(update_scoreboard)
-        .add_system(bevy::window::close_on_esc)
+        .add_system(bevy::core::close_on_esc)
         .run();
 }
 

--- a/examples/input/mouse_input_events.rs
+++ b/examples/input/mouse_input_events.rs
@@ -1,7 +1,10 @@
 //! Prints all mouse events to the console.
 
 use bevy::{
-    input::{cursor::CursorMoved, mouse::{MouseButtonInput, MouseMotion, MouseWheel}},
+    input::{
+        cursor::CursorMoved,
+        mouse::{MouseButtonInput, MouseMotion, MouseWheel},
+    },
     prelude::*,
 };
 

--- a/examples/input/mouse_input_events.rs
+++ b/examples/input/mouse_input_events.rs
@@ -1,7 +1,7 @@
 //! Prints all mouse events to the console.
 
 use bevy::{
-    input::mouse::{MouseButtonInput, MouseMotion, MouseWheel},
+    input::{cursor::CursorMoved, mouse::{MouseButtonInput, MouseMotion, MouseWheel}},
     prelude::*,
 };
 

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -10,7 +10,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(bevy::window::close_on_esc)
+        .add_system(bevy::core::close_on_esc)
         .run();
 }
 

--- a/tests/window/resizing.rs
+++ b/tests/window/resizing.rs
@@ -34,7 +34,7 @@ fn main() {
         .insert_resource(Phase::ContractingY)
         .add_system(change_window_size)
         .add_system(sync_dimensions)
-        .add_system(bevy::window::close_on_esc)
+        .add_system(bevy::core::close_on_esc)
         .add_startup_system(setup_3d)
         .add_startup_system(setup_2d)
         .run();


### PR DESCRIPTION
## Objective

- Fixes https://github.com/bevyengine/bevy/issues/6011.
- Adds `CursorMoved` event to `bevy_input`, to centralize all input events.

## Solution

- Removed the dependency of `bevy_window` on `bevy_input` by moving the `window::close_on_esc` system to `bevy_core` and then added a `window_id` field to `Touch` events.
- Moved the `CursorMoved` event from `bevy_window` to `bevy_input`.

## Migration Guide

- `bevy::window::close_on_esc` → `bevy::core::close_on_esc`

