### PR TITLE
[Merged by Bors] - Add mutating `toggle` method to `Visibility` component

### DIFF
--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -47,6 +47,11 @@ impl Visibility {
 
     /// A [`Visibility`], set as invisible.
     pub const INVISIBLE: Self = Visibility { is_visible: false };
+
+    /// Toggle the visibility.
+    pub fn toggle(&mut self) {
+        self.is_visible = !self.is_visible;
+    }
 }
 
 /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering


### PR DESCRIPTION
# Objective

Make toggling the visibility of an entity slightly more convenient.

## Solution

Add a mutating `toggle` method to the `Visibility` component

```rust
fn my_system(mut query: Query<&mut Visibility, With<SomeMarker>>) {
    let mut visibility = query.single_mut();
    // before: 
    visibility.is_visible = !visibility.is_visible;
    // after:
    visibility.toggle();
}
```

## Changelog

### Added
- Added a mutating `toggle` method to the `Visibility` component
