### PR TITLE
[Merged by Bors] - Update clap requirement from 3.2 to 4.0

### DIFF
--- a/tools/build-wasm-example/Cargo.toml
+++ b/tools/build-wasm-example/Cargo.toml
@@ -9,4 +9,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 xshell = "0.2"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.0", features = ["derive"] }

--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -6,18 +6,17 @@ use xshell::{cmd, Shell};
 #[derive(Parser, Debug)]
 struct Args {
     /// Examples to build
-    #[clap(value_parser)]
     examples: Vec<String>,
 
-    #[clap(short, long, value_parser)]
+    #[arg(short, long)]
     /// Run tests
     test: bool,
 
-    #[clap(short, long, value_parser)]
+    #[arg(short, long)]
     /// Run on the given browsers. By default, chromium, firefox, webkit
     browsers: Vec<String>,
 
-    #[clap(short, long, value_parser)]
+    #[arg(short, long)]
     /// Stop after this number of frames
     frames: Option<usize>,
 }

--- a/tools/spancmp/Cargo.toml
+++ b/tools/spancmp/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.0", features = ["derive"] }
 regex = "1.5"
 termcolor = "1.1"
 bevy_utils = { path = "../../crates/bevy_utils", version = "0.9.0-dev" }

--- a/tools/spancmp/src/main.rs
+++ b/tools/spancmp/src/main.rs
@@ -15,22 +15,20 @@ mod pretty;
 
 #[derive(Parser, Debug)]
 struct Args {
-    #[clap(short, long, value_parser, default_value_t = 0.0)]
+    #[arg(short, long, default_value_t = 0.0)]
     /// Filter spans that have an average shorther than the threshold
     threshold: f32,
 
-    #[clap(short, long, value_parser)]
+    #[arg(short, long)]
     /// Filter spans by name matching the pattern
     pattern: Option<Regex>,
 
-    #[clap(short, long, value_parser)]
+    #[arg(short, long)]
     /// Simplify system names
     short: bool,
 
-    #[clap(value_parser)]
     trace: String,
     /// Optional, second trace to compare
-    #[clap(value_parser)]
     second_trace: Option<String>,
 }
 


### PR DESCRIPTION
# Objective

Alternative to #6150

Dependabot's PR doesn't seem to break anything, but there are some deprecations that we might as well fix up.

## Solution

https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#migrating

Update clap in `build-wasm-example` and `span-cmp`. Other tools don't use clap.

Remove references to `value_parser`. It's the default now.

Change `#[clap()]` to `#[arg()]`.