### PR TITLE
[Merged by Bors] - document insert_non_send_resource panics

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -765,6 +765,7 @@ impl World {
     /// Systems with `NonSend` resources are always scheduled on the main thread.
     ///
     /// # Panics
+    ///
     /// Panics if called from a thread other than the main thread.
     #[inline]
     pub fn insert_non_send_resource<R: 'static>(&mut self, value: R) {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -765,7 +765,7 @@ impl World {
     /// Systems with `NonSend` resources are always scheduled on the main thread.
     ///
     /// # Panics
-    /// Panics if called from thread other than main thread.
+    /// Panics if called from a thread other than the main thread.
     #[inline]
     pub fn insert_non_send_resource<R: 'static>(&mut self, value: R) {
         self.validate_non_send_access::<R>();

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -763,6 +763,9 @@ impl World {
     /// `NonSend` resources cannot be sent across threads,
     /// and do not need the `Send + Sync` bounds.
     /// Systems with `NonSend` resources are always scheduled on the main thread.
+    ///
+    /// # Panics
+    /// Panics if called from thread other than main thread.
     #[inline]
     pub fn insert_non_send_resource<R: 'static>(&mut self, value: R) {
         self.validate_non_send_access::<R>();

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -750,6 +750,10 @@ impl World {
     /// The value given by the [`FromWorld::from_world`] method will be used.
     /// Note that any resource with the `Default` trait automatically implements `FromWorld`,
     /// and those default values will be here instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called from a thread other than the main thread.
     #[inline]
     pub fn init_non_send_resource<R: 'static + FromWorld>(&mut self) {
         if !self.contains_resource::<R>() {


### PR DESCRIPTION
Signed-off-by: Lena Milizé <me@lvmn.org>

# Objective

Fixes #6277.

## Solution

Adds `# Panics` section to [`fn insert_non_send_resource`](http://dev-docs.bevyengine.org/bevy/ecs/world/struct.World.html#method.insert_non_send_resource) documentation, which explains that it panics when called from thread other than main thread.