### PR TITLE
Implemented support for creating a render surface from a canvas or offscreencanvas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1548,6 +1548,13 @@ path = "tests/window/minimising.rs"
 hidden = true
 
 [[example]]
+name = "virtual"
+path = "examples/window/virtual.rs"
+
+[package.metadata.example.virtual]
+hidden = true
+
+[[example]]
 name = "window_resizing"
 path = "examples/window/window_resizing.rs"
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -154,6 +154,14 @@ impl Plugin for RenderPlugin {
                             Some(instance.create_surface(&handle.get_handle()))
                         }
                         AbstractWindowHandle::Virtual => None,
+                        #[cfg(target_arch = "wasm32")]
+                        AbstractWindowHandle::HtmlCanvas(canvas) => {
+                            Some(instance.create_surface_from_canvas(&canvas))
+                        }
+                        #[cfg(target_arch = "wasm32")]
+                        AbstractWindowHandle::OffscreenCanvas(canvas) => {
+                            Some(instance.create_surface_from_offscreen_canvas(&canvas))
+                        }
                     }
                 });
                 raw_handle

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -173,6 +173,16 @@ pub fn prepare_windows(
                     // NOTE: On some OSes this MUST be called from the main thread.
                     render_instance.create_surface(&handle.get_handle())
                 }),
+            #[cfg(target_arch = "wasm32")]
+            AbstractWindowHandle::HtmlCanvas(canvas) => window_surfaces
+                .surfaces
+                .entry(window.id)
+                .or_insert_with(|| render_instance.create_surface_from_canvas(canvas)),
+            #[cfg(target_arch = "wasm32")]
+            AbstractWindowHandle::OffscreenCanvas(canvas) => window_surfaces
+                .surfaces
+                .entry(window.id)
+                .or_insert_with(|| render_instance.create_surface_from_offscreen_canvas(canvas)),
             AbstractWindowHandle::Virtual => continue,
         };
 

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -28,3 +28,4 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = "0.3"
+wasm-bindgen = "0.2"

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -24,9 +24,9 @@ use bevy_utils::{
     Instant,
 };
 use bevy_window::{
-    CreateWindow, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, ModifiesWindows,
-    ReceivedCharacter, RequestRedraw, WindowBackendScaleFactorChanged, WindowCloseRequested,
-    WindowClosed, WindowCreated, WindowFocused, WindowMoved, WindowResized,
+    AbstractWindowHandle, CreateWindow, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop,
+    ModifiesWindows, ReceivedCharacter, RequestRedraw, WindowBackendScaleFactorChanged,
+    WindowCloseRequested, WindowClosed, WindowCreated, WindowFocused, WindowMoved, WindowResized,
     WindowScaleFactorChanged, Windows,
 };
 
@@ -709,12 +709,16 @@ fn handle_create_window_events(
         {
             let channel = world.resource_mut::<web_resize::CanvasParentResizeEventChannel>();
             if create_window_event.descriptor.fit_canvas_to_parent {
-                let selector = if let Some(selector) = &create_window_event.descriptor.canvas {
-                    selector
+                if let AbstractWindowHandle::HtmlCanvas(canvas) = window.window_handle {
+                    // PROBLEM: this path is unreachable, because we're always creating the window
+                    // based on the raw window handle above.
+                    channel.listen_to_element(create_window_event.id, canvas.clone());
                 } else {
-                    web_resize::WINIT_CANVAS_SELECTOR
-                };
-                channel.listen_to_selector(create_window_event.id, selector);
+                    channel.listen_to_selector(
+                        create_window_event.id,
+                        web_resize::WINIT_CANVAS_SELECTOR,
+                    );
+                }
             }
         }
     }

--- a/crates/bevy_winit/src/web_resize.rs
+++ b/crates/bevy_winit/src/web_resize.rs
@@ -58,7 +58,7 @@ impl Default for CanvasParentResizeEventChannel {
     }
 }
 
-fn get_size_element(element: &HtmlCanvasElement) -> Option<LogicalSize<f32>> {
+fn get_size_element(element: &web_sys::HtmlCanvasElement) -> Option<LogicalSize<f32>> {
     let parent_element = element.parent_element()?;
     let rect = parent_element.get_bounding_client_rect();
     return Some(winit::dpi::LogicalSize::new(
@@ -91,7 +91,11 @@ impl CanvasParentResizeEventChannel {
         closure.forget();
     }
 
-    pub(crate) fn listen_to_element(&self, window_id: WindowId, element: HtmlCanvasElement) {
+    pub(crate) fn listen_to_element(
+        &self,
+        window_id: WindowId,
+        element: web_sys::HtmlCanvasElement,
+    ) {
         let sender = self.sender.clone();
         let resize = move || {
             if let Some(size) = get_size_element(&element) {

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -93,26 +93,6 @@ impl WinitWindows {
         #[allow(unused_mut)]
         let mut winit_window_builder = winit_window_builder.with_title(&window_descriptor.title);
 
-        #[cfg(target_arch = "wasm32")]
-        {
-            use wasm_bindgen::JsCast;
-            use winit::platform::web::WindowBuilderExtWebSys;
-
-            if let Some(selector) = &window_descriptor.canvas {
-                let window = web_sys::window().unwrap();
-                let document = window.document().unwrap();
-                let canvas = document
-                    .query_selector(&selector)
-                    .expect("Cannot query for canvas element.");
-                if let Some(canvas) = canvas {
-                    let canvas = canvas.dyn_into::<web_sys::HtmlCanvasElement>().ok();
-                    winit_window_builder = winit_window_builder.with_canvas(canvas);
-                } else {
-                    panic!("Cannot find element: {}.", selector);
-                }
-            }
-        }
-
         let winit_window = winit_window_builder.build(event_loop).unwrap();
 
         if window_descriptor.mode == WindowMode::Windowed {
@@ -174,16 +154,14 @@ impl WinitWindows {
         {
             use winit::platform::web::WindowExtWebSys;
 
-            if window_descriptor.canvas.is_none() {
-                let canvas = winit_window.canvas();
+            let canvas = winit_window.canvas();
 
-                let window = web_sys::window().unwrap();
-                let document = window.document().unwrap();
-                let body = document.body().unwrap();
+            let window = web_sys::window().unwrap();
+            let document = window.document().unwrap();
+            let body = document.body().unwrap();
 
-                body.append_child(&canvas)
-                    .expect("Append canvas to HTML body.");
-            }
+            body.append_child(&canvas)
+                .expect("Append canvas to HTML body.");
         }
 
         let position = winit_window

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -201,7 +201,7 @@ impl WinitWindows {
             inner_size.height,
             scale_factor,
             position,
-            Some(raw_window_handle),
+            raw_window_handle,
         )
     }
 

--- a/examples/window/virtual.rs
+++ b/examples/window/virtual.rs
@@ -1,0 +1,211 @@
+//! Uses two windows to visualize a 3D model from different angles.
+
+use std::f32::consts::PI;
+
+use bevy::{
+    core_pipeline::clear_color::ClearColorConfig,
+    prelude::*,
+    render::{
+        camera::RenderTarget,
+        extract_resource::{ExtractResource, ExtractResourcePlugin},
+        render_asset::{PrepareAssetLabel, RenderAssets},
+        render_resource::{
+            Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
+        },
+        view::{ExtractedWindows, RenderLayers, WindowSystem},
+        RenderApp, RenderStage,
+    },
+    window::{PresentMode, WindowId},
+};
+
+#[derive(Clone, Resource)]
+struct WindowTexture {
+    window_id: WindowId,
+    render_texture: Handle<Image>,
+}
+
+impl ExtractResource for WindowTexture {
+    type Source = WindowTexture;
+
+    fn extract_resource(source: &WindowTexture) -> Self {
+        source.clone()
+    }
+}
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins)
+        .add_startup_system(setup)
+        .add_system(bevy::window::close_on_esc)
+        .add_plugin(ExtractResourcePlugin::<WindowTexture>::default());
+    if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+        render_app.add_system_to_stage(
+            RenderStage::Prepare,
+            prepare_window_texture
+                .after(PrepareAssetLabel::AssetPrepare)
+                .before(WindowSystem::Prepare),
+        );
+    }
+    app.run();
+}
+
+fn prepare_window_texture(
+    window_texture: Res<WindowTexture>,
+    gpu_images: Res<RenderAssets<Image>>,
+    mut extracted_windows: ResMut<ExtractedWindows>,
+) {
+    if let Some(window) = extracted_windows.get_mut(&window_texture.window_id) {
+        window.swap_chain_texture = Some(
+            gpu_images
+                .get(&window_texture.render_texture)
+                .unwrap()
+                .texture_view
+                .clone(),
+        );
+    }
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut images: ResMut<Assets<Image>>,
+    mut windows: ResMut<Windows>,
+) {
+    let window_id = WindowId::new();
+    windows.add(Window::new_virtual(
+        window_id,
+        &WindowDescriptor {
+            width: 800.,
+            height: 600.,
+            present_mode: PresentMode::AutoNoVsync,
+            title: "Second window".to_string(),
+            ..default()
+        },
+        800,
+        600,
+        1.0,
+        None,
+    ));
+
+    let size = Extent3d {
+        width: 800,
+        height: 600,
+        ..default()
+    };
+
+    // This is the texture that will be rendered to.
+    let mut image = Image {
+        texture_descriptor: TextureDescriptor {
+            label: None,
+            size,
+            dimension: TextureDimension::D2,
+            format: TextureFormat::Bgra8UnormSrgb,
+            mip_level_count: 1,
+            sample_count: 1,
+            usage: TextureUsages::TEXTURE_BINDING
+                | TextureUsages::COPY_DST
+                | TextureUsages::RENDER_ATTACHMENT,
+        },
+        ..default()
+    };
+
+    // fill image.data with zeroes
+    image.resize(size);
+
+    let image_handle = images.add(image);
+    commands.insert_resource(WindowTexture {
+        window_id,
+        render_texture: image_handle.clone(),
+    });
+
+    let cube_handle = meshes.add(Mesh::from(shape::Cube { size: 4.0 }));
+    let cube_material_handle = materials.add(StandardMaterial {
+        base_color: Color::rgb(0.8, 0.7, 0.6),
+        reflectance: 0.02,
+        unlit: false,
+        ..default()
+    });
+
+    // This specifies the layer used for the first pass, which will be attached to the first pass camera and cube.
+    let first_pass_layer = RenderLayers::layer(1);
+
+    // The cube that will be rendered to the texture.
+    commands.spawn((
+        PbrBundle {
+            mesh: cube_handle,
+            material: cube_material_handle,
+            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 1.0)),
+            ..default()
+        },
+        first_pass_layer,
+    ));
+
+    // Light
+    // NOTE: Currently lights are shared between passes - see https://github.com/bevyengine/bevy/issues/3462
+    commands.spawn(PointLightBundle {
+        transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
+        ..default()
+    });
+
+    commands.spawn((
+        Camera3dBundle {
+            camera_3d: Camera3d {
+                clear_color: ClearColorConfig::Custom(Color::WHITE),
+                ..default()
+            },
+            camera: Camera {
+                // render before the "main pass" camera
+                priority: -1,
+                target: RenderTarget::Image(image_handle.clone()),
+                ..default()
+            },
+            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
+                .looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        },
+        first_pass_layer,
+    ));
+
+    let cube_size = 4.0;
+    let cube_handle = meshes.add(Mesh::from(shape::Box::new(cube_size, cube_size, cube_size)));
+
+    // This material has the texture that has been rendered.
+    let material_handle = materials.add(StandardMaterial {
+        base_color_texture: Some(image_handle),
+        reflectance: 0.02,
+        unlit: false,
+        ..default()
+    });
+
+    // Main pass cube, with material containing the rendered first pass texture.
+    commands.spawn(PbrBundle {
+        mesh: cube_handle,
+        material: material_handle,
+        transform: Transform::from_xyz(0.0, 0.0, 1.5)
+            .with_rotation(Quat::from_rotation_x(-PI / 5.0)),
+        ..default()
+    });
+
+    // The main pass camera.
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(0.0, 0.0, 15.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+
+    let window_id = WindowId::new();
+    windows.add(Window::new_virtual(
+        window_id,
+        &WindowDescriptor {
+            width: 800.,
+            height: 600.,
+            present_mode: PresentMode::AutoNoVsync,
+            title: "Second window".to_string(),
+            ..default()
+        },
+        800,
+        600,
+        1.0,
+        None,
+    ));
+}


### PR DESCRIPTION
# Objective

- bevy uses raw-window-handle for creating a rendering context. That crate does not really work for the web target ([issue](https://github.com/rust-windowing/raw-window-handle/issues/102)).

## Solution

- Builds on PR #6256.
- This PR bypasses raw-window-handle to allow applications to specify the canvas directly.

---

## Changelog

- Added two new variants to the enum called `bevy_window::window::AbstractWindowHandle` that can take either an `HtmlCanvasElement` or `OffscreenCanvas`.
- Added three new functions to `bevy_window::window::Window`:
  - `new_canvas` for creating a Window based on a canvas element directly.
  - `new_canvas_selector` for creating a Window based on a CSS-style selector.
  - `new_offscreen_canvas` for creating a Window with an offscreen canvas.
- Added `WindowDescriptor::set_canvas_from_selector` and `WindowDescriptor::set_canvas` to allow winit to use a canvas element directly instead of creating its own (which is still supported).
- All of this only applies to the wasm target! winit only supports a regular `HtmlCanvasElement`, but not an `OffscreenCanvas`. This is a limitation of winit.

## Migration Guide

- The canvas field in `Window` does no longer exists for non-wasm targets.
- If you want to specify a canvas for winit, you now have to use `WindowDescriptor::set_canvas_from_selector` or `WindowDescriptor::set_canvas` instead.