### PR TITLE
[Merged by Bors] - add serialize feature to bevy_transform

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -45,7 +45,7 @@ wav = ["bevy_audio/wav"]
 # Enable watching file system for asset hot reload
 filesystem_watcher = ["bevy_asset/filesystem_watcher"]
 
-serialize = ["bevy_input/serialize", "bevy_time/serialize", "bevy_window/serialize"]
+serialize = ["bevy_input/serialize", "bevy_time/serialize", "bevy_window/serialize", "bevy_transform/serialize", "bevy_math/serialize"]
 
 # Display server protocol support (X11 is enabled by default)
 wayland = ["bevy_winit/wayland"]

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -9,9 +9,10 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [dependencies]
-glam = { version = "0.21", features = ["serde", "bytemuck"] }
-serde = "1"
+glam = { version = "0.21", features = ["bytemuck"] }
+serde = { version = "1", features = ["derive"], optional = true }
 
 [features]
 # Enable interoperation of glam types with mint-compatible libraries
 mint = ["glam/mint"]
+serialize = ["dep:serde", "glam/serde"]

--- a/crates/bevy_math/src/ray.rs
+++ b/crates/bevy_math/src/ray.rs
@@ -1,8 +1,8 @@
 use crate::Vec3;
-use serde::{Deserialize, Serialize};
 
 /// A ray is an infinite line starting at `origin`, going in `direction`.
-#[derive(Default, Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Default, Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ray {
     /// The origin of the ray.
     pub origin: Vec3,

--- a/crates/bevy_math/src/rect.rs
+++ b/crates/bevy_math/src/rect.rs
@@ -1,5 +1,4 @@
 use crate::Vec2;
-use serde::{Deserialize, Serialize};
 
 /// A rectangle defined by two opposite corners.
 ///
@@ -10,7 +9,8 @@ use serde::{Deserialize, Serialize};
 /// methods instead, which will ensure this invariant is met, unless you already have
 /// the minimum and maximum corners.
 #[repr(C)]
-#[derive(Default, Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Default, Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rect {
     /// The minimum corner point of the rect.
     pub min: Vec2,

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -18,7 +18,7 @@ documentation = ["bevy_reflect_derive/documentation"]
 
 [dependencies]
 # bevy
-bevy_math = { path = "../bevy_math", version = "0.9.0-dev", optional = true }
+bevy_math = { path = "../bevy_math", version = "0.9.0-dev", features = ["serialize"], optional = true }
 bevy_reflect_derive = { path = "bevy_reflect_derive", version = "0.9.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
 bevy_ptr = { path = "../bevy_ptr", version = "0.9.0-dev" }

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -15,3 +15,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.9.0-dev", features = ["bevy_refl
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.9.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.9.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.9.0-dev", features = ["bevy"] }
+serde = { version = "1", features = ["derive"], optional = true }
+
+[features]
+serialize = ["dep:serde", "bevy_math/serialize"]

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -32,6 +32,7 @@ use bevy_reflect::{std_traits::ReflectDefault, FromReflect, Reflect};
 ///
 /// [`global_vs_local_translation`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect, FromReflect)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component, Default, PartialEq)]
 pub struct GlobalTransform(Affine3A);
 

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -35,6 +35,7 @@ use std::ops::Mul;
 /// [`global_vs_local_translation`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs
 /// [`transform`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect, FromReflect)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component, Default, PartialEq)]
 pub struct Transform {
     /// Position of the entity. In 2d, the last value of the `Vec3` is used for z-ordering.


### PR DESCRIPTION
# Objective
Fixes #6378 
`bevy_transform` is missing a feature corresponding to the `serialize` feature on the `bevy` crate.

## Solution

Adds a `serialize` feature to `bevy_transform`.
Derives `serde::Serialize` and `Deserialize` when feature is enabled.