### PR TITLE
[Merged by Bors] - Add FromReflect for Timer

### DIFF
--- a/crates/bevy_time/src/stopwatch.rs
+++ b/crates/bevy_time/src/stopwatch.rs
@@ -23,7 +23,7 @@ use bevy_utils::Duration;
 /// assert!(stopwatch.paused());
 /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
 /// ```
-#[derive(Clone, Debug, Default, Reflect)]
+#[derive(Clone, Debug, Default, Reflect, FromReflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 #[reflect(Default)]
 pub struct Stopwatch {

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -9,7 +9,7 @@ use bevy_utils::Duration;
 /// exceeded, and can still be reset at any given point.
 ///
 /// Paused timers will not have elapsed time increased.
-#[derive(Clone, Debug, Default, Reflect)]
+#[derive(Clone, Debug, Default, Reflect, FromReflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 #[reflect(Default)]
 pub struct Timer {
@@ -403,7 +403,7 @@ impl Timer {
 }
 
 /// Specifies [`Timer`] behavior.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Default, Reflect)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Default, Reflect, FromReflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 #[reflect(Default)]
 pub enum TimerMode {


### PR DESCRIPTION
# Objective

- Time have `Reflect`, but doesn't have `FromReflect`.

## Solution

- Add it for `Timer`, `Stopwatch` and `TimerMode`.

---

## Changelog

### Added

* `FromReflect` derive for `Timer`, `Stopwatch` and `TimerMode`.