### PR TITLE
[Merged by Bors] - fix: explicitly specify required version of async-task

### DIFF
--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["bevy"]
 futures-lite = "1.4.0"
 async-executor = "1.3.0"
 async-channel = "1.4.2"
+async-task = "4.2.0"
 once_cell = "1.7"
 concurrent-queue = "1.2.2"
 


### PR DESCRIPTION
# Objective

Attempting to build `bevy_tasks` produces the following error:

```
error[E0599]: no method named `is_finished` found for struct `async_executor::Task` in the current scope
  --> /[...]]/bevy/crates/bevy_tasks/src/task.rs:51:16
   |
51 |         self.0.is_finished()
   |                ^^^^^^^^^^^ method not found in `async_executor::Task<T>`

```

It looks like this was introduced along with `Task::is_finished`, which delegates to `async_task::Task::is_finished`. However, the latter was only introduced in `async-task` 4.2.0; `bevy_tasks` does not explicitly depend on `async-task` but on `async-executor` ^1.3.0, which in turn depends on `async-task` ^4.0.0.

## Solution

Add an explicit dependency on `async-task` ^4.2.0.
