### PR TITLE
[Merged by Bors] - Fixes incorrect glyph positioning for text2d

### DIFF
--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -8,7 +8,8 @@ use glyph_brush_layout::{
 };
 
 use crate::{
-    error::TextError, Font, FontAtlasSet, GlyphAtlasInfo, TextAlignment, TextSettings, TextType,
+    error::TextError, Font, FontAtlasSet, GlyphAtlasInfo, TextAlignment, TextSettings,
+    YAxisOrientation,
 };
 
 pub struct GlyphBrush {
@@ -55,7 +56,7 @@ impl GlyphBrush {
         texture_atlases: &mut Assets<TextureAtlas>,
         textures: &mut Assets<Image>,
         text_settings: &TextSettings,
-        text_type: TextType,
+        y_axis_orientation: YAxisOrientation,
     ) -> Result<Vec<PositionedGlyph>, TextError> {
         if glyphs.is_empty() {
             return Ok(Vec::new());
@@ -89,6 +90,7 @@ impl GlyphBrush {
         }
         min_x = min_x.floor();
         min_y = min_y.floor();
+        max_y = max_y.floor();
 
         let mut positioned_glyphs = Vec::new();
         for sg in glyphs {
@@ -126,9 +128,9 @@ impl GlyphBrush {
 
                 let x = bounds.min.x + size.x / 2.0 - min_x;
 
-                let y = match text_type {
-                    TextType::Text2D => max_y - bounds.max.y + size.y / 2.0,
-                    TextType::Ui => bounds.min.y + size.y / 2.0 - min_y,
+                let y = match y_axis_orientation {
+                    YAxisOrientation::BottomToTop => max_y - bounds.max.y + size.y / 2.0,
+                    YAxisOrientation::TopToBottom => bounds.min.y + size.y / 2.0 - min_y,
                 };
 
                 let position = adjust.position(Vec2::new(x, y));

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -57,7 +57,7 @@ impl Default for TextSettings {
 }
 
 /// Text is rendered for two different view projections, normal `Text2DBundle` is rendered with a
-/// `BottomToTop` y axis, and UI is rendered with a `TopToBottom` y axis. This matters for text because of
+/// `BottomToTop` y axis, and UI is rendered with a `TopToBottom` y axis. This matters for text because
 /// the glyph positioning is different in either layout.
 pub enum YAxisOrientation {
     TopToBottom,

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -56,9 +56,12 @@ impl Default for TextSettings {
     }
 }
 
-pub enum TextType {
-    Ui,
-    Text2D,
+/// Text is rendered for two different view projections, normal Text2DBundle is rendered with a
+/// BottomToTop YAxis, and UI is rendered with a TopToBottom YAxis. This matters for text because of
+/// the glyph positioning is different in either layout.
+pub enum YAxisOrientation {
+    TopToBottom,
+    BottomToTop,
 }
 
 impl Plugin for TextPlugin {

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -56,8 +56,8 @@ impl Default for TextSettings {
     }
 }
 
-/// Text is rendered for two different view projections, normal Text2DBundle is rendered with a
-/// BottomToTop YAxis, and UI is rendered with a TopToBottom YAxis. This matters for text because of
+/// Text is rendered for two different view projections, normal `Text2DBundle` is rendered with a
+/// `BottomToTop` y axis, and UI is rendered with a `TopToBottom` y axis. This matters for text because of
 /// the glyph positioning is different in either layout.
 pub enum YAxisOrientation {
     TopToBottom,

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -56,6 +56,11 @@ impl Default for TextSettings {
     }
 }
 
+pub enum TextType {
+    Ui,
+    Text2D,
+}
+
 impl Plugin for TextPlugin {
     fn build(&self, app: &mut App) {
         app.add_asset::<Font>()

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -11,7 +11,7 @@ use glyph_brush_layout::{FontId, SectionText};
 
 use crate::{
     error::TextError, glyph_brush::GlyphBrush, scale_value, Font, FontAtlasSet, PositionedGlyph,
-    TextAlignment, TextSection, TextSettings,
+    TextAlignment, TextSection, TextSettings, TextType,
 };
 
 #[derive(Default, Resource)]
@@ -50,6 +50,7 @@ impl TextPipeline {
         texture_atlases: &mut Assets<TextureAtlas>,
         textures: &mut Assets<Image>,
         text_settings: &TextSettings,
+        text_type: TextType,
     ) -> Result<TextLayoutInfo, TextError> {
         let mut scaled_fonts = Vec::new();
         let sections = sections
@@ -105,6 +106,7 @@ impl TextPipeline {
             texture_atlases,
             textures,
             text_settings,
+            text_type,
         )?;
 
         Ok(TextLayoutInfo { glyphs, size })

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -11,7 +11,7 @@ use glyph_brush_layout::{FontId, SectionText};
 
 use crate::{
     error::TextError, glyph_brush::GlyphBrush, scale_value, Font, FontAtlasSet, PositionedGlyph,
-    TextAlignment, TextSection, TextSettings, TextType,
+    TextAlignment, TextSection, TextSettings, YAxisOrientation,
 };
 
 #[derive(Default, Resource)]
@@ -50,7 +50,7 @@ impl TextPipeline {
         texture_atlases: &mut Assets<TextureAtlas>,
         textures: &mut Assets<Image>,
         text_settings: &TextSettings,
-        text_type: TextType,
+        y_axis_orientation: YAxisOrientation,
     ) -> Result<TextLayoutInfo, TextError> {
         let mut scaled_fonts = Vec::new();
         let sections = sections
@@ -106,7 +106,7 @@ impl TextPipeline {
             texture_atlases,
             textures,
             text_settings,
-            text_type,
+            y_axis_orientation,
         )?;
 
         Ok(TextLayoutInfo { glyphs, size })

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -23,7 +23,7 @@ use bevy_window::{WindowId, WindowScaleFactorChanged, Windows};
 
 use crate::{
     Font, FontAtlasSet, HorizontalAlign, Text, TextError, TextLayoutInfo, TextPipeline,
-    TextSettings, TextType, VerticalAlign,
+    TextSettings, VerticalAlign, YAxisOrientation,
 };
 
 /// The calculated size of text drawn in 2D scene.
@@ -193,7 +193,7 @@ pub fn update_text2d_layout(
                 &mut *texture_atlases,
                 &mut *textures,
                 text_settings.as_ref(),
-                TextType::Text2D,
+                YAxisOrientation::BottomToTop,
             ) {
                 Err(TextError::NoSuchFont) => {
                     // There was an error processing the text layout, let's add this entity to the

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -23,7 +23,7 @@ use bevy_window::{WindowId, WindowScaleFactorChanged, Windows};
 
 use crate::{
     Font, FontAtlasSet, HorizontalAlign, Text, TextError, TextLayoutInfo, TextPipeline,
-    TextSettings, VerticalAlign,
+    TextSettings, TextType, VerticalAlign,
 };
 
 /// The calculated size of text drawn in 2D scene.
@@ -182,6 +182,7 @@ pub fn update_text2d_layout(
                 ),
                 None => Vec2::new(f32::MAX, f32::MAX),
             };
+
             match text_pipeline.queue_text(
                 &fonts,
                 &text.sections,
@@ -192,6 +193,7 @@ pub fn update_text2d_layout(
                 &mut *texture_atlases,
                 &mut *textures,
                 text_settings.as_ref(),
+                TextType::Text2D,
             ) {
                 Err(TextError::NoSuchFont) => {
                     // There was an error processing the text layout, let's add this entity to the

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -9,7 +9,8 @@ use bevy_math::Vec2;
 use bevy_render::texture::Image;
 use bevy_sprite::TextureAtlas;
 use bevy_text::{
-    Font, FontAtlasSet, Text, TextError, TextLayoutInfo, TextPipeline, TextSettings, TextType,
+    Font, FontAtlasSet, Text, TextError, TextLayoutInfo, TextPipeline, TextSettings,
+    YAxisOrientation,
 };
 use bevy_window::Windows;
 
@@ -120,7 +121,7 @@ pub fn text_system(
                 &mut *texture_atlases,
                 &mut *textures,
                 text_settings.as_ref(),
-                TextType::Ui,
+                YAxisOrientation::TopToBottom,
             ) {
                 Err(TextError::NoSuchFont) => {
                     // There was an error processing the text layout, let's add this entity to the

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -8,7 +8,9 @@ use bevy_ecs::{
 use bevy_math::Vec2;
 use bevy_render::texture::Image;
 use bevy_sprite::TextureAtlas;
-use bevy_text::{Font, FontAtlasSet, Text, TextError, TextLayoutInfo, TextPipeline, TextSettings};
+use bevy_text::{
+    Font, FontAtlasSet, Text, TextError, TextLayoutInfo, TextPipeline, TextSettings, TextType,
+};
 use bevy_window::Windows;
 
 #[derive(Debug, Default)]
@@ -118,6 +120,7 @@ pub fn text_system(
                 &mut *texture_atlases,
                 &mut *textures,
                 text_settings.as_ref(),
+                TextType::Ui,
             ) {
                 Err(TextError::NoSuchFont) => {
                     // There was an error processing the text layout, let's add this entity to the

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -19,8 +19,10 @@ fn main() {
 
 #[derive(Component)]
 struct AnimateTranslation;
+
 #[derive(Component)]
 struct AnimateRotation;
+
 #[derive(Component)]
 struct AnimateScale;
 


### PR DESCRIPTION
# Objective
Fixes #6272

## Solution
Revert to old way of positioning text for Text2D rendered text.
