### PR TITLE
First class support for spawning structures of multiple entities that can be linked together.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -782,6 +782,16 @@ category = "ECS (Entity Component System)"
 wasm = false
 
 [[example]]
+name = "entity_blueprint"
+path = "examples/ecs/entity_blueprint.rs"
+
+[package.metadata.example.entity_blueprint]
+name = "Entity Blueprint"
+description = "Shows how to create an entity from a blueprint"
+category = "ECS (Entity Component System)"
+wasm = false
+
+[[example]]
 name = "event"
 path = "examples/ecs/event.rs"
 

--- a/crates/bevy_ecs/src/blueprint.rs
+++ b/crates/bevy_ecs/src/blueprint.rs
@@ -1,0 +1,5 @@
+use crate::system::EntityCommands;
+
+pub trait EntityBlueprint {
+    fn build(self, entity: &mut EntityCommands);
+}

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -5,6 +5,7 @@
 compile_error!("bevy_ecs cannot safely compile for a 16-bit platform.");
 
 pub mod archetype;
+pub mod blueprint;
 pub mod bundle;
 pub mod change_detection;
 pub mod component;

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2,6 +2,7 @@ mod command_queue;
 mod parallel_scope;
 
 use crate::{
+    blueprint::EntityBlueprint,
     bundle::Bundle,
     entity::{Entities, Entity},
     world::{FromWorld, World},
@@ -240,6 +241,15 @@ impl<'w, 's> Commands<'w, 's> {
     pub fn spawn<'a, T: Bundle>(&'a mut self, bundle: T) -> EntityCommands<'w, 's, 'a> {
         let mut e = self.spawn_empty();
         e.insert(bundle);
+        e
+    }
+
+    pub fn spawn_blueprint<'a, T: EntityBlueprint>(
+        &'a mut self,
+        blueprint: T,
+    ) -> EntityCommands<'w, 's, 'a> {
+        let mut e = self.spawn_empty();
+        blueprint.build(&mut e);
         e
     }
 

--- a/examples/ecs/entity_blueprint.rs
+++ b/examples/ecs/entity_blueprint.rs
@@ -1,0 +1,75 @@
+//! Shows how entity blueprints can be used to create abstractions for heirarchys of entities
+//! This is useful when a component depends on a child components state to know how to function
+
+use bevy::{ecs::blueprint::EntityBlueprint, prelude::*};
+
+#[derive(Component)]
+pub struct MainComponent {
+    pub child: Entity,
+    pub other_child: Entity,
+}
+
+#[derive(Component)]
+pub struct ChildComponent {
+    pub info: f32,
+}
+
+pub struct ExampleBlueprint {
+    pub child_info: f32,
+    pub other_child_info: f32,
+}
+
+impl EntityBlueprint for ExampleBlueprint {
+    fn build(self, entity: &mut bevy::ecs::system::EntityCommands) {
+        let child = entity
+            .commands()
+            .spawn(ChildComponent {
+                info: self.child_info,
+            })
+            .id();
+
+        let other_child = entity
+            .commands()
+            .spawn(ChildComponent {
+                info: self.other_child_info,
+            })
+            .id();
+
+        entity
+            .insert(MainComponent { child, other_child })
+            // stored in main component as a direct link to entity,
+            // so it doesnt necessarily need to be a child
+            // .add_child(child)
+            .add_child(other_child);
+    }
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(setup)
+        .add_system(print_example_sum)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn_blueprint(ExampleBlueprint {
+        child_info: 5.,
+        other_child_info: 10.,
+    });
+}
+
+fn print_example_sum(query: Query<&MainComponent>, child_query: Query<&ChildComponent>) {
+    for component in query.iter() {
+        let Ok(child) = child_query.get(component.child) else {
+            return
+        };
+        let Ok(other_child) = child_query.get(component.other_child) else {
+            return
+        };
+        println!(
+            "Sum of linked object info: {:?}",
+            child.info + other_child.info
+        );
+    }
+}


### PR DESCRIPTION
# Objective

- Adds first class support for structures of entities/components via 'blueprints' (name subject to change)
- Allows spawning 'blueprints' in a way that is consistent with spawning bundles or components.

## Solution

- Uses a trait `EntityBlueprint` that can be implemented for any given struct.
- struct can be used to hold spawning parameters, or settings for the blueprint
- implementing `EntityBlueprint` requires defining `fn build(self, entity: &mut EntityCommands)` which is where the structure of the entity and its relations are built.
- Added a function `spawn_blueprint` into the `impl Commands` that accepts a `EntityBlueprint`, similar to spawning a bundle or component.

### Notes
All of this is very rudimentary and is mainly intended to be a starting point for discussion about not only the method of implementation, but the necessity for one.
