### PR TITLE
[Merged by Bors] - Correct docs for ButtonSettingsError to read 0.0..=1.0

### DIFF
--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -40,10 +40,10 @@ pub enum AxisSettingsError {
 /// Errors that occur when setting button settings for gamepad input.
 #[derive(Error, Debug, PartialEq)]
 pub enum ButtonSettingsError {
-    /// The given parameter was not in range 0.0..=2.0.
+    /// The given parameter was not in range 0.0..=1.0.
     #[error("invalid release_threshold {0}, expected value [0.0..=1.0]")]
     ReleaseThresholdOutOfRange(f32),
-    /// The given parameter was not in range 0.0..=2.0.
+    /// The given parameter was not in range 0.0..=1.0.
     #[error("invalid press_threshold {0}, expected [0.0..=1.0]")]
     PressThresholdOutOfRange(f32),
     /// Parameter `release_threshold` was not less than or equal to `press_threshold`.


### PR DESCRIPTION
# Objective

The [documentation for `ButtonSettingsError`](https://docs.rs/bevy/0.9.0/bevy/input/gamepad/enum.ButtonSettingsError.html) incorrectly describes the valid range of values as `0.0..=2.0`, probably because it was copied from `AxisSettingsError`. The actual range, as seen in the functions that return it and in its own `thiserror` description, is `0.0..=1.0`.

## Solution

Update the doc comments to reflect the correct range.
