### PR TITLE
[Merged by Bors] - Reflect Default for `ComputedVisibility` and `Handle<T>`

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -10,7 +10,9 @@ use crate::{
     Asset, Assets,
 };
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
-use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize};
+use bevy_reflect::{
+    std_traits::ReflectDefault, FromReflect, Reflect, ReflectDeserialize, ReflectSerialize,
+};
 use bevy_utils::Uuid;
 use crossbeam_channel::{Receiver, Sender};
 use serde::{Deserialize, Serialize};
@@ -100,7 +102,7 @@ impl HandleId {
 /// collisions no longer being detected for that entity.
 ///
 #[derive(Component, Reflect, FromReflect)]
-#[reflect(Component)]
+#[reflect(Component, Default)]
 pub struct Handle<T>
 where
     T: Asset,

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -51,7 +51,7 @@ impl Visibility {
 
 /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
 #[derive(Component, Clone, Reflect, Debug, Eq, PartialEq)]
-#[reflect(Component)]
+#[reflect(Component, Default)]
 pub struct ComputedVisibility {
     is_visible_in_hierarchy: bool,
     is_visible_in_view: bool,


### PR DESCRIPTION
# Objective

- Reflecting `Default` is required for scripts to create `Reflect` types at runtime with no static type information.
- Reflecting `Default` on `Handle<T>` and `ComputedVisibility` should allow scripts from `bevy_mod_js_scripting` to actually spawn sprites from scratch, without needing any hand-holding from the host-game.

## Solution

- Derive `ReflectDefault` for `Handle<T>` and `ComputedVisiblity`.

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- The `Default` trait is now reflected for `Handle<T>` and `ComputedVisibility`

