### PR TITLE
[Merged by Bors] - Add `remove` method to `Map` reflection trait.

### DIFF
--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -396,7 +396,12 @@ impl<K: FromReflect + Eq + Hash, V: FromReflect> Map for HashMap<K, V> {
     }
 
     fn remove(&mut self, key: &dyn Reflect) -> Option<Box<dyn Reflect>> {
+        let mut from_reflect = None;
         key.downcast_ref::<K>()
+            .or_else(|| {
+                from_reflect = K::from_reflect(key);
+                from_reflect.as_ref()
+            })
             .and_then(|key| self.remove(key))
             .map(|value| Box::new(value) as Box<dyn Reflect>)
     }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -394,6 +394,12 @@ impl<K: FromReflect + Eq + Hash, V: FromReflect> Map for HashMap<K, V> {
         self.insert(key, value)
             .map(|old_value| Box::new(old_value) as Box<dyn Reflect>)
     }
+
+    fn remove(&mut self, key: &dyn Reflect) -> Option<Box<dyn Reflect>> {
+        key.downcast_ref::<K>()
+            .and_then(|key| self.remove(key))
+            .map(|value| Box::new(value) as Box<dyn Reflect>)
+    }
 }
 
 impl<K: FromReflect + Eq + Hash, V: FromReflect> Reflect for HashMap<K, V> {

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -58,7 +58,7 @@ pub trait Map: Reflect {
         value: Box<dyn Reflect>,
     ) -> Option<Box<dyn Reflect>>;
 
-    /// Removes a key from the map.
+    /// Removes an entry from the map.
     ///
     /// If the map did not have this key present, `None` is returned.
     /// If the map did have this key present, the removed value is returned.

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -259,7 +259,7 @@ impl Map for DynamicMap {
                 entry.remove();
                 let (_key, value) = self.values.remove(index);
                 Some(value)
-            },
+            }
             Entry::Vacant(_) => None,
         }
     }

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -253,15 +253,11 @@ impl Map for DynamicMap {
     }
 
     fn remove(&mut self, key: &dyn Reflect) -> Option<Box<dyn Reflect>> {
-        match self.indices.entry(key.reflect_hash().expect(HASH_ERROR)) {
-            Entry::Occupied(entry) => {
-                let index = *entry.get();
-                entry.remove();
-                let (_key, value) = self.values.remove(index);
-                Some(value)
-            }
-            Entry::Vacant(_) => None,
-        }
+        let index = self
+            .indices
+            .remove(&key.reflect_hash().expect(HASH_ERROR))?;
+        let (_key, value) = self.values.remove(index);
+        Some(value)
     }
 
     fn drain(self: Box<Self>) -> Vec<(Box<dyn Reflect>, Box<dyn Reflect>)> {

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -57,6 +57,12 @@ pub trait Map: Reflect {
         key: Box<dyn Reflect>,
         value: Box<dyn Reflect>,
     ) -> Option<Box<dyn Reflect>>;
+
+    /// Removes a key from the map.
+    ///
+    /// If the map did not have this key present, `None` is returned.
+    /// If the map did have this key present, the removed value is returned.
+    fn remove(&mut self, key: &dyn Reflect) -> Option<Box<dyn Reflect>>;
 }
 
 /// A container for compile-time map info.
@@ -243,6 +249,18 @@ impl Map for DynamicMap {
                 self.values.push((key, value));
                 None
             }
+        }
+    }
+
+    fn remove(&mut self, key: &dyn Reflect) -> Option<Box<dyn Reflect>> {
+        match self.indices.entry(key.reflect_hash().expect(HASH_ERROR)) {
+            Entry::Occupied(entry) => {
+                let index = *entry.get();
+                entry.remove();
+                let (_key, value) = self.values.remove(index);
+                Some(value)
+            },
+            Entry::Vacant(_) => None,
         }
     }
 


### PR DESCRIPTION
# Objective

- Implements removal of entries from a `dyn Map`
- Fixes #6563

## Solution

- Adds a `remove` method to the `Map` trait which takes in a `&dyn Reflect` key and returns the value removed if it was present.

---

## Changelog

- Added `Map::remove`

## Migration Guide

- Implementors of `Map` will need to implement the `remove` method.
