### PR TITLE
Relax `Resource: Sync` bound

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -506,7 +506,7 @@ pub(crate) fn bevy_ecs_path() -> syn::Path {
     BevyManifest::default().get_path("bevy_ecs")
 }
 
-#[proc_macro_derive(Resource)]
+#[proc_macro_derive(Resource, attributes(resource))]
 pub fn derive_resource(input: TokenStream) -> TokenStream {
     component::derive_resource(input)
 }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -65,7 +65,6 @@ mod tests {
         world::{Mut, World},
     };
     use bevy_tasks::{ComputeTaskPool, TaskPool};
-    use std::sync::RwLock;
     use std::{
         any::TypeId,
         marker::PhantomData,
@@ -1201,13 +1200,13 @@ mod tests {
     fn non_sync_resource() {
         #[derive(Resource, Default)]
         #[resource(is_sync = false)]
-        struct SyncCounter(RwLock<()>, PhantomData<std::cell::Cell<()>>);
+        struct SyncCounter(Mutex<()>, PhantomData<std::cell::Cell<()>>);
 
         fn assert_non_sync(counter: Res<SyncCounter>) {
             // Panic if multiple instances of this system try to access `counter` at once.
             let _guard = counter
                 .0
-                .try_write()
+                .try_lock()
                 .expect("shared access is not allowed for non-`Sync` resources");
 
             // Make sure other systems have a chance to conflict with this one before dropping the guard.
@@ -1230,13 +1229,13 @@ mod tests {
     fn non_sync_resource_panic() {
         // We aren't marking the type as !Sync, so the systems will confict and panic.
         #[derive(Resource, Default)]
-        struct SyncCounter(RwLock<()>);
+        struct SyncCounter(Mutex<()>);
 
         fn assert_non_sync(counter: Res<SyncCounter>) {
             // Panic if multiple instances of this system try to access `counter` at once.
             let _guard = counter
                 .0
-                .try_write()
+                .try_lock()
                 .expect("shared access is not allowed for non-`Sync` resources");
 
             // Make sure other systems have a chance to conflict with this one before dropping the guard.

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1228,8 +1228,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn non_sync_resource_panic() {
+        // We aren't marking the type as !Sync, so the systems will confict and panic.
         #[derive(Resource, Default)]
-        #[resource(is_sync = true)] // This type *technically* is sync, but the system will panic if there's shared access.
         struct SyncCounter(RwLock<()>);
 
         fn assert_non_sync(counter: Res<SyncCounter>) {

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1249,6 +1249,9 @@ mod tests {
         let mut stage = SystemStage::parallel()
             .with_system(assert_non_sync)
             .with_system(assert_non_sync)
+            .with_system(assert_non_sync)
+            .with_system(assert_non_sync)
+            .with_system(assert_non_sync)
             .with_system(assert_non_sync);
 
         stage.run(&mut world);

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1225,38 +1225,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn non_sync_resource_panic() {
-        // We aren't marking the type as !Sync, so the systems will confict and panic.
-        #[derive(Resource, Default)]
-        struct SyncCounter(Mutex<()>);
-
-        fn assert_non_sync(counter: Res<SyncCounter>) {
-            // Panic if multiple instances of this system try to access `counter` at once.
-            let _guard = counter
-                .0
-                .try_lock()
-                .expect("shared access is not allowed for non-`Sync` resources");
-
-            // Make sure other systems have a chance to conflict with this one before dropping the guard.
-            std::thread::sleep(std::time::Duration::from_millis(100));
-        }
-
-        let mut world = World::default();
-        world.init_resource::<SyncCounter>();
-
-        let mut stage = SystemStage::parallel()
-            .with_system(assert_non_sync)
-            .with_system(assert_non_sync)
-            .with_system(assert_non_sync)
-            .with_system(assert_non_sync)
-            .with_system(assert_non_sync)
-            .with_system(assert_non_sync);
-
-        stage.run(&mut world);
-    }
-
-    #[test]
     fn trackers_query() {
         let mut world = World::default();
         let e1 = world.spawn((A(0), B(0))).id();

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -259,6 +259,18 @@ impl_param_set!();
 /// # schedule.run_once(&mut world);
 /// ```
 ///
+/// ```compile_fail
+/// # use bevy_ecs::prelude::*;
+/// #[derive(Resource)] // we forgot to mark this resource as `is_sync = false`
+/// struct MyResource(std::cell::Cell<u32>); // `Cell` can't be shared between threads
+///
+/// // it fails when we try to use the type as a resource
+/// fn my_system(res: Res<MyResource>) {
+///     // ...
+/// }
+/// # bevy_ecs::system::assert_is_system(my_system);
+/// ```
+///
 /// # Safety
 ///
 /// If [`Self::IS_SYNC`] == `true`, then `Self` must be [`Sync`].

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1427,7 +1427,7 @@ impl World {
     /// The returned pointer must not be used to modify the resource, and must not be
     /// dereferenced after the immutable borrow of the [`World`] ends.
     ///
-    /// If the resource type is `!Send`, you must not share the returned pointer between threads.
+    /// If the resource type is `!Sync`, you must not share the returned pointer between threads.
     ///
     /// **You should prefer to use the typed API [`World::get_resource`] where possible and only
     /// use this in cases where the actual types are not known at compile time.**

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -23,7 +23,7 @@ pub trait ExtractResource: Resource {
 ///
 /// Therefore it sets up the [`RenderStage::Extract`](crate::RenderStage::Extract) step
 /// for the specified [`Resource`].
-pub struct ExtractResourcePlugin<R: ExtractResource>(PhantomData<R>);
+pub struct ExtractResourcePlugin<R: ExtractResource>(PhantomData<fn() -> R>);
 
 impl<R: ExtractResource> Default for ExtractResourcePlugin<R> {
     fn default() -> Self {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -60,10 +60,6 @@ impl Plugin for WinitPlugin {
     }
 }
 
-#[derive(Resource)]
-#[resource(is_sync = false)]
-pub struct EventLoopProxy<T: 'static>(pub winit::event_loop::EventLoopProxy<T>);
-
 fn change_window(
     mut winit_windows: NonSendMut<WinitWindows>,
     mut windows: ResMut<Windows>,
@@ -359,7 +355,7 @@ pub fn winit_runner_with(mut app: App) {
     let mut redraw_event_reader = ManualEventReader::<RequestRedraw>::default();
     let mut winit_state = WinitPersistentState::default();
     app.world
-        .insert_resource(EventLoopProxy(event_loop.create_proxy()));
+        .insert_non_send_resource(event_loop.create_proxy());
 
     let return_from_run = app.world.resource::<WinitSettings>().return_from_run;
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -60,6 +60,10 @@ impl Plugin for WinitPlugin {
     }
 }
 
+#[derive(Resource)]
+#[resource(is_sync = false)]
+pub struct EventLoopProxy<T: 'static>(pub winit::event_loop::EventLoopProxy<T>);
+
 fn change_window(
     mut winit_windows: NonSendMut<WinitWindows>,
     mut windows: ResMut<Windows>,
@@ -355,7 +359,7 @@ pub fn winit_runner_with(mut app: App) {
     let mut redraw_event_reader = ManualEventReader::<RequestRedraw>::default();
     let mut winit_state = WinitPersistentState::default();
     app.world
-        .insert_non_send_resource(event_loop.create_proxy());
+        .insert_resource(EventLoopProxy(event_loop.create_proxy()));
 
     let return_from_run = app.world.resource::<WinitSettings>().return_from_run;
 


### PR DESCRIPTION
# Objective

Allow non-`Sync` types to be used as resources, without having to resort to `NonSend<>`.

Currently, non-`Sync` types are conflated with non-`Send` types, which results in overly restrictive scheduling. Any system that uses non-`Send` types must be run on the main thread, which increases thread contention and prevents parallelization. This is unnecessary, as `Send + !Sync` resources could be accessed from any thread, as long as it's only one at a time.

## Solution

* Relax the bound `Resource: Sync`.
* `Resource` trait tracks whether each type is `Sync`. The scheduler ensures that shared access to non-`Sync` types does not occur.

## Example

```rust
// This type can't be shared between threads, but it *can* be sent.
#[derive(Resource, Deref)]
#[resource(is_sync = false)] // compile fails if you forget this
pub struct MyResource(std::cell::Cell<u32>);

fn my_system(x: Res<MyResource>) {
    x.set(x.get() + 1);
}
```

## Future Work

For the time being, systems with read-only access to a non-`Sync` resource are run on the main thread. This is overly restrictive: we will need to update our `Access` model to properly support non-`Sync` reads.

---

## Changelog

+ `Resource` now supports types that do not implement `std::marker::Sync`.

## Migration Guide

The `Resource` trait is now `unsafe` to implement manually. Use of the derive macro is recommended.

```rust
// Before
struct MyResource(...);
impl Resource for MyResource {}

// After
struct MyResource(...);
unsafe impl Resource for MyResource {
    // Undefined Behavior if this is wrong. 
    const IS_SYNC: bool = true;
}
```

Any generic code that relied on `Resource: Sync` will now need to specify the `Sync` bound. 

```rust
// Before:
fn my_system<T: Resource>(
    my_resource: Res<T>,
    q: Query<...>,
) {
    // Since we access `my_resource` across threads (because of par_for_each), we need it to be `Sync`.
    q.par_for_each(|...| {
        do_something_with(&my_resource);
    })
}

// After:
fn my_system<T: Resource + Sync>( // Just add this bound.
    ...
) {
    ...
}
```