### PR TITLE
ComponentDescriptor::new_non_send

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -335,7 +335,11 @@ impl ComponentDescriptor {
         }
     }
 
-    fn new_non_send<T: Any>(storage_type: StorageType) -> Self {
+    /// Create a new non-send `ComponentDescriptor` for the type `T`.
+    ///
+    /// If type `T` is [Send] and [Sync] then it should implement [`Component`] and
+    /// call [`ComponentDescriptor::new`] instead.
+    pub fn new_non_send<T: Any>(storage_type: StorageType) -> Self {
         Self {
             name: Cow::Borrowed(std::any::type_name::<T>()),
             storage_type,


### PR DESCRIPTION
# Objective

Want to create `ComponentDescriptor` for types that cannot implement Component due to being non-Send.

## Solution

Make `ComponentDescriptor::new_non_send` public.
