### PR TITLE
[Merged by Bors] - Fix unsound `EntityMut::remove_children`. Add `EntityMut::world_scope`

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -526,7 +526,7 @@ impl<'w> EntityMut<'w> {
 
     /// Returns this `EntityMut`'s world.
     ///
-    /// See [`EntityMut::into_world_mut`] for a safe alternative.
+    /// See [`EntityMut::world_scope`] or [`EntityMut::into_world_mut`] for a safe alternative.
     ///
     /// # Safety
     /// Caller must not modify the world in a way that changes the current entity's location
@@ -541,6 +541,12 @@ impl<'w> EntityMut<'w> {
     #[inline]
     pub fn into_world_mut(self) -> &'w mut World {
         self.world
+    }
+
+    /// Gives mutable access to this `EntityMut`'s [`World`] in a temporary scope.
+    pub fn world_scope(&mut self, f: impl FnOnce(&mut World)) {
+        f(self.world);
+        self.update_location();
     }
 
     /// Updates the internal entity location to match the current location in the internal

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -515,9 +515,10 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
 
     fn remove_children(&mut self, children: &[Entity]) -> &mut Self {
         let parent = self.id();
-        // SAFETY: This doesn't change the parent's location
+        // SAFETY: The EntityLocation is updated afterwards. 
         let world = unsafe { self.world_mut() };
         remove_children(parent, children, world);
+        self.update_location();
         self
     }
 }

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -461,7 +461,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
             let mut builder = WorldChildBuilder {
                 current_entity: None,
                 parent_entities: vec![entity],
-                // SAFETY: The EntityLocation is updated afterwards.
+                // SAFETY: The EntityLocation is updated after mutable world access.
                 world: unsafe { self.world_mut() },
             };
 
@@ -474,7 +474,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
     fn push_children(&mut self, children: &[Entity]) -> &mut Self {
         let parent = self.id();
         {
-            // SAFETY: The EntityLocation is updated afterwards.
+            // SAFETY: The EntityLocation is updated after mutable world access before any methods are called on self.
             let world = unsafe { self.world_mut() };
             update_old_parents(world, parent, children);
             self.update_location();
@@ -493,7 +493,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
     fn insert_children(&mut self, index: usize, children: &[Entity]) -> &mut Self {
         let parent = self.id();
         {
-            // SAFETY: The EntityLocation is updated afterwards.
+            // SAFETY: The EntityLocation is updated after mutable world access before any methods are called on self.
             let world = unsafe { self.world_mut() };
             update_old_parents(world, parent, children);
             self.update_location();
@@ -512,7 +512,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
 
     fn remove_children(&mut self, children: &[Entity]) -> &mut Self {
         let parent = self.id();
-        // SAFETY: The EntityLocation is updated afterwards.
+        // SAFETY: The EntityLocation is updated after mutable world access.
         let world = unsafe { self.world_mut() };
         remove_children(parent, children, world);
         self.update_location();

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -461,7 +461,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
             let mut builder = WorldChildBuilder {
                 current_entity: None,
                 parent_entities: vec![entity],
-                // SAFETY: The EntityLocation is updated after mutable world access.
+                // SAFETY: The EntityLocation is updated before any other methods are called on self.
                 world: unsafe { self.world_mut() },
             };
 
@@ -474,7 +474,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
     fn push_children(&mut self, children: &[Entity]) -> &mut Self {
         let parent = self.id();
         {
-            // SAFETY: The EntityLocation is updated after mutable world access before any methods are called on self.
+            // SAFETY: The EntityLocation is updated before any other methods are called on self.
             let world = unsafe { self.world_mut() };
             update_old_parents(world, parent, children);
             self.update_location();
@@ -493,7 +493,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
     fn insert_children(&mut self, index: usize, children: &[Entity]) -> &mut Self {
         let parent = self.id();
         {
-            // SAFETY: The EntityLocation is updated after mutable world access before any methods are called on self.
+            // SAFETY: The EntityLocation is updated before any other methods are called on self.
             let world = unsafe { self.world_mut() };
             update_old_parents(world, parent, children);
             self.update_location();
@@ -512,7 +512,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
 
     fn remove_children(&mut self, children: &[Entity]) -> &mut Self {
         let parent = self.id();
-        // SAFETY: The EntityLocation is updated after mutable world access.
+        // SAFETY: The EntityLocation is updated before any other methods are called on self.
         let world = unsafe { self.world_mut() };
         remove_children(parent, children, world);
         self.update_location();

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -461,8 +461,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
             let mut builder = WorldChildBuilder {
                 current_entity: None,
                 parent_entities: vec![entity],
-                // SAFETY: self.update_location() is called below. It is impossible to make EntityMut
-                // function calls on `self` within the scope defined here
+                // SAFETY: The EntityLocation is updated afterwards.
                 world: unsafe { self.world_mut() },
             };
 
@@ -475,10 +474,9 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
     fn push_children(&mut self, children: &[Entity]) -> &mut Self {
         let parent = self.id();
         {
-            // SAFETY: parent entity is not modified and its location is updated manually
+            // SAFETY: The EntityLocation is updated afterwards.
             let world = unsafe { self.world_mut() };
             update_old_parents(world, parent, children);
-            // Inserting a bundle in the children entities may change the parent entity's location if they were of the same archetype
             self.update_location();
         }
         if let Some(mut children_component) = self.get_mut::<Children>() {
@@ -495,10 +493,9 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
     fn insert_children(&mut self, index: usize, children: &[Entity]) -> &mut Self {
         let parent = self.id();
         {
-            // SAFETY: parent entity is not modified and its location is updated manually
+            // SAFETY: The EntityLocation is updated afterwards.
             let world = unsafe { self.world_mut() };
             update_old_parents(world, parent, children);
-            // Inserting a bundle in the children entities may change the parent entity's location if they were of the same archetype
             self.update_location();
         }
 
@@ -515,7 +512,7 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
 
     fn remove_children(&mut self, children: &[Entity]) -> &mut Self {
         let parent = self.id();
-        // SAFETY: The EntityLocation is updated afterwards. 
+        // SAFETY: The EntityLocation is updated afterwards.
         let world = unsafe { self.world_mut() };
         remove_children(parent, children, world);
         self.update_location();

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -104,7 +104,7 @@ impl<'w, 's, 'a> DespawnRecursiveExt for EntityCommands<'w, 's, 'a> {
 
 impl<'w> DespawnRecursiveExt for EntityMut<'w> {
     /// Despawns the provided entity and its children.
-    fn despawn_recursive(mut self) {
+    fn despawn_recursive(self) {
         let entity = self.id();
 
         #[cfg(feature = "trace")]
@@ -114,11 +114,7 @@ impl<'w> DespawnRecursiveExt for EntityMut<'w> {
         )
         .entered();
 
-        // SAFETY: EntityMut is consumed so even though the location is no longer
-        // valid, it cannot be accessed again with the invalid location.
-        unsafe {
-            despawn_with_children_recursive(self.world_mut(), entity);
-        }
+        despawn_with_children_recursive(self.into_world_mut(), entity);
     }
 
     fn despawn_descendants(&mut self) {


### PR DESCRIPTION
`EntityMut::remove_children` does not call `self.update_location()` which is unsound.
Verified by adding the following assertion, which fails when running the tests.
```rust
let before = self.location();
self.update_location();
assert_eq!(before, self.location());
```

I also removed incorrect messages like "parent entity is not modified" and the unhelpful "Inserting a bundle in the children entities may change the parent entity's location if they were of the same archetype" which might lead people to think that's the *only* thing that can change the entity's location.

# Changelog
Added `EntityMut::world_scope`.