### PR TITLE
Support creating windows as child window.

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -935,6 +935,12 @@ pub struct WindowDescriptor {
     ///
     /// This value has no effect on non-web platforms.
     pub fit_canvas_to_parent: bool,
+    /// Parent window handle (HWND).
+    ///
+    /// If set, this selector will be used to create a window as a child window of the parent window.
+    ///
+    /// This value has no effect on non-Windows platforms.
+    pub parent_window: Option<isize>,
 }
 
 impl Default for WindowDescriptor {
@@ -956,6 +962,7 @@ impl Default for WindowDescriptor {
             transparent: false,
             canvas: None,
             fit_canvas_to_parent: false,
+            parent_window: None,
         }
     }
 }

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -116,6 +116,16 @@ impl WinitWindows {
             }
         }
 
+        #[cfg(target_os = "windows")]
+        {
+            use winit::platform::windows::WindowBuilderExtWindows;
+            
+            if let Some(parent_window_handle) = window_descriptor.parent_window {
+                winit_window_builder =
+                    winit_window_builder.with_parent_window(parent_window_handle);
+            }
+        }
+
         let winit_window = winit_window_builder.build(event_loop).unwrap();
 
         if window_descriptor.mode == WindowMode::Windowed {

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -119,7 +119,7 @@ impl WinitWindows {
         #[cfg(target_os = "windows")]
         {
             use winit::platform::windows::WindowBuilderExtWindows;
-            
+
             if let Some(parent_window_handle) = window_descriptor.parent_window {
                 winit_window_builder =
                     winit_window_builder.with_parent_window(parent_window_handle);


### PR DESCRIPTION
# Objective

- To create windows as child window in Windows.


## Solution

- Added `parent_window` selector to `WindowDescriptor` in `bevy-window`
- Added code to create windows as child window when building window in `bevy-winit` using `with_parent_window`.
