### PR TITLE
[Merged by Bors] - UI scaling fix

### DIFF
--- a/crates/bevy_text/src/error.rs
+++ b/crates/bevy_text/src/error.rs
@@ -7,6 +7,6 @@ pub enum TextError {
     NoSuchFont,
     #[error("failed to add glyph to newly-created atlas {0:?}")]
     FailedToAddGlyph(GlyphId),
-    #[error("exceeded {0:?} available TextAltases for font. This can be caused by using an excessive number of font sizes. If you are changing font sizes dynamically consider using Transform::scale to modify the size. If you need more font sizes modify TextSettings.max_font_atlases." )]
+    #[error("exceeded {0:?} available TextAltases for font. This can be caused by using an excessive number of font sizes or ui scaling. If you are changing font sizes or ui scaling dynamically consider using Transform::scale to modify the size. If you need more font sizes modify TextSettings.max_font_atlases." )]
     ExceedMaxTextAtlases(usize),
 }

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -1,6 +1,6 @@
 //! This example illustrates the [`UIScale`] resource from `bevy_ui`.
 
-use bevy::{prelude::*, utils::Duration};
+use bevy::{prelude::*, text::TextSettings, utils::Duration};
 
 const SCALE_TIME: u64 = 400;
 
@@ -10,6 +10,10 @@ struct ApplyScaling;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
+        .insert_resource(TextSettings {
+            allow_dynamic_font_size: true,
+            ..default()
+        })
         .insert_resource(TargetScale {
             start_scale: 1.0,
             target_scale: 1.0,


### PR DESCRIPTION
# Objective

Fixes: https://github.com/bevyengine/bevy/issues/6466 
Summary: The UI Scaling example dynamically scales the UI which will dynamically allocate fonts to the font atlas surpassing the protective limit, throwing a panic. 

## Solution

- Set TextSettings.allow_dynamic_font_size = true for the UI Scaling example. This is the ideal solution since the dynamic changes to the UI are not continuous yet still discrete.
- Update the panic text to reflect ui scaling as a potential cause 

