### PR TITLE
[Merged by Bors] - Mention world_query(ignore) attribute for WorldQuery derivation

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -59,8 +59,8 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 ///
 /// * also implements `WorldQuery`, or
 /// * is marked with `#[world_query(ignore)]`. Fields decorated with this attribute
-///   will be created with the default value upon realisation, so `Default` has to
-///   be implemented on its type.
+///   must implement [`Default`] and will be initialized to the default value as defined
+///   by the trait.
 ///
 /// The derive macro only supports regular structs (structs with named fields).
 ///

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -55,7 +55,13 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 /// - Methods can be implemented for the query items.
 /// - There is no hardcoded limit on the number of elements.
 ///
-/// This trait can only be derived if each field of the struct also implements `WorldQuery`.
+/// This trait can only be derived if each field either
+///
+/// * also implements `WorldQuery`, or
+/// * is marked with `#[world_query(ignore)]`. Fields decorated with this attribute
+///   will be created with the default value upon realisation, so `Default` has to
+///   be implemented on its type.
+///
 /// The derive macro only supports regular structs (structs with named fields).
 ///
 /// ```


### PR DESCRIPTION
# Objective

Add documentation `#[world_query(ignore)]`. Fixes #6283.

---

I've only described it's behavior so far (which appears to be the same as with `system_param`). Is there another use-case for this besides with `PhantomData`? I could only find a single usage of this construct on GitHub, which is [here](https://github.com/tqwewe/bevy-editor-2/blob/ffcb816927a1bbdcf1cb0136ce47864e5040f9fb/bevy/examples/ecs/custom_query_param.rs#L102). 

I was also wondering if it would make sense to add a usage example to the `custom_query_example`? 🤔 That's why it's currently still in there.


