### PR TITLE
[Merged by Bors] - Fix panic when using globals uniform in wasm builds

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -95,6 +95,8 @@ struct Globals {
     // Frame count since the start of the app.
     // It wraps to zero when it reaches the maximum value of a u32.
     frame_count: u32,
+#ifdef SIXTEEN_BYTE_ALIGNMENT
     // WebGL2 structs must be 16 byte aligned.
     _wasm_padding: f32
+#endif
 }

--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -95,4 +95,6 @@ struct Globals {
     // Frame count since the start of the app.
     // It wraps to zero when it reaches the maximum value of a u32.
     frame_count: u32,
+    // WebGL2 structs must be 16 byte aligned.
+    _wasm_padding: f32
 }

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -41,6 +41,8 @@ pub struct GlobalsUniform {
     /// Frame count since the start of the app.
     /// It wraps to zero when it reaches the maximum value of a u32.
     frame_count: u32,
+    /// Webgl2 structs must be 16 byte aligned.
+    _wasm_padding: f32,
 }
 
 /// The buffer containing the [`GlobalsUniform`]

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -42,6 +42,7 @@ pub struct GlobalsUniform {
     /// It wraps to zero when it reaches the maximum value of a u32.
     frame_count: u32,
     /// Webgl2 structs must be 16 byte aligned.
+    #[cfg(feature = "webgl")]
     _wasm_padding: f32,
 }
 

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -41,7 +41,7 @@ pub struct GlobalsUniform {
     /// Frame count since the start of the app.
     /// It wraps to zero when it reaches the maximum value of a u32.
     frame_count: u32,
-    /// Webgl2 structs must be 16 byte aligned.
+    /// WebGL2 structs must be 16 byte aligned.
     #[cfg(feature = "webgl")]
     _wasm_padding: f32,
 }

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -151,7 +151,10 @@ impl ShaderCache {
             Entry::Vacant(entry) => {
                 let mut shader_defs = shader_defs.to_vec();
                 #[cfg(feature = "webgl")]
-                shader_defs.push(String::from("NO_ARRAY_TEXTURES_SUPPORT"));
+                {
+                    shader_defs.push(String::from("NO_ARRAY_TEXTURES_SUPPORT"));
+                    shader_defs.push(String::from("SIXTEEN_BYTE_ALIGNMENT"));
+                }
 
                 // TODO: 3 is the value from CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT declared in bevy_pbr
                 // consider exposing this in shaders in a more generally useful way, such as:


### PR DESCRIPTION
# Objective

Fixes #5393 

## Solution

- Add padding to `GlobalsUniform` / `Globals` to make it 16-byte aligned.

Still not super clear on whether this is a `naga` thing or an `encase` thing or what. But now that we're offering `globals` up to users and #5393 is not just breaking an example, maybe we should do this sort of workaround?