### PR TITLE
[Merged by Bors] - Update old docs from Timer

### DIFF
--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -155,7 +155,7 @@ impl Timer {
         self.duration = duration;
     }
 
-    /// Returns `true` if the timer is repeating.
+    /// Returns the mode of the timer.
     ///
     /// # Examples
     /// ```
@@ -168,7 +168,7 @@ impl Timer {
         self.mode
     }
 
-    /// Sets whether the timer is repeating or not.
+    /// Sets the mode of the timer.
     ///
     /// # Examples
     /// ```

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -177,6 +177,7 @@ impl Timer {
     /// timer.set_mode(TimerMode::Once);
     /// assert_eq!(timer.mode(), TimerMode::Once);
     /// ```
+    #[doc(alias = "repeating")]
     #[inline]
     pub fn set_mode(&mut self, mode: TimerMode) {
         if self.mode != TimerMode::Repeating && mode == TimerMode::Repeating && self.finished {


### PR DESCRIPTION
When I was upgrading to 0.9 noticed there were some changes to the timer, mainly the `TimerMode`.  When switching from the old `is_repeating()`  and `set_repeating()` to the new `mode()` and `set_mode()` noticed the docs still had the old description.
