### PR TITLE
[Merged by Bors] - log pipeline cache errors earlier

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -625,7 +625,10 @@ impl PipelineCache {
             if let CachedPipelineState::Err(err) = &pipeline.state {
                 match err {
                     PipelineCacheError::ShaderNotLoaded(_)
-                    | PipelineCacheError::ShaderImportNotYetAvailable => { /* retry */ }
+                    | PipelineCacheError::ShaderImportNotYetAvailable => {
+                        // retry
+                        self.waiting_pipelines.insert(id);
+                    }
                     // shader could not be processed ... retrying won't help
                     PipelineCacheError::ProcessShaderError(err) => {
                         error!("failed to process shader: {}", err);
@@ -640,7 +643,6 @@ impl PipelineCache {
                         continue;
                     }
                 }
-                self.waiting_pipelines.insert(id);
             }
         }
 

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -609,7 +609,7 @@ impl PipelineCache {
 
         for id in waiting_pipelines {
             let pipeline = &mut pipelines[id];
-            if let CachedPipelineState::Ok(_) = pipeline.state {
+            if matches!(pipeline.state, CachedPipelineState::Ok(_)) {
                 continue;
             }
 


### PR DESCRIPTION
# Objective

- Currently, errors aren't logged as soon as they are found, they are logged only on the next frame. This means your shader could have an unreported error that could have been reported on the first frame.

## Solution

- Log the error as soon as they are found, don't wait until next frame

## Notes

I discovered this issue because I was simply unwrapping the `Result` from `PipelinCache::get_render_pipeline()` which caused it to fail without any explanations. Admittedly, this was a bit of a user error, I shouldn't have unwrapped that, but it seems a bit strange to wait until the next time the pipeline is processed to log the error instead of just logging it as soon as possible since we already have all the info necessary.