### PR TITLE
[Merged by Bors] - Use wgsl saturate

### DIFF
--- a/crates/bevy_pbr/src/render/utils.wgsl
+++ b/crates/bevy_pbr/src/render/utils.wgsl
@@ -2,10 +2,6 @@
 
 let PI: f32 = 3.141592653589793;
 
-fn saturate(value: f32) -> f32 {
-    return clamp(value, 0.0, 1.0);
-}
-
 fn hsv2rgb(hue: f32, saturation: f32, value: f32) -> vec3<f32> {
     let rgb = clamp(
         abs(


### PR DESCRIPTION
# Objective

Use saturate wgsl function now implemented in naga (version 0.10.0). There is now no need for one in utils.wgsl.

naga's version allows usage for not only scalars but vectors as well.

## Solution

Remove the utils.wgsl saturate function.

## Changelog

Remove saturate function from utils.wgsl in favor of saturate in naga v0.10.0.