### PR TITLE
[Merged by Bors] - Add a method for mapping `Mut<T>` -> `Mut<U>`

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -518,10 +518,11 @@ mod tests {
             added: 1,
             changed: 2,
         };
+        let (last_change_tick, change_tick) = (2, 3);
         let ticks = Ticks {
             component_ticks: &mut component_ticks,
-            last_change_tick: 2,
-            change_tick: 3,
+            last_change_tick,
+            change_tick,
         };
 
         let mut outer = Outer(0);
@@ -538,5 +539,7 @@ mod tests {
         // Mutate the inner value.
         *inner = 64;
         assert!(inner.is_changed());
+        // Modifying one field of a component should flag a change for the entire component.
+        assert!(component_ticks.is_changed(last_change_tick, change_tick));
     }
 }

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -177,7 +177,26 @@ macro_rules! impl_methods {
             /// Maps to an inner value by applying a function to the contained reference, without flagging a change.
             ///
             /// You should not modify the argument passed to the closure, unless you are familiar with `bevy_ecs` internals.
-            /// Violating this rule will likely result in logic errors, but it will not cause undefined behavior.
+            ///
+            /// ```rust
+            /// # use bevy_ecs::prelude::*;
+            /// # pub struct Transform { translation: Vec2 }
+            /// # mod my_utils {
+            /// #   pub fn set_if_not_equal<T: std::ops::PartialEq>(x: Mut<T>, val: T) {
+            /// #     if *x != val { *x = val; }
+            /// #   }
+            /// # }
+            /// // When run, zeroes the translation of every entity.
+            /// fn reset_positions(mut transforms: Query<&mut Transform>) {
+            ///     for transform in &mut transforms {
+            ///         // We pinky promise not to modify `t` within the closure.
+            ///         // Breaking this promise will result in logic errors, but will never cause undefined behavior.
+            ///         let translation = transform.map_unchanged(|t| &mut t.translation);
+            ///         // Only reset the translation if it isn't already zero;
+            ///         my_utils::set_if_not_equal(translation, Vec2::ZERO);
+            ///     }
+            /// }
+            /// ```
             pub fn map_unchanged<U: ?Sized>(self, f: impl FnOnce(&mut $target) -> &mut U) -> Mut<'a, U> {
                 Mut {
                     value: f(self.value),

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -180,9 +180,12 @@ macro_rules! impl_methods {
             ///
             /// ```rust
             /// # use bevy_ecs::prelude::*;
+            /// # pub struct Vec2;
+            /// # impl Vec2 { pub const ZERO: Self = Self; }
             /// # pub struct Transform { translation: Vec2 }
             /// # mod my_utils {
-            /// #   pub fn set_if_not_equal<T: std::ops::PartialEq>(x: Mut<T>, val: T) {
+            /// #   use super::*;
+            /// #   pub fn set_if_not_equal<T: std::cmp::PartialEq>(x: Mut<T>, val: T) {
             /// #     if *x != val { *x = val; }
             /// #   }
             /// # }

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -163,7 +163,7 @@ macro_rules! change_detection_impl {
     };
 }
 
-macro_rules! impl_into_inner {
+macro_rules! impl_methods {
     ($name:ident < $( $generics:tt ),+ >, $target:ty, $($traits:ident)?) => {
         impl<$($generics),* : ?Sized $(+ $traits)?> $name<$($generics),*> {
             /// Consume `self` and return a mutable reference to the
@@ -226,7 +226,7 @@ pub struct ResMut<'a, T: ?Sized + Resource> {
 }
 
 change_detection_impl!(ResMut<'a, T>, T, Resource);
-impl_into_inner!(ResMut<'a, T>, T, Resource);
+impl_methods!(ResMut<'a, T>, T, Resource);
 impl_debug!(ResMut<'a, T>, Resource);
 
 impl<'a, T: Resource> From<ResMut<'a, T>> for Mut<'a, T> {
@@ -258,7 +258,7 @@ pub struct NonSendMut<'a, T: ?Sized + 'static> {
 }
 
 change_detection_impl!(NonSendMut<'a, T>, T,);
-impl_into_inner!(NonSendMut<'a, T>, T,);
+impl_methods!(NonSendMut<'a, T>, T,);
 impl_debug!(NonSendMut<'a, T>,);
 
 impl<'a, T: 'static> From<NonSendMut<'a, T>> for Mut<'a, T> {
@@ -279,7 +279,7 @@ pub struct Mut<'a, T: ?Sized> {
 }
 
 change_detection_impl!(Mut<'a, T>, T,);
-impl_into_inner!(Mut<'a, T>, T,);
+impl_methods!(Mut<'a, T>, T,);
 impl_debug!(Mut<'a, T>,);
 
 /// Unique mutable borrow of resources or an entity's component.

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -196,6 +196,7 @@ macro_rules! impl_methods {
             ///         my_utils::set_if_not_equal(translation, Vec2::ZERO);
             ///     }
             /// }
+            /// # bevy_ecs::system::assert_is_system(reset_positions);
             /// ```
             pub fn map_unchanged<U: ?Sized>(self, f: impl FnOnce(&mut $target) -> &mut U) -> Mut<'a, U> {
                 Mut {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -184,10 +184,7 @@ macro_rules! impl_methods {
             /// # impl Vec2 { pub const ZERO: Self = Self; }
             /// # #[derive(Component)] pub struct Transform { translation: Vec2 }
             /// # mod my_utils {
-            /// #   use super::*;
-            /// #   pub fn set_if_not_equal<T: std::cmp::PartialEq>(x: Mut<T>, val: T) {
-            /// #     if *x != val { *x = val; }
-            /// #   }
+            /// #   pub fn set_if_not_equal<T>(x: bevy_ecs::prelude::Mut<T>, val: T) { unimplemented!() }
             /// # }
             /// // When run, zeroes the translation of every entity.
             /// fn reset_positions(mut transforms: Query<&mut Transform>) {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -182,7 +182,7 @@ macro_rules! impl_methods {
             /// # use bevy_ecs::prelude::*;
             /// # pub struct Vec2;
             /// # impl Vec2 { pub const ZERO: Self = Self; }
-            /// # pub struct Transform { translation: Vec2 }
+            /// # #[derive(Component)] pub struct Transform { translation: Vec2 }
             /// # mod my_utils {
             /// #   use super::*;
             /// #   pub fn set_if_not_equal<T: std::cmp::PartialEq>(x: Mut<T>, val: T) {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -176,7 +176,8 @@ macro_rules! impl_methods {
 
             /// Maps to an inner value by applying a function to the contained reference, without flagging a change.
             ///
-            /// You should not modify the argument passed to the closure, unless you are familiar with `bevy_ecs` internals.
+            /// You should never modify the argument passed to the closure -- if you want to modify the data
+            /// without flagging a change, consider using [`DetectChanges::bypass_change_detection`] to make your intent explicit.
             ///
             /// ```rust
             /// # use bevy_ecs::prelude::*;

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -176,7 +176,7 @@ macro_rules! impl_methods {
 
             /// Maps to an inner value by applying a function to the contained reference, without flagging a change.
             ///
-            /// You must *not* modify the argument passed to the closure.
+            /// You should not modify the argument passed to the closure, unless you are familiar with `bevy_ecs` internals.
             /// Violating this rule will likely result in logic errors, but it will not cause undefined behavior.
             pub fn map_unchanged<U: ?Sized>(self, f: impl FnOnce(&mut $target) -> &mut U) -> Mut<'a, U> {
                 Mut {


### PR DESCRIPTION
# Objective

When designing an API, you may wish to provide access only to a specific field of a component or resource. The current options for doing this in safe code are

* `*Mut::into_inner`, which flags a change no matter what.
* `*Mut::bypass_change_detection`, which misses all changes.

## Solution

Add the method `map_unchanged`.

### Example

```rust
// When run, zeroes the translation of every entity.
fn reset_all(mut transforms: Query<&mut Transform>) {
    for transform in &mut transforms {
        // We pinky promise not to modify `t` within the closure.
        let translation = transform.map_unchanged(|t| &mut t.translation);
        // Only reset the translation if it isn't already zero.
        translation.set_if_not_equal(Vec2::ZERO);
    }
}
```

---

## Changelog

+ Added the method `map_unchanged` to types `Mut<T>`, `ResMut<T>`, and `NonSendMut<T>`.
