### PR TITLE
bevy_reflect: Cleanup field attribute logic

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
@@ -229,7 +229,7 @@ impl<'a> ReflectDerive<'a> {
             .iter()
             .enumerate()
             .map(|(index, field)| -> Result<StructField, syn::Error> {
-                let attrs = parse_field_attrs(&field.attrs)?;
+                let attrs = parse_field_attrs(&field.attrs, false)?;
                 Ok(StructField {
                     index,
                     attrs,
@@ -262,7 +262,7 @@ impl<'a> ReflectDerive<'a> {
                 };
                 Ok(EnumVariant {
                     fields,
-                    attrs: parse_field_attrs(&variant.attrs)?,
+                    attrs: parse_field_attrs(&variant.attrs, true)?,
                     data: variant,
                     index,
                     #[cfg(feature = "documentation")]

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -38,8 +38,8 @@ use syn::spanned::Spanned;
 use syn::{parse_macro_input, DeriveInput};
 use type_uuid::TypeUuidDef;
 
-pub(crate) static REFLECT_ATTRIBUTE_NAME: &str = "reflect";
-pub(crate) static REFLECT_VALUE_ATTRIBUTE_NAME: &str = "reflect_value";
+pub(crate) const REFLECT_ATTRIBUTE_NAME: &str = "reflect";
+pub(crate) const REFLECT_VALUE_ATTRIBUTE_NAME: &str = "reflect_value";
 
 /// The main derive macro used by `bevy_reflect` for deriving its `Reflect` trait.
 ///


### PR DESCRIPTION
# Objective

Fixes #7049

There were a few things I noticed that were (imo) missing from the field attribute logic for `Reflect` derives. These were:

1. Attributes would compile with any of `Reflect`'s helpers (i.e. `reflect`, `reflect_value`, and `module`), but would fail to actually process the attribute
2. Variants currently do not support any attributes, but adding some would still compile
3. There was some duplicate logic and unnecessary match arms

## Solution

#### `#[module]`

Firstly, I removed the `module` helper attribute for `Reflect` derives. I don't think this is in use or how it was in use, but I figured it was best to just get rid of it entirely.

#### `#[reflect]`-only

Using `#[reflect_value]` on anything other than a struct or enum definition will fail with a compile error:

```rust
#[derive(Reflect)]
struct MyStruct {
  #[reflect_value(ignore)]
  foo: u32
}
```
```
error: cannot use `reflect_value` on a field. Did you mean to use `reflect`?
   --> my_crate/lib.rs:234:15
    |
234 |             #[reflect_value(ignore)]
    |               ^^^^^^^^^^^^^
```

#### Variant attributes

At one point, enum variants could be completely ignored. This turned out to cause lots of unintended behavior and was subsequently removed. However, now we actually throw an error if a user tries to define a variant with an attribute:

```rust
#[derive(Reflect)]
enum MyEnum {
  #[reflect(ignore)]
  Foo(u32)
}
```
```
error: cannot use reflect attribute "ignore" on enum variant
   --> crates/bevy_reflect/src/lib.rs:240:23
    |
240 |             #[reflect(ignore)]
    |                       ^^^^^^
```

Because we may want to allow variant attributes in the future, I left the scaffolding in rather than remove the ability altogether. However, if it makes sense to just remove it, I can do that.

#### General Cleanup

Lastly, I just did some general cleanup:
* Removing unnecessary match arms
* Re-organizing and documenting match arms
* De-duplicating code
* More consistent error messages
* Error messages give more context and offer a bit more help

---

## Changelog

* Removed `#[module]` helper attribute for `Reflect` derives
* Improved errors for field attributes in `Reflect` derives
* Enum variant attributes now throw an error in `Reflect` derives (0.9.0-dev change)

## Migration Guide

* Removed `#[module]` helper attribute for `Reflect` derives. If your code is relying on this attribute, please replace it with either `#[reflect]` or `#[reflect_value]` (dependent on use-case).

* (0.9.0-dev only) Enum variant attributes now throw an error in `Reflect` derives. You cannot currently define any `#[reflect]` attributes on enum variants. If you have any attributes on variants, they must be removed.
