### PR TITLE
[Merged by Bors] - Add a way to toggle `AudioSink`

### DIFF
--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -177,10 +177,21 @@ impl AudioSink {
     pub fn pause(&self) {
         self.sink.as_ref().unwrap().pause();
     }
+    
+    /// Toggles the playback of this sink.
+    ///
+    /// Will pause if playing, and will be resumed if paused.
+    pub fn toggle(&self) {
+        if self.is_paused() {
+            self.play();
+        } else {
+            self.pause();
+        }
+    }
 
     /// Is this sink paused?
     ///
-    /// Sinks can be paused and resumed using [`pause`](Self::pause) and [`play`](Self::play).
+    /// Sinks can be paused and resumed using [`pause`](Self::pause), [`play`](Self::play), and [`toggle`](Self::toggle).
     pub fn is_paused(&self) -> bool {
         self.sink.as_ref().unwrap().is_paused()
     }

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -177,7 +177,7 @@ impl AudioSink {
     pub fn pause(&self) {
         self.sink.as_ref().unwrap().pause();
     }
-    
+
     /// Toggles the playback of this sink.
     ///
     /// Will pause if playing, and will be resumed if paused.

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -43,11 +43,7 @@ fn pause(
 ) {
     if keyboard_input.just_pressed(KeyCode::Space) {
         if let Some(sink) = audio_sinks.get(&music_controller.0) {
-            if sink.is_paused() {
-                sink.play();
-            } else {
-                sink.pause();
-            }
+            sink.toggle();
         }
     }
 }


### PR DESCRIPTION
# Objective

Currently toggling an `AudioSink` (for example from a game menu) requires writing

```rs
if sink.is_paused() {
    sink.play();
} else {
    sink.pause();
}
```

It would be nicer if we could reduce this down to a single line

```rs
sink.toggle();
```

## Solution

Add an `AudioSink::toggle` method which does exactly that.

---

## Changelog

- Added `AudioSink::toggle` which can be used to toggle state of a sink.