### PR TITLE
[Merged by Bors] - Make spawn_dynamic return InstanceId

### DIFF
--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -54,10 +54,11 @@ pub enum SceneSpawnError {
 }
 
 impl SceneSpawner {
-    pub fn spawn_dynamic(&mut self, scene_handle: Handle<DynamicScene>) {
+    pub fn spawn_dynamic(&mut self, scene_handle: Handle<DynamicScene>) -> InstanceId {
         let instance_id = InstanceId::new();
         self.dynamic_scenes_to_spawn
             .push((scene_handle, instance_id));
+        instance_id
     }
 
     pub fn spawn_dynamic_as_child(


### PR DESCRIPTION
# Objective

Fixes #6661 

## Solution

Make `SceneSpawner::spawn_dynamic` return `InstanceId` like other functions there.

---

## Changelog

Make `SceneSpawner::spawn_dynamic` return `InstanceId` instead of `()`.
