### PR TITLE
[Merged by Bors] - bevy_reflect: Remove `ReflectSerialize` and `ReflectDeserialize` registrations from most glam types

### DIFF
--- a/crates/bevy_reflect/src/impls/glam.rs
+++ b/crates/bevy_reflect/src/impls/glam.rs
@@ -139,14 +139,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct Mat2 {
         x_axis: Vec2,
         y_axis: Vec2,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct Mat3 {
         x_axis: Vec3,
         y_axis: Vec3,
@@ -154,7 +154,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct Mat3A {
         x_axis: Vec3A,
         y_axis: Vec3A,
@@ -162,7 +162,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct Mat4 {
         x_axis: Vec4,
         y_axis: Vec4,
@@ -172,14 +172,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct DMat2 {
         x_axis: DVec2,
         y_axis: DVec2,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct DMat3 {
         x_axis: DVec3,
         y_axis: DVec3,
@@ -187,7 +187,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct DMat4 {
         x_axis: DVec4,
         y_axis: DVec4,
@@ -197,14 +197,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct Affine2 {
         matrix2: Mat2,
         translation: Vec2,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct Affine3A {
         matrix3: Mat3A,
         translation: Vec3A,
@@ -212,14 +212,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct DAffine2 {
         matrix2: DMat2,
         translation: DVec2,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     struct DAffine3 {
         matrix3: DMat3,
         translation: DVec3,


### PR DESCRIPTION
# Objective

> Part of #6573

When serializing a `DynamicScene` we end up treating almost all non-value types as though their type data doesn't exist. This is because when creating the `DynamicScene` we call `Reflect::clone_value` on the components, which generates a Dynamic type for all non-value types.

What this means is that the `glam` types are treated as though their `ReflectSerialize` registrations don't exist. However, the deserializer _does_ pick up the registration and attempts to use that instead. This results in the deserializer trying to operate on "malformed" data, causing this error:

```
WARN bevy_asset::asset_server: encountered an error while loading an asset: Expected float
```

## Solution

Ideally, we should better handle the serialization of possibly-Dynamic types. However, this runs into issues where the `ReflectSerialize` expects the concrete type and not a Dynamic representation, resulting in a panic:

https://github.com/bevyengine/bevy/blob/0aa4147af6d583c707863484d6a8ad50ed0ed984/crates/bevy_reflect/src/type_registry.rs#L402-L413

Since glam types are so heavily used in Bevy (specifically in `Transform` and `GlobalTransform`), it makes sense to just a quick fix in that enables them to be used properly in scenes while a proper solution is found.

This PR simply removes all `ReflectSerialize` and `ReflectDeserialize` registrations from the glam types that are reflected as structs.

---

## Changelog

- Remove `ReflectSerialize` and `ReflectDeserialize` registrations from most glam types

## Migration Guide

This PR removes `ReflectSerialize` and `ReflectDeserialize` registrations from most glam types. This means any code relying on either of those type data existing for those glam types will need to not do that.

This also means that some serialized glam types will need to be updated. For example, here is `Affine3A`:

```rust
// BEFORE
(
  "glam::f32::affine3a::Affine3A": (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0),

// AFTER
  "glam::f32::affine3a::Affine3A": (
    matrix3: (
      x_axis: (
        x: 1.0,
        y: 0.0,
        z: 0.0,
      ),
      y_axis: (
        x: 0.0,
        y: 1.0,
        z: 0.0,
      ),
      z_axis: (
        x: 0.0,
        y: 0.0,
        z: 1.0,
      ),
    ),
    translation: (
      x: 0.0,
      y: 0.0,
      z: 0.0,
    ),
  )
)
```