### PR TITLE
[Merged by Bors] - Add methods for silencing system-order ambiguity warnings

### DIFF
--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -501,7 +501,8 @@ mod tests {
         let mut test_stage = SystemStage::parallel();
         test_stage
             .add_system(resmut_system.ignore_all_ambiguities())
-            .add_system(res_system);
+            .add_system(res_system)
+            .add_system(nonsend_system);
 
         test_stage.run(&mut world);
 
@@ -520,7 +521,7 @@ mod tests {
         test_stage
             .add_system(resmut_system.ambiguous_with(IgnoreMe))
             .add_system(res_system.label(IgnoreMe))
-            .add_system(res_system.label(IgnoreMe));
+            .add_system(nonsend_system.label(IgnoreMe));
 
         test_stage.run(&mut world);
 

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -492,4 +492,52 @@ mod tests {
 
         assert_eq!(test_stage.ambiguity_count(&world), 0);
     }
+
+    #[test]
+    fn ignore_all_ambiguities() {
+        let mut world = World::new();
+        world.insert_resource(R);
+
+        let mut test_stage = SystemStage::parallel();
+        test_stage
+            .add_system(resmut_system.ignore_all_ambiguities())
+            .add_system(res_system);
+
+        test_stage.run(&mut world);
+
+        assert_eq!(test_stage.ambiguity_count(&world), 0);
+    }
+
+    #[test]
+    fn ambiguous_with_label() {
+        let mut world = World::new();
+        world.insert_resource(R);
+
+        #[derive(SystemLabel)]
+        struct IgnoreMe;
+
+        let mut test_stage = SystemStage::parallel();
+        test_stage
+            .add_system(resmut_system.ambiguous_with(IgnoreMe))
+            .add_system(res_system.label(IgnoreMe))
+            .add_system(res_system.label(IgnoreMe));
+
+        test_stage.run(&mut world);
+
+        assert_eq!(test_stage.ambiguity_count(&world), 0);
+    }
+
+    #[test]
+    fn ambiguous_with_system() {
+        let mut world = World::new();
+
+        let mut test_stage = SystemStage::parallel();
+        test_stage
+            .add_system(write_component_system.ambiguous_with(read_component_system))
+            .add_system(read_component_system);
+
+        test_stage.run(&mut world);
+
+        assert_eq!(test_stage.ambiguity_count(&world), 0);
+    }
 }

--- a/crates/bevy_ecs/src/schedule/system_container.rs
+++ b/crates/bevy_ecs/src/schedule/system_container.rs
@@ -1,7 +1,9 @@
 use crate::{
     component::ComponentId,
     query::Access,
-    schedule::{GraphNode, RunCriteriaLabelId, SystemDescriptor, SystemLabelId},
+    schedule::{
+        AmbiguityDetection, GraphNode, RunCriteriaLabelId, SystemDescriptor, SystemLabelId,
+    },
     system::System,
 };
 use std::borrow::Cow;
@@ -16,6 +18,7 @@ pub struct SystemContainer {
     labels: Vec<SystemLabelId>,
     before: Vec<SystemLabelId>,
     after: Vec<SystemLabelId>,
+    pub(crate) ambiguity_detection: AmbiguityDetection,
 }
 
 impl SystemContainer {
@@ -29,6 +32,7 @@ impl SystemContainer {
             labels: descriptor.labels,
             before: descriptor.before,
             after: descriptor.after,
+            ambiguity_detection: descriptor.ambiguity_detection,
             is_exclusive: descriptor.exclusive_insertion_point.is_some(),
         }
     }


### PR DESCRIPTION
# Background

Incremental implementation of #4299. The code is heavily borrowed from that PR.

# Objective

The execution order ambiguity checker often emits false positives, since bevy is not aware of invariants upheld by the user.

## Solution

Title

---

## Changelog

+ Added methods `SystemDescriptor::ignore_all_ambiguities` and `::ambiguous_with`. These allow you to silence warnings for specific system-order ambiguities.

## Migration Guide

***Note for maintainers**: This should replace the migration guide for #5916*

Ambiguity sets have been replaced with a simpler API.

```rust
// These systems technically conflict, but we don't care which order they run in.
fn jump_on_click(mouse: Res<Input<MouseButton>>, mut transforms: Query<&mut Transform>) { ... }
fn jump_on_spacebar(keys: Res<Input<KeyCode>>, mut transforms: Query<&mut Transform>) { ... }

//
// Before

#[derive(AmbiguitySetLabel)]
struct JumpSystems;

app
  .add_system(jump_on_click.in_ambiguity_set(JumpSystems))
  .add_system(jump_on_spacebar.in_ambiguity_set(JumpSystems));

//
// After

app
  .add_system(jump_on_click.ambiguous_with(jump_on_spacebar))
  .add_system(jump_on_spacebar);

```
