### PR TITLE
[Merged by Bors] - bevy_scene: Serialize entities to map

### DIFF
--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -1,7 +1,6 @@
 (
-  entities: [
-    (
-      entity: 0,
+  entities: {
+    0: (
       components: {
         "bevy_transform::components::transform::Transform": (
           translation: (
@@ -25,8 +24,7 @@
         ),
       },
     ),
-    (
-      entity: 1,
+    1: (
       components: {
         "scene::ComponentA": (
           x: 3.0,
@@ -34,5 +32,5 @@
         ),
       },
     ),
-  ]
+  }
 )


### PR DESCRIPTION
# Objective

Entities are unique, however, this is not reflected in the scene format. Currently, entities are stored in a list where a user could inadvertently create a duplicate of the same entity. 

## Solution

Switch from the list representation to a map representation for entities.

---

## Changelog

* The `entities` field in the scene format is now a map of entity ID to entity data

## Migration Guide

The scene format now stores its collection of entities in a map rather than a list:

```rust
// OLD
(
  entities: [
    (
      entity: 12,
      components: {
        "bevy_transform::components::transform::Transform": (
          translation: (
            x: 0.0,
            y: 0.0,
            z: 0.0
          ),
          rotation: (0.0, 0.0, 0.0, 1.0),
          scale: (
            x: 1.0,
            y: 1.0,
            z: 1.0
          ),
        ),
      },
    ),
  ],
)

// NEW
(
  entities: {
    12: (
      components: {
        "bevy_transform::components::transform::Transform": (
          translation: (
            x: 0.0,
            y: 0.0,
            z: 0.0
          ),
          rotation: (0.0, 0.0, 0.0, 1.0),
          scale: (
            x: 1.0,
            y: 1.0,
            z: 1.0
          ),
        ),
      },
    ),
  },
)
```