### PR TITLE
[Merged by Bors] - Specialize UI pipeline on "hdr-ness"

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -563,7 +563,7 @@ pub fn queue_uinodes(
     mut image_bind_groups: ResMut<UiImageBindGroups>,
     gpu_images: Res<RenderAssets<Image>>,
     ui_batches: Query<(Entity, &UiBatch)>,
-    mut views: Query<&mut RenderPhase<TransparentUi>>,
+    mut views: Query<(&ExtractedView, &mut RenderPhase<TransparentUi>)>,
     events: Res<SpriteAssetEvents>,
 ) {
     // If an image has changed, the GpuImage has (probably) changed
@@ -586,8 +586,12 @@ pub fn queue_uinodes(
             layout: &ui_pipeline.view_layout,
         }));
         let draw_ui_function = draw_functions.read().get_id::<DrawUi>().unwrap();
-        let pipeline = pipelines.specialize(&mut pipeline_cache, &ui_pipeline, UiPipelineKey {});
-        for mut transparent_phase in &mut views {
+        for (view, mut transparent_phase) in &mut views {
+            let pipeline = pipelines.specialize(
+                &mut pipeline_cache,
+                &ui_pipeline,
+                UiPipelineKey { hdr: view.hdr },
+            );
             for (entity, batch) in &ui_batches {
                 image_bind_groups
                     .values

--- a/crates/bevy_ui/src/render/pipeline.rs
+++ b/crates/bevy_ui/src/render/pipeline.rs
@@ -1,6 +1,9 @@
 use bevy_ecs::prelude::*;
 use bevy_render::{
-    render_resource::*, renderer::RenderDevice, texture::BevyDefault, view::ViewUniform,
+    render_resource::*,
+    renderer::RenderDevice,
+    texture::BevyDefault,
+    view::{ViewTarget, ViewUniform},
 };
 
 #[derive(Resource)]
@@ -57,12 +60,14 @@ impl FromWorld for UiPipeline {
 }
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
-pub struct UiPipelineKey {}
+pub struct UiPipelineKey {
+    pub hdr: bool,
+}
 
 impl SpecializedRenderPipeline for UiPipeline {
     type Key = UiPipelineKey;
-    /// FIXME: there are no specialization for now, should this be removed?
-    fn specialize(&self, _key: Self::Key) -> RenderPipelineDescriptor {
+
+    fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
         let vertex_layout = VertexBufferLayout::from_vertex_formats(
             VertexStepMode::Vertex,
             vec![
@@ -88,7 +93,11 @@ impl SpecializedRenderPipeline for UiPipeline {
                 shader_defs,
                 entry_point: "fragment".into(),
                 targets: vec![Some(ColorTargetState {
-                    format: TextureFormat::bevy_default(),
+                    format: if key.hdr {
+                        ViewTarget::TEXTURE_FORMAT_HDR
+                    } else {
+                        TextureFormat::bevy_default()
+                    },
                     blend: Some(BlendState::ALPHA_BLENDING),
                     write_mask: ColorWrites::ALL,
                 })],


### PR DESCRIPTION
# Objective

The UI pass in HDR breaks currently because the color attachment format does not match the HDR ViewTarget.

## Solution

Specialize the UI pipeline on "hdr-ness" and select the appropriate format (like we do in the other built in pipelines).
