### PR TITLE
[Merged by Bors] - Use plugin setup for resource only used at setup time

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -429,7 +429,7 @@ mod tests {
         #[uuid = "44115972-f31b-46e5-be5c-2b9aece6a52f"]
         struct MyAsset;
         let mut app = App::new();
-        app.add_plugin(bevy_core::CorePlugin)
+        app.add_plugin(bevy_core::CorePlugin::default())
             .add_plugin(crate::AssetPlugin::default());
         app.add_asset::<MyAsset>();
         let mut assets_before = app.world.resource_mut::<Assets<MyAsset>>();

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -12,7 +12,7 @@ pub use task_pool_options::*;
 pub mod prelude {
     //! The Bevy Core Prelude.
     #[doc(hidden)]
-    pub use crate::{DefaultTaskPoolOptions, Name};
+    pub use crate::{CorePlugin, Name, TaskPoolOptions};
 }
 
 use bevy_app::prelude::*;
@@ -29,16 +29,15 @@ use bevy_tasks::tick_global_task_pools_on_main_thread;
 
 /// Adds core functionality to Apps.
 #[derive(Default)]
-pub struct CorePlugin;
+pub struct CorePlugin {
+    /// Options for the [`TaskPool`](bevy_tasks::TaskPool) created at application start.
+    pub task_pool_options: TaskPoolOptions,
+}
 
 impl Plugin for CorePlugin {
     fn build(&self, app: &mut App) {
         // Setup the default bevy task pools
-        app.world
-            .get_resource::<DefaultTaskPoolOptions>()
-            .cloned()
-            .unwrap_or_default()
-            .create_default_pools();
+        self.task_pool_options.create_default_pools();
 
         #[cfg(not(target_arch = "wasm32"))]
         app.add_system_to_stage(
@@ -118,7 +117,7 @@ mod tests {
     #[test]
     fn runs_spawn_local_tasks() {
         let mut app = App::new();
-        app.add_plugin(CorePlugin);
+        app.add_plugin(CorePlugin::default());
 
         let (async_tx, async_rx) = crossbeam_channel::unbounded();
         AsyncComputeTaskPool::get()

--- a/crates/bevy_core/src/task_pool_options.rs
+++ b/crates/bevy_core/src/task_pool_options.rs
@@ -32,10 +32,9 @@ impl TaskPoolThreadAssignmentPolicy {
 }
 
 /// Helper for configuring and creating the default task pools. For end-users who want full control,
-/// insert the default task pools into the resource map manually. If the pools are already inserted,
-/// this helper will do nothing.
+/// set up [`CorePlugin`](super::CorePlugin)
 #[derive(Clone, Resource)]
-pub struct DefaultTaskPoolOptions {
+pub struct TaskPoolOptions {
     /// If the number of physical cores is less than min_total_threads, force using
     /// min_total_threads
     pub min_total_threads: usize,
@@ -51,9 +50,9 @@ pub struct DefaultTaskPoolOptions {
     pub compute: TaskPoolThreadAssignmentPolicy,
 }
 
-impl Default for DefaultTaskPoolOptions {
+impl Default for TaskPoolOptions {
     fn default() -> Self {
-        DefaultTaskPoolOptions {
+        TaskPoolOptions {
             // By default, use however many cores are available on the system
             min_total_threads: 1,
             max_total_threads: std::usize::MAX,
@@ -82,10 +81,10 @@ impl Default for DefaultTaskPoolOptions {
     }
 }
 
-impl DefaultTaskPoolOptions {
+impl TaskPoolOptions {
     /// Create a configuration that forces using the given number of threads.
     pub fn with_num_threads(thread_count: usize) -> Self {
-        DefaultTaskPoolOptions {
+        TaskPoolOptions {
             min_total_threads: thread_count,
             max_total_threads: thread_count,
             ..Default::default()

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -1,4 +1,5 @@
 use bevy_app::{PluginGroup, PluginGroupBuilder};
+use bevy_render::texture::ImagePlugin;
 
 /// This plugin group will add all the default plugins:
 /// * [`LogPlugin`](bevy_log::LogPlugin)
@@ -59,7 +60,11 @@ impl PluginGroup for DefaultPlugins {
 
         #[cfg(feature = "bevy_render")]
         {
-            group = group.add(bevy_render::RenderPlugin::default());
+            group = group
+                .add(bevy_render::RenderPlugin::default())
+                // NOTE: Load this after renderer initialization so that it knows about the supported
+                // compressed texture formats
+                .add(ImagePlugin::default());
         }
 
         #[cfg(feature = "bevy_core_pipeline")]

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -1,5 +1,4 @@
 use bevy_app::{PluginGroup, PluginGroupBuilder};
-use bevy_render::texture::ImagePlugin;
 
 /// This plugin group will add all the default plugins:
 /// * [`LogPlugin`](bevy_log::LogPlugin)
@@ -64,7 +63,7 @@ impl PluginGroup for DefaultPlugins {
                 .add(bevy_render::RenderPlugin::default())
                 // NOTE: Load this after renderer initialization so that it knows about the supported
                 // compressed texture formats
-                .add(ImagePlugin::default());
+                .add(bevy_render::texture::ImagePlugin::default());
         }
 
         #[cfg(feature = "bevy_core_pipeline")]

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -8,8 +8,8 @@
 //! By default, the [`LogPlugin`] from this crate is included in Bevy's `DefaultPlugins`
 //! and the logging macros can be used out of the box, if used.
 //!
-//! For more fine-tuned control over logging behavior, insert a [`LogSettings`] resource before
-//! adding [`LogPlugin`] or `DefaultPlugins` during app initialization.
+//! For more fine-tuned control over logging behavior, set up the [`LogPlugin`] or
+//! `DefaultPlugins` during app initialization.
 
 #[cfg(feature = "trace")]
 use std::panic;
@@ -30,8 +30,6 @@ pub use bevy_utils::tracing::{
     Level,
 };
 
-use bevy_ecs::prelude::Resource;
-
 use bevy_app::{App, Plugin};
 use tracing_log::LogTracer;
 #[cfg(feature = "tracing-chrome")]
@@ -47,18 +45,17 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// * Using [`tracing-wasm`](https://crates.io/crates/tracing-wasm) in WASM, logging
 /// to the browser console.
 ///
-/// You can configure this plugin using the resource [`LogSettings`].
+/// You can configure this plugin.
 /// ```no_run
-/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins};
-/// # use bevy_log::LogSettings;
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup};
+/// # use bevy_log::LogPlugin;
 /// # use bevy_utils::tracing::Level;
 /// fn main() {
 ///     App::new()
-///         .insert_resource(LogSettings {
+///         .add_plugins(DefaultPlugins.set(LogPlugin {
 ///             level: Level::DEBUG,
 ///             filter: "wgpu=error,bevy_render=info,bevy_ecs=trace".to_string(),
-///         })
-///         .add_plugins(DefaultPlugins)
+///         }))
 ///         .run();
 /// }
 /// ```
@@ -66,8 +63,8 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// Log level can also be changed using the `RUST_LOG` environment variable.
 /// For example, using `RUST_LOG=wgpu=error,bevy_render=info,bevy_ecs=trace cargo run ..`
 ///
-/// It has the same syntax as the field [`LogSettings::filter`], see [`EnvFilter`].
-/// If you define the `RUST_LOG` environment variable, the [`LogSettings`] resource
+/// It has the same syntax as the field [`LogPlugin::filter`], see [`EnvFilter`].
+/// If you define the `RUST_LOG` environment variable, the [`LogPlugin`] settings
 /// will be ignored.
 ///
 /// If you want to setup your own tracing collector, you should disable this
@@ -87,12 +84,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// This plugin should not be added multiple times in the same process. This plugin
 /// sets up global logging configuration for **all** Apps in a given process, and
 /// rerunning the same initialization multiple times will lead to a panic.
-#[derive(Default)]
-pub struct LogPlugin;
-
-/// `LogPlugin` settings
-#[derive(Resource)]
-pub struct LogSettings {
+pub struct LogPlugin {
     /// Filters logs using the [`EnvFilter`] format
     pub filter: String,
 
@@ -101,7 +93,7 @@ pub struct LogSettings {
     pub level: Level,
 }
 
-impl Default for LogSettings {
+impl Default for LogPlugin {
     fn default() -> Self {
         Self {
             filter: "wgpu=error".to_string(),
@@ -111,6 +103,7 @@ impl Default for LogSettings {
 }
 
 impl Plugin for LogPlugin {
+    #[allow(unused_variables)]
     fn build(&self, app: &mut App) {
         #[cfg(feature = "trace")]
         {
@@ -121,10 +114,7 @@ impl Plugin for LogPlugin {
             }));
         }
 
-        let default_filter = {
-            let settings = app.world.get_resource_or_insert_with(LogSettings::default);
-            format!("{},{}", settings.level, settings.filter)
-        };
+        let default_filter = { format!("{},{}", self.level, self.filter) };
         LogTracer::init().unwrap();
         let filter_layer = EnvFilter::try_from_default_env()
             .or_else(|_| EnvFilter::try_new(&default_filter))

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -103,7 +103,7 @@ impl Default for LogPlugin {
 }
 
 impl Plugin for LogPlugin {
-    #[allow(unused_variables)]
+    #[cfg_attr(not(feature = "tracing-chrome"), allow(unused_variables))]
     fn build(&self, app: &mut App) {
         #[cfg(feature = "trace")]
         {

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -31,7 +31,7 @@ pub mod prelude {
         mesh::{shape, Mesh},
         render_resource::Shader,
         spatial_bundle::SpatialBundle,
-        texture::{Image, ImageSettings},
+        texture::{Image, ImagePlugin},
         view::{ComputedVisibility, Msaa, Visibility, VisibilityBundle},
     };
 }
@@ -49,7 +49,7 @@ use crate::{
     render_graph::RenderGraph,
     render_resource::{PipelineCache, Shader, ShaderLoader},
     renderer::{render_system, RenderInstance, RenderTextureFormat},
-    texture::{BevyDefault, ImagePlugin},
+    texture::BevyDefault,
     view::{ViewPlugin, WindowRenderPlugin},
 };
 use bevy_app::{App, AppLabel, Plugin};
@@ -348,9 +348,6 @@ impl Plugin for RenderPlugin {
             .add_plugin(CameraPlugin)
             .add_plugin(ViewPlugin)
             .add_plugin(MeshPlugin)
-            // NOTE: Load this after renderer initialization so that it knows about the supported
-            // compressed texture formats
-            .add_plugin(ImagePlugin)
             .add_plugin(GlobalsPlugin)
             .add_plugin(FrameCountPlugin);
     }

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -113,11 +113,11 @@ pub struct Image {
 }
 
 /// Used in [`Image`], this determines what image sampler to use when rendering. The default setting,
-/// [`ImageSampler::Default`], will read the sampler from the [`ImageSettings`] resource at runtime.
+/// [`ImageSampler::Default`], will read the sampler from the [`ImagePlugin`](super::ImagePlugin) at setup.
 /// Setting this to [`ImageSampler::Descriptor`] will override the global default descriptor for this [`Image`].
 #[derive(Debug, Default, Clone)]
 pub enum ImageSampler {
-    /// Default image sampler, derived from the [`ImageSettings`] resource.
+    /// Default image sampler, derived from the [`ImagePlugin`](super::ImagePlugin) setup.
     #[default]
     Default,
     /// Custom sampler for this image which will override global default.
@@ -158,41 +158,10 @@ impl ImageSampler {
     }
 }
 
-/// Global resource for [`Image`] settings.
-///
-/// Can be set via `insert_resource` during app initialization to change the default settings.
-#[derive(Resource)]
-pub struct ImageSettings {
-    /// The default image sampler to use when [`ImageSampler`] is set to `Default`.
-    pub default_sampler: wgpu::SamplerDescriptor<'static>,
-}
-
-impl Default for ImageSettings {
-    fn default() -> Self {
-        ImageSettings::default_linear()
-    }
-}
-
-impl ImageSettings {
-    /// Creates image settings with linear sampling by default.
-    pub fn default_linear() -> ImageSettings {
-        ImageSettings {
-            default_sampler: ImageSampler::linear_descriptor(),
-        }
-    }
-
-    /// Creates image settings with nearest sampling by default.
-    pub fn default_nearest() -> ImageSettings {
-        ImageSettings {
-            default_sampler: ImageSampler::nearest_descriptor(),
-        }
-    }
-}
-
 /// A rendering resource for the default image sampler which is set during renderer
 /// initialization.
 ///
-/// The [`ImageSettings`] resource can be set during app initialization to change the default
+/// The [`ImagePlugin`](super::ImagePlugin) can be set during app initialization to change the default
 /// image sampler.
 #[derive(Resource, Debug, Clone, Deref, DerefMut)]
 pub struct DefaultImageSampler(pub(crate) Sampler);

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -91,7 +91,6 @@ impl Plugin for ImagePlugin {
             .resource_mut::<Assets<Image>>()
             .set_untracked(DEFAULT_IMAGE_HANDLE, Image::default());
 
-        // let default_sampler = ;
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             let default_sampler = {
                 let device = render_app.world.resource::<RenderDevice>();

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -36,7 +36,32 @@ use bevy_asset::{AddAsset, Assets};
 
 // TODO: replace Texture names with Image names?
 /// Adds the [`Image`] as an asset and makes sure that they are extracted and prepared for the GPU.
-pub struct ImagePlugin;
+pub struct ImagePlugin {
+    /// The default image sampler to use when [`ImageSampler`] is set to `Default`.
+    pub default_sampler: wgpu::SamplerDescriptor<'static>,
+}
+
+impl Default for ImagePlugin {
+    fn default() -> Self {
+        ImagePlugin::default_linear()
+    }
+}
+
+impl ImagePlugin {
+    /// Creates image settings with linear sampling by default.
+    pub fn default_linear() -> ImagePlugin {
+        ImagePlugin {
+            default_sampler: ImageSampler::linear_descriptor(),
+        }
+    }
+
+    /// Creates image settings with nearest sampling by default.
+    pub fn default_nearest() -> ImagePlugin {
+        ImagePlugin {
+            default_sampler: ImageSampler::nearest_descriptor(),
+        }
+    }
+}
 
 impl Plugin for ImagePlugin {
     fn build(&self, app: &mut App) {
@@ -66,15 +91,11 @@ impl Plugin for ImagePlugin {
             .resource_mut::<Assets<Image>>()
             .set_untracked(DEFAULT_IMAGE_HANDLE, Image::default());
 
-        let default_sampler = app
-            .world
-            .get_resource_or_insert_with(ImageSettings::default)
-            .default_sampler
-            .clone();
+        // let default_sampler = ;
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             let default_sampler = {
                 let device = render_app.world.resource::<RenderDevice>();
-                device.create_sampler(&default_sampler)
+                device.create_sampler(&self.default_sampler.clone())
             };
             render_app
                 .insert_resource(DefaultImageSampler(default_sampler))

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -5,8 +5,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ImageSettings::default_nearest()) // prevents blurry sprites
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest())) // prevents blurry sprites
         .add_startup_system(setup)
         .add_system(animate_sprite)
         .run();

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -6,8 +6,7 @@ use bevy::{asset::LoadState, prelude::*};
 fn main() {
     App::new()
         .init_resource::<RpgSpriteHandles>()
-        .insert_resource(ImageSettings::default_nearest()) // prevents blurry sprites
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest())) // prevents blurry sprites
         .add_state(AppState::Setup)
         .add_system_set(SystemSet::on_enter(AppState::Setup).with_system(load_textures))
         .add_system_set(SystemSet::on_update(AppState::Setup).with_system(check_textures))

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -10,8 +10,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .insert_resource(ImageSettings::default_nearest())
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_startup_system(setup)
         .add_system(rotate)
         .run();

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -4,12 +4,12 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        // Uncomment this to override the default log settings:
-        // .insert_resource(bevy::log::LogSettings {
-        //     level: bevy::log::Level::TRACE,
-        //     filter: "wgpu=warn,bevy_ecs=info".to_string(),
-        // })
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(bevy::log::LogPlugin {
+            // Uncomment this to override the default log settings:
+            // level: bevy::log::Level::TRACE,
+            // filter: "wgpu=warn,bevy_ecs=info".to_string(),
+            ..default()
+        }))
         .add_system(log_system)
         .run();
 }
@@ -24,7 +24,7 @@ fn log_system() {
     error!("something failed");
 
     // by default, trace and debug logs are ignored because they are "noisy"
-    // you can control what level is logged by adding the LogSettings resource
+    // you can control what level is logged by setting up the LogPlugin
     // alternatively you can set the log level via the RUST_LOG=LEVEL environment variable
     // ex: RUST_LOG=trace, RUST_LOG=info,bevy_ecs=warn
     // the format used here is super flexible. check out this documentation for more info:

--- a/examples/app/thread_pool_resources.rs
+++ b/examples/app/thread_pool_resources.rs
@@ -5,7 +5,8 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(DefaultTaskPoolOptions::with_num_threads(4))
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(CorePlugin {
+            task_pool_options: TaskPoolOptions::with_num_threads(4),
+        }))
         .run();
 }

--- a/examples/ecs/system_closure.rs
+++ b/examples/ecs/system_closure.rs
@@ -25,7 +25,7 @@ fn main() {
     let outside_variable = "bar".to_string();
 
     App::new()
-        .add_plugin(LogPlugin)
+        .add_plugin(LogPlugin::default())
         // we can use a closure as a system
         .add_system(simple_closure)
         // or we can use a more complex closure, and pass an argument to initialize a Local variable.


### PR DESCRIPTION
# Objective

- Build on #6336 for more plugin configurations

## Solution

- `LogSettings`, `ImageSettings` and `DefaultTaskPoolOptions` are now plugins settings rather than resources

---

## Changelog

- `LogSettings` plugin settings have been move to `LogPlugin`, `ImageSettings` to `ImagePlugin` and `DefaultTaskPoolOptions` to `CorePlugin`

## Migration Guide

The `LogSettings` settings have been moved from a resource to `LogPlugin` configuration:

```rust
// Old (Bevy 0.8)
app
  .insert_resource(LogSettings {
    level: Level::DEBUG,
    filter: "wgpu=error,bevy_render=info,bevy_ecs=trace".to_string(),
  })
  .add_plugins(DefaultPlugins)

// New (Bevy 0.9)
app.add_plugins(DefaultPlugins.set(LogPlugin {
    level: Level::DEBUG,
    filter: "wgpu=error,bevy_render=info,bevy_ecs=trace".to_string(),
}))
```


The `ImageSettings` settings have been moved from a resource to `ImagePlugin` configuration:

```rust
// Old (Bevy 0.8)
app
  .insert_resource(ImageSettings::default_nearest())
  .add_plugins(DefaultPlugins)

// New (Bevy 0.9)
app.add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
```


The `DefaultTaskPoolOptions` settings have been moved from a resource to `CorePlugin::task_pool_options`:

```rust
// Old (Bevy 0.8)
app
  .insert_resource(DefaultTaskPoolOptions::with_num_threads(4))
  .add_plugins(DefaultPlugins)

// New (Bevy 0.9)
app.add_plugins(DefaultPlugins.set(CorePlugin {
  task_pool_options: TaskPoolOptions::with_num_threads(4),
}))
```