### PR TITLE
[Merged by Bors] - Add `Windows::get_focused(_mut)`

### DIFF
--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -1,4 +1,4 @@
-use crate::{Window, WindowCloseRequested, WindowFocused, WindowId, Windows};
+use crate::{Window, WindowCloseRequested, Windows};
 
 use bevy_app::AppExit;
 use bevy_ecs::prelude::*;
@@ -36,22 +36,10 @@ pub fn close_when_requested(
 /// Close the focused window whenever the escape key (<kbd>Esc</kbd>) is pressed
 ///
 /// This is useful for examples or prototyping.
-pub fn close_on_esc(
-    mut focused: Local<Option<WindowId>>,
-    mut focused_events: EventReader<WindowFocused>,
-    mut windows: ResMut<Windows>,
-    input: Res<Input<KeyCode>>,
-) {
-    // TODO: Track this in e.g. a resource to ensure consistent behaviour across similar systems
-    for event in focused_events.iter() {
-        *focused = event.focused.then_some(event.id);
-    }
-
-    if let Some(focused) = &*focused {
-        if input.just_pressed(KeyCode::Escape) {
-            if let Some(window) = windows.get_mut(*focused) {
-                window.close();
-            }
+pub fn close_on_esc(mut windows: ResMut<Windows>, input: Res<Input<KeyCode>>) {
+    if input.just_pressed(KeyCode::Escape) {
+        if let Some(window) = windows.get_focused_mut() {
+            window.close();
         }
     }
 }

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -432,7 +432,7 @@ impl Window {
             cursor_icon: CursorIcon::Default,
             physical_cursor_position: None,
             raw_handle,
-            focused: true,
+            focused: false,
             mode: window_descriptor.mode,
             canvas: window_descriptor.canvas.clone(),
             fit_canvas_to_parent: window_descriptor.fit_canvas_to_parent,

--- a/crates/bevy_window/src/windows.rs
+++ b/crates/bevy_window/src/windows.rs
@@ -53,6 +53,16 @@ impl Windows {
             .expect("Primary window does not exist")
     }
 
+    /// Get a reference to the focused [`Window`].
+    pub fn get_focused(&self) -> Option<&Window> {
+        self.windows.values().find(|window| window.is_focused())
+    }
+
+    /// Get a mutable reference to the focused [`Window`].
+    pub fn get_focused_mut(&mut self) -> Option<&mut Window> {
+        self.windows.values_mut().find(|window| window.is_focused())
+    }
+
     /// Returns the scale factor for the [`Window`] of `id`, or `1.0` if the window does not exist.
     pub fn scale_factor(&self, id: WindowId) -> f64 {
         if let Some(window) = self.get(id) {


### PR DESCRIPTION
Add a method to get the focused window.

Use this instead of `WindowFocused` events in `close_on_esc`.
Seems that the OS/window manager might not always send focused events on application startup.

Sadly, not a fix for #5646.