### PR TITLE
[Merged by Bors] - bevy_scene: Replace root list with struct

### DIFF
--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -1,5 +1,5 @@
 (
-  entities:[
+  entities: [
     (
       entity: 0,
       components: [

--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -1,44 +1,46 @@
-[
-  (
-    entity: 0,
-    components: [
-      {
-        "bevy_transform::components::transform::Transform": (
-          translation: (
-            x: 0.0,
-            y: 0.0,
-            z: 0.0
+(
+  entities:[
+    (
+      entity: 0,
+      components: [
+        {
+          "bevy_transform::components::transform::Transform": (
+            translation: (
+              x: 0.0,
+              y: 0.0,
+              z: 0.0
+            ),
+            rotation: (0.0, 0.0, 0.0, 1.0),
+            scale: (
+              x: 1.0,
+              y: 1.0,
+              z: 1.0
+            ),
           ),
-          rotation: (0.0, 0.0, 0.0, 1.0),
-          scale: (
+        },
+        {
+          "scene::ComponentB": (
+            value: "hello",
+          ),
+        },
+        {
+          "scene::ComponentA": (
             x: 1.0,
-            y: 1.0,
-            z: 1.0
+            y: 2.0,
           ),
-        ),
-      },
-      {
-        "scene::ComponentB": (
-          value: "hello",
-        ),
-      },
-      {
-        "scene::ComponentA": (
-          x: 1.0,
-          y: 2.0,
-        ),
-      },
-    ],
-  ),
-  (
-    entity: 1,
-    components: [
-      {
-        "scene::ComponentA": (
-          x: 3.0,
-          y: 4.0,
-        ),
-      },
-    ],
-  ),
-]
+        },
+      ],
+    ),
+    (
+      entity: 1,
+      components: [
+        {
+          "scene::ComponentA": (
+            x: 3.0,
+            y: 4.0,
+          ),
+        },
+      ],
+    ),
+  ]
+)


### PR DESCRIPTION
# Objective

Scenes are currently represented as a list of entities. This is all we need currently, but we may want to add more data to this format in the future (metadata, asset lists, etc.). 

It would be nice to update the format in preparation of possible future changes. Doing so now (i.e., before 0.9) could mean reduced[^1] breakage for things added in 0.10.

[^1]: Obviously, adding features runs the risk of breaking things regardless. But if all features added are for whatever reason optional or well-contained, then users should at least have an easier time updating.

## Solution

Made the scene root a struct rather than a list.

```rust
(
  entities: [
    // Entity data here...
  ]
)
```

---

## Changelog

* The scene format now puts the entity list in a newly added `entities` field, rather than having it be the root object

## Migration Guide

The scene file format now uses a struct as the root object rather than a list of entities. The list of entities is now found in the `entities` field of this struct.

```rust
// OLD
[
  (
    entity: 0,
    components: [
      // Components...
    ]
  ),
]

// NEW
(
  entities: [
    (
      entity: 0,
      components: [
        // Components...
      ]
    ),
  ]
)
```
