### PR TITLE
Add `FromReflect::from_reflect_owned`

### DIFF
--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -149,6 +149,18 @@ where
             None
         }
     }
+
+    fn from_reflect_owned(reflect: Box<dyn Reflect>) -> Option<Self> {
+        if let ReflectOwned::List(owned_list) = reflect.reflect_owned() {
+            owned_list
+                .drain()
+                .into_iter()
+                .map(|reflect| <T as smallvec::Array>::Item::from_reflect_owned(reflect))
+                .collect()
+        } else {
+            None
+        }
+    }
 }
 
 impl<T: smallvec::Array + Send + Sync + 'static> GetTypeRegistration for SmallVec<T>

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -203,6 +203,7 @@ pub trait Reflect: Any + Send + Sync {
 pub trait FromReflect: Reflect + Sized {
     /// Constructs a concrete instance of `Self` from a reflected value.
     fn from_reflect(reflect: &dyn Reflect) -> Option<Self>;
+    fn from_reflect_owned(reflect: Box<dyn Reflect>) -> Option<Self>;
 }
 
 impl Debug for dyn Reflect {

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -583,6 +583,23 @@ macro_rules! impl_reflect_tuple {
                     None
                 }
             }
+
+            fn from_reflect_owned(reflect: Box<dyn Reflect>) -> Option<Self> {
+                if let ReflectOwned::Tuple(owned_tuple) = reflect.reflect_owned() {
+                    let mut fields = owned_tuple.drain();
+                    fields.reverse();
+                    let _len = fields.len();
+                    Some(
+                        (
+                            $(
+                                <$name as FromReflect>::from_reflect_owned(fields.swap_remove(_len - $index))?,
+                            )*
+                        )
+                    )
+                } else {
+                    None
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# Objective

Currently to apply a reflect value that was deserialized from bytes it copies all its fields. It would be nice to have an ability avoid this extra copy. For example, when doing networking and sending world state in a form of reflect - it could be a lot of extra copies.

Currently incomplete, but compiles. I just don't know how to deal with structs. See `todo!()` .

## Solution

Implement #6419.

---

## Changelog

### Added

* `FromReflect::from_reflect_owned` to create a value from `Box<dyn Reflect>` by consuming it.
