### PR TITLE
Add inverse model matrix to Mesh uniform buffer

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -405,7 +405,7 @@ pub fn queue_material_meshes<M: Material>(
                             }
                         };
 
-                        let distance = rangefinder.distance(&mesh_uniform.transform)
+                        let distance = rangefinder.distance(&mesh_uniform.model)
                             + material.properties.depth_bias;
                         match alpha_mode {
                             AlphaMode::Opaque => {

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -108,7 +108,7 @@ impl Plugin for MeshRenderPlugin {
 
 #[derive(Component, ShaderType, Clone)]
 pub struct MeshUniform {
-    pub transform: Mat4,
+    pub model: Mat4,
     pub inverse_model: Mat4,
     pub inverse_transpose_model: Mat4,
     pub flags: u32,
@@ -159,7 +159,7 @@ pub fn extract_meshes(
         }
         let uniform = MeshUniform {
             flags: flags.bits,
-            transform,
+            model: transform,
             inverse_model: transform_inverse,
             inverse_transpose_model: transform_inverse.transpose(),
         };

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -109,6 +109,7 @@ impl Plugin for MeshRenderPlugin {
 #[derive(Component, ShaderType, Clone)]
 pub struct MeshUniform {
     pub transform: Mat4,
+    pub inverse_model: Mat4,
     pub inverse_transpose_model: Mat4,
     pub flags: u32,
 }
@@ -147,6 +148,7 @@ pub fn extract_meshes(
 
     for (entity, _, transform, handle, not_receiver, not_caster) in visible_meshes {
         let transform = transform.compute_matrix();
+        let transform_inverse = transform.inverse();
         let mut flags = if not_receiver.is_some() {
             MeshFlags::empty()
         } else {
@@ -158,7 +160,8 @@ pub fn extract_meshes(
         let uniform = MeshUniform {
             flags: flags.bits,
             transform,
-            inverse_transpose_model: transform.inverse().transpose(),
+            inverse_model: transform_inverse,
+            inverse_transpose_model: transform_inverse.transpose(),
         };
         if not_caster.is_some() {
             not_caster_commands.push((entity, (handle.clone_weak(), uniform, NotShadowCaster)));

--- a/crates/bevy_pbr/src/render/mesh_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_types.wgsl
@@ -2,6 +2,7 @@
 
 struct Mesh {
     model: mat4x4<f32>,
+    inverse_model: mat4x4<f32>,
     inverse_transpose_model: mat4x4<f32>,
     // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
     flags: u32,

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -147,7 +147,7 @@ fn queue_wireframes(
                         entity,
                         pipeline: pipeline_id,
                         draw_function: draw_custom,
-                        distance: rangefinder.distance(&mesh_uniform.transform),
+                        distance: rangefinder.distance(&mesh_uniform.model),
                     });
                 }
             };

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -365,7 +365,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
                             }
                         };
 
-                        let mesh_z = mesh2d_uniform.transform.w_axis.z;
+                        let mesh_z = mesh2d_uniform.model.w_axis.z;
                         transparent_phase.add(Transparent2d {
                             entity: *visible_entity,
                             draw_function: draw_transparent_pbr,

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -111,6 +111,7 @@ impl Plugin for Mesh2dRenderPlugin {
 #[derive(Component, ShaderType, Clone)]
 pub struct Mesh2dUniform {
     pub transform: Mat4,
+    pub inverse_model: Mat4,
     pub inverse_transpose_model: Mat4,
     pub flags: u32,
 }
@@ -135,6 +136,7 @@ pub fn extract_mesh2d(
             continue;
         }
         let transform = transform.compute_matrix();
+        let inverse_transform = transform.inverse();
         values.push((
             entity,
             (
@@ -142,7 +144,8 @@ pub fn extract_mesh2d(
                 Mesh2dUniform {
                     flags: MeshFlags::empty().bits,
                     transform,
-                    inverse_transpose_model: transform.inverse().transpose(),
+                    inverse_model: inverse_transform,
+                    inverse_transpose_model: inverse_transform.transpose(),
                 },
             ),
         ));

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -110,7 +110,7 @@ impl Plugin for Mesh2dRenderPlugin {
 
 #[derive(Component, ShaderType, Clone)]
 pub struct Mesh2dUniform {
-    pub transform: Mat4,
+    pub model: Mat4,
     pub inverse_model: Mat4,
     pub inverse_transpose_model: Mat4,
     pub flags: u32,
@@ -143,7 +143,7 @@ pub fn extract_mesh2d(
                 Mesh2dHandle(handle.0.clone_weak()),
                 Mesh2dUniform {
                     flags: MeshFlags::empty().bits,
-                    transform,
+                    model: transform,
                     inverse_model: inverse_transform,
                     inverse_transpose_model: inverse_transform.transpose(),
                 },

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_types.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_types.wgsl
@@ -2,6 +2,7 @@
 
 struct Mesh2d {
     model: mat4x4<f32>,
+    inverse_model: mat4x4<f32>,
     inverse_transpose_model: mat4x4<f32>,
     // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
     flags: u32,

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -348,7 +348,7 @@ pub fn queue_colored_mesh2d(
                 let pipeline_id =
                     pipelines.specialize(&mut pipeline_cache, &colored_mesh2d_pipeline, mesh2d_key);
 
-                let mesh_z = mesh2d_uniform.transform.w_axis.z;
+                let mesh_z = mesh2d_uniform.model.w_axis.z;
                 transparent_phase.add(Transparent2d {
                     entity: *visible_entity,
                     draw_function: draw_colored_mesh2d,

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -129,7 +129,7 @@ fn queue_custom(
                     entity,
                     pipeline,
                     draw_function: draw_custom,
-                    distance: rangefinder.distance(&mesh_uniform.transform),
+                    distance: rangefinder.distance(&mesh_uniform.model),
                 });
             }
         }


### PR DESCRIPTION
# Objective

- Enable users to convert positions from world to object local space in shaders. This is often useful when f.eg. ray marching.
- Match `unity_WorldToObject` functionality from Unity

## Solution

- Add `model_inverse` field to Mesh and Mesh2d structs
- Compute and assign the variable to MeshUniform and Mesh2dUniform. This is free because we are already computing the inverse model matrix for the `inverse_transpose_model` field.
- Additional change was to rename the field from `transform` to `model` in the MeshUniform and Mesh2dUniform structs, to match structs in shaders and reduce confusion. I can revert it if this is unwanted.

