### PR TITLE
[Merged by Bors] - fix: specify required trybuild patch version

### DIFF
--- a/crates/bevy_ecs_compile_fail_tests/Cargo.toml
+++ b/crates/bevy_ecs_compile_fail_tests/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 
 [dev-dependencies]
 bevy_ecs = { path = "../bevy_ecs" }
-trybuild = "1.0"
+trybuild = "1.0.71"


### PR DESCRIPTION
# Objective

This is a follow-up to #6317, which makes use of a feature of the newest `trybuild` version, `1.0.71`, but does not specify the new patch version in `bevy_ecs_compile_fail_tests/Cargo.toml`.

The PR passed CI because CI downloaded the latest `trybuild` version satisfying the dependency specification. However, Cargo will not know an update is required if a user already has a `^1.0` version of `trybuild` cached locally, which causes the new `$N` syntax to fail the tests.

## Solution

Updated the `trybuild` requirement to `1.0.71`.
