### PR TITLE
[Merged by Bors] - Add `serialize` feature to `bevy_core`

### DIFF
--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -20,6 +20,10 @@ bevy_utils = { path = "../bevy_utils", version = "0.9.0-dev" }
 
 # other
 bytemuck = "1.5"
+serde = { version = "1.0", optional = true }
+
+[features]
+serialize = ["dep:serde"]
 
 [dev-dependencies]
 crossbeam-channel = "0.5.0"

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -2,6 +2,8 @@
 //! This crate provides core functionality for Bevy Engine.
 
 mod name;
+#[cfg(feature = "serialize")]
+mod serde;
 mod task_pool_options;
 
 use bevy_ecs::system::Resource;

--- a/crates/bevy_core/src/serde.rs
+++ b/crates/bevy_core/src/serde.rs
@@ -1,0 +1,41 @@
+use std::{
+    any,
+    fmt::{self, Formatter},
+};
+
+use serde::{
+    de::{Error, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+use super::name::Name;
+
+impl Serialize for Name {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Name {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_str(EntityVisitor)
+    }
+}
+
+struct EntityVisitor;
+
+impl<'de> Visitor<'de> for EntityVisitor {
+    type Value = Name;
+
+    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+        formatter.write_str(any::type_name::<Name>())
+    }
+
+    fn visit_str<E: Error>(self, v: &str) -> Result<Self::Value, E> {
+        Ok(Name::new(v.to_string()))
+    }
+
+    fn visit_string<E: Error>(self, v: String) -> Result<Self::Value, E> {
+        Ok(Name::new(v))
+    }
+}

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -45,7 +45,7 @@ wav = ["bevy_audio/wav"]
 # Enable watching file system for asset hot reload
 filesystem_watcher = ["bevy_asset/filesystem_watcher"]
 
-serialize = ["bevy_input/serialize", "bevy_time/serialize", "bevy_window/serialize", "bevy_transform/serialize", "bevy_math/serialize"]
+serialize = ["bevy_core/serialize", "bevy_input/serialize", "bevy_time/serialize", "bevy_window/serialize", "bevy_transform/serialize", "bevy_math/serialize"]
 
 # Display server protocol support (X11 is enabled by default)
 wayland = ["bevy_winit/wayland"]


### PR DESCRIPTION
# Objective

`bevy_core` is missing a feature corresponding to the `serialize` feature on the `bevy` crate. Similar to #6378 and https://github.com/bevyengine/bevy/pull/6379 to serialize `Name` easily.

## Solution

Add this feature and hand-written serialization for `Name` (to avoid storing `hash` field).

---

## Changelog

### Added

* `Serialize` and `Deserialize` derives for `Name` under `serialize` feature.