### PR TITLE
Move out `needs_flush` in `debug_assert!` of `Entities::verify_flushed`

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -384,8 +384,9 @@ impl Entities {
 
     /// Check that we do not have pending work requiring `flush()` to be called.
     fn verify_flushed(&mut self) {
+        let needs_flush = self.needs_flush();
         debug_assert!(
-            !self.needs_flush(),
+            !needs_flush,
             "flush() needs to be called before this operation is legal"
         );
     }


### PR DESCRIPTION
# Objective

- Initially I tried #6490 since there's no 'actual' mutation but it seems like there is a lot more background to it
- Fixes #6474

## Solution

- move out `needs_flush` call to avoid the clippy check
