### PR TITLE
implement `Reflect` for `Box<T>` where `T: Reflect`

### DIFF
--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -950,7 +950,7 @@ impl<T: Reflect> Reflect for Box<T> {
     }
 
     fn clone_value(&self) -> Box<dyn Reflect> {
-        todo!("clone value box")
+        Box::new(Wrapper::clone_dynamic(self))
     }
 }
 

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,4 +1,4 @@
-use crate::{self as bevy_reflect, ReflectFromPtr};
+use crate::{self as bevy_reflect, ReflectFromPtr, Wrapper, WrapperInfo};
 use crate::{
     map_apply, map_partial_eq, Array, ArrayInfo, ArrayIter, DynamicEnum, DynamicMap, Enum,
     EnumInfo, FromReflect, FromType, GetTypeRegistration, List, ListInfo, Map, MapInfo, MapIter,
@@ -888,6 +888,85 @@ impl FromReflect for Cow<'static, str> {
                 .downcast_ref::<Cow<'static, str>>()?
                 .clone(),
         )
+    }
+}
+
+impl<T: Reflect> Typed for Box<T> {
+    fn type_info() -> &'static TypeInfo {
+        static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
+        CELL.get_or_set(|| TypeInfo::Wrapper(WrapperInfo::new::<Self, T>()))
+    }
+}
+
+impl<T: Reflect> Reflect for Box<T> {
+    fn type_name(&self) -> &str {
+        std::any::type_name::<Self>()
+    }
+
+    fn get_type_info(&self) -> &'static TypeInfo {
+        <Self as Typed>::type_info()
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn apply(&mut self, value: &dyn Reflect) {
+        match value.reflect_ref() {
+            ReflectRef::Wrapper(wrapper) => {
+                (**self).apply(wrapper.get());
+            }
+            _ => panic!("Value is not a {}.", std::any::type_name::<Self>()),
+        }
+    }
+
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+        *self = value.take::<Self>()?;
+        Ok(())
+    }
+
+    fn reflect_ref(&self) -> ReflectRef {
+        ReflectRef::Wrapper(self)
+    }
+
+    fn reflect_mut(&mut self) -> ReflectMut {
+        ReflectMut::Wrapper(self)
+    }
+
+    fn clone_value(&self) -> Box<dyn Reflect> {
+        todo!("clone value box")
+    }
+}
+
+impl<T: Reflect> Wrapper for Box<T> {
+    fn get(&self) -> &dyn Reflect {
+        &**self
+    }
+
+    fn get_mut(&mut self) -> &mut dyn Reflect {
+        &mut **self
+    }
+}
+
+impl<T: Reflect> GetTypeRegistration for Box<T> {
+    fn get_type_registration() -> TypeRegistration {
+        TypeRegistration::of::<Self>()
     }
 }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -12,6 +12,8 @@ mod tuple_struct;
 mod type_info;
 mod type_registry;
 mod type_uuid;
+mod wrapper;
+
 mod impls {
     #[cfg(feature = "glam")]
     mod glam;
@@ -58,6 +60,7 @@ pub use tuple_struct::*;
 pub use type_info::*;
 pub use type_registry::*;
 pub use type_uuid::*;
+pub use wrapper::*;
 
 pub use bevy_reflect_derive::*;
 pub use erased_serde;

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -1,7 +1,7 @@
 use crate::{
     array_debug, enum_debug, list_debug, map_debug, serde::Serializable, struct_debug, tuple_debug,
     tuple_struct_debug, Array, Enum, List, Map, Struct, Tuple, TupleStruct, TypeInfo, Typed,
-    ValueInfo,
+    ValueInfo, Wrapper,
 };
 use std::{
     any::{self, Any, TypeId},
@@ -24,6 +24,7 @@ pub enum ReflectRef<'a> {
     List(&'a dyn List),
     Array(&'a dyn Array),
     Map(&'a dyn Map),
+    Wrapper(&'a dyn Wrapper),
     Enum(&'a dyn Enum),
     Value(&'a dyn Reflect),
 }
@@ -42,6 +43,7 @@ pub enum ReflectMut<'a> {
     Array(&'a mut dyn Array),
     Map(&'a mut dyn Map),
     Enum(&'a mut dyn Enum),
+    Wrapper(&'a mut dyn Wrapper),
     Value(&'a mut dyn Reflect),
 }
 

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -361,6 +361,7 @@ impl<'a, 'de> DeserializeSeed<'de> for TypedReflectDeserializer<'a> {
                 dynamic_enum.set_name(type_name.to_string());
                 Ok(Box::new(dynamic_enum))
             }
+            TypeInfo::Wrapper(_wrapper_info) => todo!("wrapper deserialize"),
             TypeInfo::Value(_) => {
                 // This case should already be handled
                 Err(de::Error::custom(format_args!(

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -156,6 +156,7 @@ impl<'a> Serialize for TypedReflectSerializer<'a> {
                 registry: self.registry,
             }
             .serialize(serializer),
+            ReflectRef::Wrapper(_) => todo!("serialize wrapper"),
             ReflectRef::Value(_) => Err(serializable.err().unwrap()),
         }
     }

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -1,5 +1,6 @@
 use crate::{
     ArrayInfo, EnumInfo, ListInfo, MapInfo, Reflect, StructInfo, TupleInfo, TupleStructInfo,
+    WrapperInfo,
 };
 use std::any::{Any, TypeId};
 
@@ -102,6 +103,7 @@ pub enum TypeInfo {
     Array(ArrayInfo),
     Map(MapInfo),
     Enum(EnumInfo),
+    Wrapper(WrapperInfo),
     Value(ValueInfo),
     /// Type information for "dynamic" types whose metadata can't be known at compile-time.
     ///
@@ -120,6 +122,7 @@ impl TypeInfo {
             Self::Array(info) => info.type_id(),
             Self::Map(info) => info.type_id(),
             Self::Enum(info) => info.type_id(),
+            Self::Wrapper(info) => info.type_id(),
             Self::Value(info) => info.type_id(),
             Self::Dynamic(info) => info.type_id(),
         }
@@ -137,6 +140,7 @@ impl TypeInfo {
             Self::Array(info) => info.type_name(),
             Self::Map(info) => info.type_name(),
             Self::Enum(info) => info.type_name(),
+            Self::Wrapper(info) => info.type_name(),
             Self::Value(info) => info.type_name(),
             Self::Dynamic(info) => info.type_name(),
         }

--- a/crates/bevy_reflect/src/wrapper.rs
+++ b/crates/bevy_reflect/src/wrapper.rs
@@ -1,10 +1,20 @@
 use std::any::{Any, TypeId};
 
-use crate::Reflect;
+use crate::{
+    utility::NonGenericTypeInfoCell, DynamicInfo, Reflect, ReflectMut, ReflectRef, TypeInfo, Typed,
+};
 
 pub trait Wrapper: Reflect {
     fn get(&self) -> &dyn Reflect;
+
     fn get_mut(&mut self) -> &mut dyn Reflect;
+
+    fn clone_dynamic(&self) -> DynamicWrapper {
+        DynamicWrapper {
+            name: self.type_name().to_string(),
+            value: self.get().clone_value(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -58,5 +68,115 @@ impl WrapperInfo {
     /// Check if the given type matches the wrapper inner type.
     pub fn inner_is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.inner_type_id
+    }
+}
+
+pub struct DynamicWrapper {
+    name: String,
+    value: Box<dyn Reflect>,
+}
+impl DynamicWrapper {
+    /// Returns the type name of the wrapper.
+    ///
+    /// The value returned by this method is the same value returned by
+    /// [`Reflect::type_name`].
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Sets the type name of the wrapper.
+    ///
+    /// The value set by this method is the value returned by
+    /// [`Reflect::type_name`].
+    pub fn set_name(&mut self, name: String) {
+        self.name = name;
+    }
+
+    /// Appends an element with value `value` to the tuple struct.
+    pub fn insert_boxed(&mut self, value: Box<dyn Reflect>) {
+        self.value = value;
+    }
+
+    /// Appends a typed element with value `value` to the tuple struct.
+    pub fn insert<T: Reflect>(&mut self, value: T) {
+        self.insert_boxed(Box::new(value));
+    }
+}
+
+impl Wrapper for DynamicWrapper {
+    fn get(&self) -> &dyn Reflect {
+        &*self.value
+    }
+
+    fn get_mut(&mut self) -> &mut dyn Reflect {
+        &mut *self.value
+    }
+
+    fn clone_dynamic(&self) -> DynamicWrapper {
+        DynamicWrapper {
+            name: self.name.clone(),
+            value: self.value.clone_value(),
+        }
+    }
+}
+
+impl Typed for DynamicWrapper {
+    fn type_info() -> &'static TypeInfo {
+        static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
+        CELL.get_or_set(|| TypeInfo::Dynamic(DynamicInfo::new::<Self>()))
+    }
+}
+
+impl Reflect for DynamicWrapper {
+    fn type_name(&self) -> &str {
+        self.name()
+    }
+
+    fn get_type_info(&self) -> &'static crate::TypeInfo {
+        <Self as Typed>::type_info()
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn apply(&mut self, value: &dyn Reflect) {
+        match value.reflect_ref() {
+            ReflectRef::Wrapper(wrapper) => self.get_mut().apply(wrapper.get()),
+            _ => panic!("Attempted to apply a non-wrapper type to a wrapper type."),
+        }
+    }
+
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+        *self = value.take()?;
+        Ok(())
+    }
+
+    fn reflect_ref(&self) -> ReflectRef {
+        ReflectRef::Wrapper(self)
+    }
+
+    fn reflect_mut(&mut self) -> ReflectMut {
+        ReflectMut::Wrapper(self)
+    }
+
+    fn clone_value(&self) -> Box<dyn Reflect> {
+        Box::new(Wrapper::clone_dynamic(self))
     }
 }

--- a/crates/bevy_reflect/src/wrapper.rs
+++ b/crates/bevy_reflect/src/wrapper.rs
@@ -1,6 +1,6 @@
 use std::any::{Any, TypeId};
 
-use crate::{FromReflect, Reflect};
+use crate::Reflect;
 
 pub trait Wrapper: Reflect {
     fn get(&self) -> &dyn Reflect;
@@ -17,12 +17,12 @@ pub struct WrapperInfo {
 
 impl WrapperInfo {
     /// Create a new [`WrapperInfo`].
-    pub fn new<TWrapper: Wrapper, Tinner: FromReflect>() -> Self {
+    pub fn new<TWrapper: Wrapper, TInner: 'static>() -> Self {
         Self {
             type_name: std::any::type_name::<TWrapper>(),
             type_id: TypeId::of::<TWrapper>(),
-            inner_type_name: std::any::type_name::<Tinner>(),
-            inner_type_id: TypeId::of::<Tinner>(),
+            inner_type_name: std::any::type_name::<TInner>(),
+            inner_type_id: TypeId::of::<TInner>(),
         }
     }
 

--- a/crates/bevy_reflect/src/wrapper.rs
+++ b/crates/bevy_reflect/src/wrapper.rs
@@ -1,0 +1,62 @@
+use std::any::{Any, TypeId};
+
+use crate::{FromReflect, Reflect};
+
+pub trait Wrapper: Reflect {
+    fn get(&self) -> &dyn Reflect;
+    fn get_mut(&mut self) -> &mut dyn Reflect;
+}
+
+#[derive(Clone, Debug)]
+pub struct WrapperInfo {
+    type_name: &'static str,
+    type_id: TypeId,
+    inner_type_name: &'static str,
+    inner_type_id: TypeId,
+}
+
+impl WrapperInfo {
+    /// Create a new [`WrapperInfo`].
+    pub fn new<TWrapper: Wrapper, Tinner: FromReflect>() -> Self {
+        Self {
+            type_name: std::any::type_name::<TWrapper>(),
+            type_id: TypeId::of::<TWrapper>(),
+            inner_type_name: std::any::type_name::<Tinner>(),
+            inner_type_id: TypeId::of::<Tinner>(),
+        }
+    }
+
+    /// The [type name] of the wrapper.
+    ///
+    /// [type name]: std::any::type_name
+    pub fn type_name(&self) -> &'static str {
+        self.type_name
+    }
+
+    /// The [`TypeId`] of the wrapper.
+    pub fn type_id(&self) -> TypeId {
+        self.type_id
+    }
+
+    /// Check if the given type matches the wrapper type.
+    pub fn is<T: Any>(&self) -> bool {
+        TypeId::of::<T>() == self.type_id
+    }
+
+    /// The [type name] of the inner type.
+    ///
+    /// [type name]: std::any::type_name
+    pub fn inner_type_name(&self) -> &'static str {
+        self.inner_type_name
+    }
+
+    /// The [`TypeId`] of the inner type.
+    pub fn inner_type_id(&self) -> TypeId {
+        self.inner_type_id
+    }
+
+    /// Check if the given type matches the wrapper inner type.
+    pub fn inner_is<T: Any>(&self) -> bool {
+        TypeId::of::<T>() == self.inner_type_id
+    }
+}

--- a/crates/bevy_reflect/src/wrapper.rs
+++ b/crates/bevy_reflect/src/wrapper.rs
@@ -76,6 +76,10 @@ pub struct DynamicWrapper {
     value: Box<dyn Reflect>,
 }
 impl DynamicWrapper {
+    pub fn new(name: String, value: Box<dyn Reflect>) -> DynamicWrapper {
+        DynamicWrapper { name, value }
+    }
+
     /// Returns the type name of the wrapper.
     ///
     /// The value returned by this method is the same value returned by


### PR DESCRIPTION
TODO: write the PR description

# Objective

- it would be nice to be able to reflect types containing `Box<T>` where `T` implements reflect

## Solution

- TODO: describe why `Wrapper` is introduced instead of passing everything through the inner value