### PR TITLE
[Merged by Bors] - Fix camera ambiguity warning in IOS example

### DIFF
--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -90,7 +90,6 @@ fn setup_scene(
     });
 
     // Test ui
-    commands.spawn(Camera2dBundle::default());
     commands
         .spawn(ButtonBundle {
             style: Style {


### PR DESCRIPTION
# Objective

Fix a camera ambiguity warning in the IOS example

## Solution

I'm assuming that this was accidentally added when UI cameras stopped being a thing. So just delete the extra camera.