### PR TITLE
[Merged by Bors] - add `Resources::iter` to iterate over all resource IDs

### DIFF
--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -137,6 +137,11 @@ impl Resources {
         self.resources.len()
     }
 
+    /// Iterate over all resources that have been initialized, i.e. given a [`ComponentId`]
+    pub fn iter(&self) -> impl Iterator<Item = (ComponentId, &ResourceData)> {
+        self.resources.iter().map(|(id, data)| (*id, data))
+    }
+
     /// Returns true if there are no resources stored in the [`World`],
     /// false otherwise.
     ///


### PR DESCRIPTION
# Objective

In bevy 0.8 you could list all resources using `world.archetypes().resource().components()`. As far as I can tell the resource archetype has been replaced with the `Resources` storage, and it would be nice if it could be used to iterate over all resource component IDs as well.

## Solution

- add `fn Resources::iter(&self) -> impl Iterator<Item = (ComponentId, &ResourceData)>`
