### PR TITLE
Make `Entities::needs_flush` take `&self` instead of `&mut self`

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -383,7 +383,7 @@ impl Entities {
     }
 
     /// Check that we do not have pending work requiring `flush()` to be called.
-    fn verify_flushed(&mut self) {
+    fn verify_flushed(&self) {
         debug_assert!(
             !self.needs_flush(),
             "flush() needs to be called before this operation is legal"
@@ -567,8 +567,8 @@ impl Entities {
         }
     }
 
-    fn needs_flush(&mut self) -> bool {
-        *self.free_cursor.get_mut() != self.pending.len() as IdCursor
+    fn needs_flush(&self) -> bool {
+        self.free_cursor.load(Ordering::Relaxed) != self.pending.len() as IdCursor
     }
 
     /// Allocates space for entities previously reserved with `reserve_entity` or


### PR DESCRIPTION
# Objective

- Fixes #6474

## Solution

- Use `load()` instead of `get_mut()` at the atomic i64
- Also change `verify_flushed` as `&self`
