### PR TITLE
add `MutUntyped::map_unchanged`

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -694,7 +694,7 @@ impl<'a> MutUntyped<'a> {
     /// Turn this [`MutUntyped`] into a [`Mut`] by mapping the inner [`PtrMut`] to another value,
     /// without flagging a change. [`MutUntyped`] equivalent of [`Mut::map_unchanged`].
     ///
-    /// You should never modify the argument passed to the closure – if you want to modify the data without flagging a change, consider using [`DetectChanges::bypass_change_detection`](crate::change_detection::DetectChangesMut::bypass to make your intent explicit.
+    /// You should never modify the argument passed to the closure – if you want to modify the data without flagging a change, consider using [`bypass_change_detection`](DetectChangesMut::bypass_change_detection) to make your intent explicit.
     ///
     /// If you know the type of the value you can do
     /// ```no_run

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -697,7 +697,7 @@ impl<'a> MutUntyped<'a> {
     /// # use bevy_ecs::change_detection::{Mut, MutUntyped};
     /// # let mut_untyped: MutUntyped = unimplemented!();
     /// // SAFETY: ptr is of type `u8`
-    /// mut_untyped.to_typed(|ptr| unsafe { ptr.deref_mut::<u8>() });
+    /// mut_untyped.map_unchanged(|ptr| unsafe { ptr.deref_mut::<u8>() });
     /// ```
     /// If you have a [`ReflectFromPtr`](bevy_reflect::ReflectFromPtr) that you know belongs to this [`MutUntyped`],
     /// you can do
@@ -706,9 +706,9 @@ impl<'a> MutUntyped<'a> {
     /// # let mut_untyped: MutUntyped = unimplemented!();
     /// # let reflect_from_ptr: bevy_reflect::ReflectFromPtr = unimplemented!();
     /// // SAFETY: from the context it is known that `ReflectFromPtr` was made for the type of the `MutUntyped`
-    /// mut_untyped.to_typed(|ptr| unsafe { reflect_from_ptr.as_reflect_ptr_mut(ptr) });
+    /// mut_untyped.map_unchanged(|ptr| unsafe { reflect_from_ptr.as_reflect_ptr_mut(ptr) });
     /// ```
-    pub fn to_typed<T: ?Sized>(self, f: impl FnOnce(PtrMut<'a>) -> &'a mut T) -> Mut<'a, T> {
+    pub fn map_unchanged<T: ?Sized>(self, f: impl FnOnce(PtrMut<'a>) -> &'a mut T) -> Mut<'a, T> {
         Mut {
             value: f(self.value),
             ticks: self.ticks,
@@ -1047,7 +1047,7 @@ mod tests {
 
         let reflect_from_ptr = <ReflectFromPtr as FromType<i32>>::from_type();
 
-        let mut new = value.to_typed(|ptr| {
+        let mut new = value.map_unchanged(|ptr| {
             // SAFETY: ptr has type of ReflectFromPtr
             let value = unsafe { reflect_from_ptr.as_reflect_ptr_mut(ptr) };
             value

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1031,7 +1031,7 @@ mod tests {
             added: Tick::new(1),
             changed: Tick::new(2),
         };
-        let ticks = Ticks {
+        let ticks = TicksMut {
             added: &mut component_ticks.added,
             changed: &mut component_ticks.changed,
             last_change_tick,

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -691,7 +691,11 @@ impl<'a> MutUntyped<'a> {
         self.value.as_ref()
     }
 
-    /// Turn this [`MutUntyped`] into a [`Mut`] by mapping the inner [`PtrMut`] to another value.
+    /// Turn this [`MutUntyped`] into a [`Mut`] by mapping the inner [`PtrMut`] to another value,
+    /// without flagging a change. [`MutUntyped`] equivalent of [`Mut::map_unchanged`].
+    ///
+    /// You should never modify the argument passed to the closure – if you want to modify the data without flagging a change, consider using [`DetectChanges::bypass_change_detection`](crate::change_detection::DetectChangesMut::bypass to make your intent explicit.
+    ///
     /// If you know the type of the value you can do
     /// ```no_run
     /// # use bevy_ecs::change_detection::{Mut, MutUntyped};

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -781,8 +781,6 @@ impl std::fmt::Debug for MutUntyped<'_> {
 
 #[cfg(test)]
 mod tests {
-    use std::ptr::NonNull;
-
     use bevy_ecs_macros::Resource;
     use bevy_ptr::PtrMut;
     use bevy_reflect::{FromType, ReflectFromPtr};

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -719,7 +719,6 @@ impl<'a> MutUntyped<'a> {
         }
     }
 
-
     /// Transforms this [`MutUntyped`] into a [`Mut<T>`] with the same lifetime.
     ///
     /// # Safety
@@ -799,11 +798,8 @@ mod tests {
     };
 
     use super::DetectChanges;
-<<<<<<< HEAD
     use super::DetectChangesMut;
-=======
     use super::MutUntyped;
->>>>>>> 181b463bf (add MutUntyped::to_typed)
 
     #[derive(Component, PartialEq)]
     struct C;

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -797,9 +797,7 @@ mod tests {
         world::World,
     };
 
-    use super::DetectChanges;
-    use super::DetectChangesMut;
-    use super::MutUntyped;
+    use super::{DetectChanges, DetectChangesMut, MutUntyped};
 
     #[derive(Component, PartialEq)]
     struct C;

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1038,8 +1038,7 @@ mod tests {
 
         let mut value: i32 = 5;
         let value = MutUntyped {
-            // SAFETY: lifetime does not exceed `value`
-            value: unsafe { PtrMut::new(NonNull::new(&mut value as *mut i32 as *mut u8).unwrap()) },
+            value: PtrMut::from(&mut value),
             ticks,
         };
 


### PR DESCRIPTION
# Objective

`MutUntyped` is the untyped variant of `Mut<T>` that stores a `PtrMut` instead of a `&mut T`.
Working with a `MutUntyped` is a bit annoying, because as soon you want to use the ptr e.g. as a `&mut dyn Reflect` you cannot use a type like `Mut<dyn Reflect>` but instead need to carry around a `&mut dyn Reflect` and a `impl FnMut()` to mark the value as changed.

## Solution

- Provide a method `map_unchanged` to turn a `MutUntyped` into a `Mut<T>` by mapping the `PtrMut<'a>` to a `&'a mut T`
This can be used like this:
```rust
// SAFETY: ptr is of type `u8`
let val: Mut<u8> = mut_untyped.map_unchanged(|ptr| unsafe { ptr.deref_mut::<u8>() });

// SAFETY: from the context it is known that `ReflectFromPtr` was made for the type of the `MutUntyped`
let val: Mut<dyn Reflect> = mut_untyped.map_unchanged(|ptr| unsafe { reflect_from_ptr.as_reflect_ptr_mut(ptr) });
```

Note that nothing prevents you from doing
```rust
mut_untyped.map_unchanged(|ptr| &mut ());
```
or using any other mutable reference you can get, but IMO that is fine since that will only result in a `Mut` that will dereference to that value and mark the original value as changed. The lifetimes here prevent anything bad from happening.


## Alternatives

1. Make `Ticks` public and provide a method to get construct a `Mut` from `Ticks` and `&mut T`. More powerful and more easy to misuse.
2. Do nothing. People can still do everything they want, but they need to pass (`&mut dyn Reflect, impl FnMut() + '_)` around instead of `Mut<dyn Reflect>`

## Changelog

- add `MutUntyped::map_unchanged` to turn a `MutUntyped` into its typed counterpart
