### PR TITLE
[Merged by Bors] - More explicit help how to cycle the cameras

### DIFF
--- a/examples/tools/scene_viewer.rs
+++ b/examples/tools/scene_viewer.rs
@@ -237,24 +237,41 @@ fn setup_scene_after_load(
         let size = (max - min).length();
         let aabb = Aabb::from_min_max(Vec3::from(min), Vec3::from(max));
 
-        info!("Spawning a controllable 3D perspective camera");
+        info!("Spawning first controllable 3D perspective camera");
         let mut projection = PerspectiveProjection::default();
         projection.far = projection.far.max(size * 10.0);
-        commands.spawn((
-            Camera3dBundle {
+        commands
+            .spawn(Camera3dBundle {
                 projection: projection.into(),
                 transform: Transform::from_translation(
                     Vec3::from(aabb.center) + size * Vec3::new(0.5, 0.25, 0.5),
                 )
                 .looking_at(Vec3::from(aabb.center), Vec3::Y),
                 camera: Camera {
-                    is_active: false,
+                    is_active: true,
                     ..default()
                 },
                 ..default()
-            },
-            CameraController::default(),
-        ));
+            })
+            .insert(CameraController::default());
+
+        info!("Spawning second controllable 3D perspective camera");
+        let mut projection = PerspectiveProjection::default();
+        projection.far = projection.far.max(size * 10.0);
+        commands
+            .spawn(Camera3dBundle {
+                projection: projection.into(),
+                transform: Transform::from_translation(
+                    Vec3::from(aabb.center) + size * Vec3::new(-0.5, 2.5, -0.5),
+                )
+                .looking_at(Vec3::from(aabb.center), Vec3::Y),
+                camera: Camera {
+                    is_active: true,
+                    ..default()
+                },
+                ..default()
+            })
+            .insert(CameraController::default());
 
         // Spawn a default light if the scene does not have one
         if !scene_handle.has_light {
@@ -457,80 +474,90 @@ fn camera_controller(
     mouse_button_input: Res<Input<MouseButton>>,
     key_input: Res<Input<KeyCode>>,
     mut move_toggled: Local<bool>,
-    mut query: Query<(&mut Transform, &mut CameraController), With<Camera>>,
+    mut query: Query<(Entity, &mut Transform, &mut CameraController), With<Camera>>,
+    camera_tracker: Res<CameraTracker>,
 ) {
     let dt = time.delta_seconds();
 
-    if let Ok((mut transform, mut options)) = query.get_single_mut() {
-        if !options.initialized {
-            let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);
-            options.yaw = yaw;
-            options.pitch = pitch;
-            options.initialized = true;
-        }
-        if !options.enabled {
-            return;
-        }
+    let active_camera_id = if let Some(camera) = camera_tracker.active_camera() {
+        camera.id()
+    } else {
+        return;
+    };
 
-        // Handle key input
-        let mut axis_input = Vec3::ZERO;
-        if key_input.pressed(options.key_forward) {
-            axis_input.z += 1.0;
-        }
-        if key_input.pressed(options.key_back) {
-            axis_input.z -= 1.0;
-        }
-        if key_input.pressed(options.key_right) {
-            axis_input.x += 1.0;
-        }
-        if key_input.pressed(options.key_left) {
-            axis_input.x -= 1.0;
-        }
-        if key_input.pressed(options.key_up) {
-            axis_input.y += 1.0;
-        }
-        if key_input.pressed(options.key_down) {
-            axis_input.y -= 1.0;
-        }
-        if key_input.just_pressed(options.keyboard_key_enable_mouse) {
-            *move_toggled = !*move_toggled;
-        }
+    query.for_each_mut(|(entity, mut transform, mut options)| {
+        if entity.id() == active_camera_id {
+            if !options.initialized {
+                let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);
+                options.yaw = yaw;
+                options.pitch = pitch;
+                options.initialized = true;
+            }
+            if !options.enabled {
+                return;
+            }
 
-        // Apply movement update
-        if axis_input != Vec3::ZERO {
-            let max_speed = if key_input.pressed(options.key_run) {
-                options.run_speed
+            // Handle key input
+            let mut axis_input = Vec3::ZERO;
+            if key_input.pressed(options.key_forward) {
+                axis_input.z += 1.0;
+            }
+            if key_input.pressed(options.key_back) {
+                axis_input.z -= 1.0;
+            }
+            if key_input.pressed(options.key_right) {
+                axis_input.x += 1.0;
+            }
+            if key_input.pressed(options.key_left) {
+                axis_input.x -= 1.0;
+            }
+            if key_input.pressed(options.key_up) {
+                axis_input.y += 1.0;
+            }
+            if key_input.pressed(options.key_down) {
+                axis_input.y -= 1.0;
+            }
+            if key_input.just_pressed(options.keyboard_key_enable_mouse) {
+                *move_toggled = !*move_toggled;
+            }
+
+            // Apply movement update
+            if axis_input != Vec3::ZERO {
+                let max_speed = if key_input.pressed(options.key_run) {
+                    options.run_speed
+                } else {
+                    options.walk_speed
+                };
+                options.velocity = axis_input.normalize() * max_speed;
             } else {
-                options.walk_speed
-            };
-            options.velocity = axis_input.normalize() * max_speed;
-        } else {
-            let friction = options.friction.clamp(0.0, 1.0);
-            options.velocity *= 1.0 - friction;
-            if options.velocity.length_squared() < 1e-6 {
-                options.velocity = Vec3::ZERO;
+                let friction = options.friction.clamp(0.0, 1.0);
+                options.velocity *= 1.0 - friction;
+                if options.velocity.length_squared() < 1e-6 {
+                    options.velocity = Vec3::ZERO;
+                }
+            }
+            let forward = transform.forward();
+            let right = transform.right();
+            transform.translation += options.velocity.x * dt * right
+                + options.velocity.y * dt * Vec3::Y
+                + options.velocity.z * dt * forward;
+
+            // Handle mouse input
+            let mut mouse_delta = Vec2::ZERO;
+            if mouse_button_input.pressed(options.mouse_key_enable_mouse) || *move_toggled {
+                for mouse_event in mouse_events.iter() {
+                    mouse_delta += mouse_event.delta;
+                }
+            }
+
+            if mouse_delta != Vec2::ZERO {
+                // Apply look update
+                options.pitch = (options.pitch - mouse_delta.y * 0.5 * options.sensitivity * dt)
+                    .clamp(-PI / 2., PI / 2.);
+                options.yaw -= mouse_delta.x * options.sensitivity * dt;
+                transform.rotation =
+                    Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
             }
         }
-        let forward = transform.forward();
-        let right = transform.right();
-        transform.translation += options.velocity.x * dt * right
-            + options.velocity.y * dt * Vec3::Y
-            + options.velocity.z * dt * forward;
-
-        // Handle mouse input
-        let mut mouse_delta = Vec2::ZERO;
-        if mouse_button_input.pressed(options.mouse_key_enable_mouse) || *move_toggled {
-            for mouse_event in mouse_events.iter() {
-                mouse_delta += mouse_event.delta;
-            }
-        }
-
-        if mouse_delta != Vec2::ZERO {
-            // Apply look update
-            options.pitch = (options.pitch - mouse_delta.y * 0.5 * options.sensitivity * dt)
-                .clamp(-PI / 2., PI / 2.);
-            options.yaw -= mouse_delta.x * options.sensitivity * dt;
-            transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
-        }
-    }
+    });
 }


### PR DESCRIPTION
# Objective

Scene viewer example has switch camera keys defined, but only one camera was instantiated on the scene.

## Solution

More explicit help how to cycle the cameras, explaining that more cameras must be present in loaded scene.



