### PR TITLE
Add a Simple Iter Combinations Example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -822,6 +822,16 @@ category = "ECS (Entity Component System)"
 wasm = false
 
 [[example]]
+name = "iter_combinations_simple"
+path = "examples/ecs/iter_combinations_simple.rs"
+
+[package.metadata.example.iter_combinations_simple]
+name = "Simple Iter Combinations"
+description = "Shows a simple example of how iter combinations works"
+category = "ECS (Entity Component System)"
+wasm = true
+
+[[example]]
 name = "iter_combinations"
 path = "examples/ecs/iter_combinations.rs"
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -559,8 +559,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     /// Returns an [`Iterator`] over all possible combinations of `K` query results without repetition.
     /// This can only be called for read-only queries.
     ///
-    ///  For permutations of size `K` of query returning `N` results, you will get:
-    /// - if `K == N`: one permutation of all query results
+    ///  For combinations of size `K` of query returning `N` results, you will get:
+    /// - if `K == N`: one combination of all query results
     /// - if `K < N`: all possible `K`-sized combinations of query results, without repetition
     /// - if `K > N`: empty set (no `K`-sized combinations exist)
     ///
@@ -585,8 +585,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     /// Iterates over all possible combinations of `K` query results for the given [`World`]
     /// without repetition.
     ///
-    ///  For permutations of size `K` of query returning `N` results, you will get:
-    /// - if `K == N`: one permutation of all query results
+    ///  For combinations of size `K` of query returning `N` results, you will get:
+    /// - if `K == N`: one combination of all query results
     /// - if `K < N`: all possible `K`-sized combinations of query results, without repetition
     /// - if `K > N`: empty set (no `K`-sized combinations exist)
     #[inline]

--- a/examples/ecs/iter_combinations_simple.rs
+++ b/examples/ecs/iter_combinations_simple.rs
@@ -3,15 +3,55 @@
 use bevy::prelude::*;
 
 fn main() {
-    // App::new().add_system(hello_world).run();
+    App::new()
+        .add_startup_system(add_entities)
+        .add_system(example)
+        .run();
 }
 
 #[derive(Component)]
 struct A(usize);
 
 fn add_entities(mut commands: Commands) {
-    commands.spawn();
+    commands.spawn(A(1));
+    commands.spawn(A(2));
+    commands.spawn(A(3));
+    commands.spawn(A(4));
 }
 
-// fn example(query: Query<&A>) {
-// }
+// Below is a simple example of iter_combinations.
+// The iter_combinations method produces the set of combinations of
+// components without repeats.
+
+// The iter combintions method is useful when there are a set of entities with components that all need to interact with
+// eachother in some way. Since iter_combinations does not repeat entities, you can call it without worrying about entities
+// interacting with themselves.
+fn example(query: Query<&A>) {
+    // The below loop will print out...
+    // [1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]
+
+    // Notice how it does not print out [1, 1], or [2, 2], because the function does not allow repeats.
+    // The function also does not repeat [2, 1], because order in a combination does not matter.
+    // So [2, 1] is equivalent to [1, 2].
+    // The set of items where order does matter ([1, 2] != [2, 1]) would be called a permutation.
+    let mut total = 0;
+    for [a_one, a_two] in query.iter_combinations() {
+        total += a_one.0 + a_two.0;
+    }
+
+    assert_eq!(total, 30);
+
+    // The below loop will print out...
+    // [1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4]
+
+    // The size of the items array output by each iteration of the loop is parameterized by K (in this case 3).
+    // The number of total items output (in this case 4), is defined as N.
+    // An "item" refers to each combination of numbers, not each number inside the array.
+    // See the iter_combinations documentation for more.
+    let mut total_two = 0;
+    for [a_one, a_two, a_three] in query.iter_combinations::<3>() {
+        total_two += a_one.0 + a_two.0 + a_three.0;
+    }
+
+    assert_eq!(total_two, 30);
+}

--- a/examples/ecs/iter_combinations_simple.rs
+++ b/examples/ecs/iter_combinations_simple.rs
@@ -1,0 +1,17 @@
+//! A simple example showing how iter_combinations works
+
+use bevy::prelude::*;
+
+fn main() {
+    // App::new().add_system(hello_world).run();
+}
+
+#[derive(Component)]
+struct A(usize);
+
+fn add_entities(mut commands: Commands) {
+    commands.spawn();
+}
+
+// fn example(query: Query<&A>) {
+// }


### PR DESCRIPTION
# Objective

I was trying to implement a collision system for my game, and believed that the iter_combinations method might be what I need. But I couldn't find a simple explanation of what a combination was in Bevy and thought it could use another simple example. 

## Solution

I tried to make a super simple example of iter_combinations that can hopefully explain the method to beginners. 

I also changed up the docs for the method because a combination is a different thing than a permutation but the Bevy docs seemed to use them interchangeably. 

