### PR TITLE
Fix font atlas limits

### DIFF
--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -160,6 +160,11 @@ impl FontAtlasSet {
 
     fn update_last_used(&mut self, font_size_key: &FontSizeKey) {
         if let Some(pos) = self.queue.iter().position(|i| *i == *font_size_key) {
+            // Already at the front, nothing to be done.
+            if pos == 0 {
+                return;
+            }
+
             if let Some(key) = self.queue.remove(pos) {
                 self.queue.push_front(key);
             }

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -76,12 +76,10 @@ impl FontAtlasSet {
             )]
         });
 
-        if !text_settings.allow_dynamic_font_size {
-            if len > text_settings.max_font_atlases.get() {
-                return Err(TextError::ExceedMaxTextAtlases(
-                    text_settings.max_font_atlases.get(),
-                ));
-            }
+        if !text_settings.allow_dynamic_font_size && len > text_settings.max_font_atlases.get() {
+            return Err(TextError::ExceedMaxTextAtlases(
+                text_settings.max_font_atlases.get(),
+            ));
         }
 
         let glyph_texture = Font::get_outlined_glyph_texture(outlined_glyph);

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -51,6 +51,7 @@ impl FontAtlasSet {
 
     pub fn add_glyph_to_atlas(
         &mut self,
+        font_size: f32,
         texture_atlases: &mut Assets<TextureAtlas>,
         textures: &mut Assets<Image>,
         outlined_glyph: OutlinedGlyph,
@@ -59,7 +60,6 @@ impl FontAtlasSet {
         let glyph = outlined_glyph.glyph();
         let glyph_id = glyph.id;
         let glyph_position = glyph.position;
-        let font_size = glyph.scale.y;
         let font_size_key = FloatOrd(font_size);
 
         self.update_last_used(&font_size_key);

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -119,7 +119,7 @@ impl FontAtlasSet {
 
         if text_settings.allow_dynamic_font_size {
             // Clear last space in queue to make room for new font size
-            while self.queue.len() >= text_settings.max_font_atlases.get() - 1 {
+            while self.queue.len() > text_settings.max_font_atlases.get() {
                 if let Some(font_size_key) = self.queue.pop_back() {
                     self.font_atlases.remove(&font_size_key);
                 }

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -115,6 +115,7 @@ impl GlyphBrush {
                     .map(Ok)
                     .unwrap_or_else(|| {
                         font_atlas_set.add_glyph_to_atlas(
+                            section_data.2,
                             texture_atlases,
                             textures,
                             outlined_glyph,

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -110,6 +110,8 @@ impl GlyphBrush {
                 let font_atlas_set = font_atlas_set_storage
                     .get_or_insert_with(handle_font_atlas, FontAtlasSet::default);
 
+                font_atlas_set.update_last_used(section_data.2);
+
                 let atlas_info = font_atlas_set
                     .get_glyph_atlas_info(section_data.2, glyph_id, glyph_position)
                     .map(Ok)


### PR DESCRIPTION
# Objective

Fixes #6642

## Solution

Previously, entries were added to the "last used size" queue every time a single glyph was added.

Instead, now we re-use some logic that finds the font size in the queue and moves it to the front.

## Caveats

Testing this with the minimal repro in #6642 revealed a new and exciting bug:

When closing a window that has a scale factor, there's a single frame where there is no longer a window / scale factor and the [default is used](https://github.com/bevyengine/bevy/blob/main/crates/bevy_ui/src/widget/text.rs#L73) so new font atlases are created at a different size.

At least I think that's what's going on. I don't fully understand it yet.

## TODO

~~Made this a draft because we probably only want to do some of this work if `allow_dynamic_font_sizes` is true.~~

~~It also seems a bit inefficient to update the queue in `add_glyph_to_atlas`.~~

Understand the closing-window thing.

Test more thoroughly.