### PR TITLE
[Merged by Bors] - Add `is_finished` to `Task<T>`

### DIFF
--- a/crates/bevy_tasks/src/task.rs
+++ b/crates/bevy_tasks/src/task.rs
@@ -44,7 +44,9 @@ impl<T> Task<T> {
 
     /// Returns `true` if the current task is finished.
     ///
-    /// Note that in a multithreaded environment, this task can change finish immediately after calling this function.
+    ///
+    /// Unlike poll, it doesn't resolve the final value, it just checks if the task has finished.
+    /// Note that in a multithreaded environment, this task can be finished immediately after calling this function.
     pub fn is_finished(&self) -> bool {
         self.0.is_finished()
     }

--- a/crates/bevy_tasks/src/task.rs
+++ b/crates/bevy_tasks/src/task.rs
@@ -41,6 +41,13 @@ impl<T> Task<T> {
     pub async fn cancel(self) -> Option<T> {
         self.0.cancel().await
     }
+
+    /// Returns `true` if the current task is finished.
+    ///
+    /// Note that in a multithreaded environment, this task can change finish immediately after calling this function.
+    pub fn is_finished(&self) -> bool {
+        self.0.is_finished()
+    }
 }
 
 impl<T> Future for Task<T> {


### PR DESCRIPTION
# Objective

In some scenarios it can be useful to check if a task has been finished without polling it. I added a function called `is_finished` to check if a task has been finished.

## Solution

Since `async_task` supports it out of the box, it is just a simple wrapper function.

---
