### PR TITLE
[Merged by Bors] - Fixes Camera not being serializable due to missing registrations in core functionality. 

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -35,8 +35,8 @@ impl Plugin for CorePlugin {
             .unwrap_or_default()
             .create_default_pools();
 
-        app.
-            register_type::<Entity>().register_type::<Name>()
+        app
+            .register_type::<Entity>().register_type::<Name>()
             .register_type_data::<Range<f32>, ReflectSerialize>()
             .register_type_data::<Range<f32>, ReflectDeserialize>();
 

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -36,7 +36,9 @@ impl Plugin for CorePlugin {
             .create_default_pools();
 
         app
-            .register_type::<Entity>().register_type::<Name>()
+            .register_type::<Entity>()
+            .register_type::<Name>()
+            .register_type::<Range<f32>>()
             .register_type_data::<Range<f32>, ReflectSerialize>()
             .register_type_data::<Range<f32>, ReflectDeserialize>();
 

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -17,10 +17,10 @@ pub mod prelude {
 
 use bevy_app::prelude::*;
 use bevy_ecs::entity::Entity;
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use bevy_utils::{Duration, HashSet, Instant};
 use std::borrow::Cow;
 use std::ops::Range;
-use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 /// Adds core functionality to Apps.
 #[derive(Default)]
@@ -35,8 +35,7 @@ impl Plugin for CorePlugin {
             .unwrap_or_default()
             .create_default_pools();
 
-        app
-            .register_type::<Entity>()
+        app.register_type::<Entity>()
             .register_type::<Name>()
             .register_type::<Range<f32>>()
             .register_type_data::<Range<f32>, ReflectSerialize>()

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -20,6 +20,7 @@ use bevy_ecs::entity::Entity;
 use bevy_utils::{Duration, HashSet, Instant};
 use std::borrow::Cow;
 use std::ops::Range;
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 /// Adds core functionality to Apps.
 #[derive(Default)]
@@ -34,7 +35,10 @@ impl Plugin for CorePlugin {
             .unwrap_or_default()
             .create_default_pools();
 
-        app.register_type::<Entity>().register_type::<Name>();
+        app.
+            register_type::<Entity>().register_type::<Name>()
+            .register_type_data::<Range<f32>, ReflectSerialize>()
+            .register_type_data::<Range<f32>, ReflectDeserialize>();
 
         register_rust_types(app);
         register_math_types(app);

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -22,6 +22,7 @@ impl Plugin for CameraPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Camera>()
             .register_type::<Viewport>()
+            .register_type::<Option<Viewport>>()
             .register_type::<Visibility>()
             .register_type::<ComputedVisibility>()
             .register_type::<VisibleEntities>()


### PR DESCRIPTION
…

# Objective

- Fixes Camera not being serializable due to missing registrations in core functionality. 
- Fixes #6169

## Solution

- Updated Bevy_Render CameraPlugin with registrations for Option<Viewport> and then Bevy_Core CorePlugin with registrations for ReflectSerialize and ReflectDeserialize for type data Range<f32> respectively according to the solution in #6169

