### PR TITLE
Add default implementation of Serialize and Deserialize to Timer and Stopwatch

### DIFF
--- a/crates/bevy_time/Cargo.toml
+++ b/crates/bevy_time/Cargo.toml
@@ -18,3 +18,4 @@ bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
 
 # other
 crossbeam-channel = "0.5.0"
+serde = { version = "1", features = ["derive"] }

--- a/crates/bevy_time/src/stopwatch.rs
+++ b/crates/bevy_time/src/stopwatch.rs
@@ -1,6 +1,8 @@
 use bevy_reflect::prelude::*;
 use bevy_reflect::Reflect;
 use bevy_utils::Duration;
+use serde::Deserialize;
+use serde::Serialize;
 
 /// A Stopwatch is a struct that track elapsed time when started.
 ///
@@ -23,8 +25,8 @@ use bevy_utils::Duration;
 /// assert!(stopwatch.paused());
 /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
 /// ```
-#[derive(Clone, Debug, Default, Reflect)]
-#[reflect(Default)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Reflect)]
+#[reflect(Default, Serialize, Deserialize)]
 pub struct Stopwatch {
     elapsed: Duration,
     paused: bool,

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -1,6 +1,7 @@
 use crate::Stopwatch;
 use bevy_reflect::prelude::*;
 use bevy_utils::Duration;
+use serde::{Deserialize, Serialize};
 
 /// Tracks elapsed time. Enters the finished state once `duration` is reached.
 ///
@@ -9,8 +10,8 @@ use bevy_utils::Duration;
 /// exceeded, and can still be reset at any given point.
 ///
 /// Paused timers will not have elapsed time increased.
-#[derive(Clone, Debug, Default, Reflect)]
-#[reflect(Default)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Reflect)]
+#[reflect(Default, Serialize, Deserialize)]
 pub struct Timer {
     stopwatch: Stopwatch,
     duration: Duration,


### PR DESCRIPTION
# Objective

Fixes #6244

## Solution

Uses derive to implement `Serialize` and `Deserialize` for `Timer` and `Stopwatch`

### Things to consider
- Should fields such as `finished` and `times_finished_this_tick` in `Timer` be serialized?
- Does `Countdown` and `PrintOnCompletionTimer` need to be serialized and deserialized?

## Changelog

Added `Serialize` and `Deserialize` implementations to `Timer`, `Stopwatch`, `Countdown`, and `PrintOnCompletionTimer`.
