### PR TITLE
[Merged by Bors] - Split Component Ticks

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -9,7 +9,7 @@ use crate::{
         Archetype, ArchetypeId, Archetypes, BundleComponentStatus, ComponentStatus,
         SpawnBundleStatus,
     },
-    component::{Component, ComponentId, ComponentTicks, Components, StorageType},
+    component::{Component, ComponentId, Tick, Components, StorageType},
     entity::{Entities, Entity, EntityLocation},
     storage::{SparseSetIndex, SparseSets, Storages, Table},
 };
@@ -397,7 +397,7 @@ impl BundleInfo {
                             column.initialize(
                                 table_row,
                                 component_ptr,
-                                ComponentTicks::new(change_tick),
+                                Tick::new(change_tick),
                             );
                         }
                         ComponentStatus::Mutated => {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -9,7 +9,7 @@ use crate::{
         Archetype, ArchetypeId, Archetypes, BundleComponentStatus, ComponentStatus,
         SpawnBundleStatus,
     },
-    component::{Component, ComponentId, Tick, Components, StorageType},
+    component::{Component, ComponentId, Components, StorageType, Tick},
     entity::{Entities, Entity, EntityLocation},
     storage::{SparseSetIndex, SparseSets, Storages, Table},
 };
@@ -394,11 +394,7 @@ impl BundleInfo {
                     // SAFETY: bundle_component is a valid index for this bundle
                     match bundle_component_status.get_status(bundle_component) {
                         ComponentStatus::Added => {
-                            column.initialize(
-                                table_row,
-                                component_ptr,
-                                Tick::new(change_tick),
-                            );
+                            column.initialize(table_row, component_ptr, Tick::new(change_tick));
                         }
                         ComponentStatus::Mutated => {
                             column.replace(table_row, component_ptr, change_tick);

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1,6 +1,11 @@
 //! Types that detect when their internal data mutate.
 
-use crate::{component::Tick, ptr::PtrMut, system::Resource};
+use crate::{
+    component::{Tick, TickCells},
+    ptr::PtrMut,
+    system::Resource,
+};
+use bevy_ptr::UnsafeCellDeref;
 use std::ops::{Deref, DerefMut};
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
@@ -228,6 +233,24 @@ pub(crate) struct Ticks<'a> {
     pub(crate) changed: &'a mut Tick,
     pub(crate) last_change_tick: u32,
     pub(crate) change_tick: u32,
+}
+
+impl<'a> Ticks<'a> {
+    /// # Safety
+    /// This should never alias the underlying ticks. All access must be unique.
+    #[inline]
+    pub(crate) unsafe fn from_tick_cells(
+        cells: TickCells<'a>,
+        last_change_tick: u32,
+        change_tick: u32,
+    ) -> Self {
+        Self {
+            added: cells.added.deref_mut(),
+            changed: cells.changed.deref_mut(),
+            last_change_tick,
+            change_tick,
+        }
+    }
 }
 
 /// Unique mutable borrow of a [`Resource`].

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1,6 +1,6 @@
 //! Types that detect when their internal data mutate.
 
-use crate::{component::ComponentTicks, ptr::PtrMut, system::Resource};
+use crate::{component::Tick, ptr::PtrMut, system::Resource};
 use std::ops::{Deref, DerefMut};
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
@@ -95,21 +95,21 @@ macro_rules! change_detection_impl {
             #[inline]
             fn is_added(&self) -> bool {
                 self.ticks
-                    .component_ticks
-                    .is_added(self.ticks.last_change_tick, self.ticks.change_tick)
+                    .added
+                    .is_changed(self.ticks.last_change_tick, self.ticks.change_tick)
             }
 
             #[inline]
             fn is_changed(&self) -> bool {
                 self.ticks
-                    .component_ticks
+                    .changed
                     .is_changed(self.ticks.last_change_tick, self.ticks.change_tick)
             }
 
             #[inline]
             fn set_changed(&mut self) {
                 self.ticks
-                    .component_ticks
+                    .changed
                     .set_changed(self.ticks.change_tick);
             }
 
@@ -224,7 +224,8 @@ macro_rules! impl_debug {
 }
 
 pub(crate) struct Ticks<'a> {
-    pub(crate) component_ticks: &'a mut ComponentTicks,
+    pub(crate) added: &'a mut Tick,
+    pub(crate) changed: &'a mut Tick,
     pub(crate) last_change_tick: u32,
     pub(crate) change_tick: u32,
 }
@@ -381,21 +382,21 @@ impl<'a> DetectChanges for MutUntyped<'a> {
     #[inline]
     fn is_added(&self) -> bool {
         self.ticks
-            .component_ticks
-            .is_added(self.ticks.last_change_tick, self.ticks.change_tick)
+            .added
+            .is_changed(self.ticks.last_change_tick, self.ticks.change_tick)
     }
 
     #[inline]
     fn is_changed(&self) -> bool {
         self.ticks
-            .component_ticks
+            .changed
             .is_changed(self.ticks.last_change_tick, self.ticks.change_tick)
     }
 
     #[inline]
     fn set_changed(&mut self) {
         self.ticks
-            .component_ticks
+            .changed
             .set_changed(self.ticks.change_tick);
     }
 

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -395,9 +395,7 @@ impl<'a> DetectChanges for MutUntyped<'a> {
 
     #[inline]
     fn set_changed(&mut self) {
-        self.ticks
-            .changed
-            .set_changed(self.ticks.change_tick);
+        self.ticks.changed.set_changed(self.ticks.change_tick);
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -96,14 +96,14 @@ macro_rules! change_detection_impl {
             fn is_added(&self) -> bool {
                 self.ticks
                     .added
-                    .is_changed(self.ticks.last_change_tick, self.ticks.change_tick)
+                    .is_older_than(self.ticks.last_change_tick, self.ticks.change_tick)
             }
 
             #[inline]
             fn is_changed(&self) -> bool {
                 self.ticks
                     .changed
-                    .is_changed(self.ticks.last_change_tick, self.ticks.change_tick)
+                    .is_older_than(self.ticks.last_change_tick, self.ticks.change_tick)
             }
 
             #[inline]
@@ -383,14 +383,14 @@ impl<'a> DetectChanges for MutUntyped<'a> {
     fn is_added(&self) -> bool {
         self.ticks
             .added
-            .is_changed(self.ticks.last_change_tick, self.ticks.change_tick)
+            .is_older_than(self.ticks.last_change_tick, self.ticks.change_tick)
     }
 
     #[inline]
     fn is_changed(&self) -> bool {
         self.ticks
             .changed
-            .is_changed(self.ticks.last_change_tick, self.ticks.change_tick)
+            .is_older_than(self.ticks.last_change_tick, self.ticks.change_tick)
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -518,6 +518,7 @@ impl Components {
     }
 }
 
+/// Used to track changes in state between system runs, e.g. components being added or accessed mutably.
 #[derive(Copy, Clone, Debug)]
 pub struct Tick {
     pub(crate) tick: u32,

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -5,6 +5,7 @@ use crate::{
     storage::{SparseSetIndex, Storages},
     system::Resource,
 };
+use std::cell::UnsafeCell;
 pub use bevy_ecs_macros::Component;
 use bevy_ptr::OwningPtr;
 use std::{
@@ -570,6 +571,13 @@ impl Tick {
     pub fn set_changed(&mut self, change_tick: u32) {
         self.tick = change_tick;
     }
+}
+
+/// Wrapper around [`Tick`]s for a single component
+#[derive(Copy, Clone, Debug)]
+pub struct TickCells<'a> {
+    pub added: &'a UnsafeCell<Tick>,
+    pub changed: &'a UnsafeCell<Tick>,
 }
 
 /// Records when a component was added and when it was last mutably dereferenced (or added).

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -528,9 +528,10 @@ impl Tick {
     }
 
     #[inline]
-    pub fn is_changed(&self, last_change_tick: u32, change_tick: u32) -> bool {
+    /// Returns `true` if the tick is older than the system last's run.
+    pub fn is_older_than(&self, last_change_tick: u32, change_tick: u32) -> bool {
         // This works even with wraparound because the world tick (`change_tick`) is always "newer" than
-        // `last_change_tick` and `self.added`, and we scan periodically to clamp `ComponentTicks` values
+        // `last_change_tick` and `self.tick`, and we scan periodically to clamp `ComponentTicks` values
         // so they never get older than `u32::MAX` (the difference would overflow).
         //
         // The clamp here ensures determinism (since scans could differ between app runs).
@@ -582,13 +583,13 @@ impl ComponentTicks {
     #[inline]
     /// Returns `true` if the component was added after the system last ran.
     pub fn is_added(&self, last_change_tick: u32, change_tick: u32) -> bool {
-        self.added.is_changed(last_change_tick, change_tick)
+        self.added.is_older_than(last_change_tick, change_tick)
     }
 
     #[inline]
     /// Returns `true` if the component was added or mutably dereferenced after the system last ran.
     pub fn is_changed(&self, last_change_tick: u32, change_tick: u32) -> bool {
-        self.changed.is_changed(last_change_tick, change_tick)
+        self.changed.is_older_than(last_change_tick, change_tick)
     }
 
     pub(crate) fn new(change_tick: u32) -> Self {

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -6,7 +6,7 @@ use crate::{
     system::Resource,
 };
 pub use bevy_ecs_macros::Component;
-use bevy_ptr::OwningPtr;
+use bevy_ptr::{OwningPtr, UnsafeCellDeref};
 use std::cell::UnsafeCell;
 use std::{
     alloc::Layout,
@@ -578,6 +578,18 @@ impl Tick {
 pub struct TickCells<'a> {
     pub added: &'a UnsafeCell<Tick>,
     pub changed: &'a UnsafeCell<Tick>,
+}
+
+impl<'a> TickCells<'a> {
+    /// # Safety
+    /// All cells contained within must uphold the safety invariants of [`UnsafeCellDeref::read`].
+    #[inline]
+    pub(crate) unsafe fn read(&self) -> ComponentTicks {
+        ComponentTicks {
+            added: self.added.read(),
+            changed: self.changed.read(),
+        }
+    }
 }
 
 /// Records when a component was added and when it was last mutably dereferenced (or added).

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -582,7 +582,7 @@ impl ComponentTicks {
     #[inline]
     /// Returns `true` if the component was added after the system last ran.
     pub fn is_added(&self, last_change_tick: u32, change_tick: u32) -> bool {
-        self.changed.is_changed(last_change_tick, change_tick)
+        self.added.is_changed(last_change_tick, change_tick)
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -517,23 +517,24 @@ impl Components {
     }
 }
 
-/// Records when a component was added and when it was last mutably dereferenced (or added).
 #[derive(Copy, Clone, Debug)]
-pub struct ComponentTicks {
-    pub(crate) added: u32,
-    pub(crate) changed: u32,
+pub struct Tick {
+    pub(crate) tick: u32,
 }
 
-impl ComponentTicks {
+impl Tick {
+    const fn new(tick: u32) -> Self {
+        Self { tick }
+    }
+
     #[inline]
-    /// Returns `true` if the component was added after the system last ran.
-    pub fn is_added(&self, last_change_tick: u32, change_tick: u32) -> bool {
+    pub fn is_changed(&self, last_change_tick: u32, change_tick: u32) -> bool {
         // This works even with wraparound because the world tick (`change_tick`) is always "newer" than
         // `last_change_tick` and `self.added`, and we scan periodically to clamp `ComponentTicks` values
         // so they never get older than `u32::MAX` (the difference would overflow).
         //
         // The clamp here ensures determinism (since scans could differ between app runs).
-        let ticks_since_insert = change_tick.wrapping_sub(self.added).min(MAX_CHANGE_AGE);
+        let ticks_since_insert = change_tick.wrapping_sub(self.tick).min(MAX_CHANGE_AGE);
         let ticks_since_system = change_tick
             .wrapping_sub(last_change_tick)
             .min(MAX_CHANGE_AGE);
@@ -541,32 +542,13 @@ impl ComponentTicks {
         ticks_since_system > ticks_since_insert
     }
 
-    #[inline]
-    /// Returns `true` if the component was added or mutably dereferenced after the system last ran.
-    pub fn is_changed(&self, last_change_tick: u32, change_tick: u32) -> bool {
-        // This works even with wraparound because the world tick (`change_tick`) is always "newer" than
-        // `last_change_tick` and `self.changed`, and we scan periodically to clamp `ComponentTicks` values
-        // so they never get older than `u32::MAX` (the difference would overflow).
-        //
-        // The clamp here ensures determinism (since scans could differ between app runs).
-        let ticks_since_change = change_tick.wrapping_sub(self.changed).min(MAX_CHANGE_AGE);
-        let ticks_since_system = change_tick
-            .wrapping_sub(last_change_tick)
-            .min(MAX_CHANGE_AGE);
-
-        ticks_since_system > ticks_since_change
-    }
-
-    pub(crate) fn new(change_tick: u32) -> Self {
-        Self {
-            added: change_tick,
-            changed: change_tick,
+    fn check_tick(&mut self, change_tick: u32) {
+        let age = change_tick.wrapping_sub(self.tick);
+        // This comparison assumes that `age` has not overflowed `u32::MAX` before, which will be true
+        // so long as this check always runs before that can happen.
+        if age > MAX_CHANGE_AGE {
+            self.tick = change_tick.wrapping_sub(MAX_CHANGE_AGE);
         }
-    }
-
-    pub(crate) fn check_ticks(&mut self, change_tick: u32) {
-        check_tick(&mut self.added, change_tick);
-        check_tick(&mut self.changed, change_tick);
     }
 
     /// Manually sets the change tick.
@@ -585,15 +567,58 @@ impl ComponentTicks {
     /// ```
     #[inline]
     pub fn set_changed(&mut self, change_tick: u32) {
-        self.changed = change_tick;
+        self.tick = change_tick;
     }
 }
 
-fn check_tick(last_change_tick: &mut u32, change_tick: u32) {
-    let age = change_tick.wrapping_sub(*last_change_tick);
-    // This comparison assumes that `age` has not overflowed `u32::MAX` before, which will be true
-    // so long as this check always runs before that can happen.
-    if age > MAX_CHANGE_AGE {
-        *last_change_tick = change_tick.wrapping_sub(MAX_CHANGE_AGE);
+/// Records when a component was added and when it was last mutably dereferenced (or added).
+#[derive(Copy, Clone, Debug)]
+pub struct ComponentTicks {
+    pub(crate) added: Tick,
+    pub(crate) changed: Tick,
+}
+
+impl ComponentTicks {
+    #[inline]
+    /// Returns `true` if the component was added after the system last ran.
+    pub fn is_added(&self, last_change_tick: u32, change_tick: u32) -> bool {
+        self.changed.is_changed(last_change_tick, change_tick)
+    }
+
+    #[inline]
+    /// Returns `true` if the component was added or mutably dereferenced after the system last ran.
+    pub fn is_changed(&self, last_change_tick: u32, change_tick: u32) -> bool {
+        self.changed.is_changed(last_change_tick, change_tick)
+    }
+
+    pub(crate) fn new(change_tick: u32) -> Self {
+        Self {
+            added: Tick::new(change_tick),
+            changed: Tick::new(change_tick),
+        }
+    }
+
+    pub(crate) fn check_ticks(&mut self, change_tick: u32) {
+        self.added.check_tick(change_tick);
+        self.changed.check_tick(change_tick);
+    }
+
+    /// Manually sets the change tick.
+    ///
+    /// This is normally done automatically via the [`DerefMut`](std::ops::DerefMut) implementation
+    /// on [`Mut<T>`](crate::change_detection::Mut), [`ResMut<T>`](crate::change_detection::ResMut), etc.
+    /// However, components and resources that make use of interior mutability might require manual updates.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use bevy_ecs::{world::World, component::ComponentTicks};
+    /// let world: World = unimplemented!();
+    /// let component_ticks: ComponentTicks = unimplemented!();
+    ///
+    /// component_ticks.set_changed(world.read_change_tick());
+    /// ```
+    #[inline]
+    pub fn set_changed(&mut self, change_tick: u32) {
+        self.changed.set_changed(change_tick);
     }
 }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -5,9 +5,9 @@ use crate::{
     storage::{SparseSetIndex, Storages},
     system::Resource,
 };
-use std::cell::UnsafeCell;
 pub use bevy_ecs_macros::Component;
 use bevy_ptr::OwningPtr;
+use std::cell::UnsafeCell;
 use std::{
     alloc::Layout,
     any::{Any, TypeId},

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -523,7 +523,7 @@ pub struct Tick {
 }
 
 impl Tick {
-    const fn new(tick: u32) -> Self {
+    pub const fn new(tick: u32) -> Self {
         Self { tick }
     }
 

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -542,7 +542,7 @@ impl Tick {
         ticks_since_system > ticks_since_insert
     }
 
-    fn check_tick(&mut self, change_tick: u32) {
+    pub(crate) fn check_tick(&mut self, change_tick: u32) {
         let age = change_tick.wrapping_sub(self.tick);
         // This comparison assumes that `age` has not overflowed `u32::MAX` before, which will be true
         // so long as this check always runs before that can happen.
@@ -596,11 +596,6 @@ impl ComponentTicks {
             added: Tick::new(change_tick),
             changed: Tick::new(change_tick),
         }
-    }
-
-    pub(crate) fn check_ticks(&mut self, change_tick: u32) {
-        self.added.check_tick(change_tick);
-        self.changed.check_tick(change_tick);
     }
 
     /// Manually sets the change tick.

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -760,7 +760,7 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
                 }
             }
             StorageType::SparseSet => {
-                let (component, added, changed) = fetch
+                let (component, ticks) = fetch
                     .sparse_set
                     .debug_checked_unwrap()
                     .get_with_ticks(entity)
@@ -768,8 +768,8 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
                 Mut {
                     value: component.assert_unique().deref_mut(),
                     ticks: Ticks {
-                        added: added.deref_mut(),
-                        changed: changed.deref_mut(),
+                        added: ticks.added.deref_mut(),
+                        changed: ticks.changed.deref_mut(),
                         change_tick: fetch.change_tick,
                         last_change_tick: fetch.last_change_tick,
                     },

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -767,12 +767,7 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
                     .debug_checked_unwrap();
                 Mut {
                     value: component.assert_unique().deref_mut(),
-                    ticks: Ticks {
-                        added: ticks.added.deref_mut(),
-                        changed: ticks.changed.deref_mut(),
-                        change_tick: fetch.change_tick,
-                        last_change_tick: fetch.last_change_tick,
-                    },
+                    ticks: Ticks::from_tick_cells(ticks, fetch.change_tick, fetch.last_change_tick),
                 }
             }
         }

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -508,7 +508,7 @@ macro_rules! impl_tick_filter {
                             .debug_checked_unwrap()
                             .get(table_row)
                             .deref()
-                            .is_changed(fetch.last_change_tick, fetch.change_tick)
+                            .is_older_than(fetch.last_change_tick, fetch.change_tick)
                     }
                     StorageType::SparseSet => {
                         let sparse_set = &fetch
@@ -517,7 +517,7 @@ macro_rules! impl_tick_filter {
                         $get_sparse_set(sparse_set, entity)
                             .debug_checked_unwrap()
                             .deref()
-                            .is_changed(fetch.last_change_tick, fetch.change_tick)
+                            .is_older_than(fetch.last_change_tick, fetch.change_tick)
                     }
                 }
             }

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -1,9 +1,9 @@
 use crate::{
     archetype::{Archetype, ArchetypeComponentId},
-    component::{Component, ComponentId, ComponentStorage, ComponentTicks, StorageType, Tick},
+    component::{Component, ComponentId, ComponentStorage, StorageType, Tick},
     entity::Entity,
     query::{Access, DebugCheckedUnwrap, FilteredAccess, WorldQuery},
-    storage::{ComponentSparseSet, Table},
+    storage::{Column, ComponentSparseSet, Table},
     world::World,
 };
 use bevy_ecs_macros::all_tuples;
@@ -405,7 +405,8 @@ macro_rules! impl_tick_filter {
         $name: ident,
         $(#[$fetch_meta:meta])*
         $fetch_name: ident,
-        $is_detected: expr
+        $get_slice: expr,
+        $get_sparse_set: expr
     ) => {
         $(#[$meta])*
         pub struct $name<T>(PhantomData<T>);
@@ -413,10 +414,7 @@ macro_rules! impl_tick_filter {
         #[doc(hidden)]
         $(#[$fetch_meta])*
         pub struct $fetch_name<'w, T> {
-            table_ticks: Option<(
-                ThinSlicePtr<'w, UnsafeCell<Tick>>,
-                ThinSlicePtr<'w, UnsafeCell<Tick>>
-            )>,
+            table_ticks: Option< ThinSlicePtr<'w, UnsafeCell<Tick>>>,
             marker: PhantomData<T>,
             sparse_set: Option<&'w ComponentSparseSet>,
             last_change_tick: u32,
@@ -480,10 +478,9 @@ macro_rules! impl_tick_filter {
                 let column = table
                     .get_column(component_id)
                     .debug_checked_unwrap();
-                fetch.table_ticks = Some((
-                    column.get_added_ticks_slice().into(),
-                    column.get_changed_ticks_slice().into()
-                ));
+                fetch.table_ticks = Some(
+                    $get_slice(&column).into(),
+                );
             }
 
             #[inline]
@@ -506,23 +503,21 @@ macro_rules! impl_tick_filter {
             ) -> Self::Item<'w> {
                 match T::Storage::STORAGE_TYPE {
                     StorageType::Table => {
-                        let (added, changed) = fetch.table_ticks.debug_checked_unwrap();
-                        let ticks = ComponentTicks {
-                            added: added.get(table_row).read(),
-                            changed: changed.get(table_row).read()
-                        };
-                        $is_detected(&ticks, fetch.last_change_tick, fetch.change_tick)
+                        fetch
+                            .table_ticks
+                            .debug_checked_unwrap()
+                            .get(table_row)
+                            .deref()
+                            .is_changed(fetch.last_change_tick, fetch.change_tick)
                     }
                     StorageType::SparseSet => {
-                        $is_detected(
-                            &fetch
-                                .sparse_set
-                                .debug_checked_unwrap()
-                                .get_ticks(entity)
-                                .debug_checked_unwrap(),
-                            fetch.last_change_tick,
-                            fetch.change_tick
-                        )
+                        let sparse_set = &fetch
+                            .sparse_set
+                            .debug_checked_unwrap();
+                        $get_sparse_set(sparse_set, entity)
+                            .debug_checked_unwrap()
+                            .deref()
+                            .is_changed(fetch.last_change_tick, fetch.change_tick)
                     }
                 }
             }
@@ -599,7 +594,8 @@ impl_tick_filter!(
     /// ```
     Added,
     AddedFetch,
-    ComponentTicks::is_added
+    Column::get_added_ticks_slice,
+    ComponentSparseSet::get_added_ticks
 );
 
 impl_tick_filter!(
@@ -636,7 +632,8 @@ impl_tick_filter!(
     /// ```
     Changed,
     ChangedFetch,
-    ComponentTicks::is_changed
+    Column::get_changed_ticks_slice,
+    ComponentSparseSet::get_changed_ticks
 );
 
 /// A marker trait to indicate that the filter works at an archetype level.

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -475,11 +475,12 @@ macro_rules! impl_tick_filter {
                 &component_id: &ComponentId,
                 table: &'w Table
             ) {
-                let column = table
-                    .get_column(component_id)
-                    .debug_checked_unwrap();
                 fetch.table_ticks = Some(
-                    $get_slice(&column).into(),
+                    $get_slice(
+                        &table
+                            .get_column(component_id)
+                            .debug_checked_unwrap()
+                    ).into(),
                 );
             }
 

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -1,8 +1,7 @@
 use crate::archetype::ArchetypeComponentId;
-use crate::component::{ComponentId, ComponentTicks, Components, Tick};
+use crate::component::{ComponentId, ComponentTicks, Components, TickCells};
 use crate::storage::{Column, SparseSet};
 use bevy_ptr::{OwningPtr, Ptr, UnsafeCellDeref};
-use std::cell::UnsafeCell;
 
 /// The type-erased backing storage and metadata for a single resource within a [`World`].
 ///
@@ -38,7 +37,7 @@ impl ResourceData {
     }
 
     #[inline]
-    pub(crate) fn get_with_ticks(&self) -> Option<(Ptr<'_>, &UnsafeCell<Tick>, &UnsafeCell<Tick>)> {
+    pub(crate) fn get_with_ticks(&self) -> Option<(Ptr<'_>, TickCells<'_>)> {
         self.column.get(0)
     }
 

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -1,5 +1,5 @@
 use crate::archetype::ArchetypeComponentId;
-use crate::component::{ComponentId, ComponentTicks, Components};
+use crate::component::{ComponentId, ComponentTicks, Tick, Components};
 use crate::storage::{Column, SparseSet};
 use bevy_ptr::{OwningPtr, Ptr, UnsafeCellDeref};
 use std::cell::UnsafeCell;
@@ -44,7 +44,7 @@ impl ResourceData {
     }
 
     #[inline]
-    pub(crate) fn get_with_ticks(&self) -> Option<(Ptr<'_>, &UnsafeCell<ComponentTicks>)> {
+    pub(crate) fn get_with_ticks(&self) -> Option<(Ptr<'_>, &UnsafeCell<Tick>, &UnsafeCell<Tick>)> {
         self.column.get(0)
     }
 

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -165,10 +165,7 @@ impl ComponentSparseSet {
     }
 
     #[inline]
-    pub fn get_with_ticks(
-        &self,
-        entity: Entity,
-    ) -> Option<(Ptr<'_>, TickCells<'_>)> {
+    pub fn get_with_ticks(&self, entity: Entity) -> Option<(Ptr<'_>, TickCells<'_>)> {
         let dense_index = *self.sparse.get(entity.index())? as usize;
         #[cfg(debug_assertions)]
         assert_eq!(entity, self.entities[dense_index]);
@@ -179,7 +176,7 @@ impl ComponentSparseSet {
                 TickCells {
                     added: self.dense.get_added_ticks_unchecked(dense_index),
                     changed: self.dense.get_changed_ticks_unchecked(dense_index),
-                }
+                },
             ))
         }
     }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -1,5 +1,5 @@
 use crate::{
-    component::{ComponentId, ComponentInfo, ComponentTicks},
+    component::{ComponentId, ComponentInfo, ComponentTicks, Tick},
     entity::Entity,
     storage::Column,
 };
@@ -176,6 +176,24 @@ impl ComponentSparseSet {
                 self.dense.get_ticks_unchecked(dense_index),
             ))
         }
+    }
+
+    #[inline]
+    pub fn get_added_ticks(&self, entity: Entity) -> Option<&UnsafeCell<Tick>> {
+        let dense_index = *self.sparse.get(entity.index())? as usize;
+        #[cfg(debug_assertions)]
+        assert_eq!(entity, self.entities[dense_index]);
+        // SAFETY: if the sparse index points to something in the dense vec, it exists
+        unsafe { Some(self.dense.get_added_ticks_unchecked(dense_index)) }
+    }
+
+    #[inline]
+    pub fn get_changed_ticks(&self, entity: Entity) -> Option<&UnsafeCell<Tick>> {
+        let dense_index = *self.sparse.get(entity.index())? as usize;
+        #[cfg(debug_assertions)]
+        assert_eq!(entity, self.entities[dense_index]);
+        // SAFETY: if the sparse index points to something in the dense vec, it exists
+        unsafe { Some(self.dense.get_changed_ticks_unchecked(dense_index)) }
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -165,7 +165,7 @@ impl ComponentSparseSet {
     }
 
     #[inline]
-    pub fn get_with_ticks(&self, entity: Entity) -> Option<(Ptr<'_>, &UnsafeCell<ComponentTicks>)> {
+    pub fn get_with_ticks(&self, entity: Entity) -> Option<(Ptr<'_>, &UnsafeCell<Tick>, &UnsafeCell<Tick>)> {
         let dense_index = *self.sparse.get(entity.index())? as usize;
         #[cfg(debug_assertions)]
         assert_eq!(entity, self.entities[dense_index]);
@@ -173,7 +173,8 @@ impl ComponentSparseSet {
         unsafe {
             Some((
                 self.dense.get_data_unchecked(dense_index),
-                self.dense.get_ticks_unchecked(dense_index),
+                self.dense.get_added_ticks_unchecked(dense_index),
+                self.dense.get_changed_ticks_unchecked(dense_index),
             ))
         }
     }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -1,5 +1,5 @@
 use crate::{
-    component::{ComponentId, ComponentInfo, ComponentTicks, Tick},
+    component::{ComponentId, ComponentInfo, ComponentTicks, Tick, TickCells},
     entity::Entity,
     storage::Column,
 };
@@ -168,7 +168,7 @@ impl ComponentSparseSet {
     pub fn get_with_ticks(
         &self,
         entity: Entity,
-    ) -> Option<(Ptr<'_>, &UnsafeCell<Tick>, &UnsafeCell<Tick>)> {
+    ) -> Option<(Ptr<'_>, TickCells<'_>)> {
         let dense_index = *self.sparse.get(entity.index())? as usize;
         #[cfg(debug_assertions)]
         assert_eq!(entity, self.entities[dense_index]);
@@ -176,8 +176,10 @@ impl ComponentSparseSet {
         unsafe {
             Some((
                 self.dense.get_data_unchecked(dense_index),
-                self.dense.get_added_ticks_unchecked(dense_index),
-                self.dense.get_changed_ticks_unchecked(dense_index),
+                TickCells {
+                    added: self.dense.get_added_ticks_unchecked(dense_index),
+                    changed: self.dense.get_changed_ticks_unchecked(dense_index),
+                }
             ))
         }
     }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -165,7 +165,10 @@ impl ComponentSparseSet {
     }
 
     #[inline]
-    pub fn get_with_ticks(&self, entity: Entity) -> Option<(Ptr<'_>, &UnsafeCell<Tick>, &UnsafeCell<Tick>)> {
+    pub fn get_with_ticks(
+        &self,
+        entity: Entity,
+    ) -> Option<(Ptr<'_>, &UnsafeCell<Tick>, &UnsafeCell<Tick>)> {
         let dense_index = *self.sparse.get(entity.index())? as usize;
         #[cfg(debug_assertions)]
         assert_eq!(entity, self.entities[dense_index]);
@@ -198,7 +201,7 @@ impl ComponentSparseSet {
     }
 
     #[inline]
-    pub fn get_ticks(&self, entity: Entity) -> Option<&UnsafeCell<ComponentTicks>> {
+    pub fn get_ticks(&self, entity: Entity) -> Option<ComponentTicks> {
         let dense_index = *self.sparse.get(entity.index())? as usize;
         #[cfg(debug_assertions)]
         assert_eq!(entity, self.entities[dense_index]);

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -216,7 +216,7 @@ impl Column {
                     TickCells {
                         added: self.added_ticks.get_unchecked(row),
                         changed: self.changed_ticks.get_unchecked(row),
-                    }
+                    },
                 )
             })
     }

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -62,12 +62,7 @@ impl Column {
     /// # Safety
     /// Assumes data has already been allocated for the given row.
     #[inline]
-    pub(crate) unsafe fn initialize(
-        &mut self,
-        row: usize,
-        data: OwningPtr<'_>,
-        tick: Tick,
-    ) {
+    pub(crate) unsafe fn initialize(&mut self, row: usize, data: OwningPtr<'_>, tick: Tick) {
         debug_assert!(row < self.len());
         self.data.initialize_unchecked(row, data);
         *self.added_ticks.get_unchecked_mut(row).get_mut() = tick;

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -1,5 +1,5 @@
 use crate::{
-    component::{ComponentId, ComponentInfo, ComponentTicks, Components, Tick},
+    component::{ComponentId, ComponentInfo, ComponentTicks, Components, Tick, TickCells},
     entity::Entity,
     query::DebugCheckedUnwrap,
     storage::{blob_vec::BlobVec, SparseSet},
@@ -206,15 +206,17 @@ impl Column {
     }
 
     #[inline]
-    pub fn get(&self, row: usize) -> Option<(Ptr<'_>, &UnsafeCell<Tick>, &UnsafeCell<Tick>)> {
+    pub fn get(&self, row: usize) -> Option<(Ptr<'_>, TickCells<'_>)> {
         (row < self.data.len())
             // SAFETY: The row is length checked before fetching the pointer. This is being
             // accessed through a read-only reference to the column.
             .then(|| unsafe {
                 (
                     self.data.get_unchecked(row),
-                    self.added_ticks.get_unchecked(row),
-                    self.changed_ticks.get_unchecked(row),
+                    TickCells {
+                        added: self.added_ticks.get_unchecked(row),
+                        changed: self.changed_ticks.get_unchecked(row),
+                    }
                 )
             })
     }

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -227,11 +227,17 @@ impl Column {
     }
 
     #[inline]
-    pub fn get(&self, row: usize) -> Option<(Ptr<'_>, &UnsafeCell<ComponentTicks>)> {
+    pub fn get(&self, row: usize) -> Option<(Ptr<'_>, &UnsafeCell<Tick>, &UnsafeCell<Tick>)> {
         (row < self.data.len())
             // SAFETY: The row is length checked before fetching the pointer. This is being
             // accessed through a read-only reference to the column.
-            .then(|| unsafe { (self.data.get_unchecked(row), self.ticks.get_unchecked(row)) })
+            .then(|| unsafe { 
+                (
+                    self.data.get_unchecked(row), 
+                    self.added_ticks.get_unchecked(row),
+                    self.changed_ticks.get_unchecked(row),
+                ) 
+            })
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -66,12 +66,12 @@ impl Column {
         &mut self,
         row: usize,
         data: OwningPtr<'_>,
-        ticks: ComponentTicks,
+        tick: Tick,
     ) {
         debug_assert!(row < self.len());
         self.data.initialize_unchecked(row, data);
-        *self.added_ticks.get_unchecked_mut(row).get_mut() = ticks.added;
-        *self.changed_ticks.get_unchecked_mut(row).get_mut() = ticks.changed;
+        *self.added_ticks.get_unchecked_mut(row).get_mut() = tick;
+        *self.changed_ticks.get_unchecked_mut(row).get_mut() = tick;
     }
 
     /// Writes component data to the column at given row.

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -654,7 +654,7 @@ mod tests {
     use crate::ptr::OwningPtr;
     use crate::storage::Storages;
     use crate::{
-        component::{ComponentTicks, Components},
+        component::{Components, Tick},
         entity::Entity,
         storage::Table,
     };
@@ -679,7 +679,7 @@ mod tests {
                     table.get_column_mut(component_id).unwrap().initialize(
                         row,
                         value_ptr,
-                        ComponentTicks::new(0),
+                        Tick::new(0),
                     );
                 });
             };

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -130,7 +130,7 @@ impl Column {
             // SAFETY: The row was length checked before this.
             let data = unsafe { self.data.swap_remove_and_forget_unchecked(row) };
             let added = self.added_ticks.swap_remove(row).into_inner();
-            let changed = self.added_ticks.swap_remove(row).into_inner();
+            let changed = self.changed_ticks.swap_remove(row).into_inner();
             (data, ComponentTicks { added, changed })
         })
     }
@@ -145,7 +145,7 @@ impl Column {
     ) -> (OwningPtr<'_>, ComponentTicks) {
         let data = self.data.swap_remove_and_forget_unchecked(row);
         let added = self.added_ticks.swap_remove(row).into_inner();
-        let changed = self.added_ticks.swap_remove(row).into_inner();
+        let changed = self.changed_ticks.swap_remove(row).into_inner();
         (data, ComponentTicks { added, changed })
     }
 
@@ -269,10 +269,10 @@ impl Column {
     #[inline]
     pub fn get_ticks(&self, row: usize) -> Option<ComponentTicks> {
         if row < self.data.len() {
-            None
-        } else {
             // SAFETY: The size of the column has already been checked.
             Some(unsafe { self.get_ticks_unchecked(row) })
+        } else {
+            None
         }
     }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1139,12 +1139,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendMutState<T> {
             });
         NonSendMut {
             value: ptr.assert_unique().deref_mut(),
-            ticks: Ticks {
-                added: ticks.added.deref_mut(),
-                changed: ticks.changed.deref_mut(),
-                last_change_tick: system_meta.last_change_tick,
-                change_tick,
-            },
+            ticks: Ticks::from_tick_cells(ticks, system_meta.last_change_tick, change_tick),
         }
     }
 }
@@ -1181,12 +1176,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for OptionNonSendMutState<T> {
             .get_resource_with_ticks(state.0.component_id)
             .map(|(ptr, ticks)| NonSendMut {
                 value: ptr.assert_unique().deref_mut(),
-                ticks: Ticks {
-                    added: ticks.added.deref_mut(),
-                    changed: ticks.changed.deref_mut(),
-                    last_change_tick: system_meta.last_change_tick,
-                    change_tick,
-                },
+                ticks: Ticks::from_tick_cells(ticks, system_meta.last_change_tick, change_tick),
             })
     }
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -3,7 +3,7 @@ use crate::{
     archetype::{Archetype, Archetypes},
     bundle::Bundles,
     change_detection::Ticks,
-    component::{Component, ComponentId, ComponentTicks, Tick, Components},
+    component::{Component, ComponentId, ComponentTicks, Components, Tick},
     entity::{Entities, Entity},
     query::{
         Access, FilteredAccess, FilteredAccessSet, QueryState, ReadOnlyWorldQuery, WorldQuery,
@@ -306,7 +306,8 @@ impl<'w, T: Resource> Res<'w, T> {
 
     /// Returns `true` if the resource was added after the system last ran.
     pub fn is_added(&self) -> bool {
-        self.added.is_changed(self.last_change_tick, self.change_tick)
+        self.added
+            .is_changed(self.last_change_tick, self.change_tick)
     }
 
     /// Returns `true` if the resource was added or mutably dereferenced after the system last ran.

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -408,7 +408,7 @@ impl<'w, 's, T: Resource> SystemParamFetch<'w, 's> for ResState<T> {
         world: &'w World,
         change_tick: u32,
     ) -> Self::Item {
-        let (ptr, added, changed) = world
+        let (ptr, ticks) = world
             .get_resource_with_ticks(state.component_id)
             .unwrap_or_else(|| {
                 panic!(
@@ -419,8 +419,8 @@ impl<'w, 's, T: Resource> SystemParamFetch<'w, 's> for ResState<T> {
             });
         Res {
             value: ptr.deref(),
-            added: added.deref(),
-            changed: changed.deref(),
+            added: ticks.added.deref(),
+            changed: ticks.changed.deref(),
             last_change_tick: system_meta.last_change_tick,
             change_tick,
         }
@@ -459,10 +459,10 @@ impl<'w, 's, T: Resource> SystemParamFetch<'w, 's> for OptionResState<T> {
     ) -> Self::Item {
         world
             .get_resource_with_ticks(state.0.component_id)
-            .map(|(ptr, added, changed)| Res {
+            .map(|(ptr, ticks)| Res {
                 value: ptr.deref(),
-                added: added.deref(),
-                changed: changed.deref(),
+                added: ticks.added.deref(),
+                changed: ticks.changed.deref(),
                 last_change_tick: system_meta.last_change_tick,
                 change_tick,
             })
@@ -1007,7 +1007,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendState<T> {
         change_tick: u32,
     ) -> Self::Item {
         world.validate_non_send_access::<T>();
-        let (ptr, added, changed) = world
+        let (ptr, ticks) = world
             .get_resource_with_ticks(state.component_id)
             .unwrap_or_else(|| {
                 panic!(
@@ -1020,8 +1020,8 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendState<T> {
         NonSend {
             value: ptr.deref(),
             ticks: ComponentTicks {
-                added: added.read(),
-                changed: changed.read(),
+                added: ticks.added.read(),
+                changed: ticks.changed.read(),
             },
             last_change_tick: system_meta.last_change_tick,
             change_tick,
@@ -1062,11 +1062,11 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for OptionNonSendState<T> {
         world.validate_non_send_access::<T>();
         world
             .get_resource_with_ticks(state.0.component_id)
-            .map(|(ptr, added, changed)| NonSend {
+            .map(|(ptr, ticks)| NonSend {
                 value: ptr.deref(),
                 ticks: ComponentTicks {
-                    added: added.read(),
-                    changed: changed.read(),
+                    added: ticks.added.read(),
+                    changed: ticks.changed.read(),
                 },
                 last_change_tick: system_meta.last_change_tick,
                 change_tick,
@@ -1128,7 +1128,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendMutState<T> {
         change_tick: u32,
     ) -> Self::Item {
         world.validate_non_send_access::<T>();
-        let (ptr, added, changed) = world
+        let (ptr, ticks) = world
             .get_resource_with_ticks(state.component_id)
             .unwrap_or_else(|| {
                 panic!(
@@ -1140,8 +1140,8 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendMutState<T> {
         NonSendMut {
             value: ptr.assert_unique().deref_mut(),
             ticks: Ticks {
-                added: added.deref_mut(),
-                changed: changed.deref_mut(),
+                added: ticks.added.deref_mut(),
+                changed: ticks.changed.deref_mut(),
                 last_change_tick: system_meta.last_change_tick,
                 change_tick,
             },
@@ -1179,11 +1179,11 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for OptionNonSendMutState<T> {
         world.validate_non_send_access::<T>();
         world
             .get_resource_with_ticks(state.0.component_id)
-            .map(|(ptr, added, changed)| NonSendMut {
+            .map(|(ptr, ticks)| NonSendMut {
                 value: ptr.assert_unique().deref_mut(),
                 ticks: Ticks {
-                    added: added.deref_mut(),
-                    changed: changed.deref_mut(),
+                    added: ticks.added.deref_mut(),
+                    changed: ticks.changed.deref_mut(),
                     last_change_tick: system_meta.last_change_tick,
                     change_tick,
                 },

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -307,13 +307,13 @@ impl<'w, T: Resource> Res<'w, T> {
     /// Returns `true` if the resource was added after the system last ran.
     pub fn is_added(&self) -> bool {
         self.added
-            .is_changed(self.last_change_tick, self.change_tick)
+            .is_older_than(self.last_change_tick, self.change_tick)
     }
 
     /// Returns `true` if the resource was added or mutably dereferenced after the system last ran.
     pub fn is_changed(&self) -> bool {
         self.changed
-            .is_changed(self.last_change_tick, self.change_tick)
+            .is_older_than(self.last_change_tick, self.change_tick)
     }
 
     pub fn into_inner(self) -> &'w T {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1019,10 +1019,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendState<T> {
 
         NonSend {
             value: ptr.deref(),
-            ticks: ComponentTicks {
-                added: ticks.added.read(),
-                changed: ticks.changed.read(),
-            },
+            ticks: ticks.read(),
             last_change_tick: system_meta.last_change_tick,
             change_tick,
         }
@@ -1064,10 +1061,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for OptionNonSendState<T> {
             .get_resource_with_ticks(state.0.component_id)
             .map(|(ptr, ticks)| NonSend {
                 value: ptr.deref(),
-                ticks: ComponentTicks {
-                    added: ticks.added.read(),
-                    changed: ticks.changed.read(),
-                },
+                ticks: ticks.read(),
                 last_change_tick: system_meta.last_change_tick,
                 change_tick,
             })

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2,7 +2,7 @@ use crate::{
     archetype::{Archetype, ArchetypeId, Archetypes},
     bundle::{Bundle, BundleInfo},
     change_detection::{MutUntyped, Ticks},
-    component::{Component, ComponentId, ComponentTicks, Components, StorageType},
+    component::{Component, ComponentId, Tick, ComponentTicks, Components, StorageType},
     entity::{Entities, Entity, EntityLocation},
     storage::{SparseSet, Storages},
     world::{Mut, World},
@@ -102,10 +102,11 @@ impl<'w> EntityRef<'w> {
         change_tick: u32,
     ) -> Option<Mut<'w, T>> {
         get_component_and_ticks_with_type(self.world, TypeId::of::<T>(), self.entity, self.location)
-            .map(|(value, ticks)| Mut {
+            .map(|(value, added, changed)| Mut {
                 value: value.assert_unique().deref_mut::<T>(),
                 ticks: Ticks {
-                    component_ticks: ticks.deref_mut(),
+                    added: added.deref_mut(),
+                    changed: changed.deref_mut(),
                     last_change_tick,
                     change_tick,
                 },
@@ -229,10 +230,11 @@ impl<'w> EntityMut<'w> {
     #[inline]
     pub unsafe fn get_unchecked_mut<T: Component>(&self) -> Option<Mut<'_, T>> {
         get_component_and_ticks_with_type(self.world, TypeId::of::<T>(), self.entity, self.location)
-            .map(|(value, ticks)| Mut {
+            .map(|(value, added, changed)| Mut {
                 value: value.assert_unique().deref_mut::<T>(),
                 ticks: Ticks {
-                    component_ticks: ticks.deref_mut(),
+                    added: added.deref_mut(),
+                    changed: changed.deref_mut(),
                     last_change_tick: self.world.last_change_tick(),
                     change_tick: self.world.read_change_tick(),
                 },
@@ -635,7 +637,7 @@ unsafe fn get_component_and_ticks(
     component_id: ComponentId,
     entity: Entity,
     location: EntityLocation,
-) -> Option<(Ptr<'_>, &UnsafeCell<ComponentTicks>)> {
+) -> Option<(Ptr<'_>, &UnsafeCell<Tick>, &UnsafeCell<Tick>)> {
     let archetype = &world.archetypes[location.archetype_id];
     let component_info = world.components.get_info_unchecked(component_id);
     match component_info.storage_type() {
@@ -646,7 +648,8 @@ unsafe fn get_component_and_ticks(
             // SAFETY: archetypes only store valid table_rows and the stored component type is T
             Some((
                 components.get_data_unchecked(table_row),
-                components.get_ticks_unchecked(table_row),
+                components.get_added_ticks_unchecked(table_row),
+                components.get_changed_ticks_unchecked(table_row),
             ))
         }
         StorageType::SparseSet => world
@@ -747,7 +750,7 @@ pub(crate) unsafe fn get_component_and_ticks_with_type(
     type_id: TypeId,
     entity: Entity,
     location: EntityLocation,
-) -> Option<(Ptr<'_>, &UnsafeCell<ComponentTicks>)> {
+) -> Option<(Ptr<'_>, &UnsafeCell<Tick>, &UnsafeCell<Tick>)> {
     let component_id = world.components.get_id(type_id)?;
     get_component_and_ticks(world, component_id, entity, location)
 }
@@ -909,10 +912,11 @@ pub(crate) unsafe fn get_mut<T: Component>(
     let change_tick = world.change_tick();
     let last_change_tick = world.last_change_tick();
     get_component_and_ticks_with_type(world, TypeId::of::<T>(), entity, location).map(
-        |(value, ticks)| Mut {
+        |(value, added, changed)| Mut {
             value: value.assert_unique().deref_mut::<T>(),
             ticks: Ticks {
-                component_ticks: ticks.deref_mut(),
+                added: added.deref_mut(),
+                changed: changed.deref_mut(),
                 last_change_tick,
                 change_tick,
             },
@@ -929,11 +933,12 @@ pub(crate) unsafe fn get_mut_by_id(
     component_id: ComponentId,
 ) -> Option<MutUntyped> {
     // SAFETY: world access is unique, entity location and component_id required to be valid
-    get_component_and_ticks(world, component_id, entity, location).map(|(value, ticks)| {
+    get_component_and_ticks(world, component_id, entity, location).map(|(value, added, changed)| {
         MutUntyped {
             value: value.assert_unique(),
             ticks: Ticks {
-                component_ticks: ticks.deref_mut(),
+                added: added.deref_mut(),
+                changed: changed.deref_mut(),
                 last_change_tick: world.last_change_tick(),
                 change_tick: world.read_change_tick(),
             },

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2,7 +2,7 @@ use crate::{
     archetype::{Archetype, ArchetypeId, Archetypes},
     bundle::{Bundle, BundleInfo},
     change_detection::{MutUntyped, Ticks},
-    component::{Component, ComponentId, Tick, ComponentTicks, Components, StorageType},
+    component::{Component, ComponentId, ComponentTicks, Components, StorageType, Tick},
     entity::{Entities, Entity, EntityLocation},
     storage::{SparseSet, Storages},
     world::{Mut, World},
@@ -77,12 +77,9 @@ impl<'w> EntityRef<'w> {
     /// Retrieves the change ticks for the given component. This can be useful for implementing change
     /// detection in custom runtimes.
     #[inline]
-    pub fn get_change_ticks<T: Component>(&self) -> Option<&'w ComponentTicks> {
+    pub fn get_change_ticks<T: Component>(&self) -> Option<ComponentTicks> {
         // SAFETY: entity location is valid
-        unsafe {
-            get_ticks_with_type(self.world, TypeId::of::<T>(), self.entity, self.location)
-                .map(|ticks| ticks.deref())
-        }
+        unsafe { get_ticks_with_type(self.world, TypeId::of::<T>(), self.entity, self.location) }
     }
 
     /// Gets a mutable reference to the component of type `T` associated with
@@ -209,12 +206,9 @@ impl<'w> EntityMut<'w> {
     /// Retrieves the change ticks for the given component. This can be useful for implementing change
     /// detection in custom runtimes.
     #[inline]
-    pub fn get_change_ticks<T: Component>(&self) -> Option<&ComponentTicks> {
+    pub fn get_change_ticks<T: Component>(&self) -> Option<ComponentTicks> {
         // SAFETY: entity location is valid
-        unsafe {
-            get_ticks_with_type(self.world, TypeId::of::<T>(), self.entity, self.location)
-                .map(|ticks| ticks.deref())
-        }
+        unsafe { get_ticks_with_type(self.world, TypeId::of::<T>(), self.entity, self.location) }
     }
 
     /// Gets a mutable reference to the component of type `T` associated with
@@ -666,7 +660,7 @@ unsafe fn get_ticks(
     component_id: ComponentId,
     entity: Entity,
     location: EntityLocation,
-) -> Option<&UnsafeCell<ComponentTicks>> {
+) -> Option<ComponentTicks> {
     let archetype = &world.archetypes[location.archetype_id];
     let component_info = world.components.get_info_unchecked(component_id);
     match component_info.storage_type() {
@@ -762,7 +756,7 @@ pub(crate) unsafe fn get_ticks_with_type(
     type_id: TypeId,
     entity: Entity,
     location: EntityLocation,
-) -> Option<&UnsafeCell<ComponentTicks>> {
+) -> Option<ComponentTicks> {
     let component_id = world.components.get_id(type_id)?;
     get_ticks(world, component_id, entity, location)
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1457,15 +1457,16 @@ impl World {
 
         let (ptr, added, changed) = self.get_resource_with_ticks(component_id)?;
 
-        // SAFE: This function has exclusive access to the world so nothing aliases `ticks`.
-        let ticks = Ticks {
-            // SAFETY:
-            // - index is in-bounds because the column is initialized and non-empty
-            // - no other reference to the ticks of the same row can exist at the same time
-            added: unsafe { added.deref_mut() },
-            changed: unsafe { changed.deref_mut() },
-            last_change_tick: self.last_change_tick(),
-            change_tick: self.read_change_tick(),
+        // SAFETY: This function has exclusive access to the world so nothing aliases `ticks`.
+        // - index is in-bounds because the column is initialized and non-empty
+        // - no other reference to the ticks of the same row can exist at the same time
+        let ticks = unsafe {
+            Ticks {
+                added: added.deref_mut(),
+                changed: changed.deref_mut(),
+                last_change_tick: self.last_change_tick(),
+                change_tick: self.read_change_tick(),
+            }
         };
 
         Some(MutUntyped {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -11,9 +11,7 @@ use crate::{
     archetype::{ArchetypeComponentId, ArchetypeId, Archetypes},
     bundle::{Bundle, BundleInserter, BundleSpawner, Bundles},
     change_detection::{MutUntyped, Ticks},
-    component::{
-        Component, ComponentDescriptor, ComponentId, ComponentInfo, Tick, Components,
-    },
+    component::{Component, ComponentDescriptor, ComponentId, ComponentInfo, Components, Tick},
     entity::{AllocAtWithoutReplacement, Entities, Entity},
     query::{QueryState, ReadOnlyWorldQuery, WorldQuery},
     storage::{ResourceData, SparseSet, Storages},

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     bundle::{Bundle, BundleInserter, BundleSpawner, Bundles},
     change_detection::{MutUntyped, Ticks},
     component::{
-        Component, ComponentDescriptor, ComponentId, ComponentInfo, ComponentTicks, Components,
+        Component, ComponentDescriptor, ComponentId, ComponentInfo, Tick, Components,
     },
     entity::{AllocAtWithoutReplacement, Entities, Entity},
     query::{QueryState, ReadOnlyWorldQuery, WorldQuery},
@@ -1001,7 +1001,7 @@ impl World {
     pub(crate) fn get_resource_with_ticks(
         &self,
         component_id: ComponentId,
-    ) -> Option<(Ptr<'_>, &UnsafeCell<ComponentTicks>)> {
+    ) -> Option<(Ptr<'_>, &UnsafeCell<Tick>, &UnsafeCell<Tick>)> {
         self.storages.resources.get(component_id)?.get_with_ticks()
     }
 
@@ -1194,7 +1194,8 @@ impl World {
         let value_mut = Mut {
             value: &mut value,
             ticks: Ticks {
-                component_ticks: &mut ticks,
+                added: &mut ticks.added,
+                changed: &mut ticks.changed,
                 last_change_tick,
                 change_tick,
             },
@@ -1270,11 +1271,12 @@ impl World {
         &self,
         component_id: ComponentId,
     ) -> Option<Mut<'_, R>> {
-        let (ptr, ticks) = self.get_resource_with_ticks(component_id)?;
+        let (ptr, added, changed) = self.get_resource_with_ticks(component_id)?;
         Some(Mut {
             value: ptr.assert_unique().deref_mut(),
             ticks: Ticks {
-                component_ticks: ticks.deref_mut(),
+                added: added.deref_mut(),
+                changed: changed.deref_mut(),
                 last_change_tick: self.last_change_tick(),
                 change_tick: self.read_change_tick(),
             },
@@ -1455,14 +1457,15 @@ impl World {
             self.validate_non_send_access_untyped(info.name());
         }
 
-        let (ptr, ticks) = self.get_resource_with_ticks(component_id)?;
+        let (ptr, added, changed) = self.get_resource_with_ticks(component_id)?;
 
         // SAFE: This function has exclusive access to the world so nothing aliases `ticks`.
         let ticks = Ticks {
             // SAFETY:
             // - index is in-bounds because the column is initialized and non-empty
             // - no other reference to the ticks of the same row can exist at the same time
-            component_ticks: unsafe { ticks.deref_mut() },
+            added: unsafe { added.deref_mut() },
+            changed: unsafe { changed.deref_mut() },
             last_change_tick: self.last_change_tick(),
             change_tick: self.read_change_tick(),
         };


### PR DESCRIPTION
# Objective
Fixes #4884. `ComponentTicks` stores both added and changed ticks contiguously in the same 8 bytes. This is convenient when passing around both together, but causes half the bytes fetched from memory for the purposes of change detection to effectively go unused. This is inefficient when most queries (no filter, mutating *something*) only write out to the changed ticks.

## Solution
Split the storage for change detection ticks into two separate `Vec`s inside `Column`. Fetch only what is needed during iteration.

This also potentially also removes one blocker from autovectorization of dense queries.

EDIT: This is confirmed to enable autovectorization of dense queries in `for_each` and `par_for_each`  where possible.  Unfortunately `iter` has other blockers that prevent it.

### TODO

 - [x] Microbenchmark
 - [x] Check if this allows query iteration to autovectorize simple loops.
 - [x] Clean up all of the spurious tuples now littered throughout the API

### Open Questions

 - ~~Is `Mut::is_added` absolutely necessary? Can we not just use `Added` or `ChangeTrackers`?~~ It's optimized out if unused.
 - ~~Does the fetch of the added ticks get optimized out if not used?~~ Yes it is.

---

## Changelog
Added: `Tick`, a wrapper around a single change detection tick.
Added: `Column::get_added_ticks`
Added: `Column::get_column_ticks`
Added: `SparseSet::get_added_ticks`
Added: `SparseSet::get_column_ticks`
Changed: `Column` now stores added and changed ticks separately internally.
Changed: Most APIs returning `&UnsafeCell<ComponentTicks>` now returns `TickCells` instead, which contains two separate `&UnsafeCell<Tick>` for either component ticks.
Changed: `Query::for_each(_mut)`, `Query::par_for_each(_mut)` will now leverage autovectorization to speed up query iteration where possible.

## Migration Guide
TODO