### PR TITLE
[Merged by Bors] - Fix trybuild tests broken by rust 1.65

### DIFF
--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_exact_sized_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_exact_sized_iterator_safety.stderr
@@ -16,7 +16,7 @@ error[E0277]: the trait bound `bevy_ecs::query::Changed<Foo>: ArchetypeFilter` i
              (F0, F1, F2, F3, F4, F5, F6)
              (F0, F1, F2, F3, F4, F5, F6, F7)
            and $N others
-   = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Changed<Foo>>`
+   = note: required for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Changed<Foo>>` to implement `ExactSizeIterator`
 note: required by a bound in `is_exact_size_iterator`
   --> tests/ui/query_exact_sized_iterator_safety.rs:16:30
    |
@@ -41,7 +41,7 @@ error[E0277]: the trait bound `bevy_ecs::query::Added<Foo>: ArchetypeFilter` is 
              (F0, F1, F2, F3, F4, F5, F6)
              (F0, F1, F2, F3, F4, F5, F6, F7)
            and $N others
-   = note: required because of the requirements on the impl of `ExactSizeIterator` for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Added<Foo>>`
+   = note: required for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Added<Foo>>` to implement `ExactSizeIterator`
 note: required by a bound in `is_exact_size_iterator`
   --> tests/ui/query_exact_sized_iterator_safety.rs:16:30
    |

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
@@ -17,7 +17,7 @@ error[E0277]: the trait bound `&mut A: ReadOnlyWorldQuery` is not satisfied
              (F0, F1, F2, F3, F4, F5, F6)
            and $N others
    = note: `ReadOnlyWorldQuery` is implemented for `&A`, but not for `&mut A`
-   = note: required because of the requirements on the impl of `Iterator` for `QueryCombinationIter<'_, '_, &mut A, (), _>`
+   = note: required for `QueryCombinationIter<'_, '_, &mut A, (), _>` to implement `Iterator`
 note: required by a bound in `is_iterator`
   --> tests/ui/query_iter_combinations_mut_iterator_safety.rs:13:19
    |

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_many_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_many_mut_iterator_safety.stderr
@@ -17,7 +17,7 @@ error[E0277]: the trait bound `&mut A: ReadOnlyWorldQuery` is not satisfied
              (F0, F1, F2, F3, F4, F5, F6)
            and $N others
    = note: `ReadOnlyWorldQuery` is implemented for `&A`, but not for `&mut A`
-   = note: required because of the requirements on the impl of `Iterator` for `QueryManyIter<'_, '_, &mut A, (), std::array::IntoIter<bevy_ecs::entity::Entity, 1>>`
+   = note: required for `QueryManyIter<'_, '_, &mut A, (), std::array::IntoIter<bevy_ecs::entity::Entity, 1>>` to implement `Iterator`
 note: required by a bound in `is_iterator`
   --> tests/ui/query_iter_many_mut_iterator_safety.rs:13:19
    |

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
@@ -7,10 +7,10 @@ warning: unused import: `SystemState`
   = note: `#[warn(unused_imports)]` on by default
 
 error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not satisfied
-  --> tests/ui/system_param_derive_readonly.rs:18:5
+  --> tests/ui/system_param_derive_readonly.rs:18:23
    |
 18 |     assert_readonly::<Mutable>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ReadOnlyWorldQuery` is not implemented for `&'static mut Foo`
+   |                       ^^^^^^^ the trait `ReadOnlyWorldQuery` is not implemented for `&'static mut Foo`
    |
    = help: the following other types implement trait `ReadOnlyWorldQuery`:
              &T
@@ -23,9 +23,9 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not sati
              (F0, F1, F2, F3, F4, F5, F6)
            and $N others
    = note: `ReadOnlyWorldQuery` is implemented for `&'static Foo`, but not for `&'static mut Foo`
-   = note: required because of the requirements on the impl of `ReadOnlySystemParamFetch` for `QueryState<&'static mut Foo>`
+   = note: required for `QueryState<&'static mut Foo>` to implement `ReadOnlySystemParamFetch`
    = note: 2 redundant requirements hidden
-   = note: required because of the requirements on the impl of `ReadOnlySystemParamFetch` for `FetchState<(QueryState<&'static mut Foo>,)>`
+   = note: required for `FetchState<(QueryState<&'static mut Foo>,)>` to implement `ReadOnlySystemParamFetch`
 note: required by a bound in `assert_readonly`
   --> tests/ui/system_param_derive_readonly.rs:23:32
    |


### PR DESCRIPTION
# Objective

- Fix tests that now fail in rust 1.65

## Solution

- Update `.stderr` files with new output