### PR TITLE
Separate RenderGraphPlugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,10 @@ futures-lite = "1.11.3"
 crossbeam-channel = "0.5.0"
 
 [[example]]
+name = "render_graph"
+path = "examples/experimental/render_graph.rs"
+
+[[example]]
 name = "hello_world"
 path = "examples/hello_world.rs"
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -146,10 +146,7 @@ impl Plugin for RenderPlugin {
             // The render app is added in the render graph plugin (if a backend was specified)
             let render_app = app.get_sub_app_mut(RenderApp).unwrap();
             render_app.insert_resource(sender);
-            render_app.add_system_to_stage(
-                RenderStage::Render,
-                render_system.at_end(),
-            );
+            render_app.add_system_to_stage(RenderStage::Render, render_system.at_end());
         }
 
         app.add_plugin(ValidParentCheckPlugin::<ComputedVisibility>::default())

--- a/crates/bevy_render/src/renderer/graph_runner.rs
+++ b/crates/bevy_render/src/renderer/graph_runner.rs
@@ -16,7 +16,7 @@ use crate::{
     renderer::{RenderContext, RenderDevice},
 };
 
-pub(crate) struct RenderGraphRunner;
+pub struct RenderGraphRunner;
 
 #[derive(Error, Debug)]
 pub enum RenderGraphRunnerError {

--- a/examples/experimental/render_graph.rs
+++ b/examples/experimental/render_graph.rs
@@ -1,0 +1,135 @@
+use bevy::{
+    prelude::*,
+    render::{
+        render_graph::{Node, NodeRunError, RenderGraph, RenderGraphContext},
+        render_resource::{LoadOp, Operations, RenderPassColorAttachment, RenderPassDescriptor},
+        renderer::{RenderContext, RenderDevice, RenderGraphRunner, RenderQueue},
+        view::{ExtractedWindows, ViewTarget},
+        RenderApp, RenderGraphPlugin, RenderStage, extract_resource::{ExtractResource, ExtractResourcePlugin},
+    },
+};
+
+fn main() {
+    App::new()
+        .add_plugins(MinimalPlugins)
+        .add_plugin(bevy::asset::AssetPlugin::default())
+        .add_plugin(bevy::input::InputPlugin)
+        .add_plugin(bevy::window::WindowPlugin::default())
+        .add_plugin(bevy::winit::WinitPlugin)
+        .add_plugin(RenderGraphTest)
+        .run();
+}
+
+struct RenderGraphTest;
+
+impl Plugin for RenderGraphTest {
+    fn build(&self, app: &mut App) {
+        app.add_plugin(RenderGraphPlugin);
+        // the WindowRenderPlugin acquires swapchain images,
+        // these need to be dropped again! (done by the TestNode)
+        app.add_plugin(bevy::render::view::WindowRenderPlugin);
+        
+        app.insert_resource(MyTimer(0.0))
+            .add_system(timer_advance)
+            .add_plugin(ExtractResourcePlugin::<MyTimer>::default());
+
+        let render_app = app.get_sub_app_mut(RenderApp).unwrap();
+        render_app.add_system_to_stage(
+            RenderStage::Render,
+            render_system.at_end(),
+        );
+
+        let graph = &mut render_app.world.get_resource_mut::<RenderGraph>().unwrap();
+        graph.add_node(TestNode::NAME, TestNode);
+    }
+}
+
+#[derive(Resource, ExtractResource, Clone)]
+struct MyTimer(f64);
+
+impl MyTimer {
+    const TICK: f64 = 1.0 / 60.0;
+}
+
+fn timer_advance(mut timer: ResMut<MyTimer>) {
+    timer.0 += MyTimer::TICK;
+}
+
+struct TestNode;
+
+impl TestNode {
+    const NAME: &'static str = "test_node";
+}
+
+impl Node for TestNode {
+    fn run(
+        &self,
+        _graph: &mut RenderGraphContext,
+        render_context: &mut RenderContext,
+        world: &World,
+    ) -> Result<(), NodeRunError> {
+        let timer = world.resource::<MyTimer>().0;
+        
+        let color = Color::rgb(
+            (timer.sin() * 0.5 + 0.5) as f32,
+            ((timer * 0.78).sin() * 0.5 + 0.5) as f32,
+            ((timer * 0.63).sin() * 0.5 + 0.5) as f32);
+
+        for (_id, window) in world.resource::<ExtractedWindows>().iter() {
+            // NOTE: this is important, otherwise swap chain images are not dropped
+            let swap_chain_texture = if let Some(swap_chain_texture) = &window.swap_chain_texture {
+                swap_chain_texture
+            } else {
+                continue;
+            };
+
+            let pass_descriptor = RenderPassDescriptor {
+                color_attachments: &[Some(RenderPassColorAttachment {
+                    view: swap_chain_texture,
+                    resolve_target: None,
+                    ops: Operations {
+                        // NOTE: re-export wgpu::Color?
+                        load: LoadOp::Clear(color.into()),
+                        store: true,
+                    },
+                })],
+                ..Default::default()
+            };
+
+            render_context
+                .command_encoder
+                .begin_render_pass(&pass_descriptor);
+        }
+
+        Ok(())
+    }
+}
+
+// NOTE: this is just the default `render_system` minus error handling and the timer channel
+fn render_system(world: &mut World) {
+    world.resource_scope(|world, mut graph: Mut<RenderGraph>| {
+        graph.update(world);
+    });
+    let graph = world.resource::<RenderGraph>();
+    let render_device = world.resource::<RenderDevice>();
+    let render_queue = world.resource::<RenderQueue>();
+
+    RenderGraphRunner::run(graph, render_device.clone(), &render_queue.0, world).unwrap();
+
+    let view_entities = world
+        .query_filtered::<Entity, With<ViewTarget>>()
+        .iter(world)
+        .collect::<Vec<_>>();
+    for view_entity in view_entities {
+        world.entity_mut(view_entity).remove::<ViewTarget>();
+    }
+
+    let mut windows = world.resource_mut::<ExtractedWindows>();
+    for window in windows.values_mut() {
+        if let Some(texture_view) = window.swap_chain_texture.take() {
+            if let Some(surface_texture) = texture_view.take_surface_texture() {
+                surface_texture.present();
+            }
+        }
+    }
+}

--- a/examples/experimental/render_graph.rs
+++ b/examples/experimental/render_graph.rs
@@ -1,11 +1,12 @@
 use bevy::{
     prelude::*,
     render::{
+        extract_resource::{ExtractResource, ExtractResourcePlugin},
         render_graph::{Node, NodeRunError, RenderGraph, RenderGraphContext},
         render_resource::{LoadOp, Operations, RenderPassColorAttachment, RenderPassDescriptor},
         renderer::{RenderContext, RenderDevice, RenderGraphRunner, RenderQueue},
         view::{ExtractedWindows, ViewTarget},
-        RenderApp, RenderGraphPlugin, RenderStage, extract_resource::{ExtractResource, ExtractResourcePlugin},
+        RenderApp, RenderGraphPlugin, RenderStage,
     },
 };
 
@@ -28,16 +29,13 @@ impl Plugin for RenderGraphTest {
         // the WindowRenderPlugin acquires swapchain images,
         // these need to be dropped again! (done by the TestNode)
         app.add_plugin(bevy::render::view::WindowRenderPlugin);
-        
+
         app.insert_resource(MyTimer(0.0))
             .add_system(timer_advance)
             .add_plugin(ExtractResourcePlugin::<MyTimer>::default());
 
         let render_app = app.get_sub_app_mut(RenderApp).unwrap();
-        render_app.add_system_to_stage(
-            RenderStage::Render,
-            render_system.at_end(),
-        );
+        render_app.add_system_to_stage(RenderStage::Render, render_system.at_end());
 
         let graph = &mut render_app.world.get_resource_mut::<RenderGraph>().unwrap();
         graph.add_node(TestNode::NAME, TestNode);
@@ -69,11 +67,12 @@ impl Node for TestNode {
         world: &World,
     ) -> Result<(), NodeRunError> {
         let timer = world.resource::<MyTimer>().0;
-        
+
         let color = Color::rgb(
             (timer.sin() * 0.5 + 0.5) as f32,
             ((timer * 0.78).sin() * 0.5 + 0.5) as f32,
-            ((timer * 0.63).sin() * 0.5 + 0.5) as f32);
+            ((timer * 0.63).sin() * 0.5 + 0.5) as f32,
+        );
 
         for (_id, window) in world.resource::<ExtractedWindows>().iter() {
             // NOTE: this is important, otherwise swap chain images are not dropped


### PR DESCRIPTION
# Objective

As it stands, `bevy_render` is currently very monolithic.

It is impossible to "just" use bevy's mid-level rendering abstractions - i.e. the render graph, render world and corresponding scheduling (extract, prepare, etc.). Instead, the `RenderPlugin` pulls in *a lot* of high-level features such as transforms, hierarchy, cameras, views, visiblity, materials, meshes, mesh generation, colors and possibly more. To my knowledge there's currently no way to opt out of these.

## Solution

Split the `RenderPlugin` into a separate plugin `RenderGraphPlugin`. This plugin is also used by the `RenderPlugin` to prevent code duplication.

---

## Changelog

- Split the render graph into `RenderGraphPlugin`
- Make `RenderPlugin` depend on `RenderGraphPlugin`
- Add experimental example

---

**Additional notes**

I previously tried to separate the render graph into it's own crate. It worked but the diff was too noisy to review and there were a lot of unresolved questions (what abstractions should be part of each crate). Here are some random notes about things I've encountered for anyone interested. None of these are addressed in this PR.

<details>
<summary>notes</summary>

- Mesh support `src/mesh/mesh` and mesh generation `src/mesh/shape`
  - Mesh generation seems unrelated and can probably be separated
- Color features `src/color` seem unrelated to `bevy_render`
  - It looks like `Wgpu::Color` is enough for `bevy_render` internal use
- The use of `Vec2` in `src/texture` seems out of place
  - It's used for image dimensions, but always converted from and to `u32`
  - As far as I can tell it's the only use of `bevy_math` in `src/texture`
- Confusing naming/structure of `texture` and `image`
  - `Texture` is in `src/render_resource`
  - `src/texture` contains `Image` and related formats
- Visibility bleeds into different parts of `bevy_render`
  - Extracting components has visibility specific behavior (`ExtractComponentPlugin::only_extract_visible`)
  - Visibility is part of `src/view` but seems unrelated (views should be able to exist without visibility)
- Windows, views and cameras seem tightly coupled
- Views require transforms
</details>