### PR TITLE
[Merged by Bors] - add span to winit event handler

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -16,7 +16,8 @@ trace = [
     "bevy_ecs/trace",
     "bevy_log/trace",
     "bevy_render?/trace",
-    "bevy_hierarchy/trace"
+    "bevy_hierarchy/trace",
+    "bevy_winit/trace"
 ]
 trace_chrome = [ "bevy_log/tracing-chrome" ]
 trace_tracy = ["bevy_render?/tracing-tracy", "bevy_log/tracing-tracy" ]

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
+trace = []
 wayland = ["winit/wayland"]
 x11 = ["winit/x11"]
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -356,6 +356,8 @@ pub fn winit_runner_with(mut app: App) {
     let event_handler = move |event: Event<()>,
                               event_loop: &EventLoopWindowTarget<()>,
                               control_flow: &mut ControlFlow| {
+        #[cfg(feature = "trace")]
+        let _span = bevy_utils::tracing::info_span!("winit event_handler").entered();
         match event {
             event::Event::NewEvents(start) => {
                 let winit_config = app.world.resource::<WinitSettings>();


### PR DESCRIPTION
# Objective

- Add a span for the winit event handler. I've found this useful in my PR for pipelined rendering and I've seen it come up in a few other contexts now.

![image](https://user-images.githubusercontent.com/2180432/201588888-5dc02063-2c41-471b-8937-a71aeaf174b4.png)

