### PR TITLE
feat: vertex attribute validation for Material

### DIFF
--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -15,6 +15,7 @@ webgl = []
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.9.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.9.0-dev" }
+bevy_core = { path = "../bevy_core", version = "0.9.0-dev" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.9.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.9.0-dev" }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -154,7 +154,7 @@ pub trait Material: AsBindGroup + Send + Sync + Clone + TypeUuid + Sized + 'stat
 
     /// Returns a list of vertex attributes required by this `Material`.
     ///
-    /// The default implementation of this method returns an empty `Vec`.
+    /// The default implementation of this method returns an empty slice.
     #[inline]
     fn required_vertex_attributes() -> &'static [MeshVertexAttribute] {
         &[]

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -446,11 +446,13 @@ impl Material for StandardMaterial {
     }
 
     #[inline]
-    fn required_vertex_attributes() -> Vec<MeshVertexAttribute> {
-        vec![
+    fn required_vertex_attributes() -> &'static [MeshVertexAttribute] {
+        static ATTRIBUTES: &[MeshVertexAttribute] = &[
             Mesh::ATTRIBUTE_POSITION,
             Mesh::ATTRIBUTE_NORMAL,
             Mesh::ATTRIBUTE_UV_0,
-        ]
+        ];
+
+        ATTRIBUTES
     }
 }

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -3,7 +3,10 @@ use bevy_asset::Handle;
 use bevy_math::Vec4;
 use bevy_reflect::{std_traits::ReflectDefault, FromReflect, Reflect, TypeUuid};
 use bevy_render::{
-    color::Color, mesh::MeshVertexBufferLayout, render_asset::RenderAssets, render_resource::*,
+    color::Color,
+    mesh::{Mesh, MeshVertexAttribute, MeshVertexBufferLayout},
+    render_asset::RenderAssets,
+    render_resource::*,
     texture::Image,
 };
 
@@ -440,5 +443,14 @@ impl Material for StandardMaterial {
     #[inline]
     fn depth_bias(&self) -> f32 {
         self.depth_bias
+    }
+
+    #[inline]
+    fn required_vertex_attributes() -> Vec<MeshVertexAttribute> {
+        vec![
+            Mesh::ATTRIBUTE_POSITION,
+            Mesh::ATTRIBUTE_NORMAL,
+            Mesh::ATTRIBUTE_UV_0,
+        ]
     }
 }

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -423,6 +423,16 @@ impl MeshVertexAttribute {
     pub const fn at_shader_location(&self, shader_location: u32) -> VertexAttributeDescriptor {
         VertexAttributeDescriptor::new(shader_location, self.id, self.name)
     }
+
+    /// Returns the human-readable name of the attribute.
+    pub const fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Returns the unique ID of the attribute.
+    pub const fn id(&self) -> MeshVertexAttributeId {
+        self.id
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]


### PR DESCRIPTION

# Objective

Fixes #6128. (Original suggestion from https://github.com/bevyengine/bevy/pull/6127#pullrequestreview-1125960865).

## Solution

This PR adds a new trait method, `Material::required_vertex_attributes`, which allows implementors to specify a list of vertex attributes that are required for the `Material` to function.

A new system has been added to `MaterialPlugin` which emits an error message when an entity is found to have a `Mesh` that lacks required vertex attributes for its `Material`.

---

## Changelog

### Added

- Added `Material::required_vertex_attributes` trait method, allowing implementors to specify the vertex attributes required for a `Material`.
- Added `verify_material_mesh_attributes()` system to `MaterialPlugin`. Errors are now emitted if a `Material` is applied to a `Mesh` missing required attributes.
- Added `name()` and `id()` methods on `MeshVertexAttribute` to retrieve the name and unique ID.
