### PR TITLE
bevy_reflect: Fix `DynamicScene` not respecting component registrations during serialization

### DIFF
--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -205,7 +205,7 @@ impl<'a> Serialize for StructSerializer<'a> {
 
         let serialization_data = self
             .registry
-            .get(self.struct_value.type_id())
+            .get(type_info.type_id())
             .and_then(|registration| registration.data::<SerializationData>());
         let ignored_len = serialization_data.map(|data| data.len()).unwrap_or(0);
         let mut state = serializer.serialize_struct(
@@ -255,7 +255,7 @@ impl<'a> Serialize for TupleStructSerializer<'a> {
 
         let serialization_data = self
             .registry
-            .get(self.tuple_struct.type_id())
+            .get(type_info.type_id())
             .and_then(|registration| registration.data::<SerializationData>());
         let ignored_len = serialization_data.map(|data| data.len()).unwrap_or(0);
         let mut state = serializer.serialize_tuple_struct(


### PR DESCRIPTION
# Objective

When running the scene example, you might notice we end up printing out the following:
```ron
// ...
{
  "scene::ComponentB": (
    value: "hello",
    _time_since_startup: (
      secs: 0,
      nanos: 0,
    ),
  ),
},
// ...
```

We should not be printing out `_time_since_startup` as the field is marked with `#[reflect(skip_serializing)]`:

```rust
#[derive(Component, Reflect)]
#[reflect(Component)]
struct ComponentB {
  pub value: String,
  #[reflect(skip_serializing)]
  pub _time_since_startup: Duration,
}
```

This is because when we create the `DynamicScene`, we end up calling `Reflect::clone_value`:

https://github.com/MrGVSV/bevy/blob/82126697ee4f635cf6b22e0b9f25e5aca95fda4a/crates/bevy_scene/src/dynamic_scene_builder.rs#L114-L114

This results in non-Value types being cloned into Dynamic types, which means the `TypeId` returned from `reflected_value.type_id()` is not the same as the original component's. 

And this meant we were not able to locate the correct `TypeRegistration`.

## Solution

Use `TypeInfo::type_id()` instead of calling `Any::type_id()` on the value directly.

---

## Changelog

* Fix a bug in `0.9.0-dev` where scenes disregarded component's type registrations
