### PR TITLE
Allow configuration of `WorldQuery` with runtime values

### DIFF
--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -205,6 +205,7 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
 
                 type ReadOnly = #read_only_struct_name #user_ty_generics;
                 type State = #state_struct_name #user_ty_generics;
+                type Config = ();
 
                 fn shrink<'__wlong: '__wshort, '__wshort>(
                     item: <#struct_name #user_ty_generics as #path::query::WorldQueryGats<'__wlong>>::Item
@@ -313,9 +314,11 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
                     )*
                 }
 
-                fn init_state(world: &mut #path::world::World) -> #state_struct_name #user_ty_generics {
+                fn init_state(_config: Self::Config, world: &mut #path::world::World) -> #state_struct_name #user_ty_generics {
                     #state_struct_name {
-                        #(#field_idents: <#field_types>::init_state(world),)*
+                        // TODO: instead of using `Default::default` for the config (and thus failing to compile on query types needing configuration like `Ptr<'_>`)
+                        // we could have a tuple with configuration for each field, or generate a mirror struct with the same field names but storing the configuration values
+                        #(#field_idents: <#field_types>::init_state(Default::default(), world),)*
                         #(#ignored_field_idents: Default::default(),)*
                     }
                 }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -874,7 +874,10 @@ mod tests {
             }
         }
 
-        fn get_filtered<F: ReadOnlyWorldQuery>(world: &mut World) -> Vec<Entity> {
+        fn get_filtered<F: ReadOnlyWorldQuery>(world: &mut World) -> Vec<Entity>
+        where
+            F::Config: Default,
+        {
             world
                 .query_filtered::<Entity, F>()
                 .iter(world)

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1844,6 +1844,9 @@ impl<'w> WorldQueryGats<'w> for PtrMut<'_> {
     type Item = MutUntyped<'w>;
 }
 
+// SAFETY:
+// - ReadOnly access is a subset of regular access, because `Q::ReadOnly` is a subset of `Q`expect("");
+// - `update_[archetype_]component_access` lists all accesses performed in `archetype_fetch` and `table_fetch`
 unsafe impl<Q: WorldQuery> WorldQuery for Vec<Q> {
     type ReadOnly = Vec<Q::ReadOnly>;
 

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -419,7 +419,7 @@ pub unsafe trait WorldQuery: for<'w> WorldQueryGats<'w> {
         access: &mut Access<ArchetypeComponentId>,
     );
 
-    fn init_state(world: &mut World) -> Self::State;
+    fn init_state(config: Self::Config, world: &mut World) -> Self::State;
     fn matches_component_set(
         state: &Self::State,
         set_contains_id: &impl Fn(ComponentId) -> bool,
@@ -512,7 +512,7 @@ unsafe impl WorldQuery for Entity {
     ) {
     }
 
-    fn init_state(_world: &mut World) {}
+    fn init_state(_config: Self::Config, _world: &mut World) {}
 
     fn matches_component_set(
         _state: &Self::State,
@@ -654,7 +654,7 @@ unsafe impl<T: Component> WorldQuery for &T {
         }
     }
 
-    fn init_state(world: &mut World) -> ComponentId {
+    fn init_state(_config: Self::Config, world: &mut World) -> ComponentId {
         world.init_component::<T>()
     }
 
@@ -825,7 +825,7 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
         }
     }
 
-    fn init_state(world: &mut World) -> ComponentId {
+    fn init_state(_config: Self::Config, world: &mut World) -> ComponentId {
         world.init_component::<T>()
     }
 
@@ -935,8 +935,8 @@ unsafe impl<T: WorldQuery> WorldQuery for Option<T> {
         }
     }
 
-    fn init_state(world: &mut World) -> T::State {
-        T::init_state(world)
+    fn init_state(config: Self::Config, world: &mut World) -> T::State {
+        T::init_state(config, world)
     }
 
     fn matches_component_set(
@@ -1172,7 +1172,7 @@ unsafe impl<T: Component> WorldQuery for ChangeTrackers<T> {
         }
     }
 
-    fn init_state(world: &mut World) -> ComponentId {
+    fn init_state(_config: Self::Config, world: &mut World) -> ComponentId {
         world.init_component::<T>()
     }
 
@@ -1284,8 +1284,9 @@ macro_rules! impl_tuple_fetch {
             }
 
 
-            fn init_state(_world: &mut World) -> Self::State {
-                ($($name::init_state(_world),)*)
+            fn init_state(config: Self::Config, _world: &mut World) -> Self::State {
+                let ($($state,)*) = config;
+                ($($name::init_state($state, _world),)*)
             }
 
             fn matches_component_set(state: &Self::State, _set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
@@ -1432,8 +1433,9 @@ macro_rules! impl_anytuple_fetch {
                 )*
             }
 
-            fn init_state(_world: &mut World) -> Self::State {
-                ($($name::init_state(_world),)*)
+            fn init_state(config: Self::Config, _world: &mut World) -> Self::State {
+                let ($($state,)*) = config;
+                ($($name::init_state($state, _world),)*)
             }
 
             fn matches_component_set(_state: &Self::State, _set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
@@ -1511,8 +1513,8 @@ unsafe impl<Q: WorldQuery> WorldQuery for NopWorldQuery<Q> {
     ) {
     }
 
-    fn init_state(world: &mut World) -> Self::State {
-        Q::init_state(world)
+    fn init_state(config: Self::Config, world: &mut World) -> Self::State {
+        Q::init_state(config, world)
     }
 
     fn matches_component_set(

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -114,7 +114,7 @@ unsafe impl<T: Component> WorldQuery for With<T> {
     ) {
     }
 
-    fn init_state(world: &mut World) -> ComponentId {
+    fn init_state(_config: Self::Config, world: &mut World) -> ComponentId {
         world.init_component::<T>()
     }
 
@@ -221,7 +221,7 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
     ) {
     }
 
-    fn init_state(world: &mut World) -> ComponentId {
+    fn init_state(_config: Self::Config, world: &mut World) -> ComponentId {
         world.init_component::<T>()
     }
 
@@ -411,8 +411,9 @@ macro_rules! impl_query_filter_tuple {
                 $($filter::update_archetype_component_access($filter, archetype, access);)*
             }
 
-            fn init_state(world: &mut World) -> Self::State {
-                ($($filter::init_state(world),)*)
+            fn init_state(config: Self::Config, world: &mut World) -> Self::State {
+                let ($($state,)*) = config;
+                ($($filter::init_state($state, world),)*)
             }
 
             fn matches_component_set(_state: &Self::State, _set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
@@ -580,7 +581,7 @@ macro_rules! impl_tick_filter {
                 }
             }
 
-            fn init_state(world: &mut World) -> ComponentId {
+            fn init_state(_config: Self::Config, world: &mut World) -> ComponentId {
                 world.init_component::<T>()
             }
 

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -52,6 +52,7 @@ impl<T: Component> WorldQueryGats<'_> for With<T> {
 unsafe impl<T: Component> WorldQuery for With<T> {
     type ReadOnly = Self;
     type State = ComponentId;
+    type Config = ();
 
     fn shrink<'wlong: 'wshort, 'wshort>(
         _: <Self as WorldQueryGats<'wlong>>::Item,
@@ -158,6 +159,7 @@ pub struct Without<T>(PhantomData<T>);
 unsafe impl<T: Component> WorldQuery for Without<T> {
     type ReadOnly = Self;
     type State = ComponentId;
+    type Config = ();
 
     fn shrink<'wlong: 'wshort, 'wshort>(
         _: <Self as WorldQueryGats<'wlong>>::Item,
@@ -294,6 +296,7 @@ macro_rules! impl_query_filter_tuple {
         unsafe impl<$($filter: WorldQuery),*> WorldQuery for Or<($($filter,)*)> {
             type ReadOnly = Or<($($filter::ReadOnly,)*)>;
             type State = ($($filter::State,)*);
+            type Config = ($(<$filter as WorldQuery>::Config,)*);
 
             fn shrink<'wlong: 'wshort, 'wshort>(item: super::QueryItem<'wlong, Self>) -> super::QueryItem<'wshort, Self> {
                 item
@@ -450,6 +453,7 @@ macro_rules! impl_tick_filter {
         unsafe impl<T: Component> WorldQuery for $name<T> {
             type ReadOnly = Self;
             type State = ComponentId;
+            type Config = ();
 
             fn shrink<'wlong: 'wshort, 'wshort>(item: super::QueryItem<'wlong, Self>) -> super::QueryItem<'wshort, Self> {
                 item

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -840,7 +840,7 @@ macro_rules! impl_tick_filter_untyped {
 impl_tick_filter_untyped!(
     /// A filter on a component that only retains results added after the system last ran.
     ///
-    /// Similar to [`Addded`], but instead of providing the component type via a generic type,
+    /// Similar to [`Added`], but instead of providing the component type via a generic type,
     /// it an be supplied through [`WorldQuery::Config`] with [`QueryState::new_with_config`](crate::query::QueryState::new_with_config).
     ///
     /// Note that this means that it cannot be used as a `Query<(), AddedUntyped>`, because there is no way to provide the configuration.

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -702,7 +702,7 @@ macro_rules! impl_tick_filter_untyped {
 
             unsafe fn init_fetch<'w>(world: &'w World, &id: &ComponentId, last_change_tick: u32, change_tick: u32) -> <Self as WorldQueryGats<'w>>::Fetch {
                 // SAFETY: component id is checked in `init_state`
-                let info = unsafe { world.components.get_info_unchecked(id) };
+                let info = world.components.get_info_unchecked(id);
                 QueryFetch::<'w, Self> {
                     storage_type: info.storage_type(),
                     table_ticks: None,

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -86,8 +86,10 @@ mod tests {
         fn assert_all_sizes_equal<Q, F>(world: &mut World, expected_size: usize)
         where
             Q: ReadOnlyWorldQuery,
+            Q::Config: Default,
             F: ReadOnlyWorldQuery,
             F::ReadOnly: ArchetypeFilter,
+            F::Config: Default,
         {
             let mut query = world.query_filtered::<Q, F>();
             let iter = query.iter(world);
@@ -162,8 +164,10 @@ mod tests {
         fn assert_combination<Q, F, const K: usize>(world: &mut World, expected_size: usize)
         where
             Q: WorldQuery,
+            Q::Config: Default,
             F: ReadOnlyWorldQuery,
             F::ReadOnly: ArchetypeFilter,
+            F::Config: Default,
         {
             let mut query = world.query_filtered::<Q, F>();
             let iter = query.iter_combinations::<K>(world);
@@ -173,8 +177,10 @@ mod tests {
         fn assert_all_sizes_equal<Q, F>(world: &mut World, expected_size: usize)
         where
             Q: WorldQuery,
+            Q::Config: Default,
             F: ReadOnlyWorldQuery,
             F::ReadOnly: ArchetypeFilter,
+            F::Config: Default,
         {
             let mut query = world.query_filtered::<Q, F>();
             let iter = query.iter(world);

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1443,6 +1443,33 @@ mod tests {
     }
 
     #[test]
+    fn query_state_with_config_as_readonly() {
+        let mut world = World::new();
+
+        let num = 42;
+
+        let component_id = world.init_component::<TestComponent>();
+        let spawned_entity = world.spawn(TestComponent(num)).id();
+
+        let mut query_state = QueryState::<(Entity, PtrMut<'_>), ()>::new_with_config(
+            &mut world,
+            ((), component_id),
+            (),
+        );
+
+        let results: Vec<_> = query_state.iter(&world).collect();
+        match results.as_slice() {
+            [(entity, value)] => {
+                assert_eq!(*entity, spawned_entity);
+                // SAFETY: correct type, read access
+                let value = unsafe { value.deref::<TestComponent>() };
+                assert_eq!(value.0, num);
+            }
+            _ => panic!("expected to get one result"),
+        }
+    }
+
+    #[test]
     fn query_state_with_config_vec() {
         let mut world = World::new();
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -46,7 +46,11 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> std::fmt::Debug for QueryState<Q, F> 
     }
 }
 
-impl<Q: WorldQuery, F: ReadOnlyWorldQuery> FromWorld for QueryState<Q, F> {
+impl<Q: WorldQuery, F: ReadOnlyWorldQuery> FromWorld for QueryState<Q, F>
+where
+    <Q as WorldQuery>::Config: Default,
+    <F as WorldQuery>::Config: Default,
+{
     fn from_world(world: &mut World) -> Self {
         world.query_filtered()
     }
@@ -92,9 +96,22 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
 
 impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     /// Creates a new [`QueryState`] from a given [`World`] and inherits the result of `world.id()`.
-    pub fn new(world: &mut World) -> Self {
-        let fetch_state = Q::init_state(world);
-        let filter_state = F::init_state(world);
+    pub fn new(world: &mut World) -> Self
+    where
+        <Q as WorldQuery>::Config: Default,
+        <F as WorldQuery>::Config: Default,
+    {
+        QueryState::new_with_config(world, Default::default(), Default::default())
+    }
+
+    /// Creates a new [`QueryState`] from a given [`World`] and inherits the result of `world.id()`.
+    pub fn new_with_config(
+        world: &mut World,
+        fetch_config: <Q as WorldQuery>::Config,
+        filter_config: <F as WorldQuery>::Config,
+    ) -> Self {
+        let fetch_state = Q::init_state(fetch_config, world);
+        let filter_state = F::init_state(filter_config, world);
 
         let mut component_access = FilteredAccess::default();
         Q::update_component_access(&fetch_state, &mut component_access);

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1297,7 +1297,7 @@ impl fmt::Display for QueryEntityError {
 
 #[cfg(test)]
 mod tests {
-    use bevy_ptr::Ptr;
+    use bevy_ptr::{Ptr, PtrMut};
 
     use crate::{prelude::*, query::QueryEntityError};
 
@@ -1479,6 +1479,20 @@ mod tests {
             }
             _ => panic!("expected to get one result"),
         }
+    }
+
+    #[test]
+    #[should_panic = "conflicts with a previous access in this query"]
+    fn query_state_with_config_conflicting_access() {
+        let mut world = World::new();
+
+        let component_id = world.init_component::<TestComponent>();
+
+        let mut _query_state = QueryState::<(Entity, Vec<PtrMut<'_>>), ()>::new_with_config(
+            &mut world,
+            ((), vec![component_id, component_id]),
+            (),
+        );
     }
 }
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1436,6 +1436,43 @@ mod tests {
             _ => panic!("expected to get one result"),
         }
     }
+
+    #[test]
+    fn query_state_with_config_vec() {
+        let mut world = World::new();
+
+        let num_1 = 42;
+        let num_2 = 43;
+
+        let component_id_1 = world.init_component::<TestComponent>();
+        let component_id_2 = world.init_component::<TestComponent2>();
+
+        world.spawn((TestComponent(num_1), TestComponent2(num_2)));
+
+        let mut query_state = QueryState::<Vec<Ptr<'_>>, ()>::new_with_config(
+            &mut world,
+            vec![component_id_1, component_id_2],
+            (),
+        );
+
+        let results: Vec<_> = query_state.iter(&world).collect();
+        match results.as_slice() {
+            [result] => {
+                match result.as_slice() {
+                    [val_1, val_2] => {
+                        // SAFETY: correct type, read access
+                        let val_1 = unsafe { val_1.deref::<TestComponent>() };
+                        // SAFETY: correct type, read access
+                        let val_2 = unsafe { val_2.deref::<TestComponent2>() };
+                        assert_eq!(val_1.0, num_1);
+                        assert_eq!(val_2.0, num_2);
+                    }
+                    _ => panic!("expected to get two items in query result"),
+                }
+            }
+            _ => panic!("expected to get one result"),
+        }
+    }
 }
 
 /// An error that occurs when evaluating a [`QueryState`] as a single expected resulted via

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1421,14 +1421,18 @@ mod tests {
         let num = 42;
 
         let component_id = world.init_component::<TestComponent>();
-        world.spawn(TestComponent(num));
+        let spawned_entity = world.spawn(TestComponent(num)).id();
 
-        let mut query_state =
-            QueryState::<Ptr<'_>, ()>::new_with_config(&mut world, component_id, ());
+        let mut query_state = QueryState::<(Entity, Ptr<'_>), ()>::new_with_config(
+            &mut world,
+            ((), component_id),
+            (),
+        );
 
         let results: Vec<_> = query_state.iter(&world).collect();
         match results.as_slice() {
-            [value] => {
+            [(entity, value)] => {
+                assert_eq!(*entity, spawned_entity);
                 // SAFETY: correct type, read access
                 let value = unsafe { value.deref::<TestComponent>() };
                 assert_eq!(value.0, num);
@@ -1447,17 +1451,20 @@ mod tests {
         let component_id_1 = world.init_component::<TestComponent>();
         let component_id_2 = world.init_component::<TestComponent2>();
 
-        world.spawn((TestComponent(num_1), TestComponent2(num_2)));
+        let spawned_entity = world
+            .spawn((TestComponent(num_1), TestComponent2(num_2)))
+            .id();
 
-        let mut query_state = QueryState::<Vec<Ptr<'_>>, ()>::new_with_config(
+        let mut query_state = QueryState::<(Entity, Vec<Ptr<'_>>), ()>::new_with_config(
             &mut world,
-            vec![component_id_1, component_id_2],
+            ((), vec![component_id_1, component_id_2]),
             (),
         );
 
         let results: Vec<_> = query_state.iter(&world).collect();
         match results.as_slice() {
-            [result] => {
+            [(entity, result)] => {
+                assert_eq!(*entity, spawned_entity);
                 match result.as_slice() {
                     [val_1, val_2] => {
                         // SAFETY: correct type, read access

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1299,6 +1299,7 @@ impl fmt::Display for QueryEntityError {
 mod tests {
     use bevy_ptr::{Ptr, PtrMut};
 
+    use crate::query::WithUntyped;
     use crate::{prelude::*, query::QueryEntityError};
 
     #[test]
@@ -1493,6 +1494,40 @@ mod tests {
             ((), vec![component_id, component_id]),
             (),
         );
+    }
+
+    #[test]
+    fn query_state_with_config_filter() {
+        let mut world = World::new();
+
+        let component_id_1 = world.init_component::<TestComponent>();
+        let component_id_2 = world.init_component::<TestComponent2>();
+
+        world.spawn((TestComponent(0), TestComponent2(0)));
+        world.spawn(TestComponent(0));
+        world.spawn(TestComponent2(0));
+        world.spawn_empty();
+
+        let mut query_state_1 =
+            QueryState::<(), WithUntyped>::new_with_config(&mut world, (), component_id_1);
+        let mut query_state_2 =
+            QueryState::<(), WithUntyped>::new_with_config(&mut world, (), component_id_2);
+        let mut query_state_both = QueryState::<(), (WithUntyped, WithUntyped)>::new_with_config(
+            &mut world,
+            (),
+            (component_id_1, component_id_2),
+        );
+        let mut query_state_either =
+            QueryState::<(), AnyOf<(WithUntyped, WithUntyped)>>::new_with_config(
+                &mut world,
+                (),
+                (component_id_1, component_id_2),
+            );
+
+        assert_eq!(query_state_1.iter(&world).count(), 2);
+        assert_eq!(query_state_2.iter(&world).count(), 2);
+        assert_eq!(query_state_both.iter(&world).count(), 1);
+        assert_eq!(query_state_either.iter(&world).count(), 3);
     }
 }
 

--- a/crates/bevy_ecs/src/system/exclusive_system_param.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system_param.rs
@@ -28,12 +28,18 @@ pub trait ExclusiveSystemParamFetch<'state>: ExclusiveSystemParamState {
 
 impl<'a, Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> ExclusiveSystemParam
     for &'a mut QueryState<Q, F>
+where
+    <Q as WorldQuery>::Config: Default,
+    <F as WorldQuery>::Config: Default,
 {
     type Fetch = QueryState<Q, F>;
 }
 
 impl<'s, Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> ExclusiveSystemParamFetch<'s>
     for QueryState<Q, F>
+where
+    <Q as WorldQuery>::Config: Default,
+    <F as WorldQuery>::Config: Default,
 {
     type Item = &'s mut QueryState<Q, F>;
 
@@ -44,6 +50,9 @@ impl<'s, Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> ExclusiveSyst
 
 impl<Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> ExclusiveSystemParamState
     for QueryState<Q, F>
+where
+    <Q as WorldQuery>::Config: Default,
+    <F as WorldQuery>::Config: Default,
 {
     fn init(world: &mut World, _system_meta: &mut SystemMeta) -> Self {
         QueryState::new(world)

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -137,6 +137,9 @@ pub trait SystemParamFetch<'world, 'state>: SystemParamState {
 
 impl<'w, 's, Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> SystemParam
     for Query<'w, 's, Q, F>
+where
+    <Q as WorldQuery>::Config: Default,
+    <F as WorldQuery>::Config: Default,
 {
     type Fetch = QueryState<Q, F>;
 }
@@ -151,6 +154,9 @@ unsafe impl<Q: ReadOnlyWorldQuery, F: ReadOnlyWorldQuery> ReadOnlySystemParamFet
 // this QueryState conflicts with any prior access, a panic will occur.
 unsafe impl<Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> SystemParamState
     for QueryState<Q, F>
+where
+    <Q as WorldQuery>::Config: Default,
+    <F as WorldQuery>::Config: Default,
 {
     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {
         let state = QueryState::new(world);
@@ -181,6 +187,9 @@ unsafe impl<Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> SystemPara
 
 impl<'w, 's, Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> SystemParamFetch<'w, 's>
     for QueryState<Q, F>
+where
+    <Q as WorldQuery>::Config: Default,
+    <F as WorldQuery>::Config: Default,
 {
     type Item = Query<'w, 's, Q, F>;
 
@@ -1654,7 +1663,11 @@ mod tests {
         's,
         Q: WorldQuery + Send + Sync + 'static,
         F: ReadOnlyWorldQuery + Send + Sync + 'static = (),
-    > {
+    >
+    where
+        Q::Config: Default,
+        F::Config: Default,
+    {
         _query: Query<'w, 's, Q, F>,
     }
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -662,7 +662,10 @@ impl World {
     /// ]);
     /// ```
     #[inline]
-    pub fn query<Q: WorldQuery>(&mut self) -> QueryState<Q, ()> {
+    pub fn query<Q: WorldQuery>(&mut self) -> QueryState<Q, ()>
+    where
+        <Q as WorldQuery>::Config: Default,
+    {
         self.query_filtered::<Q, ()>()
     }
 
@@ -686,7 +689,11 @@ impl World {
     /// assert_eq!(matching_entities, vec![e2]);
     /// ```
     #[inline]
-    pub fn query_filtered<Q: WorldQuery, F: ReadOnlyWorldQuery>(&mut self) -> QueryState<Q, F> {
+    pub fn query_filtered<Q: WorldQuery, F: ReadOnlyWorldQuery>(&mut self) -> QueryState<Q, F>
+    where
+        <Q as WorldQuery>::Config: Default,
+        <F as WorldQuery>::Config: Default,
+    {
         QueryState::new(self)
     }
 

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -156,7 +156,11 @@ impl<C, F> ExtractComponentPlugin<C, F> {
     }
 }
 
-impl<C: ExtractComponent> Plugin for ExtractComponentPlugin<C> {
+impl<C: ExtractComponent> Plugin for ExtractComponentPlugin<C>
+where
+    <C::Query as WorldQuery>::Config: Default,
+    <C::Filter as WorldQuery>::Config: Default,
+{
     fn build(&self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             if self.only_extract_visible {
@@ -184,7 +188,10 @@ fn extract_components<C: ExtractComponent>(
     mut commands: Commands,
     mut previous_len: Local<usize>,
     query: Extract<Query<(Entity, C::Query), C::Filter>>,
-) {
+) where
+    <C::Query as WorldQuery>::Config: Default,
+    <C::Filter as WorldQuery>::Config: Default,
+{
     let mut values = Vec::with_capacity(*previous_len);
     for (entity, query_item) in &query {
         values.push((entity, (C::extract_component(query_item),)));
@@ -198,7 +205,10 @@ fn extract_visible_components<C: ExtractComponent>(
     mut commands: Commands,
     mut previous_len: Local<usize>,
     query: Extract<Query<(Entity, &ComputedVisibility, C::Query), C::Filter>>,
-) {
+) where
+    <C::Query as WorldQuery>::Config: Default,
+    <C::Filter as WorldQuery>::Config: Default,
+{
     let mut values = Vec::with_capacity(*previous_len);
     for (entity, computed_visibility, query_item) in &query {
         if computed_visibility.is_visible() {


### PR DESCRIPTION
# Objective
Sometimes it is useful to query for types where the list of types is not known at runtime, e.g. for scripting. This can be done either by implementing all of the query machinery from scratch (see [bevy_ecs_dynamic](https://github.com/jakobhellermann/bevy_ecs_dynamic/blob/main/src/dynamic_query.rs)), *or* by extending `bevy_ecs` to handle these use-cases. This PR is an attempt to to the latter, my allowing arbitrary configuration of world query types.
This solution is an alternative to #6240, attempting to provide a safe to use and less error prone API. 

## Solution

- introduce a `Config` associated type to `WorldQuery`
  - this is `()` for current query types `&T`, `&mut T`, `Q::Config` for `Option<Q>` and `(A::Config, B::Config, ..)` for `(A, B, ..)` 
- Make `QueryState::new` require `Q::Config: Default` and `F::Config: Default`. This propagates quite far, to `world.query`, `Query: SystemParam` and `ExtractComponentPlugin`
- implement `WorldQuery` for `Ptr` and `PtrMut` with a `Config = ComponentId`, yielding `Ptr` and `MutUntyped`
- implement `WorldQuery` for `Vec<Q>` with `<Vec<Q> as WorldQuery>::Config = Vec<Q::Config>`

This allows the following:

```rust
let component_id_1 = world.init_component::<TestComponent>();
let component_id_2 = world.init_component::<TestComponent2>();

world.spawn((TestComponent(num_1), TestComponent2(num_2)));

let mut query_state = QueryState::<(Entity, Vec<Ptr<'_>>), ()>::new_with_config(
    &mut world,
    ((), vec![component_id_1, component_id_2]), // entity configuration () and vec configuration
    (), // no filter config
);

let results = query_state.iter(&world); // returns one element of (entity, vec![ptr_1, ptr_2])
```

**TODOS**:
- add untyped pendants to filter types
- decide how to handle `#[derive(WorldQuery)]`
  - current impl: it generates `Default::default` so only works with "classical" world queries
  - solution proposal 1: use a config type `(Config_Field1, Config_Field)`
  - solution proposal 2: generate a mirror type with the same fields but of the respective config type
- decide if the added `: Default` bounds are too annoying for general usage or if they regress compilation errors
  - if we were to use `WorldQuery<Config = ()>` instead things would be better, but this would not allow us to reuse `(A, B, C)` with configuration
  - maybe associated type bounds would help, but they are unstable (`WorldQuery<Config: Default>`)
- implement `WorldQuery` for `&dyn Reflect` and `&mut dyn Reflect` with `Config = TypeId` yielding `&dyn Reflect` and `Mut<dyn Reflect>`
- implement `WorldQuery` for `smallvec` and possibly other aggregation types

## Changelog

To be written