### PR TITLE
bevy_reflect: Ignored field order

### DIFF
--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -177,27 +177,6 @@ pub struct StandardMaterial {
     /// which can be done via `cull_mode`.
     pub double_sided: bool,
 
-    /// Whether to cull the "front", "back" or neither side of a mesh.
-    /// If set to `None`, the two sides of the mesh are visible.
-    ///
-    /// Defaults to `Some(Face::Back)`.
-    /// In bevy, the order of declaration of a triangle's vertices
-    /// in [`Mesh`] defines the triangle's front face.
-    ///
-    /// When a triangle is in a viewport,
-    /// if its vertices appear counter-clockwise from the viewport's perspective,
-    /// then the viewport is seeing the triangle's front face.
-    /// Conversly, if the vertices appear clockwise, you are seeing the back face.
-    ///
-    /// In short, in bevy, front faces winds counter-clockwise.
-    ///
-    /// Your 3D editing software should manage all of that.
-    ///
-    /// [`Mesh`]: bevy_render::mesh::Mesh
-    // TODO: include this in reflection somehow (maybe via remote types like serde https://serde.rs/remote-derive.html)
-    #[reflect(ignore)]
-    pub cull_mode: Option<Face>,
-
     /// Whether to apply only the base color to this material.
     ///
     /// Normals, occlusion textures, roughness, metallic, reflectance, emissive,
@@ -225,6 +204,26 @@ pub struct StandardMaterial {
     ///
     /// [z-fighting]: https://en.wikipedia.org/wiki/Z-fighting
     pub depth_bias: f32,
+    /// Whether to cull the "front", "back" or neither side of a mesh.
+    /// If set to `None`, the two sides of the mesh are visible.
+    ///
+    /// Defaults to `Some(Face::Back)`.
+    /// In bevy, the order of declaration of a triangle's vertices
+    /// in [`Mesh`] defines the triangle's front face.
+    ///
+    /// When a triangle is in a viewport,
+    /// if its vertices appear counter-clockwise from the viewport's perspective,
+    /// then the viewport is seeing the triangle's front face.
+    /// Conversly, if the vertices appear clockwise, you are seeing the back face.
+    ///
+    /// In short, in bevy, front faces winds counter-clockwise.
+    ///
+    /// Your 3D editing software should manage all of that.
+    ///
+    /// [`Mesh`]: bevy_render::mesh::Mesh
+    // TODO: include this in reflection somehow (maybe via remote types like serde https://serde.rs/remote-derive.html)
+    #[reflect(ignore)]
+    pub cull_mode: Option<Face>,
 }
 
 impl Default for StandardMaterial {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
@@ -4,6 +4,7 @@
 //! as opposed to an entire struct or enum. An example of such an attribute is
 //! the derive helper attribute for `Reflect`, which looks like: `#[reflect(ignore)]`.
 
+use crate::utility::combine_error;
 use crate::REFLECT_ATTRIBUTE_NAME;
 use proc_macro2::Span;
 use quote::ToTokens;
@@ -110,7 +111,7 @@ impl ReflectFieldAttrParser {
         for attr in attrs {
             let meta = attr.parse_meta()?;
             if let Err(err) = self.parse_meta(&mut args, &meta) {
-                Self::combine_error(err, &mut errors);
+                combine_error(err, &mut errors);
             }
         }
 
@@ -197,7 +198,7 @@ impl ReflectFieldAttrParser {
                 } else {
                     format!("fields marked with `#[reflect({IGNORE_ALL_ATTR})]` must come last in type definition")
                 };
-                Self::combine_error(syn::Error::new(span, message), errors);
+                combine_error(syn::Error::new(span, message), errors);
             }
         }
     }
@@ -212,17 +213,8 @@ impl ReflectFieldAttrParser {
                 } else {
                     format!("fields marked with `#[reflect({IGNORE_SERIALIZATION_ATTR})]` must come last in type definition (but before any fields marked `#[reflect({IGNORE_ALL_ATTR})]`)")
                 };
-                Self::combine_error(syn::Error::new(span, message), errors);
+                combine_error(syn::Error::new(span, message), errors);
             }
-        }
-    }
-
-    /// Set or combine the given error into an optionally existing error.
-    fn combine_error(err: syn::Error, errors: &mut Option<syn::Error>) {
-        if let Some(error) = errors {
-            error.combine(err);
-        } else {
-            *errors = Some(err);
         }
     }
 }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
@@ -193,11 +193,12 @@ impl ReflectFieldAttrParser {
     fn check_ignore_order(&self, args: &ReflectFieldAttr, errors: &mut Option<syn::Error>) {
         if args.ignore.is_active() {
             if let Some(span) = self.last_ignored {
-                if self.is_variant {
-                    Self::combine_error(syn::Error::new(span, format!("fields marked with `#[reflect({IGNORE_ALL_ATTR})]` must come last in variant definition")), errors);
+                let message = if self.is_variant {
+                    format!("fields marked with `#[reflect({IGNORE_ALL_ATTR})]` must come last in variant definition")
                 } else {
-                    Self::combine_error(syn::Error::new(span, format!("fields marked with `#[reflect({IGNORE_ALL_ATTR})]` must come last in type definition")), errors);
-                }
+                    format!("fields marked with `#[reflect({IGNORE_ALL_ATTR})]` must come last in type definition")
+                };
+                Self::combine_error(syn::Error::new(span, message), errors);
             }
         }
     }
@@ -207,11 +208,12 @@ impl ReflectFieldAttrParser {
     fn check_skip_order(&self, args: &ReflectFieldAttr, errors: &mut Option<syn::Error>) {
         if args.ignore == ReflectIgnoreBehavior::None {
             if let Some(span) = self.last_skipped {
-                if self.is_variant {
-                    Self::combine_error(syn::Error::new(span, format!("fields marked with `#[reflect({IGNORE_SERIALIZATION_ATTR})]` must come last in variant definition (but before any fields marked `#[reflect({IGNORE_ALL_ATTR})]`)")), errors);
+                let message = if self.is_variant {
+                    format!("fields marked with `#[reflect({IGNORE_SERIALIZATION_ATTR})]` must come last in variant definition (but before any fields marked `#[reflect({IGNORE_ALL_ATTR})]`)")
                 } else {
-                    Self::combine_error(syn::Error::new(span, format!("fields marked with `#[reflect({IGNORE_SERIALIZATION_ATTR})]` must come last in type definition (but before any fields marked `#[reflect({IGNORE_ALL_ATTR})]`)")), errors);
-                }
+                    format!("fields marked with `#[reflect({IGNORE_SERIALIZATION_ATTR})]` must come last in type definition (but before any fields marked `#[reflect({IGNORE_ALL_ATTR})]`)")
+                };
+                Self::combine_error(syn::Error::new(span, message), errors);
             }
         }
     }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
@@ -117,10 +117,9 @@ impl ReflectFieldAttrParser {
         self.check_ignore_order(&args, &mut errors);
         self.check_skip_order(&args, &mut errors);
 
-        if let Some(error) = errors {
-            Err(error)
-        } else {
-            Ok(args)
+        match errors {
+            Some(error) => Err(error),
+            None => Ok(args),
         }
     }
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -24,6 +24,15 @@ pub(crate) fn get_reflect_ident(name: &str) -> Ident {
     Ident::new(&reflected, Span::call_site())
 }
 
+/// Set or combine the given error into an optionally existing error.
+pub(crate) fn combine_error(err: syn::Error, errors: &mut Option<syn::Error>) {
+    if let Some(error) = errors {
+        error.combine(err);
+    } else {
+        *errors = Some(err);
+    }
+}
+
 /// Helper struct used to process an iterator of `Result<Vec<T>, syn::Error>`,
 /// combining errors into one along the way.
 pub(crate) struct ResultSifter<T> {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -108,11 +108,11 @@ impl<T> ResultSifter<T> {
 /// pub struct HelloWorld {
 ///     reflected_field: u32      // index: 0
 ///
-///     #[reflect(ignore)]
-///     non_reflected_field: u32  // index: N/A (not 1!)
-///
 ///     #[reflect(skip_serializing)]
 ///     non_serialized_field: u32 // index: 1
+///
+///     #[reflect(ignore)]
+///     non_reflected_field: u32  // index: N/A (not 2!)
 /// }
 /// ```
 /// Would convert to the `0b01` bitset (i.e second field is NOT serialized)

--- a/crates/bevy_reflect/src/enums/mod.rs
+++ b/crates/bevy_reflect/src/enums/mod.rs
@@ -290,9 +290,9 @@ mod tests {
             A,
             B,
             C {
+                bar: bool,
                 #[reflect(ignore)]
                 foo: f32,
-                bar: bool,
             },
         }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -349,14 +349,14 @@ mod tests {
         #[reflect(PartialEq)]
         struct Foo {
             a: u32,
+            b: Vec<isize>,
+            c: HashMap<usize, i8>,
+            d: Bar,
+            e: (i32, Vec<isize>, Bar),
+            f: Vec<(Baz, HashMap<usize, Bar>)>,
+            g: [u32; 2],
             #[reflect(ignore)]
-            _b: u32,
-            c: Vec<isize>,
-            d: HashMap<usize, i8>,
-            e: Bar,
-            f: (i32, Vec<isize>, Bar),
-            g: Vec<(Baz, HashMap<usize, Bar>)>,
-            h: [u32; 2],
+            _h: u32,
         }
 
         #[derive(Reflect, Eq, PartialEq, Clone, Debug, FromReflect)]
@@ -377,39 +377,39 @@ mod tests {
 
         let mut foo = Foo {
             a: 1,
-            _b: 1,
-            c: vec![1, 2],
-            d: hash_map,
-            e: Bar { x: 1 },
-            f: (1, vec![1, 2], Bar { x: 1 }),
-            g: vec![(Baz("string".to_string()), hash_map_baz)],
-            h: [2; 2],
+            b: vec![1, 2],
+            c: hash_map,
+            d: Bar { x: 1 },
+            e: (1, vec![1, 2], Bar { x: 1 }),
+            f: vec![(Baz("string".to_string()), hash_map_baz)],
+            g: [2; 2],
+            _h: 1,
         };
 
         let mut foo_patch = DynamicStruct::default();
         foo_patch.insert("a", 2u32);
-        foo_patch.insert("b", 2u32); // this should be ignored
+        foo_patch.insert("_h", 2u32); // this should be ignored
 
         let mut list = DynamicList::default();
         list.push(3isize);
         list.push(4isize);
         list.push(5isize);
-        foo_patch.insert("c", List::clone_dynamic(&list));
+        foo_patch.insert("b", List::clone_dynamic(&list));
 
         let mut map = DynamicMap::default();
         map.insert(2usize, 3i8);
         map.insert(3usize, 4i8);
-        foo_patch.insert("d", map);
+        foo_patch.insert("c", map);
 
         let mut bar_patch = DynamicStruct::default();
         bar_patch.insert("x", 2u32);
-        foo_patch.insert("e", bar_patch.clone_dynamic());
+        foo_patch.insert("d", bar_patch.clone_dynamic());
 
         let mut tuple = DynamicTuple::default();
         tuple.insert(2i32);
         tuple.insert(list);
         tuple.insert(bar_patch);
-        foo_patch.insert("f", tuple);
+        foo_patch.insert("e", tuple);
 
         let mut composite = DynamicList::default();
         composite.push({
@@ -430,10 +430,10 @@ mod tests {
             });
             tuple
         });
-        foo_patch.insert("g", composite);
+        foo_patch.insert("f", composite);
 
         let array = DynamicArray::from_vec(vec![2u32, 2u32]);
-        foo_patch.insert("h", array);
+        foo_patch.insert("g", array);
 
         foo.apply(&foo_patch);
 
@@ -447,13 +447,13 @@ mod tests {
 
         let expected_foo = Foo {
             a: 2,
-            _b: 1,
-            c: vec![3, 4, 5],
-            d: hash_map,
-            e: Bar { x: 2 },
-            f: (2, vec![3, 4, 5], Bar { x: 2 }),
-            g: vec![(Baz("new_string".to_string()), hash_map_baz.clone())],
-            h: [2; 2],
+            b: vec![3, 4, 5],
+            c: hash_map,
+            d: Bar { x: 2 },
+            e: (2, vec![3, 4, 5], Bar { x: 2 }),
+            f: vec![(Baz("new_string".to_string()), hash_map_baz.clone())],
+            g: [2; 2],
+            _h: 1,
         };
 
         assert_eq!(foo, expected_foo);
@@ -467,13 +467,13 @@ mod tests {
 
         let expected_new_foo = Foo {
             a: 2,
-            _b: 0,
-            c: vec![3, 4, 5],
-            d: hash_map,
-            e: Bar { x: 2 },
-            f: (2, vec![3, 4, 5], Bar { x: 2 }),
-            g: vec![(Baz("new_string".to_string()), hash_map_baz)],
-            h: [2; 2],
+            b: vec![3, 4, 5],
+            c: hash_map,
+            d: Bar { x: 2 },
+            e: (2, vec![3, 4, 5], Bar { x: 2 }),
+            f: vec![(Baz("new_string".to_string()), hash_map_baz)],
+            g: [2; 2],
+            _h: 0,
         };
 
         assert_eq!(new_foo, expected_new_foo);
@@ -484,14 +484,14 @@ mod tests {
         #[derive(Reflect)]
         struct Foo {
             a: u32,
+            b: Vec<isize>,
+            c: HashMap<usize, i8>,
+            d: Bar,
+            e: String,
+            f: (i32, Vec<isize>, Bar),
+            g: [u32; 2],
             #[reflect(ignore)]
-            _b: u32,
-            c: Vec<isize>,
-            d: HashMap<usize, i8>,
-            e: Bar,
-            f: String,
-            g: (i32, Vec<isize>, Bar),
-            h: [u32; 2],
+            _h: u32,
         }
 
         #[derive(Reflect, Serialize, Deserialize)]
@@ -505,13 +505,13 @@ mod tests {
         hash_map.insert(2, 2);
         let foo = Foo {
             a: 1,
-            _b: 1,
-            c: vec![1, 2],
-            d: hash_map,
-            e: Bar { x: 1 },
-            f: "hi".to_string(),
-            g: (1, vec![1, 2], Bar { x: 1 }),
-            h: [2; 2],
+            b: vec![1, 2],
+            c: hash_map,
+            d: Bar { x: 1 },
+            e: "hi".to_string(),
+            f: (1, vec![1, 2], Bar { x: 1 }),
+            g: [2; 2],
+            _h: 1,
         };
 
         let mut registry = TypeRegistry::default();

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -22,10 +22,10 @@ mod tests {
         #[reflect(PartialEq)]
         struct TestStruct {
             a: i32,
-            #[reflect(ignore)]
             b: i32,
             #[reflect(skip_serializing)]
             c: i32,
+            #[reflect(ignore)]
             d: i32,
         }
 
@@ -34,9 +34,9 @@ mod tests {
 
         let test_struct = TestStruct {
             a: 3,
-            b: 4,
-            c: 5,
-            d: 6,
+            b: 6,
+            c: 4,
+            d: 5,
         };
 
         let serializer = ReflectSerializer::new(&test_struct, &registry);
@@ -45,7 +45,7 @@ mod tests {
 
         let mut expected = DynamicStruct::default();
         expected.insert("a", 3);
-        expected.insert("d", 6);
+        expected.insert("b", 6);
 
         let mut deserializer = ron::de::Deserializer::from_str(&serialized).unwrap();
         let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
@@ -64,9 +64,9 @@ mod tests {
         #[reflect(PartialEq)]
         struct TestStruct(
             i32,
-            #[reflect(ignore)] i32,
-            #[reflect(skip_serializing)] i32,
             i32,
+            #[reflect(skip_serializing)] i32,
+            #[reflect(ignore)] i32,
         );
 
         let mut registry = TypeRegistry::default();
@@ -80,7 +80,7 @@ mod tests {
 
         let mut expected = DynamicTupleStruct::default();
         expected.insert(3);
-        expected.insert(6);
+        expected.insert(4);
 
         let mut deserializer = ron::de::Deserializer::from_str(&serialized).unwrap();
         let reflect_deserializer = UntypedReflectDeserializer::new(&registry);

--- a/crates/bevy_reflect_compile_fail_tests/tests/field_attributes.rs
+++ b/crates/bevy_reflect_compile_fail_tests/tests/field_attributes.rs
@@ -1,0 +1,6 @@
+#[test]
+fn test() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/field_attributes/*.fail.rs");
+    t.pass("tests/field_attributes/*.pass.rs");
+}

--- a/crates/bevy_reflect_compile_fail_tests/tests/field_attributes/ignored_order.fail.rs
+++ b/crates/bevy_reflect_compile_fail_tests/tests/field_attributes/ignored_order.fail.rs
@@ -1,0 +1,10 @@
+use bevy_reflect::Reflect;
+
+#[derive(Reflect)]
+struct Foo {
+    #[reflect(ignore)]
+    a: i32,
+    b: i32,
+}
+
+fn main() {}

--- a/crates/bevy_reflect_compile_fail_tests/tests/field_attributes/ignored_order.fail.stderr
+++ b/crates/bevy_reflect_compile_fail_tests/tests/field_attributes/ignored_order.fail.stderr
@@ -1,0 +1,5 @@
+error: fields marked with `#[reflect(ignore)]` must come last in type definition
+ --> tests/field_attributes/ignored_order.fail.rs:5:15
+  |
+5 |     #[reflect(ignore)]
+  |               ^^^^^^

--- a/crates/bevy_reflect_compile_fail_tests/tests/field_attributes/ignored_order.pass.rs
+++ b/crates/bevy_reflect_compile_fail_tests/tests/field_attributes/ignored_order.pass.rs
@@ -1,0 +1,10 @@
+use bevy_reflect::Reflect;
+
+#[derive(Reflect)]
+struct Foo {
+    a: i32,
+    #[reflect(ignore)]
+    b: i32,
+}
+
+fn main() {}

--- a/crates/bevy_reflect_compile_fail_tests/tests/field_attributes/skipped_order.fail.rs
+++ b/crates/bevy_reflect_compile_fail_tests/tests/field_attributes/skipped_order.fail.rs
@@ -1,0 +1,19 @@
+use bevy_reflect::Reflect;
+
+#[derive(Reflect)]
+struct Foo {
+    #[reflect(skip_serializing)]
+    a: i32,
+    b: i32,
+}
+
+#[derive(Reflect)]
+struct Bar {
+    a: i32,
+    #[reflect(ignore)]
+    b: i32,
+    #[reflect(skip_serializing)]
+    c: i32,
+}
+
+fn main() {}

--- a/crates/bevy_reflect_compile_fail_tests/tests/field_attributes/skipped_order.fail.stderr
+++ b/crates/bevy_reflect_compile_fail_tests/tests/field_attributes/skipped_order.fail.stderr
@@ -1,0 +1,11 @@
+error: fields marked with `#[reflect(skip_serializing)]` must come last in type definition (but before any fields marked `#[reflect(ignore)]`)
+ --> tests/field_attributes/skipped_order.fail.rs:5:15
+  |
+5 |     #[reflect(skip_serializing)]
+  |               ^^^^^^^^^^^^^^^^
+
+error: fields marked with `#[reflect(ignore)]` must come last in type definition
+  --> tests/field_attributes/skipped_order.fail.rs:13:15
+   |
+13 |     #[reflect(ignore)]
+   |               ^^^^^^

--- a/crates/bevy_reflect_compile_fail_tests/tests/field_attributes/skipped_order.pass.rs
+++ b/crates/bevy_reflect_compile_fail_tests/tests/field_attributes/skipped_order.pass.rs
@@ -1,0 +1,19 @@
+use bevy_reflect::Reflect;
+
+#[derive(Reflect)]
+struct Foo {
+    a: i32,
+    #[reflect(skip_serializing)]
+    b: i32,
+}
+
+#[derive(Reflect)]
+struct Bar {
+    a: i32,
+    #[reflect(skip_serializing)]
+    b: i32,
+    #[reflect(ignore)]
+    c: i32,
+}
+
+fn main() {}

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -91,18 +91,18 @@ pub struct Camera {
     /// If this is set to `true`, this camera will be rendered to its specified [`RenderTarget`]. If `false`, this
     /// camera will not be rendered.
     pub is_active: bool,
-    /// Computed values for this camera, such as the projection matrix and the render target size.
-    #[reflect(ignore)]
-    pub computed: ComputedCameraValues,
-    /// The "target" that this camera will render to.
-    #[reflect(ignore)]
-    pub target: RenderTarget,
     /// If this is set to `true`, the camera will use an intermediate "high dynamic range" render texture.
     /// Warning: we are still working on this feature. If MSAA is enabled, there will be artifacts in
     /// some cases. When rendering with WebGL, this will crash if MSAA is enabled.
     /// See <https://github.com/bevyengine/bevy/pull/3425> for details.
     // TODO: resolve the issues mentioned in the doc comment above, then remove the warning.
     pub hdr: bool,
+    /// Computed values for this camera, such as the projection matrix and the render target size.
+    #[reflect(ignore)]
+    pub computed: ComputedCameraValues,
+    /// The "target" that this camera will render to.
+    #[reflect(ignore)]
+    pub target: RenderTarget,
 }
 
 impl Default for Camera {


### PR DESCRIPTION
# Objective

Fixes #5101

## Solution

Make it so that placing `#[reflect(ignore)]` or `#[reflect(skip_serializing)]` on a field that is not at the end of the type definition results in a compile error.

#### Rationale

Invalid ordering is a common and annoying footgun that can be very difficult to debug— or at least very frustrating. Ignoring a field in the middle of your struct can throw off the index you get back from `Struct::index_of` and friends. This is made even worse for things like tuple structs, where doing so breaks both `FromReflect` and serialization.

It should not be so easy to completely break reflection when using the derive macro. Thus, I think it warrants an error so we prevent users from entering this state in the first place.

#### Alternatives

One alternative, would be to output a compiler warning. Unfortunately, that API is still [unstable](https://github.com/rust-lang/rust/issues/54140).

We could also print out a warning at runtime whenever we rely on ordering. However, as discussed in [this comment](https://github.com/bevyengine/bevy/issues/5101#issuecomment-1281882546), we run the risk of some things not being caught (namely by third-party crates). Doing this is also just more cumbersome and prone to error.

Lastly, we could potentially store some sort of mapping that gives us the correct _declaration_ index for a given index. This might work, but makes things like `FromReflect` a bit more difficult to implement. It also means we need to add a public API to access this information, which may be confusing/unintuitive. That being said, this is probably the most viable alternative out of the three.

---

## Changelog

- `#[reflect(ignore)]` and `#[reflect(skip_serializing)]` attributes now result in a compile error if placed in an invalid order

## Migration Guide

Fields marked with `#[reflect(ignore)]` must now be placed at the end of their respective type definition. This applies to all structs, tuple structs, and enum variants.

```rust
// OLD:
#[derive(Reflect)]
struct MyStruct {
  #[reflect(ignore)] // <- ERROR!
  _ignore_me: i32,
  foo: i32,
  bar: i32,
}

// NEW:
#[derive(Reflect)]
struct MyStruct {
  foo: i32,
  bar: i32,
  #[reflect(ignore)] // <- OK!
  _ignore_me: i32,
}
```

Additionally, `#[reflect(skip_serializing)]` must also be placed at the end of the type definition. However, it must also come _before_ `#[reflect(ignore)]`.

```rust
// OLD:
#[derive(Reflect)]
struct MyStruct {
  #[reflect(ignore)] // <- ERROR!
  _ignore_me: i32,
  #[reflect(skip_serializing)] // <-ERROR!
  _skip_me: i32,
  foo: i32,
}

// NEW:
#[derive(Reflect)]
struct MyStruct {
  foo: i32,
  #[reflect(skip_serializing)] // <- OK!
  _skip_me: i32,
  #[reflect(ignore)] // <- OK!
  _ignore_me: i32,
}
```
