### PR TITLE
Derive Resource trait for all public enums/structs in render_resource.

### DIFF
--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -8,12 +8,13 @@ use crate::{
     renderer::RenderDevice,
     texture::FallbackImage,
 };
+use bevy_ecs::system::Resource;
 use bevy_reflect::Uuid;
 use std::{ops::Deref, sync::Arc};
 use wgpu::BindingResource;
 
 /// A [`BindGroup`] identifier.
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug, Resource)]
 pub struct BindGroupId(Uuid);
 
 /// Bind groups are responsible for binding render resources (e.g. buffers, textures, samplers)
@@ -22,7 +23,7 @@ pub struct BindGroupId(Uuid);
 ///
 /// May be converted from and dereferences to a wgpu [`BindGroup`](wgpu::BindGroup).
 /// Can be created via [`RenderDevice::create_bind_group`](crate::renderer::RenderDevice::create_bind_group).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Resource)]
 pub struct BindGroup {
     id: BindGroupId,
     value: Arc<wgpu::BindGroup>,
@@ -256,12 +257,14 @@ pub trait AsBindGroup: Sized {
 }
 
 /// An error that occurs during [`AsBindGroup::as_bind_group`] calls.
+#[derive(Resource)]
 pub enum AsBindGroupError {
     /// The bind group could not be generated. Try again next frame.
     RetryNextUpdate,
 }
 
 /// A prepared bind group returned as a result of [`AsBindGroup::as_bind_group`].
+#[derive(Resource)]
 pub struct PreparedBindGroup<T: AsBindGroup> {
     pub bindings: Vec<OwnedBindingResource>,
     pub bind_group: BindGroup,
@@ -271,6 +274,7 @@ pub struct PreparedBindGroup<T: AsBindGroup> {
 /// An owned binding resource of any type (ex: a [`Buffer`], [`TextureView`], etc).
 /// This is used by types like [`PreparedBindGroup`] to hold a single list of all
 /// render resources used by bindings.
+#[derive(Resource)]
 pub enum OwnedBindingResource {
     Buffer(Buffer),
     TextureView(TextureView),

--- a/crates/bevy_render/src/render_resource/bind_group_layout.rs
+++ b/crates/bevy_render/src/render_resource/bind_group_layout.rs
@@ -1,10 +1,11 @@
+use bevy_ecs::system::Resource;
 use bevy_reflect::Uuid;
 use std::{ops::Deref, sync::Arc};
 
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug, Resource)]
 pub struct BindGroupLayoutId(Uuid);
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Resource)]
 pub struct BindGroupLayout {
     id: BindGroupLayoutId,
     value: Arc<wgpu::BindGroupLayout>,

--- a/crates/bevy_render/src/render_resource/buffer.rs
+++ b/crates/bevy_render/src/render_resource/buffer.rs
@@ -1,13 +1,14 @@
+use bevy_ecs::system::Resource;
 use bevy_utils::Uuid;
 use std::{
     ops::{Bound, Deref, RangeBounds},
     sync::Arc,
 };
 
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug, Resource)]
 pub struct BufferId(Uuid);
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Resource)]
 pub struct Buffer {
     id: BufferId,
     value: Arc<wgpu::Buffer>,
@@ -56,7 +57,7 @@ impl Deref for Buffer {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Resource)]
 pub struct BufferSlice<'a> {
     id: BufferId,
     offset: wgpu::BufferAddress,

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -3,6 +3,7 @@ use crate::{
     renderer::{RenderDevice, RenderQueue},
 };
 use bevy_core::{cast_slice, Pod};
+use bevy_ecs::system::Resource;
 use wgpu::BufferUsages;
 
 /// A structure for storing raw bytes that have already been properly formatted
@@ -26,6 +27,7 @@ use wgpu::BufferUsages;
 /// * [`DynamicUniformBuffer`](crate::render_resource::DynamicUniformBuffer)
 /// * [`BufferVec`](crate::render_resource::BufferVec)
 /// * [`Texture`](crate::render_resource::Texture)
+#[derive(Resource)]
 pub struct BufferVec<T: Pod> {
     values: Vec<T>,
     buffer: Option<Buffer>,

--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -1,5 +1,6 @@
 use crate::render_resource::{BindGroupLayout, Shader};
 use bevy_asset::Handle;
+use bevy_ecs::system::Resource;
 use bevy_reflect::Uuid;
 use std::{borrow::Cow, ops::Deref, sync::Arc};
 use wgpu::{
@@ -8,14 +9,14 @@ use wgpu::{
 };
 
 /// A [`RenderPipeline`] identifier.
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug, Resource)]
 pub struct RenderPipelineId(Uuid);
 
 /// A [`RenderPipeline`] represents a graphics pipeline and its stages (shaders), bindings and vertex buffers.
 ///
 /// May be converted from and dereferences to a wgpu [`RenderPipeline`](wgpu::RenderPipeline).
 /// Can be created via [`RenderDevice::create_render_pipeline`](crate::renderer::RenderDevice::create_render_pipeline).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Resource)]
 pub struct RenderPipeline {
     id: RenderPipelineId,
     value: Arc<wgpu::RenderPipeline>,
@@ -47,14 +48,14 @@ impl Deref for RenderPipeline {
 }
 
 /// A [`ComputePipeline`] identifier.
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug, Resource)]
 pub struct ComputePipelineId(Uuid);
 
 /// A [`ComputePipeline`] represents a compute pipeline and its single shader stage.
 ///
 /// May be converted from and dereferences to a wgpu [`ComputePipeline`](wgpu::ComputePipeline).
 /// Can be created via [`RenderDevice::create_compute_pipeline`](crate::renderer::RenderDevice::create_compute_pipeline).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Resource)]
 pub struct ComputePipeline {
     id: ComputePipelineId,
     value: Arc<wgpu::ComputePipeline>,
@@ -87,7 +88,7 @@ impl Deref for ComputePipeline {
 }
 
 /// Describes a render (graphics) pipeline.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Resource)]
 pub struct RenderPipelineDescriptor {
     /// Debug label of the pipeline. This will show up in graphics debuggers for easy identification.
     pub label: Option<Cow<'static, str>>,
@@ -105,7 +106,7 @@ pub struct RenderPipelineDescriptor {
     pub fragment: Option<FragmentState>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Resource)]
 pub struct VertexState {
     /// The compiled shader module for this stage.
     pub shader: Handle<Shader>,
@@ -118,7 +119,7 @@ pub struct VertexState {
 }
 
 /// Describes how the vertex buffer is interpreted.
-#[derive(Default, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Default, Clone, Debug, Hash, Eq, PartialEq, Resource)]
 pub struct VertexBufferLayout {
     /// The stride, in bytes, between elements of this buffer.
     pub array_stride: BufferAddress,
@@ -157,7 +158,7 @@ impl VertexBufferLayout {
 }
 
 /// Describes the fragment process in a render pipeline.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Resource)]
 pub struct FragmentState {
     /// The compiled shader module for this stage.
     pub shader: Handle<Shader>,
@@ -170,7 +171,7 @@ pub struct FragmentState {
 }
 
 /// Describes a compute pipeline.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Resource)]
 pub struct ComputePipelineDescriptor {
     pub label: Option<Cow<'static, str>>,
     pub layout: Option<Vec<BindGroupLayout>>,

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -10,8 +10,8 @@ use crate::{
     Extract,
 };
 use bevy_asset::{AssetEvent, Assets, Handle};
-use bevy_ecs::system::{Res, ResMut};
-use bevy_ecs::{event::EventReader, system::Resource};
+use bevy_ecs::event::EventReader;
+use bevy_ecs::system::{Res, ResMut, Resource};
 use bevy_utils::{
     default,
     tracing::{debug, error},
@@ -27,7 +27,7 @@ use wgpu::{
 /// A descriptor for a [`Pipeline`].
 ///
 /// Used to store an heterogenous collection of render and compute pipeline descriptors together.
-#[derive(Debug)]
+#[derive(Debug, Resource)]
 pub enum PipelineDescriptor {
     RenderPipelineDescriptor(Box<RenderPipelineDescriptor>),
     ComputePipelineDescriptor(Box<ComputePipelineDescriptor>),
@@ -36,7 +36,7 @@ pub enum PipelineDescriptor {
 /// A pipeline defining the data layout and shader logic for a specific GPU task.
 ///
 /// Used to store an heterogenous collection of render and compute pipelines together.
-#[derive(Debug)]
+#[derive(Debug, Resource)]
 pub enum Pipeline {
     RenderPipeline(RenderPipeline),
     ComputePipeline(ComputePipeline),
@@ -45,7 +45,7 @@ pub enum Pipeline {
 type CachedPipelineId = usize;
 
 /// Index of a cached render pipeline in a [`PipelineCache`].
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Resource)]
 pub struct CachedRenderPipelineId(CachedPipelineId);
 
 impl CachedRenderPipelineId {
@@ -54,7 +54,7 @@ impl CachedRenderPipelineId {
 }
 
 /// Index of a cached compute pipeline in a [`PipelineCache`].
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Resource)]
 pub struct CachedComputePipelineId(CachedPipelineId);
 
 impl CachedComputePipelineId {
@@ -62,13 +62,14 @@ impl CachedComputePipelineId {
     pub const INVALID: Self = CachedComputePipelineId(usize::MAX);
 }
 
+#[derive(Resource)]
 pub struct CachedPipeline {
     pub descriptor: PipelineDescriptor,
     pub state: CachedPipelineState,
 }
 
 /// State of a cached pipeline inserted into a [`PipelineCache`].
-#[derive(Debug)]
+#[derive(Debug, Resource)]
 pub enum CachedPipelineState {
     /// The pipeline GPU object is queued for creation.
     Queued,
@@ -763,7 +764,7 @@ fn log_shader_error(source: &ProcessedShader, error: &AsModuleDescriptorError) {
 }
 
 /// Type of error returned by a [`PipelineCache`] when the creation of a GPU pipeline object failed.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Resource)]
 pub enum PipelineCacheError {
     #[error(
         "Pipeline cound not be compiled because the following shader is not loaded yet: {0:?}"

--- a/crates/bevy_render/src/render_resource/pipeline_specializer.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_specializer.rs
@@ -157,7 +157,7 @@ impl<S: SpecializedMeshPipeline> SpecializedMeshPipelines<S> {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Resource)]
 pub enum SpecializedMeshPipelineError {
     #[error(transparent)]
     MissingVertexAttribute(#[from] MissingVertexAttributeError),

--- a/crates/bevy_render/src/render_resource/storage_buffer.rs
+++ b/crates/bevy_render/src/render_resource/storage_buffer.rs
@@ -2,6 +2,7 @@
 
 use super::Buffer;
 use crate::renderer::{RenderDevice, RenderQueue};
+use bevy_ecs::system::Resource;
 use encase::{
     internal::WriteInto, DynamicStorageBuffer as DynamicStorageBufferWrapper, ShaderType,
     StorageBuffer as StorageBufferWrapper,
@@ -27,6 +28,7 @@ use wgpu::{util::BufferInitDescriptor, BindingResource, BufferBinding, BufferUsa
 /// * [`Texture`](crate::render_resource::Texture)
 ///
 /// [std430 alignment/padding requirements]: https://www.w3.org/TR/WGSL/#address-spaces-storage
+#[derive(Resource)]
 pub struct StorageBuffer<T: ShaderType> {
     value: T,
     scratch: StorageBufferWrapper<Vec<u8>>,
@@ -146,6 +148,7 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
 /// * [`Texture`](crate::render_resource::Texture)
 ///
 /// [std430 alignment/padding requirements]: https://www.w3.org/TR/WGSL/#address-spaces-storage
+#[derive(Resource)]
 pub struct DynamicStorageBuffer<T: ShaderType> {
     values: Vec<T>,
     scratch: DynamicStorageBufferWrapper<Vec<u8>>,

--- a/crates/bevy_render/src/render_resource/texture.rs
+++ b/crates/bevy_render/src/render_resource/texture.rs
@@ -1,15 +1,16 @@
+use bevy_ecs::system::Resource;
 use bevy_utils::Uuid;
 use std::{ops::Deref, sync::Arc};
 
 /// A [`Texture`] identifier.
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug, Resource)]
 pub struct TextureId(Uuid);
 
 /// A GPU-accessible texture.
 ///
 /// May be converted from and dereferences to a wgpu [`Texture`](wgpu::Texture).
 /// Can be created via [`RenderDevice::create_texture`](crate::renderer::RenderDevice::create_texture).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Resource)]
 pub struct Texture {
     id: TextureId,
     value: Arc<wgpu::Texture>,
@@ -47,12 +48,12 @@ impl Deref for Texture {
 }
 
 /// A [`TextureView`] identifier.
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug, Resource)]
 pub struct TextureViewId(Uuid);
 
 /// This type combines wgpu's [`TextureView`](wgpu::TextureView) and
 /// [`SurfaceTexture`](wgpu::SurfaceTexture) into the same interface.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Resource)]
 pub enum TextureViewValue {
     /// The value is an actual wgpu [`TextureView`](wgpu::TextureView).
     TextureView(Arc<wgpu::TextureView>),
@@ -71,7 +72,7 @@ pub enum TextureViewValue {
 ///
 /// May be converted from a [`TextureView`](wgpu::TextureView) or [`SurfaceTexture`](wgpu::SurfaceTexture)
 /// or dereferences to a wgpu [`TextureView`](wgpu::TextureView).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Resource)]
 pub struct TextureView {
     id: TextureViewId,
     value: TextureViewValue,
@@ -128,7 +129,7 @@ impl Deref for TextureView {
 }
 
 /// A [`Sampler`] identifier.
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug, Resource)]
 pub struct SamplerId(Uuid);
 
 /// A Sampler defines how a pipeline will sample from a [`TextureView`].
@@ -136,7 +137,7 @@ pub struct SamplerId(Uuid);
 ///
 /// May be converted from and dereferences to a wgpu [`Sampler`](wgpu::Sampler).
 /// Can be created via [`RenderDevice::create_sampler`](crate::renderer::RenderDevice::create_sampler).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Resource)]
 pub struct Sampler {
     id: SamplerId,
     value: Arc<wgpu::Sampler>,

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -2,6 +2,7 @@ use crate::{
     render_resource::Buffer,
     renderer::{RenderDevice, RenderQueue},
 };
+use bevy_ecs::system::Resource;
 use encase::{
     internal::WriteInto, DynamicUniformBuffer as DynamicUniformBufferWrapper, ShaderType,
     UniformBuffer as UniformBufferWrapper,
@@ -27,6 +28,7 @@ use wgpu::{util::BufferInitDescriptor, BindingResource, BufferBinding, BufferUsa
 /// * [`Texture`](crate::render_resource::Texture)
 ///
 /// [std140 alignment/padding requirements]: https://www.w3.org/TR/WGSL/#address-spaces-uniform
+#[derive(Resource)]
 pub struct UniformBuffer<T: ShaderType> {
     value: T,
     scratch: UniformBufferWrapper<Vec<u8>>,
@@ -139,6 +141,7 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
 /// * [`Texture`](crate::render_resource::Texture)
 ///
 /// [std140 alignment/padding requirements]: https://www.w3.org/TR/WGSL/#address-spaces-uniform
+#[derive(Resource)]
 pub struct DynamicUniformBuffer<T: ShaderType> {
     values: Vec<T>,
     scratch: DynamicUniformBufferWrapper<Vec<u8>>,


### PR DESCRIPTION
# Objective

`Resource` trait should be implemented for all public enums/structs in `bevy_render/src/render_resource`
