### PR TITLE
[Merged by Bors] - Fix `mesh.wgsl` error for meshes without normals

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.wgsl
+++ b/crates/bevy_pbr/src/render/mesh.wgsl
@@ -35,12 +35,16 @@ struct VertexOutput {
 fn vertex(vertex: Vertex) -> VertexOutput {
     var out: VertexOutput;
 
-#ifdef VERTEX_NORMALS
 #ifdef SKINNED
     var model = skin_model(vertex.joint_indices, vertex.joint_weights);
-    out.world_normal = skin_normals(model, vertex.normal);
 #else
     var model = mesh.model;
+#endif
+
+#ifdef VERTEX_NORMALS
+#ifdef SKINNED
+    out.world_normal = skin_normals(model, vertex.normal);
+#else
     out.world_normal = mesh_normal_local_to_world(vertex.normal);
 #endif
 #endif

--- a/examples/3d/lines.rs
+++ b/examples/3d/lines.rs
@@ -95,12 +95,9 @@ pub struct LineList {
 impl From<LineList> for Mesh {
     fn from(line: LineList) -> Self {
         let mut vertices = vec![];
-        let mut normals = vec![];
         for (start, end) in line.lines {
             vertices.push(start.to_array());
             vertices.push(end.to_array());
-            normals.push(Vec3::ZERO.to_array());
-            normals.push(Vec3::ZERO.to_array());
         }
 
         // This tells wgpu that the positions are list of lines
@@ -108,8 +105,6 @@ impl From<LineList> for Mesh {
         let mut mesh = Mesh::new(PrimitiveTopology::LineList);
 
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
-        // Normals are currently required by bevy, but they aren't used by the [`LineMaterial`]
-        mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh
     }
 }
@@ -123,10 +118,8 @@ pub struct LineStrip {
 impl From<LineStrip> for Mesh {
     fn from(line: LineStrip) -> Self {
         let mut vertices = vec![];
-        let mut normals = vec![];
         for pos in line.points {
             vertices.push(pos.to_array());
-            normals.push(Vec3::ZERO.to_array());
         }
 
         // This tells wgpu that the positions are a list of points
@@ -134,8 +127,6 @@ impl From<LineStrip> for Mesh {
         let mut mesh = Mesh::new(PrimitiveTopology::LineStrip);
 
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
-        // Normals are currently required by bevy, but they aren't used by the [`LineMaterial`]
-        mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh
     }
 }

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -71,9 +71,6 @@ fn setup(
     );
     // Set mesh vertex normals
     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, vec![[0.0, 0.0, 1.0]; 10]);
-    // Set mesh vertex UVs. Although the mesh doesn't have any texture applied,
-    //  UVs are still required by the render pipeline. So these UVs are zeroed out.
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, vec![[0.0, 0.0]; 10]);
     // Set mesh vertex joint indices for mesh skinning.
     // Each vertex gets 4 indices used to address the `JointTransforms` array in the vertex shader
     //  as well as `SkinnedMeshJoint` array in the `SkinnedMesh` component.


### PR DESCRIPTION
# Objective
Split `model` assignment out of `#ifdef VERTEX_NORMALS`.
Remove outdated code/comments talking about required mesh attributes. 