### PR TITLE
[Merged by Bors] - Add more info to texture loading error in texture_atlas example

### DIFF
--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -51,7 +51,11 @@ fn setup(
     let mut texture_atlas_builder = TextureAtlasBuilder::default();
     for handle in &rpg_sprite_handles.handles {
         let handle = handle.typed_weak();
-        let texture = textures.get(&handle).expect("Textures folder contained a file which way matched by a loader which did not create an `Image` asset");
+        let Some(texture) = textures.get(&handle) else {
+            warn!("{:?} did not resolve to an `Image` asset.", asset_server.get_handle_path(handle));
+            continue;
+        };
+
         texture_atlas_builder.add_texture(handle, texture);
     }
 


### PR DESCRIPTION
# Objective

- Fix an awkwardly phrased/typoed error message
- Actually tell users which file caused the error
- IMO we don't need to panic

## Solution

- Add a warning including the involved asset path when a non-image is found by `load_folder`
- Note: uses `let else` which is stable now

```
2022-11-03T14:17:59.006861Z  WARN texture_atlas: Some(AssetPath { path: "textures/rpg/tiles/whatisthisdoinghere.ogg", label: None }) did not resolve to an `Image` asset.
```
