### PR TITLE
[Merged by Bors] - wasm: pad globals uniform also in 2d

### DIFF
--- a/crates/bevy_sprite/src/mesh2d/mesh2d_view_types.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_view_types.wgsl
@@ -21,4 +21,8 @@ struct Globals {
     // Frame count since the start of the app.
     // It wraps to zero when it reaches the maximum value of a u32.
     frame_count: u32,
+#ifdef SIXTEEN_BYTE_ALIGNMENT
+    // WebGL2 structs must be 16 byte aligned.
+    _wasm_padding: f32
+#endif
 }


### PR DESCRIPTION
# Objective

- Fix a panic in wasm when using globals in a shader

## Solution

- Similar to #6460 
