### PR TITLE
Add methods for accessing `SourceInfo` and computing load state for dependencies

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -245,6 +245,11 @@ impl AssetServer {
     }
 
     /// Gets the source info of an asset from the provided handle.
+    ///
+    /// The source info is located behind a lock, and isn't completely cheap
+    /// to clone.  Because of that, this method returns an `impl Deref`,
+    /// allowing access by reference while holding the (read) lock, which will
+    /// be released when the reference is dropped.
     pub fn get_source_info<H: Into<HandleId>>(
         &self,
         handle: H,

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -245,10 +245,10 @@ impl AssetServer {
     }
 
     /// Gets the source info of an asset from the provided handle.
-    pub fn get_source_info<'a, H: Into<HandleId>>(
-        &'a self,
+    pub fn get_source_info<H: Into<HandleId>>(
+        &self,
         handle: H,
-    ) -> Option<impl Deref<Target = SourceInfo> + 'a> {
+    ) -> Option<impl Deref<Target = SourceInfo> + '_> {
         match handle.into() {
             HandleId::AssetPathId(id) => {
                 let asset_sources = self.server.asset_sources.read();
@@ -282,9 +282,8 @@ impl AssetServer {
         let mut load_state = LoadState::Loaded;
 
         while let Some(handle_id) = queue.pop_front() {
-            visited.insert(handle_id);
-
-            if visited.contains(&handle_id) {
+            if !visited.insert(handle_id) {
+                // Continue if `visited` already contained `handle_id`
                 continue;
             }
 

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -34,9 +34,10 @@ fn check_textures(
     rpg_sprite_handles: ResMut<RpgSpriteHandles>,
     asset_server: Res<AssetServer>,
 ) {
-    if let LoadState::Loaded =
-        asset_server.get_group_load_state(rpg_sprite_handles.handles.iter().map(|handle| handle.id))
-    {
+    if let LoadState::Loaded = asset_server.get_group_load_state(
+        rpg_sprite_handles.handles.iter().map(|handle| handle.id),
+        false,
+    ) {
         state.set(AppState::Finished).unwrap();
     }
 }


### PR DESCRIPTION
# Objective

- Give access to asset metadata, e.g. to be able to retrieve the source of an asset from its handle.
- Make it possible to define assets with dependencies and then wait until they're fully loaded to move on to another stage.

## Solution

- Add a method `get_source_info` to `AssetServer`, to access the `SourceInfo` associated with a given `HandleId`.
- Introduce a parameter `include_dependencies` to `AssetLoader::get_group_load_state` which makes the method iterate over the dependencies of assets to make sure that they're also fully loaded.

Overall, I'm hoping these changes are small enough to be accepted, while covering enough ground to make assets a little bit more versatile before a larger refactor lands.

---

## Changelog

- Added method `AssetServer::get_source_info`
- Added parameter `include_dependencies` to `AssetLoader::get_group_load_state`

## Migration Guide

Any use of `get_group_load_state` should add a `, false` to the tail of the function call to retrieve the original behavior:

```rust
asset_server.get_group_load_state(my_assets);
// becomes
asset_server.get_group_load_state(my_assets, false);
```
