### PR TITLE
[Merged by Bors] - Fix `RemoveChildren` command 

### DIFF
--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -67,10 +67,9 @@ fn remove_children(parent: Entity, children: &[Entity], world: &mut World) {
     let mut events: SmallVec<[HierarchyEvent; 8]> = SmallVec::new();
     if let Some(parent_children) = world.get::<Children>(parent) {
         for &child in children {
-            if !parent_children.contains(&child) {
-                continue;
+            if parent_children.contains(&child) {
+                events.push(HierarchyEvent::ChildRemoved { child, parent });
             }
-            events.push(HierarchyEvent::ChildRemoved { child, parent });
         }
     } else {
         return;

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -1,7 +1,4 @@
-use crate::{
-    prelude::{Children, Parent},
-    HierarchyEvent,
-};
+use crate::{Children, HierarchyEvent, Parent};
 use bevy_ecs::{
     bundle::Bundle,
     entity::Entity,
@@ -68,12 +65,16 @@ fn update_old_parents(world: &mut World, parent: Entity, children: &[Entity]) {
 
 fn remove_children(parent: Entity, children: &[Entity], world: &mut World) {
     let mut events: SmallVec<[HierarchyEvent; 8]> = SmallVec::new();
-    for child in children {
-        world.entity_mut(*child).remove::<Parent>();
-        events.push(HierarchyEvent::ChildRemoved {
-            child: *child,
-            parent,
-        });
+    if let Some(parent_children) = world.get::<Children>(parent).map(|c| c.0.clone()) {
+        for &child in children {
+            if !parent_children.contains(&child) {
+                continue;
+            }
+            world.entity_mut(child).remove::<Parent>();
+            events.push(HierarchyEvent::ChildRemoved { child, parent });
+        }
+    } else {
+        return;
     }
     push_events(world, events);
 

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -65,16 +65,20 @@ fn update_old_parents(world: &mut World, parent: Entity, children: &[Entity]) {
 
 fn remove_children(parent: Entity, children: &[Entity], world: &mut World) {
     let mut events: SmallVec<[HierarchyEvent; 8]> = SmallVec::new();
-    if let Some(parent_children) = world.get::<Children>(parent).map(|c| c.0.clone()) {
+    if let Some(parent_children) = world.get::<Children>(parent) {
         for &child in children {
             if !parent_children.contains(&child) {
                 continue;
             }
-            world.entity_mut(child).remove::<Parent>();
             events.push(HierarchyEvent::ChildRemoved { child, parent });
         }
     } else {
         return;
+    }
+    for event in &events {
+        if let &HierarchyEvent::ChildRemoved { child, .. } = event {
+            world.entity_mut(child).remove::<Parent>();
+        }
     }
     push_events(world, events);
 


### PR DESCRIPTION
# Objective

`RemoveChildren` could remove the `Parent` component from children belonging to a different parent, which breaks the hierarchy.

This change looks a little funny because I'm reusing the events to avoid needing to clone the parent's `Children`.