### PR TITLE
[Merged by Bors] - do not set cursor grab on window creation if not asked for

### DIFF
--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -2,7 +2,8 @@ use crate::converters::convert_cursor_grab_mode;
 use bevy_math::{DVec2, IVec2};
 use bevy_utils::HashMap;
 use bevy_window::{
-    MonitorSelection, RawHandleWrapper, Window, WindowDescriptor, WindowId, WindowMode,
+    CursorGrabMode, MonitorSelection, RawHandleWrapper, Window, WindowDescriptor, WindowId,
+    WindowMode,
 };
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
 use winit::{
@@ -161,11 +162,14 @@ impl WinitWindows {
             }
         }
 
-        match winit_window
-            .set_cursor_grab(convert_cursor_grab_mode(window_descriptor.cursor_grab_mode))
-        {
-            Ok(_) | Err(winit::error::ExternalError::NotSupported(_)) => {}
-            Err(err) => Err(err).unwrap(),
+        // Do not set the grab mode on window creation if it's none, this can fail on mobile
+        if window_descriptor.cursor_grab_mode != CursorGrabMode::None {
+            match winit_window
+                .set_cursor_grab(convert_cursor_grab_mode(window_descriptor.cursor_grab_mode))
+            {
+                Ok(_) | Err(winit::error::ExternalError::NotSupported(_)) => {}
+                Err(err) => Err(err).unwrap(),
+            }
         }
 
         winit_window.set_cursor_visible(window_descriptor.cursor_visible);


### PR DESCRIPTION
# Objective

- Bevy main crashs on Safari mobile
- On Safari mobile, calling winit_window.set_cursor_grab(true) fails as the API is not implemented (as there is no cursor on Safari mobile, the api doesn't make sense there). I don't know about other mobile browsers

## Solution

- Do not call the api to release cursor grab on window creation, as the cursor is not grabbed anyway at this point
- This is #3617 which was lost in #6218