### PR TITLE
Use 64 bit for world and system tick index

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -27,6 +27,7 @@ fixedbitset = "0.4"
 fxhash = "0.2"
 downcast-rs = "1.2"
 serde = { version = "1", features = ["derive"] }
+cfg-if = "1.0"
 
 [dev-dependencies]
 rand = "0.8"

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -224,8 +224,8 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
                 unsafe fn init_fetch<'__w>(
                     _world: &'__w #path::world::World,
                     state: &Self::State,
-                    _last_change_tick: u32,
-                    _change_tick: u32
+                    _last_change_tick: #path::change_detection::Tick,
+                    _change_tick: #path::change_detection::Tick
                 ) -> <Self as #path::query::WorldQuery>::Fetch<'__w> {
                     #fetch_struct_name {
                         #(#field_idents:

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -292,7 +292,7 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
                     state: &'s mut Self,
                     system_meta: &SystemMeta,
                     world: &'w World,
-                    change_tick: u32,
+                    change_tick: Tick,
                 ) -> Self::Item {
                     ParamSet {
                         param_states: &mut state.0,
@@ -437,7 +437,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                     state: &'s mut Self,
                     system_meta: &#path::system::SystemMeta,
                     world: &'w #path::world::World,
-                    change_tick: u32,
+                    change_tick: #path::change_detection::Tick,
                 ) -> Self::Item {
                     #struct_name {
                         #(#fields: <<#field_types as #path::system::SystemParam>::Fetch as #path::system::SystemParamFetch>::get_param(&mut state.state.#field_indices, system_meta, world, change_tick),)*

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -68,7 +68,7 @@ impl Tick {
 /// When [`SmallTick`] value gets too old it is periodically updated to
 /// [`TickCounter::current() - SMALL_TICK_AGE_THRESHOLD`].
 ///
-/// This way [`SmallTick::is_later`] with target older
+/// This way [`SmallTick::is_later_than`] with target older
 /// than `SMALL_TICK_AGE_THRESHOLD` may return false positive.
 /// Which is acceptable tradeoff given that too old targets should
 /// not occur outside some edge cases.
@@ -144,12 +144,12 @@ impl SmallTick {
 /// Yields [`Tick`] values.
 ///
 /// On system without 64-bit atomics requires calls to
-/// [`TickCounter::maintenance`] to keep 32-bit atomic value from overflowing.
+/// [`TickCounter::maintain`] to keep 32-bit atomic value from overflowing.
 /// If overflow do occur then one of the calls to [`TickCounter::next`] would panic
 /// and successful calls to [`TickCounter::next`] and [`TickCounter::current`] would return
 /// out-of-order [`Tick`] values.
 /// Make sure to configure your code to either require `cfg(target_has_atomic = "64")`
-/// or arrange calls to [`TickCounter::maintenance`] frequently enough.
+/// or arrange calls to [`TickCounter::maintain`] frequently enough.
 pub struct TickCounter {
     #[cfg(not(target_has_atomic = "64"))]
     offset: NonZeroU64,

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1,7 +1,7 @@
 //! Types for declaring and storing [`Component`]s.
 
 use crate::{
-    change_detection::MAX_CHANGE_AGE,
+    change_detection::{SmallTick, Tick},
     storage::{SparseSetIndex, Storages},
     system::Resource,
 };
@@ -518,67 +518,11 @@ impl Components {
     }
 }
 
-/// Used to track changes in state between system runs, e.g. components being added or accessed mutably.
-#[derive(Copy, Clone, Debug)]
-pub struct Tick {
-    pub(crate) tick: u32,
-}
-
-impl Tick {
-    pub const fn new(tick: u32) -> Self {
-        Self { tick }
-    }
-
-    #[inline]
-    /// Returns `true` if the tick is older than the system last's run.
-    pub fn is_older_than(&self, last_change_tick: u32, change_tick: u32) -> bool {
-        // This works even with wraparound because the world tick (`change_tick`) is always "newer" than
-        // `last_change_tick` and `self.tick`, and we scan periodically to clamp `ComponentTicks` values
-        // so they never get older than `u32::MAX` (the difference would overflow).
-        //
-        // The clamp here ensures determinism (since scans could differ between app runs).
-        let ticks_since_insert = change_tick.wrapping_sub(self.tick).min(MAX_CHANGE_AGE);
-        let ticks_since_system = change_tick
-            .wrapping_sub(last_change_tick)
-            .min(MAX_CHANGE_AGE);
-
-        ticks_since_system > ticks_since_insert
-    }
-
-    pub(crate) fn check_tick(&mut self, change_tick: u32) {
-        let age = change_tick.wrapping_sub(self.tick);
-        // This comparison assumes that `age` has not overflowed `u32::MAX` before, which will be true
-        // so long as this check always runs before that can happen.
-        if age > MAX_CHANGE_AGE {
-            self.tick = change_tick.wrapping_sub(MAX_CHANGE_AGE);
-        }
-    }
-
-    /// Manually sets the change tick.
-    ///
-    /// This is normally done automatically via the [`DerefMut`](std::ops::DerefMut) implementation
-    /// on [`Mut<T>`](crate::change_detection::Mut), [`ResMut<T>`](crate::change_detection::ResMut), etc.
-    /// However, components and resources that make use of interior mutability might require manual updates.
-    ///
-    /// # Example
-    /// ```rust,no_run
-    /// # use bevy_ecs::{world::World, component::ComponentTicks};
-    /// let world: World = unimplemented!();
-    /// let component_ticks: ComponentTicks = unimplemented!();
-    ///
-    /// component_ticks.set_changed(world.read_change_tick());
-    /// ```
-    #[inline]
-    pub fn set_changed(&mut self, change_tick: u32) {
-        self.tick = change_tick;
-    }
-}
-
 /// Wrapper around [`Tick`]s for a single component
 #[derive(Copy, Clone, Debug)]
 pub struct TickCells<'a> {
-    pub added: &'a UnsafeCell<Tick>,
-    pub changed: &'a UnsafeCell<Tick>,
+    pub added: &'a UnsafeCell<SmallTick>,
+    pub changed: &'a UnsafeCell<SmallTick>,
 }
 
 impl<'a> TickCells<'a> {
@@ -596,27 +540,27 @@ impl<'a> TickCells<'a> {
 /// Records when a component was added and when it was last mutably dereferenced (or added).
 #[derive(Copy, Clone, Debug)]
 pub struct ComponentTicks {
-    pub(crate) added: Tick,
-    pub(crate) changed: Tick,
+    pub(crate) added: SmallTick,
+    pub(crate) changed: SmallTick,
 }
 
 impl ComponentTicks {
     #[inline]
     /// Returns `true` if the component was added after the system last ran.
-    pub fn is_added(&self, last_change_tick: u32, change_tick: u32) -> bool {
-        self.added.is_older_than(last_change_tick, change_tick)
+    pub fn is_added(&self, last_change_tick: Tick, change_tick: Tick) -> bool {
+        self.added.is_newer_than(last_change_tick, change_tick)
     }
 
     #[inline]
     /// Returns `true` if the component was added or mutably dereferenced after the system last ran.
-    pub fn is_changed(&self, last_change_tick: u32, change_tick: u32) -> bool {
-        self.changed.is_older_than(last_change_tick, change_tick)
+    pub fn is_changed(&self, last_change_tick: Tick, change_tick: Tick) -> bool {
+        self.changed.is_newer_than(last_change_tick, change_tick)
     }
 
-    pub(crate) fn new(change_tick: u32) -> Self {
+    pub(crate) fn new(change_tick: SmallTick) -> Self {
         Self {
-            added: Tick::new(change_tick),
-            changed: Tick::new(change_tick),
+            added: change_tick,
+            changed: change_tick,
         }
     }
 
@@ -635,7 +579,7 @@ impl ComponentTicks {
     /// component_ticks.set_changed(world.read_change_tick());
     /// ```
     #[inline]
-    pub fn set_changed(&mut self, change_tick: u32) {
+    pub fn set_changed(&mut self, change_tick: Tick) {
         self.changed.set_changed(change_tick);
     }
 }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -28,7 +28,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
         bundle::Bundle,
-        change_detection::DetectChanges,
+        change_detection::{DetectChanges, Tick},
         component::Component,
         entity::Entity,
         event::{EventReader, EventWriter, Events},

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -1,5 +1,6 @@
 use crate::{
     archetype::{ArchetypeEntity, ArchetypeId, Archetypes},
+    change_detection::Tick,
     entity::{Entities, Entity},
     prelude::World,
     query::{ArchetypeFilter, DebugCheckedUnwrap, QueryState, WorldQuery},
@@ -29,8 +30,8 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> QueryIter<'w, 's, Q, F> {
     pub(crate) unsafe fn new(
         world: &'w World,
         query_state: &'s QueryState<Q, F>,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) -> Self {
         QueryIter {
             query_state,
@@ -98,8 +99,8 @@ where
         world: &'w World,
         query_state: &'s QueryState<Q, F>,
         entity_list: EntityList,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) -> QueryManyIter<'w, 's, Q, F, I> {
         let fetch = Q::init_fetch(
             world,
@@ -299,8 +300,8 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery, const K: usize>
     pub(crate) unsafe fn new(
         world: &'w World,
         query_state: &'s QueryState<Q, F>,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) -> Self {
         // Initialize array with cursors.
         // There is no FromIterator on arrays, so instead initialize it manually with MaybeUninit
@@ -497,8 +498,8 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> QueryIterationCursor<'w, 's, 
     unsafe fn init_empty(
         world: &'w World,
         query_state: &'s QueryState<Q, F>,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) -> Self {
         QueryIterationCursor {
             table_id_iter: [].iter(),
@@ -510,8 +511,8 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> QueryIterationCursor<'w, 's, 
     unsafe fn init(
         world: &'w World,
         query_state: &'s QueryState<Q, F>,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) -> Self {
         let fetch = Q::init_fetch(
             world,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -529,7 +529,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         // SAFETY: query has unique world access
         unsafe {
             self.update_archetypes(world);
-            self.iter_unchecked_manual(world, world.last_change_tick(), world.read_change_tick())
+            let change_tick = world.change_tick();
+            self.iter_unchecked_manual(world, world.last_change_tick(), change_tick)
         }
     }
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1,5 +1,6 @@
 use crate::{
     archetype::{Archetype, ArchetypeComponentId, ArchetypeGeneration, ArchetypeId},
+    change_detection::Tick,
     component::ComponentId,
     entity::Entity,
     prelude::FromWorld,
@@ -129,7 +130,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
 
     /// Checks if the query is empty for the given [`World`], where the last change and current tick are given.
     #[inline]
-    pub fn is_empty(&self, world: &World, last_change_tick: u32, change_tick: u32) -> bool {
+    pub fn is_empty(&self, world: &World, last_change_tick: Tick, change_tick: Tick) -> bool {
         // SAFETY: NopFetch does not access any members while &self ensures no one has exclusive access
         unsafe {
             self.as_nop()
@@ -398,8 +399,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         &self,
         world: &'w World,
         entity: Entity,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) -> Result<Q::Item<'w>, QueryEntityError> {
         let location = world
             .entities
@@ -445,8 +446,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         &self,
         world: &'w World,
         entities: [Entity; N],
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) -> Result<[ROQueryItem<'w, Q>; N], QueryEntityError> {
         let mut values = [(); N].map(|_| MaybeUninit::uninit());
 
@@ -480,8 +481,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         &self,
         world: &'w World,
         entities: [Entity; N],
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) -> Result<[Q::Item<'w>; N], QueryEntityError> {
         // Verify that all entities are unique
         for i in 0..N {
@@ -725,8 +726,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     pub(crate) unsafe fn iter_unchecked_manual<'w, 's>(
         &'s self,
         world: &'w World,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) -> QueryIter<'w, 's, Q, F> {
         QueryIter::new(world, self, last_change_tick, change_tick)
     }
@@ -746,8 +747,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         &'s self,
         entities: EntityList,
         world: &'w World,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) -> QueryManyIter<'w, 's, Q, F, EntityList::IntoIter>
     where
         EntityList::Item: Borrow<Entity>,
@@ -769,8 +770,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     pub(crate) unsafe fn iter_combinations_unchecked_manual<'w, 's, const K: usize>(
         &'s self,
         world: &'w World,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) -> QueryCombinationIter<'w, 's, Q, F, K> {
         QueryCombinationIter::new(world, self, last_change_tick, change_tick)
     }
@@ -929,8 +930,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         &self,
         world: &'w World,
         mut func: FN,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) {
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
         // QueryIter, QueryIterationCursor, QueryManyIter, QueryCombinationIter, QueryState::for_each_unchecked_manual, QueryState::par_for_each_unchecked_manual
@@ -1003,8 +1004,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         world: &'w World,
         batch_size: usize,
         func: FN,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) {
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
         // QueryIter, QueryIterationCursor, QueryManyIter, QueryCombinationIter, QueryState::for_each_unchecked_manual, QueryState::par_for_each_unchecked_manual
@@ -1237,8 +1238,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     pub unsafe fn get_single_unchecked_manual<'w>(
         &self,
         world: &'w World,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) -> Result<Q::Item<'w>, QuerySingleError> {
         let mut query = self.iter_unchecked_manual(world, last_change_tick, change_tick);
         let first = query.next();

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -518,28 +518,7 @@ impl SystemStage {
     /// During each scan, any change ticks older than [`MAX_CHANGE_AGE`](crate::change_detection::MAX_CHANGE_AGE)
     /// are clamped to that age. This prevents false positives from appearing due to overflow.
     fn check_change_ticks(&mut self, world: &mut World) {
-        let change_tick = world.change_tick();
-        let ticks_since_last_check = change_tick.wrapping_sub(self.last_tick_check);
-
-        if ticks_since_last_check >= CHECK_TICK_THRESHOLD {
-            // Check all system change ticks.
-            for exclusive_system in &mut self.exclusive_at_start {
-                exclusive_system.system_mut().check_change_tick(change_tick);
-            }
-            for exclusive_system in &mut self.exclusive_before_commands {
-                exclusive_system.system_mut().check_change_tick(change_tick);
-            }
-            for exclusive_system in &mut self.exclusive_at_end {
-                exclusive_system.system_mut().check_change_tick(change_tick);
-            }
-            for parallel_system in &mut self.parallel {
-                parallel_system.system_mut().check_change_tick(change_tick);
-            }
-
-            // Check all component change ticks.
-            world.check_change_ticks();
-            self.last_tick_check = change_tick;
-        }
+        world.check_change_ticks();
     }
 
     /// Sorts run criteria and populates resolved input-criteria for piping.

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -1,4 +1,5 @@
 use crate::archetype::ArchetypeComponentId;
+use crate::change_detection::{SmallTick, Tick};
 use crate::component::{ComponentId, ComponentTicks, Components, TickCells};
 use crate::storage::{Column, SparseSet};
 use bevy_ptr::{OwningPtr, Ptr, UnsafeCellDeref};
@@ -52,7 +53,7 @@ impl ResourceData {
     ///
     /// [`World::validate_non_send_access_untyped`]: crate::world::World::validate_non_send_access_untyped
     #[inline]
-    pub(crate) unsafe fn insert(&mut self, value: OwningPtr<'_>, change_tick: u32) {
+    pub(crate) unsafe fn insert(&mut self, value: OwningPtr<'_>, change_tick: SmallTick) {
         if self.is_present() {
             self.column.replace(0, value, change_tick);
         } else {
@@ -176,7 +177,7 @@ impl Resources {
         })
     }
 
-    pub(crate) fn check_change_ticks(&mut self, change_tick: u32) {
+    pub(crate) fn check_change_ticks(&mut self, change_tick: Tick) {
         for info in self.resources.values_mut() {
             info.column.check_change_ticks(change_tick);
         }

--- a/crates/bevy_ecs/src/system/commands/parallel_scope.rs
+++ b/crates/bevy_ecs/src/system/commands/parallel_scope.rs
@@ -3,6 +3,7 @@ use std::cell::Cell;
 use thread_local::ThreadLocal;
 
 use crate::{
+    change_detection::Tick,
     entity::Entities,
     prelude::World,
     system::{SystemParam, SystemParamFetch, SystemParamState},
@@ -59,7 +60,7 @@ impl<'w, 's> SystemParamFetch<'w, 's> for ParallelCommandsState {
         state: &'s mut Self,
         _: &crate::system::SystemMeta,
         world: &'w World,
-        _: u32,
+        _: Tick,
     ) -> Self::Item {
         ParallelCommands {
             state,

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -1,13 +1,12 @@
 use crate::{
     archetype::ArchetypeComponentId,
-    change_detection::MAX_CHANGE_AGE,
+    change_detection::Tick,
     component::ComponentId,
     query::Access,
     schedule::{SystemLabel, SystemLabelId},
     system::{
-        check_system_change_tick, AsSystemLabel, ExclusiveSystemParam, ExclusiveSystemParamFetch,
-        ExclusiveSystemParamItem, ExclusiveSystemParamState, IntoSystem, System, SystemMeta,
-        SystemTypeIdLabel,
+        AsSystemLabel, ExclusiveSystemParam, ExclusiveSystemParamFetch, ExclusiveSystemParamItem,
+        ExclusiveSystemParamState, IntoSystem, System, SystemMeta, SystemTypeIdLabel,
     },
     world::{World, WorldId},
 };
@@ -101,9 +100,8 @@ where
         );
         self.func.run(world, params);
 
-        let change_tick = world.change_tick.get_mut();
-        self.system_meta.last_change_tick = *change_tick;
-        *change_tick += 1;
+        self.system_meta.last_change_tick = world.change_tick.current_mut();
+        world.change_tick.next();
         world.last_change_tick = saved_last_tick;
     }
 
@@ -112,11 +110,11 @@ where
         true
     }
 
-    fn get_last_change_tick(&self) -> u32 {
+    fn get_last_change_tick(&self) -> Tick {
         self.system_meta.last_change_tick
     }
 
-    fn set_last_change_tick(&mut self, last_change_tick: u32) {
+    fn set_last_change_tick(&mut self, last_change_tick: Tick) {
         self.system_meta.last_change_tick = last_change_tick;
     }
 
@@ -129,7 +127,7 @@ where
     #[inline]
     fn initialize(&mut self, world: &mut World) {
         self.world_id = Some(world.id());
-        self.system_meta.last_change_tick = world.change_tick().wrapping_sub(MAX_CHANGE_AGE);
+        self.system_meta.last_change_tick = Tick::new();
         self.param_state = Some(<Param::Fetch as ExclusiveSystemParamState>::init(
             world,
             &mut self.system_meta,
@@ -138,14 +136,6 @@ where
 
     fn update_archetype_component_access(&mut self, _world: &World) {}
 
-    #[inline]
-    fn check_change_tick(&mut self, change_tick: u32) {
-        check_system_change_tick(
-            &mut self.system_meta.last_change_tick,
-            change_tick,
-            self.system_meta.name.as_ref(),
-        );
-    }
     fn default_labels(&self) -> Vec<SystemLabelId> {
         vec![self.func.as_system_label().as_label()]
     }

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -1,13 +1,13 @@
 use crate::{
     archetype::{ArchetypeComponentId, ArchetypeGeneration, ArchetypeId},
-    change_detection::MAX_CHANGE_AGE,
+    change_detection::Tick,
     component::ComponentId,
     prelude::FromWorld,
     query::{Access, FilteredAccessSet},
     schedule::{SystemLabel, SystemLabelId},
     system::{
-        check_system_change_tick, ReadOnlySystemParamFetch, System, SystemParam, SystemParamFetch,
-        SystemParamItem, SystemParamState,
+        ReadOnlySystemParamFetch, System, SystemParam, SystemParamFetch, SystemParamItem,
+        SystemParamState,
     },
     world::{World, WorldId},
 };
@@ -23,7 +23,7 @@ pub struct SystemMeta {
     // NOTE: this must be kept private. making a SystemMeta non-send is irreversible to prevent
     // SystemParams from overriding each other
     is_send: bool,
-    pub(crate) last_change_tick: u32,
+    pub(crate) last_change_tick: Tick,
 }
 
 impl SystemMeta {
@@ -33,7 +33,7 @@ impl SystemMeta {
             archetype_component_access: Access::default(),
             component_access_set: FilteredAccessSet::default(),
             is_send: true,
-            last_change_tick: 0,
+            last_change_tick: Tick::new(),
         }
     }
 
@@ -143,7 +143,6 @@ pub struct SystemState<Param: SystemParam + 'static> {
 impl<Param: SystemParam> SystemState<Param> {
     pub fn new(world: &mut World) -> Self {
         let mut meta = SystemMeta::new::<Param>();
-        meta.last_change_tick = world.change_tick().wrapping_sub(MAX_CHANGE_AGE);
         let param_state = <Param::Fetch as SystemParamState>::init(world, &mut meta);
         Self {
             meta,
@@ -411,11 +410,11 @@ where
         out
     }
 
-    fn get_last_change_tick(&self) -> u32 {
+    fn get_last_change_tick(&self) -> Tick {
         self.system_meta.last_change_tick
     }
 
-    fn set_last_change_tick(&mut self, last_change_tick: u32) {
+    fn set_last_change_tick(&mut self, last_change_tick: Tick) {
         self.system_meta.last_change_tick = last_change_tick;
     }
 
@@ -428,7 +427,7 @@ where
     #[inline]
     fn initialize(&mut self, world: &mut World) {
         self.world_id = Some(world.id());
-        self.system_meta.last_change_tick = world.change_tick().wrapping_sub(MAX_CHANGE_AGE);
+        self.system_meta.last_change_tick = Tick::new();
         self.param_state = Some(<Param::Fetch as SystemParamState>::init(
             world,
             &mut self.system_meta,
@@ -450,14 +449,6 @@ where
         }
     }
 
-    #[inline]
-    fn check_change_tick(&mut self, change_tick: u32) {
-        check_system_change_tick(
-            &mut self.system_meta.last_change_tick,
-            change_tick,
-            self.system_meta.name.as_ref(),
-        );
-    }
     fn default_labels(&self) -> Vec<SystemLabelId> {
         vec![self.func.as_system_label().as_label()]
     }

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1,4 +1,5 @@
 use crate::{
+    change_detection::Tick,
     component::Component,
     entity::Entity,
     query::{
@@ -276,8 +277,8 @@ use std::{any::TypeId, borrow::Borrow, fmt::Debug};
 pub struct Query<'world, 'state, Q: WorldQuery, F: ReadOnlyWorldQuery = ()> {
     pub(crate) world: &'world World,
     pub(crate) state: &'state QueryState<Q, F>,
-    pub(crate) last_change_tick: u32,
-    pub(crate) change_tick: u32,
+    pub(crate) last_change_tick: Tick,
+    pub(crate) change_tick: Tick,
     // SAFETY: This is used to ensure that `get_component_mut::<C>` properly fails when a Query writes C
     // and gets converted to a read-only query using `to_readonly`. Without checking this, `get_component_mut` relies on
     // QueryState's archetype_component_access, which will continue allowing write access to C after being cast to
@@ -303,8 +304,8 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     pub(crate) unsafe fn new(
         world: &'w World,
         state: &'s QueryState<Q, F>,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) -> Self {
         Self {
             force_read_only_component_access: false,

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -1,9 +1,8 @@
-use bevy_utils::tracing::warn;
 use core::fmt::Debug;
 
 use crate::{
-    archetype::ArchetypeComponentId, change_detection::MAX_CHANGE_AGE, component::ComponentId,
-    query::Access, schedule::SystemLabelId, world::World,
+    archetype::ArchetypeComponentId, change_detection::Tick, component::ComponentId, query::Access,
+    schedule::SystemLabelId, world::World,
 };
 use std::borrow::Cow;
 
@@ -59,43 +58,23 @@ pub trait System: Send + Sync + 'static {
     fn initialize(&mut self, _world: &mut World);
     /// Update the system's archetype component [`Access`].
     fn update_archetype_component_access(&mut self, world: &World);
-    fn check_change_tick(&mut self, change_tick: u32);
+
     /// The default labels for the system
     fn default_labels(&self) -> Vec<SystemLabelId> {
         Vec::new()
     }
     /// Gets the system's last change tick
-    fn get_last_change_tick(&self) -> u32;
+    fn get_last_change_tick(&self) -> Tick;
     /// Sets the system's last change tick
     /// # Warning
     /// This is a complex and error-prone operation, that can have unexpected consequences on any system relying on this code.
     /// However, it can be an essential escape hatch when, for example,
     /// you are trying to synchronize representations using change detection and need to avoid infinite recursion.
-    fn set_last_change_tick(&mut self, last_change_tick: u32);
+    fn set_last_change_tick(&mut self, last_change_tick: Tick);
 }
 
 /// A convenience type alias for a boxed [`System`] trait object.
 pub type BoxedSystem<In = (), Out = ()> = Box<dyn System<In = In, Out = Out>>;
-
-pub(crate) fn check_system_change_tick(
-    last_change_tick: &mut u32,
-    change_tick: u32,
-    system_name: &str,
-) {
-    let age = change_tick.wrapping_sub(*last_change_tick);
-    // This comparison assumes that `age` has not overflowed `u32::MAX` before, which will be true
-    // so long as this check always runs before that can happen.
-    if age > MAX_CHANGE_AGE {
-        warn!(
-            "System '{}' has not run for {} ticks. \
-            Changes older than {} ticks will not be detected.",
-            system_name,
-            age,
-            MAX_CHANGE_AGE - 1,
-        );
-        *last_change_tick = change_tick.wrapping_sub(MAX_CHANGE_AGE);
-    }
-}
 
 impl Debug for dyn System<In = (), Out = ()> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/bevy_ecs/src/system/system_piping.rs
+++ b/crates/bevy_ecs/src/system/system_piping.rs
@@ -1,5 +1,6 @@
 use crate::{
     archetype::ArchetypeComponentId,
+    change_detection::Tick,
     component::ComponentId,
     query::Access,
     system::{IntoSystem, System},
@@ -113,16 +114,11 @@ impl<SystemA: System, SystemB: System<In = SystemA::Out>> System for PipeSystem<
             .extend(self.system_b.archetype_component_access());
     }
 
-    fn check_change_tick(&mut self, change_tick: u32) {
-        self.system_a.check_change_tick(change_tick);
-        self.system_b.check_change_tick(change_tick);
-    }
-
-    fn get_last_change_tick(&self) -> u32 {
+    fn get_last_change_tick(&self) -> Tick {
         self.system_a.get_last_change_tick()
     }
 
-    fn set_last_change_tick(&mut self, last_change_tick: u32) {
+    fn set_last_change_tick(&mut self, last_change_tick: Tick) {
         self.system_a.set_last_change_tick(last_change_tick);
         self.system_b.set_last_change_tick(last_change_tick);
     }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1,7 +1,7 @@
 use crate::{
     archetype::{Archetype, ArchetypeId, Archetypes},
     bundle::{Bundle, BundleInfo},
-    change_detection::{MutUntyped, Ticks},
+    change_detection::{MutUntyped, Tick, Ticks},
     component::{Component, ComponentId, ComponentTicks, Components, StorageType, TickCells},
     entity::{Entities, Entity, EntityLocation},
     storage::{SparseSet, Storages},
@@ -95,8 +95,8 @@ impl<'w> EntityRef<'w> {
     #[inline]
     pub unsafe fn get_unchecked_mut<T: Component>(
         &self,
-        last_change_tick: u32,
-        change_tick: u32,
+        last_change_tick: Tick,
+        change_tick: Tick,
     ) -> Option<Mut<'w, T>> {
         get_component_and_ticks_with_type(self.world, TypeId::of::<T>(), self.entity, self.location)
             .map(|(value, ticks)| Mut {
@@ -241,7 +241,7 @@ impl<'w> EntityMut<'w> {
     ///
     /// This will overwrite any previous value(s) of the same component type.
     pub fn insert<T: Bundle>(&mut self, bundle: T) -> &mut Self {
-        let change_tick = self.world.change_tick();
+        let change_tick = self.world.change_tick().into();
         let bundle_info = self
             .world
             .bundles

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -21,10 +21,7 @@ use crate::{
 };
 use bevy_ptr::{OwningPtr, Ptr};
 use bevy_utils::tracing::warn;
-use std::{
-    any::TypeId,
-    fmt,
-};
+use std::{any::TypeId, fmt};
 mod identifier;
 
 pub use identifier::WorldId;

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -37,7 +37,7 @@ where
             &mut world.archetypes,
             &mut world.components,
             &mut world.storages,
-            *world.change_tick.get_mut(),
+            world.change_tick.current_mut().into(),
         );
         spawner.reserve_storage(length);
 

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -84,7 +84,7 @@ where
         state: &'s mut Self,
         system_meta: &SystemMeta,
         world: &'w World,
-        change_tick: u32,
+        change_tick: Tick,
     ) -> Self::Item {
         let main_world = ResState::<MainWorld>::get_param(
             &mut state.main_world_state,

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -1,6 +1,7 @@
 use crate::Time;
 use bevy_ecs::{
     archetype::ArchetypeComponentId,
+    change_detection::Tick,
     component::ComponentId,
     query::Access,
     schedule::ShouldRun,
@@ -225,15 +226,11 @@ impl System for FixedTimestep {
             .update_archetype_component_access(world);
     }
 
-    fn check_change_tick(&mut self, change_tick: u32) {
-        self.internal_system.check_change_tick(change_tick);
-    }
-
-    fn get_last_change_tick(&self) -> u32 {
+    fn get_last_change_tick(&self) -> Tick {
         self.internal_system.get_last_change_tick()
     }
 
-    fn set_last_change_tick(&mut self, last_change_tick: u32) {
+    fn set_last_change_tick(&mut self, last_change_tick: Tick) {
         self.internal_system.set_last_change_tick(last_change_tick);
     }
 }


### PR DESCRIPTION
# Objective

- Use strongly typed ticks with 64 bit integer value within.
- Avoid tick counter overflow
- Continue using 32 bit tick id in components. Keep existing system that prevents component age to overflow 32 bit.

---

## Changelog

- Tick values are now strongly typed as `Tick` and `SmallTick`.
- `Tick` now contains `NonZeroU64` and never overflow in any reasonable time.
- `SmallTick` are used to store tick index when component addition and last modification. It contains `u32` with lower 32 bits of `Tick`s 64 bit value.
- `World` now uses `TickCounter` that implements tick incrementing and necessary bookkeeping.

## Migration Guide

- Custom `System` implementations have to switch to strongly typed `Tick` values and remove few methods.

## Pick one

This is alternative to #6327 where components get their ticks grown to 64 bit as well.
And #6327 doesn't introduce strongly typed ticks. Can be implemented though.
