### PR TITLE
[Merged by Bors] - Rename `play` to `start` and add new `play` method that won't overwrite the existing animation if it's already playing

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -115,11 +115,19 @@ impl Default for AnimationPlayer {
 
 impl AnimationPlayer {
     /// Start playing an animation, resetting state of the player
-    pub fn play(&mut self, handle: Handle<AnimationClip>) -> &mut Self {
+    pub fn start(&mut self, handle: Handle<AnimationClip>) -> &mut Self {
         *self = Self {
             animation_clip: handle,
             ..Default::default()
         };
+        self
+    }
+
+    /// Start playing an animation, resetting state of the player, unless the requested animation is already playing.
+    pub fn play(&mut self, handle: Handle<AnimationClip>) -> &mut Self {
+        if self.animation_clip != handle || self.is_paused() {
+            self.start(handle);
+        }
         self
     }
 


### PR DESCRIPTION
# Objective

- You usually want to say that a given animation *should* be playing, doing nothing if it's already playing.

## Solution

- Rename play to start and add new play method that won't overwrite the existing animation if it's already playing #6350

---

## Changelog

### Changed

`AnimationPlayer::play` will now not restart the animation if it's already playing

### Added

An `AnimationPlayer ::start` method, which has the old behavior of `play`

## Migration guide

- If you were using `play` to restart an animation that was already playing, that functionality has been moved to `start`. Now, `play` won't have any effect if the requested animation is already playing.


