### PR TITLE
[Merged by Bors] - bevy_reflect: Simplify `take`-or-else-`from_reflect` operation

### DIFF
--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -214,13 +214,11 @@ macro_rules! impl_reflect_for_veclike {
 
         impl<T: FromReflect> List for $ty {
             fn push(&mut self, value: Box<dyn Reflect>) {
-                let value = value.take::<T>().unwrap_or_else(|value| {
-                    T::from_reflect(&*value).unwrap_or_else(|| {
-                        panic!(
-                            "Attempted to push invalid value of type {}.",
-                            value.type_name()
-                        )
-                    })
+                let value = T::take_from_reflect(value).unwrap_or_else(|value| {
+                    panic!(
+                        "Attempted to push invalid value of type {}.",
+                        value.type_name()
+                    )
                 });
                 $push(self, value);
             }
@@ -391,21 +389,17 @@ impl<K: FromReflect + Eq + Hash, V: FromReflect> Map for HashMap<K, V> {
         key: Box<dyn Reflect>,
         value: Box<dyn Reflect>,
     ) -> Option<Box<dyn Reflect>> {
-        let key = key.take::<K>().unwrap_or_else(|key| {
-            K::from_reflect(&*key).unwrap_or_else(|| {
-                panic!(
-                    "Attempted to insert invalid key of type {}.",
-                    key.type_name()
-                )
-            })
+        let key = K::take_from_reflect(key).unwrap_or_else(|key| {
+            panic!(
+                "Attempted to insert invalid key of type {}.",
+                key.type_name()
+            )
         });
-        let value = value.take::<V>().unwrap_or_else(|value| {
-            V::from_reflect(&*value).unwrap_or_else(|| {
-                panic!(
-                    "Attempted to insert invalid value of type {}.",
-                    value.type_name()
-                )
-            })
+        let value = V::take_from_reflect(value).unwrap_or_else(|value| {
+            panic!(
+                "Attempted to insert invalid value of type {}.",
+                value.type_name()
+            )
         });
         self.insert(key, value)
             .map(|old_value| Box::new(old_value) as Box<dyn Reflect>)
@@ -811,25 +805,24 @@ impl<T: FromReflect> Reflect for Option<T> {
                 // New variant -> perform a switch
                 match value.variant_name() {
                     "Some" => {
-                        let field = value
-                            .field_at(0)
-                            .unwrap_or_else(|| {
-                                panic!(
-                                    "Field in `Some` variant of {} should exist",
-                                    std::any::type_name::<Option<T>>()
-                                )
-                            })
-                            .clone_value()
-                            .take::<T>()
-                            .unwrap_or_else(|value| {
-                                T::from_reflect(&*value).unwrap_or_else(|| {
+                        let field = T::take_from_reflect(
+                            value
+                                .field_at(0)
+                                .unwrap_or_else(|| {
                                     panic!(
-                                        "Field in `Some` variant of {} should be of type {}",
-                                        std::any::type_name::<Option<T>>(),
-                                        std::any::type_name::<T>()
+                                        "Field in `Some` variant of {} should exist",
+                                        std::any::type_name::<Option<T>>()
                                     )
                                 })
-                            });
+                                .clone_value(),
+                        )
+                        .unwrap_or_else(|_| {
+                            panic!(
+                                "Field in `Some` variant of {} should be of type {}",
+                                std::any::type_name::<Option<T>>(),
+                                std::any::type_name::<T>()
+                            )
+                        });
                         *self = Some(field);
                     }
                     "None" => {
@@ -878,25 +871,24 @@ impl<T: FromReflect> FromReflect for Option<T> {
         if let ReflectRef::Enum(dyn_enum) = reflect.reflect_ref() {
             match dyn_enum.variant_name() {
                 "Some" => {
-                    let field = dyn_enum
-                        .field_at(0)
-                        .unwrap_or_else(|| {
-                            panic!(
-                                "Field in `Some` variant of {} should exist",
-                                std::any::type_name::<Option<T>>()
-                            )
-                        })
-                        .clone_value()
-                        .take::<T>()
-                        .unwrap_or_else(|value| {
-                            T::from_reflect(&*value).unwrap_or_else(|| {
+                    let field = T::take_from_reflect(
+                        dyn_enum
+                            .field_at(0)
+                            .unwrap_or_else(|| {
                                 panic!(
-                                    "Field in `Some` variant of {} should be of type {}",
-                                    std::any::type_name::<Option<T>>(),
-                                    std::any::type_name::<T>()
+                                    "Field in `Some` variant of {} should exist",
+                                    std::any::type_name::<Option<T>>()
                                 )
                             })
-                        });
+                            .clone_value(),
+                    )
+                    .unwrap_or_else(|_| {
+                        panic!(
+                            "Field in `Some` variant of {} should be of type {}",
+                            std::any::type_name::<Option<T>>(),
+                            std::any::type_name::<T>()
+                        )
+                    });
                     Some(Some(field))
                 }
                 "None" => Some(None),


### PR DESCRIPTION
# Objective

There are times where we want to simply take an owned `dyn Reflect` and cast it to a type `T`.

Currently, this involves doing:

```rust
let value = value.take::<T>().unwrap_or_else(|value| {
  T::from_reflect(&*value).unwrap_or_else(|| {
    panic!(
      "expected value of type {} to convert to type {}.",
      value.type_name(),
      std::any::type_name::<T>()
    )
  })
});
```

This is a common operation that could be easily be simplified.

## Solution

Add the `FromReflect::take_from_reflect` method. This first tries to `take` the value, calling `from_reflect` iff that fails.

```rust
let value = T::take_from_reflect(value).unwrap_or_else(|value| {
  panic!(
    "expected value of type {} to convert to type {}.",
    value.type_name(),
    std::any::type_name::<T>()
  )
});
```

Based on suggestion from @soqb on [Discord](https://discord.com/channels/691052431525675048/1002362493634629796/1041046880316043374).

---

## Changelog

- Add `FromReflect::take_from_reflect` method