### PR TITLE
[Merged by Bors] - Fix outdated and badly formatted docs for `WindowDescriptor::transparent`

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -914,10 +914,7 @@ pub struct WindowDescriptor {
     ///
     /// ## Platform-specific
     /// - iOS / Android / Web: Unsupported.
-    /// - macOS X: Not working as expected.
-    /// - Windows 11: Not working as expected
-    /// macOS X transparent works with winit out of the box, so this issue might be related to: <https://github.com/gfx-rs/wgpu/issues/687>
-    /// Windows 11 is related to <https://github.com/rust-windowing/winit/issues/2082>
+    /// - macOS X: Not working as expected, possibly related to [wgpu #687](https://github.com/gfx-rs/wgpu/issues/687).
     pub transparent: bool,
     /// The "html canvas" element selector.
     ///

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -914,8 +914,8 @@ pub struct WindowDescriptor {
     ///
     /// ## Platform-specific
     /// - iOS / Android / Web: Unsupported.
-    /// - macOS: Not working as expected, possibly related to [wgpu #687](https://github.com/gfx-rs/wgpu/issues/687).
-    /// - Linux (Wayland): Not working as expected, see [bevy #5779](https://github.com/bevyengine/bevy/issues/5779).
+    /// - macOS: Not working as expected. See [Bevy #6330](https://github.com/bevyengine/bevy/issues/6330).
+    /// - Linux (Wayland): Not working as expected. See [Bevy #5779](https://github.com/bevyengine/bevy/issues/5779).
     pub transparent: bool,
     /// The "html canvas" element selector.
     ///

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -914,7 +914,8 @@ pub struct WindowDescriptor {
     ///
     /// ## Platform-specific
     /// - iOS / Android / Web: Unsupported.
-    /// - macOS X: Not working as expected, possibly related to [wgpu #687](https://github.com/gfx-rs/wgpu/issues/687).
+    /// - macOS: Not working as expected, possibly related to [wgpu #687](https://github.com/gfx-rs/wgpu/issues/687).
+    /// - Linux (Wayland): Not working as expected, see [bevy #5779](https://github.com/bevyengine/bevy/issues/5779).
     pub transparent: bool,
     /// The "html canvas" element selector.
     ///


### PR DESCRIPTION
# Objective

See title

## Before / After

<img width="988" alt="Screen Shot 2022-10-21 at 10 51 12 AM" src="https://user-images.githubusercontent.com/200550/197258517-29fec3e0-e272-4ab1-9f4c-c646b04876f2.png">
<img width="988" alt="Screen Shot 2022-10-21 at 10 51 24 AM" src="https://user-images.githubusercontent.com/200550/197258519-7fbaf058-fc2c-469e-ae34-5531f02a632f.png">

## Open questions

~~The old docs previously linked to a winit but that was preventing transparency for working on Windows 11. The recent winit upgrade should have fixed this.~~

~~I'm unable to test on Windows 11 though, so someone should verify that we no longer need to call this out as being broken.~~

edit: Seems like we're good on Windows 11, thanks.