### PR TITLE
[Merged by Bors] - Fix panicking on another scope

### DIFF
--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -299,8 +299,11 @@ impl TaskPool {
                     break result;
                 };
 
-                self.executor.try_tick();
-                task_scope_executor.try_tick();
+                std::panic::catch_unwind(|| {
+                    executor.try_tick();
+                    task_scope_executor.try_tick();
+                })
+                .ok();
             }
         }
     }

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -318,10 +318,7 @@ mod test {
         let mut temp = World::new();
         let mut app = App::new();
 
-        // FIXME: Parallel executors seem to have some odd interaction with the other
-        // tests in this crate. Using single_threaded until a root cause can be found.
-        app.add_stage("single", SystemStage::single_threaded())
-            .add_system_to_stage("single", transform_propagate_system);
+        app.add_system(transform_propagate_system);
 
         fn setup_world(world: &mut World) -> (Entity, Entity) {
             let mut grandchild = Entity::from_raw(0);


### PR DESCRIPTION
# Objective
Fix #6453. 

## Solution
Use the solution mentioned in the issue by catching the unwind and dropping the error. Wrap the `executor.try_tick` calls with `std::catch::unwind`.

Ideally this would be moved outside of the hot loop, but the mut ref to the `spawned` future is not `UnwindSafe`.

This PR only addresses the bug, we can address the perf issues (should there be any) later.