### PR TITLE
Fix `clippy::useless_let_if_seq` / `clippy::equatable_if_let` warnings.

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -512,7 +512,7 @@ impl AssetServer {
             let asset_sources = self.server.asset_sources.read();
             let asset_lifecycles = self.server.asset_lifecycles.read();
             for potential_free in potential_frees.drain(..) {
-                if let Some(&0) = ref_counts.get(&potential_free) {
+                if ref_counts.get(&potential_free) == Some(&0) {
                     let type_uuid = match potential_free {
                         HandleId::Id(type_uuid, _) => Some(type_uuid),
                         HandleId::AssetPathId(id) => asset_sources

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -454,7 +454,7 @@ impl<'w> EntityMut<'w> {
 
                 // Make sure to drop components stored in sparse sets.
                 // Dense components are dropped later in `move_to_and_drop_missing_unchecked`.
-                if let Some(StorageType::SparseSet) = old_archetype.get_storage_type(component_id) {
+                if old_archetype.get_storage_type(component_id) == Some(StorageType::SparseSet) {
                     storages
                         .sparse_sets
                         .get_mut(component_id)

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -768,7 +768,10 @@ fn compute_aabb_for_cluster(
         let p_max_near = line_intersection_to_z_plane(Vec3::ZERO, p_max.xyz(), cluster_near);
         let p_max_far = line_intersection_to_z_plane(Vec3::ZERO, p_max.xyz(), cluster_far);
 
-        (p_min_near.min(p_min_far).min(p_max_near.min(p_max_far)), p_min_near.max(p_min_far).max(p_max_near.max(p_max_far)))
+        (
+            p_min_near.min(p_min_far).min(p_max_near.min(p_max_far)),
+            p_min_near.max(p_min_far).max(p_max_near.max(p_max_far)),
+        )
     };
 
     Aabb::from_min_max(cluster_min, cluster_max)

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -721,9 +721,7 @@ fn compute_aabb_for_cluster(
     let p_min = ijk.xy() * tile_size;
     let p_max = p_min + tile_size;
 
-    let cluster_min;
-    let cluster_max;
-    if is_orthographic {
+    let (cluster_min, cluster_max) = if is_orthographic {
         // Use linear depth slicing for orthographic
 
         // Convert to view space at the cluster near and far planes
@@ -743,8 +741,7 @@ fn compute_aabb_for_cluster(
         )
         .xyz();
 
-        cluster_min = p_min.min(p_max);
-        cluster_max = p_min.max(p_max);
+        (p_min.min(p_max), p_min.max(p_max))
     } else {
         // Convert to view space at the near plane
         // NOTE: 1.0 is the near plane due to using reverse z projections
@@ -771,9 +768,8 @@ fn compute_aabb_for_cluster(
         let p_max_near = line_intersection_to_z_plane(Vec3::ZERO, p_max.xyz(), cluster_near);
         let p_max_far = line_intersection_to_z_plane(Vec3::ZERO, p_max.xyz(), cluster_far);
 
-        cluster_min = p_min_near.min(p_min_far).min(p_max_near.min(p_max_far));
-        cluster_max = p_min_near.max(p_min_far).max(p_max_near.max(p_max_far));
-    }
+        (p_min_near.min(p_min_far).min(p_max_near.min(p_max_far)), p_min_near.max(p_min_far).max(p_max_near.max(p_max_far)))
+    };
 
     Aabb::from_min_max(cluster_min, cluster_max)
 }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -380,7 +380,7 @@ pub fn queue_material_meshes<M: Material>(
                             MeshPipelineKey::from_primitive_topology(mesh.primitive_topology)
                                 | view_key;
                         let alpha_mode = material.properties.alpha_mode;
-                        if let AlphaMode::Blend = alpha_mode {
+                        if alpha_mode == AlphaMode::Blend {
                             mesh_key |= MeshPipelineKey::TRANSPARENT_MAIN_PASS;
                         }
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/reflect_value.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/reflect_value.rs
@@ -38,12 +38,13 @@ impl Parse for ReflectValueDef {
             lookahead = input.lookahead1();
         }
 
-        let mut traits = None;
-        if lookahead.peek(Paren) {
+        let traits = if lookahead.peek(Paren) {
             let content;
             parenthesized!(content in input);
-            traits = Some(content.parse::<ReflectTraits>()?);
-        }
+            Some(content.parse::<ReflectTraits>()?)
+        } else {
+            None
+        };
 
         Ok(ReflectValueDef {
             attrs,

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -416,10 +416,11 @@ impl ShaderProcessor {
                 let def = cap.get(1).unwrap();
                 scopes.push(*scopes.last().unwrap() && !shader_defs_unique.contains(def.as_str()));
             } else if self.else_regex.is_match(line) {
-                let mut is_parent_scope_truthy = true;
-                if scopes.len() > 1 {
-                    is_parent_scope_truthy = scopes[scopes.len() - 2];
-                }
+                let is_parent_scope_truthy = if scopes.len() > 1 {
+                    scopes[scopes.len() - 2]
+                } else {
+                    true
+                };
                 if let Some(last) = scopes.last_mut() {
                     *last = is_parent_scope_truthy && !*last;
                 }

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -135,8 +135,7 @@ pub async fn initialize_renderer(
 
     // Maybe get features and limits based on what is supported by the adapter/backend
     let mut features = wgpu::Features::empty();
-    let mut limits = options.limits.clone();
-    if matches!(options.priority, WgpuSettingsPriority::Functionality) {
+    let mut limits = if matches!(options.priority, WgpuSettingsPriority::Functionality) {
         features = adapter.features() | wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
         if adapter_info.device_type == wgpu::DeviceType::DiscreteGpu {
             // `MAPPABLE_PRIMARY_BUFFERS` can have a significant, negative performance impact for
@@ -145,8 +144,10 @@ pub async fn initialize_renderer(
             // integrated GPUs.
             features -= wgpu::Features::MAPPABLE_PRIMARY_BUFFERS;
         }
-        limits = adapter.limits();
-    }
+        adapter.limits()
+    } else {
+        options.limits.clone()
+    };
 
     // Enforce the disabled features
     if let Some(disabled_features) = options.disabled_features {

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -34,7 +34,8 @@ fn check_textures(
     rpg_sprite_handles: ResMut<RpgSpriteHandles>,
     asset_server: Res<AssetServer>,
 ) {
-    if asset_server.get_group_load_state(rpg_sprite_handles.handles.iter().map(|handle| handle.id)) == LoadState::Loaded
+    if asset_server.get_group_load_state(rpg_sprite_handles.handles.iter().map(|handle| handle.id))
+        == LoadState::Loaded
     {
         state.set(AppState::Finished).unwrap();
     }

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -34,8 +34,7 @@ fn check_textures(
     rpg_sprite_handles: ResMut<RpgSpriteHandles>,
     asset_server: Res<AssetServer>,
 ) {
-    if let LoadState::Loaded =
-        asset_server.get_group_load_state(rpg_sprite_handles.handles.iter().map(|handle| handle.id))
+    if asset_server.get_group_load_state(rpg_sprite_handles.handles.iter().map(|handle| handle.id)) == LoadState::Loaded
     {
         state.set(AppState::Finished).unwrap();
     }


### PR DESCRIPTION
# Objective

- Fix `clippy::nursery` lints `clippy::useless_let_if_seq` & `clippy::equatable_if_let` warnings.

## Solution

- Generally followed clippy's advice.  Some were of simple form "`if let a = b {}`" which became "`if b == a {}`", while others were of the form "`let {mut} a = b; if c { a = d};`" which became "`let a = if c { d } else { b };`"

NOTE: resulting code was untested except for passing automated CI tests