### PR TITLE
bevy_scene: Add `ReflectBundle`

### DIFF
--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -25,12 +25,17 @@
       },
     ),
     1: (
-      components: {
-        "scene::ComponentA": (
-          x: 3.0,
-          y: 4.0,
-        ),
-      },
+      components: {},
+      // Note: The `bundles` map is optional, but allows entire bundles to be spawned (if registered)
+      bundles: {
+        "scene::SomeBundle": (
+          // You may optionally override specific components of a bundle
+          a: (
+            x: 3.14,
+            y: 2.72,
+          ),
+        )
+      }
     ),
   }
 )

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -24,7 +24,7 @@ pub use bevy_ptr as ptr;
 pub mod prelude {
     #[doc(hidden)]
     #[cfg(feature = "bevy_reflect")]
-    pub use crate::reflect::{ReflectComponent, ReflectResource};
+    pub use crate::reflect::{ReflectBundle, ReflectComponent, ReflectResource};
     #[doc(hidden)]
     pub use crate::{
         bundle::Bundle,

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -109,6 +109,7 @@ impl<'w> DynamicSceneBuilder<'w> {
             let mut entry = DynamicEntity {
                 entity: index,
                 components: Vec::new(),
+                bundles: Vec::new(),
             };
 
             for component_id in self.world.entity(entity).archetype().components() {

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -45,6 +45,8 @@ pub struct SceneSpawner {
 pub enum SceneSpawnError {
     #[error("scene contains the unregistered component `{type_name}`. consider adding `#[reflect(Component)]` to your type")]
     UnregisteredComponent { type_name: String },
+    #[error("scene contains the unregistered bundle `{type_name}`. consider adding `#[reflect(Bundle)]` to your type")]
+    UnregisteredBundle { type_name: String },
     #[error("scene contains the unregistered type `{type_name}`. consider registering the type using `app.register_type::<T>()`")]
     UnregisteredType { type_name: String },
     #[error("scene does not exist")]

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -14,6 +14,7 @@ fn main() {
         }))
         .register_type::<ComponentA>()
         .register_type::<ComponentB>()
+        .register_type::<SomeBundle>()
         .add_startup_system(save_scene_system)
         .add_startup_system(load_scene_system)
         .add_startup_system(infotext_system)
@@ -52,6 +53,31 @@ impl FromWorld for ComponentB {
         ComponentB {
             _time_since_startup: time.elapsed(),
             value: "Default Value".to_string(),
+        }
+    }
+}
+
+/// For bundles, you can add `#[reflect(Bundle)]` to enable deserializing entire bundles.
+///
+/// This can be useful when manually creating scene files. Rather than writing out each component in the bundle,
+/// you can simply add the bundle to the `bundles` field of the scene.
+/// You can then modify specific components of that bundle if you need to, or just leave it blank and let it
+/// generate a default instance of that bundle. The choice is yours!
+///
+/// Note: This only works for _deserializing_ scenes. When serializing a scene, the `bundles` field will
+/// not be generated and all of the bundle's components will instead be added to the `components` field.
+#[derive(Reflect, Bundle)]
+#[reflect(Bundle)]
+struct SomeBundle {
+    a: ComponentA,
+    b: ComponentB,
+}
+
+impl FromWorld for SomeBundle {
+    fn from_world(world: &mut World) -> Self {
+        Self {
+            a: ComponentA { x: -1.0, y: -1.0 },
+            b: ComponentB::from_world(world),
         }
     }
 }


### PR DESCRIPTION
# Objective

Scenes do not currently support spawning entire bundles. This means that in order to simulate spawning a bundle, one must include all components within that bundle.

Given the following bundle:

```rust
#[derive(Reflect, Bundle)]
struct MyBundle {
  a: ComponentA,
  b: ComponentB,
  c: ComponentC,
  d: ComponentD,
  e: ComponentE,
  f: ComponentF,
  g: ComponentG,
}
```

We must then include the following in our scene file:

```json
[
  {
    "entity": 0,
    "components": [
      {
        "my_crate::ComponentA": {
          "foo": "Hello World"
        }
      },
      {
        "my_crate::ComponentB": {}
      },
      {
        "my_crate::ComponentC": {}
      },
      {
        "my_crate::ComponentD": {}
      },
      {
        "my_crate::ComponentE": {}
      },
      {
        "my_crate::ComponentF": {}
      },
      {
        "my_crate::ComponentG": {}
      }
    ]
  }
]
```

We only needed to specify data for `ComponentA`. All other components in the bundle could have just as easily been left out since we didn't have to specify anything for them (or perhaps they're just markers).

## Solution

Add `ReflectBundle` to allow scenes to spawn complete bundles. 

With this change, we can now update our example bundle:

```rust
#[derive(Reflect, Bundle)]
#[reflect(Bundle)]
struct MyBundle {
  a: ComponentA,
  b: ComponentB,
  c: ComponentC,
  d: ComponentD,
  e: ComponentE,
  f: ComponentF,
  g: ComponentG,
}
```

And add a `bundles` section to our scene files:

```json
[
  {
    "entity": 0,
    "components": []
    "bundles": {
      "a": {
        "foo": "Hello World"
      }
    }
  }
]
```

Much nicer!

### Considerations

There are some caveats to this system we might need to consider:

1. The `bundles` field will never be serialized by the `DynamicScene` serializer. This could be confusing to users who expect it to serialize. The problem is, we don't have a great way of knowing whether every necessary component exists to create a valid bundle and not lose any information. So for now it's a manually-written/deserialize-only feature.
2. Now that `Component`s also implement `Bundle`, it would be possible to register a `ReflectBundle` for a component. If this is done, then applying the "bundle" will result in each field of the component being inserted onto the entity. This is obviously not good. However, there's not a good way of knowing whether a `Bundle` is only a component or not. If we could add a `Bundle::IS_COMPONENT` constant or something, it might be possible to throw an error when attempting to create a `ReflectBundle` for a component.

---

## Changelog

- Added `ReflectBundle`
- Added `bundles` field to `DynamicEntity`
  - Allows a `bundles` map to be optionally included per entity in scene files
