### PR TITLE
[Merged by Bors] - Better bloom default settings

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -159,7 +159,7 @@ impl Default for BloomSettings {
             threshold: 1.0,
             knee: 0.1,
             scale: 1.0,
-            intensity: 1.0,
+            intensity: 0.3,
         }
     }
 }

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -805,5 +805,5 @@ fn queue_bloom_bind_groups(
 }
 
 fn calculate_mip_count(min_view: u32) -> u32 {
-    ((min_view as f32).log2().round() as u32 - 1).max(1)
+    ((min_view as f32).log2().round() as u32 - 3).max(1)
 }

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -149,7 +149,7 @@ pub struct BloomSettings {
     /// Scale used when upsampling (default: 1.0).
     pub scale: f32,
 
-    /// Intensity of the bloom effect (default: 1.0).
+    /// Intensity of the bloom effect (default: 0.3).
     pub intensity: f32,
 }
 
@@ -159,7 +159,7 @@ impl Default for BloomSettings {
             threshold: 1.0,
             knee: 0.1,
             scale: 1.0,
-            intensity: 1.0,
+            intensity: 0.3,
         }
     }
 }
@@ -655,7 +655,7 @@ fn prepare_bloom_uniforms(
                 threshold: settings.threshold,
                 knee: settings.knee,
                 scale: settings.scale * scale,
-                intensity: settings.intensity / 3.0,
+                intensity: settings.intensity,
             };
             let index = bloom_uniforms.uniforms.push(uniform);
             Some((entity, (BloomUniformIndex(index))))

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -159,7 +159,7 @@ impl Default for BloomSettings {
             threshold: 1.0,
             knee: 0.1,
             scale: 1.0,
-            intensity: 0.3,
+            intensity: 1.0,
         }
     }
 }
@@ -655,7 +655,7 @@ fn prepare_bloom_uniforms(
                 threshold: settings.threshold,
                 knee: settings.knee,
                 scale: settings.scale * scale,
-                intensity: settings.intensity,
+                intensity: settings.intensity / 3.0,
             };
             let index = bloom_uniforms.uniforms.push(uniform);
             Some((entity, (BloomUniformIndex(index))))

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -805,5 +805,5 @@ fn queue_bloom_bind_groups(
 }
 
 fn calculate_mip_count(min_view: u32) -> u32 {
-    ((min_view as f32).log2().round() as u32 - 3).max(1)
+    ((min_view as f32).log2().round() as i32 - 3).max(1) as u32
 }


### PR DESCRIPTION
# Objective

- Use better defaults for bloom

## Solution

- Divide the intensity by 3. It's still noticeable
- Change the mip level? (not sure about that change, it's from a discussion with @superdump)


### bloom example
main:
<img width="1392" alt="Screenshot 2022-11-11 at 01 09 26" src="https://user-images.githubusercontent.com/8672791/201232996-20d6cf65-2511-41bc-979b-f2c193e4e4e6.png">
this pr:
<img width="1392" alt="Screenshot 2022-11-11 at 01 08 00" src="https://user-images.githubusercontent.com/8672791/201232987-b1ebad2a-4ebf-4296-a91b-aab898544a9d.png">


### bistro scene
main:
<img width="1392" alt="Screenshot 2022-11-11 at 01 16 42" src="https://user-images.githubusercontent.com/8672791/201233028-526999a3-0060-44f7-b0dd-f78666b06c1d.png">
this pr:
<img width="1392" alt="Screenshot 2022-11-11 at 01 15 12" src="https://user-images.githubusercontent.com/8672791/201233044-50201034-e881-40e1-8455-76cabc621a9b.png">


