### PR TITLE
[Merged by Bors] - Provide public `EntityRef::get_change_ticks_by_id` that takes `ComponentId`

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -82,6 +82,21 @@ impl<'w> EntityRef<'w> {
         unsafe { get_ticks_with_type(self.world, TypeId::of::<T>(), self.entity, self.location) }
     }
 
+    /// Retrieves the change ticks for the given [`ComponentId`]. This can be useful for implementing change
+    /// detection in custom runtimes.
+    ///
+    /// **You should prefer to use the typed API where possible and only
+    /// use this in cases where the actual component types are not known at
+    /// compile time.**
+    #[inline]
+    pub fn get_change_ticks_by_id(&self, component_id: ComponentId) -> Option<&'w ComponentTicks> {
+        // SAFETY: entity location is valid
+        unsafe {
+            get_ticks(self.world, component_id, self.entity, self.location)
+                .map(|ticks| ticks.deref())
+        }
+    }
+
     /// Gets a mutable reference to the component of type `T` associated with
     /// this entity without ensuring there are no other borrows active and without
     /// ensuring that the returned reference will stay valid.
@@ -204,6 +219,21 @@ impl<'w> EntityMut<'w> {
     pub fn get_change_ticks<T: Component>(&self) -> Option<ComponentTicks> {
         // SAFETY: entity location is valid
         unsafe { get_ticks_with_type(self.world, TypeId::of::<T>(), self.entity, self.location) }
+    }
+
+    /// Retrieves the change ticks for the given [`ComponentId`]. This can be useful for implementing change
+    /// detection in custom runtimes.
+    ///
+    /// **You should prefer to use the typed API where possible and only
+    /// use this in cases where the actual component types are not known at
+    /// compile time.**
+    #[inline]
+    pub fn get_change_ticks_by_id(&self, component_id: ComponentId) -> Option<&ComponentTicks> {
+        // SAFETY: entity location is valid
+        unsafe {
+            get_ticks(self.world, component_id, self.entity, self.location)
+                .map(|ticks| ticks.deref())
+        }
     }
 
     /// Gets a mutable reference to the component of type `T` associated with

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -94,7 +94,7 @@ impl<'w> EntityRef<'w> {
             return None;
         }
 
-        // SAFETY: entity location is valid and component_id exists
+        // SAFETY: Entity location is valid and component_id exists.
         unsafe { get_ticks(self.world, component_id, self.entity, self.location) }
     }
 
@@ -234,7 +234,7 @@ impl<'w> EntityMut<'w> {
             return None;
         }
 
-        // SAFETY: entity location is valid and component_id exists
+        // SAFETY: Entity location is valid and component_id exists.
         unsafe { get_ticks(self.world, component_id, self.entity, self.location) }
     }
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -85,7 +85,7 @@ impl<'w> EntityRef<'w> {
     /// Retrieves the change ticks for the given [`ComponentId`]. This can be useful for implementing change
     /// detection in custom runtimes.
     ///
-    /// **You should prefer to use the typed API where possible and only
+    /// **You should prefer to use the typed API [`EntityRef::get_change_ticks`] where possible and only
     /// use this in cases where the actual component types are not known at
     /// compile time.**
     #[inline]
@@ -228,7 +228,7 @@ impl<'w> EntityMut<'w> {
     /// Retrieves the change ticks for the given [`ComponentId`]. This can be useful for implementing change
     /// detection in custom runtimes.
     ///
-    /// **You should prefer to use the typed API where possible and only
+    /// **You should prefer to use the typed API [`EntityMut::get_change_ticks`] where possible and only
     /// use this in cases where the actual component types are not known at
     /// compile time.**
     #[inline]

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -89,16 +89,13 @@ impl<'w> EntityRef<'w> {
     /// use this in cases where the actual component types are not known at
     /// compile time.**
     #[inline]
-    pub fn get_change_ticks_by_id(&self, component_id: ComponentId) -> Option<&'w ComponentTicks> {
+    pub fn get_change_ticks_by_id(&self, component_id: ComponentId) -> Option<ComponentTicks> {
         if !self.contains_id(component_id) {
             return None;
         }
 
         // SAFETY: entity location is valid and component_id exists
-        unsafe {
-            get_ticks(self.world, component_id, self.entity, self.location)
-                .map(|ticks| ticks.deref())
-        }
+        unsafe { get_ticks(self.world, component_id, self.entity, self.location) }
     }
 
     /// Gets a mutable reference to the component of type `T` associated with
@@ -232,16 +229,13 @@ impl<'w> EntityMut<'w> {
     /// use this in cases where the actual component types are not known at
     /// compile time.**
     #[inline]
-    pub fn get_change_ticks_by_id(&self, component_id: ComponentId) -> Option<&ComponentTicks> {
+    pub fn get_change_ticks_by_id(&self, component_id: ComponentId) -> Option<ComponentTicks> {
         if !self.contains_id(component_id) {
             return None;
         }
 
         // SAFETY: entity location is valid and component_id exists
-        unsafe {
-            get_ticks(self.world, component_id, self.entity, self.location)
-                .map(|ticks| ticks.deref())
-        }
+        unsafe { get_ticks(self.world, component_id, self.entity, self.location) }
     }
 
     /// Gets a mutable reference to the component of type `T` associated with

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -90,7 +90,11 @@ impl<'w> EntityRef<'w> {
     /// compile time.**
     #[inline]
     pub fn get_change_ticks_by_id(&self, component_id: ComponentId) -> Option<&'w ComponentTicks> {
-        // SAFETY: entity location is valid
+        if !self.contains_id(component_id) {
+            return None;
+        }
+
+        // SAFETY: entity location is valid and component_id exists
         unsafe {
             get_ticks(self.world, component_id, self.entity, self.location)
                 .map(|ticks| ticks.deref())
@@ -229,7 +233,11 @@ impl<'w> EntityMut<'w> {
     /// compile time.**
     #[inline]
     pub fn get_change_ticks_by_id(&self, component_id: ComponentId) -> Option<&ComponentTicks> {
-        // SAFETY: entity location is valid
+        if !self.contains_id(component_id) {
+            return None;
+        }
+
+        // SAFETY: entity location is valid and component_id exists
         unsafe {
             get_ticks(self.world, component_id, self.entity, self.location)
                 .map(|ticks| ticks.deref())


### PR DESCRIPTION
# Objective

Fixes #6682 

## Solution

Add `EntityRef::get_change_ticks_by_id`
Add `EntityMut::get_change_ticks_by_id`
