### PR TITLE
[Merged by Bors] - Fix get_unchecked_manual using archetype index instead of table row.

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -709,7 +709,7 @@ mod tests {
 
     #[test]
     fn query_get_works_across_sparse_removal() {
-        // Regresssion test for: https://github.com/bevyengine/bevy/issues/6623
+        // Regression test for: https://github.com/bevyengine/bevy/issues/6623
         let mut world = World::new();
         let a = world.spawn((TableStored("abc"), SparseStored(123))).id();
         let b = world.spawn((TableStored("def"), SparseStored(456))).id();

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -708,6 +708,29 @@ mod tests {
     }
 
     #[test]
+    fn query_get_works_across_sparse_removal() {
+        // Regresssion test for: https://github.com/bevyengine/bevy/issues/6623
+        let mut world = World::new();
+        let a = world.spawn((TableStored("abc"), SparseStored(123))).id();
+        let b = world.spawn((TableStored("def"), SparseStored(456))).id();
+        let c = world
+            .spawn((TableStored("ghi"), SparseStored(789), B(1)))
+            .id();
+
+        let mut query = world.query::<&TableStored>();
+        assert_eq!(query.get(&world, a).unwrap(), &TableStored("abc"));
+        assert_eq!(query.get(&world, b).unwrap(), &TableStored("def"));
+        assert_eq!(query.get(&world, c).unwrap(), &TableStored("ghi"));
+
+        world.entity_mut(b).remove::<SparseStored>();
+        world.entity_mut(c).remove::<SparseStored>();
+
+        assert_eq!(query.get(&world, a).unwrap(), &TableStored("abc"));
+        assert_eq!(query.get(&world, b).unwrap(), &TableStored("def"));
+        assert_eq!(query.get(&world, c).unwrap(), &TableStored("ghi"));
+    }
+
+    #[test]
     fn remove_tracking() {
         let mut world = World::new();
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -418,6 +418,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         let mut fetch = Q::init_fetch(world, &self.fetch_state, last_change_tick, change_tick);
         let mut filter = F::init_fetch(world, &self.filter_state, last_change_tick, change_tick);
 
+        let table_row = archetype.entity_table_row(location.index);
         let table = world
             .storages()
             .tables
@@ -426,8 +427,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         Q::set_archetype(&mut fetch, &self.fetch_state, archetype, table);
         F::set_archetype(&mut filter, &self.filter_state, archetype, table);
 
-        if F::filter_fetch(&mut filter, entity, location.index) {
-            Ok(Q::fetch(&mut fetch, entity, location.index))
+        if F::filter_fetch(&mut filter, entity, table_row) {
+            Ok(Q::fetch(&mut fetch, entity, table_row))
         } else {
             Err(QueryEntityError::QueryDoesNotMatch(entity))
         }


### PR DESCRIPTION
# Objective
Fix #6623.

## Solution
Use the right table row instead of the `EntityLocation` archetype index.