### PR TITLE
[Merged by Bors] - Fix query.to_readonly().get_component_mut() soundness bug

### DIFF
--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -116,8 +116,8 @@ mod tests {
         query::{Added, Changed, Or, With, Without},
         schedule::{Schedule, Stage, SystemStage},
         system::{
-            Commands, IntoSystem, Local, NonSend, NonSendMut, ParamSet, Query, RemovedComponents,
-            Res, ResMut, Resource, System, SystemState,
+            Commands, IntoSystem, Local, NonSend, NonSendMut, ParamSet, Query, QueryComponentError,
+            RemovedComponents, Res, ResMut, Resource, System, SystemState,
         },
         world::{FromWorld, World},
     };
@@ -141,7 +141,7 @@ mod tests {
     #[derive(Component, Resource)]
     struct F;
 
-    #[derive(Component)]
+    #[derive(Component, Debug)]
     struct W<T>(T);
 
     #[derive(StageLabel)]
@@ -1161,6 +1161,19 @@ mod tests {
             for a in &q {
                 assert_eq!(a.0, 0);
             }
+        });
+    }
+
+    #[test]
+    fn readonly_query_get_component_fails() {
+        let mut world = World::new();
+        let entity = world.spawn(W(42u32)).id();
+        run_system(&mut world, move |q: Query<&mut W<u32>>| {
+            let mut rq = q.to_readonly();
+            assert_eq!(
+                QueryComponentError::MissingWriteAccess,
+                rq.get_component_mut::<W<u32>>(entity).unwrap_err(),
+            );
         });
     }
 }

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1165,7 +1165,7 @@ mod tests {
     }
 
     #[test]
-    fn readonly_query_get_component_fails() {
+    fn readonly_query_get_mut_component_fails() {
         let mut world = World::new();
         let entity = world.spawn(W(42u32)).id();
         run_system(&mut world, move |q: Query<&mut W<u32>>| {


### PR DESCRIPTION
# Objective

Fix the soundness issue outlined in #5866. In short the problem is that `query.to_readonly().get_component_mut::<T>()` can provide unsound mutable access to the component. This PR is an alternative to just removing the offending api. Given that `to_readonly` is a useful tool, I think this approach is a preferable short term solution. Long term I think theres a better solution out there, but we can find that on its own time.

## Solution

Add what amounts to a "dirty flag" that marks Queries that have been converted to their read-only variant via `to_readonly` as dirty. When this flag is set to true, `get_component_mut` will fail with an error, preventing the unsound access. 
