### PR TITLE
Example (mouse_grab.rs) to use a supported grab method by winit 

### DIFF
--- a/examples/input/mouse_grab.rs
+++ b/examples/input/mouse_grab.rs
@@ -20,7 +20,7 @@ fn grab_mouse(
     let window = windows.primary_mut();
     if mouse.just_pressed(MouseButton::Left) {
         window.set_cursor_visibility(false);
-        window.set_cursor_grab_mode(CursorGrabMode::Locked);
+        window.set_cursor_grab_mode(CursorGrabMode::Confined);
     }
     if key.just_pressed(KeyCode::Escape) {
         window.set_cursor_visibility(true);


### PR DESCRIPTION
# Objective

- Change the example to use a supported grab method by winit 
- Fixes #6590

## Solution

- Changed to `Confined` instead of `Locked` grab mode
