### PR TITLE
[Merged by Bors] - ignore nanosec precision tests on apple m1

### DIFF
--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -442,6 +442,8 @@ mod tests {
     }
 
     #[test]
+    // Don't run on a m1 as they have a 41ns precision
+    // https://github.com/rust-lang/rust/issues/91417
     #[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
     fn update_test() {
         let start_instant = Instant::now();
@@ -575,6 +577,8 @@ mod tests {
     }
 
     #[test]
+    // Don't run on a m1 as they have a 41ns precision
+    // https://github.com/rust-lang/rust/issues/91417
     #[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
     fn relative_speed_test() {
         let start_instant = Instant::now();
@@ -678,6 +682,8 @@ mod tests {
     }
 
     #[test]
+    // Don't run on a m1 as they have a 41ns precision
+    // https://github.com/rust-lang/rust/issues/91417
     #[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
     fn pause_test() {
         let start_instant = Instant::now();

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -442,6 +442,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
     fn update_test() {
         let start_instant = Instant::now();
         let mut time = Time::new(start_instant);
@@ -574,6 +575,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
     fn relative_speed_test() {
         let start_instant = Instant::now();
         let mut time = Time::new(start_instant);
@@ -676,6 +678,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
     fn pause_test() {
         let start_instant = Instant::now();
         let mut time = Time::new(start_instant);


### PR DESCRIPTION
# Objective

- Some tests are very flaky on a m1
- m1 currently have a 41 ns precision

## Solution

- Do not run tests that compare a `Duration` or a `f64` on a m1 (and m2)
