### PR TITLE
Remove needless indirection from closures

### DIFF
--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -321,8 +321,8 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
                     }
                 }
 
-                fn matches_component_set(state: &Self::State, _set_contains_id: &impl Fn(#path::component::ComponentId) -> bool) -> bool {
-                    true #(&& <#field_types>::matches_component_set(&state.#field_idents, _set_contains_id))*
+                fn matches_component_set(state: &Self::State, _set_contains_id: impl Fn(#path::component::ComponentId) -> bool) -> bool {
+                    true #(&& <#field_types>::matches_component_set(&state.#field_idents, &_set_contains_id))*
                 }
             }
         }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -139,6 +139,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
             }
 
             #[allow(unused_variables)]
+            #[allow(unused_mut)]
             fn get_components(self, mut func: impl FnMut(#ecs_path::ptr::OwningPtr<'_>)) {
                 #(#field_get_components)*
             }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -107,7 +107,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
         <#field_type as #ecs_path::bundle::Bundle>::component_ids(components, storages, &mut ids);
         });
         field_get_components.push(quote! {
-            self.#field.get_components(&mut *func);
+            self.#field.get_components(&mut func);
         });
         field_from_components.push(quote! {
             #field: <#field_type as #ecs_path::bundle::Bundle>::from_components(ctx, &mut *func),
@@ -139,7 +139,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
             }
 
             #[allow(unused_variables)]
-            fn get_components(self, func: &mut impl FnMut(#ecs_path::ptr::OwningPtr<'_>)) {
+            fn get_components(self, mut func: impl FnMut(#ecs_path::ptr::OwningPtr<'_>)) {
                 #(#field_get_components)*
             }
         }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -104,7 +104,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
     let mut field_from_components = Vec::new();
     for (field_type, field) in field_type.iter().zip(field.iter()) {
         field_component_ids.push(quote! {
-        <#field_type as #ecs_path::bundle::Bundle>::component_ids(components, storages, &mut *ids);
+        <#field_type as #ecs_path::bundle::Bundle>::component_ids(components, storages, &mut ids);
         });
         field_get_components.push(quote! {
             self.#field.get_components(&mut *func);
@@ -123,7 +123,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
             fn component_ids(
                 components: &mut #ecs_path::component::Components,
                 storages: &mut #ecs_path::storage::Storages,
-                ids: &mut impl FnMut(#ecs_path::component::ComponentId)
+                mut ids: impl FnMut(#ecs_path::component::ComponentId)
             ){
                 #(#field_component_ids)*
             }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -130,7 +130,7 @@ pub unsafe trait Bundle: Send + Sync + 'static {
     fn component_ids(
         components: &mut Components,
         storages: &mut Storages,
-        ids: &mut impl FnMut(ComponentId),
+        ids: impl FnMut(ComponentId),
     );
 
     /// Calls `func`, which should return data for each component in the bundle, in the order of
@@ -160,7 +160,7 @@ unsafe impl<C: Component> Bundle for C {
     fn component_ids(
         components: &mut Components,
         storages: &mut Storages,
-        ids: &mut impl FnMut(ComponentId),
+        mut ids: impl FnMut(ComponentId),
     ) {
         ids(components.init_component::<C>(storages));
     }
@@ -188,8 +188,9 @@ macro_rules! tuple_impl {
         // - `Bundle::from_components` calls `func` exactly once for each `ComponentId` returned by `Bundle::component_ids`.
         unsafe impl<$($name: Bundle),*> Bundle for ($($name,)*) {
             #[allow(unused_variables)]
-            fn component_ids(components: &mut Components, storages: &mut Storages, ids: &mut impl FnMut(ComponentId)){
-                $(<$name as Bundle>::component_ids(components, storages, ids);)*
+            #[allow(unused_mut)]
+            fn component_ids(components: &mut Components, storages: &mut Storages, mut ids: impl FnMut(ComponentId)){
+                $(<$name as Bundle>::component_ids(components, storages, &mut ids);)*
             }
 
             #[allow(unused_variables, unused_mut)]

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -432,7 +432,7 @@ pub unsafe trait WorldQuery: for<'w> WorldQueryGats<'w> {
     fn init_state(world: &mut World) -> Self::State;
     fn matches_component_set(
         state: &Self::State,
-        set_contains_id: &impl Fn(ComponentId) -> bool,
+        set_contains_id: impl Fn(ComponentId) -> bool,
     ) -> bool;
 }
 
@@ -538,7 +538,7 @@ unsafe impl WorldQuery for Entity {
 
     fn matches_component_set(
         _state: &Self::State,
-        _set_contains_id: &impl Fn(ComponentId) -> bool,
+        _set_contains_id: impl Fn(ComponentId) -> bool,
     ) -> bool {
         true
     }
@@ -686,7 +686,7 @@ unsafe impl<T: Component> WorldQuery for &T {
 
     fn matches_component_set(
         &state: &ComponentId,
-        set_contains_id: &impl Fn(ComponentId) -> bool,
+        set_contains_id: impl Fn(ComponentId) -> bool,
     ) -> bool {
         set_contains_id(state)
     }
@@ -881,7 +881,7 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
 
     fn matches_component_set(
         &state: &ComponentId,
-        set_contains_id: &impl Fn(ComponentId) -> bool,
+        set_contains_id: impl Fn(ComponentId) -> bool,
     ) -> bool {
         set_contains_id(state)
     }
@@ -1019,7 +1019,7 @@ unsafe impl<T: WorldQuery> WorldQuery for Option<T> {
 
     fn matches_component_set(
         _state: &T::State,
-        _set_contains_id: &impl Fn(ComponentId) -> bool,
+        _set_contains_id: impl Fn(ComponentId) -> bool,
     ) -> bool {
         true
     }
@@ -1274,7 +1274,7 @@ unsafe impl<T: Component> WorldQuery for ChangeTrackers<T> {
 
     fn matches_component_set(
         &id: &ComponentId,
-        set_contains_id: &impl Fn(ComponentId) -> bool,
+        set_contains_id: impl Fn(ComponentId) -> bool,
     ) -> bool {
         set_contains_id(id)
     }
@@ -1378,9 +1378,9 @@ macro_rules! impl_tuple_fetch {
                 ($($name::init_state(_world),)*)
             }
 
-            fn matches_component_set(state: &Self::State, _set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
+            fn matches_component_set(state: &Self::State, _set_contains_id: impl Fn(ComponentId) -> bool) -> bool {
                 let ($($name,)*) = state;
-                true $(&& $name::matches_component_set($name, _set_contains_id))*
+                true $(&& $name::matches_component_set($name, &_set_contains_id))*
             }
         }
 
@@ -1519,9 +1519,9 @@ macro_rules! impl_anytuple_fetch {
                 ($($name::init_state(_world),)*)
             }
 
-            fn matches_component_set(_state: &Self::State, _set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
+            fn matches_component_set(_state: &Self::State, _set_contains_id: impl Fn(ComponentId) -> bool) -> bool {
                 let ($($name,)*) = _state;
-                false $(|| $name::matches_component_set($name, _set_contains_id))*
+                false $(|| $name::matches_component_set($name, &_set_contains_id))*
             }
         }
 
@@ -1600,7 +1600,7 @@ unsafe impl<Q: WorldQuery> WorldQuery for NopWorldQuery<Q> {
 
     fn matches_component_set(
         state: &Self::State,
-        set_contains_id: &impl Fn(ComponentId) -> bool,
+        set_contains_id: impl Fn(ComponentId) -> bool,
     ) -> bool {
         Q::matches_component_set(state, set_contains_id)
     }

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -120,7 +120,7 @@ unsafe impl<T: Component> WorldQuery for With<T> {
 
     fn matches_component_set(
         &id: &ComponentId,
-        set_contains_id: &impl Fn(ComponentId) -> bool,
+        set_contains_id: impl Fn(ComponentId) -> bool,
     ) -> bool {
         set_contains_id(id)
     }
@@ -227,7 +227,7 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
 
     fn matches_component_set(
         &id: &ComponentId,
-        set_contains_id: &impl Fn(ComponentId) -> bool,
+        set_contains_id: impl Fn(ComponentId) -> bool,
     ) -> bool {
         !set_contains_id(id)
     }
@@ -413,9 +413,9 @@ macro_rules! impl_query_filter_tuple {
                 ($($filter::init_state(world),)*)
             }
 
-            fn matches_component_set(_state: &Self::State, _set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
+            fn matches_component_set(_state: &Self::State, _set_contains_id: impl Fn(ComponentId) -> bool) -> bool {
                 let ($($filter,)*) = _state;
-                false $(|| $filter::matches_component_set($filter, _set_contains_id))*
+                false $(|| $filter::matches_component_set($filter, &_set_contains_id))*
             }
         }
 
@@ -553,7 +553,7 @@ macro_rules! impl_tick_filter {
                 world.init_component::<T>()
             }
 
-            fn matches_component_set(&id: &ComponentId, set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
+            fn matches_component_set(&id: &ComponentId, set_contains_id: impl Fn(ComponentId) -> bool) -> bool {
                 set_contains_id(id)
             }
         }

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -51,7 +51,7 @@ fn move_scene_entities(
 ) {
     for moved_scene_entity in &moved_scene {
         let mut offset = 0.;
-        iter_hierarchy(moved_scene_entity, &children, &mut |entity| {
+        iter_hierarchy(moved_scene_entity, &children, |entity| {
             if let Ok(mut transform) = transforms.get_mut(entity) {
                 transform.translation = Vec3::new(
                     offset * time.seconds_since_startup().sin() as f32 / 20.,
@@ -64,11 +64,11 @@ fn move_scene_entities(
     }
 }
 
-fn iter_hierarchy(entity: Entity, children_query: &Query<&Children>, f: &mut impl FnMut(Entity)) {
+fn iter_hierarchy(entity: Entity, children_query: &Query<&Children>, mut f: impl FnMut(Entity)) {
     (f)(entity);
     if let Ok(children) = children_query.get(entity) {
         for child in children.iter().copied() {
-            iter_hierarchy(child, children_query, f);
+            iter_hierarchy(child, children_query, &mut f);
         }
     }
 }


### PR DESCRIPTION
# Objective

Many function definitions in bevy accept fn parameters of the form:
```rust
fn do_thing(self, func: &mut impl FnMut(u64));
```

This kind of indirection is never necessary, since `impl Fn(..)` or `impl FnMut(..)` parameters will accept either a reference or an owned function. Forcing it to accept a reference only makes the function more awkward to call with a closure expression.

## Solution

Remove the indirection.

---

## Migration Guide

- Manual implementors of `WorldQuery` must update `matches_component_set` to match the new signature.
