### PR TITLE
[Merged by Bors] - Replace `WorldQueryGats` trait with actual gats

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -19,7 +19,7 @@ impl ExtractComponent for Camera2d {
     type Query = &'static Self;
     type Filter = With<Camera>;
 
-    fn extract_component(item: QueryItem<Self::Query>) -> Self {
+    fn extract_component(item: QueryItem<'_, Self::Query>) -> Self {
         item.clone()
     }
 }

--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -51,7 +51,7 @@ impl ExtractComponent for Camera3d {
     type Query = &'static Self;
     type Filter = With<Camera>;
 
-    fn extract_component(item: QueryItem<Self::Query>) -> Self {
+    fn extract_component(item: QueryItem<'_, Self::Query>) -> Self {
         item.clone()
     }
 }

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -283,8 +283,8 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 ///
 /// # Safety
 ///
-/// Component access of `ROQueryFetch<Self>` must be a subset of `QueryFetch<Self>`
-/// and `ROQueryFetch<Self>` must match exactly the same archetypes/tables as `QueryFetch<Self>`
+/// Component access of `Self::ReadOnly` must be a subset of `Self`
+/// and `Self::ReadOnly` must match exactly the same archetypes/tables as `Self`
 ///
 /// Implementor must ensure that
 /// [`update_component_access`] and [`update_archetype_component_access`]
@@ -296,7 +296,7 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 /// [`Added`]: crate::query::Added
 /// [`fetch`]: Self::fetch
 /// [`Changed`]: crate::query::Changed
-/// [`Fetch`]: crate::query::WorldQueryGats::Fetch
+/// [`Fetch`]: crate::query::WorldQuery::Fetch
 /// [`matches_component_set`]: Self::matches_component_set
 /// [`Or`]: crate::query::Or
 /// [`Query`]: crate::system::Query
@@ -306,17 +306,23 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 /// [`update_component_access`]: Self::update_component_access
 /// [`With`]: crate::query::With
 /// [`Without`]: crate::query::Without
-pub unsafe trait WorldQuery: for<'w> WorldQueryGats<'w> {
+pub unsafe trait WorldQuery {
+    /// The item returned by this [`WorldQuery`]
+    type Item<'a>;
+
+    /// Per archetype/table state used by this [`WorldQuery`] to fetch [`Self::Item`](crate::query::WorldQuery::Item)
+    type Fetch<'a>;
+
     /// The read-only variant of this [`WorldQuery`], which satisfies the [`ReadOnlyWorldQuery`] trait.
     type ReadOnly: ReadOnlyWorldQuery<State = Self::State>;
 
-    /// State used to construct a [`Self::Fetch`](crate::query::WorldQueryGats::Fetch). This will be cached inside [`QueryState`](crate::query::QueryState),
+    /// State used to construct a [`Self::Fetch`](crate::query::WorldQuery::Fetch). This will be cached inside [`QueryState`](crate::query::QueryState),
     /// so it is best to move as much data / computation here as possible to reduce the cost of
-    /// constructing [`Self::Fetch`](crate::query::WorldQueryGats::Fetch).
+    /// constructing [`Self::Fetch`](crate::query::WorldQuery::Fetch).
     type State: Send + Sync + Sized;
 
     /// This function manually implements subtyping for the query items.
-    fn shrink<'wlong: 'wshort, 'wshort>(item: QueryItem<'wlong, Self>) -> QueryItem<'wshort, Self>;
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort>;
 
     /// Creates a new instance of this fetch.
     ///
@@ -329,7 +335,7 @@ pub unsafe trait WorldQuery: for<'w> WorldQueryGats<'w> {
         state: &Self::State,
         last_change_tick: u32,
         change_tick: u32,
-    ) -> <Self as WorldQueryGats<'w>>::Fetch;
+    ) -> Self::Fetch<'w>;
 
     /// While this function can be called for any query, it is always safe to call if `Self: ReadOnlyWorldQuery` holds.
     ///
@@ -337,9 +343,7 @@ pub unsafe trait WorldQuery: for<'w> WorldQueryGats<'w> {
     /// While calling this method on its own cannot cause UB it is marked `unsafe` as the caller must ensure
     /// that the returned value is not used in any way that would cause two `QueryItem<Self>` for the same
     /// `archetype_index` or `table_row` to be alive at the same time.
-    unsafe fn clone_fetch<'w>(
-        fetch: &<Self as WorldQueryGats<'w>>::Fetch,
-    ) -> <Self as WorldQueryGats<'w>>::Fetch;
+    unsafe fn clone_fetch<'w>(fetch: &Self::Fetch<'w>) -> Self::Fetch<'w>;
 
     /// Returns true if (and only if) every table of every archetype matched by this fetch contains
     /// all of the matched components. This is used to select a more efficient "table iterator"
@@ -364,7 +368,7 @@ pub unsafe trait WorldQuery: for<'w> WorldQueryGats<'w> {
     /// `archetype` and `tables` must be from the [`World`] [`WorldQuery::init_state`] was called on. `state` must
     /// be the [`Self::State`] this was initialized with.
     unsafe fn set_archetype<'w>(
-        fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+        fetch: &mut Self::Fetch<'w>,
         state: &Self::State,
         archetype: &'w Archetype,
         table: &'w Table,
@@ -377,13 +381,9 @@ pub unsafe trait WorldQuery: for<'w> WorldQueryGats<'w> {
     ///
     /// `table` must be from the [`World`] [`WorldQuery::init_state`] was called on. `state` must be the
     /// [`Self::State`] this was initialized with.
-    unsafe fn set_table<'w>(
-        fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
-        state: &Self::State,
-        table: &'w Table,
-    );
+    unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, table: &'w Table);
 
-    /// Fetch [`Self::Item`](`WorldQueryGats::Item`) for either the given `entity` in the current [`Table`],
+    /// Fetch [`Self::Item`](`WorldQuery::Item`) for either the given `entity` in the current [`Table`],
     /// or for the given `entity` in the current [`Archetype`]. This must always be called after
     /// [`WorldQuery::set_table`] with a `table_row` in the range of the current [`Table`] or after
     /// [`WorldQuery::set_archetype`]  with a `entity` in the current archetype.
@@ -393,10 +393,10 @@ pub unsafe trait WorldQuery: for<'w> WorldQueryGats<'w> {
     /// Must always be called _after_ [`WorldQuery::set_table`] or [`WorldQuery::set_archetype`]. `entity` and
     /// `table_row` must be in the range of the current table and archetype.
     unsafe fn fetch<'w>(
-        fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+        fetch: &mut Self::Fetch<'w>,
         entity: Entity,
         table_row: usize,
-    ) -> <Self as WorldQueryGats<'w>>::Item;
+    ) -> Self::Item<'w>;
 
     /// # Safety
     ///
@@ -404,11 +404,7 @@ pub unsafe trait WorldQuery: for<'w> WorldQueryGats<'w> {
     /// `table_row` must be in the range of the current table and archetype.
     #[allow(unused_variables)]
     #[inline(always)]
-    unsafe fn filter_fetch(
-        fetch: &mut <Self as WorldQueryGats<'_>>::Fetch,
-        entity: Entity,
-        table_row: usize,
-    ) -> bool {
+    unsafe fn filter_fetch(fetch: &mut Self::Fetch<'_>, entity: Entity, table_row: usize) -> bool {
         true
     }
 
@@ -430,14 +426,6 @@ pub unsafe trait WorldQuery: for<'w> WorldQueryGats<'w> {
     ) -> bool;
 }
 
-/// A helper trait for [`WorldQuery`] that works around Rust's lack of Generic Associated Types.
-///
-/// **Note**: Consider using the type aliases [`QueryItem`] and [`QueryFetch`] when using `Item` or `Fetch`.
-pub trait WorldQueryGats<'world> {
-    type Item;
-    type Fetch;
-}
-
 /// A world query that is read only.
 ///
 /// # Safety
@@ -446,9 +434,9 @@ pub trait WorldQueryGats<'world> {
 pub unsafe trait ReadOnlyWorldQuery: WorldQuery<ReadOnly = Self> {}
 
 /// The `Fetch` of a [`WorldQuery`], which is used to store state for each archetype/table.
-pub type QueryFetch<'w, Q> = <Q as WorldQueryGats<'w>>::Fetch;
+pub type QueryFetch<'w, Q> = <Q as WorldQuery>::Fetch<'w>;
 /// The item type returned when a [`WorldQuery`] is iterated over
-pub type QueryItem<'w, Q> = <Q as WorldQueryGats<'w>>::Item;
+pub type QueryItem<'w, Q> = <Q as WorldQuery>::Item<'w>;
 /// The read-only `Fetch` of a [`WorldQuery`], which is used to store state for each archetype/table.
 pub type ROQueryFetch<'w, Q> = QueryFetch<'w, <Q as WorldQuery>::ReadOnly>;
 /// The read-only variant of the item type returned when a [`WorldQuery`] is iterated over immutably
@@ -456,10 +444,12 @@ pub type ROQueryItem<'w, Q> = QueryItem<'w, <Q as WorldQuery>::ReadOnly>;
 
 /// SAFETY: no component or archetype access
 unsafe impl WorldQuery for Entity {
+    type Fetch<'w> = ();
+    type Item<'w> = Entity;
     type ReadOnly = Self;
     type State = ();
 
-    fn shrink<'wlong: 'wshort, 'wshort>(item: QueryItem<'wlong, Self>) -> QueryItem<'wshort, Self> {
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
         item
     }
 
@@ -472,17 +462,14 @@ unsafe impl WorldQuery for Entity {
         _state: &Self::State,
         _last_change_tick: u32,
         _change_tick: u32,
-    ) -> <Self as WorldQueryGats<'w>>::Fetch {
+    ) -> Self::Fetch<'w> {
     }
 
-    unsafe fn clone_fetch<'w>(
-        _fetch: &<Self as WorldQueryGats<'w>>::Fetch,
-    ) -> <Self as WorldQueryGats<'w>>::Fetch {
-    }
+    unsafe fn clone_fetch<'w>(_fetch: &Self::Fetch<'w>) -> Self::Fetch<'w> {}
 
     #[inline]
     unsafe fn set_archetype<'w>(
-        _fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+        _fetch: &mut Self::Fetch<'w>,
         _state: &Self::State,
         _archetype: &'w Archetype,
         _table: &Table,
@@ -490,19 +477,15 @@ unsafe impl WorldQuery for Entity {
     }
 
     #[inline]
-    unsafe fn set_table<'w>(
-        _fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
-        _state: &Self::State,
-        _table: &'w Table,
-    ) {
+    unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _table: &'w Table) {
     }
 
     #[inline(always)]
     unsafe fn fetch<'w>(
-        _fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+        _fetch: &mut Self::Fetch<'w>,
         entity: Entity,
         _table_row: usize,
-    ) -> <Self as WorldQueryGats<'w>>::Item {
+    ) -> Self::Item<'w> {
         entity
     }
 
@@ -525,11 +508,6 @@ unsafe impl WorldQuery for Entity {
     }
 }
 
-impl<'w> WorldQueryGats<'w> for Entity {
-    type Fetch = ();
-    type Item = Entity;
-}
-
 /// SAFETY: access is read only
 unsafe impl ReadOnlyWorldQuery for Entity {}
 
@@ -541,8 +519,10 @@ pub struct ReadFetch<'w, T> {
     sparse_set: Option<&'w ComponentSparseSet>,
 }
 
-/// SAFETY: `ROQueryFetch<Self>` is the same as `QueryFetch<Self>`
+/// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl<T: Component> WorldQuery for &T {
+    type Fetch<'w> = ReadFetch<'w, T>;
+    type Item<'w> = &'w T;
     type ReadOnly = Self;
     type State = ComponentId;
 
@@ -577,9 +557,7 @@ unsafe impl<T: Component> WorldQuery for &T {
         }
     }
 
-    unsafe fn clone_fetch<'w>(
-        fetch: &<Self as WorldQueryGats<'w>>::Fetch,
-    ) -> <Self as WorldQueryGats<'w>>::Fetch {
+    unsafe fn clone_fetch<'w>(fetch: &Self::Fetch<'w>) -> Self::Fetch<'w> {
         ReadFetch {
             table_components: fetch.table_components,
             sparse_set: fetch.sparse_set,
@@ -615,10 +593,10 @@ unsafe impl<T: Component> WorldQuery for &T {
 
     #[inline(always)]
     unsafe fn fetch<'w>(
-        fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+        fetch: &mut Self::Fetch<'w>,
         entity: Entity,
         table_row: usize,
-    ) -> <Self as WorldQueryGats<'w>>::Item {
+    ) -> Self::Item<'w> {
         match T::Storage::STORAGE_TYPE {
             StorageType::Table => fetch
                 .table_components
@@ -671,11 +649,6 @@ unsafe impl<T: Component> WorldQuery for &T {
 /// SAFETY: access is read only
 unsafe impl<T: Component> ReadOnlyWorldQuery for &T {}
 
-impl<'w, T: Component> WorldQueryGats<'w> for &T {
-    type Fetch = ReadFetch<'w, T>;
-    type Item = &'w T;
-}
-
 #[doc(hidden)]
 pub struct WriteFetch<'w, T> {
     // T::Storage = TableStorage
@@ -692,6 +665,8 @@ pub struct WriteFetch<'w, T> {
 
 /// SAFETY: access of `&T` is a subset of `&mut T`
 unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
+    type Fetch<'w> = WriteFetch<'w, T>;
+    type Item<'w> = Mut<'w, T>;
     type ReadOnly = &'__w T;
     type State = ComponentId;
 
@@ -728,9 +703,7 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
         }
     }
 
-    unsafe fn clone_fetch<'w>(
-        fetch: &<Self as WorldQueryGats<'w>>::Fetch,
-    ) -> <Self as WorldQueryGats<'w>>::Fetch {
+    unsafe fn clone_fetch<'w>(fetch: &Self::Fetch<'w>) -> Self::Fetch<'w> {
         WriteFetch {
             table_data: fetch.table_data,
             sparse_set: fetch.sparse_set,
@@ -768,10 +741,10 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
 
     #[inline(always)]
     unsafe fn fetch<'w>(
-        fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+        fetch: &mut Self::Fetch<'w>,
         entity: Entity,
         table_row: usize,
-    ) -> <Self as WorldQueryGats<'w>>::Item {
+    ) -> Self::Item<'w> {
         match T::Storage::STORAGE_TYPE {
             StorageType::Table => {
                 let (table_components, table_ticks) = fetch
@@ -838,23 +811,20 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
     }
 }
 
-impl<'w, T: Component> WorldQueryGats<'w> for &mut T {
-    type Fetch = WriteFetch<'w, T>;
-    type Item = Mut<'w, T>;
-}
-
 #[doc(hidden)]
 pub struct OptionFetch<'w, T: WorldQuery> {
-    fetch: <T as WorldQueryGats<'w>>::Fetch,
+    fetch: T::Fetch<'w>,
     matches: bool,
 }
 
 // SAFETY: defers to soundness of `T: WorldQuery` impl
 unsafe impl<T: WorldQuery> WorldQuery for Option<T> {
+    type Fetch<'w> = OptionFetch<'w, T>;
+    type Item<'w> = Option<T::Item<'w>>;
     type ReadOnly = Option<T::ReadOnly>;
     type State = T::State;
 
-    fn shrink<'wlong: 'wshort, 'wshort>(item: QueryItem<'wlong, Self>) -> QueryItem<'wshort, Self> {
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
         item.map(T::shrink)
     }
 
@@ -874,9 +844,7 @@ unsafe impl<T: WorldQuery> WorldQuery for Option<T> {
         }
     }
 
-    unsafe fn clone_fetch<'w>(
-        fetch: &<Self as WorldQueryGats<'w>>::Fetch,
-    ) -> <Self as WorldQueryGats<'w>>::Fetch {
+    unsafe fn clone_fetch<'w>(fetch: &Self::Fetch<'w>) -> Self::Fetch<'w> {
         OptionFetch {
             fetch: T::clone_fetch(&fetch.fetch),
             matches: fetch.matches,
@@ -906,10 +874,10 @@ unsafe impl<T: WorldQuery> WorldQuery for Option<T> {
 
     #[inline(always)]
     unsafe fn fetch<'w>(
-        fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+        fetch: &mut Self::Fetch<'w>,
         entity: Entity,
         table_row: usize,
-    ) -> <Self as WorldQueryGats<'w>>::Item {
+    ) -> Self::Item<'w> {
         fetch
             .matches
             .then(|| T::fetch(&mut fetch.fetch, entity, table_row))
@@ -949,11 +917,6 @@ unsafe impl<T: WorldQuery> WorldQuery for Option<T> {
 
 /// SAFETY: [`OptionFetch`] is read only because `T` is read only
 unsafe impl<T: ReadOnlyWorldQuery> ReadOnlyWorldQuery for Option<T> {}
-
-impl<'w, T: WorldQuery> WorldQueryGats<'w> for Option<T> {
-    type Fetch = OptionFetch<'w, T>;
-    type Item = Option<QueryItem<'w, T>>;
-}
 
 /// [`WorldQuery`] that tracks changes and additions for component `T`.
 ///
@@ -1044,10 +1007,12 @@ pub struct ChangeTrackersFetch<'w, T> {
 
 // SAFETY: `ROQueryFetch<Self>` is the same as `QueryFetch<Self>`
 unsafe impl<T: Component> WorldQuery for ChangeTrackers<T> {
+    type Fetch<'w> = ChangeTrackersFetch<'w, T>;
+    type Item<'w> = ChangeTrackers<T>;
     type ReadOnly = Self;
     type State = ComponentId;
 
-    fn shrink<'wlong: 'wshort, 'wshort>(item: QueryItem<'wlong, Self>) -> QueryItem<'wshort, Self> {
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
         item
     }
 
@@ -1081,9 +1046,7 @@ unsafe impl<T: Component> WorldQuery for ChangeTrackers<T> {
         }
     }
 
-    unsafe fn clone_fetch<'w>(
-        fetch: &<Self as WorldQueryGats<'w>>::Fetch,
-    ) -> <Self as WorldQueryGats<'w>>::Fetch {
+    unsafe fn clone_fetch<'w>(fetch: &Self::Fetch<'w>) -> Self::Fetch<'w> {
         ChangeTrackersFetch {
             table_ticks: fetch.table_ticks,
             sparse_set: fetch.sparse_set,
@@ -1122,10 +1085,10 @@ unsafe impl<T: Component> WorldQuery for ChangeTrackers<T> {
 
     #[inline(always)]
     unsafe fn fetch<'w>(
-        fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+        fetch: &mut Self::Fetch<'w>,
         entity: Entity,
         table_row: usize,
-    ) -> <Self as WorldQueryGats<'w>>::Item {
+    ) -> Self::Item<'w> {
         match T::Storage::STORAGE_TYPE {
             StorageType::Table => ChangeTrackers {
                 component_ticks: {
@@ -1186,28 +1149,18 @@ unsafe impl<T: Component> WorldQuery for ChangeTrackers<T> {
 /// SAFETY: access is read only
 unsafe impl<T: Component> ReadOnlyWorldQuery for ChangeTrackers<T> {}
 
-impl<'w, T: Component> WorldQueryGats<'w> for ChangeTrackers<T> {
-    type Fetch = ChangeTrackersFetch<'w, T>;
-    type Item = ChangeTrackers<T>;
-}
-
 macro_rules! impl_tuple_fetch {
     ($(($name: ident, $state: ident)),*) => {
-        #[allow(unused_variables)]
-        #[allow(non_snake_case)]
-        impl<'w, $($name: WorldQueryGats<'w>),*> WorldQueryGats<'w> for ($($name,)*) {
-            type Fetch = ($($name::Fetch,)*);
-            type Item = ($($name::Item,)*);
-        }
-
         #[allow(non_snake_case)]
         #[allow(clippy::unused_unit)]
         // SAFETY: defers to soundness `$name: WorldQuery` impl
         unsafe impl<$($name: WorldQuery),*> WorldQuery for ($($name,)*) {
+            type Fetch<'w> = ($($name::Fetch<'w>,)*);
+            type Item<'w> = ($($name::Item<'w>,)*);
             type ReadOnly = ($($name::ReadOnly,)*);
             type State = ($($name::State,)*);
 
-            fn shrink<'wlong: 'wshort, 'wshort>(item: QueryItem<'wlong, Self>) -> QueryItem<'wshort, Self> {
+            fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
                 let ($($name,)*) = item;
                 ($(
                     $name::shrink($name),
@@ -1215,14 +1168,14 @@ macro_rules! impl_tuple_fetch {
             }
 
             #[allow(clippy::unused_unit)]
-            unsafe fn init_fetch<'w>(_world: &'w World, state: &Self::State, _last_change_tick: u32, _change_tick: u32) -> <Self as WorldQueryGats<'w>>::Fetch {
+            unsafe fn init_fetch<'w>(_world: &'w World, state: &Self::State, _last_change_tick: u32, _change_tick: u32) -> Self::Fetch<'w> {
                 let ($($name,)*) = state;
                 ($($name::init_fetch(_world, $name, _last_change_tick, _change_tick),)*)
             }
 
             unsafe fn clone_fetch<'w>(
-                fetch: &<Self as WorldQueryGats<'w>>::Fetch,
-            ) -> <Self as WorldQueryGats<'w>>::Fetch {
+                fetch: &Self::Fetch<'w>,
+            ) -> Self::Fetch<'w> {
                 let ($($name,)*) = &fetch;
                 ($($name::clone_fetch($name),)*)
             }
@@ -1233,7 +1186,7 @@ macro_rules! impl_tuple_fetch {
 
             #[inline]
             unsafe fn set_archetype<'w>(
-                _fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+                _fetch: &mut Self::Fetch<'w>,
                 _state: &Self::State,
                 _archetype: &'w Archetype,
                 _table: &'w Table
@@ -1244,7 +1197,7 @@ macro_rules! impl_tuple_fetch {
             }
 
             #[inline]
-            unsafe fn set_table<'w>(_fetch: &mut <Self as WorldQueryGats<'w>>::Fetch, _state: &Self::State, _table: &'w Table) {
+            unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _table: &'w Table) {
                 let ($($name,)*) = _fetch;
                 let ($($state,)*) = _state;
                 $($name::set_table($name, $state, _table);)*
@@ -1253,17 +1206,17 @@ macro_rules! impl_tuple_fetch {
             #[inline(always)]
             #[allow(clippy::unused_unit)]
             unsafe fn fetch<'w>(
-                _fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+                _fetch: &mut Self::Fetch<'w>,
                 _entity: Entity,
                 _table_row: usize
-            ) -> <Self as WorldQueryGats<'w>>::Item {
+            ) -> Self::Item<'w> {
                 let ($($name,)*) = _fetch;
                 ($($name::fetch($name, _entity, _table_row),)*)
             }
 
             #[inline(always)]
             unsafe fn filter_fetch<'w>(
-                _fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+                _fetch: &mut Self::Fetch<'w>,
                 _entity: Entity,
                 _table_row: usize
             ) -> bool {
@@ -1307,21 +1260,16 @@ pub struct AnyOf<T>(PhantomData<T>);
 
 macro_rules! impl_anytuple_fetch {
     ($(($name: ident, $state: ident)),*) => {
-        #[allow(unused_variables)]
-        #[allow(non_snake_case)]
-        impl<'w, $($name: WorldQueryGats<'w>),*> WorldQueryGats<'w> for AnyOf<($($name,)*)> {
-            type Fetch = ($(($name::Fetch, bool),)*);
-            type Item = ($(Option<$name::Item>,)*);
-        }
-
         #[allow(non_snake_case)]
         #[allow(clippy::unused_unit)]
         // SAFETY: defers to soundness of `$name: WorldQuery` impl
         unsafe impl<$($name: WorldQuery),*> WorldQuery for AnyOf<($($name,)*)> {
+            type Fetch<'w> = ($(($name::Fetch<'w>, bool),)*);
+            type Item<'w> = ($(Option<$name::Item<'w>>,)*);
             type ReadOnly = AnyOf<($($name::ReadOnly,)*)>;
             type State = ($($name::State,)*);
 
-            fn shrink<'wlong: 'wshort, 'wshort>(item: QueryItem<'wlong, Self>) -> QueryItem<'wshort, Self> {
+            fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
                 let ($($name,)*) = item;
                 ($(
                     $name.map($name::shrink),
@@ -1329,14 +1277,14 @@ macro_rules! impl_anytuple_fetch {
             }
 
             #[allow(clippy::unused_unit)]
-            unsafe fn init_fetch<'w>(_world: &'w World, state: &Self::State, _last_change_tick: u32, _change_tick: u32) -> <Self as WorldQueryGats<'w>>::Fetch {
+            unsafe fn init_fetch<'w>(_world: &'w World, state: &Self::State, _last_change_tick: u32, _change_tick: u32) -> Self::Fetch<'w> {
                 let ($($name,)*) = state;
                 ($(($name::init_fetch(_world, $name, _last_change_tick, _change_tick), false),)*)
             }
 
             unsafe fn clone_fetch<'w>(
-                fetch: &<Self as WorldQueryGats<'w>>::Fetch,
-            ) -> <Self as WorldQueryGats<'w>>::Fetch {
+                fetch: &Self::Fetch<'w>,
+            ) -> Self::Fetch<'w> {
                 let ($($name,)*) = &fetch;
                 ($(($name::clone_fetch(& $name.0), $name.1),)*)
             }
@@ -1347,7 +1295,7 @@ macro_rules! impl_anytuple_fetch {
 
             #[inline]
             unsafe fn set_archetype<'w>(
-                _fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+                _fetch: &mut Self::Fetch<'w>,
                 _state: &Self::State,
                 _archetype: &'w Archetype,
                 _table: &'w Table
@@ -1363,7 +1311,7 @@ macro_rules! impl_anytuple_fetch {
             }
 
             #[inline]
-            unsafe fn set_table<'w>(_fetch: &mut <Self as WorldQueryGats<'w>>::Fetch, _state: &Self::State, _table: &'w Table) {
+            unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _table: &'w Table) {
                 let ($($name,)*) = _fetch;
                 let ($($state,)*) = _state;
                 $(
@@ -1377,10 +1325,10 @@ macro_rules! impl_anytuple_fetch {
             #[inline(always)]
             #[allow(clippy::unused_unit)]
             unsafe fn fetch<'w>(
-                _fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+                _fetch: &mut Self::Fetch<'w>,
                 _entity: Entity,
                 _table_row: usize
-            ) -> <Self as WorldQueryGats<'w>>::Item {
+            ) -> Self::Item<'w> {
                 let ($($name,)*) = _fetch;
                 ($(
                     $name.1.then(|| $name::fetch(&mut $name.0, _entity, _table_row)),
@@ -1455,6 +1403,8 @@ pub struct NopWorldQuery<Q: WorldQuery>(PhantomData<Q>);
 
 /// SAFETY: `Self::ReadOnly` is `Self`
 unsafe impl<Q: WorldQuery> WorldQuery for NopWorldQuery<Q> {
+    type Fetch<'w> = ();
+    type Item<'w> = ();
     type ReadOnly = Self;
     type State = Q::State;
 
@@ -1473,10 +1423,7 @@ unsafe impl<Q: WorldQuery> WorldQuery for NopWorldQuery<Q> {
     ) {
     }
 
-    unsafe fn clone_fetch<'w>(
-        _fetch: &<Self as WorldQueryGats<'w>>::Fetch,
-    ) -> <Self as WorldQueryGats<'w>>::Fetch {
-    }
+    unsafe fn clone_fetch<'w>(_fetch: &Self::Fetch<'w>) -> Self::Fetch<'w> {}
 
     #[inline(always)]
     unsafe fn set_archetype(
@@ -1492,10 +1439,10 @@ unsafe impl<Q: WorldQuery> WorldQuery for NopWorldQuery<Q> {
 
     #[inline(always)]
     unsafe fn fetch<'w>(
-        _fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+        _fetch: &mut Self::Fetch<'w>,
         _entity: Entity,
         _table_row: usize,
-    ) -> <Self as WorldQueryGats<'w>>::Item {
+    ) -> Self::Item<'w> {
     }
 
     fn update_component_access(_state: &Q::State, _access: &mut FilteredAccess<ComponentId>) {}
@@ -1519,9 +1466,5 @@ unsafe impl<Q: WorldQuery> WorldQuery for NopWorldQuery<Q> {
     }
 }
 
-impl<'a, Q: WorldQuery> WorldQueryGats<'a> for NopWorldQuery<Q> {
-    type Fetch = ();
-    type Item = ();
-}
 /// SAFETY: `NopFetch` never accesses any data
 unsafe impl<Q: WorldQuery> ReadOnlyWorldQuery for NopWorldQuery<Q> {}

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -2,9 +2,7 @@ use crate::{
     archetype::{Archetype, ArchetypeComponentId},
     component::{Component, ComponentId, ComponentStorage, ComponentTicks, StorageType},
     entity::Entity,
-    query::{
-        debug_checked_unreachable, Access, FilteredAccess, QueryFetch, WorldQuery, WorldQueryGats,
-    },
+    query::{debug_checked_unreachable, Access, FilteredAccess, WorldQuery},
     storage::{ComponentSparseSet, Table},
     world::World,
 };
@@ -43,20 +41,14 @@ use super::ReadOnlyWorldQuery;
 /// ```
 pub struct With<T>(PhantomData<T>);
 
-impl<T: Component> WorldQueryGats<'_> for With<T> {
-    type Fetch = ();
-    type Item = ();
-}
-
-// SAFETY: `ROQueryFetch<Self>` is the same as `QueryFetch<Self>`
+// SAFETY: `Self::ReadOnly` is the same as `Self`
 unsafe impl<T: Component> WorldQuery for With<T> {
+    type Fetch<'w> = ();
+    type Item<'w> = ();
     type ReadOnly = Self;
     type State = ComponentId;
 
-    fn shrink<'wlong: 'wshort, 'wshort>(
-        _: <Self as WorldQueryGats<'wlong>>::Item,
-    ) -> <Self as WorldQueryGats<'wshort>>::Item {
-    }
+    fn shrink<'wlong: 'wshort, 'wshort>(_: Self::Item<'wlong>) -> Self::Item<'wshort> {}
 
     unsafe fn init_fetch(
         _world: &World,
@@ -66,10 +58,7 @@ unsafe impl<T: Component> WorldQuery for With<T> {
     ) {
     }
 
-    unsafe fn clone_fetch<'w>(
-        _fetch: &<Self as WorldQueryGats<'w>>::Fetch,
-    ) -> <Self as WorldQueryGats<'w>>::Fetch {
-    }
+    unsafe fn clone_fetch<'w>(_fetch: &Self::Fetch<'w>) -> Self::Fetch<'w> {}
 
     const IS_DENSE: bool = {
         match T::Storage::STORAGE_TYPE {
@@ -94,10 +83,10 @@ unsafe impl<T: Component> WorldQuery for With<T> {
 
     #[inline(always)]
     unsafe fn fetch<'w>(
-        _fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+        _fetch: &mut Self::Fetch<'w>,
         _entity: Entity,
         _table_row: usize,
-    ) -> <Self as WorldQueryGats<'w>>::Item {
+    ) -> Self::Item<'w> {
     }
 
     #[inline]
@@ -154,15 +143,14 @@ unsafe impl<T: Component> ReadOnlyWorldQuery for With<T> {}
 /// ```
 pub struct Without<T>(PhantomData<T>);
 
-// SAFETY: `ROQueryFetch<Self>` is the same as `QueryFetch<Self>`
+// SAFETY: `Self::ReadOnly` is the same as `Self`
 unsafe impl<T: Component> WorldQuery for Without<T> {
+    type Fetch<'w> = ();
+    type Item<'w> = ();
     type ReadOnly = Self;
     type State = ComponentId;
 
-    fn shrink<'wlong: 'wshort, 'wshort>(
-        _: <Self as WorldQueryGats<'wlong>>::Item,
-    ) -> <Self as WorldQueryGats<'wshort>>::Item {
-    }
+    fn shrink<'wlong: 'wshort, 'wshort>(_: Self::Item<'wlong>) -> Self::Item<'wshort> {}
 
     unsafe fn init_fetch(
         _world: &World,
@@ -172,10 +160,7 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
     ) {
     }
 
-    unsafe fn clone_fetch<'w>(
-        _fetch: &<Self as WorldQueryGats<'w>>::Fetch,
-    ) -> <Self as WorldQueryGats<'w>>::Fetch {
-    }
+    unsafe fn clone_fetch<'w>(_fetch: &Self::Fetch<'w>) -> Self::Fetch<'w> {}
 
     const IS_DENSE: bool = {
         match T::Storage::STORAGE_TYPE {
@@ -200,10 +185,10 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
 
     #[inline(always)]
     unsafe fn fetch<'w>(
-        _fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+        _fetch: &mut Self::Fetch<'w>,
         _entity: Entity,
         _table_row: usize,
-    ) -> <Self as WorldQueryGats<'w>>::Item {
+    ) -> Self::Item<'w> {
     }
 
     #[inline]
@@ -229,11 +214,6 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
     ) -> bool {
         !set_contains_id(id)
     }
-}
-
-impl<T: Component> WorldQueryGats<'_> for Without<T> {
-    type Fetch = ();
-    type Item = ();
 }
 
 // SAFETY: no component access or archetype component access
@@ -273,7 +253,7 @@ pub struct Or<T>(pub T);
 
 #[doc(hidden)]
 pub struct OrFetch<'w, T: WorldQuery> {
-    fetch: QueryFetch<'w, T>,
+    fetch: T::Fetch<'w>,
     matches: bool,
 }
 
@@ -281,21 +261,15 @@ macro_rules! impl_query_filter_tuple {
     ($(($filter: ident, $state: ident)),*) => {
         #[allow(unused_variables)]
         #[allow(non_snake_case)]
-        impl<'w, $($filter: WorldQuery),*> WorldQueryGats<'w> for Or<($($filter,)*)> {
-            type Fetch = ($(OrFetch<'w, $filter>,)*);
-            type Item = bool;
-        }
-
-
-        #[allow(unused_variables)]
-        #[allow(non_snake_case)]
         #[allow(clippy::unused_unit)]
         // SAFETY: defers to soundness of `$filter: WorldQuery` impl
         unsafe impl<$($filter: WorldQuery),*> WorldQuery for Or<($($filter,)*)> {
+            type Fetch<'w> = ($(OrFetch<'w, $filter>,)*);
+            type Item<'w> = bool;
             type ReadOnly = Or<($($filter::ReadOnly,)*)>;
             type State = ($($filter::State,)*);
 
-            fn shrink<'wlong: 'wshort, 'wshort>(item: super::QueryItem<'wlong, Self>) -> super::QueryItem<'wshort, Self> {
+            fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
                 item
             }
 
@@ -303,7 +277,7 @@ macro_rules! impl_query_filter_tuple {
 
             const IS_ARCHETYPAL: bool = true $(&& $filter::IS_ARCHETYPAL)*;
 
-            unsafe fn init_fetch<'w>(world: &'w World, state: &Self::State, last_change_tick: u32, change_tick: u32) -> <Self as WorldQueryGats<'w>>::Fetch {
+            unsafe fn init_fetch<'w>(world: &'w World, state: &Self::State, last_change_tick: u32, change_tick: u32) -> Self::Fetch<'w> {
                 let ($($filter,)*) = state;
                 ($(OrFetch {
                     fetch: $filter::init_fetch(world, $filter, last_change_tick, change_tick),
@@ -312,8 +286,8 @@ macro_rules! impl_query_filter_tuple {
             }
 
             unsafe fn clone_fetch<'w>(
-                fetch: &<Self as WorldQueryGats<'w>>::Fetch,
-            ) -> <Self as WorldQueryGats<'w>>::Fetch {
+                fetch: &Self::Fetch<'w>,
+            ) -> Self::Fetch<'w> {
                 let ($($filter,)*) = &fetch;
                 ($(
                     OrFetch {
@@ -324,7 +298,7 @@ macro_rules! impl_query_filter_tuple {
             }
 
             #[inline]
-            unsafe fn set_table<'w>(fetch: &mut <Self as WorldQueryGats<'w>>::Fetch, state: &Self::State, table: &'w Table) {
+            unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, table: &'w Table) {
                 let ($($filter,)*) = fetch;
                 let ($($state,)*) = state;
                 $(
@@ -337,7 +311,7 @@ macro_rules! impl_query_filter_tuple {
 
             #[inline]
             unsafe fn set_archetype<'w>(
-                fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+                fetch: &mut Self::Fetch<'w>,
                 state: & Self::State,
                 archetype: &'w Archetype,
                 table: &'w Table
@@ -354,17 +328,17 @@ macro_rules! impl_query_filter_tuple {
 
             #[inline(always)]
             unsafe fn fetch<'w>(
-                fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+                fetch: &mut Self::Fetch<'w>,
                 _entity: Entity,
                 _table_row: usize
-            ) -> <Self as WorldQueryGats<'w>>::Item {
+            ) -> Self::Item<'w> {
                 let ($($filter,)*) = fetch;
                 false $(|| ($filter.matches && $filter::filter_fetch(&mut $filter.fetch, _entity, _table_row)))*
             }
 
             #[inline(always)]
             unsafe fn filter_fetch<'w>(
-                fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+                fetch: &mut Self::Fetch<'w>,
                 entity: Entity,
                 table_row: usize
             ) -> bool {
@@ -446,17 +420,19 @@ macro_rules! impl_tick_filter {
             change_tick: u32,
         }
 
-        // SAFETY: `ROQueryFetch<Self>` is the same as `QueryFetch<Self>`
+        // SAFETY: `Self::ReadOnly` is the same as `Self`
         unsafe impl<T: Component> WorldQuery for $name<T> {
+            type Fetch<'w> = $fetch_name<'w, T>;
+            type Item<'w> = bool;
             type ReadOnly = Self;
             type State = ComponentId;
 
-            fn shrink<'wlong: 'wshort, 'wshort>(item: super::QueryItem<'wlong, Self>) -> super::QueryItem<'wshort, Self> {
+            fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
                 item
             }
 
-            unsafe fn init_fetch<'w>(world: &'w World, &id: &ComponentId, last_change_tick: u32, change_tick: u32) -> <Self as WorldQueryGats<'w>>::Fetch {
-                QueryFetch::<'w, Self> {
+            unsafe fn init_fetch<'w>(world: &'w World, &id: &ComponentId, last_change_tick: u32, change_tick: u32) -> Self::Fetch<'w> {
+                Self::Fetch::<'w> {
                     table_ticks: None,
                     sparse_set: (T::Storage::STORAGE_TYPE == StorageType::SparseSet)
                         .then(|| {
@@ -472,8 +448,8 @@ macro_rules! impl_tick_filter {
             }
 
             unsafe fn clone_fetch<'w>(
-                fetch: &<Self as WorldQueryGats<'w>>::Fetch,
-            ) -> <Self as WorldQueryGats<'w>>::Fetch {
+                fetch: &Self::Fetch<'w>,
+            ) -> Self::Fetch<'w> {
                 $fetch_name {
                     table_ticks: fetch.table_ticks,
                     sparse_set: fetch.sparse_set,
@@ -494,7 +470,7 @@ macro_rules! impl_tick_filter {
 
             #[inline]
             unsafe fn set_table<'w>(
-                fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+                fetch: &mut Self::Fetch<'w>,
                 &component_id: &ComponentId,
                 table: &'w Table
             ) {
@@ -508,7 +484,7 @@ macro_rules! impl_tick_filter {
 
             #[inline]
             unsafe fn set_archetype<'w>(
-                fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+                fetch: &mut Self::Fetch<'w>,
                 component_id: &ComponentId,
                 _archetype: &'w Archetype,
                 table: &'w Table
@@ -520,10 +496,10 @@ macro_rules! impl_tick_filter {
 
             #[inline(always)]
             unsafe fn fetch<'w>(
-                fetch: &mut <Self as WorldQueryGats<'w>>::Fetch,
+                fetch: &mut Self::Fetch<'w>,
                 entity: Entity,
                 table_row: usize
-            ) -> <Self as WorldQueryGats<'w>>::Item {
+            ) -> Self::Item<'w> {
                 match T::Storage::STORAGE_TYPE {
                     StorageType::Table => {
                         $is_detected(&*(
@@ -549,7 +525,7 @@ macro_rules! impl_tick_filter {
 
             #[inline(always)]
             unsafe fn filter_fetch<'w>(
-                fetch: &mut QueryFetch<'w, Self>,
+                fetch: &mut Self::Fetch<'w>,
                 entity: Entity,
                 table_row: usize
             ) -> bool {
@@ -583,11 +559,6 @@ macro_rules! impl_tick_filter {
             fn matches_component_set(&id: &ComponentId, set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
                 set_contains_id(id)
             }
-        }
-
-        impl<'w, T: Component> WorldQueryGats<'w> for $name<T> {
-            type Fetch = $fetch_name<'w, T>;
-            type Item = bool;
         }
 
         /// SAFETY: read-only access

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use std::{borrow::Borrow, iter::FusedIterator, marker::PhantomData, mem::MaybeUninit};
 
-use super::{QueryFetch, QueryItem, ReadOnlyWorldQuery};
+use super::ReadOnlyWorldQuery;
 
 /// An [`Iterator`] over query results of a [`Query`](crate::system::Query).
 ///
@@ -42,7 +42,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> QueryIter<'w, 's, Q, F> {
 }
 
 impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Iterator for QueryIter<'w, 's, Q, F> {
-    type Item = QueryItem<'w, Q>;
+    type Item = Q::Item<'w>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -86,8 +86,8 @@ where
     entities: &'w Entities,
     tables: &'w Tables,
     archetypes: &'w Archetypes,
-    fetch: QueryFetch<'w, Q>,
-    filter: QueryFetch<'w, F>,
+    fetch: Q::Fetch<'w>,
+    filter: F::Fetch<'w>,
     query_state: &'s QueryState<Q, F>,
 }
 
@@ -137,7 +137,7 @@ where
     ///
     /// It is always safe for shared access.
     #[inline(always)]
-    unsafe fn fetch_next_aliased_unchecked(&mut self) -> Option<QueryItem<'w, Q>> {
+    unsafe fn fetch_next_aliased_unchecked(&mut self) -> Option<Q::Item<'w>> {
         for entity in self.entity_iter.by_ref() {
             let entity = *entity.borrow();
             let location = match self.entities.get(entity) {
@@ -186,7 +186,7 @@ where
 
     /// Get next result from the query
     #[inline(always)]
-    pub fn fetch_next(&mut self) -> Option<QueryItem<'_, Q>> {
+    pub fn fetch_next(&mut self) -> Option<Q::Item<'_>> {
         // SAFETY: we are limiting the returned reference to self,
         // making sure this method cannot be called multiple times without getting rid
         // of any previously returned unique references first, thus preventing aliasing.
@@ -199,7 +199,7 @@ impl<'w, 's, Q: ReadOnlyWorldQuery, F: ReadOnlyWorldQuery, I: Iterator> Iterator
 where
     I::Item: Borrow<Entity>,
 {
-    type Item = QueryItem<'w, Q>;
+    type Item = Q::Item<'w>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -343,7 +343,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery, const K: usize>
     /// references to the same component, leading to unique reference aliasing.
     ///.
     /// It is always safe for shared access.
-    unsafe fn fetch_next_aliased_unchecked(&mut self) -> Option<[QueryItem<'w, Q>; K]> {
+    unsafe fn fetch_next_aliased_unchecked(&mut self) -> Option<[Q::Item<'w>; K]> {
         if K == 0 {
             return None;
         }
@@ -368,9 +368,9 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery, const K: usize>
             }
         }
 
-        let mut values = MaybeUninit::<[QueryItem<'w, Q>; K]>::uninit();
+        let mut values = MaybeUninit::<[Q::Item<'w>; K]>::uninit();
 
-        let ptr = values.as_mut_ptr().cast::<QueryItem<'w, Q>>();
+        let ptr = values.as_mut_ptr().cast::<Q::Item<'w>>();
         for (offset, cursor) in self.cursors.iter_mut().enumerate() {
             ptr.add(offset).write(cursor.peek_last().unwrap());
         }
@@ -380,7 +380,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery, const K: usize>
 
     /// Get next combination of queried components
     #[inline]
-    pub fn fetch_next(&mut self) -> Option<[QueryItem<'_, Q>; K]> {
+    pub fn fetch_next(&mut self) -> Option<[Q::Item<'_>; K]> {
         // SAFETY: we are limiting the returned reference to self,
         // making sure this method cannot be called multiple times without getting rid
         // of any previously returned unique references first, thus preventing aliasing.
@@ -397,7 +397,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery, const K: usize>
 impl<'w, 's, Q: ReadOnlyWorldQuery, F: ReadOnlyWorldQuery, const K: usize> Iterator
     for QueryCombinationIter<'w, 's, Q, F, K>
 {
-    type Item = [QueryItem<'w, Q>; K];
+    type Item = [Q::Item<'w>; K];
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -468,8 +468,8 @@ struct QueryIterationCursor<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> {
     archetype_id_iter: std::slice::Iter<'s, ArchetypeId>,
     table_entities: &'w [Entity],
     archetype_entities: &'w [ArchetypeEntity],
-    fetch: QueryFetch<'w, Q>,
-    filter: QueryFetch<'w, F>,
+    fetch: Q::Fetch<'w>,
+    filter: F::Fetch<'w>,
     // length of the table table or length of the archetype, depending on whether both `Q`'s and `F`'s fetches are dense
     current_len: usize,
     // either table row or archetype index, depending on whether both `Q`'s and `F`'s fetches are dense
@@ -549,7 +549,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> QueryIterationCursor<'w, 's, 
 
     /// retrieve item returned from most recent `next` call again.
     #[inline]
-    unsafe fn peek_last(&mut self) -> Option<QueryItem<'w, Q>> {
+    unsafe fn peek_last(&mut self) -> Option<Q::Item<'w>> {
         if self.current_index > 0 {
             let index = self.current_index - 1;
             if Self::IS_DENSE {
@@ -580,7 +580,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> QueryIterationCursor<'w, 's, 
         tables: &'w Tables,
         archetypes: &'w Archetypes,
         query_state: &'s QueryState<Q, F>,
-    ) -> Option<QueryItem<'w, Q>> {
+    ) -> Option<Q::Item<'w>> {
         if Self::IS_DENSE {
             loop {
                 // we are on the beginning of the query, or finished processing a table, so skip to the next

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -2,8 +2,8 @@ use crate::{
     component::Component,
     entity::Entity,
     query::{
-        QueryCombinationIter, QueryEntityError, QueryItem, QueryIter, QueryManyIter,
-        QuerySingleError, QueryState, ROQueryItem, ReadOnlyWorldQuery, WorldQuery,
+        QueryCombinationIter, QueryEntityError, QueryIter, QueryManyIter, QuerySingleError,
+        QueryState, ROQueryItem, ReadOnlyWorldQuery, WorldQuery,
     },
     world::{Mut, World},
 };
@@ -712,7 +712,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     /// - [`for_each`](Self::for_each) to operate on read-only query items.
     /// - [`iter_mut`](Self::iter_mut) for the iterator based alternative.
     #[inline]
-    pub fn for_each_mut<'a>(&'a mut self, f: impl FnMut(QueryItem<'a, Q>)) {
+    pub fn for_each_mut<'a>(&'a mut self, f: impl FnMut(Q::Item<'a>)) {
         // SAFETY: system runs without conflicts with other systems. same-system queries have runtime
         // borrow checks when they conflict
         unsafe {
@@ -786,7 +786,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     pub fn par_for_each_mut<'a>(
         &'a mut self,
         batch_size: usize,
-        f: impl Fn(QueryItem<'a, Q>) + Send + Sync + Clone,
+        f: impl Fn(Q::Item<'a>) + Send + Sync + Clone,
     ) {
         // SAFETY: system runs without conflicts with other systems. same-system queries have runtime
         // borrow checks when they conflict
@@ -945,7 +945,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     ///
     /// - [`get`](Self::get) to get a read-only query item.
     #[inline]
-    pub fn get_mut(&mut self, entity: Entity) -> Result<QueryItem<'_, Q>, QueryEntityError> {
+    pub fn get_mut(&mut self, entity: Entity) -> Result<Q::Item<'_>, QueryEntityError> {
         // SAFETY: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict
         unsafe {
@@ -970,7 +970,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     pub fn get_many_mut<const N: usize>(
         &mut self,
         entities: [Entity; N],
-    ) -> Result<[QueryItem<'_, Q>; N], QueryEntityError> {
+    ) -> Result<[Q::Item<'_>; N], QueryEntityError> {
         // SAFETY: scheduler ensures safe Query world access
         unsafe {
             self.state.get_many_unchecked_manual(
@@ -1031,7 +1031,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     /// - [`get_many_mut`](Self::get_many_mut) for the non panicking version.
     /// - [`many`](Self::many) to get read-only query items.
     #[inline]
-    pub fn many_mut<const N: usize>(&mut self, entities: [Entity; N]) -> [QueryItem<'_, Q>; N] {
+    pub fn many_mut<const N: usize>(&mut self, entities: [Entity; N]) -> [Q::Item<'_>; N] {
         self.get_many_mut(entities).unwrap()
     }
 
@@ -1048,10 +1048,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     ///
     /// - [`get_mut`](Self::get_mut) for the safe version.
     #[inline]
-    pub unsafe fn get_unchecked(
-        &self,
-        entity: Entity,
-    ) -> Result<QueryItem<'_, Q>, QueryEntityError> {
+    pub unsafe fn get_unchecked(&self, entity: Entity) -> Result<Q::Item<'_>, QueryEntityError> {
         // SEMI-SAFETY: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict
         self.state
@@ -1302,7 +1299,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     /// - [`get_single_mut`](Self::get_single_mut) for the non-panicking version.
     /// - [`single`](Self::single) to get the read-only query item.
     #[track_caller]
-    pub fn single_mut(&mut self) -> QueryItem<'_, Q> {
+    pub fn single_mut(&mut self) -> Q::Item<'_> {
         self.get_single_mut().unwrap()
     }
 
@@ -1332,7 +1329,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     /// - [`get_single`](Self::get_single) to get the read-only query item.
     /// - [`single_mut`](Self::single_mut) for the panicking version.
     #[inline]
-    pub fn get_single_mut(&mut self) -> Result<QueryItem<'_, Q>, QuerySingleError> {
+    pub fn get_single_mut(&mut self) -> Result<Q::Item<'_>, QuerySingleError> {
         // SAFETY:
         // the query ensures mutable access to the components it accesses, and the query
         // is uniquely borrowed
@@ -1415,7 +1412,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> IntoIterator for &'w Query<'_
 }
 
 impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> IntoIterator for &'w mut Query<'_, 's, Q, F> {
-    type Item = QueryItem<'w, Q>;
+    type Item = Q::Item<'w>;
     type IntoIter = QueryIter<'w, 's, Q, F>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/crates/bevy_hierarchy/src/query_extension.rs
+++ b/crates/bevy_hierarchy/src/query_extension.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use bevy_ecs::{
     entity::Entity,
-    query::{ReadOnlyWorldQuery, WorldQuery, WorldQueryGats},
+    query::{ReadOnlyWorldQuery, WorldQuery},
     system::Query,
 };
 
@@ -32,7 +32,7 @@ pub trait HierarchyQueryExt<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> {
     /// ```
     fn iter_descendants(&'w self, entity: Entity) -> DescendantIter<'w, 's, Q, F>
     where
-        Q::ReadOnly: WorldQueryGats<'w, Item = &'w Children>;
+        Q::ReadOnly: WorldQuery<Item<'w> = &'w Children>;
 
     /// Returns an [`Iterator`] of [`Entity`]s over all of `entity`s ancestors.
     ///
@@ -54,7 +54,7 @@ pub trait HierarchyQueryExt<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> {
     /// ```
     fn iter_ancestors(&'w self, entity: Entity) -> AncestorIter<'w, 's, Q, F>
     where
-        Q::ReadOnly: WorldQueryGats<'w, Item = &'w Parent>;
+        Q::ReadOnly: WorldQuery<Item<'w> = &'w Parent>;
 }
 
 impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> HierarchyQueryExt<'w, 's, Q, F>
@@ -62,14 +62,14 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> HierarchyQueryExt<'w, 's, Q, 
 {
     fn iter_descendants(&'w self, entity: Entity) -> DescendantIter<'w, 's, Q, F>
     where
-        Q::ReadOnly: WorldQueryGats<'w, Item = &'w Children>,
+        Q::ReadOnly: WorldQuery<Item<'w> = &'w Children>,
     {
         DescendantIter::new(self, entity)
     }
 
     fn iter_ancestors(&'w self, entity: Entity) -> AncestorIter<'w, 's, Q, F>
     where
-        Q::ReadOnly: WorldQueryGats<'w, Item = &'w Parent>,
+        Q::ReadOnly: WorldQuery<Item<'w> = &'w Parent>,
     {
         AncestorIter::new(self, entity)
     }
@@ -80,7 +80,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> HierarchyQueryExt<'w, 's, Q, 
 /// Traverses the hierarchy breadth-first.
 pub struct DescendantIter<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery>
 where
-    Q::ReadOnly: WorldQueryGats<'w, Item = &'w Children>,
+    Q::ReadOnly: WorldQuery<Item<'w> = &'w Children>,
 {
     children_query: &'w Query<'w, 's, Q, F>,
     vecdeque: VecDeque<Entity>,
@@ -88,7 +88,7 @@ where
 
 impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> DescendantIter<'w, 's, Q, F>
 where
-    Q::ReadOnly: WorldQueryGats<'w, Item = &'w Children>,
+    Q::ReadOnly: WorldQuery<Item<'w> = &'w Children>,
 {
     /// Returns a new [`DescendantIter`].
     pub fn new(children_query: &'w Query<'w, 's, Q, F>, entity: Entity) -> Self {
@@ -106,7 +106,7 @@ where
 
 impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Iterator for DescendantIter<'w, 's, Q, F>
 where
-    Q::ReadOnly: WorldQueryGats<'w, Item = &'w Children>,
+    Q::ReadOnly: WorldQuery<Item<'w> = &'w Children>,
 {
     type Item = Entity;
 
@@ -124,7 +124,7 @@ where
 /// An [`Iterator`] of [`Entity`]s over the ancestors of an [`Entity`].
 pub struct AncestorIter<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery>
 where
-    Q::ReadOnly: WorldQueryGats<'w, Item = &'w Parent>,
+    Q::ReadOnly: WorldQuery<Item<'w> = &'w Parent>,
 {
     parent_query: &'w Query<'w, 's, Q, F>,
     next: Option<Entity>,
@@ -132,7 +132,7 @@ where
 
 impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> AncestorIter<'w, 's, Q, F>
 where
-    Q::ReadOnly: WorldQueryGats<'w, Item = &'w Parent>,
+    Q::ReadOnly: WorldQuery<Item<'w> = &'w Parent>,
 {
     /// Returns a new [`AncestorIter`].
     pub fn new(parent_query: &'w Query<'w, 's, Q, F>, entity: Entity) -> Self {
@@ -145,7 +145,7 @@ where
 
 impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Iterator for AncestorIter<'w, 's, Q, F>
 where
-    Q::ReadOnly: WorldQueryGats<'w, Item = &'w Parent>,
+    Q::ReadOnly: WorldQuery<Item<'w> = &'w Parent>,
 {
     type Item = Entity;
 

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -38,7 +38,7 @@ pub trait ExtractComponent: Component {
     /// Filters the entities with additional constraints.
     type Filter: WorldQuery + ReadOnlyWorldQuery;
     /// Defines how the component is transferred into the "render world".
-    fn extract_component(item: QueryItem<Self::Query>) -> Self;
+    fn extract_component(item: QueryItem<'_, Self::Query>) -> Self;
 }
 
 /// This plugin prepares the components of the corresponding type for the GPU
@@ -174,7 +174,7 @@ impl<T: Asset> ExtractComponent for Handle<T> {
     type Filter = ();
 
     #[inline]
-    fn extract_component(handle: QueryItem<Self::Query>) -> Self {
+    fn extract_component(handle: QueryItem<'_, Self::Query>) -> Self {
         handle.clone_weak()
     }
 }

--- a/crates/bevy_ui/src/entity.rs
+++ b/crates/bevy_ui/src/entity.rs
@@ -266,7 +266,7 @@ impl ExtractComponent for UiCameraConfig {
     type Query = &'static Self;
     type Filter = With<Camera>;
 
-    fn extract_component(item: QueryItem<Self::Query>) -> Self {
+    fn extract_component(item: QueryItem<'_, Self::Query>) -> Self {
         item.clone()
     }
 }

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -2,7 +2,10 @@
 
 use bevy::{
     core_pipeline::core_3d::Transparent3d,
-    ecs::system::{lifetimeless::*, SystemParamItem},
+    ecs::{
+        query::QueryItem,
+        system::{lifetimeless::*, SystemParamItem},
+    },
     pbr::{MeshPipeline, MeshPipelineKey, MeshUniform, SetMeshBindGroup, SetMeshViewBindGroup},
     prelude::*,
     render::{
@@ -67,7 +70,7 @@ impl ExtractComponent for InstanceMaterialData {
     type Query = &'static InstanceMaterialData;
     type Filter = ();
 
-    fn extract_component(item: bevy::ecs::query::QueryItem<Self::Query>) -> Self {
+    fn extract_component(item: QueryItem<'_, Self::Query>) -> Self {
         InstanceMaterialData(item.0.clone())
     }
 }


### PR DESCRIPTION
# Objective

Replace `WorldQueryGats` trait with actual gats

## Solution

Replace `WorldQueryGats` trait with actual gats

---

## Changelog

- Replaced `WorldQueryGats` trait with actual gats

## Migration Guide

- Replace usage of `WorldQueryGats` assoc types with the actual gats on `WorldQuery` trait
