### PR TITLE
[Merged by Bors] - Update post_processing example to not render UI with first pass camera

### DIFF
--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -42,42 +42,10 @@ fn setup(
 ) {
     let window = windows.primary_mut();
     let size = Extent3d {
-        width: window.width() as u32,
-        height: window.height() as u32,
+        width: window.physical_width(),
+        height: window.physical_height(),
         ..default()
     };
-
-    commands
-        .spawn(NodeBundle {
-            style: Style {
-                justify_content: JustifyContent::FlexEnd,
-                size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
-                ..default()
-            },
-            background_color: BackgroundColor(Color::NONE),
-            ..default()
-        })
-        .with_children(|commands| {
-            commands
-                .spawn(NodeBundle {
-                    background_color: BackgroundColor(Color::MAROON),
-                    style: Style {
-                        size: Size::new(Val::Px(100.0), Val::Auto),
-                        ..default()
-                    },
-                    ..default()
-                })
-                .with_children(|commands| {
-                    commands.spawn(NodeBundle {
-                        background_color: BackgroundColor(Color::PINK),
-                        style: Style {
-                            size: Size::new(Val::Percent(100.0), Val::Percent(50.0)),
-                            ..default()
-                        },
-                        ..default()
-                    });
-                });
-        });
 
     // This is the texture that will be rendered to.
     let mut image = Image {
@@ -127,19 +95,24 @@ fn setup(
     });
 
     // Main camera, first to render
-    commands.spawn(Camera3dBundle {
-        camera_3d: Camera3d {
-            clear_color: ClearColorConfig::Custom(Color::WHITE),
+    commands.spawn((
+        Camera3dBundle {
+            camera_3d: Camera3d {
+                clear_color: ClearColorConfig::Custom(Color::WHITE),
+                ..default()
+            },
+            camera: Camera {
+                target: RenderTarget::Image(image_handle.clone()),
+                ..default()
+            },
+            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
+                .looking_at(Vec3::default(), Vec3::Y),
             ..default()
         },
-        camera: Camera {
-            target: RenderTarget::Image(image_handle.clone()),
-            ..default()
-        },
-        transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
-            .looking_at(Vec3::default(), Vec3::Y),
-        ..default()
-    });
+        // Disable UI rendering for the first pass camera. This prevents double rendering of UI at
+        // the cost of rendering the UI without any post processing effects.
+        UiCameraConfig { show_ui: false },
+    ));
 
     // This specifies the layer used for the post processing camera, which will be attached to the post processing camera and 2d quad.
     let post_processing_pass_layer = RenderLayers::layer((RenderLayers::TOTAL_LAYERS - 1) as u8);
@@ -179,7 +152,6 @@ fn setup(
             ..Camera2dBundle::default()
         },
         post_processing_pass_layer,
-        UiCameraConfig { show_ui: false },
     ));
 }
 

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -42,10 +42,42 @@ fn setup(
 ) {
     let window = windows.primary_mut();
     let size = Extent3d {
-        width: window.physical_width(),
-        height: window.physical_height(),
+        width: window.width() as u32,
+        height: window.height() as u32,
         ..default()
     };
+
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                justify_content: JustifyContent::FlexEnd,
+                size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
+                ..default()
+            },
+            background_color: BackgroundColor(Color::NONE),
+            ..default()
+        })
+        .with_children(|commands| {
+            commands
+                .spawn(NodeBundle {
+                    background_color: BackgroundColor(Color::MAROON),
+                    style: Style {
+                        size: Size::new(Val::Px(100.0), Val::Auto),
+                        ..default()
+                    },
+                    ..default()
+                })
+                .with_children(|commands| {
+                    commands.spawn(NodeBundle {
+                        background_color: BackgroundColor(Color::PINK),
+                        style: Style {
+                            size: Size::new(Val::Percent(100.0), Val::Percent(50.0)),
+                            ..default()
+                        },
+                        ..default()
+                    });
+                });
+        });
 
     // This is the texture that will be rendered to.
     let mut image = Image {
@@ -147,6 +179,7 @@ fn setup(
             ..Camera2dBundle::default()
         },
         post_processing_pass_layer,
+        UiCameraConfig { show_ui: false },
     ));
 }
 


### PR DESCRIPTION
# Objective

Make sure the post processing example won't render UI twice.

## Solution

Disable UI on the first pass camera with `UiCameraConfig`