### PR TITLE
Add #[must_use] to App

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -54,6 +54,7 @@ pub struct AppTypeRegistry(pub bevy_reflect::TypeRegistryArc);
 ///    println!("hello world");
 /// }
 /// ```
+#[must_use = "An unused app cannot be run. Please use run with App::run or use a custom loop."]
 pub struct App {
     /// The main ECS [`World`] of the [`App`].
     /// This stores and provides access to all the main data of the application.


### PR DESCRIPTION
# Objective
Fix #5386. Forgetting `App::run` or running a custom loop will currently silently fail.

## Solution
Mark `App` as `#[must_use]` and leave a descriptive message to ensure that users know a common solution.

---

## Changelog
Changed: `App` now marked as `#[must_use]`. The compiler will now emit a warning if `App::update` or `App::run` are not used.