### PR TITLE
[Merged by Bors] - bevy_pbr: Normalize skinned normals

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -91,12 +91,12 @@ fn apply_normal_mapping(
     // calculates the normal maps so there is no error introduced. Do not change this code
     // unless you really know what you are doing.
     // http://www.mikktspace.com/
-    N = normalize(Nt.x * T + Nt.y * B + Nt.z * N);
+    N = Nt.x * T + Nt.y * B + Nt.z * N;
 #endif
 #endif
 #endif
 
-    return N;
+    return normalize(N);
 }
 
 // NOTE: Correctly calculates the view vector depending on whether

--- a/crates/bevy_pbr/src/render/skinning.wgsl
+++ b/crates/bevy_pbr/src/render/skinning.wgsl
@@ -30,9 +30,13 @@ fn skin_normals(
     model: mat4x4<f32>,
     normal: vec3<f32>,
 ) -> vec3<f32> {
-    return inverse_transpose_3x3(mat3x3<f32>(
-        model[0].xyz,
-        model[1].xyz,
-        model[2].xyz
-    )) * normal;
+    return normalize(
+        inverse_transpose_3x3(
+            mat3x3<f32>(
+                model[0].xyz,
+                model[1].xyz,
+                model[2].xyz
+            )
+        ) * normal
+    );
 }


### PR DESCRIPTION
# Objective

- Make the many foxes not unnecessarily bright. Broken since #5666.
- Fixes #6528 

## Solution

- In #5666 normalisation of normals was moved from the fragment stage to the vertex stage. However, it was not added to the vertex stage for skinned normals. The many foxes are skinned and their skinned normals were not unit normals. which made them brighter. Normalising the skinned normals fixes this.

---

## Changelog

- Fixed: Non-unit length skinned normals are now normalized.