### PR TITLE
[Merged by Bors] - Fix `clippy::iter_with_drain`

### DIFF
--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -87,7 +87,7 @@ impl<T: Asset> LoadedAsset<T> {
     /// Adds dependencies on other assets at the provided paths.
     #[must_use]
     pub fn with_dependencies(mut self, asset_paths: Vec<AssetPath<'static>>) -> Self {
-        for asset_path in asset_paths.into_iter() {
+        for asset_path in asset_paths {
             self.add_dependency(asset_path);
         }
         self

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -86,8 +86,8 @@ impl<T: Asset> LoadedAsset<T> {
 
     /// Adds dependencies on other assets at the provided paths.
     #[must_use]
-    pub fn with_dependencies(mut self, mut asset_paths: Vec<AssetPath<'static>>) -> Self {
-        for asset_path in asset_paths.drain(..) {
+    pub fn with_dependencies(mut self, asset_paths: Vec<AssetPath<'static>>) -> Self {
+        for asset_path in asset_paths.into_iter() {
             self.add_dependency(asset_path);
         }
         self

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -235,9 +235,9 @@ fn find_ambiguities(systems: &[SystemContainer]) -> Vec<(usize, usize, Vec<Compo
         }
         all_dependants[index] = dependants;
     }
-    let mut all_relations = all_dependencies
-        .drain(..)
-        .zip(all_dependants.drain(..))
+    let all_relations = all_dependencies
+        .into_iter()
+        .zip(all_dependants.into_iter())
         .enumerate()
         .map(|(index, (dependencies, dependants))| {
             let mut relations = FixedBitSet::with_capacity(systems.len());
@@ -250,7 +250,7 @@ fn find_ambiguities(systems: &[SystemContainer]) -> Vec<(usize, usize, Vec<Compo
     let mut ambiguities = Vec::new();
     let full_bitset: FixedBitSet = (0..systems.len()).collect();
     let mut processed = FixedBitSet::with_capacity(systems.len());
-    for (index_a, relations) in all_relations.drain(..).enumerate() {
+    for (index_a, relations) in all_relations.into_iter().enumerate() {
         // TODO: prove that `.take(index_a)` would be correct here, and uncomment it if so.
         for index_b in full_bitset.difference(&relations)
         // .take(index_a)

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -309,7 +309,7 @@ impl SystemStage {
                 }
             }
         });
-        for system in systems.drain(..) {
+        for system in systems.into_iter() {
             self.add_system_inner(system, set_run_criteria_index);
         }
         self

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -309,7 +309,7 @@ impl SystemStage {
                 }
             }
         });
-        for system in systems.into_iter() {
+        for system in systems {
             self.add_system_inner(system, set_run_criteria_index);
         }
         self

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -203,12 +203,12 @@ fn assert_component_access_compatibility(
     current: &FilteredAccess<ComponentId>,
     world: &World,
 ) {
-    let mut conflicts = system_access.get_conflicts_single(current);
+    let conflicts = system_access.get_conflicts_single(current);
     if conflicts.is_empty() {
         return;
     }
     let conflicting_components = conflicts
-        .drain(..)
+        .into_iter()
         .map(|component_id| world.components.get_info(component_id).unwrap().name())
         .collect::<Vec<&str>>();
     let accesses = conflicting_components.join(", ");

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -536,8 +536,8 @@ fn prepare_materials<M: Material>(
     fallback_image: Res<FallbackImage>,
     pipeline: Res<MaterialPipeline<M>>,
 ) {
-    let mut queued_assets = std::mem::take(&mut prepare_next_frame.assets);
-    for (handle, material) in queued_assets.drain(..) {
+    let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
+    for (handle, material) in queued_assets.into_iter() {
         match prepare_material(
             &material,
             &render_device,

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -187,7 +187,7 @@ fn prepare_assets<R: RenderAsset>(
 ) {
     let mut param = param.into_inner();
     let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
-    for (handle, extracted_asset) in queued_assets.into_iter() {
+    for (handle, extracted_asset) in queued_assets {
         match R::prepare_asset(extracted_asset, &mut param) {
             Ok(prepared_asset) => {
                 render_assets.insert(handle, prepared_asset);

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -186,8 +186,8 @@ fn prepare_assets<R: RenderAsset>(
     param: StaticSystemParam<<R as RenderAsset>::Param>,
 ) {
     let mut param = param.into_inner();
-    let mut queued_assets = std::mem::take(&mut prepare_next_frame.assets);
-    for (handle, extracted_asset) in queued_assets.drain(..) {
+    let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
+    for (handle, extracted_asset) in queued_assets.into_iter() {
         match R::prepare_asset(extracted_asset, &mut param) {
             Ok(prepared_asset) => {
                 render_assets.insert(handle, prepared_asset);

--- a/crates/bevy_render/src/render_phase/mod.rs
+++ b/crates/bevy_render/src/render_phase/mod.rs
@@ -35,8 +35,7 @@ impl<I: BatchedPhaseItem> RenderPhase<I> {
     /// Batches the compatible [`BatchedPhaseItem`]s of this render phase
     pub fn batch(&mut self) {
         // TODO: this could be done in-place
-        let mut items = std::mem::take(&mut self.items);
-        let mut items = items.drain(..);
+        let mut items = std::mem::take(&mut self.items).into_iter();
 
         self.items.reserve(items.len());
 

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -471,8 +471,8 @@ fn prepare_materials_2d<M: Material2d>(
     fallback_image: Res<FallbackImage>,
     pipeline: Res<Material2dPipeline<M>>,
 ) {
-    let mut queued_assets = std::mem::take(&mut prepare_next_frame.assets);
-    for (handle, material) in queued_assets.drain(..) {
+    let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
+    for (handle, material) in queued_assets.into_iter() {
         match prepare_material2d(
             &material,
             &render_device,

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -472,7 +472,7 @@ fn prepare_materials_2d<M: Material2d>(
     pipeline: Res<Material2dPipeline<M>>,
 ) {
     let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
-    for (handle, material) in queued_assets.into_iter() {
+    for (handle, material) in queued_assets {
         match prepare_material2d(
             &material,
             &render_device,


### PR DESCRIPTION
# Objective

Fixes #6483.

- Fix the [`clippy::iter_with_drain`](https://rust-lang.github.io/rust-clippy/master/index.html#iter_with_drain) warnings
- From the docs: "`.into_iter()` is simpler with better performance"

## Solution

- Replace `.drain(..)` for `Vec` with `.into_iter()`
