### PR TITLE
[Merged by Bors] - Remove `Transform::apply_non_uniform_scale`

### DIFF
--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -346,13 +346,6 @@ impl Transform {
         value += self.translation;
         value
     }
-
-    /// Changes the `scale` of this [`Transform`], multiplying the current `scale` by
-    /// `scale_factor`.
-    #[inline]
-    pub fn apply_non_uniform_scale(&mut self, scale_factor: Vec3) {
-        self.scale *= scale_factor;
-    }
 }
 
 impl Default for Transform {


### PR DESCRIPTION
This is a holdover from back when `Transform` was backed by a private `Mat4` two years ago.
Not particularly useful anymore :)

## Migration Guide
`Transform::apply_non_uniform_scale` has been removed.
It can be replaced with the following snippet:
```rust
transform.scale *= scale_factor;
```
