### PR TITLE
[Merged by Bors] - Show prelude re-exports in docs

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -24,7 +24,7 @@ use bevy_utils::{tracing::warn, HashMap};
 
 #[allow(missing_docs)]
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         AnimationClip, AnimationPlayer, AnimationPlugin, EntityPath, Keyframes, VariableCurve,
     };

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -19,9 +19,9 @@ pub use schedule_runner::*;
 #[allow(missing_docs)]
 pub mod prelude {
     #[cfg(feature = "bevy_reflect")]
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::AppTypeRegistry;
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         app::App, CoreStage, DynamicPlugin, Plugin, PluginGroup, StartupSchedule, StartupStage,
     };

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -29,7 +29,7 @@ mod reflect;
 
 /// The `bevy_asset` prelude.
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         AddAsset, AssetEvent, AssetPlugin, AssetServer, Assets, Handle, HandleUntyped,
     };

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -28,7 +28,7 @@ mod audio_source;
 
 #[allow(missing_docs)]
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{Audio, AudioOutput, AudioSource, Decodable, PlaybackSettings};
 }
 

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -13,7 +13,7 @@ pub use task_pool_options::*;
 
 pub mod prelude {
     //! The Bevy Core Prelude.
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{CorePlugin, Name, TaskPoolOptions};
 }
 

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -7,7 +7,7 @@ pub mod tonemapping;
 pub mod upscaling;
 
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         clear_color::ClearColor,
         core_2d::{Camera2d, Camera2dBundle},

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -22,10 +22,10 @@ pub use bevy_ptr as ptr;
 
 /// Most commonly used re-exported types.
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     #[cfg(feature = "bevy_reflect")]
     pub use crate::reflect::{ReflectComponent, ReflectResource};
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         bundle::Bundle,
         change_detection::DetectChanges,

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -22,9 +22,9 @@ pub use valid_parent_check_plugin::*;
 mod query_extension;
 pub use query_extension::*;
 
-#[doc(hidden)]
+#[allow(missing_docs)]
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         child_builder::*, components::*, hierarchy::*, query_extension::*, HierarchyPlugin,
         ValidParentCheckPlugin,

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -9,7 +9,7 @@ pub use axis::*;
 pub use input::*;
 
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         gamepad::{
             Gamepad, GamepadAxis, GamepadAxisType, GamepadButton, GamepadButtonType, GamepadEvent,

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -1,4 +1,4 @@
-#[doc(hidden)]
+#[doc(no_inline)]
 pub use crate::{
     app::prelude::*, core::prelude::*, ecs::prelude::*, hierarchy::prelude::*, input::prelude::*,
     log::prelude::*, math::prelude::*, reflect::prelude::*, time::prelude::*,
@@ -7,50 +7,50 @@ pub use crate::{
 
 pub use bevy_derive::{bevy_main, Deref, DerefMut};
 
-#[doc(hidden)]
+#[doc(no_inline)]
 #[cfg(feature = "bevy_asset")]
 pub use crate::asset::prelude::*;
 
-#[doc(hidden)]
+#[doc(no_inline)]
 #[cfg(feature = "bevy_audio")]
 pub use crate::audio::prelude::*;
 
-#[doc(hidden)]
+#[doc(no_inline)]
 #[cfg(feature = "bevy_animation")]
 pub use crate::animation::prelude::*;
 
-#[doc(hidden)]
+#[doc(no_inline)]
 #[cfg(feature = "bevy_core_pipeline")]
 pub use crate::core_pipeline::prelude::*;
 
-#[doc(hidden)]
+#[doc(no_inline)]
 #[cfg(feature = "bevy_pbr")]
 pub use crate::pbr::prelude::*;
 
-#[doc(hidden)]
+#[doc(no_inline)]
 #[cfg(feature = "bevy_render")]
 pub use crate::render::prelude::*;
 
-#[doc(hidden)]
+#[doc(no_inline)]
 #[cfg(feature = "bevy_scene")]
 pub use crate::scene::prelude::*;
 
-#[doc(hidden)]
+#[doc(no_inline)]
 #[cfg(feature = "bevy_sprite")]
 pub use crate::sprite::prelude::*;
 
-#[doc(hidden)]
+#[doc(no_inline)]
 #[cfg(feature = "bevy_text")]
 pub use crate::text::prelude::*;
 
-#[doc(hidden)]
+#[doc(no_inline)]
 #[cfg(feature = "bevy_ui")]
 pub use crate::ui::prelude::*;
 
-#[doc(hidden)]
+#[doc(no_inline)]
 #[cfg(feature = "bevy_dynamic_plugin")]
 pub use crate::dynamic_plugin::*;
 
-#[doc(hidden)]
+#[doc(no_inline)]
 #[cfg(feature = "bevy_gilrs")]
 pub use crate::gilrs::*;

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -19,7 +19,7 @@ mod android_tracing;
 
 pub mod prelude {
     //! The Bevy Log Prelude.
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use bevy_utils::tracing::{
         debug, debug_span, error, error_span, info, info_span, trace, trace_span, warn, warn_span,
     };

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -14,7 +14,7 @@ pub use rect::Rect;
 
 /// The `bevy_math` prelude.
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         BVec2, BVec3, BVec4, EulerRot, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4, Quat, Ray, Rect,
         UVec2, UVec3, UVec4, Vec2, Vec3, Vec4,

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -17,7 +17,7 @@ pub use render::*;
 use bevy_window::ModifiesWindows;
 
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         alpha::AlphaMode,
         bundle::{

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -37,7 +37,7 @@ pub mod utility;
 
 pub mod prelude {
     pub use crate::std_traits::*;
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         reflect_trait, FromReflect, GetField, GetTupleStructField, Reflect, ReflectDeserialize,
         ReflectSerialize, Struct, TupleStruct,

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -24,7 +24,7 @@ use bevy_hierarchy::ValidParentCheckPlugin;
 pub use extract_param::Extract;
 
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         camera::{Camera, OrthographicProjection, PerspectiveProjection, Projection},
         color::Color,

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -14,7 +14,7 @@ pub use scene_loader::*;
 pub use scene_spawner::*;
 
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         DynamicScene, DynamicSceneBuilder, DynamicSceneBundle, Scene, SceneBundle, SceneSpawner,
     };

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -9,7 +9,7 @@ mod texture_atlas_builder;
 pub mod collide_aabb;
 
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         bundle::{SpriteBundle, SpriteSheetBundle},
         sprite::Sprite,

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -27,7 +27,7 @@ pub use iter::ParallelIterator;
 
 #[allow(missing_docs)]
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         iter::ParallelIterator,
         slice::{ParallelSlice, ParallelSliceMut},

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -19,7 +19,7 @@ pub use text::*;
 pub use text2d::*;
 
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         Font, HorizontalAlign, Text, Text2dBundle, TextAlignment, TextError, TextSection,
         TextStyle, VerticalAlign,

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -15,7 +15,7 @@ use crossbeam_channel::{Receiver, Sender};
 
 pub mod prelude {
     //! The Bevy Time Prelude.
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{Time, Timer, TimerMode};
 }
 

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -6,9 +6,9 @@ pub mod components;
 mod systems;
 pub use crate::systems::transform_propagate_system;
 
-#[doc(hidden)]
+#[allow(missing_docs)]
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{components::*, TransformBundle, TransformPlugin};
 }
 

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -19,9 +19,8 @@ pub use geometry::*;
 pub use render::*;
 pub use ui_node::*;
 
-#[doc(hidden)]
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{entity::*, geometry::*, ui_node::*, widget::Button, Interaction, UiScale};
 }
 

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -14,7 +14,7 @@ pub use window::*;
 pub use windows::*;
 
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(no_inline)]
     pub use crate::{
         CursorEntered, CursorIcon, CursorLeft, CursorMoved, FileDragAndDrop, MonitorSelection,
         ReceivedCharacter, Window, WindowDescriptor, WindowMode, WindowMoved, WindowPlugin,


### PR DESCRIPTION
# Objective

- Right now re-exports are completely hidden in prelude docs.
- Fixes #6433

## Solution

- We could show the re-exports without inlining their documentation.