### PR TITLE
[Merged by Bors] - Remove LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1610,9 +1610,6 @@ target_sdk_version = 31
 icon = "@mipmap/ic_launcher"
 label = "Bevy Example"
 
-[profile.release]
-lto = true
-
 [profile.wasm-release]
 inherits = "release"
 opt-level = "z"


### PR DESCRIPTION
# Objective
#6461 introduced `lto = true` as a profile setting for release builds. This is causing the  `run-examples` CI task to timeout.

## Solution
Remove it.