### PR TITLE
[Merged by Bors] - flaky test: put panicking system in a single threaded stage

### DIFF
--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -318,7 +318,10 @@ mod test {
         let mut temp = World::new();
         let mut app = App::new();
 
-        app.add_system(transform_propagate_system);
+        // Adding the system in a single threaded stage. As the system will panic, this will
+        // only bring down the current test thread.
+        app.add_stage("single", SystemStage::single_threaded())
+            .add_system_to_stage("single", transform_propagate_system);
 
         fn setup_world(world: &mut World) -> (Entity, Entity) {
             let mut grandchild = Entity::from_raw(0);


### PR DESCRIPTION
# Objective

- Fix #5285 

## Solution

- Put the panicking system in a single threaded stage during the test
- This way only the main thread will panic, which is handled by `cargo test`
