### PR TITLE
Respect mipmap_filter when create ImageDescriptor with linear()/nearest()

### DIFF
--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -143,6 +143,7 @@ impl ImageSampler {
         wgpu::SamplerDescriptor {
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Linear,
             ..Default::default()
         }
     }
@@ -153,6 +154,7 @@ impl ImageSampler {
         wgpu::SamplerDescriptor {
             mag_filter: wgpu::FilterMode::Nearest,
             min_filter: wgpu::FilterMode::Nearest,
+            mipmap_filter: wgpu::FilterMode::Nearest,
             ..Default::default()
         }
     }


### PR DESCRIPTION
Respect mipmap_filter when create ImageDescriptor with linear()/nearest()

# Objective

Fixes #6348

## Migration Guide

This PR changes default `ImageSettings` and may lead to unexpected behaviour for existing projects with mipmapped textures. Users should provide custom `ImageSettings` resource with `mipmap_filter=FilterMode::Nearest` if they want to  keep old behaviour.