### PR TITLE
Use u64 for change ticks

### DIFF
--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -223,8 +223,8 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
                 unsafe fn init_fetch<'__w>(
                     _world: &'__w #path::world::World,
                     state: &Self::State,
-                    _last_change_tick: u32,
-                    _change_tick: u32
+                    _last_change_tick: u64,
+                    _change_tick: u64
                 ) -> <Self as #path::query::WorldQueryGats<'__w>>::Fetch {
                     #fetch_struct_name {
                         #(#field_idents:

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -240,7 +240,7 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
                     state: &'s mut Self,
                     system_meta: &SystemMeta,
                     world: &'w World,
-                    change_tick: u32,
+                    change_tick: u64,
                 ) -> Self::Item {
                     ParamSet {
                         param_states: &mut state.0,
@@ -385,7 +385,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                     state: &'s mut Self,
                     system_meta: &#path::system::SystemMeta,
                     world: &'w #path::world::World,
-                    change_tick: u32,
+                    change_tick: u64,
                 ) -> Self::Item {
                     #struct_name {
                         #(#fields: <<#field_types as #path::system::SystemParam>::Fetch as #path::system::SystemParamFetch>::get_param(&mut state.state.#field_indices, system_meta, world, change_tick),)*

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -267,7 +267,7 @@ impl BundleInfo {
         components: &mut Components,
         storages: &'a mut Storages,
         archetype_id: ArchetypeId,
-        change_tick: u32,
+        change_tick: u64,
     ) -> BundleInserter<'a, 'b> {
         let new_archetype_id =
             self.add_bundle_to_archetype(archetypes, storages, components, archetype_id);
@@ -326,7 +326,7 @@ impl BundleInfo {
         archetypes: &'a mut Archetypes,
         components: &mut Components,
         storages: &'a mut Storages,
-        change_tick: u32,
+        change_tick: u64,
     ) -> BundleSpawner<'a, 'b> {
         let new_archetype_id =
             self.add_bundle_to_archetype(archetypes, storages, components, ArchetypeId::EMPTY);
@@ -357,7 +357,7 @@ impl BundleInfo {
         add_bundle: &AddBundle,
         entity: Entity,
         table_row: usize,
-        change_tick: u32,
+        change_tick: u64,
         bundle: T,
     ) {
         // NOTE: get_components calls this closure on each component in "bundle order".
@@ -482,7 +482,7 @@ pub(crate) struct BundleInserter<'a, 'b> {
     sparse_sets: &'a mut SparseSets,
     result: InsertBundleResult<'a>,
     archetypes_ptr: *mut Archetype,
-    change_tick: u32,
+    change_tick: u64,
 }
 
 pub(crate) enum InsertBundleResult<'a> {
@@ -618,7 +618,7 @@ pub(crate) struct BundleSpawner<'a, 'b> {
     bundle_info: &'b BundleInfo,
     table: &'a mut Table,
     sparse_sets: &'a mut SparseSets,
-    change_tick: u32,
+    change_tick: u64,
 }
 
 impl<'a, 'b> BundleSpawner<'a, 'b> {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -379,28 +379,6 @@ mod tests {
     struct R;
 
     #[test]
-    fn change_tick_wraparound() {
-        fn change_detected(query: Query<ChangeTrackers<C>>) -> bool {
-            query.single().is_changed()
-        }
-
-        let mut world = World::new();
-        world.last_change_tick = u64::MAX;
-        *world.change_tick.get_mut() = 0;
-
-        // component added: 0, changed: 0
-        world.spawn(C);
-
-        // system last ran: u64::MAX
-        let mut change_detected_system = IntoSystem::into_system(change_detected);
-        change_detected_system.initialize(&mut world);
-
-        // Since the world is always ahead, as long as changes can't get older than `u64::MAX` (which we ensure),
-        // the wrapping difference will always be positive, so wraparound doesn't matter.
-        assert!(change_detected_system.run((), &mut world));
-    }
-
-    #[test]
     fn mut_from_res_mut() {
         let mut component_ticks = ComponentTicks {
             added: 1,

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -367,9 +367,6 @@ mod tests {
         self as bevy_ecs,
         change_detection::{ComponentTicks, Mut, NonSendMut, ResMut, Ticks},
         component::Component,
-        query::ChangeTrackers,
-        system::{IntoSystem, Query, System},
-        world::World,
     };
 
     #[derive(Component)]

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -527,13 +527,13 @@ impl ComponentTicks {
     #[inline]
     /// Returns `true` if the component was added after the system last ran.
     pub fn is_added(&self, last_change_tick: u64) -> bool {
-        self.added < last_change_tick
+        self.added > last_change_tick
     }
 
     #[inline]
     /// Returns `true` if the component was added or mutably dereferenced after the system last ran.
     pub fn is_changed(&self, last_change_tick: u64) -> bool {
-        self.changed < last_change_tick
+        self.changed > last_change_tick
     }
 
     pub(crate) fn new(change_tick: u64) -> Self {

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -446,7 +446,6 @@ macro_rules! impl_tick_filter {
             entities: Option<ThinSlicePtr<'w, Entity>>,
             sparse_set: Option<&'w ComponentSparseSet>,
             last_change_tick: u64,
-            change_tick: u64,
         }
 
         // SAFETY: `ROQueryFetch<Self>` is the same as `QueryFetch<Self>`
@@ -458,7 +457,7 @@ macro_rules! impl_tick_filter {
                 item
             }
 
-            unsafe fn init_fetch<'w>(world: &'w World, &id: &ComponentId, last_change_tick: u64, change_tick: u64) -> <Self as WorldQueryGats<'w>>::Fetch {
+            unsafe fn init_fetch<'w>(world: &'w World, &id: &ComponentId, last_change_tick: u64, _change_tick: u64) -> <Self as WorldQueryGats<'w>>::Fetch {
                 QueryFetch::<'w, Self> {
                     table_ticks: None,
                     entities: None,
@@ -467,7 +466,6 @@ macro_rules! impl_tick_filter {
                         .then(|| world.storages().sparse_sets.get(id).unwrap()),
                     marker: PhantomData,
                     last_change_tick,
-                    change_tick,
                 }
             }
 
@@ -575,7 +573,6 @@ macro_rules! impl_tick_filter {
                     entities: self.entities.clone(),
                     sparse_set: self.sparse_set.clone(),
                     last_change_tick: self.last_change_tick.clone(),
-                    change_tick: self.change_tick.clone(),
                 }
             }
         }

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -29,8 +29,8 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> QueryIter<'w, 's, Q, F> {
     pub(crate) unsafe fn new(
         world: &'w World,
         query_state: &'s QueryState<Q, F>,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) -> Self {
         QueryIter {
             query_state,
@@ -101,8 +101,8 @@ where
         world: &'w World,
         query_state: &'s QueryState<Q, F>,
         entity_list: EntityList,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) -> QueryManyIter<'w, 's, Q, F, I> {
         let fetch = Q::init_fetch(
             world,
@@ -285,8 +285,8 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery, const K: usize>
     pub(crate) unsafe fn new(
         world: &'w World,
         query_state: &'s QueryState<Q, F>,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) -> Self {
         // Initialize array with cursors.
         // There is no FromIterator on arrays, so instead initialize it manually with MaybeUninit
@@ -511,8 +511,8 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> QueryIterationCursor<'w, 's, 
     unsafe fn init_empty(
         world: &'w World,
         query_state: &'s QueryState<Q, F>,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) -> Self {
         QueryIterationCursor {
             table_id_iter: [].iter(),
@@ -524,8 +524,8 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> QueryIterationCursor<'w, 's, 
     unsafe fn init(
         world: &'w World,
         query_state: &'s QueryState<Q, F>,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) -> Self {
         let fetch = Q::init_fetch(
             world,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -127,7 +127,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
 
     /// Checks if the query is empty for the given [`World`], where the last change and current tick are given.
     #[inline]
-    pub fn is_empty(&self, world: &World, last_change_tick: u32, change_tick: u32) -> bool {
+    pub fn is_empty(&self, world: &World, last_change_tick: u64, change_tick: u64) -> bool {
         // SAFETY: NopFetch does not access any members while &self ensures no one has exclusive access
         unsafe {
             self.as_nop()
@@ -396,8 +396,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         &self,
         world: &'w World,
         entity: Entity,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) -> Result<QueryItem<'w, Q>, QueryEntityError> {
         let location = world
             .entities
@@ -443,8 +443,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         &self,
         world: &'w World,
         entities: [Entity; N],
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) -> Result<[ROQueryItem<'w, Q>; N], QueryEntityError> {
         // SAFETY: fetch is read-only
         // and world must be validated
@@ -480,8 +480,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         &self,
         world: &'w World,
         entities: [Entity; N],
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) -> Result<[QueryItem<'w, Q>; N], QueryEntityError> {
         // Verify that all entities are unique
         for i in 0..N {
@@ -702,8 +702,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     pub(crate) unsafe fn iter_unchecked_manual<'w, 's>(
         &'s self,
         world: &'w World,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) -> QueryIter<'w, 's, Q, F> {
         QueryIter::new(world, self, last_change_tick, change_tick)
     }
@@ -723,8 +723,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         &'s self,
         entities: EntityList,
         world: &'w World,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) -> QueryManyIter<'w, 's, Q, F, EntityList::IntoIter>
     where
         EntityList::Item: Borrow<Entity>,
@@ -746,8 +746,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     pub(crate) unsafe fn iter_combinations_unchecked_manual<'w, 's, const K: usize>(
         &'s self,
         world: &'w World,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) -> QueryCombinationIter<'w, 's, Q, F, K> {
         QueryCombinationIter::new(world, self, last_change_tick, change_tick)
     }
@@ -910,8 +910,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         &self,
         world: &'w World,
         mut func: FN,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) {
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
         // QueryIter, QueryIterationCursor, QueryManyIter, QueryCombinationIter, QueryState::for_each_unchecked_manual, QueryState::par_for_each_unchecked_manual
@@ -973,8 +973,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         world: &'w World,
         batch_size: usize,
         func: FN,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) {
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
         // QueryIter, QueryIterationCursor, QueryManyIter, QueryCombinationIter, QueryState::for_each_unchecked_manual, QueryState::par_for_each_unchecked_manual
@@ -1186,8 +1186,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     pub unsafe fn get_single_unchecked_manual<'w>(
         &self,
         world: &'w World,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) -> Result<QueryItem<'w, Q>, QuerySingleError> {
         let mut query = self.iter_unchecked_manual(world, last_change_tick, change_tick);
         let first = query.next();

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -119,7 +119,7 @@ impl ComponentSparseSet {
     /// # Safety
     /// The `value` pointer must point to a valid address that matches the [`Layout`](std::alloc::Layout)
     /// inside the [`ComponentInfo`] given when constructing this sparse set.
-    pub(crate) unsafe fn insert(&mut self, entity: Entity, value: OwningPtr<'_>, change_tick: u32) {
+    pub(crate) unsafe fn insert(&mut self, entity: Entity, value: OwningPtr<'_>, change_tick: u64) {
         if let Some(&dense_index) = self.sparse.get(entity.id()) {
             #[cfg(debug_assertions)]
             assert_eq!(entity, self.entities[dense_index as usize]);
@@ -232,10 +232,6 @@ impl ComponentSparseSet {
         } else {
             false
         }
-    }
-
-    pub(crate) fn check_change_ticks(&mut self, change_tick: u32) {
-        self.dense.check_change_ticks(change_tick);
     }
 }
 
@@ -422,12 +418,6 @@ impl SparseSets {
     pub fn clear(&mut self) {
         for set in self.sets.values_mut() {
             set.clear();
-        }
-    }
-
-    pub(crate) fn check_change_ticks(&mut self, change_tick: u32) {
-        for set in self.sets.values_mut() {
-            set.check_change_ticks(change_tick);
         }
     }
 }

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -77,7 +77,7 @@ impl Column {
     /// # Safety
     /// Assumes data has already been allocated for the given row.
     #[inline]
-    pub(crate) unsafe fn replace(&mut self, row: usize, data: OwningPtr<'_>, change_tick: u32) {
+    pub(crate) unsafe fn replace(&mut self, row: usize, data: OwningPtr<'_>, change_tick: u64) {
         debug_assert!(row < self.len());
         self.data.replace_unchecked(row, data);
         self.ticks
@@ -197,13 +197,6 @@ impl Column {
     pub fn clear(&mut self) {
         self.data.clear();
         self.ticks.clear();
-    }
-
-    #[inline]
-    pub(crate) fn check_change_ticks(&mut self, change_tick: u32) {
-        for component_ticks in &mut self.ticks {
-            component_ticks.get_mut().check_ticks(change_tick);
-        }
     }
 }
 
@@ -412,12 +405,6 @@ impl Table {
         self.entities.is_empty()
     }
 
-    pub(crate) fn check_change_ticks(&mut self, change_tick: u32) {
-        for column in self.columns.values_mut() {
-            column.check_change_ticks(change_tick);
-        }
-    }
-
     pub fn iter(&self) -> impl Iterator<Item = &Column> {
         self.columns.values()
     }
@@ -511,12 +498,6 @@ impl Tables {
     pub(crate) fn clear(&mut self) {
         for table in &mut self.tables {
             table.clear();
-        }
-    }
-
-    pub(crate) fn check_change_ticks(&mut self, change_tick: u32) {
-        for table in &mut self.tables {
-            table.check_change_ticks(change_tick);
         }
     }
 }

--- a/crates/bevy_ecs/src/system/commands/parallel_scope.rs
+++ b/crates/bevy_ecs/src/system/commands/parallel_scope.rs
@@ -59,7 +59,7 @@ impl<'w, 's> SystemParamFetch<'w, 's> for ParallelCommandsState {
         state: &'s mut Self,
         _: &crate::system::SystemMeta,
         world: &'w World,
-        _: u32,
+        _: u64,
     ) -> Self::Item {
         ParallelCommands {
             state,

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -1,13 +1,11 @@
 use crate::{
     archetype::ArchetypeComponentId,
-    change_detection::MAX_CHANGE_AGE,
     component::ComponentId,
     query::Access,
     schedule::{SystemLabel, SystemLabelId},
     system::{
-        check_system_change_tick, AsSystemLabel, ExclusiveSystemParam, ExclusiveSystemParamFetch,
-        ExclusiveSystemParamItem, ExclusiveSystemParamState, IntoSystem, System, SystemMeta,
-        SystemTypeIdLabel,
+        AsSystemLabel, ExclusiveSystemParam, ExclusiveSystemParamFetch, ExclusiveSystemParamItem,
+        ExclusiveSystemParamState, IntoSystem, System, SystemMeta, SystemTypeIdLabel,
     },
     world::{World, WorldId},
 };
@@ -112,11 +110,11 @@ where
         true
     }
 
-    fn get_last_change_tick(&self) -> u32 {
+    fn get_last_change_tick(&self) -> u64 {
         self.system_meta.last_change_tick
     }
 
-    fn set_last_change_tick(&mut self, last_change_tick: u32) {
+    fn set_last_change_tick(&mut self, last_change_tick: u64) {
         self.system_meta.last_change_tick = last_change_tick;
     }
 
@@ -129,7 +127,7 @@ where
     #[inline]
     fn initialize(&mut self, world: &mut World) {
         self.world_id = Some(world.id());
-        self.system_meta.last_change_tick = world.change_tick().wrapping_sub(MAX_CHANGE_AGE);
+        self.system_meta.last_change_tick = world.change_tick();
         self.param_state = Some(<Param::Fetch as ExclusiveSystemParamState>::init(
             world,
             &mut self.system_meta,
@@ -138,14 +136,6 @@ where
 
     fn update_archetype_component_access(&mut self, _world: &World) {}
 
-    #[inline]
-    fn check_change_tick(&mut self, change_tick: u32) {
-        check_system_change_tick(
-            &mut self.system_meta.last_change_tick,
-            change_tick,
-            self.system_meta.name.as_ref(),
-        );
-    }
     fn default_labels(&self) -> Vec<SystemLabelId> {
         vec![self.func.as_system_label().as_label()]
     }

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -142,7 +142,7 @@ pub struct SystemState<Param: SystemParam + 'static> {
 impl<Param: SystemParam> SystemState<Param> {
     pub fn new(world: &mut World) -> Self {
         let mut meta = SystemMeta::new::<Param>();
-        meta.last_change_tick = world.change_tick();
+        meta.last_change_tick = world.last_change_tick();
         let param_state = <Param::Fetch as SystemParamState>::init(world, &mut meta);
         Self {
             meta,
@@ -427,7 +427,7 @@ where
     #[inline]
     fn initialize(&mut self, world: &mut World) {
         self.world_id = Some(world.id());
-        self.system_meta.last_change_tick = world.change_tick();
+        self.system_meta.last_change_tick = world.last_change_tick();
         self.param_state = Some(<Param::Fetch as SystemParamState>::init(
             world,
             &mut self.system_meta,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -276,8 +276,8 @@ use std::{any::TypeId, borrow::Borrow, fmt::Debug};
 pub struct Query<'world, 'state, Q: WorldQuery, F: ReadOnlyWorldQuery = ()> {
     pub(crate) world: &'world World,
     pub(crate) state: &'state QueryState<Q, F>,
-    pub(crate) last_change_tick: u32,
-    pub(crate) change_tick: u32,
+    pub(crate) last_change_tick: u64,
+    pub(crate) change_tick: u64,
 }
 
 impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> std::fmt::Debug for Query<'w, 's, Q, F> {
@@ -297,8 +297,8 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     pub(crate) unsafe fn new(
         world: &'w World,
         state: &'s QueryState<Q, F>,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) -> Self {
         Self {
             world,

--- a/crates/bevy_ecs/src/system/system_piping.rs
+++ b/crates/bevy_ecs/src/system/system_piping.rs
@@ -107,16 +107,11 @@ impl<SystemA: System, SystemB: System<In = SystemA::Out>> System for PipeSystem<
             .extend(self.system_b.archetype_component_access());
     }
 
-    fn check_change_tick(&mut self, change_tick: u32) {
-        self.system_a.check_change_tick(change_tick);
-        self.system_b.check_change_tick(change_tick);
-    }
-
-    fn get_last_change_tick(&self) -> u32 {
+    fn get_last_change_tick(&self) -> u64 {
         self.system_a.get_last_change_tick()
     }
 
-    fn set_last_change_tick(&mut self, last_change_tick: u32) {
+    fn set_last_change_tick(&mut self, last_change_tick: u64) {
         self.system_a.set_last_change_tick(last_change_tick);
         self.system_b.set_last_change_tick(last_change_tick);
     }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -97,8 +97,8 @@ impl<'w> EntityRef<'w> {
     #[inline]
     pub unsafe fn get_unchecked_mut<T: Component>(
         &self,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: u64,
+        change_tick: u64,
     ) -> Option<Mut<'w, T>> {
         get_component_and_ticks_with_type(self.world, TypeId::of::<T>(), self.entity, self.location)
             .map(|(value, ticks)| Mut {

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -84,7 +84,7 @@ where
         state: &'s mut Self,
         system_meta: &SystemMeta,
         world: &'w World,
-        change_tick: u32,
+        change_tick: u64,
     ) -> Self::Item {
         let main_world = ResState::<MainWorld>::get_param(
             &mut state.main_world_state,

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -225,15 +225,11 @@ impl System for FixedTimestep {
             .update_archetype_component_access(world);
     }
 
-    fn check_change_tick(&mut self, change_tick: u32) {
-        self.internal_system.check_change_tick(change_tick);
-    }
-
-    fn get_last_change_tick(&self) -> u32 {
+    fn get_last_change_tick(&self) -> u64 {
         self.internal_system.get_last_change_tick()
     }
 
-    fn set_last_change_tick(&mut self, last_change_tick: u32) {
+    fn set_last_change_tick(&mut self, last_change_tick: u64) {
         self.internal_system.set_last_change_tick(last_change_tick);
     }
 }


### PR DESCRIPTION
# Objective

Allows detecting arbitrary old changes
Simplifies a lot of code along the way
Would play nice with query that detects changes since arbitrary tick that I'll implement next.

## Solution

Replace `u32` with `u64` for tick values.
Maintenance code to guard against overflow is simply removed.

Downside - requires `AtomicU64`.
A workaround should be implemented for when `AtomicU64` is not available on target platform.

---

## Changelog

### Changed

Type of values that represent ticks are changed from `u32` to `u64`.
World's `change_tick` is `AtomicU64` now.

## Migration Guide

Some trait methods became obsolete and were removed.
Many users would need to change nothing as said traits are rarely used directly.