### PR TITLE
[Merged by Bors] - make Handle::<T> field id private, and replace with a getter

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -33,21 +33,21 @@ impl<T: Asset> Debug for AssetEvent<T> {
                     "AssetEvent<{}>::Created",
                     std::any::type_name::<T>()
                 ))
-                .field("handle", &handle.id)
+                .field("handle", &handle.id())
                 .finish(),
             AssetEvent::Modified { handle } => f
                 .debug_struct(&format!(
                     "AssetEvent<{}>::Modified",
                     std::any::type_name::<T>()
                 ))
-                .field("handle", &handle.id)
+                .field("handle", &handle.id())
                 .finish(),
             AssetEvent::Removed { handle } => f
                 .debug_struct(&format!(
                     "AssetEvent<{}>::Removed",
                     std::any::type_name::<T>()
                 ))
-                .field("handle", &handle.id)
+                .field("handle", &handle.id())
                 .finish(),
         }
     }

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -105,8 +105,7 @@ pub struct Handle<T>
 where
     T: Asset,
 {
-    /// The ID of the asset as contained within its respective [`Assets`] collection
-    pub id: HandleId,
+    id: HandleId,
     #[reflect(ignore)]
     handle_type: HandleType,
     #[reflect(ignore)]
@@ -149,6 +148,12 @@ impl<T: Asset> Handle<T> {
             handle_type: HandleType::Weak,
             marker: PhantomData,
         }
+    }
+
+    /// The ID of the asset as contained within its respective [`Assets`] collection.
+    #[inline]
+    pub fn id(&self) -> HandleId {
+        self.id
     }
 
     /// Recasts this handle as a weak handle of an Asset `U`.

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -261,7 +261,7 @@ pub fn extract_sprites(
             custom_size: sprite.custom_size,
             flip_x: sprite.flip_x,
             flip_y: sprite.flip_y,
-            image_handle_id: handle.id,
+            image_handle_id: handle.id(),
             anchor: sprite.anchor.as_vec(),
         });
     }
@@ -281,7 +281,7 @@ pub fn extract_sprites(
                 custom_size: atlas_sprite.custom_size,
                 flip_x: atlas_sprite.flip_x,
                 flip_y: atlas_sprite.flip_y,
-                image_handle_id: texture_atlas.texture.id,
+                image_handle_id: texture_atlas.texture.id(),
                 anchor: atlas_sprite.anchor.as_vec(),
             });
         }

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -34,7 +34,7 @@ impl TextPipeline {
         let brush = &mut self.brush;
         *self
             .map_font_id
-            .entry(handle.id)
+            .entry(handle.id())
             .or_insert_with(|| brush.add_font(handle.clone(), font.font.clone()))
     }
 

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -134,7 +134,7 @@ pub fn extract_text2d_sprite(
                 color,
                 rect,
                 custom_size: None,
-                image_handle_id: handle.id,
+                image_handle_id: handle.id(),
                 flip_x: false,
                 flip_y: false,
                 anchor: Anchor::Center.as_vec(),


### PR DESCRIPTION
# Objective

- Field `id` of `Handle<T>` is public: https://docs.rs/bevy/latest/bevy/asset/struct.Handle.html#structfield.id
- Changing the value of this field doesn't make sense as it could mean changing the previous handle without dropping it, breaking asset cleanup detection for the old handle and the new one

## Solution

- Make the field private, and add a public getter


Opened after discussion in #6171. Pinging @zicklag 

---

## Migration Guide

- If you were accessing the value `handle.id`, you can now do so with `handle.id()`
