### PR TITLE
Add `update_with_instant` method to `App`

### DIFF
--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -44,6 +44,12 @@ impl Plugin for TimePlugin {
     }
 }
 
+/// Resource for updating time with a specific value.
+/// 
+/// See [`update_with_interval`](self::TimeUpdater::update_with_instant) for more details.
+#[derive(Resource)]
+struct UpdateTime(Instant);
+
 /// Channel resource used to receive time from render world
 #[derive(Resource)]
 pub struct TimeReceiver(pub Receiver<Instant>);
@@ -64,6 +70,7 @@ pub fn create_time_channels() -> (TimeSender, TimeReceiver) {
 /// there to this system through channels. Otherwise the time is updated in this system.
 fn time_system(
     mut time: ResMut<Time>,
+    update_time: Option<Res<UpdateTime>>,
     time_recv: Option<Res<TimeReceiver>>,
     mut has_received_time: Local<bool>,
 ) {
@@ -76,6 +83,10 @@ fn time_system(
             warn!("time_system did not receive the time from the render world! Calculations depending on the time may be incorrect.");
         }
     } else {
-        time.update();
+        if let Some(update_time) = update_time {
+            time.update_with_instant(update_time.0);
+        } else {
+            time.update();
+        }
     }
 }

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -2,7 +2,13 @@ use bevy_ecs::{reflect::ReflectResource, system::Resource};
 use bevy_reflect::{FromReflect, Reflect};
 use bevy_utils::{Duration, Instant};
 
+use crate::UpdateTime;
+
 const SECONDS_PER_HOUR: u64 = 60 * 60;
+
+pub trait TimeUpdater {
+    fn update_with_instant(&mut self, instant: Instant);
+}
 
 /// Tracks elapsed time since the last update and since the App has started
 #[derive(Resource, Reflect, FromReflect, Debug, Clone)]
@@ -167,6 +173,18 @@ impl Time {
     #[inline]
     pub fn time_since_startup(&self) -> Duration {
         self.time_since_startup
+    }
+}
+
+impl TimeUpdater for bevy_app::App {
+
+    /// Runs the app's schedule once, manually setting the [`Time`] resource to the provided value.
+    ///
+    /// This is ordinarily done automatically, but setting this time value directly can be useful when writing tests,
+    /// dealing with networking code, or similar. 
+    fn update_with_instant(&mut self, instant: Instant)  {
+        self.world.insert_resource(UpdateTime(instant));
+        self.update();
     }
 }
 


### PR DESCRIPTION
# Objective

- Adds `update_with_instant` method from #6146 

## Solution

- Allow `App` access to bevy_time crate by creating a new trait inside of `bevy_time::Time` with update method
- Insert `UpdateTime` resource with desired value (only accessible in bevy_time crate)
- `Option<UpdateTime>` is used in time_system, allowing users to set Time value before `time.update()` is called
---

## Changelog

- Add `UpdateTime(Instant)` resource
- Update `bevy_time::time_system` to use optional `UpdateTime` resource
- Add TimeUpdater trait with `update_with_instant` method
- Update `App` to implement the new trait