### PR TITLE
[Merged by Bors] - Add globals struct to mesh2d

### DIFF
--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -8,6 +8,7 @@ use bevy_math::{Mat4, Vec2};
 use bevy_reflect::{Reflect, TypeUuid};
 use bevy_render::{
     extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
+    globals::{GlobalsBuffer, GlobalsUniform},
     mesh::{GpuBufferInfo, Mesh, MeshVertexBufferLayout},
     render_asset::RenderAssets,
     render_phase::{EntityRenderCommand, RenderCommandResult, TrackedRenderPass},
@@ -173,6 +174,16 @@ impl FromWorld for Mesh2dPipeline {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: true,
                         min_binding_size: Some(ViewUniform::min_size()),
+                    },
+                    count: None,
+                },
+                BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: ShaderStages::VERTEX_FRAGMENT,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: Some(GlobalsUniform::min_size()),
                     },
                     count: None,
                 },
@@ -418,14 +429,24 @@ pub fn queue_mesh2d_view_bind_groups(
     mesh2d_pipeline: Res<Mesh2dPipeline>,
     view_uniforms: Res<ViewUniforms>,
     views: Query<Entity, With<ExtractedView>>,
+    globals_buffer: Res<GlobalsBuffer>,
 ) {
-    if let Some(view_binding) = view_uniforms.uniforms.binding() {
+    if let (Some(view_binding), Some(globals)) = (
+        view_uniforms.uniforms.binding(),
+        globals_buffer.buffer.binding(),
+    ) {
         for entity in &views {
             let view_bind_group = render_device.create_bind_group(&BindGroupDescriptor {
-                entries: &[BindGroupEntry {
-                    binding: 0,
-                    resource: view_binding.clone(),
-                }],
+                entries: &[
+                    BindGroupEntry {
+                        binding: 0,
+                        resource: view_binding.clone(),
+                    },
+                    BindGroupEntry {
+                        binding: 1,
+                        resource: globals.clone(),
+                    },
+                ],
                 label: Some("mesh2d_view_bind_group"),
                 layout: &mesh2d_pipeline.view_layout,
             });

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_view_bindings.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_view_bindings.wgsl
@@ -4,3 +4,6 @@
 
 @group(0) @binding(0)
 var<uniform> view: View;
+
+@group(0) @binding(1)
+var<uniform> globals: Globals;

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_view_types.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_view_types.wgsl
@@ -11,3 +11,14 @@ struct View {
     // viewport(x_origin, y_origin, width, height)
     viewport: vec4<f32>,
 };
+
+struct Globals {
+    // The time since startup in seconds
+    // Wraps to 0 after 1 hour.
+    time: f32,
+    // The delta time since the previous frame in seconds
+    delta_time: f32,
+    // Frame count since the start of the app.
+    // It wraps to zero when it reaches the maximum value of a u32.
+    frame_count: u32,
+}


### PR DESCRIPTION
See commit message.
I noticed I couldn't use `globals.time` when using `Material2d`.

I copied the solution from 807336203903e516a8705a13316c2c2c20c0f5bb , and now `Material2d` works for me.

Perhaps some of these struct definitions could be shared in the future, but for now I've just copy pasted it (it looked like the `View` struct was done that way).

Ping @IceSentry , I saw a comment on the linked commit that you intended to do this work at some point in the future.