### PR TITLE
Non panic apply

### DIFF
--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -1,6 +1,6 @@
 use crate::{
     utility::NonGenericTypeInfoCell, DynamicInfo, Reflect, ReflectMut, ReflectOwned, ReflectRef,
-    TypeInfo, Typed,
+    TypeInfo, Typed, ReflectError,
 };
 use std::{
     any::{Any, TypeId},
@@ -212,8 +212,8 @@ impl Reflect for DynamicArray {
         self
     }
 
-    fn apply(&mut self, value: &dyn Reflect) {
-        array_apply(self, value);
+    fn apply(&mut self, value: &dyn Reflect) -> Result<(), ReflectError> {
+        array_apply(self, value)
     }
 
     #[inline]
@@ -346,7 +346,7 @@ pub fn array_hash<A: Array>(array: &A) -> Option<u64> {
 /// * Panics if the reflected value is not a [valid array](ReflectRef::Array).
 ///
 #[inline]
-pub fn array_apply<A: Array>(array: &mut A, reflect: &dyn Reflect) {
+pub fn array_apply<A: Array>(array: &mut A, reflect: &dyn Reflect) -> Result<(), ReflectError> {
     if let ReflectRef::Array(reflect_array) = reflect.reflect_ref() {
         if array.len() != reflect_array.len() {
             panic!("Attempted to apply different sized `Array` types.");
@@ -355,8 +355,10 @@ pub fn array_apply<A: Array>(array: &mut A, reflect: &dyn Reflect) {
             let v = array.get_mut(i).unwrap();
             v.apply(value);
         }
+        return Ok(());
     } else {
-        panic!("Attempted to apply a non-`Array` type to an `Array` type.");
+        // panic!("Attempted to apply a non-`Array` type to an `Array` type.");
+        return Err(ReflectError::MismatchedTypes(String::from("Array")));
     }
 }
 

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -4,7 +4,7 @@ use std::any::Any;
 use crate::utility::GenericTypeInfoCell;
 use crate::{
     Array, ArrayIter, FromReflect, FromType, GetTypeRegistration, List, ListInfo, Reflect,
-    ReflectFromPtr, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypeRegistration, Typed,
+    ReflectFromPtr, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypeRegistration, Typed, ReflectError,
 };
 
 impl<T: smallvec::Array + Send + Sync + 'static> Array for SmallVec<T>
@@ -102,8 +102,8 @@ where
         self
     }
 
-    fn apply(&mut self, value: &dyn Reflect) {
-        crate::list_apply(self, value);
+    fn apply(&mut self, value: &dyn Reflect) -> Result<(), ReflectError> {
+        crate::list_apply(self, value)
     }
 
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Formatter};
 
 use crate::utility::NonGenericTypeInfoCell;
 use crate::{
-    Array, ArrayIter, DynamicArray, DynamicInfo, FromReflect, Reflect, ReflectMut, ReflectOwned,
+    Array, ArrayIter, DynamicArray, DynamicInfo, FromReflect, Reflect, ReflectError, ReflectMut, ReflectOwned,
     ReflectRef, TypeInfo, Typed,
 };
 
@@ -231,8 +231,8 @@ impl Reflect for DynamicList {
         self
     }
 
-    fn apply(&mut self, value: &dyn Reflect) {
-        list_apply(self, value);
+    fn apply(&mut self, value: &dyn Reflect) -> Result<(), ReflectError> {
+        list_apply(self, value)
     }
 
     #[inline]
@@ -308,7 +308,7 @@ impl IntoIterator for DynamicList {
 ///
 /// This function panics if `b` is not a list.
 #[inline]
-pub fn list_apply<L: List>(a: &mut L, b: &dyn Reflect) {
+pub fn list_apply<L: List>(a: &mut L, b: &dyn Reflect) -> Result<(), ReflectError> {
     if let ReflectRef::List(list_value) = b.reflect_ref() {
         for (i, value) in list_value.iter().enumerate() {
             if i < a.len() {
@@ -319,8 +319,10 @@ pub fn list_apply<L: List>(a: &mut L, b: &dyn Reflect) {
                 List::push(a, value.clone_value());
             }
         }
+        return Ok(());
     } else {
-        panic!("Attempted to apply a non-list type to a list type.");
+        // panic!("Attempted to apply a non-list type to a list type.");
+        return Err(ReflectError::MismatchedTypes(String::from("list")));
     }
 }
 

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 use bevy_utils::{Entry, HashMap};
 
 use crate::utility::NonGenericTypeInfoCell;
-use crate::{DynamicInfo, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, Typed};
+use crate::{DynamicInfo, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, Typed, ReflectError};
 
 /// An ordered mapping between [`Reflect`] values.
 ///
@@ -288,8 +288,8 @@ impl Reflect for DynamicMap {
         self
     }
 
-    fn apply(&mut self, value: &dyn Reflect) {
-        map_apply(self, value);
+    fn apply(&mut self, value: &dyn Reflect) -> Result<(), ReflectError> {
+        map_apply(self, value)
     }
 
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
@@ -436,7 +436,7 @@ pub fn map_debug(dyn_map: &dyn Map, f: &mut std::fmt::Formatter<'_>) -> std::fmt
 ///
 /// This function panics if `b` is not a reflected map.
 #[inline]
-pub fn map_apply<M: Map>(a: &mut M, b: &dyn Reflect) {
+pub fn map_apply<M: Map>(a: &mut M, b: &dyn Reflect) -> Result<(), ReflectError> {
     if let ReflectRef::Map(map_value) = b.reflect_ref() {
         for (key, b_value) in map_value.iter() {
             if let Some(a_value) = a.get_mut(key) {
@@ -445,8 +445,10 @@ pub fn map_apply<M: Map>(a: &mut M, b: &dyn Reflect) {
                 a.insert_boxed(key.clone_value(), b_value.clone_value());
             }
         }
+        return Ok(());
     } else {
-        panic!("Attempted to apply a non-map type to a map type.");
+        // panic!("Attempted to apply a non-map type to a map type.");
+        return Err(ReflectError::MismatchedTypes(String::from("map")));
     }
 }
 

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -10,6 +10,17 @@ use std::{
 
 use crate::utility::NonGenericTypeInfoCell;
 pub use bevy_utils::AHasher as ReflectHasher;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ReflectError {
+    #[error("Attempted to apply non-{0} type to {0} type.")]
+    MismatchedTypes(String),
+    #[error("Value is not a {0}.")]
+    WrongType(String),
+    #[error("Attempted to apply different sized {0} types.")]
+    DifferentSize(String)
+}
 
 /// An immutable enumeration of "kinds" of reflected type.
 ///
@@ -141,7 +152,7 @@ pub trait Reflect: Any + Send + Sync {
     /// - If `T` is any complex type and the corresponding fields or elements of
     ///   `self` and `value` are not of the same type.
     /// - If `T` is a value type and `self` cannot be downcast to `T`
-    fn apply(&mut self, value: &dyn Reflect);
+    fn apply(&mut self, value: &dyn Reflect) -> Result<(), ReflectError>;
 
     /// Performs a type-checked assignment of a reflected value to this value.
     ///

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -1,6 +1,6 @@
 use crate::utility::NonGenericTypeInfoCell;
 use crate::{
-    DynamicInfo, NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, Typed,
+    DynamicInfo, NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, Typed, ReflectError,
 };
 use bevy_utils::{Entry, HashMap};
 use std::fmt::{Debug, Formatter};
@@ -439,7 +439,7 @@ impl Reflect for DynamicStruct {
         ReflectOwned::Struct(self)
     }
 
-    fn apply(&mut self, value: &dyn Reflect) {
+    fn apply(&mut self, value: &dyn Reflect) -> Result<(), ReflectError> {
         if let ReflectRef::Struct(struct_value) = value.reflect_ref() {
             for (i, value) in struct_value.iter_fields().enumerate() {
                 let name = struct_value.name_at(i).unwrap();
@@ -447,8 +447,10 @@ impl Reflect for DynamicStruct {
                     v.apply(value);
                 }
             }
+            return Ok(());
         } else {
-            panic!("Attempted to apply non-struct type to struct type.");
+            // panic!("Attempted to apply non-struct type to struct type.");
+            return Err(ReflectError::MismatchedTypes(String::from("struct")));
         }
     }
 

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -1,6 +1,6 @@
 use crate::utility::NonGenericTypeInfoCell;
 use crate::{
-    DynamicInfo, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, Typed, UnnamedField,
+    DynamicInfo, Reflect, ReflectError, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, Typed, UnnamedField,
 };
 use std::any::{Any, TypeId};
 use std::fmt::{Debug, Formatter};
@@ -342,15 +342,17 @@ impl Reflect for DynamicTupleStruct {
         ReflectOwned::TupleStruct(self)
     }
 
-    fn apply(&mut self, value: &dyn Reflect) {
+    fn apply(&mut self, value: &dyn Reflect) -> Result<(), ReflectError> {
         if let ReflectRef::TupleStruct(tuple_struct) = value.reflect_ref() {
             for (i, value) in tuple_struct.iter_fields().enumerate() {
                 if let Some(v) = self.field_mut(i) {
                     v.apply(value);
                 }
             }
+            return Ok(());
         } else {
-            panic!("Attempted to apply non-TupleStruct type to TupleStruct type.");
+            // panic!("Attempted to apply non-TupleStruct type to TupleStruct type.");
+            return Err(ReflectError::MismatchedTypes(String::from("TupleStruct")));
         }
     }
 

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -56,7 +56,7 @@ use std::any::{Any, TypeId};
 /// #   fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> { todo!() }
 /// #   fn as_reflect(&self) -> &dyn Reflect { todo!() }
 /// #   fn as_reflect_mut(&mut self) -> &mut dyn Reflect { todo!() }
-/// #   fn apply(&mut self, value: &dyn Reflect) { todo!() }
+/// #   fn apply(&mut self, value: &dyn Reflect) -> Result<(), ReflectError> { todo!() }
 /// #   fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> { todo!() }
 /// #   fn reflect_ref(&self) -> ReflectRef { todo!() }
 /// #   fn reflect_mut(&mut self) -> ReflectMut { todo!() }


### PR DESCRIPTION
# Objective
 Currently the apply functions for Reflects panic when an error occurs (eg. wrong types). I am working on a solution where errors can be propagated to the user where they can handle it on their end. 

# Solutions

* I've created a new pub enum ReflectError which uses thiserror crate to log errors. 
```Rust
#[derive(Error, Debug)]
pub enum ReflectError {
    #[error("Attempted to apply non-{0} type to {0} type.")]
    MismatchedTypes(String),
    #[error("Value is not a {0}.")]
    WrongType(String),
    #[error("Attempted to apply different sized {0} types.")]
    DifferentSize(String)
}
```

* I've changed the return values of the apply function on all the types. for example:
```Rust
#[inline]
pub fn map_apply<M: Map>(a: &mut M, b: &dyn Reflect) -> Result<(), ReflectError> {
    if let ReflectRef::Map(map_value) = b.reflect_ref() {
        for (key, b_value) in map_value.iter() {
            if let Some(a_value) = a.get_mut(key) {
                a_value.apply(b_value);
            } else {
                a.insert_boxed(key.clone_value(), b_value.clone_value());
            }
        }
        return Ok(());
    } else {
        // panic!("Attempted to apply a non-map type to a map type.");
        return Err(ReflectError::MismatchedTypes(String::from("map")));
    }
}
```
# Problems

Either my implementation is completely wrong or there is still somewhere in the code where I still have to change the return type. I've also looked in the `bevy_reflect_derive` folder and made changes there but to no avail. 

Some pointers in the right direction would be appreciated!

I get errors from places in the code where `derive(Reflect)` is called or the macro `impl_reflect_value!`. 

Errors are: ```method `apply` has an incompatible type for trait
expected fn pointer `fn(&mut enums::tests::enum_should_allow_struct_fields::TestEnum, &(dyn reflect::Reflect + 'static)) -> Result<(), reflect::ReflectError>`
   found fn pointer `fn(&mut enums::tests::enum_should_allow_struct_fields::TestEnum, &(dyn reflect::Reflect + 'static))`rustc[E0053](https://doc.rust-lang.org/error-index.html#E0053)
mod.rs(359, 18): Error originated from macro call here
reflect.rs(155, 49): type in trait
mod.rs(359, 18): change the output type to match the trait: `-> Result<(), reflect::ReflectError> ```



