### PR TITLE
[Merged by Bors] - Remove outdated uses of single-tuple bundles

### DIFF
--- a/benches/benches/bevy_ecs/components/add_remove.rs
+++ b/benches/benches/bevy_ecs/components/add_remove.rs
@@ -12,7 +12,7 @@ impl Benchmark {
         let mut world = World::default();
 
         let entities = world
-            .spawn_batch((0..10000).map(|_| (A(0.0),)))
+            .spawn_batch((0..10000).map(|_| A(0.0)))
             .collect::<Vec<_>>();
 
         Self(world, entities)

--- a/benches/benches/bevy_ecs/world/world_get.rs
+++ b/benches/benches/bevy_ecs/world/world_get.rs
@@ -31,7 +31,7 @@ fn deterministic_rand() -> ChaCha8Rng {
 
 fn setup<T: Component + Default>(entity_count: u32) -> World {
     let mut world = World::default();
-    world.spawn_batch((0..entity_count).map(|_| (T::default(),)));
+    world.spawn_batch((0..entity_count).map(|_| T::default()));
     black_box(world)
 }
 
@@ -308,7 +308,7 @@ pub fn query_get_component(criterion: &mut Criterion) {
         group.bench_function(format!("{}_entities_table", entity_count), |bencher| {
             let mut world = World::default();
             let mut entities: Vec<_> = world
-                .spawn_batch((0..entity_count).map(|_| (Table::default(),)))
+                .spawn_batch((0..entity_count).map(|_| Table::default()))
                 .collect();
             entities.shuffle(&mut deterministic_rand());
             let mut query = SystemState::<Query<&Table>>::new(&mut world);
@@ -330,7 +330,7 @@ pub fn query_get_component(criterion: &mut Criterion) {
         group.bench_function(format!("{}_entities_sparse", entity_count), |bencher| {
             let mut world = World::default();
             let mut entities: Vec<_> = world
-                .spawn_batch((0..entity_count).map(|_| (Sparse::default(),)))
+                .spawn_batch((0..entity_count).map(|_| Sparse::default()))
                 .collect();
             entities.shuffle(&mut deterministic_rand());
             let mut query = SystemState::<Query<&Sparse>>::new(&mut world);
@@ -363,7 +363,7 @@ pub fn query_get(criterion: &mut Criterion) {
         group.bench_function(format!("{}_entities_table", entity_count), |bencher| {
             let mut world = World::default();
             let mut entities: Vec<_> = world
-                .spawn_batch((0..entity_count).map(|_| (Table::default(),)))
+                .spawn_batch((0..entity_count).map(|_| Table::default()))
                 .collect();
             entities.shuffle(&mut deterministic_rand());
             let mut query = SystemState::<Query<&Table>>::new(&mut world);

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -97,8 +97,8 @@ mod tests {
 
         let mut world = World::new();
         world.spawn((A(1), B(1)));
-        world.spawn((A(2),));
-        world.spawn((A(3),));
+        world.spawn(A(2));
+        world.spawn(A(3));
 
         assert_all_sizes_equal::<&A, With<B>>(&mut world, 1);
         assert_all_sizes_equal::<&A, Without<B>>(&mut world, 2);
@@ -110,10 +110,10 @@ mod tests {
         world.spawn((A(4), C(4)));
         world.spawn((A(5), C(5)));
         world.spawn((A(6), C(6)));
-        world.spawn((A(7),));
-        world.spawn((A(8),));
-        world.spawn((A(9),));
-        world.spawn((A(10),));
+        world.spawn(A(7));
+        world.spawn(A(8));
+        world.spawn(A(9));
+        world.spawn(A(10));
 
         // With/Without for B and C
         assert_all_sizes_equal::<&A, With<B>>(&mut world, 3);
@@ -444,7 +444,7 @@ mod tests {
     fn query_iter_combinations_sparse() {
         let mut world = World::new();
 
-        world.spawn_batch((1..=4).map(|i| (Sparse(i),)));
+        world.spawn_batch((1..=4).map(|i| Sparse(i)));
 
         let mut query = world.query::<&mut Sparse>();
         let mut combinations = query.iter_combinations_mut(&mut world);

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -444,7 +444,7 @@ mod tests {
     fn query_iter_combinations_sparse() {
         let mut world = World::new();
 
-        world.spawn_batch((1..=4).map(|i| Sparse(i)));
+        world.spawn_batch((1..=4).map(Sparse));
 
         let mut query = world.query::<&mut Sparse>();
         let mut combinations = query.iter_combinations_mut(&mut world);

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -632,7 +632,7 @@ mod tests {
     fn push_and_insert_and_remove_children_commands() {
         let mut world = World::default();
         let entities = world
-            .spawn_batch(vec![(C(1),), (C(2),), (C(3),), (C(4),), (C(5),)])
+            .spawn_batch(vec![C(1), C(2), C(3), C(4), C(5)])
             .collect::<Vec<Entity>>();
 
         let mut queue = CommandQueue::default();
@@ -693,7 +693,7 @@ mod tests {
     fn push_and_insert_and_remove_children_world() {
         let mut world = World::default();
         let entities = world
-            .spawn_batch(vec![(C(1),), (C(2),), (C(3),), (C(4),), (C(5),)])
+            .spawn_batch(vec![C(1), C(2), C(3), C(4), C(5)])
             .collect::<Vec<Entity>>();
 
         world.entity_mut(entities[0]).push_children(&entities[1..3]);
@@ -737,7 +737,7 @@ mod tests {
     fn children_removed_when_empty_world() {
         let mut world = World::default();
         let entities = world
-            .spawn_batch(vec![(C(1),), (C(2),), (C(3),)])
+            .spawn_batch(vec![C(1), C(2), C(3)])
             .collect::<Vec<Entity>>();
 
         let parent1 = entities[0];
@@ -769,7 +769,7 @@ mod tests {
     fn children_removed_when_empty_commands() {
         let mut world = World::default();
         let entities = world
-            .spawn_batch(vec![(C(1),), (C(2),), (C(3),)])
+            .spawn_batch(vec![C(1), C(2), C(3)])
             .collect::<Vec<Entity>>();
 
         let parent1 = entities[0];

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -239,7 +239,7 @@ pub fn extract_skinned_meshes(
             SkinnedMeshJoints::build(skin, &inverse_bindposes, &joint_query, &mut joints)
         {
             last_start = last_start.max(skinned_joints.index as usize);
-            values.push((entity, (skinned_joints.to_buffer_index(),)));
+            values.push((entity, skinned_joints.to_buffer_index()));
         }
     }
 

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -187,7 +187,7 @@ fn extract_components<C: ExtractComponent>(
 ) {
     let mut values = Vec::with_capacity(*previous_len);
     for (entity, query_item) in &query {
-        values.push((entity, (C::extract_component(query_item),)));
+        values.push((entity, C::extract_component(query_item)));
     }
     *previous_len = values.len();
     commands.insert_or_spawn_batch(values);
@@ -202,7 +202,7 @@ fn extract_visible_components<C: ExtractComponent>(
     let mut values = Vec::with_capacity(*previous_len);
     for (entity, computed_visibility, query_item) in &query {
         if computed_visibility.is_visible() {
-            values.push((entity, (C::extract_component(query_item),)));
+            values.push((entity, C::extract_component(query_item)));
         }
     }
     *previous_len = values.len();

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -115,10 +115,10 @@ fn prepare_uniform_components<C: Component>(
         .map(|(entity, component)| {
             (
                 entity,
-                (DynamicUniformIndex::<C> {
+                DynamicUniformIndex::<C> {
                     index: component_uniforms.uniforms.push(component.clone()),
                     marker: PhantomData,
-                },),
+                },
             )
         })
         .collect::<Vec<_>>();

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -555,7 +555,7 @@ pub fn queue_sprites(
                     {
                         current_batch = new_batch;
                         current_image_size = Vec2::new(gpu_image.size.x, gpu_image.size.y);
-                        current_batch_entity = commands.spawn((current_batch,)).id();
+                        current_batch_entity = commands.spawn(current_batch).id();
 
                         image_bind_groups
                             .values

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -425,11 +425,11 @@ pub fn prepare_uinodes(
     for extracted_uinode in &extracted_uinodes.uinodes {
         if current_batch_handle != extracted_uinode.image {
             if start != end {
-                commands.spawn((UiBatch {
+                commands.spawn(UiBatch {
                     range: start..end,
                     image: current_batch_handle,
                     z: last_z,
-                },));
+                });
                 start = end;
             }
             current_batch_handle = extracted_uinode.image.clone_weak();

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -300,7 +300,7 @@ pub fn extract_colored_mesh2d(
         if !computed_visibility.is_visible() {
             continue;
         }
-        values.push((entity, (ColoredMesh2d,)));
+        values.push((entity, ColoredMesh2d));
     }
     *previous_len = values.len();
     commands.insert_or_spawn_batch(values);


### PR DESCRIPTION
# Objective

Bevy still has many instances of using single-tuples `(T,)` to create a bundle. Due to #2975, this is no longer necessary.

## Solution

Search for regex `\(.+\s*,\)`. This should have found every instance.
