### PR TITLE
[Merged by Bors] - Add AutoMax next to ScalingMode::AutoMin

### DIFF
--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -187,7 +187,10 @@ pub enum ScalingMode {
     WindowSize,
     /// Use minimal possible viewport size while keeping the aspect ratio.
     /// Arguments are in world units.
-    Auto { min_width: f32, min_height: f32 },
+    AutoMin { min_width: f32, min_height: f32 },
+    /// Use maximal possible viewport size while keeping the aspect ratio.
+    /// Arguments are in world units.
+    AutoMax { max_width: f32, max_height: f32 },
     /// Keep vertical axis constant; resize horizontal with aspect ratio.
     /// The argument is the desired height of the viewport in world units.
     FixedVertical(f32),
@@ -227,7 +230,7 @@ impl CameraProjection for OrthographicProjection {
     fn update(&mut self, width: f32, height: f32) {
         let (viewport_width, viewport_height) = match self.scaling_mode {
             ScalingMode::WindowSize => (width, height),
-            ScalingMode::Auto {
+            ScalingMode::AutoMin {
                 min_width,
                 min_height,
             } => {
@@ -235,6 +238,16 @@ impl CameraProjection for OrthographicProjection {
                     (width * min_height / height, min_height)
                 } else {
                     (min_width, height * min_width / width)
+                }
+            }
+            ScalingMode::AutoMax {
+                max_width,
+                max_height,
+            } => {
+                if width * max_height < max_width * height {
+                    (width * max_height / height, max_height)
+                } else {
+                    (max_width, height * max_width / width)
                 }
             }
             ScalingMode::FixedVertical(viewport_height) => {

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -247,7 +247,7 @@ impl CameraProjection for OrthographicProjection {
                 max_height,
             } => {
                 // Compare Pixels of current width and maximal height and Pixels of maximal width with current height.
-                // Then use smaller (max_heigth when true) as what it referres to (height when true) and calculate rest so it can't get over maximum.
+                // Then use smaller (max_height when true) as what it refers to (height when true) and calculate rest so it can't get over maximum.
                 if width * max_height < max_width * height {
                     (width * max_height / height, max_height)
                 } else {

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -234,6 +234,8 @@ impl CameraProjection for OrthographicProjection {
                 min_width,
                 min_height,
             } => {
+                // Compare Pixels of current width and minimal height and Pixels of minimal width with current height.
+                // Then use bigger (min_heigth when true) as what it referres to (height when true) and calculate rest so it can't get under minimum.
                 if width * min_height > min_width * height {
                     (width * min_height / height, min_height)
                 } else {
@@ -244,6 +246,8 @@ impl CameraProjection for OrthographicProjection {
                 max_width,
                 max_height,
             } => {
+                // Compare Pixels of current width and maximal height and Pixels of maximal width with current height.
+                // Then use smaller (max_heigth when true) as what it referres to (height when true) and calculate rest so it can't get over maximum.
                 if width * max_height < max_width * height {
                     (width * max_height / height, max_height)
                 } else {

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -185,10 +185,10 @@ pub enum ScalingMode {
     None,
     /// Match the window size. 1 world unit = 1 pixel.
     WindowSize,
-    /// Use minimal possible viewport size while keeping the aspect ratio.
+    /// Keeping the aspect ratio while the axes can't be smaller than given minimum.
     /// Arguments are in world units.
     AutoMin { min_width: f32, min_height: f32 },
-    /// Use maximal possible viewport size while keeping the aspect ratio.
+    /// Keeping the aspect ratio while the axes can't be bigger than given maximum.
     /// Arguments are in world units.
     AutoMax { max_width: f32, max_height: f32 },
     /// Keep vertical axis constant; resize horizontal with aspect ratio.

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -235,7 +235,7 @@ impl CameraProjection for OrthographicProjection {
                 min_height,
             } => {
                 // Compare Pixels of current width and minimal height and Pixels of minimal width with current height.
-                // Then use bigger (min_heigth when true) as what it referres to (height when true) and calculate rest so it can't get under minimum.
+                // Then use bigger (min_height when true) as what it refers to (height when true) and calculate rest so it can't get under minimum.
                 if width * min_height > min_width * height {
                     (width * min_height / height, min_height)
                 } else {


### PR DESCRIPTION
# Objective

`ScalingMode::Auto` for cameras only targets min_height and min_width, or as the docs say it `Use minimal possible viewport size while keeping the aspect ratio.`

But there is no ScalingMode that targets max_height and Max_width or `Use maximal possible viewport size while keeping the aspect ratio.`

## Solution

Added `ScalingMode::AutoMax` that does the exact opposite of `ScalingMode::Auto`

---

## Changelog

Renamed `ScalingMode::Auto` to `ScalingMode::AutoMin`.

## Migration Guide

just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
