### PR TITLE
[Merged by Bors] - Cleanup dynamic scene before building

### DIFF
--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -292,13 +292,15 @@ mod tests {
         atr.write().register::<ComponentA>();
         world.insert_resource(atr);
 
-        let entity = world.spawn(ComponentB).id();
+        let entity_a = world.spawn(ComponentA).id();
+        let entity_b = world.spawn(ComponentB).id();
 
         let mut builder = DynamicSceneBuilder::from_world(&world);
-        builder.extract_entity(entity);
+        builder.extract_entities([entity_a, entity_b].into_iter());
         builder.remove_empty_entities();
         let scene = builder.build();
 
-        assert_eq!(scene.entities.len(), 0);
+        assert_eq!(scene.entities.len(), 1);
+        assert_eq!(scene.entities[0].entity, entity_a.id());
     }
 }

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -302,6 +302,6 @@ mod tests {
         let scene = builder.build();
 
         assert_eq!(scene.entities.len(), 1);
-        assert_eq!(scene.entities[0].entity, entity_a.id());
+        assert_eq!(scene.entities[0].entity, entity_a.index());
     }
 }

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -58,6 +58,9 @@ impl<'w> DynamicSceneBuilder<'w> {
     }
 
     /// Consume the builder, producing a [`DynamicScene`].
+    ///
+    /// To make sure the dynamic scene doesn't contain entities without any components, call
+    /// [`Self::remove_empty_entities`] before building the scene.
     pub fn build(self) -> DynamicScene {
         DynamicScene {
             entities: self.extracted_scene.into_values().collect(),

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -78,10 +78,8 @@ impl<'w> DynamicSceneBuilder<'w> {
     ///
     /// These were likely created because none of their components were present in the provided type registry upon extraction.
     pub fn remove_empty_entities(&mut self) -> &mut Self {
-        self.extracted_scene = self
-            .extracted_scene
-            .drain_filter(|_, entity| !entity.components.is_empty())
-            .collect();
+        self.extracted_scene
+            .retain(|_, entity| !entity.components.is_empty());
 
         self
     }

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -71,6 +71,9 @@ impl<'w> DynamicSceneBuilder<'w> {
         self.extract_entities(std::iter::once(entity))
     }
 
+    /// Despawns all enitities with no components.
+    ///
+    /// These were likely created because none of their components were present in the provided type registry upon extraction.
     pub fn remove_empty_entities(&mut self) -> &mut Self {
         self.extracted_scene = self
             .extracted_scene


### PR DESCRIPTION
# Objective

- Dynamic scene builder can build scenes without components, if they didn't have any matching the type registry
- Those entities are not really useful in the final `DynamicScene`

## Solution

- Add a method `remove_empty_entities` that will remove empty entities. It's not called by default when calling `build`, I'm not sure if that's a good idea or not.
