### PR TITLE
[Merged by Bors] - Add Eq & PartialEq to AssetPath

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 /// Represents a path to an asset in the file system.
-#[derive(Debug, Hash, Clone, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize)]
 pub struct AssetPath<'a> {
     path: Cow<'a, Path>,
     label: Option<Cow<'a, str>>,


### PR DESCRIPTION
Adds `Eq` and `ArtialEq` to `AssetPath` to make `AssetPath` usable inside HashMaps.