### PR TITLE
[Merged by Bors] - Fix tests breaking when new WorldQuery impls are added

### DIFF
--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_combin_exact_sized_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_combin_exact_sized_iterator_safety.stderr
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `bevy_ecs::query::Changed<Foo>: ArchetypeFilter` i
              (F0, F1, F2, F3, F4, F5)
              (F0, F1, F2, F3, F4, F5, F6)
              (F0, F1, F2, F3, F4, F5, F6, F7)
-           and 26 others
+           and $N others
    = note: required because of the requirements on the impl of `ArchetypeFilter` for `bevy_ecs::query::Or<(bevy_ecs::query::Changed<Foo>, bevy_ecs::query::With<Bar>)>`
    = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryCombinationIter<'_, '_, &Foo, bevy_ecs::query::Or<(bevy_ecs::query::Changed<Foo>, bevy_ecs::query::With<Bar>)>, 2>`
 note: required by a bound in `is_exact_size_iterator`
@@ -41,7 +41,7 @@ error[E0277]: the trait bound `bevy_ecs::query::Added<Foo>: ArchetypeFilter` is 
              (F0, F1, F2, F3, F4, F5)
              (F0, F1, F2, F3, F4, F5, F6)
              (F0, F1, F2, F3, F4, F5, F6, F7)
-           and 26 others
+           and $N others
    = note: required because of the requirements on the impl of `ArchetypeFilter` for `(bevy_ecs::query::Added<Foo>, bevy_ecs::query::Without<Bar>)`
    = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryCombinationIter<'_, '_, &Foo, (bevy_ecs::query::Added<Foo>, bevy_ecs::query::Without<Bar>), 2>`
 note: required by a bound in `is_exact_size_iterator`

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_exact_sized_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_exact_sized_iterator_safety.stderr
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `bevy_ecs::query::Changed<Foo>: ArchetypeFilter` i
              (F0, F1, F2, F3, F4, F5)
              (F0, F1, F2, F3, F4, F5, F6)
              (F0, F1, F2, F3, F4, F5, F6, F7)
-           and 26 others
+           and $N others
    = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Changed<Foo>>`
 note: required by a bound in `is_exact_size_iterator`
   --> tests/ui/query_exact_sized_iterator_safety.rs:16:30
@@ -40,7 +40,7 @@ error[E0277]: the trait bound `bevy_ecs::query::Added<Foo>: ArchetypeFilter` is 
              (F0, F1, F2, F3, F4, F5)
              (F0, F1, F2, F3, F4, F5, F6)
              (F0, F1, F2, F3, F4, F5, F6, F7)
-           and 26 others
+           and $N others
    = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Added<Foo>>`
 note: required by a bound in `is_exact_size_iterator`
   --> tests/ui/query_exact_sized_iterator_safety.rs:16:30

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `&mut A: ReadOnlyWorldQuery` is not satisfied
              (F0, F1, F2, F3, F4)
              (F0, F1, F2, F3, F4, F5)
              (F0, F1, F2, F3, F4, F5, F6)
-           and 49 others
+           and $N others
    = note: `ReadOnlyWorldQuery` is implemented for `&A`, but not for `&mut A`
    = note: required because of the requirements on the impl of `Iterator` for `QueryCombinationIter<'_, '_, &mut A, (), _>`
 note: required by a bound in `is_iterator`

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_many_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_many_mut_iterator_safety.stderr
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `&mut A: ReadOnlyWorldQuery` is not satisfied
              (F0, F1, F2, F3, F4)
              (F0, F1, F2, F3, F4, F5)
              (F0, F1, F2, F3, F4, F5, F6)
-           and 49 others
+           and $N others
    = note: `ReadOnlyWorldQuery` is implemented for `&A`, but not for `&mut A`
    = note: required because of the requirements on the impl of `Iterator` for `QueryManyIter<'_, '_, &mut A, (), std::array::IntoIter<bevy_ecs::entity::Entity, 1>>`
 note: required by a bound in `is_iterator`

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
@@ -21,7 +21,7 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not sati
              (F0, F1, F2, F3, F4)
              (F0, F1, F2, F3, F4, F5)
              (F0, F1, F2, F3, F4, F5, F6)
-           and 49 others
+           and $N others
    = note: `ReadOnlyWorldQuery` is implemented for `&'static Foo`, but not for `&'static mut Foo`
    = note: required because of the requirements on the impl of `ReadOnlySystemParamFetch` for `QueryState<&'static mut Foo>`
    = note: 2 redundant requirements hidden

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_derive.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_derive.stderr
@@ -13,7 +13,7 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not sati
             (F0, F1, F2, F3, F4)
             (F0, F1, F2, F3, F4, F5)
             (F0, F1, F2, F3, F4, F5, F6)
-          and 52 others
+          and $N others
 note: required by a bound in `_::assert_readonly`
  --> tests/ui/world_query_derive.rs:7:10
   |
@@ -36,7 +36,7 @@ error[E0277]: the trait bound `MutableMarked: ReadOnlyWorldQuery` is not satisfi
              (F0, F1, F2, F3, F4)
              (F0, F1, F2, F3, F4, F5)
              (F0, F1, F2, F3, F4, F5, F6)
-           and 52 others
+           and $N others
 note: required by a bound in `_::assert_readonly`
   --> tests/ui/world_query_derive.rs:18:10
    |


### PR DESCRIPTION
# Objective

I recently wanted to look at the possibility of adding `Mutated` and `Unchanged` query filters and was confronted with some seemingly unrelated broken tests.

These tests were written in such a way that changing the number of WorldQuery impls in the project would break them.

Fortunately, a [very recent release of trybuild](https://github.com/dtolnay/trybuild/releases/tag/1.0.70) has made this unnecessary. 

## Solution

Replace hardcoded numbers in test output with `$N` placeholders.
