### PR TITLE
[Merged by Bors] - Fix spawning empty bundles

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -48,7 +48,7 @@ pub struct AddBundle {
 
 /// This trait is used to report the status of [`Bundle`](crate::bundle::Bundle) components
 /// being added to a given entity, relative to that entity's original archetype.
-/// See [`crate::bundle::Bundle::write_components`] for more info.
+/// See [`crate::bundle::BundleInfo::write_components`] for more info.
 pub(crate) trait BundleComponentStatus {
     /// Returns the Bundle's component status for the given "bundle index"
     ///

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -48,6 +48,7 @@ pub struct AddBundle {
 
 /// This trait is used to report the status of [`Bundle`](crate::bundle::Bundle) components
 /// being added to a given entity, relative to that entity's original archetype.
+/// See [`crate::bundle::Bundle::write_components`] for more info.
 pub(crate) trait BundleComponentStatus {
     /// Returns the Bundle's component status for the given "bundle index"
     ///

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -46,6 +46,8 @@ pub struct AddBundle {
     pub(crate) bundle_status: Vec<ComponentStatus>,
 }
 
+/// This trait is used to report the status of [`Bundle`](crate::bundle::Bundle) components
+/// being added to a given entity, relative to that entity's original archetype.
 pub(crate) trait BundleComponentStatus {
     /// Returns the Bundle's component status for the given "bundle index"
     ///
@@ -68,6 +70,7 @@ pub(crate) struct SpawnBundleStatus;
 impl BundleComponentStatus for SpawnBundleStatus {
     #[inline]
     unsafe fn get_status(&self, _index: usize) -> ComponentStatus {
+        // Components added during a spawn_bundle call are always treated as added
         ComponentStatus::Added
     }
 }

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -35,6 +35,7 @@ impl ArchetypeId {
     }
 }
 
+#[derive(Copy, Clone)]
 pub(crate) enum ComponentStatus {
     Added,
     Mutated,
@@ -43,6 +44,32 @@ pub(crate) enum ComponentStatus {
 pub struct AddBundle {
     pub archetype_id: ArchetypeId,
     pub(crate) bundle_status: Vec<ComponentStatus>,
+}
+
+pub(crate) trait BundleComponentStatus {
+    /// Returns the Bundle's component status for the given "bundle index"
+    ///
+    /// # Safety
+    /// Callers must ensure that index is always a valid bundle index for the
+    /// Bundle associated with this [`BundleComponentStatus`]
+    unsafe fn get_status(&self, index: usize) -> ComponentStatus;
+}
+
+impl BundleComponentStatus for AddBundle {
+    #[inline]
+    unsafe fn get_status(&self, index: usize) -> ComponentStatus {
+        // SAFETY: caller has ensured index is a valid bundle index for this bundle
+        *self.bundle_status.get_unchecked(index)
+    }
+}
+
+pub(crate) struct SpawnBundleStatus;
+
+impl BundleComponentStatus for SpawnBundleStatus {
+    #[inline]
+    unsafe fn get_status(&self, _index: usize) -> ComponentStatus {
+        ComponentStatus::Added
+    }
 }
 
 /// Archetypes and bundles form a graph. Adding or removing a bundle moves

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -355,7 +355,20 @@ impl BundleInfo {
         }
     }
 
+    /// This writes components from a given [`Bundle`] to the given entity.
+    ///
     /// # Safety
+    ///
+    /// `bundle_component_status` must return the "correct" [`ComponentStatus`] for each component
+    /// in the [`Bundle`], with respect to the entity's original archetype (prior to the bundle being added)
+    /// For example, if the original archetype already has `ComponentA` and `T` also has `ComponentA`, the status
+    /// should be `Mutated`. If the original archetype does not have `ComponentA`, the status should be `Added`.
+    /// When "inserting" a bundle into an existing entity, [`AddBundle`](crate::archetype::AddBundle)
+    /// should be used, which will report `Added` vs `Mutated` status based on the current archetype's structure.
+    /// When spawning a bundle, [`SpawnBundleStatus`] can be used instead, which removes the need
+    /// to look up the [`AddBundle`](crate::archetype::AddBundle) in the archetype graph, which requires
+    /// ownership of the entity's current archetype.
+    ///
     /// `table` must be the "new" table for `entity`. `table_row` must have space allocated for the
     /// `entity`, `bundle` must match this [`BundleInfo`]'s type
     #[inline]

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1594,6 +1594,7 @@ mod tests {
     use crate::{
         change_detection::DetectChanges,
         component::{ComponentDescriptor, ComponentInfo, StorageType},
+        prelude::Bundle,
         ptr::OwningPtr,
         system::Resource,
     };
@@ -1939,5 +1940,13 @@ mod tests {
         iterate_and_count_entities(&world, &mut entity_counters);
 
         assert_eq!(entity_counters.len(), 0);
+    }
+
+    #[test]
+    fn blah() {
+        #[derive(Bundle)]
+        struct EmptyBundle {}
+        let mut world = World::new();
+        world.spawn(EmptyBundle {});
     }
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1943,10 +1943,8 @@ mod tests {
     }
 
     #[test]
-    fn blah() {
-        #[derive(Bundle)]
-        struct EmptyBundle {}
+    fn spawn_empty_bundle() {
         let mut world = World::new();
-        world.spawn(EmptyBundle {});
+        world.spawn(());
     }
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1594,7 +1594,6 @@ mod tests {
     use crate::{
         change_detection::DetectChanges,
         component::{ComponentDescriptor, ComponentInfo, StorageType},
-        prelude::Bundle,
         ptr::OwningPtr,
         system::Resource,
     };


### PR DESCRIPTION
# Objective

Alternative to #6424 
Fixes #6226

Fixes spawning empty bundles

## Solution

Add `BundleComponentStatus` trait and implement it for `AddBundle` and a new `SpawnBundleStatus` type (which always returns an Added status). `write_components` is now generic on `BundleComponentStatus` instead of taking `AddBundle` directly. This means BundleSpawner can now avoid needing AddBundle from the Empty archetype, which means BundleSpawner no longer needs a reference to the original archetype.

In theory this cuts down on the work done in `write_components` when spawning, but I'm seeing no change in the spawn benchmarks.
