### PR TITLE
[Merged by Bors] - tick local executor

### DIFF
--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -20,3 +20,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
 
 # other
 bytemuck = "1.5"
+
+[dev-dependencies]
+crossbeam-channel = "0.5.0"

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -4,7 +4,6 @@
 mod name;
 mod task_pool_options;
 
-use bevy_ecs::schedule::IntoSystemDescriptor;
 use bevy_ecs::system::Resource;
 pub use bytemuck::{bytes_of, cast_slice, Pod, Zeroable};
 pub use name::*;
@@ -18,10 +17,14 @@ pub mod prelude {
 
 use bevy_app::prelude::*;
 use bevy_ecs::entity::Entity;
-use bevy_tasks::prelude::tick_global_task_pools_on_main_thread;
 use bevy_utils::{Duration, HashSet, Instant};
 use std::borrow::Cow;
 use std::ops::Range;
+
+#[cfg(not(target_arch = "wasm32"))]
+use bevy_ecs::schedule::IntoSystemDescriptor;
+#[cfg(not(target_arch = "wasm32"))]
+use bevy_tasks::tick_global_task_pools_on_main_thread;
 
 /// Adds core functionality to Apps.
 #[derive(Default)]
@@ -36,6 +39,7 @@ impl Plugin for CorePlugin {
             .unwrap_or_default()
             .create_default_pools();
 
+        #[cfg(not(target_arch = "wasm32"))]
         app.add_system_to_stage(
             bevy_app::CoreStage::Last,
             tick_global_task_pools_on_main_thread.at_end(),

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -6,7 +6,6 @@ mod task_pool_options;
 
 use bevy_ecs::schedule::IntoSystemDescriptor;
 use bevy_ecs::system::Resource;
-use bevy_ecs::world::World;
 pub use bytemuck::{bytes_of, cast_slice, Pod, Zeroable};
 pub use name::*;
 pub use task_pool_options::*;
@@ -37,12 +36,10 @@ impl Plugin for CorePlugin {
             .unwrap_or_default()
             .create_default_pools();
 
-        // run function in an exclusive system to make sure it runs on main thread
-        fn tick_local_executors(_world: &mut World) {
-            tick_global_task_pools_on_main_thread();
-        }
-
-        app.add_system_to_stage(bevy_app::CoreStage::Last, tick.at_end());
+        app.add_system_to_stage(
+            bevy_app::CoreStage::Last,
+            tick_global_task_pools_on_main_thread.at_end(),
+        );
 
         app.register_type::<Entity>().register_type::<Name>();
 

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -18,6 +18,8 @@ mod single_threaded_task_pool;
 pub use single_threaded_task_pool::{Scope, TaskPool, TaskPoolBuilder};
 
 mod usages;
+#[cfg(not(target_arch = "wasm32"))]
+pub use usages::tick_global_task_pools_on_main_thread;
 pub use usages::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool};
 
 mod iter;
@@ -29,10 +31,7 @@ pub mod prelude {
     pub use crate::{
         iter::ParallelIterator,
         slice::{ParallelSlice, ParallelSliceMut},
-        usages::{
-            tick_global_task_pools_on_main_thread, AsyncComputeTaskPool, ComputeTaskPool,
-            IoTaskPool,
-        },
+        usages::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool},
     };
 }
 

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -29,7 +29,10 @@ pub mod prelude {
     pub use crate::{
         iter::ParallelIterator,
         slice::{ParallelSlice, ParallelSliceMut},
-        usages::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool},
+        usages::{
+            tick_global_task_pools_on_main_thread, AsyncComputeTaskPool, ComputeTaskPool,
+            IoTaskPool,
+        },
     };
 }
 

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -223,75 +223,71 @@ impl TaskPool {
         F: for<'scope> FnOnce(&'scope Scope<'scope, 'env, T>),
         T: Send + 'static,
     {
-        TaskPool::LOCAL_EXECUTOR.with(|local_executor| {
-            // SAFETY: This safety comment applies to all references transmuted to 'env.
-            // Any futures spawned with these references need to return before this function completes.
-            // This is guaranteed because we drive all the futures spawned onto the Scope
-            // to completion in this function. However, rust has no way of knowing this so we
-            // transmute the lifetimes to 'env here to appease the compiler as it is unable to validate safety.
-            let executor: &async_executor::Executor = &*self.executor;
-            let executor: &'env async_executor::Executor = unsafe { mem::transmute(executor) };
-            let task_scope_executor = &async_executor::Executor::default();
-            let task_scope_executor: &'env async_executor::Executor =
-                unsafe { mem::transmute(task_scope_executor) };
-            let spawned: ConcurrentQueue<async_executor::Task<T>> = ConcurrentQueue::unbounded();
-            let spawned_ref: &'env ConcurrentQueue<async_executor::Task<T>> =
-                unsafe { mem::transmute(&spawned) };
+        // SAFETY: This safety comment applies to all references transmuted to 'env.
+        // Any futures spawned with these references need to return before this function completes.
+        // This is guaranteed because we drive all the futures spawned onto the Scope
+        // to completion in this function. However, rust has no way of knowing this so we
+        // transmute the lifetimes to 'env here to appease the compiler as it is unable to validate safety.
+        let executor: &async_executor::Executor = &*self.executor;
+        let executor: &'env async_executor::Executor = unsafe { mem::transmute(executor) };
+        let task_scope_executor = &async_executor::Executor::default();
+        let task_scope_executor: &'env async_executor::Executor =
+            unsafe { mem::transmute(task_scope_executor) };
+        let spawned: ConcurrentQueue<async_executor::Task<T>> = ConcurrentQueue::unbounded();
+        let spawned_ref: &'env ConcurrentQueue<async_executor::Task<T>> =
+            unsafe { mem::transmute(&spawned) };
 
-            let scope = Scope {
-                executor,
-                task_scope_executor,
-                spawned: spawned_ref,
-                scope: PhantomData,
-                env: PhantomData,
+        let scope = Scope {
+            executor,
+            task_scope_executor,
+            spawned: spawned_ref,
+            scope: PhantomData,
+            env: PhantomData,
+        };
+
+        let scope_ref: &'env Scope<'_, 'env, T> = unsafe { mem::transmute(&scope) };
+
+        f(scope_ref);
+
+        if spawned.is_empty() {
+            Vec::new()
+        } else {
+            let get_results = async move {
+                let mut results = Vec::with_capacity(spawned.len());
+                while let Ok(task) = spawned.pop() {
+                    results.push(task.await);
+                }
+
+                results
             };
 
-            let scope_ref: &'env Scope<'_, 'env, T> = unsafe { mem::transmute(&scope) };
+            // Pin the futures on the stack.
+            pin!(get_results);
 
-            f(scope_ref);
+            // SAFETY: This function blocks until all futures complete, so we do not read/write
+            // the data from futures outside of the 'scope lifetime. However,
+            // rust has no way of knowing this so we must convert to 'static
+            // here to appease the compiler as it is unable to validate safety.
+            let get_results: Pin<&mut (dyn Future<Output = Vec<T>> + 'static + Send)> = get_results;
+            let get_results: Pin<&'static mut (dyn Future<Output = Vec<T>> + 'static + Send)> =
+                unsafe { mem::transmute(get_results) };
 
-            if spawned.is_empty() {
-                Vec::new()
-            } else {
-                let get_results = async move {
-                    let mut results = Vec::with_capacity(spawned.len());
-                    while let Ok(task) = spawned.pop() {
-                        results.push(task.await);
-                    }
+            // The thread that calls scope() will participate in driving tasks in the pool
+            // forward until the tasks that are spawned by this scope() call
+            // complete. (If the caller of scope() happens to be a thread in
+            // this thread pool, and we only have one thread in the pool, then
+            // simply calling future::block_on(spawned) would deadlock.)
+            let mut spawned = task_scope_executor.spawn(get_results);
 
-                    results
+            loop {
+                if let Some(result) = future::block_on(future::poll_once(&mut spawned)) {
+                    break result;
                 };
 
-                // Pin the futures on the stack.
-                pin!(get_results);
-
-                // SAFETY: This function blocks until all futures complete, so we do not read/write
-                // the data from futures outside of the 'scope lifetime. However,
-                // rust has no way of knowing this so we must convert to 'static
-                // here to appease the compiler as it is unable to validate safety.
-                let get_results: Pin<&mut (dyn Future<Output = Vec<T>> + 'static + Send)> =
-                    get_results;
-                let get_results: Pin<&'static mut (dyn Future<Output = Vec<T>> + 'static + Send)> =
-                    unsafe { mem::transmute(get_results) };
-
-                // The thread that calls scope() will participate in driving tasks in the pool
-                // forward until the tasks that are spawned by this scope() call
-                // complete. (If the caller of scope() happens to be a thread in
-                // this thread pool, and we only have one thread in the pool, then
-                // simply calling future::block_on(spawned) would deadlock.)
-                let mut spawned = task_scope_executor.spawn(get_results);
-
-                loop {
-                    if let Some(result) = future::block_on(future::poll_once(&mut spawned)) {
-                        break result;
-                    };
-
-                    self.executor.try_tick();
-                    task_scope_executor.try_tick();
-                    local_executor.try_tick();
-                }
+                self.executor.try_tick();
+                task_scope_executor.try_tick();
             }
-        })
+        }
     }
 
     /// Spawns a static future onto the thread pool. The returned Task is a future. It can also be

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -317,6 +317,24 @@ impl TaskPool {
     {
         Task::new(TaskPool::LOCAL_EXECUTOR.with(|executor| executor.spawn(future)))
     }
+
+    /// Runs a function with the local executor. Typically used to tick
+    /// the local executor on the main thread as it needs to share time with
+    /// other things.
+    ///
+    /// ```rust
+    /// use bevy_tasks::TaskPool;
+    ///
+    /// TaskPool::new().with_local_executor(|local_executor| {
+    ///     local_executor.try_tick();
+    /// });
+    /// ```
+    pub fn with_local_executor<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&async_executor::LocalExecutor) -> R,
+    {
+        Self::LOCAL_EXECUTOR.with(f)
+    }
 }
 
 impl Default for TaskPool {

--- a/crates/bevy_tasks/src/usages.rs
+++ b/crates/bevy_tasks/src/usages.rs
@@ -112,6 +112,7 @@ impl Deref for IoTaskPool {
 
 /// Used by `bevy_core` to tick the global tasks pools on the main thread.
 /// This will run a maximum of 100 local tasks per executor per call to this function.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn tick_global_task_pools_on_main_thread() {
     COMPUTE_TASK_POOL
         .get()

--- a/crates/bevy_tasks/src/usages.rs
+++ b/crates/bevy_tasks/src/usages.rs
@@ -109,3 +109,27 @@ impl Deref for IoTaskPool {
         &self.0
     }
 }
+
+/// Used by `bevy_app` to tick the global tasks pools on the main thread.
+pub fn tick_global_task_pools_on_main_thread() {
+    COMPUTE_TASK_POOL
+        .get()
+        .unwrap()
+        .with_local_executor(|compute_local_executor| {
+            ASYNC_COMPUTE_TASK_POOL
+                .get()
+                .unwrap()
+                .with_local_executor(|async_local_executor| {
+                    IO_TASK_POOL
+                        .get()
+                        .unwrap()
+                        .with_local_executor(|io_local_executor| {
+                            for _ in 0..20 {
+                                compute_local_executor.try_tick();
+                                async_local_executor.try_tick();
+                                io_local_executor.try_tick();
+                            }
+                        });
+                });
+        });
+}

--- a/crates/bevy_tasks/src/usages.rs
+++ b/crates/bevy_tasks/src/usages.rs
@@ -110,7 +110,8 @@ impl Deref for IoTaskPool {
     }
 }
 
-/// Used by `bevy_app` to tick the global tasks pools on the main thread.
+/// Used by `bevy_core` to tick the global tasks pools on the main thread.
+/// This will run a maximum of 100 local tasks per executor per call to this function.
 pub fn tick_global_task_pools_on_main_thread() {
     COMPUTE_TASK_POOL
         .get()
@@ -124,7 +125,7 @@ pub fn tick_global_task_pools_on_main_thread() {
                         .get()
                         .unwrap()
                         .with_local_executor(|io_local_executor| {
-                            for _ in 0..20 {
+                            for _ in 0..100 {
                                 compute_local_executor.try_tick();
                                 async_local_executor.try_tick();
                                 io_local_executor.try_tick();


### PR DESCRIPTION
# Objective

- #4466 broke local tasks running.
- Fixes https://github.com/bevyengine/bevy/issues/6120

## Solution

- Add system for ticking local executors on main thread into bevy_core where the tasks pools are initialized.
- Add ticking local executors into thread executors

## Changelog

- tick all thread local executors in task pool.

## Notes

- ~~Not 100% sure about this PR. Ticking the local executor for the main thread in scope feels a little kludgy as it requires users of bevy_tasks to be calling scope periodically for those tasks to make progress.~~ took this out in favor of a system that ticks the local executors.