### PR TITLE
Render Graph: Actually replace the node if the name is already present

### DIFF
--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -96,7 +96,7 @@ impl RenderGraph {
         let id = *self
             .node_names
             .entry(name.clone())
-            .or_insert_with(|| NodeId::new());
+            .or_insert_with(NodeId::new);
 
         let mut new_node_state = NodeState::new(id, node);
         new_node_state.name = Some(name);


### PR DESCRIPTION
# Objective

According to the comments on `RenderGraph::add_node`, if the node name is already present, it is supposed to replace it instead.

The current behavior is that it will add a new node, and any future operations on the same node name will be pointed towards the new node. However the old node and connected edges will stay in place.

## Solution

This PR attempts to fix this mismatch by changing the implementation of `RenderGraph::add_node` to match the description.

Alternatively, we can also add a new method `RenderGraph::replace_node` to allow actually replacing the node. At the same time, make `RenderGraph::add_node` panic if the node name is already present.

## Migration Guide

Users who are calling `RenderGraph::add_node` on the same node name twice will have to select a different node name.

