### PR TITLE
Remove `World::get_resource_with_id` and `World::get_non_send_with_id`

### DIFF
--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -186,9 +186,10 @@ impl<'w> WorldCell<'w> {
         let archetype_component_id = self
             .world
             .get_resource_archetype_component_id(component_id)?;
+        let p = self.world.get_resource_by_id(component_id)?;
         Some(WorldBorrow::new(
             // SAFETY: ComponentId matches TypeId
-            unsafe { self.world.get_resource_with_id(component_id)? },
+            unsafe { p.deref() },
             archetype_component_id,
             self.access.clone(),
         ))
@@ -255,9 +256,10 @@ impl<'w> WorldCell<'w> {
         let archetype_component_id = self
             .world
             .get_resource_archetype_component_id(component_id)?;
+        let p = self.world.get_resource_by_id(component_id)?;
         Some(WorldBorrow::new(
             // SAFETY: ComponentId matches TypeId
-            unsafe { self.world.get_non_send_with_id(component_id)? },
+            unsafe { p.deref() },
             archetype_component_id,
             self.access.clone(),
         ))


### PR DESCRIPTION
Change to use `World::get_resource_by_id` in `mod.rs`, `world_cell.rs`.

# Objective

- Fixes #6294

## Solution

- Removed `World::get_resource_with_id` and `World::get_non_send_with_id`.  They were only called in `WorldCell`. Instead called `World::get_resource_by_id` there and `deref()`.
