### PR TITLE
[Merged by Bors] - Add CameraRenderGraph::set

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -289,9 +289,16 @@ impl Camera {
 pub struct CameraRenderGraph(Cow<'static, str>);
 
 impl CameraRenderGraph {
+    /// Creates a new [`CameraRenderGraph`] from any string-like type.
     #[inline]
     pub fn new<T: Into<Cow<'static, str>>>(name: T) -> Self {
         Self(name.into())
+    }
+
+    #[inline]
+    /// Sets the graph name.
+    pub fn set<T: Into<Cow<'static, str>>>(&mut self, name: T) {
+        self.0 = name.into();
     }
 }
 


### PR DESCRIPTION
# Objective

Some render plugins, like [bevy-hikari](https://github.com/cryscan/bevy-hikari) require to set `CameraRenderGraph`. In order to switch between render graphs I need to insert a new `CameraRenderGraph` component. It's not very ergonomic.

## Solution

Add `CameraRenderGraph::set` like in [Name](https://docs.rs/bevy/latest/bevy/core/struct.Name.html).

---

## Changelog

### Added

- `CameraRenderGraph::set`.