### PR TITLE
[Merged by Bors] - Register `Wireframe` type

### DIFF
--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -36,7 +36,8 @@ impl Plugin for WireframePlugin {
             Shader::from_wgsl
         );
 
-        app.register_type::<WireframeConfig>()
+        app.register_type::<Wireframe>()
+            .register_type::<WireframeConfig>()
             .init_resource::<WireframeConfig>()
             .add_plugin(ExtractResourcePlugin::<WireframeConfig>::default());
 


### PR DESCRIPTION
# Objective

The `Wireframe` type implements `Reflect`, but is never registered, making its reflection inaccessible.

## Solution

Call `App::register_type::<Wireframe>()` in the `Plugin::build` implementation of `WireframePlugin`.

---

## Changelog

Fixed `Wireframe` type reflection not getting registered.
