### PR TITLE
[Merged by Bors] - Add a method for accessing the width of a `Table`

### DIFF
--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -587,7 +587,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> QueryIterationCursor<'w, 's, 
                     // `fetch_state`/`filter_state` are the states that `fetch/filter` were initialized with
                     Q::set_table(&mut self.fetch, &query_state.fetch_state, table);
                     F::set_table(&mut self.filter, &query_state.filter_state, table);
-                    self.current_len = table.len();
+                    self.current_len = table.entity_count();
                     self.current_index = 0;
                     continue;
                 }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -925,7 +925,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
                 Q::set_table(&mut fetch, &self.fetch_state, table);
                 F::set_table(&mut filter, &self.filter_state, table);
 
-                for table_index in 0..table.len() {
+                for table_index in 0..table.entity_count() {
                     if !F::table_filter_fetch(&mut filter, table_index) {
                         continue;
                     }
@@ -984,9 +984,9 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
                 for table_id in &self.matched_table_ids {
                     let table = &tables[*table_id];
                     let mut offset = 0;
-                    while offset < table.len() {
+                    while offset < table.entity_count() {
                         let func = func.clone();
-                        let len = batch_size.min(table.len() - offset);
+                        let len = batch_size.min(table.entity_count() - offset);
                         let task = async move {
                             let mut fetch = Q::init_fetch(
                                 world,

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -262,7 +262,7 @@ impl Table {
         row: usize,
         new_table: &mut Table,
     ) -> TableMoveResult {
-        debug_assert!(row < self.len());
+        debug_assert!(row < self.entity_count());
         let is_last = row == self.entities.len() - 1;
         let new_row = new_table.allocate(self.entities.swap_remove(row));
         for (component_id, column) in self.columns.iter_mut() {
@@ -294,7 +294,7 @@ impl Table {
         row: usize,
         new_table: &mut Table,
     ) -> TableMoveResult {
-        debug_assert!(row < self.len());
+        debug_assert!(row < self.entity_count());
         let is_last = row == self.entities.len() - 1;
         let new_row = new_table.allocate(self.entities.swap_remove(row));
         for (component_id, column) in self.columns.iter_mut() {
@@ -325,7 +325,7 @@ impl Table {
         row: usize,
         new_table: &mut Table,
     ) -> TableMoveResult {
-        debug_assert!(row < self.len());
+        debug_assert!(row < self.entity_count());
         let is_last = row == self.entities.len() - 1;
         let new_row = new_table.allocate(self.entities.swap_remove(row));
         for (component_id, column) in self.columns.iter_mut() {
@@ -570,7 +570,7 @@ mod tests {
             };
         }
 
-        assert_eq!(table.capacity(), 256);
-        assert_eq!(table.len(), 200);
+        assert_eq!(table.entity_capacity(), 256);
+        assert_eq!(table.entity_count(), 200);
     }
 }

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -388,18 +388,23 @@ impl Table {
     }
 
     #[inline]
-    pub fn component_count(&self) -> usize {
-        self.columns.len()
-    }
-
-    #[inline]
     pub fn entity_count(&self) -> usize {
         self.entities.len()
     }
 
     #[inline]
+    pub fn component_count(&self) -> usize {
+        self.columns.len()
+    }
+
+    #[inline]
     pub fn entity_capacity(&self) -> usize {
         self.entities.capacity()
+    }
+
+    #[inline]
+    pub fn component_capacity(&self) -> usize {
+        self.columns.capacity()
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -388,13 +388,18 @@ impl Table {
     }
 
     #[inline]
-    pub fn capacity(&self) -> usize {
-        self.entities.capacity()
+    pub fn component_count(&self) -> usize {
+        self.columns.len()
     }
 
     #[inline]
-    pub fn len(&self) -> usize {
+    pub fn entity_count(&self) -> usize {
         self.entities.len()
+    }
+
+    #[inline]
+    pub fn entity_capacity(&self) -> usize {
+        self.entities.capacity()
     }
 
     #[inline]


### PR DESCRIPTION
# Objective

There is currently no good way of getting the width (# of components) of a table outside of `bevy_ecs`.

# Solution

Added the methods `Table::{component_count, component_capacity}`
For consistency and clarity, renamed `Table::{len, capacity}` to `entity_count` and `entity_capacity`.

## Changelog

- Added the methods `Table::component_count` and `Table::component_capacity`
- Renamed `Table::len` and `Table::capacity` to `entity_count` and `entity_capacity`

## Migration Guide

Any use of `Table::len` should now be `Table::entity_count`. Any use of `Table::capacity` should now be `Table::entity_capacity`.
