### PR TITLE
[Merged by Bors] - fix #6062 incorrect links for render module docs

### DIFF
--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -136,9 +136,9 @@ pub mod pbr {
 #[cfg(feature = "bevy_render")]
 pub mod render {
     //! Cameras, meshes, textures, shaders, and pipelines.
-    //! Use [`RenderDevice::features`](bevy_render::renderer::RenderDevice::features),
-    //! [`RenderDevice::limits`](bevy_render::renderer::RenderDevice::limits), and the
-    //! [`WgpuAdapterInfo`](bevy_render::render_resource::WgpuAdapterInfo) resource to
+    //! Use [`RenderDevice::features`](crate::render::renderer::RenderDevice::features),
+    //! [`RenderDevice::limits`](crate::render::renderer::RenderDevice::limits), and the
+    //! [`WgpuAdapterInfo`](crate::render::render_resource::WgpuAdapterInfo) resource to
     //! get runtime information about the actual adapter, backend, features, and limits.
     pub use bevy_render::*;
 }


### PR DESCRIPTION
# Objective

- Fixes #6062

## Solution

- Change path to `(crate::render::renderer)` from `(bevy_render::renderer)` in `crates/bevy_internal/src/lib.rs`

---