### PR TITLE
Expose set_cursor_hittest() from winit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1443,6 +1443,10 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "fallthrough"
+path = "examples/ui/fallthrough.rs"
+
+[[example]]
 name = "font_atlas_debug"
 path = "examples/ui/font_atlas_debug.rs"
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -286,6 +286,7 @@ pub struct Window {
     cursor_icon: CursorIcon,
     cursor_visible: bool,
     cursor_grab_mode: CursorGrabMode,
+    hittest: bool,
     physical_cursor_position: Option<DVec2>,
     raw_handle: Option<RawHandleWrapper>,
     focused: bool,
@@ -350,6 +351,10 @@ pub enum WindowCommand {
     /// Set the cursor's position.
     SetCursorPosition {
         position: Vec2,
+    },
+    /// Set whether or not mouse events within *this* window are captured, or fall through to the Window below.
+    SetCursorHitTest {
+        hittest: bool,
     },
     /// Set whether or not the window is maximized.
     SetMaximized {
@@ -435,6 +440,7 @@ impl Window {
             cursor_visible: window_descriptor.cursor_visible,
             cursor_grab_mode: window_descriptor.cursor_grab_mode,
             cursor_icon: CursorIcon::Default,
+            hittest: true,
             physical_cursor_position: None,
             raw_handle,
             focused: false,
@@ -723,6 +729,12 @@ impl Window {
         self.cursor_grab_mode = grab_mode;
         self.command_queue
             .push(WindowCommand::SetCursorGrabMode { grab_mode });
+    }
+    /// Modifies whether the window catches cursor events.
+    ///
+    /// If true, the window will catch the cursor events. If false, events are passed through the window such that any other window behind it receives them. By default hittest is enabled.
+    pub fn set_cursor_hittest(&mut self, hittest: bool) {
+        self.hittest = hittest;
     }
     /// Get whether or not the cursor is visible.
     ///

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -730,12 +730,6 @@ impl Window {
         self.command_queue
             .push(WindowCommand::SetCursorGrabMode { grab_mode });
     }
-    /// Modifies whether the window catches cursor events.
-    ///
-    /// If true, the window will catch the cursor events. If false, events are passed through the window such that any other window behind it receives them. By default hittest is enabled.
-    pub fn set_cursor_hittest(&mut self, hittest: bool) {
-        self.hittest = hittest;
-    }
     /// Get whether or not the cursor is visible.
     ///
     /// ## Platform-specific
@@ -789,7 +783,19 @@ impl Window {
         self.command_queue
             .push(WindowCommand::SetCursorPosition { position });
     }
-
+    /// Modifies whether the window catches cursor events.
+    ///
+    /// If true, the window will catch the cursor events. If false, events are passed through the window such that any other window behind it receives them. By default hittest is enabled.
+    pub fn set_cursor_hittest(&mut self, hittest: bool) {
+        self.hittest = hittest;
+        self.command_queue
+            .push(WindowCommand::SetCursorHitTest { hittest })
+    }
+    /// Get whether or not the hittest is active.
+    #[inline]
+    pub fn hittest(&self) -> bool {
+        self.hittest
+    }
     #[allow(missing_docs)]
     #[inline]
     pub fn update_focused_status_from_backend(&mut self, focused: bool) {
@@ -973,6 +979,8 @@ pub struct WindowDescriptor {
     pub cursor_visible: bool,
     /// Sets whether and how the window grabs the cursor.
     pub cursor_grab_mode: CursorGrabMode,
+    /// Sets whether or not the window listens for 'hits' of mouse activity over _this_ window.
+    pub hittest: bool,
     /// Sets the [`WindowMode`](crate::WindowMode).
     ///
     /// The monitor to go fullscreen on can be selected with the `monitor` field.
@@ -1025,6 +1033,7 @@ impl Default for WindowDescriptor {
             decorations: true,
             cursor_grab_mode: CursorGrabMode::None,
             cursor_visible: true,
+            hittest: true,
             mode: WindowMode::Windowed,
             transparent: false,
             canvas: None,

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -237,6 +237,10 @@ fn change_window(
                     // No need to run any further commands - this drops the rest of the commands, although the `bevy_window::Window` will be dropped later anyway
                     break;
                 }
+                bevy_window::WindowCommand::SetCursorHitTest { hittest } => {
+                    let window = winit_windows.get_window(id).unwrap();
+                    window.set_cursor_hittest(hittest).unwrap();
+                }
             }
         }
     }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -230,16 +230,16 @@ fn change_window(
                     let window = winit_windows.get_window(id).unwrap();
                     window.set_always_on_top(always_on_top);
                 }
+                bevy_window::WindowCommand::SetCursorHitTest { hittest } => {
+                    let window = winit_windows.get_window(id).unwrap();
+                    _ = window.set_cursor_hittest(!hittest).unwrap();
+                }
                 bevy_window::WindowCommand::Close => {
                     // Since we have borrowed `windows` to iterate through them, we can't remove the window from it.
                     // Add the removal requests to a queue to solve this
                     removed_windows.push(id);
                     // No need to run any further commands - this drops the rest of the commands, although the `bevy_window::Window` will be dropped later anyway
                     break;
-                }
-                bevy_window::WindowCommand::SetCursorHitTest { hittest } => {
-                    let window = winit_windows.get_window(id).unwrap();
-                    window.set_cursor_hittest(hittest).unwrap();
                 }
             }
         }

--- a/examples/ui/fallthrough.rs
+++ b/examples/ui/fallthrough.rs
@@ -1,0 +1,71 @@
+//! This example illustrates how have a mouse's clicks/wheel/movement etc fall through the spawned transparent window to a window below.
+//!
+//! If you build this, and hit 'P' it should toggle on/off the mouse's passthrough.
+//!
+
+use bevy::prelude::*;
+
+const WIDTH: f32 = 1920.;
+const HEIGHT: f32 = 1080.;
+
+fn main() {
+    let window_desc = WindowDescriptor {
+        width: WIDTH,
+        height: HEIGHT,
+        transparent: true,
+        decorations: true,
+        always_on_top: true,
+        ..default()
+    };
+    App::new()
+        .insert_resource(ClearColor(Color::NONE)) // Use a transparent window, to make effects obvious.
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            window: window_desc,
+            ..default()
+        }))
+        .add_startup_system(setup)
+        .add_system(toggle_mouse_passthrough) // This allows us to hit 'P' to toggle on/off the mouse's passthrough
+        .run();
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    // UI camera
+    commands.spawn(Camera2dBundle::default());
+    // Text with one section
+    commands.spawn((
+        // Create a TextBundle that has a Text with a single section.
+        TextBundle::from_section(
+            // Accepts a `String` or any type that converts into a `String`, such as `&str`
+            "Hit 'P' then scroll/click around!",
+            TextStyle {
+                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                font_size: 100.0, // Nice and big so you can see it!
+                color: Color::WHITE,
+            },
+        )
+        // Set the style of the TextBundle itself.
+        .with_style(Style {
+            position_type: PositionType::Absolute,
+            position: UiRect {
+                bottom: Val::Px(HEIGHT / 4.),
+                right: Val::Px(WIDTH / 4.),
+                ..default()
+            },
+            ..default()
+        }),
+    ));
+}
+fn toggle_mouse_passthrough(keyboard_input: Res<Input<KeyCode>>, mut windows: ResMut<Windows>) {
+    if keyboard_input.just_pressed(KeyCode::P) {
+        let window = windows.primary_mut();
+
+        let hittest: bool = window.hittest();
+        if hittest {
+            info!("Hittesting the window.");
+        } else {
+            info!("Hittesting off.");
+        }
+
+        window.set_cursor_hittest(!hittest);
+    }
+}


### PR DESCRIPTION
# Objective

- Bevy should be usable to create 'overlay' type apps, where the input is not captured by Bevy, but passed down/into a target app, or to allow passive displays/widgets etc.
 
## Solution

- the `winit::window::Window` already has a `set_cursor_hittest()` which basically does this for mouse input events, so I've exposed it (trying to copy the style laid out in the existing wrappings, and added a simple demo.

---

## Changelog

- Added `hittest` to `WindowAttributes`
- Added the `hittest`'s setters/getters
- Modified the `WindowBuilder`
- Modifed the `WindowDescriptor`'s `Default` impl.
- Added an example `cargo run --example fallthrough`
 