### PR TITLE
[Merged by Bors] - use bevy default texture format if the surface is not yet available

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -168,7 +168,7 @@ impl Plugin for RenderPlugin {
                 available_texture_formats
                     .get(0)
                     .cloned()
-                    .unwrap_or_else(|| TextureFormat::bevy_default()),
+                    .unwrap_or_else(TextureFormat::bevy_default),
             );
             debug!("Configured wgpu adapter Limits: {:#?}", device.limits());
             debug!("Configured wgpu adapter Features: {:#?}", device.features());

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -39,6 +39,7 @@ pub mod prelude {
 use globals::GlobalsPlugin;
 pub use once_cell;
 use prelude::ComputedVisibility;
+use wgpu::TextureFormat;
 
 use crate::{
     camera::CameraPlugin,
@@ -48,7 +49,7 @@ use crate::{
     render_graph::RenderGraph,
     render_resource::{PipelineCache, Shader, ShaderLoader},
     renderer::{render_system, RenderInstance, RenderTextureFormat},
-    texture::ImagePlugin,
+    texture::{BevyDefault, ImagePlugin},
     view::{ViewPlugin, WindowRenderPlugin},
 };
 use bevy_app::{App, AppLabel, Plugin};
@@ -163,9 +164,12 @@ impl Plugin for RenderPlugin {
                     &options,
                     &request_adapter_options,
                 ));
-            // `available_texture_formats` won't be empty, or else will panick in the former
-            // `initialize_renderer` call.
-            let first_available_texture_format = RenderTextureFormat(available_texture_formats[0]);
+            let texture_format = RenderTextureFormat(
+                available_texture_formats
+                    .get(0)
+                    .cloned()
+                    .unwrap_or_else(|| TextureFormat::bevy_default()),
+            );
             debug!("Configured wgpu adapter Limits: {:#?}", device.limits());
             debug!("Configured wgpu adapter Features: {:#?}", device.features());
             app.insert_resource(device.clone())
@@ -173,7 +177,7 @@ impl Plugin for RenderPlugin {
                 .insert_resource(adapter_info.clone())
                 .insert_resource(render_adapter.clone())
                 .insert_resource(available_texture_formats.clone())
-                .insert_resource(first_available_texture_format.clone())
+                .insert_resource(texture_format.clone())
                 .init_resource::<ScratchMainWorld>()
                 .register_type::<Frustum>()
                 .register_type::<CubemapFrusta>();
@@ -217,7 +221,7 @@ impl Plugin for RenderPlugin {
                 .insert_resource(queue)
                 .insert_resource(render_adapter)
                 .insert_resource(available_texture_formats)
-                .insert_resource(first_available_texture_format)
+                .insert_resource(texture_format)
                 .insert_resource(adapter_info)
                 .insert_resource(pipeline_cache)
                 .insert_resource(asset_server);

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -9,16 +9,13 @@ pub use render_device::*;
 use crate::{
     render_graph::RenderGraph,
     settings::{WgpuSettings, WgpuSettingsPriority},
-    texture::BevyDefault,
     view::{ExtractedWindows, ViewTarget},
 };
 use bevy_ecs::prelude::*;
 use bevy_time::TimeSender;
 use bevy_utils::Instant;
 use std::sync::Arc;
-use wgpu::{
-    Adapter, AdapterInfo, CommandEncoder, Instance, Queue, RequestAdapterOptions, TextureFormat,
-};
+use wgpu::{Adapter, AdapterInfo, CommandEncoder, Instance, Queue, RequestAdapterOptions};
 
 /// Updates the [`RenderGraph`] with all of its nodes and then runs it to render the entire frame.
 pub fn render_system(world: &mut World) {
@@ -106,7 +103,7 @@ pub struct RenderInstance(pub Instance);
 pub struct RenderAdapterInfo(pub AdapterInfo);
 
 /// The [`TextureFormat`](wgpu::TextureFormat) used for rendering.
-/// Initially it's the first element in `AvailableTextureFormats`.
+/// Initially it's the first element in `AvailableTextureFormats`, or Bevy default format.
 #[derive(Resource, Clone, Deref, DerefMut)]
 pub struct RenderTextureFormat(pub wgpu::TextureFormat);
 
@@ -282,9 +279,6 @@ pub async fn initialize_renderer(
     if let Some(s) = request_adapter_options.compatible_surface {
         available_texture_formats = s.get_supported_formats(&adapter);
     };
-    if available_texture_formats.is_empty() {
-        available_texture_formats.push(TextureFormat::bevy_default());
-    }
     let available_texture_formats = Arc::new(available_texture_formats);
     (
         RenderDevice::from(device),

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -9,13 +9,16 @@ pub use render_device::*;
 use crate::{
     render_graph::RenderGraph,
     settings::{WgpuSettings, WgpuSettingsPriority},
+    texture::BevyDefault,
     view::{ExtractedWindows, ViewTarget},
 };
 use bevy_ecs::prelude::*;
 use bevy_time::TimeSender;
 use bevy_utils::Instant;
 use std::sync::Arc;
-use wgpu::{Adapter, AdapterInfo, CommandEncoder, Instance, Queue, RequestAdapterOptions};
+use wgpu::{
+    Adapter, AdapterInfo, CommandEncoder, Instance, Queue, RequestAdapterOptions, TextureFormat,
+};
 
 /// Updates the [`RenderGraph`] with all of its nodes and then runs it to render the entire frame.
 pub fn render_system(world: &mut World) {
@@ -278,11 +281,10 @@ pub async fn initialize_renderer(
     let mut available_texture_formats = Vec::new();
     if let Some(s) = request_adapter_options.compatible_surface {
         available_texture_formats = s.get_supported_formats(&adapter);
-        if available_texture_formats.is_empty() {
-            info!("{:?}", adapter_info);
-            panic!("No supported texture formats found!");
-        }
     };
+    if available_texture_formats.is_empty() {
+        available_texture_formats.push(TextureFormat::bevy_default())
+    }
     let available_texture_formats = Arc::new(available_texture_formats);
     (
         RenderDevice::from(device),

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -283,7 +283,7 @@ pub async fn initialize_renderer(
         available_texture_formats = s.get_supported_formats(&adapter);
     };
     if available_texture_formats.is_empty() {
-        available_texture_formats.push(TextureFormat::bevy_default())
+        available_texture_formats.push(TextureFormat::bevy_default());
     }
     let available_texture_formats = Arc::new(available_texture_formats);
     (


### PR DESCRIPTION
# Objective

- Fix #6231

## Solution

- In case no supported format is found, try to use Bevy default instead of panicking