### PR TITLE
Automatically generate vertex tangents for mesh primitives

### DIFF
--- a/crates/bevy_render/src/mesh/shape/capsule.rs
+++ b/crates/bevy_render/src/mesh/shape/capsule.rs
@@ -369,6 +369,7 @@ impl From<Capsule> for Mesh {
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, vns);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vts);
         mesh.set_indices(Some(Indices::U32(tris)));
+        mesh.generate_tangents().unwrap();
         mesh
     }
 }

--- a/crates/bevy_render/src/mesh/shape/icosphere.rs
+++ b/crates/bevy_render/src/mesh/shape/icosphere.rs
@@ -98,6 +98,7 @@ impl From<Icosphere> for Mesh {
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, points);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+        mesh.generate_tangents().unwrap();
         mesh
     }
 }

--- a/crates/bevy_render/src/mesh/shape/mod.rs
+++ b/crates/bevy_render/src/mesh/shape/mod.rs
@@ -110,6 +110,7 @@ impl From<Box> for Mesh {
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
         mesh.set_indices(Some(indices));
+        mesh.generate_tangents().unwrap();
         mesh
     }
 }
@@ -163,6 +164,7 @@ impl From<Quad> for Mesh {
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+        mesh.generate_tangents().unwrap();
         mesh
     }
 }
@@ -202,6 +204,7 @@ impl From<Plane> for Mesh {
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+        mesh.generate_tangents().unwrap();
         mesh
     }
 }

--- a/crates/bevy_render/src/mesh/shape/regular_polygon.rs
+++ b/crates/bevy_render/src/mesh/shape/regular_polygon.rs
@@ -56,6 +56,7 @@ impl From<RegularPolygon> for Mesh {
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
         mesh.set_indices(Some(Indices::U32(indices)));
+        mesh.generate_tangents().unwrap();
         mesh
     }
 }

--- a/crates/bevy_render/src/mesh/shape/torus.rs
+++ b/crates/bevy_render/src/mesh/shape/torus.rs
@@ -89,6 +89,7 @@ impl From<Torus> for Mesh {
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+        mesh.generate_tangents().unwrap();
         mesh
     }
 }

--- a/crates/bevy_render/src/mesh/shape/uvsphere.rs
+++ b/crates/bevy_render/src/mesh/shape/uvsphere.rs
@@ -85,6 +85,7 @@ impl From<UVSphere> for Mesh {
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+        mesh.generate_tangents().unwrap();
         mesh
     }
 }


### PR DESCRIPTION
# Objective
Generate vertex tangents for meshes created from `bevy_render::mesh::shape` without manually calling `generate_tangents`
Fixes #3121
## Solution  

Call `generate_tangents` when converting from the primitives to the mesh.

## Changelog

Meshes generated from the primitives of `bevy_render::mesh::shape` have vertex tangents