### PR TITLE
can spawn empty bundle from world

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -449,6 +449,9 @@ impl World {
     /// assert_eq!(position.x, 2.0);
     /// ```
     pub fn spawn<B: Bundle>(&mut self, bundle: B) -> EntityMut {
+        if std::any::TypeId::of::<B>() == std::any::TypeId::of::<()>() {
+            return self.spawn_empty();
+        }
         self.flush();
         let entity = self.entities.alloc();
         let entity_location = {


### PR DESCRIPTION
# Objective

- Fix `world.spawn(())`
- Fix #6226 

## Solution

- If the bundle being inserted is `()`, use `world.spawn_empty()` instead
- Maybe not the best fix, but it works and it's easy 😄 
