### PR TITLE
[Merged by Bors] - Make `AudioOutput` a Resource

### DIFF
--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -1,6 +1,6 @@
 use crate::{Audio, AudioSource, Decodable};
 use bevy_asset::{Asset, Assets};
-use bevy_ecs::system::{NonSend, Res, ResMut, Resource};
+use bevy_ecs::system::{Res, ResMut, Resource};
 use bevy_reflect::TypeUuid;
 use bevy_utils::tracing::warn;
 use rodio::{OutputStream, OutputStreamHandle, Sink, Source};
@@ -85,7 +85,7 @@ where
 
 /// Plays audio currently queued in the [`Audio`] resource through the [`AudioOutput`] resource
 pub fn play_queued_audio_system<Source: Asset + Decodable>(
-    audio_output: NonSend<AudioOutput<Source>>,
+    audio_output: Res<AudioOutput<Source>>,
     audio_sources: Option<Res<Assets<Source>>>,
     mut audio: ResMut<Audio<Source>>,
     mut sinks: ResMut<Assets<AudioSink>>,

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -22,9 +22,8 @@ where
 {
     fn default() -> Self {
         if let Ok((stream, stream_handle)) = OutputStream::try_default() {
-            // We don't let `OutputStream` be dropped automatically
-            // as it will stop the audio from playing.
-            let _ = std::mem::ManuallyDrop::new(stream);
+            // We leak `OutputStream` to prevent the audio from stopping.
+            std::mem::forget(stream);
             Self {
                 stream_handle: Some(stream_handle),
                 phantom: PhantomData,

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -7,6 +7,17 @@ use rodio::{OutputStream, OutputStreamHandle, Sink, Source};
 use std::marker::PhantomData;
 
 /// Used internally to play audio on the current "audio device"
+///
+/// ## Note
+///
+/// Initializing this resource will leak [`rodio::OutputStream`](rodio::OutputStream)
+/// using [`std::mem::forget`].
+/// This is done to avoid storing this in the struct (and making this `!Send`)
+/// while preventing it from dropping (to avoid halting of audio).
+///
+/// This is fine when initializing this once (as is default when adding this plugin),
+/// since the memory cost will be the same.
+/// However, repeatedly inserting this resource into the app will **leak more memory**.
 #[derive(Resource)]
 pub struct AudioOutput<Source = AudioSource>
 where

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -50,7 +50,7 @@ pub struct AudioPlugin;
 
 impl Plugin for AudioPlugin {
     fn build(&self, app: &mut App) {
-        app.init_non_send_resource::<AudioOutput<AudioSource>>()
+        app.init_resource::<AudioOutput<AudioSource>>()
             .add_asset::<AudioSource>()
             .add_asset::<AudioSink>()
             .init_resource::<Audio<AudioSource>>()


### PR DESCRIPTION
# Objective

- Make `AudioOutput` a `Resource`.

## Solution

- Do not store `OutputStream` in the struct.
- `mem::forget` `OutputStream`.

---

## Changelog

### Added

- `AudioOutput` is now a `Resource`.

## Migration Guide

- Use `Res<AudioOutput<Source>>` instead of `NonSend<AudioOutput<Source>>`. Same for `Mut` variants.