### PR TITLE
Turn the `Visibility` struct into an enum

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -465,7 +465,7 @@ async fn load_gltf<'a, 'b>(
         let mut entity_to_skin_index_map = HashMap::new();
 
         world
-            .spawn(SpatialBundle::VISIBLE_IDENTITY)
+            .spawn(SpatialBundle::SHOWN_IDENTITY)
             .with_children(|parent| {
                 for node in scene.nodes() {
                     let result = load_node(

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -465,7 +465,7 @@ async fn load_gltf<'a, 'b>(
         let mut entity_to_skin_index_map = HashMap::new();
 
         world
-            .spawn(SpatialBundle::SHOWN_IDENTITY)
+            .spawn(SpatialBundle::INHERITED_IDENTITY)
             .with_children(|parent| {
                 for node in scene.nodes() {
                     let result = load_node(

--- a/crates/bevy_render/src/spatial_bundle.rs
+++ b/crates/bevy_render/src/spatial_bundle.rs
@@ -33,22 +33,22 @@ impl SpatialBundle {
     pub const fn from_transform(transform: Transform) -> Self {
         SpatialBundle {
             transform,
-            ..Self::VISIBLE_IDENTITY
+            ..Self::SHOWN_IDENTITY
         }
     }
 
     /// A visible [`SpatialBundle`], with no translation, rotation, and a scale of 1 on all axes.
-    pub const VISIBLE_IDENTITY: Self = SpatialBundle {
-        visibility: Visibility::Visible,
-        computed: ComputedVisibility::INVISIBLE,
+    pub const SHOWN_IDENTITY: Self = SpatialBundle {
+        visibility: Visibility::Shown,
+        computed: ComputedVisibility::HIDDEN,
         transform: Transform::IDENTITY,
         global_transform: GlobalTransform::IDENTITY,
     };
 
     /// An invisible [`SpatialBundle`], with no translation, rotation, and a scale of 1 on all axes.
-    pub const INVISIBLE_IDENTITY: Self = SpatialBundle {
-        visibility: Visibility::Invisible,
-        ..Self::VISIBLE_IDENTITY
+    pub const HIDDEN_IDENTITY: Self = SpatialBundle {
+        visibility: Visibility::Hidden,
+        ..Self::SHOWN_IDENTITY
     };
 }
 

--- a/crates/bevy_render/src/spatial_bundle.rs
+++ b/crates/bevy_render/src/spatial_bundle.rs
@@ -33,13 +33,13 @@ impl SpatialBundle {
     pub const fn from_transform(transform: Transform) -> Self {
         SpatialBundle {
             transform,
-            ..Self::SHOWN_IDENTITY
+            ..Self::INHERITED_IDENTITY
         }
     }
 
     /// A visible [`SpatialBundle`], with no translation, rotation, and a scale of 1 on all axes.
-    pub const SHOWN_IDENTITY: Self = SpatialBundle {
-        visibility: Visibility::Shown,
+    pub const INHERITED_IDENTITY: Self = SpatialBundle {
+        visibility: Visibility::Inherited,
         computed: ComputedVisibility::HIDDEN,
         transform: Transform::IDENTITY,
         global_transform: GlobalTransform::IDENTITY,
@@ -48,7 +48,7 @@ impl SpatialBundle {
     /// An invisible [`SpatialBundle`], with no translation, rotation, and a scale of 1 on all axes.
     pub const HIDDEN_IDENTITY: Self = SpatialBundle {
         visibility: Visibility::Hidden,
-        ..Self::SHOWN_IDENTITY
+        ..Self::INHERITED_IDENTITY
     };
 }
 

--- a/crates/bevy_render/src/spatial_bundle.rs
+++ b/crates/bevy_render/src/spatial_bundle.rs
@@ -39,7 +39,7 @@ impl SpatialBundle {
 
     /// A visible [`SpatialBundle`], with no translation, rotation, and a scale of 1 on all axes.
     pub const VISIBLE_IDENTITY: Self = SpatialBundle {
-        visibility: Visibility::VISIBLE,
+        visibility: Visibility::Visible,
         computed: ComputedVisibility::INVISIBLE,
         transform: Transform::IDENTITY,
         global_transform: GlobalTransform::IDENTITY,
@@ -47,7 +47,7 @@ impl SpatialBundle {
 
     /// An invisible [`SpatialBundle`], with no translation, rotation, and a scale of 1 on all axes.
     pub const INVISIBLE_IDENTITY: Self = SpatialBundle {
-        visibility: Visibility::INVISIBLE,
+        visibility: Visibility::Invisible,
         ..Self::VISIBLE_IDENTITY
     };
 }

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -64,6 +64,12 @@ impl Visibility {
     pub fn toggle(&mut self) {
         *self = !*self;
     }
+
+    /// Set the visibility using a boolean expression.
+    #[inline]
+    pub fn set(&mut self, shown: bool) {
+        *self = if shown { Self::Shown } else { Self::Hidden }
+    }
 }
 
 /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
@@ -555,5 +561,13 @@ mod test {
             !is_visible(root2_child2_grandchild1),
             "child's invisibility propagates down to grandchild"
         );
+    }
+
+    #[test]
+    fn ensure_visibility_enum_size() {
+        use std::mem;
+        assert_eq!(1, mem::size_of::<Visibility>());
+        assert_eq!(1, mem::size_of::<Option<Visibility>>());
+        assert_eq!(1, mem::size_of::<Option<Option<Visibility>>>());
     }
 }

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -25,12 +25,16 @@ use crate::{
 
 /// User indication of whether an entity is visible. Propagates down the entity hierarchy.
 
-/// If an entity is hidden in this way,  all [`Children`] (and all of their children and so on) will also be hidden.
+/// If an entity is hidden in this way, all [`Children`] (and all of their children and so on) who are set to
+/// `Inherited` will also be hidden.
 /// This is done by setting the values of their [`ComputedVisibility`] component.
 #[derive(Component, Clone, Copy, Reflect, Debug, PartialEq, Eq)]
 #[reflect(Component, Default)]
 pub enum Visibility {
+    /// An entity with `Visibility::Inherited` will inherit the Visibility of its [`Parent`].
     Inherited,
+    /// An entity with `Visibility::Hidden` will be unconditionally hidden, and will also cause any
+    /// of its [`Children`] which are set to `Visibility::Inherited` to also be hidden.
     Hidden,
 }
 

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -25,13 +25,18 @@ use crate::{
 
 /// User indication of whether an entity is visible. Propagates down the entity hierarchy.
 
-/// If an entity is hidden in this way, all [`Children`] (and all of their children and so on) who are set to
-/// `Inherited` will also be hidden.
+/// If an entity is hidden in this way, all [`Children`] (and all of their children and so on) who
+/// are set to `Inherited` will also be hidden.
 /// This is done by setting the values of their [`ComputedVisibility`] component.
+///
+/// A root-level entity that is set to `Inherited` will be visible, and as such will cause any of
+/// its [`Children`] entities which are set to `Inherited` to also be visible.
 #[derive(Component, Clone, Copy, Reflect, Debug, PartialEq, Eq)]
 #[reflect(Component, Default)]
 pub enum Visibility {
     /// An entity with `Visibility::Inherited` will inherit the Visibility of its [`Parent`].
+    ///
+    /// A root-level entity that is set to `Inherited` will be visible.
     Inherited,
     /// An entity with `Visibility::Hidden` will be unconditionally hidden, and will also cause any
     /// of its [`Children`] which are set to `Visibility::Inherited` to also be hidden.

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -11,6 +11,7 @@ use bevy_reflect::Reflect;
 use bevy_transform::components::GlobalTransform;
 use bevy_transform::TransformSystem;
 use std::cell::Cell;
+use std::ops::Not;
 use thread_local::ThreadLocal;
 
 use crate::{
@@ -26,7 +27,7 @@ use crate::{
 
 /// If an entity is hidden in this way,  all [`Children`] (and all of their children and so on) will also be hidden.
 /// This is done by setting the values of their [`ComputedVisibility`] component.
-#[derive(Component, Clone, Reflect, Debug, PartialEq, Eq)]
+#[derive(Component, Clone, Copy, Reflect, Debug, PartialEq, Eq)]
 #[reflect(Component, Default)]
 pub enum Visibility {
     Shown,
@@ -39,23 +40,29 @@ impl Default for Visibility {
     }
 }
 
+impl Not for Visibility {
+    type Output = Visibility;
+
+    #[inline]
+    fn not(self) -> Visibility {
+        match self {
+            Visibility::Shown => Visibility::Hidden,
+            Visibility::Hidden => Visibility::Shown,
+        }
+    }
+}
+
 impl Visibility {
     /// Whether this entity is visible.
     #[inline]
     pub const fn is_visible(&self) -> bool {
-        match self {
-            Self::Shown => true,
-            Self::Hidden => false,
-        }
+        matches!(self, Self::Shown)
     }
 
     /// Toggle the visibility.
     #[inline]
     pub fn toggle(&mut self) {
-        *self = match self {
-            Self::Shown => Self::Hidden,
-            Self::Hidden => Self::Shown,
-        }
+        *self = !*self;
     }
 }
 

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -26,16 +26,16 @@ use crate::{
 
 /// If an entity is hidden in this way,  all [`Children`] (and all of their children and so on) will also be hidden.
 /// This is done by setting the values of their [`ComputedVisibility`] component.
-#[derive(Component, Clone, Reflect, Debug)]
+#[derive(Component, Clone, Reflect, Debug, PartialEq, Eq)]
 #[reflect(Component, Default)]
 pub enum Visibility {
-    Visible,
-    Invisible,
+    Shown,
+    Hidden,
 }
 
 impl Default for Visibility {
     fn default() -> Self {
-        Self::Visible
+        Self::Shown
     }
 }
 
@@ -44,8 +44,8 @@ impl Visibility {
     #[inline]
     pub const fn is_visible(&self) -> bool {
         match self {
-            Self::Visible => true,
-            Self::Invisible => false,
+            Self::Shown => true,
+            Self::Hidden => false,
         }
     }
 
@@ -53,8 +53,8 @@ impl Visibility {
     #[inline]
     pub fn toggle(&mut self) {
         *self = match self {
-            Self::Visible => Self::Invisible,
-            Self::Invisible => Self::Visible,
+            Self::Shown => Self::Hidden,
+            Self::Hidden => Self::Shown,
         }
     }
 }
@@ -69,13 +69,13 @@ pub struct ComputedVisibility {
 
 impl Default for ComputedVisibility {
     fn default() -> Self {
-        Self::INVISIBLE
+        Self::HIDDEN
     }
 }
 
 impl ComputedVisibility {
     /// A [`ComputedVisibility`], set as invisible.
-    pub const INVISIBLE: Self = ComputedVisibility {
+    pub const HIDDEN: Self = ComputedVisibility {
         is_visible_in_hierarchy: false,
         is_visible_in_view: false,
     };
@@ -438,7 +438,7 @@ mod test {
 
         let root1 = app
             .world
-            .spawn((Visibility::Invisible, ComputedVisibility::default()))
+            .spawn((Visibility::Hidden, ComputedVisibility::default()))
             .id();
         let root1_child1 = app
             .world
@@ -446,7 +446,7 @@ mod test {
             .id();
         let root1_child2 = app
             .world
-            .spawn((Visibility::Invisible, ComputedVisibility::default()))
+            .spawn((Visibility::Hidden, ComputedVisibility::default()))
             .id();
         let root1_child1_grandchild1 = app
             .world
@@ -477,7 +477,7 @@ mod test {
             .id();
         let root2_child2 = app
             .world
-            .spawn((Visibility::Invisible, ComputedVisibility::default()))
+            .spawn((Visibility::Hidden, ComputedVisibility::default()))
             .id();
         let root2_child1_grandchild1 = app
             .world

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -103,7 +103,7 @@ fn star(
         // The `Handle<Mesh>` needs to be wrapped in a `Mesh2dHandle` to use 2d rendering instead of 3d
         Mesh2dHandle(meshes.add(star)),
         // This bundle's components are needed for something to be rendered
-        SpatialBundle::SHOWN_IDENTITY,
+        SpatialBundle::INHERITED_IDENTITY,
     ));
 
     // Spawn the camera

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -103,7 +103,7 @@ fn star(
         // The `Handle<Mesh>` needs to be wrapped in a `Mesh2dHandle` to use 2d rendering instead of 3d
         Mesh2dHandle(meshes.add(star)),
         // This bundle's components are needed for something to be rendered
-        SpatialBundle::VISIBLE_IDENTITY,
+        SpatialBundle::SHOWN_IDENTITY,
     ));
 
     // Spawn the camera

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -129,7 +129,7 @@ fn setup(
         .with_children(|p| {
             // This entity is just used for animation, but doesn't display anything
             p.spawn((
-                SpatialBundle::SHOWN_IDENTITY,
+                SpatialBundle::INHERITED_IDENTITY,
                 // Add the Name component
                 orbit_controller,
             ))

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -129,7 +129,7 @@ fn setup(
         .with_children(|p| {
             // This entity is just used for animation, but doesn't display anything
             p.spawn((
-                SpatialBundle::VISIBLE_IDENTITY,
+                SpatialBundle::SHOWN_IDENTITY,
                 // Add the Name component
                 orbit_controller,
             ))

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -32,7 +32,7 @@ fn main() {
 fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
     commands.spawn((
         meshes.add(Mesh::from(shape::Cube { size: 0.5 })),
-        SpatialBundle::VISIBLE_IDENTITY,
+        SpatialBundle::SHOWN_IDENTITY,
         InstanceMaterialData(
             (1..=10)
                 .flat_map(|x| (1..=10).map(move |y| (x as f32 / 10.0, y as f32 / 10.0)))

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -32,7 +32,7 @@ fn main() {
 fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
     commands.spawn((
         meshes.add(Mesh::from(shape::Cube { size: 0.5 })),
-        SpatialBundle::SHOWN_IDENTITY,
+        SpatialBundle::INHERITED_IDENTITY,
         InstanceMaterialData(
             (1..=10)
                 .flat_map(|x| (1..=10).map(move |y| (x as f32 / 10.0, y as f32 / 10.0)))

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -111,7 +111,7 @@ fn setup(
         let (base_rotation, ring_direction) = ring_directions[ring_index % 2];
         let ring_parent = commands
             .spawn((
-                SpatialBundle::VISIBLE_IDENTITY,
+                SpatialBundle::SHOWN_IDENTITY,
                 ring_direction,
                 Ring { radius },
             ))

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -111,7 +111,7 @@ fn setup(
         let (base_rotation, ring_direction) = ring_directions[ring_index % 2];
         let ring_parent = commands
             .spawn((
-                SpatialBundle::SHOWN_IDENTITY,
+                SpatialBundle::INHERITED_IDENTITY,
                 ring_direction,
                 Ring { radius },
             ))


### PR DESCRIPTION
# Objective

The current implementation of the `Visibility` struct simply wraps a boolean.. which seems like an odd pattern when rust has such nice enums that allow for more expression using pattern-matching.

## Solution

Make `Visibility` into an enum.

---

## Changelog

### Changed

`Visibility` is now an enum

## Migration Guide

- Code that checks the `visibility.is_visible` field should now call it as a method `visibility.is_inherited()`, use `==`, or refactor to use a `match`.
- Code that used to set or unset the `visibility.is_visible` field should now directly set the value: `*visibility = Visibility::Inherited`, or use the `.toggle()` or `.set(bool)` methods.
- Any usages of the associated constants `Visibility::VISIBLE` or `Visibility::INVISIBLE` should now use the enum variants, `Visibility::Inherited` or `Visibility::Hidden`.
- `ComputedVisibility::INVISIBLE` and `SpatialBundle::VISIBLE_IDENTITY` have been renamed to `ComputedVisibility::HIDDEN` and `SpatialBundle::INHERITED_IDENTITY` respectively.



