### PR TITLE
Support no_std compilation for various crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1032,7 +1032,7 @@ current changes on git with [previous release tags][git_tag_comparison].
 - [Make Remove Command's fields public][2449]
 - [bevy_utils: Re-introduce `with_capacity()`.][2393]
 - [Update rodio requirement from 0.13 to 0.14][2244]
-- [Optimize Events::extend and impl std::iter::Extend][2207]
+- [Optimize Events::extend and impl core::iter::Extend][2207]
 - [Bump winit to 0.25][2186]
 - [Improve legibility of RunOnce::run_unsafe param][2181]
 - [Update gltf requirement from 0.15.2 to 0.16.0][2196]

--- a/benches/benches/bevy_ecs/change_detection.rs
+++ b/benches/benches/bevy_ecs/change_detection.rs
@@ -67,7 +67,7 @@ fn generic_bench<P: Copy>(
 
 fn all_added_detection_generic<T: Component + Default>(group: &mut BenchGroup, entity_count: u32) {
     group.bench_function(
-        format!("{}_entities_{}", entity_count, std::any::type_name::<T>()),
+        format!("{}_entities_{}", entity_count, core::any::type_name::<T>()),
         |bencher| {
             bencher.iter_batched(
                 || setup::<T>(entity_count),
@@ -107,7 +107,7 @@ fn all_changed_detection_generic<T: Component + Default + BenchModify>(
     entity_count: u32,
 ) {
     group.bench_function(
-        format!("{}_entities_{}", entity_count, std::any::type_name::<T>()),
+        format!("{}_entities_{}", entity_count, core::any::type_name::<T>()),
         |bencher| {
             bencher.iter_batched(
                 || {
@@ -157,7 +157,7 @@ fn few_changed_detection_generic<T: Component + Default + BenchModify>(
     let ratio_to_modify = 0.1;
     let amount_to_modify = (entity_count as f32 * ratio_to_modify) as usize;
     group.bench_function(
-        format!("{}_entities_{}", entity_count, std::any::type_name::<T>()),
+        format!("{}_entities_{}", entity_count, core::any::type_name::<T>()),
         |bencher| {
             bencher.iter_batched(
                 || {
@@ -205,7 +205,7 @@ fn none_changed_detection_generic<T: Component + Default>(
     entity_count: u32,
 ) {
     group.bench_function(
-        format!("{}_entities_{}", entity_count, std::any::type_name::<T>()),
+        format!("{}_entities_{}", entity_count, core::any::type_name::<T>()),
         |bencher| {
             bencher.iter_batched(
                 || {

--- a/benches/benches/bevy_ecs/change_detection.rs
+++ b/benches/benches/bevy_ecs/change_detection.rs
@@ -41,7 +41,7 @@ impl BenchModify for Sparse {
     }
 }
 
-const RANGE_ENTITIES_TO_BENCH_COUNT: std::ops::Range<u32> = 5..7;
+const RANGE_ENTITIES_TO_BENCH_COUNT: core::ops::Range<u32> = 5..7;
 
 type BenchGroup<'a> = criterion::BenchmarkGroup<'a, criterion::measurement::WallTime>;
 
@@ -88,8 +88,8 @@ fn all_added_detection_generic<T: Component + Default>(group: &mut BenchGroup, e
 
 fn all_added_detection(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("all_added_detection");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
     for entity_count in RANGE_ENTITIES_TO_BENCH_COUNT.map(|i| i * 10_000) {
         generic_bench(
             &mut group,
@@ -136,8 +136,8 @@ fn all_changed_detection_generic<T: Component + Default + BenchModify>(
 
 fn all_changed_detection(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("all_changed_detection");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
     for entity_count in RANGE_ENTITIES_TO_BENCH_COUNT.map(|i| i * 10_000) {
         generic_bench(
             &mut group,
@@ -186,8 +186,8 @@ fn few_changed_detection_generic<T: Component + Default + BenchModify>(
 
 fn few_changed_detection(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("few_changed_detection");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
     for entity_count in RANGE_ENTITIES_TO_BENCH_COUNT.map(|i| i * 10_000) {
         generic_bench(
             &mut group,
@@ -230,8 +230,8 @@ fn none_changed_detection_generic<T: Component + Default>(
 
 fn none_changed_detection(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("none_changed_detection");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
     for entity_count in RANGE_ENTITIES_TO_BENCH_COUNT.map(|i| i * 10_000) {
         generic_bench(
             &mut group,

--- a/benches/benches/bevy_ecs/components/mod.rs
+++ b/benches/benches/bevy_ecs/components/mod.rs
@@ -21,8 +21,8 @@ criterion_group!(
 
 fn add_remove(c: &mut Criterion) {
     let mut group = c.benchmark_group("add_remove");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
     group.bench_function("table", |b| {
         let mut bench = add_remove_table::Benchmark::new();
         b.iter(move || bench.run());
@@ -36,8 +36,8 @@ fn add_remove(c: &mut Criterion) {
 
 fn add_remove_big(c: &mut Criterion) {
     let mut group = c.benchmark_group("add_remove_big");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
     group.bench_function("table", |b| {
         let mut bench = add_remove_big_table::Benchmark::new();
         b.iter(move || bench.run());
@@ -51,8 +51,8 @@ fn add_remove_big(c: &mut Criterion) {
 
 fn insert_simple(c: &mut Criterion) {
     let mut group = c.benchmark_group("insert_simple");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
     group.bench_function("base", |b| {
         let mut bench = insert_simple::Benchmark::new();
         b.iter(move || bench.run());

--- a/benches/benches/bevy_ecs/iteration/heavy_compute.rs
+++ b/benches/benches/bevy_ecs/iteration/heavy_compute.rs
@@ -17,8 +17,8 @@ pub fn heavy_compute(c: &mut Criterion) {
     struct Transform(Mat4);
 
     let mut group = c.benchmark_group("heavy_compute");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
     group.bench_function("base", |b| {
         ComputeTaskPool::init(TaskPool::default);
 

--- a/benches/benches/bevy_ecs/iteration/mod.rs
+++ b/benches/benches/bevy_ecs/iteration/mod.rs
@@ -31,8 +31,8 @@ criterion_group!(
 
 fn iter_simple(c: &mut Criterion) {
     let mut group = c.benchmark_group("iter_simple");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
     group.bench_function("base", |b| {
         let mut bench = iter_simple::Benchmark::new();
         b.iter(move || bench.run());
@@ -74,8 +74,8 @@ fn iter_simple(c: &mut Criterion) {
 
 fn iter_frag(c: &mut Criterion) {
     let mut group = c.benchmark_group("iter_fragmented");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
     group.bench_function("base", |b| {
         let mut bench = iter_frag::Benchmark::new();
         b.iter(move || bench.run());
@@ -97,8 +97,8 @@ fn iter_frag(c: &mut Criterion) {
 
 fn iter_frag_sparse(c: &mut Criterion) {
     let mut group = c.benchmark_group("iter_fragmented_sparse");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
     group.bench_function("base", |b| {
         let mut bench = iter_frag_sparse::Benchmark::new();
         b.iter(move || bench.run());

--- a/benches/benches/bevy_ecs/scheduling/run_criteria.rs
+++ b/benches/benches/bevy_ecs/scheduling/run_criteria.rs
@@ -15,8 +15,8 @@ enum Always {
 pub fn run_criteria_yes(criterion: &mut Criterion) {
     let mut world = World::new();
     let mut group = criterion.benchmark_group("run_criteria/yes");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(3));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(3));
     fn empty() {}
     fn always_yes() -> ShouldRun {
         ShouldRun::Yes
@@ -47,8 +47,8 @@ pub fn run_criteria_yes(criterion: &mut Criterion) {
 pub fn run_criteria_no(criterion: &mut Criterion) {
     let mut world = World::new();
     let mut group = criterion.benchmark_group("run_criteria/no");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(3));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(3));
     fn empty() {}
     fn always_no() -> ShouldRun {
         ShouldRun::No
@@ -78,8 +78,8 @@ pub fn run_criteria_no(criterion: &mut Criterion) {
 pub fn run_criteria_yes_with_labels(criterion: &mut Criterion) {
     let mut world = World::new();
     let mut group = criterion.benchmark_group("run_criteria/yes_with_labels");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(3));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(3));
     fn empty() {}
     fn always_yes() -> ShouldRun {
         ShouldRun::Yes
@@ -110,8 +110,8 @@ pub fn run_criteria_yes_with_labels(criterion: &mut Criterion) {
 pub fn run_criteria_no_with_labels(criterion: &mut Criterion) {
     let mut world = World::new();
     let mut group = criterion.benchmark_group("run_criteria/no_with_labels");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(3));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(3));
     fn empty() {}
     fn always_no() -> ShouldRun {
         ShouldRun::No
@@ -146,8 +146,8 @@ pub fn run_criteria_yes_with_query(criterion: &mut Criterion) {
     let mut world = World::new();
     world.spawn(TestBool(true));
     let mut group = criterion.benchmark_group("run_criteria/yes_using_query");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(3));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(3));
     fn empty() {}
     fn yes_with_query(query: Query<&TestBool>) -> ShouldRun {
         query.single().0.into()
@@ -178,8 +178,8 @@ pub fn run_criteria_yes_with_resource(criterion: &mut Criterion) {
     let mut world = World::new();
     world.insert_resource(TestBool(true));
     let mut group = criterion.benchmark_group("run_criteria/yes_using_resource");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(3));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(3));
     fn empty() {}
     fn yes_with_resource(res: Res<TestBool>) -> ShouldRun {
         res.0.into()

--- a/benches/benches/bevy_ecs/scheduling/schedule.rs
+++ b/benches/benches/bevy_ecs/scheduling/schedule.rs
@@ -16,19 +16,19 @@ pub fn schedule(c: &mut Criterion) {
 
     fn ab(mut query: Query<(&mut A, &mut B)>) {
         query.for_each_mut(|(mut a, mut b)| {
-            std::mem::swap(&mut a.0, &mut b.0);
+            core::mem::swap(&mut a.0, &mut b.0);
         });
     }
 
     fn cd(mut query: Query<(&mut C, &mut D)>) {
         query.for_each_mut(|(mut c, mut d)| {
-            std::mem::swap(&mut c.0, &mut d.0);
+            core::mem::swap(&mut c.0, &mut d.0);
         });
     }
 
     fn ce(mut query: Query<(&mut C, &mut E)>) {
         query.for_each_mut(|(mut c, mut e)| {
-            std::mem::swap(&mut c.0, &mut e.0);
+            core::mem::swap(&mut c.0, &mut e.0);
         });
     }
 

--- a/benches/benches/bevy_ecs/scheduling/schedule.rs
+++ b/benches/benches/bevy_ecs/scheduling/schedule.rs
@@ -33,8 +33,8 @@ pub fn schedule(c: &mut Criterion) {
     }
 
     let mut group = c.benchmark_group("schedule");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
     group.bench_function("base", |b| {
         let mut world = World::default();
 
@@ -76,8 +76,8 @@ pub fn build_schedule(criterion: &mut Criterion) {
     }
 
     let mut group = criterion.benchmark_group("build_schedule");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(15));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(15));
 
     // Method: generate a set of `graph_size` systems which have a One True Ordering.
     // Add system to the stage with full constraints. Hopefully this should be maximimally

--- a/benches/benches/bevy_ecs/scheduling/stages.rs
+++ b/benches/benches/bevy_ecs/scheduling/stages.rs
@@ -26,8 +26,8 @@ const ENTITY_BUNCH: usize = 5000;
 pub fn empty_systems(criterion: &mut Criterion) {
     let mut world = World::new();
     let mut group = criterion.benchmark_group("empty_systems");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(3));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(3));
     fn empty() {}
     for amount in 0..5 {
         let mut stage = SystemStage::parallel();
@@ -79,8 +79,8 @@ pub fn busy_systems(criterion: &mut Criterion) {
     }
     let mut world = World::new();
     let mut group = criterion.benchmark_group("busy_systems");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(3));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(3));
     for entity_bunches in 1..6 {
         world.spawn_batch((0..4 * ENTITY_BUNCH).map(|_| (A(0.0), B(0.0))));
         world.spawn_batch((0..4 * ENTITY_BUNCH).map(|_| (A(0.0), B(0.0), C(0.0))));
@@ -131,8 +131,8 @@ pub fn contrived(criterion: &mut Criterion) {
     }
     let mut world = World::new();
     let mut group = criterion.benchmark_group("contrived");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(3));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(3));
     for entity_bunches in 1..6 {
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (A(0.0), B(0.0), C(0.0), D(0.0))));
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (A(0.0), B(0.0))));

--- a/benches/benches/bevy_ecs/scheduling/stages.rs
+++ b/benches/benches/bevy_ecs/scheduling/stages.rs
@@ -64,17 +64,17 @@ pub fn empty_systems(criterion: &mut Criterion) {
 pub fn busy_systems(criterion: &mut Criterion) {
     fn ab(mut q: Query<(&mut A, &mut B)>) {
         q.for_each_mut(|(mut a, mut b)| {
-            std::mem::swap(&mut a.0, &mut b.0);
+            core::mem::swap(&mut a.0, &mut b.0);
         });
     }
     fn cd(mut q: Query<(&mut C, &mut D)>) {
         q.for_each_mut(|(mut c, mut d)| {
-            std::mem::swap(&mut c.0, &mut d.0);
+            core::mem::swap(&mut c.0, &mut d.0);
         });
     }
     fn ce(mut q: Query<(&mut C, &mut E)>) {
         q.for_each_mut(|(mut c, mut e)| {
-            std::mem::swap(&mut c.0, &mut e.0);
+            core::mem::swap(&mut c.0, &mut e.0);
         });
     }
     let mut world = World::new();
@@ -113,20 +113,20 @@ pub fn busy_systems(criterion: &mut Criterion) {
 pub fn contrived(criterion: &mut Criterion) {
     fn s_0(mut q_0: Query<(&mut A, &mut B)>) {
         q_0.for_each_mut(|(mut c_0, mut c_1)| {
-            std::mem::swap(&mut c_0.0, &mut c_1.0);
+            core::mem::swap(&mut c_0.0, &mut c_1.0);
         });
     }
     fn s_1(mut q_0: Query<(&mut A, &mut C)>, mut q_1: Query<(&mut B, &mut D)>) {
         q_0.for_each_mut(|(mut c_0, mut c_1)| {
-            std::mem::swap(&mut c_0.0, &mut c_1.0);
+            core::mem::swap(&mut c_0.0, &mut c_1.0);
         });
         q_1.for_each_mut(|(mut c_0, mut c_1)| {
-            std::mem::swap(&mut c_0.0, &mut c_1.0);
+            core::mem::swap(&mut c_0.0, &mut c_1.0);
         });
     }
     fn s_2(mut q_0: Query<(&mut C, &mut D)>) {
         q_0.for_each_mut(|(mut c_0, mut c_1)| {
-            std::mem::swap(&mut c_0.0, &mut c_1.0);
+            core::mem::swap(&mut c_0.0, &mut c_1.0);
         });
     }
     let mut world = World::new();

--- a/benches/benches/bevy_ecs/world/commands.rs
+++ b/benches/benches/bevy_ecs/world/commands.rs
@@ -189,7 +189,7 @@ impl Default for LargeStruct {
 
 pub fn sized_commands_impl<T: Default + Command>(criterion: &mut Criterion) {
     let mut group =
-        criterion.benchmark_group(format!("sized_commands_{}_bytes", std::mem::size_of::<T>()));
+        criterion.benchmark_group(format!("sized_commands_{}_bytes", core::mem::size_of::<T>()));
     group.warm_up_time(std::time::Duration::from_millis(500));
     group.measurement_time(std::time::Duration::from_secs(4));
 

--- a/benches/benches/bevy_ecs/world/commands.rs
+++ b/benches/benches/bevy_ecs/world/commands.rs
@@ -15,8 +15,8 @@ struct C;
 
 pub fn empty_commands(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("empty_commands");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
 
     group.bench_function("0_entities", |bencher| {
         let mut world = World::default();
@@ -32,8 +32,8 @@ pub fn empty_commands(criterion: &mut Criterion) {
 
 pub fn spawn_commands(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("spawn_commands");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
 
     for entity_count in (1..5).map(|i| i * 2 * 1000) {
         group.bench_function(format!("{}_entities", entity_count), |bencher| {
@@ -78,8 +78,8 @@ struct Vec3([f32; 3]);
 
 pub fn insert_commands(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("insert_commands");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
 
     let entity_count = 10_000;
     group.bench_function(format!("insert"), |bencher| {
@@ -143,8 +143,8 @@ impl Command for FakeCommandB {
 
 pub fn fake_commands(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("fake_commands");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
 
     for command_count in (1..5).map(|i| i * 2 * 1000) {
         group.bench_function(format!("{}_commands", command_count), |bencher| {
@@ -190,8 +190,8 @@ impl Default for LargeStruct {
 pub fn sized_commands_impl<T: Default + Command>(criterion: &mut Criterion) {
     let mut group =
         criterion.benchmark_group(format!("sized_commands_{}_bytes", core::mem::size_of::<T>()));
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
 
     for command_count in (1..5).map(|i| i * 2 * 1000) {
         group.bench_function(format!("{}_commands", command_count), |bencher| {
@@ -226,8 +226,8 @@ pub fn large_sized_commands(criterion: &mut Criterion) {
 
 pub fn get_or_spawn(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("get_or_spawn");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
 
     group.bench_function("individual", |bencher| {
         let mut world = World::default();

--- a/benches/benches/bevy_ecs/world/spawn.rs
+++ b/benches/benches/bevy_ecs/world/spawn.rs
@@ -9,8 +9,8 @@ struct B(Vec4);
 
 pub fn world_spawn(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("spawn_world");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
 
     for entity_count in (0..5).map(|i| 10_u32.pow(i)) {
         group.bench_function(format!("{}_entities", entity_count), |bencher| {

--- a/benches/benches/bevy_ecs/world/world_get.rs
+++ b/benches/benches/bevy_ecs/world/world_get.rs
@@ -23,7 +23,7 @@ struct WideTable<const X: usize>(f32);
 #[component(storage = "SparseSet")]
 struct WideSparse<const X: usize>(f32);
 
-const RANGE: std::ops::Range<u32> = 5..6;
+const RANGE: core::ops::Range<u32> = 5..6;
 
 fn deterministic_rand() -> ChaCha8Rng {
     ChaCha8Rng::seed_from_u64(42)
@@ -43,8 +43,8 @@ fn setup_wide<T: Bundle + Default>(entity_count: u32) -> World {
 
 pub fn world_entity(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("world_entity");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{}_entities", entity_count), |bencher| {
@@ -64,8 +64,8 @@ pub fn world_entity(criterion: &mut Criterion) {
 
 pub fn world_get(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("world_get");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{}_entities_table", entity_count), |bencher| {
@@ -95,8 +95,8 @@ pub fn world_get(criterion: &mut Criterion) {
 
 pub fn world_query_get(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("world_query_get");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{}_entities_table", entity_count), |bencher| {
@@ -181,8 +181,8 @@ pub fn world_query_get(criterion: &mut Criterion) {
 
 pub fn world_query_iter(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("world_query_iter");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{}_entities_table", entity_count), |bencher| {
@@ -220,8 +220,8 @@ pub fn world_query_iter(criterion: &mut Criterion) {
 
 pub fn world_query_for_each(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("world_query_for_each");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{}_entities_table", entity_count), |bencher| {
@@ -262,8 +262,8 @@ pub fn query_get_component_simple(criterion: &mut Criterion) {
     struct A(f32);
 
     let mut group = criterion.benchmark_group("query_get_component_simple");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
 
     group.bench_function("unchecked", |bencher| {
         let mut world = World::new();
@@ -301,8 +301,8 @@ pub fn query_get_component_simple(criterion: &mut Criterion) {
 
 pub fn query_get_component(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("query_get_component");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{}_entities_table", entity_count), |bencher| {
@@ -356,8 +356,8 @@ pub fn query_get_component(criterion: &mut Criterion) {
 
 pub fn query_get(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("query_get");
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(4));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{}_entities_table", entity_count), |bencher| {
@@ -405,8 +405,8 @@ pub fn query_get(criterion: &mut Criterion) {
 
 pub fn query_get_many<const N: usize>(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group(&format!("query_get_many_{N}"));
-    group.warm_up_time(std::time::Duration::from_millis(500));
-    group.measurement_time(std::time::Duration::from_secs(2 * N as u64));
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(2 * N as u64));
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{}_calls_table", entity_count), |bencher| {

--- a/benches/benches/bevy_reflect/list.rs
+++ b/benches/benches/bevy_reflect/list.rs
@@ -1,4 +1,4 @@
-use std::{iter, time::Duration};
+use core::{iter, time::Duration};
 
 use bevy_reflect::{DynamicList, List};
 use criterion::{

--- a/benches/benches/bevy_reflect/map.rs
+++ b/benches/benches/bevy_reflect/map.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Write, iter, time::Duration};
+use core::{fmt::Write, iter, time::Duration};
 
 use bevy_reflect::{DynamicMap, Map};
 use bevy_utils::HashMap;

--- a/benches/benches/bevy_reflect/struct.rs
+++ b/benches/benches/bevy_reflect/struct.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use core::time::Duration;
 
 use bevy_reflect::{DynamicStruct, GetField, Reflect, Struct};
 use criterion::{

--- a/benches/benches/bevy_tasks/iter.rs
+++ b/benches/benches/bevy_tasks/iter.rs
@@ -1,22 +1,22 @@
 use bevy_tasks::{ParallelIterator, TaskPoolBuilder};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
-struct ParChunks<'a, T>(std::slice::Chunks<'a, T>);
-impl<'a, T> ParallelIterator<std::slice::Iter<'a, T>> for ParChunks<'a, T>
+struct ParChunks<'a, T>(core::slice::Chunks<'a, T>);
+impl<'a, T> ParallelIterator<core::slice::Iter<'a, T>> for ParChunks<'a, T>
 where
     T: 'a + Send + Sync,
 {
-    fn next_batch(&mut self) -> Option<std::slice::Iter<'a, T>> {
+    fn next_batch(&mut self) -> Option<core::slice::Iter<'a, T>> {
         self.0.next().map(|s| s.iter())
     }
 }
 
-struct ParChunksMut<'a, T>(std::slice::ChunksMut<'a, T>);
-impl<'a, T> ParallelIterator<std::slice::IterMut<'a, T>> for ParChunksMut<'a, T>
+struct ParChunksMut<'a, T>(core::slice::ChunksMut<'a, T>);
+impl<'a, T> ParallelIterator<core::slice::IterMut<'a, T>> for ParChunksMut<'a, T>
 where
     T: 'a + Send + Sync,
 {
-    fn next_batch(&mut self) -> Option<std::slice::IterMut<'a, T>> {
+    fn next_batch(&mut self) -> Option<core::slice::IterMut<'a, T>> {
         self.0.next().map(|s| s.iter_mut())
     }
 }

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![warn(missing_docs)]
 
-use std::ops::Deref;
+use core::ops::Deref;
 
 use bevy_app::{App, CoreStage, Plugin};
 use bevy_asset::{AddAsset, Assets, Handle};

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1,7 +1,7 @@
+use crate::{CoreStage, Plugin, PluginGroup, StartupSchedule, StartupStage};
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use crate::{CoreStage, Plugin, PluginGroup, StartupSchedule, StartupStage};
 pub use bevy_derive::AppLabel;
 use bevy_ecs::{
     event::{Event, Events},

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1,3 +1,6 @@
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use crate::{CoreStage, Plugin, PluginGroup, StartupSchedule, StartupStage};
 pub use bevy_derive::AppLabel;
 use bevy_ecs::{

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -11,7 +11,7 @@ use bevy_ecs::{
     world::World,
 };
 use bevy_utils::{tracing::debug, HashMap, HashSet};
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::info_span;
@@ -76,7 +76,7 @@ pub struct App {
 }
 
 impl Debug for App {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "App {{ sub_apps: ")?;
         f.debug_map()
             .entries(self.sub_apps.iter().map(|(k, v)| (k, v)))
@@ -92,7 +92,7 @@ struct SubApp {
 }
 
 impl Debug for SubApp {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "SubApp {{ app: ")?;
         f.debug_map()
             .entries(self.app.sub_apps.iter().map(|(k, v)| (k, v)))
@@ -163,8 +163,8 @@ impl App {
         #[cfg(feature = "trace")]
         let _bevy_app_run_span = info_span!("bevy_app").entered();
 
-        let mut app = std::mem::replace(self, App::empty());
-        let runner = std::mem::replace(&mut app.runner, Box::new(run_once));
+        let mut app = core::mem::replace(self, App::empty());
+        let runner = core::mem::replace(&mut app.runner, Box::new(run_once));
         (runner)(app);
     }
 
@@ -418,7 +418,7 @@ impl App {
         stage_label: impl StageLabel,
         system: impl IntoSystemDescriptor<Params>,
     ) -> &mut Self {
-        use std::any::TypeId;
+        use core::any::TypeId;
         assert!(
             stage_label.type_id() != TypeId::of::<StartupStage>(),
             "use `add_startup_system_to_stage` instead of `add_system_to_stage` to add a system to a StartupStage"
@@ -453,7 +453,7 @@ impl App {
         stage_label: impl StageLabel,
         system_set: SystemSet,
     ) -> &mut Self {
-        use std::any::TypeId;
+        use core::any::TypeId;
         assert!(
             stage_label.type_id() != TypeId::of::<StartupStage>(),
             "use `add_startup_system_set_to_stage` instead of `add_system_set_to_stage` to add system sets to a StartupStage"

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -1,6 +1,9 @@
 //! This crate is about everything concerning the highest-level, application layer of a Bevy app.
 
+#![forbid(unsafe_code)]
 #![warn(missing_docs)]
+
+extern crate alloc;
 
 mod app;
 mod plugin;

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -1,7 +1,7 @@
 use downcast_rs::{impl_downcast, Downcast};
 
 use crate::App;
-use std::any::Any;
+use core::any::Any;
 
 /// A collection of Bevy app logic and configuration.
 ///
@@ -18,7 +18,7 @@ pub trait Plugin: Downcast + Any + Send + Sync {
     fn build(&self, app: &mut App);
     /// Configures a name for the [`Plugin`] which is primarily used for debugging.
     fn name(&self) -> &str {
-        std::any::type_name::<Self>()
+        core::any::type_name::<Self>()
     }
     /// If the plugin can be meaningfully instantiated several times in an [`App`](crate::App),
     /// override this method to return `false`.

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -1,7 +1,7 @@
+use crate::{App, AppError, Plugin};
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use crate::{App, AppError, Plugin};
 use bevy_utils::{tracing::debug, tracing::warn, HashMap};
 use core::any::TypeId;
 

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -1,3 +1,6 @@
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use crate::{App, AppError, Plugin};
 use bevy_utils::{tracing::debug, tracing::warn, HashMap};
 use core::any::TypeId;

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -1,6 +1,6 @@
 use crate::{App, AppError, Plugin};
 use bevy_utils::{tracing::debug, tracing::warn, HashMap};
-use std::any::TypeId;
+use core::any::TypeId;
 
 /// Combines multiple [`Plugin`]s into a single unit.
 pub trait PluginGroup: Sized {
@@ -8,7 +8,7 @@ pub trait PluginGroup: Sized {
     fn build(self) -> PluginGroupBuilder;
     /// Configures a name for the [`PluginGroup`] which is primarily used for debugging.
     fn name() -> String {
-        std::any::type_name::<Self>().to_string()
+        core::any::type_name::<Self>().to_string()
     }
     /// Sets the value of the given [`Plugin`], if it exists
     fn set<T: Plugin>(self, plugin: T) -> PluginGroupBuilder {
@@ -58,7 +58,7 @@ impl PluginGroupBuilder {
             Some(i) => i,
             None => panic!(
                 "Plugin does not exist in group: {}.",
-                std::any::type_name::<Target>()
+                core::any::type_name::<Target>()
             ),
         }
     }
@@ -100,7 +100,7 @@ impl PluginGroupBuilder {
         let entry = self.plugins.get_mut(&TypeId::of::<T>()).unwrap_or_else(|| {
             panic!(
                 "{} does not exist in this PluginGroup",
-                std::any::type_name::<T>(),
+                core::any::type_name::<T>(),
             )
         });
         entry.plugin = Box::new(plugin);
@@ -240,9 +240,9 @@ mod tests {
         assert_eq!(
             group.order,
             vec![
-                std::any::TypeId::of::<PluginA>(),
-                std::any::TypeId::of::<PluginB>(),
-                std::any::TypeId::of::<PluginC>(),
+                core::any::TypeId::of::<PluginA>(),
+                core::any::TypeId::of::<PluginB>(),
+                core::any::TypeId::of::<PluginC>(),
             ]
         );
     }
@@ -257,9 +257,9 @@ mod tests {
         assert_eq!(
             group.order,
             vec![
-                std::any::TypeId::of::<PluginA>(),
-                std::any::TypeId::of::<PluginC>(),
-                std::any::TypeId::of::<PluginB>(),
+                core::any::TypeId::of::<PluginA>(),
+                core::any::TypeId::of::<PluginC>(),
+                core::any::TypeId::of::<PluginB>(),
             ]
         );
     }
@@ -274,9 +274,9 @@ mod tests {
         assert_eq!(
             group.order,
             vec![
-                std::any::TypeId::of::<PluginA>(),
-                std::any::TypeId::of::<PluginC>(),
-                std::any::TypeId::of::<PluginB>(),
+                core::any::TypeId::of::<PluginA>(),
+                core::any::TypeId::of::<PluginC>(),
+                core::any::TypeId::of::<PluginB>(),
             ]
         );
     }
@@ -292,9 +292,9 @@ mod tests {
         assert_eq!(
             group.order,
             vec![
-                std::any::TypeId::of::<PluginA>(),
-                std::any::TypeId::of::<PluginC>(),
-                std::any::TypeId::of::<PluginB>(),
+                core::any::TypeId::of::<PluginA>(),
+                core::any::TypeId::of::<PluginC>(),
+                core::any::TypeId::of::<PluginB>(),
             ]
         );
     }
@@ -310,9 +310,9 @@ mod tests {
         assert_eq!(
             group.order,
             vec![
-                std::any::TypeId::of::<PluginA>(),
-                std::any::TypeId::of::<PluginC>(),
-                std::any::TypeId::of::<PluginB>(),
+                core::any::TypeId::of::<PluginA>(),
+                core::any::TypeId::of::<PluginC>(),
+                core::any::TypeId::of::<PluginB>(),
             ]
         );
     }
@@ -328,9 +328,9 @@ mod tests {
         assert_eq!(
             group.order,
             vec![
-                std::any::TypeId::of::<PluginA>(),
-                std::any::TypeId::of::<PluginC>(),
-                std::any::TypeId::of::<PluginB>(),
+                core::any::TypeId::of::<PluginA>(),
+                core::any::TypeId::of::<PluginC>(),
+                core::any::TypeId::of::<PluginB>(),
             ]
         );
     }

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -1,8 +1,8 @@
-use alloc::borrow::ToOwned;
 use crate::{
     app::{App, AppExit},
     plugin::Plugin,
 };
+use alloc::borrow::ToOwned;
 use bevy_ecs::event::{Events, ManualEventReader};
 use bevy_ecs::prelude::Resource;
 use bevy_utils::{Duration, Instant};

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::ToOwned;
 use crate::{
     app::{App, AppExit},
     plugin::Plugin,

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -151,7 +151,7 @@ impl AssetServer {
             .is_some()
         {
             panic!("Error while registering new asset type: {:?} with UUID: {:?}. Another type with the same UUID is already registered. Can not register new asset type with the same UUID",
-                std::any::type_name::<T>(), T::TYPE_UUID);
+                core::any::type_name::<T>(), T::TYPE_UUID);
         }
         Assets::new(self.server.asset_ref_counter.channel.sender.clone())
     }

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -10,8 +10,8 @@ use bevy_ecs::{
 };
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect};
 use bevy_utils::HashMap;
+use core::fmt::Debug;
 use crossbeam_channel::Sender;
-use std::fmt::Debug;
 
 /// Events that involve assets of type `T`.
 ///
@@ -27,26 +27,26 @@ pub enum AssetEvent<T: Asset> {
 }
 
 impl<T: Asset> Debug for AssetEvent<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             AssetEvent::Created { handle } => f
                 .debug_struct(&format!(
                     "AssetEvent<{}>::Created",
-                    std::any::type_name::<T>()
+                    core::any::type_name::<T>()
                 ))
                 .field("handle", &handle.id())
                 .finish(),
             AssetEvent::Modified { handle } => f
                 .debug_struct(&format!(
                     "AssetEvent<{}>::Modified",
-                    std::any::type_name::<T>()
+                    core::any::type_name::<T>()
                 ))
                 .field("handle", &handle.id())
                 .finish(),
             AssetEvent::Removed { handle } => f
                 .debug_struct(&format!(
                     "AssetEvent<{}>::Removed",
-                    std::any::type_name::<T>()
+                    core::any::type_name::<T>()
                 ))
                 .field("handle", &handle.id())
                 .finish(),

--- a/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
+++ b/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
@@ -5,13 +5,13 @@ use bevy_ecs::system::{Res, ResMut};
 
 /// Adds an asset count diagnostic to an [`App`] for assets of type `T`.
 pub struct AssetCountDiagnosticsPlugin<T: Asset> {
-    marker: std::marker::PhantomData<T>,
+    marker: core::marker::PhantomData<T>,
 }
 
 impl<T: Asset> Default for AssetCountDiagnosticsPlugin<T> {
     fn default() -> Self {
         Self {
-            marker: std::marker::PhantomData,
+            marker: core::marker::PhantomData,
         }
     }
 }

--- a/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
+++ b/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
@@ -33,7 +33,7 @@ impl<T: Asset> AssetCountDiagnosticsPlugin<T> {
 
     /// Registers the asset count diagnostic for the current application.
     pub fn setup_system(mut diagnostics: ResMut<Diagnostics>) {
-        let asset_type_name = std::any::type_name::<T>();
+        let asset_type_name = core::any::type_name::<T>();
         let max_length = MAX_DIAGNOSTIC_NAME_WIDTH - "asset_count ".len();
         diagnostics.add(Diagnostic::new(
             Self::diagnostic_id(),

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -299,7 +299,7 @@ impl<T: Asset> Default for Handle<T> {
 }
 
 impl<T: Asset> Debug for Handle<T> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> std::result::Result<(), core::fmt::Error> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error> {
         let name = core::any::type_name::<T>().split("::").last().unwrap();
         write!(f, "{:?}Handle<{name}>({:?})", self.handle_type, self.id)
     }

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -125,7 +125,7 @@ enum HandleType {
 }
 
 impl Debug for HandleType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             HandleType::Weak => f.write_str("Weak"),
             HandleType::Strong(_) => f.write_str("Strong"),
@@ -299,8 +299,8 @@ impl<T: Asset> Default for Handle<T> {
 }
 
 impl<T: Asset> Debug for Handle<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        let name = std::any::type_name::<T>().split("::").last().unwrap();
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> std::result::Result<(), core::fmt::Error> {
+        let name = core::any::type_name::<T>().split("::").last().unwrap();
         write!(f, "{:?}Handle<{name}>({:?})", self.handle_type, self.id)
     }
 }
@@ -419,7 +419,7 @@ impl Drop for HandleUntyped {
 
 impl<A: Asset> From<Handle<A>> for HandleUntyped {
     fn from(mut handle: Handle<A>) -> Self {
-        let handle_type = std::mem::replace(&mut handle.handle_type, HandleType::Weak);
+        let handle_type = core::mem::replace(&mut handle.handle_type, HandleType::Weak);
         HandleUntyped {
             id: handle.id,
             handle_type,

--- a/crates/bevy_asset/src/io/android_asset_io.rs
+++ b/crates/bevy_asset/src/io/android_asset_io.rs
@@ -45,7 +45,7 @@ impl AssetIo for AndroidAssetIo {
         &self,
         _path: &Path,
     ) -> Result<Box<dyn Iterator<Item = PathBuf>>, AssetIoError> {
-        Ok(Box::new(std::iter::empty::<PathBuf>()))
+        Ok(Box::new(core::iter::empty::<PathBuf>()))
     }
 
     fn watch_path_for_changes(&self, _path: &Path) -> Result<(), AssetIoError> {

--- a/crates/bevy_asset/src/io/wasm_asset_io.rs
+++ b/crates/bevy_asset/src/io/wasm_asset_io.rs
@@ -53,7 +53,7 @@ impl AssetIo for WasmAssetIo {
         _path: &Path,
     ) -> Result<Box<dyn Iterator<Item = PathBuf>>, AssetIoError> {
         bevy_log::warn!("Loading folders is not supported in WASM");
-        Ok(Box::new(std::iter::empty::<PathBuf>()))
+        Ok(Box::new(core::iter::empty::<PathBuf>()))
     }
 
     fn watch_path_for_changes(&self, _path: &Path) -> Result<(), AssetIoError> {

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -246,7 +246,7 @@ impl<T: AssetDynamic> AssetLifecycle for AssetLifecycleChannel<T> {
         } else {
             panic!(
                 "Failed to downcast asset to {}.",
-                std::any::type_name::<T>()
+                core::any::type_name::<T>()
             );
         }
     }

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -1,4 +1,4 @@
-use std::any::{Any, TypeId};
+use core::any::{Any, TypeId};
 
 use bevy_ecs::world::World;
 use bevy_reflect::{FromReflect, FromType, Reflect, Uuid};
@@ -255,7 +255,7 @@ impl<A: Asset> FromType<Handle<A>> for ReflectHandle {
 
 #[cfg(test)]
 mod tests {
-    use std::any::TypeId;
+    use core::any::TypeId;
 
     use bevy_app::{App, AppTypeRegistry};
     use bevy_reflect::{FromReflect, Reflect, ReflectMut, TypeUuid};

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -4,7 +4,7 @@ use bevy_ecs::system::{NonSend, Res, ResMut};
 use bevy_reflect::TypeUuid;
 use bevy_utils::tracing::warn;
 use rodio::{OutputStream, OutputStreamHandle, Sink, Source};
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Used internally to play audio on the current "audio device"
 pub struct AudioOutput<Source = AudioSource>

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -3,8 +3,8 @@ use bevy_asset::{Asset, Assets};
 use bevy_ecs::system::{NonSend, Res, ResMut};
 use bevy_reflect::TypeUuid;
 use bevy_utils::tracing::warn;
-use rodio::{OutputStream, OutputStreamHandle, Sink, Source};
 use core::marker::PhantomData;
+use rodio::{OutputStream, OutputStreamHandle, Sink, Source};
 
 /// Used internally to play audio on the current "audio device"
 pub struct AudioOutput<Source = AudioSource>

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -22,7 +22,7 @@ use bevy_ecs::entity::Entity;
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use bevy_utils::{Duration, HashSet, Instant};
 use std::borrow::Cow;
-use std::ops::Range;
+use core::ops::Range;
 
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_ecs::schedule::IntoSystemDescriptor;

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -21,8 +21,8 @@ use bevy_app::prelude::*;
 use bevy_ecs::entity::Entity;
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use bevy_utils::{Duration, HashSet, Instant};
-use std::borrow::Cow;
 use core::ops::Range;
+use std::borrow::Cow;
 
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_ecs::schedule::IntoSystemDescriptor;

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -1,11 +1,14 @@
 #![warn(missing_docs)]
 //! This crate provides core functionality for Bevy Engine.
 
+extern crate alloc;
+
 mod name;
 #[cfg(feature = "serialize")]
 mod serde;
 mod task_pool_options;
 
+use alloc::string::String;
 use bevy_ecs::system::Resource;
 pub use bytemuck::{bytes_of, cast_slice, Pod, Zeroable};
 pub use name::*;
@@ -17,12 +20,12 @@ pub mod prelude {
     pub use crate::{CorePlugin, Name, TaskPoolOptions};
 }
 
+use alloc::borrow::Cow;
 use bevy_app::prelude::*;
 use bevy_ecs::entity::Entity;
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use bevy_utils::{Duration, HashSet, Instant};
 use core::ops::Range;
-use std::borrow::Cow;
 
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_ecs::schedule::IntoSystemDescriptor;

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -69,10 +69,10 @@ impl Name {
     }
 }
 
-impl std::fmt::Display for Name {
+impl core::fmt::Display for Name {
     #[inline(always)]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.name, f)
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        core::fmt::Display::fmt(&self.name, f)
     }
 }
 
@@ -132,13 +132,13 @@ impl PartialEq for Name {
 impl Eq for Name {}
 
 impl PartialOrd for Name {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         self.name.partial_cmp(&other.name)
     }
 }
 
 impl Ord for Name {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.name.cmp(&other.name)
     }
 }

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -1,12 +1,12 @@
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::string::String;
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_reflect::Reflect;
 use bevy_reflect::{std_traits::ReflectDefault, FromReflect};
 use bevy_utils::AHasher;
-use std::{
-    borrow::Cow,
-    hash::{Hash, Hasher},
-    ops::Deref,
-};
+use core::ops::Deref;
+use std::hash::{Hash, Hasher};
 
 /// Component used to identify an entity. Stores a hash for faster comparisons
 /// The hash is eagerly re-computed upon each update to the name.

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -6,7 +6,7 @@ use bevy_reflect::Reflect;
 use bevy_reflect::{std_traits::ReflectDefault, FromReflect};
 use bevy_utils::AHasher;
 use core::ops::Deref;
-use std::hash::{Hash, Hasher};
+use core::hash::{Hash, Hasher};
 
 /// Component used to identify an entity. Stores a hash for faster comparisons
 /// The hash is eagerly re-computed upon each update to the name.

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -5,8 +5,8 @@ use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_reflect::Reflect;
 use bevy_reflect::{std_traits::ReflectDefault, FromReflect};
 use bevy_utils::AHasher;
-use core::ops::Deref;
 use core::hash::{Hash, Hasher};
+use core::ops::Deref;
 
 /// Component used to identify an entity. Stores a hash for faster comparisons
 /// The hash is eagerly re-computed upon each update to the name.

--- a/crates/bevy_core/src/task_pool_options.rs
+++ b/crates/bevy_core/src/task_pool_options.rs
@@ -55,7 +55,7 @@ impl Default for TaskPoolOptions {
         TaskPoolOptions {
             // By default, use however many cores are available on the system
             min_total_threads: 1,
-            max_total_threads: std::usize::MAX,
+            max_total_threads: core::usize::MAX,
 
             // Use 25% of cores for IO, at least 1, no more than 4
             io: TaskPoolThreadAssignmentPolicy {
@@ -74,7 +74,7 @@ impl Default for TaskPoolOptions {
             // Use all remaining cores for compute (at least 1)
             compute: TaskPoolThreadAssignmentPolicy {
                 min_threads: 1,
-                max_threads: std::usize::MAX,
+                max_threads: core::usize::MAX,
                 percent: 1.0, // This 1.0 here means "whatever is left over"
             },
         }

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -23,7 +23,7 @@ use bevy_render::{
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::info_span;
 use bevy_utils::HashMap;
-use std::num::NonZeroU32;
+use core::num::NonZeroU32;
 
 pub mod draw_3d_graph {
     pub mod node {

--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -31,7 +31,7 @@ use bevy_render::{
     Extract, RenderApp, RenderStage,
 };
 use bevy_utils::FloatOrd;
-use std::ops::Range;
+use core::ops::Range;
 
 use crate::{tonemapping::TonemappingNode, upscaling::UpscalingNode};
 

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -14,7 +14,7 @@ pub mod graph {
     }
 }
 
-use std::cmp::Reverse;
+use core::cmp::Reverse;
 
 pub use camera_3d::*;
 pub use main_pass_3d_node::*;

--- a/crates/bevy_derive/src/derefs.rs
+++ b/crates/bevy_derive/src/derefs.rs
@@ -15,7 +15,7 @@ pub fn derive_deref(input: TokenStream) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
 
     TokenStream::from(quote! {
-        impl #impl_generics ::std::ops::Deref for #ident #ty_generics #where_clause {
+        impl #impl_generics ::core::ops::Deref for #ident #ty_generics #where_clause {
             type Target = #field_type;
 
             fn deref(&self) -> &Self::Target {
@@ -38,7 +38,7 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
 
     TokenStream::from(quote! {
-        impl #impl_generics ::std::ops::DerefMut for #ident #ty_generics #where_clause {
+        impl #impl_generics ::core::ops::DerefMut for #ident #ty_generics #where_clause {
             fn deref_mut(&mut self) -> &mut Self::Target {
                 &mut self.#field_member
             }

--- a/crates/bevy_derive/src/enum_variant_meta.rs
+++ b/crates/bevy_derive/src/enum_variant_meta.rs
@@ -1,3 +1,4 @@
+use alloc::string::ToString;
 use proc_macro::{Span, TokenStream};
 use quote::quote;
 use syn::{parse_macro_input, Data, DeriveInput};

--- a/crates/bevy_derive/src/lib.rs
+++ b/crates/bevy_derive/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+#![forbid(unsafe_code)]
+
+extern crate alloc;
 extern crate proc_macro;
 
 mod app_plugin;

--- a/crates/bevy_derive/src/lib.rs
+++ b/crates/bevy_derive/src/lib.rs
@@ -37,9 +37,9 @@ pub fn derive_dynamic_plugin(input: TokenStream) -> TokenStream {
 /// assert_eq!(5, foo.len());
 /// ```
 ///
-/// [`Deref`]: std::ops::Deref
+/// [`Deref`]: core::ops::Deref
 /// [newtype]: https://doc.rust-lang.org/rust-by-example/generics/new_types.html
-/// [`DerefMut`]: std::ops::DerefMut
+/// [`DerefMut`]: core::ops::DerefMut
 /// [derive]: crate::derive_deref_mut
 #[proc_macro_derive(Deref)]
 pub fn derive_deref(input: TokenStream) -> TokenStream {
@@ -65,9 +65,9 @@ pub fn derive_deref(input: TokenStream) -> TokenStream {
 /// assert_eq!("Hello World!", *foo);
 /// ```
 ///
-/// [`DerefMut`]: std::ops::DerefMut
+/// [`DerefMut`]: core::ops::DerefMut
 /// [newtype]: https://doc.rust-lang.org/rust-by-example/generics/new_types.html
-/// [`Deref`]: std::ops::Deref
+/// [`Deref`]: core::ops::Deref
 /// [derive]: crate::derive_deref
 #[proc_macro_derive(DerefMut)]
 pub fn derive_deref_mut(input: TokenStream) -> TokenStream {

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -41,7 +41,7 @@ pub trait DynamicPluginExt {
 impl DynamicPluginExt for App {
     unsafe fn load_plugin(&mut self, path: &str) -> &mut Self {
         let (lib, plugin) = dynamically_load_plugin(path).unwrap();
-        std::mem::forget(lib); // Ensure that the library is not automatically unloaded
+        core::mem::forget(lib); // Ensure that the library is not automatically unloaded
         plugin.build(self);
         self
     }

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::prelude::*;
 use rand::Rng;
-use std::ops::Deref;
+use core::ops::Deref;
 
 // In this example we will simulate a population of entities. In every tick we will:
 // 1. spawn a new entity with a certain possibility

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::prelude::*;
-use rand::Rng;
 use core::ops::Deref;
+use rand::Rng;
 
 // In this example we will simulate a population of entities. In every tick we will:
 // 1. spawn a new entity with a certain possibility

--- a/crates/bevy_ecs/examples/derive_label.rs
+++ b/crates/bevy_ecs/examples/derive_label.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use bevy_ecs::prelude::*;
 

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::prelude::*;
-use rand::Rng;
 use core::ops::Deref;
+use rand::Rng;
 
 // In this example we add a counter resource and increase it's value in one system,
 // while a different system prints the current count to the console.

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::prelude::*;
 use rand::Rng;
-use std::ops::Deref;
+use core::ops::Deref;
 
 // In this example we add a counter resource and increase it's value in one system,
 // while a different system prints the current count to the console.

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -1,3 +1,4 @@
+use alloc::format;
 use bevy_macro_utils::{get_lit_str, Symbol};
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -1,3 +1,4 @@
+use alloc::{format, vec::Vec};
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
 use quote::{quote, ToTokens};

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -416,14 +416,14 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
             #[doc(hidden)]
             #fetch_struct_visibility struct FetchState <TSystemParamState, #punctuated_generic_idents> {
                 state: TSystemParamState,
-                marker: std::marker::PhantomData<fn()->(#punctuated_generic_idents)>
+                marker: core::marker::PhantomData<fn()->(#punctuated_generic_idents)>
             }
 
             unsafe impl<TSystemParamState: #path::system::SystemParamState, #punctuated_generics> #path::system::SystemParamState for FetchState <TSystemParamState, #punctuated_generic_idents> #where_clause {
                 fn init(world: &mut #path::world::World, system_meta: &mut #path::system::SystemMeta) -> Self {
                     Self {
                         state: TSystemParamState::init(world, system_meta),
-                        marker: std::marker::PhantomData,
+                        marker: core::marker::PhantomData,
                     }
                 }
 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -1,9 +1,14 @@
+#![no_std]
+#![forbid(unsafe_code)]
+
+extern crate alloc;
 extern crate proc_macro;
 
 mod component;
 mod fetch;
 
 use crate::fetch::derive_world_query_impl;
+use alloc::{format, string::String, vec, vec::Vec};
 use bevy_macro_utils::{derive_label, get_named_struct_fields, BevyManifest};
 use proc_macro::TokenStream;
 use proc_macro2::Span;

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -89,7 +89,7 @@ use std::{any::TypeId, collections::HashMap};
 ///
 /// If you want to add `PhantomData` to your `Bundle` you have to mark it with `#[bundle(ignore)]`.
 /// ```
-/// # use std::marker::PhantomData;
+/// # use core::marker::PhantomData;
 /// use bevy_ecs::{component::Component, bundle::Bundle};
 ///
 /// #[derive(Component)]

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -713,7 +713,7 @@ impl Bundles {
             let id = BundleId(bundle_infos.len());
             // SAFETY: T::component_id ensures info was created
             let bundle_info = unsafe {
-                initialize_bundle(std::any::type_name::<T>(), component_ids, id, components)
+                initialize_bundle(core::any::type_name::<T>(), component_ids, id, components)
             };
             bundle_infos.push(bundle_info);
             id

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -210,10 +210,10 @@ macro_rules! impl_methods {
 
 macro_rules! impl_debug {
     ($name:ident < $( $generics:tt ),+ >, $($traits:ident)?) => {
-        impl<$($generics),* : ?Sized $(+ $traits)?> std::fmt::Debug for $name<$($generics),*>
-            where T: std::fmt::Debug
+        impl<$($generics),* : ?Sized $(+ $traits)?> core::fmt::Debug for $name<$($generics),*>
+            where T: core::fmt::Debug
         {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 f.debug_tuple(stringify!($name))
                     .field(&self.value)
                     .finish()
@@ -415,8 +415,8 @@ impl<'a> DetectChanges for MutUntyped<'a> {
     }
 }
 
-impl std::fmt::Debug for MutUntyped<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for MutUntyped<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("MutUntyped")
             .field(&self.value.as_ptr())
             .finish()

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1,7 +1,7 @@
 //! Types that detect when their internal data mutate.
 
 use crate::{component::ComponentTicks, ptr::PtrMut, system::Resource};
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
 ///

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -268,8 +268,8 @@ pub struct ComponentDescriptor {
 }
 
 // We need to ignore the `drop` field in our `Debug` impl
-impl std::fmt::Debug for ComponentDescriptor {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ComponentDescriptor {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ComponentDescriptor")
             .field("name", &self.name)
             .field("storage_type", &self.storage_type)
@@ -289,7 +289,7 @@ impl ComponentDescriptor {
     /// Create a new `ComponentDescriptor` for the type `T`.
     pub fn new<T: Component>() -> Self {
         Self {
-            name: Cow::Borrowed(std::any::type_name::<T>()),
+            name: Cow::Borrowed(core::any::type_name::<T>()),
             storage_type: T::Storage::STORAGE_TYPE,
             is_send_and_sync: true,
             type_id: Some(TypeId::of::<T>()),
@@ -324,7 +324,7 @@ impl ComponentDescriptor {
     /// The [`StorageType`] for resources is always [`TableStorage`].
     pub fn new_resource<T: Resource>() -> Self {
         Self {
-            name: Cow::Borrowed(std::any::type_name::<T>()),
+            name: Cow::Borrowed(core::any::type_name::<T>()),
             // PERF: `SparseStorage` may actually be a more
             // reasonable choice as `storage_type` for resources.
             storage_type: StorageType::Table,
@@ -337,7 +337,7 @@ impl ComponentDescriptor {
 
     fn new_non_send<T: Any>(storage_type: StorageType) -> Self {
         Self {
-            name: Cow::Borrowed(std::any::type_name::<T>()),
+            name: Cow::Borrowed(core::any::type_name::<T>()),
             storage_type,
             is_send_and_sync: false,
             type_id: Some(TypeId::of::<T>()),

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -97,7 +97,7 @@ use std::{
 /// use bevy_ecs::component::Component;
 ///
 /// // `Duration` is defined in the `std` crate.
-/// use std::time::Duration;
+/// use core::time::Duration;
 ///
 /// // It is not possible to implement `Component` for `Duration` from this position, as they are
 /// // both foreign items, defined in an external crate. However, nothing prevents to define a new
@@ -571,7 +571,7 @@ impl ComponentTicks {
 
     /// Manually sets the change tick.
     ///
-    /// This is normally done automatically via the [`DerefMut`](std::ops::DerefMut) implementation
+    /// This is normally done automatically via the [`DerefMut`](core::ops::DerefMut) implementation
     /// on [`Mut<T>`](crate::change_detection::Mut), [`ResMut<T>`](crate::change_detection::ResMut), etc.
     /// However, components and resources that make use of interior mutability might require manual updates.
     ///

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -1,6 +1,6 @@
 use crate::entity::Entity;
 use bevy_utils::{Entry, HashMap};
-use std::fmt;
+use core::fmt;
 
 #[derive(Debug)]
 pub enum MapEntitiesError {

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -232,7 +232,7 @@ pub struct ReserveEntitiesIterator<'a> {
     meta: &'a [EntityMeta],
 
     // Reserved indices formerly in the freelist to hand out.
-    index_iter: std::slice::Iter<'a, u32>,
+    index_iter: core::slice::Iter<'a, u32>,
 
     // New Entity indices to hand out, outside the range of meta.len().
     index_range: std::ops::Range<u32>,

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -235,7 +235,7 @@ pub struct ReserveEntitiesIterator<'a> {
     index_iter: core::slice::Iter<'a, u32>,
 
     // New Entity indices to hand out, outside the range of meta.len().
-    index_range: std::ops::Range<u32>,
+    index_range: core::ops::Range<u32>,
 }
 
 impl<'a> Iterator for ReserveEntitiesIterator<'a> {

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -3,7 +3,7 @@
 use crate as bevy_ecs;
 use crate::system::{Local, Res, ResMut, Resource, SystemParam};
 use bevy_utils::tracing::{trace, warn};
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 use std::{fmt, hash::Hash, marker::PhantomData};
 
 /// A type that can be stored in an [`Events<E>`] resource

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -561,7 +561,7 @@ impl<E: Event> Events<E> {
     }
 }
 
-impl<E: Event> std::iter::Extend<E> for Events<E> {
+impl<E: Event> core::iter::Extend<E> for Events<E> {
     fn extend<I>(&mut self, iter: I)
     where
         I: IntoIterator<Item = E>,

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -41,7 +41,7 @@ impl<E: Event> fmt::Debug for EventId<E> {
         write!(
             f,
             "event<{}>#{}",
-            std::any::type_name::<E>().split("::").last().unwrap(),
+            core::any::type_name::<E>().split("::").last().unwrap(),
             self.id,
         )
     }
@@ -357,7 +357,7 @@ impl<E: Event> ManualEventReader<E> {
         let missed = self.missed_events(events);
         if missed > 0 {
             let plural = if missed == 1 { "event" } else { "events" };
-            let type_name = std::any::type_name::<E>();
+            let type_name = core::any::type_name::<E>();
             warn!("Missed {missed} `{type_name}` {plural}. Consider reading from the `EventReader` more often (generally the best solution) or calling Events::update() less frequently (normally this is called once per frame). This problem is most likely due to run criteria/fixed timesteps or consuming events conditionally. See the Events documentation for more information.");
         }
 
@@ -498,7 +498,7 @@ impl<E: Event> Events<E> {
     /// Swaps the event buffers and clears the oldest event buffer. In general, this should be
     /// called once per frame/update.
     pub fn update(&mut self) {
-        std::mem::swap(&mut self.events_a, &mut self.events_b);
+        core::mem::swap(&mut self.events_a, &mut self.events_b);
         self.events_b.clear();
         self.events_b.start_event_count = self.event_count;
         debug_assert_eq!(

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2,7 +2,6 @@
 #![doc = include_str!("../README.md")]
 
 #[no_std]
-
 #[cfg(target_pointer_width = "16")]
 compile_error!("bevy_ecs cannot safely compile for a 16-bit platform.");
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1,8 +1,12 @@
 #![warn(clippy::undocumented_unsafe_blocks)]
 #![doc = include_str!("../README.md")]
 
+#[no_std]
+
 #[cfg(target_pointer_width = "16")]
 compile_error!("bevy_ecs cannot safely compile for a 16-bit platform.");
+
+extern crate alloc;
 
 pub mod archetype;
 pub mod bundle;

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -1,7 +1,7 @@
 use crate::storage::SparseSetIndex;
 use bevy_utils::HashSet;
-use fixedbitset::FixedBitSet;
 use core::marker::PhantomData;
+use fixedbitset::FixedBitSet;
 
 /// Tracks read and write access to specific elements in a collection.
 ///

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -1,7 +1,7 @@
 use crate::storage::SparseSetIndex;
 use bevy_utils::HashSet;
 use fixedbitset::FixedBitSet;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Tracks read and write access to specific elements in a collection.
 ///

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -213,7 +213,7 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 /// }
 ///
 /// // This function statically checks that `T` implements `Debug`.
-/// fn assert_debug<T: std::fmt::Debug>() {}
+/// fn assert_debug<T: core::fmt::Debug>() {}
 ///
 /// assert_debug::<CustomQueryItem>();
 /// assert_debug::<CustomQueryReadOnlyItem>();
@@ -619,7 +619,7 @@ unsafe impl<T: Component> WorldQuery for &T {
         assert!(
             !access.access().has_write(component_id),
             "&{} conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
-                std::any::type_name::<T>(),
+                core::any::type_name::<T>(),
         );
         access.add_read(component_id);
     }
@@ -780,7 +780,7 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
         assert!(
             !access.access().has_read(component_id),
             "&mut {} conflicts with a previous access in this query. Mutable component access must be unique.",
-                std::any::type_name::<T>(),
+                core::any::type_name::<T>(),
         );
         access.add_write(component_id);
     }
@@ -965,8 +965,8 @@ impl<T: Component> Clone for ChangeTrackers<T> {
 }
 impl<T: Component> Copy for ChangeTrackers<T> {}
 
-impl<T: Component> std::fmt::Debug for ChangeTrackers<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: Component> core::fmt::Debug for ChangeTrackers<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ChangeTrackers")
             .field("component_ticks", &self.component_ticks)
             .field("last_change_tick", &self.last_change_tick)
@@ -1113,7 +1113,7 @@ unsafe impl<T: Component> WorldQuery for ChangeTrackers<T> {
         assert!(
             !access.access().has_write(id),
             "ChangeTrackers<{}> conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
-                std::any::type_name::<T>()
+                core::any::type_name::<T>()
         );
         access.add_read(id);
     }

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -536,7 +536,7 @@ macro_rules! impl_tick_filter {
             fn update_component_access(&id: &ComponentId, access: &mut FilteredAccess<ComponentId>) {
                 if access.access().has_write(id) {
                     panic!("$state_name<{}> conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
-                        std::any::type_name::<T>());
+                        core::any::type_name::<T>());
                 }
                 access.add_read(id);
             }

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -637,7 +637,7 @@ impl_tick_filter!(
 
 /// A marker trait to indicate that the filter works at an archetype level.
 ///
-/// This is needed to implement [`ExactSizeIterator`](std::iter::ExactSizeIterator) for
+/// This is needed to implement [`ExactSizeIterator`](core::iter::ExactSizeIterator) for
 /// [`QueryIter`](crate::query::QueryIter) that contains archetype-level filters.
 ///
 /// The trait must only be implement for filters where its corresponding [`WorldQuery::IS_ARCHETYPAL`](crate::query::WorldQuery::IS_ARCHETYPAL)

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -603,7 +603,7 @@ impl_tick_filter!(
     ///
     /// A common use for this filter is avoiding redundant work when values have not changed.
     ///
-    /// **Note** that simply *mutably dereferencing* a component is considered a change ([`DerefMut`](std::ops::DerefMut)).
+    /// **Note** that simply *mutably dereferencing* a component is considered a change ([`DerefMut`](core::ops::DerefMut)).
     /// Bevy does not compare components to their previous values.
     ///
     /// To retain all results without filtering but still check whether they were changed after the

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -467,8 +467,8 @@ impl<'w, 's, Q: ReadOnlyWorldQuery, F: ReadOnlyWorldQuery, const K: usize> Fused
 }
 
 struct QueryIterationCursor<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> {
-    table_id_iter: std::slice::Iter<'s, TableId>,
-    archetype_id_iter: std::slice::Iter<'s, ArchetypeId>,
+    table_id_iter: core::slice::Iter<'s, TableId>,
+    archetype_id_iter: core::slice::Iter<'s, ArchetypeId>,
     table_entities: &'w [Entity],
     archetype_entities: &'w [ArchetypeEntity],
     fetch: Q::Fetch<'w>,

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -63,7 +63,7 @@ mod tests {
     use crate::query::{ArchetypeFilter, QueryCombinationIter};
     use crate::system::{IntoSystem, Query, System, SystemState};
     use crate::{self as bevy_ecs, component::Component, world::World};
-    use std::any::type_name;
+    use core::any::type_name;
     use std::collections::HashSet;
 
     #[derive(Component, Debug, Hash, Eq, PartialEq, Clone, Copy)]

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -449,7 +449,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     ) -> Result<[ROQueryItem<'w, Q>; N], QueryEntityError> {
         let mut values = [(); N].map(|_| MaybeUninit::uninit());
 
-        for (value, entity) in std::iter::zip(&mut values, entities) {
+        for (value, entity) in core::iter::zip(&mut values, entities) {
             // SAFETY: fetch is read-only
             // and world must be validated
             let item = self.as_readonly().get_unchecked_manual(
@@ -493,7 +493,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
 
         let mut values = [(); N].map(|_| MaybeUninit::uninit());
 
-        for (value, entity) in std::iter::zip(&mut values, entities) {
+        for (value, entity) in core::iter::zip(&mut values, entities) {
             let item = self.get_unchecked_manual(world, entity, last_change_tick, change_tick)?;
             *value = MaybeUninit::new(item);
         }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -37,7 +37,7 @@ pub struct QueryState<Q: WorldQuery, F: ReadOnlyWorldQuery = ()> {
     pub(crate) filter_state: F::State,
 }
 
-impl<Q: WorldQuery, F: ReadOnlyWorldQuery> std::fmt::Debug for QueryState<Q, F> {
+impl<Q: WorldQuery, F: ReadOnlyWorldQuery> core::fmt::Debug for QueryState<Q, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -149,7 +149,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         self.validate_world(world);
         let archetypes = world.archetypes();
         let new_generation = archetypes.generation();
-        let old_generation = std::mem::replace(&mut self.archetype_generation, new_generation);
+        let old_generation = core::mem::replace(&mut self.archetype_generation, new_generation);
         let archetype_index_range = old_generation.value()..new_generation.value();
 
         for archetype_index in archetype_index_range {
@@ -162,7 +162,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         assert!(
             world.id() == self.world_id,
             "Attempted to use {} with a mismatched World. QueryStates can only be used with the World they were created from.",
-                std::any::type_name::<Self>(),
+                core::any::type_name::<Self>(),
         );
     }
 
@@ -1049,8 +1049,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
                         #[cfg(feature = "trace")]
                         let span = bevy_utils::tracing::info_span!(
                             "par_for_each",
-                            query = std::any::type_name::<Q>(),
-                            filter = std::any::type_name::<F>(),
+                            query = core::any::type_name::<Q>(),
+                            filter = core::any::type_name::<F>(),
                             count = len,
                         );
                         #[cfg(feature = "trace")]
@@ -1112,8 +1112,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
                         #[cfg(feature = "trace")]
                         let span = bevy_utils::tracing::info_span!(
                             "par_for_each",
-                            query = std::any::type_name::<Q>(),
-                            filter = std::any::type_name::<F>(),
+                            query = core::any::type_name::<Q>(),
+                            filter = core::any::type_name::<F>(),
                             count = len,
                         );
                         #[cfg(feature = "trace")]
@@ -1245,8 +1245,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
 
         match (first, extra) {
             (Some(r), false) => Ok(r),
-            (None, _) => Err(QuerySingleError::NoEntities(std::any::type_name::<Self>())),
-            (Some(_), _) => Err(QuerySingleError::MultipleEntities(std::any::type_name::<
+            (None, _) => Err(QuerySingleError::NoEntities(core::any::type_name::<Self>())),
+            (Some(_), _) => Err(QuerySingleError::MultipleEntities(core::any::type_name::<
                 Self,
             >())),
         }
@@ -1397,8 +1397,8 @@ pub enum QuerySingleError {
 
 impl std::error::Error for QuerySingleError {}
 
-impl std::fmt::Display for QuerySingleError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for QuerySingleError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             QuerySingleError::NoEntities(query) => write!(f, "No entities fit the query {query}"),
             QuerySingleError::MultipleEntities(query) => {

--- a/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
+++ b/crates/bevy_ecs/src/schedule/ambiguity_detection.rs
@@ -81,7 +81,7 @@ impl SystemStage {
     /// The output may be incorrect if this stage has not been initialized with `world`.
     pub fn report_ambiguities(&self, world: &World) {
         debug_assert!(!self.systems_modified);
-        use std::fmt::Write;
+        use core::fmt::Write;
         let ambiguities = self.ambiguities(world);
         if !ambiguities.is_empty() {
             let mut string = "Execution order ambiguities detected, you might want to \

--- a/crates/bevy_ecs/src/schedule/executor.rs
+++ b/crates/bevy_ecs/src/schedule/executor.rs
@@ -10,7 +10,7 @@ pub trait ParallelSystemExecutor: Downcast + Send + Sync {
 }
 
 impl Debug for dyn ParallelSystemExecutor {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "dyn ParallelSystemExecutor")
     }
 }

--- a/crates/bevy_ecs/src/schedule/graph_utils.rs
+++ b/crates/bevy_ecs/src/schedule/graph_utils.rs
@@ -115,7 +115,7 @@ pub fn topological_order<Labels: Clone>(
             let last_window = [*current.last().unwrap(), current[0]];
             let mut windows = current
                 .windows(2)
-                .chain(std::iter::once(&last_window as &[usize]));
+                .chain(core::iter::once(&last_window as &[usize]));
             while let Some(&[dependant, dependency]) = windows.next() {
                 cycle.push((dependant, graph[&dependant][&dependency].clone()));
             }

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -26,7 +26,7 @@ pub use system_container::*;
 pub use system_descriptor::*;
 pub use system_set::*;
 
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use crate::{system::IntoSystem, world::World};
 use bevy_utils::HashMap;

--- a/crates/bevy_ecs/src/schedule/run_criteria.rs
+++ b/crates/bevy_ecs/src/schedule/run_criteria.rs
@@ -154,7 +154,7 @@ impl GraphNode for RunCriteriaContainer {
 
     fn labels(&self) -> &[RunCriteriaLabelId] {
         if let Some(ref label) = self.label {
-            std::slice::from_ref(label)
+            core::slice::from_ref(label)
         } else {
             &[]
         }
@@ -356,7 +356,7 @@ impl RunCriteria {
 }
 
 impl Debug for dyn System<In = (), Out = ShouldRun> + 'static {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "System {} with In=(), Out=ShouldRun: {{{}}}",
@@ -379,7 +379,7 @@ impl Debug for dyn System<In = (), Out = ShouldRun> + 'static {
 }
 
 impl Debug for dyn System<In = ShouldRun, Out = ShouldRun> + 'static {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "System {} with In=ShouldRun, Out=ShouldRun: {{{}}}",

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -27,7 +27,7 @@ pub trait Stage: Downcast + Send + Sync {
 }
 
 impl Debug for dyn Stage {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if let Some(as_systemstage) = self.as_any().downcast_ref::<SystemStage>() {
             write!(f, "{as_systemstage:?}")
         } else if let Some(as_schedule) = self.as_any().downcast_ref::<Schedule>() {
@@ -446,7 +446,7 @@ impl SystemStage {
                 && self.uninitialized_before_commands.is_empty()
                 && self.uninitialized_at_end.is_empty()
         );
-        fn unwrap_dependency_cycle_error<Node: GraphNode, Output, Labels: std::fmt::Debug>(
+        fn unwrap_dependency_cycle_error<Node: GraphNode, Output, Labels: core::fmt::Debug>(
             result: Result<Output, DependencyGraphError<Labels>>,
             nodes: &[Node],
             nodes_description: &'static str,
@@ -454,7 +454,7 @@ impl SystemStage {
             match result {
                 Ok(output) => output,
                 Err(DependencyGraphError::GraphCycles(cycle)) => {
-                    use std::fmt::Write;
+                    use core::fmt::Write;
                     let mut message = format!("Found a dependency cycle in {nodes_description}:");
                     writeln!(message).unwrap();
                     for (index, labels) in &cycle {
@@ -602,8 +602,8 @@ impl SystemStage {
         &self,
         name: &str,
         v: &Vec<SystemContainer>,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
+        f: &mut core::fmt::Formatter<'_>,
+    ) -> core::fmt::Result {
         write!(f, "{name}: ")?;
         if v.len() > 1 {
             writeln!(f, "[")?;
@@ -617,8 +617,8 @@ impl SystemStage {
     }
 }
 
-impl std::fmt::Debug for SystemStage {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SystemStage {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "SystemStage: {{ ")?;
         write!(
             f,

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -67,7 +67,7 @@ impl RunCriteriaLabel for DriverLabel {
 
 impl DriverLabel {
     fn of<T: 'static>() -> Self {
-        Self(TypeId::of::<T>(), std::any::type_name::<T>())
+        Self(TypeId::of::<T>(), core::any::type_name::<T>())
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/system_container.rs
+++ b/crates/bevy_ecs/src/schedule/system_container.rs
@@ -85,7 +85,7 @@ impl SystemContainer {
 }
 
 impl Debug for SystemContainer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{{{:?}}}", &self.system())
     }
 }

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -24,8 +24,8 @@ pub(super) struct BlobVec {
 }
 
 // We want to ignore the `drop` field in our `Debug` impl
-impl std::fmt::Debug for BlobVec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for BlobVec {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("BlobVec")
             .field("item_layout", &self.item_layout)
             .field("capacity", &self.capacity)
@@ -306,7 +306,7 @@ impl BlobVec {
     /// The type `T` must be the type of the items in this [`BlobVec`].
     pub unsafe fn get_slice<T>(&self) -> &[UnsafeCell<T>] {
         // SAFETY: the inner data will remain valid for as long as 'self.
-        std::slice::from_raw_parts(self.data.as_ptr() as *const UnsafeCell<T>, self.len)
+        core::slice::from_raw_parts(self.data.as_ptr() as *const UnsafeCell<T>, self.len)
     }
 
     pub fn clear(&mut self) {

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -2,7 +2,7 @@ use crate::archetype::ArchetypeComponentId;
 use crate::component::{ComponentId, ComponentTicks, Components};
 use crate::storage::{Column, SparseSet};
 use bevy_ptr::{OwningPtr, Ptr, UnsafeCellDeref};
-use std::cell::UnsafeCell;
+use core::cell::UnsafeCell;
 
 /// The type-erased backing storage and metadata for a single resource within a [`World`].
 ///

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -559,7 +559,7 @@ impl Tables {
         *value
     }
 
-    pub fn iter(&self) -> std::slice::Iter<'_, Table> {
+    pub fn iter(&self) -> core::slice::Iter<'_, Table> {
         self.tables.iter()
     }
 

--- a/crates/bevy_ecs/src/system/commands/command_queue.rs
+++ b/crates/bevy_ecs/src/system/commands/command_queue.rs
@@ -1,4 +1,4 @@
-use std::mem::{ManuallyDrop, MaybeUninit};
+use core::mem::{ManuallyDrop, MaybeUninit};
 
 use super::Command;
 use crate::world::World;
@@ -42,7 +42,7 @@ impl CommandQueue {
             command.write(world);
         }
 
-        let size = std::mem::size_of::<C>();
+        let size = core::mem::size_of::<C>();
         let old_len = self.bytes.len();
 
         self.metas.push(CommandMeta {

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 use bevy_utils::tracing::{error, info};
 pub use command_queue::CommandQueue;
 pub use parallel_scope::*;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use super::Resource;
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use bevy_utils::tracing::{error, info};
 pub use command_queue::CommandQueue;
-pub use parallel_scope::*;
 use core::marker::PhantomData;
+pub use parallel_scope::*;
 
 use super::Resource;
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -806,7 +806,7 @@ where
         if let Err(invalid_entities) = world.insert_or_spawn_batch(self.bundles_iter) {
             error!(
                 "Failed to 'insert or spawn' bundle of type {} into the following invalid entities: {:?}",
-                std::any::type_name::<B>(),
+                core::any::type_name::<B>(),
                 invalid_entities
             );
         }
@@ -837,7 +837,7 @@ where
         if let Some(mut entity) = world.get_entity_mut(self.entity) {
             entity.insert(self.bundle);
         } else {
-            panic!("error[B0003]: Could not insert a bundle (of type `{}`) for entity {:?} because it doesn't exist in this World.", std::any::type_name::<T>(), self.entity);
+            panic!("error[B0003]: Could not insert a bundle (of type `{}`) for entity {:?} because it doesn't exist in this World.", core::any::type_name::<T>(), self.entity);
         }
     }
 }

--- a/crates/bevy_ecs/src/system/commands/parallel_scope.rs
+++ b/crates/bevy_ecs/src/system/commands/parallel_scope.rs
@@ -1,4 +1,4 @@
-use std::cell::Cell;
+use core::cell::Cell;
 
 use thread_local::ThreadLocal;
 

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -502,7 +502,7 @@ impl<T> Copy for SystemTypeIdLabel<T> {}
 /// To create something like [`PipeSystem`], but in entirely safe code.
 ///
 /// ```rust
-/// use std::num::ParseIntError;
+/// use core::num::ParseIntError;
 ///
 /// use bevy_ecs::prelude::*;
 /// use bevy_ecs::system::{SystemParam, SystemParamItem};

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -29,7 +29,7 @@ pub struct SystemMeta {
 impl SystemMeta {
     pub(crate) fn new<T>() -> Self {
         Self {
-            name: std::any::type_name::<T>().into(),
+            name: core::any::type_name::<T>().into(),
             archetype_component_access: Access::default(),
             component_access_set: FilteredAccessSet::default(),
             is_send: true,
@@ -200,7 +200,7 @@ impl<Param: SystemParam> SystemState<Param> {
         assert!(self.matches_world(world), "Encountered a mismatched World. A SystemState cannot be used with Worlds other than the one it was created with.");
         let archetypes = world.archetypes();
         let new_generation = archetypes.generation();
-        let old_generation = std::mem::replace(&mut self.archetype_generation, new_generation);
+        let old_generation = core::mem::replace(&mut self.archetype_generation, new_generation);
         let archetype_index_range = old_generation.value()..new_generation.value();
 
         for archetype_index in archetype_index_range {
@@ -439,7 +439,7 @@ where
         assert!(self.world_id == Some(world.id()), "Encountered a mismatched World. A System cannot be used with Worlds other than the one it was initialized with.");
         let archetypes = world.archetypes();
         let new_generation = archetypes.generation();
-        let old_generation = std::mem::replace(&mut self.archetype_generation, new_generation);
+        let old_generation = core::mem::replace(&mut self.archetype_generation, new_generation);
         let archetype_index_range = old_generation.value()..new_generation.value();
 
         for archetype_index in archetype_index_range {
@@ -469,14 +469,14 @@ pub struct SystemTypeIdLabel<T: 'static>(pub(crate) PhantomData<fn() -> T>);
 impl<T: 'static> SystemLabel for SystemTypeIdLabel<T> {
     #[inline]
     fn as_str(&self) -> &'static str {
-        std::any::type_name::<T>()
+        core::any::type_name::<T>()
     }
 }
 
 impl<T> Debug for SystemTypeIdLabel<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("SystemTypeIdLabel")
-            .field(&std::any::type_name::<T>())
+            .field(&core::any::type_name::<T>())
             .finish()
     }
 }

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -102,7 +102,7 @@ pub fn assert_is_system<In, Out, Params, S: IntoSystem<In, Out, Params>>(sys: S)
 
 #[cfg(test)]
 mod tests {
-    use std::any::TypeId;
+    use core::any::TypeId;
 
     use crate::prelude::StageLabel;
 
@@ -640,7 +640,7 @@ mod tests {
                 let archetype = archetypes.get(location.archetype_id).unwrap();
                 let archetype_components = archetype.components().collect::<Vec<_>>();
                 let bundle_id = bundles
-                    .get_id(std::any::TypeId::of::<(W<i32>, W<bool>)>())
+                    .get_id(core::any::TypeId::of::<(W<i32>, W<bool>)>())
                     .expect("Bundle used to spawn entity should exist");
                 let bundle_info = bundles.get(bundle_id).unwrap();
                 let mut bundle_components = bundle_info.components().to_vec();

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -286,8 +286,8 @@ pub struct Query<'world, 'state, Q: WorldQuery, F: ReadOnlyWorldQuery = ()> {
     pub(crate) force_read_only_component_access: bool,
 }
 
-impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> std::fmt::Debug for Query<'w, 's, Q, F> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> core::fmt::Debug for Query<'w, 's, Q, F> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Query {{ matched entities: {}, world: {:?}, state: {:?}, last_change_tick: {}, change_tick: {} }}", self.iter().count(), self.world, self.state, self.last_change_tick, self.change_tick)
     }
 }
@@ -1431,8 +1431,8 @@ pub enum QueryComponentError {
 
 impl std::error::Error for QueryComponentError {}
 
-impl std::fmt::Display for QueryComponentError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for QueryComponentError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             QueryComponentError::MissingReadAccess => {
                 write!(

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -98,7 +98,7 @@ pub(crate) fn check_system_change_tick(
 }
 
 impl Debug for dyn System<In = (), Out = ()> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "System {}: {{{}}}", self.name(), {
             if self.is_send() {
                 if self.is_exclusive() {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -156,8 +156,8 @@ unsafe impl<Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> SystemPara
         let state = QueryState::new(world);
         assert_component_access_compatibility(
             &system_meta.name,
-            std::any::type_name::<Q>(),
-            std::any::type_name::<F>(),
+            core::any::type_name::<Q>(),
+            core::any::type_name::<F>(),
             &system_meta.component_access_set,
             &state.component_access,
             world,
@@ -285,7 +285,7 @@ impl<'w, T: Resource> Debug for Res<'w, T>
 where
     T: Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("Res").field(&self.value).finish()
     }
 }
@@ -376,7 +376,7 @@ unsafe impl<T: Resource> SystemParamState for ResState<T> {
         assert!(
             !combined_access.has_write(component_id),
             "error[B0002]: Res<{}> in system {} conflicts with a previous ResMut<{0}> access. Consider removing the duplicate access.",
-            std::any::type_name::<T>(),
+            core::any::type_name::<T>(),
             system_meta.name,
         );
         combined_access.add_read(component_id);
@@ -410,7 +410,7 @@ impl<'w, 's, T: Resource> SystemParamFetch<'w, 's> for ResState<T> {
                 panic!(
                     "Resource requested by {} does not exist: {}",
                     system_meta.name,
-                    std::any::type_name::<T>()
+                    core::any::type_name::<T>()
                 )
             });
         Res {
@@ -483,11 +483,11 @@ unsafe impl<T: Resource> SystemParamState for ResMutState<T> {
         if combined_access.has_write(component_id) {
             panic!(
                 "error[B0002]: ResMut<{}> in system {} conflicts with a previous ResMut<{0}> access. Consider removing the duplicate access.",
-                std::any::type_name::<T>(), system_meta.name);
+                core::any::type_name::<T>(), system_meta.name);
         } else if combined_access.has_read(component_id) {
             panic!(
                 "error[B0002]: ResMut<{}> in system {} conflicts with a previous Res<{0}> access. Consider removing the duplicate access.",
-                std::any::type_name::<T>(), system_meta.name);
+                core::any::type_name::<T>(), system_meta.name);
         }
         combined_access.add_write(component_id);
 
@@ -520,7 +520,7 @@ impl<'w, 's, T: Resource> SystemParamFetch<'w, 's> for ResMutState<T> {
                 panic!(
                     "Resource requested by {} does not exist: {}",
                     system_meta.name,
-                    std::any::type_name::<T>()
+                    core::any::type_name::<T>()
                 )
             });
         ResMut {
@@ -710,7 +710,7 @@ impl<'a, T: FromWorld + Send + Sync + 'static> Debug for Local<'a, T>
 where
     T: Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("Local").field(&self.0).finish()
     }
 }
@@ -826,14 +826,14 @@ pub struct RemovedComponents<'a, T: Component> {
 
 impl<'a, T: Component> RemovedComponents<'a, T> {
     /// Returns an iterator over the entities that had their `T` [`Component`] removed.
-    pub fn iter(&self) -> std::iter::Cloned<std::slice::Iter<'_, Entity>> {
+    pub fn iter(&self) -> std::iter::Cloned<core::slice::Iter<'_, Entity>> {
         self.world.removed_with_id(self.component_id)
     }
 }
 
 impl<'a, T: Component> IntoIterator for &'a RemovedComponents<'a, T> {
     type Item = Entity;
-    type IntoIter = std::iter::Cloned<std::slice::Iter<'a, Entity>>;
+    type IntoIter = std::iter::Cloned<core::slice::Iter<'a, Entity>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -909,7 +909,7 @@ impl<'w, T> Debug for NonSend<'w, T>
 where
     T: Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("NonSend").field(&self.value).finish()
     }
 }
@@ -967,7 +967,7 @@ unsafe impl<T: 'static> SystemParamState for NonSendState<T> {
         assert!(
             !combined_access.has_write(component_id),
             "error[B0002]: NonSend<{}> in system {} conflicts with a previous mutable resource access ({0}). Consider removing the duplicate access.",
-            std::any::type_name::<T>(),
+            core::any::type_name::<T>(),
             system_meta.name,
         );
         combined_access.add_read(component_id);
@@ -1002,7 +1002,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendState<T> {
                 panic!(
                     "Non-send resource requested by {} does not exist: {}",
                     system_meta.name,
-                    std::any::type_name::<T>()
+                    core::any::type_name::<T>()
                 )
             });
 
@@ -1079,11 +1079,11 @@ unsafe impl<T: 'static> SystemParamState for NonSendMutState<T> {
         if combined_access.has_write(component_id) {
             panic!(
                 "error[B0002]: NonSendMut<{}> in system {} conflicts with a previous mutable resource access ({0}). Consider removing the duplicate access.",
-                std::any::type_name::<T>(), system_meta.name);
+                core::any::type_name::<T>(), system_meta.name);
         } else if combined_access.has_read(component_id) {
             panic!(
                 "error[B0002]: NonSendMut<{}> in system {} conflicts with a previous immutable resource access ({0}). Consider removing the duplicate access.",
-                std::any::type_name::<T>(), system_meta.name);
+                core::any::type_name::<T>(), system_meta.name);
         }
         combined_access.add_write(component_id);
 
@@ -1117,7 +1117,7 @@ impl<'w, 's, T: 'static> SystemParamFetch<'w, 's> for NonSendMutState<T> {
                 panic!(
                     "Non-send resource requested by {} does not exist: {}",
                     system_meta.name,
-                    std::any::type_name::<T>()
+                    core::any::type_name::<T>()
                 )
             });
         NonSendMut {
@@ -1396,17 +1396,17 @@ impl<'s> From<SystemName<'s>> for &'s str {
     }
 }
 
-impl<'s> std::fmt::Debug for SystemName<'s> {
+impl<'s> core::fmt::Debug for SystemName<'s> {
     #[inline(always)]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_tuple("SystemName").field(&self.name()).finish()
     }
 }
 
-impl<'s> std::fmt::Display for SystemName<'s> {
+impl<'s> core::fmt::Display for SystemName<'s> {
     #[inline(always)]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.name(), f)
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        core::fmt::Display::fmt(&self.name(), f)
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -53,7 +53,7 @@ use std::{
 /// # use bevy_ecs::prelude::*;
 /// # #[derive(Resource)]
 /// # struct SomeResource;
-/// use std::marker::PhantomData;
+/// use core::marker::PhantomData;
 /// use bevy_ecs::system::SystemParam;
 ///
 /// #[derive(SystemParam)]

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -826,14 +826,14 @@ pub struct RemovedComponents<'a, T: Component> {
 
 impl<'a, T: Component> RemovedComponents<'a, T> {
     /// Returns an iterator over the entities that had their `T` [`Component`] removed.
-    pub fn iter(&self) -> std::iter::Cloned<core::slice::Iter<'_, Entity>> {
+    pub fn iter(&self) -> core::iter::Cloned<core::slice::Iter<'_, Entity>> {
         self.world.removed_with_id(self.component_id)
     }
 }
 
 impl<'a, T: Component> IntoIterator for &'a RemovedComponents<'a, T> {
     type Item = Entity;
-    type IntoIter = std::iter::Cloned<core::slice::Iter<'a, Entity>>;
+    type IntoIter = core::iter::Cloned<core::slice::Iter<'a, Entity>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/crates/bevy_ecs/src/system/system_piping.rs
+++ b/crates/bevy_ecs/src/system/system_piping.rs
@@ -161,7 +161,7 @@ where
 /// A collection of common adapters for [piping](super::PipeSystem) the result of a system.
 pub mod adapter {
     use crate::system::In;
-    use std::fmt::Debug;
+    use core::fmt::Debug;
 
     /// Converts a regular function into a system adapter.
     ///
@@ -175,7 +175,7 @@ pub mod adapter {
     ///     .pipe(print);
     ///
     /// fn return1() -> u64 { 1 }
-    /// fn print(In(x): In<impl std::fmt::Debug>) {
+    /// fn print(In(x): In<impl core::fmt::Debug>) {
     ///     println!("{x:?}");
     /// }
     /// ```

--- a/crates/bevy_ecs/src/system/system_piping.rs
+++ b/crates/bevy_ecs/src/system/system_piping.rs
@@ -21,7 +21,7 @@ use std::borrow::Cow;
 /// # Examples
 ///
 /// ```
-/// use std::num::ParseIntError;
+/// use core::num::ParseIntError;
 ///
 /// use bevy_ecs::prelude::*;
 ///

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -977,7 +977,7 @@ mod tests {
         let entity = world.spawn(TestComponent(42)).id();
         let component_id = world
             .components()
-            .get_id(std::any::TypeId::of::<TestComponent>())
+            .get_id(core::any::TypeId::of::<TestComponent>())
             .unwrap();
 
         let entity = world.entity(entity);
@@ -994,7 +994,7 @@ mod tests {
         let entity = world.spawn(TestComponent(42)).id();
         let component_id = world
             .components()
-            .get_id(std::any::TypeId::of::<TestComponent>())
+            .get_id(core::any::TypeId::of::<TestComponent>())
             .unwrap();
 
         let mut entity_mut = world.entity_mut(entity);

--- a/crates/bevy_ecs/src/world/identifier.rs
+++ b/crates/bevy_ecs/src/world/identifier.rs
@@ -32,7 +32,7 @@ mod tests {
 
     #[test]
     fn world_ids_unique() {
-        let ids = std::iter::repeat_with(WorldId::new)
+        let ids = core::iter::repeat_with(WorldId::new)
             .take(50)
             .map(Option::unwrap)
             .collect::<Vec<_>>();
@@ -49,7 +49,7 @@ mod tests {
     // #[should_panic]
     // fn panic_on_overflow() {
     //     MAX_WORLD_ID.store(usize::MAX - 50, Ordering::Relaxed);
-    //     std::iter::repeat_with(WorldId::new)
+    //     core::iter::repeat_with(WorldId::new)
     //         .take(500)
     //         .for_each(|_| ());
     // }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -692,7 +692,7 @@ impl World {
 
     /// Returns an iterator of entities that had components of type `T` removed
     /// since the last call to [`World::clear_trackers`].
-    pub fn removed<T: Component>(&self) -> std::iter::Cloned<std::slice::Iter<'_, Entity>> {
+    pub fn removed<T: Component>(&self) -> std::iter::Cloned<core::slice::Iter<'_, Entity>> {
         if let Some(component_id) = self.components.get_id(TypeId::of::<T>()) {
             self.removed_with_id(component_id)
         } else {
@@ -705,7 +705,7 @@ impl World {
     pub fn removed_with_id(
         &self,
         component_id: ComponentId,
-    ) -> std::iter::Cloned<std::slice::Iter<'_, Entity>> {
+    ) -> std::iter::Cloned<core::slice::Iter<'_, Entity>> {
         if let Some(removed) = self.removed_components.get(component_id) {
             removed.iter().cloned()
         } else {
@@ -857,7 +857,7 @@ impl World {
                 Did you forget to add it using `app.insert_resource` / `app.init_resource`? 
                 Resources are also implicitly added via `app.add_event`,
                 and can be added by plugins.",
-                std::any::type_name::<R>()
+                core::any::type_name::<R>()
             ),
         }
     }
@@ -881,7 +881,7 @@ impl World {
                 Did you forget to add it using `app.insert_resource` / `app.init_resource`? 
                 Resources are also implicitly added via `app.add_event`,
                 and can be added by plugins.",
-                std::any::type_name::<R>()
+                core::any::type_name::<R>()
             ),
         }
     }
@@ -942,7 +942,7 @@ impl World {
                 "Requested non-send resource {} does not exist in the `World`. 
                 Did you forget to add it using `app.insert_non_send_resource` / `app.init_non_send_resource`? 
                 Non-send resources can also be be added by plugins.",
-                std::any::type_name::<R>()
+                core::any::type_name::<R>()
             ),
         }
     }
@@ -962,7 +962,7 @@ impl World {
                 "Requested non-send resource {} does not exist in the `World`. 
                 Did you forget to add it using `app.insert_non_send_resource` / `app.init_non_send_resource`? 
                 Non-send resources can also be be added by plugins.",
-                std::any::type_name::<R>()
+                core::any::type_name::<R>()
             ),
         }
     }
@@ -1174,7 +1174,7 @@ impl World {
         let component_id = self
             .components
             .get_resource_id(TypeId::of::<R>())
-            .unwrap_or_else(|| panic!("resource does not exist: {}", std::any::type_name::<R>()));
+            .unwrap_or_else(|| panic!("resource does not exist: {}", core::any::type_name::<R>()));
         // If the resource isn't send and sync, validate that we are on the main thread, so that we can access it.
         let component_info = self.components().get_info(component_id).unwrap();
         if !component_info.is_send_and_sync() {
@@ -1187,7 +1187,7 @@ impl World {
             .get_mut(component_id)
             // SAFETY: The type R is Send and Sync or we've already validated that we're on the main thread.
             .and_then(|info| unsafe { info.remove() })
-            .unwrap_or_else(|| panic!("resource does not exist: {}", std::any::type_name::<R>()));
+            .unwrap_or_else(|| panic!("resource does not exist: {}", core::any::type_name::<R>()));
         // Read the value onto the stack to avoid potential mut aliasing.
         // SAFETY: pointer is of type R
         let mut value = unsafe { ptr.read::<R>() };
@@ -1203,7 +1203,7 @@ impl World {
         assert!(!self.contains_resource::<R>(),
             "Resource `{}` was inserted during a call to World::resource_scope.\n\
             This is not allowed as the original resource is reinserted to the world after the FnOnce param is invoked.",
-            std::any::type_name::<R>());
+            core::any::type_name::<R>());
 
         OwningPtr::make(value, |ptr| {
             // SAFETY: pointer is of type R
@@ -1215,7 +1215,7 @@ impl World {
                     .unwrap_or_else(|| {
                         panic!(
                             "No resource of type {} exists in the World.",
-                            std::any::type_name::<R>()
+                            core::any::type_name::<R>()
                         )
                     });
             }
@@ -1243,7 +1243,7 @@ impl World {
             Some(mut events_resource) => events_resource.extend(events),
             None => bevy_utils::tracing::error!(
                     "Unable to send event `{}`\n\tEvent must be added to the app with `add_event()`\n\thttps://docs.rs/bevy/*/bevy/app/struct.App.html#method.add_event ",
-                    std::any::type_name::<E>()
+                    core::any::type_name::<E>()
                 ),
         }
     }
@@ -1360,7 +1360,7 @@ impl World {
         assert!(
             self.main_thread_validator.is_main_thread(),
             "attempted to access NonSend resource {} off of the main thread",
-            std::any::type_name::<T>(),
+            core::any::type_name::<T>(),
         );
     }
 
@@ -1734,7 +1734,7 @@ mod tests {
         world.insert_resource(TestResource(42));
         let component_id = world
             .components()
-            .get_resource_id(std::any::TypeId::of::<TestResource>())
+            .get_resource_id(core::any::TypeId::of::<TestResource>())
             .unwrap();
 
         let resource = world.get_resource_by_id(component_id).unwrap();
@@ -1750,7 +1750,7 @@ mod tests {
         world.insert_resource(TestResource(42));
         let component_id = world
             .components()
-            .get_resource_id(std::any::TypeId::of::<TestResource>())
+            .get_resource_id(core::any::TypeId::of::<TestResource>())
             .unwrap();
 
         {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -692,7 +692,7 @@ impl World {
 
     /// Returns an iterator of entities that had components of type `T` removed
     /// since the last call to [`World::clear_trackers`].
-    pub fn removed<T: Component>(&self) -> std::iter::Cloned<core::slice::Iter<'_, Entity>> {
+    pub fn removed<T: Component>(&self) -> core::iter::Cloned<core::slice::Iter<'_, Entity>> {
         if let Some(component_id) = self.components.get_id(TypeId::of::<T>()) {
             self.removed_with_id(component_id)
         } else {
@@ -705,7 +705,7 @@ impl World {
     pub fn removed_with_id(
         &self,
         component_id: ComponentId,
-    ) -> std::iter::Cloned<core::slice::Iter<'_, Entity>> {
+    ) -> core::iter::Cloned<core::slice::Iter<'_, Entity>> {
         if let Some(removed) = self.removed_components.get(component_id) {
             removed.iter().cloned()
         } else {
@@ -1227,13 +1227,13 @@ impl World {
     /// Sends an [`Event`](crate::event::Event).
     #[inline]
     pub fn send_event<E: crate::event::Event>(&mut self, event: E) {
-        self.send_event_batch(std::iter::once(event));
+        self.send_event_batch(core::iter::once(event));
     }
 
     /// Sends the default value of the [`Event`](crate::event::Event) of type `E`.
     #[inline]
     pub fn send_event_default<E: crate::event::Event + Default>(&mut self) {
-        self.send_event_batch(std::iter::once(E::default()));
+        self.send_event_batch(core::iter::once(E::default()));
     }
 
     /// Sends a batch of [`Event`](crate::event::Event)s from an iterator.

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -3,7 +3,7 @@ use crate::{
     entity::Entity,
     world::World,
 };
-use std::iter::FusedIterator;
+use core::iter::FusedIterator;
 
 pub struct SpawnBatchIter<'w, I>
 where

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -77,7 +77,7 @@ impl<'w> Drop for WorldCell<'w> {
     fn drop(&mut self) {
         let mut access = self.access.borrow_mut();
         // give world ArchetypeComponentAccess back to reuse allocations
-        std::mem::swap(&mut self.world.archetype_component_access, &mut *access);
+        core::mem::swap(&mut self.world.archetype_component_access, &mut *access);
     }
 }
 
@@ -96,7 +96,7 @@ impl<'w, T> WorldBorrow<'w, T> {
         assert!(
             access.borrow_mut().read(archetype_component_id),
             "Attempted to immutably access {}, but it is already mutably borrowed",
-            std::any::type_name::<T>(),
+            core::any::type_name::<T>(),
         );
         Self {
             value,
@@ -137,7 +137,7 @@ impl<'w, T> WorldBorrowMut<'w, T> {
         assert!(
             access.borrow_mut().write(archetype_component_id),
             "Attempted to mutably access {}, but it is already mutably borrowed",
-            std::any::type_name::<T>(),
+            core::any::type_name::<T>(),
         );
         Self {
             value,
@@ -172,7 +172,7 @@ impl<'w, T> Drop for WorldBorrowMut<'w, T> {
 impl<'w> WorldCell<'w> {
     pub(crate) fn new(world: &'w mut World) -> Self {
         // this is cheap because ArchetypeComponentAccess::new() is const / allocation free
-        let access = std::mem::replace(
+        let access = core::mem::replace(
             &mut world.archetype_component_access,
             ArchetypeComponentAccess::new(),
         );
@@ -211,7 +211,7 @@ impl<'w> WorldCell<'w> {
                 Did you forget to add it using `app.insert_resource` / `app.init_resource`? 
                 Resources are also implicitly added via `app.add_event`,
                 and can be added by plugins.",
-                std::any::type_name::<T>()
+                core::any::type_name::<T>()
             ),
         }
     }
@@ -247,7 +247,7 @@ impl<'w> WorldCell<'w> {
                 Did you forget to add it using `app.insert_resource` / `app.init_resource`? 
                 Resources are also implicitly added via `app.add_event`,
                 and can be added by plugins.",
-                std::any::type_name::<T>()
+                core::any::type_name::<T>()
             ),
         }
     }
@@ -280,7 +280,7 @@ impl<'w> WorldCell<'w> {
                 "Requested non-send resource {} does not exist in the `World`. 
                 Did you forget to add it using `app.insert_non_send_resource` / `app.init_non_send_resource`? 
                 Non-send resources can also be be added by plugins.",
-                std::any::type_name::<T>()
+                core::any::type_name::<T>()
             ),
         }
     }
@@ -316,7 +316,7 @@ impl<'w> WorldCell<'w> {
                 "Requested non-send resource {} does not exist in the `World`. 
                 Did you forget to add it using `app.insert_non_send_resource` / `app.init_non_send_resource`? 
                 Non-send resources can also be be added by plugins.",
-                std::any::type_name::<T>()
+                core::any::type_name::<T>()
             ),
         }
     }
@@ -340,7 +340,7 @@ impl<'w> WorldCell<'w> {
             Some(mut events_resource) => events_resource.extend(events),
             None => error!(
                     "Unable to send event `{}`\n\tEvent must be added to the app with `add_event()`\n\thttps://docs.rs/bevy/*/bevy/app/struct.App.html#method.add_event ",
-                    std::any::type_name::<E>()
+                    core::any::type_name::<E>()
                 ),
         }
     }
@@ -351,7 +351,7 @@ mod tests {
     use super::BASE_ACCESS;
     use crate as bevy_ecs;
     use crate::{system::Resource, world::World};
-    use std::any::TypeId;
+    use core::any::TypeId;
 
     #[derive(Resource)]
     struct A(u32);

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -324,13 +324,13 @@ impl<'w> WorldCell<'w> {
     /// Sends an [`Event`](crate::event::Event).
     #[inline]
     pub fn send_event<E: Event>(&self, event: E) {
-        self.send_event_batch(std::iter::once(event));
+        self.send_event_batch(core::iter::once(event));
     }
 
     /// Sends the default value of the [`Event`](crate::event::Event) of type `E`.
     #[inline]
     pub fn send_event_default<E: Event + Default>(&self) {
-        self.send_event_batch(std::iter::once(E::default()));
+        self.send_event_batch(core::iter::once(E::default()));
     }
 
     /// Sends a batch of [`Event`](crate::event::Event)s from an iterator.

--- a/crates/bevy_encase_derive/src/lib.rs
+++ b/crates/bevy_encase_derive/src/lib.rs
@@ -1,3 +1,6 @@
+#![no_std]
+#![forbid(unsafe_code)]
+
 use bevy_macro_utils::BevyManifest;
 use encase_derive_impl::{implement, syn};
 

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -838,7 +838,7 @@ fn load_node(
                             // NOTE: KHR_punctual_lights defines the intensity units for point lights in
                             // candela (lm/sr) which is luminous intensity and we need luminous power.
                             // For a point light, luminous power = 4 * pi * luminous intensity
-                            intensity: light.intensity() * std::f32::consts::PI * 4.0,
+                            intensity: light.intensity() * core::f32::consts::PI * 4.0,
                             range: light.range().unwrap_or(20.0),
                             radius: light.range().unwrap_or(0.0),
                             ..Default::default()
@@ -864,7 +864,7 @@ fn load_node(
                             // NOTE: KHR_punctual_lights defines the intensity units for spot lights in
                             // candela (lm/sr) which is luminous intensity and we need luminous power.
                             // For a spot light, we map luminous power = 4 * pi * luminous intensity
-                            intensity: light.intensity() * std::f32::consts::PI * 4.0,
+                            intensity: light.intensity() * core::f32::consts::PI * 4.0,
                             range: light.range().unwrap_or(20.0),
                             radius: light.range().unwrap_or(0.0),
                             inner_angle: inner_cone_angle,

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -1,5 +1,5 @@
-use alloc::{vec, vec::Vec};
 use crate::{Children, HierarchyEvent, Parent};
+use alloc::{vec, vec::Vec};
 use bevy_ecs::{
     bundle::Bundle,
     entity::Entity,

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -1,3 +1,4 @@
+use alloc::{vec, vec::Vec};
 use crate::{Children, HierarchyEvent, Parent};
 use bevy_ecs::{
     bundle::Bundle,

--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -8,7 +8,7 @@ use bevy_ecs::{
 use bevy_reflect::Reflect;
 use core::slice;
 use smallvec::SmallVec;
-use std::ops::Deref;
+use core::ops::Deref;
 
 /// Contains references to the child entities of this entity.
 ///

--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+use alloc::string::ToString;
 use bevy_ecs::{
     component::Component,
     entity::{Entity, EntityMap, MapEntities, MapEntitiesError},

--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -6,9 +6,9 @@ use bevy_ecs::{
     world::World,
 };
 use bevy_reflect::Reflect;
+use core::ops::Deref;
 use core::slice;
 use smallvec::SmallVec;
-use core::ops::Deref;
 
 /// Contains references to the child entities of this entity.
 ///

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+use alloc::string::ToString;
 use bevy_ecs::{
     component::Component,
     entity::{Entity, EntityMap, MapEntities, MapEntitiesError},

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     world::{FromWorld, World},
 };
 use bevy_reflect::Reflect;
-use std::ops::Deref;
+use core::ops::Deref;
 
 /// Holds a reference to the parent entity of this entity.
 /// This component should only be present on entities that actually have a parent entity.

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -36,7 +36,7 @@ pub fn despawn_with_children_recursive(world: &mut World, entity: Entity) {
 // Should only be called by `despawn_with_children_recursive`!
 fn despawn_with_children_recursive_inner(world: &mut World, entity: Entity) {
     if let Some(mut children) = world.get_mut::<Children>(entity) {
-        for e in std::mem::take(&mut children.0) {
+        for e in core::mem::take(&mut children.0) {
             despawn_with_children_recursive_inner(world, e);
         }
     }
@@ -48,7 +48,7 @@ fn despawn_with_children_recursive_inner(world: &mut World, entity: Entity) {
 
 fn despawn_children(world: &mut World, entity: Entity) {
     if let Some(mut children) = world.get_mut::<Children>(entity) {
-        for e in std::mem::take(&mut children.0) {
+        for e in core::mem::take(&mut children.0) {
             despawn_with_children_recursive_inner(world, e);
         }
     }

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -1,8 +1,11 @@
+#![no_std]
 #![warn(missing_docs)]
 //! `bevy_hierarchy` can be used to define hierarchies of entities.
 //!
 //! Most commonly, these hierarchies are used for inheriting `Transform` values
 //! from the [`Parent`] to its [`Children`].
+
+extern crate alloc;
 
 mod components;
 pub use components::*;

--- a/crates/bevy_hierarchy/src/query_extension.rs
+++ b/crates/bevy_hierarchy/src/query_extension.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use alloc::collections::VecDeque;
 
 use bevy_ecs::{
     entity::Entity,

--- a/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
+++ b/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
@@ -1,6 +1,6 @@
-use core::marker::PhantomData;
 use alloc::borrow::ToOwned;
 use alloc::format;
+use core::marker::PhantomData;
 
 use bevy_app::{App, CoreStage, Plugin};
 use bevy_core::Name;

--- a/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
+++ b/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
@@ -1,4 +1,6 @@
 use core::marker::PhantomData;
+use alloc::borrow::ToOwned;
+use alloc::format;
 
 use bevy_app::{App, CoreStage, Plugin};
 use bevy_core::Name;

--- a/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
+++ b/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use bevy_app::{App, CoreStage, Plugin};
 use bevy_core::Name;

--- a/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
+++ b/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
@@ -51,7 +51,7 @@ pub fn check_hierarchy_component_has_valid_parent<T: Component>(
             warn!(
                 "warning[B0004]: {name} with the {ty_name} component has a parent without {ty_name}.\n\
                 This will cause inconsistent behaviors! See https://bevyengine.org/learn/errors/#B0004",
-                ty_name = get_short_name(std::any::type_name::<T>()),
+                ty_name = get_short_name(core::any::type_name::<T>()),
                 name = name.map_or("An entity".to_owned(), |s| format!("The {s} entity")),
             );
         }

--- a/crates/bevy_input/src/axis.rs
+++ b/crates/bevy_input/src/axis.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::system::Resource;
 use bevy_utils::HashMap;
-use std::hash::Hash;
+use core::hash::Hash;
 
 /// Stores the position data of the input devices of type `T`.
 ///

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -1,7 +1,7 @@
 use bevy_ecs::system::Resource;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_utils::HashSet;
-use std::hash::Hash;
+use core::hash::Hash;
 
 // unused import, but needed for intra doc link to work
 #[allow(unused_imports)]

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+#![forbid(unsafe_code)]
 #![warn(missing_docs)]
 //! This module is separated into its own crate to enable simple dynamic linking for Bevy, and should not be used directly
 

--- a/crates/bevy_log/src/android_tracing.rs
+++ b/crates/bevy_log/src/android_tracing.rs
@@ -3,7 +3,7 @@ use bevy_utils::tracing::{
     span::{Attributes, Record},
     Event, Id, Level, Subscriber,
 };
-use std::fmt::{Debug, Write};
+use core::fmt::{Debug, Write};
 use tracing_subscriber::{field::Visit, layer::Context, registry::LookupSpan, Layer};
 
 #[derive(Default)]

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![warn(missing_docs)]
 //! This crate provides logging functions and configuration for [Bevy](https://bevyengine.org)
 //! apps, and automatically configures platform specific log handlers (i.e. WASM or Android).
@@ -11,8 +12,10 @@
 //! For more fine-tuned control over logging behavior, set up the [`LogPlugin`] or
 //! `DefaultPlugins` during app initialization.
 
+extern crate alloc;
+
 #[cfg(feature = "trace")]
-use std::panic;
+use core::panic;
 
 #[cfg(target_os = "android")]
 mod android_tracing;
@@ -30,6 +33,8 @@ pub use bevy_utils::tracing::{
     Level,
 };
 
+use alloc::format;
+use alloc::string::{String, ToString};
 use bevy_app::{App, Plugin};
 use tracing_log::LogTracer;
 #[cfg(feature = "tracing-chrome")]

--- a/crates/bevy_macro_utils/src/attrs.rs
+++ b/crates/bevy_macro_utils/src/attrs.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+use alloc::format;
 use syn::DeriveInput;
 
 use crate::symbol::Symbol;

--- a/crates/bevy_macro_utils/src/attrs.rs
+++ b/crates/bevy_macro_utils/src/attrs.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use alloc::format;
+use alloc::vec::Vec;
 use syn::DeriveInput;
 
 use crate::symbol::Symbol;

--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -1,6 +1,6 @@
 #![forbid(unsafe_code)]
-extern crate proc_macro;
 extern crate alloc;
+extern crate proc_macro;
 
 mod attrs;
 mod shape;
@@ -10,13 +10,13 @@ pub use attrs::*;
 pub use shape::*;
 pub use symbol::*;
 
+use alloc::format;
+use alloc::string::{String, ToString};
 use proc_macro::TokenStream;
 use quote::{quote, quote_spanned};
 use std::{env, path::PathBuf};
 use syn::spanned::Spanned;
 use toml::{map::Map, Value};
-use alloc::format;
-use alloc::string::{String, ToString};
 
 pub struct BevyManifest {
     manifest: Map<String, Value>,

--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -1,4 +1,6 @@
+#![forbid(unsafe_code)]
 extern crate proc_macro;
+extern crate alloc;
 
 mod attrs;
 mod shape;
@@ -13,6 +15,8 @@ use quote::{quote, quote_spanned};
 use std::{env, path::PathBuf};
 use syn::spanned::Spanned;
 use toml::{map::Map, Value};
+use alloc::format;
+use alloc::string::{String, ToString};
 
 pub struct BevyManifest {
     manifest: Map<String, Value>,

--- a/crates/bevy_macro_utils/src/symbol.rs
+++ b/crates/bevy_macro_utils/src/symbol.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Display};
+use core::fmt::{self, Display};
 use syn::{Ident, Path};
 
 #[derive(Copy, Clone)]

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -5,6 +5,8 @@
 //! like [`Quat`].
 
 #![warn(missing_docs)]
+#![forbid(unsafe_code)]
+#![no_std]
 
 mod ray;
 mod rect;

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -45,7 +45,8 @@
     unused_variables
 )]
 
-use std::ptr::null_mut;
+use alloc::{vec, vec::Vec};
+use core::ptr::null_mut;
 
 use glam::Vec3;
 

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -1,5 +1,7 @@
+#![no_std]
 #![allow(clippy::all)]
 
+extern crate alloc;
 use glam::{Vec2, Vec3};
 
 mod generated;

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1501,8 +1501,11 @@ pub fn update_point_light_frusta(
         Or<(Changed<GlobalTransform>, Changed<PointLight>)>,
     >,
 ) {
-    let projection =
-        Mat4::perspective_infinite_reverse_rh(core::f32::consts::FRAC_PI_2, 1.0, POINT_LIGHT_NEAR_Z);
+    let projection = Mat4::perspective_infinite_reverse_rh(
+        core::f32::consts::FRAC_PI_2,
+        1.0,
+        POINT_LIGHT_NEAR_Z,
+    );
     let view_rotations = CUBE_MAP_FACES
         .iter()
         .map(|CubeMapFace { target, up }| Transform::IDENTITY.looking_at(*target, *up))

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -788,7 +788,7 @@ fn compute_aabb_for_cluster(
 pub(crate) fn point_light_order(
     (entity_1, shadows_enabled_1, is_spot_light_1): (&Entity, &bool, &bool),
     (entity_2, shadows_enabled_2, is_spot_light_2): (&Entity, &bool, &bool),
-) -> std::cmp::Ordering {
+) -> core::cmp::Ordering {
     is_spot_light_1
         .cmp(is_spot_light_2) // pointlights before spot lights
         .then_with(|| shadows_enabled_2.cmp(shadows_enabled_1)) // shadow casters before non-casters
@@ -802,7 +802,7 @@ pub(crate) fn point_light_order(
 pub(crate) fn directional_light_order(
     (entity_1, shadows_enabled_1): (&Entity, &bool),
     (entity_2, shadows_enabled_2): (&Entity, &bool),
-) -> std::cmp::Ordering {
+) -> core::cmp::Ordering {
     shadows_enabled_2
         .cmp(shadows_enabled_1) // shadow casters before non-casters
         .then_with(|| entity_1.cmp(entity_2)) // stable

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -133,7 +133,7 @@ impl Default for SpotLight {
             shadow_depth_bias: Self::DEFAULT_SHADOW_DEPTH_BIAS,
             shadow_normal_bias: Self::DEFAULT_SHADOW_NORMAL_BIAS,
             inner_angle: 0.0,
-            outer_angle: std::f32::consts::FRAC_PI_4,
+            outer_angle: core::f32::consts::FRAC_PI_4,
         }
     }
 }
@@ -1502,7 +1502,7 @@ pub fn update_point_light_frusta(
     >,
 ) {
     let projection =
-        Mat4::perspective_infinite_reverse_rh(std::f32::consts::FRAC_PI_2, 1.0, POINT_LIGHT_NEAR_Z);
+        Mat4::perspective_infinite_reverse_rh(core::f32::consts::FRAC_PI_2, 1.0, POINT_LIGHT_NEAR_Z);
     let view_rotations = CUBE_MAP_FACES
         .iter()
         .map(|CubeMapFace { target, up }| Transform::IDENTITY.looking_at(*target, *up))

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1117,7 +1117,7 @@ pub(crate) fn assign_lights_to_clusters(
 
         // initialize empty cluster bounding spheres
         cluster_aabb_spheres.clear();
-        cluster_aabb_spheres.extend(std::iter::repeat(None).take(cluster_count));
+        cluster_aabb_spheres.extend(core::iter::repeat(None).take(cluster_count));
 
         // Calculate the x/y/z cluster frustum planes in view space
         let mut x_planes = Vec::with_capacity(clusters.dimensions.x as usize + 1);

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -41,8 +41,8 @@ use bevy_render::{
     Extract, RenderApp, RenderStage,
 };
 use bevy_utils::{tracing::error, HashMap, HashSet};
-use std::hash::Hash;
 use core::marker::PhantomData;
+use std::hash::Hash;
 
 /// Materials are used alongside [`MaterialPlugin`] and [`MaterialMeshBundle`](crate::MaterialMeshBundle)
 /// to spawn entities that are rendered with a specific [`Material`] type. They serve as an easy to use high level

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -540,7 +540,7 @@ fn prepare_materials<M: Material>(
     fallback_image: Res<FallbackImage>,
     pipeline: Res<MaterialPipeline<M>>,
 ) {
-    let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
+    let queued_assets = core::mem::take(&mut prepare_next_frame.assets);
     for (handle, material) in queued_assets.into_iter() {
         match prepare_material(
             &material,
@@ -558,11 +558,11 @@ fn prepare_materials<M: Material>(
         }
     }
 
-    for removed in std::mem::take(&mut extracted_assets.removed) {
+    for removed in core::mem::take(&mut extracted_assets.removed) {
         render_materials.remove(&removed);
     }
 
-    for (handle, material) in std::mem::take(&mut extracted_assets.extracted) {
+    for (handle, material) in core::mem::take(&mut extracted_assets.extracted) {
         match prepare_material(
             &material,
             &render_device,

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -41,8 +41,8 @@ use bevy_render::{
     Extract, RenderApp, RenderStage,
 };
 use bevy_utils::{tracing::error, HashMap, HashSet};
-use core::marker::PhantomData;
 use core::hash::Hash;
+use core::marker::PhantomData;
 
 /// Materials are used alongside [`MaterialPlugin`] and [`MaterialMeshBundle`](crate::MaterialMeshBundle)
 /// to spawn entities that are rendered with a specific [`Material`] type. They serve as an easy to use high level

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -42,7 +42,7 @@ use bevy_render::{
 };
 use bevy_utils::{tracing::error, HashMap, HashSet};
 use std::hash::Hash;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Materials are used alongside [`MaterialPlugin`] and [`MaterialMeshBundle`](crate::MaterialMeshBundle)
 /// to spawn entities that are rendered with a specific [`Material`] type. They serve as an easy to use high level

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -42,7 +42,7 @@ use bevy_render::{
 };
 use bevy_utils::{tracing::error, HashMap, HashSet};
 use core::marker::PhantomData;
-use std::hash::Hash;
+use core::hash::Hash;
 
 /// Materials are used alongside [`MaterialPlugin`] and [`MaterialMeshBundle`](crate::MaterialMeshBundle)
 /// to spawn entities that are rendered with a specific [`Material`] type. They serve as an easy to use high level
@@ -221,7 +221,7 @@ impl<M: Material> Hash for MaterialPipelineKey<M>
 where
     M::Data: Hash,
 {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.mesh_key.hash(state);
         self.bind_group_data.hash(state);
     }

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -773,8 +773,11 @@ pub fn prepare_lights(
     light_meta.view_gpu_lights.clear();
 
     // Pre-calculate for PointLights
-    let cube_face_projection =
-        Mat4::perspective_infinite_reverse_rh(core::f32::consts::FRAC_PI_2, 1.0, POINT_LIGHT_NEAR_Z);
+    let cube_face_projection = Mat4::perspective_infinite_reverse_rh(
+        core::f32::consts::FRAC_PI_2,
+        1.0,
+        POINT_LIGHT_NEAR_Z,
+    );
     let cube_face_rotations = CUBE_MAP_FACES
         .iter()
         .map(|CubeMapFace { target, up }| Transform::IDENTITY.looking_at(*target, *up))

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -37,7 +37,7 @@ use bevy_utils::{
     tracing::{error, warn},
     HashMap,
 };
-use std::num::{NonZeroU32, NonZeroU64};
+use core::num::{NonZeroU32, NonZeroU64};
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
 pub enum RenderLightSystems {

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -480,7 +480,7 @@ pub fn extract_lights(
                         // NOTE: Map from luminous power in lumens to luminous intensity in lumens per steradian
                         // for a point light. See https://google.github.io/filament/Filament.html#mjx-eqn-pointLightLuminousPower
                         // for details.
-                        intensity: point_light.intensity / (4.0 * std::f32::consts::PI),
+                        intensity: point_light.intensity / (4.0 * core::f32::consts::PI),
                         range: point_light.range,
                         radius: point_light.radius,
                         transform: *transform,
@@ -489,7 +489,7 @@ pub fn extract_lights(
                         // The factor of SQRT_2 is for the worst-case diagonal offset
                         shadow_normal_bias: point_light.shadow_normal_bias
                             * point_light_texel_size
-                            * std::f32::consts::SQRT_2,
+                            * core::f32::consts::SQRT_2,
                         spot_light_angles: None,
                     },
                     render_cubemap_visible_entities,
@@ -523,7 +523,7 @@ pub fn extract_lights(
                         // Note: Filament uses a divisor of PI for spot lights. We choose to use the same 4*PI divisor
                         // in both cases so that toggling between point light and spot light keeps lit areas lit equally,
                         // which seems least surprising for users
-                        intensity: spot_light.intensity / (4.0 * std::f32::consts::PI),
+                        intensity: spot_light.intensity / (4.0 * core::f32::consts::PI),
                         range: spot_light.range,
                         radius: spot_light.radius,
                         transform: *transform,
@@ -532,7 +532,7 @@ pub fn extract_lights(
                         // The factor of SQRT_2 is for the worst-case diagonal offset
                         shadow_normal_bias: spot_light.shadow_normal_bias
                             * texel_size
-                            * std::f32::consts::SQRT_2,
+                            * core::f32::consts::SQRT_2,
                         spot_light_angles: Some((spot_light.inner_angle, spot_light.outer_angle)),
                     },
                     render_visible_entities,
@@ -774,7 +774,7 @@ pub fn prepare_lights(
 
     // Pre-calculate for PointLights
     let cube_face_projection =
-        Mat4::perspective_infinite_reverse_rh(std::f32::consts::FRAC_PI_2, 1.0, POINT_LIGHT_NEAR_Z);
+        Mat4::perspective_infinite_reverse_rh(core::f32::consts::FRAC_PI_2, 1.0, POINT_LIGHT_NEAR_Z);
     let cube_face_rotations = CUBE_MAP_FACES
         .iter()
         .map(|CubeMapFace { target, up }| Transform::IDENTITY.looking_at(*target, *up))

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -29,7 +29,7 @@ use bevy_render::{
     Extract, RenderApp, RenderStage,
 };
 use bevy_transform::components::GlobalTransform;
-use std::num::NonZeroU64;
+use core::num::NonZeroU64;
 
 #[derive(Default)]
 pub struct MeshRenderPlugin;
@@ -458,7 +458,7 @@ impl FromWorld for MeshPipeline {
                 ImageDataLayout {
                     offset: 0,
                     bytes_per_row: Some(
-                        std::num::NonZeroU32::new(
+                        core::num::NonZeroU32::new(
                             image.texture_descriptor.size.width * format_size as u32,
                         )
                         .unwrap(),

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -35,7 +35,7 @@ use std::num::NonZeroU64;
 pub struct MeshRenderPlugin;
 
 const MAX_JOINTS: usize = 256;
-const JOINT_SIZE: usize = std::mem::size_of::<Mat4>();
+const JOINT_SIZE: usize = core::mem::size_of::<Mat4>();
 pub(crate) const JOINT_BUFFER_SIZE: usize = MAX_JOINTS * JOINT_SIZE;
 
 pub const MESH_VERTEX_OUTPUT: HandleUntyped =
@@ -213,7 +213,7 @@ impl SkinnedMeshJoints {
     }
 
     pub fn to_buffer_index(mut self) -> Self {
-        self.index *= std::mem::size_of::<Mat4>() as u32;
+        self.index *= core::mem::size_of::<Mat4>() as u32;
         self
     }
 }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
@@ -137,7 +137,7 @@ impl ReflectTraits {
             match nested_meta {
                 // Handles `#[reflect( Hash, Default, ... )]`
                 NestedMeta::Meta(Meta::Path(path)) => {
-                    // Get the first ident in the path (hopefully the path only contains one and not `std::hash::Hash`)
+                    // Get the first ident in the path (hopefully the path only contains one and not `core::hash::Hash`)
                     let Some(segment) = path.segments.iter().next() else {
                         continue;
                     };
@@ -171,7 +171,7 @@ impl ReflectTraits {
                 }
                 // Handles `#[reflect( Hash(custom_hash_fn) )]`
                 NestedMeta::Meta(Meta::List(list)) => {
-                    // Get the first ident in the path (hopefully the path only contains one and not `std::hash::Hash`)
+                    // Get the first ident in the path (hopefully the path only contains one and not `core::hash::Hash`)
                     let Some(segment) = list.path.segments.iter().next() else {
                         continue;
                     };
@@ -224,7 +224,7 @@ impl ReflectTraits {
         match &self.hash {
             &TraitImpl::Implemented(span) => Some(quote_spanned! {span=>
                 fn reflect_hash(&self) -> Option<u64> {
-                    use std::hash::{Hash, Hasher};
+                    use core::hash::{Hash, Hasher};
                     let mut hasher = #bevy_reflect_path::ReflectHasher::default();
                     Hash::hash(&core::any::Any::type_id(self), &mut hasher);
                     Hash::hash(self, &mut hasher);

--- a/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
@@ -226,7 +226,7 @@ impl ReflectTraits {
                 fn reflect_hash(&self) -> Option<u64> {
                     use std::hash::{Hash, Hasher};
                     let mut hasher = #bevy_reflect_path::ReflectHasher::default();
-                    Hash::hash(&std::any::Any::type_id(self), &mut hasher);
+                    Hash::hash(&core::any::Any::type_id(self), &mut hasher);
                     Hash::hash(self, &mut hasher);
                     Some(hasher.finish())
                 }
@@ -252,7 +252,7 @@ impl ReflectTraits {
                 fn reflect_partial_eq(&self, value: &dyn #bevy_reflect_path::Reflect) -> Option<bool> {
                     let value = value.as_any();
                     if let Some(value) = value.downcast_ref::<Self>() {
-                        Some(std::cmp::PartialEq::eq(self, value))
+                        Some(core::cmp::PartialEq::eq(self, value))
                     } else {
                         Some(false)
                     }
@@ -273,12 +273,12 @@ impl ReflectTraits {
     pub fn get_debug_impl(&self) -> Option<proc_macro2::TokenStream> {
         match &self.debug {
             &TraitImpl::Implemented(span) => Some(quote_spanned! {span=>
-                fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    std::fmt::Debug::fmt(self, f)
+                fn debug(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    core::fmt::Debug::fmt(self, f)
                 }
             }),
             &TraitImpl::Custom(ref impl_fn, span) => Some(quote_spanned! {span=>
-                fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                fn debug(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                     #impl_fn(self, f)
                 }
             }),

--- a/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
@@ -6,6 +6,7 @@
 //! `#[reflect(PartialEq, Default, ...)]` and `#[reflect_value(PartialEq, Default, ...)]`.
 
 use crate::utility;
+use alloc::{string::ToString, vec::Vec};
 use proc_macro2::{Ident, Span};
 use quote::quote_spanned;
 use syn::parse::{Parse, ParseStream};

--- a/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
@@ -1,6 +1,7 @@
 use crate::container_attributes::ReflectTraits;
 use crate::field_attributes::{parse_field_attrs, ReflectFieldAttr};
 use crate::utility::members_to_serialization_denylist;
+use alloc::vec::Vec;
 use bit_set::BitSet;
 use quote::quote;
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/enum_utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/enum_utility.rs
@@ -2,6 +2,9 @@ use crate::{
     derive_data::{EnumVariantFields, ReflectEnum},
     utility::ident_or_index,
 };
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use proc_macro2::Ident;
 use quote::{quote, ToTokens};
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
@@ -5,6 +5,7 @@
 //! the derive helper attribute for `Reflect`, which looks like: `#[reflect(ignore)]`.
 
 use crate::REFLECT_ATTRIBUTE_NAME;
+use alloc::format;
 use quote::ToTokens;
 use syn::spanned::Spanned;
 use syn::{Attribute, Lit, Meta, NestedMeta};

--- a/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
@@ -3,6 +3,8 @@ use crate::derive_data::ReflectEnum;
 use crate::enum_utility::{get_variant_constructors, EnumVariantConstructors};
 use crate::field_attributes::DefaultBehavior;
 use crate::{ReflectMeta, ReflectStruct};
+use alloc::string::ToString;
+use alloc::vec::Vec;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;

--- a/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
@@ -53,7 +53,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
                 if let #bevy_reflect_path::ReflectRef::Enum(#ref_value) = #ref_value.reflect_ref() {
                     match #ref_value.variant_name() {
                         #(#variant_names => Some(#variant_constructors),)*
-                        name => panic!("variant with name `{}` does not exist on enum `{}`", name, std::any::type_name::<Self>()),
+                        name => panic!("variant with name `{}` does not exist on enum `{}`", name, core::any::type_name::<Self>()),
                     }
                 } else {
                     None

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -181,7 +181,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
         impl #impl_generics #bevy_reflect_path::Reflect for #enum_name #ty_generics #where_clause {
             #[inline]
             fn type_name(&self) -> &str {
-                std::any::type_name::<Self>()
+                core::any::type_name::<Self>()
             }
 
             #[inline]
@@ -190,17 +190,17 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
             }
 
             #[inline]
-            fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+            fn into_any(self: Box<Self>) -> Box<dyn core::any::Any> {
                 self
             }
 
             #[inline]
-            fn as_any(&self) -> &dyn std::any::Any {
+            fn as_any(&self) -> &dyn core::any::Any {
                 self
             }
 
             #[inline]
-            fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+            fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
                 self
             }
 
@@ -255,7 +255,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
                             #(#variant_names => {
                                 *self = #variant_constructors
                             })*
-                            name => panic!("variant with name `{}` does not exist on enum `{}`", name, std::any::type_name::<Self>()),
+                            name => panic!("variant with name `{}` does not exist on enum `{}`", name, core::any::type_name::<Self>()),
                         }
                     }
                 } else {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -1,6 +1,8 @@
 use crate::derive_data::{EnumVariant, EnumVariantFields, ReflectEnum, StructField};
 use crate::enum_utility::{get_variant_constructors, EnumVariantConstructors};
 use crate::impls::impl_typed;
+use alloc::string::ToString;
+use alloc::vec::Vec;
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
 use quote::quote;

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
@@ -162,7 +162,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
         impl #impl_generics #bevy_reflect_path::Reflect for #struct_name #ty_generics #where_clause {
             #[inline]
             fn type_name(&self) -> &str {
-                std::any::type_name::<Self>()
+                core::any::type_name::<Self>()
             }
 
             #[inline]
@@ -171,17 +171,17 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
             }
 
             #[inline]
-            fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+            fn into_any(self: Box<Self>) -> Box<dyn core::any::Any> {
                 self
             }
 
             #[inline]
-            fn as_any(&self) -> &dyn std::any::Any {
+            fn as_any(&self) -> &dyn core::any::Any {
                 self
             }
 
             #[inline]
-            fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+            fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
                 self
             }
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
@@ -1,5 +1,7 @@
 use crate::impls::impl_typed;
 use crate::ReflectStruct;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Index, Member};

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
@@ -1,5 +1,7 @@
 use crate::impls::impl_typed;
 use crate::ReflectStruct;
+use alloc::string::ToString;
+use alloc::vec::Vec;
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Index, Member};

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
@@ -124,7 +124,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
         impl #impl_generics #bevy_reflect_path::Reflect for #struct_name #ty_generics #where_clause {
             #[inline]
             fn type_name(&self) -> &str {
-                std::any::type_name::<Self>()
+                core::any::type_name::<Self>()
             }
 
             #[inline]
@@ -133,17 +133,17 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
             }
 
             #[inline]
-            fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+            fn into_any(self: Box<Self>) -> Box<dyn core::any::Any> {
                 self
             }
 
             #[inline]
-            fn as_any(&self) -> &dyn std::any::Any {
+            fn as_any(&self) -> &dyn core::any::Any {
                 self
             }
 
             #[inline]
-            fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+            fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
                 self
             }
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
@@ -41,7 +41,7 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
         impl #impl_generics #bevy_reflect_path::Reflect for #type_name #ty_generics #where_clause  {
             #[inline]
             fn type_name(&self) -> &str {
-                std::any::type_name::<Self>()
+                core::any::type_name::<Self>()
             }
 
             #[inline]
@@ -50,17 +50,17 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
             }
 
             #[inline]
-            fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+            fn into_any(self: Box<Self>) -> Box<dyn core::any::Any> {
                 self
             }
 
             #[inline]
-            fn as_any(&self) -> &dyn std::any::Any {
+            fn as_any(&self) -> &dyn core::any::Any {
                 self
             }
 
             #[inline]
-            fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+            fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
                 self
             }
 
@@ -81,16 +81,16 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
 
             #[inline]
             fn clone_value(&self) -> Box<dyn #bevy_reflect_path::Reflect> {
-                Box::new(std::clone::Clone::clone(self))
+                Box::new(core::clone::Clone::clone(self))
             }
 
             #[inline]
             fn apply(&mut self, value: &dyn #bevy_reflect_path::Reflect) {
                 let value = value.as_any();
                 if let Some(value) = value.downcast_ref::<Self>() {
-                    *self = std::clone::Clone::clone(value);
+                    *self = core::clone::Clone::clone(value);
                 } else {
-                    panic!("Value is not {}.", std::any::type_name::<Self>());
+                    panic!("Value is not {}.", core::any::type_name::<Self>());
                 }
             }
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -12,6 +12,10 @@
 //! [`TypeUuid`]: crate::derive_type_uuid
 //! [`reflect_trait`]: macro@reflect_trait
 
+#![no_std]
+#![forbid(unsafe_code)]
+
+extern crate alloc;
 extern crate proc_macro;
 
 mod container_attributes;

--- a/crates/bevy_reflect/bevy_reflect_derive/src/reflect_value.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/reflect_value.rs
@@ -1,4 +1,5 @@
 use crate::container_attributes::ReflectTraits;
+use alloc::vec::Vec;
 use proc_macro2::Ident;
 use syn::parse::{Parse, ParseStream};
 use syn::token::{Paren, Where};

--- a/crates/bevy_reflect/bevy_reflect_derive/src/trait_reflection.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/trait_reflection.rs
@@ -1,3 +1,5 @@
+use alloc::format;
+use alloc::string::ToString;
 use bevy_macro_utils::BevyManifest;
 use proc_macro::TokenStream;
 use quote::quote;

--- a/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
@@ -1,5 +1,6 @@
 extern crate proc_macro;
 
+use alloc::format;
 use bevy_macro_utils::BevyManifest;
 use quote::quote;
 use syn::*;

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -1,6 +1,8 @@
 //! General-purpose utility functions for internal usage within this crate.
 
 use crate::field_attributes::ReflectIgnoreBehavior;
+use alloc::format;
+use alloc::vec::Vec;
 use bevy_macro_utils::BevyManifest;
 use bit_set::BitSet;
 use proc_macro2::{Ident, Span};

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -2,6 +2,9 @@ use crate::{
     utility::NonGenericTypeInfoCell, DynamicInfo, Reflect, ReflectMut, ReflectOwned, ReflectRef,
     TypeInfo, Typed,
 };
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
 use std::{
     any::{Any, TypeId},
     fmt::Debug,
@@ -63,9 +66,9 @@ impl ArrayInfo {
     ///
     pub fn new<TArray: Array, TItem: Reflect>(capacity: usize) -> Self {
         Self {
-            type_name: std::any::type_name::<TArray>(),
+            type_name: core::any::type_name::<TArray>(),
             type_id: TypeId::of::<TArray>(),
-            item_type_name: std::any::type_name::<TItem>(),
+            item_type_name: core::any::type_name::<TItem>(),
             item_type_id: TypeId::of::<TItem>(),
             capacity,
             #[cfg(feature = "documentation")]
@@ -86,7 +89,7 @@ impl ArrayInfo {
 
     /// The [type name] of the array.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     pub fn type_name(&self) -> &'static str {
         self.type_name
     }
@@ -103,7 +106,7 @@ impl ArrayInfo {
 
     /// The [type name] of the array item.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     pub fn item_type_name(&self) -> &'static str {
         self.item_type_name
     }
@@ -330,7 +333,7 @@ impl<'a> ExactSizeIterator for ArrayIter<'a> {}
 #[inline]
 pub fn array_hash<A: Array>(array: &A) -> Option<u64> {
     let mut hasher = crate::ReflectHasher::default();
-    std::any::Any::type_id(array).hash(&mut hasher);
+    core::any::Any::type_id(array).hash(&mut hasher);
     array.len().hash(&mut hasher);
     for value in array.iter() {
         hasher.write_u64(value.reflect_hash()?);
@@ -399,7 +402,7 @@ pub fn array_partial_eq<A: Array>(array: &A, reflect: &dyn Reflect) -> Option<bo
 /// // ]
 /// ```
 #[inline]
-pub fn array_debug(dyn_array: &dyn Array, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+pub fn array_debug(dyn_array: &dyn Array, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
     let mut debug = f.debug_list();
     for item in dyn_array.iter() {
         debug.entry(&item as &dyn Debug);

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -4,8 +4,10 @@ use crate::{
     Reflect, ReflectMut, ReflectOwned, ReflectRef, Struct, Tuple, TypeInfo, Typed,
     VariantFieldIter, VariantType,
 };
-use std::any::Any;
-use std::fmt::Formatter;
+use alloc::boxed::Box;
+use alloc::string::String;
+use core::any::Any;
+use core::fmt::Formatter;
 
 /// A dynamic representation of an enum variant.
 #[derive(Debug)]
@@ -417,7 +419,7 @@ impl Reflect for DynamicEnum {
     }
 
     #[inline]
-    fn debug(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn debug(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "DynamicEnum(")?;
         enum_debug(self, f)?;
         write!(f, ")")

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -1,7 +1,10 @@
 use crate::{DynamicEnum, Reflect, VariantInfo, VariantType};
+use alloc::boxed::Box;
+use alloc::format;
+use alloc::string::String;
 use bevy_utils::HashMap;
-use std::any::{Any, TypeId};
-use std::slice::Iter;
+use core::any::{Any, TypeId};
+use core::slice::Iter;
 
 /// A trait representing a [reflected] enum.
 ///
@@ -161,7 +164,7 @@ impl EnumInfo {
 
         Self {
             name,
-            type_name: std::any::type_name::<TEnum>(),
+            type_name: core::any::type_name::<TEnum>(),
             type_id: TypeId::of::<TEnum>(),
             variants: variants.to_vec().into_boxed_slice(),
             variant_names,
@@ -232,7 +235,7 @@ impl EnumInfo {
 
     /// The [type name] of the enum.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     pub fn type_name(&self) -> &'static str {
         self.type_name
     }

--- a/crates/bevy_reflect/src/enums/helpers.rs
+++ b/crates/bevy_reflect/src/enums/helpers.rs
@@ -1,12 +1,12 @@
 use crate::{Enum, Reflect, ReflectRef, VariantType};
-use std::fmt::Debug;
+use core::fmt::Debug;
 use std::hash::{Hash, Hasher};
 
 /// Returns the `u64` hash of the given [enum](Enum).
 #[inline]
 pub fn enum_hash<TEnum: Enum>(value: &TEnum) -> Option<u64> {
     let mut hasher = crate::ReflectHasher::default();
-    std::any::Any::type_id(value).hash(&mut hasher);
+    core::any::Any::type_id(value).hash(&mut hasher);
     value.variant_name().hash(&mut hasher);
     value.variant_type().hash(&mut hasher);
     for field in value.iter_fields() {
@@ -98,7 +98,7 @@ pub fn enum_partial_eq<TEnum: Enum>(a: &TEnum, b: &dyn Reflect) -> Option<bool> 
 /// // )
 /// ```
 #[inline]
-pub fn enum_debug(dyn_enum: &dyn Enum, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+pub fn enum_debug(dyn_enum: &dyn Enum, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
     match dyn_enum.variant_type() {
         VariantType::Unit => f.write_str(dyn_enum.variant_name()),
         VariantType::Tuple => {

--- a/crates/bevy_reflect/src/enums/helpers.rs
+++ b/crates/bevy_reflect/src/enums/helpers.rs
@@ -1,6 +1,6 @@
 use crate::{Enum, Reflect, ReflectRef, VariantType};
 use core::fmt::Debug;
-use std::hash::{Hash, Hasher};
+use core::hash::{Hash, Hasher};
 
 /// Returns the `u64` hash of the given [enum](Enum).
 #[inline]

--- a/crates/bevy_reflect/src/enums/mod.rs
+++ b/crates/bevy_reflect/src/enums/mod.rs
@@ -25,7 +25,7 @@ mod tests {
         let info = MyEnum::type_info();
         if let TypeInfo::Enum(info) = info {
             assert!(info.is::<MyEnum>(), "expected type to be `MyEnum`");
-            assert_eq!(std::any::type_name::<MyEnum>(), info.type_name());
+            assert_eq!(core::any::type_name::<MyEnum>(), info.type_name());
 
             // === MyEnum::A === //
             assert_eq!("A", info.variant_at(0).unwrap().name());
@@ -342,14 +342,14 @@ mod tests {
         // === Tuple === //
         let mut data = DynamicTuple::default();
         data.insert(1.23_f32);
-        let dyn_enum = DynamicEnum::new(std::any::type_name::<TestEnum<f32>>(), "B", data);
+        let dyn_enum = DynamicEnum::new(core::any::type_name::<TestEnum<f32>>(), "B", data);
         value.apply(&dyn_enum);
         assert_eq!(TestEnum::B(1.23), value);
 
         // === Struct === //
         let mut data = DynamicStruct::default();
         data.insert("value", 1.23_f32);
-        let dyn_enum = DynamicEnum::new(std::any::type_name::<TestEnum<f32>>(), "C", data);
+        let dyn_enum = DynamicEnum::new(core::any::type_name::<TestEnum<f32>>(), "C", data);
         value.apply(&dyn_enum);
         assert_eq!(TestEnum::C { value: 1.23 }, value);
     }
@@ -371,14 +371,14 @@ mod tests {
         // === Tuple === //
         let mut data = DynamicTuple::default();
         data.insert(TestStruct(123));
-        let dyn_enum = DynamicEnum::new(std::any::type_name::<TestEnum>(), "B", data);
+        let dyn_enum = DynamicEnum::new(core::any::type_name::<TestEnum>(), "B", data);
         value.apply(&dyn_enum);
         assert_eq!(TestEnum::B(TestStruct(123)), value);
 
         // === Struct === //
         let mut data = DynamicStruct::default();
         data.insert("value", TestStruct(123));
-        let dyn_enum = DynamicEnum::new(std::any::type_name::<TestEnum>(), "C", data);
+        let dyn_enum = DynamicEnum::new(core::any::type_name::<TestEnum>(), "C", data);
         value.apply(&dyn_enum);
         assert_eq!(
             TestEnum::C {
@@ -409,14 +409,14 @@ mod tests {
         // === Tuple === //
         let mut data = DynamicTuple::default();
         data.insert(OtherEnum::B(123));
-        let dyn_enum = DynamicEnum::new(std::any::type_name::<TestEnum>(), "B", data);
+        let dyn_enum = DynamicEnum::new(core::any::type_name::<TestEnum>(), "B", data);
         value.apply(&dyn_enum);
         assert_eq!(TestEnum::B(OtherEnum::B(123)), value);
 
         // === Struct === //
         let mut data = DynamicStruct::default();
         data.insert("value", OtherEnum::C { value: 1.23 });
-        let dyn_enum = DynamicEnum::new(std::any::type_name::<TestEnum>(), "C", data);
+        let dyn_enum = DynamicEnum::new(core::any::type_name::<TestEnum>(), "C", data);
         value.apply(&dyn_enum);
         assert_eq!(
             TestEnum::C {

--- a/crates/bevy_reflect/src/enums/variants.rs
+++ b/crates/bevy_reflect/src/enums/variants.rs
@@ -1,6 +1,7 @@
 use crate::{NamedField, UnnamedField};
+use alloc::boxed::Box;
 use bevy_utils::HashMap;
-use std::slice::Iter;
+use core::slice::Iter;
 
 /// Describes the form of an enum variant.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -1,5 +1,5 @@
 use crate::Reflect;
-use std::any::{Any, TypeId};
+use core::any::{Any, TypeId};
 
 /// The named field of a reflected struct.
 #[derive(Clone, Debug)]
@@ -16,7 +16,7 @@ impl NamedField {
     pub fn new<T: Reflect>(name: &'static str) -> Self {
         Self {
             name,
-            type_name: std::any::type_name::<T>(),
+            type_name: core::any::type_name::<T>(),
             type_id: TypeId::of::<T>(),
             #[cfg(feature = "documentation")]
             docs: None,
@@ -36,7 +36,7 @@ impl NamedField {
 
     /// The [type name] of the field.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     pub fn type_name(&self) -> &'static str {
         self.type_name
     }
@@ -72,7 +72,7 @@ impl UnnamedField {
     pub fn new<T: Reflect>(index: usize) -> Self {
         Self {
             index,
-            type_name: std::any::type_name::<T>(),
+            type_name: core::any::type_name::<T>(),
             type_id: TypeId::of::<T>(),
             #[cfg(feature = "documentation")]
             docs: None,
@@ -92,7 +92,7 @@ impl UnnamedField {
 
     /// The [type name] of the field.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     pub fn type_name(&self) -> &'static str {
         self.type_name
     }

--- a/crates/bevy_reflect/src/impls/glam.rs
+++ b/crates/bevy_reflect/src/impls/glam.rs
@@ -2,6 +2,7 @@ use crate as bevy_reflect;
 use crate::prelude::ReflectDefault;
 use crate::reflect::Reflect;
 use crate::{ReflectDeserialize, ReflectSerialize};
+use alloc::boxed::Box;
 use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_struct, impl_reflect_value};
 use glam::*;
 

--- a/crates/bevy_reflect/src/impls/rect.rs
+++ b/crates/bevy_reflect/src/impls/rect.rs
@@ -2,6 +2,7 @@ use crate as bevy_reflect;
 use crate::prelude::ReflectDefault;
 use crate::reflect::Reflect;
 use crate::{ReflectDeserialize, ReflectSerialize};
+use alloc::boxed::Box;
 use bevy_math::{Rect, Vec2};
 use bevy_reflect_derive::impl_reflect_struct;
 

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -1,5 +1,7 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::any::Any;
 use smallvec::SmallVec;
-use std::any::Any;
 
 use crate::utility::GenericTypeInfoCell;
 use crate::{
@@ -71,7 +73,7 @@ where
     T::Item: FromReflect,
 {
     fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
+        core::any::type_name::<Self>()
     }
 
     fn get_type_info(&self) -> &'static TypeInfo {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!("../README.md")]
 
+extern crate alloc;
+
 mod array;
 mod fields;
 mod list;
@@ -99,11 +101,11 @@ mod tests {
     use ::glam::{vec3, Vec3};
     use ::serde::{de::DeserializeSeed, Deserialize, Serialize};
     use bevy_utils::HashMap;
+    use core::fmt::{Debug, Formatter};
     use ron::{
         ser::{to_string_pretty, PrettyConfig},
         Deserializer,
     };
-    use std::fmt::{Debug, Formatter};
 
     use super::prelude::*;
     use super::*;
@@ -569,17 +571,17 @@ mod tests {
     fn dynamic_names() {
         let list = Vec::<usize>::new();
         let dyn_list = List::clone_dynamic(&list);
-        assert_eq!(dyn_list.type_name(), std::any::type_name::<Vec<usize>>());
+        assert_eq!(dyn_list.type_name(), core::any::type_name::<Vec<usize>>());
 
         let array = [b'0'; 4];
         let dyn_array = Array::clone_dynamic(&array);
-        assert_eq!(dyn_array.type_name(), std::any::type_name::<[u8; 4]>());
+        assert_eq!(dyn_array.type_name(), core::any::type_name::<[u8; 4]>());
 
         let map = HashMap::<usize, String>::default();
         let dyn_map = map.clone_dynamic();
         assert_eq!(
             dyn_map.type_name(),
-            std::any::type_name::<HashMap<usize, String>>()
+            core::any::type_name::<HashMap<usize, String>>()
         );
 
         let tuple = (0usize, "1".to_string(), 2.0f32);
@@ -587,7 +589,7 @@ mod tests {
         dyn_tuple.insert::<usize>(3);
         assert_eq!(
             dyn_tuple.type_name(),
-            std::any::type_name::<(usize, String, f32, usize)>()
+            core::any::type_name::<(usize, String, f32, usize)>()
         );
 
         #[derive(Reflect)]
@@ -596,7 +598,7 @@ mod tests {
         }
         let struct_ = TestStruct { a: 0 };
         let dyn_struct = struct_.clone_dynamic();
-        assert_eq!(dyn_struct.type_name(), std::any::type_name::<TestStruct>());
+        assert_eq!(dyn_struct.type_name(), core::any::type_name::<TestStruct>());
 
         #[derive(Reflect)]
         struct TestTupleStruct(usize);
@@ -604,7 +606,7 @@ mod tests {
         let dyn_tuple_struct = tuple_struct.clone_dynamic();
         assert_eq!(
             dyn_tuple_struct.type_name(),
-            std::any::type_name::<TestTupleStruct>()
+            core::any::type_name::<TestTupleStruct>()
         );
     }
 
@@ -612,12 +614,12 @@ mod tests {
     fn reflect_type_info() {
         // TypeInfo
         let info = i32::type_info();
-        assert_eq!(std::any::type_name::<i32>(), info.type_name());
-        assert_eq!(std::any::TypeId::of::<i32>(), info.type_id());
+        assert_eq!(core::any::type_name::<i32>(), info.type_name());
+        assert_eq!(core::any::TypeId::of::<i32>(), info.type_id());
 
         // TypeInfo (unsized)
         assert_eq!(
-            std::any::TypeId::of::<dyn Reflect>(),
+            core::any::TypeId::of::<dyn Reflect>(),
             <dyn Reflect as Typed>::type_info().type_id()
         );
 
@@ -636,19 +638,19 @@ mod tests {
         let info = MyStruct::type_info();
         if let TypeInfo::Struct(info) = info {
             assert!(info.is::<MyStruct>());
-            assert_eq!(std::any::type_name::<MyStruct>(), info.type_name());
+            assert_eq!(core::any::type_name::<MyStruct>(), info.type_name());
             assert_eq!(
-                std::any::type_name::<i32>(),
+                core::any::type_name::<i32>(),
                 info.field("foo").unwrap().type_name()
             );
             assert_eq!(
-                std::any::TypeId::of::<i32>(),
+                core::any::TypeId::of::<i32>(),
                 info.field("foo").unwrap().type_id()
             );
             assert!(info.field("foo").unwrap().is::<i32>());
             assert_eq!("foo", info.field("foo").unwrap().name());
             assert_eq!(
-                std::any::type_name::<usize>(),
+                core::any::type_name::<usize>(),
                 info.field_at(1).unwrap().type_name()
             );
         } else {
@@ -670,16 +672,16 @@ mod tests {
         if let TypeInfo::Struct(info) = info {
             assert!(info.is::<MyGenericStruct<i32>>());
             assert_eq!(
-                std::any::type_name::<MyGenericStruct<i32>>(),
+                core::any::type_name::<MyGenericStruct<i32>>(),
                 info.type_name()
             );
             assert_eq!(
-                std::any::type_name::<i32>(),
+                core::any::type_name::<i32>(),
                 info.field("foo").unwrap().type_name()
             );
             assert_eq!("foo", info.field("foo").unwrap().name());
             assert_eq!(
-                std::any::type_name::<usize>(),
+                core::any::type_name::<usize>(),
                 info.field_at(1).unwrap().type_name()
             );
         } else {
@@ -700,9 +702,9 @@ mod tests {
         let info = MyTupleStruct::type_info();
         if let TypeInfo::TupleStruct(info) = info {
             assert!(info.is::<MyTupleStruct>());
-            assert_eq!(std::any::type_name::<MyTupleStruct>(), info.type_name());
+            assert_eq!(core::any::type_name::<MyTupleStruct>(), info.type_name());
             assert_eq!(
-                std::any::type_name::<i32>(),
+                core::any::type_name::<i32>(),
                 info.field_at(1).unwrap().type_name()
             );
             assert!(info.field_at(1).unwrap().is::<i32>());
@@ -716,9 +718,9 @@ mod tests {
         let info = MyTuple::type_info();
         if let TypeInfo::Tuple(info) = info {
             assert!(info.is::<MyTuple>());
-            assert_eq!(std::any::type_name::<MyTuple>(), info.type_name());
+            assert_eq!(core::any::type_name::<MyTuple>(), info.type_name());
             assert_eq!(
-                std::any::type_name::<f32>(),
+                core::any::type_name::<f32>(),
                 info.field_at(1).unwrap().type_name()
             );
         } else {
@@ -736,8 +738,8 @@ mod tests {
         if let TypeInfo::List(info) = info {
             assert!(info.is::<MyList>());
             assert!(info.item_is::<usize>());
-            assert_eq!(std::any::type_name::<MyList>(), info.type_name());
-            assert_eq!(std::any::type_name::<usize>(), info.item_type_name());
+            assert_eq!(core::any::type_name::<MyList>(), info.type_name());
+            assert_eq!(core::any::type_name::<usize>(), info.item_type_name());
         } else {
             panic!("Expected `TypeInfo::List`");
         }
@@ -755,8 +757,8 @@ mod tests {
             if let TypeInfo::List(info) = info {
                 assert!(info.is::<MySmallVec>());
                 assert!(info.item_is::<String>());
-                assert_eq!(std::any::type_name::<MySmallVec>(), info.type_name());
-                assert_eq!(std::any::type_name::<String>(), info.item_type_name());
+                assert_eq!(core::any::type_name::<MySmallVec>(), info.type_name());
+                assert_eq!(core::any::type_name::<String>(), info.item_type_name());
             } else {
                 panic!("Expected `TypeInfo::List`");
             }
@@ -774,8 +776,8 @@ mod tests {
         if let TypeInfo::Array(info) = info {
             assert!(info.is::<MyArray>());
             assert!(info.item_is::<usize>());
-            assert_eq!(std::any::type_name::<MyArray>(), info.type_name());
-            assert_eq!(std::any::type_name::<usize>(), info.item_type_name());
+            assert_eq!(core::any::type_name::<MyArray>(), info.type_name());
+            assert_eq!(core::any::type_name::<usize>(), info.item_type_name());
             assert_eq!(3, info.capacity());
         } else {
             panic!("Expected `TypeInfo::Array`");
@@ -793,9 +795,9 @@ mod tests {
             assert!(info.is::<MyMap>());
             assert!(info.key_is::<usize>());
             assert!(info.value_is::<f32>());
-            assert_eq!(std::any::type_name::<MyMap>(), info.type_name());
-            assert_eq!(std::any::type_name::<usize>(), info.key_type_name());
-            assert_eq!(std::any::type_name::<f32>(), info.value_type_name());
+            assert_eq!(core::any::type_name::<MyMap>(), info.type_name());
+            assert_eq!(core::any::type_name::<usize>(), info.key_type_name());
+            assert_eq!(core::any::type_name::<f32>(), info.value_type_name());
         } else {
             panic!("Expected `TypeInfo::Map`");
         }
@@ -810,7 +812,7 @@ mod tests {
         let info = MyValue::type_info();
         if let TypeInfo::Value(info) = info {
             assert!(info.is::<MyValue>());
-            assert_eq!(std::any::type_name::<MyValue>(), info.type_name());
+            assert_eq!(core::any::type_name::<MyValue>(), info.type_name());
         } else {
             panic!("Expected `TypeInfo::Value`");
         }
@@ -825,7 +827,7 @@ mod tests {
         let info = MyDynamic::type_info();
         if let TypeInfo::Dynamic(info) = info {
             assert!(info.is::<MyDynamic>());
-            assert_eq!(std::any::type_name::<MyDynamic>(), info.type_name());
+            assert_eq!(core::any::type_name::<MyDynamic>(), info.type_name());
         } else {
             panic!("Expected `TypeInfo::Dynamic`");
         }
@@ -1057,7 +1059,7 @@ mod tests {
         #[reflect(Debug)]
         struct CustomDebug;
         impl Debug for CustomDebug {
-            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
                 f.write_str("Cool debug!")
             }
         }
@@ -1125,7 +1127,7 @@ bevy_reflect::tests::should_reflect_debug::Test {
         struct Foo(i32);
 
         impl Debug for Foo {
-            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
                 write!(f, "Foo")
             }
         }
@@ -1146,7 +1148,7 @@ bevy_reflect::tests::should_reflect_debug::Test {
         struct Foo(i32);
 
         impl Debug for Foo {
-            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
                 write!(f, "Foo")
             }
         }

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -1,5 +1,8 @@
-use std::any::{Any, TypeId};
-use std::fmt::{Debug, Formatter};
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::any::{Any, TypeId};
+use core::fmt::{Debug, Formatter};
 
 use crate::utility::NonGenericTypeInfoCell;
 use crate::{
@@ -42,9 +45,9 @@ impl ListInfo {
     /// Create a new [`ListInfo`].
     pub fn new<TList: List, TItem: FromReflect>() -> Self {
         Self {
-            type_name: std::any::type_name::<TList>(),
+            type_name: core::any::type_name::<TList>(),
             type_id: TypeId::of::<TList>(),
-            item_type_name: std::any::type_name::<TItem>(),
+            item_type_name: core::any::type_name::<TItem>(),
             item_type_id: TypeId::of::<TItem>(),
             #[cfg(feature = "documentation")]
             docs: None,
@@ -59,7 +62,7 @@ impl ListInfo {
 
     /// The [type name] of the list.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     pub fn type_name(&self) -> &'static str {
         self.type_name
     }
@@ -76,7 +79,7 @@ impl ListInfo {
 
     /// The [type name] of the list item.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     pub fn item_type_name(&self) -> &'static str {
         self.item_type_name
     }
@@ -270,7 +273,7 @@ impl Reflect for DynamicList {
         list_partial_eq(self, value)
     }
 
-    fn debug(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn debug(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "DynamicList(")?;
         list_debug(self, f)?;
         write!(f, ")")
@@ -278,7 +281,7 @@ impl Reflect for DynamicList {
 }
 
 impl Debug for DynamicList {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         self.debug(f)
     }
 }
@@ -292,7 +295,7 @@ impl Typed for DynamicList {
 
 impl IntoIterator for DynamicList {
     type Item = Box<dyn Reflect>;
-    type IntoIter = std::vec::IntoIter<Self::Item>;
+    type IntoIter = alloc::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.values.into_iter()
@@ -370,7 +373,7 @@ pub fn list_partial_eq<L: List>(a: &L, b: &dyn Reflect) -> Option<bool> {
 /// // ]
 /// ```
 #[inline]
-pub fn list_debug(dyn_list: &dyn List, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+pub fn list_debug(dyn_list: &dyn List, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
     let mut debug = f.debug_list();
     for item in dyn_list.iter() {
         debug.entry(&item as &dyn Debug);

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -1,5 +1,8 @@
-use std::any::{Any, TypeId};
-use std::fmt::{Debug, Formatter};
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::any::{Any, TypeId};
+use core::fmt::{Debug, Formatter};
 use std::hash::Hash;
 
 use bevy_utils::{Entry, HashMap};
@@ -76,11 +79,11 @@ impl MapInfo {
     /// Create a new [`MapInfo`].
     pub fn new<TMap: Map, TKey: Hash + Reflect, TValue: Reflect>() -> Self {
         Self {
-            type_name: std::any::type_name::<TMap>(),
+            type_name: core::any::type_name::<TMap>(),
             type_id: TypeId::of::<TMap>(),
-            key_type_name: std::any::type_name::<TKey>(),
+            key_type_name: core::any::type_name::<TKey>(),
             key_type_id: TypeId::of::<TKey>(),
-            value_type_name: std::any::type_name::<TValue>(),
+            value_type_name: core::any::type_name::<TValue>(),
             value_type_id: TypeId::of::<TValue>(),
             #[cfg(feature = "documentation")]
             docs: None,
@@ -95,7 +98,7 @@ impl MapInfo {
 
     /// The [type name] of the map.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     pub fn type_name(&self) -> &'static str {
         self.type_name
     }
@@ -112,7 +115,7 @@ impl MapInfo {
 
     /// The [type name] of the key.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     pub fn key_type_name(&self) -> &'static str {
         self.key_type_name
     }
@@ -129,7 +132,7 @@ impl MapInfo {
 
     /// The [type name] of the value.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     pub fn value_type_name(&self) -> &'static str {
         self.value_type_name
     }
@@ -235,7 +238,7 @@ impl Map for DynamicMap {
         match self.indices.entry(key.reflect_hash().expect(HASH_ERROR)) {
             Entry::Occupied(entry) => {
                 let (_old_key, old_value) = self.values.get_mut(*entry.get()).unwrap();
-                std::mem::swap(old_value, &mut value);
+                core::mem::swap(old_value, &mut value);
                 Some(value)
             }
             Entry::Vacant(entry) => {
@@ -317,7 +320,7 @@ impl Reflect for DynamicMap {
         map_partial_eq(self, value)
     }
 
-    fn debug(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn debug(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "DynamicMap(")?;
         map_debug(self, f)?;
         write!(f, ")")
@@ -325,7 +328,7 @@ impl Reflect for DynamicMap {
 }
 
 impl Debug for DynamicMap {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         self.debug(f)
     }
 }
@@ -360,7 +363,7 @@ impl<'a> Iterator for MapIter<'a> {
 
 impl IntoIterator for DynamicMap {
     type Item = (Box<dyn Reflect>, Box<dyn Reflect>);
-    type IntoIter = std::vec::IntoIter<Self::Item>;
+    type IntoIter = alloc::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.values.into_iter()
@@ -420,7 +423,7 @@ pub fn map_partial_eq<M: Map>(a: &M, b: &dyn Reflect) -> Option<bool> {
 /// // }
 /// ```
 #[inline]
-pub fn map_debug(dyn_map: &dyn Map, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+pub fn map_debug(dyn_map: &dyn Map, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
     let mut debug = f.debug_map();
     for (key, value) in dyn_map.iter() {
         debug.entry(&key as &dyn Debug, &value as &dyn Debug);

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -3,7 +3,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::any::{Any, TypeId};
 use core::fmt::{Debug, Formatter};
-use std::hash::Hash;
+use core::hash::Hash;
 
 use bevy_utils::{Entry, HashMap};
 

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -1,4 +1,4 @@
-use std::num::ParseIntError;
+use core::num::ParseIntError;
 
 use crate::{Array, Reflect, ReflectMut, ReflectRef};
 use thiserror::Error;

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -3,7 +3,8 @@ use crate::{
     tuple_struct_debug, Array, Enum, List, Map, Struct, Tuple, TupleStruct, TypeInfo, Typed,
     ValueInfo,
 };
-use std::{
+use alloc::boxed::Box;
+use core::{
     any::{self, Any, TypeId},
     fmt::Debug,
 };
@@ -70,7 +71,7 @@ pub enum ReflectOwned {
 /// When using `#[derive(Reflect)]` on a struct, tuple struct or enum, the suitable subtrait for that
 /// type (`Struct`, `TupleStruct` or `Enum`) is derived automatically.
 pub trait Reflect: Any + Send + Sync {
-    /// Returns the [type name][std::any::type_name] of the underlying type.
+    /// Returns the [type name][core::any::type_name] of the underlying type.
     fn type_name(&self) -> &str;
 
     /// Returns the [`TypeInfo`] of the underlying type.
@@ -83,13 +84,13 @@ pub trait Reflect: Any + Send + Sync {
     /// [`TypeRegistry::get_type_info`]: crate::TypeRegistry::get_type_info
     fn get_type_info(&self) -> &'static TypeInfo;
 
-    /// Returns the value as a [`Box<dyn Any>`][std::any::Any].
+    /// Returns the value as a [`Box<dyn Any>`][core::any::Any].
     fn into_any(self: Box<Self>) -> Box<dyn Any>;
 
-    /// Returns the value as a [`&dyn Any`][std::any::Any].
+    /// Returns the value as a [`&dyn Any`][core::any::Any].
     fn as_any(&self) -> &dyn Any;
 
-    /// Returns the value as a [`&mut dyn Any`][std::any::Any].
+    /// Returns the value as a [`&mut dyn Any`][core::any::Any].
     fn as_any_mut(&mut self) -> &mut dyn Any;
 
     /// Casts this type to a boxed reflected value.
@@ -194,7 +195,7 @@ pub trait Reflect: Any + Send + Sync {
     /// where `type_name` is the [type name] of the underlying type.
     ///
     /// [type name]: Self::type_name
-    fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn debug(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self.reflect_ref() {
             ReflectRef::Struct(dyn_struct) => struct_debug(dyn_struct, f),
             ReflectRef::TupleStruct(dyn_tuple_struct) => tuple_struct_debug(dyn_tuple_struct, f),
@@ -231,7 +232,7 @@ pub trait FromReflect: Reflect + Sized {
 }
 
 impl Debug for dyn Reflect {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.debug(f)
     }
 }

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -992,7 +992,7 @@ fn get_registration<'a, E: Error>(
 mod tests {
     use bincode::Options;
     use core::any::TypeId;
-    use std::f32::consts::PI;
+    use core::f32::consts::PI;
 
     use serde::de::DeserializeSeed;
     use serde::Deserialize;

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -6,15 +6,18 @@ use crate::{
     TupleStructInfo, TupleVariantInfo, TypeInfo, TypeRegistration, TypeRegistry, UnnamedField,
     VariantInfo,
 };
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::any::TypeId;
+use core::fmt;
+use core::fmt::{Debug, Display, Formatter};
+use core::slice::Iter;
 use erased_serde::Deserializer;
 use serde::de::{
     self, DeserializeSeed, EnumAccess, Error, MapAccess, SeqAccess, VariantAccess, Visitor,
 };
 use serde::Deserialize;
-use std::any::TypeId;
-use std::fmt;
-use std::fmt::{Debug, Display, Formatter};
-use std::slice::Iter;
 
 pub trait DeserializeValue {
     fn deserialize(
@@ -233,7 +236,7 @@ impl<'de> Visitor<'de> for U32Visitor {
 /// [`DynamicStruct`]: crate::DynamicStruct
 /// [`DynamicList`]: crate::DynamicList
 /// [`FromReflect`]: crate::FromReflect
-/// [type name]: std::any::type_name
+/// [type name]: core::any::type_name
 pub struct UntypedReflectDeserializer<'a> {
     registry: &'a TypeRegistry,
 }
@@ -264,7 +267,7 @@ struct UntypedReflectDeserializerVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for UntypedReflectDeserializerVisitor<'a> {
     type Value = Box<dyn Reflect>;
 
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
         formatter.write_str("map containing `type` and `value` entries for the reflected value")
     }
 
@@ -445,7 +448,7 @@ struct StructVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for StructVisitor<'a> {
     type Value = DynamicStruct;
 
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
         formatter.write_str("reflected struct value")
     }
 
@@ -490,7 +493,7 @@ struct TupleStructVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for TupleStructVisitor<'a> {
     type Value = DynamicTupleStruct;
 
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
         formatter.write_str("reflected tuple struct value")
     }
 
@@ -547,7 +550,7 @@ struct TupleVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for TupleVisitor<'a> {
     type Value = DynamicTuple;
 
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
         formatter.write_str("reflected tuple value")
     }
 
@@ -567,7 +570,7 @@ struct ArrayVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for ArrayVisitor<'a> {
     type Value = DynamicArray;
 
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
         formatter.write_str("reflected array value")
     }
 
@@ -607,7 +610,7 @@ struct ListVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for ListVisitor<'a> {
     type Value = DynamicList;
 
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
         formatter.write_str("reflected list value")
     }
 
@@ -639,7 +642,7 @@ struct MapVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for MapVisitor<'a> {
     type Value = DynamicMap;
 
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
         formatter.write_str("reflected map value")
     }
 
@@ -681,7 +684,7 @@ struct EnumVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for EnumVisitor<'a> {
     type Value = DynamicEnum;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
         formatter.write_str("reflected enum value")
     }
 
@@ -793,7 +796,7 @@ struct StructVariantVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for StructVariantVisitor<'a> {
     type Value = DynamicStruct;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
         formatter.write_str("reflected struct variant value")
     }
 
@@ -837,7 +840,7 @@ struct TupleVariantVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for TupleVariantVisitor<'a> {
     type Value = DynamicTuple;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
         formatter.write_str("reflected tuple variant value")
     }
 
@@ -988,7 +991,7 @@ fn get_registration<'a, E: Error>(
 #[cfg(test)]
 mod tests {
     use bincode::Options;
-    use std::any::TypeId;
+    use core::any::TypeId;
     use std::f32::consts::PI;
 
     use serde::de::DeserializeSeed;

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -473,10 +473,10 @@ mod tests {
     use crate::serde::ReflectSerializer;
     use crate::{FromReflect, Reflect, ReflectSerialize, TypeRegistry};
     use bevy_utils::HashMap;
+    use core::f32::consts::PI;
     use ron::extensions::Extensions;
     use ron::ser::PrettyConfig;
     use serde::Serialize;
-    use core::f32::consts::PI;
 
     #[derive(Reflect, Debug, PartialEq)]
     struct MyStruct {

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -476,7 +476,7 @@ mod tests {
     use ron::extensions::Extensions;
     use ron::ser::PrettyConfig;
     use serde::Serialize;
-    use std::f32::consts::PI;
+    use core::f32::consts::PI;
 
     #[derive(Reflect, Debug, PartialEq)]
     struct MyStruct {

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -2,6 +2,7 @@ use crate::{
     Array, Enum, List, Map, Reflect, ReflectRef, ReflectSerialize, Struct, Tuple, TupleStruct,
     TypeInfo, TypeRegistry, VariantInfo, VariantType,
 };
+use alloc::boxed::Box;
 use serde::ser::{
     Error, SerializeStruct, SerializeStructVariant, SerializeTuple, SerializeTupleStruct,
     SerializeTupleVariant,
@@ -70,7 +71,7 @@ fn get_type_info<E: Error>(
 /// 1. `type`: The _full_ [type name]
 /// 2. `value`: The serialized value of the reflected type
 ///
-/// [type name]: std::any::type_name
+/// [type name]: core::any::type_name
 pub struct ReflectSerializer<'a> {
     pub value: &'a dyn Reflect,
     pub registry: &'a TypeRegistry,

--- a/crates/bevy_reflect/src/std_traits.rs
+++ b/crates/bevy_reflect/src/std_traits.rs
@@ -1,4 +1,5 @@
 use crate::{FromType, Reflect};
+use alloc::boxed::Box;
 
 /// A struct used to provide the default value of a type.
 ///

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -2,8 +2,11 @@ use crate::utility::NonGenericTypeInfoCell;
 use crate::{
     DynamicInfo, NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, Typed,
 };
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
 use bevy_utils::{Entry, HashMap};
-use std::fmt::{Debug, Formatter};
+use core::fmt::{Debug, Formatter};
 use std::{
     any::{Any, TypeId},
     borrow::Cow,
@@ -100,7 +103,7 @@ impl StructInfo {
 
         Self {
             name,
-            type_name: std::any::type_name::<T>(),
+            type_name: core::any::type_name::<T>(),
             type_id: TypeId::of::<T>(),
             fields: fields.to_vec().into_boxed_slice(),
             field_names,
@@ -159,7 +162,7 @@ impl StructInfo {
 
     /// The [type name] of the struct.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     pub fn type_name(&self) -> &'static str {
         self.type_name
     }
@@ -461,7 +464,7 @@ impl Reflect for DynamicStruct {
         struct_partial_eq(self, value)
     }
 
-    fn debug(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn debug(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "DynamicStruct(")?;
         struct_debug(self, f)?;
         write!(f, ")")
@@ -469,7 +472,7 @@ impl Reflect for DynamicStruct {
 }
 
 impl Debug for DynamicStruct {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         self.debug(f)
     }
 }
@@ -535,7 +538,10 @@ pub fn struct_partial_eq<S: Struct>(a: &S, b: &dyn Reflect) -> Option<bool> {
 /// // }
 /// ```
 #[inline]
-pub fn struct_debug(dyn_struct: &dyn Struct, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+pub fn struct_debug(
+    dyn_struct: &dyn Struct,
+    f: &mut core::fmt::Formatter<'_>,
+) -> core::fmt::Result {
     let mut debug = f.debug_struct(dyn_struct.type_name());
     for field_index in 0..dyn_struct.field_len() {
         let field = dyn_struct.field_at(field_index).unwrap();

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -3,9 +3,13 @@ use crate::{
     DynamicInfo, FromReflect, GetTypeRegistration, Reflect, ReflectMut, ReflectOwned, ReflectRef,
     TypeInfo, TypeRegistration, Typed, UnnamedField,
 };
-use std::any::{Any, TypeId};
-use std::fmt::{Debug, Formatter};
-use std::slice::Iter;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::any::{Any, TypeId};
+use core::fmt::{Debug, Formatter};
+use core::slice::Iter;
 
 /// A reflected Rust tuple.
 ///
@@ -147,7 +151,7 @@ impl TupleInfo {
     ///
     pub fn new<T: Reflect>(fields: &[UnnamedField]) -> Self {
         Self {
-            type_name: std::any::type_name::<T>(),
+            type_name: core::any::type_name::<T>(),
             type_id: TypeId::of::<T>(),
             fields: fields.to_vec().into_boxed_slice(),
             #[cfg(feature = "documentation")]
@@ -178,7 +182,7 @@ impl TupleInfo {
 
     /// The [type name] of the tuple.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     pub fn type_name(&self) -> &'static str {
         self.type_name
     }
@@ -364,7 +368,7 @@ impl Reflect for DynamicTuple {
         tuple_partial_eq(self, value)
     }
 
-    fn debug(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn debug(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "DynamicTuple(")?;
         tuple_debug(self, f)?;
         write!(f, ")")
@@ -442,7 +446,7 @@ pub fn tuple_partial_eq<T: Tuple>(a: &T, b: &dyn Reflect) -> Option<bool> {
 /// // )
 /// ```
 #[inline]
-pub fn tuple_debug(dyn_tuple: &dyn Tuple, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+pub fn tuple_debug(dyn_tuple: &dyn Tuple, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
     let mut debug = f.debug_tuple("");
     for field in dyn_tuple.iter_fields() {
         debug.field(&field as &dyn Debug);
@@ -506,7 +510,7 @@ macro_rules! impl_reflect_tuple {
 
         impl<$($name: Reflect),*> Reflect for ($($name,)*) {
             fn type_name(&self) -> &str {
-                std::any::type_name::<Self>()
+                core::any::type_name::<Self>()
             }
 
             fn get_type_info(&self) -> &'static TypeInfo {

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -2,9 +2,12 @@ use crate::utility::NonGenericTypeInfoCell;
 use crate::{
     DynamicInfo, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, Typed, UnnamedField,
 };
-use std::any::{Any, TypeId};
-use std::fmt::{Debug, Formatter};
-use std::slice::Iter;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::any::{Any, TypeId};
+use core::fmt::{Debug, Formatter};
+use core::slice::Iter;
 
 /// A reflected Rust tuple struct.
 ///
@@ -70,7 +73,7 @@ impl TupleStructInfo {
     pub fn new<T: Reflect>(name: &'static str, fields: &[UnnamedField]) -> Self {
         Self {
             name,
-            type_name: std::any::type_name::<T>(),
+            type_name: core::any::type_name::<T>(),
             type_id: TypeId::of::<T>(),
             fields: fields.to_vec().into_boxed_slice(),
             #[cfg(feature = "documentation")]
@@ -110,7 +113,7 @@ impl TupleStructInfo {
 
     /// The [type name] of the tuple struct.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     pub fn type_name(&self) -> &'static str {
         self.type_name
     }
@@ -363,7 +366,7 @@ impl Reflect for DynamicTupleStruct {
         tuple_struct_partial_eq(self, value)
     }
 
-    fn debug(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn debug(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "DynamicTupleStruct(")?;
         tuple_struct_debug(self, f)?;
         write!(f, ")")
@@ -371,7 +374,7 @@ impl Reflect for DynamicTupleStruct {
 }
 
 impl Debug for DynamicTupleStruct {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         self.debug(f)
     }
 }
@@ -435,8 +438,8 @@ pub fn tuple_struct_partial_eq<S: TupleStruct>(a: &S, b: &dyn Reflect) -> Option
 #[inline]
 pub fn tuple_struct_debug(
     dyn_tuple_struct: &dyn TupleStruct,
-    f: &mut std::fmt::Formatter<'_>,
-) -> std::fmt::Result {
+    f: &mut core::fmt::Formatter<'_>,
+) -> core::fmt::Result {
     let mut debug = f.debug_tuple(dyn_tuple_struct.type_name());
     for field in dyn_tuple_struct.iter_fields() {
         debug.field(&field as &dyn Debug);

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -1,7 +1,7 @@
 use crate::{
     ArrayInfo, EnumInfo, ListInfo, MapInfo, Reflect, StructInfo, TupleInfo, TupleStructInfo,
 };
-use std::any::{Any, TypeId};
+use core::any::{Any, TypeId};
 
 /// A static accessor to compile-time type information.
 ///
@@ -22,7 +22,7 @@ use std::any::{Any, TypeId};
 /// # Example
 ///
 /// ```
-/// # use std::any::Any;
+/// # use core::any::Any;
 /// # use bevy_reflect::{NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, StructInfo, TypeInfo, ValueInfo};
 /// # use bevy_reflect::utility::NonGenericTypeInfoCell;
 /// use bevy_reflect::Typed;
@@ -93,8 +93,8 @@ pub trait Typed: Reflect {
 ///
 /// [`Reflect::get_type_info`]: crate::Reflect::get_type_info
 /// [`TypeRegistry::get_type_info`]: crate::TypeRegistry::get_type_info
-/// [`TypeId`]: std::any::TypeId
-/// [type name]: std::any::type_name
+/// [`TypeId`]: core::any::TypeId
+/// [type name]: core::any::type_name
 #[derive(Debug, Clone)]
 pub enum TypeInfo {
     Struct(StructInfo),
@@ -129,7 +129,7 @@ impl TypeInfo {
 
     /// The [name] of the underlying type.
     ///
-    /// [name]: std::any::type_name
+    /// [name]: core::any::type_name
     pub fn type_name(&self) -> &'static str {
         match self {
             Self::Struct(info) => info.type_name(),
@@ -185,7 +185,7 @@ pub struct ValueInfo {
 impl ValueInfo {
     pub fn new<T: Reflect + ?Sized>() -> Self {
         Self {
-            type_name: std::any::type_name::<T>(),
+            type_name: core::any::type_name::<T>(),
             type_id: TypeId::of::<T>(),
             #[cfg(feature = "documentation")]
             docs: None,
@@ -200,7 +200,7 @@ impl ValueInfo {
 
     /// The [type name] of the value.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     pub fn type_name(&self) -> &'static str {
         self.type_name
     }
@@ -241,7 +241,7 @@ pub struct DynamicInfo {
 impl DynamicInfo {
     pub fn new<T: Reflect>() -> Self {
         Self {
-            type_name: std::any::type_name::<T>(),
+            type_name: core::any::type_name::<T>(),
             type_id: TypeId::of::<T>(),
             #[cfg(feature = "documentation")]
             docs: None,
@@ -256,7 +256,7 @@ impl DynamicInfo {
 
     /// The [type name] of the dynamic value.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     pub fn type_name(&self) -> &'static str {
         self.type_name
     }

--- a/crates/bevy_reflect/src/type_uuid.rs
+++ b/crates/bevy_reflect/src/type_uuid.rs
@@ -34,7 +34,7 @@ mod test {
     use super::*;
     use crate as bevy_reflect;
     use bevy_reflect_derive::TypeUuid;
-    use std::marker::PhantomData;
+    use core::marker::PhantomData;
 
     #[derive(TypeUuid)]
     #[uuid = "af6466c2-a9f4-11eb-bcbc-0242ac130002"]

--- a/crates/bevy_reflect/src/type_uuid.rs
+++ b/crates/bevy_reflect/src/type_uuid.rs
@@ -23,9 +23,9 @@ where
 
     /// Returns the [type name] of this value's type.
     ///
-    /// [type name]: std::any::type_name
+    /// [type name]: core::any::type_name
     fn type_name(&self) -> &'static str {
-        std::any::type_name::<Self>()
+        core::any::type_name::<Self>()
     }
 }
 

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -1,10 +1,11 @@
 //! Helpers for working with Bevy reflection.
 
 use crate::TypeInfo;
+use alloc::boxed::Box;
 use bevy_utils::HashMap;
+use core::any::{Any, TypeId};
 use once_cell::race::OnceBox;
 use parking_lot::RwLock;
-use std::any::{Any, TypeId};
 
 /// A container for [`TypeInfo`] over non-generic types, allowing instances to be stored statically.
 ///
@@ -15,7 +16,7 @@ use std::any::{Any, TypeId};
 /// ## Example
 ///
 /// ```
-/// # use std::any::Any;
+/// # use core::any::Any;
 /// # use bevy_reflect::{NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, StructInfo, Typed, TypeInfo};
 /// use bevy_reflect::utility::NonGenericTypeInfoCell;
 ///
@@ -80,7 +81,7 @@ impl NonGenericTypeInfoCell {
 /// ## Example
 ///
 /// ```
-/// # use std::any::Any;
+/// # use core::any::Any;
 /// # use bevy_reflect::{Reflect, ReflectMut, ReflectOwned, ReflectRef, TupleStructInfo, Typed, TypeInfo, UnnamedField};
 /// use bevy_reflect::utility::GenericTypeInfoCell;
 ///

--- a/crates/bevy_render/macros/src/as_bind_group.rs
+++ b/crates/bevy_render/macros/src/as_bind_group.rs
@@ -1,3 +1,4 @@
+use alloc::{format, vec, vec::Vec};
 use bevy_macro_utils::{get_lit_bool, get_lit_str, BevyManifest, Symbol};
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};

--- a/crates/bevy_render/macros/src/lib.rs
+++ b/crates/bevy_render/macros/src/lib.rs
@@ -1,3 +1,8 @@
+#![no_std]
+#![forbid(unsafe_code)]
+
+extern crate alloc;
+
 mod as_bind_group;
 mod extract_resource;
 

--- a/crates/bevy_render/src/camera/camera_driver_node.rs
+++ b/crates/bevy_render/src/camera/camera_driver_node.rs
@@ -37,7 +37,7 @@ impl Node for CameraDriverNode {
             .collect::<Vec<_>>();
         // sort by priority and ensure within a priority, RenderTargets of the same type are packed together
         sorted_cameras.sort_by(|(_, p1, t1), (_, p2, t2)| match p1.cmp(p2) {
-            std::cmp::Ordering::Equal => t1.cmp(t2),
+            core::cmp::Ordering::Equal => t1.cmp(t2),
             ord => ord,
         });
         let mut camera_windows = HashSet::new();

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use bevy_app::{App, CoreStage, Plugin, StartupStage};
 use bevy_ecs::{prelude::*, reflect::ReflectComponent};
@@ -161,7 +161,7 @@ impl CameraProjection for PerspectiveProjection {
 impl Default for PerspectiveProjection {
     fn default() -> Self {
         PerspectiveProjection {
-            fov: std::f32::consts::PI / 4.0,
+            fov: core::f32::consts::PI / 4.0,
             near: 0.1,
             far: 1000.0,
             aspect_ratio: 1.0,

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -5,8 +5,8 @@ pub use colorspace::*;
 use crate::color::{HslRepresentation, SrgbColorSpace};
 use bevy_math::{Vec3, Vec4};
 use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize};
-use serde::{Deserialize, Serialize};
 use core::ops::{Add, AddAssign, Mul, MulAssign};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -6,7 +6,7 @@ use crate::color::{HslRepresentation, SrgbColorSpace};
 use bevy_math::{Vec3, Vec4};
 use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize};
 use serde::{Deserialize, Serialize};
-use std::ops::{Add, AddAssign, Mul, MulAssign};
+use core::ops::{Add, AddAssign, Mul, MulAssign};
 use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
         SystemParamItem, SystemParamState, SystemState,
     },
 };
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 /// A helper for accessing [`MainWorld`] content using a system parameter.
 ///

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use bevy_app::{App, Plugin};
 #[cfg(debug_assertions)]

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -57,7 +57,7 @@ pub fn extract_resource<R: ExtractResource>(
             bevy_log::warn!(
                 "Removing resource {} from render world not expected, adding using `Commands`.
                 This may decrease performance",
-                std::any::type_name::<R>()
+                core::any::type_name::<R>()
             );
         }
         commands.insert_resource(R::extract_resource(&main_resource));

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -353,14 +353,14 @@ fn extract(app_world: &mut World, render_app: &mut App) {
 
     // temporarily add the app world to the render world as a resource
     let scratch_world = app_world.remove_resource::<ScratchMainWorld>().unwrap();
-    let inserted_world = std::mem::replace(app_world, scratch_world.0);
+    let inserted_world = core::mem::replace(app_world, scratch_world.0);
     let running_world = &mut render_app.world;
     running_world.insert_resource(MainWorld(inserted_world));
 
     extract.run(running_world);
     // move the app world back, as if nothing happened.
     let inserted_world = running_world.remove_resource::<MainWorld>().unwrap();
-    let scratch_world = std::mem::replace(app_world, inserted_world.0);
+    let scratch_world = core::mem::replace(app_world, inserted_world.0);
     app_world.insert_resource(ScratchMainWorld(scratch_world));
 
     // Note: We apply buffers (read, Commands) after the `MainWorld` has been removed from the render app's world

--- a/crates/bevy_render/src/mesh/mesh/conversions.rs
+++ b/crates/bevy_render/src/mesh/mesh/conversions.rs
@@ -40,7 +40,7 @@ impl FromVertexAttributeError {
     fn new<T: 'static>(from: VertexAttributeValues) -> Self {
         Self {
             variant: from.enum_variant_name(),
-            into: std::any::type_name::<T>(),
+            into: core::any::type_name::<T>(),
             from,
         }
     }

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -382,12 +382,12 @@ impl Mesh {
                 minimum = minimum.min(Vec3::from_slice(p));
                 maximum = maximum.max(Vec3::from_slice(p));
             }
-            if minimum.x != std::f32::MAX
-                && minimum.y != std::f32::MAX
-                && minimum.z != std::f32::MAX
-                && maximum.x != std::f32::MIN
-                && maximum.y != std::f32::MIN
-                && maximum.z != std::f32::MIN
+            if minimum.x != core::f32::MAX
+                && minimum.y != core::f32::MAX
+                && minimum.z != core::f32::MAX
+                && maximum.x != core::f32::MIN
+                && maximum.y != core::f32::MIN
+                && maximum.z != core::f32::MIN
             {
                 return Some(Aabb::from_min_max(minimum, maximum));
             }
@@ -522,8 +522,8 @@ struct MeshAttributeData {
     values: VertexAttributeValues,
 }
 
-const VEC3_MIN: Vec3 = Vec3::splat(std::f32::MIN);
-const VEC3_MAX: Vec3 = Vec3::splat(std::f32::MAX);
+const VEC3_MIN: Vec3 = Vec3::splat(core::f32::MIN);
+const VEC3_MAX: Vec3 = Vec3::splat(core::f32::MAX);
 
 fn face_normal(a: [f32; 3], b: [f32; 3], c: [f32; 3]) -> [f32; 3] {
     let (a, b, c) = (Vec3::from(a), Vec3::from(b), Vec3::from(c));

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -769,8 +769,8 @@ impl Indices {
 
 /// An Iterator for the [`Indices`].
 enum IndicesIter<'a> {
-    U16(std::slice::Iter<'a, u16>),
-    U32(std::slice::Iter<'a, u32>),
+    U16(core::slice::Iter<'a, u16>),
+    U32(core::slice::Iter<'a, u32>),
 }
 
 impl Iterator for IndicesIter<'_> {

--- a/crates/bevy_render/src/mesh/mesh/skinning.rs
+++ b/crates/bevy_render/src/mesh/mesh/skinning.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
 };
 use bevy_math::Mat4;
 use bevy_reflect::{Reflect, TypeUuid};
-use std::ops::Deref;
+use core::ops::Deref;
 
 #[derive(Component, Debug, Default, Clone, Reflect)]
 #[reflect(Component, MapEntities)]

--- a/crates/bevy_render/src/mesh/shape/capsule.rs
+++ b/crates/bevy_render/src/mesh/shape/capsule.rs
@@ -87,8 +87,8 @@ impl From<Capsule> for Mesh {
         let mut vts: Vec<Vec2> = vec![Vec2::ZERO; vert_len];
         let mut vns: Vec<Vec3> = vec![Vec3::ZERO; vert_len];
 
-        let to_theta = 2.0 * std::f32::consts::PI / longitudes as f32;
-        let to_phi = std::f32::consts::PI / latitudes as f32;
+        let to_theta = 2.0 * core::f32::consts::PI / longitudes as f32;
+        let to_phi = core::f32::consts::PI / latitudes as f32;
         let to_tex_horizontal = 1.0 / longitudes as f32;
         let to_tex_vertical = 1.0 / half_lats as f32;
 

--- a/crates/bevy_render/src/mesh/shape/icosphere.rs
+++ b/crates/bevy_render/src/mesh/shape/icosphere.rs
@@ -64,8 +64,8 @@ impl From<Icosphere> for Mesh {
             let inclination = point.y.acos();
             let azimuth = point.z.atan2(point.x);
 
-            let norm_inclination = inclination / std::f32::consts::PI;
-            let norm_azimuth = 0.5 - (azimuth / std::f32::consts::TAU);
+            let norm_inclination = inclination / core::f32::consts::PI;
+            let norm_azimuth = 0.5 - (azimuth / core::f32::consts::TAU);
 
             [norm_azimuth, norm_inclination]
         });

--- a/crates/bevy_render/src/mesh/shape/regular_polygon.rs
+++ b/crates/bevy_render/src/mesh/shape/regular_polygon.rs
@@ -36,9 +36,9 @@ impl From<RegularPolygon> for Mesh {
         let mut normals = Vec::with_capacity(sides);
         let mut uvs = Vec::with_capacity(sides);
 
-        let step = std::f32::consts::TAU / sides as f32;
+        let step = core::f32::consts::TAU / sides as f32;
         for i in 0..sides {
-            let theta = std::f32::consts::FRAC_PI_2 - i as f32 * step;
+            let theta = core::f32::consts::FRAC_PI_2 - i as f32 * step;
             let (sin, cos) = theta.sin_cos();
 
             positions.push([cos * radius, sin * radius, 0.0]);

--- a/crates/bevy_render/src/mesh/shape/torus.rs
+++ b/crates/bevy_render/src/mesh/shape/torus.rs
@@ -32,8 +32,8 @@ impl From<Torus> for Mesh {
         let mut normals: Vec<[f32; 3]> = Vec::with_capacity(n_vertices);
         let mut uvs: Vec<[f32; 2]> = Vec::with_capacity(n_vertices);
 
-        let segment_stride = 2.0 * std::f32::consts::PI / torus.subdivisions_segments as f32;
-        let side_stride = 2.0 * std::f32::consts::PI / torus.subdivisions_sides as f32;
+        let segment_stride = 2.0 * core::f32::consts::PI / torus.subdivisions_segments as f32;
+        let side_stride = 2.0 * core::f32::consts::PI / torus.subdivisions_sides as f32;
 
         for segment in 0..=torus.subdivisions_segments {
             let theta = segment_stride * segment as f32;

--- a/crates/bevy_render/src/mesh/shape/uvsphere.rs
+++ b/crates/bevy_render/src/mesh/shape/uvsphere.rs
@@ -1,7 +1,7 @@
 use wgpu::PrimitiveTopology;
 
 use crate::mesh::{Indices, Mesh};
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 /// A sphere made of sectors and stacks.
 #[allow(clippy::upper_case_acronyms)]

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
     system::{StaticSystemParam, SystemParam, SystemParamItem},
 };
 use bevy_utils::{HashMap, HashSet};
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 pub enum PrepareAssetError<E: Send + Sync + 'static> {
     RetryNextUpdate(E),

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -186,7 +186,7 @@ fn prepare_assets<R: RenderAsset>(
     param: StaticSystemParam<<R as RenderAsset>::Param>,
 ) {
     let mut param = param.into_inner();
-    let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
+    let queued_assets = core::mem::take(&mut prepare_next_frame.assets);
     for (handle, extracted_asset) in queued_assets {
         match R::prepare_asset(extracted_asset, &mut param) {
             Ok(prepared_asset) => {
@@ -198,11 +198,11 @@ fn prepare_assets<R: RenderAsset>(
         }
     }
 
-    for removed in std::mem::take(&mut extracted_assets.removed) {
+    for removed in core::mem::take(&mut extracted_assets.removed) {
         render_assets.remove(&removed);
     }
 
-    for (handle, extracted_asset) in std::mem::take(&mut extracted_assets.extracted) {
+    for (handle, extracted_asset) in core::mem::take(&mut extracted_assets.extracted) {
         match R::prepare_asset(extracted_asset, &mut param) {
             Ok(prepared_asset) => {
                 render_assets.insert(handle, prepared_asset);

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -517,7 +517,7 @@ impl RenderGraph {
 }
 
 impl Debug for RenderGraph {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         for node in self.iter_nodes() {
             writeln!(f, "{:?}", node.id)?;
             writeln!(f, "  in: {:?}", node.input_slots)?;

--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -218,7 +218,7 @@ pub struct NodeState {
 }
 
 impl Debug for NodeState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         writeln!(f, "{:?} ({:?})", self.id, self.name)
     }
 }
@@ -236,7 +236,7 @@ impl NodeState {
             input_slots: node.input().into(),
             output_slots: node.output().into(),
             node: Box::new(node),
-            type_name: std::any::type_name::<T>(),
+            type_name: core::any::type_name::<T>(),
             edges: Edges {
                 id,
                 input_edges: Vec::new(),

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -350,7 +350,7 @@ impl AddRenderCommand for App {
                 panic!(
                     "DrawFunctions<{}> must be added to the world as a resource \
                      before adding render commands to it",
-                    std::any::type_name::<P>(),
+                    core::any::type_name::<P>(),
                 );
             });
         draw_functions.write().add_with::<C, _>(draw_function);

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 use bevy_utils::tracing::trace;
-use std::ops::Range;
+use core::ops::Range;
 use wgpu::{IndexFormat, RenderPass};
 
 /// Tracks the current [`TrackedRenderPass`] state to ensure draw calls are valid.

--- a/crates/bevy_render/src/render_phase/mod.rs
+++ b/crates/bevy_render/src/render_phase/mod.rs
@@ -35,7 +35,7 @@ impl<I: BatchedPhaseItem> RenderPhase<I> {
     /// Batches the compatible [`BatchedPhaseItem`]s of this render phase
     pub fn batch(&mut self) {
         // TODO: this could be done in-place
-        let mut items = std::mem::take(&mut self.items).into_iter();
+        let mut items = core::mem::take(&mut self.items).into_iter();
 
         self.items.reserve(items.len());
 

--- a/crates/bevy_render/src/render_phase/mod.rs
+++ b/crates/bevy_render/src/render_phase/mod.rs
@@ -74,7 +74,7 @@ pub fn batch_phase_system<I: BatchedPhaseItem>(mut render_phases: Query<&mut Ren
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Range;
+    use core::ops::Range;
 
     use bevy_ecs::entity::Entity;
 
@@ -102,11 +102,11 @@ mod tests {
             }
         }
         impl BatchedPhaseItem for TestPhaseItem {
-            fn batch_range(&self) -> &Option<std::ops::Range<u32>> {
+            fn batch_range(&self) -> &Option<core::ops::Range<u32>> {
                 &self.batch_range
             }
 
-            fn batch_range_mut(&mut self) -> &mut Option<std::ops::Range<u32>> {
+            fn batch_range_mut(&mut self) -> &mut Option<core::ops::Range<u32>> {
                 &mut self.batch_range
             }
         }

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -42,7 +42,7 @@ impl<T: Pod> BufferVec<T> {
             values: Vec::new(),
             buffer: None,
             capacity: 0,
-            item_size: std::mem::size_of::<T>(),
+            item_size: core::mem::size_of::<T>(),
             buffer_usage,
             label: None,
             label_changed: false,
@@ -90,7 +90,7 @@ impl<T: Pod> BufferVec<T> {
     }
 
     /// Creates a [`Buffer`](crate::render_resource::Buffer) on the [`RenderDevice`](crate::renderer::RenderDevice) with size
-    /// at least `std::mem::size_of::<T>() * capacity`, unless a such a buffer already exists.
+    /// at least `core::mem::size_of::<T>() * capacity`, unless a such a buffer already exists.
     ///
     /// If a [`Buffer`](crate::render_resource::Buffer) exists, but is too small, references to it will be discarded,
     /// and a new [`Buffer`](crate::render_resource::Buffer) will be created. Any previously created [`Buffer`](crate::render_resource::Buffer)s

--- a/crates/bevy_render/src/render_resource/pipeline_specializer.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_specializer.rs
@@ -120,7 +120,7 @@ impl<S: SpecializedMeshPipeline> SpecializedMeshPipelines<S> {
                         {
                             let SpecializedMeshPipelineError::MissingVertexAttribute(err) =
                                 &mut err;
-                            err.pipeline_type = Some(std::any::type_name::<S>());
+                            err.pipeline_type = Some(core::any::type_name::<S>());
                         }
                         err
                     })?;
@@ -143,7 +143,7 @@ impl<S: SpecializedMeshPipeline> SpecializedMeshPipelines<S> {
                         if cfg!(debug_assertions) {
                             let stored_descriptor = cache.get_render_pipeline_descriptor(*entry.get());
                             if stored_descriptor != &descriptor {
-                                error!("The cached pipeline descriptor for {} is not equal to the generated descriptor for the given key. This means the SpecializePipeline implementation uses 'unused' MeshVertexBufferLayout information to specialize the pipeline. This is not allowed because it would invalidate the pipeline cache.", std::any::type_name::<S>());
+                                error!("The cached pipeline descriptor for {} is not equal to the generated descriptor for the given key. This means the SpecializePipeline implementation uses 'unused' MeshVertexBufferLayout information to specialize the pipeline. This is not allowed because it would invalidate the pipeline cache.", core::any::type_name::<S>());
                             }
                         }
                         *entry.into_mut()

--- a/crates/bevy_render/src/renderer/graph_runner.rs
+++ b/crates/bevy_render/src/renderer/graph_runner.rs
@@ -2,9 +2,9 @@ use bevy_ecs::world::World;
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::info_span;
 use bevy_utils::HashMap;
-use smallvec::{smallvec, SmallVec};
 #[cfg(feature = "trace")]
 use core::ops::Deref;
+use smallvec::{smallvec, SmallVec};
 use std::{borrow::Cow, collections::VecDeque};
 use thiserror::Error;
 

--- a/crates/bevy_render/src/renderer/graph_runner.rs
+++ b/crates/bevy_render/src/renderer/graph_runner.rs
@@ -4,7 +4,7 @@ use bevy_utils::tracing::info_span;
 use bevy_utils::HashMap;
 use smallvec::{smallvec, SmallVec};
 #[cfg(feature = "trace")]
-use std::ops::Deref;
+use core::ops::Deref;
 use std::{borrow::Cow, collections::VecDeque};
 use thiserror::Error;
 

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -16,7 +16,7 @@ use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::system::{lifetimeless::SRes, Resource, SystemParamItem};
 use bevy_math::Vec2;
 use bevy_reflect::{FromReflect, Reflect, TypeUuid};
-use std::hash::Hash;
+use core::hash::Hash;
 use thiserror::Error;
 use wgpu::{
     Extent3d, ImageCopyTexture, ImageDataLayout, Origin3d, TextureDimension, TextureFormat,

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -647,13 +647,13 @@ impl RenderAsset for Image {
                 ImageDataLayout {
                     offset: 0,
                     bytes_per_row: Some(
-                        std::num::NonZeroU32::new(
+                        core::num::NonZeroU32::new(
                             image.texture_descriptor.size.width * format_size as u32,
                         )
                         .unwrap(),
                     ),
                     rows_per_image: if image.texture_descriptor.size.depth_or_array_layers > 1 {
-                        std::num::NonZeroU32::new(image.texture_descriptor.size.height)
+                        core::num::NonZeroU32::new(image.texture_descriptor.size.height)
                     } else {
                         None
                     },

--- a/crates/bevy_render/src/texture/image_texture_loader.rs
+++ b/crates/bevy_render/src/texture/image_texture_loader.rs
@@ -87,7 +87,7 @@ pub struct FileTextureError {
     path: String,
 }
 impl core::fmt::Display for FileTextureError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> std::result::Result<(), core::fmt::Error> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error> {
         write!(
             f,
             "Error reading image file {}: {}, this is an error in `bevy_render`.",

--- a/crates/bevy_render/src/texture/image_texture_loader.rs
+++ b/crates/bevy_render/src/texture/image_texture_loader.rs
@@ -86,8 +86,8 @@ pub struct FileTextureError {
     error: TextureError,
     path: String,
 }
-impl std::fmt::Display for FileTextureError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+impl core::fmt::Display for FileTextureError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> std::result::Result<(), core::fmt::Error> {
         write!(
             f,
             "Error reading image file {}: {}, this is an error in `bevy_render`.",

--- a/crates/bevy_render/src/texture/ktx2.rs
+++ b/crates/bevy_render/src/texture/ktx2.rs
@@ -392,7 +392,7 @@ enum DataType {
     Sint,
 }
 
-// This can be obtained from std::mem::transmute::<f32, u32>(1.0f32). It is used for identifying
+// This can be obtained from core::mem::transmute::<f32, u32>(1.0f32). It is used for identifying
 // normalized sample types as in Unorm or Snorm.
 const F32_1_AS_U32: u32 = 1065353216;
 

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -10,7 +10,7 @@ use bevy_reflect::Reflect;
 use bevy_reflect::{std_traits::ReflectDefault, FromReflect};
 use bevy_transform::components::GlobalTransform;
 use bevy_transform::TransformSystem;
-use std::cell::Cell;
+use core::cell::Cell;
 use thread_local::ThreadLocal;
 
 use crate::{

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -24,8 +24,8 @@ pub type Layer = u8;
 #[reflect(Component, Default, PartialEq)]
 pub struct RenderLayers(LayerMask);
 
-impl std::fmt::Debug for RenderLayers {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for RenderLayers {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("RenderLayers")
             .field(&self.iter().collect::<Vec<_>>())
             .finish()
@@ -47,7 +47,7 @@ impl Default for RenderLayers {
 
 impl RenderLayers {
     /// The total number of layers supported.
-    pub const TOTAL_LAYERS: usize = std::mem::size_of::<LayerMask>() * 8;
+    pub const TOTAL_LAYERS: usize = core::mem::size_of::<LayerMask>() * 8;
 
     /// Create a new `RenderLayers` belonging to the given layer.
     pub const fn layer(n: Layer) -> Self {

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -32,7 +32,7 @@ impl core::fmt::Debug for RenderLayers {
     }
 }
 
-impl std::iter::FromIterator<Layer> for RenderLayers {
+impl core::iter::FromIterator<Layer> for RenderLayers {
     fn from_iter<T: IntoIterator<Item = Layer>>(i: T) -> Self {
         i.into_iter().fold(Self::none(), |mask, g| mask.with(g))
     }
@@ -174,7 +174,7 @@ mod rendering_mask_tests {
         );
         assert_eq!(
             RenderLayers::from_layers(&[0, 1, 2]),
-            <RenderLayers as std::iter::FromIterator<Layer>>::from_iter(vec![0, 1, 2]),
+            <RenderLayers as core::iter::FromIterator<Layer>>::from_iter(vec![0, 1, 2]),
             "from_layers and from_iter are equivalent"
         );
     }

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -9,7 +9,7 @@ use bevy_utils::{tracing::debug, HashMap, HashSet};
 use bevy_window::{
     CompositeAlphaMode, PresentMode, RawHandleWrapper, WindowClosed, WindowId, Windows,
 };
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 use wgpu::TextureFormat;
 
 /// Token to ensure a system runs on the main thread.

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -1,3 +1,6 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use alloc::string::String;
 use crate::{serde::SceneSerializer, DynamicSceneBuilder, Scene, SceneSpawnError};
 use anyhow::Result;
 use bevy_app::AppTypeRegistry;

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -1,7 +1,7 @@
-use alloc::boxed::Box;
-use alloc::vec::Vec;
-use alloc::string::String;
 use crate::{serde::SceneSerializer, DynamicSceneBuilder, Scene, SceneSpawnError};
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
 use anyhow::Result;
 use bevy_app::AppTypeRegistry;
 use bevy_ecs::{

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -1,8 +1,9 @@
+use alloc::vec::Vec;
+use alloc::collections::BTreeMap;
 use crate::{DynamicEntity, DynamicScene};
 use bevy_app::AppTypeRegistry;
 use bevy_ecs::{prelude::Entity, reflect::ReflectComponent, world::World};
 use bevy_utils::default;
-use std::collections::BTreeMap;
 
 /// A [`DynamicScene`] builder, used to build a scene from a [`World`] by extracting some entities.
 ///
@@ -68,7 +69,7 @@ impl<'w> DynamicSceneBuilder<'w> {
     ///
     /// Re-extracting an entity that was already extracted will have no effect.
     pub fn extract_entity(&mut self, entity: Entity) -> &mut Self {
-        self.extract_entities(std::iter::once(entity))
+        self.extract_entities(core::iter::once(entity))
     }
 
     /// Extract entities from the builder's [`World`].

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -1,6 +1,6 @@
-use alloc::vec::Vec;
-use alloc::collections::BTreeMap;
 use crate::{DynamicEntity, DynamicScene};
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
 use bevy_app::AppTypeRegistry;
 use bevy_ecs::{prelude::Entity, reflect::ReflectComponent, world::World};
 use bevy_utils::default;

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 mod bundle;
 mod dynamic_scene;
 mod dynamic_scene_builder;

--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use crate::serde::SceneDeserializer;
 use anyhow::Result;
 use bevy_app::AppTypeRegistry;

--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -1,5 +1,5 @@
-use alloc::boxed::Box;
 use crate::serde::SceneDeserializer;
+use alloc::boxed::Box;
 use anyhow::Result;
 use bevy_app::AppTypeRegistry;
 use bevy_asset::{AssetLoader, LoadContext, LoadedAsset};

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -1,6 +1,6 @@
-use alloc::vec::Vec;
-use alloc::string::String;
 use crate::{DynamicScene, Scene};
+use alloc::string::String;
+use alloc::vec::Vec;
 use bevy_app::AppTypeRegistry;
 use bevy_asset::{AssetEvent, Assets, Handle};
 use bevy_ecs::{

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -205,7 +205,7 @@ impl SceneSpawner {
     }
 
     pub fn despawn_queued_scenes(&mut self, world: &mut World) -> Result<(), SceneSpawnError> {
-        let scenes_to_despawn = std::mem::take(&mut self.scenes_to_despawn);
+        let scenes_to_despawn = core::mem::take(&mut self.scenes_to_despawn);
 
         for scene_handle in scenes_to_despawn {
             self.despawn_sync(world, scene_handle)?;
@@ -214,7 +214,7 @@ impl SceneSpawner {
     }
 
     pub fn despawn_queued_instances(&mut self, world: &mut World) {
-        let instances_to_despawn = std::mem::take(&mut self.instances_to_despawn);
+        let instances_to_despawn = core::mem::take(&mut self.instances_to_despawn);
 
         for instance_id in instances_to_despawn {
             self.despawn_instance_sync(world, &instance_id);
@@ -222,7 +222,7 @@ impl SceneSpawner {
     }
 
     pub fn spawn_queued_scenes(&mut self, world: &mut World) -> Result<(), SceneSpawnError> {
-        let scenes_to_spawn = std::mem::take(&mut self.dynamic_scenes_to_spawn);
+        let scenes_to_spawn = core::mem::take(&mut self.dynamic_scenes_to_spawn);
 
         for (scene_handle, instance_id) in scenes_to_spawn {
             let mut entity_map = EntityMap::default();
@@ -245,7 +245,7 @@ impl SceneSpawner {
             }
         }
 
-        let scenes_to_spawn = std::mem::take(&mut self.scenes_to_spawn);
+        let scenes_to_spawn = core::mem::take(&mut self.scenes_to_spawn);
 
         for (scene_handle, instance_id) in scenes_to_spawn {
             match self.spawn_sync_internal(world, scene_handle, instance_id) {
@@ -261,7 +261,7 @@ impl SceneSpawner {
     }
 
     pub(crate) fn set_scene_instance_parent_sync(&mut self, world: &mut World) {
-        let scenes_with_parent = std::mem::take(&mut self.scenes_with_parent);
+        let scenes_with_parent = core::mem::take(&mut self.scenes_with_parent);
 
         for (instance_id, parent) in scenes_with_parent {
             if let Some(instance) = self.spawned_instances.get(&instance_id) {

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+use alloc::string::String;
 use crate::{DynamicScene, Scene};
 use bevy_app::AppTypeRegistry;
 use bevy_asset::{AssetEvent, Assets, Handle};

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -3,13 +3,13 @@ use anyhow::Result;
 use bevy_reflect::serde::{TypedReflectDeserializer, TypedReflectSerializer};
 use bevy_reflect::{serde::UntypedReflectDeserializer, Reflect, TypeRegistry, TypeRegistryArc};
 use bevy_utils::HashSet;
+use core::fmt::Formatter;
 use serde::ser::SerializeMap;
 use serde::{
     de::{DeserializeSeed, Error, MapAccess, SeqAccess, Visitor},
     ser::SerializeStruct,
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::fmt::Formatter;
 
 pub const SCENE_STRUCT: &str = "Scene";
 pub const SCENE_ENTITIES: &str = "entities";
@@ -152,7 +152,7 @@ struct SceneVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for SceneVisitor<'a> {
     type Value = DynamicScene;
 
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
         formatter.write_str("scene struct")
     }
 
@@ -217,7 +217,7 @@ struct SceneEntitiesVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for SceneEntitiesVisitor<'a> {
     type Value = Vec<DynamicEntity>;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
         formatter.write_str("map of entities")
     }
 
@@ -269,7 +269,7 @@ struct SceneEntityVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for SceneEntityVisitor<'a> {
     type Value = DynamicEntity;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
         formatter.write_str("entities")
     }
 
@@ -342,7 +342,7 @@ struct ComponentVisitor<'a> {
 impl<'a, 'de> Visitor<'de> for ComponentVisitor<'a> {
     type Value = Vec<Box<dyn Reflect>>;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
         formatter.write_str("map of components")
     }
 

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -1,7 +1,7 @@
-use alloc::vec::Vec;
-use alloc::format;
-use alloc::boxed::Box;
 use crate::{DynamicEntity, DynamicScene};
+use alloc::boxed::Box;
+use alloc::format;
+use alloc::vec::Vec;
 use anyhow::Result;
 use bevy_reflect::serde::{TypedReflectDeserializer, TypedReflectSerializer};
 use bevy_reflect::{serde::UntypedReflectDeserializer, Reflect, TypeRegistry, TypeRegistryArc};

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -1,3 +1,6 @@
+use alloc::vec::Vec;
+use alloc::format;
+use alloc::boxed::Box;
 use crate::{DynamicEntity, DynamicScene};
 use anyhow::Result;
 use bevy_reflect::serde::{TypedReflectDeserializer, TypedReflectSerializer};
@@ -156,7 +159,7 @@ impl<'a, 'de> Visitor<'de> for SceneVisitor<'a> {
         formatter.write_str("scene struct")
     }
 
-    fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+    fn visit_map<A>(self, mut map: A) -> core::result::Result<Self::Value, A::Error>
     where
         A: MapAccess<'de>,
     {
@@ -273,7 +276,7 @@ impl<'a, 'de> Visitor<'de> for SceneEntityVisitor<'a> {
         formatter.write_str("entities")
     }
 
-    fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
+    fn visit_seq<A>(self, mut seq: A) -> core::result::Result<Self::Value, A::Error>
     where
         A: SeqAccess<'de>,
     {
@@ -346,7 +349,7 @@ impl<'a, 'de> Visitor<'de> for ComponentVisitor<'a> {
         formatter.write_str("map of components")
     }
 
-    fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+    fn visit_map<A>(self, mut map: A) -> core::result::Result<Self::Value, A::Error>
     where
         A: MapAccess<'de>,
     {

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 mod bundle;
 mod dynamic_texture_atlas_builder;
 mod mesh2d;

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+use alloc::{vec, vec::Vec};
 use bevy_app::{App, Plugin};
 use bevy_asset::{load_internal_asset, AddAsset, Assets, Handle, HandleUntyped};
 use bevy_math::Vec4;

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -37,8 +37,8 @@ use bevy_render::{
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 use bevy_utils::{FloatOrd, HashMap, HashSet};
-use core::marker::PhantomData;
 use core::hash::Hash;
+use core::marker::PhantomData;
 
 use crate::{
     DrawMesh2d, Mesh2dHandle, Mesh2dPipeline, Mesh2dPipelineKey, Mesh2dUniform, SetMesh2dBindGroup,

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -1,3 +1,4 @@
+use alloc::{vec, vec::Vec};
 use bevy_app::{App, Plugin};
 use bevy_asset::{AddAsset, AssetEvent, AssetServer, Assets, Handle};
 use bevy_core_pipeline::{core_2d::Transparent2d, tonemapping::Tonemapping};
@@ -37,7 +38,7 @@ use bevy_render::{
 use bevy_transform::components::{GlobalTransform, Transform};
 use bevy_utils::{FloatOrd, HashMap, HashSet};
 use core::marker::PhantomData;
-use std::hash::Hash;
+use core::hash::Hash;
 
 use crate::{
     DrawMesh2d, Mesh2dHandle, Mesh2dPipeline, Mesh2dPipelineKey, Mesh2dUniform, SetMesh2dBindGroup,
@@ -212,7 +213,7 @@ impl<M: Material2d> Hash for Material2dKey<M>
 where
     M::Data: Hash,
 {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.mesh_key.hash(state);
         self.bind_group_data.hash(state);
     }

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -37,7 +37,7 @@ use bevy_render::{
 use bevy_transform::components::{GlobalTransform, Transform};
 use bevy_utils::{FloatOrd, HashMap, HashSet};
 use std::hash::Hash;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::{
     DrawMesh2d, Mesh2dHandle, Mesh2dPipeline, Mesh2dPipelineKey, Mesh2dUniform, SetMesh2dBindGroup,

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -36,8 +36,8 @@ use bevy_render::{
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 use bevy_utils::{FloatOrd, HashMap, HashSet};
-use std::hash::Hash;
 use core::marker::PhantomData;
+use std::hash::Hash;
 
 use crate::{
     DrawMesh2d, Mesh2dHandle, Mesh2dPipeline, Mesh2dPipelineKey, Mesh2dUniform, SetMesh2dBindGroup,

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -475,7 +475,7 @@ fn prepare_materials_2d<M: Material2d>(
     fallback_image: Res<FallbackImage>,
     pipeline: Res<Material2dPipeline<M>>,
 ) {
-    let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
+    let queued_assets = core::mem::take(&mut prepare_next_frame.assets);
     for (handle, material) in queued_assets {
         match prepare_material2d(
             &material,
@@ -493,11 +493,11 @@ fn prepare_materials_2d<M: Material2d>(
         }
     }
 
-    for removed in std::mem::take(&mut extracted_assets.removed) {
+    for removed in core::mem::take(&mut extracted_assets.removed) {
         render_materials.remove(&removed);
     }
 
-    for (handle, material) in std::mem::take(&mut extracted_assets.extracted) {
+    for (handle, material) in core::mem::take(&mut extracted_assets.extracted) {
         match prepare_material2d(
             &material,
             &render_device,

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -1,6 +1,6 @@
+use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::{vec, vec::Vec};
-use alloc::boxed::Box;
 use bevy_app::Plugin;
 use bevy_asset::{load_internal_asset, Handle, HandleUntyped};
 use bevy_ecs::{

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -1,3 +1,6 @@
+use alloc::string::String;
+use alloc::{vec, vec::Vec};
+use alloc::boxed::Box;
 use bevy_app::Plugin;
 use bevy_asset::{load_internal_asset, Handle, HandleUntyped};
 use bevy_ecs::{

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -231,7 +231,7 @@ impl FromWorld for Mesh2dPipeline {
                 ImageDataLayout {
                     offset: 0,
                     bytes_per_row: Some(
-                        std::num::NonZeroU32::new(
+                        core::num::NonZeroU32::new(
                             image.texture_descriptor.size.width * format_size as u32,
                         )
                         .unwrap(),

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 use crate::{
     texture_atlas::{TextureAtlas, TextureAtlasSprite},

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -1,3 +1,4 @@
+use alloc::{vec, vec::Vec};
 use core::cmp::Ordering;
 
 use crate::{

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -112,7 +112,7 @@ impl FromWorld for SpritePipeline {
                 ImageDataLayout {
                     offset: 0,
                     bytes_per_row: Some(
-                        std::num::NonZeroU32::new(
+                        core::num::NonZeroU32::new(
                             image.texture_descriptor.size.width * format_size as u32,
                         )
                         .unwrap(),

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use bevy_ecs::component::Component;
 use bevy_math::{Rect, Vec2};
 use bevy_reflect::Reflect;

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use crate::Anchor;
 use bevy_asset::Handle;
 use bevy_ecs::component::Component;

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -1,6 +1,6 @@
+use crate::Anchor;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use crate::Anchor;
 use bevy_asset::Handle;
 use bevy_ecs::component::Component;
 use bevy_math::{Rect, Vec2};

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -1,5 +1,5 @@
-use alloc::{vec, vec::Vec};
 use alloc::collections::BTreeMap;
+use alloc::{vec, vec::Vec};
 use bevy_asset::{Assets, Handle};
 use bevy_log::{debug, error, warn};
 use bevy_math::{Rect, Vec2};

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -1,3 +1,5 @@
+use alloc::{vec, vec::Vec};
+use alloc::collections::BTreeMap;
 use bevy_asset::{Assets, Handle};
 use bevy_log::{debug, error, warn};
 use bevy_math::{Rect, Vec2};
@@ -168,7 +170,7 @@ impl TextureAtlasBuilder {
 
             let last_attempt = current_height == max_height && current_width == max_width;
 
-            let mut target_bins = std::collections::BTreeMap::new();
+            let mut target_bins = BTreeMap::new();
             target_bins.insert(0, TargetBin::new(current_width, current_height, 1));
             rect_placements = match pack_rects(
                 &self.rects_to_place,

--- a/crates/bevy_tasks/src/iter/adapters.rs
+++ b/crates/bevy_tasks/src/iter/adapters.rs
@@ -30,13 +30,13 @@ pub struct Map<P, F> {
     pub(crate) f: F,
 }
 
-impl<B, U, T, F> ParallelIterator<std::iter::Map<B, F>> for Map<U, F>
+impl<B, U, T, F> ParallelIterator<core::iter::Map<B, F>> for Map<U, F>
 where
     B: Iterator + Send,
     U: ParallelIterator<B>,
     F: FnMut(B::Item) -> T + Send + Clone,
 {
-    fn next_batch(&mut self) -> Option<std::iter::Map<B, F>> {
+    fn next_batch(&mut self) -> Option<core::iter::Map<B, F>> {
         self.iter.next_batch().map(|b| b.map(self.f.clone()))
     }
 }
@@ -47,13 +47,13 @@ pub struct Filter<P, F> {
     pub(crate) predicate: F,
 }
 
-impl<B, P, F> ParallelIterator<std::iter::Filter<B, F>> for Filter<P, F>
+impl<B, P, F> ParallelIterator<core::iter::Filter<B, F>> for Filter<P, F>
 where
     B: Iterator + Send,
     P: ParallelIterator<B>,
     F: FnMut(&B::Item) -> bool + Send + Clone,
 {
-    fn next_batch(&mut self) -> Option<std::iter::Filter<B, F>> {
+    fn next_batch(&mut self) -> Option<core::iter::Filter<B, F>> {
         self.iter
             .next_batch()
             .map(|b| b.filter(self.predicate.clone()))
@@ -66,13 +66,13 @@ pub struct FilterMap<P, F> {
     pub(crate) f: F,
 }
 
-impl<B, P, R, F> ParallelIterator<std::iter::FilterMap<B, F>> for FilterMap<P, F>
+impl<B, P, R, F> ParallelIterator<core::iter::FilterMap<B, F>> for FilterMap<P, F>
 where
     B: Iterator + Send,
     P: ParallelIterator<B>,
     F: FnMut(B::Item) -> Option<R> + Send + Clone,
 {
-    fn next_batch(&mut self) -> Option<std::iter::FilterMap<B, F>> {
+    fn next_batch(&mut self) -> Option<core::iter::FilterMap<B, F>> {
         self.iter.next_batch().map(|b| b.filter_map(self.f.clone()))
     }
 }
@@ -83,7 +83,7 @@ pub struct FlatMap<P, F> {
     pub(crate) f: F,
 }
 
-impl<B, P, U, F> ParallelIterator<std::iter::FlatMap<B, U, F>> for FlatMap<P, F>
+impl<B, P, U, F> ParallelIterator<core::iter::FlatMap<B, U, F>> for FlatMap<P, F>
 where
     B: Iterator + Send,
     P: ParallelIterator<B>,
@@ -93,7 +93,7 @@ where
 {
     // This extends each batch using the flat map. The other option is
     // to turn each IntoIter into its own batch.
-    fn next_batch(&mut self) -> Option<std::iter::FlatMap<B, U, F>> {
+    fn next_batch(&mut self) -> Option<core::iter::FlatMap<B, U, F>> {
         self.iter.next_batch().map(|b| b.flat_map(self.f.clone()))
     }
 }
@@ -103,7 +103,7 @@ pub struct Flatten<P> {
     pub(crate) iter: P,
 }
 
-impl<B, P> ParallelIterator<std::iter::Flatten<B>> for Flatten<P>
+impl<B, P> ParallelIterator<core::iter::Flatten<B>> for Flatten<P>
 where
     B: Iterator + Send,
     P: ParallelIterator<B>,
@@ -112,7 +112,7 @@ where
 {
     // This extends each batch using the flatten. The other option is to
     // turn each IntoIter into its own batch.
-    fn next_batch(&mut self) -> Option<std::iter::Flatten<B>> {
+    fn next_batch(&mut self) -> Option<core::iter::Flatten<B>> {
         self.iter.next_batch().map(|b| b.flatten())
     }
 }
@@ -144,13 +144,13 @@ pub struct Inspect<P, F> {
     pub(crate) f: F,
 }
 
-impl<B, P, F> ParallelIterator<std::iter::Inspect<B, F>> for Inspect<P, F>
+impl<B, P, F> ParallelIterator<core::iter::Inspect<B, F>> for Inspect<P, F>
 where
     B: Iterator + Send,
     P: ParallelIterator<B>,
     F: FnMut(&B::Item) + Send + Clone,
 {
-    fn next_batch(&mut self) -> Option<std::iter::Inspect<B, F>> {
+    fn next_batch(&mut self) -> Option<core::iter::Inspect<B, F>> {
         self.iter.next_batch().map(|b| b.inspect(self.f.clone()))
     }
 }
@@ -160,13 +160,13 @@ pub struct Copied<P> {
     pub(crate) iter: P,
 }
 
-impl<'a, B, P, T> ParallelIterator<std::iter::Copied<B>> for Copied<P>
+impl<'a, B, P, T> ParallelIterator<core::iter::Copied<B>> for Copied<P>
 where
     B: Iterator<Item = &'a T> + Send,
     P: ParallelIterator<B>,
     T: 'a + Copy,
 {
-    fn next_batch(&mut self) -> Option<std::iter::Copied<B>> {
+    fn next_batch(&mut self) -> Option<core::iter::Copied<B>> {
         self.iter.next_batch().map(|b| b.copied())
     }
 }
@@ -176,13 +176,13 @@ pub struct Cloned<P> {
     pub(crate) iter: P,
 }
 
-impl<'a, B, P, T> ParallelIterator<std::iter::Cloned<B>> for Cloned<P>
+impl<'a, B, P, T> ParallelIterator<core::iter::Cloned<B>> for Cloned<P>
 where
     B: Iterator<Item = &'a T> + Send,
     P: ParallelIterator<B>,
     T: 'a + Copy,
 {
-    fn next_batch(&mut self) -> Option<std::iter::Cloned<B>> {
+    fn next_batch(&mut self) -> Option<core::iter::Cloned<B>> {
         self.iter.next_batch().map(|b| b.cloned())
     }
 }

--- a/crates/bevy_tasks/src/iter/mod.rs
+++ b/crates/bevy_tasks/src/iter/mod.rs
@@ -3,7 +3,7 @@ use crate::TaskPool;
 mod adapters;
 pub use adapters::*;
 
-/// [`ParallelIterator`] closely emulates the `std::iter::Iterator`
+/// [`ParallelIterator`] closely emulates the `core::iter::Iterator`
 /// interface. However, it uses `bevy_task` to compute batches in parallel.
 ///
 /// Note that the overhead of [`ParallelIterator`] is high relative to some
@@ -192,7 +192,7 @@ where
     // TODO: Investigate optimizations for less copying
     fn collect<C>(mut self, pool: &TaskPool) -> C
     where
-        C: std::iter::FromIterator<BatchIter::Item>,
+        C: core::iter::FromIterator<BatchIter::Item>,
         BatchIter::Item: Send + 'static,
     {
         pool.scope(|s| {
@@ -479,8 +479,8 @@ where
     /// See [`Iterator::sum()`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.sum)
     fn sum<S, R>(mut self, pool: &TaskPool) -> R
     where
-        S: std::iter::Sum<BatchIter::Item> + Send + 'static,
-        R: std::iter::Sum<S>,
+        S: core::iter::Sum<BatchIter::Item> + Send + 'static,
+        R: core::iter::Sum<S>,
     {
         pool.scope(|s| {
             while let Some(batch) = self.next_batch() {
@@ -496,8 +496,8 @@ where
     /// See [`Iterator::product()`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.product)
     fn product<S, R>(mut self, pool: &TaskPool) -> R
     where
-        S: std::iter::Product<BatchIter::Item> + Send + 'static,
-        R: std::iter::Product<S>,
+        S: core::iter::Product<BatchIter::Item> + Send + 'static,
+        R: core::iter::Product<S>,
     {
         pool.scope(|s| {
             while let Some(batch) = self.next_batch() {

--- a/crates/bevy_tasks/src/iter/mod.rs
+++ b/crates/bevy_tasks/src/iter/mod.rs
@@ -385,7 +385,7 @@ where
     /// See [`Iterator::max_by()`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.max_by)
     fn max_by<F>(mut self, pool: &TaskPool, f: F) -> Option<BatchIter::Item>
     where
-        F: FnMut(&BatchIter::Item, &BatchIter::Item) -> std::cmp::Ordering + Send + Sync + Clone,
+        F: FnMut(&BatchIter::Item, &BatchIter::Item) -> core::cmp::Ordering + Send + Sync + Clone,
         BatchIter::Item: Send + 'static,
     {
         pool.scope(|s| {
@@ -425,7 +425,7 @@ where
     /// See [`Iterator::min_by()`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.min_by)
     fn min_by<F>(mut self, pool: &TaskPool, f: F) -> Option<BatchIter::Item>
     where
-        F: FnMut(&BatchIter::Item, &BatchIter::Item) -> std::cmp::Ordering + Send + Sync + Clone,
+        F: FnMut(&BatchIter::Item, &BatchIter::Item) -> core::cmp::Ordering + Send + Sync + Clone,
         BatchIter::Item: Send + 'static,
     {
         pool.scope(|s| {

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -35,7 +35,7 @@ pub mod prelude {
     };
 }
 
-use std::num::NonZeroUsize;
+use core::num::NonZeroUsize;
 
 /// Gets the logical CPU core count available to the current process.
 ///

--- a/crates/bevy_tasks/src/slice.rs
+++ b/crates/bevy_tasks/src/slice.rs
@@ -80,9 +80,9 @@ pub trait ParallelSlice<T: Sync>: AsRef<[T]> {
         R: Send + 'static,
     {
         let slice = self.as_ref();
-        let chunk_size = std::cmp::max(
+        let chunk_size = core::cmp::max(
             1,
-            std::cmp::max(
+            core::cmp::max(
                 slice.len() / task_pool.thread_num(),
                 slice.len() / max_tasks.unwrap_or(usize::MAX),
             ),
@@ -185,9 +185,9 @@ pub trait ParallelSliceMut<T: Send>: AsMut<[T]> {
         R: Send + 'static,
     {
         let mut slice = self.as_mut();
-        let chunk_size = std::cmp::max(
+        let chunk_size = core::cmp::max(
             1,
-            std::cmp::max(
+            core::cmp::max(
                 slice.len() / task_pool.thread_num(),
                 slice.len() / max_tasks.unwrap_or(usize::MAX),
             ),

--- a/crates/bevy_tasks/src/usages.rs
+++ b/crates/bevy_tasks/src/usages.rs
@@ -11,8 +11,8 @@
 //! for consumption. (likely via channels)
 
 use super::TaskPool;
-use once_cell::sync::OnceCell;
 use core::ops::Deref;
+use once_cell::sync::OnceCell;
 
 static COMPUTE_TASK_POOL: OnceCell<ComputeTaskPool> = OnceCell::new();
 static ASYNC_COMPUTE_TASK_POOL: OnceCell<AsyncComputeTaskPool> = OnceCell::new();

--- a/crates/bevy_tasks/src/usages.rs
+++ b/crates/bevy_tasks/src/usages.rs
@@ -12,7 +12,7 @@
 
 use super::TaskPool;
 use once_cell::sync::OnceCell;
-use std::ops::Deref;
+use core::ops::Deref;
 
 static COMPUTE_TASK_POOL: OnceCell<ComputeTaskPool> = OnceCell::new();
 static ASYNC_COMPUTE_TASK_POOL: OnceCell<AsyncComputeTaskPool> = OnceCell::new();

--- a/crates/bevy_text/src/font.rs
+++ b/crates/bevy_text/src/font.rs
@@ -1,4 +1,5 @@
 use ab_glyph::{FontArc, FontVec, InvalidFont, OutlinedGlyph};
+use alloc::{vec, vec::Vec};
 use bevy_reflect::TypeUuid;
 use bevy_render::{
     render_resource::{Extent3d, TextureDimension, TextureFormat},

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -1,5 +1,6 @@
 use crate::{error::TextError, Font, FontAtlas, TextSettings};
 use ab_glyph::{GlyphId, OutlinedGlyph, Point};
+use alloc::{vec, vec::Vec};
 use bevy_asset::{Assets, Handle};
 use bevy_math::Vec2;
 use bevy_reflect::TypeUuid;

--- a/crates/bevy_text/src/font_loader.rs
+++ b/crates/bevy_text/src/font_loader.rs
@@ -1,4 +1,5 @@
 use crate::Font;
+use alloc::boxed::Box;
 use anyhow::Result;
 use bevy_asset::{AssetLoader, LoadContext, LoadedAsset};
 use bevy_utils::BoxedFuture;

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -1,4 +1,5 @@
 use ab_glyph::{Font as _, FontArc, Glyph, ScaleFont as _};
+use alloc::vec::Vec;
 use bevy_asset::{Assets, Handle};
 use bevy_math::Vec2;
 use bevy_render::texture::Image;

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -77,9 +77,9 @@ impl GlyphBrush {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut min_x = std::f32::MAX;
-        let mut min_y = std::f32::MAX;
-        let mut max_y = std::f32::MIN;
+        let mut min_x = core::f32::MAX;
+        let mut min_y = core::f32::MAX;
+        let mut max_y = core::f32::MIN;
         for sg in &glyphs {
             let glyph = &sg.glyph;
 

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 mod error;
 mod font;
 mod font_atlas;
@@ -8,6 +10,7 @@ mod pipeline;
 mod text;
 mod text2d;
 
+use alloc::vec::Vec;
 pub use error::*;
 pub use font::*;
 pub use font_atlas::*;
@@ -32,7 +35,7 @@ use bevy_ecs::{schedule::IntoSystemDescriptor, system::Resource};
 use bevy_render::{camera::CameraUpdateSystem, RenderApp, RenderStage};
 use bevy_sprite::SpriteSystem;
 use bevy_window::ModifiesWindows;
-use std::num::NonZeroUsize;
+use core::num::NonZeroUsize;
 
 #[derive(Default)]
 pub struct TextPlugin;

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -82,10 +82,10 @@ impl TextPipeline {
             return Ok(TextLayoutInfo::default());
         }
 
-        let mut min_x: f32 = std::f32::MAX;
-        let mut min_y: f32 = std::f32::MAX;
-        let mut max_x: f32 = std::f32::MIN;
-        let mut max_y: f32 = std::f32::MIN;
+        let mut min_x: f32 = core::f32::MAX;
+        let mut min_y: f32 = core::f32::MAX;
+        let mut max_x: f32 = core::f32::MIN;
+        let mut max_y: f32 = core::f32::MIN;
 
         for sg in &section_glyphs {
             let scaled_font = scaled_fonts[sg.section_index];

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -1,4 +1,5 @@
 use ab_glyph::{PxScale, ScaleFont};
+use alloc::vec::Vec;
 use bevy_asset::{Assets, Handle, HandleId};
 use bevy_ecs::component::Component;
 use bevy_ecs::system::Resource;

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -1,3 +1,6 @@
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::{vec, vec::Vec};
 use bevy_asset::Handle;
 use bevy_ecs::{prelude::Component, reflect::ReflectComponent};
 use bevy_reflect::{prelude::*, FromReflect};

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use bevy_asset::Assets;
 use bevy_ecs::{
     bundle::Bundle,

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -243,8 +243,8 @@ mod test {
     use super::*;
     use bevy_ecs::prelude::*;
     use bevy_utils::Instant;
-    use std::ops::{Add, Mul};
-    use std::time::Duration;
+    use core::time::Duration;
+    use core::ops::{Add, Mul};
 
     #[derive(Resource)]
     struct Count(usize);

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -174,7 +174,7 @@ impl System for FixedTimestep {
     type Out = ShouldRun;
 
     fn name(&self) -> Cow<'static, str> {
-        Cow::Borrowed(std::any::type_name::<FixedTimestep>())
+        Cow::Borrowed(core::any::type_name::<FixedTimestep>())
     }
 
     fn archetype_component_access(&self) -> &Access<ArchetypeComponentId> {

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -1,4 +1,7 @@
 use crate::Time;
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
 use bevy_ecs::{
     archetype::ArchetypeComponentId,
     component::ComponentId,
@@ -8,7 +11,6 @@ use bevy_ecs::{
     world::World,
 };
 use bevy_utils::HashMap;
-use std::borrow::Cow;
 
 /// The internal state of each [`FixedTimestep`].
 #[derive(Debug)]
@@ -243,8 +245,8 @@ mod test {
     use super::*;
     use bevy_ecs::prelude::*;
     use bevy_utils::Instant;
-    use core::time::Duration;
     use core::ops::{Add, Mul};
+    use core::time::Duration;
 
     #[derive(Resource)]
     struct Count(usize);

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+
 mod fixed_timestep;
 mod stopwatch;
 #[allow(clippy::module_inception)]

--- a/crates/bevy_time/src/stopwatch.rs
+++ b/crates/bevy_time/src/stopwatch.rs
@@ -8,7 +8,7 @@ use bevy_utils::Duration;
 ///
 /// ```
 /// # use bevy_time::*;
-/// use std::time::Duration;
+/// use core::time::Duration;
 /// let mut stopwatch = Stopwatch::new();
 /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
 ///
@@ -51,7 +51,7 @@ impl Stopwatch {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
     /// stopwatch.tick(Duration::from_secs(1));
     /// assert_eq!(stopwatch.elapsed(), Duration::from_secs(1));
@@ -72,7 +72,7 @@ impl Stopwatch {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
     /// stopwatch.tick(Duration::from_secs(1));
     /// assert_eq!(stopwatch.elapsed_secs(), 1.0);
@@ -104,7 +104,7 @@ impl Stopwatch {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
     /// stopwatch.set_elapsed(Duration::from_secs_f32(1.0));
     /// assert_eq!(stopwatch.elapsed_secs(), 1.0);
@@ -121,7 +121,7 @@ impl Stopwatch {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
     /// stopwatch.tick(Duration::from_secs_f32(1.5));
     /// assert_eq!(stopwatch.elapsed_secs(), 1.5);
@@ -139,7 +139,7 @@ impl Stopwatch {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
     /// stopwatch.pause();
     /// stopwatch.tick(Duration::from_secs_f32(1.5));
@@ -156,7 +156,7 @@ impl Stopwatch {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
     /// stopwatch.pause();
     /// stopwatch.tick(Duration::from_secs_f32(1.0));
@@ -192,7 +192,7 @@ impl Stopwatch {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
     /// stopwatch.tick(Duration::from_secs_f32(1.5));
     /// stopwatch.reset();

--- a/crates/bevy_time/src/stopwatch.rs
+++ b/crates/bevy_time/src/stopwatch.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+use alloc::string::ToString;
 use bevy_reflect::prelude::*;
 use bevy_reflect::Reflect;
 use bevy_utils::Duration;

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+use alloc::string::ToString;
 use bevy_ecs::{reflect::ReflectResource, system::Resource};
 use bevy_reflect::{FromReflect, Reflect};
 use bevy_utils::{Duration, Instant};

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -351,7 +351,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -53,7 +53,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(1.5));
     /// assert!(timer.finished());
@@ -70,7 +70,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(1.5));
     /// assert!(timer.just_finished());
@@ -90,7 +90,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert_eq!(timer.elapsed(), Duration::from_secs_f32(0.5));
@@ -114,7 +114,7 @@ impl Timer {
     /// #
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.set_elapsed(Duration::from_secs(2));
     /// assert_eq!(timer.elapsed(), Duration::from_secs(2));
@@ -131,7 +131,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let timer = Timer::new(Duration::from_secs(1), TimerMode::Once);
     /// assert_eq!(timer.duration(), Duration::from_secs(1));
     /// ```
@@ -145,7 +145,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.5, TimerMode::Once);
     /// timer.set_duration(Duration::from_secs(1));
     /// assert_eq!(timer.duration(), Duration::from_secs(1));
@@ -196,7 +196,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// let mut repeating = Timer::from_seconds(1.0, TimerMode::Repeating);
     /// timer.tick(Duration::from_secs_f32(1.5));
@@ -245,7 +245,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.pause();
     /// timer.tick(Duration::from_secs_f32(0.5));
@@ -263,7 +263,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.pause();
     /// timer.tick(Duration::from_secs_f32(0.5));
@@ -302,7 +302,7 @@ impl Timer {
     /// Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(1.5));
     /// timer.reset();
@@ -321,7 +321,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert_eq!(timer.percent(), 0.25);
@@ -336,7 +336,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert_eq!(timer.percent_left(), 0.75);
@@ -352,7 +352,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use core::cmp::Ordering;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// let result = timer.remaining_secs().total_cmp(&1.5);
@@ -368,7 +368,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert_eq!(timer.remaining(), Duration::from_secs_f32(1.5));
@@ -387,7 +387,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Repeating);
     /// timer.tick(Duration::from_secs_f32(6.0));
     /// assert_eq!(timer.times_finished_this_tick(), 6);

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -1,4 +1,6 @@
 use crate::Stopwatch;
+use alloc::boxed::Box;
+use alloc::string::ToString;
 use bevy_reflect::prelude::*;
 use bevy_utils::Duration;
 

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -1,4 +1,4 @@
-use std::ops::Mul;
+use core::ops::Mul;
 
 use super::Transform;
 use bevy_ecs::{component::Component, reflect::ReflectComponent};

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+use alloc::string::ToString;
 use core::ops::Mul;
 
 use super::Transform;
@@ -38,13 +40,13 @@ pub struct GlobalTransform(Affine3A);
 
 macro_rules! impl_local_axis {
     ($pos_name: ident, $neg_name: ident, $axis: ident) => {
-        #[doc=std::concat!("Return the local ", std::stringify!($pos_name), " vector (", std::stringify!($axis) ,").")]
+        #[doc=core::concat!("Return the local ", core::stringify!($pos_name), " vector (", core::stringify!($axis) ,").")]
         #[inline]
         pub fn $pos_name(&self) -> Vec3 {
             (self.0.matrix3 * Vec3::$axis).normalize()
         }
 
-        #[doc=std::concat!("Return the local ", std::stringify!($neg_name), " vector (-", std::stringify!($axis) ,").")]
+        #[doc=core::concat!("Return the local ", core::stringify!($neg_name), " vector (-", core::stringify!($axis) ,").")]
         #[inline]
         pub fn $neg_name(&self) -> Vec3 {
             -self.$pos_name()

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -3,7 +3,7 @@ use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_math::{Affine3A, Mat3, Mat4, Quat, Vec3};
 use bevy_reflect::prelude::*;
 use bevy_reflect::Reflect;
-use std::ops::Mul;
+use core::ops::Mul;
 
 /// Describe the position of an entity. If the entity has a parent, the position is relative
 /// to its parent position.

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -1,4 +1,6 @@
 use super::GlobalTransform;
+use alloc::boxed::Box;
+use alloc::string::ToString;
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_math::{Affine3A, Mat3, Mat4, Quat, Vec3};
 use bevy_reflect::prelude::*;

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -1,5 +1,8 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
+#![no_std]
+
+extern crate alloc;
 
 /// The basic components of the transform crate
 pub mod components;

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -343,7 +343,7 @@ mod test {
         app.world
             .spawn(TransformBundle::IDENTITY)
             .push_children(&[child]);
-        std::mem::swap(
+        core::mem::swap(
             &mut *app.world.get_mut::<Parent>(child).unwrap(),
             &mut *temp.get_mut::<Parent>(grandchild).unwrap(),
         );

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -1,5 +1,7 @@
 mod convert;
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use crate::{CalculatedSize, Node, Style, UiScale};
 use bevy_ecs::{
     entity::Entity,

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -1,8 +1,8 @@
 mod convert;
 
+use crate::{CalculatedSize, Node, Style, UiScale};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use crate::{CalculatedSize, Node, Style, UiScale};
 use bevy_ecs::{
     entity::Entity,
     event::EventReader,

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -13,7 +13,7 @@ use bevy_math::Vec2;
 use bevy_transform::components::Transform;
 use bevy_utils::HashMap;
 use bevy_window::{Window, WindowId, WindowScaleFactorChanged, Windows};
-use std::fmt;
+use core::fmt;
 use taffy::{number::Number, Taffy};
 
 #[derive(Resource)]

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use crate::{camera_config::UiCameraConfig, CalculatedClip, Node, UiStack};
 use bevy_ecs::{
     entity::Entity,

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -1,6 +1,6 @@
+use crate::{camera_config::UiCameraConfig, CalculatedClip, Node, UiStack};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use crate::{camera_config::UiCameraConfig, CalculatedClip, Node, UiStack};
 use bevy_ecs::{
     entity::Entity,
     prelude::Component,

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use crate::Val;
 use bevy_reflect::Reflect;
 use core::ops::{Div, DivAssign, Mul, MulAssign};

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -1,6 +1,6 @@
 use crate::Val;
 use bevy_reflect::Reflect;
-use std::ops::{Div, DivAssign, Mul, MulAssign};
+use core::ops::{Div, DivAssign, Mul, MulAssign};
 
 /// A type which is commonly used to define positions, margins, paddings and borders.
 ///

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -1,5 +1,5 @@
-use alloc::boxed::Box;
 use crate::Val;
+use alloc::boxed::Box;
 use bevy_reflect::Reflect;
 use core::ops::{Div, DivAssign, Mul, MulAssign};
 

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -2,6 +2,9 @@
 //! # Basic usage
 //! Spawn UI elements with [`node_bundles::ButtonBundle`], [`node_bundles::ImageBundle`], [`node_bundles::TextBundle`] and [`node_bundles::NodeBundle`]
 //! This UI is laid out with the Flexbox paradigm (see <https://cssreference.io/flexbox/>)
+
+extern crate alloc;
+
 mod flex;
 mod focus;
 mod geometry;

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -1,10 +1,10 @@
 //! This module contains basic node bundles used to build UIs
 
-use alloc::string::String;
 use crate::{
     widget::{Button, ImageMode},
     BackgroundColor, CalculatedSize, FocusPolicy, Interaction, Node, Style, UiImage, ZIndex,
 };
+use alloc::string::String;
 use bevy_ecs::bundle::Bundle;
 use bevy_render::{
     prelude::{Color, ComputedVisibility},

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -1,5 +1,6 @@
 //! This module contains basic node bundles used to build UIs
 
+use alloc::string::String;
 use crate::{
     widget::{Button, ImageMode},
     BackgroundColor, CalculatedSize, FocusPolicy, Interaction, Node, Style, UiImage, ZIndex,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -31,7 +31,7 @@ use bevy_utils::FloatOrd;
 use bevy_utils::HashMap;
 use bevy_window::{WindowId, Windows};
 use bytemuck::{Pod, Zeroable};
-use std::ops::Range;
+use core::ops::Range;
 
 pub mod node {
     pub const UI_PASS_DRIVER: &str = "ui_pass_driver";

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -1,6 +1,7 @@
 mod pipeline;
 mod render_pass;
 
+use alloc::{vec, vec::Vec};
 use bevy_core_pipeline::{core_2d::Camera2d, core_3d::Camera3d};
 pub use pipeline::*;
 pub use render_pass::*;

--- a/crates/bevy_ui/src/render/pipeline.rs
+++ b/crates/bevy_ui/src/render/pipeline.rs
@@ -1,3 +1,4 @@
+use alloc::{vec, vec::Vec};
 use bevy_ecs::prelude::*;
 use bevy_render::{
     render_resource::*,

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -1,3 +1,4 @@
+use alloc::{vec, vec::Vec};
 use super::{UiBatch, UiImageBindGroups, UiMeta};
 use crate::{prelude::UiCameraConfig, DefaultCameraView};
 use bevy_ecs::{

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -1,6 +1,6 @@
-use alloc::{vec, vec::Vec};
 use super::{UiBatch, UiImageBindGroups, UiMeta};
 use crate::{prelude::UiCameraConfig, DefaultCameraView};
+use alloc::{vec, vec::Vec};
 use bevy_ecs::{
     prelude::*,
     system::{lifetimeless::*, SystemParamItem},

--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -1,5 +1,6 @@
 //! This module contains the systems that update the stored UI nodes stack
 
+use alloc::vec::Vec;
 use bevy_ecs::prelude::*;
 use bevy_hierarchy::prelude::*;
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1,5 +1,5 @@
-use alloc::boxed::Box;
 use crate::{Size, UiRect};
+use alloc::boxed::Box;
 use bevy_asset::Handle;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{prelude::Component, reflect::ReflectComponent};

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use crate::{Size, UiRect};
 use bevy_asset::Handle;
 use bevy_derive::{Deref, DerefMut};

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -9,7 +9,7 @@ use bevy_render::{
     texture::{Image, DEFAULT_IMAGE_HANDLE},
 };
 use serde::{Deserialize, Serialize};
-use std::ops::{Div, DivAssign, Mul, MulAssign};
+use core::ops::{Div, DivAssign, Mul, MulAssign};
 use thiserror::Error;
 
 /// Describes the size of a UI node

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -8,8 +8,8 @@ use bevy_render::{
     color::Color,
     texture::{Image, DEFAULT_IMAGE_HANDLE},
 };
-use serde::{Deserialize, Serialize};
 use core::ops::{Div, DivAssign, Mul, MulAssign};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Describes the size of a UI node

--- a/crates/bevy_ui/src/widget/button.rs
+++ b/crates/bevy_ui/src/widget/button.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use bevy_ecs::prelude::Component;
 use bevy_ecs::reflect::ReflectComponent;
 use bevy_reflect::std_traits::ReflectDefault;

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use crate::{CalculatedSize, Size, UiImage, Val};
 use bevy_asset::Assets;
 use bevy_ecs::{

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,5 +1,5 @@
-use alloc::boxed::Box;
 use crate::{CalculatedSize, Size, UiImage, Val};
+use alloc::boxed::Box;
 use bevy_asset::Assets;
 use bevy_ecs::{
     component::Component,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use crate::{CalculatedSize, Size, Style, UiScale, Val};
+use alloc::vec::Vec;
 use bevy_asset::Assets;
 use bevy_ecs::{
     entity::Entity,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use crate::{CalculatedSize, Size, Style, UiScale, Val};
 use bevy_asset::Assets;
 use bevy_ecs::{

--- a/crates/bevy_utils/src/default.rs
+++ b/crates/bevy_utils/src/default.rs
@@ -26,5 +26,5 @@
 /// ```
 #[inline]
 pub fn default<T: Default>() -> T {
-    std::default::Default::default()
+    core::default::Default::default()
 }

--- a/crates/bevy_utils/src/float_ord.rs
+++ b/crates/bevy_utils/src/float_ord.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     cmp::Ordering,
     hash::{Hash, Hasher},
     ops::Neg,

--- a/crates/bevy_utils/src/futures.rs
+++ b/crates/bevy_utils/src/futures.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     future::Future,
     pin::Pin,
     task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
@@ -25,7 +25,7 @@ unsafe fn noop(_data: *const ()) {}
 const NOOP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(noop_clone, noop, noop, noop);
 
 fn noop_raw_waker() -> RawWaker {
-    RawWaker::new(std::ptr::null(), &NOOP_WAKER_VTABLE)
+    RawWaker::new(core::ptr::null(), &NOOP_WAKER_VTABLE)
 }
 
 fn noop_waker() -> Waker {

--- a/crates/bevy_utils/src/label.rs
+++ b/crates/bevy_utils/src/label.rs
@@ -1,6 +1,6 @@
 //! Traits used by label implementations
 
-use std::{
+use core::{
     any::Any,
     hash::{Hash, Hasher},
 };

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+
 pub mod prelude {
     pub use crate::default;
 }
@@ -20,8 +24,8 @@ pub use tracing;
 pub use uuid::Uuid;
 
 use ahash::RandomState;
-use hashbrown::hash_map::RawEntryMut;
-use std::{
+use alloc::boxed::Box;
+use core::{
     fmt::Debug,
     future::Future,
     hash::{BuildHasher, Hash, Hasher},
@@ -29,6 +33,7 @@ use std::{
     ops::Deref,
     pin::Pin,
 };
+use hashbrown::hash_map::RawEntryMut;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
@@ -42,7 +47,7 @@ pub type Entry<'a, K, V> = hashbrown::hash_map::Entry<'a, K, V, RandomState>;
 #[derive(Debug, Clone, Default)]
 pub struct FixedState;
 
-impl std::hash::BuildHasher for FixedState {
+impl core::hash::BuildHasher for FixedState {
     type Hasher = AHasher;
 
     #[inline]
@@ -141,7 +146,7 @@ impl<V: PartialEq, H> PartialEq for Hashed<V, H> {
 }
 
 impl<V: Debug, H> Debug for Hashed<V, H> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Hashed")
             .field("hash", &self.hash)
             .field("value", &self.value)

--- a/crates/bevy_utils/src/short_names.rs
+++ b/crates/bevy_utils/src/short_names.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+
 /// Shortens a type name to remove all module paths.
 ///
 /// The short name of a type is its full name as returned by

--- a/crates/bevy_utils/src/short_names.rs
+++ b/crates/bevy_utils/src/short_names.rs
@@ -3,7 +3,7 @@ use alloc::string::String;
 /// Shortens a type name to remove all module paths.
 ///
 /// The short name of a type is its full name as returned by
-/// [`std::any::type_name`], but with the prefix of all paths removed. For
+/// [`core::any::type_name`], but with the prefix of all paths removed. For
 /// example, the short name of `alloc::vec::Vec<core::option::Option<u32>>`
 /// would be `Vec<Option<u32>>`.
 pub fn get_short_name(full_name: &str) -> String {

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -1,5 +1,4 @@
 #[warn(missing_docs)]
-
 extern crate alloc;
 
 mod cursor;

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -1,4 +1,7 @@
 #[warn(missing_docs)]
+
+extern crate alloc;
+
 mod cursor;
 mod event;
 mod raw_handle;

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,3 +1,7 @@
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use alloc::boxed::Box;
+use core::hash::Hash;
 use bevy_math::{DVec2, IVec2, UVec2, Vec2};
 use bevy_reflect::{FromReflect, Reflect};
 use bevy_utils::{tracing::warn, Uuid};

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -102,7 +102,7 @@ impl WindowId {
 }
 
 use crate::CursorIcon;
-use std::fmt;
+use core::fmt;
 
 use crate::raw_handle::RawHandleWrapper;
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,10 +1,10 @@
+use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use alloc::boxed::Box;
-use core::hash::Hash;
 use bevy_math::{DVec2, IVec2, UVec2, Vec2};
 use bevy_reflect::{FromReflect, Reflect};
 use bevy_utils::{tracing::warn, Uuid};
+use core::hash::Hash;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Reflect, FromReflect)]
 #[reflect_value(PartialEq, Hash)]

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -1,9 +1,14 @@
+#![no_std]
+
+extern crate alloc;
+
 mod converters;
 #[cfg(target_arch = "wasm32")]
 mod web_resize;
 mod winit_config;
 mod winit_windows;
 
+use alloc::vec::Vec;
 use converters::convert_cursor_grab_mode;
 pub use winit_config::*;
 pub use winit_windows::*;
@@ -66,7 +71,7 @@ fn change_window(
     mut window_dpi_changed_events: EventWriter<WindowScaleFactorChanged>,
     mut window_close_events: EventWriter<WindowClosed>,
 ) {
-    let mut removed_windows = vec![];
+    let mut removed_windows = Vec::new();
     for bevy_window in windows.iter_mut() {
         let id = bevy_window.id();
         for command in bevy_window.drain_commands() {

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -247,7 +247,7 @@ pub fn get_fitting_videomode(
     }
 
     modes.sort_by(|a, b| {
-        use std::cmp::Ordering::*;
+        use core::cmp::Ordering::*;
         match abs_diff(a.size().width, width).cmp(&abs_diff(b.size().width, width)) {
             Equal => {
                 match abs_diff(a.size().height, height).cmp(&abs_diff(b.size().height, height)) {
@@ -267,7 +267,7 @@ pub fn get_fitting_videomode(
 pub fn get_best_videomode(monitor: &winit::monitor::MonitorHandle) -> winit::monitor::VideoMode {
     let mut modes = monitor.video_modes().collect::<Vec<_>>();
     modes.sort_by(|a, b| {
-        use std::cmp::Ordering::*;
+        use core::cmp::Ordering::*;
         match b.size().width.cmp(&a.size().width) {
             Equal => match b.size().height.cmp(&a.size().height) {
                 Equal => b

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use crate::converters::convert_cursor_grab_mode;
 use bevy_math::{DVec2, IVec2};
 use bevy_utils::HashMap;

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use crate::converters::convert_cursor_grab_mode;
+use alloc::vec::Vec;
 use bevy_math::{DVec2, IVec2};
 use bevy_utils::HashMap;
 use bevy_window::{

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -3,7 +3,7 @@
 //! It doesn't use the [`Material2d`] abstraction, but changes the vertex buffer to include vertex color.
 //! Check out the "mesh2d" example for simpler / higher level 2d meshes.
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::{
     core_pipeline::core_2d::Transparent2d,

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -1,7 +1,7 @@
 //! This example demonstrates the built-in 3d shapes in Bevy.
 //! The scene includes a patterned texture and a rotation for visualizing the normals and UVs.
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::{
     prelude::*,

--- a/examples/3d/fxaa.rs
+++ b/examples/3d/fxaa.rs
@@ -1,6 +1,6 @@
 //! This examples compares MSAA (Multi-Sample Anti-Aliasing) and FXAA (Fast Approximate Anti-Aliasing).
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::{
     core_pipeline::fxaa::{Fxaa, Sensitivity},

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -1,7 +1,7 @@
 //! Illustrates different lights of various types and colors, some static, some moving over
 //! a simple scene.
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::prelude::*;
 

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -1,6 +1,6 @@
 //! Loads and renders a glTF file as a scene.
 
-use std::f32::consts::*;
+use core::f32::consts::*;
 
 use bevy::prelude::*;
 

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -1,6 +1,6 @@
 //! Shows how to render to a texture. Useful for mirrors, UI, or exporting images.
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::{
     core_pipeline::clear_color::ClearColorConfig,

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -1,6 +1,6 @@
 //! Demonstrates how shadow biases affect shadows in a 3d scene.
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::{input::mouse::MouseMotion, prelude::*};
 

--- a/examples/3d/shadow_caster_receiver.rs
+++ b/examples/3d/shadow_caster_receiver.rs
@@ -1,6 +1,6 @@
 //! Demonstrates how to prevent meshes from casting/receiving shadows in a 3d scene.
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::{
     pbr::{NotShadowCaster, NotShadowReceiver},

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -1,6 +1,6 @@
 //! Load a cubemap texture onto a cube like a skybox and cycle through different compressed texture formats
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::{
     asset::LoadState,

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -1,6 +1,6 @@
 //! Renders two cameras to the same window to accomplish "split screen".
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::{
     core_pipeline::clear_color::ClearColorConfig,

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -1,4 +1,4 @@
-use std::f32::consts::*;
+use core::f32::consts::*;
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -1,6 +1,6 @@
 //! This example shows various ways to configure texture materials in 3D.
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::prelude::*;
 

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -1,6 +1,6 @@
 //! Plays animations from a skinned glTF.
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::prelude::*;
 

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -1,6 +1,6 @@
 //! Create and play an animation defined by code that operates on the `Transform` component.
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::prelude::*;
 

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -1,7 +1,7 @@
 //! Skinned mesh example with mesh and joints data defined in code.
 //! Example taken from <https://github.com/KhronosGroup/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_019_SimpleSkin.md>
 
-use std::f32::consts::*;
+use core::f32::consts::*;
 
 use bevy::{
     pbr::AmbientLight,

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -1,7 +1,7 @@
 //! Skinned mesh example with mesh and joints data loaded from a glTF file.
 //! Example taken from <https://github.com/KhronosGroup/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_019_SimpleSkin.md>
 
-use std::f32::consts::*;
+use core::f32::consts::*;
 
 use bevy::{pbr::AmbientLight, prelude::*, render::mesh::skinning::SkinnedMesh};
 

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -5,9 +5,9 @@ use bevy::{
     prelude::*,
     tasks::{AsyncComputeTaskPool, Task},
 };
+use core::time::{Duration, Instant};
 use futures_lite::future;
 use rand::Rng;
-use std::time::{Duration, Instant};
 
 fn main() {
     App::new()

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -2,9 +2,9 @@
 
 use bevy::prelude::*;
 // Using crossbeam_channel instead of std as std `Receiver` is `!Sync`
+use core::time::{Duration, Instant};
 use crossbeam_channel::{bounded, Receiver};
 use rand::Rng;
-use std::time::{Duration, Instant};
 
 fn main() {
     App::new()

--- a/examples/ecs/custom_query_param.rs
+++ b/examples/ecs/custom_query_param.rs
@@ -13,7 +13,7 @@
 //! For more details on the `WorldQuery` derive macro, see the trait documentation.
 
 use bevy::{ecs::query::WorldQuery, prelude::*};
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 fn main() {
     App::new()

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -1,6 +1,6 @@
 //! Creates a hierarchy of parents and children entities.
 
-use std::f32::consts::*;
+use core::f32::consts::*;
 
 use bevy::prelude::*;
 

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -1,6 +1,6 @@
 //! Eat the cakes. Eat them all. An example 3D game.
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::{ecs::schedule::SystemSet, prelude::*};
 use rand::Rng;

--- a/examples/reflection/generic_reflection.rs
+++ b/examples/reflection/generic_reflection.rs
@@ -1,7 +1,7 @@
 //! Demonstrates how reflection is used with generic Rust types.
 
 use bevy::prelude::*;
-use std::any::TypeId;
+use core::any::TypeId;
 
 fn main() {
     App::new()

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -191,7 +191,7 @@ impl SpecializedMeshPipeline for CustomPipeline {
         let mut descriptor = self.mesh_pipeline.specialize(key, layout)?;
         descriptor.vertex.shader = self.shader.clone();
         descriptor.vertex.buffers.push(VertexBufferLayout {
-            array_stride: std::mem::size_of::<InstanceData>() as u64,
+            array_stride: core::mem::size_of::<InstanceData>() as u64,
             step_mode: VertexStepMode::Instance,
             attributes: vec![
                 VertexAttribute {

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -6,7 +6,7 @@
 //! To measure performance realistically, be sure to run this in release mode.
 //! `cargo run --example many_animated_sprites --release`
 
-use std::time::Duration;
+use core::time::Duration;
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -1,7 +1,7 @@
 //! Loads animations from a skinned glTF, spawns many of them, and plays the
 //! animation to stress test skinned meshes.
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -440,7 +440,7 @@ fn gen_tree(depth: u32, branch_width: u32) -> Vec<usize> {
     // the tree is built using this pattern:
     // 0, 0, 0, ... 1, 1, 1, ... 2, 2, 2, ... (count - 1)
     (0..count)
-        .flat_map(|i| std::iter::repeat(i).take(branch_width.try_into().unwrap()))
+        .flat_map(|i| core::iter::repeat(i).take(branch_width.try_into().unwrap()))
         .collect()
 }
 

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -1,6 +1,6 @@
 //! Shows a visualization of gamepad buttons, sticks, and triggers
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::{
     input::gamepad::{GamepadButton, GamepadSettings},

--- a/examples/tools/scene_viewer.rs
+++ b/examples/tools/scene_viewer.rs
@@ -14,7 +14,7 @@ use bevy::{
     scene::InstanceId,
 };
 
-use std::f32::consts::*;
+use core::f32::consts::*;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
 struct CameraControllerCheckSystem;

--- a/examples/transforms/3d_rotation.rs
+++ b/examples/transforms/3d_rotation.rs
@@ -2,7 +2,7 @@
 
 use bevy::prelude::*;
 
-use std::f32::consts::TAU;
+use core::f32::consts::TAU;
 
 // Define a component to designate a rotation speed to an entity.
 #[derive(Component)]

--- a/examples/transforms/scale.rs
+++ b/examples/transforms/scale.rs
@@ -1,6 +1,6 @@
 //! Illustrates how to scale an object in each direction.
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::math::Vec3Swizzles;
 use bevy::prelude::*;

--- a/examples/transforms/transform.rs
+++ b/examples/transforms/transform.rs
@@ -1,6 +1,6 @@
 //! Shows multiple transformations of objects.
 
-use std::f32::consts::PI;
+use core::f32::consts::PI;
 
 use bevy::prelude::*;
 

--- a/tools/spancmp/src/main.rs
+++ b/tools/spancmp/src/main.rs
@@ -1,7 +1,7 @@
 //! helper to extract span stats from a chrome trace file
 //! spec: <https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#heading=h.puwqg050lyuy>
 
-use std::ops::Div;
+use core::ops::Div;
 
 use clap::Parser;
 use parse::read_trace;


### PR DESCRIPTION
# Objective
Partially addresses #6370. Make many of the crates `no_std`.

## Solution
Replace `std` with `core` and `alloc`.

Also sprinkles a few `forbid(unsafe_code)` where it's trivial to add it to a crate.

This does not guarantee all of these crates will build for `no_std` environments. Many still have dependencies with `std` deps.