### PR TITLE
[Merged by Bors] - Register `RenderLayers` type in `CameraPlugin`

### DIFF
--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -10,7 +10,7 @@ pub use projection::*;
 use crate::{
     primitives::Aabb,
     render_graph::RenderGraph,
-    view::{ComputedVisibility, Visibility, VisibleEntities},
+    view::{ComputedVisibility, RenderLayers, Visibility, VisibleEntities},
     RenderApp, RenderStage,
 };
 use bevy_app::{App, Plugin};
@@ -30,6 +30,7 @@ impl Plugin for CameraPlugin {
             .register_type::<ScalingMode>()
             .register_type::<Aabb>()
             .register_type::<CameraRenderGraph>()
+            .register_type::<RenderLayers>()
             .add_plugin(CameraProjectionPlugin::<Projection>::default())
             .add_plugin(CameraProjectionPlugin::<OrthographicProjection>::default())
             .add_plugin(CameraProjectionPlugin::<PerspectiveProjection>::default());


### PR DESCRIPTION
# Objective

The `RenderLayers` type is never registered, making it unavailable for reflection.

## Solution

Register it in `CameraPlugin`, the same plugin that registers the related `Visibility*` types.