### PR TITLE
bevy_pbr: Normalize `world_normal`

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -57,7 +57,7 @@ fn apply_normal_mapping(
     // Unreal Engine, Godot, and more all use the mikktspace method. Do not change this code
     // unless you really know what you are doing.
     // http://www.mikktspace.com/
-    var N: vec3<f32> = world_normal;
+    var N: vec3<f32> = normalize(world_normal);
 
 #ifdef VERTEX_TANGENTS
 #ifdef STANDARDMATERIAL_NORMAL_MAP


### PR DESCRIPTION
# Objective

Fixes #6528

## Solution

Commit 681c9c6dc859be52565609e56ce9dc7f6f1c1f12 introduced a bug for certain GPUs where the foxes in the `many_foxes` stress test example were not shaded correctly. The cause of this bug (at least on my machine) is `apply_normal_mapping()` no longer normalizing the `world_normal` vector.

Note that this solution is not ideal as the comment specifically says:
```
NOTE: The mikktspace method of normal mapping explicitly requires that the world normal NOT
be re-normalized in the fragment shader. This is primarily to match the way mikktspace
bakes vertex tangents and normal maps so that this is the exact inverse. Blender, Unity,
Unreal Engine, Godot, and more all use the mikktspace method. Do not change this code
unless you really know what you are doing.
http://www.mikktspace.com/
```

We may want to revert this in the future, but for now it seems to fix this bug.

---

## Changelog

Reverted part of 681c9c6dc859be52565609e56ce9dc7f6f1c1f12
