### PR TITLE
[Merged by Bors] - Fix return_after_run example

### DIFF
--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -54,7 +54,7 @@ pub struct WindowPlugin {
     /// create 'headless' processes (processes without windows), which may
     /// surprise your users. It is recommended to leave this setting as `true`.
     ///
-    /// If true, this plugin will add [`exit_on_all_closed`] to [`CoreStage::Update`].
+    /// If true, this plugin will add [`exit_on_all_closed`] to [`CoreStage::PostUpdate`].
     pub exit_on_all_closed: bool,
     /// Whether to close windows when they are requested to be closed (i.e.
     /// when the close button is pressed).

--- a/examples/app/return_after_run.rs
+++ b/examples/app/return_after_run.rs
@@ -11,12 +11,12 @@ fn main() {
         })
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             window: WindowDescriptor {
-                title: "Close window to return to main function".to_owned(),
+                title: "Close the window to return to the main function".to_owned(),
                 ..default()
             },
             ..default()
         }))
-        .add_system(system1)
+        .add_system(system)
         .run();
     println!("Bevy App has exited. We are back in our main function.");
 }

--- a/examples/app/return_after_run.rs
+++ b/examples/app/return_after_run.rs
@@ -21,6 +21,6 @@ fn main() {
     println!("Bevy App has exited. We are back in our main function.");
 }
 
-fn system1() {
+fn system() {
     info!("Logging from Bevy App");
 }

--- a/examples/app/return_after_run.rs
+++ b/examples/app/return_after_run.rs
@@ -3,33 +3,24 @@
 use bevy::{prelude::*, winit::WinitSettings};
 
 fn main() {
-    println!("Running first App.");
+    println!("Running Bevy App");
     App::new()
         .insert_resource(WinitSettings {
             return_from_run: true,
             ..default()
         })
-        .insert_resource(ClearColor(Color::rgb(0.2, 0.2, 0.8)))
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            window: WindowDescriptor {
+                title: "Close window to return to main function".to_owned(),
+                ..default()
+            },
+            ..default()
+        }))
         .add_system(system1)
         .run();
-    println!("Running another App.");
-    App::new()
-        .insert_resource(WinitSettings {
-            return_from_run: true,
-            ..default()
-        })
-        .insert_resource(ClearColor(Color::rgb(0.2, 0.8, 0.2)))
-        .add_plugins(DefaultPlugins.build().disable::<bevy::log::LogPlugin>())
-        .add_system(system2)
-        .run();
-    println!("Done.");
+    println!("Bevy App has exited. We are back in our main function.");
 }
 
 fn system1() {
-    info!("logging from first app");
-}
-
-fn system2() {
-    info!("logging from second app");
+    info!("Logging from Bevy App");
 }


### PR DESCRIPTION
# Objective

- Fixes  #6311
- Make it clearer what should be done in the example (close the Bevy app window)

## Solution

- Remove the second windowed Bevy App [since winit does not support this](https://github.com/rust-windowing/winit/blob/v0.27.4/src/event_loop.rs#L82-L83)
- Add title to the Bevy window asking the user to close it

This is more of a quick fix to have a working example. It would be nicer if we had a small real usecase for this functionality.
Another alternativ that I tried out: If we want to showcase a second Bevy app as it was before, we could still do this as long as one of them does not have a window. But I don't see how this is helpful in the context of the example, so I stuck with only one Bevy app and a simple print afterwards.