### PR TITLE
[Merged by Bors] - Use `cbrt()` instead of `powf(1./3.)`

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -349,7 +349,7 @@ pub fn extract_text_uinodes(
                     .get(&text_glyph.atlas_info.texture_atlas)
                     .unwrap();
                 let texture = atlas.texture.clone_weak();
-                let index = text_glyph.atlas_info.glyph_index as usize;
+                let index = text_glyph.atlas_info.glyph_index;
                 let rect = atlas.textures[index];
                 let atlas_size = Some(atlas.size);
 

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -73,7 +73,7 @@ fn generate_bodies(
             rng.gen_range(-1.0..1.0),
         )
         .normalize()
-            * rng.gen_range(0.2f32..1.0).powf(1. / 3.)
+            * rng.gen_range(0.2f32..1.0).cbrt()
             * 15.;
 
         commands.spawn(BodyBundle {


### PR DESCRIPTION
# Objective

- Use cube root library function instead of handrolling.

## Solution

- Instead of `powf(1./3.)` use `cbrt()`.
