### PR TITLE
[Merged by Bors] - Remove ImageMode

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -104,7 +104,6 @@ impl Plugin for UiPlugin {
             .register_type::<UiImage>()
             .register_type::<Val>()
             .register_type::<widget::Button>()
-            .register_type::<widget::ImageMode>()
             .add_system_to_stage(
                 CoreStage::PreUpdate,
                 ui_focus_system.label(UiSystem::Focus).after(InputSystem),

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -126,7 +126,7 @@ impl Plugin for UiPlugin {
             )
             .add_system_to_stage(
                 CoreStage::PostUpdate,
-                widget::image_node_system
+                widget::update_image_calculated_size_system
                     .before(UiSystem::Flex)
                     // Potential conflicts: `Assets<Image>`
                     // They run independently since `widget::image_node_system` will only ever observe

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -1,8 +1,8 @@
 //! This module contains basic node bundles used to build UIs
 
 use crate::{
-    widget::Button,
-    BackgroundColor, CalculatedSize, FocusPolicy, Interaction, Node, Style, UiImage, ZIndex,
+    widget::Button, BackgroundColor, CalculatedSize, FocusPolicy, Interaction, Node, Style,
+    UiImage, ZIndex,
 };
 use bevy_ecs::bundle::Bundle;
 use bevy_render::{

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -1,7 +1,7 @@
 //! This module contains basic node bundles used to build UIs
 
 use crate::{
-    widget::{Button, ImageMode},
+    widget::Button,
     BackgroundColor, CalculatedSize, FocusPolicy, Interaction, Node, Style, UiImage, ZIndex,
 };
 use bevy_ecs::bundle::Bundle;
@@ -67,8 +67,6 @@ pub struct ImageBundle {
     pub node: Node,
     /// Describes the style including flexbox settings
     pub style: Style,
-    /// Configures how the image should scale
-    pub image_mode: ImageMode,
     /// The calculated size based on the given image
     pub calculated_size: CalculatedSize,
     /// The background color, which serves as a "fill" for this node

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -8,7 +8,7 @@ use bevy_render::texture::Image;
 use bevy_text::Text;
 
 /// Updates calculated size of the node based on the image provided
-pub fn image_node_system(
+pub fn update_image_calculated_size_system(
     textures: Res<Assets<Image>>,
     mut query: Query<(&mut CalculatedSize, &UiImage), Without<Text>>,
 ) {

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,29 +1,16 @@
 use crate::{CalculatedSize, Size, UiImage, Val};
 use bevy_asset::Assets;
 use bevy_ecs::{
-    component::Component,
-    query::{With, Without},
-    reflect::ReflectComponent,
+    query::Without,
     system::{Query, Res},
 };
-use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render::texture::Image;
 use bevy_text::Text;
-use serde::{Deserialize, Serialize};
-
-/// Describes how to resize the Image node
-#[derive(Component, Debug, Default, Clone, Reflect, Serialize, Deserialize)]
-#[reflect(Component, Serialize, Deserialize)]
-pub enum ImageMode {
-    /// Keep the aspect ratio of the image
-    #[default]
-    KeepAspect,
-}
 
 /// Updates calculated size of the node based on the image provided
 pub fn image_node_system(
     textures: Res<Assets<Image>>,
-    mut query: Query<(&mut CalculatedSize, &UiImage), (With<ImageMode>, Without<Text>)>,
+    mut query: Query<(&mut CalculatedSize, &UiImage), Without<Text>>,
 ) {
     for (mut calculated_size, image) in &mut query {
         if let Some(texture) = textures.get(&image.texture) {


### PR DESCRIPTION
# Objective

Delete `ImageMode`. It doesn't do anything except mislead people into thinking it controls the aspect ratio of images somehow.

Fixes #3933 and #6637

## Solution

Delete `ImageMode`

## Changelog

Removes the `ImageMode` enum.
Removes the `image_mode` field from `ImageBundle`
Removes the `With<ImageMode>` query filter from `image_node_system`
Renames `image_node_system` to` update_image_calculated_size_system`
