### PR TITLE
[Merged by Bors] - Avoid creating `SurfaceConfiguration` in `prepare_windows`

### DIFF
--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -171,6 +171,7 @@ pub fn prepare_windows(
                 render_instance.create_surface(&window.handle.get_handle())
             });
 
+        // Creates a closure to avoid calling this logic unnecessarily
         let create_swap_chain_descriptor = || wgpu::SurfaceConfiguration {
             format: *surface
                 .get_supported_formats(&render_adapter)

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -171,7 +171,7 @@ pub fn prepare_windows(
                 render_instance.create_surface(&window.handle.get_handle())
             });
 
-        let swap_chain_descriptor = wgpu::SurfaceConfiguration {
+        let create_swap_chain_descriptor = || wgpu::SurfaceConfiguration {
             format: *surface
                 .get_supported_formats(&render_adapter)
                 .get(0)
@@ -195,22 +195,25 @@ pub fn prepare_windows(
 
         // Do the initial surface configuration if it hasn't been configured yet. Or if size or
         // present mode changed.
-        if window_surfaces.configured_windows.insert(window.id)
+        let frame = if window_surfaces.configured_windows.insert(window.id)
             || window.size_changed
             || window.present_mode_changed
         {
-            render_device.configure_surface(surface, &swap_chain_descriptor);
-        }
-
-        let frame = match surface.get_current_texture() {
-            Ok(swap_chain_frame) => swap_chain_frame,
-            Err(wgpu::SurfaceError::Outdated) => {
-                render_device.configure_surface(surface, &swap_chain_descriptor);
-                surface
-                    .get_current_texture()
-                    .expect("Error reconfiguring surface")
+            render_device.configure_surface(surface, &create_swap_chain_descriptor());
+            surface
+                .get_current_texture()
+                .expect("Error configuring surface")
+        } else {
+            match surface.get_current_texture() {
+                Ok(swap_chain_frame) => swap_chain_frame,
+                Err(wgpu::SurfaceError::Outdated) => {
+                    render_device.configure_surface(surface, &create_swap_chain_descriptor());
+                    surface
+                        .get_current_texture()
+                        .expect("Error reconfiguring surface")
+                }
+                err => err.expect("Failed to acquire next swap chain texture!"),
             }
-            err => err.expect("Failed to acquire next swap chain texture!"),
         };
 
         window.swap_chain_texture = Some(TextureView::from(frame));


### PR DESCRIPTION
# Objective

- Avoids creating a `SurfaceConfiguration` for every window in every frame for the `prepare_windows` system
- As such also avoid calling `get_supported_formats` for every window in every frame

## Solution

- Construct `SurfaceConfiguration` lazyly in `prepare_windows`

---

This also changes the error message for failed initial surface configuration from "Failed to acquire next swapchain texture" to "Error configuring surface".