### PR TITLE
[Merged by Bors] - Link to `linux_dependencies.md` in the panic message when failing to detect a GPU

### DIFF
--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -116,7 +116,8 @@ pub struct AvailableTextureFormats(pub Arc<Vec<wgpu::TextureFormat>>);
 const GPU_NOT_FOUND_ERROR_MESSAGE: &str = "Unable to find a GPU! Make sure you have installed required drivers! For extra information, see: https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md";
 
 #[cfg(not(target_os = "linux"))]
-const GPU_NOT_FOUND_ERROR_MESSAGE: &str = "Unable to find a GPU! Make sure you have installed required drivers!";
+const GPU_NOT_FOUND_ERROR_MESSAGE: &str =
+    "Unable to find a GPU! Make sure you have installed required drivers!";
 
 /// Initializes the renderer by retrieving and preparing the GPU instance, device and queue
 /// for the specified backend.

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -112,12 +112,11 @@ pub struct RenderTextureFormat(pub wgpu::TextureFormat);
 #[derive(Resource, Clone, Deref, DerefMut)]
 pub struct AvailableTextureFormats(pub Arc<Vec<wgpu::TextureFormat>>);
 
-#[cfg(target_os = "linux")]
-const GPU_NOT_FOUND_ERROR_MESSAGE: &str = "Unable to find a GPU! Make sure you have installed required drivers! For extra information, see: https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md";
-
-#[cfg(not(target_os = "linux"))]
-const GPU_NOT_FOUND_ERROR_MESSAGE: &str =
-    "Unable to find a GPU! Make sure you have installed required drivers!";
+const GPU_NOT_FOUND_ERROR_MESSAGE: &str = if cfg!(target_os = "linux") {
+    "Unable to find a GPU! Make sure you have installed required drivers! For extra information, see: https://github.com/bevyengine/bevy/blob/latest/docs/linux_dependencies.md"
+} else {
+    "Unable to find a GPU! Make sure you have installed required drivers!"
+};
 
 /// Initializes the renderer by retrieving and preparing the GPU instance, device and queue
 /// for the specified backend.

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -112,6 +112,12 @@ pub struct RenderTextureFormat(pub wgpu::TextureFormat);
 #[derive(Resource, Clone, Deref, DerefMut)]
 pub struct AvailableTextureFormats(pub Arc<Vec<wgpu::TextureFormat>>);
 
+#[cfg(target_os = "linux")]
+const GPU_NOT_FOUND_ERROR_MESSAGE: &str = "Unable to find a GPU! Make sure you have installed required drivers! For extra information, see: https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md";
+
+#[cfg(not(target_os = "linux"))]
+const GPU_NOT_FOUND_ERROR_MESSAGE: &str = "Unable to find a GPU! Make sure you have installed required drivers!";
+
 /// Initializes the renderer by retrieving and preparing the GPU instance, device and queue
 /// for the specified backend.
 pub async fn initialize_renderer(
@@ -128,7 +134,7 @@ pub async fn initialize_renderer(
     let adapter = instance
         .request_adapter(request_adapter_options)
         .await
-        .expect("Unable to find a GPU! Make sure you have installed required drivers!");
+        .expect(GPU_NOT_FOUND_ERROR_MESSAGE);
 
     let adapter_info = adapter.get_info();
     info!("{:?}", adapter_info);


### PR DESCRIPTION
As suggested in #6104, it would be nice to link directly to `linux_dependencies.md` file in the panic message when running on Linux. And when not compiling for Linux, we fall back to the old message.

Signed-off-by: Lena Milizé <me@lvmn.org>

# Objective

Resolves #6104.

## Solution

Add link to `linux_dependencies.md` when compiling for Linux, and fall back to the old one when not.