### PR TITLE
[Merged by Bors] - fix nightly clippy warnings

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -147,10 +147,7 @@ impl AssetServer {
             .server
             .asset_lifecycles
             .write()
-            .insert(
-                T::TYPE_UUID,
-                Box::new(AssetLifecycleChannel::<T>::default()),
-            )
+            .insert(T::TYPE_UUID, Box::<AssetLifecycleChannel<T>>::default())
             .is_some()
         {
             panic!("Error while registering new asset type: {:?} with UUID: {:?}. Another type with the same UUID is already registered. Can not register new asset type with the same UUID",

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -62,6 +62,7 @@ impl HandleId {
 
     /// Creates the default id for an asset of type `T`.
     #[inline]
+    #[allow(clippy::should_implement_trait)] // `Default` is not implemented for `HandleId`, the default value depends on the asset type
     pub fn default<T: Asset>() -> Self {
         HandleId::Id(T::TYPE_UUID, 0)
     }

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -294,7 +294,7 @@ impl<T: Asset> Default for Handle<T> {
 impl<T: Asset> Debug for Handle<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         let name = std::any::type_name::<T>().split("::").last().unwrap();
-        write!(f, "{:?}Handle<{}>({:?})", self.handle_type, name, self.id)
+        write!(f, "{:?}Handle<{name}>({:?})", self.handle_type, self.id)
     }
 }
 

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -36,7 +36,7 @@ fn main() {
 
     // Simulate 10 frames in our world
     for iteration in 1..=10 {
-        println!("Simulating frame {}/10", iteration);
+        println!("Simulating frame {iteration}/10");
         schedule.run(&mut world);
     }
 }
@@ -66,7 +66,7 @@ enum SimulationSystem {
 fn spawn_entities(mut commands: Commands, mut entity_counter: ResMut<EntityCounter>) {
     if rand::thread_rng().gen_bool(0.6) {
         let entity_id = commands.spawn(Age::default()).id();
-        println!("    spawning {:?}", entity_id);
+        println!("    spawning {entity_id:?}");
         entity_counter.value += 1;
     }
 }
@@ -82,10 +82,10 @@ fn print_changed_entities(
     entity_with_mutated_component: Query<(Entity, &Age), Changed<Age>>,
 ) {
     for entity in &entity_with_added_component {
-        println!("    {:?} has it's first birthday!", entity);
+        println!("    {entity:?} has it's first birthday!");
     }
     for (entity, value) in &entity_with_mutated_component {
-        println!("    {:?} is now {:?} frames old", entity, value);
+        println!("    {entity:?} is now {value:?} frames old");
     }
 }
 
@@ -100,7 +100,7 @@ fn age_all_entities(mut entities: Query<&mut Age>) {
 fn remove_old_entities(mut commands: Commands, entities: Query<(Entity, &Age)>) {
     for (entity, age) in &entities {
         if age.frames > 2 {
-            println!("    despawning {:?} due to age > 2", entity);
+            println!("    despawning {entity:?} due to age > 2");
             commands.entity(entity).despawn();
         }
     }

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -35,7 +35,7 @@ fn main() {
 
     // Simulate 10 frames of our world
     for iteration in 1..=10 {
-        println!("Simulating frame {}/10", iteration);
+        println!("Simulating frame {iteration}/10");
         schedule.run(&mut world);
     }
 }

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -27,7 +27,7 @@ fn main() {
     schedule.add_stage(Update, update);
 
     for iteration in 1..=10 {
-        println!("Simulating frame {}/10", iteration);
+        println!("Simulating frame {iteration}/10");
         schedule.run(&mut world);
     }
 }

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -76,7 +76,7 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
             }
             Ok(())
         })
-        .unwrap_or_else(|_| panic!("Invalid `{}` attribute format", WORLD_QUERY_ATTRIBUTE_NAME));
+        .unwrap_or_else(|_| panic!("Invalid `{WORLD_QUERY_ATTRIBUTE_NAME}` attribute format"));
     }
 
     let path = bevy_ecs_path();
@@ -93,26 +93,26 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
 
     let struct_name = ast.ident.clone();
     let read_only_struct_name = if fetch_struct_attributes.is_mutable {
-        Ident::new(&format!("{}ReadOnly", struct_name), Span::call_site())
+        Ident::new(&format!("{struct_name}ReadOnly"), Span::call_site())
     } else {
         struct_name.clone()
     };
 
-    let item_struct_name = Ident::new(&format!("{}Item", struct_name), Span::call_site());
+    let item_struct_name = Ident::new(&format!("{struct_name}Item"), Span::call_site());
     let read_only_item_struct_name = if fetch_struct_attributes.is_mutable {
-        Ident::new(&format!("{}ReadOnlyItem", struct_name), Span::call_site())
+        Ident::new(&format!("{struct_name}ReadOnlyItem"), Span::call_site())
     } else {
         item_struct_name.clone()
     };
 
-    let fetch_struct_name = Ident::new(&format!("{}Fetch", struct_name), Span::call_site());
+    let fetch_struct_name = Ident::new(&format!("{struct_name}Fetch"), Span::call_site());
     let read_only_fetch_struct_name = if fetch_struct_attributes.is_mutable {
-        Ident::new(&format!("{}ReadOnlyFetch", struct_name), Span::call_site())
+        Ident::new(&format!("{struct_name}ReadOnlyFetch"), Span::call_site())
     } else {
         fetch_struct_name.clone()
     };
 
-    let state_struct_name = Ident::new(&format!("{}State", struct_name), Span::call_site());
+    let state_struct_name = Ident::new(&format!("{struct_name}State"), Span::call_site());
 
     let fields = match &ast.data {
         Data::Struct(DataStruct {
@@ -438,9 +438,7 @@ fn read_world_query_field_info(field: &Field) -> WorldQueryFieldInfo {
                 }
                 Ok(())
             })
-            .unwrap_or_else(|_| {
-                panic!("Invalid `{}` attribute format", WORLD_QUERY_ATTRIBUTE_NAME)
-            });
+            .unwrap_or_else(|_| panic!("Invalid `{WORLD_QUERY_ATTRIBUTE_NAME}` attribute format"));
 
             is_ignored
         });

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -208,12 +208,12 @@ fn get_idents(fmt_string: fn(usize) -> String, count: usize) -> Vec<Ident> {
 pub fn impl_param_set(_input: TokenStream) -> TokenStream {
     let mut tokens = TokenStream::new();
     let max_params = 8;
-    let params = get_idents(|i| format!("P{}", i), max_params);
-    let params_fetch = get_idents(|i| format!("PF{}", i), max_params);
-    let metas = get_idents(|i| format!("m{}", i), max_params);
+    let params = get_idents(|i| format!("P{i}"), max_params);
+    let params_fetch = get_idents(|i| format!("PF{i}"), max_params);
+    let metas = get_idents(|i| format!("m{i}"), max_params);
     let mut param_fn_muts = Vec::new();
     for (i, param) in params.iter().enumerate() {
-        let fn_name = Ident::new(&format!("p{}", i), Span::call_site());
+        let fn_name = Ident::new(&format!("p{i}"), Span::call_site());
         let index = Index::from(i);
         param_fn_muts.push(quote! {
             pub fn #fn_name<'a>(&'a mut self) -> <#param::Fetch as SystemParamFetch<'a, 'a>>::Item {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1400,9 +1400,9 @@ impl std::error::Error for QuerySingleError {}
 impl std::fmt::Display for QuerySingleError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            QuerySingleError::NoEntities(query) => write!(f, "No entities fit the query {}", query),
+            QuerySingleError::NoEntities(query) => write!(f, "No entities fit the query {query}"),
             QuerySingleError::MultipleEntities(query) => {
-                write!(f, "Multiple entities fit the query {}!", query)
+                write!(f, "Multiple entities fit the query {query}!")
             }
         }
     }

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -101,7 +101,7 @@ impl SystemStage {
                     last_segment_kind = Some(segment);
                 }
 
-                writeln!(string, " -- {:?} and {:?}", system_a, system_b).unwrap();
+                writeln!(string, " -- {system_a:?} and {system_b:?}").unwrap();
 
                 if !conflicts.is_empty() {
                     writeln!(string, "    conflicts: {conflicts:?}").unwrap();

--- a/crates/bevy_ecs/src/schedule/executor_parallel.rs
+++ b/crates/bevy_ecs/src/schedule/executor_parallel.rs
@@ -558,7 +558,7 @@ mod tests {
                 StartedSystems(1),
             ]
         );
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
     }
 }

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -117,7 +117,7 @@ impl Schedule {
         let label = label.as_label();
         self.stage_order.push(label);
         let prev = self.stages.insert(label, Box::new(stage));
-        assert!(prev.is_none(), "Stage already exists: {:?}.", label);
+        assert!(prev.is_none(), "Stage already exists: {label:?}.");
         self
     }
 
@@ -152,11 +152,11 @@ impl Schedule {
             .enumerate()
             .find(|(_i, stage_label)| **stage_label == target)
             .map(|(i, _)| i)
-            .unwrap_or_else(|| panic!("Target stage does not exist: {:?}.", target));
+            .unwrap_or_else(|| panic!("Target stage does not exist: {target:?}."));
 
         self.stage_order.insert(target_index + 1, label);
         let prev = self.stages.insert(label, Box::new(stage));
-        assert!(prev.is_none(), "Stage already exists: {:?}.", label);
+        assert!(prev.is_none(), "Stage already exists: {label:?}.");
         self
     }
 
@@ -192,11 +192,11 @@ impl Schedule {
             .enumerate()
             .find(|(_i, stage_label)| **stage_label == target)
             .map(|(i, _)| i)
-            .unwrap_or_else(|| panic!("Target stage does not exist: {:?}.", target));
+            .unwrap_or_else(|| panic!("Target stage does not exist: {target:?}."));
 
         self.stage_order.insert(target_index, label);
         let prev = self.stages.insert(label, Box::new(stage));
-        assert!(prev.is_none(), "Stage already exists: {:?}.", label);
+        assert!(prev.is_none(), "Stage already exists: {label:?}.");
         self
     }
 

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -29,9 +29,9 @@ pub trait Stage: Downcast + Send + Sync {
 impl Debug for dyn Stage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(as_systemstage) = self.as_any().downcast_ref::<SystemStage>() {
-            write!(f, "{:?}", as_systemstage)
+            write!(f, "{as_systemstage:?}")
         } else if let Some(as_schedule) = self.as_any().downcast_ref::<Schedule>() {
-            write!(f, "{:?}", as_schedule)
+            write!(f, "{as_schedule:?}")
         } else {
             write!(f, "Unknown dyn Stage")
         }
@@ -132,11 +132,11 @@ impl SystemStage {
     }
 
     pub fn single_threaded() -> Self {
-        Self::new(Box::new(SingleThreadedExecutor::default()))
+        Self::new(Box::<SingleThreadedExecutor>::default())
     }
 
     pub fn parallel() -> Self {
-        Self::new(Box::new(ParallelExecutor::default()))
+        Self::new(Box::<ParallelExecutor>::default())
     }
 
     pub fn get_executor<T: ParallelSystemExecutor>(&self) -> Option<&T> {
@@ -455,7 +455,7 @@ impl SystemStage {
                 Ok(output) => output,
                 Err(DependencyGraphError::GraphCycles(cycle)) => {
                     use std::fmt::Write;
-                    let mut message = format!("Found a dependency cycle in {}:", nodes_description);
+                    let mut message = format!("Found a dependency cycle in {nodes_description}:");
                     writeln!(message).unwrap();
                     for (index, labels) in &cycle {
                         writeln!(message, " - {}", nodes[*index].name()).unwrap();
@@ -604,15 +604,15 @@ impl SystemStage {
         v: &Vec<SystemContainer>,
         f: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
-        write!(f, "{}: ", name)?;
+        write!(f, "{name}: ")?;
         if v.len() > 1 {
             writeln!(f, "[")?;
             for sc in v.iter() {
-                writeln!(f, "{:?},", sc)?;
+                writeln!(f, "{sc:?},")?;
             }
             write!(f, "], ")
         } else {
-            write!(f, "{:?}, ", v)
+            write!(f, "{v:?}, ")
         }
     }
 }
@@ -671,7 +671,7 @@ fn process_systems(
         if let Some(index) = container.run_criteria_label().map(|label| {
             *run_criteria_labels
                 .get(label)
-                .unwrap_or_else(|| panic!("No run criteria with label {:?} found.", label))
+                .unwrap_or_else(|| panic!("No run criteria with label {label:?} found."))
         }) {
             container.set_run_criteria(index);
         }
@@ -961,7 +961,7 @@ mod tests {
             .with_system(make_exclusive(3).at_end());
         stage.run(&mut world);
         assert_eq!(world.resource_mut::<EntityCount>().0, vec![0, 1, 2, 3]);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(
             world.resource::<EntityCount>().0,
@@ -976,7 +976,7 @@ mod tests {
             .with_system(make_exclusive(0).at_start());
         stage.run(&mut world);
         assert_eq!(world.resource::<EntityCount>().0, vec![0, 1, 2, 3]);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(
             world.resource::<EntityCount>().0,
@@ -991,7 +991,7 @@ mod tests {
             .with_system(make_parallel(0).at_start());
         stage.run(&mut world);
         assert_eq!(world.resource::<EntityCount>().0, vec![0, 1, 2, 3]);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(
             world.resource::<EntityCount>().0,
@@ -1021,7 +1021,7 @@ mod tests {
             .with_system(make_exclusive(2).after(L1))
             .with_system(make_exclusive(0).label(L0));
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(world.resource::<EntityCount>().0, vec![0, 1, 2, 0, 1, 2]);
     }
@@ -1035,7 +1035,7 @@ mod tests {
             .with_system(make_exclusive(2).label(L2))
             .with_system(make_exclusive(0).before(L1));
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(world.resource::<EntityCount>().0, vec![0, 1, 2, 0, 1, 2]);
     }
@@ -1051,7 +1051,7 @@ mod tests {
             .with_system(make_exclusive(4).label(L4))
             .with_system(make_exclusive(3).after(L2).before(L4));
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(
             world.resource::<EntityCount>().0,
@@ -1068,7 +1068,7 @@ mod tests {
             .with_system(make_exclusive(2).after(First))
             .with_system(make_exclusive(0).label(First).label(L0));
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(world.resource::<EntityCount>().0, vec![0, 1, 2, 0, 1, 2]);
 
@@ -1080,7 +1080,7 @@ mod tests {
             .with_system(make_exclusive(4).label(L4))
             .with_system(make_exclusive(3).after(L2).before(L4));
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(
             world.resource::<EntityCount>().0,
@@ -1095,7 +1095,7 @@ mod tests {
             .with_system(make_exclusive(4).label(L234).label(L4))
             .with_system(make_exclusive(3).label(L234).after(L2).before(L4));
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(
             world.resource::<EntityCount>().0,
@@ -1114,7 +1114,7 @@ mod tests {
             .with_system(make_exclusive(4).label(L4).after(L3))
             .with_system(make_exclusive(3).label(L3).after(L2).before(L4));
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(
             world.resource::<EntityCount>().0,
@@ -1136,7 +1136,7 @@ mod tests {
             )
             .with_system(make_exclusive(1).after(L0).before(L2));
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(
             world.resource::<EntityCount>().0,
@@ -1158,7 +1158,7 @@ mod tests {
             .with_system(make_exclusive(2).after(L1));
         stage.run(&mut world);
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         stage.run(&mut world);
         assert_eq!(
@@ -1208,7 +1208,7 @@ mod tests {
             .with_system(make_parallel(2).after(L1))
             .with_system(make_parallel(0).label(L0));
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(world.resource::<EntityCount>().0, vec![0, 1, 2, 0, 1, 2]);
     }
@@ -1222,7 +1222,7 @@ mod tests {
             .with_system(make_parallel(2).label(L2))
             .with_system(make_parallel(0).before(L1));
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(world.resource::<EntityCount>().0, vec![0, 1, 2, 0, 1, 2]);
     }
@@ -1238,7 +1238,7 @@ mod tests {
             .with_system(make_parallel(4).label(L4))
             .with_system(make_parallel(3).after(L2).before(L4));
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(
             world.resource::<EntityCount>().0,
@@ -1255,7 +1255,7 @@ mod tests {
             .with_system(make_parallel(2).after(First))
             .with_system(make_parallel(0).label(First).label(L0));
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(world.resource::<EntityCount>().0, vec![0, 1, 2, 0, 1, 2]);
 
@@ -1267,7 +1267,7 @@ mod tests {
             .with_system(make_parallel(4).label(L4))
             .with_system(make_parallel(3).after(L2).before(L4));
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(
             world.resource::<EntityCount>().0,
@@ -1282,7 +1282,7 @@ mod tests {
             .with_system(make_parallel(4).label(L234).label(L4))
             .with_system(make_parallel(3).label(L234).after(L2).before(L4));
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(
             world.resource::<EntityCount>().0,
@@ -1304,7 +1304,7 @@ mod tests {
         for container in &stage.parallel {
             assert!(container.dependencies().len() <= 1);
         }
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(
             world.resource::<EntityCount>().0,
@@ -1326,7 +1326,7 @@ mod tests {
             )
             .with_system(make_parallel(1).after(L0).before(L2));
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         assert_eq!(
             world.resource::<EntityCount>().0,
@@ -1351,7 +1351,7 @@ mod tests {
             .with_system(make_parallel(1).after(L0));
         stage.run(&mut world);
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         stage.run(&mut world);
         assert_eq!(world.resource::<EntityCount>().0, vec![0, 1, 1, 0, 1, 1]);
@@ -1367,7 +1367,7 @@ mod tests {
             .with_system(make_parallel(2).after(L1));
         stage.run(&mut world);
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         stage.run(&mut world);
         assert_eq!(
@@ -1390,7 +1390,7 @@ mod tests {
             .with_system(make_parallel(3).after(L2));
         stage.run(&mut world);
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         stage.run(&mut world);
         assert_eq!(
@@ -1436,7 +1436,7 @@ mod tests {
         for _ in 0..4 {
             stage.run(&mut world);
         }
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         for _ in 0..5 {
             stage.run(&mut world);
         }
@@ -1464,7 +1464,8 @@ mod tests {
             .with_system(make_parallel(3).after(L2));
         stage.run(&mut world);
         stage.run(&mut world);
-        stage.set_executor(Box::new(SingleThreadedExecutor::default()));
+        // false positive, `Box::default` cannot coerce `SingleThreadedExecutor` to `dyn ParallelSystemExectutor`
+        stage.set_executor(Box::<SingleThreadedExecutor>::default());
         stage.run(&mut world);
         stage.run(&mut world);
         assert_eq!(

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -151,7 +151,7 @@ mod tests {
     fn simple_system() {
         fn sys(query: Query<&A>) {
             for a in &query {
-                println!("{:?}", a);
+                println!("{a:?}");
             }
         }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -219,7 +219,7 @@ impl World {
     pub fn entity(&self, entity: Entity) -> EntityRef {
         // Lazily evaluate panic!() via unwrap_or_else() to avoid allocation unless failure
         self.get_entity(entity)
-            .unwrap_or_else(|| panic!("Entity {:?} does not exist", entity))
+            .unwrap_or_else(|| panic!("Entity {entity:?} does not exist"))
     }
 
     /// Retrieves an [`EntityMut`] that exposes read and write operations for the given `entity`.
@@ -245,7 +245,7 @@ impl World {
     pub fn entity_mut(&mut self, entity: Entity) -> EntityMut {
         // Lazily evaluate panic!() via unwrap_or_else() to avoid allocation unless failure
         self.get_entity_mut(entity)
-            .unwrap_or_else(|| panic!("Entity {:?} does not exist", entity))
+            .unwrap_or_else(|| panic!("Entity {entity:?} does not exist"))
     }
 
     /// Returns the components of an [`Entity`](crate::entity::Entity) through [`ComponentInfo`](crate::component::ComponentInfo).
@@ -254,7 +254,7 @@ impl World {
         let entity_location = self
             .entities()
             .get(entity)
-            .unwrap_or_else(|| panic!("Entity {:?} does not exist", entity));
+            .unwrap_or_else(|| panic!("Entity {entity:?} does not exist"));
 
         let archetype = self
             .archetypes()
@@ -1634,7 +1634,7 @@ mod tests {
             should_panic: bool,
             id: u8,
         ) -> Self {
-            println!("creating component with id {}", id);
+            println!("creating component with id {id}");
             drop_log.lock().unwrap().push(DropLogItem::Create(id));
 
             Self {

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -578,8 +578,8 @@ async fn load_texture<'a>(
     let is_srgb = !linear_textures.contains(&gltf_texture.index());
     let mut texture = match gltf_texture.source().source() {
         gltf::image::Source::View { view, mime_type } => {
-            let start = view.offset() as usize;
-            let end = (view.offset() + view.length()) as usize;
+            let start = view.offset();
+            let end = view.offset() + view.length();
             let buffer = &buffer_data[view.buffer().index()][start..end];
             Image::from_buffer(
                 buffer,
@@ -920,7 +920,7 @@ fn primitive_label(mesh: &gltf::Mesh, primitive: &Primitive) -> String {
 /// Returns the label for the `material`.
 fn material_label(material: &gltf::Material) -> String {
     if let Some(index) = material.index() {
-        format!("Material{}", index)
+        format!("Material{index}")
     } else {
         "MaterialDefault".to_string()
     }

--- a/crates/bevy_macro_utils/src/attrs.rs
+++ b/crates/bevy_macro_utils/src/attrs.rs
@@ -10,7 +10,7 @@ pub fn parse_attrs(ast: &DeriveInput, attr_name: Symbol) -> syn::Result<Vec<syn:
             other => {
                 return Err(syn::Error::new_spanned(
                     other,
-                    format!("expected #[{}(...)]", attr_name),
+                    format!("expected #[{attr_name}(...)]"),
                 ))
             }
         }

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1031,8 +1031,7 @@ pub(crate) fn assign_lights_to_clusters(
                 // this not not guaranteed to be small enough due to overlapped tiles, but
                 // the conservative estimate is more than sufficient to cover the
                 // difference
-                let index_ratio =
-                    ViewClusterBindings::MAX_INDICES as f32 / cluster_index_estimate as f32;
+                let index_ratio = ViewClusterBindings::MAX_INDICES as f32 / cluster_index_estimate;
                 let xy_ratio = index_ratio.sqrt();
 
                 requested_cluster_dimensions.x =

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1076,7 +1076,7 @@ pub fn prepare_lights(
                 .spawn((
                     ShadowView {
                         depth_texture_view,
-                        pass_name: format!("shadow pass spot light {}", light_index,),
+                        pass_name: format!("shadow pass spot light {light_index}",),
                     },
                     ExtractedView {
                         viewport: UVec4::new(
@@ -1160,7 +1160,7 @@ pub fn prepare_lights(
                     .spawn((
                         ShadowView {
                             depth_texture_view,
-                            pass_name: format!("shadow pass directional light {}", i),
+                            pass_name: format!("shadow pass directional light {i}"),
                         },
                         ExtractedView {
                             viewport: UVec4::new(

--- a/crates/bevy_reflect/bevy_reflect_derive/src/documentation.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/documentation.rs
@@ -51,7 +51,7 @@ impl Documentation {
                 .enumerate()
                 .map(|(index, doc)| {
                     if index < len - 1 {
-                        format!("{}\n", doc)
+                        format!("{doc}\n")
                     } else {
                         doc.to_owned()
                     }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
@@ -15,7 +15,7 @@ pub(crate) fn impl_get_type_registration(
 ) -> proc_macro2::TokenStream {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let serialization_data = serialization_denylist.map(|denylist| {
-        let denylist = denylist.into_iter().map(|v| v as usize);
+        let denylist = denylist.into_iter();
         quote! {
             let ignored_indices = [#(#denylist),*].into_iter();
             registration.insert::<#bevy_reflect_path::serde::SerializationData>(#bevy_reflect_path::serde::SerializationData::new(ignored_indices));

--- a/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
@@ -55,7 +55,7 @@ pub(crate) fn type_uuid_derive(input: proc_macro::TokenStream) -> proc_macro::To
     let bytes = uuid
         .as_bytes()
         .iter()
-        .map(|byte| format!("{:#X}", byte))
+        .map(|byte| format!("{byte:#X}"))
         .map(|byte_str| syn::parse_str::<LitInt>(&byte_str).unwrap());
 
     let base = quote! { #bevy_reflect_path::Uuid::from_bytes([#( #bytes ),*]) };

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -20,7 +20,7 @@ pub(crate) fn get_bevy_reflect_path() -> Path {
 /// assert_eq!("ReflectHash", reflected.to_string());
 /// ```
 pub(crate) fn get_reflect_ident(name: &str) -> Ident {
-    let reflected = format!("Reflect{}", name);
+    let reflected = format!("Reflect{name}");
     Ident::new(&reflected, Span::call_site())
 }
 

--- a/crates/bevy_reflect/examples/reflect_docs.rs
+++ b/crates/bevy_reflect/examples/reflect_docs.rs
@@ -37,14 +37,14 @@ fn main() {
     // From here, we already have access to the struct's docs:
     let player_docs = player_info.docs().unwrap();
     assert_eq!(" The struct that defines our player.\n\n # Example\n\n ```\n let player = Player::new(\"Urist McPlayer\");\n ```", player_docs);
-    println!("=====[ Player ]=====\n{}", player_docs);
+    println!("=====[ Player ]=====\n{player_docs}");
 
     // We can then iterate through our struct's fields to get their documentation as well:
     if let TypeInfo::Struct(struct_info) = player_info {
         for field in struct_info.iter() {
             let field_name = field.name();
             let field_docs = field.docs().unwrap_or("<NO_DOCUMENTATION>");
-            println!("-----[ Player::{} ]-----\n{}", field_name, field_docs);
+            println!("-----[ Player::{field_name} ]-----\n{field_docs}");
         }
     }
 }

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -194,7 +194,7 @@ impl EnumInfo {
     ///
     /// This does _not_ check if the given variant exists.
     pub fn variant_path(&self, name: &str) -> String {
-        format!("{}::{}", self.type_name(), name)
+        format!("{}::{name}", self.type_name())
     }
 
     /// Checks if a variant with the given name exists within this enum.

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1099,7 +1099,7 @@ bevy_reflect::tests::should_reflect_debug::Test {
     custom: Cool debug!,
 }"#;
 
-        assert_eq!(expected, format!("\n{:#?}", reflected));
+        assert_eq!(expected, format!("\n{reflected:#?}"));
     }
 
     #[test]
@@ -1171,7 +1171,7 @@ bevy_reflect::tests::should_reflect_debug::Test {
     ),
 }"#;
 
-            assert_eq!(expected, format!("\n{}", output));
+            assert_eq!(expected, format!("\n{output}"));
         }
 
         #[test]

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -105,7 +105,7 @@ impl<T: Display> Debug for ExpectedValues<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let len = self.0.len();
         for (index, item) in self.0.iter().enumerate() {
-            write!(f, "`{}`", item)?;
+            write!(f, "`{item}`")?;
             if index < len - 1 {
                 write!(f, ", ")?;
             }
@@ -218,7 +218,7 @@ impl<'a, 'de> Visitor<'de> for UntypedReflectDeserializerVisitor<'a> {
             .ok_or_else(|| Error::invalid_length(0, &"at least one entry"))?;
 
         let registration = self.registry.get_with_name(&type_name).ok_or_else(|| {
-            Error::custom(format_args!("No registration found for `{}`", type_name))
+            Error::custom(format_args!("No registration found for `{type_name}`"))
         })?;
         let value = map.next_value_seed(TypedReflectDeserializer {
             registration,

--- a/crates/bevy_reflect/src/std_traits.rs
+++ b/crates/bevy_reflect/src/std_traits.rs
@@ -17,7 +17,7 @@ impl ReflectDefault {
 impl<T: Reflect + Default> FromType<T> for ReflectDefault {
     fn from_type() -> Self {
         ReflectDefault {
-            default: || Box::new(T::default()),
+            default: || Box::<T>::default(),
         }
     }
 }

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -128,7 +128,8 @@ impl GenericTypeInfoCell {
         F: FnOnce() -> TypeInfo,
     {
         let type_id = TypeId::of::<T>();
-        let mapping = self.0.get_or_init(|| Box::new(RwLock::default()));
+        // let mapping = self.0.get_or_init(|| Box::new(RwLock::default()));
+        let mapping = self.0.get_or_init(Box::default);
         if let Some(info) = mapping.read().get(&type_id) {
             return info;
         }

--- a/crates/bevy_render/src/mesh/mesh/conversions.rs
+++ b/crates/bevy_render/src/mesh/mesh/conversions.rs
@@ -525,7 +525,7 @@ mod tests {
             error.to_string(),
             "cannot convert VertexAttributeValues::Uint32x4 to alloc::vec::Vec<u32>"
         );
-        assert_eq!(format!("{:?}", error),
+        assert_eq!(format!("{error:?}"),
                "FromVertexAttributeError { from: Uint32x4([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]), variant: \"Uint32x4\", into: \"alloc::vec::Vec<u32>\" }");
     }
 }

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -114,8 +114,8 @@ impl Mesh {
         let values_format = VertexFormat::from(&values);
         if values_format != attribute.format {
             panic!(
-                "Failed to insert attribute. Invalid attribute format for {}. Given format is {:?} but expected {:?}",
-                attribute.name, values_format, attribute.format
+                "Failed to insert attribute. Invalid attribute format for {}. Given format is {values_format:?} but expected {:?}",
+                attribute.name, attribute.format
             );
         }
 
@@ -240,7 +240,7 @@ impl Mesh {
             let attribute_len = attribute_data.values.len();
             if let Some(previous_vertex_count) = vertex_count {
                 assert_eq!(previous_vertex_count, attribute_len,
-                        "{:?} has a different vertex count ({}) than other attributes ({}) in this mesh.", attribute_id, attribute_len, previous_vertex_count);
+                        "{attribute_id:?} has a different vertex count ({attribute_len}) than other attributes ({previous_vertex_count}) in this mesh.");
             }
             vertex_count = Some(attribute_len);
         }

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -579,10 +579,10 @@ mod tests {
         pub fn new(inputs: usize, outputs: usize) -> Self {
             TestNode {
                 inputs: (0..inputs)
-                    .map(|i| SlotInfo::new(format!("in_{}", i), SlotType::TextureView))
+                    .map(|i| SlotInfo::new(format!("in_{i}"), SlotType::TextureView))
                     .collect(),
                 outputs: (0..outputs)
-                    .map(|i| SlotInfo::new(format!("out_{}", i), SlotType::TextureView))
+                    .map(|i| SlotInfo::new(format!("out_{i}"), SlotType::TextureView))
                     .collect(),
             }
         }

--- a/crates/bevy_render/src/render_graph/node_slot.rs
+++ b/crates/bevy_render/src/render_graph/node_slot.rs
@@ -172,14 +172,14 @@ impl SlotInfos {
     /// Retrieves the [`SlotInfo`] for the provided label.
     pub fn get_slot(&self, label: impl Into<SlotLabel>) -> Option<&SlotInfo> {
         let label = label.into();
-        let index = self.get_slot_index(&label)?;
+        let index = self.get_slot_index(label)?;
         self.slots.get(index)
     }
 
     /// Retrieves the [`SlotInfo`] for the provided label mutably.
     pub fn get_slot_mut(&mut self, label: impl Into<SlotLabel>) -> Option<&mut SlotInfo> {
         let label = label.into();
-        let index = self.get_slot_index(&label)?;
+        let index = self.get_slot_index(label)?;
         self.slots.get_mut(index)
     }
 

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -127,7 +127,7 @@ impl<'a> TrackedRenderPass<'a> {
     ) {
         if self
             .state
-            .is_bind_group_set(index as usize, bind_group.id(), dynamic_uniform_indices)
+            .is_bind_group_set(index, bind_group.id(), dynamic_uniform_indices)
         {
             trace!(
                 "set bind_group {} (already set): {:?} ({:?})",
@@ -147,7 +147,7 @@ impl<'a> TrackedRenderPass<'a> {
         self.pass
             .set_bind_group(index as u32, bind_group, dynamic_uniform_indices);
         self.state
-            .set_bind_group(index as usize, bind_group.id(), dynamic_uniform_indices);
+            .set_bind_group(index, bind_group.id(), dynamic_uniform_indices);
     }
 
     /// Assign a vertex buffer to a slot.

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -258,7 +258,7 @@ impl AssetLoader for ShaderLoader {
                     String::from_utf8(Vec::from(bytes))?,
                     naga::ShaderStage::Compute,
                 ),
-                _ => panic!("unhandled extension: {}", ext),
+                _ => panic!("unhandled extension: {ext}"),
             };
 
             let shader_imports = SHADER_IMPORT_PROCESSOR.get_imports(&shader);

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -44,7 +44,7 @@ pub fn render_system(world: &mut World) {
             }
         }
 
-        panic!("Error running render graph: {}", e);
+        panic!("Error running render graph: {e}");
     }
 
     {

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -169,7 +169,7 @@ pub struct DefaultImageSampler(pub(crate) Sampler);
 impl Default for Image {
     fn default() -> Self {
         let format = wgpu::TextureFormat::bevy_default();
-        let data = vec![255; format.pixel_size() as usize];
+        let data = vec![255; format.pixel_size()];
         Image {
             data,
             texture_descriptor: wgpu::TextureDescriptor {
@@ -366,9 +366,9 @@ impl Image {
                 ktx2_buffer_to_image(buffer, supported_compressed_formats, is_srgb)
             }
             _ => {
-                let image_crate_format = format.as_image_crate_format().ok_or_else(|| {
-                    TextureError::UnsupportedTextureFormat(format!("{:?}", format))
-                })?;
+                let image_crate_format = format
+                    .as_image_crate_format()
+                    .ok_or_else(|| TextureError::UnsupportedTextureFormat(format!("{format:?}")))?;
                 let mut reader = image::io::Reader::new(std::io::Cursor::new(buffer));
                 reader.set_format(image_crate_format);
                 reader.no_limits();

--- a/crates/bevy_render/src/texture/ktx2.rs
+++ b/crates/bevy_render/src/texture/ktx2.rs
@@ -24,9 +24,8 @@ pub fn ktx2_buffer_to_image(
     supported_compressed_formats: CompressedImageFormats,
     is_srgb: bool,
 ) -> Result<Image, TextureError> {
-    let ktx2 = ktx2::Reader::new(buffer).map_err(|err| {
-        TextureError::InvalidData(format!("Failed to parse ktx2 file: {:?}", err))
-    })?;
+    let ktx2 = ktx2::Reader::new(buffer)
+        .map_err(|err| TextureError::InvalidData(format!("Failed to parse ktx2 file: {err:?}")))?;
     let Header {
         pixel_width: width,
         pixel_height: height,
@@ -367,7 +366,7 @@ pub fn ktx2_get_texture_format<Data: AsRef<[u8]>>(
         if data_format_descriptor.header == DataFormatDescriptorHeader::BASIC {
             let basic_data_format_descriptor =
                 BasicDataFormatDescriptor::parse(data_format_descriptor.data)
-                    .map_err(|err| TextureError::InvalidData(format!("KTX2: {:?}", err)))?;
+                    .map_err(|err| TextureError::InvalidData(format!("KTX2: {err:?}")))?;
             let sample_information = basic_data_format_descriptor
                 .sample_information()
                 .collect::<Vec<_>>();

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -104,7 +104,7 @@ impl<'a> Serialize for ComponentsSerializer<'a> {
         for component in self.components {
             state.serialize_entry(
                 component.type_name(),
-                &TypedReflectSerializer::new(&**component, &*self.registry.read()),
+                &TypedReflectSerializer::new(&**component, &self.registry.read()),
             )?;
         }
         state.end()
@@ -344,13 +344,13 @@ impl<'a, 'de> Visitor<'de> for ComponentVisitor<'a> {
         let mut components = Vec::new();
         while let Some(key) = map.next_key::<&str>()? {
             if !added.insert(key) {
-                return Err(Error::custom(format!("duplicate component: `{}`", key)));
+                return Err(Error::custom(format!("duplicate component: `{key}`")));
             }
 
             let registration = self
                 .registry
                 .get_with_name(key)
-                .ok_or_else(|| Error::custom(format!("no registration found for `{}`", key)))?;
+                .ok_or_else(|| Error::custom(format!("no registration found for `{key}`")))?;
             components.push(
                 map.next_value_seed(TypedReflectDeserializer::new(registration, self.registry))?,
             );

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -353,7 +353,7 @@ pub fn extract_sprites(
             continue;
         }
         if let Some(texture_atlas) = texture_atlases.get(texture_atlas_handle) {
-            let rect = Some(texture_atlas.textures[atlas_sprite.index as usize]);
+            let rect = Some(texture_atlas.textures[atlas_sprite.index]);
             extracted_sprites.sprites.push(ExtractedSprite {
                 entity,
                 color: atlas_sprite.color,

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -105,9 +105,9 @@ impl TaskPool {
                 let shutdown_rx = shutdown_rx.clone();
 
                 let thread_name = if let Some(thread_name) = thread_name {
-                    format!("{} ({})", thread_name, i)
+                    format!("{thread_name} ({i})")
                 } else {
-                    format!("TaskPool ({})", i)
+                    format!("TaskPool ({i})")
                 };
                 let mut thread_builder = thread::Builder::new().name(thread_name);
 

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -123,7 +123,7 @@ impl GlyphBrush {
                     })?;
 
                 let texture_atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
-                let glyph_rect = texture_atlas.textures[atlas_info.glyph_index as usize];
+                let glyph_rect = texture_atlas.textures[atlas_info.glyph_index];
                 let size = Vec2::new(glyph_rect.width(), glyph_rect.height());
 
                 let x = bounds.min.x + size.x / 2.0 - min_x;

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -117,7 +117,7 @@ pub fn extract_text2d_sprite(
                 .get(&text_glyph.atlas_info.texture_atlas)
                 .unwrap();
             let handle = atlas.texture.clone_weak();
-            let index = text_glyph.atlas_info.glyph_index as usize;
+            let index = text_glyph.atlas_info.glyph_index;
             let rect = Some(atlas.textures[index]);
 
             let glyph_transform = Transform::from_translation(
@@ -207,7 +207,7 @@ pub fn update_text2d_layout(
                 }
                 Err(e @ TextError::FailedToAddGlyph(_))
                 | Err(e @ TextError::ExceedMaxTextAtlases(_)) => {
-                    panic!("Fatal error when processing text: {}.", e);
+                    panic!("Fatal error when processing text: {e}.");
                 }
                 Ok(info) => {
                     calculated_size.size = Vec2::new(

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -341,7 +341,7 @@ pub fn extract_text_uinodes(
                 .get(&text_glyph.atlas_info.texture_atlas)
                 .unwrap();
             let texture = atlas.texture.clone_weak();
-            let index = text_glyph.atlas_info.glyph_index as usize;
+            let index = text_glyph.atlas_info.glyph_index;
             let rect = atlas.textures[index];
             let atlas_size = Some(atlas.size);
 

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -135,7 +135,7 @@ pub fn text_system(
                 }
                 Err(e @ TextError::FailedToAddGlyph(_))
                 | Err(e @ TextError::ExceedMaxTextAtlases(_)) => {
-                    panic!("Fatal error when processing text: {}.", e);
+                    panic!("Fatal error when processing text: {e}.");
                 }
                 Ok(info) => {
                     calculated_size.size = Size {

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -42,7 +42,7 @@ pub fn convert_touch_input(
             winit::event::TouchPhase::Ended => TouchPhase::Ended,
             winit::event::TouchPhase::Cancelled => TouchPhase::Cancelled,
         },
-        position: Vec2::new(location.x as f32, location.y as f32),
+        position: Vec2::new(location.x, location.y),
         force: touch_input.force.map(|f| match f {
             winit::event::Force::Calibrated {
                 force,

--- a/examples/ecs/custom_query_param.rs
+++ b/examples/ecs/custom_query_param.rs
@@ -170,10 +170,10 @@ fn print_components_tuple(
 ) {
     println!("Print components (tuple):");
     for (entity, a, b, nested, (generic_c, generic_d)) in &query {
-        println!("Entity: {:?}", entity);
-        println!("A: {:?}", a);
-        println!("B: {:?}", b);
+        println!("Entity: {entity:?}");
+        println!("A: {a:?}");
+        println!("B: {b:?}");
         println!("Nested: {:?} {:?}", nested.0, nested.1);
-        println!("Generic: {:?} {:?}", generic_c, generic_d);
+        println!("Generic: {generic_c:?} {generic_d:?}");
     }
 }

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -131,7 +131,7 @@ fn game_over_system(
     mut app_exit_events: EventWriter<AppExit>,
 ) {
     if let Some(ref player) = game_state.winning_player {
-        println!("{} won the game!", player);
+        println!("{player} won the game!");
         app_exit_events.send(AppExit);
     } else if game_state.current_round == game_rules.max_rounds {
         println!("Ran out of rounds. Nobody wins!");

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -134,6 +134,6 @@ fn change_color(time: Res<Time>, mut query: Query<&mut Sprite>) {
     for mut sprite in &mut query {
         sprite
             .color
-            .set_b((time.elapsed_seconds() * 0.5).sin() as f32 + 2.0);
+            .set_b((time.elapsed_seconds() * 0.5).sin() + 2.0);
     }
 }

--- a/examples/ecs/system_closure.rs
+++ b/examples/ecs/system_closure.rs
@@ -15,7 +15,7 @@ fn main() {
             info!("Hello from a complex closure! {:?}", value);
 
             // we can modify the value inside the closure. this will be saved between calls.
-            value = format!("{} - updated", value);
+            value = format!("{value} - updated");
 
             // you could also use an outside variable like presented in the inlined closures
             // info!("outside_variable! {:?}", outside_variable);

--- a/examples/ecs/system_piping.rs
+++ b/examples/ecs/system_piping.rs
@@ -24,7 +24,7 @@ fn parse_message_system(message: Res<Message>) -> Result<usize> {
 // message printed.
 fn handler_system(In(result): In<Result<usize>>) {
     match result {
-        Ok(value) => println!("parsed message: {}", value),
-        Err(err) => println!("encountered an error: {:?}", err),
+        Ok(value) => println!("parsed message: {value}"),
+        Err(err) => println!("encountered an error: {err:?}"),
     }
 }

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -115,7 +115,7 @@ fn save_scene_system(world: &mut World) {
     IoTaskPool::get()
         .spawn(async move {
             // Write the scene RON data to file
-            File::create(format!("assets/{}", NEW_SCENE_FILE_PATH))
+            File::create(format!("assets/{NEW_SCENE_FILE_PATH}"))
                 .and_then(|mut file| file.write(serialized_scene.as_bytes()))
                 .expect("Error while writing scene to file");
         })

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -179,8 +179,8 @@ fn spawn_birds(
     texture: Handle<Image>,
 ) {
     let window = windows.primary();
-    let bird_x = (window.width() as f32 / -2.) + HALF_BIRD_SIZE;
-    let bird_y = (window.height() as f32 / 2.) - HALF_BIRD_SIZE;
+    let bird_x = (window.width() / -2.) + HALF_BIRD_SIZE;
+    let bird_y = (window.height() / 2.) - HALF_BIRD_SIZE;
     let mut rng = thread_rng();
 
     for count in 0..spawn_count {
@@ -221,8 +221,8 @@ fn movement_system(time: Res<Time>, mut bird_query: Query<(&mut Bird, &mut Trans
 
 fn collision_system(windows: Res<Windows>, mut bird_query: Query<(&mut Bird, &Transform)>) {
     let window = windows.primary();
-    let half_width = window.width() as f32 * 0.5;
-    let half_height = window.height() as f32 * 0.5;
+    let half_width = window.width() * 0.5;
+    let half_height = window.height() * 0.5;
 
     for (mut bird, transform) in &mut bird_query {
         let x_vel = bird.velocity.x;

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -131,7 +131,7 @@ fn setup(
             commands.entity(ring_parent).with_children(|builder| {
                 builder.spawn(SceneBundle {
                     scene: fox_handle.clone(),
-                    transform: Transform::from_xyz(x as f32, 0.0, z as f32)
+                    transform: Transform::from_xyz(x, 0.0, z)
                         .with_scale(Vec3::splat(0.01))
                         .with_rotation(base_rotation * Quat::from_rotation_y(-fox_angle)),
                     ..default()

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -102,7 +102,7 @@ fn setup(
         mesh,
         material,
         transform: Transform {
-            translation: Vec3::new(0.0, RADIUS as f32, 0.0),
+            translation: Vec3::new(0.0, RADIUS, 0.0),
             scale: Vec3::splat(5.0),
             ..default()
         },

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -179,7 +179,7 @@ fn main() {
         }
     };
 
-    println!("\n{:#?}", cfg);
+    println!("\n{cfg:#?}");
 
     App::new()
         .insert_resource(cfg)
@@ -317,7 +317,7 @@ fn setup(mut commands: Commands, cfg: Res<Cfg>) {
         }
     };
 
-    println!("\n{:#?}", result);
+    println!("\n{result:#?}");
 }
 
 /// overview of the inserted hierarchy

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -475,7 +475,7 @@ fn update_button_values(
         if let GamepadEventType::ButtonChanged(button_type, value) = event.event_type {
             for (mut text, text_with_button_value) in query.iter_mut() {
                 if button_type == **text_with_button_value {
-                    text.sections[0].value = format!("{:.3}", value);
+                    text.sections[0].value = format!("{value:.3}");
                 }
             }
         }
@@ -499,10 +499,10 @@ fn update_axes(
             }
             for (mut text, text_with_axes) in text_query.iter_mut() {
                 if axis_type == text_with_axes.x_axis {
-                    text.sections[0].value = format!("{:.3}", value);
+                    text.sections[0].value = format!("{value:.3}");
                 }
                 if axis_type == text_with_axes.y_axis {
-                    text.sections[2].value = format!("{:.3}", value);
+                    text.sections[2].value = format!("{value:.3}");
                 }
             }
         }

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -177,8 +177,8 @@ fn change_text_system(
             fps, frame_time,
         );
 
-        text.sections[2].value = format!("{:.1}", fps);
+        text.sections[2].value = format!("{fps:.1}");
 
-        text.sections[4].value = format!("{:.3}", frame_time);
+        text.sections[4].value = format!("{frame_time:.3}");
     }
 }

--- a/tools/build-example-pages/src/main.rs
+++ b/tools/build-example-pages/src/main.rs
@@ -105,7 +105,7 @@ fn parse_examples(panic_on_missing: bool) -> Vec<Example> {
         .flat_map(|val| {
             let technical_name = val["name"].as_str().unwrap().to_string();
             if panic_on_missing && metadatas.get(&technical_name).is_none() {
-                panic!("Missing metadata for example {}", technical_name);
+                panic!("Missing metadata for example {technical_name}");
             }
 
             if metadatas

--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -23,14 +23,14 @@ struct Args {
 
 fn main() {
     let cli = Args::parse();
-    eprintln!("{:?}", cli);
+    eprintln!("{cli:?}");
 
     assert!(!cli.examples.is_empty(), "must have at least one example");
 
     let mut bevy_ci_testing = vec![];
     if let Some(frames) = cli.frames {
         let mut file = File::create("ci_testing_config.ron").unwrap();
-        file.write_fmt(format_args!("(exit_after: Some({}))", frames))
+        file.write_fmt(format_args!("(exit_after: Some({frames}))"))
             .unwrap();
         bevy_ci_testing = vec!["--features", "bevy_ci_testing"];
     }

--- a/tools/spancmp/src/main.rs
+++ b/tools/spancmp/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
                 if cli.short {
                     println!("{}", simplify_name(span));
                 } else {
-                    println!("{}", span);
+                    println!("{span}");
                 }
                 set_bold(&mut stdout, false);
                 print!("  ");
@@ -71,7 +71,7 @@ fn main() {
                 if cli.short {
                     println!("{}", simplify_name(span));
                 } else {
-                    println!("{}", span);
+                    println!("{span}");
                 }
                 set_bold(&mut stdout, false);
                 print!("  ");
@@ -88,7 +88,7 @@ fn main() {
                 if cli.short {
                     println!("{}", simplify_name(span));
                 } else {
-                    println!("{}", span);
+                    println!("{span}");
                 }
                 set_bold(&mut stdout, false);
                 print!("  ");

--- a/tools/spancmp/src/pretty.rs
+++ b/tools/spancmp/src/pretty.rs
@@ -190,7 +190,7 @@ impl Scale {
         } else {
             3
         };
-        print!("{:5.precision$}{}", v, self.name, precision = precision);
+        print!("{v:5.precision$}{}", self.name);
     }
 
     pub fn print_with_scale(&self, v: f32, v_scale: f32) {


### PR DESCRIPTION
# Objective

- fix new clippy lints before they get stable and break CI

## Solution

- run `clippy --fix` to auto-fix machine-applicable lints
- silence `clippy::should_implement_trait` for `fn HandleId::default<T: Asset>`

## Changes
- always prefer `format!("{inline}")` over `format!("{}", not_inline)`
- prefer `Box::default` (or `Box::<T>::default` if necessary) over `Box::new(T::default())`