### PR TITLE
[Merged by Bors] - Derive clone and debug for `AssetPlugin`

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -62,6 +62,7 @@ pub enum AssetStage {
 ///
 /// Assets are typed collections with change tracking, which are added as App Resources. Examples of
 /// assets: textures, sounds, 3d models, maps, scenes
+#[derive(Debug, Clone)]
 pub struct AssetPlugin {
     /// The base folder where assets are loaded from, relative to the executable.
     pub asset_folder: String,


### PR DESCRIPTION
# Objective

- Derive Clone and Debug for `AssetPlugin`
- Make it possible to log asset server settings
- And get an owned instance if wrapping `AssetPlugin` in another plugin. See: https://github.com/johanhelsing/bevy_web_asset/blob/129224ef72a609ce54088f01183f6962fed8780e/src/web_asset_plugin.rs#L45