### PR TITLE
[Merged by Bors] - Reflect Default for GlobalTransform

### DIFF
--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -3,7 +3,7 @@ use std::ops::Mul;
 use super::Transform;
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_math::{Affine3A, Mat4, Quat, Vec3, Vec3A};
-use bevy_reflect::{FromReflect, Reflect};
+use bevy_reflect::{std_traits::ReflectDefault, FromReflect, Reflect};
 
 /// Describe the position of an entity relative to the reference frame.
 ///
@@ -32,7 +32,7 @@ use bevy_reflect::{FromReflect, Reflect};
 ///
 /// [`global_vs_local_translation`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect, FromReflect)]
-#[reflect(Component, PartialEq)]
+#[reflect(Component, Default, PartialEq)]
 pub struct GlobalTransform(Affine3A);
 
 macro_rules! impl_local_axis {


### PR DESCRIPTION
# Objective

Make `GlobalTransform` constructible from scripts, in the same vein as #6187.

## Solution

- Use the derive macro to reflect default

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- `GlobalTransform` now reflects the `Default` trait.

