### PR TITLE
[Merged by Bors] - make `register` on `TypeRegistry` idempotent

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -47,12 +47,8 @@ impl Plugin for CorePlugin {
             tick_global_task_pools_on_main_thread.at_end(),
         );
 
-        app.register_type::<Entity>().register_type::<Name>();
         app.register_type::<Entity>()
-            .register_type::<Name>()
-            .register_type::<Range<f32>>()
-            .register_type_data::<Range<f32>, ReflectSerialize>()
-            .register_type_data::<Range<f32>, ReflectDeserialize>();
+            .register_type::<Name>();
 
         register_rust_types(app);
         register_math_types(app);
@@ -63,6 +59,8 @@ impl Plugin for CorePlugin {
 
 fn register_rust_types(app: &mut App) {
     app.register_type::<Range<f32>>()
+        .register_type_data::<Range<f32>, ReflectSerialize>()
+        .register_type_data::<Range<f32>, ReflectDeserialize>()
         .register_type::<String>()
         .register_type::<HashSet<String>>()
         .register_type::<Option<String>>()

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -47,8 +47,7 @@ impl Plugin for CorePlugin {
             tick_global_task_pools_on_main_thread.at_end(),
         );
 
-        app.register_type::<Entity>()
-            .register_type::<Name>();
+        app.register_type::<Entity>().register_type::<Name>();
 
         register_rust_types(app);
         register_math_types(app);

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -87,6 +87,10 @@ impl TypeRegistry {
 
     /// Registers the type described by `registration`.
     pub fn add_registration(&mut self, registration: TypeRegistration) {
+        if self.registrations.contains_key(&registration.type_id()) {
+            return;
+        }
+
         let short_name = registration.short_name.to_string();
         if self.short_name_to_id.contains_key(&short_name)
             || self.ambiguous_names.contains(&short_name)


### PR DESCRIPTION
# Objective

- adding a new `.register` should not overwrite old type data
- separate crates should both be able to register the same type

I ran into this while debugging why `register::<Handle<T>>` removed the `ReflectHandle` type data from a prior `register_asset_reflect`.


## Solution

- make `register` do nothing if called again for the same type
- I also removed some unnecessary duplicate registrations