### PR TITLE
[Merged by Bors] - Fix doctest warnings

### DIFF
--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -431,7 +431,7 @@ pub enum KeyCode {
 ///
 /// ## Usage
 ///
-/// It is used as the generic <T> value of an [`Input`](crate::Input) to create a `Res<Input<ScanCode>>`.
+/// It is used as the generic `<T>` value of an [`Input`](crate::Input) to create a `Res<Input<ScanCode>>`.
 /// The resource values are mapped to the physical location of a key on the keyboard and correlate to an [`KeyCode`](KeyCode)
 ///
 /// ## Updating

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -68,9 +68,9 @@ impl TaskPoolBuilder {
 pub struct TaskPool {
     /// The executor for the pool
     ///
-    /// This has to be separate from TaskPoolInner because we have to create an Arc<Executor> to
+    /// This has to be separate from TaskPoolInner because we have to create an `Arc<Executor>` to
     /// pass into the worker threads, and we must create the worker threads before we can create
-    /// the Vec<Task<T>> contained within TaskPoolInner
+    /// the `Vec<Task<T>>` contained within `TaskPoolInner`
     executor: Arc<async_executor::Executor<'static>>,
 
     /// Inner state of the pool


### PR DESCRIPTION
# Objective

- Fixes doctest warnings from upcoming Rust release.

` cargo doc --workspace --all-features --no-deps --document-private-items` using `beta-x86_64-pc-windows-msvc (default)
rustc 1.66.0-beta.1 (e080cc5a6 2022-11-01)` was giving warnings on a few comments.

## Solution

- Quoted the Rust code parts.