### PR TITLE
[Merged by Bors] - Unique plugin

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1063,3 +1063,49 @@ fn run_once(mut app: App) {
 /// frame is over.
 #[derive(Debug, Clone, Default)]
 pub struct AppExit;
+
+#[cfg(test)]
+mod tests {
+    use crate::{App, Plugin};
+
+    struct PluginA;
+    impl Plugin for PluginA {
+        fn build(&self, _app: &mut crate::App) {}
+    }
+    struct PluginB;
+    impl Plugin for PluginB {
+        fn build(&self, _app: &mut crate::App) {}
+    }
+    struct PluginC<T>(T);
+    impl<T: Send + Sync + 'static> Plugin for PluginC<T> {
+        fn build(&self, _app: &mut crate::App) {}
+    }
+    struct PluginD;
+    impl Plugin for PluginD {
+        fn build(&self, _app: &mut crate::App) {}
+        fn is_unique(&self) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn can_add_two_plugins() {
+        App::new().add_plugin(PluginA).add_plugin(PluginB);
+    }
+
+    #[test]
+    #[should_panic]
+    fn cant_add_twice_the_same_plugin() {
+        App::new().add_plugin(PluginA).add_plugin(PluginA);
+    }
+
+    #[test]
+    fn can_add_twice_the_same_plugin_with_different_type_param() {
+        App::new().add_plugin(PluginC(0)).add_plugin(PluginC(true));
+    }
+
+    #[test]
+    fn can_add_twice_the_same_plugin_not_unique() {
+        App::new().add_plugin(PluginD).add_plugin(PluginD);
+    }
+}

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -859,7 +859,7 @@ impl App {
         {
             Err(AppError::DuplicatePlugin {
                 plugin_name: plugin.name().to_string(),
-            })?
+            })?;
         }
         plugin.build(self);
         self.plugin_registry.push(plugin);

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -833,6 +833,15 @@ impl App {
     /// Boxed variant of `add_plugin`, can be used from a [`PluginGroup`]
     pub(crate) fn add_boxed_plugin(&mut self, plugin: Box<dyn Plugin>) -> &mut Self {
         debug!("added plugin: {}", plugin.name());
+        if plugin.is_unique()
+            && self
+                .plugin_registry
+                .iter()
+                .map(|plugin| plugin.name())
+                .any(|name| name == plugin.name())
+        {
+            panic!("Can't add plugin {} twice.", plugin.name());
+        }
         plugin.build(self);
         self.plugin_registry.push(plugin);
         self

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -932,7 +932,7 @@ impl App {
     /// Panics if one of the plugin in the group was already added to the application.
     pub fn add_plugins<T: PluginGroup>(&mut self, group: T) -> &mut Self {
         let builder = group.build();
-        builder.finish::<T>(self);
+        builder.finish(self);
         self
     }
 

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -6,13 +6,21 @@ use std::any::Any;
 /// A collection of Bevy app logic and configuration.
 ///
 /// Plugins configure an [`App`]. When an [`App`] registers a plugin,
-/// the plugin's [`Plugin::build`] function is run.
+/// the plugin's [`Plugin::build`] function is run. By default, a plugin
+/// can only be added once to an [`App`]. If the plugin may need to be
+/// added twice or more, the function [`is_unique`](Plugin::is_unique)
+/// should be overriden to return `false`.
 pub trait Plugin: Downcast + Any + Send + Sync {
     /// Configures the [`App`] to which this plugin is added.
     fn build(&self, app: &mut App);
     /// Configures a name for the [`Plugin`] which is primarily used for debugging.
     fn name(&self) -> &str {
         std::any::type_name::<Self>()
+    }
+    /// If the plugin can be meaningfully instantiated several times in an [`App`](crate::App),
+    /// override this method to return `false`.
+    fn is_unique(&self) -> bool {
+        true
     }
 }
 

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -7,9 +7,12 @@ use std::any::Any;
 ///
 /// Plugins configure an [`App`]. When an [`App`] registers a plugin,
 /// the plugin's [`Plugin::build`] function is run. By default, a plugin
-/// can only be added once to an [`App`]. If the plugin may need to be
-/// added twice or more, the function [`is_unique`](Plugin::is_unique)
-/// should be overriden to return `false`.
+/// can only be added once to an [`App`].
+///
+/// If the plugin may need to be added twice or more, the function [`is_unique()`](Self::is_unique)
+/// should be overriden to return `false`. Plugins are considered duplicate if they have the same
+/// [`name()`](Self::name). The default `name()` implementation returns the type name, which means
+/// generic plugins with different type parameters will not be considered duplicates.
 pub trait Plugin: Downcast + Any + Send + Sync {
     /// Configures the [`App`] to which this plugin is added.
     fn build(&self, app: &mut App);

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -7,8 +7,8 @@ pub trait PluginGroup: Sized {
     /// Configures the [`Plugin`]s that are to be added.
     fn build(self) -> PluginGroupBuilder;
     /// Configures a name for the [`PluginGroup`] which is primarily used for debugging.
-    fn name() -> &'static str {
-        std::any::type_name::<Self>()
+    fn name() -> String {
+        std::any::type_name::<Self>().to_string()
     }
     /// Sets the value of the given [`Plugin`], if it exists
     fn set<T: Plugin>(self, plugin: T) -> PluginGroupBuilder {
@@ -41,7 +41,7 @@ impl PluginGroupBuilder {
     /// Start a new builder for the [`PluginGroup`].
     pub fn start<PG: PluginGroup>() -> Self {
         Self {
-            group_name: PG::name().to_string(),
+            group_name: PG::name(),
             plugins: Default::default(),
             order: Default::default(),
         }

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -26,7 +26,7 @@ pub struct DefaultPlugins;
 
 impl PluginGroup for DefaultPlugins {
     fn build(self) -> PluginGroupBuilder {
-        let mut group = PluginGroupBuilder::default();
+        let mut group = PluginGroupBuilder::start::<Self>();
         group = group
             .add(bevy_log::LogPlugin::default())
             .add(bevy_core::CorePlugin::default())
@@ -127,7 +127,7 @@ pub struct MinimalPlugins;
 
 impl PluginGroup for MinimalPlugins {
     fn build(self) -> PluginGroupBuilder {
-        PluginGroupBuilder::default()
+        PluginGroupBuilder::start::<Self>()
             .add(bevy_core::CorePlugin::default())
             .add(bevy_time::TimePlugin::default())
             .add(bevy_app::ScheduleRunnerPlugin::default())

--- a/examples/app/plugin_group.rs
+++ b/examples/app/plugin_group.rs
@@ -26,7 +26,7 @@ pub struct HelloWorldPlugins;
 
 impl PluginGroup for HelloWorldPlugins {
     fn build(self) -> PluginGroupBuilder {
-        PluginGroupBuilder::default()
+        PluginGroupBuilder::start::<Self>()
             .add(PrintHelloPlugin)
             .add(PrintWorldPlugin)
     }


### PR DESCRIPTION
# Objective

- Make it impossible to add a plugin twice
- This is going to be more a risk for plugins with configurations, to avoid things like `App::new().add_plugins(DefaultPlugins).add_plugin(ImagePlugin::default_nearest())`

## Solution

- Panic when a plugin is added twice
- It's still possible to mark a plugin as not unique by overriding `is_unique`
- ~~Simpler version of~~ #3988 (not simpler anymore because of how `PluginGroupBuilder` implements `PluginGroup`)
