### PR TITLE
[Merged by Bors] - Removed Mobile Touch event y-axis flip

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -469,7 +469,7 @@ pub fn winit_runner_with(mut app: App) {
 
                         // On a mobile window, the start is from the top while on PC/Linux/OSX from
                         // bottom
-                        if cfg!(target_os = "android") || cfg!(target_os = "ios") {
+                        if cfg!(target_os = "ios") {
                             let window_height = windows.primary().height();
                             location.y = window_height - location.y;
                         }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -465,15 +465,7 @@ pub fn winit_runner_with(mut app: App) {
                         }
                     },
                     WindowEvent::Touch(touch) => {
-                        let mut location = touch.location.to_logical(window.scale_factor());
-
-                        // On a mobile window, the start is from the top while on PC/Linux/OSX from
-                        // bottom
-                        if cfg!(target_os = "ios") {
-                            let window_height = windows.primary().height();
-                            location.y = window_height - location.y;
-                        }
-
+                        let location = touch.location.to_logical(window.scale_factor());
                         world.send_event(converters::convert_touch_input(touch, location));
                     }
                     WindowEvent::ReceivedCharacter(c) => {


### PR DESCRIPTION
# Objective

Fix android touch events being flipped.  Only removed test for android, don't have ios device to test with.  Tested with emulator and physical device.

## Solution

Remove check, no longer needed with coordinate change in 0.9

