### PR TITLE
Updated 3d_scene example

### DIFF
--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -16,20 +16,20 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // plane
-    commands.spawn(PbrBundle {
+    commands.spawn().insert_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
         material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
         ..default()
     });
     // cube
-    commands.spawn(PbrBundle {
+    commands.spawn().insert_bundle(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });
     // light
-    commands.spawn(PointLightBundle {
+    commands.spawn().insert_bundle(PointLightBundle {
         point_light: PointLight {
             intensity: 1500.0,
             shadows_enabled: true,
@@ -39,8 +39,7 @@ fn setup(
         ..default()
     });
     // camera
-    commands.spawn(Camera3dBundle {
+    commands.spawn().insert_bundle(Camera3dBundle {
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
     });
-}

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -43,3 +43,4 @@ fn setup(
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
     });
+}


### PR DESCRIPTION
# Objective

The example is broken, even when copy+pasting it doesn't compile. 

## Solution

Updated the 3d_scene example to use the new way to insert bundles with the spawn command.
No longer commands.spawn(BUNDLE). 
Now is commands.spawn().insert_bundle(BUNDLE)

---