### PR TITLE
[Merged by Bors] - add `UnsafeWorldCell` abstraction

### DIFF
--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -148,7 +148,8 @@ impl<A: Asset + FromReflect> FromType<A> for ReflectAsset {
             get_unchecked_mut: |world, handle| {
                 let assets = unsafe {
                     world
-                        .get_resource_unchecked_mut::<Assets<A>>()
+                        .as_interior_mutable()
+                        .get_resource_mut::<Assets<A>>()
                         .unwrap()
                         .into_inner()
                 };

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -145,6 +145,8 @@ impl<A: Asset + FromReflect> FromType<A> for ReflectAsset {
                 asset.map(|asset| asset as &dyn Reflect)
             },
             get_unchecked_mut: |world, handle| {
+                // SAFETY: `get_unchecked_mut` must be callied with `InteriorMutableWorld` having access to `Assets<A>`,
+                // and must ensure to only have at most one reference to it live at all times.
                 let assets = unsafe { world.get_resource_mut::<Assets<A>>().unwrap().into_inner() };
                 let asset = assets.get_mut(&handle.typed());
                 asset.map(|asset| asset as &mut dyn Reflect)

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -71,11 +71,12 @@ impl ReflectAsset {
     /// # use bevy_asset::{ReflectAsset, HandleUntyped};
     /// # use bevy_ecs::prelude::World;
     /// # let reflect_asset: ReflectAsset = unimplemented!();
-    /// # let world: World = unimplemented!();
+    /// # let mut world: World = unimplemented!();
     /// # let handle_1: HandleUntyped = unimplemented!();
     /// # let handle_2: HandleUntyped = unimplemented!();
-    /// let a = unsafe { reflect_asset.get_unchecked_mut(&world, handle_1).unwrap() };
-    /// let b = unsafe { reflect_asset.get_unchecked_mut(&world, handle_2).unwrap() };
+    /// let interior_mutable_world = world.as_interior_mutable();
+    /// let a = unsafe { reflect_asset.get_unchecked_mut(interior_mutable_world, handle_1).unwrap() };
+    /// let b = unsafe { reflect_asset.get_unchecked_mut(interior_mutable_world, handle_2).unwrap() };
     /// // ^ not allowed, two mutable references through the same asset resource, even though the
     /// // handles are distinct
     ///

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -61,7 +61,7 @@ impl ReflectAsset {
         unsafe { (self.get_unchecked_mut)(world.as_interior_mutable(), handle) }
     }
 
-    /// Equivalent of [`Assets::get_mut`], but works with a [`InteriorMutableWorld`].
+    /// Equivalent of [`Assets::get_mut`], but works with an [`InteriorMutableWorld`].
     ///
     /// Only use this method when you have ensured that you are the *only* one with access to the [`Assets`] resource of the asset type.
     /// Furthermore, this does *not* allow you to have look up two distinct handles,

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -5,7 +5,7 @@ use crate::{
     component::Component,
     entity::{Entity, EntityMap, MapEntities, MapEntitiesError},
     system::Resource,
-    world::{FromWorld, World},
+    world::{interior_mutable_world::InteriorMutableWorld, FromWorld, World},
 };
 use bevy_reflect::{
     impl_from_reflect_value, impl_reflect_value, FromType, Reflect, ReflectDeserialize,
@@ -52,7 +52,8 @@ pub struct ReflectComponentFns {
     /// Function pointer implementing [`ReflectComponent::reflect()`].
     pub reflect: fn(&World, Entity) -> Option<&dyn Reflect>,
     /// Function pointer implementing [`ReflectComponent::reflect_mut()`].
-    pub reflect_mut: unsafe fn(&World, Entity) -> Option<Mut<dyn Reflect>>,
+    /// The function may only be called with a InteriorMutableWorld that can be used to access the relevant component on the given entity
+    pub reflect_mut: unsafe fn(InteriorMutableWorld<'_>, Entity) -> Option<Mut<'_, dyn Reflect>>,
     /// Function pointer implementing [`ReflectComponent::copy()`].
     pub copy: fn(&World, &mut World, Entity, Entity),
 }
@@ -117,20 +118,20 @@ impl ReflectComponent {
         entity: Entity,
     ) -> Option<Mut<'a, dyn Reflect>> {
         // SAFETY: unique world access
-        unsafe { (self.0.reflect_mut)(world, entity) }
+        unsafe { (self.0.reflect_mut)(world.as_interior_mutable(), entity) }
     }
 
     /// # Safety
     /// This method does not prevent you from having two mutable pointers to the same data,
     /// violating Rust's aliasing rules. To avoid this:
-    /// * Only call this method in an exclusive system to avoid sharing across threads (or use a
-    ///   scheduler that enforces safe memory access).
+    /// * Only call this method with a [`InteriorMutableWorld`] that may be used to access the component on the entity `entity`
     /// * Don't call this method more than once in the same scope for a given [`Component`].
     pub unsafe fn reflect_unchecked_mut<'a>(
         &self,
-        world: &'a World,
+        world: InteriorMutableWorld<'a>,
         entity: Entity,
     ) -> Option<Mut<'a, dyn Reflect>> {
+        // SAFETY: safety requirements deferred to caller
         (self.0.reflect_mut)(world, entity)
     }
 
@@ -212,6 +213,9 @@ impl<C: Component + Reflect + FromWorld> FromType<C> for ReflectComponent {
                 // SAFETY: reflect_mut is an unsafe function pointer used by `reflect_unchecked_mut` which promises to never
                 // produce aliasing mutable references, and reflect_mut, which has mutable world access
                 unsafe {
+                    // SAFETY: entity access through the InteriorMutableWorld is not implemented yet.
+                    // The following code only accesses the component `C` through the entity `entity`
+                    let world = world.world();
                     world
                         .get_entity(entity)?
                         .get_unchecked_mut::<C>(world.last_change_tick(), world.read_change_tick())
@@ -265,7 +269,7 @@ pub struct ReflectResourceFns {
     /// Function pointer implementing [`ReflectResource::reflect()`].
     pub reflect: fn(&World) -> Option<&dyn Reflect>,
     /// Function pointer implementing [`ReflectResource::reflect_unchecked_mut()`].
-    pub reflect_unchecked_mut: unsafe fn(&World) -> Option<Mut<dyn Reflect>>,
+    pub reflect_unchecked_mut: unsafe fn(InteriorMutableWorld<'_>) -> Option<Mut<'_, dyn Reflect>>,
     /// Function pointer implementing [`ReflectResource::copy()`].
     pub copy: fn(&World, &mut World),
 }
@@ -314,19 +318,18 @@ impl ReflectResource {
     /// Gets the value of this [`Resource`] type from the world as a mutable reflected reference.
     pub fn reflect_mut<'a>(&self, world: &'a mut World) -> Option<Mut<'a, dyn Reflect>> {
         // SAFETY: unique world access
-        unsafe { (self.0.reflect_unchecked_mut)(world) }
+        unsafe { (self.0.reflect_unchecked_mut)(world.as_interior_mutable()) }
     }
 
     /// # Safety
     /// This method does not prevent you from having two mutable pointers to the same data,
     /// violating Rust's aliasing rules. To avoid this:
-    /// * Only call this method in an exclusive system to avoid sharing across threads (or use a
-    ///   scheduler that enforces safe memory access).
+    /// * Only call this method with a [`InteriorMutableWorld`] which can be used to access the resource.
     /// * Don't call this method more than once in the same scope for a given [`Resource`].
-    pub unsafe fn reflect_unchecked_mut<'a>(
+    pub unsafe fn reflect_unchecked_mut<'w>(
         &self,
-        world: &'a World,
-    ) -> Option<Mut<'a, dyn Reflect>> {
+        world: InteriorMutableWorld<'w>,
+    ) -> Option<Mut<'w, dyn Reflect>> {
         // SAFETY: caller promises to uphold uniqueness guarantees
         (self.0.reflect_unchecked_mut)(world)
     }
@@ -385,13 +388,10 @@ impl<C: Resource + Reflect + FromWorld> FromType<C> for ReflectResource {
                 // SAFETY: all usages of `reflect_unchecked_mut` guarantee that there is either a single mutable
                 // reference or multiple immutable ones alive at any given point
                 unsafe {
-                    world
-                        .as_interior_mutable()
-                        .get_resource_mut::<C>()
-                        .map(|res| Mut {
-                            value: res.value as &mut dyn Reflect,
-                            ticks: res.ticks,
-                        })
+                    world.get_resource_mut::<C>().map(|res| Mut {
+                        value: res.value as &mut dyn Reflect,
+                        ticks: res.ticks,
+                    })
                 }
             },
             copy: |source_world, destination_world| {

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -385,10 +385,13 @@ impl<C: Resource + Reflect + FromWorld> FromType<C> for ReflectResource {
                 // SAFETY: all usages of `reflect_unchecked_mut` guarantee that there is either a single mutable
                 // reference or multiple immutable ones alive at any given point
                 unsafe {
-                    world.get_resource_unchecked_mut::<C>().map(|res| Mut {
-                        value: res.value as &mut dyn Reflect,
-                        ticks: res.ticks,
-                    })
+                    world
+                        .as_interior_mutable()
+                        .get_resource_mut::<C>()
+                        .map(|res| Mut {
+                            value: res.value as &mut dyn Reflect,
+                            ticks: res.ticks,
+                        })
                 }
             },
             copy: |source_world, destination_world| {

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -52,7 +52,7 @@ pub struct ReflectComponentFns {
     /// Function pointer implementing [`ReflectComponent::reflect()`].
     pub reflect: fn(&World, Entity) -> Option<&dyn Reflect>,
     /// Function pointer implementing [`ReflectComponent::reflect_mut()`].
-    /// SAFETY:  The function may only be called with an InteriorMutableWorld that can be used to mutably access the relevant component on the given entity
+    /// SAFETY: The function may only be called with an InteriorMutableWorld that can be used to mutably access the relevant component on the given entity
     pub reflect_mut: unsafe fn(InteriorMutableWorld<'_>, Entity) -> Option<Mut<'_, dyn Reflect>>,
     /// Function pointer implementing [`ReflectComponent::copy()`].
     pub copy: fn(&World, &mut World, Entity, Entity),

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -210,19 +210,14 @@ impl<C: Component + Reflect + FromWorld> FromType<C> for ReflectComponent {
                     .map(|c| c as &dyn Reflect)
             },
             reflect_mut: |world, entity| {
-                // SAFETY: reflect_mut is an unsafe function pointer used by `reflect_unchecked_mut` which promises to never
-                // produce aliasing mutable references, and reflect_mut, which has mutable world access
+                // SAFETY: reflect_mut is an unsafe function pointer used by
+                // 1. `reflect_unchecked_mut` which must be called with an InteriorMutableWorld with access the the component `C` on the `entity`, and
+                // 2. reflect_mut, which has mutable world access
                 unsafe {
-                    // SAFETY: entity access through the InteriorMutableWorld is not implemented yet.
-                    // The following code only accesses the component `C` through the entity `entity`
-                    let world = world.world();
-                    world
-                        .get_entity(entity)?
-                        .get_unchecked_mut::<C>(world.last_change_tick(), world.read_change_tick())
-                        .map(|c| Mut {
-                            value: c.value as &mut dyn Reflect,
-                            ticks: c.ticks,
-                        })
+                    world.get_entity(entity)?.get_mut::<C>().map(|c| Mut {
+                        value: c.value as &mut dyn Reflect,
+                        ticks: c.ticks,
+                    })
                 }
             },
         })

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -52,7 +52,9 @@ pub struct ReflectComponentFns {
     /// Function pointer implementing [`ReflectComponent::reflect()`].
     pub reflect: fn(&World, Entity) -> Option<&dyn Reflect>,
     /// Function pointer implementing [`ReflectComponent::reflect_mut()`].
-    /// SAFETY: The function may only be called with an InteriorMutableWorld that can be used to mutably access the relevant component on the given entity
+    ///
+    /// # Safety
+    /// The function may only be called with an [`InteriorMutableWorld`] that can be used to mutably access the relevant component on the given entity.
     pub reflect_mut: unsafe fn(InteriorMutableWorld<'_>, Entity) -> Option<Mut<'_, dyn Reflect>>,
     /// Function pointer implementing [`ReflectComponent::copy()`].
     pub copy: fn(&World, &mut World, Entity, Entity),
@@ -211,8 +213,8 @@ impl<C: Component + Reflect + FromWorld> FromType<C> for ReflectComponent {
             },
             reflect_mut: |world, entity| {
                 // SAFETY: reflect_mut is an unsafe function pointer used by
-                // 1. `reflect_unchecked_mut` which must be called with an InteriorMutableWorld with access the the component `C` on the `entity`, and
-                // 2. reflect_mut, which has mutable world access
+                // 1. `reflect_unchecked_mut` which must be called with an InteriorMutableWorld with access to the the component `C` on the `entity`, and
+                // 2. `reflect_mut`, which has mutable world access
                 unsafe {
                     world.get_entity(entity)?.get_mut::<C>().map(|c| Mut {
                         value: c.value as &mut dyn Reflect,
@@ -264,7 +266,9 @@ pub struct ReflectResourceFns {
     /// Function pointer implementing [`ReflectResource::reflect()`].
     pub reflect: fn(&World) -> Option<&dyn Reflect>,
     /// Function pointer implementing [`ReflectResource::reflect_unchecked_mut()`].
-    /// SAFETY: The function may only be called with an InteriorMutableWorld that can be used to mutably access the relevant resource
+    ///
+    /// # Safety
+    /// The function may only be called with an [`InteriorMutableWorld`] that can be used to mutably access the relevant resource.
     pub reflect_unchecked_mut: unsafe fn(InteriorMutableWorld<'_>) -> Option<Mut<'_, dyn Reflect>>,
     /// Function pointer implementing [`ReflectResource::copy()`].
     pub copy: fn(&World, &mut World),
@@ -320,7 +324,7 @@ impl ReflectResource {
     /// # Safety
     /// This method does not prevent you from having two mutable pointers to the same data,
     /// violating Rust's aliasing rules. To avoid this:
-    /// * Only call this method with a [`InteriorMutableWorld`] which can be used to mutably access the resource.
+    /// * Only call this method with an [`InteriorMutableWorld`] which can be used to mutably access the resource.
     /// * Don't call this method more than once in the same scope for a given [`Resource`].
     pub unsafe fn reflect_unchecked_mut<'w>(
         &self,

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -52,7 +52,7 @@ pub struct ReflectComponentFns {
     /// Function pointer implementing [`ReflectComponent::reflect()`].
     pub reflect: fn(&World, Entity) -> Option<&dyn Reflect>,
     /// Function pointer implementing [`ReflectComponent::reflect_mut()`].
-    /// The function may only be called with a InteriorMutableWorld that can be used to access the relevant component on the given entity
+    /// SAFETY:  The function may only be called with an InteriorMutableWorld that can be used to mutably access the relevant component on the given entity
     pub reflect_mut: unsafe fn(InteriorMutableWorld<'_>, Entity) -> Option<Mut<'_, dyn Reflect>>,
     /// Function pointer implementing [`ReflectComponent::copy()`].
     pub copy: fn(&World, &mut World, Entity, Entity),
@@ -124,7 +124,7 @@ impl ReflectComponent {
     /// # Safety
     /// This method does not prevent you from having two mutable pointers to the same data,
     /// violating Rust's aliasing rules. To avoid this:
-    /// * Only call this method with a [`InteriorMutableWorld`] that may be used to access the component on the entity `entity`
+    /// * Only call this method with a [`InteriorMutableWorld`] that may be used to mutably access the component on the entity `entity`
     /// * Don't call this method more than once in the same scope for a given [`Component`].
     pub unsafe fn reflect_unchecked_mut<'a>(
         &self,
@@ -264,6 +264,7 @@ pub struct ReflectResourceFns {
     /// Function pointer implementing [`ReflectResource::reflect()`].
     pub reflect: fn(&World) -> Option<&dyn Reflect>,
     /// Function pointer implementing [`ReflectResource::reflect_unchecked_mut()`].
+    /// SAFETY: The function may only be called with an InteriorMutableWorld that can be used to mutably access the relevant resource
     pub reflect_unchecked_mut: unsafe fn(InteriorMutableWorld<'_>) -> Option<Mut<'_, dyn Reflect>>,
     /// Function pointer implementing [`ReflectResource::copy()`].
     pub copy: fn(&World, &mut World),
@@ -319,7 +320,7 @@ impl ReflectResource {
     /// # Safety
     /// This method does not prevent you from having two mutable pointers to the same data,
     /// violating Rust's aliasing rules. To avoid this:
-    /// * Only call this method with a [`InteriorMutableWorld`] which can be used to access the resource.
+    /// * Only call this method with a [`InteriorMutableWorld`] which can be used to mutably access the resource.
     /// * Don't call this method more than once in the same scope for a given [`Resource`].
     pub unsafe fn reflect_unchecked_mut<'w>(
         &self,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1134,7 +1134,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
         }
         let world = self.world;
         let entity_ref = world
-            .as_interior_mutable()
+            .as_interior_mutable_migration_internal()
             .get_entity(entity)
             .ok_or(QueryComponentError::NoSuchEntity)?;
         let component_id = world

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1134,6 +1134,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
         }
         let world = self.world;
         let entity_ref = world
+            .as_interior_mutable()
             .get_entity(entity)
             .ok_or(QueryComponentError::NoSuchEntity)?;
         let component_id = world
@@ -1150,7 +1151,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
             .has_write(archetype_component)
         {
             entity_ref
-                .get_unchecked_mut::<T>(self.last_change_tick, self.change_tick)
+                .get_mut_using_ticks::<T>(self.last_change_tick, self.change_tick)
                 .ok_or(QueryComponentError::MissingComponent)
         } else {
             Err(QueryComponentError::MissingWriteAccess)

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1134,7 +1134,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
         }
         let world = self.world;
         let entity_ref = world
-            .as_interior_mutable_migration_internal()
+            .as_unsafe_world_cell_migration_internal()
             .get_entity(entity)
             .ok_or(QueryComponentError::NoSuchEntity)?;
         let component_id = world

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -541,7 +541,8 @@ unsafe impl<'a, T: Resource> SystemParam for ResMut<'a, T> {
         change_tick: u32,
     ) -> Self::Item<'w, 's> {
         let value = world
-            .get_resource_unchecked_mut_with_id(component_id)
+            .as_interior_mutable()
+            .get_resource_mut_with_id(component_id)
             .unwrap_or_else(|| {
                 panic!(
                     "Resource requested by {} does not exist: {}",
@@ -578,7 +579,8 @@ unsafe impl<'a, T: Resource> SystemParam for Option<ResMut<'a, T>> {
         change_tick: u32,
     ) -> Self::Item<'w, 's> {
         world
-            .get_resource_unchecked_mut_with_id(component_id)
+            .as_interior_mutable()
+            .get_resource_mut_with_id(component_id)
             .map(|value| ResMut {
                 value: value.value,
                 ticks: TicksMut {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -541,7 +541,7 @@ unsafe impl<'a, T: Resource> SystemParam for ResMut<'a, T> {
         change_tick: u32,
     ) -> Self::Item<'w, 's> {
         let value = world
-            .as_interior_mutable_migration_internal()
+            .as_unsafe_world_cell_migration_internal()
             .get_resource_mut_with_id(component_id)
             .unwrap_or_else(|| {
                 panic!(
@@ -579,7 +579,7 @@ unsafe impl<'a, T: Resource> SystemParam for Option<ResMut<'a, T>> {
         change_tick: u32,
     ) -> Self::Item<'w, 's> {
         world
-            .as_interior_mutable_migration_internal()
+            .as_unsafe_world_cell_migration_internal()
             .get_resource_mut_with_id(component_id)
             .map(|value| ResMut {
                 value: value.value,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -541,7 +541,7 @@ unsafe impl<'a, T: Resource> SystemParam for ResMut<'a, T> {
         change_tick: u32,
     ) -> Self::Item<'w, 's> {
         let value = world
-            .as_interior_mutable()
+            .as_interior_mutable_migration_internal()
             .get_resource_mut_with_id(component_id)
             .unwrap_or_else(|| {
                 panic!(
@@ -579,7 +579,7 @@ unsafe impl<'a, T: Resource> SystemParam for Option<ResMut<'a, T>> {
         change_tick: u32,
     ) -> Self::Item<'w, 's> {
         world
-            .as_interior_mutable()
+            .as_interior_mutable_migration_internal()
             .get_resource_mut_with_id(component_id)
             .map(|value| ResMut {
                 value: value.value,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -13,7 +13,7 @@ use bevy_ptr::{OwningPtr, Ptr};
 use bevy_utils::tracing::debug;
 use std::any::TypeId;
 
-use super::unsafe_world_cell::UnsafeEntityRefCell;
+use super::unsafe_world_cell::UnsafeWorldCellEntityRef;
 
 /// A read-only reference to a particular [`Entity`] and all of its components
 #[derive(Copy, Clone)]
@@ -42,8 +42,8 @@ impl<'w> EntityRef<'w> {
         }
     }
 
-    fn as_unsafe_world_cell_readonly(&self) -> UnsafeEntityRefCell<'w> {
-        UnsafeEntityRefCell::new(
+    fn as_unsafe_world_cell_readonly(&self) -> UnsafeWorldCellEntityRef<'w> {
+        UnsafeWorldCellEntityRef::new(
             self.world.as_unsafe_world_cell_readonly(),
             self.entity,
             self.location,
@@ -148,15 +148,15 @@ pub struct EntityMut<'w> {
 }
 
 impl<'w> EntityMut<'w> {
-    fn as_unsafe_world_cell_readonly(&self) -> UnsafeEntityRefCell<'_> {
-        UnsafeEntityRefCell::new(
+    fn as_unsafe_world_cell_readonly(&self) -> UnsafeWorldCellEntityRef<'_> {
+        UnsafeWorldCellEntityRef::new(
             self.world.as_unsafe_world_cell_readonly(),
             self.entity,
             self.location,
         )
     }
-    fn as_unsafe_world_cell(&mut self) -> UnsafeEntityRefCell<'_> {
-        UnsafeEntityRefCell::new(
+    fn as_unsafe_world_cell(&mut self) -> UnsafeWorldCellEntityRef<'_> {
+        UnsafeWorldCellEntityRef::new(
             self.world.as_unsafe_world_cell(),
             self.entity,
             self.location,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -151,7 +151,7 @@ impl<'w> EntityRef<'w> {
         let info = self.world.components().get_info(component_id)?;
         // SAFETY:
         // - entity_location and entity are valid
-        // . component_id is valid as checked by the line above
+        // - component_id is valid as checked by the line above
         // - the storage type is accurate as checked by the fetched ComponentInfo
         unsafe {
             self.world.get_component(
@@ -808,7 +808,7 @@ pub(crate) unsafe fn get_mut<T: Component>(
     // SAFETY:
     // - world access is unique
     // - entity location is valid
-    // - and returned component is of type T
+    // - returned component is of type T
     world
         .get_component_and_ticks_with_type(
             TypeId::of::<T>(),
@@ -839,7 +839,7 @@ pub(crate) unsafe fn get_mut_by_id(
     // SAFETY:
     // - world access is unique
     // - entity location is valid
-    // - and returned component is of type T
+    // - returned component is of type T
     world
         .get_component_and_ticks(component_id, info.storage_type(), entity, location)
         .map(|(value, ticks)| MutUntyped {

--- a/crates/bevy_ecs/src/world/interior_mutable_world.rs
+++ b/crates/bevy_ecs/src/world/interior_mutable_world.rs
@@ -143,6 +143,17 @@ impl<'w> InteriorMutableWorld<'w> {
         self.0.get_resource_by_id(component_id)
     }
 
+    /// Gets a reference to the non-send resource of the given type if it exists
+    ///
+    /// # Safety
+    /// All [`InteriorMutableWorld`] methods take `&self` and thus do not check that there is only one unique reference or multiple shared ones.
+    /// It is the callers responsibility to make sure that there will never be a mutable reference to a value that has other references pointing to it,
+    /// and that no arbitrary safe code can access a `&World` while some value is mutably borrowed.
+    #[inline]
+    pub unsafe fn get_non_send_resource<R: 'static>(&self) -> Option<&'w R> {
+        self.0.get_non_send_resource()
+    }
+
     /// Gets a mutable reference to the resource of the given type if it exists
     ///
     /// # Safety
@@ -189,6 +200,19 @@ impl<'w> InteriorMutableWorld<'w> {
             value: unsafe { ptr.assert_unique() },
             ticks,
         })
+    }
+
+    /// Gets a mutable reference to the non-send resource of the given type if it exists
+    ///
+    /// # Safety
+    /// All [`InteriorMutableWorld`] methods take `&self` and thus do not check that there is only one unique reference or multiple shared ones.
+    /// It is the callers responsibility to make sure that there will never be a mutable reference to a value that has other references pointing to it,
+    /// and that no arbitrary safe code can access a `&World` while some value is mutably borrowed.
+    #[inline]
+    pub unsafe fn get_non_send_resource_mut<R: 'static>(&self) -> Option<Mut<'w, R>> {
+        let component_id = self.0.components.get_resource_id(TypeId::of::<R>())?;
+        // SAFETY: component_id matches `R`, rest is promised by caller
+        unsafe { self.get_non_send_mut_with_id(component_id) }
     }
 }
 

--- a/crates/bevy_ecs/src/world/interior_mutable_world.rs
+++ b/crates/bevy_ecs/src/world/interior_mutable_world.rs
@@ -82,7 +82,7 @@ impl<'w> InteriorMutableWorld<'w> {
     /// **Note**: You *must not* hand out a `&World` reference to arbitrary safe code when the [`InteriorMutableWorld`] is currently
     /// being used for mutable accesses.
     ///
-    /// SAFETY:
+    /// # Safety:
     /// - the world must not be used to access any resources or components. You can use it to safely access metadata.
     pub unsafe fn world(&self) -> &'w World {
         self.0
@@ -409,7 +409,7 @@ impl<'w> InteriorMutableEntityRef<'w> {
         last_change_tick: u32,
         change_tick: u32,
     ) -> Option<Mut<'w, T>> {
-        // # Safety
+        // SAFETY:
         // - `storage_type` is correct
         // - `location` is valid
         // - aliasing rules are ensured by caller

--- a/crates/bevy_ecs/src/world/interior_mutable_world.rs
+++ b/crates/bevy_ecs/src/world/interior_mutable_world.rs
@@ -147,7 +147,7 @@ impl<'w> InteriorMutableWorld<'w> {
     /// # Safety
     /// It is the callers responsibility to ensure that
     /// - the [`InteriorMutableWorld`] has permission to access the resource
-    /// - no other mutable references to the resource exist at the same time
+    /// - no mutable reference to the resource exists at the same time
     #[inline]
     pub unsafe fn get_resource<R: Resource>(self) -> Option<&'w R> {
         self.0.get_resource::<R>()
@@ -163,7 +163,7 @@ impl<'w> InteriorMutableWorld<'w> {
     /// # Safety
     /// It is the callers responsibility to ensure that
     /// - the [`InteriorMutableWorld`] has permission to access the resource
-    /// - no other mutable references to the resource exist at the same time
+    /// - no mutable reference to the resource exists at the same time
     #[inline]
     pub unsafe fn get_resource_by_id(self, component_id: ComponentId) -> Option<Ptr<'w>> {
         self.0.get_resource_by_id(component_id)
@@ -174,7 +174,7 @@ impl<'w> InteriorMutableWorld<'w> {
     /// # Safety
     /// It is the callers responsibility to ensure that
     /// - the [`InteriorMutableWorld`] has permission to access the resource
-    /// - no other mutable references to the resource exist at the same time
+    /// - no mutable reference to the resource exists at the same time
     #[inline]
     pub unsafe fn get_non_send_resource<R: 'static>(self) -> Option<&'w R> {
         self.0.get_non_send_resource()
@@ -193,7 +193,7 @@ impl<'w> InteriorMutableWorld<'w> {
     /// # Safety
     /// It is the callers responsibility to ensure that
     /// - the [`InteriorMutableWorld`] has permission to access the resource
-    /// - no other mutable references to the resource exist at the same time
+    /// - no mutable reference to the resource exists at the same time
     #[inline]
     pub unsafe fn get_non_send_resource_by_id(self, component_id: ComponentId) -> Option<Ptr<'w>> {
         self.0

--- a/crates/bevy_ecs/src/world/interior_mutable_world.rs
+++ b/crates/bevy_ecs/src/world/interior_mutable_world.rs
@@ -63,8 +63,9 @@ use std::any::TypeId;
 ///
 /// // the two interior mutable worlds borrow from the `&mut World`, so it cannot be accessed while they are live
 /// fn split_world_access(world: &mut World) -> (OnlyResourceAccessWorld<'_>, OnlyComponentAccessWorld<'_>) {
-///     let resource_access = OnlyResourceAccessWorld(unsafe { world.as_interior_mutable() });
-///     let component_access = OnlyComponentAccessWorld(unsafe { world.as_interior_mutable() });
+///     let interior_mutable_world = world.as_interior_mutable();
+///     let resource_access = OnlyResourceAccessWorld(interior_mutable_world);
+///     let component_access = OnlyComponentAccessWorld(interior_mutable_world);
 ///     (resource_access, component_access)
 /// }
 /// ```

--- a/crates/bevy_ecs/src/world/interior_mutable_world.rs
+++ b/crates/bevy_ecs/src/world/interior_mutable_world.rs
@@ -83,7 +83,7 @@ impl<'w> InteriorMutableWorld<'w> {
     /// **Note**: You *must not* hand out a `&World` reference to arbitrary safe code when the [`InteriorMutableWorld`] is currently
     /// being used for mutable accesses.
     ///
-    /// # Safety:
+    /// # Safety
     /// - the world must not be used to access any resources or components. You can use it to safely access metadata.
     pub unsafe fn world(&self) -> &'w World {
         self.0

--- a/crates/bevy_ecs/src/world/interior_mutable_world.rs
+++ b/crates/bevy_ecs/src/world/interior_mutable_world.rs
@@ -1,0 +1,181 @@
+#![warn(unsafe_op_in_unsafe_fn)]
+
+use super::{Mut, World};
+use crate::{
+    change_detection::{MutUntyped, Ticks},
+    component::ComponentId,
+    system::Resource,
+};
+use bevy_ptr::Ptr;
+use bevy_ptr::UnsafeCellDeref;
+use std::any::TypeId;
+
+/// Variant of the [`World`] where resource and component accesses takes a `&World`, and the responsibility to avoid
+/// aliasing violations are given to the caller instead of being checked at compile-time by rust's unique XOR shared rule.
+///
+/// ### Rationale
+/// In rust, having a `&mut World` means that there are absolutely no other references to the safe world alive at the same time,
+/// without exceptions. Not even unsafe code can change this.
+///
+/// But there are situations where careful shared mutable access through a type is possible and safe. For this, rust provides the [`UnsafeCell`](std::cell::UnsafeCell)
+/// escape hatch, which allows you to get a `*mut T` from a `&UnsafeCell<T>` and around which safe abstractions can be built.
+///
+/// Access to resources and components can be done uniquely using [`World::resource_mut`] and [`World::entity_mut`], and shared using [`World::resource`] and [`World::entity`].
+/// These methods use lifetimes to check at compile time that no aliasing rules are being broken.
+///
+/// This alone is not enough to implement bevy systems where multiple systems can access *disjoint* parts of the world concurrently. For this, bevy stores all values of
+/// resources and components (and [`ComponentTicks`](crate::component::ComponentTicks)) in [`UnsafeCell`](std::cell::UnsafeCell)s, and carefully validates disjoint access patterns using
+/// APIs like [`System::component_access`](crate::system::System::component_access).
+///
+/// A system then can be executed using [`System::run_unsafe`](crate::system::System::run_unsafe) with a `&World` and use methods with interior mutability to access resource values.
+/// access resource values.
+///
+/// ### Example Usage
+///
+/// [`InteriorMutableWorld`] can be used as a building block for writing APIs that safely allow disjoint access into the world.
+/// In the following example, the world is split into a resource access half and a component access half, where each one can
+/// safely hand out mutable references.
+///
+/// ```
+/// use bevy_ecs::world::World;
+/// use bevy_ecs::change_detection::Mut;
+/// use bevy_ecs::system::Resource;
+/// use bevy_ecs::world::interior_mutable_world::InteriorMutableWorld;
+///
+/// // INVARIANT: existance of this struct means that users of it are the only ones being able to access resources in the world
+/// struct OnlyResourceAccessWorld<'w>(InteriorMutableWorld<'w>);
+/// // INVARIANT: existance of this struct means that users of it are the only ones being able to access components in the world
+/// struct OnlyComponentAccessWorld<'w>(InteriorMutableWorld<'w>);
+///
+/// impl<'w> OnlyResourceAccessWorld<'w> {
+///     fn get_resource_mut<T: Resource>(&mut self) -> Option<Mut<'w, T>> {
+///         // SAFETY: resource access is allowed through this InteriorMutableWorld
+///         unsafe { self.0.get_resource_mut::<T>() }
+///     }
+/// }
+/// // impl<'w> OnlyComponentAccessWorld<'w> {
+/// //     ...
+/// // }
+///
+/// // the two interior mutable worlds borrow from the `&mut World`, so it cannot be accessed while they are live
+/// fn split_world_access(world: &mut World) -> (OnlyResourceAccessWorld<'_>, OnlyComponentAccessWorld<'_>) {
+///     let resource_access = OnlyResourceAccessWorld(unsafe { world.as_interior_mutable() });
+///     let component_access = OnlyComponentAccessWorld(unsafe { world.as_interior_mutable() });
+///     (resource_access, component_access)
+/// }
+/// ```
+#[derive(Copy, Clone)]
+pub struct InteriorMutableWorld<'w>(&'w World);
+
+impl<'w> InteriorMutableWorld<'w> {
+    pub(crate) fn new(world: &'w World) -> Self {
+        InteriorMutableWorld(world)
+    }
+
+    /// Gets a reference to the [`&World`](crate::world::World) this [`InteriorMutableWorld`] belongs to.
+    /// This can be used to call methods like [`World::read_change_tick`] which aren't exposed here but don't perform any accesses.
+    ///
+    /// **Note**: You *must not* hand out a `&World` reference to arbitrary safe code when the [`InteriorMutableWorld`] is currently
+    /// being used for mutable accesses.
+    ///
+    /// SAFETY:
+    /// - the world must not be used to access any resources or components. You can use it to safely access metadata.
+    pub unsafe fn world(&self) -> &'w World {
+        self.0
+    }
+
+    /// Gets a reference to the resource of the given type if it exists
+    ///
+    /// # Safety
+    /// All [`InteriorMutableWorld`] methods take `&self` and thus do not check that there is only one unique reference or multiple shared ones.
+    /// It is the callers responsibility to make sure that there will never be a mutable reference to a value that has other references pointing to it,
+    /// and that no arbitrary safe code can access a `&World` while some value is mutably borrowed.
+    #[inline]
+    pub unsafe fn get_resource<R: Resource>(&self) -> Option<&'w R> {
+        self.0.get_resource::<R>()
+    }
+
+    /// Gets a pointer to the resource with the id [`ComponentId`] if it exists.
+    /// The returned pointer must not be used to modify the resource, and must not be
+    /// dereferenced after the borrow of the [`World`] ends.
+    ///
+    /// **You should prefer to use the typed API [`InteriorMutableWorld::get_resource`] where possible and only
+    /// use this in cases where the actual types are not known at compile time.**
+    ///
+    /// # Safety
+    /// All [`InteriorMutableWorld`] methods take `&self` and thus do not check that there is only one unique reference or multiple shared ones.
+    /// It is the callers responsibility to make sure that there will never be a mutable reference to a value that has other references pointing to it,
+    /// and that no arbitrary safe code can access a `&World` while some value is mutably borrowed.
+    #[inline]
+    pub unsafe fn get_resource_by_id(&self, component_id: ComponentId) -> Option<Ptr<'w>> {
+        self.0.get_resource_by_id(component_id)
+    }
+
+    /// Gets a mutable reference to the resource of the given type if it exists
+    ///
+    /// # Safety
+    /// All [`InteriorMutableWorld`] methods take `&self` and thus do not check that there is only one unique reference or multiple shared ones.
+    /// It is the callers responsibility to make sure that there will never be a mutable reference to a value that has other references pointing to it,
+    /// and that no arbitrary safe code can access a `&World` while some value is mutably borrowed.
+    #[inline]
+    pub unsafe fn get_resource_mut<R: Resource>(&self) -> Option<Mut<'w, R>> {
+        let component_id = self.0.components.get_resource_id(TypeId::of::<R>())?;
+        // SAFETY:
+        // - component_id is of type `R`
+        // - caller ensures aliasing rules
+        // - `R` is Send + Sync
+        unsafe { self.0.get_resource_unchecked_mut_with_id(component_id) }
+    }
+
+    /// Gets a pointer to the resource with the id [`ComponentId`] if it exists.
+    /// The returned pointer may be used to modify the resource, as long as the mutable borrow
+    /// of the [`InteriorMutableWorld`] is still valid.
+    ///
+    /// **You should prefer to use the typed API [`InteriorMutableWorld::get_resource_mut`] where possible and only
+    /// use this in cases where the actual types are not known at compile time.**
+    ///
+    /// # Safety
+    /// All [`InteriorMutableWorld`] methods take `&self` and thus do not check that there is only one unique reference or multiple shared ones.
+    /// It is the callers responsibility to make sure that there will never be a mutable reference to a value that has other references pointing to it,
+    /// and that no arbitrary safe code can access a `&World` while some value is mutably borrowed.
+    #[inline]
+    pub unsafe fn get_resource_mut_by_id(
+        &self,
+        component_id: ComponentId,
+    ) -> Option<MutUntyped<'w>> {
+        let info = self.0.components.get_info(component_id)?;
+        if !info.is_send_and_sync() {
+            self.0.validate_non_send_access_untyped(info.name());
+        }
+
+        let (ptr, ticks) = self.0.get_resource_with_ticks(component_id)?;
+
+        // SAFETY:
+        // - index is in-bounds because the column is initialized and non-empty
+        // - the caller promises that no other reference to the ticks of the same row can exist at the same time
+        let ticks = unsafe {
+            Ticks::from_tick_cells(ticks, self.0.last_change_tick(), self.0.read_change_tick())
+        };
+
+        Some(MutUntyped {
+            // SAFETY: This function has exclusive access to the world so nothing aliases `ptr`.
+            value: unsafe { ptr.assert_unique() },
+            ticks,
+        })
+    }
+
+    /// Gets a reference to the non-send resource of the given type, if it exists.
+    /// Otherwise returns [None]
+    #[inline]
+    pub unsafe fn get_non_send_resource<R: 'static>(&self) -> Option<&R> {
+        self.0.get_non_send_resource::<R>()
+    }
+    /// Gets a mutable reference to the non-send resource of the given type, if it exists.
+    /// Otherwise returns [None]
+    #[inline]
+    pub unsafe fn get_non_send_resource_mut<R: 'static>(&mut self) -> Option<Mut<'w, R>> {
+        let component_id = self.0.components.get_resource_id(TypeId::of::<R>())?;
+        // SAFETY: safety requirement is deferred to the caller
+        unsafe { self.0.get_non_send_unchecked_mut_with_id(component_id) }
+    }
+}

--- a/crates/bevy_ecs/src/world/interior_mutable_world.rs
+++ b/crates/bevy_ecs/src/world/interior_mutable_world.rs
@@ -456,6 +456,34 @@ impl<'w> InteriorMutableEntityRef<'w> {
         }
     }
 
+    /// Retrieves the change ticks for the given [`ComponentId`]. This can be useful for implementing change
+    /// detection in custom runtimes.
+    ///
+    /// **You should prefer to use the typed API [`InteriorMutableEntityRef::get_change_ticks`] where possible and only
+    /// use this in cases where the actual component types are not known at
+    /// compile time.**
+    ///
+    /// # Safety
+    /// It is the callers responsibility to ensure that
+    /// - the [`InteriorMutableEntityRef`] has permission to access the component
+    /// - no other mutable references to the component exist at the same time
+    #[inline]
+    pub fn get_change_ticks_by_id(&self, component_id: ComponentId) -> Option<ComponentTicks> {
+        let info = self.world.components().get_info(component_id)?;
+        // SAFETY:
+        // - entity location and entity is valid
+        // - world access is immutable, lifetime tied to `&self`
+        // - the storage type provided is correct for T
+        unsafe {
+            self.world.0.get_ticks(
+                component_id,
+                info.storage_type(),
+                self.entity,
+                self.location,
+            )
+        }
+    }
+
     /// # Safety
     /// It is the callers responsibility to ensure that
     /// - the [`InteriorMutableEntityRef`] has permission to access the component mutably

--- a/crates/bevy_ecs/src/world/interior_mutable_world.rs
+++ b/crates/bevy_ecs/src/world/interior_mutable_world.rs
@@ -85,59 +85,59 @@ impl<'w> InteriorMutableWorld<'w> {
     ///
     /// # Safety
     /// - the world must not be used to access any resources or components. You can use it to safely access metadata.
-    pub unsafe fn world(&self) -> &'w World {
+    pub unsafe fn world(self) -> &'w World {
         self.0
     }
 
     /// Retrieves this world's [Entities] collection
     #[inline]
-    pub fn entities(&self) -> &'w Entities {
+    pub fn entities(self) -> &'w Entities {
         &self.0.entities
     }
 
     /// Retrieves this world's [Archetypes] collection
     #[inline]
-    pub fn archetypes(&self) -> &'w Archetypes {
+    pub fn archetypes(self) -> &'w Archetypes {
         &self.0.archetypes
     }
 
     /// Retrieves this world's [Components] collection
     #[inline]
-    pub fn components(&self) -> &'w Components {
+    pub fn components(self) -> &'w Components {
         &self.0.components
     }
 
     /// Retrieves this world's [Storages] collection
     #[inline]
-    pub fn storages(&self) -> &'w Storages {
+    pub fn storages(self) -> &'w Storages {
         &self.0.storages
     }
 
     /// Retrieves this world's [Bundles] collection
     #[inline]
-    pub fn bundles(&self) -> &'w Bundles {
+    pub fn bundles(self) -> &'w Bundles {
         &self.0.bundles
     }
 
     /// Reads the current change tick of this world.
     #[inline]
-    pub fn read_change_tick(&self) -> u32 {
+    pub fn read_change_tick(self) -> u32 {
         self.0.read_change_tick()
     }
 
     #[inline]
-    pub fn last_change_tick(&self) -> u32 {
+    pub fn last_change_tick(self) -> u32 {
         self.0.last_change_tick()
     }
 
     #[inline]
-    pub fn increment_change_tick(&self) -> u32 {
+    pub fn increment_change_tick(self) -> u32 {
         self.0.increment_change_tick()
     }
 
     /// Retrieves an [`InteriorMutableEntityRef`] that exposes read and write operations for the given `entity`.
     /// Similar to the [`InteriorMutableWorld`], you are in charge of making sure that no aliasing rules are violated.
-    pub fn get_entity(&self, entity: Entity) -> Option<InteriorMutableEntityRef<'w>> {
+    pub fn get_entity(self, entity: Entity) -> Option<InteriorMutableEntityRef<'w>> {
         let location = self.0.entities.get(entity)?;
         Some(InteriorMutableEntityRef {
             world: InteriorMutableWorld(self.0),
@@ -153,7 +153,7 @@ impl<'w> InteriorMutableWorld<'w> {
     /// - the [`InteriorMutableWorld`] has permission to access the resource
     /// - no other mutable references to the resource exist at the same time
     #[inline]
-    pub unsafe fn get_resource<R: Resource>(&self) -> Option<&'w R> {
+    pub unsafe fn get_resource<R: Resource>(self) -> Option<&'w R> {
         self.0.get_resource::<R>()
     }
 
@@ -169,7 +169,7 @@ impl<'w> InteriorMutableWorld<'w> {
     /// - the [`InteriorMutableWorld`] has permission to access the resource
     /// - no other mutable references to the resource exist at the same time
     #[inline]
-    pub unsafe fn get_resource_by_id(&self, component_id: ComponentId) -> Option<Ptr<'w>> {
+    pub unsafe fn get_resource_by_id(self, component_id: ComponentId) -> Option<Ptr<'w>> {
         self.0.get_resource_by_id(component_id)
     }
 
@@ -180,7 +180,7 @@ impl<'w> InteriorMutableWorld<'w> {
     /// - the [`InteriorMutableWorld`] has permission to access the resource
     /// - no other mutable references to the resource exist at the same time
     #[inline]
-    pub unsafe fn get_non_send_resource<R: 'static>(&self) -> Option<&'w R> {
+    pub unsafe fn get_non_send_resource<R: 'static>(self) -> Option<&'w R> {
         self.0.get_non_send_resource()
     }
 
@@ -199,7 +199,7 @@ impl<'w> InteriorMutableWorld<'w> {
     /// - the [`InteriorMutableWorld`] has permission to access the resource
     /// - no other mutable references to the resource exist at the same time
     #[inline]
-    pub unsafe fn get_non_send_resource_by_id(&self, component_id: ComponentId) -> Option<Ptr<'_>> {
+    pub unsafe fn get_non_send_resource_by_id(self, component_id: ComponentId) -> Option<Ptr<'w>> {
         self.0
             .storages
             .non_send_resources
@@ -214,7 +214,7 @@ impl<'w> InteriorMutableWorld<'w> {
     /// - the [`InteriorMutableWorld`] has permission to access the resource mutably
     /// - no other references to the resource exist at the same time
     #[inline]
-    pub unsafe fn get_resource_mut<R: Resource>(&self) -> Option<Mut<'w, R>> {
+    pub unsafe fn get_resource_mut<R: Resource>(self) -> Option<Mut<'w, R>> {
         let component_id = self.0.components.get_resource_id(TypeId::of::<R>())?;
         // SAFETY:
         // - component_id is of type `R`
@@ -262,7 +262,7 @@ impl<'w> InteriorMutableWorld<'w> {
     /// - the [`InteriorMutableWorld`] has permission to access the resource mutably
     /// - no other references to the resource exist at the same time
     #[inline]
-    pub unsafe fn get_non_send_resource_mut<R: 'static>(&self) -> Option<Mut<'w, R>> {
+    pub unsafe fn get_non_send_resource_mut<R: 'static>(self) -> Option<Mut<'w, R>> {
         let component_id = self.0.components.get_resource_id(TypeId::of::<R>())?;
         // SAFETY: component_id matches `R`, rest is promised by caller
         unsafe { self.get_non_send_mut_with_id(component_id) }
@@ -369,37 +369,37 @@ pub struct InteriorMutableEntityRef<'w> {
 impl<'w> InteriorMutableEntityRef<'w> {
     #[inline]
     #[must_use = "Omit the .id() call if you do not need to store the `Entity` identifier."]
-    pub fn id(&self) -> Entity {
+    pub fn id(self) -> Entity {
         self.entity
     }
 
     #[inline]
-    pub fn location(&self) -> EntityLocation {
+    pub fn location(self) -> EntityLocation {
         self.location
     }
 
     #[inline]
-    pub fn archetype(&self) -> &Archetype {
+    pub fn archetype(self) -> &'w Archetype {
         &self.world.0.archetypes[self.location.archetype_id]
     }
 
     #[inline]
-    pub fn world(&self) -> InteriorMutableWorld<'w> {
+    pub fn world(self) -> InteriorMutableWorld<'w> {
         self.world
     }
 
     #[inline]
-    pub fn contains<T: Component>(&self) -> bool {
+    pub fn contains<T: Component>(self) -> bool {
         self.contains_type_id(TypeId::of::<T>())
     }
 
     #[inline]
-    pub fn contains_id(&self, component_id: ComponentId) -> bool {
+    pub fn contains_id(self, component_id: ComponentId) -> bool {
         entity_ref::contains_component_with_id(self.world.0, component_id, self.location)
     }
 
     #[inline]
-    pub fn contains_type_id(&self, type_id: TypeId) -> bool {
+    pub fn contains_type_id(self, type_id: TypeId) -> bool {
         entity_ref::contains_component_with_type(self.world.0, type_id, self.location)
     }
 
@@ -408,7 +408,7 @@ impl<'w> InteriorMutableEntityRef<'w> {
     /// - the [`InteriorMutableEntityRef`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
-    pub unsafe fn get<T: Component>(&self) -> Option<&'w T> {
+    pub unsafe fn get<T: Component>(self) -> Option<&'w T> {
         // SAFETY:
         // - entity location is valid
         // - proper world access is promised by caller
@@ -434,7 +434,7 @@ impl<'w> InteriorMutableEntityRef<'w> {
     /// - the [`InteriorMutableEntityRef`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
-    pub unsafe fn get_change_ticks<T: Component>(&self) -> Option<ComponentTicks> {
+    pub unsafe fn get_change_ticks<T: Component>(self) -> Option<ComponentTicks> {
         // SAFETY:
         // - entity location is valid
         // - proper world acess is promised by caller
@@ -453,7 +453,7 @@ impl<'w> InteriorMutableEntityRef<'w> {
     /// - the [`InteriorMutableEntityRef`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     #[inline]
-    pub unsafe fn get_mut<T: Component>(&self) -> Option<Mut<'w, T>> {
+    pub unsafe fn get_mut<T: Component>(self) -> Option<Mut<'w, T>> {
         // SAFETY: same safety requirements
         unsafe {
             self.get_mut_using_ticks(self.world.last_change_tick(), self.world.read_change_tick())
@@ -506,7 +506,7 @@ impl<'w> InteriorMutableEntityRef<'w> {
     /// - the [`InteriorMutableEntityRef`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
-    pub unsafe fn get_by_id(&self, component_id: ComponentId) -> Option<Ptr<'w>> {
+    pub unsafe fn get_by_id(self, component_id: ComponentId) -> Option<Ptr<'w>> {
         let info = self.world.0.components.get_info(component_id)?;
         // SAFETY: entity_location is valid, component_id is valid as checked by the line above
         unsafe {
@@ -530,7 +530,7 @@ impl<'w> InteriorMutableEntityRef<'w> {
     /// - the [`InteriorMutableEntityRef`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     #[inline]
-    pub unsafe fn get_mut_by_id(&self, component_id: ComponentId) -> Option<MutUntyped<'w>> {
+    pub unsafe fn get_mut_by_id(self, component_id: ComponentId) -> Option<MutUntyped<'w>> {
         let info = self.world.0.components.get_info(component_id)?;
         // SAFETY: entity_location is valid, component_id is valid as checked by the line above
         unsafe {

--- a/crates/bevy_ecs/src/world/interior_mutable_world.rs
+++ b/crates/bevy_ecs/src/world/interior_mutable_world.rs
@@ -14,7 +14,7 @@ use crate::{
 use bevy_ptr::Ptr;
 use std::any::TypeId;
 
-/// Variant of the [`World`] where resource and component accesses takes a `&World`, and the responsibility to avoid
+/// Variant of the [`World`] where resource and component accesses take `&self`, and the responsibility to avoid
 /// aliasing violations are given to the caller instead of being checked at compile-time by rust's unique XOR shared rule.
 ///
 /// ### Rationale
@@ -46,9 +46,9 @@ use std::any::TypeId;
 /// use bevy_ecs::system::Resource;
 /// use bevy_ecs::world::interior_mutable_world::InteriorMutableWorld;
 ///
-/// // INVARIANT: existance of this struct means that users of it are the only ones being able to access resources in the world
+/// // INVARIANT: existence of this struct means that users of it are the only ones being able to access resources in the world
 /// struct OnlyResourceAccessWorld<'w>(InteriorMutableWorld<'w>);
-/// // INVARIANT: existance of this struct means that users of it are the only ones being able to access components in the world
+/// // INVARIANT: existence of this struct means that users of it are the only ones being able to access components in the world
 /// struct OnlyComponentAccessWorld<'w>(InteriorMutableWorld<'w>);
 ///
 /// impl<'w> OnlyResourceAccessWorld<'w> {

--- a/crates/bevy_ecs/src/world/interior_mutable_world.rs
+++ b/crates/bevy_ecs/src/world/interior_mutable_world.rs
@@ -2,12 +2,15 @@
 
 use super::{Mut, World};
 use crate::{
+    archetype::Archetypes,
+    bundle::Bundles,
     change_detection::{MutUntyped, Ticks},
-    component::ComponentId,
+    component::{ComponentId, Components},
+    entity::Entities,
+    storage::Storages,
     system::Resource,
 };
 use bevy_ptr::Ptr;
-use bevy_ptr::UnsafeCellDeref;
 use std::any::TypeId;
 
 /// Variant of the [`World`] where resource and component accesses takes a `&World`, and the responsibility to avoid
@@ -84,6 +87,35 @@ impl<'w> InteriorMutableWorld<'w> {
         self.0
     }
 
+    /// Retrieves this world's [Entities] collection
+    #[inline]
+    pub fn entities(&self) -> &'w Entities {
+        &self.0.entities
+    }
+
+    /// Retrieves this world's [Archetypes] collection
+    #[inline]
+    pub fn archetypes(&self) -> &'w Archetypes {
+        &self.0.archetypes
+    }
+
+    /// Retrieves this world's [Components] collection
+    #[inline]
+    pub fn components(&self) -> &'w Components {
+        &self.0.components
+    }
+
+    /// Retrieves this world's [Storages] collection
+    #[inline]
+    pub fn storages(&self) -> &'w Storages {
+        &self.0.storages
+    }
+
+    /// Retrieves this world's [Bundles] collection
+    #[inline]
+    pub fn bundles(&self) -> &'w Bundles {
+        &self.0.bundles
+    }
     /// Gets a reference to the resource of the given type if it exists
     ///
     /// # Safety

--- a/crates/bevy_ecs/src/world/interior_mutable_world.rs
+++ b/crates/bevy_ecs/src/world/interior_mutable_world.rs
@@ -139,11 +139,7 @@ impl<'w> InteriorMutableWorld<'w> {
     /// Similar to the [`InteriorMutableWorld`], you are in charge of making sure that no aliasing rules are violated.
     pub fn get_entity(self, entity: Entity) -> Option<InteriorMutableEntityRef<'w>> {
         let location = self.0.entities.get(entity)?;
-        Some(InteriorMutableEntityRef {
-            world: InteriorMutableWorld(self.0),
-            entity,
-            location,
-        })
+        Some(InteriorMutableEntityRef::new(self, entity, location))
     }
 
     /// Gets a reference to the resource of the given type if it exists
@@ -367,6 +363,18 @@ pub struct InteriorMutableEntityRef<'w> {
 }
 
 impl<'w> InteriorMutableEntityRef<'w> {
+    pub(crate) fn new(
+        world: InteriorMutableWorld<'w>,
+        entity: Entity,
+        location: EntityLocation,
+    ) -> Self {
+        InteriorMutableEntityRef {
+            world,
+            entity,
+            location,
+        }
+    }
+
     #[inline]
     #[must_use = "Omit the .id() call if you do not need to store the `Entity` identifier."]
     pub fn id(self) -> Entity {

--- a/crates/bevy_ecs/src/world/interior_mutable_world.rs
+++ b/crates/bevy_ecs/src/world/interior_mutable_world.rs
@@ -468,7 +468,10 @@ impl<'w> InteriorMutableEntityRef<'w> {
     /// - the [`InteriorMutableEntityRef`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
-    pub fn get_change_ticks_by_id(&self, component_id: ComponentId) -> Option<ComponentTicks> {
+    pub unsafe fn get_change_ticks_by_id(
+        &self,
+        component_id: ComponentId,
+    ) -> Option<ComponentTicks> {
         let info = self.world.components().get_info(component_id)?;
         // SAFETY:
         // - entity location and entity is valid

--- a/crates/bevy_ecs/src/world/interior_mutable_world.rs
+++ b/crates/bevy_ecs/src/world/interior_mutable_world.rs
@@ -184,6 +184,29 @@ impl<'w> InteriorMutableWorld<'w> {
         self.0.get_non_send_resource()
     }
 
+    /// Gets a `!Send` resource to the resource with the id [`ComponentId`] if it exists.
+    /// The returned pointer must not be used to modify the resource, and must not be
+    /// dereferenced after the immutable borrow of the [`World`] ends.
+    ///
+    /// **You should prefer to use the typed API [`InteriorMutableWorld::get_non_send_resource`] where possible and only
+    /// use this in cases where the actual types are not known at compile time.**
+    ///
+    /// # Panics
+    /// This function will panic if it isn't called from the same thread that the resource was inserted from.
+    ///
+    /// # Safety
+    /// It is the callers responsibility to ensure that
+    /// - the [`InteriorMutableWorld`] has permission to access the resource
+    /// - no other mutable references to the resource exist at the same time
+    #[inline]
+    pub unsafe fn get_non_send_resource_by_id(&self, component_id: ComponentId) -> Option<Ptr<'_>> {
+        self.0
+            .storages
+            .non_send_resources
+            .get(component_id)?
+            .get_data()
+    }
+
     /// Gets a mutable reference to the resource of the given type if it exists
     ///
     /// # Safety
@@ -243,6 +266,41 @@ impl<'w> InteriorMutableWorld<'w> {
         let component_id = self.0.components.get_resource_id(TypeId::of::<R>())?;
         // SAFETY: component_id matches `R`, rest is promised by caller
         unsafe { self.get_non_send_mut_with_id(component_id) }
+    }
+
+    /// Gets a `!Send` resource to the resource with the id [`ComponentId`] if it exists.
+    /// The returned pointer may be used to modify the resource, as long as the mutable borrow
+    /// of the [`World`] is still valid.
+    ///
+    /// **You should prefer to use the typed API [`InteriorMutableWorld::get_non_send_resource_mut`] where possible and only
+    /// use this in cases where the actual types are not known at compile time.**
+    ///
+    /// # Panics
+    /// This function will panic if it isn't called from the same thread that the resource was inserted from.
+    ///
+    /// # Safety
+    /// It is the callers responsibility to ensure that
+    /// - the [`InteriorMutableWorld`] has permission to access the resource mutably
+    /// - no other references to the resource exist at the same time
+    #[inline]
+    pub unsafe fn get_non_send_resource_mut_by_id(
+        &mut self,
+        component_id: ComponentId,
+    ) -> Option<MutUntyped<'_>> {
+        let change_tick = self.read_change_tick();
+        let (ptr, ticks) = self.0.get_non_send_with_ticks(component_id)?;
+
+        let ticks =
+            // SAFETY: This function has exclusive access to the world so nothing aliases `ticks`.
+            // - index is in-bounds because the column is initialized and non-empty
+            // - no other reference to the ticks of the same row can exist at the same time
+            unsafe { TicksMut::from_tick_cells(ticks, self.last_change_tick(), change_tick) };
+
+        Some(MutUntyped {
+            // SAFETY: This function has exclusive access to the world so nothing aliases `ptr`.
+            value: unsafe { ptr.assert_unique() },
+            ticks,
+        })
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1751,7 +1751,7 @@ impl World {
 }
 
 impl World {
-    /// Get a raw pointer to a particular [`Component`](crate::component::Component) and its [`ComponentTicks`] identified by their [`TypeId`]
+    /// Get an untyped pointer to a particular [`Component`](crate::component::Component) and its [`ComponentTicks`] identified by their [`TypeId`]
     ///
     /// # Safety
     /// - `storage_type` must accurately reflect where the components for `component_id` are stored.
@@ -1770,7 +1770,7 @@ impl World {
         self.get_component_and_ticks(component_id, storage_type, entity, location)
     }
 
-    /// Get a raw pointer to a particular [`Component`](crate::component::Component) and its [`ComponentTicks`]
+    /// Get an untyped pointer to a particular [`Component`](crate::component::Component) and its [`ComponentTicks`]
     ///
     /// # Safety
     /// - `location` must refer to an archetype that contains `entity`
@@ -1802,7 +1802,7 @@ impl World {
         }
     }
 
-    /// Get a raw pointer to a particular [`Component`](crate::component::Component) on a particular [`Entity`], identified by the component's type
+    /// Get an untyped pointer to a particular [`Component`](crate::component::Component) on a particular [`Entity`], identified by the component's type
     ///
     /// # Safety
     /// - `location` must refer to an archetype that contains `entity`
@@ -1822,7 +1822,7 @@ impl World {
         self.get_component(component_id, storage_type, entity, location)
     }
 
-    /// Get a raw pointer to a particular [`Component`](crate::component::Component) on a particular [`Entity`] in the provided [`World`](crate::world::World).
+    /// Get an untyped pointer to a particular [`Component`](crate::component::Component) on a particular [`Entity`] in the provided [`World`](crate::world::World).
     ///
     /// # Safety
     /// - `location` must refer to an archetype that contains `entity`
@@ -1849,7 +1849,7 @@ impl World {
         }
     }
 
-    /// Get a raw pointer to the [`ComponentTicks`] on a particular [`Entity`], identified by the component's [`TypeId`]
+    /// Get an untyped pointer to the [`ComponentTicks`] on a particular [`Entity`], identified by the component's [`TypeId`]
     ///
     /// # Safety
     /// - `location` must refer to an archetype that contains `entity`
@@ -1869,7 +1869,7 @@ impl World {
         self.get_ticks(component_id, storage_type, entity, location)
     }
 
-    /// Get a raw pointer to the [`ComponentTicks`] on a particular [`Entity`]
+    /// Get an untyped pointer to the [`ComponentTicks`] on a particular [`Entity`]
     ///
     /// # Safety
     /// - `location` must refer to an archetype that contains `entity`

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -112,6 +112,7 @@ impl World {
     pub fn as_interior_mutable(&mut self) -> InteriorMutableWorld<'_> {
         InteriorMutableWorld::new(self)
     }
+
     /// Creates a new [`InteriorMutableWorld`] view with only read access to everything.
     pub fn as_interior_mutable_readonly(&self) -> InteriorMutableWorld<'_> {
         InteriorMutableWorld::new(self)

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1,4 +1,5 @@
 mod entity_ref;
+pub mod interior_mutable_world;
 mod spawn_batch;
 mod world_cell;
 
@@ -32,6 +33,8 @@ use std::{
 mod identifier;
 
 pub use identifier::WorldId;
+
+use self::interior_mutable_world::InteriorMutableWorld;
 
 /// Stores and exposes operations on [entities](Entity), [components](Component), resources,
 /// and their associated metadata.
@@ -103,6 +106,10 @@ impl World {
     #[inline]
     pub fn id(&self) -> WorldId {
         self.id
+    }
+
+    pub fn as_interior_mutable(&self) -> InteriorMutableWorld<'_> {
+        InteriorMutableWorld::new(self)
     }
 
     /// Retrieves this world's [Entities] collection
@@ -1655,7 +1662,7 @@ impl World {
 }
 
 impl World {
-    /// Gets a resource to the resource with the id [`ComponentId`] if it exists.
+    /// Gets a pointer to the resource with the id [`ComponentId`] if it exists.
     /// The returned pointer must not be used to modify the resource, and must not be
     /// dereferenced after the immutable borrow of the [`World`] ends.
     ///
@@ -1666,7 +1673,7 @@ impl World {
         self.storages.resources.get(component_id)?.get_data()
     }
 
-    /// Gets a resource to the resource with the id [`ComponentId`] if it exists.
+    /// Gets a pointer to the resource with the id [`ComponentId`] if it exists.
     /// The returned pointer may be used to modify the resource, as long as the mutable borrow
     /// of the [`World`] is still valid.
     ///

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -118,7 +118,7 @@ impl World {
     }
 
     /// Creates a new [`InteriorMutableWorld`] with read+write access from a [&World](World).
-    /// This is only a temporary measure until every `&World` that is semantically a [InteriorMutableWorld]
+    /// This is only a temporary measure until every `&World` that is semantically a [`InteriorMutableWorld`]
     /// has been replaced.
     pub(crate) fn as_interior_mutable_migration_internal(&self) -> InteriorMutableWorld<'_> {
         InteriorMutableWorld::new(self)

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -107,7 +107,19 @@ impl World {
         self.id
     }
 
-    pub fn as_interior_mutable(&self) -> InteriorMutableWorld<'_> {
+    /// Creates a new [`InteriorMutableWorld`] view with complete read+write access
+    pub fn as_interior_mutable(&mut self) -> InteriorMutableWorld<'_> {
+        InteriorMutableWorld::new(self)
+    }
+    /// Creates a new [`InteriorMutableWorld`] view only read access to everything
+    pub fn as_interior_mutable_readonly(&self) -> InteriorMutableWorld<'_> {
+        InteriorMutableWorld::new(self)
+    }
+
+    /// Creates a new [`InteriorMutableWorld`] with read+write access from a [&World](World).
+    /// This is only a temporary measure until every `&World` that is semantically a [InteriorMutableWorld]
+    /// has been replaced.
+    pub(crate) fn as_interior_mutable_migration_internal(&self) -> InteriorMutableWorld<'_> {
         InteriorMutableWorld::new(self)
     }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -108,11 +108,11 @@ impl World {
         self.id
     }
 
-    /// Creates a new [`InteriorMutableWorld`] view with complete read+write access
+    /// Creates a new [`InteriorMutableWorld`] view with complete read+write access.
     pub fn as_interior_mutable(&mut self) -> InteriorMutableWorld<'_> {
         InteriorMutableWorld::new(self)
     }
-    /// Creates a new [`InteriorMutableWorld`] view only read access to everything
+    /// Creates a new [`InteriorMutableWorld`] view with only read access to everything.
     pub fn as_interior_mutable_readonly(&self) -> InteriorMutableWorld<'_> {
         InteriorMutableWorld::new(self)
     }

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -135,11 +135,11 @@ impl<'w> UnsafeWorldCell<'w> {
         self.0.increment_change_tick()
     }
 
-    /// Retrieves an [`UnsafeEntityRefCell`] that exposes read and write operations for the given `entity`.
+    /// Retrieves an [`UnsafeWorldCellEntityRef`] that exposes read and write operations for the given `entity`.
     /// Similar to the [`UnsafeWorldCell`], you are in charge of making sure that no aliasing rules are violated.
-    pub fn get_entity(self, entity: Entity) -> Option<UnsafeEntityRefCell<'w>> {
+    pub fn get_entity(self, entity: Entity) -> Option<UnsafeWorldCellEntityRef<'w>> {
         let location = self.0.entities.get(entity)?;
-        Some(UnsafeEntityRefCell::new(self, entity, location))
+        Some(UnsafeWorldCellEntityRef::new(self, entity, location))
     }
 
     /// Gets a reference to the resource of the given type if it exists
@@ -356,19 +356,19 @@ impl<'w> UnsafeWorldCell<'w> {
 
 /// A interior-mutable reference to a particular [`Entity`] and all of its components
 #[derive(Copy, Clone)]
-pub struct UnsafeEntityRefCell<'w> {
+pub struct UnsafeWorldCellEntityRef<'w> {
     world: UnsafeWorldCell<'w>,
     entity: Entity,
     location: EntityLocation,
 }
 
-impl<'w> UnsafeEntityRefCell<'w> {
+impl<'w> UnsafeWorldCellEntityRef<'w> {
     pub(crate) fn new(
         world: UnsafeWorldCell<'w>,
         entity: Entity,
         location: EntityLocation,
     ) -> Self {
-        UnsafeEntityRefCell {
+        UnsafeWorldCellEntityRef {
             world,
             entity,
             location,
@@ -413,7 +413,7 @@ impl<'w> UnsafeEntityRefCell<'w> {
 
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - the [`UnsafeEntityRefCell`] has permission to access the component
+    /// - the [`UnsafeWorldCellEntityRef`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
     pub unsafe fn get<T: Component>(self) -> Option<&'w T> {
@@ -439,7 +439,7 @@ impl<'w> UnsafeEntityRefCell<'w> {
     ///
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - the [`UnsafeEntityRefCell`] has permission to access the component
+    /// - the [`UnsafeWorldCellEntityRef`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
     pub unsafe fn get_change_ticks<T: Component>(self) -> Option<ComponentTicks> {
@@ -459,13 +459,13 @@ impl<'w> UnsafeEntityRefCell<'w> {
     /// Retrieves the change ticks for the given [`ComponentId`]. This can be useful for implementing change
     /// detection in custom runtimes.
     ///
-    /// **You should prefer to use the typed API [`UnsafeEntityRefCell::get_change_ticks`] where possible and only
+    /// **You should prefer to use the typed API [`UnsafeWorldCellEntityRef::get_change_ticks`] where possible and only
     /// use this in cases where the actual component types are not known at
     /// compile time.**
     ///
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - the [`UnsafeEntityRefCell`] has permission to access the component
+    /// - the [`UnsafeWorldCellEntityRef`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
     pub unsafe fn get_change_ticks_by_id(
@@ -489,7 +489,7 @@ impl<'w> UnsafeEntityRefCell<'w> {
 
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - the [`UnsafeEntityRefCell`] has permission to access the component mutably
+    /// - the [`UnsafeWorldCellEntityRef`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     #[inline]
     pub unsafe fn get_mut<T: Component>(self) -> Option<Mut<'w, T>> {
@@ -501,7 +501,7 @@ impl<'w> UnsafeEntityRefCell<'w> {
 
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - the [`UnsafeEntityRefCell`] has permission to access the component mutably
+    /// - the [`UnsafeWorldCellEntityRef`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     #[inline]
     pub(crate) unsafe fn get_mut_using_ticks<T: Component>(
@@ -530,19 +530,19 @@ impl<'w> UnsafeEntityRefCell<'w> {
     }
 }
 
-impl<'w> UnsafeEntityRefCell<'w> {
+impl<'w> UnsafeWorldCellEntityRef<'w> {
     /// Gets the component of the given [`ComponentId`] from the entity.
     ///
     /// **You should prefer to use the typed API where possible and only
     /// use this in cases where the actual component types are not known at
     /// compile time.**
     ///
-    /// Unlike [`UnsafeEntityRefCell::get`], this returns a raw pointer to the component,
+    /// Unlike [`UnsafeWorldCellEntityRef::get`], this returns a raw pointer to the component,
     /// which is only valid while the `'w` borrow of the lifetime is active.
     ///
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - the [`UnsafeEntityRefCell`] has permission to access the component
+    /// - the [`UnsafeWorldCellEntityRef`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
     pub unsafe fn get_by_id(self, component_id: ComponentId) -> Option<Ptr<'w>> {
@@ -561,12 +561,12 @@ impl<'w> UnsafeEntityRefCell<'w> {
     /// Retrieves a mutable untyped reference to the given `entity`'s [Component] of the given [`ComponentId`].
     /// Returns [None] if the `entity` does not have a [Component] of the given type.
     ///
-    /// **You should prefer to use the typed API [`UnsafeEntityRefCell::get_mut`] where possible and only
+    /// **You should prefer to use the typed API [`UnsafeWorldCellEntityRef::get_mut`] where possible and only
     /// use this in cases where the actual types are not known at compile time.**
     ///
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - the [`UnsafeEntityRefCell`] has permission to access the component mutably
+    /// - the [`UnsafeWorldCellEntityRef`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     #[inline]
     pub unsafe fn get_mut_by_id(self, component_id: ComponentId) -> Option<MutUntyped<'w>> {

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -295,11 +295,11 @@ impl<'w> WorldCell<'w> {
             .world
             .get_non_send_archetype_component_id(component_id)?;
         WorldBorrowMut::try_new(
-            // SAFETY: ComponentId matches TypeId and access is checked by WorldBorrowMut
+            // SAFETY: access is checked by WorldBorrowMut
             || unsafe {
                 self.world
                     .as_interior_mutable()
-                    .get_non_send_mut_with_id(component_id)
+                    .get_non_send_resource_mut::<T>()
             },
             archetype_component_id,
             self.access.clone(),

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -226,7 +226,11 @@ impl<'w> WorldCell<'w> {
             .get_resource_archetype_component_id(component_id)?;
         WorldBorrowMut::try_new(
             // SAFETY: ComponentId matches TypeId and access is checked by WorldBorrowMut
-            || unsafe { self.world.get_resource_unchecked_mut_with_id(component_id) },
+            || unsafe {
+                self.world
+                    .as_interior_mutable()
+                    .get_resource_mut_with_id(component_id)
+            },
             archetype_component_id,
             self.access.clone(),
         )
@@ -292,7 +296,11 @@ impl<'w> WorldCell<'w> {
             .get_non_send_archetype_component_id(component_id)?;
         WorldBorrowMut::try_new(
             // SAFETY: ComponentId matches TypeId and access is checked by WorldBorrowMut
-            || unsafe { self.world.get_non_send_unchecked_mut_with_id(component_id) },
+            || unsafe {
+                self.world
+                    .as_interior_mutable()
+                    .get_non_send_mut_with_id(component_id)
+            },
             archetype_component_id,
             self.access.clone(),
         )

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -228,7 +228,7 @@ impl<'w> WorldCell<'w> {
             // SAFETY: ComponentId matches TypeId and access is checked by WorldBorrowMut
             || unsafe {
                 self.world
-                    .as_interior_mutable()
+                    .as_interior_mutable_migration_internal()
                     .get_resource_mut_with_id(component_id)
             },
             archetype_component_id,
@@ -298,7 +298,7 @@ impl<'w> WorldCell<'w> {
             // SAFETY: access is checked by WorldBorrowMut
             || unsafe {
                 self.world
-                    .as_interior_mutable()
+                    .as_interior_mutable_migration_internal()
                     .get_non_send_resource_mut::<T>()
             },
             archetype_component_id,

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -14,12 +14,12 @@ use std::{
     rc::Rc,
 };
 
-use super::interior_mutable_world::InteriorMutableWorld;
+use super::unsafe_world_cell::UnsafeWorldCell;
 
 /// Exposes safe mutable access to multiple resources at a time in a World. Attempting to access
 /// World in a way that violates Rust's mutability rules will panic thanks to runtime checks.
 pub struct WorldCell<'w> {
-    pub(crate) world: InteriorMutableWorld<'w>,
+    pub(crate) world: UnsafeWorldCell<'w>,
     pub(crate) access: Rc<RefCell<ArchetypeComponentAccess>>,
 }
 
@@ -190,7 +190,7 @@ impl<'w> WorldCell<'w> {
         );
         // world's ArchetypeComponentAccess is recycled to cut down on allocations
         Self {
-            world: world.as_interior_mutable(),
+            world: world.as_unsafe_world_cell(),
             access: Rc::new(RefCell::new(access)),
         }
     }


### PR DESCRIPTION
alternative to #5922, implements #5956 
builds on top of https://github.com/bevyengine/bevy/pull/6402

# Objective

https://github.com/bevyengine/bevy/issues/5956 goes into more detail, but the TLDR is:
- bevy systems ensure disjoint accesses to resources and components, and for that to work there are methods `World::get_resource_unchecked_mut(&self)`, ..., `EntityRef::get_mut_unchecked(&self)` etc.
- we don't have these unchecked methods for `by_id` variants, so third-party crate authors cannot build their own safe disjoint-access abstractions with these
- having `_unchecked_mut` methods is not great, because in their presence safe code can accidentally violate subtle invariants. Having to go through `world.as_unsafe_world_cell().unsafe_method()` forces you to stop and think about what you want to write in your `// SAFETY` comment.

The alternative is to keep exposing `_unchecked_mut` variants for every operation that we want third-party crates to build upon, but we'd prefer to avoid using these methods alltogether: https://github.com/bevyengine/bevy/pull/5922#issuecomment-1241954543

Also, this is something that **cannot be implemented outside of bevy**, so having either this PR or #5922 as an escape hatch with lots of discouraging comments would be great.

## Solution

- add `UnsafeWorldCell` with `unsafe fn get_resource(&self)`, `unsafe fn get_resource_mut(&self)`
- add `fn World::as_unsafe_world_cell(&mut self) -> UnsafeWorldCell<'_>` (and `as_unsafe_world_cell_readonly(&self)`)
- add `UnsafeWorldCellEntityRef` with `unsafe fn get`, `unsafe fn get_mut` and the other utilities on `EntityRef` (no methods for spawning, despawning, insertion)
- use the `UnsafeWorldCell` abstraction in `ReflectComponent`, `ReflectResource` and `ReflectAsset`, so these APIs are easier to reason about
- remove `World::get_resource_mut_unchecked`, `EntityRef::get_mut_unchecked` and use `unsafe { world.as_unsafe_world_cell().get_mut() }` and `unsafe { world.as_unsafe_world_cell().get_entity(entity)?.get_mut() }` instead

This PR does **not** make use of `UnsafeWorldCell` for anywhere else in `bevy_ecs` such as `SystemParam` or `Query`. That is a much larger change, and I am convinced that having `UnsafeWorldCell` is already useful for third-party crates.

Implemented API:

```rust
struct World { .. }
impl World {
  fn as_unsafe_world_cell(&self) -> UnsafeWorldCell<'_>;
}

struct UnsafeWorldCell<'w>(&'w World);
impl<'w> UnsafeWorldCell {
  unsafe fn world(&self) -> &World;

  fn get_entity(&self) -> UnsafeWorldCellEntityRef<'w>; // returns 'w which is `'self` of the `World::as_unsafe_world_cell(&'w self)`

  unsafe fn get_resource<T>(&self) -> Option<&'w T>;
  unsafe fn get_resource_by_id(&self, ComponentId) -> Option<&'w T>;
  unsafe fn get_resource_mut<T>(&self) -> Option<Mut<'w, T>>;
  unsafe fn get_resource_mut_by_id(&self) -> Option<MutUntyped<'w>>;
  unsafe fn get_non_send_resource<T>(&self) -> Option<&'w T>;
  unsafe fn get_non_send_resource_mut<T>(&self) -> Option<Mut<'w, T>>>;

  // not included: remove, remove_resource, despawn, anything that might change archetypes
}

struct UnsafeWorldCellEntityRef<'w> { .. }
impl UnsafeWorldCellEntityRef<'w> {
  unsafe fn get<T>(&self, Entity) -> Option<&'w T>;
  unsafe fn get_by_id(&self, Entity, ComponentId) -> Option<Ptr<'w>>;
  unsafe fn get_mut<T>(&self, Entity) -> Option<Mut<'w, T>>;
  unsafe fn get_mut_by_id(&self, Entity, ComponentId) -> Option<MutUntyped<'w>>;
  unsafe fn get_change_ticks<T>(&self, Entity) -> Option<Mut<'w, T>>;
  // fn id, archetype, contains, contains_id, containts_type_id
}
```

<details>
<summary>UnsafeWorldCell docs</summary>

Variant of the [`World`] where resource and component accesses takes a `&World`, and the responsibility to avoid
aliasing violations are given to the caller instead of being checked at compile-time by rust's unique XOR shared rule.

### Rationale
In rust, having a `&mut World` means that there are absolutely no other references to the safe world alive at the same time,
without exceptions. Not even unsafe code can change this.

But there are situations where careful shared mutable access through a type is possible and safe. For this, rust provides the [`UnsafeCell`](std::cell::UnsafeCell)
escape hatch, which allows you to get a `*mut T` from a `&UnsafeCell<T>` and around which safe abstractions can be built.

Access to resources and components can be done uniquely using [`World::resource_mut`] and [`World::entity_mut`], and shared using [`World::resource`] and [`World::entity`].
These methods use lifetimes to check at compile time that no aliasing rules are being broken.

This alone is not enough to implement bevy systems where multiple systems can access *disjoint* parts of the world concurrently. For this, bevy stores all values of
resources and components (and [`ComponentTicks`](crate::component::ComponentTicks)) in [`UnsafeCell`](std::cell::UnsafeCell)s, and carefully validates disjoint access patterns using
APIs like [`System::component_access`](crate::system::System::component_access).

A system then can be executed using [`System::run_unsafe`](crate::system::System::run_unsafe) with a `&World` and use methods with interior mutability to access resource values.
access resource values.

### Example Usage

[`UnsafeWorldCell`] can be used as a building block for writing APIs that safely allow disjoint access into the world.
In the following example, the world is split into a resource access half and a component access half, where each one can
safely hand out mutable references.

```rust
use bevy_ecs::world::World;
use bevy_ecs::change_detection::Mut;
use bevy_ecs::system::Resource;
use bevy_ecs::world::unsafe_world_cell_world::UnsafeWorldCell;

// INVARIANT: existance of this struct means that users of it are the only ones being able to access resources in the world
struct OnlyResourceAccessWorld<'w>(UnsafeWorldCell<'w>);
// INVARIANT: existance of this struct means that users of it are the only ones being able to access components in the world
struct OnlyComponentAccessWorld<'w>(UnsafeWorldCell<'w>);

impl<'w> OnlyResourceAccessWorld<'w> {
    fn get_resource_mut<T: Resource>(&mut self) -> Option<Mut<'w, T>> {
        // SAFETY: resource access is allowed through this UnsafeWorldCell
        unsafe { self.0.get_resource_mut::<T>() }
    }
}
// impl<'w> OnlyComponentAccessWorld<'w> {
//     ...
// }

// the two interior mutable worlds borrow from the `&mut World`, so it cannot be accessed while they are live
fn split_world_access(world: &mut World) -> (OnlyResourceAccessWorld<'_>, OnlyComponentAccessWorld<'_>) {
    let resource_access = OnlyResourceAccessWorld(unsafe { world.as_unsafe_world_cell() });
    let component_access = OnlyComponentAccessWorld(unsafe { world.as_unsafe_world_cell() });
    (resource_access, component_access)
}
```


</details>