### PR TITLE
Add folder skeleton for schedule-v3

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -14,6 +14,8 @@ pub mod query;
 #[cfg(feature = "bevy_reflect")]
 pub mod reflect;
 pub mod schedule;
+// This module must remain private until it replaces the existing schedule module
+mod schedule_v3;
 pub mod storage;
 pub mod system;
 pub mod world;

--- a/crates/bevy_ecs/src/schedule_v3/mod.rs
+++ b/crates/bevy_ecs/src/schedule_v3/mod.rs
@@ -1,0 +1,3 @@
+//! WIP code for the [stageless scheduling rework](https://github.com/bevyengine/rfcs/blob/main/rfcs/45-stageless.md)
+//!
+//! This code is not intended to be intercompatible with the existing code in `schedule`, but should work with the rest of `bevy_ecs`.


### PR DESCRIPTION
# Objective

This PR is just the barest of skeleton for the [stageless scheduling rework](https://github.com/bevyengine/rfcs/blob/main/rfcs/45-stageless.md).

My plan here is:

- add the folder structure
- incrementally add functionality, writing tests and docs as we go in bite-sized PRs
- when we're at the target feature parity, make a migration PR to swap everything else over
- force other work on `bevy_ecs/schedule` to target both folders while this is in flight (this has largely been frozen already)

## Why not a feature flag?
- annoying
- hard to test
- easy to forget about 

## Why not a long-lived branch
- merge conflicts 😭 

## Why not a giant PR?
- reviewability
- ability to share the work across team members