### PR TITLE
[Merged by Bors] - Replace the `bool` argument of `Timer` with `TimerMode`

### DIFF
--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -2,7 +2,7 @@ use super::{Diagnostic, DiagnosticId, Diagnostics};
 use bevy_app::prelude::*;
 use bevy_ecs::system::{Res, ResMut, Resource};
 use bevy_log::{debug, info};
-use bevy_time::{Time, Timer};
+use bevy_time::{Time, Timer, TimerMode};
 use bevy_utils::Duration;
 
 /// An App Plugin that logs diagnostics to the console
@@ -32,7 +32,7 @@ impl Default for LogDiagnosticsPlugin {
 impl Plugin for LogDiagnosticsPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(LogDiagnosticsState {
-            timer: Timer::new(self.wait_duration, true),
+            timer: Timer::new(self.wait_duration, TimerMode::Repeating),
             filter: self.filter.clone(),
         });
 

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -16,7 +16,7 @@ use crossbeam_channel::{Receiver, Sender};
 pub mod prelude {
     //! The Bevy Time Prelude.
     #[doc(hidden)]
-    pub use crate::{Time, Timer};
+    pub use crate::{Time, Timer, TimerMode};
 }
 
 use bevy_app::prelude::*;

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -177,7 +177,7 @@ impl Timer {
     /// ```
     #[inline]
     pub fn set_mode(&mut self, mode: TimerMode) {
-        if !self.mode.repeating() && mode.repeating() && self.finished {
+        if self.mode != TimerMode::Repeating && mode == TimerMode::Repeating && self.finished {
             self.stopwatch.reset();
             self.finished = self.just_finished();
         }
@@ -204,13 +204,13 @@ impl Timer {
     pub fn tick(&mut self, delta: Duration) -> &Self {
         if self.paused() {
             self.times_finished_this_tick = 0;
-            if self.mode.repeating() {
+            if self.mode == TimerMode::Repeating {
                 self.finished = false;
             }
             return self;
         }
 
-        if !self.mode.repeating() && self.finished() {
+        if self.mode != TimerMode::Repeating && self.finished() {
             self.times_finished_this_tick = 0;
             return self;
         }
@@ -219,7 +219,7 @@ impl Timer {
         self.finished = self.elapsed() >= self.duration();
 
         if self.finished() {
-            if self.mode.repeating() {
+            if self.mode == TimerMode::Repeating {
                 self.times_finished_this_tick =
                     (self.elapsed().as_nanos() / self.duration().as_nanos()) as u32;
                 // Duration does not have a modulo
@@ -408,12 +408,6 @@ pub enum TimerMode {
     Once,
     /// Reset when finished.
     Repeating,
-}
-
-impl TimerMode {
-    pub fn repeating(self) -> bool {
-        self == Self::Repeating
-    }
 }
 
 #[cfg(test)]

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -159,7 +159,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Repeating);
-    /// assert!(timer.repeating());
+    /// assert!(timer.mode() == TimerMode::Repeating);
     /// ```
     #[inline]
     pub fn mode(&self) -> TimerMode {
@@ -172,8 +172,8 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Repeating);
-    /// timer.set_repeating(false);
-    /// assert!(!timer.repeating());
+    /// timer.set_mode(TimerMode::Once);
+    /// assert!(timer.mode() != TimerMode::Repeating);
     /// ```
     #[inline]
     pub fn set_mode(&mut self, mode: TimerMode) {
@@ -431,7 +431,7 @@ mod tests {
         assert!(!t.finished());
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
-        assert!(!t.repeating());
+        assert!(t.mode() != TimerMode::Repeating);
         assert_eq!(t.percent(), 0.025);
         assert_eq!(t.percent_left(), 0.975);
         // Ticking while paused changes nothing
@@ -442,7 +442,7 @@ mod tests {
         assert!(!t.finished());
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
-        assert!(!t.repeating());
+        assert!(t.mode() != TimerMode::Repeating);
         assert_eq!(t.percent(), 0.025);
         assert_eq!(t.percent_left(), 0.975);
         // Tick past the end and make sure elapsed doesn't go past 0.0 and other things update
@@ -474,7 +474,7 @@ mod tests {
         assert!(!t.finished());
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
-        assert!(t.repeating());
+        assert!(t.mode() == TimerMode::Repeating);
         assert_eq!(t.percent(), 0.375);
         assert_eq!(t.percent_left(), 0.625);
         // Tick past the end and make sure elapsed wraps

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -173,7 +173,7 @@ impl Timer {
     /// # use bevy_time::*;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Repeating);
     /// timer.set_mode(TimerMode::Once);
-    /// assert_ne!(timer.mode(), TimerMode::Repeating);
+    /// assert_eq!(timer.mode(), TimerMode::Once);
     /// ```
     #[inline]
     pub fn set_mode(&mut self, mode: TimerMode) {
@@ -425,7 +425,7 @@ mod tests {
         assert!(!t.finished());
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
-        assert_ne!(t.mode(), TimerMode::Repeating);
+        assert_eq!(t.mode(), TimerMode::Once);
         assert_eq!(t.percent(), 0.025);
         assert_eq!(t.percent_left(), 0.975);
         // Ticking while paused changes nothing
@@ -436,7 +436,7 @@ mod tests {
         assert!(!t.finished());
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
-        assert_ne!(t.mode(), TimerMode::Repeating);
+        assert_eq!(t.mode(), TimerMode::Once);
         assert_eq!(t.percent(), 0.025);
         assert_eq!(t.percent_left(), 0.975);
         // Tick past the end and make sure elapsed doesn't go past 0.0 and other things update

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -159,7 +159,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Repeating);
-    /// assert!(timer.mode() == TimerMode::Repeating);
+    /// assert_eq!(timer.mode(), TimerMode::Repeating);
     /// ```
     #[inline]
     pub fn mode(&self) -> TimerMode {
@@ -173,7 +173,7 @@ impl Timer {
     /// # use bevy_time::*;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Repeating);
     /// timer.set_mode(TimerMode::Once);
-    /// assert!(timer.mode() != TimerMode::Repeating);
+    /// assert_ne!(timer.mode(), TimerMode::Repeating);
     /// ```
     #[inline]
     pub fn set_mode(&mut self, mode: TimerMode) {
@@ -431,7 +431,7 @@ mod tests {
         assert!(!t.finished());
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
-        assert!(t.mode() != TimerMode::Repeating);
+        assert_ne!(t.mode(), TimerMode::Repeating);
         assert_eq!(t.percent(), 0.025);
         assert_eq!(t.percent_left(), 0.975);
         // Ticking while paused changes nothing
@@ -442,7 +442,7 @@ mod tests {
         assert!(!t.finished());
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
-        assert!(t.mode() != TimerMode::Repeating);
+        assert_ne!(t.mode(), TimerMode::Repeating);
         assert_eq!(t.percent(), 0.025);
         assert_eq!(t.percent_left(), 0.975);
         // Tick past the end and make sure elapsed doesn't go past 0.0 and other things update
@@ -474,7 +474,7 @@ mod tests {
         assert!(!t.finished());
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
-        assert!(t.mode() == TimerMode::Repeating);
+        assert_eq!(t.mode(), TimerMode::Repeating);
         assert_eq!(t.percent(), 0.375);
         assert_eq!(t.percent_left(), 0.625);
         // Tick past the end and make sure elapsed wraps

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -14,7 +14,7 @@ use bevy_utils::Duration;
 pub struct Timer {
     stopwatch: Stopwatch,
     duration: Duration,
-    repeating: bool,
+    mode: TimerMode,
     finished: bool,
     times_finished_this_tick: u32,
 }
@@ -23,10 +23,10 @@ impl Timer {
     /// Creates a new timer with a given duration.
     ///
     /// See also [`Timer::from_seconds`](Timer::from_seconds).
-    pub fn new(duration: Duration, repeating: bool) -> Self {
+    pub fn new(duration: Duration, mode: TimerMode) -> Self {
         Self {
             duration,
-            repeating,
+            mode,
             ..Default::default()
         }
     }
@@ -36,12 +36,12 @@ impl Timer {
     /// # Example
     /// ```
     /// # use bevy_time::*;
-    /// let mut timer = Timer::from_seconds(1.0, false);
+    /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// ```
-    pub fn from_seconds(duration: f32, repeating: bool) -> Self {
+    pub fn from_seconds(duration: f32, mode: TimerMode) -> Self {
         Self {
             duration: Duration::from_secs_f32(duration),
-            repeating,
+            mode,
             ..Default::default()
         }
     }
@@ -52,7 +52,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
+    /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(1.5));
     /// assert!(timer.finished());
     /// timer.tick(Duration::from_secs_f32(0.5));
@@ -69,7 +69,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
+    /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(1.5));
     /// assert!(timer.just_finished());
     /// timer.tick(Duration::from_secs_f32(0.5));
@@ -89,7 +89,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
+    /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert_eq!(timer.elapsed(), Duration::from_secs_f32(0.5));
     /// ```
@@ -113,7 +113,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
+    /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.set_elapsed(Duration::from_secs(2));
     /// assert_eq!(timer.elapsed(), Duration::from_secs(2));
     /// // the timer is not finished even if the elapsed time is greater than the duration.
@@ -130,7 +130,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let timer = Timer::new(Duration::from_secs(1), false);
+    /// let timer = Timer::new(Duration::from_secs(1), TimerMode::Once);
     /// assert_eq!(timer.duration(), Duration::from_secs(1));
     /// ```
     #[inline]
@@ -144,7 +144,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.5, false);
+    /// let mut timer = Timer::from_seconds(1.5, TimerMode::Once);
     /// timer.set_duration(Duration::from_secs(1));
     /// assert_eq!(timer.duration(), Duration::from_secs(1));
     /// ```
@@ -158,12 +158,12 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// let mut timer = Timer::from_seconds(1.0, true);
+    /// let mut timer = Timer::from_seconds(1.0, TimerMode::Repeating);
     /// assert!(timer.repeating());
     /// ```
     #[inline]
     pub fn repeating(&self) -> bool {
-        self.repeating
+        self.mode.repeating()
     }
 
     /// Sets whether the timer is repeating or not.
@@ -171,17 +171,21 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// let mut timer = Timer::from_seconds(1.0, true);
+    /// let mut timer = Timer::from_seconds(1.0, TimerMode::Repeating);
     /// timer.set_repeating(false);
     /// assert!(!timer.repeating());
     /// ```
     #[inline]
     pub fn set_repeating(&mut self, repeating: bool) {
-        if !self.repeating && repeating && self.finished {
+        if !self.mode.repeating() && repeating && self.finished {
             self.stopwatch.reset();
             self.finished = self.just_finished();
         }
-        self.repeating = repeating;
+        self.mode = if repeating {
+            TimerMode::Repeating
+        } else {
+            TimerMode::Once
+        };
     }
 
     /// Advance the timer by `delta` seconds.
@@ -194,8 +198,8 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
-    /// let mut repeating = Timer::from_seconds(1.0, true);
+    /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
+    /// let mut repeating = Timer::from_seconds(1.0, TimerMode::Repeating);
     /// timer.tick(Duration::from_secs_f32(1.5));
     /// repeating.tick(Duration::from_secs_f32(1.5));
     /// assert_eq!(timer.elapsed_secs(), 1.0);
@@ -243,7 +247,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
+    /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.pause();
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert_eq!(timer.elapsed_secs(), 0.0);
@@ -261,7 +265,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
+    /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.pause();
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// timer.unpause();
@@ -280,7 +284,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// let mut timer = Timer::from_seconds(1.0, false);
+    /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// assert!(!timer.paused());
     /// timer.pause();
     /// assert!(timer.paused());
@@ -300,7 +304,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, false);
+    /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(1.5));
     /// timer.reset();
     /// assert!(!timer.finished());
@@ -319,7 +323,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(2.0, false);
+    /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert_eq!(timer.percent(), 0.25);
     /// ```
@@ -334,7 +338,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(2.0, false);
+    /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert_eq!(timer.percent_left(), 0.75);
     /// ```
@@ -350,7 +354,7 @@ impl Timer {
     /// # use bevy_time::*;
     /// use std::cmp::Ordering;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(2.0, false);
+    /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// let result = timer.remaining_secs().total_cmp(&1.5);
     /// assert_eq!(Ordering::Equal, result);
@@ -366,7 +370,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(2.0, false);
+    /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert_eq!(timer.remaining(), Duration::from_secs_f32(1.5));
     /// ```
@@ -385,7 +389,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut timer = Timer::from_seconds(1.0, true);
+    /// let mut timer = Timer::from_seconds(1.0, TimerMode::Repeating);
     /// timer.tick(Duration::from_secs_f32(6.0));
     /// assert_eq!(timer.times_finished_this_tick(), 6);
     /// timer.tick(Duration::from_secs_f32(2.0));
@@ -399,6 +403,28 @@ impl Timer {
     }
 }
 
+/// Specifies [`Timer`] behavior.
+#[derive(Debug, Clone, Copy, Reflect)]
+#[reflect(Default)]
+pub enum TimerMode {
+    /// Run once and stop.
+    Once,
+    /// Reset when finished.
+    Repeating,
+}
+
+impl TimerMode {
+    pub fn repeating(self) -> bool {
+        matches!(self, Self::Repeating)
+    }
+}
+
+impl Default for TimerMode {
+    fn default() -> Self {
+        Self::Once
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::float_cmp)]
 mod tests {
@@ -406,7 +432,7 @@ mod tests {
 
     #[test]
     fn non_repeating_timer() {
-        let mut t = Timer::from_seconds(10.0, false);
+        let mut t = Timer::from_seconds(10.0, TimerMode::Once);
         // Tick once, check all attributes
         t.tick(Duration::from_secs_f32(0.25));
         assert_eq!(t.elapsed_secs(), 0.25);
@@ -449,7 +475,7 @@ mod tests {
 
     #[test]
     fn repeating_timer() {
-        let mut t = Timer::from_seconds(2.0, true);
+        let mut t = Timer::from_seconds(2.0, TimerMode::Repeating);
         // Tick once, check all attributes
         t.tick(Duration::from_secs_f32(0.75));
         assert_eq!(t.elapsed_secs(), 0.75);
@@ -480,7 +506,7 @@ mod tests {
 
     #[test]
     fn times_finished_repeating() {
-        let mut t = Timer::from_seconds(1.0, true);
+        let mut t = Timer::from_seconds(1.0, TimerMode::Repeating);
         assert_eq!(t.times_finished_this_tick(), 0);
         t.tick(Duration::from_secs_f32(3.5));
         assert_eq!(t.times_finished_this_tick(), 3);
@@ -493,7 +519,7 @@ mod tests {
 
     #[test]
     fn times_finished_this_tick() {
-        let mut t = Timer::from_seconds(1.0, false);
+        let mut t = Timer::from_seconds(1.0, TimerMode::Once);
         assert_eq!(t.times_finished_this_tick(), 0);
         t.tick(Duration::from_secs_f32(1.5));
         assert_eq!(t.times_finished_this_tick(), 1);
@@ -503,7 +529,7 @@ mod tests {
 
     #[test]
     fn times_finished_this_tick_precise() {
-        let mut t = Timer::from_seconds(0.01, true);
+        let mut t = Timer::from_seconds(0.01, TimerMode::Repeating);
         let duration = Duration::from_secs_f64(0.333);
 
         // total duration: 0.333 => 33 times finished
@@ -522,7 +548,7 @@ mod tests {
 
     #[test]
     fn paused() {
-        let mut t = Timer::from_seconds(10.0, false);
+        let mut t = Timer::from_seconds(10.0, TimerMode::Once);
 
         t.tick(Duration::from_secs_f32(10.0));
         assert!(t.just_finished());
@@ -536,7 +562,7 @@ mod tests {
 
     #[test]
     fn paused_repeating() {
-        let mut t = Timer::from_seconds(10.0, true);
+        let mut t = Timer::from_seconds(10.0, TimerMode::Repeating);
 
         t.tick(Duration::from_secs_f32(10.0));
         assert!(t.just_finished());

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -49,6 +49,6 @@ fn setup(
             transform: Transform::from_scale(Vec3::splat(6.0)),
             ..default()
         },
-        AnimationTimer(Timer::from_seconds(0.1, true)),
+        AnimationTimer(Timer::from_seconds(0.1, TimerMode::Repeating)),
     ));
 }

--- a/examples/app/plugin.rs
+++ b/examples/app/plugin.rs
@@ -29,7 +29,7 @@ impl Plugin for PrintMessagePlugin {
     fn build(&self, app: &mut App) {
         let state = PrintMessageState {
             message: self.message.clone(),
-            timer: Timer::new(self.wait_duration, true),
+            timer: Timer::new(self.wait_duration, TimerMode::Repeating),
         };
         app.insert_resource(state).add_system(print_message_system);
     }

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -30,7 +30,7 @@ struct EventTriggerState {
 impl Default for EventTriggerState {
     fn default() -> Self {
         EventTriggerState {
-            event_timer: Timer::from_seconds(1.0, true),
+            event_timer: Timer::from_seconds(1.0, TimerMode::Repeating),
         }
     }
 }

--- a/examples/ecs/generic_system.rs
+++ b/examples/ecs/generic_system.rs
@@ -51,13 +51,13 @@ fn main() {
 
 fn setup_system(mut commands: Commands) {
     commands.spawn((
-        PrinterTick(Timer::from_seconds(1.0, true)),
+        PrinterTick(Timer::from_seconds(1.0, TimerMode::Repeating)),
         TextToPrint("I will print until you press space.".to_string()),
         MenuClose,
     ));
 
     commands.spawn((
-        PrinterTick(Timer::from_seconds(1.0, true)),
+        PrinterTick(Timer::from_seconds(1.0, TimerMode::Repeating)),
         TextToPrint("I will always print".to_string()),
         LevelUnload,
     ));

--- a/examples/ecs/timers.rs
+++ b/examples/ecs/timers.rs
@@ -24,8 +24,8 @@ pub struct Countdown {
 impl Countdown {
     pub fn new() -> Self {
         Self {
-            percent_trigger: Timer::from_seconds(4.0, true),
-            main_timer: Timer::from_seconds(20.0, false),
+            percent_trigger: Timer::from_seconds(4.0, TimerMode::Repeating),
+            main_timer: Timer::from_seconds(20.0, TimerMode::Once),
         }
     }
 }
@@ -38,7 +38,10 @@ impl Default for Countdown {
 
 fn setup(mut commands: Commands) {
     // Add an entity to the world with a timer
-    commands.spawn(PrintOnCompletionTimer(Timer::from_seconds(5.0, false)));
+    commands.spawn(PrintOnCompletionTimer(Timer::from_seconds(
+        5.0,
+        TimerMode::Once,
+    )));
 }
 
 /// This system ticks all the `Timer` components on entities within the scene

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -17,7 +17,10 @@ struct BonusSpawnTimer(Timer);
 fn main() {
     App::new()
         .init_resource::<Game>()
-        .insert_resource(BonusSpawnTimer(Timer::from_seconds(5.0, true)))
+        .insert_resource(BonusSpawnTimer(Timer::from_seconds(
+            5.0,
+            TimerMode::Repeating,
+        )))
         .add_plugins(DefaultPlugins)
         .add_state(GameState::Playing)
         .add_startup_system(setup_cameras)
@@ -98,7 +101,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
     game.score = 0;
     game.player.i = BOARD_SIZE_I / 2;
     game.player.j = BOARD_SIZE_J / 2;
-    game.player.move_cooldown = Timer::from_seconds(0.3, false);
+    game.player.move_cooldown = Timer::from_seconds(0.3, TimerMode::Once);
 
     commands.spawn(PointLightBundle {
         transform: Transform::from_xyz(4.0, 10.0, 4.0),

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -39,7 +39,7 @@ struct SelectionState {
 impl Default for SelectionState {
     fn default() -> Self {
         Self {
-            timer: Timer::from_seconds(SHOWCASE_TIMER_SECS, true),
+            timer: Timer::from_seconds(SHOWCASE_TIMER_SECS, TimerMode::Repeating),
             has_triggered: false,
         }
     }

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -96,7 +96,7 @@ mod splash {
             OnSplashScreen,
         ));
         // Insert the timer as a resource
-        commands.insert_resource(SplashTimer(Timer::from_seconds(1.0, false)));
+        commands.insert_resource(SplashTimer(Timer::from_seconds(1.0, TimerMode::Once)));
     }
 
     // Tick the timer, and change state when finished
@@ -215,7 +215,7 @@ mod game {
                 );
             });
         // Spawn a 5 seconds timer to trigger going back to the menu
-        commands.insert_resource(GameTimer(Timer::from_seconds(5.0, false)));
+        commands.insert_resource(GameTimer(Timer::from_seconds(5.0, TimerMode::Once)));
     }
 
     // Tick the timer, and change state when finished

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -61,7 +61,7 @@ fn setup(
             let translation = (position * tile_size).extend(rng.gen::<f32>());
             let rotation = Quat::from_rotation_z(rng.gen::<f32>());
             let scale = Vec3::splat(rng.gen::<f32>() * 2.0);
-            let mut timer = Timer::from_seconds(0.1, true);
+            let mut timer = Timer::from_seconds(0.1, TimerMode::Repeating);
             timer.set_elapsed(Duration::from_secs_f32(rng.gen::<f32>()));
 
             commands.spawn((
@@ -118,7 +118,7 @@ struct PrintingTimer(Timer);
 
 impl Default for PrintingTimer {
     fn default() -> Self {
-        Self(Timer::from_seconds(1.0, true))
+        Self(Timer::from_seconds(1.0, TimerMode::Repeating))
     }
 }
 

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -185,6 +185,6 @@ struct PrintingTimer(Timer);
 
 impl Default for PrintingTimer {
     fn default() -> Self {
-        Self(Timer::from_seconds(1.0, true))
+        Self(Timer::from_seconds(1.0, TimerMode::Repeating))
     }
 }

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -187,6 +187,6 @@ struct PrintingTimer(Timer);
 
 impl Default for PrintingTimer {
     fn default() -> Self {
-        Self(Timer::from_seconds(1.0, true))
+        Self(Timer::from_seconds(1.0, TimerMode::Repeating))
     }
 }

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -103,7 +103,7 @@ struct PrintingTimer(Timer);
 
 impl Default for PrintingTimer {
     fn default() -> Self {
-        Self(Timer::from_seconds(1.0, true))
+        Self(Timer::from_seconds(1.0, TimerMode::Repeating))
     }
 }
 

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -26,7 +26,7 @@ impl Default for State {
         Self {
             atlas_count: 0,
             handle: Handle::default(),
-            timer: Timer::from_seconds(0.05, true),
+            timer: Timer::from_seconds(0.05, TimerMode::Repeating),
         }
     }
 }

--- a/examples/ui/scaling.rs
+++ b/examples/ui/scaling.rs
@@ -13,7 +13,7 @@ fn main() {
         .insert_resource(TargetScale {
             start_scale: 1.0,
             target_scale: 1.0,
-            target_time: Timer::new(Duration::from_millis(SCALE_TIME), false),
+            target_time: Timer::new(Duration::from_millis(SCALE_TIME), TimerMode::Once),
         })
         .add_startup_system(setup)
         .add_system(apply_scaling.label(ApplyScaling))


### PR DESCRIPTION
As mentioned in #2926, it's better to have an explicit type that clearly communicates the intent of the timer mode rather than an opaque boolean, which can be only understood when knowing the signature or having to look up the documentation.

This also opens up a way to merge different timers, such as `Stopwatch`, and possibly future ones, such as `DiscreteStopwatch` and `DiscreteTimer` from #2683, into one struct.

Signed-off-by: Lena Milizé <me@lvmn.org>

# Objective

Fixes #2926.

## Solution

Introduce `TimerMode` which replaces the `bool` argument of `Timer` constructors. A `Default` value for `TimerMode` is `Once`.

---

## Changelog

### Added

- `TimerMode` enum, along with variants `TimerMode::Once` and `TimerMode::Repeating`

### Changed

- Replace `bool` argument of `Timer::new` and `Timer::from_seconds` with `TimerMode`
- Change `repeating: bool` field of `Timer` with `mode: TimerMode`

## Migration Guide

- Replace `Timer::new(duration, false)` with `Timer::new(duration, TimerMode::Once)`.
- Replace `Timer::new(duration, true)` with `Timer::new(duration, TimerMode::Repeating)`.
- Replace `Timer::from_seconds(seconds, false)` with `Timer::from_seconds(seconds, TimerMode::Once)`.
- Replace `Timer::from_seconds(seconds, true)` with `Timer::from_seconds(seconds, TimerMode::Repeating)`.
- Change `timer.repeating()` to `timer.mode() == TimerMode::Repeating`.