### PR TITLE
Fix: incorrect usage of `commands.spawn` in example `2d/move_sprite.rs`

### DIFF
--- a/examples/2d/move_sprite.rs
+++ b/examples/2d/move_sprite.rs
@@ -17,15 +17,13 @@ enum Direction {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
-    commands.spawn((
-        SpriteBundle {
-            texture: asset_server.load("branding/icon.png"),
-            transform: Transform::from_xyz(100., 0., 0.),
-            ..default()
-        },
-        Direction::Up,
-    ));
+    commands.spawn_bundle(Camera2dBundle::default());
+    commands.spawn_bundle(SpriteBundle {
+        texture: asset_server.load("branding/icon.png"),
+        transform: Transform::from_xyz(100., 0., 0.),
+        ..default()
+    })
+    .insert(Direction::Up);
 }
 
 /// The sprite is animated by changing its translation depending on the time that has passed since


### PR DESCRIPTION
# Objective

- Describe the objective or issue this PR addresses.
I've edited the code and removed the incorrect usage of `Commands.spawn` used in the example. 

## Solution

- Describe the solution used to achieve the objective above.
I've replaced the incorrect usage with `.spawn_bundle` and after that calling `.insert` to insert the `Direction` component.