### PR TITLE
[Merged by Bors] - Remove unnecessary struct in Material AsBindGroup example

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -100,12 +100,8 @@ use std::marker::PhantomData;
 /// In WGSL shaders, the material's binding would look like this:
 ///
 /// ```wgsl
-/// struct CustomMaterial {
-///     color: vec4<f32>,
-/// }
-///
 /// @group(1) @binding(0)
-/// var<uniform> material: CustomMaterial;
+/// var<uniform> color: vec4<f32>;
 /// @group(1) @binding(1)
 /// var color_texture: texture_2d<f32>;
 /// @group(1) @binding(2)

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -93,12 +93,8 @@ impl Deref for BindGroup {
 /// In WGSL shaders, the binding would look like this:
 ///
 /// ```wgsl
-/// struct CoolMaterial {
-///     color: vec4<f32>,
-/// };
-///
 /// @group(1) @binding(0)
-/// var<uniform> material: CoolMaterial;
+/// var<uniform> color: vec4<f32>;
 /// @group(1) @binding(1)
 /// var color_texture: texture_2d<f32>;
 /// @group(1) @binding(2)


### PR DESCRIPTION
# Objective

- Reduce confusion around uniform bindings in materials. I've seen multiple people on discord get confused by it because it uses a struct that is named the same in the rust code and the wgsl code, but doesn't contain the same data. Also, the only reason this works is mostly by chance because the memory happens to align correctly.

## Solution

- Remove the confusing parts of the doc

## Notes

It's not super clear in the diff why this causes confusion, but essentially, the rust code defines a `CustomMaterial` struct with a color and a texture, but in the wgsl code the struct with the same name only contains the color. People are confused by it because the struct in wgsl doesn't need to be there.

You _can_ have complex structs on each side and the macro will even combine it for you if you reuse a binding index, but as it is now, this example seems to confuse more than help people.
