### PR TITLE
Add documentation to camera helper functions using GlobalTransform

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -195,7 +195,7 @@ impl Camera {
     ///
     /// Note that the [`GlobalTransform`] can be out of sync with the [`Transform`] when
     /// you modify the [`Transform`] of the camera in a system. When it seems the result of this function
-    /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
+    /// lags behind the actual position make sure to run the system using this function in the [`CoreStage::PostUpdate`]
     /// stage after the [`TransformSystem::TransformPropagate`] label.
     ///
     /// To get the coordinates in Normalized Device Coordinates, you should use
@@ -225,7 +225,7 @@ impl Camera {
     ///
     /// Note that the [`GlobalTransform`] can be out of sync with the [`Transform`] when
     /// you modify the [`Transform`] of the camera in a system. When it seems the result of this function
-    /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
+    /// lags behind the actual position make sure to run the system using this function in the [`CoreStage::PostUpdate`]
     /// stage after the [`TransformSystem::TransformPropagate`] label.
     ///
     /// To get the world space coordinates with Normalized Device Coordinates, you should use
@@ -252,7 +252,7 @@ impl Camera {
     ///
     /// Note that the [`GlobalTransform`] can be out of sync with the [`Transform`] when
     /// you modify the [`Transform`] of the camera in a system. When it seems the result of this function
-    /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
+    /// lags behind the actual position make sure to run the system using this function in the [`CoreStage::PostUpdate`]
     /// stage after the [`TransformSystem::TransformPropagate`] label.
     ///
     /// When the position is within the viewport the values returned will be between -1.0 and 1.0 on the X and Y axes,
@@ -280,7 +280,7 @@ impl Camera {
     ///
     /// Note that the [`GlobalTransform`] can be out of sync with the [`Transform`] when
     /// you modify the [`Transform`] of the camera in a system. When it seems the result of this function
-    /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
+    /// lags behind the actual position make sure to run the system using this function in the [`CoreStage::PostUpdate`]
     /// stage after the [`TransformSystem::TransformPropagate`] label.
     ///
     /// To get the world space coordinates with the viewport position, you should use

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -196,7 +196,7 @@ impl Camera {
     /// Note that the [`GlobalTransform`] can be out of sync with the [`Transform`] when
     /// you modify the [`Transform`] of the camera in a system. When it seems the result of this function
     /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
-    /// stage after the TransformSystem::TransformPropagate label.
+    /// stage after the [`TransformSystem::TransformPropagate`] label.
     ///
     /// To get the coordinates in Normalized Device Coordinates, you should use
     /// [`world_to_ndc`](Self::world_to_ndc).
@@ -226,7 +226,7 @@ impl Camera {
     /// Note that the [`GlobalTransform`] can be out of sync with the [`Transform`] when
     /// you modify the [`Transform`] of the camera in a system. When it seems the result of this function
     /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
-    /// stage after the TransformSystem::TransformPropagate label.
+    /// stage after the [`TransformSystem::TransformPropagate`] label.
     ///
     /// To get the world space coordinates with Normalized Device Coordinates, you should use
     /// [`ndc_to_world`](Self::ndc_to_world).
@@ -253,7 +253,7 @@ impl Camera {
     /// Note that the [`GlobalTransform`] can be out of sync with the [`Transform`] when
     /// you modify the [`Transform`] of the camera in a system. When it seems the result of this function
     /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
-    /// stage after the TransformSystem::TransformPropagate label.
+    /// stage after the [`TransformSystem::TransformPropagate`] label.
     ///
     /// When the position is within the viewport the values returned will be between -1.0 and 1.0 on the X and Y axes,
     /// and between 0.0 and 1.0 on the Z axis.
@@ -281,7 +281,7 @@ impl Camera {
     /// Note that the [`GlobalTransform`] can be out of sync with the [`Transform`] when
     /// you modify the [`Transform`] of the camera in a system. When it seems the result of this function
     /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
-    /// stage after the TransformSystem::TransformPropagate label.
+    /// stage after the [`TransformSystem::TransformPropagate`] label.
     ///
     /// To get the world space coordinates with the viewport position, you should use
     /// [`world_to_viewport`](Self::world_to_viewport).

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -193,8 +193,10 @@ impl Camera {
 
     /// Given a position in world space, use the camera to compute the viewport-space coordinates.
     ///
-    /// Note that the GlobalTransform can be out of sync with the Transform until after
-    /// the TransformSystem::TransformPropagate system runs in the PostUpdate stage.
+    /// Note that the GlobalTransform can be out of sync with the Transform when
+    /// you modify the Transform of the camera in a system. When it seems the result of this function
+    /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
+    /// stage after the TransformSystem::TransformPropagate label.
     ///
     /// To get the coordinates in Normalized Device Coordinates, you should use
     /// [`world_to_ndc`](Self::world_to_ndc).
@@ -221,8 +223,10 @@ impl Camera {
     ///
     /// If the camera's projection is orthographic the direction of the ray is always equal to `camera_transform.forward()`.
     ///
-    /// Note that the GlobalTransform can be out of sync with the Transform until after
-    /// the TransformSystem::TransformPropagate system runs in the PostUpdate stage.
+    /// Note that the GlobalTransform can be out of sync with the Transform when
+    /// you modify the Transform of the camera in a system. When it seems the result of this function
+    /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
+    /// stage after the TransformSystem::TransformPropagate label.
     ///
     /// To get the world space coordinates with Normalized Device Coordinates, you should use
     /// [`ndc_to_world`](Self::ndc_to_world).
@@ -246,8 +250,10 @@ impl Camera {
 
     /// Given a position in world space, use the camera's viewport to compute the Normalized Device Coordinates.
     ///
-    /// Note that the GlobalTransform can be out of sync with the Transform until after
-    /// the TransformSystem::TransformPropagate system runs in the PostUpdate stage.
+    /// Note that the GlobalTransform can be out of sync with the Transform when
+    /// you modify the Transform of the camera in a system. When it seems the result of this function
+    /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
+    /// stage after the TransformSystem::TransformPropagate label.
     ///
     /// When the position is within the viewport the values returned will be between -1.0 and 1.0 on the X and Y axes,
     /// and between 0.0 and 1.0 on the Z axis.
@@ -272,8 +278,10 @@ impl Camera {
     /// When the position is within the viewport the values returned will be between -1.0 and 1.0 on the X and Y axes,
     /// and between 0.0 and 1.0 on the Z axis.
     ///
-    /// Note that the GlobalTransform can be out of sync with the Transform until after
-    /// the TransformSystem::TransformPropagate system runs in the PostUpdate stage.
+    /// Note that the GlobalTransform can be out of sync with the Transform when
+    /// you modify the Transform of the camera in a system. When it seems the result of this function
+    /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
+    /// stage after the TransformSystem::TransformPropagate label.
     ///
     /// To get the world space coordinates with the viewport position, you should use
     /// [`world_to_viewport`](Self::world_to_viewport).

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -193,6 +193,9 @@ impl Camera {
 
     /// Given a position in world space, use the camera to compute the viewport-space coordinates.
     ///
+    /// Note that the GlobalTransform can be out of sync with the Transform until after
+    /// the TransformSystem::TransformPropagate system runs in the PostUpdate stage.
+    ///
     /// To get the coordinates in Normalized Device Coordinates, you should use
     /// [`world_to_ndc`](Self::world_to_ndc).
     #[doc(alias = "world_to_screen")]
@@ -218,6 +221,9 @@ impl Camera {
     ///
     /// If the camera's projection is orthographic the direction of the ray is always equal to `camera_transform.forward()`.
     ///
+    /// Note that the GlobalTransform can be out of sync with the Transform until after
+    /// the TransformSystem::TransformPropagate system runs in the PostUpdate stage.
+    ///
     /// To get the world space coordinates with Normalized Device Coordinates, you should use
     /// [`ndc_to_world`](Self::ndc_to_world).
     pub fn viewport_to_world(
@@ -239,6 +245,9 @@ impl Camera {
     }
 
     /// Given a position in world space, use the camera's viewport to compute the Normalized Device Coordinates.
+    ///
+    /// Note that the GlobalTransform can be out of sync with the Transform until after
+    /// the TransformSystem::TransformPropagate system runs in the PostUpdate stage.
     ///
     /// When the position is within the viewport the values returned will be between -1.0 and 1.0 on the X and Y axes,
     /// and between 0.0 and 1.0 on the Z axis.
@@ -262,6 +271,10 @@ impl Camera {
     ///
     /// When the position is within the viewport the values returned will be between -1.0 and 1.0 on the X and Y axes,
     /// and between 0.0 and 1.0 on the Z axis.
+    ///
+    /// Note that the GlobalTransform can be out of sync with the Transform until after
+    /// the TransformSystem::TransformPropagate system runs in the PostUpdate stage.
+    ///
     /// To get the world space coordinates with the viewport position, you should use
     /// [`world_to_viewport`](Self::world_to_viewport).
     pub fn ndc_to_world(&self, camera_transform: &GlobalTransform, ndc: Vec3) -> Option<Vec3> {

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -193,8 +193,8 @@ impl Camera {
 
     /// Given a position in world space, use the camera to compute the viewport-space coordinates.
     ///
-    /// Note that the GlobalTransform can be out of sync with the Transform when
-    /// you modify the Transform of the camera in a system. When it seems the result of this function
+    /// Note that the [`GlobalTransform`] can be out of sync with the [`Transform`] when
+    /// you modify the [`Transform`] of the camera in a system. When it seems the result of this function
     /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
     /// stage after the TransformSystem::TransformPropagate label.
     ///
@@ -223,8 +223,8 @@ impl Camera {
     ///
     /// If the camera's projection is orthographic the direction of the ray is always equal to `camera_transform.forward()`.
     ///
-    /// Note that the GlobalTransform can be out of sync with the Transform when
-    /// you modify the Transform of the camera in a system. When it seems the result of this function
+    /// Note that the [`GlobalTransform`] can be out of sync with the [`Transform`] when
+    /// you modify the [`Transform`] of the camera in a system. When it seems the result of this function
     /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
     /// stage after the TransformSystem::TransformPropagate label.
     ///
@@ -250,8 +250,8 @@ impl Camera {
 
     /// Given a position in world space, use the camera's viewport to compute the Normalized Device Coordinates.
     ///
-    /// Note that the GlobalTransform can be out of sync with the Transform when
-    /// you modify the Transform of the camera in a system. When it seems the result of this function
+    /// Note that the [`GlobalTransform`] can be out of sync with the [`Transform`] when
+    /// you modify the [`Transform`] of the camera in a system. When it seems the result of this function
     /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
     /// stage after the TransformSystem::TransformPropagate label.
     ///
@@ -278,8 +278,8 @@ impl Camera {
     /// When the position is within the viewport the values returned will be between -1.0 and 1.0 on the X and Y axes,
     /// and between 0.0 and 1.0 on the Z axis.
     ///
-    /// Note that the GlobalTransform can be out of sync with the Transform when
-    /// you modify the Transform of the camera in a system. When it seems the result of this function
+    /// Note that the [`GlobalTransform`] can be out of sync with the [`Transform`] when
+    /// you modify the [`Transform`] of the camera in a system. When it seems the result of this function
     /// lags behind the actual position make sure to run the system using this funciont in the PostUpdate
     /// stage after the TransformSystem::TransformPropagate label.
     ///


### PR DESCRIPTION
# Objective
I ran into the issue to position a UI element based on a 3d coordinate in the world:
When changing the transform of the camera, the GlobalTransform of the camera will always lag behind one frame. Because these functions on the Camera struct all require GlobalTransform I can imagine this an issue more people will run into.

## Solution

Add docs explaining that the GlobalTransform can lag behind.

---

## Changelog
Only docs have changed.

## Migration Guide
No code changed.