### PR TITLE
Add support for loading sub-assets as if they were separate files.

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -32,6 +32,7 @@ downcast-rs = "1.2.0"
 fastrand = "1.7.0"
 notify = { version = "5.0.0", optional = true }
 parking_lot = "0.12.1"
+async-recursion = "1.0.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }


### PR DESCRIPTION
# Objective

The current `AssetServer` system does not support loading assets from inside of container assets that have no way of knowing what they might contain such as zip files or Doom-style WAD files. This aims to add support for this style of asset storage.

Fixes #3319 

## Solution

This implementation adds a way to defer loading internal assets (a.k.a. sub-assets) from a container asset's (a.k.a. super-asset) `AssetLoader`. These deferred loads are then loaded using the existing `Asset` loading system once the container asset's `AssetLoader` returns.

This system required changes to the existing `AssetPath` to allow the system to determine both the sub-asset's path for `Asset` IDs and to determine the right `AssetLoader` and the super-asset path to determine the file on the filesystem backing the sub-asset.

---

## Changelog

### Added
- Added sub-asset support to `AssetPath`
- Added ability to register sub-assets from an `AssetLoader`