### PR TITLE
[Merged by Bors] - Don't use the UIBundle's Transform Fields

### DIFF
--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -30,8 +30,12 @@ pub struct NodeBundle {
     /// Whether this node should block interaction with lower nodes
     pub focus_policy: FocusPolicy,
     /// The transform of the node
+    /// This field is not to be used to set the position of the node inside the NodeBundle.
+    /// Use the [`Style`]'s `position` field to set node position.
     pub transform: Transform,
     /// The global transform of the node
+    /// This field is not to be used to set the position of the node inside the NodeBundle.
+    /// Use the [`Style`]'s `position` field to set node position.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
@@ -57,8 +61,12 @@ pub struct ImageBundle {
     /// Whether this node should block interaction with lower nodes
     pub focus_policy: FocusPolicy,
     /// The transform of the node
+    /// This field is not to be used to set the position of the image inside the ImageBundle.
+    /// Use the [`Style`]'s `position` field to set image position.
     pub transform: Transform,
     /// The global transform of the node
+    /// This field is not to be used to set the position of the image inside the ImageBundle.
+    /// Use the [`Style`]'s `position` field to set image position.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
@@ -84,6 +92,8 @@ pub struct TextBundle {
     /// Use the [`Style`]'s `position` field to set text position.
     pub transform: Transform,
     /// The global transform of the node
+    /// This field is not to be used to set the position of the text inside the TextBundle.
+    /// Use the [`Style`]'s `position` field to set text position.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
@@ -159,8 +169,12 @@ pub struct ButtonBundle {
     /// The image of the node
     pub image: UiImage,
     /// The transform of the node
+    /// This field is not to be used to set the position of the button inside the ButtonBundle.
+    /// Use the [`Style`]'s `position` field to set button position.
     pub transform: Transform,
     /// The global transform of the node
+    /// This field is not to be used to set the position of the button inside the ButtonBundle.
+    /// Use the [`Style`]'s `position` field to set button position.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -81,7 +81,7 @@ pub struct TextBundle {
     pub focus_policy: FocusPolicy,
     /// The transform of the node
     /// This field is not to be used to set the position of the text inside the TextBundle.
-    /// Use the Style's position field to set text position.
+    /// Use the [`Style`]'s `position` field to set text position.
     pub transform: Transform,
     /// The global transform of the node
     pub global_transform: GlobalTransform,

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -30,12 +30,12 @@ pub struct NodeBundle {
     /// Whether this node should block interaction with lower nodes
     pub focus_policy: FocusPolicy,
     /// The transform of the node
-    /// This field is not to be used to set the position of the node inside the NodeBundle.
-    /// Use the [`Style`]'s `position` field to set node position.
+    /// This field is automatically managed by the UI layout system.
+    /// To alter the position of the NodeBundle, use the properties of the Style component.
     pub transform: Transform,
     /// The global transform of the node
-    /// This field is not to be used to set the position of the node inside the NodeBundle.
-    /// Use the [`Style`]'s `position` field to set node position.
+    /// This field is automatically managed by the UI layout system.
+    /// To alter the position of the NodeBundle, use the properties of the Style component.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
@@ -61,12 +61,12 @@ pub struct ImageBundle {
     /// Whether this node should block interaction with lower nodes
     pub focus_policy: FocusPolicy,
     /// The transform of the node
-    /// This field is not to be used to set the position of the image inside the ImageBundle.
-    /// Use the [`Style`]'s `position` field to set image position.
+    /// This field is automatically managed by the UI layout system.
+    /// To alter the position of the NodeBundle, use the properties of the Style component.
     pub transform: Transform,
     /// The global transform of the node
-    /// This field is not to be used to set the position of the image inside the ImageBundle.
-    /// Use the [`Style`]'s `position` field to set image position.
+    /// This field is automatically managed by the UI layout system.
+    /// To alter the position of the NodeBundle, use the properties of the Style component.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
@@ -88,12 +88,12 @@ pub struct TextBundle {
     /// Whether this node should block interaction with lower nodes
     pub focus_policy: FocusPolicy,
     /// The transform of the node
-    /// This field is not to be used to set the position of the text inside the TextBundle.
-    /// Use the [`Style`]'s `position` field to set text position.
+    /// This field is automatically managed by the UI layout system.
+    /// To alter the position of the NodeBundle, use the properties of the Style component.
     pub transform: Transform,
     /// The global transform of the node
-    /// This field is not to be used to set the position of the text inside the TextBundle.
-    /// Use the [`Style`]'s `position` field to set text position.
+    /// This field is automatically managed by the UI layout system.
+    /// To alter the position of the NodeBundle, use the properties of the Style component.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
@@ -169,12 +169,12 @@ pub struct ButtonBundle {
     /// The image of the node
     pub image: UiImage,
     /// The transform of the node
-    /// This field is not to be used to set the position of the button inside the ButtonBundle.
-    /// Use the [`Style`]'s `position` field to set button position.
+    /// This field is automatically managed by the UI layout system.
+    /// To alter the position of the NodeBundle, use the properties of the Style component.
     pub transform: Transform,
     /// The global transform of the node
-    /// This field is not to be used to set the position of the button inside the ButtonBundle.
-    /// Use the [`Style`]'s `position` field to set button position.
+    /// This field is automatically managed by the UI layout system.
+    /// To alter the position of the NodeBundle, use the properties of the Style component.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -32,12 +32,12 @@ pub struct NodeBundle {
     /// The transform of the node
     ///
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
+    /// To alter the position of the `nodebundle`, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
     ///
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
+    /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
@@ -65,12 +65,12 @@ pub struct ImageBundle {
     /// The transform of the node
     ///
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
+    /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
     ///
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
+    /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
@@ -94,12 +94,12 @@ pub struct TextBundle {
     /// The transform of the node
     ///
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
+    /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
     ///
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
+    /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
@@ -177,12 +177,12 @@ pub struct ButtonBundle {
     /// The transform of the node
     ///
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
+    /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
     ///
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
+    /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -80,6 +80,8 @@ pub struct TextBundle {
     /// Whether this node should block interaction with lower nodes
     pub focus_policy: FocusPolicy,
     /// The transform of the node
+    /// This field is not to be used to set the position of the text inside the TextBundle.
+    /// Use the Style's position field to set text position.
     pub transform: Transform,
     /// The global transform of the node
     pub global_transform: GlobalTransform,

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -31,11 +31,11 @@ pub struct NodeBundle {
     pub focus_policy: FocusPolicy,
     /// The transform of the node
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the Style component.
+    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the Style component.
+    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
@@ -62,11 +62,11 @@ pub struct ImageBundle {
     pub focus_policy: FocusPolicy,
     /// The transform of the node
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the Style component.
+    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the Style component.
+    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
@@ -89,11 +89,11 @@ pub struct TextBundle {
     pub focus_policy: FocusPolicy,
     /// The transform of the node
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the Style component.
+    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the Style component.
+    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
@@ -170,11 +170,11 @@ pub struct ButtonBundle {
     pub image: UiImage,
     /// The transform of the node
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the Style component.
+    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
     /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the NodeBundle, use the properties of the Style component.
+    /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -30,10 +30,12 @@ pub struct NodeBundle {
     /// Whether this node should block interaction with lower nodes
     pub focus_policy: FocusPolicy,
     /// The transform of the node
+    ///
     /// This field is automatically managed by the UI layout system.
     /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
+    ///
     /// This field is automatically managed by the UI layout system.
     /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub global_transform: GlobalTransform,
@@ -61,10 +63,12 @@ pub struct ImageBundle {
     /// Whether this node should block interaction with lower nodes
     pub focus_policy: FocusPolicy,
     /// The transform of the node
+    ///
     /// This field is automatically managed by the UI layout system.
     /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
+    ///
     /// This field is automatically managed by the UI layout system.
     /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub global_transform: GlobalTransform,
@@ -88,10 +92,12 @@ pub struct TextBundle {
     /// Whether this node should block interaction with lower nodes
     pub focus_policy: FocusPolicy,
     /// The transform of the node
+    ///
     /// This field is automatically managed by the UI layout system.
     /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
+    ///
     /// This field is automatically managed by the UI layout system.
     /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub global_transform: GlobalTransform,
@@ -169,10 +175,12 @@ pub struct ButtonBundle {
     /// The image of the node
     pub image: UiImage,
     /// The transform of the node
+    ///
     /// This field is automatically managed by the UI layout system.
     /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
+    ///
     /// This field is automatically managed by the UI layout system.
     /// To alter the position of the NodeBundle, use the properties of the [`Style`] component.
     pub global_transform: GlobalTransform,


### PR DESCRIPTION
# Objective

I was working with the TextBundle component bundle because I wanted to change the position of the text that the bundle was holding. I used the transform field on the TextBundle at first because that is normally what controls the position of sprites in Bevy and that's what I was used to working with. 

But the actual way to change the position of text inside of a TextBundle is to use the Style's position field, not the TextBundle's transform field. 

Anecdotally, it was mentioned on the discord that other users have had this issue too. 

## Solution

I added a small doc comment to the TextBundle's transform telling users not to use it to set the position of text. And since this issue applies to the other UI bundles, I added comments there as well! 



