### PR TITLE
[Merged by Bors] - Improve logging consistency for entity despawning

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -820,9 +820,7 @@ pub struct Despawn {
 
 impl Command for Despawn {
     fn write(self, world: &mut World) {
-        if !world.despawn(self.entity) {
-            warn!("error[B0003]: Could not despawn entity {:?} because it doesn't exist in this World.", self.entity);
-        }
+        world.despawn(self.entity);
     }
 }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     entity::{Entities, Entity},
     world::{FromWorld, World},
 };
-use bevy_utils::tracing::{error, info, warn};
+use bevy_utils::tracing::{error, info};
 pub use command_queue::CommandQueue;
 pub use parallel_scope::*;
 use std::marker::PhantomData;

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -8,6 +8,7 @@ use crate::{
     world::{Mut, World},
 };
 use bevy_ptr::{OwningPtr, Ptr, UnsafeCellDeref};
+use bevy_utils::tracing::debug;
 use std::{any::TypeId, cell::UnsafeCell};
 
 /// A read-only reference to a particular [`Entity`] and all of its components
@@ -480,6 +481,7 @@ impl<'w> EntityMut<'w> {
     }
 
     pub fn despawn(self) {
+        debug!("Despawning entity {:?}", self.entity);
         let world = self.world;
         world.flush();
         let location = world

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -581,15 +581,13 @@ impl World {
     /// ```
     #[inline]
     pub fn despawn(&mut self, entity: Entity) -> bool {
-        self.get_entity_mut(entity)
-            .map(|e| {
-                e.despawn();
-                true
-            })
-            .unwrap_or_else(|| {
-                debug!("Attempted to despawn non-existent entity {:?}", entity);
-                false
-            })
+        if let Some(entity) = self.get_entity_mut(entity) {
+            entity.despawn();
+            true
+        } else {
+            debug!("Attempted to despawn non-existent entity {:?}", entity);
+            false
+        }
     }
 
     /// Clears component tracker state

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     system::Resource,
 };
 use bevy_ptr::{OwningPtr, Ptr, UnsafeCellDeref};
-use bevy_utils::tracing::debug;
+use bevy_utils::tracing::warn;
 use std::{
     any::TypeId,
     cell::UnsafeCell,
@@ -585,7 +585,7 @@ impl World {
             entity.despawn();
             true
         } else {
-            debug!("Attempted to despawn non-existent entity {:?}", entity);
+            warn!("error[B0003]: Could not despawn entity {:?} because it doesn't exist in this World.", self.entity);
             false
         }
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -20,7 +20,6 @@ use crate::{
     system::Resource,
 };
 use bevy_ptr::{OwningPtr, Ptr, UnsafeCellDeref};
-use bevy_utils::tracing::debug;
 use std::{
     any::TypeId,
     cell::UnsafeCell,
@@ -581,7 +580,6 @@ impl World {
     /// ```
     #[inline]
     pub fn despawn(&mut self, entity: Entity) -> bool {
-        debug!("Despawning entity {:?}", entity);
         self.get_entity_mut(entity)
             .map(|e| {
                 e.despawn();

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -585,7 +585,7 @@ impl World {
             entity.despawn();
             true
         } else {
-            warn!("error[B0003]: Could not despawn entity {:?} because it doesn't exist in this World.", self.entity);
+            warn!("error[B0003]: Could not despawn entity {:?} because it doesn't exist in this World.", entity);
             false
         }
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -20,6 +20,7 @@ use crate::{
     system::Resource,
 };
 use bevy_ptr::{OwningPtr, Ptr, UnsafeCellDeref};
+use bevy_utils::tracing::debug;
 use std::{
     any::TypeId,
     cell::UnsafeCell,
@@ -585,7 +586,10 @@ impl World {
                 e.despawn();
                 true
             })
-            .unwrap_or(false)
+            .unwrap_or_else(|| {
+                debug!("Attempted to despawn non-existent entity {:?}", entity);
+                false
+            })
     }
 
     /// Clears component tracker state


### PR DESCRIPTION
 * Move the despawn debug log from `World::despawn` to `EntityMut::despawn`.
 * Move the despawn non-existent warning log from `Commands::despawn` to `World::despawn`.

This should make logging consistent regardless of which of the three `despawn` methods is used.