### PR TITLE
Physically based bloom

### DIFF
--- a/examples/3d/bloom.rs
+++ b/examples/3d/bloom.rs
@@ -34,7 +34,7 @@ fn setup_scene(
     ));
 
     let material_emissive = materials.add(StandardMaterial {
-        emissive: Color::rgb_linear(5.2, 1.2, 0.8), // 3. Set StandardMaterial::emissive using Color::rgb_linear, for entities we want to apply bloom to
+        emissive: Color::rgb_linear(8000.0, 100.0, 0.8), // 3. Set StandardMaterial::emissive using Color::rgb_linear, for entities we want to apply bloom to
         ..default()
     });
     let material_non_emissive = materials.add(StandardMaterial {
@@ -110,8 +110,8 @@ fn update_bloom_settings(
 
     *text = "BloomSettings\n".to_string();
     text.push_str("-------------\n");
-    text.push_str(&format!("Threshold: {}\n", bloom_settings.threshold));
-    text.push_str(&format!("Knee: {}\n", bloom_settings.knee));
+    // text.push_str(&format!("Threshold: {}\n", bloom_settings.threshold));
+    // text.push_str(&format!("Knee: {}\n", bloom_settings.knee));
     text.push_str(&format!("Scale: {}\n", bloom_settings.scale));
     text.push_str(&format!("Intensity: {}\n", bloom_settings.intensity));
 
@@ -126,19 +126,19 @@ fn update_bloom_settings(
 
     let dt = time.delta_seconds();
 
-    if keycode.pressed(KeyCode::Q) {
-        bloom_settings.threshold -= dt;
-    }
-    if keycode.pressed(KeyCode::W) {
-        bloom_settings.threshold += dt;
-    }
+    // if keycode.pressed(KeyCode::Q) {
+    //     bloom_settings.threshold -= dt;
+    // }
+    // if keycode.pressed(KeyCode::W) {
+    //     bloom_settings.threshold += dt;
+    // }
 
-    if keycode.pressed(KeyCode::E) {
-        bloom_settings.knee -= dt;
-    }
-    if keycode.pressed(KeyCode::R) {
-        bloom_settings.knee += dt;
-    }
+    // if keycode.pressed(KeyCode::E) {
+    //     bloom_settings.knee -= dt;
+    // }
+    // if keycode.pressed(KeyCode::R) {
+    //     bloom_settings.knee += dt;
+    // }
 
     if keycode.pressed(KeyCode::A) {
         bloom_settings.scale -= dt;
@@ -148,10 +148,10 @@ fn update_bloom_settings(
     }
 
     if keycode.pressed(KeyCode::D) {
-        bloom_settings.intensity -= dt;
+        bloom_settings.intensity = (bloom_settings.intensity - dt).max(0.0);
     }
     if keycode.pressed(KeyCode::F) {
-        bloom_settings.intensity += dt;
+        bloom_settings.intensity = (bloom_settings.intensity + dt).min(1.0);
     }
 }
 

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -3,7 +3,7 @@
 
 use std::f32::consts::PI;
 
-use bevy::prelude::*;
+use bevy::{prelude::*, core_pipeline::bloom::BloomSettings};
 
 fn main() {
     App::new()
@@ -211,10 +211,20 @@ fn setup(
     });
 
     // camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3dBundle {
+            camera: Camera {
+                hdr: true,
+                ..default()
+            },
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        },
+        BloomSettings {
+            intensity: 0.5,
+            ..default()
+        },
+    ));
 }
 
 fn animate_light_direction(


### PR DESCRIPTION
# Objective

- Make the bloom effect energy conserving
- Make the bloom effect impossible to misconfigure
- Add a physically based alternative to threshold to preserve existing flexibility

## Explanation

### What is bloom

Bloom occurs in real life when light passes through an imperfect medium such as a lens and slightly scatters around before continuing on its way to the sensor or the retina. Bloom is effectively just a blur effect created by imperfections in glass or human eyes.

### Motivation

To emulate it in a natural-looking way it should be energy-conserving and based on its real-life counterpart. The existing implementation is quite close but it does not emulate the scattering perfectly and is certainly not energy-conserving. As a result, the current implementation is easy to configure in an obnoxious way and ruin the look of the game.

### Examples

<figure>
  <figcaption>Bloom example with existing implementation:</figcaption>
  <img src="https://user-images.githubusercontent.com/55361752/202927475-fc85949b-0dca-41ec-b1e1-ede5dd89025e.png" />
</figure>

<figure>
  <figcaption>Bloom example in this PR:</figcaption>
  <img src="https://user-images.githubusercontent.com/55361752/202927489-30d5cfdf-7888-4ce7-b7b4-27aa331aac54.png" />
</figure>

<figure>
  <figcaption>Lighting example with existing implementation of bloom:</figcaption>
  <img src="https://user-images.githubusercontent.com/55361752/202927601-9240c00e-d752-4478-ad23-8e09dab8f5c7.png" />
</figure>

<figure>
  <figcaption>Lighting example with bloom in this PR:</figcaption>
  <img src="https://user-images.githubusercontent.com/55361752/202927608-1252862b-883b-4508-9dd5-ca044b678727.png" />
</figure>

*Note: The existing implementation could look closer to this PR if the intensity is turned down, however, the existing implementation never results in a natural look at high intensity values, that is what the examples try to highlight.*

<figure>
  <figcaption>Existing implementation with intensity of 1 (not related to a physical parameter):</figcaption>
  <img src="https://user-images.githubusercontent.com/55361752/202928761-150cd7d8-9b6a-4b7e-a166-45904b17d22e.png" />
</figure>

<figure>
  <figcaption>Bloom in this PR with intensity of 1 (light is equally as likely to exit at any point of the lens). <i>This is still WIP since the whole screen should be the same color</i></figcaption>
  <img src="https://user-images.githubusercontent.com/55361752/202928765-23ee9735-51ec-4f0f-b034-c9eabb7b4199.png" />
</figure>

## Solution

- [ ] Calculate mip amount differently so that there the screen can be averaged to a single color at intensity of 1.
- [x] Interpolate between each mip based on bloom intensity rather than adding them together.
- [ ] Implement "deblooming" (same as tinting the lens and increasing the exposure; that way light that scatters more loses energy. This restores the artistic control previously provided by threshold but in a physically-based manner)

---

## Changelog

Changed:
- Bloom has a more natural look.
- Deblooming parameter replaces threshold and knee.

## Migration Guide

- Remove `threshold` and `knee` fields from all instances of `core_pipeline::bloom::BloomSettings`.
- Optinally use the `deblooming` filed to approximate the look threshold values above 0 created.
