### PR TITLE
Warn if we add ExtractResourcePlugin to an App that doesn't have a RenderApp

### DIFF
--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -35,6 +35,8 @@ impl<R: ExtractResource> Plugin for ExtractResourcePlugin<R> {
     fn build(&self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.add_system_to_stage(RenderStage::Extract, extract_resource::<R>);
+        } else {
+            bevy_log::warn!("ExtractResourcePlugin could not find a RenderApp to extract to. Did you add this plugin to the render app instead of the base app?");
         }
     }
 }


### PR DESCRIPTION
# Objective

- I am a moron and frequently make this mistake.
- Others like me will save time if there is a warning when ExtractResourcePlugin is added to the wrong app.

## Solution

- Maybe a compile time solution would be better?
