### PR TITLE
Add AssetServer.get_typed_weak, AssetServer.get_typed

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -31,8 +31,8 @@ pub enum AssetServerError {
     },
 
     /// The handle type does not match the type of the loaded asset.
-    #[error("the given type does not match the type of the loaded asset")]
-    IncorrectHandleType,
+    #[error("the given type does not match the type of the loaded asset: {0}")]
+    IncorrectHandleType(Uuid),
 
     /// Encountered an error while processing an asset.
     #[error("encountered an error while loading an asset: {0}")]
@@ -302,6 +302,16 @@ impl AssetServer {
     #[must_use = "not using the returned strong handle may result in the unexpected release of the asset"]
     pub fn load<'a, T: Asset, P: Into<AssetPath<'a>>>(&self, path: P) -> Handle<T> {
         self.load_untyped(path).typed()
+    }
+
+    /// Similar to [`AssetServer::load`] but this version will not panic. Instead, it will
+    /// emit an [`AssetServerError::IncorrectHandleType`] if there's a type mismatch.
+    #[must_use = "not using the returned strong handle may result in the unexpected release of the asset"]
+    pub fn try_load<'a, T: Asset, P: Into<AssetPath<'a>>>(
+        &self,
+        path: P,
+    ) -> Result<Handle<T>, AssetServerError> {
+        self.load_untyped(path).get_typed()
     }
 
     async fn load_async(


### PR DESCRIPTION
# Objective

Loading assets via `AssetServer.load_folder` returns a list of `HandleUntyped`'s. To actually get at the data in these handles, you have to call `HandleUntyped.typed`. Unfortunately, this function panics if there is a type mismatch. This is problematic if you are loading multiple types of assets from within the same folder and want to check whether a handle refers to a specific type of asset without panicking.

## Solution

The solution is to add two new methods that don't panic:

```rust
pub fn get_typed_weak<T: Asset>(&self) -> Result<Handle<T>, AssetServerError>
pub fn get_typed<T: Asset>(mut self) -> Result<Handle<T>, AssetServerError>
```

Additionally, the following method has been added to `AssetServer`:

```rust
pub fn try_load<'a, T: Asset, P: Into<AssetPath<'a>>>(&self, path: P) -> Result<Handle<T>, AssetServerError>
```

## Migration Guide

No migration necessary.
