### PR TITLE
[Merged by Bors] - Note about flex in `Style` docs

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -190,9 +190,6 @@ impl Val {
 /// Describes the style of a UI node
 ///
 /// It uses the [Flexbox](https://cssreference.io/flexbox/) system.
-///
-/// **Note:** Bevy's UI is upside down compared to how Flexbox normally works, to stay consistent with engine paradigms about layouting from
-/// the upper left corner of the display
 #[derive(Component, Clone, PartialEq, Debug, Reflect)]
 #[reflect(Component, Default, PartialEq)]
 pub struct Style {


### PR DESCRIPTION
# Objective 

- Fixes #6606 

## Solution

- Deleted the note Bevy's UI being upside down since it's no longer true as of version 0.9.0
