### PR TITLE
[Merged by Bors] - Respect alignment for zero-sized types stored in the world

### DIFF
--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -549,6 +549,8 @@ mod tests {
 
     #[test]
     fn aligned_zst() {
+        // NOTE: This test is explicitly for uncovering potential UB with miri.
+
         #[derive(Component)]
         #[repr(align(32))]
         struct Zst;

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -50,9 +50,10 @@ impl BlobVec {
         capacity: usize,
     ) -> BlobVec {
         if item_layout.size() == 0 {
+            let align = NonZeroUsize::new(item_layout.align()).expect("alignment must be > 0");
             BlobVec {
                 swap_scratch: NonNull::dangling(),
-                data: NonNull::dangling(),
+                data: bevy_ptr::dangling_with_align(align),
                 capacity: usize::MAX,
                 len: 0,
                 item_layout,

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -2,7 +2,9 @@
 #![no_std]
 #![warn(missing_docs)]
 
-use core::{cell::UnsafeCell, marker::PhantomData, mem::MaybeUninit, ptr::NonNull};
+use core::{
+    cell::UnsafeCell, marker::PhantomData, mem::MaybeUninit, num::NonZeroUsize, ptr::NonNull,
+};
 
 /// Type-erased borrow of some unknown type chosen when constructing this type.
 ///
@@ -241,6 +243,14 @@ impl<'a, T> From<&'a [T]> for ThinSlicePtr<'a, T> {
             _marker: PhantomData,
         }
     }
+}
+
+/// Creates a dangling pointer with specified alignment.
+/// See [`NonNull::dangling`].
+pub fn dangling_with_align(align: NonZeroUsize) -> NonNull<u8> {
+    // SAFETY: The pointer will not be null, since it was created
+    // from the address of a `NonZeroUsize`.
+    unsafe { NonNull::new_unchecked(align.get() as *mut u8) }
 }
 
 mod private {


### PR DESCRIPTION
# Objective

Fixes #6615.

`BlobVec` does not respect alignment for zero-sized types, which results in UB whenever a ZST with alignment other than 1 is used in the world.

## Solution

Add the fn `bevy_ptr::dangling_with_align`.

---

## Changelog

+ Added the function `dangling_with_align` to `bevy_ptr`, which creates a well-aligned dangling pointer to a type whose alignment is not known at compile time.
